### PR TITLE
Add webtransport support

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -72,50 +72,50 @@ jobs:
       - name: Test doc
         run: cargo test --doc
 
-#  test:
-#    name: Test
-#    runs-on: ubuntu-latest
-#    steps:
-#      - name: Clone repo
-#        uses: actions/checkout@v4
-#
-#      - name: Install stable toolchain
-#        uses: dtolnay/rust-toolchain@stable
-#
-#      - name: Cache crates
-#        uses: Swatinem/rust-cache@v2
-#
-#      - name: Install LLVM tools
-#        run: rustup component add llvm-tools-preview
-#
-#      - name: Install Tarpaulin
-#        run: cargo install cargo-tarpaulin
-#
-#      - name: Test
-#        run: cargo tarpaulin --engine llvm --out lcov
-#
-#      - name: Upload code coverage results
-#        if: github.actor != 'dependabot[bot]'
-#        uses: actions/upload-artifact@v3
-#        with:
-#          name: code-coverage-report
-#          path: lcov.info
-#
-#  codecov:
-#    name: Upload to Codecov
-#    if: github.actor != 'dependabot[bot]'
-#    needs: [format, lint, doctest, test]
-#    runs-on: ubuntu-latest
-#    steps:
-#      - name: Clone repo
-#        uses: actions/checkout@v4
-#
-#      - name: Download code coverage results
-#        uses: actions/download-artifact@v3
-#        with:
-#          name: code-coverage-report
-#
-#      - name: Upload to Codecov
-#        uses: codecov/codecov-action@v3
-#        with:
-#          token: ${{ secrets.CODECOV_TOKEN }}
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone repo
+        uses: actions/checkout@v4
+
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache crates
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install LLVM tools
+        run: rustup component add llvm-tools-preview
+
+      - name: Install Tarpaulin
+        run: cargo install cargo-tarpaulin
+
+      - name: Test
+        run: cargo tarpaulin --engine llvm --out lcov
+
+      - name: Upload code coverage results
+        if: github.actor != 'dependabot[bot]'
+        uses: actions/upload-artifact@v3
+        with:
+          name: code-coverage-report
+          path: lcov.info
+
+  codecov:
+    name: Upload to Codecov
+    if: github.actor != 'dependabot[bot]'
+    needs: [format, lint, doctest, test]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone repo
+        uses: actions/checkout@v4
+
+      - name: Download code coverage results
+        uses: actions/download-artifact@v3
+        with:
+          name: code-coverage-report
+
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -76,6 +76,9 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
+      - name: Install packages
+        run: sudo apt-get update && sudo apt-get install -y libasound2-dev pkg-config libusb-1.0-0-dev libftdi1-dev libudev-dev;
+        
       - name: Clone repo
         uses: actions/checkout@v4
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -38,7 +38,7 @@ metrics = ["lightyear/metrics", "dep:metrics-exporter-prometheus"]
 mock_time = ["lightyear/mock_time"]
 
 [dependencies]
-lightyear = { path = "../lightyear" }
+lightyear = { path = "../lightyear", features = ["webtransport"] }
 serde = { version = "1.0.188", features = ["derive"] }
 anyhow = { version = "1.0.75", features = [] }
 tracing = "0.1"
@@ -50,3 +50,4 @@ clap = { version = "4.4", features = ["derive"] }
 mock_instant = "0.3"
 metrics-exporter-prometheus = { version = "0.12.1", optional = true }
 bevy-inspector-egui = "0.21.0"
+tokio = "1.33.0"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -50,4 +50,4 @@ clap = { version = "4.4", features = ["derive"] }
 mock_instant = "0.3"
 metrics-exporter-prometheus = { version = "0.12.1", optional = true }
 bevy-inspector-egui = "0.21.0"
-tokio = "1.33.0"
+tokio = { version = "1.34.0", features = ["rt", "macros"] }

