### PR TITLE
Release 0.3.0

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -5,6 +5,16 @@
   - one server: 1 game room per core?
 
 
+- DEBUGGING SIMPLE_BOX:
+  - inputs aren't propagated.
+  - we don't receive any update acks either.
+  - need to add replication-specific tests. Also step-style tests.
+
+  - Right now, we are sending some updates at the beginning at the same time of inserts, even though nothing changes since the insert.
+    - need to make sure we send updates since the most recent of 'last_ack_updates' or 'last_sent_actions'
+  - THE PROBLEM IS EITHER IN READ_BUFFERED_UPDATES OR APPLY_WORLD!
+
+
 - FINAL CHOICE:
   - send all actions per group on an reliable unordered channel
     - ordering is done per group, with a sequenced id (1,2,3)

--- a/NOTES.md
+++ b/NOTES.md
@@ -135,6 +135,23 @@ ReplicationManager:
   - when we receive a server update for tick T, don't apply server updates immediately, but buffer them wait for k * packet_loss + k' * jitter.
     - then we consider that we got the entire consistent world state for tick T, and apply everything. 
 
+
+
+ACK SYSTEM: 
+- we can receive an ack for a given packet, but systems can't be notified right now if a single given message they sent got received
+- 2 problems: can't track acks for unreliable-sender [A], and can't notify other systems [B]
+- [A]:
+  - create an unordered unreliable sender with ACKs management.
+  - includes message-ids, message-acks
+- [B]:
+  - calling BufferSend returns Option<MessageId> with the id we want to track
+  - add a function Channel::follow_acks() -> Receiver<MessageId> that tells us that the message was received.
+- SEND message (with notif) -> create a custom id for the notif (re-use message-id for sequenced/reliable senders)
+- then store the info in packet-to-message-ack. Maybe MessageAck contains ack-id instead of message-id; or store in dedicated AckId.
+- we update packet-to-message-acks if: channel is reliable (message-id is set)
+- when we receive, we remove the bundle of message-acks from packet-to-message-ack for the packet we just got
+- for each message-ack, we send a 'ACK' via a crossbeam channel?
+
 NEW REPLICATION APPROACH:
 - priority:
   - accumulate priority score per entity (or group)

--- a/NOTES.md
+++ b/NOTES.md
@@ -8,6 +8,8 @@
 - DEBUGGING SIMPLE_BOX:
   - If jitter is too big, or there is packet loss? it looks like inputs keep getting sent to client 1.
     - the cube goes all the way to the left and exits the screen. There is continuous rollback fails
+  - on interest management, we still have this problem where interpolation is stuck at the beginning and doesn't move. Probably 
+    because start tick or end tick are not updated correctly in some edge cases.
   
   
 

--- a/NOTES.md
+++ b/NOTES.md
@@ -4,15 +4,221 @@
   - use local executors for async, and use one process/thread per core instead of doing multi-threading (more complicated and less performant
   - one server: 1 game room per core?
 
+
+- FINAL CHOICE:
+  - send all actions per group on an reliable unordered channel
+    - ordering is done per group, with a sequenced id (1,2,3)
+    - thus we cannot receive a despawn before a spawn, or a component removal before a component insert
+    - actions are still buffered in advance, so that whenever the latest arrives we apply all of them
+  - send all updates per group on an unreliable unordered channel
+    - sequencing is done per group
+    - updates only modify components, do not create them
+    - we do not send an update for a component that has an insert
+    - we apply updates immediately for components that exist, and we buffer updates for components/entities that don't exist (this means not in a component)
+      - this means that some components (at insert time), can be stuck behind other components; but it's quickly fixed afterwards. All update components are always on the same tick
+    - prediction:
+      - we store the component history, along with the correct ticks, on the confirmed entity
+      - we check rollback on each action or each update for each entity predicted. We rollback on the oldest rollback tick across all predicted entities.
+        we restore each predicted entity to their latest update tick.
+      - simpler: put all predicted entities in the same group so they have the same tick
+      - even simpler: send all updates+actions for predicted entities in the same packet, so updates AND components are all on the same tick.
+    - interpolation:
+      - we store the component history, along with the correct ticks, on the confirmed entity
+  - groups:
+    - by default, entities are in their own group GroupId = Entity
+    - can specify a group for an entity, and then all entities in that group are in the same group and have their actions / updates sent together
+      - useful for hierarchical entities (parent/children)
+      - need to make sure parents are sent first in groups I think ? for entity mapping
+  - events:
+    - for actions: send an event for each action
+    - for updates: send an event for each component update received (buffer)? or applied? applied would be in order, which be better
+
+ReplicationManager:
+- ActionsManager:
+  - for each group, maintain a sequence id for the ordering, and a buffer of actions that are more recent than the sequence_id we are waiting for (waiting-actions)
+  - an ActionMessage is GroupId + SequenceId + HashMap<Entity, Spawn or Despawn, Vec<ComponentInserts>, Vec<ComponentRemoves>>
+- UpdatesManager:
+  - can just use the packet tick for sequencing
+  - Maintain a buffer of updates for components/entities that don't exist (waiting-updates), or components that refer to entities that don't exist?
+  - an UpdateMessage is GroupId + HashMap<Entity, Vec<ComponentUpdates>>
+  - ORDER:
+    - recv ReplicationMessage
+    - buffer actions
+    - read all actions until we get None.
+    - apply actions to world
+    - flush?
+    - read updates. if updates tick is < latest_actions_tick; discard
+    - if updates_tick >= latest_actions_tick; apply updates
+    - for components that exist (we know them just by checking the world), just apply updates
+    - for components that don't exist, buffer updates so that we can apply them as soon as component is created.
+- GroupsManager: groups can be tracked as part of Replicate component
+- Priority: accumulator for each group? 
+- Prediction/Interpolation:
+  - probably update component history and check for prediction based on events.
+
+      
+
+
+- in any case, i can't keep using sequenced reliable/unreliable if i send one message per entity (because then getting packet P2 would prevent me from reading packet P1)
+
+- Several options:
+  - one big packet containing ALL actions+updates, in a reliable sequenced channel
+    - world is always consistent
+  - one big packet containing ALL actions+updates, in a reliable sequenced channel. If no actions, use unreliable sequenced channel.
+  - one packet per group actions+updates, in an reliable unordered channel. And we keep track of received tick per group to do sequencing.
+    - con: we don't need to retry reliable for the entity updates? but maybe we do if we insist on a consistent state
+    - pros: if all the predicted entities are in the same group, no need to use confirmed history for prediction?
+  - one reliable unordered packet for group actions, one unreliable unordered packet for group updates
+    - apply sequencing manually via a group action tick and group update tick
+    - update tick could be ahead of action tick
+      (action13: C1 spawn, C3 remove, update14: C1 update, C2 update, C3 update. (C2 already exists) We receive update14 first.
+      - option 1: We apply it for all components that exist and set update tick to 14? but then it's not consistent for the components that don't exist)
+        C2 is updated to tick 14. When we receive action13, we apply it for C1, and apply the buffered update for C1 so we bring it 14 immediately
+        (so that all update ticks are consistent, important for interpolation/prediction)
+        -> we still know for each component at which tick we are, but we could be at a state never reached by the server
+      - option 2: we apply it for all components, spawning those that don't exist.
+        C2 is updated to tick 14, C1 is spawned and set to tick 14.
+        -> problem, could get some inconsistency in the entity's archetype. When we receive action13, we don't apply it for C1 (since it exists)
+      - option 3: we buffer updates-14, and only apply it when we get action 13 (which could be empty)
+        -> in the updates-message, we include the latest action tick for that entity that we send (13).
+        -> when we receive updates-14, if we have already received actions-13, then we can apply the updates immediately. If we haven't, we know we need to buffer
+        -> it just means we are as slow as the archetype, but that's ok
+        -> also if we receive action-13 but update-13 gets lost then it's ok, because they are for different components
+           - for each component we still know at which tick we are (important for interpolation/prediction)
+        -> so basically we are as far as the latest actions received
+    - actions are applied in order. (if we receive actions 14, we buffer them and wait for actions 13.) 
+      How do we make sure of that? For every group, the actions are sent with an id that is incremented in order (1,2,3,4,etc.)
+      We wait until we receive the one from the previous id before applying the actions.
+      Basically re-implement ordered channel, but manually for this entity/group.
+      
+    - con: we don't need to retry reliable for the entity updates? but maybe we do if we insist on a consistent state
+  - when we receive a server update for tick T, don't apply server updates immediately, but buffer them wait for k * packet_loss + k' * jitter.
+    - then we consider that we got the entire consistent world state for tick T, and apply everything. 
+
+NEW REPLICATION APPROACH:
+- priority:
+  - accumulate priority score per entity (or group)
+- replication:
+  - maybe send the entire actions+updates as one sequenced reliable message?
+  - or, if there are no actions this tick, send as sequenced unreliable?
+- rooms:
+  - this was done to limit the size of messages, but paradoxically it might increase the size if the entity doesn't get updated a lot
+  - for example, if it's just some background entity, it's better to send them all once, instead of constantly sending them and despawning them
+  - for a mmorpg with fixed instances/rooms; is there need to despawn? maybe better if client just despawns anything in the room, and server just stops replicating stuff outside the main room (without despawning though)
+- entity actions are sent as a single message, so that the archetype world state is always consistent
+  - or do that only within groups! (so entities in a given group are always consistent)
+  - groups could use priority with accumulation to do throttling.
+- updates are sent as one group of update per entity.
+- for an entity, we can track:
+  - it's actions-tick (tick at which the server entity actions were sent)
+  - it's updates-tick (tick at which the server entity updates were sent)
+
+
+
+Some scenarios:
+- we send E-spawn on tick 13, E-despawn on tick 14. E-despawn arrives first.
+  - then we update our internal state to have E: action-tick = 14, so we ignore the tick-13 spawn -> GOOD
+  - TODO: this means we need to keep track of the action-tick/updates-tick OUTSIDE of a component, since we need to update it even if the component does not exist
+  - we keep track of an entity's replication state for at least time to handle de-sync like this:
+    - k * send_interval + k' * jitter (k' = 3 for 99% jitter, k = 2 to handle 1 packet lost)
+- we send C-insert on tick 13, C-remove on tick 14, C-insert on tick 15. We receive 14, 15, 13.
+  - we update our internal state to have C: remove-tick = 14, so we ignore the tick-13 insert -> GOOD
+  - we update our internal state to have C: updates-tick = 15, so we add the component -> GOOD
+- we send C-insert on tick 13, C-update on tick 14. We receive 14, 13
+  - TODO: don't send insert and update on the same tick, only send insert!
+  - EITHER:
+    - we spawn C with value of 14. And then we can ignore insert. But then the world state in terms of archetypes could again be incorrect?
+    - we buffer C as a pending update. Then later when we receive 13, we spawn C with value of 13, and immediately apply the update
+      Action tick = 13, update tick = 14.
+      TODO: need a buffer of component updates along with their tick.
+      - we might need it either way for prediction/interpolation
+    
+- Update interpolation history:
+  - stop using latest_recv_server_tick to put stuff in the history, instead use the entity's update-tick
+- Prediction
+  - let's say that all the entities that are predicted at the same time are in the same group. Then their world is consistent
+  - we know they all receive an update at the same tick (entity update tick)
+  - so whenever we receive a new server packet for any entities in the group, we know that all the entities are consistently on tick T
+  - we check if need to rollback for tick T
+  - if yes, we rollback from tick T, which is easy (no need to have confirmed histories)
+   
+
 PROBLEMS/BUGS:
+- Big problem with sequencing. Right now we use a single channel for all entity updates.
+  - but imagine we send [A1, B2, C3] in packet 1, and [B4] in packet 2 (the numbers are the message ids, incremented in the SequencedSender)
+  - then we receive [B4] before the other packet. That means that because of sequencing we ignore [A1, B2, C3].
+  - ignoring B2 is good because we received a more recent update for B, but we should not ignore A1 and C3.
+  - that means we should have separate sequencing guarantees for each entity/component?
+  - in our case, remember that all updates for one entity are in the same message. But we could have B be the updates for entity B and A for entity A.
+    then we would completely not receive the updates for entity A.
+  - Instead we can:
+    - use unordered unreliable channel
+    - keep track of the latest tick received per entity update
+  - REMEMBER THAT THOSE PROBLEMS ARISE ONLY IF WE HAVE MULTIPLE PACKETS, MIGHT BE REALLY RATE?
+    - can happen if lots of replication stuff to send
+
+
+- Other sequencing problem:
+  - let's say that we send [E-A-update] in packet 1, [E-A-removal] in packet 2 and packet 2 arrives before packet 1
+    - can only happen if jitter is big compared with send_interval
+    - within a single frame, we won't send both an update and a removal for the same entity/component
+  - then removal of component A for entity E gets applied, but then we receive update, which re-inserts the entity!
+  - TODO: Maybe updates should just update the entity and not re-insert it!
+
+- TLDR: Basically lots of bugs if jitter is big compared with send_interval! 
+  (i.e. if some packets)
+  
+
+
+
 - more rollbacks than expected (Especially with rooms). Let's check what happens with 0 jitter -> there should be 0 rollback no?
   - is it because we are sending too much data to the client? (a lot of entity spawn/despawn)
   - is it because the ticks are not in sync?
   - with 0 jitter, the problem completely disappears, prediction becomes butter smooth
   - with higher send_interval, the prediction becomes extremely jittery!!!
   - It could be something like:
