### PR TITLE
Add interest management

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -104,6 +104,7 @@ TODO:
 
 - Replication Systems:
   - EntitySpawn:
+    - we can have ReplicationMode::room or ReplicationMode::force. Force means we always replicate to everyone, without caring baout rooms
     - check through all ClientGainedVisibility -> send SpawnEntity
     - check through all clients in cache -> send SpawnEntity
   - ComponengUpdate:

--- a/NOTES.md
+++ b/NOTES.md
@@ -5,7 +5,58 @@
   - one server: 1 game room per core?
 
 PROBLEMS/BUGS:
-- None right now
+- more rollbacks than expected (Especially with rooms). Let's check what happens with 0 jitter -> there should be 0 rollback no?
+  - is it because we are sending too much data to the client? (a lot of entity spawn/despawn)
+  - is it because the ticks are not in sync?
+  - with 0 jitter, the problem completely disappears, prediction becomes butter smooth
+  - with higher send_interval, the prediction becomes extremely jittery!!!
+  - It could be something like:
+    - we are sending the player position update for a tick T1 in a packet
+      is only received after. So at tick 20, we think we have the world state for tick 20, but we don't. We don't even have the world state for tick 18.
+
+  - also it seems like our frames are smaller than our fixed update. This could cause issues?
+  - CONFIRMATION:
+    - the problem is indeed that we receive a ping for tick 20, but the world state for tick 20 is only received after
+      so the rollback thinks there is a problem
+    - it was more prevalent with send_interval = 0 because the frame_duration was lower than tick_duration. So sometimes
+      we would have: frame1/tick20: send updates. frame2/tick20: send ping. And the ping would arrive before.
+    - BASICALLY, when we receive a packet for tick 10, we think the whole word is replicated at tick 10, but that's not the case.
+      Only the entities in that packet. TO fix this:
+      - try hard to put all messages for a single entity in the same packet. Even though they might have different channels
+      - if we can't, let's care mostly about the latest tick for the entity-updates.
+      - for rollback, we track for each entity the latest tick for which we have received an update.
+      - during rollback check, we check if there is a mismatch for each entity (and we take the latest entity-update for that entity)
+      - if there is a mismatch, we 
+  
+  - i think the reason is this:
+    - we send multiple packets for tick 20
+    - some of them (entity spawn, etc.) arrive at tick 25 on client. latest_serv_tick = 20
+    - we consider that the world update for tick 20 is received!
+    - some of them (player position) arrive later on client.
+
+- room management:
+  - when moving fast, some entities don't get despawned on the client
+    - it's probably because the spawn message (from joining a room) arrives after the despawn message
+
+
+
+- interpolation has some lag at the beginning, it looks like the entity isn't moving. Probably because we only got an end but no start?
+  - is it because the start history got deleted? or we should interpolate from current to end?
+  - 
+- interpolation is very unsmooth when the server update is small.  
+   - SOLVED: That's because we used interpolation delay = ratio, and the send_interval was 0.0
+   - we need a setting that is ratio with min-delay
+
+- prediction/interpolation are sometimes not spawning anymore. This must be a ordering issue
+  - maybe because the Predicted/Interpolated component are only added if client/entity are in the same room
+  - or because we only run entity_spawn for the given NetworkTarget, but those are 
+
+
+ADD TESTS FOR TRICKY SCENARIOS:
+- replication at the beginning while RTT is 0?
+- replication when multiple inserts/removes/updates at same tick
+- replication where the data gets split between multiple packets
+
 
 ROUGH EDGES:
 - users cannot derive traits on ComponentProtocol or MessageProtocol because we add some extra variants to those enums
@@ -34,6 +85,9 @@ TODO:
   - all types must be Encode/Decode always. If a type is Serialize/Deserialize, then we can convert it to Encode/Decode ?
 
 - Prediction:
+  - TODO: output the rollback output. Instead of snapping the entity to the rollback output, provide the rollback output to the user
+    and they can choose themselves how they want to handle it (they could either snap to the rollback output, or lerp from prediction output to rollback output)
+   
   - TODO: handle despawns, spawns
       - despawn another entity TODO:
         - we let the user decide 
@@ -79,6 +133,9 @@ TODO:
 
 
 # Interest Management
+
+TODO: What is the benefit of doing this room thing instead of just letting the user set
+replication_target = "Select(hashSet<ClientId>)" ?
 
 - Clients can belong to multiple rooms, rooms can contain multiple clients
   - we have a Map<ClientId, Hashset<RoomId>>

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -32,6 +32,7 @@
     - [Interpolation](./boncepts/advanced_replication/interpolation.md)
     - [Prediction](./concepts/advanced_replication/prediction.md)
     - [ComponentSyncMode](./concepts/advanced_replication/component_sync_mode.md)
+    - [Interest management](./concepts/advanced_replication/interest_management.md)
 
 
 - [Appendix](./appendix/title.md)

--- a/book/src/concepts/advanced_replication/interest_management.md
+++ b/book/src/concepts/advanced_replication/interest_management.md
@@ -1,0 +1,77 @@
+# Interest management
+
+Interest management is the concept of only replicating to clients the entities that they need.
+
+For example: in a MMORPG, replicating only the entities that are "close" to the player.
+
+
+There are two main advantages:
+- bandwidth savings: it is pointless to replicate entities that are far away from the player, or that the player cannot interact with.
+  Those bandwidth savings become especially important when you have a lot of concurrent connected clients.
+- prevent cheating: if you replicate entities that the player is not supposed to see, there is a risk that clients read that data and use it to cheat.
+  For example, in a RTS, you can avoid replicating units that are in fog-of-war.
+
+
+
+## Implementation
+
+In lightyear, interest management is implemented with the concept of `Rooms`.
+
+An entity can join one or more rooms, and clients can similarly join one or more rooms.
+
+We then compute which entities should be replicated to which clients by looking at which rooms they are both in.
+
+To summarize:
+- if a client is in a room but the entity is not (or vice-versa), we will not replicate that entity to that client
+- if the client and entity are both in the same room, we will replicate that entity to that client
+- if a client leaves a room that the entity is in (or an entity leaves a room that the client is in), we will despawn that entity for that client
+- if a client joins a room that the entity is in (or an entity joins a room that the client is in), we will spawn that entity for that client
+
+
+Since it can be annoying to have always add your entities to the correct rooms, especially if you want to just replicate them to everyone.
+We introduce several concepts to make this more convenient.
+
+#### NetworkTarget
+
+```rust,noplayground
+/// NetworkTarget indicated which clients should receive some message
+pub enum NetworkTarget {
+    #[default]
+    /// Message sent to no client
+    None,
+    /// Message sent to all clients except for one
+    AllExcept(ClientId),
+    /// Message sent to all clients
+    All,
+    /// Message sent to only one client
+    Only(ClientId),
+}
+```
+
+NetworkTarget is used to indicate very roughly to which clients a given entity should be replicated.
+Note that this is in addition of rooms.
+
+Even if an entity and a client are in the same room, the entity will not be replicated to the client if the NetworkTarget forbids it (for instance, it is not `All` or `Only(client_id)`)
+
+However, if a `NetworkTarget` is `All`, that doesn't necessarily mean that the entity will be replicated to all clients; they still need to be in the same rooms.
+There is a setting to change this behaviour, the `ReplicationMode`.
+
+
+#### ReplicationMode
+
+We also introduce:
+```rust,noplayground
+#[derive(Default)]
+pub enum ReplicationMode {
+  /// Use rooms for replication
+  Room,
+  /// We will replicate this entity to clients using only the [`NetworkTarget`], without caring about rooms
+  #[default]
+  NetworkTarget
+}
+```
+
+If the `ReplicationMode` is `Room`, then the `NetworkTarget` is a prerequisite for replication, but not sufficient.
+i.e. the entity will be replicated if they are in the same room AND if the `NetworkTarget` allows it.
+
+If the `ReplicationMode` is `NetworkTarget`, then we will only use the value of `replicate.replication_target` without checking rooms at all.

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -13,6 +13,9 @@ license = "MIT OR Apache-2.0"
 exclude = ["/tests"]
 publish = false
 
+[[example]]
+name = "interest_management"
+path = "interest_management/main.rs"
 
 [[example]]
 name = "simple_box"

--- a/examples/interest_management/README.md
+++ b/examples/interest_management/README.md
@@ -1,16 +1,20 @@
-# Simple box
+# Interest management
 
-A simple example that shows how to use Lightyear to create a server-authoritative multiplayer game.
+A simple example that shows how to use Lightyear to perform interest management.
 
-It also showcases how to enable client-side prediction and snapshot interpolation.
+Interest management is a technique to reduce the amount of data that is sent to each client:
+we want to send only the data that is relevant to each client.
+
+In this example, we are going to replicate entities that are within a certain distance of the client.
+
 
 
 ## Running the example
 
-To start the server, run `cargo run --example simple_box server`
+To start the server, run `cargo run --example interest_management -- server`
 
 Then you can launch multiple clients with the commands:
 
-- `cargo run --example simple_box client -c 1`
+- `cargo run --example interest_management -- client -c 1`
 
-- `cargo run --example simple_box client -c 2 --client-port 2000`
+- `cargo run --example interest_management -- client -c 2 --client-port 2000`

--- a/examples/interest_management/README.md
+++ b/examples/interest_management/README.md
@@ -1,0 +1,16 @@
+# Simple box
+
+A simple example that shows how to use Lightyear to create a server-authoritative multiplayer game.
+
+It also showcases how to enable client-side prediction and snapshot interpolation.
+
+
+## Running the example
+
+To start the server, run `cargo run --example simple_box server`
+
+Then you can launch multiple clients with the commands:
+
+- `cargo run --example simple_box client -c 1`
+
+- `cargo run --example simple_box client -c 2 --client-port 2000`

--- a/examples/interest_management/client.rs
+++ b/examples/interest_management/client.rs
@@ -1,0 +1,190 @@
+use crate::protocol::{Direction, Inputs, Message1, MyProtocol, PlayerColor, PlayerPosition};
+use crate::shared::{shared_config, shared_movement_behaviour};
+use crate::{Transports, KEY, PROTOCOL_ID};
+use bevy::prelude::*;
+use lightyear::prelude::client::*;
+use lightyear::prelude::*;
+use std::net::{Ipv4Addr, SocketAddr};
+use std::str::FromStr;
+use std::time::Duration;
+
+#[derive(Resource, Clone, Copy)]
+pub struct MyClientPlugin {
+    pub(crate) client_id: ClientId,
+    pub(crate) client_port: u16,
+    pub(crate) server_port: u16,
+    pub(crate) transport: Transports,
+}
+
+impl Plugin for MyClientPlugin {
+    fn build(&self, app: &mut App) {
+        let server_addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), self.server_port);
+        let auth = Authentication::Manual {
+            server_addr,
+            client_id: self.client_id,
+            private_key: KEY,
+            protocol_id: PROTOCOL_ID,
+        };
+        let client_addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), self.client_port);
+        let link_conditioner = LinkConditionerConfig {
+            incoming_latency: Duration::from_millis(100),
+            incoming_jitter: Duration::from_millis(10),
+            incoming_loss: 0.00,
+        };
+        let transport = match self.transport {
+            Transports::Udp => TransportConfig::UdpSocket(client_addr),
+            Transports::Webtransport => TransportConfig::WebTransportClient {
+                client_addr,
+                server_addr,
+            },
+        };
+        let io = Io::from_config(
+            &IoConfig::from_transport(transport).with_conditioner(link_conditioner),
+        );
+        let config = ClientConfig {
+            shared: shared_config().clone(),
+            input: InputConfig::default(),
+            netcode: Default::default(),
+            ping: PingConfig::default(),
+            sync: SyncConfig::default(),
+            prediction: PredictionConfig::default(),
+            // we are sending updates every frame (60fps), let's add a delay of 6 network-ticks
+            interpolation: InterpolationConfig::default()
+                .with_delay(InterpolationDelay::Ratio(2.0)),
+        };
+        let plugin_config = PluginConfig::new(config, io, MyProtocol::default(), auth);
+        app.add_plugins(ClientPlugin::new(plugin_config));
+        app.add_plugins(crate::shared::SharedPlugin);
+        app.insert_resource(self.clone());
+        app.add_systems(Startup, init);
+        app.add_systems(
+            FixedUpdate,
+            buffer_input.in_set(InputSystemSet::BufferInputs),
+        );
+        app.add_systems(FixedUpdate, movement.in_set(FixedUpdateSet::Main));
+        app.add_systems(
+            Update,
+            (
+                receive_message1,
+                receive_entity_spawn,
+                receive_entity_despawn,
+                handle_predicted_spawn,
+                handle_interpolated_spawn,
+            ),
+        );
+    }
+}
+
+// Startup system for the client
+pub(crate) fn init(
+    mut commands: Commands,
+    mut client: ResMut<Client<MyProtocol>>,
+    plugin: Res<MyClientPlugin>,
+) {
+    commands.spawn(Camera2dBundle::default());
+    commands.spawn(TextBundle::from_section(
+        format!("Client {}", plugin.client_id),
+        TextStyle {
+            font_size: 30.0,
+            color: Color::WHITE,
+            ..default()
+        },
+    ));
+    client.connect();
+    // client.set_base_relative_speed(0.001);
+}
+
+// System that reads from peripherals and adds inputs to the buffer
+pub(crate) fn buffer_input(mut client: ResMut<Client<MyProtocol>>, keypress: Res<Input<KeyCode>>) {
+    let mut input = Direction {
+        up: false,
+        down: false,
+        left: false,
+        right: false,
+    };
+    if keypress.pressed(KeyCode::W) || keypress.pressed(KeyCode::Up) {
+        input.up = true;
+    }
+    if keypress.pressed(KeyCode::S) || keypress.pressed(KeyCode::Down) {
+        input.down = true;
+    }
+    if keypress.pressed(KeyCode::A) || keypress.pressed(KeyCode::Left) {
+        input.left = true;
+    }
+    if keypress.pressed(KeyCode::D) || keypress.pressed(KeyCode::Right) {
+        input.right = true;
+    }
+    if keypress.pressed(KeyCode::Delete) {
+        // currently, inputs is an enum and we can only add one input per tick
+        return client.add_input(Inputs::Delete);
+    }
+    if keypress.pressed(KeyCode::Space) {
+        return client.add_input(Inputs::Spawn);
+    }
+    // TODO: should we only send an input if it's not all NIL?
+    // info!("Sending input: {:?} on tick: {:?}", &input, client.tick());
+    if !input.is_none() {
+        client.add_input(Inputs::Direction(input));
+    }
+}
+
+// The client input only gets applied to predicted entities that we own
+// This works because we only predict the user's controlled entity.
+// If we were predicting more entities, we would have to only apply movement to the player owned one.
+pub(crate) fn movement(
+    // TODO: maybe make prediction mode a separate component!!!
+    mut position_query: Query<&mut PlayerPosition, With<Predicted>>,
+    mut input_reader: EventReader<InputEvent<Inputs>>,
+) {
+    if PlayerPosition::mode() != ComponentSyncMode::Full {
+        return;
+    }
+    for input in input_reader.read() {
+        if let Some(input) = input.input() {
+            for mut position in position_query.iter_mut() {
+                shared_movement_behaviour(&mut position, input);
+            }
+        }
+    }
+}
+
+// System to receive messages on the client
+pub(crate) fn receive_message1(mut reader: EventReader<MessageEvent<Message1>>) {
+    for event in reader.read() {
+        info!("Received message: {:?}", event.message());
+    }
+}
+
+// Example system to handle EntitySpawn events
+pub(crate) fn receive_entity_spawn(mut reader: EventReader<EntitySpawnEvent>) {
+    for event in reader.read() {
+        info!("Received entity spawn: {:?}", event.entity());
+    }
+}
+
+// Example system to handle EntitySpawn events
+pub(crate) fn receive_entity_despawn(mut reader: EventReader<EntityDespawnEvent>) {
+    for event in reader.read() {
+        info!("Received entity despawn: {:?}", event.entity());
+    }
+}
+
+// When the predicted copy of the client-owned entity is spawned, do stuff
+// - assign it a different saturation
+// - keep track of it in the Global resource
+pub(crate) fn handle_predicted_spawn(mut predicted: Query<&mut PlayerColor, Added<Predicted>>) {
+    for mut color in predicted.iter_mut() {
+        color.0.set_s(0.2);
+    }
+}
+
+// When the predicted copy of the client-owned entity is spawned, do stuff
+// - assign it a different saturation
+// - keep track of it in the Global resource
+pub(crate) fn handle_interpolated_spawn(
+    mut interpolated: Query<&mut PlayerColor, Added<Interpolated>>,
+) {
+    for mut color in interpolated.iter_mut() {
+        color.0.set_s(0.2);
+    }
+}