--- a/examples/simple_box/main.rs
+++ b/examples/simple_box/main.rs
@@ -24,7 +24,7 @@ use crate::server::MyServerPlugin;
 use lightyear::netcode::{ClientId, Key};
 use lightyear::prelude::TransportConfig;
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 async fn main() {
     let cli = Cli::parse();
     let mut app = App::new();

--- a/examples/simple_box/shared.rs
+++ b/examples/simple_box/shared.rs
@@ -14,7 +14,7 @@ pub fn shared_config() -> SharedConfig {
             tick_duration: Duration::from_secs_f64(1.0 / 64.0),
         },
         log: LogConfig {
-            level: Level::INFO,
+            level: Level::DEBUG,
             filter: "wgpu=error,wgpu_hal=error,naga=warn,bevy_app=info,bevy_render=warn"
                 .to_string(),
         },
@@ -25,7 +25,6 @@ pub struct SharedPlugin;
 
 impl Plugin for SharedPlugin {
     fn build(&self, app: &mut App) {
-        // app.add_plugins(WorldInspectorPlugin::new());
         app.add_systems(Update, draw_boxes);
     }
 }
@@ -54,16 +53,7 @@ pub(crate) fn shared_movement_behaviour(position: &mut PlayerPosition, input: &I
 
 /// System that draws the boxed of the player positions.
 /// The components should be replicated from the server to the client
-pub(crate) fn draw_boxes(
-    mut gizmos: Gizmos,
-    players: Query<(&PlayerPosition, &PlayerColor)>,
-    // client: Option<Res<Client<MyProtocol>>>,
-) {
-    // if let Some(client) = client {
-    //     if !client.is_synced() {
-    //         return;
-    //     }
-    // }
+pub(crate) fn draw_boxes(mut gizmos: Gizmos, players: Query<(&PlayerPosition, &PlayerColor)>) {
     for (position, color) in &players {
         gizmos.rect(
             Vec3::new(position.x, position.y, 0.0),

--- a/lightyear/Cargo.toml
+++ b/lightyear/Cargo.toml
@@ -13,10 +13,10 @@ metrics = [
   "tokio",
 ]
 mock_time = ["dep:mock_instant"]
-webtransport = ["dep:wtransport", "tokio/sync", "wtransport/dangerous-configuration"]
-#webtransport = ["dep:wtransport", "tokio/sync"]
+webtransport = ["dep:wtransport", "tokio/sync", "wtransport/dangerous-configuration", "dep:ring", "dep:base64", "dep:rcgen", "dep:time"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
 
 [dependencies]
 # utils
@@ -30,16 +30,18 @@ cfg-if = "1.0"
 mock_instant = { version = "0.3.1", optional = true }
 
 # transport
-#webtransport-quinn = { version = "0.6.1", optional = true }
-wtransport = { version = "0.1.8", optional = true}
-#webtransport-quinn = { version = "0.6.1"}
-quinn = { version = "0.10.2"}
+# TODO: we are using this version because we need Certificate to be Cloneable. Upgrade when this is merged
+wtransport = { git = "https://github.com/cBournhonesque/wtransport.git", branch = "cb/0.1.8andClone", optional = true}
+ring = { version = "0.17.6", optional = true }
+base64 = { version = "0.21.4", optional = true }
+rcgen = { version = "0.11.3", optional = true}
+time = {version = "0.3.1", optional = true}
 
 
 # serialization
 bitcode = { git = "https://github.com/cBournhonesque/bitcode.git", branch = "cb/latest", features = [
   "serde",
-] }
+]}
 bytes = { version = "1.5", features = ["serde"] }
 self_cell = "1.0"
 serde = { version = "1.0.188", features = ["derive"] }
@@ -57,7 +59,7 @@ tracing-log = "0.1.3"
 tracing-subscriber = { version = "0.3.17", features = [
   "registry",
   "env-filter",
-] }
+]}
 
 # server
 crossbeam-channel = { version = "0.5.8", features = [] }
@@ -75,8 +77,8 @@ tokio = { version = "1.33", features = ["rt", "net", "time"], optional = true }
 rand = "0.8"
 ringbuffer = "0.15"
 bevy = { version = "0.12", default-features = false }
-taplo-cli = "0.8.1"
 derive_more = "0.99.17"
+
 
 [dev-dependencies]
 derive_more = { version = "0.99", features = ["add", "mul"] }

--- a/lightyear/Cargo.toml
+++ b/lightyear/Cargo.toml
@@ -13,6 +13,8 @@ metrics = [
   "tokio",
 ]
 mock_time = ["dep:mock_instant"]
+webtransport = ["dep:wtransport", "tokio/sync", "wtransport/dangerous-configuration"]
+#webtransport = ["dep:wtransport", "tokio/sync"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -26,6 +28,12 @@ thiserror = "1.0.50"
 paste = "1.0"
 cfg-if = "1.0"
 mock_instant = { version = "0.3.1", optional = true }
+
+# transport
+#webtransport-quinn = { version = "0.6.1", optional = true }
+wtransport = { version = "0.1.8", optional = true}
+#webtransport-quinn = { version = "0.6.1"}
+quinn = { version = "0.10.2"}
 
 
 # serialization
@@ -62,6 +70,7 @@ metrics-exporter-prometheus = { version = "0.12.1", optional = true, default-fea
   "http-listener",
 ] }
 tokio = { version = "1.33", features = ["rt", "net", "time"], optional = true }
+#tokio = { version = "1.33", features = ["rt", "net", "sync", "time"]}
 
 rand = "0.8"
 ringbuffer = "0.15"

--- a/lightyear/Cargo.toml
+++ b/lightyear/Cargo.toml
@@ -13,7 +13,15 @@ metrics = [
   "tokio",
 ]
 mock_time = ["dep:mock_instant"]
-webtransport = ["dep:wtransport", "tokio/sync", "wtransport/dangerous-configuration", "dep:ring", "dep:base64", "dep:rcgen", "dep:time"]
+webtransport = [
+  "dep:wtransport",
+  "tokio/sync",
+  "wtransport/dangerous-configuration",
+  "dep:ring",
+  "dep:base64",
+  "dep:rcgen",
+  "dep:time",
+]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -31,17 +39,17 @@ mock_instant = { version = "0.3.1", optional = true }
 
 # transport
 # TODO: we are using this version because we need Certificate to be Cloneable. Upgrade when this is merged
-wtransport = { git = "https://github.com/cBournhonesque/wtransport.git", branch = "cb/0.1.8andClone", optional = true}
+wtransport = { git = "https://github.com/cBournhonesque/wtransport.git", branch = "cb/0.1.8andClone", optional = true }
 ring = { version = "0.17.6", optional = true }
 base64 = { version = "0.21.4", optional = true }
-rcgen = { version = "0.11.3", optional = true}
-time = {version = "0.3.1", optional = true}
+rcgen = { version = "0.11.3", optional = true }
+time = { version = "0.3.1", optional = true }
 
 
 # serialization
 bitcode = { git = "https://github.com/cBournhonesque/bitcode.git", branch = "cb/latest", features = [
   "serde",
-]}
+] }
 bytes = { version = "1.5", features = ["serde"] }
 self_cell = "1.0"
 serde = { version = "1.0.188", features = ["derive"] }
@@ -59,7 +67,7 @@ tracing-log = "0.1.3"
 tracing-subscriber = { version = "0.3.17", features = [
   "registry",
   "env-filter",
-]}
+] }
 
 # server
 crossbeam-channel = { version = "0.5.8", features = [] }

--- a/lightyear/src/client/resource.rs
+++ b/lightyear/src/client/resource.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use anyhow::Result;
 use bevy::prelude::{Resource, Time, Virtual, World};
-use tracing::trace;
+use tracing::{debug, trace};
 
 use crate::channel::builder::Channel;
 use crate::connection::events::ConnectionEvents;