-    - we are sending the player position update for a tick T1 in a packet
-      is only received after. So at tick 20, we think we have the world state for tick 20, but we don't. We don't even have the world state for tick 18.
+    - we are sending the player position update for a tick 18 in a packet
+      is only received after. So if we first receive a PING for tick 20, we think we have the world state for tick 20, but we don't. We don't even have the world state for tick 18 for that one entity.
+    - worst part is that we do a wrong rollback for at tick! We do a rollback for tick 20, but then we don't do it when we later receive the update for tick 18, because it's not a latest_recv_server_tick
+
+  - this is exacerbated for entity actions because they are sent on a reliable channel.
+    the packet tick may say tick 300, but the entity insert was actually done only at tick 290. (because of packet loss, the message is sent again on a different packet)
+    Should entity actions include the tick at which they were actually inserted?
+    Actually this is for any replication message that is sent on a reliable channel.
+
+  - SOL 1:
+    - keep checkinf for rollback only when we receive a new latest_received_server_tick.
+    - when receive a packet at tick T and we have last_received_server_tick = T, we know that we should do a rollback check after 2 * k * jitter has elapsed (jitter could be in both directions).
+      because at this time all the packets for tick T have been received. At that time, the confirmed state is for tick T.
+      This might not work if the server send_interval is small compared to jitter.
+      Thus we only start checking for rollback at (server_latest_recv_time + 2 * k * jitter) (and that's what we should do anyway,
+      because only then do we know that we have a full world state)
+    - PROS: more elegant?
+    - CONS: 
+      - seems to not work well if send_interval is very small, because the server state at server_ltaest_recv_time + 2 * k * jitter won't be the server state for tick T
+        but for a tick T + x, as we we will have received other updates
+ 
+ 
+  - SOL 2:
+    - when we receive an update for an entity, keep track of the server_tick for that update and add it to a ConfirmedHistory for that tick.
+      - maybe keep track of the tick for each component?
+      - maybe keep track of the tick for updates / removes / inserts?
+      - maybe keep track of the tick for the entity?
+    - then we do a rollback check for that entity. If there is mismatch, we need to do a rollback for at least tick T (tick of the packet that contained the entity update)
+    - we do this across all entities for which we receive an update, and we compute that the earliest rollback we need to do. (earliest tick across all entities) T*
+    - we can do the rollback because:
+      - we have the history of all confirmed components since T*
+        - we need to keep histories for at most 2*k*jitter + packet-loss ?
+      - we have client inputs since T* (we cannot do the rollback if we don't have client inputs since T*)
+    - note that we have a similar problem for interpolation:
+      - we could send C1 at tick 18, C2 at tick 20. (happens if we send updates quickly)
+      - but C2 is received first because of jitter, so latest_recv_server_tick is set to 20.
+      - we then add C2 in history with tick 20 because it changes.
+      - we receive C1 later, we add C1 in history for tick 20 (which is incorrect because it should be for tick 18)
+      - in general, knowing the exact tick of the update is valuable
+
+
+
 
   - also it seems like our frames are smaller than our fixed update. This could cause issues?
   - CONFIRMATION:
@@ -53,6 +259,8 @@ PROBLEMS/BUGS:
 - interpolation is very unsmooth when the server update is small.  
    - SOLVED: That's because we used interpolation delay = ratio, and the send_interval was 0.0
    - we need a setting that is ratio with min-delay
+
+- map entities is not working
 
 
 ADD TESTS FOR TRICKY SCENARIOS:

--- a/NOTES.md
+++ b/NOTES.md
@@ -6,13 +6,16 @@
 
 
 - DEBUGGING SIMPLE_BOX:
-  - inputs aren't propagated.
-  - we don't receive any update acks either.
-  - need to add replication-specific tests. Also step-style tests.
+  - If jitter is too big, or there is packet loss? it looks like inputs keep getting sent to client 1.
+    - the cube goes all the way to the left and exits the screen. There is continuous rollback fails
+  
+  
 
-  - Right now, we are sending some updates at the beginning at the same time of inserts, even though nothing changes since the insert.
-    - need to make sure we send updates since the most recent of 'last_ack_updates' or 'last_sent_actions'
-  - THE PROBLEM IS EITHER IN READ_BUFFERED_UPDATES OR APPLY_WORLD!
+- TODO:
+  - implement Message for common bevy transforms
+  - maybe have a ClientReplicate component to transfer all the replication data that is useful to clients? (group, prediciton, interpolation, etc.)
+
+   
 
 
 - FINAL CHOICE:

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -28,6 +28,7 @@
     - [Server](./concepts/bevy_integration/server.md)
     - [Events](./concepts/bevy_integration/events.md)
   - [Advanced Replication](./concepts/advanced_replication/title.md)
+    - [Replication Logic](./concepts/advanced_replication/replication_logic.md)
     - [Inputs](./concepts/advanced_replication/inputs.md)
     - [Interpolation](./boncepts/advanced_replication/interpolation.md)
     - [Prediction](./concepts/advanced_replication/prediction.md)

--- a/book/src/concepts/advanced_replication/replication_logic.md
+++ b/book/src/concepts/advanced_replication/replication_logic.md
@@ -1,0 +1,78 @@
+# Replication Logic
+
+This page explains how replication works and what guarantees can be made.
+
+Replication makes a distinction between:
+- Entity Actions (entity spawn/despawn, component insert/remove): these events change the archetype of an entity
+- Entity Updates (component update): these events don't change the archetype of an entity but simply update the value of some components. 
+    Most (90%+) replication messages should be Entity Updates.
+
+Those two are handled differently by the replication system.
+
+## Invariants
+
+There are certain invariants/guarantees that we wish to maintain with replication.
+
+
+Rule #1: we would like a replicated entity to be in a consistent state compared to what it was on the server: at no point do we want a situation where
+a given component is on tick T1 but another component of the same entity is on tick T2. Similarly, we would not want one component of an entity to be inserted
+later than other components. This could be disastrous because some other system could depend on both components being present together!
+
+Rule #2: we want to be able to extend this guarantee to multiple entities.
+I will give two relevant examples:
+- client prediction: for client-prediction, we want to rollback if a receives server-state doesn't match with the predicted history.
+    If we are running client-prediction for multiple entities that are not in the same tick, we could have situations where we need to rollback one entity starting from tick T1
+    and another entity starting from tick T2. This can be fairly hard to achieve, so we'd like to have all predicted entities be on the same tick.
+- hierarchies: some entities have relationships. For example you could have an entity with a component Head, and an entity Body with a component `HasParent(Entity)`
+  which points to the Head entity. If we want to replicate this hierarchy, we need to make sure that the Head entity is replicated before the Body entity.
+  (otherwise the `Entity` pointed to in `HasParent` would be invalid on the client). Therefore we need to make sure that all updates for both the parent and the head
+  are in sync.
+
+
+The only way to guarantee that these rules are respected is to send all the updates for a given "replication group" as a single message.
+(if we send multiple messages, they could be added to multiple packets, and therefore arrive in a different time/order on the client because of jitter and packet loss)
+
+Lightyear introduces the concept of a [`ReplicationGroup`] which is a group of entity whose `EntityActions` and `EntityUpdates` will be sent 
+over the network as a single message.
+It is **guaranteed** that the state of all entities in a given `ReplicationGroup` will be consistent on the client, i.e.
+will be equivalent to the state of the group on the server at a given previous tick T.
+
+
+
+## Entity Actions
+
+For each [`ReplicationGroup`], Entity Actions are replicated in an `OrderedReliable` manner:
+- we apply each action message *in order*
+
+### Send
+
+Whenever there are any actions for a given [`ReplicationGroup`], we send them as a single message AND we include any updates for this group as well.
+This is to guarantee consistency; if we sent them as 2 separate messages, the packet containing the updates could get lost and we would be in an inconsistent state.
+
+## Entity Updates
+
+### Send
+
+We gather all updates since the most recent of:
+- last time we sent some EntityActions for the Replication Group
+- last time we got an ACK from the client that the EntityUpdates was received
+
+The reason for this is:
+- we could be gathering all the component changes since the last time we sent EntityActions, but then it could be wasteful if the last time we had any entity actions was a long time ago 
+  and many components got updated since
+- we could be gathering all the component changes since the last time we sent a message, but then we could have a situation where:
+  - we send changes for C1 on tick 1
+  - we send changes for C2 on tick 2
+  - packet for C1 gets lost, and we apply the C2 changes -> the entity is now in an inconsistent state at C2
+
+
+### Receive
+
+
+For each [`ReplicationGroup`], Entity Updates are replicated in a `SequencedUnreliable` manner.
+We have some additional constraints:
+- we only apply EntityUpdates if we have already applied all the EntityActions for the given [`ReplicationGroup`] that were sent when the Updates were sent.
+  - for example we send A1, U2, A3, U4; we receive U4 first, but we only apply it if we have applied A3, as those are the latest EntityActions sent when U4 was sent
+- if we received a more rencet updates that can be applied, we discard the older one (Sequencing)
+  - for example if we send A1, U2, U3 and we receive A1 then U3, we discard U2 because it is older than U3
+    

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -22,10 +22,6 @@ name = "simple_box"
 path = "simple_box/main.rs"
 
 [[example]]
-name = "connection_soak"
-path = "connection_soak.rs"
-
-[[example]]
 name = "bevy_headless"
 path = "bevy_headless.rs"
 

--- a/examples/bevy_headless.rs
+++ b/examples/bevy_headless.rs
@@ -9,7 +9,7 @@ use tracing_subscriber::fmt::format::FmtSpan;
 use lightyear::netcode::generate_key;
 use lightyear::prelude::client::{Authentication, Client};
 use lightyear::prelude::*;
-use lightyear_examples::protocol::{Channel2, MyProtocol};
+use lightyear_examples::protocol::MyProtocol;
 
 fn client_init(mut client: ResMut<Client<MyProtocol>>) {
     info!("Connecting to server");
@@ -19,7 +19,6 @@ fn client_init(mut client: ResMut<Client<MyProtocol>>) {
 fn server_init(mut commands: Commands) {
     info!("Spawning entity on server");
     commands.spawn(Replicate {
-        updates_channel: ChannelKind::of::<Channel2>(),
         ..Default::default()
     });
 }

--- a/examples/bevy_simple.rs
+++ b/examples/bevy_simple.rs
@@ -11,7 +11,7 @@ use tracing_subscriber::fmt::format::FmtSpan;
 use lightyear::netcode::generate_key;
 use lightyear::prelude::client::{Authentication, Client};
 use lightyear::prelude::*;
-use lightyear_examples::protocol::{Channel2, MyProtocol};
+use lightyear_examples::protocol::MyProtocol;
 
 fn client_init(mut client: ResMut<Client<MyProtocol>>) {
     info!("Connecting to server");
@@ -21,7 +21,6 @@ fn client_init(mut client: ResMut<Client<MyProtocol>>) {
 fn server_init(mut commands: Commands) {
     info!("Spawning entity on server");
     commands.spawn(Replicate {
-        updates_channel: ChannelKind::of::<Channel2>(),
         ..Default::default()
     });
 }

--- a/examples/connection_soak.rs
+++ b/examples/connection_soak.rs
@@ -1,3 +1,4 @@
+use bevy::ecs::component::Tick as BevyTick;
 use bevy::prelude::World;
 use std::net::SocketAddr;
 use std::str::FromStr;
@@ -90,7 +91,7 @@ fn main() -> anyhow::Result<()> {
         let mut rng = rand::thread_rng();
         loop {
             server.update(start.elapsed())?;
-            server.recv_packets()?;
+            server.recv_packets(BevyTick::new(0))?;
             server.send_packets()?;
             server.receive(&mut world);
 

--- a/examples/input_buffer_step.rs
+++ b/examples/input_buffer_step.rs
@@ -33,7 +33,6 @@ fn client_init(mut client: ResMut<Client<MyProtocol>>) {
 fn server_init(mut commands: Commands) {
     info!("Spawning entity on server");
     commands.spawn(Replicate {
-        updates_channel: ChannelKind::of::<Channel2>(),
         ..Default::default()
     });
 }

--- a/examples/interest_management/protocol.rs
+++ b/examples/interest_management/protocol.rs
@@ -20,8 +20,8 @@ impl PlayerBundle {
             position: Position(position),
             color: PlayerColor(color),
             replicate: Replicate {
-                prediction_target: NetworkTarget::Only(id),
-                interpolation_target: NetworkTarget::AllExcept(id),
+                prediction_target: NetworkTarget::Only(vec![id]),
+                interpolation_target: NetworkTarget::AllExcept(vec![id]),
                 // use rooms for replication
                 replication_mode: ReplicationMode::Room,
                 ..default()
@@ -62,7 +62,7 @@ impl MapEntities for PlayerParent {
     }
 }
 
-#[component_protocol(protocol = "MyProtocol", derive(Debug))]
+#[component_protocol(protocol = "MyProtocol")]
 pub enum Components {
     #[sync(once)]
     PlayerId(PlayerId),

--- a/examples/interest_management/server.rs
+++ b/examples/interest_management/server.rs
@@ -29,7 +29,7 @@ impl Plugin for MyServerPlugin {
             .with_key(KEY);
         let link_conditioner = LinkConditionerConfig {
             incoming_latency: Duration::from_millis(100),
-            incoming_jitter: Duration::from_millis(5),
+            incoming_jitter: Duration::from_millis(10),
             incoming_loss: 0.00,
         };
         let transport = match self.transport {
@@ -137,7 +137,7 @@ pub(crate) fn handle_connections(
 pub(crate) fn log(server: Res<Server<MyProtocol>>, position: Query<&Position, With<PlayerId>>) {
     let server_tick = server.tick();
     for pos in position.iter() {
-        info!(?server_tick, "Confirmed position: {:?}", pos);
+        debug!(?server_tick, "Confirmed position: {:?}", pos);
     }
 }
 
@@ -178,7 +178,7 @@ pub(crate) fn movement(
     for input in input_reader.read() {
         let client_id = input.context();
         if let Some(input) = input.input() {
-            info!(server_tick = ?server.tick(), ?input, "Recv input");
+            debug!(server_tick = ?server.tick(), ?input, "Recv input");
             debug!(
                 "Receiving input: {:?} from client: {:?} on tick: {:?}",
                 input,
@@ -201,7 +201,7 @@ pub(crate) fn send_message(mut server: ResMut<Server<MyProtocol>>, input: Res<In
         let message = Message1(5);
         info!("Send message: {:?}", message);
         server
-            .broadcast_send::<Channel1, Message1>(Message1(5))
+            .send_to_target::<Channel1, Message1>(Message1(5), NetworkTarget::All)
             .unwrap_or_else(|e| {
                 error!("Failed to send message: {:?}", e);
             });

--- a/examples/interest_management/shared.rs
+++ b/examples/interest_management/shared.rs
@@ -12,7 +12,7 @@ pub fn shared_config() -> SharedConfig {
         enable_replication: true,
         client_send_interval: Duration::default(),
         // server_send_interval: Duration::default(),
-        server_send_interval: Duration::from_millis(30),
+        server_send_interval: Duration::from_millis(40),
         tick: TickConfig {
             // right now, we NEED the tick_duration to be smaller than the send_interval
             // (otherwise we can send multiple packets for the same tick at different frames)

--- a/examples/interest_management/shared.rs
+++ b/examples/interest_management/shared.rs
@@ -14,7 +14,7 @@ pub fn shared_config() -> SharedConfig {
         // server_send_interval: Duration::default(),
         server_send_interval: Duration::from_millis(30),
         tick: TickConfig {
-            // right now, we NEED the tick_duration to be smaller than the frame_duration
+            // right now, we NEED the tick_duration to be smaller than the send_interval
             // (otherwise we can send multiple packets for the same tick at different frames)
             tick_duration: Duration::from_secs_f64(1.0 / 64.0),
         },

--- a/examples/simple_box/client.rs
+++ b/examples/simple_box/client.rs
@@ -1,4 +1,5 @@
-use crate::protocol::{Direction, Inputs, Message1, MyProtocol, PlayerColor, PlayerPosition};
+use crate::protocol::Direction;
+use crate::protocol::*;
 use crate::shared::{shared_config, shared_movement_behaviour};
 use crate::{Transports, KEY, PROTOCOL_ID};
 use bevy::prelude::*;
@@ -27,9 +28,9 @@ impl Plugin for MyClientPlugin {
         };
         let client_addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), self.client_port);
         let link_conditioner = LinkConditionerConfig {
-            incoming_latency: Duration::from_millis(100),
-            incoming_jitter: Duration::from_millis(10),
-            incoming_loss: 0.00,
+            incoming_latency: Duration::from_millis(200),
+            incoming_jitter: Duration::from_millis(20),
+            incoming_loss: 0.05,
         };
         let transport = match self.transport {
             Transports::Udp => TransportConfig::UdpSocket(client_addr),
@@ -52,7 +53,7 @@ impl Plugin for MyClientPlugin {
             interpolation: InterpolationConfig::default()
                 .with_delay(InterpolationDelay::default().with_send_interval_ratio(2.0)),
         };
-        let plugin_config = PluginConfig::new(config, io, MyProtocol::default(), auth);
+        let plugin_config = PluginConfig::new(config, io, protocol(), auth);
         app.add_plugins(ClientPlugin::new(plugin_config));
         app.add_plugins(crate::shared::SharedPlugin);
         app.insert_resource(self.clone());
@@ -174,7 +175,7 @@ pub(crate) fn receive_entity_despawn(mut reader: EventReader<EntityDespawnEvent>
 // - keep track of it in the Global resource
 pub(crate) fn handle_predicted_spawn(mut predicted: Query<&mut PlayerColor, Added<Predicted>>) {
     for mut color in predicted.iter_mut() {
-        color.0.set_s(0.2);
+        color.0.set_s(0.3);
     }
 }
 
@@ -185,6 +186,6 @@ pub(crate) fn handle_interpolated_spawn(
     mut interpolated: Query<&mut PlayerColor, Added<Interpolated>>,
 ) {
     for mut color in interpolated.iter_mut() {
-        color.0.set_s(0.2);
+        color.0.set_s(0.1);
     }
 }

--- a/examples/simple_box/protocol.rs
+++ b/examples/simple_box/protocol.rs
@@ -56,7 +56,8 @@ impl MapEntities for PlayerParent {
     }
 }
 
-#[component_protocol(protocol = "MyProtocol", derive(Debug))]
+// #[component_protocol(protocol = "MyProtocol", derive(Debug))]
+#[component_protocol(protocol = "MyProtocol")]
 pub enum Components {
     #[sync(once)]
     PlayerId(PlayerId),

--- a/examples/simple_box/protocol.rs
+++ b/examples/simple_box/protocol.rs
@@ -19,9 +19,9 @@ impl PlayerBundle {
             position: PlayerPosition(position),
             color: PlayerColor(color),
             replicate: Replicate {
-                prediction_target: NetworkTarget::None,
-                // prediction_target: NetworkTarget::Only(id),
-                interpolation_target: NetworkTarget::AllExcept(id),
+                // prediction_target: NetworkTarget::None,
+                prediction_target: NetworkTarget::Only(vec![id]),
+                interpolation_target: NetworkTarget::AllExcept(vec![id]),
                 ..default()
             },
         }

--- a/examples/simple_box/protocol.rs
+++ b/examples/simple_box/protocol.rs
@@ -19,8 +19,8 @@ impl PlayerBundle {
             position: PlayerPosition(position),
             color: PlayerColor(color),
             replicate: Replicate {
-                // prediction_target: NetworkTarget::None,
-                prediction_target: NetworkTarget::Only(id),
+                prediction_target: NetworkTarget::None,
+                // prediction_target: NetworkTarget::Only(id),
                 interpolation_target: NetworkTarget::AllExcept(id),
                 ..default()
             },

--- a/examples/simple_box/server.rs
+++ b/examples/simple_box/server.rs
@@ -20,9 +20,9 @@ impl Plugin for MyServerPlugin {
             .with_protocol_id(PROTOCOL_ID)
             .with_key(KEY);
         let link_conditioner = LinkConditionerConfig {
-            incoming_latency: Duration::from_millis(100),
-            incoming_jitter: Duration::from_millis(10),
-            incoming_loss: 0.00,
+            incoming_latency: Duration::from_millis(200),
+            incoming_jitter: Duration::from_millis(20),
+            incoming_loss: 0.05,
         };
         let transport = match self.transport {
             Transports::Udp => TransportConfig::UdpSocket(server_addr),
@@ -39,7 +39,7 @@ impl Plugin for MyServerPlugin {
             netcode: netcode_config,
             ping: PingConfig::default(),
         };
-        let plugin_config = PluginConfig::new(config, io, MyProtocol::default());
+        let plugin_config = PluginConfig::new(config, io, protocol());
         app.add_plugins(server::ServerPlugin::new(plugin_config));
         app.add_plugins(shared::SharedPlugin);
         app.init_resource::<Global>();
@@ -130,7 +130,7 @@ pub(crate) fn send_message(mut server: ResMut<Server<MyProtocol>>, input: Res<In
         let message = Message1(5);
         info!("Send message: {:?}", message);
         server
-            .broadcast_send::<Channel1, Message1>(Message1(5))
+            .send_to_target::<Channel1, Message1>(Message1(5), NetworkTarget::All)
             .unwrap_or_else(|e| {
                 error!("Failed to send message: {:?}", e);
             });

--- a/examples/simple_box/shared.rs
+++ b/examples/simple_box/shared.rs
@@ -9,7 +9,8 @@ pub fn shared_config() -> SharedConfig {
     SharedConfig {
         enable_replication: true,
         client_send_interval: Duration::default(),
-        server_send_interval: Duration::from_millis(100),
+        server_send_interval: Duration::from_millis(40),
+        // server_send_interval: Duration::from_millis(100),
         tick: TickConfig {
             tick_duration: Duration::from_secs_f64(1.0 / 64.0),
         },

--- a/examples/src/protocol.rs
+++ b/examples/src/protocol.rs
@@ -27,7 +27,8 @@ pub struct Component2(pub f32);
 #[derive(Component, Message, Serialize, Deserialize, Clone, Debug, PartialEq, Add, Mul)]
 pub struct Component3(pub f32);
 
-#[component_protocol(protocol = "MyProtocol", derive(Debug))]
+// #[component_protocol(protocol = "MyProtocol", derive(Debug))]
+#[component_protocol(protocol = "MyProtocol")]
 pub enum MyComponentsProtocol {
     #[sync(full)]
     Component1(Component1),

--- a/lightyear/Cargo.toml
+++ b/lightyear/Cargo.toml
@@ -63,7 +63,7 @@ chacha20poly1305 = { version = "0.10", features = ["std"] }
 byteorder = "1.5.0"
 
 # derive
-lightyear_macros = {  version = "0.2.0", path = "../macros" }
+lightyear_macros = { version = "0.2.0", path = "../macros" }
 
 # tracing
 tracing = "0.1.40"
@@ -90,7 +90,7 @@ tokio = { version = "1.34", features = [
   "time",
 ], optional = true }
 
-bevy = { version = "0.12", default-features = false}
+bevy = { version = "0.12", default-features = false }
 
 
 [dev-dependencies]

--- a/lightyear/Cargo.toml
+++ b/lightyear/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lightyear"
-version = "0.3.0-alpha.0"
+version = "0.3.0"
 authors = ["Charles Bournhonesque <charlesbour@gmail.com>"]
 edition = "2021"
 rust-version = "1.65"

--- a/lightyear/Cargo.toml
+++ b/lightyear/Cargo.toml
@@ -62,8 +62,8 @@ chacha20poly1305 = { version = "0.10", features = ["std"] }
 byteorder = "1.5.0"
 
 # derive
-#lightyear_macros = { path = "../macros" }
-lightyear_macros = "0.1.0"
+lightyear_macros = { path = "../macros" }
+#lightyear_macros = "0.1.0"
 
 # tracing
 tracing = "0.1.40"

--- a/lightyear/Cargo.toml
+++ b/lightyear/Cargo.toml
@@ -22,6 +22,7 @@ metrics = [
   "tokio",
 ]
 mock_time = ["dep:mock_instant"]
+render = ["bevy/bevy_render"]
 webtransport = [
   "dep:wtransport",
   "tokio/sync",
@@ -62,8 +63,7 @@ chacha20poly1305 = { version = "0.10", features = ["std"] }
 byteorder = "1.5.0"
 
 # derive
-lightyear_macros = { path = "../macros" }
-#lightyear_macros = "0.1.0"
+lightyear_macros = {  version = "0.2.0", path = "../macros" }
 
 # tracing
 tracing = "0.1.40"
@@ -90,7 +90,7 @@ tokio = { version = "1.34", features = [
   "time",
 ], optional = true }
 
-bevy = { version = "0.12", default-features = false }
+bevy = { version = "0.12", default-features = false}
 
 
 [dev-dependencies]

--- a/lightyear/src/channel/builder.rs
+++ b/lightyear/src/channel/builder.rs
@@ -13,6 +13,7 @@ use crate::channel::senders::reliable::ReliableSender;
 use crate::channel::senders::sequenced_unreliable::SequencedUnreliableSender;
 use crate::channel::senders::tick_unreliable::TickUnreliableSender;
 use crate::channel::senders::unordered_unreliable::UnorderedUnreliableSender;
+use crate::channel::senders::unordered_unreliable_with_acks::UnorderedUnreliableWithAcksSender;
 use crate::channel::senders::ChannelSender;
 use crate::utils::named::TypeNamed;
 
@@ -48,6 +49,10 @@ impl ChannelContainer {
         let sender: ChannelSender;
         let settings_clone = settings.clone();
         match settings.mode {
+            ChannelMode::UnorderedUnreliableWithAcks => {
+                receiver = UnorderedUnreliableReceiver::new().into();
+                sender = UnorderedUnreliableWithAcksSender::new().into();
+            }
             ChannelMode::UnorderedUnreliable => {
                 receiver = UnorderedUnreliableReceiver::new().into();
                 sender = UnorderedUnreliableSender::new().into();

--- a/lightyear/src/channel/builder.rs
+++ b/lightyear/src/channel/builder.rs
@@ -15,6 +15,7 @@ use crate::channel::senders::tick_unreliable::TickUnreliableSender;
 use crate::channel::senders::unordered_unreliable::UnorderedUnreliableSender;
 use crate::channel::senders::unordered_unreliable_with_acks::UnorderedUnreliableWithAcksSender;
 use crate::channel::senders::ChannelSender;
+use crate::prelude::ChannelKind;
 use crate::utils::named::TypeNamed;
 
 /// A ChannelContainer is a struct that implements the [`Channel`] trait
@@ -28,6 +29,13 @@ pub struct ChannelContainer {
 /// You can define the direction, ordering, reliability of the channel
 pub trait Channel: 'static + TypeNamed {
     fn get_builder(settings: ChannelSettings) -> ChannelBuilder;
+
+    fn kind() -> ChannelKind
+    where
+        Self: Sized,
+    {
+        ChannelKind::of::<Self>()
+    }
 }
 
 #[doc(hidden)]

--- a/lightyear/src/channel/senders/fragment_ack_receiver.rs
+++ b/lightyear/src/channel/senders/fragment_ack_receiver.rs
@@ -45,7 +45,7 @@ impl FragmentAckReceiver {
         fragment_index: FragmentIndex,
         current_time: Option<WrappedTime>,
     ) -> bool {
-        let mut fragment_ack_tracker = self.fragment_messages.get(&message_id) else {
+        let Some(fragment_ack_tracker) = self.fragment_messages.get_mut(&message_id) else {
             error!("Received fragment ack for unknown message id");
             return false;
         };

--- a/lightyear/src/channel/senders/reliable.rs
+++ b/lightyear/src/channel/senders/reliable.rs
@@ -3,6 +3,7 @@ use std::collections::{BTreeMap, HashSet};
 use std::time::Duration;
 
 use bytes::Bytes;
+use crossbeam_channel::Receiver;
 use tracing::{info, trace};
 
 use crate::channel::builder::ReliableSettings;
@@ -89,11 +90,12 @@ impl ChannelSend for ReliableSender {
 
     /// Add a new message to the buffer of messages to be sent.
     /// This is a client-facing function, to be called when you want to send a message
-    fn buffer_send(&mut self, message: Bytes) {
+    fn buffer_send(&mut self, message: Bytes) -> Option<MessageId> {
+        let message_id = self.next_send_message_id;
         let unacked_message = if message.len() > self.fragment_sender.fragment_size {
-            let fragments =
-                self.fragment_sender
-                    .build_fragments(self.next_send_message_id, None, message);
+            let fragments = self
+                .fragment_sender
+                .build_fragments(message_id, None, message);
             UnackedMessage::Fragmented(
                 fragments
                     .into_iter()
@@ -110,9 +112,9 @@ impl ChannelSend for ReliableSender {
                 last_sent: None,
             }
         };
-        self.unacked_messages
-            .insert(self.next_send_message_id, unacked_message);
+        self.unacked_messages.insert(message_id, unacked_message);
         self.next_send_message_id += 1;
+        Some(message_id)
     }
 
     /// Take messages from the buffer of messages to be sent, and build a list of packets
@@ -235,6 +237,10 @@ impl ChannelSend for ReliableSender {
 
     fn has_messages_to_send(&self) -> bool {
         !self.single_messages_to_send.is_empty() || !self.fragmented_messages_to_send.is_empty()
+    }
+
+    fn subscribe_acks(&mut self) -> Receiver<MessageId> {
+        todo!()
     }
 }
 

--- a/lightyear/src/channel/senders/sequenced_unreliable.rs
+++ b/lightyear/src/channel/senders/sequenced_unreliable.rs
@@ -1,6 +1,7 @@
 use std::collections::VecDeque;
 
 use bytes::Bytes;
+use crossbeam_channel::Receiver;
 
 use crate::channel::senders::fragment_sender::FragmentSender;
 use crate::channel::senders::ChannelSend;
@@ -39,19 +40,21 @@ impl ChannelSend for SequencedUnreliableSender {
 
     /// Add a new message to the buffer of messages to be sent.
     /// This is a client-facing function, to be called when you want to send a message
-    fn buffer_send(&mut self, message: Bytes) {
+    fn buffer_send(&mut self, message: Bytes) -> Option<MessageId> {
+        let message_id = self.next_send_message_id;
         if message.len() > self.fragment_sender.fragment_size {
-            for fragment in
-                self.fragment_sender
-                    .build_fragments(self.next_send_message_id, None, message)
+            for fragment in self
+                .fragment_sender
+                .build_fragments(message_id, None, message)
             {
                 self.fragmented_messages_to_send.push_back(fragment);
             }
         } else {
-            let single_data = SingleData::new(Some(self.next_send_message_id), message);
+            let single_data = SingleData::new(Some(message_id), message);
             self.single_messages_to_send.push_back(single_data);
         }
         self.next_send_message_id += 1;
+        Some(message_id)
     }
 
     /// Take messages from the buffer of messages to be sent, and build a list of packets
@@ -74,6 +77,10 @@ impl ChannelSend for SequencedUnreliableSender {
 
     fn has_messages_to_send(&self) -> bool {
         !self.single_messages_to_send.is_empty() || !self.fragmented_messages_to_send.is_empty()
+    }
+
+    fn subscribe_acks(&mut self) -> Receiver<MessageId> {
+        unreachable!()
     }
 }
 

--- a/lightyear/src/channel/senders/tick_unreliable.rs
+++ b/lightyear/src/channel/senders/tick_unreliable.rs
@@ -1,6 +1,7 @@
 use std::collections::VecDeque;
 
 use bytes::Bytes;
+use crossbeam_channel::Receiver;
 
 use crate::channel::senders::fragment_sender::FragmentSender;
 use crate::channel::senders::ChannelSend;
@@ -44,7 +45,7 @@ impl ChannelSend for TickUnreliableSender {
 
     /// Add a new message to the buffer of messages to be sent.
     /// This is a client-facing function, to be called when you want to send a message
-    fn buffer_send(&mut self, message: Bytes) {
+    fn buffer_send(&mut self, message: Bytes) -> Option<MessageId> {
         if message.len() > self.fragment_sender.fragment_size {
             for fragment in self.fragment_sender.build_fragments(
                 self.next_send_fragmented_message_id,
@@ -54,10 +55,12 @@ impl ChannelSend for TickUnreliableSender {
                 self.fragmented_messages_to_send.push_back(fragment);
             }
             self.next_send_fragmented_message_id += 1;
+            return Some(self.next_send_fragmented_message_id - 1);
         } else {
             let mut single_data = SingleData::new(None, message);
             single_data.tick = Some(self.current_tick);
             self.single_messages_to_send.push_back(single_data);
+            return None;
         }
     }
 
@@ -80,6 +83,10 @@ impl ChannelSend for TickUnreliableSender {
 
     fn has_messages_to_send(&self) -> bool {
         !self.single_messages_to_send.is_empty() || !self.fragmented_messages_to_send.is_empty()
+    }
+
+    fn subscribe_acks(&mut self) -> Receiver<MessageId> {
+        unreachable!()
     }
 }
 

--- a/lightyear/src/channel/senders/tick_unreliable.rs
+++ b/lightyear/src/channel/senders/tick_unreliable.rs
@@ -55,12 +55,12 @@ impl ChannelSend for TickUnreliableSender {
                 self.fragmented_messages_to_send.push_back(fragment);
             }
             self.next_send_fragmented_message_id += 1;
-            return Some(self.next_send_fragmented_message_id - 1);
+            Some(self.next_send_fragmented_message_id - 1)
         } else {
             let mut single_data = SingleData::new(None, message);
             single_data.tick = Some(self.current_tick);
             self.single_messages_to_send.push_back(single_data);
-            return None;
+            None
         }
     }
 

--- a/lightyear/src/channel/senders/unordered_unreliable.rs
+++ b/lightyear/src/channel/senders/unordered_unreliable.rs
@@ -50,11 +50,11 @@ impl ChannelSend for UnorderedUnreliableSender {
                 self.fragmented_messages_to_send.push_back(fragment);
             }
             self.next_send_fragmented_message_id += 1;
-            return Some(self.next_send_fragmented_message_id - 1);
+            Some(self.next_send_fragmented_message_id - 1)
         } else {
             let single_data = SingleData::new(None, message);
             self.single_messages_to_send.push_back(single_data);
-            return None;
+            None
         }
     }
 

--- a/lightyear/src/channel/senders/unordered_unreliable_with_acks.rs
+++ b/lightyear/src/channel/senders/unordered_unreliable_with_acks.rs
@@ -72,7 +72,7 @@ impl ChannelSend for UnorderedUnreliableWithAcksSender {
                 self.fragmented_messages_to_send.push_back(fragment);
             }
         } else {
-            let single_data = SingleData::new(None, message);
+            let single_data = SingleData::new(Some(message_id), message);
             self.single_messages_to_send.push_back(single_data);
         }
         self.next_send_message_id += 1;

--- a/lightyear/src/channel/senders/unordered_unreliable_with_acks.rs
+++ b/lightyear/src/channel/senders/unordered_unreliable_with_acks.rs
@@ -1,0 +1,137 @@
+use bevy::utils::HashMap;
+use std::collections::VecDeque;
+
+use bytes::Bytes;
+
+use crate::channel::senders::fragment_ack_receiver::FragmentAckReceiver;
+use crate::channel::senders::fragment_sender::FragmentSender;
+use crate::channel::senders::ChannelSend;
+use crate::packet::message::{FragmentData, FragmentIndex, MessageAck, MessageId, SingleData};
+use crate::shared::ping::manager::PingManager;
+use crate::shared::tick_manager::TickManager;
+use crate::shared::time_manager::{TimeManager, WrappedTime};
+use crossbeam_channel::{Receiver, Sender};
+
+const DISCARD_AFTER: chrono::Duration = chrono::Duration::milliseconds(3000);
+
+/// A sender that simply sends the messages without applying any reliability or unordered
+/// Same as UnorderedUnreliableSender, but includes a message id to each message,
+/// Which can let us track if a message was acked
+pub struct UnorderedUnreliableWithAcksSender {
+    /// list of single messages that we want to fit into packets and send
+    single_messages_to_send: VecDeque<SingleData>,
+    /// list of fragmented messages that we want to fit into packets and send
+    fragmented_messages_to_send: VecDeque<FragmentData>,
+    /// Message id to use for the next message to be sent
+    next_send_message_id: MessageId,
+    /// Used to split a message into fragments if the message is too big
+    fragment_sender: FragmentSender,
+
+    // TODO: add this to reliable as well?
+    // TODO: use a crate to broadcast to all subscribers?
+    /// List of senders that want to be notified when a message is acked
+    ack_senders: Vec<Sender<MessageId>>,
+    /// Keep track of which fragments were acked, so we can know when the entire fragment message
+    /// was acked
+    fragment_ack_receiver: FragmentAckReceiver,
+    current_time: WrappedTime,
+}
+
+impl UnorderedUnreliableWithAcksSender {
+    pub(crate) fn new() -> Self {
+        Self {
+            single_messages_to_send: VecDeque::new(),
+            fragmented_messages_to_send: VecDeque::new(),
+            next_send_message_id: MessageId::default(),
+            fragment_sender: FragmentSender::new(),
+            ack_senders: Vec::new(),
+            fragment_ack_receiver: FragmentAckReceiver::new(),
+            current_time: WrappedTime::default(),
+        }
+    }
+}
+
+impl ChannelSend for UnorderedUnreliableWithAcksSender {
+    fn update(&mut self, time_manager: &TimeManager, _: &PingManager, _: &TickManager) {
+        self.current_time = time_manager.current_time();
+        self.fragment_ack_receiver
+            .cleanup(self.current_time - DISCARD_AFTER);
+    }
+
+    /// Add a new message to the buffer of messages to be sent.
+    /// This is a client-facing function, to be called when you want to send a message
+    fn buffer_send(&mut self, message: Bytes) -> Option<MessageId> {
+        let message_id = self.next_send_message_id;
+        if message.len() > self.fragment_sender.fragment_size {
+            let fragments = self
+                .fragment_sender
+                .build_fragments(message_id, None, message);
+            self.fragment_ack_receiver
+                .add_new_fragment_to_wait_for(message_id, fragments.len());
+            for fragment in fragments {
+                self.fragmented_messages_to_send.push_back(fragment);
+            }
+        } else {
+            let single_data = SingleData::new(None, message);
+            self.single_messages_to_send.push_back(single_data);
+        }
+        self.next_send_message_id += 1;
+        Some(message_id)
+    }
+
+    /// Take messages from the buffer of messages to be sent, and build a list of packets to be sent
+    fn send_packet(&mut self) -> (VecDeque<SingleData>, VecDeque<FragmentData>) {
+        (
+            std::mem::take(&mut self.single_messages_to_send),
+            std::mem::take(&mut self.fragmented_messages_to_send),
+        )
+        // let messages_to_send = std::mem::take(&mut self.messages_to_send);
+        // let (remaining_messages_to_send, _) =
+        //     packet_manager.pack_messages_within_channel(messages_to_send);
+        // self.messages_to_send = remaining_messages_to_send;
+    }
+
+    // not necessary for an unreliable sender (all the buffered messages can be sent)
+    fn collect_messages_to_send(&mut self) {}
+
+    /// Notify any subscribers that a message was acked
+    fn notify_message_delivered(&mut self, ack: &MessageAck) {
+        ack.fragment_id.map_or_else(
+            || {
+                for sender in &self.ack_senders {
+                    sender.send(ack.message_id).unwrap();
+                }
+            },
+            |fragment_index| {
+                if self.fragment_ack_receiver.receive_fragment_ack(
+                    ack.message_id,
+                    fragment_index,
+                    None,
+                ) {
+                    for sender in &self.ack_senders {
+                        sender.send(ack.message_id).unwrap();
+                    }
+                }
+            },
+        );
+    }
+
+    fn has_messages_to_send(&self) -> bool {
+        !self.single_messages_to_send.is_empty() || !self.fragmented_messages_to_send.is_empty()
+    }
+
+    /// Create a new receiver that will receive a message id when a message is acked
+    fn subscribe_acks(&mut self) -> Receiver<MessageId> {
+        let (sender, receiver) = crossbeam_channel::unbounded();
+        self.ack_senders.push(sender);
+        receiver
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    // #[test]
+    // fn test_unordered_unreliable_sender_internals() {
+    //     todo!()
+    // }
+}

--- a/lightyear/src/client/events.rs
+++ b/lightyear/src/client/events.rs
@@ -1,6 +1,7 @@
 //! Wrapper around [`ConnectionEvents`] that adds client-specific functionality
 //!
 use crate::connection::events::ConnectionEvents;
+use crate::prelude::Tick;
 use crate::protocol::Protocol;
 
 pub struct ClientEvents<P: Protocol> {
@@ -17,7 +18,7 @@ pub type InputEvent<I> = crate::shared::events::InputEvent<I, ()>;
 
 pub type EntitySpawnEvent = crate::shared::events::EntitySpawnEvent<()>;
 pub type EntityDespawnEvent = crate::shared::events::EntityDespawnEvent<()>;
-pub type ComponentUpdateEvent<C> = crate::shared::events::ComponentUpdateEvent<C, ()>;
-pub type ComponentInsertEvent<C> = crate::shared::events::ComponentInsertEvent<C, ()>;
-pub type ComponentRemoveEvent<C> = crate::shared::events::ComponentRemoveEvent<C, ()>;
+pub type ComponentUpdateEvent<C> = crate::shared::events::ComponentUpdateEvent<C, Tick>;
+pub type ComponentInsertEvent<C> = crate::shared::events::ComponentInsertEvent<C, Tick>;
+pub type ComponentRemoveEvent<C> = crate::shared::events::ComponentRemoveEvent<C, Tick>;
 pub type MessageEvent<M> = crate::shared::events::MessageEvent<M, ()>;

--- a/lightyear/src/client/events.rs
+++ b/lightyear/src/client/events.rs
@@ -18,7 +18,7 @@ pub type InputEvent<I> = crate::shared::events::InputEvent<I, ()>;
 
 pub type EntitySpawnEvent = crate::shared::events::EntitySpawnEvent<()>;
 pub type EntityDespawnEvent = crate::shared::events::EntityDespawnEvent<()>;
-pub type ComponentUpdateEvent<C> = crate::shared::events::ComponentUpdateEvent<C, Tick>;
-pub type ComponentInsertEvent<C> = crate::shared::events::ComponentInsertEvent<C, Tick>;
-pub type ComponentRemoveEvent<C> = crate::shared::events::ComponentRemoveEvent<C, Tick>;
+pub type ComponentUpdateEvent<C> = crate::shared::events::ComponentUpdateEvent<C, ()>;
+pub type ComponentInsertEvent<C> = crate::shared::events::ComponentInsertEvent<C, ()>;
+pub type ComponentRemoveEvent<C> = crate::shared::events::ComponentRemoveEvent<C, ()>;
 pub type MessageEvent<M> = crate::shared::events::MessageEvent<M, ()>;

--- a/lightyear/src/client/interpolation/despawn.rs
+++ b/lightyear/src/client/interpolation/despawn.rs
@@ -44,6 +44,7 @@ pub(crate) fn removed_components<C: SyncComponent>(
 }
 
 /// Despawn interpolated entities when the confirmed entity gets despawned
+/// TODO: we should despawn interpolated only when it reaches the latest confirmed snapshot?
 pub(crate) fn despawn_interpolated(
     mut commands: Commands,
     mut mapping: ResMut<InterpolationMapping>,

--- a/lightyear/src/client/interpolation/interpolate.rs
+++ b/lightyear/src/client/interpolation/interpolate.rs
@@ -40,6 +40,7 @@ pub(crate) fn update_interpolate_status<C: SyncComponent, P: Protocol>(
     if !client.is_synced() {
         return;
     }
+
     // how many ticks between each interpolation (add 1 to roughly take the ceil)
     let send_interval_delta_tick =
         (SEND_INTERVAL_TICK_FACTOR * client.config().shared.server_send_interval.as_secs_f32()

--- a/lightyear/src/client/interpolation/interpolation_history.rs
+++ b/lightyear/src/client/interpolation/interpolation_history.rs
@@ -1,12 +1,13 @@
 use std::ops::Deref;
 
 use bevy::prelude::{
-    Commands, Component, DetectChanges, Entity, Query, Ref, Res, ResMut, With, Without,
+    Commands, Component, DetectChanges, Entity, EventReader, Query, Ref, Res, ResMut, With, Without,
 };
 use tracing::{debug, error, info};
 
 use crate::client::components::Confirmed;
 use crate::client::components::{ComponentSyncMode, SyncComponent};
+use crate::client::events::ComponentUpdateEvent;
 use crate::client::interpolation::interpolate::InterpolateStatus;
 use crate::client::interpolation::Interpolated;
 use crate::client::resource::Client;
@@ -118,41 +119,81 @@ pub(crate) fn add_component_history<T: SyncComponent, P: Protocol>(
 /// or update the interpolated component directly if InterpolatedComponentMode::Sync
 pub(crate) fn apply_confirmed_update<T: SyncComponent, P: Protocol>(
     client: Res<Client<P>>,
+    mut confirmed_updates: EventReader<ComponentUpdateEvent<T>>,
     mut interpolated_entities: Query<
         (&mut T, Option<&mut ConfirmedHistory<T>>),
         (With<Interpolated>, Without<Confirmed>),
     >,
     confirmed_entities: Query<(&Confirmed, Ref<T>)>,
 ) {
-    let latest_server_tick = client.latest_received_server_tick();
-    for (confirmed_entity, confirmed_component) in confirmed_entities.iter() {
-        if let Some(p) = confirmed_entity.interpolated {
-            if confirmed_component.is_changed() {
-                if let Ok((mut interpolated_component, history_option)) =
-                    interpolated_entities.get_mut(p)
-                {
-                    match T::mode() {
-                        ComponentSyncMode::Full => {
-                            if let Some(mut history) = history_option {
-                                history.buffer.add_item(
-                                    latest_server_tick,
-                                    confirmed_component.deref().clone(),
-                                );
-                            } else {
-                                error!(
-                                    "Interpolated entity {:?} doesn't have a ComponentHistory",
-                                    p
-                                );
+    // TODO: seems inefficient to cycle through all updates just to find the ones for the confirmed entity
+    //  have a way for events to also give us the list of updates for a single entity
+    //  maybe make ConnectionEvents a SystemParam/WorldQuery or something?
+    //  or add an ComponentEvent<T> component for each sync component that has mode::Full?
+    for update in confirmed_updates.read() {
+        let tick = *update.context();
+        if let Ok((confirmed_entity, confirmed_component)) =
+            confirmed_entities.get(*update.entity())
+        {
+            if let Some(p) = confirmed_entity.interpolated {
+                assert!(confirmed_component.is_changed());
+                if confirmed_component.is_changed() {
+                    if let Ok((mut interpolated_component, history_option)) =
+                        interpolated_entities.get_mut(p)
+                    {
+                        match T::mode() {
+                            ComponentSyncMode::Full => {
+                                if let Some(mut history) = history_option {
+                                    history
+                                        .buffer
+                                        .add_item(tick, confirmed_component.deref().clone());
+                                } else {
+                                    error!(
+                                        "Interpolated entity {:?} doesn't have a ComponentHistory",
+                                        p
+                                    );
+                                }
                             }
+                            // for sync-components, we just match the confirmed component
+                            ComponentSyncMode::Simple => {
+                                *interpolated_component = confirmed_component.deref().clone();
+                            }
+                            ComponentSyncMode::Once => {}
                         }
-                        // for sync-components, we just match the confirmed component
-                        ComponentSyncMode::Simple => {
-                            *interpolated_component = confirmed_component.deref().clone();
-                        }
-                        ComponentSyncMode::Once => {}
                     }
                 }
             }
         }
     }
+
+    // for (confirmed_entity, confirmed_component) in confirmed_entities.iter() {
+    //     if let Some(p) = confirmed_entity.interpolated {
+    //         if confirmed_component.is_changed() {
+    //             if let Ok((mut interpolated_component, history_option)) =
+    //                 interpolated_entities.get_mut(p)
+    //             {
+    //                 match T::mode() {
+    //                     ComponentSyncMode::Full => {
+    //                         if let Some(mut history) = history_option {
+    //                             history.buffer.add_item(
+    //                                 latest_server_tick,
+    //                                 confirmed_component.deref().clone(),
+    //                             );
+    //                         } else {
+    //                             error!(
+    //                                 "Interpolated entity {:?} doesn't have a ComponentHistory",
+    //                                 p
+    //                             );
+    //                         }
+    //                     }
+    //                     // for sync-components, we just match the confirmed component
+    //                     ComponentSyncMode::Simple => {
+    //                         *interpolated_component = confirmed_component.deref().clone();
+    //                     }
+    //                     ComponentSyncMode::Once => {}
+    //                 }
+    //             }
+    //         }
+    //     }
+    // }
 }

--- a/lightyear/src/client/interpolation/interpolation_history.rs
+++ b/lightyear/src/client/interpolation/interpolation_history.rs
@@ -119,81 +119,82 @@ pub(crate) fn add_component_history<T: SyncComponent, P: Protocol>(
 /// or update the interpolated component directly if InterpolatedComponentMode::Sync
 pub(crate) fn apply_confirmed_update<T: SyncComponent, P: Protocol>(
     client: Res<Client<P>>,
-    mut confirmed_updates: EventReader<ComponentUpdateEvent<T>>,
+    // mut confirmed_updates: EventReader<ComponentUpdateEvent<T>>,
     mut interpolated_entities: Query<
         (&mut T, Option<&mut ConfirmedHistory<T>>),
         (With<Interpolated>, Without<Confirmed>),
     >,
     confirmed_entities: Query<(&Confirmed, Ref<T>)>,
 ) {
-    // TODO: seems inefficient to cycle through all updates just to find the ones for the confirmed entity
-    //  have a way for events to also give us the list of updates for a single entity
-    //  maybe make ConnectionEvents a SystemParam/WorldQuery or something?
-    //  or add an ComponentEvent<T> component for each sync component that has mode::Full?
-    for update in confirmed_updates.read() {
-        let tick = *update.context();
-        if let Ok((confirmed_entity, confirmed_component)) =
-            confirmed_entities.get(*update.entity())
-        {
-            if let Some(p) = confirmed_entity.interpolated {
-                assert!(confirmed_component.is_changed());
-                if confirmed_component.is_changed() {
-                    if let Ok((mut interpolated_component, history_option)) =
-                        interpolated_entities.get_mut(p)
-                    {
-                        match T::mode() {
-                            ComponentSyncMode::Full => {
-                                if let Some(mut history) = history_option {
-                                    history
-                                        .buffer
-                                        .add_item(tick, confirmed_component.deref().clone());
-                                } else {
-                                    error!(
-                                        "Interpolated entity {:?} doesn't have a ComponentHistory",
-                                        p
-                                    );
-                                }
-                            }
-                            // for sync-components, we just match the confirmed component
-                            ComponentSyncMode::Simple => {
-                                *interpolated_component = confirmed_component.deref().clone();
-                            }
-                            ComponentSyncMode::Once => {}
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    // for (confirmed_entity, confirmed_component) in confirmed_entities.iter() {
-    //     if let Some(p) = confirmed_entity.interpolated {
-    //         if confirmed_component.is_changed() {
-    //             if let Ok((mut interpolated_component, history_option)) =
-    //                 interpolated_entities.get_mut(p)
-    //             {
-    //                 match T::mode() {
-    //                     ComponentSyncMode::Full => {
-    //                         if let Some(mut history) = history_option {
-    //                             history.buffer.add_item(
-    //                                 latest_server_tick,
-    //                                 confirmed_component.deref().clone(),
-    //                             );
-    //                         } else {
-    //                             error!(
-    //                                 "Interpolated entity {:?} doesn't have a ComponentHistory",
-    //                                 p
-    //                             );
+    // // TODO: seems inefficient to cycle through all updates just to find the ones for the confirmed entity
+    // //  have a way for events to also give us the list of updates for a single entity
+    // //  maybe make ConnectionEvents a SystemParam/WorldQuery or something?
+    // //  or add an ComponentEvent<T> component for each sync component that has mode::Full?
+    // for update in confirmed_updates.read() {
+    //     let tick = *update.context();
+    //     if let Ok((confirmed_entity, confirmed_component)) =
+    //         confirmed_entities.get(*update.entity())
+    //     {
+    //         if let Some(p) = confirmed_entity.interpolated {
+    //             assert!(confirmed_component.is_changed());
+    //             if confirmed_component.is_changed() {
+    //                 if let Ok((mut interpolated_component, history_option)) =
+    //                     interpolated_entities.get_mut(p)
+    //                 {
+    //                     match T::mode() {
+    //                         ComponentSyncMode::Full => {
+    //                             if let Some(mut history) = history_option {
+    //                                 history
+    //                                     .buffer
+    //                                     .add_item(tick, confirmed_component.deref().clone());
+    //                             } else {
+    //                                 error!(
+    //                                     "Interpolated entity {:?} doesn't have a ComponentHistory",
+    //                                     p
+    //                                 );
+    //                             }
     //                         }
+    //                         // for sync-components, we just match the confirmed component
+    //                         ComponentSyncMode::Simple => {
+    //                             *interpolated_component = confirmed_component.deref().clone();
+    //                         }
+    //                         ComponentSyncMode::Once => {}
     //                     }
-    //                     // for sync-components, we just match the confirmed component
-    //                     ComponentSyncMode::Simple => {
-    //                         *interpolated_component = confirmed_component.deref().clone();
-    //                     }
-    //                     ComponentSyncMode::Once => {}
     //                 }
     //             }
     //         }
     //     }
     // }
+
+    let latest_server_tick = client.latest_received_server_tick();
+    for (confirmed_entity, confirmed_component) in confirmed_entities.iter() {
+        if let Some(p) = confirmed_entity.interpolated {
+            if confirmed_component.is_changed() {
+                if let Ok((mut interpolated_component, history_option)) =
+                    interpolated_entities.get_mut(p)
+                {
+                    match T::mode() {
+                        ComponentSyncMode::Full => {
+                            if let Some(mut history) = history_option {
+                                history.buffer.add_item(
+                                    latest_server_tick,
+                                    confirmed_component.deref().clone(),
+                                );
+                            } else {
+                                error!(
+                                    "Interpolated entity {:?} doesn't have a ComponentHistory",
+                                    p
+                                );
+                            }
+                        }
+                        // for sync-components, we just match the confirmed component
+                        ComponentSyncMode::Simple => {
+                            *interpolated_component = confirmed_component.deref().clone();
+                        }
+                        ComponentSyncMode::Once => {}
+                    }
+                }
+            }
+        }
+    }
 }

--- a/lightyear/src/client/interpolation/interpolation_history.rs
+++ b/lightyear/src/client/interpolation/interpolation_history.rs
@@ -3,7 +3,7 @@ use std::ops::Deref;
 use bevy::prelude::{
     Commands, Component, DetectChanges, Entity, EventReader, Query, Ref, Res, ResMut, With, Without,
 };
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, trace};
 
 use crate::client::components::Confirmed;
 use crate::client::components::{ComponentSyncMode, SyncComponent};

--- a/lightyear/src/client/prediction/despawn.rs
+++ b/lightyear/src/client/prediction/despawn.rs
@@ -107,326 +107,327 @@ pub(crate) fn remove_despawn_marker(
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use crate::_reexport::*;
-    use crate::prelude::client::*;
-    use crate::prelude::*;
-    use crate::tests::protocol::*;
-    use crate::tests::stepper::{BevyStepper, Step};
-    use bevy::prelude::*;
-    use std::time::Duration;
-
-    fn increment_component_and_despawn(
-        mut commands: Commands,
-        mut query: Query<(Entity, &mut Component1), With<Predicted>>,
-    ) {
-        for (entity, mut component) in query.iter_mut() {
-            component.0 += 1.0;
-            if component.0 == 5.0 {
-                commands.entity(entity).prediction_despawn::<MyProtocol>();
-            }
-        }
-    }
-
-    // Test that if a predicted entity gets despawned erroneously
-    // We are still able to rollback properly (the rollback re-adds the predicted entity, or prevents it from despawning)
-    #[test]
-    fn test_despawned_predicted_rollback() -> anyhow::Result<()> {
-        let frame_duration = Duration::from_millis(10);
-        let tick_duration = Duration::from_millis(10);
-        let shared_config = SharedConfig {
-            enable_replication: false,
-            tick: TickConfig::new(tick_duration),
-            ..Default::default()
-        };
-        let link_conditioner = LinkConditionerConfig {
-            incoming_latency: Duration::from_millis(40),
-            incoming_jitter: Duration::from_millis(5),
-            incoming_loss: 0.05,
-        };
-        let sync_config = SyncConfig::default().speedup_factor(1.0);
-        let prediction_config = PredictionConfig::default().disable(false);
-        let interpolation_delay = Duration::from_millis(100);
-        let interpolation_config = InterpolationConfig::default().with_delay(InterpolationDelay {
-            min_delay: interpolation_delay,
-            send_interval_ratio: 0.0,
-        });
-        let mut stepper = BevyStepper::new(
-            shared_config,
-            sync_config,
-            prediction_config,
-            interpolation_config,
-            link_conditioner,
-            frame_duration,
-        );
-        stepper.client_mut().set_synced();
-        stepper.client_app.add_systems(
-            FixedUpdate,
-            increment_component_and_despawn.in_set(FixedUpdateSet::Main),
-        );
-
-        // Create a confirmed entity
-        let confirmed = stepper
-            .client_app
-            .world
-            .spawn((Component1(0.0), ShouldBePredicted))
-            .id();
-
-        // Tick once
-        stepper.frame_step();
-        assert_eq!(stepper.client().tick(), Tick(1));
-        let predicted = stepper
-            .client_app
-            .world
-            .get::<Confirmed>(confirmed)
-            .unwrap()
-            .predicted
-            .unwrap();
-
-        // check that the predicted entity got spawned
-        assert_eq!(
-            stepper
-                .client_app
-                .world
-                .get::<Predicted>(predicted)
-                .unwrap()
-                .confirmed_entity,
-            confirmed
-        );
-
-        // check that the component history got created
-        let mut history = PredictionHistory::<Component1>::default();
-        history
-            .buffer
-            .add_item(Tick(0), ComponentState::Updated(Component1(0.0)));
-        history
-            .buffer
-            .add_item(Tick(1), ComponentState::Updated(Component1(1.0)));
-        assert_eq!(
-            stepper
-                .client_app
-                .world
-                .get::<PredictionHistory<Component1>>(predicted)
-                .unwrap(),
-            &history,
-        );
-        // check that the confirmed component got replicated
-        assert_eq!(
-            stepper
-                .client_app
-                .world
-                .get::<Component1>(predicted)
-                .unwrap(),
-            &Component1(1.0)
-        );
-
-        // advance five more frames, so that the component gets removed on predicted
-        for i in 0..5 {
-            stepper.frame_step();
-        }
-        assert_eq!(stepper.client().tick(), Tick(6));
-
-        // check that the component got removed on predicted
-        assert!(stepper
-            .client_app
-            .world
-            .get::<Component1>(predicted)
-            .is_none());
-        // // check that predicted has the despawn marker
-        // assert_eq!(
-        //     stepper
-        //         .client_app
-        //         .world
-        //         .get::<PredictionDespawnMarker>(predicted)
-        //         .unwrap(),
-        //     &PredictionDespawnMarker {
-        //         death_tick: Tick(5)
-        //     }
-        // );
-        // check that the component history is still there and that the value of the component history is correct
-        let mut history = PredictionHistory::<Component1>::default();
-        for i in 0..5 {
-            history
-                .buffer
-                .add_item(Tick(i), ComponentState::Updated(Component1(i as f32)));
-        }
-        history.buffer.add_item(Tick(5), ComponentState::Removed);
-        assert_eq!(
-            stepper
-                .client_app
-                .world
-                .get::<PredictionHistory<Component1>>(predicted)
-                .unwrap(),
-            &history,
-        );
-
-        // create a rollback situation
-        stepper.client_mut().set_synced();
-        stepper
-            .client_mut()
-            .set_latest_received_server_tick(Tick(3));
-        stepper
-            .client_app
-            .world
-            .get_mut::<Component1>(confirmed)
-            .unwrap()
-            .0 = 1.0;
-        // update without incrementing time, because we want to force a rollback check
-        stepper.client_app.update();
-
-        // check that rollback happened
-        // predicted exists, and got the component re-added
-        stepper
-            .client_app
-            .world
-            .get_mut::<Component1>(predicted)
-            .unwrap()
-            .0 = 4.0;
-        // check that the history is how we expect after rollback
-        let mut history = PredictionHistory::<Component1>::default();
-        for i in 3..7 {
-            history
-                .buffer
-                .add_item(Tick(i), ComponentState::Updated(Component1(i as f32 - 2.0)));
-        }
-        assert_eq!(
-            stepper
-                .client_app
-                .world
-                .get::<PredictionHistory<Component1>>(predicted)
-                .unwrap(),
-            &history
-        );
-        Ok(())
-    }
-
-    // Test that if another entity gets added during prediction,
-    // - either it should get despawned if there is a rollback that doesn't add it anymore
-    // - or we should just let it live? (imagine it's audio, etc.)
-
-    fn increment_component_and_despawn_both(
-        mut commands: Commands,
-        mut query: Query<(Entity, &mut Component1)>,
-    ) {
-        for (entity, mut component) in query.iter_mut() {
-            component.0 += 1.0;
-            if component.0 == 5.0 {
-                commands.entity(entity).prediction_despawn::<MyProtocol>();
-            }
-        }
-    }
-
-    // Test that if a confirmed entity gets despawned,
-    // the corresponding predicted entity gets despawned as well
-    // Test that if a predicted entity gets despawned erroneously
-    // We are still able to rollback properly (the rollback re-adds the predicted entity, or prevents it from despawning)
-    #[test]
-    fn test_despawned_confirmed_rollback() -> anyhow::Result<()> {
-        let frame_duration = Duration::from_millis(10);
-        let tick_duration = Duration::from_millis(10);
-        let shared_config = SharedConfig {
-            enable_replication: false,
-            tick: TickConfig::new(tick_duration),
-            ..Default::default()
-        };
-        let link_conditioner = LinkConditionerConfig {
-            incoming_latency: Duration::from_millis(40),
-            incoming_jitter: Duration::from_millis(5),
-            incoming_loss: 0.05,
-        };
-        let sync_config = SyncConfig::default().speedup_factor(1.0);
-        let prediction_config = PredictionConfig::default().disable(false);
-        let interpolation_delay = Duration::from_millis(100);
-        let interpolation_config = InterpolationConfig::default().with_delay(InterpolationDelay {
-            min_delay: interpolation_delay,
-            send_interval_ratio: 0.0,
-        });
-        let mut stepper = BevyStepper::new(
-            shared_config,
-            sync_config,
-            prediction_config,
-            interpolation_config,
-            link_conditioner,
-            frame_duration,
-        );
-        stepper.client_app.add_systems(
-            FixedUpdate,
-            increment_component_and_despawn_both.in_set(FixedUpdateSet::Main),
-        );
-
-        // Create a confirmed entity
-        let confirmed = stepper
-            .client_app
-            .world
-            .spawn((Component1(0.0), ShouldBePredicted))
-            .id();
-
-        // Tick once
-        stepper.frame_step();
-        assert_eq!(stepper.client().tick(), Tick(1));
-        let predicted = stepper
-            .client_app
-            .world
-            .get::<Confirmed>(confirmed)
-            .unwrap()
-            .predicted
-            .unwrap();
-
-        // check that the predicted entity got spawned
-        assert_eq!(
-            stepper
-                .client_app
-                .world
-                .get::<Predicted>(predicted)
-                .unwrap()
-                .confirmed_entity,
-            confirmed
-        );
-
-        // check that the component history got created
-        let mut history = PredictionHistory::<Component1>::default();
-        history
-            .buffer
-            .add_item(Tick(1), ComponentState::Updated(Component1(1.0)));
-        assert_eq!(
-            stepper
-                .client_app
-                .world
-                .get::<PredictionHistory<Component1>>(predicted)
-                .unwrap(),
-            &history,
-        );
-        // check that the confirmed component got replicated
-        assert_eq!(
-            stepper
-                .client_app
-                .world
-                .get::<Component1>(predicted)
-                .unwrap(),
-            &Component1(1.0)
-        );
-
-        // create a situation where the confirmed entity gets despawned during FixedUpdate::Main
-        stepper.client_mut().set_synced();
-        stepper
-            .client_mut()
-            .set_latest_received_server_tick(Tick(0));
-        // we set it to 5 so that it gets despawned during FixedUpdate::Main
-        stepper
-            .client_app
-            .world
-            .get_mut::<Component1>(confirmed)
-            .unwrap()
-            .0 = 4.0;
-        // update without incrementing time, because we want to force a rollback check
-        stepper.frame_step();
-
-        // check that rollback happened
-        // confirmed and predicted both got despawned
-        assert!(stepper.client_app.world.get_entity(confirmed).is_none());
-        assert!(stepper.client_app.world.get_entity(predicted).is_none());
-
-        Ok(())
-    }
-}
+// TODO: revisit this; rollbacks happen when we receive a replication message now
+// #[cfg(test)]
+// mod tests {
+//     use crate::_reexport::*;
+//     use crate::prelude::client::*;
+//     use crate::prelude::*;
+//     use crate::tests::protocol::*;
+//     use crate::tests::stepper::{BevyStepper, Step};
+//     use bevy::prelude::*;
+//     use std::time::Duration;
+//
+//     fn increment_component_and_despawn(
+//         mut commands: Commands,
+//         mut query: Query<(Entity, &mut Component1), With<Predicted>>,
+//     ) {
+//         for (entity, mut component) in query.iter_mut() {
+//             component.0 += 1.0;
+//             if component.0 == 5.0 {
+//                 commands.entity(entity).prediction_despawn::<MyProtocol>();
+//             }
+//         }
+//     }
+//
+//     // Test that if a predicted entity gets despawned erroneously
+//     // We are still able to rollback properly (the rollback re-adds the predicted entity, or prevents it from despawning)
+//     #[test]
+//     fn test_despawned_predicted_rollback() -> anyhow::Result<()> {
+//         let frame_duration = Duration::from_millis(10);
+//         let tick_duration = Duration::from_millis(10);
+//         let shared_config = SharedConfig {
+//             enable_replication: false,
+//             tick: TickConfig::new(tick_duration),
+//             ..Default::default()
+//         };
+//         let link_conditioner = LinkConditionerConfig {
+//             incoming_latency: Duration::from_millis(40),
+//             incoming_jitter: Duration::from_millis(5),
+//             incoming_loss: 0.05,
+//         };
+//         let sync_config = SyncConfig::default().speedup_factor(1.0);
+//         let prediction_config = PredictionConfig::default().disable(false);
+//         let interpolation_delay = Duration::from_millis(100);
+//         let interpolation_config = InterpolationConfig::default().with_delay(InterpolationDelay {
+//             min_delay: interpolation_delay,
+//             send_interval_ratio: 0.0,
+//         });
+//         let mut stepper = BevyStepper::new(
+//             shared_config,
+//             sync_config,
+//             prediction_config,
+//             interpolation_config,
+//             link_conditioner,
+//             frame_duration,
+//         );
+//         stepper.client_mut().set_synced();
+//         stepper.client_app.add_systems(
+//             FixedUpdate,
+//             increment_component_and_despawn.in_set(FixedUpdateSet::Main),
+//         );
+//
+//         // Create a confirmed entity
+//         let confirmed = stepper
+//             .client_app
+//             .world
+//             .spawn((Component1(0.0), ShouldBePredicted))
+//             .id();
+//
+//         // Tick once
+//         stepper.frame_step();
+//         assert_eq!(stepper.client().tick(), Tick(1));
+//         let predicted = stepper
+//             .client_app
+//             .world
+//             .get::<Confirmed>(confirmed)
+//             .unwrap()
+//             .predicted
+//             .unwrap();
+//
+//         // check that the predicted entity got spawned
+//         assert_eq!(
+//             stepper
+//                 .client_app
+//                 .world
+//                 .get::<Predicted>(predicted)
+//                 .unwrap()
+//                 .confirmed_entity,
+//             confirmed
+//         );
+//
+//         // check that the component history got created
+//         let mut history = PredictionHistory::<Component1>::default();
+//         history
+//             .buffer
+//             .add_item(Tick(0), ComponentState::Updated(Component1(0.0)));
+//         history
+//             .buffer
+//             .add_item(Tick(1), ComponentState::Updated(Component1(1.0)));
+//         assert_eq!(
+//             stepper
+//                 .client_app
+//                 .world
+//                 .get::<PredictionHistory<Component1>>(predicted)
+//                 .unwrap(),
+//             &history,
+//         );
+//         // check that the confirmed component got replicated
+//         assert_eq!(
+//             stepper
+//                 .client_app
+//                 .world
+//                 .get::<Component1>(predicted)
+//                 .unwrap(),
+//             &Component1(1.0)
+//         );
+//
+//         // advance five more frames, so that the component gets removed on predicted
+//         for i in 0..5 {
+//             stepper.frame_step();
+//         }
+//         assert_eq!(stepper.client().tick(), Tick(6));
+//
+//         // check that the component got removed on predicted
+//         assert!(stepper
+//             .client_app
+//             .world
+//             .get::<Component1>(predicted)
+//             .is_none());
+//         // // check that predicted has the despawn marker
+//         // assert_eq!(
+//         //     stepper
+//         //         .client_app
+//         //         .world
+//         //         .get::<PredictionDespawnMarker>(predicted)
+//         //         .unwrap(),
+//         //     &PredictionDespawnMarker {
+//         //         death_tick: Tick(5)
+//         //     }
+//         // );
+//         // check that the component history is still there and that the value of the component history is correct
+//         let mut history = PredictionHistory::<Component1>::default();
+//         for i in 0..5 {
+//             history
+//                 .buffer
+//                 .add_item(Tick(i), ComponentState::Updated(Component1(i as f32)));
+//         }
+//         history.buffer.add_item(Tick(5), ComponentState::Removed);
+//         assert_eq!(
+//             stepper
+//                 .client_app
+//                 .world
+//                 .get::<PredictionHistory<Component1>>(predicted)
+//                 .unwrap(),
+//             &history,
+//         );
+//
+//         // create a rollback situation
+//         stepper.client_mut().set_synced();
+//         stepper
+//             .client_mut()
+//             .set_latest_received_server_tick(Tick(3));
+//         stepper
+//             .client_app
+//             .world
+//             .get_mut::<Component1>(confirmed)
+//             .unwrap()
+//             .0 = 1.0;
+//         // update without incrementing time, because we want to force a rollback check
+//         stepper.client_app.update();
+//
+//         // check that rollback happened
+//         // predicted exists, and got the component re-added
+//         stepper
+//             .client_app
+//             .world
+//             .get_mut::<Component1>(predicted)
+//             .unwrap()
+//             .0 = 4.0;
+//         // check that the history is how we expect after rollback
+//         let mut history = PredictionHistory::<Component1>::default();
+//         for i in 3..7 {
+//             history
+//                 .buffer
+//                 .add_item(Tick(i), ComponentState::Updated(Component1(i as f32 - 2.0)));
+//         }
+//         assert_eq!(
+//             stepper
+//                 .client_app
+//                 .world
+//                 .get::<PredictionHistory<Component1>>(predicted)
+//                 .unwrap(),
+//             &history
+//         );
+//         Ok(())
+//     }
+//
+//     // Test that if another entity gets added during prediction,
+//     // - either it should get despawned if there is a rollback that doesn't add it anymore
+//     // - or we should just let it live? (imagine it's audio, etc.)
+//
+//     fn increment_component_and_despawn_both(
+//         mut commands: Commands,
+//         mut query: Query<(Entity, &mut Component1)>,
+//     ) {
+//         for (entity, mut component) in query.iter_mut() {
+//             component.0 += 1.0;
+//             if component.0 == 5.0 {
+//                 commands.entity(entity).prediction_despawn::<MyProtocol>();
+//             }
+//         }
+//     }
+//
+//     // Test that if a confirmed entity gets despawned,
+//     // the corresponding predicted entity gets despawned as well
+//     // Test that if a predicted entity gets despawned erroneously
+//     // We are still able to rollback properly (the rollback re-adds the predicted entity, or prevents it from despawning)
+//     #[test]
+//     fn test_despawned_confirmed_rollback() -> anyhow::Result<()> {
+//         let frame_duration = Duration::from_millis(10);
+//         let tick_duration = Duration::from_millis(10);
+//         let shared_config = SharedConfig {
+//             enable_replication: false,
+//             tick: TickConfig::new(tick_duration),
+//             ..Default::default()
+//         };
+//         let link_conditioner = LinkConditionerConfig {
+//             incoming_latency: Duration::from_millis(40),
+//             incoming_jitter: Duration::from_millis(5),
+//             incoming_loss: 0.05,
+//         };
+//         let sync_config = SyncConfig::default().speedup_factor(1.0);
+//         let prediction_config = PredictionConfig::default().disable(false);
+//         let interpolation_delay = Duration::from_millis(100);
+//         let interpolation_config = InterpolationConfig::default().with_delay(InterpolationDelay {
+//             min_delay: interpolation_delay,
+//             send_interval_ratio: 0.0,
+//         });
+//         let mut stepper = BevyStepper::new(
+//             shared_config,
+//             sync_config,
+//             prediction_config,
+//             interpolation_config,
+//             link_conditioner,
+//             frame_duration,
+//         );
+//         stepper.client_app.add_systems(
+//             FixedUpdate,
+//             increment_component_and_despawn_both.in_set(FixedUpdateSet::Main),
+//         );
+//
+//         // Create a confirmed entity
+//         let confirmed = stepper
+//             .client_app
+//             .world
+//             .spawn((Component1(0.0), ShouldBePredicted))
+//             .id();
+//
+//         // Tick once
+//         stepper.frame_step();
+//         assert_eq!(stepper.client().tick(), Tick(1));
+//         let predicted = stepper
+//             .client_app
+//             .world
+//             .get::<Confirmed>(confirmed)
+//             .unwrap()
+//             .predicted
+//             .unwrap();
+//
+//         // check that the predicted entity got spawned
+//         assert_eq!(
+//             stepper
+//                 .client_app
+//                 .world
+//                 .get::<Predicted>(predicted)
+//                 .unwrap()
+//                 .confirmed_entity,
+//             confirmed
+//         );
+//
+//         // check that the component history got created
+//         let mut history = PredictionHistory::<Component1>::default();
+//         history
+//             .buffer
+//             .add_item(Tick(1), ComponentState::Updated(Component1(1.0)));
+//         assert_eq!(
+//             stepper
+//                 .client_app
+//                 .world
+//                 .get::<PredictionHistory<Component1>>(predicted)
+//                 .unwrap(),
+//             &history,
+//         );
+//         // check that the confirmed component got replicated
+//         assert_eq!(
+//             stepper
+//                 .client_app
+//                 .world
+//                 .get::<Component1>(predicted)
+//                 .unwrap(),
+//             &Component1(1.0)
+//         );
+//
+//         // create a situation where the confirmed entity gets despawned during FixedUpdate::Main
+//         stepper.client_mut().set_synced();
+//         stepper
+//             .client_mut()
+//             .set_latest_received_server_tick(Tick(0));
+//         // we set it to 5 so that it gets despawned during FixedUpdate::Main
+//         stepper
+//             .client_app
+//             .world
+//             .get_mut::<Component1>(confirmed)
+//             .unwrap()
+//             .0 = 4.0;
+//         // update without incrementing time, because we want to force a rollback check
+//         stepper.frame_step();
+//
+//         // check that rollback happened
+//         // confirmed and predicted both got despawned
+//         assert!(stepper.client_app.world.get_entity(confirmed).is_none());
+//         assert!(stepper.client_app.world.get_entity(predicted).is_none());
+//
+//         Ok(())
+//     }
+// }

--- a/lightyear/src/client/prediction/predicted_history.rs
+++ b/lightyear/src/client/prediction/predicted_history.rs
@@ -151,17 +151,13 @@ pub fn add_component_history<T: SyncComponent + Named, P: Protocol>(
                         match T::mode() {
                             ComponentSyncMode::Full => {
                                 // insert history, it will be quickly filled by a rollback (since it starts empty before the current client tick)
-                                let history = PredictionHistory::<T>::default();
+                                let mut history = PredictionHistory::<T>::default();
+                                history.buffer.add_item(
+                                    client.tick(),
+                                    ComponentState::Updated(confirmed_component.deref().clone()),
+                                );
                                 predicted_entity_mut
                                     .insert((confirmed_component.deref().clone(), history));
-
-                                // insert a confirmed history for the component, that will be needed for rollback
-                                // safety: we know the entity exists
-                                let mut confirmed_entity_mut =
-                                    commands.get_entity(confirmed_entity).unwrap();
-                                confirmed_entity_mut.insert(ConfirmedHistory::<T>::default());
-                                // TODO: add the value of the component along with the tick!
-                                // TODO: how do we access the tick?
                             }
                             _ => {
                                 // we only sync the components once, but we don't do rollback so no need for a component history

--- a/lightyear/src/client/prediction/rollback.rs
+++ b/lightyear/src/client/prediction/rollback.rs
@@ -36,6 +36,7 @@ use super::{Predicted, Rollback, RollbackState};
 /// If we need to run rollback, we clear the predicted history and snap the history back to the server-state
 // TODO: do not rollback if client is not time synced
 #[allow(clippy::type_complexity)]
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn client_rollback_check<C: SyncComponent, P: Protocol>(
     // TODO: have a way to only get the updates of entities that are predicted?
     mut commands: Commands,
@@ -272,437 +273,442 @@ pub(crate) fn increment_rollback_tick(mut rollback: ResMut<Rollback>) {
         *current_tick += 1;
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use std::time::Duration;
-
-    use bevy::prelude::*;
-    use tracing::{debug, info};
-
-    use crate::_reexport::*;
-    use crate::prelude::client::*;
-    use crate::prelude::*;
-    use crate::tests::protocol::*;
-    use crate::tests::stepper::{BevyStepper, Step};
-
-    fn increment_component(
-        mut commands: Commands,
-        mut query: Query<(Entity, &mut Component1), With<Predicted>>,
-    ) {
-        for (entity, mut component) in query.iter_mut() {
-            component.0 += 1.0;
-            if component.0 == 5.0 {
-                commands.entity(entity).remove::<Component1>();
-            }
-        }
-    }
-
-    fn setup() -> BevyStepper {
-        let frame_duration = Duration::from_millis(10);
-        let tick_duration = Duration::from_millis(10);
-        let shared_config = SharedConfig {
-            enable_replication: false,
-            tick: TickConfig::new(tick_duration),
-            ..Default::default()
-        };
-        let link_conditioner = LinkConditionerConfig {
-            incoming_latency: Duration::from_millis(40),
-            incoming_jitter: Duration::from_millis(5),
-            incoming_loss: 0.05,
-        };
-        let sync_config = SyncConfig::default().speedup_factor(1.0);
-        let prediction_config = PredictionConfig::default().disable(false);
-        let interpolation_delay = Duration::from_millis(100);
-        let interpolation_config = InterpolationConfig::default().with_delay(InterpolationDelay {
-            min_delay: interpolation_delay,
-            send_interval_ratio: 0.0,
-        });
-        let mut stepper = BevyStepper::new(
-            shared_config,
-            sync_config,
-            prediction_config,
-            interpolation_config,
-            link_conditioner,
-            frame_duration,
-        );
-        stepper.client_mut().set_synced();
-        stepper.client_app.add_systems(
-            FixedUpdate,
-            increment_component.in_set(FixedUpdateSet::Main),
-        );
-        stepper
-    }
-
-    // Test that if a component gets removed from the predicted entity erroneously
-    // We are still able to rollback properly (the rollback adds the component to the predicted entity)
-    #[test]
-    fn test_removed_predicted_component_rollback() -> anyhow::Result<()> {
-        let mut stepper = setup();
-
-        // Create a confirmed entity
-        let confirmed = stepper
-            .client_app
-            .world
-            .spawn((Component1(0.0), ShouldBePredicted))
-            .id();
-
-        // Tick once
-        stepper.frame_step();
-        assert_eq!(stepper.client().tick(), Tick(1));
-        let predicted = stepper
-            .client_app
-            .world
-            .get::<Confirmed>(confirmed)
-            .unwrap()
-            .predicted
-            .unwrap();
-
-        // check that the predicted entity got spawned
-        assert_eq!(
-            stepper
-                .client_app
-                .world
-                .get::<Predicted>(predicted)
-                .unwrap()
-                .confirmed_entity,
-            confirmed
-        );
-
-        // check that the component history got created
-        let mut history = PredictionHistory::<Component1>::default();
-        // this is added during the first rollback call after we create the history
-        history
-            .buffer
-            .add_item(Tick(0), ComponentState::Updated(Component1(0.0)));
-        history
-            .buffer
-            .add_item(Tick(1), ComponentState::Updated(Component1(1.0)));
-        assert_eq!(
-            stepper
-                .client_app
-                .world
-                .get::<PredictionHistory<Component1>>(predicted)
-                .unwrap(),
-            &history,
-        );
-        // check that the confirmed component got replicated
-        assert_eq!(
-            stepper
-                .client_app
-                .world
-                .get::<Component1>(predicted)
-                .unwrap(),
-            &Component1(1.0)
-        );
-
-        // advance five more frames, so that the component gets removed on predicted
-        for i in 0..5 {
-            stepper.frame_step();
-        }
-        assert_eq!(stepper.client().tick(), Tick(6));
-
-        // check that the component got removed on predicted
-        assert!(stepper
-            .client_app
-            .world
-            .get::<Component1>(predicted)
-            .is_none());
-        // check that the component history is still there and that the value of the component history is correct
-        let mut history = PredictionHistory::<Component1>::default();
-        for i in 0..5 {
-            history
-                .buffer
-                .add_item(Tick(i), ComponentState::Updated(Component1(i as f32)));
-        }
-        history.buffer.add_item(Tick(5), ComponentState::Removed);
-        assert_eq!(
-            stepper
-                .client_app
-                .world
-                .get::<PredictionHistory<Component1>>(predicted)
-                .unwrap(),
-            &history,
-        );
-
-        // create a rollback situation
-        stepper.client_mut().set_synced();
-        stepper
-            .client_mut()
-            .set_latest_received_server_tick(Tick(3));
-        stepper
-            .client_app
-            .world
-            .get_mut::<Component1>(confirmed)
-            .unwrap()
-            .0 = 1.0;
-        // update without incrementing time, because we want to force a rollback check
-        stepper.client_app.update();
-
-        // check that rollback happened
-        // predicted got the component re-added
-        stepper
-            .client_app
-            .world
-            .get_mut::<Component1>(predicted)
-            .unwrap()
-            .0 = 4.0;
-        // check that the history is how we expect after rollback
-        let mut history = PredictionHistory::<Component1>::default();
-        for i in 3..7 {
-            history
-                .buffer
-                .add_item(Tick(i), ComponentState::Updated(Component1(i as f32 - 2.0)));
-        }
-        assert_eq!(
-            stepper
-                .client_app
-                .world
-                .get::<PredictionHistory<Component1>>(predicted)
-                .unwrap(),
-            &history
-        );
-
-        Ok(())
-    }
-
-    // Test that if a component gets added to the predicted entity erroneously but didn't exist on the confirmed entity)
-    // We are still able to rollback properly (the rollback removes the component from the predicted entity)
-    #[test]
-    fn test_added_predicted_component_rollback() -> anyhow::Result<()> {
-        let mut stepper = setup();
-
-        // Create a confirmed entity
-        let confirmed = stepper.client_app.world.spawn(ShouldBePredicted).id();
-
-        // Tick once
-        stepper.frame_step();
-        assert_eq!(stepper.client().tick(), Tick(1));
-        let predicted = stepper
-            .client_app
-            .world
-            .get::<Confirmed>(confirmed)
-            .unwrap()
-            .predicted
-            .unwrap();
-
-        // check that the predicted entity got spawned
-        assert_eq!(
-            stepper
-                .client_app
-                .world
-                .get::<Predicted>(predicted)
-                .unwrap()
-                .confirmed_entity,
-            confirmed
-        );
-
-        // add a new component to Predicted
-        stepper
-            .client_app
-            .world
-            .entity_mut(predicted)
-            .insert(Component1(1.0));
-
-        // create a rollback situation (confirmed doesn't have a component that predicted has)
-        stepper.client_mut().set_synced();
-        stepper
-            .client_mut()
-            .set_latest_received_server_tick(Tick(1));
-        // update without incrementing time, because we want to force a rollback check
-        stepper.client_app.update();
-
-        // check that rollback happened: the component got removed from predicted
-        assert!(stepper
-            .client_app
-            .world
-            .get::<Component1>(predicted)
-            .is_none());
-
-        // check that history contains the removal
-        let mut history = PredictionHistory::<Component1>::default();
-        history.buffer.add_item(Tick(1), ComponentState::Removed);
-        assert_eq!(
-            stepper
-                .client_app
-                .world
-                .get::<PredictionHistory<Component1>>(predicted)
-                .unwrap(),
-            &history,
-        );
-        Ok(())
-    }
-
-    // Test that if a component gets removed from the confirmed entity
-    // We are still able to rollback properly (the rollback removes the component from the predicted entity)
-    #[test]
-    fn test_removed_confirmed_component_rollback() -> anyhow::Result<()> {
-        let mut stepper = setup();
-
-        // Create a confirmed entity
-        let confirmed = stepper
-            .client_app
-            .world
-            .spawn((Component1(0.0), ShouldBePredicted))
-            .id();
-
-        // Tick once
-        stepper.frame_step();
-        assert_eq!(stepper.client().tick(), Tick(1));
-        let predicted = stepper
-            .client_app
-            .world
-            .get::<Confirmed>(confirmed)
-            .unwrap()
-            .predicted
-            .unwrap();
-
-        // check that the predicted entity got spawned
-        assert_eq!(
-            stepper
-                .client_app
-                .world
-                .get::<Predicted>(predicted)
-                .unwrap()
-                .confirmed_entity,
-            confirmed
-        );
-
-        // check that the component history got created
-        let mut history = PredictionHistory::<Component1>::default();
-        history
-            .buffer
-            .add_item(Tick(0), ComponentState::Updated(Component1(0.0)));
-        history
-            .buffer
-            .add_item(Tick(1), ComponentState::Updated(Component1(1.0)));
-        assert_eq!(
-            stepper
-                .client_app
-                .world
-                .get::<PredictionHistory<Component1>>(predicted)
-                .unwrap(),
-            &history,
-        );
-
-        // create a rollback situation by removing the component on confirmed
-        stepper.client_mut().set_synced();
-        stepper
-            .client_mut()
-            .set_latest_received_server_tick(Tick(1));
-        stepper
-            .client_app
-            .world
-            .entity_mut(confirmed)
-            .remove::<Component1>();
-        // update without incrementing time, because we want to force a rollback check
-        // (need duration_since_latest_received_server_tick = 0)
-        stepper.client_app.update();
-
-        // check that rollback happened
-        // predicted got the component removed
-        assert!(stepper
-            .client_app
-            .world
-            .get_mut::<Component1>(predicted)
-            .is_none());
-
-        // check that the history is how we expect after rollback
-        let mut history = PredictionHistory::<Component1>::default();
-        history.buffer.add_item(Tick(1), ComponentState::Removed);
-        assert_eq!(
-            stepper
-                .client_app
-                .world
-                .get::<PredictionHistory<Component1>>(predicted)
-                .unwrap(),
-            &history
-        );
-
-        Ok(())
-    }
-
-    // Test that if a component gets added to the confirmed entity (but didn't exist on the predicted entity)
-    // We are still able to rollback properly (the rollback adds the component to the predicted entity)
-    #[test]
-    fn test_added_confirmed_component_rollback() -> anyhow::Result<()> {
-        let mut stepper = setup();
-
-        // Create a confirmed entity
-        let confirmed = stepper.client_app.world.spawn(ShouldBePredicted).id();
-
-        // Tick once
-        stepper.frame_step();
-        assert_eq!(stepper.client().tick(), Tick(1));
-        let predicted = stepper
-            .client_app
-            .world
-            .get::<Confirmed>(confirmed)
-            .unwrap()
-            .predicted
-            .unwrap();
-
-        // check that the predicted entity got spawned
-        assert_eq!(
-            stepper
-                .client_app
-                .world
-                .get::<Predicted>(predicted)
-                .unwrap()
-                .confirmed_entity,
-            confirmed
-        );
-
-        // check that the component history did not get created
-        assert!(stepper
-            .client_app
-            .world
-            .get::<PredictionHistory<Component1>>(predicted)
-            .is_none());
-
-        // advance five more frames, so that the component gets removed on predicted
-        for i in 0..5 {
-            stepper.frame_step();
-        }
-        assert_eq!(stepper.client().tick(), Tick(6));
-
-        // create a rollback situation by adding the component on confirmed
-        stepper.client_mut().set_synced();
-        stepper
-            .client_mut()
-            .set_latest_received_server_tick(Tick(3));
-        stepper
-            .client_app
-            .world
-            .entity_mut(confirmed)
-            .insert(Component1(1.0));
-        // update without incrementing time, because we want to force a rollback check
-        stepper.client_app.update();
-
-        // check that rollback happened
-        // predicted got the component re-added
-        stepper
-            .client_app
-            .world
-            .get_mut::<Component1>(predicted)
-            .unwrap()
-            .0 = 4.0;
-        // check that the history is how we expect after rollback
-        let mut history = PredictionHistory::<Component1>::default();
-        for i in 3..7 {
-            history
-                .buffer
-                .add_item(Tick(i), ComponentState::Updated(Component1(i as f32 - 2.0)));
-        }
-        assert_eq!(
-            stepper
-                .client_app
-                .world
-                .get::<PredictionHistory<Component1>>(predicted)
-                .unwrap(),
-            &history
-        );
-
-        Ok(())
-    }
-}
+//
+// #[cfg(test)]
+// mod tests {
+//     use std::time::Duration;
+//
+//     use bevy::prelude::*;
+//     use tracing::{debug, info};
+//
+//     use crate::_reexport::*;
+//     use crate::prelude::client::*;
+//     use crate::prelude::*;
+//     use crate::tests::protocol::*;
+//     use crate::tests::stepper::{BevyStepper, Step};
+//
+//     fn increment_component(
+//         mut commands: Commands,
+//         mut query: Query<(Entity, &mut Component1), With<Predicted>>,
+//     ) {
+//         for (entity, mut component) in query.iter_mut() {
+//             component.0 += 1.0;
+//             if component.0 == 5.0 {
+//                 commands.entity(entity).remove::<Component1>();
+//             }
+//         }
+//     }
+//
+//     fn setup() -> BevyStepper {
+//         let frame_duration = Duration::from_millis(10);
+//         let tick_duration = Duration::from_millis(10);
+//         let shared_config = SharedConfig {
+//             enable_replication: false,
+//             tick: TickConfig::new(tick_duration),
+//             log: LogConfig {
+//                 level: tracing::Level::DEBUG,
+//                 ..Default::default()
+//             },
+//             ..Default::default()
+//         };
+//         let link_conditioner = LinkConditionerConfig {
+//             incoming_latency: Duration::from_millis(40),
+//             incoming_jitter: Duration::from_millis(5),
+//             incoming_loss: 0.05,
+//         };
+//         let sync_config = SyncConfig::default().speedup_factor(1.0);
+//         let prediction_config = PredictionConfig::default().disable(false);
+//         let interpolation_delay = Duration::from_millis(100);
+//         let interpolation_config = InterpolationConfig::default().with_delay(InterpolationDelay {
+//             min_delay: interpolation_delay,
+//             send_interval_ratio: 0.0,
+//         });
+//         let mut stepper = BevyStepper::new(
+//             shared_config,
+//             sync_config,
+//             prediction_config,
+//             interpolation_config,
+//             link_conditioner,
+//             frame_duration,
+//         );
+//         stepper.client_mut().set_synced();
+//         stepper.client_app.add_systems(
+//             FixedUpdate,
+//             increment_component.in_set(FixedUpdateSet::Main),
+//         );
+//         stepper
+//     }
+//
+//     // Test that if a component gets removed from the predicted entity erroneously
+//     // We are still able to rollback properly (the rollback adds the component to the predicted entity)
+//     #[test]
+//     fn test_removed_predicted_component_rollback() -> anyhow::Result<()> {
+//         let mut stepper = setup();
+//
+//         // Create a confirmed entity
+//         let confirmed = stepper
+//             .client_app
+//             .world
+//             .spawn((Component1(0.0), ShouldBePredicted))
+//             .id();
+//
+//         // Tick once
+//         stepper.frame_step();
+//         assert_eq!(stepper.client().tick(), Tick(1));
+//         let predicted = stepper
+//             .client_app
+//             .world
+//             .get::<Confirmed>(confirmed)
+//             .unwrap()
+//             .predicted
+//             .unwrap();
+//
+//         // check that the predicted entity got spawned
+//         assert_eq!(
+//             stepper
+//                 .client_app
+//                 .world
+//                 .get::<Predicted>(predicted)
+//                 .unwrap()
+//                 .confirmed_entity,
+//             confirmed
+//         );
+//
+//         // check that the component history got created
+//         let mut history = PredictionHistory::<Component1>::default();
+//         // this is added during the first rollback call after we create the history
+//         history
+//             .buffer
+//             .add_item(Tick(0), ComponentState::Updated(Component1(0.0)));
+//         history
+//             .buffer
+//             .add_item(Tick(1), ComponentState::Updated(Component1(1.0)));
+//         assert_eq!(
+//             stepper
+//                 .client_app
+//                 .world
+//                 .get::<PredictionHistory<Component1>>(predicted)
+//                 .unwrap(),
+//             &history,
+//         );
+//         // check that the confirmed component got replicated
+//         assert_eq!(
+//             stepper
+//                 .client_app
+//                 .world
+//                 .get::<Component1>(predicted)
+//                 .unwrap(),
+//             &Component1(1.0)
+//         );
+//
+//         // advance five more frames, so that the component gets removed on predicted
+//         for i in 0..5 {
+//             stepper.frame_step();
+//         }
+//         assert_eq!(stepper.client().tick(), Tick(6));
+//
+//         // check that the component got removed on predicted
+//         assert!(stepper
+//             .client_app
+//             .world
+//             .get::<Component1>(predicted)
+//             .is_none());
+//         // check that the component history is still there and that the value of the component history is correct
+//         let mut history = PredictionHistory::<Component1>::default();
+//         for i in 0..5 {
+//             history
+//                 .buffer
+//                 .add_item(Tick(i), ComponentState::Updated(Component1(i as f32)));
+//         }
+//         history.buffer.add_item(Tick(5), ComponentState::Removed);
+//         assert_eq!(
+//             stepper
+//                 .client_app
+//                 .world
+//                 .get::<PredictionHistory<Component1>>(predicted)
+//                 .unwrap(),
+//             &history,
+//         );
+//
+//         // TODO: need to revisit this, a rollback situation is created from receiving a replication update now
+//         // create a rollback situation
+//         stepper.client_mut().set_synced();
+//         stepper
+//             .client_mut()
+//             .set_latest_received_server_tick(Tick(3));
+//         stepper
+//             .client_app
+//             .world
+//             .get_mut::<Component1>(confirmed)
+//             .unwrap()
+//             .0 = 1.0;
+//         // update without incrementing time, because we want to force a rollback check
+//         stepper.client_app.update();
+//
+//         // check that rollback happened
+//         // predicted got the component re-added
+//         stepper
+//             .client_app
+//             .world
+//             .get_mut::<Component1>(predicted)
+//             .unwrap()
+//             .0 = 4.0;
+//         // check that the history is how we expect after rollback
+//         let mut history = PredictionHistory::<Component1>::default();
+//         for i in 3..7 {
+//             history
+//                 .buffer
+//                 .add_item(Tick(i), ComponentState::Updated(Component1(i as f32 - 2.0)));
+//         }
+//         assert_eq!(
+//             stepper
+//                 .client_app
+//                 .world
+//                 .get::<PredictionHistory<Component1>>(predicted)
+//                 .unwrap(),
+//             &history
+//         );
+//
+//         Ok(())
+//     }
+//
+//     // Test that if a component gets added to the predicted entity erroneously but didn't exist on the confirmed entity)
+//     // We are still able to rollback properly (the rollback removes the component from the predicted entity)
+//     #[test]
+//     fn test_added_predicted_component_rollback() -> anyhow::Result<()> {
+//         let mut stepper = setup();
+//
+//         // Create a confirmed entity
+//         let confirmed = stepper.client_app.world.spawn(ShouldBePredicted).id();
+//
+//         // Tick once
+//         stepper.frame_step();
+//         assert_eq!(stepper.client().tick(), Tick(1));
+//         let predicted = stepper
+//             .client_app
+//             .world
+//             .get::<Confirmed>(confirmed)
+//             .unwrap()
+//             .predicted
+//             .unwrap();
+//
+//         // check that the predicted entity got spawned
+//         assert_eq!(
+//             stepper
+//                 .client_app
+//                 .world
+//                 .get::<Predicted>(predicted)
+//                 .unwrap()
+//                 .confirmed_entity,
+//             confirmed
+//         );
+//
+//         // add a new component to Predicted
+//         stepper
+//             .client_app
+//             .world
+//             .entity_mut(predicted)
+//             .insert(Component1(1.0));
+//
+//         // create a rollback situation (confirmed doesn't have a component that predicted has)
+//         stepper.client_mut().set_synced();
+//         stepper
+//             .client_mut()
+//             .set_latest_received_server_tick(Tick(1));
+//         // update without incrementing time, because we want to force a rollback check
+//         stepper.client_app.update();
+//
+//         // check that rollback happened: the component got removed from predicted
+//         assert!(stepper
+//             .client_app
+//             .world
+//             .get::<Component1>(predicted)
+//             .is_none());
+//
+//         // check that history contains the removal
+//         let mut history = PredictionHistory::<Component1>::default();
+//         history.buffer.add_item(Tick(1), ComponentState::Removed);
+//         assert_eq!(
+//             stepper
+//                 .client_app
+//                 .world
+//                 .get::<PredictionHistory<Component1>>(predicted)
+//                 .unwrap(),
+//             &history,
+//         );
+//         Ok(())
+//     }
+//
+//     // Test that if a component gets removed from the confirmed entity
+//     // We are still able to rollback properly (the rollback removes the component from the predicted entity)
+//     #[test]
+//     fn test_removed_confirmed_component_rollback() -> anyhow::Result<()> {
+//         let mut stepper = setup();
+//
+//         // Create a confirmed entity
+//         let confirmed = stepper
+//             .client_app
+//             .world
+//             .spawn((Component1(0.0), ShouldBePredicted))
+//             .id();
+//
+//         // Tick once
+//         stepper.frame_step();
+//         assert_eq!(stepper.client().tick(), Tick(1));
+//         let predicted = stepper
+//             .client_app
+//             .world
+//             .get::<Confirmed>(confirmed)
+//             .unwrap()
+//             .predicted
+//             .unwrap();
+//
+//         // check that the predicted entity got spawned
+//         assert_eq!(
+//             stepper
+//                 .client_app
+//                 .world
+//                 .get::<Predicted>(predicted)
+//                 .unwrap()
+//                 .confirmed_entity,
+//             confirmed
+//         );
+//
+//         // check that the component history got created
+//         let mut history = PredictionHistory::<Component1>::default();
+//         history
+//             .buffer
+//             .add_item(Tick(0), ComponentState::Updated(Component1(0.0)));
+//         history
+//             .buffer
+//             .add_item(Tick(1), ComponentState::Updated(Component1(1.0)));
+//         assert_eq!(
+//             stepper
+//                 .client_app
+//                 .world
+//                 .get::<PredictionHistory<Component1>>(predicted)
+//                 .unwrap(),
+//             &history,
+//         );
+//
+//         // create a rollback situation by removing the component on confirmed
+//         stepper.client_mut().set_synced();
+//         stepper
+//             .client_mut()
+//             .set_latest_received_server_tick(Tick(1));
+//         stepper
+//             .client_app
+//             .world
+//             .entity_mut(confirmed)
+//             .remove::<Component1>();
+//         // update without incrementing time, because we want to force a rollback check
+//         // (need duration_since_latest_received_server_tick = 0)
+//         stepper.client_app.update();
+//
+//         // check that rollback happened
+//         // predicted got the component removed
+//         assert!(stepper
+//             .client_app
+//             .world
+//             .get_mut::<Component1>(predicted)
+//             .is_none());
+//
+//         // check that the history is how we expect after rollback
+//         let mut history = PredictionHistory::<Component1>::default();
+//         history.buffer.add_item(Tick(1), ComponentState::Removed);
+//         assert_eq!(
+//             stepper
+//                 .client_app
+//                 .world
+//                 .get::<PredictionHistory<Component1>>(predicted)
+//                 .unwrap(),
+//             &history
+//         );
+//
+//         Ok(())
+//     }
+//
+//     // Test that if a component gets added to the confirmed entity (but didn't exist on the predicted entity)
+//     // We are still able to rollback properly (the rollback adds the component to the predicted entity)
+//     #[test]
+//     fn test_added_confirmed_component_rollback() -> anyhow::Result<()> {
+//         let mut stepper = setup();
+//
+//         // Create a confirmed entity
+//         let confirmed = stepper.client_app.world.spawn(ShouldBePredicted).id();
+//
+//         // Tick once
+//         stepper.frame_step();
+//         assert_eq!(stepper.client().tick(), Tick(1));
+//         let predicted = stepper
+//             .client_app
+//             .world
+//             .get::<Confirmed>(confirmed)
+//             .unwrap()
+//             .predicted
+//             .unwrap();
+//
+//         // check that the predicted entity got spawned
+//         assert_eq!(
+//             stepper
+//                 .client_app
+//                 .world
+//                 .get::<Predicted>(predicted)
+//                 .unwrap()
+//                 .confirmed_entity,
+//             confirmed
+//         );
+//
+//         // check that the component history did not get created
+//         assert!(stepper
+//             .client_app
+//             .world
+//             .get::<PredictionHistory<Component1>>(predicted)
+//             .is_none());
+//
+//         // advance five more frames, so that the component gets removed on predicted
+//         for i in 0..5 {
+//             stepper.frame_step();
+//         }
+//         assert_eq!(stepper.client().tick(), Tick(6));
+//
+//         // create a rollback situation by adding the component on confirmed
+//         stepper.client_mut().set_synced();
+//         stepper
+//             .client_mut()
+//             .set_latest_received_server_tick(Tick(3));
+//         stepper
+//             .client_app
+//             .world
+//             .entity_mut(confirmed)
+//             .insert(Component1(1.0));
+//         // update without incrementing time, because we want to force a rollback check
+//         stepper.client_app.update();
+//
+//         // check that rollback happened
+//         // predicted got the component re-added
+//         stepper
+//             .client_app
+//             .world
+//             .get_mut::<Component1>(predicted)
+//             .unwrap()
+//             .0 = 4.0;
+//         // check that the history is how we expect after rollback
+//         let mut history = PredictionHistory::<Component1>::default();
+//         for i in 3..7 {
+//             history
+//                 .buffer
+//                 .add_item(Tick(i), ComponentState::Updated(Component1(i as f32 - 2.0)));
+//         }
+//         assert_eq!(
+//             stepper
+//                 .client_app
+//                 .world
+//                 .get::<PredictionHistory<Component1>>(predicted)
+//                 .unwrap(),
+//             &history
+//         );
+//
+//         Ok(())
+//     }
+// }

--- a/lightyear/src/client/prediction/rollback.rs
+++ b/lightyear/src/client/prediction/rollback.rs
@@ -1,9 +1,13 @@
 use std::fmt::Debug;
 
-use bevy::prelude::{Commands, Entity, FixedUpdate, Query, Res, ResMut, Without, World};
+use bevy::prelude::{
+    Commands, Entity, EventReader, FixedUpdate, Query, Res, ResMut, Without, World,
+};
+use bevy::utils::{EntityHashSet, HashSet};
 use tracing::{debug, error, info, trace, trace_span, warn};
 
 use crate::client::components::{ComponentSyncMode, Confirmed, SyncComponent};
+use crate::client::events::{ComponentInsertEvent, ComponentRemoveEvent, ComponentUpdateEvent};
 use crate::client::prediction::predicted_history::ComponentState;
 use crate::client::resource::Client;
 use crate::protocol::Protocol;
@@ -11,33 +15,12 @@ use crate::protocol::Protocol;
 use super::predicted_history::PredictionHistory;
 use super::{Predicted, Rollback, RollbackState};
 
-/// When we  want to create newly predicted entities, we need to:
-/// - spawn an entity on the server for that client
-/// - create a copy of that entity with Confirmed on the client
-/// - replicate that copy to the server
-// pub(crate) fn spawn_predicted(
-//
-// )
+// TODO (unrelated): pattern for enabling replication-behaviour for a component/entity. (for example don't replicate this component)
+//  Added a ReplicationBehaviour<C>.
+//  And then maybe we can add an EntityCommands extension that adds a ReplicationBehaviour<C>
 
-// TODO: maybe add a condition for running rollback
-// pub(crate) fn should_rollback_check(rollback: Res<Rollback>) {
-//
-// }
+// NOTE: for rollback to work, all entities that are predicted need to be replicated on the same tick!
 
-// rollback table:
-// - confirm exist. rollback if:
-//    - predicted history exists and is different
-//    - predicted history does not exist
-//    To rollback:
-//    - update the predicted component to the confirmed component if it exists
-//    - insert the confirmed component to the predicted entity if it doesn't exist
-// - confirm does not exist. rollback if:
-//    - predicted history exists and doesn't contain Removed
-//    -
-//    To rollback:
-//    - we remove the component from predicted.
-//
-//
 // We need:
 // - Removed because we need to know if the component was removed on predicted, but we have to keep the history for the rest of rollback
 // - To be able to handle missing component histories; (if a component suddenly gets added on confirmed for the first time, it won't exist on predicted, so existed wont have a history)
@@ -49,7 +32,7 @@ use super::{Predicted, Rollback, RollbackState};
 // TODO: it seems pretty suboptimal to have one system per component, refactor to loop through all components
 //  ESPECIALLY BECAUSE WE ROLLBACK EVERYTHING IF ONE COMPONENT IS MISPREDICTED!
 /// Systems that try to see if we should perform rollback for the predicted entity.
-/// For each companent, we compare the confirmed component (server-state) with the history.
+/// For each component, we compare the confirmed component (server-state) with the history.
 /// If we need to run rollback, we clear the predicted history and snap the history back to the server-state
 // TODO: do not rollback if client is not time synced
 #[allow(clippy::type_complexity)]
@@ -58,20 +41,9 @@ pub(crate) fn client_rollback_check<C: SyncComponent, P: Protocol>(
     mut commands: Commands,
     client: Res<Client<P>>,
 
-    // mut updates: EventReader<ComponentUpdateEvent<C>>,
-    // mut inserts: EventReader<ComponentInsertEvent<C>>,
-    // mut removals: EventReader<ComponentRemoveEvent<C>>,
-
-    // TODO: here we basically snap back the value only for the ComponentHistory components
-    //  but we might want to copy the predictive state of some components from Confirmed to Predicted, without caring
-    //  about rollback
-    //  So there would be three states:
-    //  #[replication(predicted)]  -> do full rollback
-    //  #[replication(copy)]  -> prediction just copy the state of the server when it arrives (even if the server state is a bit late. Useful for
-    //     components that don't get updated often, such as Color, Name, etc.)
-    //  -> no replication at all, the component is replicated to the Confirmed entity but not the predicted one.
-    //  IDEALLY THIS GET BE SET PER ENTITY, NOT IN THE PROTOCOL ITSELF?
-    //  MAYBE A PREDICTION-STATE for each component, similar to prediction history?
+    mut updates: EventReader<ComponentUpdateEvent<C>>,
+    mut inserts: EventReader<ComponentInsertEvent<C>>,
+    mut removals: EventReader<ComponentRemoveEvent<C>>,
 
     // We also snap the value of the component to the server state if we are in rollback
     // We use Option<> because the predicted component could have been removed while it still exists in Confirmed
@@ -84,7 +56,7 @@ pub(crate) fn client_rollback_check<C: SyncComponent, P: Protocol>(
         ),
         Without<Confirmed>,
     >,
-    confirmed_query: Query<(Entity, Option<&C>, &Confirmed)>,
+    confirmed_query: Query<(Option<&C>, &Confirmed)>,
     mut rollback: ResMut<Rollback>,
 )
 // where
@@ -100,126 +72,98 @@ pub(crate) fn client_rollback_check<C: SyncComponent, P: Protocol>(
     // TODO: can just enable bevy spans?
     let _span = trace_span!("client rollback check");
 
-    // 0. We will compare the history and the confirmed entity for this tick
-    // - Confirmed contains the server state at the tick
-    // - History contains the history of what we predicted at the tick
-    let latest_server_tick = client.latest_received_server_tick();
+    // 0. We want to do a rollback check every time the component for the confirmed entity got modified in any way (removed/added/updated)
+    let confirmed_entity_with_updates = updates
+        .read()
+        .map(|event| *event.entity())
+        .chain(inserts.read().map(|event| *event.entity()))
+        .chain(removals.read().map(|event| *event.entity()))
+        .collect::<EntityHashSet<Entity>>();
 
-    // 1. We want to do a rollback check every time the component got modified (removed/added/updated) on the confirmed entity
-    // NOTE: actually we should just check for rollback if latest_received_server_tick got modified
-    //  because even if server state didn't change, our history did
+    for confirmed_entity in confirmed_entity_with_updates {
+        let Ok((confirmed_component, confirmed)) = confirmed_query.get(confirmed_entity) else {
+            // this could happen if the entity was despawned but we received updates for it.
+            // maybe only send events for an entity if it still exists?
+            debug!(
+                "could not find the confirmed entity: {:?} that received an update",
+                confirmed_entity
+            );
+            continue;
+        };
 
-    // let confirmed_entity_updates = updates
-    //     .read()
-    //     .map(|event| event.entity())
-    //     .chain(inserts.read().map(|event| event.entity()))
-    //     .chain(removals.read().map(|event| event.entity()));
-    // TODO: does this contain duplicates? if so, we should dedup
-
-    // TODO: should we clear these? so that we don't see them again in the next tick?
-    //  or should we just keep track of the last time we ran this system, and what the last_received_server_tick was.
-    //  if the last_received_server_tick didn't change, then no point in redoing the rollback check
-
-    // for event in updates.read() {
-    for (confirmed_entity, confirmed_component, confirmed) in confirmed_query.iter() {
         // TODO: get the tick of the update from context of ComponentUpdateEvent if we switch to that
         // let confirmed_entity = event.entity();
         // TODO: no need to get the Predicted component because we're not using it right now..
         //  we could use it in the future if we add more state in the Predicted Component
-        // 2. Get the predicted entity, and it's history
+        // 1. Get the predicted entity, and it's history
         if let Some(p) = confirmed.predicted {
-            if let Ok((predicted_entity, predicted, predicted_component, mut predicted_history)) =
+            let Ok((predicted_entity, predicted, predicted_component, mut predicted_history)) =
                 predicted_query.get_mut(p)
-            {
-                // Note: it may seem like an optimization to only compare the history/server-state if we are not sure
-                // that we should rollback (RollbackState::Default)
-                // That is not the case, because if we do rollback we will need to snap the client entity to the server state
-                // So either way we will need to do an operation.
-                match rollback.state {
-                    // 3.a We are still not sure if we should do rollback. Compare history against confirmed
-                    // We rollback if there's no history (newly added predicted entity, or if there is a mismatch)
-                    RollbackState::Default => {
-                        // rollback table:
-                        // - confirm exist. rollback if:
-                        //    - predicted history exists and is different
-                        //    - predicted history does not exist
-                        //    To rollback:
-                        //    - update the predicted component to the confirmed component if it exists
-                        //    - insert the confirmed component to the predicted entity if it doesn't exist
-                        // - confirm does not exist. rollback if:
-                        //    - predicted history exists and doesn't contain Removed
-                        //    -
-                        //    To rollback:
-                        //    - we remove the component from predicted.
-                        let history_value = predicted_history.pop_until_tick(latest_server_tick);
-                        let should_rollback = match confirmed_component {
-                            // TODO: history-value should not be empty here; should we panic if it is?
-                            // confirm does not exist. rollback if history value is not Removed
-                            None => history_value.map_or(false, |history_value| {
-                                history_value != ComponentState::Removed
-                            }),
-                            // confirm exist. rollback if history value is different
-                            Some(c) => {
-                                history_value.map_or(true, |history_value| match history_value {
-                                    ComponentState::Updated(history_value) => history_value != *c,
-                                    ComponentState::Removed => true,
-                                })
-                            }
-                        };
-                        if should_rollback {
-                            info!(
+            else {
+                debug!("Predicted entity {:?} was not found", confirmed.predicted);
+                continue;
+            };
+
+            // 2. We will compare the predicted history and the confirmed entity at the current confirmed entity tick
+            // - Confirmed contains the server state at the tick
+            // - History contains the history of what we predicted at the tick
+            // get the tick that the confirmed entity is at
+            let Some(channel) = client
+                .replication_manager()
+                .channel_by_local(confirmed_entity)
+            else {
+                error!(
+                    "Could not find replication channel for entity {:?}",
+                    confirmed_entity
+                );
+                continue;
+            };
+            let tick = channel.latest_tick;
+
+            // Note: it may seem like an optimization to only compare the history/server-state if we are not sure
+            // that we should rollback (RollbackState::Default)
+            // That is not the case, because if we do rollback we will need to snap the client entity to the server state
+            // So either way we will need to do an operation.
+            match rollback.state {
+                // 3.a We are still not sure if we should do rollback. Compare history against confirmed
+                // We rollback if there's no history (newly added predicted entity, or if there is a mismatch)
+                RollbackState::Default => {
+                    // rollback table:
+                    // - confirm exist. rollback if:
+                    //    - predicted history exists and is different
+                    //    - predicted history does not exist
+                    //    To rollback:
+                    //    - update the predicted component to the confirmed component if it exists
+                    //    - insert the confirmed component to the predicted entity if it doesn't exist
+                    // - confirm does not exist. rollback if:
+                    //    - predicted history exists and doesn't contain Removed
+                    //    -
+                    //    To rollback:
+                    //    - we remove the component from predicted.
+
+                    let history_value = predicted_history.pop_until_tick(tick);
+                    let should_rollback = match confirmed_component {
+                        // TODO: history-value should not be empty here; should we panic if it is?
+                        // confirm does not exist. rollback if history value is not Removed
+                        None => history_value.map_or(false, |history_value| {
+                            history_value != ComponentState::Removed
+                        }),
+                        // confirm exist. rollback if history value is different
+                        Some(c) => {
+                            history_value.map_or(true, |history_value| match history_value {
+                                ComponentState::Updated(history_value) => history_value != *c,
+                                ComponentState::Removed => true,
+                            })
+                        }
+                    };
+                    if should_rollback {
+                        info!(
                                 "Rollback check: mismatch for component between predicted and confirmed {:?}",
                                 confirmed_entity
                             );
-                            // info!(
-                            //     "Rollback check: mismatch for component {:?} between predicted and confirmed {:?}", C::name(),
-                            //     confirmed_entity
-                            // );
-                            // TODO (unrelated): pattern for enabling replication-behaviour for a component/entity.
-                            //  Added a ReplicationBehaviour<C>.
-                            //  And then maybe we can add an EntityCommands extension that adds a ReplicationBehaviour<C>
 
-                            // we need to clear the history so we can write a new one
-                            predicted_history.clear();
-                            // SAFETY: we know the predicted entity exists
-                            let mut entity_mut = commands.entity(predicted_entity);
-                            match confirmed_component {
-                                // confirm does not exist, remove on predicted
-                                None => {
-                                    predicted_history
-                                        .buffer
-                                        .add_item(latest_server_tick, ComponentState::Removed);
-                                    entity_mut.remove::<C>();
-                                }
-                                // confirm exist, update or insert on predicted
-                                Some(c) => {
-                                    predicted_history.buffer.add_item(
-                                        latest_server_tick,
-                                        ComponentState::Updated(c.clone()),
-                                    );
-                                    match predicted_component {
-                                        None => {
-                                            entity_mut.insert(c.clone());
-                                        }
-                                        Some(mut predicted_component) => {
-                                            *predicted_component = c.clone();
-                                        }
-                                    };
-                                }
-                            };
-                            // TODO: try atomic enum update
-                            rollback.state = RollbackState::ShouldRollback {
-                                // we already replicated the latest_server_tick state
-                                // after this we will start right away with a physics update, so we need to start taking the inputs from the next tick
-                                current_tick: latest_server_tick + 1,
-                            };
-                        }
-                    }
-                    // 3.b We already know we should do rollback (because of another entity/component), start the rollback
-                    RollbackState::ShouldRollback { .. } => {
                         // we need to clear the history so we can write a new one
                         predicted_history.clear();
-
                         // SAFETY: we know the predicted entity exists
                         let mut entity_mut = commands.entity(predicted_entity);
                         match confirmed_component {
@@ -227,15 +171,14 @@ pub(crate) fn client_rollback_check<C: SyncComponent, P: Protocol>(
                             None => {
                                 predicted_history
                                     .buffer
-                                    .add_item(latest_server_tick, ComponentState::Removed);
+                                    .add_item(tick, ComponentState::Removed);
                                 entity_mut.remove::<C>();
                             }
                             // confirm exist, update or insert on predicted
                             Some(c) => {
-                                predicted_history.buffer.add_item(
-                                    latest_server_tick,
-                                    ComponentState::Updated(c.clone()),
-                                );
+                                predicted_history
+                                    .buffer
+                                    .add_item(tick, ComponentState::Updated(c.clone()));
                                 match predicted_component {
                                     None => {
                                         entity_mut.insert(c.clone());
@@ -246,29 +189,64 @@ pub(crate) fn client_rollback_check<C: SyncComponent, P: Protocol>(
                                 };
                             }
                         };
-                        // return;
+                        // TODO: try atomic enum update
+                        rollback.state = RollbackState::ShouldRollback {
+                            // we already rolled-back the state for the entity's latest_tick
+                            // after this we will start right away with a physics update, so we need to start taking the inputs from the next tick
+                            current_tick: tick + 1,
+                        };
                     }
                 }
-            } else {
-                debug!("Predicted entity {:?} was not found", confirmed.predicted);
+                // 3.b We already know we should do rollback (because of another entity/component), start the rollback
+                RollbackState::ShouldRollback { .. } => {
+                    // we need to clear the history so we can write a new one
+                    predicted_history.clear();
+
+                    // SAFETY: we know the predicted entity exists
+                    let mut entity_mut = commands.entity(predicted_entity);
+                    match confirmed_component {
+                        // confirm does not exist, remove on predicted
+                        None => {
+                            predicted_history
+                                .buffer
+                                .add_item(tick, ComponentState::Removed);
+                            entity_mut.remove::<C>();
+                        }
+                        // confirm exist, update or insert on predicted
+                        Some(c) => {
+                            predicted_history
+                                .buffer
+                                .add_item(tick, ComponentState::Updated(c.clone()));
+                            match predicted_component {
+                                None => {
+                                    entity_mut.insert(c.clone());
+                                }
+                                Some(mut predicted_component) => {
+                                    *predicted_component = c.clone();
+                                }
+                            };
+                        }
+                    };
+                }
             }
         }
     }
 }
 
-// TODO: check how we handle the user inputs here??
 pub(crate) fn run_rollback<P: Protocol>(world: &mut World) {
     let client = world.get_resource::<Client<P>>().unwrap();
-    let num_rollback_ticks = client.tick() - client.latest_received_server_tick();
-    debug!(
-        "Rollback between {:?} and {:?}",
-        client.latest_received_server_tick(),
-        client.tick()
-    );
-
     let rollback = world.get_resource::<Rollback>().unwrap();
+
+    // NOTE: all predicted entities should be on the same tick!
     // TODO: might not need to check the state, because we only run this system if we are in rollback
-    if let RollbackState::ShouldRollback { .. } = rollback.state {
+    if let RollbackState::ShouldRollback { current_tick } = rollback.state {
+        let num_rollback_ticks = client.tick() - current_tick;
+        debug!(
+            "Rollback between {:?} and {:?}",
+            current_tick,
+            client.tick()
+        );
+
         // run the physics fixed update schedule (which should contain ALL predicted/rollback components)
         for i in 0..num_rollback_ticks {
             // TODO: if we are in rollback, there are some FixedUpdate systems that we don't want to re-run ??

--- a/lightyear/src/connection/events.rs
+++ b/lightyear/src/connection/events.rs
@@ -1,13 +1,13 @@
 /*! Defines a [`ConnectionEvents`] struct that is used to store all events that are received from a [`Connection`](crate::connection::Connection).
 */
-use std::collections::HashMap;
 use std::iter;
 
 use bevy::prelude::{Component, Entity};
+use bevy::utils::{EntityHashMap, HashMap, HashSet};
 use tracing::{info, trace};
 
 use crate::packet::message::Message;
-use crate::prelude::Named;
+use crate::prelude::{Named, Tick};
 use crate::protocol::channel::ChannelKind;
 use crate::protocol::component::IntoKind;
 use crate::protocol::message::{MessageBehaviour, MessageKind};
@@ -28,14 +28,20 @@ pub struct ConnectionEvents<P: Protocol> {
     pub despawns: Vec<Entity>,
     // TODO: key by entity or by kind?
     // TODO: include the actual value in the event, or just the type? let's just include the type for now
-    pub component_inserts: HashMap<P::ComponentKinds, Vec<Entity>>,
+    pub component_inserts: HashMap<P::ComponentKinds, Vec<(Entity, Tick)>>,
     // pub insert_components: HashMap<Entity, Vec<P::Components>>,
-    pub component_removes: HashMap<P::ComponentKinds, Vec<Entity>>,
+    pub component_removes: HashMap<P::ComponentKinds, Vec<(Entity, Tick)>>,
     // TODO: here as well, we could only include the type.. we already apply the changes to the entity directly, so users could keep track of changes
     //  let's just start with the kind...
     //  also, normally the updates are sequenced
-    // TODO: include the tick for each update?
-    pub component_updates: HashMap<P::ComponentKinds, Vec<Entity>>,
+    // pub component_updates: HashMap<P::ComponentKinds, Vec<(Entity, Tick)>>,
+    // TODO: what happens if we receive on the same frame an Update for tick 4 and update for tick 10?
+    //  can we just discard the older one? what about for inserts/removes?
+    pub component_updates: EntityHashMap<Entity, HashMap<P::ComponentKinds, Tick>>,
+    components_with_updates: HashSet<P::ComponentKinds>,
+
+    // How can i easily get the events (inserts/adds/removes) for a given entity? add components on that entity
+    // that track that?
     empty: bool,
 }
 
@@ -60,6 +66,7 @@ impl<P: Protocol> ConnectionEvents<P> {
             component_inserts: Default::default(),
             component_removes: Default::default(),
             component_updates: Default::default(),
+            components_with_updates: Default::default(),
             // bookkeeping
             empty: true,
         }
@@ -125,7 +132,12 @@ impl<P: Protocol> ConnectionEvents<P> {
         self.empty = false;
     }
 
-    pub(crate) fn push_insert_component(&mut self, entity: Entity, component: P::ComponentKinds) {
+    pub(crate) fn push_insert_component(
+        &mut self,
+        entity: Entity,
+        component: P::ComponentKinds,
+        tick: Tick,
+    ) {
         trace!(?entity, ?component, "Received insert component");
         #[cfg(feature = "metrics")]
         {
@@ -134,11 +146,16 @@ impl<P: Protocol> ConnectionEvents<P> {
         self.component_inserts
             .entry(component)
             .or_default()
-            .push(entity);
+            .push((entity, tick));
         self.empty = false;
     }
 
-    pub(crate) fn push_remove_component(&mut self, entity: Entity, component: P::ComponentKinds) {
+    pub(crate) fn push_remove_component(
+        &mut self,
+        entity: Entity,
+        component: P::ComponentKinds,
+        tick: Tick,
+    ) {
         trace!(?entity, ?component, "Received remove component");
         #[cfg(feature = "metrics")]
         {
@@ -147,21 +164,37 @@ impl<P: Protocol> ConnectionEvents<P> {
         self.component_removes
             .entry(component)
             .or_default()
-            .push(entity);
+            .push((entity, tick));
         self.empty = false;
     }
 
     // TODO: how do distinguish between multiple updates for the same component/entity? add ticks?
-    pub(crate) fn push_update_component(&mut self, entity: Entity, component: P::ComponentKinds) {
+    pub(crate) fn push_update_component(
+        &mut self,
+        entity: Entity,
+        component: P::ComponentKinds,
+        tick: Tick,
+    ) {
         trace!(?entity, ?component, "Received update component");
         #[cfg(feature = "metrics")]
         {
             metrics::increment_counter!("component_update", "kind" => component);
         }
+        self.components_with_updates.insert(component.clone());
         self.component_updates
-            .entry(component)
+            .entry(entity)
             .or_default()
-            .push(entity);
+            .entry(component)
+            .and_modify(|t| {
+                if tick > *t {
+                    *t = tick;
+                }
+            })
+            .or_insert(tick);
+        // self.component_updates
+        //     .entry(component)
+        //     .or_default()
+        //     .push((entity, tick));
         self.empty = false;
     }
 }
@@ -231,41 +264,64 @@ impl<P: Protocol> IterEntityDespawnEvent for ConnectionEvents<P> {
     }
 }
 
-pub trait IterComponentUpdateEvent<P: Protocol, Ctx: EventContext = ()> {
-    fn into_iter_component_update<C: Component>(
+/// Iterate through all the events for a given entity
+pub trait IterComponentUpdateEvent<P: Protocol, Ctx: EventContext = Tick> {
+    /// Find all the updates of component C
+    fn iter_component_update<C: Component>(
         &mut self,
     ) -> Box<dyn Iterator<Item = (Entity, Ctx)> + '_>
     where
         C: IntoKind<P::ComponentKinds>;
+
+    /// Is there any update for component C
     fn has_component_update<C: Component>(&self) -> bool
+    where
+        C: IntoKind<P::ComponentKinds>;
+
+    /// Find all the updates of component C for a given entity
+    fn get_component_update<C: Component>(&self, entity: Entity) -> Option<Ctx>
     where
         C: IntoKind<P::ComponentKinds>;
 }
 
 impl<P: Protocol> IterComponentUpdateEvent<P> for ConnectionEvents<P> {
-    fn into_iter_component_update<C: Component>(
+    fn iter_component_update<C: Component>(
         &mut self,
-    ) -> Box<dyn Iterator<Item = (Entity, ())> + '_>
+    ) -> Box<dyn Iterator<Item = (Entity, Tick)> + '_>
     where
         C: IntoKind<P::ComponentKinds>,
     {
-        let component_kind = C::into_kind();
-        if let Some(data) = self.component_updates.remove(&component_kind) {
-            return Box::new(data.into_iter().map(|entity| (entity, ())));
-        }
-        Box::new(iter::empty())
+        Box::new(
+            self.component_updates
+                .iter()
+                .filter_map(|(entity, updates)| {
+                    updates.get(&C::into_kind()).map(|tick| (*entity, *tick))
+                }),
+        )
     }
 
     fn has_component_update<C: Component>(&self) -> bool
     where
         C: IntoKind<P::ComponentKinds>,
     {
-        let component_kind = C::into_kind();
-        self.component_updates.contains_key(&component_kind)
+        self.components_with_updates.contains(&C::into_kind())
+    }
+
+    // TODO: is it possible to receive multiple updates for the same component/entity?
+    //  it shouldn't be possible for a Sequenced channel,
+    //  maybe just take the first value that matches, then?
+    fn get_component_update<C: Component>(&self, entity: Entity) -> Option<Tick>
+    where
+        C: IntoKind<P::ComponentKinds>,
+    {
+        self.component_updates
+            .get(&entity)
+            .map(|updates| updates.get(&C::into_kind()).cloned())
+            .flatten()
     }
 }
 
-pub trait IterComponentRemoveEvent<P: Protocol, Ctx: EventContext = ()> {
+pub trait IterComponentRemoveEvent<P: Protocol, Ctx: EventContext = Tick> {
     fn into_iter_component_remove<C: Component>(
         &mut self,
     ) -> Box<dyn Iterator<Item = (Entity, Ctx)> + '_>
@@ -276,16 +332,17 @@ pub trait IterComponentRemoveEvent<P: Protocol, Ctx: EventContext = ()> {
         C: IntoKind<P::ComponentKinds>;
 }
 
+// TODO: move these implementations to client?
 impl<P: Protocol> IterComponentRemoveEvent<P> for ConnectionEvents<P> {
     fn into_iter_component_remove<C: Component>(
         &mut self,
-    ) -> Box<dyn Iterator<Item = (Entity, ())> + '_>
+    ) -> Box<dyn Iterator<Item = (Entity, Tick)> + '_>
     where
         C: IntoKind<P::ComponentKinds>,
     {
         let component_kind = C::into_kind();
         if let Some(data) = self.component_removes.remove(&component_kind) {
-            return Box::new(data.into_iter().map(|entity| (entity, ())));
+            return Box::new(data.into_iter());
         }
         Box::new(iter::empty())
     }
@@ -299,7 +356,7 @@ impl<P: Protocol> IterComponentRemoveEvent<P> for ConnectionEvents<P> {
     }
 }
 
-pub trait IterComponentInsertEvent<P: Protocol, Ctx: EventContext = ()> {
+pub trait IterComponentInsertEvent<P: Protocol, Ctx: EventContext = Tick> {
     fn into_iter_component_insert<C: Component>(
         &mut self,
     ) -> Box<dyn Iterator<Item = (Entity, Ctx)> + '_>
@@ -313,13 +370,13 @@ pub trait IterComponentInsertEvent<P: Protocol, Ctx: EventContext = ()> {
 impl<P: Protocol> IterComponentInsertEvent<P> for ConnectionEvents<P> {
     fn into_iter_component_insert<C: Component>(
         &mut self,
-    ) -> Box<dyn Iterator<Item = (Entity, ())> + '_>
+    ) -> Box<dyn Iterator<Item = (Entity, Tick)> + '_>
     where
         C: IntoKind<P::ComponentKinds>,
     {
         let component_kind = C::into_kind();
         if let Some(data) = self.component_inserts.remove(&component_kind) {
-            return Box::new(data.into_iter().map(|entity| (entity, ())));
+            return Box::new(data.into_iter());
         }
         Box::new(iter::empty())
     }
@@ -335,11 +392,9 @@ impl<P: Protocol> IterComponentInsertEvent<P> for ConnectionEvents<P> {
 
 #[cfg(test)]
 mod tests {
-    use crate::tests::protocol::{
-        Channel1, Channel2, Message1, Message2, MyMessageProtocol, MyProtocol,
-    };
-
     use super::*;
+    use crate::tests::protocol::*;
+    use bevy::utils::HashSet;
 
     #[test]
     fn test_iter_messages() {
@@ -368,5 +423,38 @@ mod tests {
 
         // check that we still have the other message kinds
         assert!(events.messages.contains_key(&MessageKind::of::<Message2>()));
+    }
+
+    #[test]
+    fn test_iter_component_updates() {
+        let mut events = ConnectionEvents::<MyProtocol>::new();
+        let channel_kind_1 = ChannelKind::of::<Channel1>();
+        let channel_kind_2 = ChannelKind::of::<Channel2>();
+        let entity_1 = Entity::from_raw(1);
+        let entity_2 = Entity::from_raw(2);
+        events.push_update_component(entity_1, MyComponentsProtocolKind::Component1, Tick(1));
+        events.push_update_component(entity_1, MyComponentsProtocolKind::Component2, Tick(2));
+        events.push_update_component(entity_2, MyComponentsProtocolKind::Component2, Tick(3));
+
+        assert!(events
+            .get_component_update::<Component1>(entity_2)
+            .is_none());
+        assert_eq!(
+            events.get_component_update::<Component2>(entity_2),
+            Some(Tick(3))
+        );
+
+        let component_1_updates: HashSet<(Entity, Tick)> =
+            events.iter_component_update::<Component1>().collect();
+        assert!(component_1_updates.contains(&(entity_1, Tick(1))));
+
+        let component_2_updates: HashSet<(Entity, Tick)> =
+            events.iter_component_update::<Component2>().collect();
+        assert!(component_2_updates.contains(&(entity_1, Tick(2))));
+        assert!(component_2_updates.contains(&(entity_2, Tick(3))));
+
+        let component_3_updates: HashSet<(Entity, Tick)> =
+            events.iter_component_update::<Component3>().collect();
+        assert!(component_3_updates.is_empty());
     }
 }

--- a/lightyear/src/connection/message.rs
+++ b/lightyear/src/connection/message.rs
@@ -7,11 +7,11 @@ use crate::prelude::{EntityMap, MapEntities, Tick};
 use crate::protocol::channel::ChannelKind;
 use crate::protocol::Protocol;
 use crate::shared::ping::message::SyncMessage;
-use crate::shared::replication::ReplicationMessage;
+use crate::shared::replication::{ReplicationMessage, ReplicationMessageData};
 use crate::shared::time_manager::TimeManager;
 use crate::utils::named::Named;
 use serde::{Deserialize, Serialize};
-use tracing::{info, trace, trace_span};
+use tracing::{info, info_span, trace, trace_span};
 
 // pub enum InternalMessage<P: Protocol> {
 //     InputMessage(InputMessage<P::Input>),
@@ -57,66 +57,81 @@ impl<P: Protocol> ProtocolMessage<P> {
                 #[cfg(metrics)]
                 metrics::increment_counter!("send_message", "channel" => channel_name, "message" => message_name);
             }
-            ProtocolMessage::Replication(message) => match message {
-                ReplicationMessage::SpawnEntity(entity, components) => {
-                    let components = components
-                        .iter()
-                        .map(|c| c.into())
-                        .collect::<Vec<P::ComponentKinds>>();
-                    info!(channel = ?channel_name, ?entity, ?components, "Sending entity spawn");
-                    #[cfg(metrics)]
-                    {
-                        metrics::increment_counter!("send_entity_spawn", "channel" => channel_name);
-                        for component in components {
-                            let kind: P::ComponentKinds = component.into();
-                            metrics::increment_counter!("send_component_insert", "channel" => channel_name, "component" => kind);
+            ProtocolMessage::Replication(message) => {
+                let _span = info_span!("send replication message", channel = ?channel_name, group_id = ?message.group_id);
+                #[cfg(metrics)]
+                metrics::increment_counter!("send_replication_actions");
+                match &message.data {
+                    ReplicationMessageData::Actions(m) => {
+                        for (entity, actions) in &m.actions {
+                            let _span = info_span!("send replication actions", ?entity);
+                            if actions.spawn {
+                                info!("Send entity spawn");
+                                #[cfg(metrics)]
+                                metrics::increment_counter!("send_entity_spawn");
+                            }
+                            if actions.despawn {
+                                info!("Send entity despawn");
+                                #[cfg(metrics)]
+                                metrics::increment_counter!("send_entity_despawn");
+                            }
+                            if !actions.insert.is_empty() {
+                                let components = actions
+                                    .insert
+                                    .iter()
+                                    .map(|c| c.into())
+                                    .collect::<Vec<P::ComponentKinds>>();
+                                info!(?components, "Sending component insert");
+                                #[cfg(metrics)]
+                                {
+                                    for component in components {
+                                        metrics::increment_counter!("send_component_insert", "component" => kind);
+                                    }
+                                }
+                            }
+                            if !actions.remove.is_empty() {
+                                info!(?actions.remove, "Sending component remove");
+                                #[cfg(metrics)]
+                                {
+                                    for kind in actions.remove {
+                                        metrics::increment_counter!("send_component_remove", "component" => kind);
+                                    }
+                                }
+                            }
+                            if !actions.updates.is_empty() {
+                                let components = actions
+                                    .updates
+                                    .iter()
+                                    .map(|c| c.into())
+                                    .collect::<Vec<P::ComponentKinds>>();
+                                info!(?components, "Sending component update");
+                                #[cfg(metrics)]
+                                {
+                                    for component in components {
+                                        metrics::increment_counter!("send_component_update", "component" => kind);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    ReplicationMessageData::Updates(m) => {
+                        for (entity, updates) in &m.updates {
+                            let _span = info_span!("send replication updates", ?entity);
+                            let components = updates
+                                .iter()
+                                .map(|c| c.into())
+                                .collect::<Vec<P::ComponentKinds>>();
+                            info!(?components, "Sending component update");
+                            #[cfg(metrics)]
+                            {
+                                for component in components {
+                                    metrics::increment_counter!("send_component_update", "component" => kind);
+                                }
+                            }
                         }
                     }
                 }
-                ReplicationMessage::DespawnEntity(entity) => {
-                    info!(channel = ?channel_name, ?entity, "Sending entity despawn");
-                    #[cfg(metrics)]
-                    metrics::increment_counter!("send_entity_despawn", "channel" => channel_name);
-                }
-                ReplicationMessage::InsertComponent(entity, components) => {
-                    let components = components
-                        .iter()
-                        .map(|c| c.into())
-                        .collect::<Vec<P::ComponentKinds>>();
-                    info!(channel = ?channel_name, ?entity, ?components, "Sending component insert");
-                    #[cfg(metrics)]
-                    {
-                        for component in components {
-                            let kind: P::ComponentKinds = component.into();
-                            metrics::increment_counter!("send_component_insert", "channel" => channel_name, "component" => kind);
-                        }
-                    }
-                }
-                ReplicationMessage::RemoveComponent(entity, components) => {
-                    info!(channel = ?channel_name, ?entity, ?components, "Sending component remove");
-                    #[cfg(metrics)]
-                    {
-                        for component in components {
-                            let kind: P::ComponentKinds = component.into();
-                            metrics::increment_counter!("send_component_remove", "channel" => channel_name, "component" => kind);
-                        }
-                    }
-                }
-                ReplicationMessage::EntityUpdate(entity, components) => {
-                    let components = components
-                        .iter()
-                        .map(|c| c.into())
-                        .collect::<Vec<P::ComponentKinds>>();
-                    info!(channel = ?channel_name, ?entity, ?components, "Sending entity update");
-                    #[cfg(metrics)]
-                    {
-                        for component in components {
-                            let kind: P::ComponentKinds = component.into();
-                            metrics::increment_counter!("send_component_update", "channel" => channel_name, "component" => kind);
-                        }
-                    }
-                }
-            },
+            }
             ProtocolMessage::Sync(message) => match message {
                 SyncMessage::Ping(_) => {
                     trace!(channel = ?channel_name, "Sending ping");
@@ -131,55 +146,59 @@ impl<P: Protocol> ProtocolMessage<P> {
             },
         }
     }
-    pub(crate) fn push_to_events(
-        self,
-        channel_kind: ChannelKind,
-        events: &mut ConnectionEvents<P>,
-        entity_map: &EntityMap,
-        time_manager: &TimeManager,
-        // tick of the remote when they sent that message. This means this message represents
-        // the state of the remote world for this tick
-        tick: Tick,
-    ) {
-        let _span = trace_span!("receive");
-        match self {
-            ProtocolMessage::Message(message) => {
-                events.push_message(channel_kind, message);
-            }
-            ProtocolMessage::Replication(replication) => match replication {
-                ReplicationMessage::SpawnEntity(entity, components) => {
-                    // convert the remote entity to the local before sending to events
-                    // if we can't find the local entity, just use the remote
-                    let local_entity = *entity_map.get_local(entity).unwrap_or(&entity);
-                    events.push_spawn(local_entity);
-                    for component in components {
-                        events.push_insert_component(local_entity, (&component).into(), tick);
-                    }
-                }
-                ReplicationMessage::DespawnEntity(entity) => {
-                    let local_entity = *entity_map.get_local(entity).unwrap_or(&entity);
-                    events.push_despawn(local_entity);
-                }
-                ReplicationMessage::InsertComponent(entity, components) => {
-                    let local_entity = *entity_map.get_local(entity).unwrap_or(&entity);
-                    for component in components {
-                        events.push_insert_component(local_entity, (&component).into(), tick);
-                    }
-                }
-                ReplicationMessage::RemoveComponent(entity, component_kinds) => {
-                    let local_entity = *entity_map.get_local(entity).unwrap_or(&entity);
-                    for component_kind in component_kinds {
-                        events.push_remove_component(local_entity, component_kind, tick);
-                    }
-                }
-                ReplicationMessage::EntityUpdate(entity, components) => {
-                    let local_entity = *entity_map.get_local(entity).unwrap_or(&entity);
-                    for component in components {
-                        events.push_update_component(local_entity, (&component).into(), tick);
-                    }
-                }
-            },
-            _ => {}
-        }
-    }
+
+    // pub(crate) fn push_to_events(
+    //     self,
+    //     channel_kind: ChannelKind,
+    //     events: &mut ConnectionEvents<P>,
+    //     entity_map: &EntityMap,
+    //     time_manager: &TimeManager,
+    //     // tick of the remote when they sent that message. This means this message represents
+    //     // the state of the remote world for this tick
+    //     tick: Tick,
+    // ) {
+    //     let _span = trace_span!("receive");
+    //     match self {
+    //         ProtocolMessage::Message(message) => {
+    //             events.push_message(channel_kind, message);
+    //         }
+    //         ProtocolMessage::Replication(replication) => match replication {
+    //             ReplicationMessage::SpawnEntity(entity, components) => {
+    //                 // convert the remote entity to the local before sending to events
+    //                 // if we can't find the local entity, just use the remote
+    //                 let local_entity = *entity_map.get_local(entity).unwrap_or(&entity);
+    //                 events.push_spawn(local_entity);
+    //                 for component in components {
+    //                     let kind: P::ComponentKinds = (&component).into();
+    //                     events.push_insert_component(local_entity, kind, tick);
+    //                 }
+    //             }
+    //             ReplicationMessage::DespawnEntity(entity) => {
+    //                 let local_entity = *entity_map.get_local(entity).unwrap_or(&entity);
+    //                 events.push_despawn(local_entity);
+    //             }
+    //             ReplicationMessage::InsertComponent(entity, components) => {
+    //                 let local_entity = *entity_map.get_local(entity).unwrap_or(&entity);
+    //                 for component in components {
+    //                     let kind: P::ComponentKinds = (&component).into();
+    //                     events.push_insert_component(local_entity, kind, tick);
+    //                 }
+    //             }
+    //             ReplicationMessage::RemoveComponent(entity, component_kinds) => {
+    //                 let local_entity = *entity_map.get_local(entity).unwrap_or(&entity);
+    //                 for component_kind in component_kinds {
+    //                     events.push_remove_component(local_entity, component_kind, tick);
+    //                 }
+    //             }
+    //             ReplicationMessage::EntityUpdate(entity, components) => {
+    //                 let local_entity = *entity_map.get_local(entity).unwrap_or(&entity);
+    //                 for component in components {
+    //                     let kind: P::ComponentKinds = (&component).into();
+    //                     events.push_update_component(local_entity, kind, tick);
+    //                 }
+    //             }
+    //         },
+    //         _ => {}
+    //     }
+    // }
 }

--- a/lightyear/src/connection/message.rs
+++ b/lightyear/src/connection/message.rs
@@ -53,7 +53,7 @@ impl<P: Protocol> ProtocolMessage<P> {
         match self {
             ProtocolMessage::Message(message) => {
                 let message_name = message.name();
-                info!(channel = ?channel_name, message = ?message_name, "Sending message");
+                trace!(channel = ?channel_name, message = ?message_name, "Sending message");
                 #[cfg(metrics)]
                 metrics::increment_counter!("send_message", "channel" => channel_name, "message" => message_name);
             }
@@ -66,12 +66,12 @@ impl<P: Protocol> ProtocolMessage<P> {
                         for (entity, actions) in &m.actions {
                             let _span = info_span!("send replication actions", ?entity);
                             if actions.spawn {
-                                info!("Send entity spawn");
+                                trace!("Send entity spawn");
                                 #[cfg(metrics)]
                                 metrics::increment_counter!("send_entity_spawn");
                             }
                             if actions.despawn {
-                                info!("Send entity despawn");
+                                trace!("Send entity despawn");
                                 #[cfg(metrics)]
                                 metrics::increment_counter!("send_entity_despawn");
                             }
@@ -81,7 +81,7 @@ impl<P: Protocol> ProtocolMessage<P> {
                                     .iter()
                                     .map(|c| c.into())
                                     .collect::<Vec<P::ComponentKinds>>();
-                                info!(?components, "Sending component insert");
+                                trace!(?components, "Sending component insert");
                                 #[cfg(metrics)]
                                 {
                                     for component in components {
@@ -90,7 +90,7 @@ impl<P: Protocol> ProtocolMessage<P> {
                                 }
                             }
                             if !actions.remove.is_empty() {
-                                info!(?actions.remove, "Sending component remove");
+                                trace!(?actions.remove, "Sending component remove");
                                 #[cfg(metrics)]
                                 {
                                     for kind in actions.remove {
@@ -104,7 +104,7 @@ impl<P: Protocol> ProtocolMessage<P> {
                                     .iter()
                                     .map(|c| c.into())
                                     .collect::<Vec<P::ComponentKinds>>();
-                                info!(?components, "Sending component update");
+                                trace!(?components, "Sending component update");
                                 #[cfg(metrics)]
                                 {
                                     for component in components {
@@ -121,7 +121,7 @@ impl<P: Protocol> ProtocolMessage<P> {
                                 .iter()
                                 .map(|c| c.into())
                                 .collect::<Vec<P::ComponentKinds>>();
-                            info!(?components, "Sending component update");
+                            trace!(?components, "Sending component update");
                             #[cfg(metrics)]
                             {
                                 for component in components {

--- a/lightyear/src/connection/mod.rs
+++ b/lightyear/src/connection/mod.rs
@@ -105,12 +105,15 @@ impl<P: Protocol> Connection<P> {
 
             if !messages.is_empty() {
                 trace!(?channel_name, "Received messages");
-                for mut message in messages {
+                for (tick, mut message) in messages {
                     // map entities from remote to local
                     message.map_entities(&self.replication_manager.entity_map);
                     // other message-handling logic
                     match message {
                         ProtocolMessage::Replication(ref replication) => {
+                            // TODO: maybe only apply to the world if the tick is more recent than
+                            //  what we have for that (component/entity) ?
+
                             // TODO: maybe only run apply world if the client is time-synced!
                             //  that would mean that for now, apply_world only runs on client, and not on server :)
                             self.replication_manager
@@ -137,6 +140,7 @@ impl<P: Protocol> Connection<P> {
                         &mut self.events,
                         &self.replication_manager.entity_map,
                         time_manager,
+                        tick,
                     );
                 }
             }

--- a/lightyear/src/connection/mod.rs
+++ b/lightyear/src/connection/mod.rs
@@ -163,12 +163,14 @@ impl<P: Protocol> Connection<P> {
                         }
                     }
                 }
+                // NOTE: ON THE RECEIVING SIDE, THE CHANNELS USE THE REMOTE_ENTITY AS KEY!
+                //  - either map all entities in map_entities (requires World access to spawn entities if needed)
 
                 // Check if we have any replication messages we can apply to the World (and emit events)
                 // TODO: maybe only run apply world if the client is time-synced!
                 //  that would mean that for now, apply_world only runs on client, and not on server :)
                 for (group, replication_list) in self.replication_manager.read_messages() {
-                    info!(?replication_list, "read replication messages");
+                    trace!(?group, ?replication_list, "read replication messages");
                     replication_list.into_iter().for_each(|(_, replication)| {
                         // TODO: we could include the server tick when this replication_message was sent.
                         self.replication_manager

--- a/lightyear/src/connection/mod.rs
+++ b/lightyear/src/connection/mod.rs
@@ -9,7 +9,7 @@ pub(crate) mod message;
 use anyhow::Result;
 use bevy::prelude::{Entity, World};
 use serde::{Deserialize, Serialize};
-use tracing::{trace, trace_span};
+use tracing::{info, trace, trace_span};
 
 use crate::channel::builder::{EntityUpdatesChannel, PingChannel};
 use crate::channel::senders::ChannelSend;
@@ -96,7 +96,7 @@ impl<P: Protocol> Connection<P> {
                     .name(&channel)
                     .unwrap_or("unknown")
                     .to_string();
-                let message = ProtocolMessage::Replication(ReplicationMessage {
+                let message = Replication(ReplicationMessage {
                     group_id,
                     data: message_data,
                 });
@@ -168,6 +168,7 @@ impl<P: Protocol> Connection<P> {
                 // TODO: maybe only run apply world if the client is time-synced!
                 //  that would mean that for now, apply_world only runs on client, and not on server :)
                 for (group, replication_list) in self.replication_manager.read_messages() {
+                    info!(?replication_list, "read replication messages");
                     replication_list.into_iter().for_each(|(_, replication)| {
                         // TODO: we could include the server tick when this replication_message was sent.
                         self.replication_manager
@@ -226,4 +227,22 @@ impl<P: Protocol> Connection<P> {
     pub fn recv_packet(&mut self, reader: &mut impl ReadBuffer) -> Result<Tick> {
         self.message_manager.recv_packet(reader)
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tests::protocol::*;
+
+    // #[test]
+    // fn test_notify_ack() -> Result<()> {
+    //     let protocol = protocol();
+    //     let ping_config = PingConfig::default();
+    //     let mut connection = Connection::new(protocol.channel_registry(), &ping_config);
+    //
+    //     con
+    //
+    //
+    //     Ok(())
+    // }
 }

--- a/lightyear/src/packet/message.rs
+++ b/lightyear/src/packet/message.rs
@@ -314,6 +314,27 @@ impl MessageContainer {
         };
     }
 
+    /// Set the tick of the remote when this message was sent
+    ///
+    /// Note that in some cases the tick can be already set (for example for tick-buffered channel,
+    /// or for reliable channels, since the tick set in the packet header might not correspond to the tick
+    /// where the message was initially set)
+    /// In those cases we don't override the tick
+    pub fn set_tick(&mut self, tick: Tick) {
+        match self {
+            MessageContainer::Single(data) => {
+                if data.tick.is_some() {
+                    data.tick = Some(tick);
+                }
+            }
+            MessageContainer::Fragment(data) => {
+                if data.tick.is_some() {
+                    data.tick = Some(tick);
+                }
+            }
+        };
+    }
+
     /// Get access to the underlying bytes (clone is a cheap operation for `Bytes`)
     pub fn bytes(&self) -> Bytes {
         match self {

--- a/lightyear/src/packet/message.rs
+++ b/lightyear/src/packet/message.rs
@@ -323,12 +323,12 @@ impl MessageContainer {
     pub fn set_tick(&mut self, tick: Tick) {
         match self {
             MessageContainer::Single(data) => {
-                if data.tick.is_some() {
+                if data.tick.is_none() {
                     data.tick = Some(tick);
                 }
             }
             MessageContainer::Fragment(data) => {
-                if data.tick.is_some() {
+                if data.tick.is_none() {
                     data.tick = Some(tick);
                 }
             }

--- a/lightyear/src/packet/message_manager.rs
+++ b/lightyear/src/packet/message_manager.rs
@@ -240,7 +240,7 @@ impl<M: BitSerializable> MessageManager<M> {
                 // TODO: why do we need finish read? to check for errors?
                 // reader.finish_read()?;
 
-                // SAFETY: when we read, we set the tick of the message to the header tick
+                // SAFETY: when we receive the message, we set the tick of the message to the header tick
                 // so every message has a tick
                 messages.push((single_data.tick.unwrap(), message));
             }

--- a/lightyear/src/packet/message_manager.rs
+++ b/lightyear/src/packet/message_manager.rs
@@ -261,35 +261,16 @@ mod tests {
 
     use serde::{Deserialize, Serialize};
 
-    use lightyear_macros::ChannelInternal;
-
+    use crate::_reexport::*;
     use crate::channel::builder::{
         ChannelDirection, ChannelMode, ChannelSettings, ReliableSettings,
     };
     use crate::packet::message::MessageId;
     use crate::packet::packet::FRAGMENT_SIZE;
+    use crate::prelude::*;
+    use crate::tests::protocol::*;
 
     use super::*;
-
-    // Messages
-    #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
-    pub struct Message1(pub u8);
-
-    #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
-    pub struct Message2(pub Vec<u8>);
-
-    #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
-    pub enum MyMessageProtocol {
-        Message1(Message1),
-        Message2(Message2),
-    }
-
-    // Channels
-    #[derive(ChannelInternal)]
-    struct Channel1;
-
-    #[derive(ChannelInternal)]
-    struct Channel2;
 
     #[test]
     /// We want to test that we can send/receive messages over a connection
@@ -300,24 +281,16 @@ mod tests {
         //     .init();
 
         let time_manager = TimeManager::new(Duration::default());
-        let mut channel_registry = ChannelRegistry::new();
-        channel_registry.add::<Channel1>(ChannelSettings {
-            mode: ChannelMode::OrderedReliable(ReliableSettings::default()),
-            direction: ChannelDirection::Bidirectional,
-        });
-        channel_registry.add::<Channel2>(ChannelSettings {
-            mode: ChannelMode::UnorderedUnreliable,
-            direction: ChannelDirection::Bidirectional,
-        });
+        let protocol = protocol();
 
         // Create message managers
         let mut client_message_manager =
-            MessageManager::<MyMessageProtocol>::new(&channel_registry);
+            MessageManager::<MyMessageProtocol>::new(protocol.channel_registry());
         let mut server_message_manager =
-            MessageManager::<MyMessageProtocol>::new(&channel_registry);
+            MessageManager::<MyMessageProtocol>::new(protocol.channel_registry());
 
         // client: buffer send messages, and then send
-        let message = MyMessageProtocol::Message1(Message1(1));
+        let message = MyMessageProtocol::Message1(Message1("1".to_string()));
         let channel_kind_1 = ChannelKind::of::<Channel1>();
         let channel_kind_2 = ChannelKind::of::<Channel2>();
         client_message_manager.buffer_send(message.clone(), channel_kind_1)?;
@@ -328,7 +301,7 @@ mod tests {
             HashMap::from([(
                 PacketId(0),
                 HashMap::from([(
-                    channel_kind_1,
+                    channel_kind_2,
                     vec![MessageAck {
                         message_id: MessageId(0),
                         fragment_id: None,
@@ -395,25 +368,19 @@ mod tests {
         //     .with_span_events(FmtSpan::ENTER)
         //     .with_max_level(tracing::Level::TRACE)
         //     .init();
-        let mut channel_registry = ChannelRegistry::new();
-        channel_registry.add::<Channel1>(ChannelSettings {
-            mode: ChannelMode::OrderedReliable(ReliableSettings::default()),
-            direction: ChannelDirection::Bidirectional,
-        });
-        channel_registry.add::<Channel2>(ChannelSettings {
-            mode: ChannelMode::UnorderedUnreliable,
-            direction: ChannelDirection::Bidirectional,
-        });
+        let protocol = protocol();
 
         // Create message managers
         let mut client_message_manager =
-            MessageManager::<MyMessageProtocol>::new(&channel_registry);
+            MessageManager::<MyMessageProtocol>::new(protocol.channel_registry());
         let mut server_message_manager =
-            MessageManager::<MyMessageProtocol>::new(&channel_registry);
+            MessageManager::<MyMessageProtocol>::new(protocol.channel_registry());
 
         // client: buffer send messages, and then send
-        let message_size = (1.5 * FRAGMENT_SIZE as f32) as usize;
-        let message = MyMessageProtocol::Message2(Message2(vec![1; message_size]));
+        const MESSAGE_SIZE: usize = (1.5 * FRAGMENT_SIZE as f32) as usize;
+
+        let data = std::str::from_utf8(&[0; MESSAGE_SIZE]).unwrap().to_string();
+        let message = MyMessageProtocol::Message1(Message1(data));
         let channel_kind_1 = ChannelKind::of::<Channel1>();
         let channel_kind_2 = ChannelKind::of::<Channel2>();
         client_message_manager.buffer_send(message.clone(), channel_kind_1)?;
@@ -424,9 +391,9 @@ mod tests {
             client_message_manager.packet_to_message_ack_map,
             HashMap::from([
                 (
-                    PacketId(0),
+                    PacketId(2),
                     HashMap::from([(
-                        channel_kind_1,
+                        channel_kind_2,
                         vec![MessageAck {
                             message_id: MessageId(0),
                             fragment_id: Some(0),
@@ -434,9 +401,9 @@ mod tests {
                     )])
                 ),
                 (
-                    PacketId(1),
+                    PacketId(3),
                     HashMap::from([(
-                        channel_kind_1,
+                        channel_kind_2,
                         vec![MessageAck {
                             message_id: MessageId(0),
                             fragment_id: Some(1),
@@ -485,8 +452,10 @@ mod tests {
             .contains_key(&PacketId(1)));
 
         // Server sends back a message
-        server_message_manager
-            .buffer_send(MyMessageProtocol::Message1(Message1(0)), channel_kind_1)?;
+        server_message_manager.buffer_send(
+            MyMessageProtocol::Message1(Message1("b".to_string())),
+            channel_kind_1,
+        )?;
         let mut packet_bytes = server_message_manager.send_packets(Tick(0))?;
 
         // On client side: keep looping to receive bytes on the network, then process them into messages
@@ -500,6 +469,63 @@ mod tests {
         // TODO: check that client_channel_1's sender's unacked messages is empty
         // let client_channel_1 = client_connection.channels.get(&channel_kind_1).unwrap();
         // assert_eq!(client_channel_1.sender.)
+        Ok(())
+    }
+
+    #[test]
+    fn test_notify_ack() -> anyhow::Result<()> {
+        let protocol = protocol();
+
+        // Create message managers
+        let mut client_message_manager =
+            MessageManager::<MyMessageProtocol>::new(protocol.channel_registry());
+        let mut server_message_manager =
+            MessageManager::<MyMessageProtocol>::new(protocol.channel_registry());
+
+        let update_acks_tracker = client_message_manager
+            .channels
+            .get_mut(&ChannelKind::of::<Channel2>())
+            .unwrap()
+            .sender
+            .subscribe_acks();
+
+        let message_id = client_message_manager
+            .buffer_send(MyMessageProtocol::Message2(Message2(1)), Channel2::kind())?
+            .unwrap();
+        assert_eq!(message_id, MessageId(0));
+        let mut payloads = client_message_manager.send_packets(Tick(0))?;
+        assert_eq!(
+            client_message_manager.packet_to_message_ack_map,
+            HashMap::from([(
+                PacketId(0),
+                HashMap::from([(
+                    Channel2::kind(),
+                    vec![MessageAck {
+                        message_id,
+                        fragment_id: None,
+                    }]
+                )])
+            )])
+        );
+
+        // server: receive bytes from the sent messages, then process them into messages
+        for payload in payloads.iter_mut() {
+            server_message_manager
+                .recv_packet(&mut ReadWordBuffer::start_read(payload.as_slice()))?;
+        }
+
+        // Server sends back a message (to ack the message)
+        server_message_manager
+            .buffer_send(MyMessageProtocol::Message2(Message2(1)), Channel2::kind())?;
+        let mut packet_bytes = server_message_manager.send_packets(Tick(0))?;
+
+        // On client side: keep looping to receive bytes on the network, then process them into messages
+        for packet_byte in packet_bytes.iter_mut() {
+            client_message_manager
+                .recv_packet(&mut ReadWordBuffer::start_read(packet_byte.as_slice()))?;
+        }
+
+        assert_eq!(update_acks_tracker.try_recv()?, message_id);
         Ok(())
     }
 }

--- a/lightyear/src/packet/message_manager.rs
+++ b/lightyear/src/packet/message_manager.rs
@@ -29,7 +29,7 @@ pub struct MessageManager<M: BitSerializable> {
     /// Handles sending/receiving packets (including acks)
     packet_manager: PacketBuilder,
     // TODO: add ordering of channels per priority
-    channels: HashMap<ChannelKind, ChannelContainer>,
+    pub(crate) channels: HashMap<ChannelKind, ChannelContainer>,
     pub(crate) channel_registry: ChannelRegistry,
     // TODO: can use Vec<ChannelKind, Vec<MessageId>> to be more efficient?
     /// Map to keep track of which messages have been sent in which packets, so that

--- a/lightyear/src/protocol/component.rs
+++ b/lightyear/src/protocol/component.rs
@@ -82,7 +82,7 @@ impl<T: Component> ComponentBehaviour for T {
 
     // Apply a ComponentUpdate to an entity
     fn update(self, entity: &mut EntityWorldMut) {
-        if let Some(c) = entity.get_mut::<T>() {
+        if let Some(mut c) = entity.get_mut::<T>() {
             *c = self;
         }
         // match entity.get_mut::<T>() {

--- a/lightyear/src/protocol/component.rs
+++ b/lightyear/src/protocol/component.rs
@@ -82,12 +82,15 @@ impl<T: Component> ComponentBehaviour for T {
 
     // Apply a ComponentUpdate to an entity
     fn update(self, entity: &mut EntityWorldMut) {
-        match entity.get_mut::<T>() {
-            Some(mut c) => *c = self,
-            None => {
-                entity.insert(self);
-            }
+        if let Some(c) = entity.get_mut::<T>() {
+            *c = self;
         }
+        // match entity.get_mut::<T>() {
+        //     Some(mut c) => *c = self,
+        //     None => {
+        //         entity.insert(self);
+        //     }
+        // }
     }
 }
 

--- a/lightyear/src/protocol/component.rs
+++ b/lightyear/src/protocol/component.rs
@@ -25,6 +25,7 @@ pub trait ComponentProtocol:
     + DeserializeOwned
     + MapEntities
     + ComponentBehaviour
+    + Debug
     + Send
     + Sync
     + From<ShouldBePredicted>

--- a/lightyear/src/protocol/component.rs
+++ b/lightyear/src/protocol/component.rs
@@ -75,9 +75,9 @@ impl<T: Component> ComponentBehaviour for T {
         // because otherwise the insert could override an component-update that was received later?
 
         // but this could cause some issues if we wanted the component to be updated from the insert
-        if entity.get::<T>().is_none() {
-            entity.insert(self);
-        }
+        // if entity.get::<T>().is_none() {
+        entity.insert(self);
+        // }
     }
 
     // Apply a ComponentUpdate to an entity

--- a/lightyear/src/protocol/mod.rs
+++ b/lightyear/src/protocol/mod.rs
@@ -133,7 +133,7 @@ macro_rules! protocolize {
                         direction: ChannelDirection::Bidirectional,
                     });
                     protocol.add_channel::<EntityUpdatesChannel>(ChannelSettings {
-                        mode: ChannelMode::SequencedUnreliable,
+                        mode: ChannelMode::UnorderedUnreliableWithAcks,
                         direction: ChannelDirection::Bidirectional,
                     });
                     protocol.add_channel::<PingChannel>(ChannelSettings {

--- a/lightyear/src/protocol/mod.rs
+++ b/lightyear/src/protocol/mod.rs
@@ -9,6 +9,7 @@ use bevy::prelude::App;
 use lightyear_macros::ChannelInternal;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
+use std::fmt::Debug;
 
 use crate::channel::builder::{Channel, ChannelSettings};
 use crate::inputs::UserInput;
@@ -66,7 +67,7 @@ pub(crate) mod registry;
 ///
 ///# fn main() {}
 /// ```
-pub trait Protocol: Send + Sync + Clone + 'static {
+pub trait Protocol: Send + Sync + Clone + Debug + 'static {
     type Input: UserInput;
     type Message: MessageProtocol<Protocol = Self>;
     type Components: ComponentProtocol<Protocol = Self>;

--- a/lightyear/src/server/connection.rs
+++ b/lightyear/src/server/connection.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 
 use crate::_reexport::ReadBuffer;
 use anyhow::Result;
+use bevy::ecs::component::Tick as BevyTick;
 use bevy::prelude::World;
 use tracing::trace;
 
@@ -16,7 +17,6 @@ use crate::protocol::channel::{ChannelKind, ChannelRegistry};
 use crate::protocol::Protocol;
 use crate::shared::ping::manager::{PingConfig, PingManager};
 use crate::shared::ping::message::{Ping, Pong, SyncMessage};
-use crate::shared::replication::manager::BevyTick;
 use crate::shared::tick_manager::TickManager;
 use crate::shared::time_manager::TimeManager;
 

--- a/lightyear/src/server/connection.rs
+++ b/lightyear/src/server/connection.rs
@@ -2,6 +2,7 @@
 use std::pin::pin;
 use std::time::Duration;
 
+use crate::_reexport::ReadBuffer;
 use anyhow::Result;
 use bevy::prelude::World;
 use tracing::trace;
@@ -15,6 +16,7 @@ use crate::protocol::channel::{ChannelKind, ChannelRegistry};
 use crate::protocol::Protocol;
 use crate::shared::ping::manager::{PingConfig, PingManager};
 use crate::shared::ping::message::{Ping, Pong, SyncMessage};
+use crate::shared::replication::manager::BevyTick;
 use crate::shared::tick_manager::TickManager;
 use crate::shared::time_manager::TimeManager;
 
@@ -31,6 +33,19 @@ impl<P: Protocol> Connection<P> {
             base: crate::connection::Connection::new(channel_registry, ping_config),
             input_buffer: InputBuffer::default(),
         }
+    }
+
+    /// Receive a packet and buffer it
+    /// Also handle any acks that we read from that packet
+    pub fn recv_packet(&mut self, reader: &mut impl ReadBuffer, bevy_tick: BevyTick) -> Result<()> {
+        // receive packet
+        self.base.recv_packet(reader)?;
+
+        // TODO: maybe do this also on client connection? Instead of only on server connection?
+        // update the bevy ticks associated with the update messages
+        self.base.replication_manager.recv_update_acks(bevy_tick);
+
+        Ok(())
     }
 
     /// Read messages received from buffer (either messages or replication events) and push them to events

--- a/lightyear/src/server/resource.rs
+++ b/lightyear/src/server/resource.rs
@@ -482,14 +482,15 @@ impl<P: Protocol> ReplicationSend<P> for Server<P> {
                 .context("group not found")?
                 .latest_updates_ack_bevy_tick;
             // send the update for all changes newer than the last ack bevy tick for the group
-            info!(
-                change_tick = ?component_change_tick,
-                last_ack_tick = ?last_updates_ack_bevy_tick,
-                current_tick = ?system_current_tick,
-                "prepare entity update changed check"
-            );
+
             if component_change_tick.is_newer_than(last_updates_ack_bevy_tick, system_current_tick)
             {
+                info!(
+                    change_tick = ?component_change_tick,
+                    last_ack_tick = ?last_updates_ack_bevy_tick,
+                    current_tick = ?system_current_tick,
+                    "prepare entity update changed check"
+                );
                 info!(
                     ?entity,
                     component = ?kind,

--- a/lightyear/src/server/resource.rs
+++ b/lightyear/src/server/resource.rs
@@ -486,7 +486,7 @@ impl<P: Protocol> ReplicationSend<P> for Server<P> {
                     .get_mut(client_id)
                     .context("client not found")?
                     .base
-                    .buffer_replication_messages()
+                    .buffer_replication_messages(self.tick_manager.current_tick())
             })
     }
 }

--- a/lightyear/src/server/resource.rs
+++ b/lightyear/src/server/resource.rs
@@ -5,6 +5,7 @@ use std::net::SocketAddr;
 use std::time::Duration;
 
 use anyhow::{anyhow, Context, Result};
+use bevy::ecs::component::Tick as BevyTick;
 use bevy::prelude::{Entity, Resource, World};
 use crossbeam_channel::Sender;
 use tracing::{debug, debug_span, info, trace, trace_span};
@@ -19,7 +20,6 @@ use crate::shared::ping::manager::PingManager;
 use crate::shared::ping::message::SyncMessage;
 use crate::shared::replication::components::{NetworkTarget, Replicate};
 use crate::shared::replication::components::{ShouldBeInterpolated, ShouldBePredicted};
-use crate::shared::replication::manager::BevyTick;
 use crate::shared::replication::ReplicationSend;
 use crate::shared::tick_manager::TickManager;
 use crate::shared::tick_manager::{Tick, TickManaged};

--- a/lightyear/src/server/room.rs
+++ b/lightyear/src/server/room.rs
@@ -10,7 +10,7 @@ use bevy::prelude::{
     Entity, IntoSystemConfigs, IntoSystemSetConfigs, Plugin, PostUpdate, Query, RemovedComponents,
     Res, ResMut, Resource, SystemSet,
 };
-use std::collections::{HashMap, HashSet};
+use bevy::utils::{HashMap, HashSet};
 use tracing::info;
 
 // Id for a room, used to perform interest management

--- a/lightyear/src/server/systems.rs
+++ b/lightyear/src/server/systems.rs
@@ -19,11 +19,10 @@ pub(crate) fn receive<P: Protocol>(world: &mut World) {
         // update client state, send keep-alives, receive packets from io
         server.update(time.delta()).unwrap();
         // buffer packets into message managers
-        server.recv_packets().unwrap();
+        server.recv_packets(world.change_tick()).unwrap();
 
         // receive events
         server.receive(world);
-        // let mut events = server.receive(world);
 
         // Write the received events into bevy events
         if !server.events.is_empty() {

--- a/lightyear/src/server/systems.rs
+++ b/lightyear/src/server/systems.rs
@@ -89,7 +89,7 @@ pub(crate) fn send<P: Protocol>(mut server: ResMut<Server<P>>) {
     // send buffered packets to io
     server.send_packets().unwrap();
 
-    server.clear_new_clients();
+    server.new_clients.clear();
 }
 
 pub(crate) fn clear_events<P: Protocol>(mut server: ResMut<Server<P>>) {

--- a/lightyear/src/shared/replication/components.rs
+++ b/lightyear/src/shared/replication/components.rs
@@ -46,7 +46,7 @@ impl Replicate {
     }
 }
 
-#[derive(Default)]
+#[derive(Debug, Default, Copy, Clone)]
 pub enum ReplicationGroup {
     // the group id is the entity id
     #[default]

--- a/lightyear/src/shared/replication/components.rs
+++ b/lightyear/src/shared/replication/components.rs
@@ -164,12 +164,10 @@ mod tests {
         assert!(target.should_send_to(&1));
         target.exclude(vec![0, 1]);
         assert!(matches!(target, NetworkTarget::AllExcept(_)));
-        match target {
-            NetworkTarget::AllExcept(ids) => {
-                assert!(ids.contains(&0));
-                assert!(ids.contains(&1));
-            }
-            _ => {}
+
+        if let NetworkTarget::AllExcept(ids) = target {
+            assert!(ids.contains(&0));
+            assert!(ids.contains(&1));
         }
 
         target = NetworkTarget::Only(vec![0]);

--- a/lightyear/src/shared/replication/components.rs
+++ b/lightyear/src/shared/replication/components.rs
@@ -58,7 +58,7 @@ pub enum ReplicationGroup {
 }
 
 #[derive(Default, Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct ReplicationGroupId(u64);
+pub struct ReplicationGroupId(pub u64);
 
 #[derive(Clone, Copy, Default, Debug, PartialEq)]
 pub enum ReplicationMode {

--- a/lightyear/src/shared/replication/components.rs
+++ b/lightyear/src/shared/replication/components.rs
@@ -41,8 +41,13 @@ pub enum ReplicationGroup {
     #[default]
     FromEntity,
     // choose a different group id
+    // note: it must not be the same as any entity id!
+    // TODO: how can i generate one that doesn't conflict? maybe take u32 as input, and apply generation = u32::MAX - 1?
     Group(u64),
 }
+
+#[derive(Default, Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct ReplicationGroupId(u64);
 
 #[derive(Clone, Copy, Default, Debug, PartialEq)]
 pub enum ReplicationMode {

--- a/lightyear/src/shared/replication/components.rs
+++ b/lightyear/src/shared/replication/components.rs
@@ -35,9 +35,20 @@ pub struct Replicate {
     pub replication_group: ReplicationGroup,
 }
 
+impl Replicate {
+    pub(crate) fn group_id(&self, entity: Option<Entity>) -> ReplicationGroupId {
+        match self.replication_group {
+            ReplicationGroup::FromEntity => {
+                ReplicationGroupId(entity.expect("need to provide an entity").to_bits())
+            }
+            ReplicationGroup::Group(id) => ReplicationGroupId(id),
+        }
+    }
+}
+
 #[derive(Default)]
 pub enum ReplicationGroup {
-    // the groups's id is the entity id
+    // the group id is the entity id
     #[default]
     FromEntity,
     // choose a different group id
@@ -66,6 +77,7 @@ impl Default for Replicate {
             interpolation_target: NetworkTarget::None,
             replication_clients_cache: HashMap::new(),
             replication_mode: ReplicationMode::default(),
+            replication_group: Default::default(),
         }
     }
 }

--- a/lightyear/src/shared/replication/entity_map.rs
+++ b/lightyear/src/shared/replication/entity_map.rs
@@ -1,4 +1,5 @@
 //! Map between local and remote entities
+use anyhow::Context;
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 
@@ -24,6 +25,17 @@ impl EntityMap {
 
     pub(crate) fn get_remote(&self, local_entity: Entity) -> Option<&Entity> {
         self.local_to_remote.get(&local_entity)
+    }
+
+    /// Get the corresponding local entity for a given remote entity, or create it if it doesn't exist.
+    pub(super) fn get_by_remote<'a>(
+        &mut self,
+        world: &'a mut World,
+        remote_entity: Entity,
+    ) -> anyhow::Result<EntityWorldMut<'a>> {
+        self.get_local(remote_entity)
+            .and_then(|e| world.get_entity_mut(*e))
+            .with_context("Failed to get local entity")
     }
 
     /// Get the corresponding local entity for a given remote entity, or create it if it doesn't exist.

--- a/lightyear/src/shared/replication/entity_map.rs
+++ b/lightyear/src/shared/replication/entity_map.rs
@@ -35,7 +35,7 @@ impl EntityMap {
     ) -> anyhow::Result<EntityWorldMut<'a>> {
         self.get_local(remote_entity)
             .and_then(|e| world.get_entity_mut(*e))
-            .with_context("Failed to get local entity")
+            .context("Failed to get local entity")
     }
 
     /// Get the corresponding local entity for a given remote entity, or create it if it doesn't exist.

--- a/lightyear/src/shared/replication/manager.rs
+++ b/lightyear/src/shared/replication/manager.rs
@@ -8,6 +8,7 @@ use crate::_reexport::{EntityActionsChannel, EntityUpdatesChannel};
 use crate::connection::events::ConnectionEvents;
 use bevy::ecs::component::Tick as BevyTick;
 use bevy::prelude::{Entity, EntityWorldMut, World};
+use bevy::utils::petgraph::data::ElementIterator;
 use bevy::utils::EntityHashMap;
 use crossbeam_channel::Receiver;
 use tracing::{debug, error, info, trace, trace_span};
@@ -20,6 +21,7 @@ use super::{
     ReplicationMessageData,
 };
 use crate::connection::message::ProtocolMessage;
+use crate::netcode::ClientId;
 use crate::packet::message::MessageId;
 use crate::prelude::Tick;
 use crate::protocol::channel::ChannelKind;
@@ -27,26 +29,15 @@ use crate::protocol::component::{ComponentBehaviour, ComponentKindBehaviour};
 use crate::protocol::Protocol;
 use crate::shared::replication::components::{ReplicationGroup, ReplicationGroupId};
 
-// TODO: maybe store additional information about the entity?
-//  (e.g. the value of the replicate component)?
-pub enum EntityStatus {
-    JustSpawned,
-    Spawning,
-    Spawned,
-}
-
+// TODO: maybe separate send/receive side for clarity?
 pub(crate) struct ReplicationManager<P: Protocol> {
-    pub remote_entity_status: HashMap<Entity, EntityStatus>,
     // pub global_replication_data: &'a ReplicationData,
-    /// Map between local and remote entities. (used mostly on client because it's when we receive entity updates)
-    pub entity_map: EntityMap,
-    /// Buffer to so that we have an ordered receiver per group
-    pub group_channels: EntityHashMap<ReplicationGroupId, GroupChannel<P>>,
+
+    // SEND
     /// Get notified whenever a message-id that was sent has been received by the remote
     pub updates_ack_tracker: Receiver<MessageId>,
     /// Map from message-id to the corresponding group-id that sent this update message
     pub updates_message_id_to_group_id: HashMap<MessageId, ReplicationGroupId>,
-
     /// messages that are being written. We need to hold a buffer of messages because components actions/updates
     /// are being buffered individually but we want to group them inside a message
     pub pending_actions: EntityHashMap<
@@ -54,103 +45,31 @@ pub(crate) struct ReplicationManager<P: Protocol> {
         BTreeMap<Entity, EntityActions<P::Components, P::ComponentKinds>>,
     >,
     pub pending_updates: EntityHashMap<ReplicationGroupId, BTreeMap<Entity, Vec<P::Components>>>,
-}
 
-/// Channel to keep track of receiving/sending replication messages for a given Group
-#[derive(Debug)]
-pub struct GroupChannel<P: Protocol> {
-    // actions
-    pub actions_next_send_message_id: MessageId,
-    pub actions_pending_recv_message_id: MessageId,
-    pub actions_recv_message_buffer:
-        BTreeMap<MessageId, (Tick, EntityActionMessage<P::Components, P::ComponentKinds>)>,
-    // last tick for which we sent an action message
-    pub last_action_tick: Tick,
+    // RECEIVE
+    /// Map between local and remote entities. (used mostly on client because it's when we receive entity updates)
+    pub entity_map: EntityMap,
+    /// Map from remote entity to the replication group-id
+    pub remote_entity_to_group: EntityHashMap<Entity, ReplicationGroupId>,
 
-    // updates
-    // map from necessary_last_action_tick to the buffered message
-    // the first tick is the last_action_tick
-    // the second tick is the update's server tick when it was sent
-    pub buffered_updates: BTreeMap<Tick, BTreeMap<Tick, EntityUpdatesMessage<P::Components>>>,
-    // TODO: maybe also keep track of which Tick this bevy-tick corresponds to? (will enable doing diff-compression)
-    // TODO: maybe this should be an Option, so that we make sure that when we need it's always is_some()
-    // bevy tick when we received an ack of an update for this group
-    pub latest_updates_ack_bevy_tick: BevyTick,
-
-    // both
-    /// last server tick that we applied to the client world
-    pub latest_tick: Tick,
-}
-
-impl<P: Protocol> Default for GroupChannel<P> {
-    fn default() -> Self {
-        Self {
-            actions_next_send_message_id: MessageId(0),
-            actions_pending_recv_message_id: MessageId(0),
-            actions_recv_message_buffer: BTreeMap::new(),
-            last_action_tick: Tick(0),
-            buffered_updates: Default::default(),
-            latest_updates_ack_bevy_tick: BevyTick::new(0),
-            latest_tick: Tick(0),
-        }
-    }
-}
-
-impl<P: Protocol> GroupChannel<P> {
-    /// Reads a message from the internal buffer to get its content
-    /// Since we are receiving messages in order, we don't return from the buffer
-    /// until we have received the message we are waiting for (the next expected MessageId)
-    /// This assumes that the sender sends all message ids sequentially.
-    ///
-    /// If had received updates that were waiting on a given action, we also return them
-    fn read_action(
-        &mut self,
-    ) -> Option<(Tick, EntityActionMessage<P::Components, P::ComponentKinds>)> {
-        // Check if we have received the message we are waiting for
-        let Some(message) = self
-            .actions_recv_message_buffer
-            .remove(&self.actions_pending_recv_message_id)
-        else {
-            return None;
-        };
-
-        self.actions_pending_recv_message_id += 1;
-        // Update the latest server tick that we have processed
-        self.latest_tick = message.0;
-        Some(message)
-    }
-
-    fn read_buffered_updates(&mut self) -> Vec<(Tick, EntityUpdatesMessage<P::Components>)> {
-        // go through all the buffered updates whose last_action_tick has been reached
-        let not_ready = self.buffered_updates.split_off(&(self.latest_tick + 1));
-
-        let mut res = vec![];
-        let buffered_updates_to_consider = std::mem::take(&mut self.buffered_updates);
-        for (necessary_action_tick, updates) in buffered_updates_to_consider.into_iter() {
-            // only push the update if the entity is at more recent tick than the last_action_tick
-            if necessary_action_tick < self.latest_tick {
-                for (tick, update) in updates {
-                    self.latest_tick = tick;
-                    res.push((tick, update));
-                }
-            }
-        }
-        self.buffered_updates = not_ready;
-        res
-    }
+    // BOTH
+    /// Buffer to so that we have an ordered receiver per group
+    pub group_channels: EntityHashMap<ReplicationGroupId, GroupChannel<P>>,
 }
 
 impl<P: Protocol> ReplicationManager<P> {
     pub(crate) fn new(updates_ack_tracker: Receiver<MessageId>) -> Self {
         Self {
-            entity_map: EntityMap::default(),
-            remote_entity_status: HashMap::new(),
+            // SEND
             pending_actions: EntityHashMap::default(),
             pending_updates: EntityHashMap::default(),
-            // global_replication_data,
-            group_channels: Default::default(),
             updates_ack_tracker,
             updates_message_id_to_group_id: Default::default(),
+            // RECEIVE
+            entity_map: EntityMap::default(),
+            remote_entity_to_group: Default::default(),
+            // BOTH
+            group_channels: Default::default(),
         }
     }
 
@@ -161,16 +80,13 @@ impl<P: Protocol> ReplicationManager<P> {
         while let Ok(message_id) = self.updates_ack_tracker.try_recv() {
             if let Some(group_id) = self.updates_message_id_to_group_id.get(&message_id) {
                 let channel = self.group_channels.entry(*group_id).or_default();
-                // TODO: should we do a max? yes, if we also deal with action tick
-                // if bevy_tick > channel.latest_updates_ack_bevy_tick
-                channel.latest_updates_ack_bevy_tick = bevy_tick;
+                channel.update_collect_changes_since_this_tick(bevy_tick);
             } else {
                 error!(
                     "Received an update message-id ack but we don't have the corresponding group"
                 );
             }
         }
-        // TODO: should we do the same thing for self.actions_ack_tracker?
     }
 
     /// Recv a new replication message and buffer it
@@ -179,10 +95,14 @@ impl<P: Protocol> ReplicationManager<P> {
         message: ReplicationMessage<P::Components, P::ComponentKinds>,
         tick: Tick,
     ) {
-        info!(?message, ?tick, "Received replication message");
+        trace!(?message, ?tick, "Received replication message");
         let channel = self.group_channels.entry(message.group_id).or_default();
         match message.data {
             ReplicationMessageData::Actions(m) => {
+                // update the mapping from entity to group-id
+                m.actions.keys().for_each(|e| {
+                    self.remote_entity_to_group.insert(*e, message.group_id);
+                });
                 // if the message is too old, ignore it
                 if m.sequence_id < channel.actions_pending_recv_message_id {
                     return;
@@ -195,6 +115,10 @@ impl<P: Protocol> ReplicationManager<P> {
                     .insert(m.sequence_id, (tick, m));
             }
             ReplicationMessageData::Updates(m) => {
+                // update the mapping from entity to group-id
+                m.updates.keys().for_each(|e| {
+                    self.remote_entity_to_group.insert(*e, message.group_id);
+                });
                 // if we have already applied a more recent update for this group, no need to keep this one
                 if tick <= channel.latest_tick {
                     return;
@@ -211,7 +135,7 @@ impl<P: Protocol> ReplicationManager<P> {
                     .or_insert(m);
             }
         }
-        info!(?channel, "group channel after buffering");
+        trace!(?channel, "group channel after buffering");
     }
 
     /// Return the list of replication messages that are ready to be applied to the World
@@ -229,7 +153,7 @@ impl<P: Protocol> ReplicationManager<P> {
     )> {
         self.group_channels
             .iter_mut()
-            .map(|(group_id, channel)| {
+            .filter_map(|(group_id, channel)| {
                 let mut res = Vec::new();
 
                 // check for any actions that are ready to be applied
@@ -247,12 +171,29 @@ impl<P: Protocol> ReplicationManager<P> {
                         .map(|(tick, updates)| (tick, ReplicationMessageData::Updates(updates))),
                 );
 
-                (*group_id, res)
+                (!res.is_empty()).then_some((*group_id, res))
             })
             .collect()
     }
+
+    // USED BY RECEIVE SIDE (SEND SIZE CAN GET THE GROUP_ID EASILY)
+    /// Get the group channel associated with a given entity
+    pub(crate) fn channel_by_local(&self, local_entity: Entity) -> Option<&GroupChannel<P>> {
+        self.entity_map
+            .get_remote(local_entity)
+            .and_then(|remote_entity| self.channel_by_remote(*remote_entity))
+    }
+
+    // USED BY RECEIVE SIDE (SEND SIZE CAN GET THE GROUP_ID EASILY)
+    /// Get the group channel associated with a given entity
+    pub(crate) fn channel_by_remote(&self, remote_entity: Entity) -> Option<&GroupChannel<P>> {
+        self.remote_entity_to_group
+            .get(&remote_entity)
+            .and_then(|group_id| self.group_channels.get(group_id))
+    }
 }
 
+// TODO: handle duplicate inserts/updates/removes?
 /// We want:
 /// - entity actions to be done reliably
 /// - entity updates (component updates) to be done unreliably
@@ -344,14 +285,22 @@ impl<P: Protocol> ReplicationManager<P> {
 
         // if there are any entity actions, send EntityActions
         for (group_id, mut actions) in self.pending_actions.drain() {
-            // add any updates for that group
+            // add any updates for that group into the actions message
             if let Some(updates) = self.pending_updates.remove(&group_id) {
                 for (entity, components) in updates {
-                    actions
+                    // for any update that was not already in insert, add it to the update list
+                    // TODO: also check if it's not already in updates?
+                    let existing_inserts = actions
                         .entry(entity)
                         .or_default()
-                        .updates
-                        .extend(components);
+                        .insert
+                        .iter()
+                        .map(|c| c.into())
+                        .collect::<HashSet<P::ComponentKinds>>();
+                    components
+                        .into_iter()
+                        .filter(|c| !existing_inserts.contains(&c.into()))
+                        .for_each(|c| actions.entry(entity).or_default().updates.push(c));
                 }
             }
             let channel = self.group_channels.entry(group_id).or_default();
@@ -379,6 +328,10 @@ impl<P: Protocol> ReplicationManager<P> {
                     updates,
                 }),
             ));
+        }
+
+        if !messages.is_empty() {
+            trace!(?messages, "Sending replication messages");
         }
 
         messages
@@ -498,101 +451,102 @@ impl<P: Protocol> ReplicationManager<P> {
             }
         }
     }
+}
 
-    // /// Apply any replication messages to the world
-    // pub(crate) fn apply_world(
-    //     &mut self,
-    //     world: &mut World,
-    //     replication: ReplicationMessage<P::Components, P::ComponentKinds>,
-    // ) {
-    //     let _span = trace_span!("Apply received replication message to world").entered();
-    //     match replication {
-    //         ReplicationMessage::SpawnEntity(entity, components) => {
-    //             let component_kinds = components
-    //                 .iter()
-    //                 .map(|c| c.into())
-    //                 .collect::<Vec<P::ComponentKinds>>();
-    //             debug!(remote_entity = ?entity, ?component_kinds, "Received spawn entity");
-    //
-    //             // TODO: we only run spawn_entity if we don't already have an entity in the process of being spawned
-    //             //  so we need a data-structure to keep track of entities that are being spawned
-    //             //  or do we? I'm not sure we would send this twice, because of the bevy system logic
-    //             //  but maybe we would do, if we remove Replicate and then Re-add it?
-    //
-    //             // Ignore if we already received the entity
-    //             if self.entity_map.get_local(entity).is_some() {
-    //                 return;
-    //             }
-    //             let mut local_entity_mut = world.spawn_empty();
-    //
-    //             // TODO: optimize by using batch functions?
-    //             for component in components {
-    //                 component.insert(&mut local_entity_mut);
-    //             }
-    //             self.entity_map.insert(entity, local_entity_mut.id());
-    //         }
-    //         ReplicationMessage::DespawnEntity(entity) => {
-    //             // TODO: we only run this if the entity has been confirmed to be spawned on client?
-    //             //  or should we send the message right away and let the receiver handle the ordering?
-    //             //  (what if they receive despawn before spawn?)
-    //             if let Some(local_entity) = self.entity_map.remove_by_remote(entity) {
-    //                 world.despawn(local_entity);
-    //             }
-    //         }
-    //         ReplicationMessage::InsertComponent(entity, components) => {
-    //             let kinds = components
-    //                 .iter()
-    //                 .map(|c| c.into())
-    //                 .collect::<Vec<P::ComponentKinds>>();
-    //             debug!(remote_entity = ?entity, ?kinds, "Received InsertComponent");
-    //             // it's possible that we received InsertComponent before the entity actually exists.
-    //             // In that case, we need to spawn the entity first.
-    //             // TODO: this might not be what we want? imagine we receive a DespawnEntity or RemoveComponent right before that?
-    //             let mut local_entity_mut = self.entity_map.get_by_remote_or_spawn(world, entity);
-    //             // TODO: maybe check if the component already exists?
-    //             for component in components {
-    //                 component.insert(&mut local_entity_mut);
-    //             }
-    //         }
-    //         ReplicationMessage::RemoveComponent(entity, component_kinds) => {
-    //             debug!(remote_entity = ?entity, kinds = ?component_kinds, "Received RemoveComponent");
-    //             if let Some(local_entity) = self.entity_map.get_local(entity) {
-    //                 if let Some(mut entity_mut) = world.get_entity_mut(*local_entity) {
-    //                     for kind in component_kinds {
-    //                         kind.remove(&mut entity_mut);
-    //                     }
-    //                 } else {
-    //                     debug!(
-    //                         "Could not remove component because local entity {:?} was not found",
-    //                         local_entity
-    //                     );
-    //                 }
-    //             }
-    //             debug!(
-    //                 "Could not remove component because remote entity {:?} was not found",
-    //                 entity
-    //             );
-    //         }
-    //         ReplicationMessage::EntityUpdate(entity, components) => {
-    //             let kinds = components
-    //                 .iter()
-    //                 .map(|c| c.into())
-    //                 .collect::<Vec<P::ComponentKinds>>();
-    //             trace!(?entity, ?kinds, "Received entity update");
-    //             // if the entity does not exist, create it
-    //             let mut local_entity_mut = self.entity_map.get_by_remote_or_spawn(world, entity);
-    //             // TODO: keep track of the components inserted?
-    //             for component in components {
-    //                 component.update(&mut local_entity_mut);
-    //             }
-    //         }
-    //     }
-    // }
+/// Channel to keep track of receiving/sending replication messages for a given Group
+#[derive(Debug)]
+pub struct GroupChannel<P: Protocol> {
+    // SEND
+    pub actions_next_send_message_id: MessageId,
+    // TODO: maybe also keep track of which Tick this bevy-tick corresponds to? (will enable doing diff-compression)
+    // TODO: maybe this should be an Option, so that we make sure that when we need it's always is_some()
+    // bevy tick when we received an ack of an update for this group
+    pub collect_changes_since_this_tick: BevyTick,
+    // last tick for which we sent an action message
+    pub last_action_tick: Tick,
 
-    // pub fn buffer_spawn_entity<C: Channel>(&mut self, entity: Entity) {
-    //     let message = MessageContainer::new(ReplicationMessage::SpawnEntity(entity));
-    //     self.message_manager.buffer_send::<C>(message);
-    // }
+    // RECEIVE
+    pub actions_pending_recv_message_id: MessageId,
+    pub actions_recv_message_buffer:
+        BTreeMap<MessageId, (Tick, EntityActionMessage<P::Components, P::ComponentKinds>)>,
+    // updates
+    // map from necessary_last_action_tick to the buffered message
+    // the first tick is the last_action_tick
+    // the second tick is the update's server tick when it was sent
+    pub buffered_updates: BTreeMap<Tick, BTreeMap<Tick, EntityUpdatesMessage<P::Components>>>,
+
+    // BOTH SEND/RECEIVE
+    /// last server tick that we applied to the client world
+    pub latest_tick: Tick,
+}
+
+impl<P: Protocol> Default for GroupChannel<P> {
+    fn default() -> Self {
+        Self {
+            actions_next_send_message_id: MessageId(0),
+            actions_pending_recv_message_id: MessageId(0),
+            actions_recv_message_buffer: BTreeMap::new(),
+            last_action_tick: Tick(0),
+            buffered_updates: Default::default(),
+            collect_changes_since_this_tick: BevyTick::new(0),
+            latest_tick: Tick(0),
+        }
+    }
+}
+
+impl<P: Protocol> GroupChannel<P> {
+    pub(crate) fn update_collect_changes_since_this_tick(&mut self, bevy_tick: BevyTick) {
+        // the bevy_tick passed is either at receive or send, and is always more recent
+        // than the previous bevy_tick
+
+        // if bevy_tick is bigger than current tick, set current_tick to bevy_tick
+        // if bevy_tick.is_newer_than(self.collect_changes_since_this_tick, BevyTick::MAX) {
+        self.collect_changes_since_this_tick = bevy_tick;
+        // }
+    }
+
+    /// Reads a message from the internal buffer to get its content
+    /// Since we are receiving messages in order, we don't return from the buffer
+    /// until we have received the message we are waiting for (the next expected MessageId)
+    /// This assumes that the sender sends all message ids sequentially.
+    ///
+    /// If had received updates that were waiting on a given action, we also return them
+    fn read_action(
+        &mut self,
+    ) -> Option<(Tick, EntityActionMessage<P::Components, P::ComponentKinds>)> {
+        // Check if we have received the message we are waiting for
+        let Some(message) = self
+            .actions_recv_message_buffer
+            .remove(&self.actions_pending_recv_message_id)
+        else {
+            return None;
+        };
+
+        self.actions_pending_recv_message_id += 1;
+        // Update the latest server tick that we have processed
+        self.latest_tick = message.0;
+        Some(message)
+    }
+
+    fn read_buffered_updates(&mut self) -> Vec<(Tick, EntityUpdatesMessage<P::Components>)> {
+        // go through all the buffered updates whose last_action_tick has been reached
+        // (the update's last_action_tick <= latest_tick)
+        let not_ready = self.buffered_updates.split_off(&(self.latest_tick + 1));
+
+        let mut res = vec![];
+        let buffered_updates_to_consider = std::mem::take(&mut self.buffered_updates);
+        for (necessary_action_tick, updates) in buffered_updates_to_consider.into_iter() {
+            for (tick, update) in updates {
+                // only push the update if the update's tick is more recent than the entity's current latest_tick
+                if self.latest_tick < tick {
+                    self.latest_tick = tick;
+                    res.push((tick, update));
+                }
+            }
+        }
+        self.buffered_updates = not_ready;
+        res
+    }
 }
 
 #[cfg(test)]
@@ -794,6 +748,62 @@ mod tests {
             .get(&Tick(1))
             .is_some());
 
-        // TODO: add more tests
+        // add updates before actions (last_action_tick is 2)
+        manager.recv_message(
+            ReplicationMessage {
+                group_id: ReplicationGroupId(0),
+                data: ReplicationMessageData::Updates(EntityUpdatesMessage {
+                    last_action_tick: Tick(2),
+                    updates: Default::default(),
+                }),
+            },
+            Tick(4),
+        );
+        assert!(manager
+            .group_channels
+            .get(&group_id)
+            .unwrap()
+            .buffered_updates
+            .get(&Tick(2))
+            .unwrap()
+            .get(&Tick(4))
+            .is_some());
+
+        // read messages: only read the first action and update
+        let read_messages = manager.read_messages();
+        let replication_data = &read_messages.first().unwrap().1;
+        assert_eq!(replication_data.get(0).unwrap().0, Tick(0));
+        assert_eq!(replication_data.get(1).unwrap().0, Tick(1));
+
+        // recv actions-3: should be buffered, we are still waiting for actions-2
+        manager.recv_message(
+            ReplicationMessage {
+                group_id: ReplicationGroupId(0),
+                data: ReplicationMessageData::Actions(EntityActionMessage {
+                    sequence_id: MessageId(2),
+                    actions: Default::default(),
+                }),
+            },
+            Tick(3),
+        );
+        assert!(manager.read_messages().is_empty());
+
+        // recv actions-2: we should now be able to read actions-2, actions-3, updates-4
+        manager.recv_message(
+            ReplicationMessage {
+                group_id: ReplicationGroupId(0),
+                data: ReplicationMessageData::Actions(EntityActionMessage {
+                    sequence_id: MessageId(1),
+                    actions: Default::default(),
+                }),
+            },
+            Tick(2),
+        );
+        let read_messages = manager.read_messages();
+        let replication_data = &read_messages.first().unwrap().1;
+        assert_eq!(replication_data.len(), 3);
+        assert_eq!(replication_data.get(0).unwrap().0, Tick(2));
+        assert_eq!(replication_data.get(1).unwrap().0, Tick(3));
+        assert_eq!(replication_data.get(2).unwrap().0, Tick(4));
     }
 }

--- a/lightyear/src/shared/replication/manager.rs
+++ b/lightyear/src/shared/replication/manager.rs
@@ -6,6 +6,7 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 
 use crate::_reexport::{EntityActionsChannel, EntityUpdatesChannel};
 use crate::connection::events::ConnectionEvents;
+use bevy::ecs::component::Tick as BevyTick;
 use bevy::prelude::{Entity, EntityWorldMut, World};
 use bevy::utils::EntityHashMap;
 use crossbeam_channel::Receiver;
@@ -33,8 +34,6 @@ pub enum EntityStatus {
     Spawning,
     Spawned,
 }
-
-pub type BevyTick = bevy::ecs::component::Tick;
 
 pub(crate) struct ReplicationManager<P: Protocol> {
     pub remote_entity_status: HashMap<Entity, EntityStatus>,

--- a/lightyear/src/shared/replication/manager.rs
+++ b/lightyear/src/shared/replication/manager.rs
@@ -1,23 +1,28 @@
 //! General struct handling replication
+use anyhow::Context;
 use bevy::a11y::accesskit::Action;
 use std::collections::hash_map::Entry;
 use std::collections::{BTreeMap, HashMap, HashSet};
 
-use bevy::prelude::{Entity, World};
+use crate::connection::events::ConnectionEvents;
+use bevy::prelude::{Entity, EntityWorldMut, World};
 use bevy::utils::EntityHashMap;
 use tracing::{debug, error, info, trace, trace_span};
 use tracing_subscriber::filter::FilterExt;
 use tracing_subscriber::fmt::writer::MakeWriterExt;
 
 use super::entity_map::EntityMap;
-use super::{EntityActionMessage, EntityActions, Replicate, ReplicationMessage};
+use super::{
+    EntityActionMessage, EntityActions, EntityUpdatesMessage, Replicate, ReplicationMessage,
+    ReplicationMessageData,
+};
 use crate::connection::message::ProtocolMessage;
 use crate::packet::message::MessageId;
 use crate::prelude::Tick;
 use crate::protocol::channel::ChannelKind;
 use crate::protocol::component::{ComponentBehaviour, ComponentKindBehaviour};
 use crate::protocol::Protocol;
-use crate::shared::replication::components::ReplicationGroup;
+use crate::shared::replication::components::{ReplicationGroup, ReplicationGroupId};
 
 // TODO: maybe store additional information about the entity?
 //  (e.g. the value of the replicate component)?
@@ -30,135 +35,177 @@ pub enum EntityStatus {
 pub(crate) struct ReplicationManager<P: Protocol> {
     pub remote_entity_status: HashMap<Entity, EntityStatus>,
     // pub global_replication_data: &'a ReplicationData,
+    /// Map between local and remote entities. (used mostly on client because it's when we receive entity updates)
+    pub entity_map: EntityMap,
+    /// Buffer to so that we have an ordered receiver per group
+    pub group_channels: EntityHashMap<ReplicationGroupId, GroupChannel<P>>,
+
+    /// messages that are being written. We need to hold a buffer of messages because components actions/updates
+    /// are being buffered individually but we want to group them inside a message
+    pub pending_actions: EntityHashMap<
+        ReplicationGroupId,
+        EntityHashMap<Entity, EntityActions<P::Components, P::ComponentKinds>>,
+    >,
+    pub pending_updates:
+        EntityHashMap<ReplicationGroupId, EntityHashMap<Entity, Vec<P::Components>>>,
 }
 
-pub struct ActionChannel<P: Protocol> {
-    pub pending_recv_message_id: MessageId,
+/// Channel to keep track of receiving/sending replication messages for a given Group
+pub struct GroupChannel<P: Protocol> {
+    // actions
+    pub actions_next_send_message_id: MessageId,
+    pub actions_pending_recv_message_id: MessageId,
+    pub actions_recv_message_buffer:
+        BTreeMap<MessageId, (Tick, EntityActionMessage<P::Components, P::ComponentKinds>)>,
+    // last tick for which we sent an action message
+    pub last_action_tick: Tick,
+    // updates
+    // map from necessary_last_action_tick to the buffered message
+    pub updates_waiting_for_insert:
+        BTreeMap<Tick, BTreeMap<Tick, EntityUpdatesMessage<P::Components, P::ComponentKinds>>>,
+    // list of update messages that we can apply immediately (in order)
+    pub updates_ready_to_apply: Vec<(Tick, EntityUpdatesMessage<P::Components, P::ComponentKinds>)>,
     /// last server tick that we applied to the client world
     pub latest_tick: Tick,
-    pub recv_message_buffer: BTreeMap<
-        MessageId,
-        (
-            Tick,
-            EntityHashMap<Entity, EntityActions<P::Component, P::ComponentKinds>>,
-        ),
-    >,
 }
 
-impl<P: Protocol> Default for ActionChannel<P> {
+impl<P: Protocol> Default for GroupChannel<P> {
     fn default() -> Self {
         Self {
-            pending_recv_message_id: MessageId(0),
+            actions_next_send_message_id: MessageId(0),
+            actions_pending_recv_message_id: MessageId(0),
+            actions_recv_message_buffer: BTreeMap::new(),
+            last_action_tick: Tick(0),
+            updates_waiting_for_insert: Default::default(),
+            updates_ready_to_apply: vec![],
             latest_tick: Tick(0),
-            recv_message_buffer: BTreeMap::new(),
         }
     }
 }
 
-impl<P: Protocol> ActionChannel<P> {
+impl<P: Protocol> GroupChannel<P> {
     /// Reads a message from the internal buffer to get its content
     /// Since we are receiving messages in order, we don't return from the buffer
     /// until we have received the message we are waiting for (the next expected MessageId)
     /// This assumes that the sender sends all message ids sequentially.
+    ///
+    /// If had received updates that were waiting on a given action, we also return them
     fn read_action(
         &mut self,
-    ) -> Option<(
-        Tick,
-        EntityHashMap<Entity, EntityActions<P::Component, P::ComponentKinds>>,
-    )> {
+    ) -> Option<(Tick, EntityActionMessage<P::Components, P::ComponentKinds>)> {
         // Check if we have received the message we are waiting for
         let Some(message) = self
-            .recv_message_buffer
-            .remove(&self.pending_recv_message_id)
+            .actions_recv_message_buffer
+            .remove(&self.actions_pending_recv_message_id)
         else {
             return None;
         };
 
-        self.pending_recv_message_id += 1;
+        self.actions_pending_recv_message_id += 1;
         // Update the latest server tick that we have processed
         self.latest_tick = message.0;
         Some(message)
     }
-}
 
-pub struct UpdateChannel<P: Protocol> {
-    /// last server tick for updates that we applied to the client world
-    pub latest_tick: Tick,
-    pub updates_waiting_for_inserts: EntityHashMap<Entity, HashSet<P::Components>>,
-}
-
-pub(crate) struct ReplicationReceiver<P: Protocol> {
-    /// Map between local and remote entities. (used mostly on client because it's when we receive entity updates)
-    pub entity_map: EntityMap,
-    /// Buffer to so that we have an ordered receiver per group
-    pub action_channels: EntityHashMap<ReplicationGroup, ActionChannel<P>>,
-    /// Buffer for updates, so that when the component insert arrives we can apply updates immediately
-    /// C1 could have updates 14, 15, 16
-    /// C2 could have updates 15 (which means either it was removed on 16, or it didn't change)
-    /// so we know that the updates-tick is 16
-    /// so we need to keep the latest tick per entity
-    /// -> maybe map from Map<entity, Map<ComponentKind, latest-value for that component>>>
-    /// and whenever a value is applied (because component exists), we can remove it from the buffer!
-    /// so just need:
-    /// - keep track of latest server tick received (which means the latest tick per component is either the insert tick or the action tick)
-    /// - keep track of buffered components for components that don't exist yet
-    pub update_buffer: EntityHashMap<ReplicationGroup, UpdateChannel<P>>,
-}
-
-impl<P: Protocol> ReplicationReceiver<P> {
-    fn buffer_action(
+    /// Return the update that we are ready to apply now
+    fn read_update(
         &mut self,
-        message: EntityActionMessage<P::Components, P::ComponentKinds>,
+    ) -> Vec<(Tick, EntityUpdatesMessage<P::Components, P::ComponentKinds>)> {
+        std::mem::take(&mut self.updates_ready_to_apply)
+    }
+
+    fn read_buffered_updates(
+        &mut self,
+    ) -> Vec<(Tick, EntityUpdatesMessage<P::Components, P::ComponentKinds>)> {
+        // go through all the buffered updates whose last_action_tick has been reached
+        let not_ready = self.updates_waiting_for_insert.split_off(&self.latest_tick);
+
+        let mut res = vec![];
+        for (_, updates) in self.updates_ready_to_apply.into_iter() {
+            for (tick, update) in updates {
+                // if we have applied a more recent tick, just discard the update
+                if tick > self.latest_tick {
+                    self.latest_tick = tick;
+                    res.push((update.last_action_tick, update.clone()));
+                }
+            }
+        }
+        std::mem::replace(&mut self.updates_waiting_for_insert, not_ready);
+        res
+    }
+}
+
+impl<P: Protocol> ReplicationManager<P> {
+    /// Recv a new replication message and buffer it
+    pub(crate) fn recv_message(
+        &mut self,
+        message: ReplicationMessage<P::Components, P::ComponentKinds>,
         tick: Tick,
     ) {
-        let channel = self.action_channels.entry(message.group_id).or_default();
+        let channel = self.group_channels.entry(message.group_id).or_default();
+        match message.data {
+            ReplicationMessageData::Actions(m) => {
+                // if the message is too old, ignore it
+                if m.sequence_id < channel.actions_pending_recv_message_id {
+                    return;
+                }
 
-        // if the message is too old, ignore it
-        if message.sequence_id < channel.pending_recv_message_id {
-            return;
+                // add the message to the buffer
+                // TODO: I guess this handles potential duplicates?
+                channel
+                    .actions_recv_message_buffer
+                    .insert(m.sequence_id, (tick, m));
+            }
+            ReplicationMessageData::Updates(m) => {
+                // TODO: instead of m.last_action_tick, we could include m.last_ack_tick?
+                // if we haven't applied the required actions tick, buffer the updates
+                if channel.latest_tick <= m.last_action_tick {
+                    channel
+                        .updates_waiting_for_insert
+                        .entry(m.last_action_tick)
+                        .or_default()
+                        .entry(tick)
+                        .or_insert(m);
+                    return;
+                }
+                // if we have already applied a more recent update for this group, no need to keep this one
+                if tick <= channel.latest_tick {
+                    return;
+                }
+
+                // update is ready to be applied immediately!
+                channel.latest_tick = tick;
+                channel.updates_ready_to_apply.push((tick, m));
+            }
         }
-
-        // add the message to the buffer
-        // handle duplicates?
-        channel
-            .recv_message_buffer
-            .insert(message.sequence_id, (tick, message.actions));
     }
 
-    /// Reads a message from the internal buffer to get its content
-    /// Since we are receiving messages in order, we don't return from the buffer
-    /// until we have received the message we are waiting for (the next expected MessageId)
-    /// This assumes that the sender sends all message ids sequentially.
-    fn read_action(
+    /// Return the list of replication messages that are ready to be applied to the World
+    /// Updates the `latest_tick` for this group
+    pub(crate) fn read_messages(
         &mut self,
-        group_id: ReplicationGroup,
-    ) -> Option<(Tick, EntityActionMessage<P::Components, P::ComponentKinds>)> {
-        let Some(channel) = self.action_channels.get_mut(&group_id) else {
-            return None;
-        };
-        channel.read_action().map(|(tick, actions)| {
-            (
-                tick,
-                EntityActionMessage {
-                    group_id,
-                    sequence_id: channel.pending_recv_message_id,
-                    actions,
-                },
-            )
+    ) -> impl Iterator<
+        Item = (
+            ReplicationGroup,
+            Vec<ReplicationMessageData<P::Components, P::ComponentKinds>>,
+        ),
+    > {
+        self.group_channels.iter_mut().map(|(group_id, channel)| {
+            let mut res = Vec::new();
+            // check for any actions that are ready to be applied
+            while let Some((tick, actions)) = channel.read_action() {
+                res.push(ReplicationMessageData::Actions(actions));
+            }
+
+            // check for any updates that are ready to be applied
+            res.extend(channel.read_update());
+
+            // check for any buffered updates that are ready to be applied now that we have applied more actions/updates
+            res.extend(channel.read_buffered_updates());
+
+            (group_id, res)
         })
     }
-
-    fn buffer_update()
-}
-
-pub(crate) struct ReplicationSender<P: Protocol> {
-    /// messages that are being written. We need to hold a buffer of messages because components actions/updates
-    /// are being buffered individually but we want to group them inside a message
-    pub pending_spawns: HashMap<Entity, Vec<P::Components>>,
-    pub pending_despawns: HashSet<Entity>,
-    pub pending_inserts: HashMap<Entity, Vec<P::Components>>,
-    pub pending_removes: HashMap<Entity, Vec<P::ComponentKinds>>,
-    pub pending_updates: HashMap<Entity, Vec<P::Components>>,
 }
 
 impl<P: Protocol> Default for ReplicationManager<P> {
@@ -166,14 +213,10 @@ impl<P: Protocol> Default for ReplicationManager<P> {
         Self {
             entity_map: EntityMap::default(),
             remote_entity_status: HashMap::new(),
-            pending_spawns: HashMap::new(),
-            pending_despawns: HashSet::default(),
-            pending_inserts: HashMap::default(),
-            pending_removes: HashMap::default(),
-            pending_updates: HashMap::default(),
-            entity_actions_channel: HashMap::default(),
-            entity_updates_channel: HashMap::default(),
+            pending_actions: EntityHashMap::default(),
+            pending_updates: EntityHashMap::default(),
             // global_replication_data,
+            group_channels: Default::default(),
         }
     }
 }
@@ -193,35 +236,27 @@ impl<P: Protocol> ReplicationManager<P> {
     pub(crate) fn prepare_entity_spawn(
         &mut self,
         entity: Entity,
+        group: ReplicationGroupId,
         components: Vec<P::Components>,
         channel_kind: ChannelKind,
     ) {
-        // TODO: send error if there was another channel for this entity?
-        self.entity_actions_channel.insert(entity, channel_kind);
-
-        // TODO: check if we have already sent SpawnMessage for this entity?
-
-        self.pending_spawns
+        let mut actions = self
+            .pending_actions
+            .entry(group)
+            .or_default()
             .entry(entity)
-            .and_modify(|_| {
-                error!("Entity already has a pending spawn");
-            })
-            .or_insert(components);
-
-        // // if we have already sent the Spawn Entity, don't do it again
-        // if self.remote_entity_status.get(&entity).is_some() {
-        //     return false;
-        // }
-        // self.remote_entity_status
-        //     .insert(entity, EntityStatus::Spawning);
-        // true
+            .or_default();
+        actions.spawn = true;
+        actions.insert.extend(components);
     }
 
-    pub(crate) fn prepare_entity_despawn(&mut self, entity: Entity, channel_kind: ChannelKind) {
-        self.entity_actions_channel.insert(entity, channel_kind);
-        // TODO: check if we have already sent DespawnMessage for this entity? (send error message?)
-        //  or if the SpawnEntity was sent/received?
-        self.pending_despawns.insert(entity);
+    pub(crate) fn prepare_entity_despawn(&mut self, entity: Entity, group: ReplicationGroupId) {
+        self.pending_actions
+            .entry(group)
+            .or_default()
+            .entry(entity)
+            .or_default()
+            .despawn = true;
     }
 
     // we want to send all component inserts that happen together for the same entity in a single message
@@ -230,214 +265,285 @@ impl<P: Protocol> ReplicationManager<P> {
     pub(crate) fn prepare_component_insert(
         &mut self,
         entity: Entity,
-        component: P::Components,
-        channel: ChannelKind,
+        group: ReplicationGroupId,
+        components: P::Components,
     ) {
-        self.entity_actions_channel.insert(entity, channel);
-
-        // if the entity is about to be despawned, don't send the insert
-        if self.pending_despawns.contains(&entity) {
-            return;
-        }
-
-        // if the entity is spawning, add the component insert to the spawn message directly
-        // NOTE: this works because we handle spawns before component inserts
-        if let Some(components) = self.pending_spawns.get_mut(&entity) {
-            components.push(component);
-        } else {
-            self.pending_inserts
-                .entry(entity)
-                .or_default()
-                .push(component);
-        }
+        self.pending_actions
+            .entry(group)
+            .or_default()
+            .entry(entity)
+            .or_default()
+            .insert
+            .extend(components);
     }
 
     pub(crate) fn prepare_component_remove(
         &mut self,
         entity: Entity,
-        component: P::ComponentKinds,
-        channel: ChannelKind,
+        group: ReplicationGroupId,
+        components: P::ComponentKinds,
     ) {
-        // if the entity is about to be despawned, don't send the remove
-        if self.pending_despawns.contains(&entity) {
-            return;
-        }
-
-        self.entity_actions_channel.insert(entity, channel);
-        self.pending_removes
+        self.pending_actions
+            .entry(group)
+            .or_default()
             .entry(entity)
             .or_default()
-            .push(component);
+            .remove
+            .extend(components);
     }
 
     pub(crate) fn prepare_entity_update(
         &mut self,
         entity: Entity,
+        group: ReplicationGroupId,
         component: P::Components,
-        channel: ChannelKind,
     ) {
-        self.entity_updates_channel.insert(entity, channel);
-
-        // if the entity is about to be despawned, don't send the update
-        if self.pending_despawns.contains(&entity) {
-            return;
-        }
-
-        // TODO: if the component is spawning, should we put the update in the spawn message?
-        //  because else the update might arrive before the entity spawn
         self.pending_updates
+            .entry(group)
+            .or_default()
             .entry(entity)
             .or_default()
             .push(component);
     }
 
     /// Finalize the replication messages
-    pub(crate) fn finalize(&mut self) -> Vec<(ChannelKind, ProtocolMessage<P>)> {
+    pub(crate) fn finalize(&mut self, tick: Tick) -> Vec<(ProtocolMessage<P>)> {
         let mut messages = Vec::new();
 
-        // entity actions
-        for (entity, components) in self.pending_spawns.drain() {
-            // SAFETY: we made sure that each entity has a channel
-            let channel = self.entity_actions_channel.get(&entity).unwrap();
-            messages.push((
-                *channel,
-                ProtocolMessage::Replication(ReplicationMessage::SpawnEntity(entity, components)),
-            ));
-        }
-        for entity in self.pending_despawns.drain() {
-            // SAFETY: we made sure that each entity has a channel
-            let channel = self.entity_actions_channel.get(&entity).unwrap();
-            messages.push((
-                *channel,
-                ProtocolMessage::Replication(ReplicationMessage::DespawnEntity(entity)),
-            ));
-        }
-        for (entity, components) in self.pending_inserts.drain() {
-            // SAFETY: we made sure that each entity has a channel
-            let channel = self.entity_actions_channel.get(&entity).unwrap();
-            messages.push((
-                *channel,
-                ProtocolMessage::Replication(ReplicationMessage::InsertComponent(
-                    entity, components,
-                )),
-            ));
-        }
-        for (entity, components) in self.pending_removes.drain() {
-            // SAFETY: we made sure that each entity has a channel
-            let channel = self.entity_actions_channel.get(&entity).unwrap();
-            messages.push((
-                *channel,
-                ProtocolMessage::Replication(ReplicationMessage::RemoveComponent(
-                    entity, components,
-                )),
-            ));
+        // if there are any entity actions, send EntityActions
+        for (group_id, mut actions) in self.pending_actions.drain() {
+            // add any updates for that group
+            if let Some(updates) = self.pending_updates.remove(&group_id) {
+                for (entity, components) in updates {
+                    actions
+                        .entry(entity)
+                        .or_default()
+                        .updates
+                        .extend(components);
+                }
+            }
+            let channel = self.group_channels.entry(group_id).or_default();
+            let message_id = channel.actions_next_send_message_id;
+            channel.actions_next_send_message_id += 1;
+            channel.last_action_tick = tick;
+            messages.push(ProtocolMessage::Replication(ReplicationMessage {
+                group_id,
+                data: ReplicationMessageData::Actions(EntityActionMessage {
+                    sequence_id: message_id,
+                    actions,
+                }),
+            }));
         }
 
-        // entity updates
-        for (entity, components) in self.pending_updates.drain() {
-            // SAFETY: we made sure that each entity has a channel
-            let channel = self.entity_updates_channel.remove(&entity).unwrap();
-            messages.push((
-                channel,
-                ProtocolMessage::Replication(ReplicationMessage::EntityUpdate(entity, components)),
-            ));
+        // send the remaining updates
+        for (group_id, updates) in self.pending_updates.drain() {
+            let channel = self.group_channels.entry(group_id).or_default();
+            messages.push(ProtocolMessage::Replication(ReplicationMessage {
+                group_id,
+                data: ReplicationMessageData::Updates(EntityUpdatesMessage {
+                    last_action_tick: channel.last_action_tick,
+                    updates,
+                }),
+            }));
         }
-
-        // clear
-        self.entity_actions_channel.clear();
 
         messages
     }
 
-    /// Apply any replication messages to the world
+    /// Apply any replication messages to the world, and emit an event
+    /// I think we don't need to emit a tick with the event anymore, because
+    /// we can access the tick via the replication manager
     pub(crate) fn apply_world(
         &mut self,
         world: &mut World,
-        replication: ReplicationMessage<P::Components, P::ComponentKinds>,
+        replication: ReplicationMessageData<P::Components, P::ComponentKinds>,
+        events: &mut ConnectionEvents<P>,
     ) {
         let _span = trace_span!("Apply received replication message to world").entered();
         match replication {
-            ReplicationMessage::SpawnEntity(entity, components) => {
-                let component_kinds = components
-                    .iter()
-                    .map(|c| c.into())
-                    .collect::<Vec<P::ComponentKinds>>();
-                debug!(remote_entity = ?entity, ?component_kinds, "Received spawn entity");
+            ReplicationMessageData::Actions(m) => {
+                for (entity, actions) in m.actions.into_iter() {
+                    debug!(remote_entity = ?entity, "Received entity actions");
 
-                // TODO: we only run spawn_entity if we don't already have an entity in the process of being spawned
-                //  so we need a data-structure to keep track of entities that are being spawned
-                //  or do we? I'm not sure we would send this twice, because of the bevy system logic
-                //  but maybe we would do, if we remove Replicate and then Re-add it?
+                    // spawn
+                    let mut local_entity: EntityWorldMut;
+                    if actions.spawn {
+                        // TODO: optimization: spawn the bundle of insert components
+                        local_entity = world.spawn_empty();
+                        self.entity_map.insert(entity, local_entity.id());
 
-                // Ignore if we already received the entity
-                if self.entity_map.get_local(entity).is_some() {
-                    return;
-                }
-                let mut local_entity_mut = world.spawn_empty();
-
-                // TODO: optimize by using batch functions?
-                for component in components {
-                    component.insert(&mut local_entity_mut);
-                }
-                self.entity_map.insert(entity, local_entity_mut.id());
-            }
-            ReplicationMessage::DespawnEntity(entity) => {
-                // TODO: we only run this if the entity has been confirmed to be spawned on client?
-                //  or should we send the message right away and let the receiver handle the ordering?
-                //  (what if they receive despawn before spawn?)
-                if let Some(local_entity) = self.entity_map.remove_by_remote(entity) {
-                    world.despawn(local_entity);
-                }
-            }
-            ReplicationMessage::InsertComponent(entity, components) => {
-                let kinds = components
-                    .iter()
-                    .map(|c| c.into())
-                    .collect::<Vec<P::ComponentKinds>>();
-                debug!(remote_entity = ?entity, ?kinds, "Received InsertComponent");
-                // it's possible that we received InsertComponent before the entity actually exists.
-                // In that case, we need to spawn the entity first.
-                // TODO: this might not be what we want? imagine we receive a DespawnEntity or RemoveComponent right before that?
-                let mut local_entity_mut = self.entity_map.get_by_remote_or_spawn(world, entity);
-                // TODO: maybe check if the component already exists?
-                for component in components {
-                    component.insert(&mut local_entity_mut);
-                }
-            }
-            ReplicationMessage::RemoveComponent(entity, component_kinds) => {
-                debug!(remote_entity = ?entity, kinds = ?component_kinds, "Received RemoveComponent");
-                if let Some(local_entity) = self.entity_map.get_local(entity) {
-                    if let Some(mut entity_mut) = world.get_entity_mut(*local_entity) {
-                        for kind in component_kinds {
-                            kind.remove(&mut entity_mut);
-                        }
+                        debug!(remote_entity = ?entity, "Received entity spawn");
+                        events.push_spawn(local_entity.id());
                     } else {
-                        debug!(
-                            "Could not remove component because local entity {:?} was not found",
-                            local_entity
-                        );
+                        if let Ok(l) = self.entity_map.get_by_remote(world, entity) {
+                            local_entity = l;
+                        } else {
+                            continue;
+                        }
+                    }
+
+                    // despawn
+                    if actions.despawn {
+                        debug!(remote_entity = ?entity, "Received entity despawn");
+                        if let Some(local_entity) = self.entity_map.remove_by_remote(entity) {
+                            events.push_despawn(local_entity);
+                            world.despawn(local_entity);
+                        } else {
+                            error!("Received despawn for an entity that does not exist")
+                        }
+                    }
+                    // inserts
+                    let kinds = actions
+                        .insert
+                        .iter()
+                        .map(|c| c.into())
+                        .collect::<Vec<P::ComponentKinds>>();
+                    debug!(remote_entity = ?entity, ?kinds, "Received InsertComponent");
+                    for component in actions.insert {
+                        // TODO: figure out what to do with tick here
+                        events.push_insert_component(local_entity.id(), component.into(), Tick(0));
+                        component.insert(&mut local_entity);
+                    }
+
+                    // removals
+                    debug!(remote_entity = ?entity, ?actions.remove, "Received RemoveComponent");
+                    for kind in actions.remove {
+                        events.push_remove_component(local_entity.id(), kind, Tick(0));
+                        kind.remove(&mut local_entity);
+                    }
+
+                    // (no need to run apply_deferred after applying actions, that is only for Commands)
+
+                    // updates
+                    let kinds = actions
+                        .updates
+                        .iter()
+                        .map(|c| c.into())
+                        .collect::<Vec<P::ComponentKinds>>();
+                    debug!(remote_entity = ?entity, ?kinds, "Received UpdateComponent");
+                    for component in actions.updates {
+                        events.push_update_component(local_entity.id(), component.into(), Tick(0));
+                        component.update(&mut local_entity);
                     }
                 }
-                debug!(
-                    "Could not remove component because remote entity {:?} was not found",
-                    entity
-                );
             }
-            ReplicationMessage::EntityUpdate(entity, components) => {
-                let kinds = components
-                    .iter()
-                    .map(|c| c.into())
-                    .collect::<Vec<P::ComponentKinds>>();
-                trace!(?entity, ?kinds, "Received entity update");
-                // if the entity does not exist, create it
-                let mut local_entity_mut = self.entity_map.get_by_remote_or_spawn(world, entity);
-                // TODO: keep track of the components inserted?
-                for component in components {
-                    component.update(&mut local_entity_mut);
+            ReplicationMessageData::Updates(m) => {
+                for (entity, components) in m.updates.into_iter() {
+                    debug!(remote_entity = ?entity, "Received entity updates");
+                    let kinds = components
+                        .iter()
+                        .map(|c| c.into())
+                        .collect::<Vec<P::ComponentKinds>>();
+                    debug!(?entity, ?kinds, "Received UpdateComponent");
+                    // if the entity does not exist, create it
+                    if let Ok(mut local_entity) = self.entity_map.get_by_remote(world, entity) {
+                        for component in components {
+                            events.push_update_component(
+                                local_entity.id(),
+                                component.into(),
+                                Tick(0),
+                            );
+                            component.update(&mut local_entity);
+                        }
+                    } else {
+                        // the entity has been despawned by one of the previous actions
+                        // still, is this possible? we should only receive updates that are after the despawn...
+                        error!("update for entity that doesn't exist?");
+                    }
                 }
             }
         }
     }
+
+    // /// Apply any replication messages to the world
+    // pub(crate) fn apply_world(
+    //     &mut self,
+    //     world: &mut World,
+    //     replication: ReplicationMessage<P::Components, P::ComponentKinds>,
+    // ) {
+    //     let _span = trace_span!("Apply received replication message to world").entered();
+    //     match replication {
+    //         ReplicationMessage::SpawnEntity(entity, components) => {
+    //             let component_kinds = components
+    //                 .iter()
+    //                 .map(|c| c.into())
+    //                 .collect::<Vec<P::ComponentKinds>>();
+    //             debug!(remote_entity = ?entity, ?component_kinds, "Received spawn entity");
+    //
+    //             // TODO: we only run spawn_entity if we don't already have an entity in the process of being spawned
+    //             //  so we need a data-structure to keep track of entities that are being spawned
+    //             //  or do we? I'm not sure we would send this twice, because of the bevy system logic
+    //             //  but maybe we would do, if we remove Replicate and then Re-add it?
+    //
+    //             // Ignore if we already received the entity
+    //             if self.entity_map.get_local(entity).is_some() {
+    //                 return;
+    //             }
+    //             let mut local_entity_mut = world.spawn_empty();
+    //
+    //             // TODO: optimize by using batch functions?
+    //             for component in components {
+    //                 component.insert(&mut local_entity_mut);
+    //             }
+    //             self.entity_map.insert(entity, local_entity_mut.id());
+    //         }
+    //         ReplicationMessage::DespawnEntity(entity) => {
+    //             // TODO: we only run this if the entity has been confirmed to be spawned on client?
+    //             //  or should we send the message right away and let the receiver handle the ordering?
+    //             //  (what if they receive despawn before spawn?)
+    //             if let Some(local_entity) = self.entity_map.remove_by_remote(entity) {
+    //                 world.despawn(local_entity);
+    //             }
+    //         }
+    //         ReplicationMessage::InsertComponent(entity, components) => {
+    //             let kinds = components
+    //                 .iter()
+    //                 .map(|c| c.into())
+    //                 .collect::<Vec<P::ComponentKinds>>();
+    //             debug!(remote_entity = ?entity, ?kinds, "Received InsertComponent");
+    //             // it's possible that we received InsertComponent before the entity actually exists.
+    //             // In that case, we need to spawn the entity first.
+    //             // TODO: this might not be what we want? imagine we receive a DespawnEntity or RemoveComponent right before that?
+    //             let mut local_entity_mut = self.entity_map.get_by_remote_or_spawn(world, entity);
+    //             // TODO: maybe check if the component already exists?
+    //             for component in components {
+    //                 component.insert(&mut local_entity_mut);
+    //             }
+    //         }
+    //         ReplicationMessage::RemoveComponent(entity, component_kinds) => {
+    //             debug!(remote_entity = ?entity, kinds = ?component_kinds, "Received RemoveComponent");
+    //             if let Some(local_entity) = self.entity_map.get_local(entity) {
+    //                 if let Some(mut entity_mut) = world.get_entity_mut(*local_entity) {
+    //                     for kind in component_kinds {
+    //                         kind.remove(&mut entity_mut);
+    //                     }
+    //                 } else {
+    //                     debug!(
+    //                         "Could not remove component because local entity {:?} was not found",
+    //                         local_entity
+    //                     );
+    //                 }
+    //             }
+    //             debug!(
+    //                 "Could not remove component because remote entity {:?} was not found",
+    //                 entity
+    //             );
+    //         }
+    //         ReplicationMessage::EntityUpdate(entity, components) => {
+    //             let kinds = components
+    //                 .iter()
+    //                 .map(|c| c.into())
+    //                 .collect::<Vec<P::ComponentKinds>>();
+    //             trace!(?entity, ?kinds, "Received entity update");
+    //             // if the entity does not exist, create it
+    //             let mut local_entity_mut = self.entity_map.get_by_remote_or_spawn(world, entity);
+    //             // TODO: keep track of the components inserted?
+    //             for component in components {
+    //                 component.update(&mut local_entity_mut);
+    //             }
+    //         }
+    //     }
+    // }
 
     // pub fn buffer_spawn_entity<C: Channel>(&mut self, entity: Entity) {
     //     let message = MessageContainer::new(ReplicationMessage::SpawnEntity(entity));

--- a/lightyear/src/shared/replication/manager.rs
+++ b/lightyear/src/shared/replication/manager.rs
@@ -372,13 +372,11 @@ impl<P: Protocol> ReplicationManager<P> {
                             error!("Received despawn for an entity that does not exist")
                         }
                         continue;
+                    } else if let Ok(l) = self.entity_map.get_by_remote(world, entity) {
+                        local_entity = l;
                     } else {
-                        if let Ok(l) = self.entity_map.get_by_remote(world, entity) {
-                            local_entity = l;
-                        } else {
-                            error!("cannot find entity");
-                            continue;
-                        }
+                        error!("cannot find entity");
+                        continue;
                     }
 
                     // inserts
@@ -676,6 +674,7 @@ mod tests {
         );
     }
 
+    #[allow(clippy::get_first)]
     #[test]
     fn test_recv_replication_messages() {
         let (sender, receiver) = crossbeam_channel::unbounded();

--- a/lightyear/src/shared/replication/mod.rs
+++ b/lightyear/src/shared/replication/mod.rs
@@ -1,6 +1,7 @@
 //! Module to handle replicating entities and components from server to client
 use crate::_reexport::{ComponentProtocol, ComponentProtocolKind};
 use anyhow::Result;
+use bevy::ecs::component::Tick as BevyTick;
 use bevy::ecs::system::SystemChangeTick;
 use bevy::prelude::{Component, Entity, Resource};
 use bevy::reflect::Map;
@@ -15,7 +16,6 @@ use crate::prelude::{EntityMap, MapEntities, NetworkTarget, Tick};
 use crate::protocol::channel::ChannelKind;
 use crate::protocol::Protocol;
 use crate::shared::replication::components::{Replicate, ReplicationGroup, ReplicationGroupId};
-use crate::shared::replication::manager::BevyTick;
 
 pub mod components;
 

--- a/lightyear/src/shared/replication/mod.rs
+++ b/lightyear/src/shared/replication/mod.rs
@@ -45,7 +45,7 @@ pub mod systems;
 //     EntityUpdate(Entity, Vec<C>),
 // }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
 pub struct EntityActions<C, K> {
     // TODO: do we even need spawn?
     pub(crate) spawn: bool,
@@ -71,7 +71,7 @@ impl<C, K> Default for EntityActions<C, K> {
 
 // TODO: 99% of the time the ReplicationGroup is the same as the Entity in the hashmap, and there's only 1 entity
 //  have an optimization for that
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
 pub struct EntityActionMessage<C, K> {
     sequence_id: MessageId,
     // TODO: maybe we want a sorted hash map here?
@@ -81,7 +81,7 @@ pub struct EntityActionMessage<C, K> {
     pub(crate) actions: BTreeMap<Entity, EntityActions<C, K>>,
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
 pub struct EntityUpdatesMessage<C> {
     /// The last tick for which we sent an EntityActionsMessage for this group
     last_action_tick: Tick,
@@ -89,7 +89,7 @@ pub struct EntityUpdatesMessage<C> {
     pub(crate) updates: BTreeMap<Entity, Vec<C>>,
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
 pub enum ReplicationMessageData<C, K> {
     /// All the entity actions (Spawn/despawn/inserts/removals) for a given group
     Actions(EntityActionMessage<C, K>),
@@ -97,7 +97,7 @@ pub enum ReplicationMessageData<C, K> {
     Updates(EntityUpdatesMessage<C>),
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
 pub struct ReplicationMessage<C, K> {
     pub(crate) group_id: ReplicationGroupId,
     pub(crate) data: ReplicationMessageData<C, K>,

--- a/lightyear/src/shared/replication/systems.rs
+++ b/lightyear/src/shared/replication/systems.rs
@@ -62,7 +62,7 @@ fn send_entity_despawn<P: Protocol, R: ReplicationSend<P>>(
                         sender
                             .prepare_entity_despawn(
                                 entity,
-                                &replicate,
+                                replicate,
                                 NetworkTarget::Only(vec![*client_id]),
                                 system_bevy_ticks.this_run(),
                             )
@@ -253,7 +253,7 @@ fn send_component_update<C: Component + Clone, P: Protocol, R: ReplicationSend<P
                     .prepare_component_insert(
                         entity,
                         component.clone().into(),
-                        &replicate,
+                        replicate,
                         NetworkTarget::Only(new_connected_clients.clone()),
                         system_bevy_ticks.this_run(),
                     )

--- a/lightyear/src/shared/replication/systems.rs
+++ b/lightyear/src/shared/replication/systems.rs
@@ -159,7 +159,7 @@ fn send_entity_spawn<P: Protocol, R: ReplicationSend<P>>(
 /// (currently we only check for the second condition, which is enough but less efficient)
 fn send_component_update<C: Component + Clone, P: Protocol, R: ReplicationSend<P>>(
     query: Query<(Entity, Ref<C>, &Replicate)>,
-    system_bevy_ticks: &SystemChangeTick,
+    system_bevy_ticks: SystemChangeTick,
     mut sender: ResMut<R>,
 ) where
     <P as Protocol>::Components: From<C>,

--- a/lightyear/src/shared/systems/events.rs
+++ b/lightyear/src/shared/systems/events.rs
@@ -95,7 +95,7 @@ pub fn push_component_update_events<
         let mut event_writer = world
             .get_resource_mut::<Events<ComponentUpdateEvent<C, Ctx>>>()
             .unwrap();
-        for (entity, ctx) in events.into_iter_component_update::<C>() {
+        for (entity, ctx) in events.iter_component_update::<C>() {
             let event = ComponentUpdateEvent::new(entity, ctx);
             event_writer.send(event);
         }

--- a/lightyear/src/tests/examples/connection_soak.rs
+++ b/lightyear/src/tests/examples/connection_soak.rs
@@ -1,3 +1,5 @@
+//! The connection soak test how sending messages/packets works with a real connection, and loss/jitter
+//! We put this test here because it uses some private methods.
 use bevy::ecs::component::Tick as BevyTick;
 use bevy::prelude::World;
 use std::net::SocketAddr;
@@ -7,13 +9,15 @@ use std::time::Duration;
 use rand::Rng;
 use tracing::debug;
 
-use lightyear::connection::events::IterMessageEvent;
-use lightyear::prelude::client::{Authentication, Client, ClientConfig, SyncConfig};
-use lightyear::prelude::server::{NetcodeConfig, Server, ServerConfig};
-use lightyear::prelude::*;
-use lightyear_examples::protocol::{protocol, Channel1, Message1};
+use crate::connection::events::IterMessageEvent;
+use crate::prelude::client::{Authentication, Client, ClientConfig, SyncConfig};
+use crate::prelude::server::{NetcodeConfig, Server, ServerConfig};
+use crate::prelude::*;
+use crate::tests::protocol::*;
 
-fn main() -> anyhow::Result<()> {
+#[test]
+#[ignore]
+fn test_connection_soak() -> anyhow::Result<()> {
     tracing_subscriber::FmtSubscriber::builder()
         .with_max_level(tracing::Level::DEBUG)
         .init();
@@ -109,7 +113,7 @@ fn main() -> anyhow::Result<()> {
                     .collect();
                 let message = Message1(s);
                 debug!("Sending message {message:?}");
-                server.broadcast_send::<Channel1, Message1>(message)?;
+                server.send_to_target::<Channel1, Message1>(message, NetworkTarget::All)?;
             }
             std::thread::sleep(tick_rate_secs);
         }

--- a/lightyear/src/tests/examples/mod.rs
+++ b/lightyear/src/tests/examples/mod.rs
@@ -1,0 +1,1 @@
+mod connection_soak;

--- a/lightyear/src/tests/mod.rs
+++ b/lightyear/src/tests/mod.rs
@@ -2,6 +2,7 @@
 #![allow(unused_variables)]
 #![allow(dead_code)]
 pub mod client;
+mod examples;
 pub mod protocol;
 pub mod server;
 pub mod stepper;

--- a/lightyear/src/tests/protocol.rs
+++ b/lightyear/src/tests/protocol.rs
@@ -12,7 +12,7 @@ pub struct Message1(pub String);
 #[derive(MessageInternal, Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct Message2(pub u32);
 
-#[message_protocol_internal(protocol = "MyProtocol")]
+#[message_protocol_internal(protocol = "MyProtocol", derive(Debug))]
 pub enum MyMessageProtocol {
     Message1(Message1),
     Message2(Message2),
@@ -38,7 +38,7 @@ impl MapEntities for Component4 {
     }
 }
 
-#[component_protocol_internal(protocol = "MyProtocol")]
+#[component_protocol_internal(protocol = "MyProtocol", derive(Debug))]
 pub enum MyComponentsProtocol {
     #[sync(full)]
     Component1(Component1),
@@ -58,7 +58,6 @@ pub struct MyInput(pub i16);
 impl UserInput for MyInput {}
 
 // Protocol
-
 protocolize! {
     Self = MyProtocol,
     Message = MyMessageProtocol,
@@ -77,11 +76,11 @@ pub struct Channel2;
 pub fn protocol() -> MyProtocol {
     let mut p = MyProtocol::default();
     p.add_channel::<Channel1>(ChannelSettings {
-        mode: ChannelMode::OrderedReliable(ReliableSettings::default()),
+        mode: ChannelMode::UnorderedUnreliable,
         direction: ChannelDirection::Bidirectional,
     });
     p.add_channel::<Channel2>(ChannelSettings {
-        mode: ChannelMode::UnorderedUnreliable,
+        mode: ChannelMode::UnorderedUnreliableWithAcks,
         direction: ChannelDirection::Bidirectional,
     });
     p

--- a/lightyear/src/tests/protocol.rs
+++ b/lightyear/src/tests/protocol.rs
@@ -38,7 +38,8 @@ impl MapEntities for Component4 {
     }
 }
 
-#[component_protocol_internal(protocol = "MyProtocol", derive(Debug))]
+// #[component_protocol_internal(protocol = "MyProtocol", derive(Debug))]
+#[component_protocol_internal(protocol = "MyProtocol")]
 pub enum MyComponentsProtocol {
     #[sync(full)]
     Component1(Component1),

--- a/lightyear/src/utils/bevy.rs
+++ b/lightyear/src/utils/bevy.rs
@@ -1,0 +1,44 @@
+//! Implement lightyear traits for some common bevy types
+use crate::prelude::{EntityMap, MapEntities, Message, Named};
+use bevy::prelude::Transform;
+
+impl Named for Transform {
+    fn name(&self) -> String {
+        "Transform".to_string()
+    }
+}
+
+impl MapEntities for Transform {
+    fn map_entities(&mut self, entity_map: &EntityMap) {}
+}
+
+impl Message for Transform {}
+
+cfg_if::cfg_if! {
+    if #[cfg(feature = "render")] {
+        use bevy::prelude::{Color,  Visibility};
+        impl Named for Color {
+            fn name(&self) -> String {
+                "Color".to_string()
+            }
+        }
+
+        impl MapEntities for Color {
+            fn map_entities(&mut self, entity_map: &EntityMap) {}
+        }
+
+        impl Message for Color {}
+
+        impl Named for Visibility {
+            fn name(&self) -> String {
+                "Visibility".to_string()
+            }
+        }
+
+        impl MapEntities for Visibility {
+            fn map_entities(&mut self, entity_map: &EntityMap) {}
+        }
+
+        impl Message for Visibility {}
+    }
+}

--- a/lightyear/src/utils/mod.rs
+++ b/lightyear/src/utils/mod.rs
@@ -1,13 +1,11 @@
 //! Contains a set of useful utilities
 
-/// Name of a struct of type
 pub mod named;
 
-/// Wrapper around a heap
 pub(crate) mod ready_buffer;
 
-/// Wrapper around a list where the index is a wrapping key
 pub(crate) mod sequence_buffer;
 
-/// u16 that wraps around when it reaches the maximum value
+pub mod bevy;
+
 pub mod wrapping_id;

--- a/lightyear/src/utils/named.rs
+++ b/lightyear/src/utils/named.rs
@@ -1,3 +1,5 @@
+//! Name of a struct or type
+
 // TODO: replace with bevy TypePath? that would mean that we:
 // - derive Reflect for Messages
 // - require to derive Reflect for Components ?

--- a/lightyear/src/utils/ready_buffer.rs
+++ b/lightyear/src/utils/ready_buffer.rs
@@ -1,3 +1,4 @@
+//! Wrapper around a min-heap
 use std::{cmp::Ordering, collections::BinaryHeap};
 
 /// A buffer that contains items associated with a key (a Tick, Instant, etc.)

--- a/lightyear/src/utils/sequence_buffer.rs
+++ b/lightyear/src/utils/sequence_buffer.rs
@@ -1,3 +1,4 @@
+//! Wrapper around a list where the index is a wrapping key
 use std::marker::PhantomData;
 
 use crate::utils::wrapping_id::WrappedId;

--- a/lightyear/src/utils/wrapping_id.rs
+++ b/lightyear/src/utils/wrapping_id.rs
@@ -1,3 +1,4 @@
+//! u16 that wraps around when it reaches the maximum value
 pub trait WrappedId {
     // return self % total
     // used for sequence buffers

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lightyear_macros"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Charles Bournhonesque <charlesbour@gmail.com>"]
 edition = "2021"
 rust-version = "1.65"

--- a/macros/src/channel.rs
+++ b/macros/src/channel.rs
@@ -34,7 +34,7 @@ pub fn channel_impl(
     let gen = quote! {
         #[doc(hidden)]
         mod #module_name {
-            pub use #shared_crate_name::prelude::{Channel, ChannelBuilder, ChannelContainer, ChannelSettings, TypeNamed};
+            pub use #shared_crate_name::prelude::{Channel, ChannelKind, ChannelBuilder, ChannelContainer, ChannelSettings, TypeNamed};
             use super::*;
 
             impl Channel for #struct_name {

--- a/macros/src/component.rs
+++ b/macros/src/component.rs
@@ -187,6 +187,13 @@ pub fn component_protocol_impl(
                 #add_sync_systems_method
             }
 
+            impl std::fmt::Debug for #enum_name {
+                fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+                    let kind: #enum_kind_name = self.into();
+                    kind.fmt(f)
+                }
+            }
+
             #sync_component_impl
             #delegate_method
 

--- a/macros/tests/derive_component.rs
+++ b/macros/tests/derive_component.rs
@@ -12,7 +12,7 @@ pub mod some_component {
     #[derive(Component, Message, Serialize, Deserialize, Debug, PartialEq, Clone, Add, Mul)]
     pub struct Component2(pub f32);
 
-    #[component_protocol(protocol = "MyProtocol", derive(Debug))]
+    #[component_protocol(protocol = "MyProtocol")]
     pub enum MyComponentProtocol {
         #[sync(full)]
         Component1(Component1),


### PR DESCRIPTION
# Release 0.3.0

# Added

- Added interest management via the concept of `Room`, to be able to replicate only a subset entities to a certain client to save bandwidth and prevent cheating. See more information [here](https://cbournhonesque.github.io/lightyear/book/concepts/advanced_replication/interest_management.html)
- Updated the replication manager to be much more robust. The new manager:
  - makes sure that an entity or a group of entities (via `ReplicationGroup`) are replicated with a consistent state. See more information [here](https://cbournhonesque.github.io/lightyear/book/concepts/advanced_replication/replication_logic.html)
  - inspired by what `bevy_replicon` is doing
  - this fixes some edge cases with prediction/interpolation; in particular when send_interval is small compared with jitter
- Added a new `UnreliableSenderWithAck` channel where senders can get notified when a given message has been ACK-ed
- Some common `bevy` structs (`Transform`, `Color`, `Visibility`) now implement the `Message` trait and can be used for replication

# Updated
- the `ComponentProtocol` now derives `Debug` directly (which shows the type of the replicated Component, but not the value)

# Fixed
- the existing world state is now replicated properly to newly connected clients (whether they use `Room` or not for replication)
  
 
  # Notes
  - There are still some bugs related to replication (interpolation sometimes gets stuck at the beginning?), I can look at them in a future releaase