--- a/examples/interest_management/main.rs
+++ b/examples/interest_management/main.rs
@@ -1,0 +1,96 @@
+#![allow(unused_imports)]
+#![allow(unused_variables)]
+#![allow(dead_code)]
+
+//! Run with
+//! - `cargo run --example bevy_cli server`
+//! - `cargo run --example bevy_cli client`
+mod client;
+mod protocol;
+mod server;
+mod shared;
+
+use std::str::FromStr;
+
+use bevy::log::LogPlugin;
+use bevy::prelude::*;
+use bevy::DefaultPlugins;
+use clap::{Parser, ValueEnum};
+use serde::{Deserialize, Serialize};
+use tracing_subscriber::fmt::format::FmtSpan;
+
+use crate::client::MyClientPlugin;
+use crate::server::MyServerPlugin;
+use lightyear::netcode::{ClientId, Key};
+use lightyear::prelude::TransportConfig;
+
+#[tokio::main]
+async fn main() {
+    let cli = Cli::parse();
+    let mut app = App::new();
+    app.add_plugins(DefaultPlugins.build().disable::<LogPlugin>());
+    setup(&mut app, cli);
+
+    app.run();
+}
+
+pub const CLIENT_PORT: u16 = 6000;
+pub const SERVER_PORT: u16 = 5000;
+pub const PROTOCOL_ID: u64 = 0;
+
+pub const KEY: Key = [0; 32];
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
+pub enum Transports {
+    Udp,
+    Webtransport,
+}
+
+#[derive(Parser, PartialEq, Debug)]
+enum Cli {
+    SinglePlayer,
+    Server {
+        #[arg(short, long, default_value_t = SERVER_PORT)]
+        port: u16,
+
+        #[arg(short, long, value_enum, default_value_t = Transports::Udp)]
+        transport: Transports,
+    },
+    Client {
+        #[arg(short, long, default_value_t = ClientId::default())]
+        client_id: ClientId,
+
+        #[arg(long, default_value_t = CLIENT_PORT)]
+        client_port: u16,
+
+        #[arg(short, long, default_value_t = SERVER_PORT)]
+        server_port: u16,
+
+        #[arg(short, long, value_enum, default_value_t = Transports::Udp)]
+        transport: Transports,
+    },
+}
+
+fn setup(app: &mut App, cli: Cli) {
+    match cli {
+        Cli::SinglePlayer => {}
+        Cli::Server { port, transport } => {
+            let server_plugin = MyServerPlugin { port, transport };
+            app.add_plugins(server_plugin);
+        }
+        Cli::Client {
+            client_id,
+            client_port,
+            server_port,
+            transport,
+        } => {
+            let client_plugin = MyClientPlugin {
+                client_id,
+                client_port,
+                server_port,
+                transport,
+            };
+            app.add_plugins(client_plugin);
+        }
+    }
+}

--- a/examples/interest_management/main.rs
+++ b/examples/interest_management/main.rs
@@ -57,8 +57,8 @@ enum Cli {
         transport: Transports,
     },
     Client {
-        #[arg(short, long, default_value_t = ClientId::default())]
-        client_id: ClientId,
+        #[arg(short, long, default_value_t = 0)]
+        client_id: u16,
 
         #[arg(long, default_value_t = CLIENT_PORT)]
         client_port: u16,

--- a/examples/interest_management/protocol.rs
+++ b/examples/interest_management/protocol.rs
@@ -1,0 +1,125 @@
+use bevy::prelude::{default, Bundle, Color, Component, Deref, DerefMut, Entity, Vec2};
+use derive_more::{Add, Mul};
+use lightyear::prelude::*;
+use serde::{Deserialize, Serialize};
+
+// Player
+#[derive(Bundle)]
+pub(crate) struct PlayerBundle {
+    id: PlayerId,
+    position: PlayerPosition,
+    color: PlayerColor,
+    replicate: Replicate,
+}
+
+impl PlayerBundle {
+    pub(crate) fn new(id: ClientId, position: Vec2, color: Color) -> Self {
+        Self {
+            id: PlayerId(id),
+            position: PlayerPosition(position),
+            color: PlayerColor(color),
+            replicate: Replicate {
+                // prediction_target: NetworkTarget::None,
+                prediction_target: NetworkTarget::Only(id),
+                interpolation_target: NetworkTarget::AllExcept(id),
+                ..default()
+            },
+        }
+    }
+}
+
+// Components
+
+#[derive(Component, Message, Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct PlayerId(ClientId);
+
+#[derive(
+    Component, Message, Serialize, Deserialize, Clone, Debug, PartialEq, Deref, DerefMut, Add, Mul,
+)]
+pub struct PlayerPosition(Vec2);
+
+#[derive(Component, Message, Deserialize, Serialize, Clone, Debug, PartialEq)]
+pub struct PlayerColor(pub(crate) Color);
+
+// Example of a component that contains an entity.
+// This component, when replicated, needs to have the inner entity mapped from the Server world
+// to the client World.
+// This can be done by adding a `#[message(custom_map)]` attribute to the component, and then
+// deriving the `MapEntities` trait for the component.
+#[derive(Component, Message, Deserialize, Serialize, Clone, Debug, PartialEq)]
+#[message(custom_map)]
+pub struct PlayerParent(Entity);
+
+impl MapEntities for PlayerParent {
+    fn map_entities(&mut self, entity_map: &EntityMap) {
+        self.0.map_entities(entity_map);
+    }
+}
+
+#[component_protocol(protocol = "MyProtocol", derive(Debug))]
+pub enum Components {
+    #[sync(once)]
+    PlayerId(PlayerId),
+    #[sync(full)]
+    PlayerPosition(PlayerPosition),
+    #[sync(once)]
+    PlayerColor(PlayerColor),
+}
+
+// Channels
+
+#[derive(Channel)]
+pub struct Channel1;
+
+// Messages
+
+#[derive(Message, Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct Message1(pub usize);
+
+#[message_protocol(protocol = "MyProtocol", derive(Debug))]
+pub enum Messages {
+    Message1(Message1),
+}
+
+// Inputs
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+pub struct Direction {
+    pub(crate) up: bool,
+    pub(crate) down: bool,
+    pub(crate) left: bool,
+    pub(crate) right: bool,
+}
+
+impl Direction {
+    pub(crate) fn is_none(&self) -> bool {
+        !self.up && !self.down && !self.left && !self.right
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+pub enum Inputs {
+    Direction(Direction),
+    Delete,
+    Spawn,
+}
+
+impl UserInput for Inputs {}
+
+// Protocol
+
+protocolize! {
+    Self = MyProtocol,
+    Message = Messages,
+    Component = Components,
+    Input = Inputs,
+}
+
+pub(crate) fn protocol() -> MyProtocol {
+    let mut protocol = MyProtocol::default();
+    protocol.add_channel::<Channel1>(ChannelSettings {
+        mode: ChannelMode::OrderedReliable(ReliableSettings::default()),
+        direction: ChannelDirection::Bidirectional,
+    });
+    protocol
+}

--- a/examples/interest_management/server.rs
+++ b/examples/interest_management/server.rs
@@ -1,0 +1,138 @@
+use crate::protocol::*;
+use crate::shared::{shared_config, shared_movement_behaviour};
+use crate::{shared, Transports, KEY, PROTOCOL_ID};
+use bevy::prelude::*;
+use lightyear::prelude::server::*;
+use lightyear::prelude::*;
+use std::collections::HashMap;
+use std::net::{Ipv4Addr, SocketAddr};
+use std::time::Duration;
+
+pub struct MyServerPlugin {
+    pub(crate) port: u16,
+    pub(crate) transport: Transports,
+}
+
+impl Plugin for MyServerPlugin {
+    fn build(&self, app: &mut App) {
+        let server_addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), self.port);
+        let netcode_config = NetcodeConfig::default()
+            .with_protocol_id(PROTOCOL_ID)
+            .with_key(KEY);
+        let link_conditioner = LinkConditionerConfig {
+            incoming_latency: Duration::from_millis(100),
+            incoming_jitter: Duration::from_millis(10),
+            incoming_loss: 0.00,
+        };
+        let transport = match self.transport {
+            Transports::Udp => TransportConfig::UdpSocket(server_addr),
+            Transports::Webtransport => TransportConfig::WebTransportServer {
+                server_addr,
+                certificate: Certificate::self_signed(&["localhost"]),
+            },
+        };
+        let io = Io::from_config(
+            &IoConfig::from_transport(transport).with_conditioner(link_conditioner),
+        );
+        let config = ServerConfig {
+            shared: shared_config().clone(),
+            netcode: netcode_config,
+            ping: PingConfig::default(),
+        };
+        let plugin_config = PluginConfig::new(config, io, MyProtocol::default());
+        app.add_plugins(server::ServerPlugin::new(plugin_config));
+        app.add_plugins(shared::SharedPlugin);
+        app.init_resource::<Global>();
+        app.add_systems(Startup, init);
+        // the physics/FixedUpdates systems that consume inputs should be run in this set
+        app.add_systems(FixedUpdate, movement.in_set(FixedUpdateSet::Main));
+        app.add_systems(Update, (handle_connections, send_message));
+    }
+}
+
+#[derive(Resource, Default)]
+pub(crate) struct Global {
+    pub client_id_to_entity_id: HashMap<ClientId, Entity>,
+}
+
+pub(crate) fn init(mut commands: Commands) {
+    commands.spawn(Camera2dBundle::default());
+    commands.spawn(TextBundle::from_section(
+        "Server",
+        TextStyle {
+            font_size: 30.0,
+            color: Color::WHITE,
+            ..default()
+        },
+    ));
+}
+
+/// Server connection system, create a player upon connection
+pub(crate) fn handle_connections(
+    mut connections: EventReader<ConnectEvent>,
+    mut disconnections: EventReader<DisconnectEvent>,
+    mut global: ResMut<Global>,
+    mut commands: Commands,
+) {
+    for connection in connections.read() {
+        let client_id = connection.context();
+        // Generate pseudo random color from client id.
+        let h = (((client_id * 30) % 360) as f32) / 360.0;
+        let s = 0.8;
+        let l = 0.5;
+        let entity = commands.spawn(PlayerBundle::new(
+            *client_id,
+            Vec2::ZERO,
+            Color::hsl(h, s, l),
+        ));
+        // Add a mapping from client id to entity id
+        global
+            .client_id_to_entity_id
+            .insert(*client_id, entity.id());
+    }
+    for disconnection in disconnections.read() {
+        let client_id = disconnection.context();
+        if let Some(entity) = global.client_id_to_entity_id.remove(client_id) {
+            commands.entity(entity).despawn();
+        }
+    }
+}
+
+/// Read client inputs and move players
+pub(crate) fn movement(
+    mut position_query: Query<&mut PlayerPosition>,
+    mut input_reader: EventReader<InputEvent<Inputs>>,
+    global: Res<Global>,
+    server: Res<Server<MyProtocol>>,
+) {
+    for input in input_reader.read() {
+        let client_id = input.context();
+        if let Some(input) = input.input() {
+            debug!(
+                "Receiving input: {:?} from client: {:?} on tick: {:?}",
+                input,
+                client_id,
+                server.tick()
+            );
+            if let Some(player_entity) = global.client_id_to_entity_id.get(client_id) {
+                if let Ok(mut position) = position_query.get_mut(*player_entity) {
+                    shared_movement_behaviour(&mut position, input);
+                }
+            }
+        }
+    }
+}
+
+/// Send messages from server to clients
+pub(crate) fn send_message(mut server: ResMut<Server<MyProtocol>>, input: Res<Input<KeyCode>>) {
+    if input.pressed(KeyCode::M) {
+        // TODO: add way to send message to all
+        let message = Message1(5);
+        info!("Send message: {:?}", message);
+        server
+            .broadcast_send::<Channel1, Message1>(Message1(5))
+            .unwrap_or_else(|e| {
+                error!("Failed to send message: {:?}", e);
+            });
+    }
+}

--- a/examples/interest_management/server.rs
+++ b/examples/interest_management/server.rs
@@ -4,6 +4,7 @@ use crate::{shared, Transports, KEY, PROTOCOL_ID};
 use bevy::prelude::*;
 use lightyear::prelude::server::*;
 use lightyear::prelude::*;
