### PR TITLE
Fix the bug with the interpolation start

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -17,7 +17,7 @@ PROBLEMS/BUGS:
   - also it seems like our frames are smaller than our fixed update. This could cause issues?
   - CONFIRMATION:
     - the problem is indeed that we receive a ping for tick 20, but the world state for tick 20 is only received after
-      so the rollback thinks there is a problem
+      so the rollback thinks there is a problem (mismatch at tick 20 + rolls-back to a faulty state 20)
     - it was more prevalent with send_interval = 0 because the frame_duration was lower than tick_duration. So sometimes
       we would have: frame1/tick20: send updates. frame2/tick20: send ping. And the ping would arrive before.
     - BASICALLY, when we receive a packet for tick 10, we think the whole word is replicated at tick 10, but that's not the case.
@@ -39,17 +39,20 @@ PROBLEMS/BUGS:
     - it's probably because the spawn message (from joining a room) arrives after the despawn message
 
 
-
 - interpolation has some lag at the beginning, it looks like the entity isn't moving. Probably because we only got an end but no start?
   - is it because the start history got deleted? or we should interpolate from current to end?
-  - 
+  - the problem is that we get regular update roughly every send_interval when the entity is moving. But when it's not the delay between start and end becomes bigger.
+  - when we have start = X, end = None, we should keep pushing start forward at roughly send-interval rate?
+   
+- interpolation
+  - how come the interpolation_tick is not behind the latest_server_tick, even after setting the interpolation_delay to 50ms?
+    (server update is 80ms)
+    normally it should be fine because we already make sure that interpolation time is behind the latest_server_tick...
+    need to look into that.
+
 - interpolation is very unsmooth when the server update is small.  
    - SOLVED: That's because we used interpolation delay = ratio, and the send_interval was 0.0
    - we need a setting that is ratio with min-delay
-
-- prediction/interpolation are sometimes not spawning anymore. This must be a ordering issue
-  - maybe because the Predicted/Interpolated component are only added if client/entity are in the same room
-  - or because we only run entity_spawn for the given NetworkTarget, but those are 
 
 
 ADD TESTS FOR TRICKY SCENARIOS:

--- a/examples/interest_management/client.rs
+++ b/examples/interest_management/client.rs
@@ -29,7 +29,7 @@ impl Plugin for MyClientPlugin {
         let client_addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), self.client_port);
         let link_conditioner = LinkConditionerConfig {
             incoming_latency: Duration::from_millis(100),
-            incoming_jitter: Duration::from_millis(20),
+            incoming_jitter: Duration::from_millis(5),
             incoming_loss: 0.00,
         };
         let transport = match self.transport {
@@ -51,7 +51,9 @@ impl Plugin for MyClientPlugin {
             prediction: PredictionConfig::default(),
             // we are sending updates every frame (60fps), let's add a delay of 6 network-ticks
             interpolation: InterpolationConfig::default().with_delay(
-                InterpolationDelay::default().with_min_delay(Duration::from_millis(150)),
+                InterpolationDelay::default()
+                    .with_min_delay(Duration::from_millis(50))
+                    .with_send_interval_ratio(2.0),
             ),
             // .with_delay(InterpolationDelay::Ratio(2.0)),
         };
@@ -178,11 +180,11 @@ pub(crate) fn log(
 ) {
     let server_tick = client.latest_received_server_tick();
     for confirmed_pos in confirmed.iter() {
-        info!(?server_tick, "Confirmed position: {:?}", confirmed_pos);
+        debug!(?server_tick, "Confirmed position: {:?}", confirmed_pos);
     }
     let client_tick = client.tick();
     for predicted_pos in predicted.iter() {
-        info!(?client_tick, "Predicted position: {:?}", predicted_pos);
+        debug!(?client_tick, "Predicted position: {:?}", predicted_pos);
     }
     for event in interp_event.read() {
         info!("Interpolated event: {:?}", event.entity());

--- a/examples/interest_management/server.rs
+++ b/examples/interest_management/server.rs
@@ -29,7 +29,7 @@ impl Plugin for MyServerPlugin {
             .with_key(KEY);
         let link_conditioner = LinkConditionerConfig {
             incoming_latency: Duration::from_millis(100),
-            incoming_jitter: Duration::from_millis(20),
+            incoming_jitter: Duration::from_millis(5),
             incoming_loss: 0.00,
         };
         let transport = match self.transport {

--- a/examples/interest_management/shared.rs
+++ b/examples/interest_management/shared.rs
@@ -12,14 +12,14 @@ pub fn shared_config() -> SharedConfig {
         enable_replication: true,
         client_send_interval: Duration::default(),
         // server_send_interval: Duration::default(),
-        server_send_interval: Duration::from_millis(80),
+        server_send_interval: Duration::from_millis(30),
         tick: TickConfig {
             // right now, we NEED the tick_duration to be smaller than the frame_duration
             // (otherwise we can send multiple packets for the same tick at different frames)
             tick_duration: Duration::from_secs_f64(1.0 / 64.0),
         },
         log: LogConfig {
-            level: Level::WARN,
+            level: Level::INFO,
             filter: "wgpu=error,wgpu_hal=error,naga=warn,bevy_app=info,bevy_render=warn,quinn=warn"
                 .to_string(),
         },

--- a/lightyear/src/client/interpolation/plugin.rs
+++ b/lightyear/src/client/interpolation/plugin.rs
@@ -53,6 +53,7 @@ impl InterpolationDelay {
 
     /// How much behind the latest server update we want the interpolation time to be
     pub(crate) fn to_duration(&self, server_send_interval: Duration) -> Duration {
+        // TODO: deal with server_send_interval = 0 (set to frame rate)
         let ratio_value = server_send_interval.mul_f32(self.send_interval_ratio);
         std::cmp::max(ratio_value, self.min_delay)
     }

--- a/lightyear/src/client/sync.rs
+++ b/lightyear/src/client/sync.rs
@@ -238,7 +238,7 @@ impl SyncManager {
     ) -> WrappedTime {
         // We want the interpolation time to be just a little bit behind the latest server time
         // We add `duration_since_latest_received_server_tick` because we receive them intermittently
-        // TODO: maybe integrate?
+        // TODO: maybe integrate because of jitter?
         let objective_time = WrappedTime::from_duration(
             self.latest_received_server_tick.0 as u32 * tick_manager.config.tick_duration
                 + self.duration_since_latest_received_server_tick,
@@ -248,6 +248,7 @@ impl SyncManager {
         let objective_delta =
             chrono::Duration::from_std(interpolation_delay.to_duration(server_send_interval))
                 .unwrap();
+        // info!("objective_delta: {:?}", objective_delta);
         objective_time - objective_delta
     }
 


### PR DESCRIPTION
# Fixed

- Fixed an issue with the start of interpolation. Anytime we started moving the player, the interpolation would start moving a bit slowly at the beginning. That's because the start tick is really old (last time we received an update for that component) and the end tick is very far. What we do is created a new fake 'confirmed history' tick at roughly `end_tick - send_interval_in_ticks` so that the interpolation is still done over roughly send_interval



## TODO

However there are new issues uncovered with this PR:
- `interpolation_tick` seems to be not correct at the beginning, and is even bigger than `last_received_server_tick`! I think there's an issue with how syncing is done at the beginning
- client side prediction has a huge delay at the beginning, probably a similar issue where the `prediction_time` seems to be set too far in advance? Problem in sync
---> all this seems to happen when i spawn both clients at the same time! If i spawn client 1 first, and then client 2 later, everything works fine.
---> as time passes, the objective time/prediction time are correcting themselves via speedup/speeddown, but it's weird how the initial time can be very bad.