--- a/lightyear/src/lib.rs
+++ b/lightyear/src/lib.rs
@@ -69,7 +69,6 @@ pub mod prelude {
     pub use crate::shared::tick_manager::{Tick, TickConfig};
     pub use crate::transport::conditioner::LinkConditionerConfig;
     pub use crate::transport::io::{Io, IoConfig, TransportConfig};
-    pub use crate::transport::udp::UdpSocket;
     pub use crate::utils::named::{Named, TypeNamed};
 
     pub mod client {

--- a/lightyear/src/shared/log.rs
+++ b/lightyear/src/shared/log.rs
@@ -21,21 +21,7 @@ use tracing_log::LogTracer;
 /// rerunning the same initialization multiple times will lead to a panic.
 // TODO: take directly log config?
 pub struct LogPlugin {
-    /// Filters logs using the [`EnvFilter`] format
-    pub filter: String,
-
-    /// Filters out logs that are "less than" the given level.
-    /// This can be further filtered using the `filter` setting.
-    pub level: Level,
-}
-
-impl Default for LogPlugin {
-    fn default() -> Self {
-        Self {
-            filter: "wgpu=error,wgpu_hal=error,naga=warn,bevy_app=info".to_string(),
-            level: Level::INFO,
-        }
-    }
+    pub config: LogConfig,
 }
 
 #[derive(Clone)]
@@ -61,11 +47,11 @@ impl Default for LogConfig {
 impl Plugin for LogPlugin {
     fn build(&self, app: &mut App) {
         let finished_subscriber;
-        let default_filter = { format!("{},{}", self.level, self.filter) };
-        dbg!(&default_filter);
+        let default_filter = { format!("{},{}", self.config.level, self.config.filter) };
         let filter_layer = EnvFilter::try_from_default_env()
             .or_else(|_| EnvFilter::try_new(&default_filter))
             .unwrap();
+        println!("Log filter: {:?}", default_filter);
         let subscriber = Registry::default().with(filter_layer);
 
         let fmt_layer = tracing_subscriber::fmt::Layer::default()

--- a/lightyear/src/shared/plugin.rs
+++ b/lightyear/src/shared/plugin.rs
@@ -17,14 +17,11 @@ impl Plugin for SharedPlugin {
             self.config.tick.tick_duration.as_secs_f64(),
         ));
         app.init_resource::<ReplicationData>();
-        // SYSTEMS
-        // app.add_systems(FixedUpdate, increment_tick);
 
-        // TODO: set log config
+        // SYSTEMS
+        // TODO: increment_tick should be shared
+        // app.add_systems(FixedUpdate, increment_tick);
         let log_config = self.config.log.clone();
-        app.add_plugins(log::LogPlugin {
-            level: log_config.level,
-            filter: log_config.filter,
-        });
+        app.add_plugins(log::LogPlugin { config: log_config });
     }
 }

--- a/lightyear/src/transport/io.rs
+++ b/lightyear/src/transport/io.rs
@@ -6,22 +6,28 @@ use std::net::{IpAddr, SocketAddr};
 
 #[cfg(feature = "metrics")]
 use metrics;
-use wtransport::tls::Certificate;
 
 use crate::transport::conditioner::{ConditionedPacketReceiver, LinkConditionerConfig};
 use crate::transport::local::{LocalChannel, LOCAL_SOCKET};
 use crate::transport::udp::UdpSocket;
-use crate::transport::webtransport::client::{WebTransportClientSocket, WebTransportClientSocket};
+
+#[cfg(feature = "webtransport")]
+use crate::transport::webtransport::client::WebTransportClientSocket;
+#[cfg(feature = "webtransport")]
 use crate::transport::webtransport::server::WebTransportServerSocket;
 use crate::transport::{PacketReceiver, PacketSender, Transport};
+#[cfg(feature = "webtransport")]
+use wtransport::tls::Certificate;
 
 #[derive(Clone)]
 pub enum TransportConfig {
     UdpSocket(SocketAddr),
+    #[cfg(feature = "webtransport")]
     WebTransportClient {
         client_addr: SocketAddr,
         server_addr: SocketAddr,
     },
+    #[cfg(feature = "webtransport")]
     WebTransportServer {
         server_addr: SocketAddr,
         certificate: Certificate,
@@ -33,10 +39,12 @@ impl TransportConfig {
     pub fn get_io(&self) -> Io {
         let mut transport: Box<dyn Transport> = match self {
             TransportConfig::UdpSocket(addr) => Box::new(UdpSocket::new(addr).unwrap()),
+            #[cfg(feature = "webtransport")]
             TransportConfig::WebTransportClient {
                 client_addr,
                 server_addr,
             } => Box::new(WebTransportClientSocket::new(*client_addr, *server_addr)),
+            #[cfg(feature = "webtransport")]
             TransportConfig::WebTransportServer {
                 server_addr,
                 certificate,

--- a/lightyear/src/transport/io.rs
+++ b/lightyear/src/transport/io.rs
@@ -6,50 +6,50 @@ use std::net::{IpAddr, SocketAddr};
 
 #[cfg(feature = "metrics")]
 use metrics;
+use wtransport::tls::Certificate;
 
 use crate::transport::conditioner::{ConditionedPacketReceiver, LinkConditionerConfig};
 use crate::transport::local::{LocalChannel, LOCAL_SOCKET};
 use crate::transport::udp::UdpSocket;
+use crate::transport::webtransport::client::{WebTransportClientSocket, WebTransportClientSocket};
+use crate::transport::webtransport::server::WebTransportServerSocket;
 use crate::transport::{PacketReceiver, PacketSender, Transport};
 
 #[derive(Clone)]
 pub enum TransportConfig {
     UdpSocket(SocketAddr),
+    WebTransportClient {
+        client_addr: SocketAddr,
+        server_addr: SocketAddr,
+    },
+    WebTransportServer {
+        server_addr: SocketAddr,
+        certificate: Certificate,
+    },
     LocalChannel,
 }
 
 impl TransportConfig {
     pub fn get_io(&self) -> Io {
-        match self {
-            TransportConfig::UdpSocket(addr) => {
-                let socket = UdpSocket::new(addr).unwrap();
-                Io::new(*addr, Box::new(socket.clone()), Box::new(socket))
-            }
-            TransportConfig::LocalChannel => {
-                let channel = LocalChannel::new();
-                Io::new(LOCAL_SOCKET, Box::new(channel.clone()), Box::new(channel))
-            }
-        }
+        let mut transport: Box<dyn Transport> = match self {
+            TransportConfig::UdpSocket(addr) => Box::new(UdpSocket::new(addr).unwrap()),
+            TransportConfig::WebTransportClient {
+                client_addr,
+                server_addr,
+            } => Box::new(WebTransportClientSocket::new(*client_addr, *server_addr)),
+            TransportConfig::WebTransportServer {
+                server_addr,
+                certificate,
+            } => Box::new(WebTransportServerSocket::new(
+                *server_addr,
+                certificate.clone(),
+            )),
+            TransportConfig::LocalChannel => Box::new(LocalChannel::new()),
+        };
+        let addr = transport.local_addr();
+        let (sender, receiver) = transport.listen();
+        Io::new(addr, sender, receiver)
     }
-    // pub fn get_local_addr(&self) -> SocketAddr {
-    //     match self {
-    //         TransportConfig::UdpSocket(addr) => *addr,
-    //         TransportConfig::LocalChannel => LOCAL_SOCKET,
-    //     }
-    // }
-    // pub fn get_sender(&self) -> Box<dyn PacketSender + Send + Sync> {
-    //     match self {
-    //         TransportConfig::UdpSocket(addr) => Box::new(UdpSocket::new(addr).unwrap()),
-    //         TransportConfig::LocalChannel => Box::new(LocalChannel::new()),
-    //     }
-    // }
-    //
-    // pub fn get_receiver(&self) -> Box<dyn PacketReceiver + Send + Sync> {
-    //     match self {
-    //         TransportConfig::UdpSocket(addr) => Box::new(UdpSocket::new(addr).unwrap()),
-    //         TransportConfig::LocalChannel => Box::new(LocalChannel::new()),
-    //     }
-    // }
 }
 
 #[derive(Clone)]
@@ -90,42 +90,23 @@ impl IoConfig {
         }
         io
     }
-
-    // pub fn get_local_addr(&self) -> SocketAddr {
-    //     self.transport.get_local_addr()
-    // }
-    // pub fn get_sender(&self) -> Box<dyn PacketSender + Send + Sync> {
-    //     self.transport.get_sender()
-    // }
-    //
-    // pub fn get_receiver(&self) -> Box<dyn PacketReceiver + Send + Sync> {
-    //     let mut receiver = self.transport.get_receiver();
-    //     if let Some(conditioner) = &self.conditioner {
-    //         receiver = Box::new(ConditionedPacketReceiver::new(receiver, conditioner));
-    //     }
-    //     receiver
-    // }
 }
 
 pub struct Io {
     local_addr: SocketAddr,
-    sender: Box<dyn PacketSender + Send + Sync>,
-    receiver: Box<dyn PacketReceiver + Send + Sync>,
+    sender: Box<dyn PacketSender>,
+    receiver: Box<dyn PacketReceiver>,
 }
 
 impl Io {
     pub fn from_config(config: &IoConfig) -> Self {
         config.get_io()
-        // let local_addr = config.transport.get_local_addr();
-        // let sender = config.transport.get_sender();
-        // let receiver = config.transport.get_receiver();
-        // Self::new(local_addr, sender, receiver)
     }
 
     pub fn new(
         local_addr: SocketAddr,
-        sender: Box<dyn PacketSender + Send + Sync>,
-        receiver: Box<dyn PacketReceiver + Send + Sync>,
+        sender: Box<dyn PacketSender>,
+        receiver: Box<dyn PacketReceiver>,
     ) -> Self {
         Self {
             local_addr,
@@ -133,22 +114,15 @@ impl Io {
             receiver,
         }
     }
+    pub fn local_addr(&self) -> SocketAddr {
+        self.local_addr
+    }
 
-    pub fn to_parts(
-        self,
-    ) -> (
-        Box<dyn PacketReceiver + Send + Sync>,
-        Box<dyn PacketSender + Send + Sync>,
-    ) {
+    pub fn to_parts(self) -> (Box<dyn PacketReceiver>, Box<dyn PacketSender>) {
         (self.receiver, self.sender)
     }
 
-    pub fn split(
-        &mut self,
-    ) -> (
-        &mut Box<dyn PacketSender + Send + Sync>,
-        &mut Box<dyn PacketReceiver + Send + Sync>,
-    ) {
+    pub fn split(&mut self) -> (&mut Box<dyn PacketSender>, &mut Box<dyn PacketReceiver>) {
         (&mut self.sender, &mut self.receiver)
     }
 }
@@ -201,8 +175,12 @@ impl PacketReceiver for Box<dyn PacketReceiver + Send + Sync> {
     }
 }
 
-impl Transport for Io {
-    fn local_addr(&self) -> SocketAddr {
-        self.local_addr
-    }
-}
+// impl Transport for Io {
+//     fn local_addr(&self) -> SocketAddr {
+//         self.local_addr
+//     }
+//
+//     fn listen(&mut self) -> (Box<dyn PacketSender>, Box<dyn PacketReceiver>) {
+//         (self.sender.clone(), self.receiver.clone())
+//     }
+// }

--- a/lightyear/src/transport/mod.rs
+++ b/lightyear/src/transport/mod.rs
@@ -12,6 +12,10 @@ pub(crate) mod local;
 /// The transport is a UDP socket
 pub(crate) mod udp;
 
+/// The transport is using WebTransport
+#[cfg(feature = "webtransport")]
+pub(crate) mod webtransport;
+
 use std::io::Result;
 use std::net::SocketAddr;
 

--- a/lightyear/src/transport/udp.rs
+++ b/lightyear/src/transport/udp.rs
@@ -43,9 +43,9 @@ impl Transport for UdpSocket {
             .expect("error getting local addr")
     }
 
-    // fn split(&mut self) -> (Box<dyn PacketReceiver>, Box<dyn PacketSender>) {
-    //     (Box::new(self.socket.clone()), Box::new(self.socket.clone()))
-    // }
+    fn listen(&mut self) -> (Box<dyn PacketSender>, Box<dyn PacketReceiver>) {
+        (Box::new(self.clone()), Box::new(self.clone()))
+    }
 }
 
 impl PacketSender for UdpSocket {
@@ -61,25 +61,6 @@ impl PacketSender for UdpSocket {
 }
 
 impl PacketReceiver for UdpSocket {
-    // /// Receive a packet from the socket and store the results in the provided buffer
-    // /// Return the number of bytes written
-    // fn recv(&mut self, buffer: &[u8]) -> Result<Option<(&[u8], SocketAddr)>> {
-    //     match self
-    //         .socket
-    //         .as_ref()
-    //         .lock()
-    //         .unwrap()
-    //         .recv_from(&mut self.buffer)
-    //     {
-    //         Ok((recv_len, address)) => Ok(Some((&self.buffer[..recv_len], address))),
-    //         Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
-    //             // Nothing to receive on the socket
-    //             Ok(None)
-    //         }
-    //         Err(e) => Err(anyhow!(e).context("error receiving from udp socket")),
-    //     }
-    // }
-
     /// Receives a packet from the socket, and stores the results in the provided buffer
     fn recv(&mut self) -> Result<Option<(&mut [u8], SocketAddr)>> {
         match self

--- a/lightyear/src/transport/webtransport/cert.rs
+++ b/lightyear/src/transport/webtransport/cert.rs
@@ -35,11 +35,10 @@ pub fn generate_local_certificate() -> wtransport::tls::Certificate {
         .unwrap();
 
     let rcgen_certificate = Certificate::from_params(cert_params).unwrap();
-    let certificate = wtransport::tls::Certificate::new(
+    wtransport::tls::Certificate::new(
         vec![rcgen_certificate.serialize_der().unwrap().to_vec()],
         rcgen_certificate.serialize_private_key_der().to_vec(),
-    );
-    certificate
+    )
 }
 
 pub(crate) fn dump_certificate(certificate: Certificate) {

--- a/lightyear/src/transport/webtransport/cert.rs
+++ b/lightyear/src/transport/webtransport/cert.rs
@@ -1,0 +1,55 @@
+//! Generate a self-signed certificate for use with WebTransport.
+use base64::engine::general_purpose::STANDARD as Base64Engine;
+use base64::Engine;
+use rcgen::DistinguishedName;
+use rcgen::DnType;
+use rcgen::KeyPair;
+use rcgen::PKCS_ECDSA_P256_SHA256;
+use rcgen::{Certificate, CertificateParams};
+use ring::digest::digest;
+use ring::digest::SHA256;
+use std::fs;
+use std::io::Write;
+use time::Duration;
+use time::OffsetDateTime;
+
+pub fn generate_local_certificate() -> wtransport::tls::Certificate {
+    const COMMON_NAME: &str = "localhost";
+
+    let mut dname = DistinguishedName::new();
+    dname.push(DnType::CommonName, COMMON_NAME);
+
+    let keypair = KeyPair::generate(&PKCS_ECDSA_P256_SHA256).unwrap();
+
+    let digest = digest(&SHA256, &keypair.public_key_der());
+
+    let mut cert_params = CertificateParams::new(vec![COMMON_NAME.to_string()]);
+    cert_params.distinguished_name = dname;
+    cert_params.alg = &PKCS_ECDSA_P256_SHA256;
+    cert_params.key_pair = Some(keypair);
+    cert_params.not_before = OffsetDateTime::now_utc()
+        .checked_sub(Duration::days(2))
+        .unwrap();
+    cert_params.not_after = OffsetDateTime::now_utc()
+        .checked_add(Duration::days(2))
+        .unwrap();
+
+    let rcgen_certificate = Certificate::from_params(cert_params).unwrap();
+    let certificate = wtransport::tls::Certificate::new(
+        vec![rcgen_certificate.serialize_der().unwrap().to_vec()],
+        rcgen_certificate.serialize_private_key_der().to_vec(),
+    );
+    certificate
+}
+
+pub(crate) fn dump_certificate(certificate: Certificate) {
+    fs::File::create("cert.pem")
+        .unwrap()
+        .write_all(certificate.serialize_pem().unwrap().as_bytes())
+        .unwrap();
+
+    fs::File::create("key.pem")
+        .unwrap()
+        .write_all(certificate.serialize_private_key_pem().as_bytes())
+        .unwrap();
+}

--- a/lightyear/src/transport/webtransport/client.rs
+++ b/lightyear/src/transport/webtransport/client.rs
@@ -1,3 +1,4 @@
+//! WebTransport client implementation.
 use crate::transport::webtransport::server::WebTransportServerSocket;
 use crate::transport::webtransport::MTU;
 use crate::transport::{PacketReceiver, PacketSender, Transport};
@@ -10,6 +11,7 @@ use wtransport;
 use wtransport::datagram::Datagram;
 use wtransport::ClientConfig;
 
+/// WebTransport client socket
 pub struct WebTransportClientSocket {
     client_addr: SocketAddr,
     server_addr: SocketAddr,
@@ -86,7 +88,7 @@ impl Transport for WebTransportClientSocket {
     }
 }
 
-pub struct WebTransportClientPacketSender {
+struct WebTransportClientPacketSender {
     to_server_sender: mpsc::UnboundedSender<Box<[u8]>>,
 }
 
@@ -99,7 +101,7 @@ impl PacketSender for WebTransportClientPacketSender {
     }
 }
 
-pub struct WebTransportClientPacketReceiver {
+struct WebTransportClientPacketReceiver {
     server_addr: SocketAddr,
     from_server_receiver: mpsc::UnboundedReceiver<Datagram>,
     buffer: [u8; MTU],

--- a/lightyear/src/transport/webtransport/client.rs
+++ b/lightyear/src/transport/webtransport/client.rs
@@ -1,0 +1,74 @@
+use crate::transport::PacketSender;
+use bevy::tasks::TaskPool;
+use std::net::SocketAddr;
+use tokio::sync::mpsc;
+use tracing::error;
+use wtransport;
+use wtransport::datagram::Datagram;
+use wtransport::ClientConfig;
+
+/// UDP Socket
+// #[derive(Clone)]
+pub struct WebTransportConnection {
+    /// The underlying UDP Socket. This is wrapped in an Arc<Mutex<>> so that it
+    /// can be shared between threads
+    // buffer: [u8; MTU],
+    // session: Session,
+    // config: ClientConfig,
+    from_server_receiver: mpsc::UnboundedReceiver<Datagram>,
+    to_server_sender: mpsc::UnboundedSender<Vec<u8>>,
+}
+
+impl WebTransportConnection {
+    pub fn connect(addr: SocketAddr) -> Self {
+        let config = ClientConfig::builder()
+            .with_bind_default()
+            .with_no_cert_validation()
+            .build();
+        let server_addr = "127.0.0.1:5000";
+        let (to_server_sender, mut to_server_receiver) = mpsc::unbounded_channel::<Vec<u8>>();
+        let (from_server_sender, from_server_receiver) = mpsc::unbounded_channel();
+
+        let executor = TaskPool::get_thread_executor().spawn(async move {
+            let connection = wtransport::Endpoint::client(config)
+                .unwrap()
+                .connect(server_addr)
+                .await
+                .unwrap();
+
+            loop {
+                tokio::select! {
+                    // receive messages from server
+                    x = connection.receive_datagram() => {
+                        match x {
+                            Ok(data) => {
+                                from_server_sender.send(data).unwrap();
+                            }
+                            Err(e) => {
+                                error!("receive_datagram error: {:?}", e);
+                            }
+                        }
+                    }
+
+                    // send messages to server
+                    Some(msg) = to_server_receiver.recv() => {
+                        connection.send_datagram(msg.as_slice()).unwrap_or_else(|e| {
+                            error!("send_datagram error: {:?}", e);
+                        });
+                    }
+                }
+            }
+        });
+        Self {
+            // config,
+            from_server_receiver,
+            to_server_sender,
+        }
+    }
+}
+
+impl PacketSender for WebTransportConnection {
+    fn send(&mut self, payload: &[u8], address: &SocketAddr) -> std::io::Result<()> {
+        todo!()
+    }
+}

--- a/lightyear/src/transport/webtransport/client.rs
+++ b/lightyear/src/transport/webtransport/client.rs
@@ -1,41 +1,58 @@
-use crate::transport::PacketSender;
-use bevy::tasks::TaskPool;
+use crate::transport::webtransport::server::WebTransportServerSocket;
+use crate::transport::webtransport::MTU;
+use crate::transport::{PacketReceiver, PacketSender, Transport};
+use bevy::tasks::{IoTaskPool, TaskPool};
 use std::net::SocketAddr;
 use tokio::sync::mpsc;
-use tracing::error;
+use tokio::sync::mpsc::error::TryRecvError;
+use tracing::{debug, error, info};
 use wtransport;
 use wtransport::datagram::Datagram;
 use wtransport::ClientConfig;
 
-/// UDP Socket
-// #[derive(Clone)]
-pub struct WebTransportConnection {
-    /// The underlying UDP Socket. This is wrapped in an Arc<Mutex<>> so that it
-    /// can be shared between threads
-    // buffer: [u8; MTU],
-    // session: Session,
-    // config: ClientConfig,
-    from_server_receiver: mpsc::UnboundedReceiver<Datagram>,
-    to_server_sender: mpsc::UnboundedSender<Vec<u8>>,
+pub struct WebTransportClientSocket {
+    client_addr: SocketAddr,
+    server_addr: SocketAddr,
 }
 
-impl WebTransportConnection {
-    pub fn connect(addr: SocketAddr) -> Self {
-        let config = ClientConfig::builder()
-            .with_bind_default()
-            .with_no_cert_validation()
-            .build();
-        let server_addr = "127.0.0.1:5000";
-        let (to_server_sender, mut to_server_receiver) = mpsc::unbounded_channel::<Vec<u8>>();
+impl WebTransportClientSocket {
+    pub fn new(client_addr: SocketAddr, server_addr: SocketAddr) -> Self {
+        Self {
+            client_addr,
+            server_addr,
+        }
+    }
+}
+
+impl Transport for WebTransportClientSocket {
+    fn local_addr(&self) -> SocketAddr {
+        self.client_addr
+    }
+
+    fn listen(&mut self) -> (Box<dyn PacketSender>, Box<dyn PacketReceiver>) {
+        let client_addr = self.client_addr;
+        let server_addr = self.server_addr;
+        let (to_server_sender, mut to_server_receiver) = mpsc::unbounded_channel();
         let (from_server_sender, from_server_receiver) = mpsc::unbounded_channel();
 
-        let executor = TaskPool::get_thread_executor().spawn(async move {
-            let connection = wtransport::Endpoint::client(config)
+        tokio::spawn(async move {
+            let config = ClientConfig::builder()
+                .with_bind_address(client_addr)
+                .with_no_cert_validation()
+                .build();
+            let server_url = format!("https://{}", server_addr);
+            debug!(
+                "Starting client webtransport task with server url: {}",
+                &server_url
+            );
+            let Ok(connection) = wtransport::Endpoint::client(config)
                 .unwrap()
-                .connect(server_addr)
+                .connect(server_url)
                 .await
-                .unwrap();
-
+            else {
+                error!("failed to connect to server");
+                return;
+            };
             loop {
                 tokio::select! {
                     // receive messages from server
@@ -52,23 +69,59 @@ impl WebTransportConnection {
 
                     // send messages to server
                     Some(msg) = to_server_receiver.recv() => {
-                        connection.send_datagram(msg.as_slice()).unwrap_or_else(|e| {
+                        connection.send_datagram(msg).unwrap_or_else(|e| {
                             error!("send_datagram error: {:?}", e);
                         });
                     }
                 }
             }
         });
-        Self {
-            // config,
+        let packet_sender = WebTransportClientPacketSender { to_server_sender };
+        let packet_receiver = WebTransportClientPacketReceiver {
+            server_addr,
             from_server_receiver,
-            to_server_sender,
-        }
+            buffer: [0; MTU],
+        };
+        (Box::new(packet_sender), Box::new(packet_receiver))
     }
 }
 
-impl PacketSender for WebTransportConnection {
+pub struct WebTransportClientPacketSender {
+    to_server_sender: mpsc::UnboundedSender<Box<[u8]>>,
+}
+
+impl PacketSender for WebTransportClientPacketSender {
     fn send(&mut self, payload: &[u8], address: &SocketAddr) -> std::io::Result<()> {
-        todo!()
+        let data = payload.to_vec().into_boxed_slice();
+        self.to_server_sender
+            .send(data)
+            .map_err(|e| std::io::Error::other(format!("send_datagram error: {:?}", e)))
+    }
+}
+
+pub struct WebTransportClientPacketReceiver {
+    server_addr: SocketAddr,
+    from_server_receiver: mpsc::UnboundedReceiver<Datagram>,
+    buffer: [u8; MTU],
+}
+
+impl PacketReceiver for WebTransportClientPacketReceiver {
+    fn recv(&mut self) -> std::io::Result<Option<(&mut [u8], SocketAddr)>> {
+        match self.from_server_receiver.try_recv() {
+            Ok(data) => {
+                self.buffer[..data.len()].copy_from_slice(data.payload().as_ref());
+                Ok(Some((&mut self.buffer[..data.len()], self.server_addr)))
+            }
+            Err(e) => {
+                if e == TryRecvError::Empty {
+                    Ok(None)
+                } else {
+                    Err(std::io::Error::other(format!(
+                        "receive_datagram error: {:?}",
+                        e
+                    )))
+                }
+            }
+        }
     }
 }

--- a/lightyear/src/transport/webtransport/mod.rs
+++ b/lightyear/src/transport/webtransport/mod.rs
@@ -1,0 +1,1 @@
+mod client;

--- a/lightyear/src/transport/webtransport/mod.rs
+++ b/lightyear/src/transport/webtransport/mod.rs
@@ -1,3 +1,4 @@
+//! Transport using the WebTransport protocol (based on QUIC)
 pub(crate) mod client;
 pub(crate) mod server;
 

--- a/lightyear/src/transport/webtransport/mod.rs
+++ b/lightyear/src/transport/webtransport/mod.rs
@@ -1,1 +1,65 @@
-mod client;
+pub(crate) mod client;
+pub(crate) mod server;
+
+pub mod cert;
+
+// Maximum transmission units; maximum size in bytes of a UDP packet
+// See: https://gafferongames.com/post/packet_fragmentation_and_reassembly/
+const MTU: usize = 1472;
+
+#[cfg(test)]
+mod tests {
+    use super::client::*;
+    use super::server::*;
+    use crate::transport::webtransport::cert::{dump_certificate, generate_local_certificate};
+    use crate::transport::{PacketReceiver, PacketSender, Transport};
+    use bevy::tasks::{IoTaskPool, TaskPoolBuilder};
+    use std::time::Duration;
+    use tracing::info;
+    use tracing_subscriber::fmt::format::FmtSpan;
+    use wtransport::tls::Certificate;
+
+    #[tokio::test]
+    async fn test_webtransport_socket() -> anyhow::Result<()> {
+        // tracing_subscriber::FmtSubscriber::builder()
+        //     .with_span_events(FmtSpan::ENTER)
+        //     .with_max_level(tracing::Level::INFO)
+        //     .init();
+        let certificate = generate_local_certificate();
+        let server_addr = "127.0.0.1:7000".parse().unwrap();
+        let client_addr = "127.0.0.1:8000".parse().unwrap();
+
+        let mut client_socket = WebTransportClientSocket::new(client_addr, server_addr);
+        let mut server_socket = WebTransportServerSocket::new(server_addr, certificate);
+
+        let (mut server_send, mut server_recv) = server_socket.listen();
+        let (mut client_send, mut client_recv) = client_socket.listen();
+
+        let msg = b"hello world";
+
+        // client to server
+        client_send.send(msg, &server_addr)?;
+
+        // sleep a little to give time to the message to arrive in the socket
+        tokio::time::sleep(Duration::from_millis(20)).await;
+
+        let Some((recv_msg, address)) = server_recv.recv()? else {
+            panic!("server expected to receive a packet from client");
+        };
+        assert_eq!(address, client_addr);
+        assert_eq!(recv_msg, msg);
+
+        // server to client
+        server_send.send(msg, &client_addr)?;
+
+        // sleep a little to give time to the message to arrive in the socket
+        tokio::time::sleep(Duration::from_millis(20)).await;
+
+        let Some((recv_msg, address)) = client_recv.recv()? else {
+            panic!("client expected to receive a packet from server");
+        };
+        assert_eq!(address, server_addr);
+        assert_eq!(recv_msg, msg);
+        Ok(())
+    }
+}

--- a/lightyear/src/transport/webtransport/server.rs
+++ b/lightyear/src/transport/webtransport/server.rs
@@ -1,0 +1,170 @@
+use crate::transport::webtransport::MTU;
+use crate::transport::{PacketReceiver, PacketSender, Transport};
+use bevy::tasks::{IoTaskPool, TaskPool};
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::sync::{Arc, Mutex};
+use tokio::sync::mpsc;
+use tokio::sync::mpsc::error::TryRecvError;
+use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
+use tracing::{debug, error, info};
+use wtransport;
+use wtransport::datagram::Datagram;
+use wtransport::endpoint::IncomingSession;
+use wtransport::tls::Certificate;
+use wtransport::{ClientConfig, ServerConfig};
+
+pub struct WebTransportServerSocket {
+    server_addr: SocketAddr,
+    certificate: Option<Certificate>,
+}
+
+impl WebTransportServerSocket {
+    pub(crate) fn new(server_addr: SocketAddr, certificate: Certificate) -> Self {
+        Self {
+            server_addr,
+            certificate: Some(certificate),
+        }
+    }
+
+    pub async fn handle_client(
+        incoming_session: IncomingSession,
+        from_client_sender: UnboundedSender<(Datagram, SocketAddr)>,
+        to_client_channels: Arc<Mutex<HashMap<SocketAddr, UnboundedSender<Box<[u8]>>>>>,
+    ) {
+        let session_request = incoming_session.await.unwrap();
+        let connection = session_request.accept().await.unwrap();
+        let client_addr = connection.remote_address();
+        debug!(
+            "Spawning new task to create connection with client: {}",
+            client_addr
+        );
+
+        // add a new pair of channels for this client
+        let (to_client_sender, mut to_client_receiver) = mpsc::unbounded_channel::<Box<[u8]>>();
+        to_client_channels
+            .lock()
+            .unwrap()
+            .insert(client_addr, to_client_sender);
+
+        // connection established, waiting for data from client
+        loop {
+            tokio::select! {
+                // receive messages from client
+                x = connection.receive_datagram() => {
+                    match x {
+                        Ok(data) => {
+                            from_client_sender.send((data, client_addr)).unwrap();
+                        }
+                        Err(e) => {
+                            error!("receive_datagram error: {:?}", e);
+                        }
+                    }
+                }
+                // send messages to client
+                Some(msg) = to_client_receiver.recv() => {
+                    connection.send_datagram(msg.as_ref()).unwrap_or_else(|e| {
+                        error!("send_datagram error: {:?}", e);
+                    });
+                }
+            }
+        }
+    }
+}
+
+impl Transport for WebTransportServerSocket {
+    fn local_addr(&self) -> SocketAddr {
+        self.server_addr
+    }
+
+    fn listen(&mut self) -> (Box<dyn PacketSender>, Box<dyn PacketReceiver>) {
+        // TODO: should i create my own task pool?
+        let server_addr = self.server_addr;
+        let certificate = std::mem::take(&mut self.certificate).unwrap();
+        let (to_client_sender, to_client_receiver) =
+            mpsc::unbounded_channel::<(Box<[u8]>, SocketAddr)>();
+        let (from_client_sender, from_client_receiver) = mpsc::unbounded_channel();
+        let to_client_senders = Arc::new(Mutex::new(HashMap::new()));
+
+        let packet_sender = WebTransportServerSocketSender {
+            server_addr,
+            to_client_senders: to_client_senders.clone(),
+        };
+        let packet_receiver = WebTransportServerSocketReceiver {
+            buffer: [0; MTU],
+            server_addr,
+            from_client_receiver,
+        };
+
+        tokio::spawn(async move {
+            debug!("Starting server webtransport task");
+            let config = ServerConfig::builder()
+                .with_bind_address(server_addr)
+                .with_certificate(certificate)
+                .build();
+            let server = wtransport::Endpoint::server(config).unwrap();
+
+            loop {
+                // clone the channel for each client
+                let from_client_sender = from_client_sender.clone();
+                let to_client_senders = to_client_senders.clone();
+
+                // new client connecting
+                let incoming_session = server.accept().await;
+
+                tokio::spawn(Self::handle_client(
+                    incoming_session,
+                    from_client_sender,
+                    to_client_senders,
+                ));
+            }
+        });
+        (Box::new(packet_sender), Box::new(packet_receiver))
+    }
+}
+
+pub struct WebTransportServerSocketSender {
+    server_addr: SocketAddr,
+    to_client_senders: Arc<Mutex<HashMap<SocketAddr, UnboundedSender<Box<[u8]>>>>>,
+}
+
+impl PacketSender for WebTransportServerSocketSender {
+    fn send(&mut self, payload: &[u8], address: &SocketAddr) -> std::io::Result<()> {
+        if let Some(to_client_sender) = self.to_client_senders.lock().unwrap().get(address) {
+            to_client_sender.send(payload.into()).map_err(|e| {
+                std::io::Error::other(format!("unable to send message to client: {}", e))
+            })
+        } else {
+            Err(std::io::Error::other(format!(
+                "unable to find channel for client: {}",
+                address
+            )))
+        }
+    }
+}
+
+pub struct WebTransportServerSocketReceiver {
+    buffer: [u8; MTU],
+    server_addr: SocketAddr,
+    from_client_receiver: UnboundedReceiver<(Datagram, SocketAddr)>,
+}
+impl PacketReceiver for WebTransportServerSocketReceiver {
+    fn recv(&mut self) -> std::io::Result<Option<(&mut [u8], SocketAddr)>> {
+        match self.from_client_receiver.try_recv() {
+            Ok((data, addr)) => {
+                self.buffer[..data.len()].copy_from_slice(data.payload().as_ref());
+                Ok(Some((&mut self.buffer[..data.len()], addr)))
+            }
+            Err(e) => {
+                if e == TryRecvError::Empty {
+                    Ok(None)
+                } else {
+                    Err(std::io::Error::other(format!(
+                        "unable to receive message from client: {}",
+                        e
+                    )))
+                }
+            }
+        }
+    }
+}

--- a/lightyear/src/transport/webtransport/server.rs
+++ b/lightyear/src/transport/webtransport/server.rs
@@ -1,3 +1,4 @@
+//! WebTransport client implementation.
 use crate::transport::webtransport::MTU;
 use crate::transport::{PacketReceiver, PacketSender, Transport};
 use bevy::tasks::{IoTaskPool, TaskPool};
@@ -14,6 +15,7 @@ use wtransport::endpoint::IncomingSession;
 use wtransport::tls::Certificate;
 use wtransport::{ClientConfig, ServerConfig};
 
+/// WebTransport client socket
 pub struct WebTransportServerSocket {
     server_addr: SocketAddr,
     certificate: Option<Certificate>,
@@ -123,7 +125,7 @@ impl Transport for WebTransportServerSocket {
     }
 }
 
-pub struct WebTransportServerSocketSender {
+struct WebTransportServerSocketSender {
     server_addr: SocketAddr,
     to_client_senders: Arc<Mutex<HashMap<SocketAddr, UnboundedSender<Box<[u8]>>>>>,
 }
@@ -143,7 +145,7 @@ impl PacketSender for WebTransportServerSocketSender {
     }
 }
 
-pub struct WebTransportServerSocketReceiver {
+struct WebTransportServerSocketReceiver {
     buffer: [u8; MTU],
     server_addr: SocketAddr,
     from_client_receiver: UnboundedReceiver<(Datagram, SocketAddr)>,


### PR DESCRIPTION
# Changes

Add support for the `WebTransport` support layer (using the QUIC protocol).
Note that this is for native only currently, and is not compatible with wasm.

Refactored the `Transport` trait to have a `listen()` function that returns a `(PacketSender, PacketReceiver)`