+use lightyear::shared::replication::components::ReplicationMode;
 use std::collections::HashMap;
 use std::net::{Ipv4Addr, SocketAddr};
 use std::time::Duration;
@@ -13,6 +14,13 @@ pub struct MyServerPlugin {
     pub(crate) transport: Transports,
 }
 
+const GRID_SIZE: f32 = 50.0;
+const NUM_CIRCLES: i32 = 10;
+const INTEREST_RADIUS: f32 = 200.0;
+
+// Special room for the player entities (so that all player entities always see each other)
+const PLAYER_ROOM: RoomId = RoomId(6000);
+
 impl Plugin for MyServerPlugin {
     fn build(&self, app: &mut App) {
         let server_addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), self.port);
@@ -21,7 +29,7 @@ impl Plugin for MyServerPlugin {
             .with_key(KEY);
         let link_conditioner = LinkConditionerConfig {
             incoming_latency: Duration::from_millis(100),
-            incoming_jitter: Duration::from_millis(10),
+            incoming_jitter: Duration::from_millis(20),
             incoming_loss: 0.00,
         };
         let transport = match self.transport {
@@ -40,19 +48,23 @@ impl Plugin for MyServerPlugin {
             ping: PingConfig::default(),
         };
         let plugin_config = PluginConfig::new(config, io, MyProtocol::default());
-        app.add_plugins(server::ServerPlugin::new(plugin_config));
+        app.add_plugins(ServerPlugin::new(plugin_config));
         app.add_plugins(shared::SharedPlugin);
         app.init_resource::<Global>();
         app.add_systems(Startup, init);
         // the physics/FixedUpdates systems that consume inputs should be run in this set
         app.add_systems(FixedUpdate, movement.in_set(FixedUpdateSet::Main));
-        app.add_systems(Update, (handle_connections, send_message));
+        app.add_systems(
+            Update,
+            (handle_connections, send_message, interest_management, log),
+        );
     }
 }
 
 #[derive(Resource, Default)]
 pub(crate) struct Global {
     pub client_id_to_entity_id: HashMap<ClientId, Entity>,
+    pub client_id_to_room_id: HashMap<ClientId, RoomId>,
 }
 
 pub(crate) fn init(mut commands: Commands) {
@@ -65,10 +77,26 @@ pub(crate) fn init(mut commands: Commands) {
             ..default()
         },
     ));
+
+    // spawn dots in a grid
+    for x in -NUM_CIRCLES..NUM_CIRCLES {
+        for y in -NUM_CIRCLES..NUM_CIRCLES {
+            commands.spawn((
+                Position(Vec2::new(x as f32 * GRID_SIZE, y as f32 * GRID_SIZE)),
+                Circle,
+                Replicate {
+                    // use rooms for replication
+                    replication_mode: ReplicationMode::Room,
+                    ..default()
+                },
+            ));
+        }
+    }
 }
 
 /// Server connection system, create a player upon connection
 pub(crate) fn handle_connections(
+    mut server: ResMut<Server<MyProtocol>>,
     mut connections: EventReader<ConnectEvent>,
     mut disconnections: EventReader<DisconnectEvent>,
     mut global: ResMut<Global>,
@@ -85,10 +113,18 @@ pub(crate) fn handle_connections(
             Vec2::ZERO,
             Color::hsl(h, s, l),
         ));
-        // Add a mapping from client id to entity id
+        // Add a mapping from client id to entity id (so that when we receive an input from a client,
+        // we know which entity to move)
         global
             .client_id_to_entity_id
             .insert(*client_id, entity.id());
+        // we will create a room for each client. To keep things simple, the room id will be the client id
+        let room_id = RoomId((*client_id) as u16);
+        server.room_mut(room_id).add_client(*client_id);
+        server.room_mut(PLAYER_ROOM).add_client(*client_id);
+        // also add the player entity to that room
+        server.room_mut(room_id).add_entity(entity.id());
+        server.room_mut(PLAYER_ROOM).add_entity(entity.id());
     }
     for disconnection in disconnections.read() {
         let client_id = disconnection.context();
@@ -98,9 +134,43 @@ pub(crate) fn handle_connections(
     }
 }
 
+pub(crate) fn log(server: Res<Server<MyProtocol>>, position: Query<&Position, With<PlayerId>>) {
+    let server_tick = server.tick();
+    for pos in position.iter() {
+        info!(?server_tick, "Confirmed position: {:?}", pos);
+    }
+}
+
+/// This is where we perform scope management:
+/// - we will add/remove other entities from the player's room only if they are close
+pub(crate) fn interest_management(
+    mut server: ResMut<Server<MyProtocol>>,
+    player_query: Query<(&PlayerId, Ref<Position>), Without<Circle>>,
+    circle_query: Query<(Entity, &Position), With<Circle>>,
+) {
+    for (client_id, position) in player_query.iter() {
+        if position.is_changed() {
+            let room_id = RoomId((client_id.0) as u16);
+            // let circles_in_room = server.room(room_id).entities();
+            let mut room = server.room_mut(room_id);
+            for (circle_entity, circle_position) in circle_query.iter() {
+                let distance = position.distance(**circle_position);
+                if distance < INTEREST_RADIUS {
+                    // add the circle to the player's room
+                    room.add_entity(circle_entity)
+                } else {
+                    // if circles_in_room.contains(&circle_entity) {
+                    room.remove_entity(circle_entity);
+                    // }
+                }
+            }
+        }
+    }
+}
+
 /// Read client inputs and move players
 pub(crate) fn movement(
-    mut position_query: Query<&mut PlayerPosition>,
+    mut position_query: Query<&mut Position>,
     mut input_reader: EventReader<InputEvent<Inputs>>,
     global: Res<Global>,
     server: Res<Server<MyProtocol>>,
@@ -108,6 +178,7 @@ pub(crate) fn movement(
     for input in input_reader.read() {
         let client_id = input.context();
         if let Some(input) = input.input() {
+            info!(server_tick = ?server.tick(), ?input, "Recv input");
             debug!(
                 "Receiving input: {:?} from client: {:?} on tick: {:?}",
                 input,

--- a/examples/interest_management/shared.rs
+++ b/examples/interest_management/shared.rs
@@ -1,0 +1,66 @@
+use crate::protocol::*;
+use bevy::prelude::*;
+use bevy_inspector_egui::quick::WorldInspectorPlugin;
+use lightyear::prelude::*;
+use std::time::Duration;
+use tracing::Level;
+
+pub fn shared_config() -> SharedConfig {
+    SharedConfig {
+        enable_replication: true,
+        client_send_interval: Duration::default(),
+        server_send_interval: Duration::from_millis(100),
+        tick: TickConfig {
+            tick_duration: Duration::from_secs_f64(1.0 / 64.0),
+        },
+        log: LogConfig {
+            level: Level::INFO,
+            filter: "wgpu=error,wgpu_hal=error,naga=warn,bevy_app=info,bevy_render=warn,quinn=warn"
+                .to_string(),
+        },
+    }
+}
+
+pub struct SharedPlugin;
+
+impl Plugin for SharedPlugin {
+    fn build(&self, app: &mut App) {
+        // app.add_plugins(WorldInspectorPlugin::new());
+        app.add_systems(Update, draw_boxes);
+    }
+}
+
+// This system defines how we update the player's positions when we receive an input
+pub(crate) fn shared_movement_behaviour(position: &mut PlayerPosition, input: &Inputs) {
+    const MOVE_SPEED: f32 = 10.0;
+    match input {
+        Inputs::Direction(direction) => {
+            if direction.up {
+                position.y += MOVE_SPEED;
+            }
+            if direction.down {
+                position.y -= MOVE_SPEED;
+            }
+            if direction.left {
+                position.x -= MOVE_SPEED;
+            }
+            if direction.right {
+                position.x += MOVE_SPEED;
+            }
+        }
+        _ => {}
+    }
+}
+
+/// System that draws the boxed of the player positions.
+/// The components should be replicated from the server to the client
+pub(crate) fn draw_boxes(mut gizmos: Gizmos, players: Query<(&PlayerPosition, &PlayerColor)>) {
+    for (position, color) in &players {
+        gizmos.rect(
+            Vec3::new(position.x, position.y, 0.0),
+            Quat::IDENTITY,
+            Vec2::ONE * 50.0,
+            color.0,
+        );
+    }
+}

--- a/examples/simple_box/client.rs
+++ b/examples/simple_box/client.rs
@@ -50,7 +50,7 @@ impl Plugin for MyClientPlugin {
             prediction: PredictionConfig::default(),
             // we are sending updates every frame (60fps), let's add a delay of 6 network-ticks
             interpolation: InterpolationConfig::default()
-                .with_delay(InterpolationDelay::Ratio(2.0)),
+                .with_delay(InterpolationDelay::default().with_send_interval_ratio(2.0)),
         };
         let plugin_config = PluginConfig::new(config, io, MyProtocol::default(), auth);
         app.add_plugins(ClientPlugin::new(plugin_config));

--- a/lightyear/Cargo.toml
+++ b/lightyear/Cargo.toml
@@ -27,12 +27,7 @@ webtransport = [
   "tokio/sync",
   "wtransport/dangerous-configuration",
 ]
-wtransport-cert = [
-  "dep:ring",
-  "dep:base64",
-  "dep:rcgen",
-  "dep:time",
-]
+wtransport-cert = ["dep:ring", "dep:base64", "dep:rcgen", "dep:time"]
 
 
 [dependencies]

--- a/lightyear/Cargo.toml
+++ b/lightyear/Cargo.toml
@@ -26,6 +26,8 @@ webtransport = [
   "dep:wtransport",
   "tokio/sync",
   "wtransport/dangerous-configuration",
+]
+wtransport-cert = [
   "dep:ring",
   "dep:base64",
   "dep:rcgen",

--- a/lightyear/Cargo.toml
+++ b/lightyear/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lightyear"
-version = "0.2.0"
+version = "0.3.0-alpha.0"
 authors = ["Charles Bournhonesque <charlesbour@gmail.com>"]
 edition = "2021"
 rust-version = "1.65"

--- a/lightyear/src/channel/senders/mod.rs
+++ b/lightyear/src/channel/senders/mod.rs
@@ -4,6 +4,7 @@ use bytes::Bytes;
 use enum_dispatch::enum_dispatch;
 
 use crate::packet::message::{FragmentData, MessageAck, SingleData};
+use crate::shared::ping::manager::PingManager;
 use crate::shared::tick_manager::TickManager;
 use crate::shared::time_manager::TimeManager;
 
@@ -18,7 +19,12 @@ pub(crate) mod unordered_unreliable;
 #[enum_dispatch]
 pub trait ChannelSend {
     /// Bookkeeping for the channel
-    fn update(&mut self, time_manager: &TimeManager, tick_manager: &TickManager);
+    fn update(
+        &mut self,
+        time_manager: &TimeManager,
+        ping_manager: &PingManager,
+        tick_manager: &TickManager,
+    );
 
     /// Queues a message to be transmitted
     fn buffer_send(&mut self, message: Bytes);

--- a/lightyear/src/channel/senders/sequenced_unreliable.rs
+++ b/lightyear/src/channel/senders/sequenced_unreliable.rs
@@ -5,6 +5,7 @@ use bytes::Bytes;
 use crate::channel::senders::fragment_sender::FragmentSender;
 use crate::channel::senders::ChannelSend;
 use crate::packet::message::{FragmentData, MessageAck, MessageId, SingleData};
+use crate::shared::ping::manager::PingManager;
 use crate::shared::tick_manager::TickManager;
 use crate::shared::time_manager::TimeManager;
 
@@ -34,7 +35,7 @@ impl SequencedUnreliableSender {
 }
 
 impl ChannelSend for SequencedUnreliableSender {
-    fn update(&mut self, _: &TimeManager, _: &TickManager) {}
+    fn update(&mut self, _: &TimeManager, _: &PingManager, _: &TickManager) {}
 
     /// Add a new message to the buffer of messages to be sent.
     /// This is a client-facing function, to be called when you want to send a message

--- a/lightyear/src/channel/senders/tick_unreliable.rs
+++ b/lightyear/src/channel/senders/tick_unreliable.rs
@@ -5,6 +5,7 @@ use bytes::Bytes;
 use crate::channel::senders::fragment_sender::FragmentSender;
 use crate::channel::senders::ChannelSend;
 use crate::packet::message::{FragmentData, MessageAck, MessageId, SingleData};
+use crate::shared::ping::manager::PingManager;
 use crate::shared::tick_manager::Tick;
 use crate::shared::tick_manager::TickManager;
 use crate::shared::time_manager::TimeManager;
@@ -37,7 +38,7 @@ impl TickUnreliableSender {
 }
 
 impl ChannelSend for TickUnreliableSender {
-    fn update(&mut self, _: &TimeManager, tick_manager: &TickManager) {
+    fn update(&mut self, _: &TimeManager, _: &PingManager, tick_manager: &TickManager) {
         self.current_tick = tick_manager.current_tick();
     }
 

--- a/lightyear/src/channel/senders/unordered_unreliable.rs
+++ b/lightyear/src/channel/senders/unordered_unreliable.rs
@@ -5,6 +5,7 @@ use bytes::Bytes;
 use crate::channel::senders::fragment_sender::FragmentSender;
 use crate::channel::senders::ChannelSend;
 use crate::packet::message::{FragmentData, MessageAck, MessageId, SingleData};
+use crate::shared::ping::manager::PingManager;
 use crate::shared::tick_manager::TickManager;
 use crate::shared::time_manager::TimeManager;
 
@@ -34,7 +35,7 @@ impl UnorderedUnreliableSender {
 }
 
 impl ChannelSend for UnorderedUnreliableSender {
-    fn update(&mut self, _: &TimeManager, _: &TickManager) {}
+    fn update(&mut self, _: &TimeManager, _: &PingManager, _: &TickManager) {}
 
     /// Add a new message to the buffer of messages to be sent.
     /// This is a client-facing function, to be called when you want to send a message

--- a/lightyear/src/client/connection.rs
+++ b/lightyear/src/client/connection.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use anyhow::Result;
 use bevy::prelude::World;
-use tracing::{debug, trace};
+use tracing::{debug, info, trace};
 
 use crate::channel::builder::PingChannel;
 use crate::client::sync::SyncConfig;
@@ -63,7 +63,7 @@ impl<P: Protocol> Connection<P> {
         tick_manager: &TickManager,
     ) -> Result<()> {
         let tick = self.base.recv_packet(reader)?;
-        debug!("Recv server packet with tick: {:?}", tick);
+        debug!("Received server packet with tick: {:?}", tick);
         if tick >= self.sync_manager.latest_received_server_tick {
             self.sync_manager.latest_received_server_tick = tick;
             // TODO: add 'received_new_server_tick' ?
@@ -76,6 +76,7 @@ impl<P: Protocol> Connection<P> {
                 self.base.ping_manager.rtt(),
             );
         }
+        debug!(?tick, last_server_tick = ?self.sync_manager.latest_received_server_tick, "Recv server packet");
         Ok(())
     }
 

--- a/lightyear/src/client/prediction/despawn.rs
+++ b/lightyear/src/client/prediction/despawn.rs
@@ -148,8 +148,10 @@ mod tests {
         let sync_config = SyncConfig::default().speedup_factor(1.0);
         let prediction_config = PredictionConfig::default().disable(false);
         let interpolation_delay = Duration::from_millis(100);
-        let interpolation_config = InterpolationConfig::default()
-            .with_delay(InterpolationDelay::Delay(interpolation_delay));
+        let interpolation_config = InterpolationConfig::default().with_delay(InterpolationDelay {
+            min_delay: interpolation_delay,
+            send_interval_ratio: 0.0,
+        });
         let mut stepper = BevyStepper::new(
             shared_config,
             sync_config,
@@ -336,8 +338,10 @@ mod tests {
         let sync_config = SyncConfig::default().speedup_factor(1.0);
         let prediction_config = PredictionConfig::default().disable(false);
         let interpolation_delay = Duration::from_millis(100);
-        let interpolation_config = InterpolationConfig::default()
-            .with_delay(InterpolationDelay::Delay(interpolation_delay));
+        let interpolation_config = InterpolationConfig::default().with_delay(InterpolationDelay {
+            min_delay: interpolation_delay,
+            send_interval_ratio: 0.0,
+        });
         let mut stepper = BevyStepper::new(
             shared_config,
             sync_config,

--- a/lightyear/src/client/prediction/rollback.rs
+++ b/lightyear/src/client/prediction/rollback.rs
@@ -336,8 +336,10 @@ mod tests {
         let sync_config = SyncConfig::default().speedup_factor(1.0);
         let prediction_config = PredictionConfig::default().disable(false);
         let interpolation_delay = Duration::from_millis(100);
-        let interpolation_config = InterpolationConfig::default()
-            .with_delay(InterpolationDelay::Delay(interpolation_delay));
+        let interpolation_config = InterpolationConfig::default().with_delay(InterpolationDelay {
+            min_delay: interpolation_delay,
+            send_interval_ratio: 0.0,
+        });
         let mut stepper = BevyStepper::new(
             shared_config,
             sync_config,

--- a/lightyear/src/connection/message.rs
+++ b/lightyear/src/connection/message.rs
@@ -1,7 +1,7 @@
 /*!
 Provides a [`ProtocolMessage`] enum that is a wrapper around all the possible messages that can be sent over the network
 */
-use crate::_reexport::{InputMessage, ShouldBeInterpolated, ShouldBePredicted};
+use crate::_reexport::{InputMessage, ShouldBeInterpolated, ShouldBePredicted, TickManager};
 use crate::connection::events::ConnectionEvents;
 use crate::prelude::{EntityMap, MapEntities};
 use crate::protocol::channel::ChannelKind;
@@ -11,6 +11,7 @@ use crate::shared::replication::ReplicationMessage;
 use crate::shared::time_manager::TimeManager;
 use crate::utils::named::Named;
 use serde::{Deserialize, Serialize};
+use tracing::{info, trace, trace_span};
 
 // pub enum InternalMessage<P: Protocol> {
 //     InputMessage(InputMessage<P::Input>),
@@ -48,6 +49,88 @@ impl<P: Protocol> MapEntities for ProtocolMessage<P> {
 }
 
 impl<P: Protocol> ProtocolMessage<P> {
+    pub(crate) fn emit_send_logs(&self, channel_name: &str) {
+        match self {
+            ProtocolMessage::Message(message) => {
+                let message_name = message.name();
+                info!(channel = ?channel_name, message = ?message_name, "Sending message");
+                #[cfg(metrics)]
+                metrics::increment_counter!("send_message", "channel" => channel_name, "message" => message_name);
+            }
+            ProtocolMessage::Replication(message) => match message {
+                ReplicationMessage::SpawnEntity(entity, components) => {
+                    let components = components
+                        .iter()
+                        .map(|c| c.into())
+                        .collect::<Vec<P::ComponentKinds>>();
+                    info!(channel = ?channel_name, ?entity, ?components, "Sending entity spawn");
+                    #[cfg(metrics)]
+                    {
+                        metrics::increment_counter!("send_entity_spawn", "channel" => channel_name);
+                        for component in components {
+                            let kind: P::ComponentKinds = component.into();
+                            metrics::increment_counter!("send_component_insert", "channel" => channel_name, "component" => kind);
+                        }
+                    }
+                }
+                ReplicationMessage::DespawnEntity(entity) => {
+                    info!(channel = ?channel_name, ?entity, "Sending entity despawn");
+                    #[cfg(metrics)]
+                    metrics::increment_counter!("send_entity_despawn", "channel" => channel_name);
+                }
+                ReplicationMessage::InsertComponent(entity, components) => {
+                    let components = components
+                        .iter()
+                        .map(|c| c.into())
+                        .collect::<Vec<P::ComponentKinds>>();
+                    info!(channel = ?channel_name, ?entity, ?components, "Sending component insert");
+                    #[cfg(metrics)]
+                    {
+                        for component in components {
+                            let kind: P::ComponentKinds = component.into();
+                            metrics::increment_counter!("send_component_insert", "channel" => channel_name, "component" => kind);
+                        }
+                    }
+                }
+                ReplicationMessage::RemoveComponent(entity, components) => {
+                    info!(channel = ?channel_name, ?entity, ?components, "Sending component remove");
+                    #[cfg(metrics)]
+                    {
+                        for component in components {
+                            let kind: P::ComponentKinds = component.into();
+                            metrics::increment_counter!("send_component_remove", "channel" => channel_name, "component" => kind);
+                        }
+                    }
+                }
+                ReplicationMessage::EntityUpdate(entity, components) => {
+                    let components = components
+                        .iter()
+                        .map(|c| c.into())
+                        .collect::<Vec<P::ComponentKinds>>();
+                    info!(channel = ?channel_name, ?entity, ?components, "Sending entity update");
+                    #[cfg(metrics)]
+                    {
+                        for component in components {
+                            let kind: P::ComponentKinds = component.into();
+                            metrics::increment_counter!("send_component_update", "channel" => channel_name, "component" => kind);
+                        }
+                    }
+                }
+            },
+            ProtocolMessage::Sync(message) => match message {
+                SyncMessage::Ping(_) => {
+                    trace!(channel = ?channel_name, "Sending ping");
+                    #[cfg(metrics)]
+                    metrics::increment_counter!("send_ping", "channel" => channel_name);
+                }
+                SyncMessage::Pong(_) => {
+                    trace!(channel = ?channel_name, "Sending pong");
+                    #[cfg(metrics)]
+                    metrics::increment_counter!("send_pong", "channel" => channel_name);
+                }
+            },
+        }
+    }
     pub(crate) fn push_to_events(
         self,
         channel_kind: ChannelKind,
@@ -55,13 +138,9 @@ impl<P: Protocol> ProtocolMessage<P> {
         entity_map: &EntityMap,
         time_manager: &TimeManager,
     ) {
+        let _span = trace_span!("receive");
         match self {
             ProtocolMessage::Message(message) => {
-                #[cfg(feature = "metrics")]
-                {
-                    let message_name = message.name();
-                    metrics::increment_counter!(format!("receive_message.{}", message_name));
-                }
                 events.push_message(channel_kind, message);
             }
             ProtocolMessage::Replication(replication) => match replication {
@@ -78,13 +157,17 @@ impl<P: Protocol> ProtocolMessage<P> {
                     let local_entity = *entity_map.get_local(entity).unwrap_or(&entity);
                     events.push_despawn(local_entity);
                 }
-                ReplicationMessage::InsertComponent(entity, component) => {
+                ReplicationMessage::InsertComponent(entity, components) => {
                     let local_entity = *entity_map.get_local(entity).unwrap_or(&entity);
-                    events.push_insert_component(local_entity, (&component).into());
+                    for component in components {
+                        events.push_insert_component(local_entity, (&component).into());
+                    }
                 }
-                ReplicationMessage::RemoveComponent(entity, component_kind) => {
+                ReplicationMessage::RemoveComponent(entity, component_kinds) => {
                     let local_entity = *entity_map.get_local(entity).unwrap_or(&entity);
-                    events.push_remove_component(local_entity, component_kind);
+                    for component_kind in component_kinds {
+                        events.push_remove_component(local_entity, component_kind);
+                    }
                 }
                 ReplicationMessage::EntityUpdate(entity, components) => {
                     let local_entity = *entity_map.get_local(entity).unwrap_or(&entity);

--- a/lightyear/src/inputs/input_buffer.rs
+++ b/lightyear/src/inputs/input_buffer.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::inputs::UserInput;
 use lightyear_macros::MessageInternal;
+use tracing::info;
 
 use crate::protocol::BitSerializable;
 use crate::shared::tick_manager::Tick;
@@ -87,7 +88,9 @@ impl<T: UserInput> InputBuffer<T> {
             self.buffer.pop_front();
         }
         self.start_tick = tick + 1;
-        self.buffer.pop_front().unwrap()
+        let a = self.buffer.pop_front().unwrap();
+        info!(?self, "input buffer");
+        a
     }
 
     pub(crate) fn get(&self, tick: Tick) -> Option<&T> {

--- a/lightyear/src/lib.rs
+++ b/lightyear/src/lib.rs
@@ -98,6 +98,7 @@ pub mod prelude {
         };
         pub use crate::server::plugin::{PluginConfig, ServerPlugin};
         pub use crate::server::resource::Server;
+        pub use crate::server::room::{RoomId, RoomMut, RoomRef};
         #[cfg(feature = "webtransport")]
         pub use wtransport::tls::Certificate;
     }

--- a/lightyear/src/netcode/server.rs
+++ b/lightyear/src/netcode/server.rs
@@ -889,11 +889,13 @@ impl<Ctx> Server<Ctx> {
         Ok(())
     }
 
-    pub fn connected_client_ids(&self) -> impl Iterator<Item = ClientId> + '_ {
+    pub fn connected_client_ids(&self) -> Vec<ClientId> {
         self.conn_cache
             .clients
             .iter()
-            .filter_map(|(id, c)| c.is_connected().then_some(*id))
+            .filter_map(|(id, c)| c.is_connected().then_some(id))
+            .cloned()
+            .collect()
     }
 
     pub fn client_ids(&self) -> impl Iterator<Item = ClientId> + '_ {

--- a/lightyear/src/packet/message.rs
+++ b/lightyear/src/packet/message.rs
@@ -141,6 +141,7 @@ pub struct SingleData {
     // TODO: for now, we include the tick into every single data because it's easier
     //  for optimizing size later, we want the tick channels to use a different SingleData type that contains tick
     //  basically each channel should have either SingleData or TickData as associated type ?
+    // NOTE: This is only used for tick buffered receiver, so that the message is read at the same exact tick it was sent
     pub tick: Option<Tick>,
     pub bytes: Bytes,
 }

--- a/lightyear/src/protocol/component.rs
+++ b/lightyear/src/protocol/component.rs
@@ -61,16 +61,33 @@ pub trait ComponentProtocol:
 /// Trait to delegate a method from the ComponentProtocol enum to the inner Component type
 #[enum_delegate::register]
 pub trait ComponentBehaviour {
-    /// Insert the component for an entity
+    /// Apply a ComponentInsert to an entity
     fn insert(self, entity: &mut EntityWorldMut);
+
+    /// Apply a ComponentUpdate to an entity
+    fn update(self, entity: &mut EntityWorldMut);
 }
 
 impl<T: Component> ComponentBehaviour for T {
+    // Apply a ComponentInsert to an entity
     fn insert(self, entity: &mut EntityWorldMut) {
         // only insert if the entity didn't have the component
-        // if entity.get::<T>().is_none() {
-        entity.insert(self);
-        // }
+        // because otherwise the insert could override an component-update that was received later?
+
+        // but this could cause some issues if we wanted the component to be updated from the insert
+        if entity.get::<T>().is_none() {
+            entity.insert(self);
+        }
+    }
+
+    // Apply a ComponentUpdate to an entity
+    fn update(self, entity: &mut EntityWorldMut) {
+        match entity.get_mut::<T>() {
+            Some(mut c) => *c = self,
+            None => {
+                entity.insert(self);
+            }
+        }
     }
 }
 

--- a/lightyear/src/server/mod.rs
+++ b/lightyear/src/server/mod.rs
@@ -15,4 +15,6 @@ pub mod plugin;
 
 pub mod resource;
 
+pub mod room;
+
 mod systems;

--- a/lightyear/src/server/plugin.rs
+++ b/lightyear/src/server/plugin.rs
@@ -91,10 +91,18 @@ impl<P: Protocol> PluginType for ServerPlugin<P> {
                     (
                         ReplicationSet::SendEntityUpdates,
                         ReplicationSet::SendComponentUpdates,
+                        ReplicationSet::ReplicationSystems,
+                    )
+                        .in_set(ReplicationSet::All),
+                    (
+                        ReplicationSet::SendEntityUpdates,
+                        ReplicationSet::SendComponentUpdates,
                         MainSet::SendPackets,
                     )
                         .chain()
                         .in_set(MainSet::Send),
+                    // ReplicationSystems runs once per frame, so we cannot put it in the `Send` set
+                    // which runs every send_interval
                     (ReplicationSet::ReplicationSystems, MainSet::SendPackets).chain(),
                 ),
             )

--- a/lightyear/src/server/plugin.rs
+++ b/lightyear/src/server/plugin.rs
@@ -14,6 +14,7 @@ use crate::protocol::Protocol;
 use crate::server::events::{ConnectEvent, DisconnectEvent, EntityDespawnEvent, EntitySpawnEvent};
 use crate::server::input::InputPlugin;
 use crate::server::resource::Server;
+use crate::server::room::RoomPlugin;
 use crate::server::systems::{clear_events, is_ready_to_send};
 use crate::shared::plugin::SharedPlugin;
 use crate::shared::replication::resources::ReplicationData;
@@ -77,6 +78,7 @@ impl<P: Protocol> PluginType for ServerPlugin<P> {
                 config: config.server_config.shared.clone(),
             })
             .add_plugins(InputPlugin::<P>::default())
+            .add_plugins(RoomPlugin::<P>::default())
             // RESOURCES //
             .insert_resource(server)
             // SYSTEM SETS //

--- a/lightyear/src/server/resource.rs
+++ b/lightyear/src/server/resource.rs
@@ -18,6 +18,7 @@ use crate::shared::ping::manager::PingManager;
 use crate::shared::ping::message::SyncMessage;
 use crate::shared::replication::components::{NetworkTarget, Replicate};
 use crate::shared::replication::components::{ShouldBeInterpolated, ShouldBePredicted};
+use crate::shared::replication::room::RoomId;
 use crate::shared::replication::ReplicationSend;
 use crate::shared::tick_manager::TickManager;
 use crate::shared::tick_manager::{Tick, TickManaged};
@@ -367,6 +368,13 @@ impl<P: Protocol> Server<P> {
     /// Clear the list of clients that were recently connected but haven't received any replication packages yet
     pub(crate) fn clear_new_clients(&mut self) {
         self.new_clients.clear();
+    }
+
+    pub fn room(&mut self, id: RoomId) -> RoomMut {
+        RoomMut {
+            id: RoomId,
+            manager: &self.room_manager,
+        }
     }
 }
 

--- a/lightyear/src/server/room.rs
+++ b/lightyear/src/server/room.rs
@@ -1,13 +1,19 @@
 use crate::netcode::ClientId;
-use crate::utils::wrapping_id::wrapping_id;
-use bevy::prelude::{Entity, Query, Res, ResMut, Resource};
-use std::collections::{HashMap, HashSet};
-use crate::prelude::Replicate;
+use crate::prelude::{MainSet, Replicate};
 use crate::protocol::Protocol;
 use crate::server::resource::Server;
+use crate::server::systems::is_ready_to_send;
+use crate::shared::replication::components::DespawnTracker;
+use crate::utils::wrapping_id::wrapping_id;
+use bevy::app::App;
+use bevy::prelude::{
+    Entity, IntoSystemConfigs, IntoSystemSetConfigs, Plugin, PostUpdate, Query, RemovedComponents,
+    Res, ResMut, Resource, SystemSet,
+};
+use std::collections::{HashMap, HashSet};
 
-/// Id for a room, used to perform interest management
-/// An entity will be replicated to a client only if they are in the same room
+// Id for a room, used to perform interest management
+// An entity will be replicated to a client only if they are in the same room
 wrapping_id!(RoomId);
 
 /// Resource that will track any changes in the rooms
@@ -18,10 +24,10 @@ wrapping_id!(RoomId);
 /// This will be cleared every time the Server sends updates to the Client (every send_interval)
 #[derive(Resource)]
 pub struct RoomEvents {
-    client_enter_room: HashMap<RoomId, HashSet<ClientId>>,
-    client_leave_room: HashMap<RoomId, HashSet<ClientId>>,
-    entity_enter_room: HashMap<RoomId, HashSet<Entity>>,
-    entity_leave_room: HashMap<RoomId, HashSet<Entity>>,
+    client_enter_room: HashMap<ClientId, HashSet<RoomId>>,
+    client_leave_room: HashMap<ClientId, HashSet<RoomId>>,
+    entity_enter_room: HashMap<Entity, HashSet<RoomId>>,
+    entity_leave_room: HashMap<Entity, HashSet<RoomId>>,
 }
 
 impl Default for RoomEvents {
@@ -35,39 +41,180 @@ impl Default for RoomEvents {
     }
 }
 
+#[derive(Default)]
 pub struct RoomData {
     client_to_rooms: HashMap<ClientId, HashSet<RoomId>>,
     entity_to_rooms: HashMap<Entity, HashSet<RoomId>>,
-    // TODO: or HashMap<RoomId, Room> and Room contains the list of clients/entities?
+    rooms: HashMap<RoomId, Room>,
 }
 
+#[derive(Default)]
+pub struct Room {
+    /// list of clients that are in the room
+    clients: HashSet<ClientId>,
+    /// list of entities that are in the room
+    entities: HashSet<Entity>,
+}
 
+#[derive(Default)]
 pub struct RoomManager {
     events: RoomEvents,
     data: RoomData,
 }
 
-// room manager: events + room status ?
+#[derive(Default)]
+pub struct RoomPlugin<P: Protocol> {
+    _marker: std::marker::PhantomData<P>,
+}
 
+/// System sets related to Rooms
+#[derive(SystemSet, Debug, Hash, PartialEq, Eq, Clone, Copy)]
+pub enum RoomSystemSets {
+    /// Use all the room events that happened, and use those to update
+    /// the replication caches
+    UpdateReplicationCaches,
+    /// Perform bookkeeping for the rooms
+    /// (remove despawned entities, update the replication caches, etc.)
+    RoomBookkeeping,
+}
+
+impl<P: Protocol> Plugin for RoomPlugin<P> {
+    fn build(&self, app: &mut App) {
+        // SETS
+        app.configure_sets(
+            PostUpdate,
+            (
+                RoomSystemSets::UpdateReplicationCaches,
+                MainSet::Send,
+                RoomSystemSets::RoomBookkeeping,
+            )
+                .chain()
+                .run_if(is_ready_to_send::<P>),
+        );
+        // SYSTEMS
+        app.add_systems(
+            PostUpdate,
+            (
+                update_entity_replication_cache::<P>
+                    .in_set(RoomSystemSets::UpdateReplicationCaches),
+                (
+                    clear_entity_replication_cache::<P>,
+                    clean_entity_despawns::<P>,
+                )
+                    .in_set(RoomSystemSets::RoomBookkeeping),
+            ),
+        );
+    }
+}
+
+impl RoomManager {
+    /// Remove the client from all the rooms it was in
+    pub(crate) fn client_disconnect(&mut self, client_id: ClientId) {
+        if let Some(rooms) = self.data.client_to_rooms.remove(&client_id) {
+            for room_id in rooms {
+                RoomMut::new(self, room_id).remove_client(client_id);
+                self.remove_client(room_id, client_id);
+            }
+        }
+    }
+
+    /// Remove the entity from all the rooms it was in
+    pub(crate) fn entity_despawn(&mut self, entity: Entity) {
+        if let Some(rooms) = self.data.entity_to_rooms.remove(&entity) {
+            for room_id in rooms {
+                RoomMut::new(self, room_id).remove_entity(entity);
+                self.remove_entity(room_id, entity);
+            }
+        }
+    }
+
+    fn add_client(&mut self, room_id: RoomId, client_id: ClientId) {
+        self.data
+            .client_to_rooms
+            .entry(client_id)
+            .or_default()
+            .insert(room_id);
+        self.data
+            .rooms
+            .entry(room_id)
+            .or_default()
+            .clients
+            .insert(client_id);
+        self.events.client_enter_room(room_id, client_id);
+    }
+
+    fn remove_client(&mut self, room_id: RoomId, client_id: ClientId) {
+        self.data
+            .client_to_rooms
+            .entry(client_id)
+            .or_default()
+            .remove(&room_id);
+        self.data
+            .rooms
+            .entry(room_id)
+            .or_default()
+            .clients
+            .remove(&client_id);
+        self.events.client_leave_room(room_id, client_id);
+    }
+
+    fn add_entity(&mut self, room_id: RoomId, entity: Entity) {
+        self.data
+            .entity_to_rooms
+            .entry(entity)
+            .or_default()
+            .insert(room_id);
+        self.data
+            .rooms
+            .entry(room_id)
+            .or_default()
+            .entities
+            .insert(entity);
+        self.events.entity_enter_room(room_id, entity);
+    }
+
+    fn remove_entity(&mut self, room_id: RoomId, entity: Entity) {
+        self.data
+            .entity_to_rooms
+            .entry(entity)
+            .or_default()
+            .remove(&room_id);
+        self.data
+            .rooms
+            .entry(room_id)
+            .or_default()
+            .entities
+            .remove(&entity);
+        self.events.entity_leave_room(room_id, entity);
+    }
+}
+
+/// Convenient wrapper to mutate a room
 pub struct RoomMut<'s> {
-    id: RoomId,
-    manager: &'s mut RoomManager
+    pub(crate) id: RoomId,
+    pub(crate) manager: &'s mut RoomManager,
 }
 
 impl<'s> RoomMut<'s> {
     fn new(manager: &'s mut RoomManager, id: RoomId) -> Self {
-        Self {
-            id,
-            manager,
-        }
+        Self { id, manager }
     }
 
-    fn add_client(&mut self, client_id: ClientId) {
-        self.manager.data.client_to_rooms.entry(client_id).or_default().insert(self.id);
-        self.manager.events.client_enter_room(self.id, client_id);
-        // self.manager.events.client_enter_room.entry(self.id).or_default().insert(client_id);
+    pub fn add_client(&mut self, client_id: ClientId) {
+        self.manager.add_client(self.id, client_id)
     }
 
+    pub fn remove_client(&mut self, client_id: ClientId) {
+        self.manager.remove_client(self.id, client_id)
+    }
+
+    pub fn add_entity(&mut self, entity: Entity) {
+        self.manager.add_entity(self.id, entity)
+    }
+
+    pub fn remove_entity(&mut self, entity: Entity) {
+        self.manager.remove_entity(self.id, entity)
+    }
 }
 
 impl RoomEvents {
@@ -76,89 +223,175 @@ impl RoomEvents {
         // if the client had left the room, no need to track the enter
         if !self
             .client_leave_room
-            .entry(room_id)
+            .entry(client_id)
             .or_default()
-            .remove(&client_id)
+            .remove(&room_id)
         {
             self.client_enter_room
-                .entry(room_id)
+                .entry(client_id)
                 .or_default()
-                .insert(client_id);
+                .insert(room_id);
         }
     }
 
     pub fn client_leave_room(&mut self, room_id: RoomId, client_id: ClientId) {
         if !self
             .client_enter_room
-            .entry(room_id)
+            .entry(client_id)
             .or_default()
-            .remove(&client_id)
+            .remove(&room_id)
         {
             self.client_leave_room
-                .entry(room_id)
+                .entry(client_id)
                 .or_default()
-                .insert(client_id);
+                .insert(room_id);
         }
     }
 
     pub fn entity_enter_room(&mut self, room_id: RoomId, entity: Entity) {
         if !self
             .entity_leave_room
-            .entry(room_id)
+            .entry(entity)
             .or_default()
-            .remove(&entity)
+            .remove(&room_id)
         {
             self.entity_enter_room
-                .entry(room_id)
+                .entry(entity)
                 .or_default()
-                .insert(entity);
+                .insert(room_id);
         }
     }
 
     pub fn entity_leave_room(&mut self, room_id: RoomId, entity: Entity) {
         if !self
             .entity_enter_room
-            .entry(room_id)
+            .entry(entity)
             .or_default()
-            .remove(&entity)
+            .remove(&room_id)
         {
             self.entity_leave_room
-                .entry(room_id)
+                .entry(entity)
                 .or_default()
-                .insert(entity);
+                .insert(room_id);
         }
     }
 
-    pub fn iter_client_enter_room(&self) -> impl Iterator<Item = (&RoomId, &HashSet<ClientId>)> {
+    fn iter_client_enter_room(&self) -> impl Iterator<Item = (&ClientId, &HashSet<RoomId>)> {
         self.client_enter_room.iter()
     }
 
-    pub fn iter_client_leave_room(&self) -> impl Iterator<Item = (&RoomId, &HashSet<ClientId>)> {
+    fn iter_client_leave_room(&self) -> impl Iterator<Item = (&ClientId, &HashSet<RoomId>)> {
         self.client_leave_room.iter()
     }
 
-    pub fn iter_entity_enter_room(&self) -> impl Iterator<Item = (&RoomId, &HashSet<Entity>)> {
+    fn iter_entity_enter_room(&self) -> impl Iterator<Item = (&Entity, &HashSet<RoomId>)> {
         self.entity_enter_room.iter()
     }
 
-    pub fn iter_entity_leave_room(&self) -> impl Iterator<Item = (&RoomId, &HashSet<Entity>)> {
+    fn iter_entity_leave_room(&self) -> impl Iterator<Item = (&Entity, &HashSet<RoomId>)> {
         self.entity_leave_room.iter()
     }
 }
 
-// the rooms have already been updated
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub(crate) enum ClientVisibility {
+    /// the entity was not replicated to the client, but now is
+    Gained,
+    /// the entity was replicated to the client, but not anymore
+    Lost,
+    /// the entity was already replicated to the client, and still is
+    Maintained,
+}
 
 /// Update each entities' replication-client-list based on the room events
-fn update_entity_rooms<P: Protocol>(
-    server: ResMut<Server<P>>,
-    mut query: Query<(Entity, &mut Replicate)>,
+/// Note that the rooms' entities/clients have already been updated at this point
+fn update_entity_replication_cache<P: Protocol>(
+    server: Res<Server<P>>,
+    mut query: Query<&mut Replicate>,
 ) {
-    //
-    for (room_id, entities) in room_events.iter_entity_enter_room().
+    // entity joined room
+    for (entity, rooms) in server.room_manager.events.iter_entity_enter_room() {
+        // for each room joined, update the entity's client visibility list
+        rooms.iter().for_each(|room_id| {
+            let room = server.room_manager.data.rooms.get(room_id).unwrap();
+            room.clients.iter().for_each(|client_id| {
+                if let Ok(mut replicate) = query.get_mut(*entity) {
+                    // only set it to gained if it wasn't present before
+                    replicate
+                        .replication_clients_cache
+                        .entry(*client_id)
+                        .or_insert(ClientVisibility::Gained);
+                }
+            });
+        });
+    }
+    // entity left room
+    for (entity, rooms) in server.room_manager.events.iter_entity_leave_room() {
+        // for each room left, update the entity's client visibility list
+        rooms.iter().for_each(|room_id| {
+            let room = server.room_manager.data.rooms.get(room_id).unwrap();
+            room.clients.iter().for_each(|client_id| {
+                if let Ok(mut replicate) = query.get_mut(*entity) {
+                    replicate
+                        .replication_clients_cache
+                        .insert(*client_id, ClientVisibility::Lost);
+                }
+            });
+        });
+    }
+    // client joined room: update all the entities that are in that room
+    for (client_id, rooms) in server.room_manager.events.iter_client_enter_room() {
+        rooms.iter().for_each(|room_id| {
+            let room = server.room_manager.data.rooms.get(room_id).unwrap();
+            room.entities.iter().for_each(|entity| {
+                if let Ok(mut replicate) = query.get_mut(*entity) {
+                    replicate
+                        .replication_clients_cache
+                        .entry(*client_id)
+                        .or_insert(ClientVisibility::Gained);
+                }
+            });
+        });
+    }
+    // client left room: update all the entities that are in that room
+    for (client_id, rooms) in server.room_manager.events.iter_client_leave_room() {
+        rooms.iter().for_each(|room_id| {
+            let room = server.room_manager.data.rooms.get(room_id).unwrap();
+            room.entities.iter().for_each(|entity| {
+                if let Ok(mut replicate) = query.get_mut(*entity) {
+                    replicate
+                        .replication_clients_cache
+                        .insert(*client_id, ClientVisibility::Lost);
+                }
+            });
+        });
+    }
+}
 
-    query.par_iter_mut().for_each(|(entity, mut replicate)| {
+/// After replication, update the Replication Cache:
+/// - Visibility Gained becomes Visibility Maintained
+/// - Visibility Lost gets removed from the cache
+fn clear_entity_replication_cache<P: Protocol>(mut query: Query<&mut Replicate>) {
+    for mut replicate in query.iter_mut() {
+        replicate
+            .replication_clients_cache
+            .retain(|_, visibility| match visibility {
+                ClientVisibility::Gained => {
+                    *visibility = ClientVisibility::Maintained;
+                    true
+                }
+                ClientVisibility::Lost => false,
+                ClientVisibility::Maintained => true,
+            });
+    }
+}
 
-
-
-    })
+/// Clear out the room metadata for any entity that was ever replicated
+fn clean_entity_despawns<P: Protocol>(
+    mut server: ResMut<Server<P>>,
+    mut despawned: RemovedComponents<DespawnTracker>,
+) {
+    for entity in despawned.read() {
+        server.room_manager.entity_despawn(entity);
+    }
 }

--- a/lightyear/src/server/room.rs
+++ b/lightyear/src/server/room.rs
@@ -1,0 +1,164 @@
+use crate::netcode::ClientId;
+use crate::utils::wrapping_id::wrapping_id;
+use bevy::prelude::{Entity, Query, Res, ResMut, Resource};
+use std::collections::{HashMap, HashSet};
+use crate::prelude::Replicate;
+use crate::protocol::Protocol;
+use crate::server::resource::Server;
+
+/// Id for a room, used to perform interest management
+/// An entity will be replicated to a client only if they are in the same room
+wrapping_id!(RoomId);
+
+/// Resource that will track any changes in the rooms
+/// (we cannot use bevy `Events` directly because we don't need to send this every frame.
+/// Also, we only need to keep track of updates for each send_interval frame. That means that if an entity
+/// leaves then re-joins a room within the same send_interval period, we don't need to send any update)
+///
+/// This will be cleared every time the Server sends updates to the Client (every send_interval)
+#[derive(Resource)]
+pub struct RoomEvents {
+    client_enter_room: HashMap<RoomId, HashSet<ClientId>>,
+    client_leave_room: HashMap<RoomId, HashSet<ClientId>>,
+    entity_enter_room: HashMap<RoomId, HashSet<Entity>>,
+    entity_leave_room: HashMap<RoomId, HashSet<Entity>>,
+}
+
+impl Default for RoomEvents {
+    fn default() -> Self {
+        Self {
+            client_enter_room: HashMap::new(),
+            client_leave_room: HashMap::new(),
+            entity_enter_room: HashMap::new(),
+            entity_leave_room: HashMap::new(),
+        }
+    }
+}
+
+pub struct RoomData {
+    client_to_rooms: HashMap<ClientId, HashSet<RoomId>>,
+    entity_to_rooms: HashMap<Entity, HashSet<RoomId>>,
+    // TODO: or HashMap<RoomId, Room> and Room contains the list of clients/entities?
+}
+
+
+pub struct RoomManager {
+    events: RoomEvents,
+    data: RoomData,
+}
+
+// room manager: events + room status ?
+
+pub struct RoomMut<'s> {
+    id: RoomId,
+    manager: &'s mut RoomManager
+}
+
+impl<'s> RoomMut<'s> {
+    fn new(manager: &'s mut RoomManager, id: RoomId) -> Self {
+        Self {
+            id,
+            manager,
+        }
+    }
+
+    fn add_client(&mut self, client_id: ClientId) {
+        self.manager.data.client_to_rooms.entry(client_id).or_default().insert(self.id);
+        self.manager.events.client_enter_room(self.id, client_id);
+        // self.manager.events.client_enter_room.entry(self.id).or_default().insert(client_id);
+    }
+
+}
+
+impl RoomEvents {
+    /// A client joined a room
+    pub fn client_enter_room(&mut self, room_id: RoomId, client_id: ClientId) {
+        // if the client had left the room, no need to track the enter
+        if !self
+            .client_leave_room
+            .entry(room_id)
+            .or_default()
+            .remove(&client_id)
+        {
+            self.client_enter_room
+                .entry(room_id)
+                .or_default()
+                .insert(client_id);
+        }
+    }
+
+    pub fn client_leave_room(&mut self, room_id: RoomId, client_id: ClientId) {
+        if !self
+            .client_enter_room
+            .entry(room_id)
+            .or_default()
+            .remove(&client_id)
+        {
+            self.client_leave_room
+                .entry(room_id)
+                .or_default()
+                .insert(client_id);
+        }
+    }
+
+    pub fn entity_enter_room(&mut self, room_id: RoomId, entity: Entity) {
+        if !self
+            .entity_leave_room
+            .entry(room_id)
+            .or_default()
+            .remove(&entity)
+        {
+            self.entity_enter_room
+                .entry(room_id)
+                .or_default()
+                .insert(entity);
+        }
+    }
+
+    pub fn entity_leave_room(&mut self, room_id: RoomId, entity: Entity) {
+        if !self
+            .entity_enter_room
+            .entry(room_id)
+            .or_default()
+            .remove(&entity)
+        {
+            self.entity_leave_room
+                .entry(room_id)
+                .or_default()
+                .insert(entity);
+        }
+    }
+
+    pub fn iter_client_enter_room(&self) -> impl Iterator<Item = (&RoomId, &HashSet<ClientId>)> {
+        self.client_enter_room.iter()
+    }
+
+    pub fn iter_client_leave_room(&self) -> impl Iterator<Item = (&RoomId, &HashSet<ClientId>)> {
+        self.client_leave_room.iter()
+    }
+
+    pub fn iter_entity_enter_room(&self) -> impl Iterator<Item = (&RoomId, &HashSet<Entity>)> {
+        self.entity_enter_room.iter()
+    }
+
+    pub fn iter_entity_leave_room(&self) -> impl Iterator<Item = (&RoomId, &HashSet<Entity>)> {
+        self.entity_leave_room.iter()
+    }
+}
+
+// the rooms have already been updated
+
+/// Update each entities' replication-client-list based on the room events
+fn update_entity_rooms<P: Protocol>(
+    server: ResMut<Server<P>>,
+    mut query: Query<(Entity, &mut Replicate)>,
+) {
+    //
+    for (room_id, entities) in room_events.iter_entity_enter_room().
+
+    query.par_iter_mut().for_each(|(entity, mut replicate)| {
+
+
+
+    })
+}

--- a/lightyear/src/server/systems.rs
+++ b/lightyear/src/server/systems.rs
@@ -84,7 +84,7 @@ pub(crate) fn receive<P: Protocol>(world: &mut World) {
 pub(crate) fn send<P: Protocol>(mut server: ResMut<Server<P>>) {
     trace!("Send packets to clients");
     // finalize any packets that are needed for replication
-    server.prepare_replicate_send().unwrap_or_else(|e| {
+    server.buffer_replication_messages().unwrap_or_else(|e| {
         error!("Error preparing replicate send: {}", e);
     });
     // send buffered packets to io

--- a/lightyear/src/shared/ping/manager.rs
+++ b/lightyear/src/shared/ping/manager.rs
@@ -55,10 +55,19 @@ pub struct PingManager {
 }
 
 /// Connection stats aggregated over several [`SyncStats`]
-#[derive(Default)]
 pub struct FinalStats {
     pub rtt: Duration,
     pub jitter: Duration,
+}
+
+impl Default for FinalStats {
+    fn default() -> Self {
+        Self {
+            // start with a conservative estimate
+            rtt: Duration::from_millis(100),
+            jitter: Duration::default(),
+        }
+    }
 }
 
 /// Stats computed from each pong
@@ -80,6 +89,7 @@ impl PingManager {
             pongs_to_send: vec![],
             // sync
             sync_stats: SyncStatsBuffer::new(),
+            // TODO: should we start with a bigger RTT estimate?
             final_stats: FinalStats::default(),
         }
     }

--- a/lightyear/src/shared/replication/components.rs
+++ b/lightyear/src/shared/replication/components.rs
@@ -31,10 +31,13 @@ pub struct Replicate {
     // TODO: maybe an entity can belong to only one room at a time?
     /// Which rooms does this entity belong to?
     // pub rooms: HashSet<RoomId>,
+
+    // TODO: this should not be public, but replicate is public... how to fix that?
+    //  have a separate component ReplicateVisibility?
     /// List of clients that we the entity is currently replicated to.
     /// Will be updated before the other replication systems
-    pub(crate) replication_clients_cache: HashMap<ClientId, ClientVisibility>,
-    // pub replication_mode: ReplicationMode,
+    pub replication_clients_cache: HashMap<ClientId, ClientVisibility>,
+    pub replication_mode: ReplicationMode,
     // TODO: currently, if the host removes Replicate, then the entity is not removed in the remote
     //  it just keeps living but doesn't receive any updates. Should we make this configurable?
 }
@@ -43,9 +46,9 @@ pub struct Replicate {
 pub enum ReplicationMode {
     /// We will replicate this entity only to clients that are in the same room as the entity
     Room,
-    /// We will replicate this entity to all clients
+    /// We will replicate this entity to clients using only the [`NetworkTarget`], without caring about rooms
     #[default]
-    All,
+    NetworkTarget,
 }
 
 impl Replicate {
@@ -68,7 +71,7 @@ impl Default for Replicate {
             interpolation_target: NetworkTarget::None,
             // rooms: HashSet::new(),
             replication_clients_cache: HashMap::new(),
-            // replication_mode: ReplicationMode::default(),
+            replication_mode: ReplicationMode::default(),
         }
     }
 }

--- a/lightyear/src/shared/replication/components.rs
+++ b/lightyear/src/shared/replication/components.rs
@@ -2,9 +2,11 @@
 use crate::channel::builder::{Channel, EntityActionsChannel, EntityUpdatesChannel};
 use crate::netcode::ClientId;
 use crate::protocol::channel::ChannelKind;
+use crate::server::room::RoomId;
 use bevy::prelude::Component;
 use lightyear_macros::MessageInternal;
 use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
 
 /// Component inserted to each replicable entities, to detect when they are despawned
 #[derive(Component, Clone, Copy)]
@@ -25,7 +27,12 @@ pub struct Replicate {
     pub prediction_target: NetworkTarget,
     /// Which clients should interpolated this entity
     pub interpolation_target: NetworkTarget,
-    // pub owner:
+
+    /// Which rooms does this entity belong to?
+    pub rooms: HashSet<RoomId>,
+    /// List of clients that we the entity is currently replicated to.
+    /// Will be updated before the other replication systems
+    pub replication_clients_cache: HashSet<ClientId>,
     // TODO: currently, if the host removes Replicate, then the entity is not removed in the remote
     //  it just keeps living but doesn't receive any updates. Should we make this configurable?
 }

--- a/lightyear/src/shared/replication/components.rs
+++ b/lightyear/src/shared/replication/components.rs
@@ -34,7 +34,7 @@ pub struct Replicate {
     /// List of clients that we the entity is currently replicated to.
     /// Will be updated before the other replication systems
     pub(crate) replication_clients_cache: HashMap<ClientId, ClientVisibility>,
-    pub replication_mode: ReplicationMode,
+    // pub replication_mode: ReplicationMode,
     // TODO: currently, if the host removes Replicate, then the entity is not removed in the remote
     //  it just keeps living but doesn't receive any updates. Should we make this configurable?
 }
@@ -68,7 +68,7 @@ impl Default for Replicate {
             interpolation_target: NetworkTarget::None,
             // rooms: HashSet::new(),
             replication_clients_cache: HashMap::new(),
-            replication_mode: ReplicationMode::default(),
+            // replication_mode: ReplicationMode::default(),
         }
     }
 }

--- a/lightyear/src/shared/replication/entity_map.rs
+++ b/lightyear/src/shared/replication/entity_map.rs
@@ -76,6 +76,11 @@ pub trait MapEntities {
 
 impl MapEntities for Entity {
     fn map_entities(&mut self, entity_map: &EntityMap) {
+        // TODO: if the entity is inside a component, then we don't want to just use the remote entity in the component
+        //  instead we should say:
+        //  - there is a remote entity that we haven't mapped yet
+        //  - wait for it to appear
+        //  - if it appears, we finish the mapping and spawn the entity
         if let Some(local) = entity_map.get_local(*self) {
             *self = *local;
         }

--- a/lightyear/src/shared/replication/manager.rs
+++ b/lightyear/src/shared/replication/manager.rs
@@ -1,8 +1,11 @@
 //! General struct handling replication
-use std::collections::HashMap;
+use std::collections::hash_map::Entry;
+use std::collections::{HashMap, HashSet};
 
 use bevy::prelude::{Entity, World};
-use tracing::{debug, info, trace, trace_span};
+use tracing::{debug, error, info, trace, trace_span};
+use tracing_subscriber::filter::FilterExt;
+use tracing_subscriber::fmt::writer::MakeWriterExt;
 
 use super::entity_map::EntityMap;
 use super::{Replicate, ReplicationMessage};
@@ -14,14 +17,24 @@ use crate::protocol::Protocol;
 // TODO: maybe store additional information about the entity?
 //  (e.g. the value of the replicate component)?
 pub enum EntityStatus {
+    JustSpawned,
     Spawning,
     Spawned,
 }
 
-pub struct ReplicationManager<P: Protocol> {
+pub(crate) struct ReplicationManager<P: Protocol> {
     pub entity_map: EntityMap,
     pub remote_entity_status: HashMap<Entity, EntityStatus>,
-    pub individual_component_updates: HashMap<(Entity, ChannelKind), Vec<P::Components>>,
+
+    /// messages that are being written. We need to hold a buffer of messages because components actions/updates
+    /// are being buffered individually but we want to group them inside a message
+    pub pending_spawns: HashMap<Entity, Vec<P::Components>>,
+    pub pending_despawns: HashSet<Entity>,
+    pub pending_inserts: HashMap<Entity, Vec<P::Components>>,
+    pub pending_removes: HashMap<Entity, Vec<P::ComponentKinds>>,
+    pub pending_updates: HashMap<Entity, Vec<P::Components>>,
+    pub entity_actions_channel: HashMap<Entity, ChannelKind>,
+    pub entity_updates_channel: HashMap<Entity, ChannelKind>,
     // pub global_replication_data: &'a ReplicationData,
 }
 
@@ -30,7 +43,13 @@ impl<P: Protocol> Default for ReplicationManager<P> {
         Self {
             entity_map: EntityMap::default(),
             remote_entity_status: HashMap::new(),
-            individual_component_updates: HashMap::new(),
+            pending_spawns: HashMap::new(),
+            pending_despawns: HashSet::default(),
+            pending_inserts: HashMap::default(),
+            pending_removes: HashMap::default(),
+            pending_updates: HashMap::default(),
+            entity_actions_channel: HashMap::default(),
+            entity_updates_channel: HashMap::default(),
             // global_replication_data,
         }
     }
@@ -39,106 +58,173 @@ impl<P: Protocol> Default for ReplicationManager<P> {
 /// We want:
 /// - entity actions to be done reliably
 /// - entity updates (component updates) to be done unreliably
+///
+/// - all component inserts/removes/updates for an entity to be grouped together in a single message
 impl<P: Protocol> ReplicationManager<P> {
-    // pub fn new(global_replication_data: &ReplicationData) -> Self {
-    //     Self {
-    //         entity_map: EntityMap::default(),
-    //         remote_entity_status: HashMap::new(),
-    //         individual_component_updates: HashMap::new(),
-    //
-    //         global_replication_data,
-    //     }
-    // }
+    // TODO: how can I emit metrics here that contain the channel kind?
+    //  use a OnceCell that gets set with the channel name mapping when the protocol is finalized?
+    //  the other option is to have wrappers in Connection, but that's pretty ugly
 
     /// Host has spawned an entity, and we want to replicate this to remote
     /// Returns true if we should send a message
-    pub(crate) fn send_entity_spawn(&mut self, entity: Entity) -> bool {
-        // if we have already sent the Spawn Entity, don't do it again
-        if self.remote_entity_status.get(&entity).is_some() {
-            return false;
+    pub(crate) fn prepare_entity_spawn(
+        &mut self,
+        entity: Entity,
+        components: Vec<P::Components>,
+        channel_kind: ChannelKind,
+    ) {
+        // TODO: send error if there was another channel for this entity?
+        self.entity_actions_channel.insert(entity, channel_kind);
+
+        // TODO: check if we have already sent SpawnMessage for this entity?
+
+        self.pending_spawns
+            .entry(entity)
+            .and_modify(|_| {
+                error!("Entity already has a pending spawn");
+            })
+            .or_insert(components);
+
+        // // if we have already sent the Spawn Entity, don't do it again
+        // if self.remote_entity_status.get(&entity).is_some() {
+        //     return false;
+        // }
+        // self.remote_entity_status
+        //     .insert(entity, EntityStatus::Spawning);
+        // true
+    }
+
+    pub(crate) fn prepare_entity_despawn(&mut self, entity: Entity, channel_kind: ChannelKind) {
+        self.entity_actions_channel.insert(entity, channel_kind);
+        // TODO: check if we have already sent DespawnMessage for this entity? (send error message?)
+        //  or if the SpawnEntity was sent/received?
+        self.pending_despawns.insert(entity);
+    }
+
+    // we want to send all component inserts that happen together for the same entity in a single message
+    // (because otherwise the inserts might be received at different packets/ticks by the remote, and
+    // the remote might expect the components insert to be received at the same time)
+    pub(crate) fn prepare_component_insert(
+        &mut self,
+        entity: Entity,
+        component: P::Components,
+        channel: ChannelKind,
+    ) {
+        self.entity_actions_channel.insert(entity, channel);
+
+        // if the entity is about to be despawned, don't send the insert
+        if self.pending_despawns.contains(&entity) {
+            return;
         }
-        self.remote_entity_status
-            .insert(entity, EntityStatus::Spawning);
-        true
+
+        // if the entity is spawning, add the component insert to the spawn message directly
+        // NOTE: this works because we handle spawns before component inserts
+        if let Some(components) = self.pending_spawns.get_mut(&entity) {
+            components.push(component);
+        } else {
+            self.pending_inserts
+                .entry(entity)
+                .or_default()
+                .push(component);
+        }
     }
 
-    pub(crate) fn send_component_insert(
+    pub(crate) fn prepare_component_remove(
+        &mut self,
+        entity: Entity,
+        component: P::ComponentKinds,
+        channel: ChannelKind,
+    ) {
+        // if the entity is about to be despawned, don't send the remove
+        if self.pending_despawns.contains(&entity) {
+            return;
+        }
+
+        self.entity_actions_channel.insert(entity, channel);
+        self.pending_removes
+            .entry(entity)
+            .or_default()
+            .push(component);
+    }
+
+    pub(crate) fn prepare_entity_update(
         &mut self,
         entity: Entity,
         component: P::Components,
         channel: ChannelKind,
     ) {
-        // buffer the component update for that entity
-        self.individual_component_updates
-            .entry((entity, channel))
+        self.entity_updates_channel.insert(entity, channel);
+
+        // if the entity is about to be despawned, don't send the update
+        if self.pending_despawns.contains(&entity) {
+            return;
+        }
+
+        // TODO: if the component is spawning, should we put the update in the spawn message?
+        //  because else the update might arrive before the entity spawn
+        self.pending_updates
+            .entry(entity)
             .or_default()
             .push(component);
     }
 
-    pub(crate) fn send_component_remove(
-        &mut self,
-        _entity: Entity,
-        _component: P::ComponentKinds,
-        _channel: ChannelKind,
-    ) {
-        todo!()
-    }
-
-    pub(crate) fn send_entity_update_single_component(
-        &mut self,
-        entity: Entity,
-        component: P::Components,
-        channel: ChannelKind,
-    ) {
-        // buffer the component update for that entity
-        self.individual_component_updates
-            .entry((entity, channel))
-            .or_default()
-            .push(component);
-    }
-
-    pub(crate) fn prepare_send(&mut self) -> Vec<(ChannelKind, ProtocolMessage<P>)> {
+    /// Finalize the replication messages
+    pub(crate) fn finalize(&mut self) -> Vec<(ChannelKind, ProtocolMessage<P>)> {
         let mut messages = Vec::new();
-        for ((entity, channel), components) in self.individual_component_updates.drain() {
+
+        // entity actions
+        for (entity, components) in self.pending_spawns.drain() {
+            // SAFETY: we made sure that each entity has a channel
+            let channel = self.entity_actions_channel.get(&entity).unwrap();
+            messages.push((
+                *channel,
+                ProtocolMessage::Replication(ReplicationMessage::SpawnEntity(entity, components)),
+            ));
+        }
+        for entity in self.pending_despawns.drain() {
+            // SAFETY: we made sure that each entity has a channel
+            let channel = self.entity_actions_channel.get(&entity).unwrap();
+            messages.push((
+                *channel,
+                ProtocolMessage::Replication(ReplicationMessage::DespawnEntity(entity)),
+            ));
+        }
+        for (entity, components) in self.pending_inserts.drain() {
+            // SAFETY: we made sure that each entity has a channel
+            let channel = self.entity_actions_channel.get(&entity).unwrap();
+            messages.push((
+                *channel,
+                ProtocolMessage::Replication(ReplicationMessage::InsertComponent(
+                    entity, components,
+                )),
+            ));
+        }
+        for (entity, components) in self.pending_removes.drain() {
+            // SAFETY: we made sure that each entity has a channel
+            let channel = self.entity_actions_channel.get(&entity).unwrap();
+            messages.push((
+                *channel,
+                ProtocolMessage::Replication(ReplicationMessage::RemoveComponent(
+                    entity, components,
+                )),
+            ));
+        }
+
+        // entity updates
+        for (entity, components) in self.pending_updates.drain() {
+            // SAFETY: we made sure that each entity has a channel
+            let channel = self.entity_updates_channel.remove(&entity).unwrap();
             messages.push((
                 channel,
                 ProtocolMessage::Replication(ReplicationMessage::EntityUpdate(entity, components)),
             ));
         }
+
+        // clear
+        self.entity_actions_channel.clear();
+
         messages
     }
-
-    pub(crate) fn send_entity_update(&mut self, entity: Entity, _replicate: Replicate) -> bool {
-        // if we have already sent the Spawn Entity, don't do it again
-        if self.remote_entity_status.get(&entity).is_some() {
-            return false;
-        }
-        self.remote_entity_status
-            .insert(entity, EntityStatus::Spawning);
-        true
-    }
-
-    // /// Host has despawned an entity, and we want to replicate this to remote
-    // /// Returns true if we should send a message
-    // pub(crate) fn send_entity_despawn(&mut self, entity: Entity) -> bool {
-    //     // if we have already sent the Spawn Entity, don't do it again
-    //     if self.remote_entity_status.get(&entity).is_none() {
-    //         panic!("Cannot find spawned entity in host metadata!");
-    //         return false;
-    //     }
-    //     match self.remote_entity_status.get(&entity) {
-    //         Some(EntityStatus::Spawning(replicate)) | Some(EntityStatus::Spawned(replicate)) => {
-    //             return true;
-    //             panic!("Cannot despawn entity that is still spawning!");
-    //             return false;
-    //         }
-    //     }
-    //     if let Some(status) = self.remote_entity_status.get(&entity).unwrap() {}
-    //
-    //     self.remote_entity_status
-    //         .insert(entity, EntityStatus::Spawning(replicate));
-    //     true
-    // }
 
     /// Apply any replication messages to the world
     pub(crate) fn apply_world(
@@ -153,7 +239,7 @@ impl<P: Protocol> ReplicationManager<P> {
                     .iter()
                     .map(|c| c.into())
                     .collect::<Vec<P::ComponentKinds>>();
-                debug!(?entity, ?component_kinds, "Received spawn entity");
+                debug!(remote_entity = ?entity, ?component_kinds, "Received spawn entity");
 
                 // TODO: we only run spawn_entity if we don't already have an entity in the process of being spawned
                 //  so we need a data-structure to keep track of entities that are being spawned
@@ -180,21 +266,28 @@ impl<P: Protocol> ReplicationManager<P> {
                     world.despawn(local_entity);
                 }
             }
-            ReplicationMessage::InsertComponent(entity, component) => {
-                let kind: P::ComponentKinds = (&component).into();
-                debug!(?entity, ?kind, "Received InsertComponent");
+            ReplicationMessage::InsertComponent(entity, components) => {
+                let kinds = components
+                    .iter()
+                    .map(|c| c.into())
+                    .collect::<Vec<P::ComponentKinds>>();
+                debug!(remote_entity = ?entity, ?kinds, "Received InsertComponent");
                 // it's possible that we received InsertComponent before the entity actually exists.
                 // In that case, we need to spawn the entity first.
                 // TODO: this might not be what we want? imagine we receive a DespawnEntity or RemoveComponent right before that?
                 let mut local_entity_mut = self.entity_map.get_by_remote_or_spawn(world, entity);
                 // TODO: maybe check if the component already exists?
-                component.insert(&mut local_entity_mut);
+                for component in components {
+                    component.insert(&mut local_entity_mut);
+                }
             }
-            ReplicationMessage::RemoveComponent(entity, component_kind) => {
-                debug!(?entity, ?component_kind, "Received RemoveComponent");
+            ReplicationMessage::RemoveComponent(entity, component_kinds) => {
+                debug!(remote_entity = ?entity, kinds = ?component_kinds, "Received RemoveComponent");
                 if let Some(local_entity) = self.entity_map.get_local(entity) {
                     if let Some(mut entity_mut) = world.get_entity_mut(*local_entity) {
-                        component_kind.remove(&mut entity_mut);
+                        for kind in component_kinds {
+                            kind.remove(&mut entity_mut);
+                        }
                     } else {
                         debug!(
                             "Could not remove component because local entity {:?} was not found",
@@ -217,7 +310,7 @@ impl<P: Protocol> ReplicationManager<P> {
                 let mut local_entity_mut = self.entity_map.get_by_remote_or_spawn(world, entity);
                 // TODO: keep track of the components inserted?
                 for component in components {
-                    component.insert(&mut local_entity_mut);
+                    component.update(&mut local_entity_mut);
                 }
             }
         }

--- a/lightyear/src/shared/replication/mod.rs
+++ b/lightyear/src/shared/replication/mod.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::channel::builder::{Channel, EntityActionsChannel, EntityUpdatesChannel};
 use crate::netcode::ClientId;
-use crate::prelude::{EntityMap, MapEntities};
+use crate::prelude::{EntityMap, MapEntities, NetworkTarget};
 use crate::protocol::channel::ChannelKind;
 use crate::protocol::Protocol;
 use crate::shared::replication::components::Replicate;
@@ -72,15 +72,22 @@ pub trait ReplicationSend<P: Protocol>: Resource {
         entity: Entity,
         components: Vec<P::Components>,
         replicate: &Replicate,
+        target: NetworkTarget,
     ) -> Result<()>;
 
-    fn entity_despawn(&mut self, entity: Entity, replicate: &Replicate) -> Result<()>;
+    fn entity_despawn(
+        &mut self,
+        entity: Entity,
+        replicate: &Replicate,
+        target: NetworkTarget,
+    ) -> Result<()>;
 
     fn component_insert(
         &mut self,
         entity: Entity,
         component: P::Components,
         replicate: &Replicate,
+        target: NetworkTarget,
     ) -> Result<()>;
 
     fn component_remove(
@@ -88,6 +95,7 @@ pub trait ReplicationSend<P: Protocol>: Resource {
         entity: Entity,
         component_kind: P::ComponentKinds,
         replicate: &Replicate,
+        target: NetworkTarget,
     ) -> Result<()>;
 
     fn entity_update_single_component(
@@ -95,6 +103,7 @@ pub trait ReplicationSend<P: Protocol>: Resource {
         entity: Entity,
         component: P::Components,
         replicate: &Replicate,
+        target: NetworkTarget,
     ) -> Result<()>;
 
     fn entity_update(
@@ -102,6 +111,7 @@ pub trait ReplicationSend<P: Protocol>: Resource {
         entity: Entity,
         components: Vec<P::Components>,
         replicate: &Replicate,
+        target: NetworkTarget,
     ) -> Result<()>;
 
     /// Any operation that needs to happen before we can send the replication messages

--- a/lightyear/src/shared/replication/resources.rs
+++ b/lightyear/src/shared/replication/resources.rs
@@ -1,7 +1,9 @@
 //! Bevy [`bevy::prelude::Resource`]s used for replication
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
+use crate::netcode::ClientId;
 use crate::shared::replication::components::Replicate;
+use crate::shared::replication::room::RoomId;
 use bevy::ecs::component::ComponentId;
 use bevy::prelude::{Entity, FromWorld, Resource, World};
 
@@ -16,6 +18,7 @@ pub(crate) struct ReplicationData {
     /// Needed to know the value of the Replicate component after the entity gets despawned, to know how we replicate the EntityDespawn
     pub owned_entities: HashMap<Entity, Replicate>,
     // pub received_entities: HashMap<Entity, Replicate>,
+    // pub client_to_rooms: HashMap<ClientId, HashSet<RoomId>>,
 }
 
 impl FromWorld for ReplicationData {
@@ -23,6 +26,7 @@ impl FromWorld for ReplicationData {
         Self {
             // replication_id: world.init_component::<Replicate>(),
             owned_entities: HashMap::new(),
+            // client_to_rooms: HashMap::new(),
             // received_entities: HashMap::new(),
         }
     }

--- a/lightyear/src/shared/replication/resources.rs
+++ b/lightyear/src/shared/replication/resources.rs
@@ -3,7 +3,6 @@ use std::collections::{HashMap, HashSet};
 
 use crate::netcode::ClientId;
 use crate::shared::replication::components::Replicate;
-use crate::shared::replication::room::RoomId;
 use bevy::ecs::component::ComponentId;
 use bevy::prelude::{Entity, FromWorld, Resource, World};
 

--- a/lightyear/src/shared/replication/systems.rs
+++ b/lightyear/src/shared/replication/systems.rs
@@ -2,7 +2,7 @@
 use std::ops::Deref;
 
 use bevy::prelude::{
-    Added, App, Commands, Component, DetectChanges, Entity, EventReader, IntoSystemConfigs,
+    Added, App, Commands, Component, DetectChanges, Entity, EventReader, IntoSystemConfigs, Mut,
     PostUpdate, Query, Ref, RemovedComponents, ResMut,
 };
 use tracing::{debug, info};
@@ -11,6 +11,7 @@ use crate::netcode::ClientId;
 use crate::prelude::NetworkTarget;
 use crate::protocol::component::IntoKind;
 use crate::protocol::Protocol;
+use crate::server::room::ClientVisibility;
 use crate::shared::events::ConnectEvent;
 use crate::shared::replication::components::{DespawnTracker, Replicate};
 use crate::shared::replication::resources::ReplicationData;
@@ -22,8 +23,8 @@ use crate::shared::sets::ReplicationSet;
 
 // TODO: run these systems only if there is at least 1 remote connected!!!
 
-/// This system adds DespawnTracker to each entity that was every replicated, so that we can track
-/// when they are despawned
+/// This system adds DespawnTracker to each entity that was every replicated,
+/// so that we can track when they are despawned
 fn add_despawn_tracker(
     mut replication: ResMut<ReplicationData>,
     mut commands: Commands,
@@ -31,21 +32,42 @@ fn add_despawn_tracker(
 ) {
     for (entity, replicate) in query.iter() {
         commands.entity(entity).insert(DespawnTracker);
-        replication.owned_entities.insert(entity, *replicate);
+        replication.owned_entities.insert(entity, replicate.clone());
     }
 }
 
 fn send_entity_despawn<P: Protocol, R: ReplicationSend<P>>(
     mut replication: ResMut<ReplicationData>,
-    // query: Query<(Entity, Ref<Replicate>), RemovedComponents<>>
+    query: Query<(Entity, Ref<Replicate>)>,
     // TODO: ideally we want to send despawns for entities that still had REPLICATE at the time of despawn
     //  not just entities that had despawn tracker once
     mut despawn_removed: RemovedComponents<DespawnTracker>,
     mut sender: ResMut<R>,
 ) {
+    // Despawn entities for clients that lost visibility
+    query.iter().for_each(|(entity, replicate)| {
+        replicate
+            .replication_clients_cache
+            .iter()
+            .for_each(|(client_id, visibility)| {
+                if replicate.replication_target.should_send_to(client_id) {
+                    if matches!(visibility, ClientVisibility::Lost) {
+                        sender
+                            .entity_despawn(entity, &replicate, NetworkTarget::Only(*client_id))
+                            .unwrap();
+                    }
+                }
+            });
+    });
+    // Despawn entities when the entity got despawned on local world
     for entity in despawn_removed.read() {
         if let Some(replicate) = replication.owned_entities.remove(&entity) {
-            sender.entity_despawn(entity, &replicate).unwrap();
+            // TODO: maybe check the status of replicate.replication_clients_cache
+            //  and only despawn for the entities in the cache?
+            //  but that means we have to update the owned_entity value every time the replication_clients_cache is updated
+            sender
+                .entity_despawn(entity, &replicate, replicate.replication_target)
+                .unwrap();
         }
     }
 }
@@ -60,25 +82,40 @@ fn send_entity_spawn<P: Protocol, R: ReplicationSend<P>>(
 ) {
     // Replicate to already connected clients (replicate only new entities)
     query.iter().for_each(|(entity, replicate)| {
-        // we might want to replicate this entity to newly connected clients
-        // (we cannot use ConnectEvent, because events are reset every frame, but the Replication systems
-        //  might run less frequently than every frame)
-        for client_id in sender.new_remote_peers() {
-            if replicate.replication_target.should_send_to(&client_id) {
-                let mut replicate_copy = *replicate;
-                replicate_copy.replication_target = NetworkTarget::Only(client_id);
-                sender
-                    .entity_spawn(entity, vec![], &replicate_copy)
-                    .unwrap();
-            }
-        }
-        // try doing entity spawn whenever replicate gets added
-        if replicate.is_added() {
-            replication.owned_entities.insert(entity, *replicate);
-            sender
-                .entity_spawn(entity, vec![], replicate.deref())
-                .unwrap();
-        }
+        replicate
+            .replication_clients_cache
+            .iter()
+            .for_each(|(client_id, visibility)| {
+                if replicate.replication_target.should_send_to(client_id) {
+                    match visibility {
+                        ClientVisibility::Gained => {
+                            sender
+                                .entity_spawn(
+                                    entity,
+                                    vec![],
+                                    &replicate,
+                                    NetworkTarget::Only(*client_id),
+                                )
+                                .unwrap();
+                        }
+                        ClientVisibility::Lost => {}
+                        ClientVisibility::Maintained => {
+                            // only try to replicate if the replicate component was just added
+                            if replicate.is_added() {
+                                replication.owned_entities.insert(entity, replicate.clone());
+                                sender
+                                    .entity_spawn(
+                                        entity,
+                                        vec![],
+                                        replicate.deref(),
+                                        NetworkTarget::Only(*client_id),
+                                    )
+                                    .unwrap();
+                            }
+                        }
+                    }
+                }
+            });
     })
 }
 
@@ -92,31 +129,50 @@ fn send_component_update<C: Component + Clone, P: Protocol, R: ReplicationSend<P
     <P as Protocol>::Components: From<C>,
 {
     query.iter().for_each(|(entity, component, replicate)| {
-        for client_id in sender.new_remote_peers() {
-            // we might want to replicate this component to newly connected clients
-            // (we cannot use ConnectEvent, because events are reset every frame, but the Replication systems
-            //  might run less frequently than every frame)
-            if replicate.replication_target.should_send_to(&client_id) {
-                let mut replicate_copy = *replicate;
-                replicate_copy.replication_target = NetworkTarget::Only(client_id);
-                sender
-                    .component_insert(entity, component.clone().into(), &replicate_copy)
-                    .unwrap();
-            }
-        }
-        // send an component_insert for components that were newly added
-        if component.is_added() {
-            sender
-                .component_insert(entity, component.clone().into(), replicate)
-                .unwrap();
-        }
-        // only update components that were not newly added ?
-        if component.is_changed() && !component.is_added() {
-            sender
-                .entity_update_single_component(entity, component.clone().into(), replicate)
-                .unwrap();
-        }
-    })
+        replicate
+            .replication_clients_cache
+            .iter()
+            .for_each(|(client_id, visibility)| {
+                if replicate.replication_target.should_send_to(&client_id) {
+                    match visibility {
+                        ClientVisibility::Gained => {
+                            sender
+                                .component_insert(
+                                    entity,
+                                    component.clone().into(),
+                                    &replicate,
+                                    NetworkTarget::Only(*client_id),
+                                )
+                                .unwrap();
+                        }
+                        ClientVisibility::Lost => {}
+                        ClientVisibility::Maintained => {
+                            // send an component_insert for components that were newly added
+                            if component.is_added() {
+                                sender
+                                    .component_insert(
+                                        entity,
+                                        component.clone().into(),
+                                        &replicate,
+                                        NetworkTarget::Only(*client_id),
+                                    )
+                                    .unwrap();
+                            // only update components that were not newly added
+                            } else if component.is_changed() {
+                                sender
+                                    .entity_update_single_component(
+                                        entity,
+                                        component.clone().into(),
+                                        &replicate,
+                                        NetworkTarget::Only(*client_id),
+                                    )
+                                    .unwrap();
+                            }
+                        }
+                    }
+                }
+            })
+    });
 }
 
 /// This system sends updates for all components that were removed
@@ -130,9 +186,24 @@ fn send_component_removed<C: Component + Clone, P: Protocol, R: ReplicationSend<
 {
     removed.read().for_each(|entity| {
         if let Ok(replicate) = query.get(entity) {
-            sender
-                .component_remove(entity, C::into_kind(), replicate)
-                .unwrap()
+            replicate
+                .replication_clients_cache
+                .iter()
+                .for_each(|(client_id, visibility)| {
+                    if replicate.replication_target.should_send_to(&client_id) {
+                        // TODO: maybe send no matter the vis?
+                        if matches!(visibility, ClientVisibility::Maintained) {
+                            sender
+                                .component_remove(
+                                    entity,
+                                    C::into_kind(),
+                                    &replicate,
+                                    NetworkTarget::Only(*client_id),
+                                )
+                                .unwrap();
+                        }
+                    }
+                })
         }
     })
 }

--- a/lightyear/src/shared/sets.rs
+++ b/lightyear/src/shared/sets.rs
@@ -12,6 +12,9 @@ pub enum ReplicationSet {
     /// These systems only run once every send_interval
     SendEntityUpdates,
     SendComponentUpdates,
+
+    // SystemSet that encompasses all replication systems
+    All,
 }
 
 /// Main SystemSets used by lightyear to receive and send data

--- a/lightyear/src/tests/stepper.rs
+++ b/lightyear/src/tests/stepper.rs
@@ -130,16 +130,19 @@ impl BevyStepper {
         }
     }
 
-    pub fn client(&self) -> &Client<MyProtocol> {
+    pub(crate) fn client(&self) -> &Client<MyProtocol> {
         self.client_app.world.resource::<Client<MyProtocol>>()
     }
 
-    pub fn client_mut(&mut self) -> Mut<Client<MyProtocol>> {
+    pub(crate) fn client_mut(&mut self) -> Mut<Client<MyProtocol>> {
         self.client_app.world.resource_mut::<Client<MyProtocol>>()
     }
 
-    fn server(&self) -> &Server<MyProtocol> {
+    pub(crate) fn server(&self) -> &Server<MyProtocol> {
         self.server_app.world.resource::<Server<MyProtocol>>()
+    }
+    pub(crate) fn server_mut(&mut self) -> Mut<Server<MyProtocol>> {
+        self.server_app.world.resource_mut::<Server<MyProtocol>>()
     }
 }
 

--- a/vendor/bitcode/src/buffer.rs
+++ b/vendor/bitcode/src/buffer.rs
@@ -65,7 +65,9 @@ pub trait BufferTrait: Default {
     /// Returns the written bytes.
     fn finish_write(&mut self, writer: Self::Writer) -> &[u8];
 
-    fn start_read<'a, 'b>(&'a mut self, bytes: &'b [u8]) -> (Self::Reader<'a>, Self::Context) where 'a: 'b;
+    fn start_read<'a, 'b>(&'a mut self, bytes: &'b [u8]) -> (Self::Reader<'a>, Self::Context)
+    where
+        'a: 'b;
     /// Check for errors such as Eof and ExpectedEof
     fn finish_read(reader: Self::Reader<'_>, context: Self::Context) -> Result<()>;
     /// Overrides decoding errors with Eof since the reader might allow reading slightly past the

--- a/vendor/bitcode/src/word_buffer.rs
+++ b/vendor/bitcode/src/word_buffer.rs
@@ -121,7 +121,10 @@ impl BufferTrait for WordBuffer {
         &bytemuck::cast_slice(written_words)[..written_bytes]
     }
 
-    fn start_read<'a, 'b>(&'a mut self, bytes: &'b [u8]) -> (Self::Reader<'a>, Self::Context) where 'a: 'b {
+    fn start_read<'a, 'b>(&'a mut self, bytes: &'b [u8]) -> (Self::Reader<'a>, Self::Context)
+    where
+        'a: 'b,
+    {
         let words = self.allocation.make_vec();
         words.clear();
 


### PR DESCRIPTION


# Added

- Interest management with the concept of Rooms. Entities are replicated to clients only if they are in the same room.
- Example for interest_management
- The `ReliableSettings` now have an option `rtt_resend_min_delay` which is the minimum duration to wait before re-sending a message that hasn't been ack-ed yet
- Added metrics for sending/receiving messages

# Fixed

- the estimated RTT is now passed correctly to the `ReliableSender` channel
- do not run the `BufferInpu`t systems on the client during rollback
- For a given entity, all ComponentInserts, ComponentRemoves, EntityUpdates will be sent as a single message (so they will be in the same packet)
- The MTU is computed correctly by taking into account that the packet header is now 11 bytes because we include the `Tick`

# Updated

- the `InterpolationDelay` is now the maximum between the `interp_ratio` and `interp_delay`
- Simplified the plumbing logic for sending replication messages
- Distinguish between `component_insert` that only inserts the component if it's not already there, and `component_update` which always updates the component


# Future bug fixes
- Make prediction work even if if the world state for tick T gets split between multiple packets that don't arrive at the correct time
- Make prediction work even if the frame_rate is faster than the fixed_update schedule
- Make entity_mapping work correctly for Entity that are inside component (should wait for the mapped entity to be present)
- Make interpolation smoother at the beginning 

