### PR TITLE
Improve entity mapping, interpolation, prediction

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -47,12 +47,6 @@
         is it just because of the margin we took?
       - applied a best guess estimate for lost inputs that uses the last input sent as fallback, works well!
 
-  
-
-  
-  
-
-
 - FINAL CHOICE:
   - send all actions per group on an reliable unordered channel
     - ordering is done per group, with a sequenced id (1,2,3)

--- a/NOTES.md
+++ b/NOTES.md
@@ -34,8 +34,20 @@
     - TODO: tried to make my custom interpolation logic working, but there still seems to be edge cases that are not handled well.
       - there's weird panics now, and sometimes the interpolated entity doesn't move at all
   - INTERP TIME is sometimes too late; i.e. we receive updates that are way after interp time.
+  - SYNC:
+    - seems to not work well for at the beginning..
   - PREDICTION; rollback is weird and fucked
     - looks like sending pings more frequently fixed the issue?, to investigate..
+    - is it that we don't receive the inputs on time at the client?
+    - imagine we lost some packets and server didn't receive the inputs... then when server receives a later packet it should receive the past 15 inputs.
+      server should then use this to rollback?
+      - server should ask client to speed up (via a message), when we have lost inputs (to increase the buffer size)
+      - it should re-use the previous input as a best guess estimate
+      - it looks like our input buffer on server is too big; it contains like 15 ticks worth of inputs, even though the client messages should arrive right before.
+        is it just because of the margin we took?
+      - applied a best guess estimate for lost inputs that uses the last input sent as fallback, works well!
+
+  
 
   
   

--- a/NOTES.md
+++ b/NOTES.md
@@ -12,17 +12,14 @@
     because start tick or end tick are not updated correctly in some edge cases.
 
 
-- Interpolation:
-  - should let users do interpolation for multiple components themselves (for better splines)
-    - i.e. they handle completely interpolation!
-  - or for a given component, let them use linear or custom interpolation
-
 
 - DEBUGGING REPLICATION BOX:
-  - I think the general map_entities logic works pretty well (with the topological sort)
   - the sync from confirmed to predict might not only be for replicated components, but also components that were
     spawned on confirmed world directly.
     - which means it's not to apply topological sort during replication; we need to apply it on prediction level directly
+    - create a 'PredictionGroup': all predicted entities must be in the same group, and we apply topological sort on that group
+      - we actually could have different prediction groups, for entities that we know are not interacting at all!
+      - each group has a dependency graph as well
     - maybe maintain a topological sort for each predicted replication group?
       - what about adding new entities to the prediction group? because that's the main problem, otherwise if all the entities
         are known at the beginning we are good!
@@ -32,7 +29,10 @@
     - do we need to introduce the concept of a PredictionGroup, which is a super-set of a replicationGroup? (because some of the entities
         might not come from replication?)
   - how to get smooth interpolation when there can be diagonal movements?
-    - allow custom interpolation, so that we can make sure that interpolation respects corners as well
+    - allow custom interpolation, so that we can make sure that interpolation respects corners as well. The interpolation follows the path
+    - WEIRD: when we just do normal interpolation for player heads, and just use 'interp=start' for tails, it actually looks really smooth!
+    - TODO: tried to make my custom interpolation logic working, but there still seems to be edge cases that are not handled well.
+      - there's weird panics now, and sometimes the interpolated entity doesn't move at all
 
   
   

--- a/NOTES.md
+++ b/NOTES.md
@@ -12,6 +12,21 @@
     because start tick or end tick are not updated correctly in some edge cases.
 
 
+- add PredictionGroup and InterpolationGroup.
+  - on top of ReplicationGroup?
+  - or do we just re-use the replication group id (that usually will have a remote entity id) and use it to see the prediction/interpolation group?
+  - then we add the prediction group id on the Confirmed or Predicted components?
+- Then we don't really need the Confirmed/Predicted components anymore, we could just have resources on the Prediction or Interpolation plugin
+- The resource needs:
+  - confirmed<->predicted mapping
+  - for a given prediction-group, the dependency graph of the entities (using confirmed entities?)
+- The prediction systems will:
+  - iterate through the dependency graph of the prediction group
+  - for each entity, fetch the confirmed/predicted entity
+  - do entity mapping if needed
+- users can add their own entities in the prediction group (even if thre )
+
+
 
 - DEBUGGING REPLICATION BOX:
   - the sync from confirmed to predict might not only be for replicated components, but also components that were

--- a/NOTES.md
+++ b/NOTES.md
@@ -12,13 +12,28 @@
     because start tick or end tick are not updated correctly in some edge cases.
 
 
+- Interpolation:
+  - should let users do interpolation for multiple components themselves (for better splines)
+    - i.e. they handle completely interpolation!
+  - or for a given component, let them use linear or custom interpolation
+
+
 - DEBUGGING REPLICATION BOX:
   - I think the general map_entities logic works pretty well (with the topological sort)
-  - the problem is that the PlayerEntity component gets replicated from Confirmed to Predicted, but it must now refer 
-    to another entity (the predicted head!)
-    - I guess we need a similar MapEntities to map entities inside components from Confirmed to Predicted?
-    - Similarly, we need a topological order in which we spawn the Predicted entities?
-    - complicated...
+  - the sync from confirmed to predict might not only be for replicated components, but also components that were
+    spawned on confirmed world directly.
+    - which means it's not to apply topological sort during replication; we need to apply it on prediction level directly
+    - maybe maintain a topological sort for each predicted replication group?
+      - what about adding new entities to the prediction group? because that's the main problem, otherwise if all the entities
+        are known at the beginning we are good!
+      - maybe don't need toplogical sort but can just use the vec from the replication to have the order
+      - but then how do we iterate through the entities in that order?
+    - the components during prediction sync need to be mapped!
+    - do we need to introduce the concept of a PredictionGroup, which is a super-set of a replicationGroup? (because some of the entities
+        might not come from replication?)
+  - how to get smooth interpolation when there can be diagonal movements?
+    - allow custom interpolation, so that we can make sure that interpolation respects corners as well
+
   
   
 

--- a/NOTES.md
+++ b/NOTES.md
@@ -10,6 +10,15 @@
     - the cube goes all the way to the left and exits the screen. There is continuous rollback fails
   - on interest management, we still have this problem where interpolation is stuck at the beginning and doesn't move. Probably 
     because start tick or end tick are not updated correctly in some edge cases.
+
+
+- DEBUGGING REPLICATION BOX:
+  - I think the general map_entities logic works pretty well (with the topological sort)
+  - the problem is that the PlayerEntity component gets replicated from Confirmed to Predicted, but it must now refer 
+    to another entity (the predicted head!)
+    - I guess we need a similar MapEntities to map entities inside components from Confirmed to Predicted?
+    - Similarly, we need a topological order in which we spawn the Predicted entities?
+    - complicated...
   
   
 

--- a/NOTES.md
+++ b/NOTES.md
@@ -33,15 +33,12 @@
     - WEIRD: when we just do normal interpolation for player heads, and just use 'interp=start' for tails, it actually looks really smooth!
     - TODO: tried to make my custom interpolation logic working, but there still seems to be edge cases that are not handled well.
       - there's weird panics now, and sometimes the interpolated entity doesn't move at all
+  - INTERP TIME is sometimes too late; i.e. we receive updates that are way after interp time.
+  - PREDICTION; rollback is weird and fucked
+    - looks like sending pings more frequently fixed the issue?, to investigate..
 
   
   
-
-- TODO:
-  - implement Message for common bevy transforms
-  - maybe have a ClientReplicate component to transfer all the replication data that is useful to clients? (group, prediciton, interpolation, etc.)
-
-   
 
 
 - FINAL CHOICE:
@@ -385,6 +382,10 @@ ROUGH EDGES:
 
 
 TODO:
+
+- Inputs:
+  - instead of sending the last 15 inputs, send all inputs until the last acked input message (with a max)
+  - also remember to keep around inputs that we might need for prediction!
 
 - Serialization:
   - have a NetworkMessage macro that all network messages must derive (Input, Message, Component)

--- a/book/src/concepts/advanced_replication/interpolation.md
+++ b/book/src/concepts/advanced_replication/interpolation.md
@@ -1,0 +1,84 @@
+# Interpolation
+
+## Introduction
+Interpolation means that we will store replicated entities in a buffer, and then interpolate between the last two states to get a smoother movement.
+
+See this excellent explanation from Valve: [link](https://developer.valvesoftware.com/wiki/Source_Multiplayer_Networking)
+or this one from Gabriel Gambetta: [link](https://www.gabrielgambetta.com/entity-interpolation.html)
+
+
+## Implementation
+
+In lightyear, interpolation can be automatically managed for you.
+
+Every replicated entity can specify to which clients it should be interpolated to:
+```rust,noplayground
+Replicate {
+    interpolation_target: NetworkTarget::AllExcept(vec![id]),
+    ..default()
+},
+```
+
+This means that all clients except for the one with id `id` will interpolate this entity.
+In practice, it means that they will store in a buffer the history for all components that are enabled for Interpolation.
+
+
+## Component Sync Mode
+
+Not all components in the protocol are necessarily interpolated.
+Each component can implement a `ComponentSyncMode` that defines how it gets handled for the `Predicted` and `Interpolated` entities.
+
+Only components that have `ComponentSyncMode::Full` will be interpolated.
+
+
+## Interpolation function
+
+By default, the implementation function for a given component will be linear interpolation.
+It is also possibly to override this behaviour by implementing a custom interpolation function.
+
+Here is an example:
+
+```rust,noplayground
+    #[derive(Component, Message, Serialize, Deserialize, Debug, PartialEq, Clone)]
+    pub struct Component1(pub f32);
+    #[derive(Component, Message, Serialize, Deserialize, Debug, PartialEq, Clone)]
+    pub struct Component2(pub f32);
+
+    #[component_protocol(protocol = "MyProtocol")]
+    pub enum MyComponentProtocol {
+        #[sync(full)]
+        Component1(Component1),
+        #[sync(full, lerp = "MyCustomInterpFn")]
+        Component2(Component2),
+    }
+
+    // custom interpolation logic
+    pub struct MyCustomInterpFn;
+    impl<C> InterpFn<C> for MyCustomInterpFn {
+        fn lerp(start: C, _other: C, _t: f32) -> C {
+            start
+        }
+    }
+```
+
+You will have to add the attribute `lerp = "TYPE_NAME"` to the component.
+The `TYPE_NAME` must be a type that implements the `InterpFn` trait.
+```rust,noplayground
+pub trait InterpFn<C> {
+    fn lerp(start: C, other: C, t: f32) -> C;
+}
+```
+
+
+## Complex interpolation
+
+In some cases, the interpolation logic can be more complex than a simple linear interpolation.
+For example, we might want to have different interpolation functions for different entities, even if they have the same component type.
+Or we might want to do interpolation based on multiple comments (applying some cubic spline interpolation that relies not only on the position,
+but also on the velocity and acceleration).
+
+In those cases, you can disable the default per-component interpolation logic and provide your own custom logic.
+```rust,noplayground```
+
+
+

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -18,6 +18,10 @@ name = "interest_management"
 path = "interest_management/main.rs"
 
 [[example]]
+name = "replication_groups"
+path = "replication_groups/main.rs"
+
+[[example]]
 name = "simple_box"
 path = "simple_box/main.rs"
 

--- a/examples/interest_management/protocol.rs
+++ b/examples/interest_management/protocol.rs
@@ -92,7 +92,7 @@ pub struct Channel1;
 #[derive(Message, Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct Message1(pub usize);
 
-#[message_protocol(protocol = "MyProtocol", derive(Debug))]
+#[message_protocol(protocol = "MyProtocol")]
 pub enum Messages {
     Message1(Message1),
 }

--- a/examples/interest_management/protocol.rs
+++ b/examples/interest_management/protocol.rs
@@ -1,8 +1,10 @@
 use bevy::prelude::{default, Bundle, Color, Component, Deref, DerefMut, Entity, Vec2};
+use bevy::utils::EntityHashSet;
 use derive_more::{Add, Mul};
 use lightyear::prelude::*;
 use lightyear::shared::replication::components::ReplicationMode;
 use serde::{Deserialize, Serialize};
+use tracing::info;
 
 // Player
 #[derive(Bundle)]
@@ -56,9 +58,15 @@ pub struct Circle;
 #[message(custom_map)]
 pub struct PlayerParent(Entity);
 
-impl MapEntities for PlayerParent {
-    fn map_entities(&mut self, entity_map: &EntityMap) {
-        self.0.map_entities(entity_map);
+impl<'a> MapEntities<'a> for PlayerParent {
+    fn map_entities(&mut self, entity_mapper: Box<dyn EntityMapper + 'a>) {
+        info!("mapping parent entity {:?}", self.0);
+        self.0.map_entities(entity_mapper);
+        info!("After mapping: {:?}", self.0);
+    }
+
+    fn entities(&self) -> EntityHashSet<Entity> {
+        EntityHashSet::from_iter(vec![self.0])
     }
 }
 

--- a/examples/replication_groups/README.md
+++ b/examples/replication_groups/README.md
@@ -1,0 +1,24 @@
+# Replication groups
+
+This is an example that shows how to make Lightyear replicate multiple entities in a single message,
+to make sure that they are always in a consistent state (i.e. that entities in a group are all replicated on the same tick).
+
+Without a replication group, it is possible that one entity is replicated with the server's tick 10, and another entity
+is replicated with the server's tick 11. This is not a problem if the entities are independent, but if they depend on each other (for example
+for client prediction) it could cause issues.
+
+This is especially useful if you have an entity that depends on another entity (e.g. a player and its weapon),
+the weapon might have a component `Parent(owner: Entity)` which references the player entity.
+In which case we **need** the player entity to be spawned before the weapon entity, otherwise `Parent` component
+will reference an entity that does not exist.
+
+
+## Running the example
+
+To start the server, run `cargo run --example replication_groups server`
+
+Then you can launch multiple clients with the commands:
+
+- `cargo run --example replication_groups client -c 1`
+
+- `cargo run --example replication_groups client -c 2 --client-port 2000`

--- a/examples/replication_groups/client.rs
+++ b/examples/replication_groups/client.rs
@@ -1,0 +1,185 @@
+use crate::protocol::Direction;
+use crate::protocol::*;
+use crate::shared::{shared_config, shared_movement_behaviour, shared_tail_behaviour};
+use crate::{Transports, KEY, PROTOCOL_ID};
+use bevy::prelude::*;
+use lightyear::prelude::client::*;
+use lightyear::prelude::*;
+use std::net::{Ipv4Addr, SocketAddr};
+use std::str::FromStr;
+use std::time::Duration;
+
+#[derive(Resource, Clone, Copy)]
+pub struct MyClientPlugin {
+    pub(crate) client_id: ClientId,
+    pub(crate) client_port: u16,
+    pub(crate) server_port: u16,
+    pub(crate) transport: Transports,
+}
+
+impl Plugin for MyClientPlugin {
+    fn build(&self, app: &mut App) {
+        let server_addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), self.server_port);
+        let auth = Authentication::Manual {
+            server_addr,
+            client_id: self.client_id,
+            private_key: KEY,
+            protocol_id: PROTOCOL_ID,
+        };
+        let client_addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), self.client_port);
+        let link_conditioner = LinkConditionerConfig {
+            incoming_latency: Duration::from_millis(200),
+            incoming_jitter: Duration::from_millis(20),
+            incoming_loss: 0.05,
+        };
+        let transport = match self.transport {
+            Transports::Udp => TransportConfig::UdpSocket(client_addr),
+            Transports::Webtransport => TransportConfig::WebTransportClient {
+                client_addr,
+                server_addr,
+            },
+        };
+        let io = Io::from_config(
+            &IoConfig::from_transport(transport).with_conditioner(link_conditioner),
+        );
+        let config = ClientConfig {
+            shared: shared_config().clone(),
+            input: InputConfig::default(),
+            netcode: Default::default(),
+            ping: PingConfig::default(),
+            sync: SyncConfig::default(),
+            prediction: PredictionConfig::default(),
+            // we are sending updates every frame (60fps), let's add a delay of 6 network-ticks
+            interpolation: InterpolationConfig::default()
+                .with_delay(InterpolationDelay::default().with_send_interval_ratio(2.0)),
+        };
+        let plugin_config = PluginConfig::new(config, io, protocol(), auth);
+        app.add_plugins(ClientPlugin::new(plugin_config));
+        app.add_plugins(crate::shared::SharedPlugin);
+        app.insert_resource(self.clone());
+        app.add_systems(Startup, init);
+        app.add_systems(
+            FixedUpdate,
+            buffer_input.in_set(InputSystemSet::BufferInputs),
+        );
+        app.add_systems(
+            FixedUpdate,
+            (movement, shared_tail_behaviour)
+                .chain()
+                .in_set(FixedUpdateSet::Main),
+        );
+        app.add_systems(
+            Update,
+            (
+                receive_message1,
+                receive_entity_spawn,
+                receive_entity_despawn,
+                handle_predicted_spawn,
+                handle_interpolated_spawn,
+            ),
+        );
+    }
+}
+
+// Startup system for the client
+pub(crate) fn init(
+    mut commands: Commands,
+    mut client: ResMut<Client<MyProtocol>>,
+    plugin: Res<MyClientPlugin>,
+) {
+    commands.spawn(Camera2dBundle::default());
+    commands.spawn(TextBundle::from_section(
+        format!("Client {}", plugin.client_id),
+        TextStyle {
+            font_size: 30.0,
+            color: Color::WHITE,
+            ..default()
+        },
+    ));
+    client.connect();
+    // client.set_base_relative_speed(0.001);
+}
+
+// System that reads from peripherals and adds inputs to the buffer
+pub(crate) fn buffer_input(mut client: ResMut<Client<MyProtocol>>, keypress: Res<Input<KeyCode>>) {
+    if keypress.pressed(KeyCode::W) || keypress.pressed(KeyCode::Up) {
+        return client.add_input(Inputs::Direction(Direction::Up));
+    }
+    if keypress.pressed(KeyCode::S) || keypress.pressed(KeyCode::Down) {
+        return client.add_input(Inputs::Direction(Direction::Down));
+    }
+    if keypress.pressed(KeyCode::A) || keypress.pressed(KeyCode::Left) {
+        return client.add_input(Inputs::Direction(Direction::Left));
+    }
+    if keypress.pressed(KeyCode::D) || keypress.pressed(KeyCode::Right) {
+        return client.add_input(Inputs::Direction(Direction::Right));
+    }
+    if keypress.pressed(KeyCode::Delete) {
+        // currently, inputs is an enum and we can only add one input per tick
+        return client.add_input(Inputs::Delete);
+    }
+    if keypress.pressed(KeyCode::Space) {
+        return client.add_input(Inputs::Spawn);
+    }
+}
+
+// The client input only gets applied to predicted entities that we own
+// This works because we only predict the user's controlled entity.
+// If we were predicting more entities, we would have to only apply movement to the player owned one.
+pub(crate) fn movement(
+    // TODO: maybe make prediction mode a separate component!!!
+    mut position_query: Query<&mut PlayerPosition, With<Predicted>>,
+    mut input_reader: EventReader<InputEvent<Inputs>>,
+) {
+    if PlayerPosition::mode() != ComponentSyncMode::Full {
+        return;
+    }
+    for input in input_reader.read() {
+        if let Some(input) = input.input() {
+            for mut position in position_query.iter_mut() {
+                shared_movement_behaviour(&mut position, input);
+            }
+        }
+    }
+}
+
+// System to receive messages on the client
+pub(crate) fn receive_message1(mut reader: EventReader<MessageEvent<Message1>>) {
+    for event in reader.read() {
+        info!("Received message: {:?}", event.message());
+    }
+}
+
+// Example system to handle EntitySpawn events
+pub(crate) fn receive_entity_spawn(mut reader: EventReader<EntitySpawnEvent>) {
+    for event in reader.read() {
+        info!("Received entity spawn: {:?}", event.entity());
+    }
+}
+
+// Example system to handle EntitySpawn events
+pub(crate) fn receive_entity_despawn(mut reader: EventReader<EntityDespawnEvent>) {
+    for event in reader.read() {
+        info!("Received entity despawn: {:?}", event.entity());
+    }
+}
+
+// When the predicted copy of the client-owned entity is spawned, do stuff
+// - assign it a different saturation
+// - keep track of it in the Global resource
+pub(crate) fn handle_predicted_spawn(mut predicted: Query<&mut PlayerColor, Added<Predicted>>) {
+    for mut color in predicted.iter_mut() {
+        color.0.set_s(0.3);
+    }
+}
+
+// When the predicted copy of the client-owned entity is spawned, do stuff
+// - assign it a different saturation
+// - keep track of it in the Global resource
+pub(crate) fn handle_interpolated_spawn(
+    mut interpolated: Query<&mut PlayerColor, Added<Interpolated>>,
+) {
+    for mut color in interpolated.iter_mut() {
+        color.0.set_s(0.1);
+    }
+}

--- a/examples/replication_groups/client.rs
+++ b/examples/replication_groups/client.rs
@@ -198,7 +198,7 @@ pub(crate) fn debug_prediction_pre_rollback(
         inputs = ?client.get_input_buffer(),
         "prediction pre rollback debug");
     for (parent, tail_history) in tail_query.iter() {
-        let (parent_history) = parent_query
+        let parent_history = parent_query
             .get(parent.0)
             .expect("Tail entity has no parent entity!");
         info!(?parent_history, "parent");
@@ -213,7 +213,7 @@ pub(crate) fn debug_prediction_post_rollback(
 ) {
     info!(tick = ?client.tick(), "prediction post rollback debug");
     for (parent, tail_history) in tail_query.iter() {
-        let (parent_history) = parent_query
+        let parent_history = parent_query
             .get(parent.0)
             .expect("Tail entity has no parent entity!");
         info!(?parent_history, "parent");

--- a/examples/replication_groups/main.rs
+++ b/examples/replication_groups/main.rs
@@ -1,0 +1,96 @@
+#![allow(unused_imports)]
+#![allow(unused_variables)]
+#![allow(dead_code)]
+
+//! Run with
+//! - `cargo run --example bevy_cli server`
+//! - `cargo run --example bevy_cli client`
+mod client;
+mod protocol;
+mod server;
+mod shared;
+
+use std::str::FromStr;
+
+use bevy::log::LogPlugin;
+use bevy::prelude::*;
+use bevy::DefaultPlugins;
+use clap::{Parser, ValueEnum};
+use serde::{Deserialize, Serialize};
+use tracing_subscriber::fmt::format::FmtSpan;
+
+use crate::client::MyClientPlugin;
+use crate::server::MyServerPlugin;
+use lightyear::netcode::{ClientId, Key};
+use lightyear::prelude::TransportConfig;
+
+#[tokio::main]
+async fn main() {
+    let cli = Cli::parse();
+    let mut app = App::new();
+    app.add_plugins(DefaultPlugins.build().disable::<LogPlugin>());
+    setup(&mut app, cli);
+
+    app.run();
+}
+
+pub const CLIENT_PORT: u16 = 6000;
+pub const SERVER_PORT: u16 = 5000;
+pub const PROTOCOL_ID: u64 = 0;
+
+pub const KEY: Key = [0; 32];
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
+pub enum Transports {
+    Udp,
+    Webtransport,
+}
+
+#[derive(Parser, PartialEq, Debug)]
+enum Cli {
+    SinglePlayer,
+    Server {
+        #[arg(short, long, default_value_t = SERVER_PORT)]
+        port: u16,
+
+        #[arg(short, long, value_enum, default_value_t = Transports::Udp)]
+        transport: Transports,
+    },
+    Client {
+        #[arg(short, long, default_value_t = ClientId::default())]
+        client_id: ClientId,
+
+        #[arg(long, default_value_t = CLIENT_PORT)]
+        client_port: u16,
+
+        #[arg(short, long, default_value_t = SERVER_PORT)]
+        server_port: u16,
+
+        #[arg(short, long, value_enum, default_value_t = Transports::Udp)]
+        transport: Transports,
+    },
+}
+
+fn setup(app: &mut App, cli: Cli) {
+    match cli {
+        Cli::SinglePlayer => {}
+        Cli::Server { port, transport } => {
+            let server_plugin = MyServerPlugin { port, transport };
+            app.add_plugins(server_plugin);
+        }
+        Cli::Client {
+            client_id,
+            client_port,
+            server_port,
+            transport,
+        } => {
+            let client_plugin = MyClientPlugin {
+                client_id,
+                client_port,
+                server_port,
+                transport,
+            };
+            app.add_plugins(client_plugin);
+        }
+    }
+}

--- a/examples/replication_groups/protocol.rs
+++ b/examples/replication_groups/protocol.rs
@@ -1,6 +1,7 @@
 use bevy::prelude::{default, Bundle, Color, Component, Deref, DerefMut, Entity, Reflect, Vec2};
 use bevy::utils::EntityHashSet;
 use derive_more::{Add, Mul};
+use lightyear::prelude::client::InterpFn;
 use lightyear::prelude::*;
 use lightyear::shared::replication::components::ReplicationGroup;
 use serde::{Deserialize, Serialize};
@@ -87,6 +88,13 @@ pub struct TailLength(pub(crate) f32);
 // tail inflection points, from front (point closest to the head) to back (tail end point)
 pub struct TailPoints(pub(crate) VecDeque<(Vec2, Direction)>);
 
+pub struct TailPointsInterpolation;
+impl InterpFn<TailPoints> for TailPointsInterpolation {
+    fn lerp(start: TailPoints, other: TailPoints, t: f32) -> TailPoints {
+        start
+    }
+}
+
 pub fn segment_length(from: Vec2, to: Vec2) -> f32 {
     (from - to).length()
 }
@@ -162,7 +170,7 @@ pub enum Components {
     PlayerColor(PlayerColor),
     #[sync(once)]
     TailLength(TailLength),
-    #[sync(simple)]
+    #[sync(full, lerp = "TailPointsInterpolation")]
     TailPoints(TailPoints),
     #[sync(once)]
     PlayerParent(PlayerParent),

--- a/examples/replication_groups/protocol.rs
+++ b/examples/replication_groups/protocol.rs
@@ -289,6 +289,10 @@ pub enum Inputs {
     Direction(Direction),
     Delete,
     Spawn,
+    // NOTE: the server MUST be able to distinguish between an input saying "the user is not doing any actions" and
+    // "we haven't received the input for this tick", which means that the client must send inputs every tick
+    // even if the user is not doing anything.
+    None,
 }
 
 impl UserInput for Inputs {}

--- a/examples/replication_groups/protocol.rs
+++ b/examples/replication_groups/protocol.rs
@@ -1,0 +1,241 @@
+use bevy::prelude::{default, Bundle, Color, Component, Deref, DerefMut, Entity, Vec2};
+use derive_more::{Add, Mul};
+use lightyear::prelude::*;
+use lightyear::shared::replication::components::ReplicationGroup;
+use serde::{Deserialize, Serialize};
+use std::collections::VecDeque;
+use tracing::{info, trace};
+
+// Player
+#[derive(Bundle)]
+pub(crate) struct PlayerBundle {
+    id: PlayerId,
+    position: PlayerPosition,
+    color: PlayerColor,
+    replicate: Replicate,
+}
+
+// Tail
+#[derive(Bundle)]
+pub(crate) struct TailBundle {
+    parent: PlayerParent,
+    points: TailPoints,
+    length: TailLength,
+    replicate: Replicate,
+}
+
+impl PlayerBundle {
+    pub(crate) fn new(id: ClientId, position: Vec2, color: Color) -> Self {
+        Self {
+            id: PlayerId(id),
+            position: PlayerPosition(position),
+            color: PlayerColor(color),
+            replicate: Replicate {
+                // prediction_target: NetworkTarget::None,
+                prediction_target: NetworkTarget::Only(vec![id]),
+                interpolation_target: NetworkTarget::AllExcept(vec![id]),
+                // this is the default: the replication group id is a u64 value generated from the entity (`entity.to_bits()`)
+                replication_group: ReplicationGroup::FromEntity,
+                ..default()
+            },
+        }
+    }
+}
+
+impl TailBundle {
+    pub(crate) fn new(id: ClientId, parent: Entity, parent_position: Vec2, length: f32) -> Self {
+        let default_direction = Direction::default();
+        let tail = default_direction.get_tail(parent_position, length);
+        let mut points = VecDeque::new();
+        points.push_front((tail, default_direction));
+        Self {
+            parent: PlayerParent(parent),
+            points: TailPoints(points),
+            length: TailLength(length),
+            replicate: Replicate {
+                // prediction_target: NetworkTarget::None,
+                prediction_target: NetworkTarget::Only(vec![id]),
+                interpolation_target: NetworkTarget::AllExcept(vec![id]),
+                // replicate this entity within the same replication group as the parent
+                replication_group: ReplicationGroup::Group(parent.to_bits()),
+                ..default()
+            },
+        }
+    }
+}
+
+// Components
+
+#[derive(Component, Message, Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct PlayerId(ClientId);
+
+#[derive(
+    Component, Message, Serialize, Deserialize, Clone, Debug, PartialEq, Deref, DerefMut, Add, Mul,
+)]
+pub struct PlayerPosition(pub(crate) Vec2);
+
+#[derive(Component, Message, Deserialize, Serialize, Clone, Debug, PartialEq)]
+pub struct PlayerColor(pub(crate) Color);
+
+#[derive(Component, Message, Deserialize, Serialize, Clone, Debug, PartialEq)]
+pub struct TailLength(pub(crate) f32);
+
+#[derive(Component, Message, Deserialize, Serialize, Clone, Debug, PartialEq)]
+// tail inflection points, from front (point closest to the head) to back (tail end point)
+pub struct TailPoints(pub(crate) VecDeque<(Vec2, Direction)>);
+
+pub fn segment_length(from: Vec2, to: Vec2) -> f32 {
+    (from - to).length()
+}
+impl TailPoints {
+    /// Make sure that the tail is exactly `length` long
+    pub(crate) fn shorten_back(&mut self, head: Vec2, length: f32) {
+        // find the index of the first point to modify (all points after that needs to be discarded)
+
+        // treat the first point separately
+        let mut current_length = segment_length(head, self.0.front().unwrap().0);
+        if current_length >= length {
+            trace!("shortening first segment");
+            let direction = self.0.front().unwrap().1;
+            let new_point = direction.get_tail(head, length);
+            self.0 = VecDeque::new();
+            self.0.push_front((new_point, direction));
+            return;
+        }
+        for i in 1..self.0.len() {
+            let segment_length = segment_length(self.0[i - 1].0, self.0[i].0);
+            current_length += segment_length;
+            if current_length > length {
+                trace!("shortening tail");
+                let direction = self.0[i].1;
+                let new_segment_length = segment_length - (current_length - length);
+
+                // shorten the segment, and drop the rest
+                if new_segment_length > 0.0 {
+                    let new_point = direction
+                        .get_tail(self.0[i - 1].0, segment_length - (current_length - length));
+                    // drop all elements from [i, ..[
+                    let _ = self.0.split_off(i);
+                    self.0.push_back((new_point, direction));
+                } else {
+                    // drop all elements from [i, ..[
+                    let _ = self.0.split_off(i);
+                }
+                trace!("new tail: {:?}", self.0);
+                return;
+            }
+        }
+    }
+}
+
+// Example of a component that contains an entity.
+// This component, when replicated, needs to have the inner entity mapped from the Server world
+// to the client World.
+// This can be done by adding a `#[message(custom_map)]` attribute to the component, and then
+// deriving the `MapEntities` trait for the component.
+#[derive(Component, Message, Deserialize, Serialize, Clone, Debug, PartialEq)]
+#[message(custom_map)]
+pub struct PlayerParent(pub(crate) Entity);
+
+impl MapEntities for PlayerParent {
+    fn map_entities(&mut self, entity_map: &EntityMap) {
+        self.0.map_entities(entity_map);
+    }
+}
+
+#[component_protocol(protocol = "MyProtocol")]
+pub enum Components {
+    #[sync(once)]
+    PlayerId(PlayerId),
+    #[sync(full)]
+    PlayerPosition(PlayerPosition),
+    #[sync(once)]
+    PlayerColor(PlayerColor),
+}
+
+// Channels
+
+#[derive(Channel)]
+pub struct Channel1;
+
+// Messages
+
+#[derive(Message, Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct Message1(pub usize);
+
+#[message_protocol(protocol = "MyProtocol", derive(Debug))]
+pub enum Messages {
+    Message1(Message1),
+}
+
+// Inputs
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Copy, Default)]
+// To simplify, we only allow one direction at a time
+pub enum Direction {
+    #[default]
+    Up,
+    Down,
+    Left,
+    Right,
+}
+
+impl Direction {
+    // Get the direction from `from` to `to` (doesn't handle diagonals)
+    pub fn from_points(from: Vec2, to: Vec2) -> Option<Self> {
+        if from.x != to.x && from.y != to.y {
+            trace!(?from, ?to, "diagonal");
+            return None;
+        }
+        if from.y < to.y {
+            return Some(Self::Up);
+        }
+        if from.y > to.y {
+            return Some(Self::Down);
+        }
+        if from.x > to.x {
+            return Some(Self::Left);
+        }
+        if from.x < to.x {
+            return Some(Self::Right);
+        }
+        return None;
+    }
+
+    // Get the position of the point that would become `head` if we applied `length` * `self`
+    pub fn get_tail(&self, head: Vec2, length: f32) -> Vec2 {
+        match self {
+            Direction::Up => Vec2::new(head.x, head.y - length),
+            Direction::Down => Vec2::new(head.x, head.y + length),
+            Direction::Left => Vec2::new(head.x + length, head.y),
+            Direction::Right => Vec2::new(head.x - length, head.y),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+pub enum Inputs {
+    Direction(Direction),
+    Delete,
+    Spawn,
+}
+
+impl UserInput for Inputs {}
+
+// Protocol
+
+protocolize! {
+    Self = MyProtocol,
+    Message = Messages,
+    Component = Components,
+    Input = Inputs,
+}
+
+pub(crate) fn protocol() -> MyProtocol {
+    let mut protocol = MyProtocol::default();
+    protocol.add_channel::<Channel1>(ChannelSettings {
+        mode: ChannelMode::OrderedReliable(ReliableSettings::default()),
+        direction: ChannelDirection::Bidirectional,
+    });
+    protocol
+}

--- a/examples/replication_groups/protocol.rs
+++ b/examples/replication_groups/protocol.rs
@@ -33,7 +33,8 @@ impl PlayerBundle {
             replicate: Replicate {
                 // prediction_target: NetworkTarget::None,
                 prediction_target: NetworkTarget::Only(vec![id]),
-                interpolation_target: NetworkTarget::AllExcept(vec![id]),
+                interpolation_target: NetworkTarget::None,
+                // interpolation_target: NetworkTarget::AllExcept(vec![id]),
                 // this is the default: the replication group id is a u64 value generated from the entity (`entity.to_bits()`)
                 replication_group: ReplicationGroup::FromEntity,
                 ..default()
@@ -151,6 +152,12 @@ pub enum Components {
     PlayerPosition(PlayerPosition),
     #[sync(once)]
     PlayerColor(PlayerColor),
+    #[sync(once)]
+    TailLength(TailLength),
+    #[sync(simple)]
+    TailPoints(TailPoints),
+    #[sync(once)]
+    PlayerParent(PlayerParent),
 }
 
 // Channels
@@ -163,7 +170,7 @@ pub struct Channel1;
 #[derive(Message, Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct Message1(pub usize);
 
-#[message_protocol(protocol = "MyProtocol", derive(Debug))]
+#[message_protocol(protocol = "MyProtocol")]
 pub enum Messages {
     Message1(Message1),
 }

--- a/examples/replication_groups/protocol.rs
+++ b/examples/replication_groups/protocol.rs
@@ -132,17 +132,6 @@ pub struct TailLength(pub(crate) f32);
 // tail inflection points, from front (point closest to the head) to back (tail end point)
 pub struct TailPoints(pub(crate) VecDeque<(Vec2, Direction)>);
 
-pub struct TailPointsInterpolation;
-// TODO: annoyingly, we still need to implement InterpFn for TailPointsInterpolation
-//  even if we completely disable interpolation, because the derive macro demands it.
-//  maybe also add an attribute on the derive macro?
-impl InterpFn<TailPoints> for TailPointsInterpolation {
-    fn lerp(start: TailPoints, other: TailPoints, t: f32) -> TailPoints {
-        panic!("hi");
-        start
-    }
-}
-
 pub fn segment_length(from: Vec2, to: Vec2) -> f32 {
     (from - to).length()
 }
@@ -218,7 +207,9 @@ pub enum Components {
     PlayerColor(PlayerColor),
     #[sync(once)]
     TailLength(TailLength),
-    #[sync(full, lerp = "TailPointsInterpolation")]
+    // we set the interpolation function to NoInterpolation because we are using our own custom interpolation logic
+    // (by default it would use LinearInterpolation, which requires Add and Mul bounds on this component)
+    #[sync(full, lerp = "NoInterpolation")]
     TailPoints(TailPoints),
     #[sync(once)]
     PlayerParent(PlayerParent),

--- a/examples/replication_groups/protocol.rs
+++ b/examples/replication_groups/protocol.rs
@@ -1,4 +1,5 @@
 use bevy::prelude::{default, Bundle, Color, Component, Deref, DerefMut, Entity, Vec2};
+use bevy::utils::EntityHashSet;
 use derive_more::{Add, Mul};
 use lightyear::prelude::*;
 use lightyear::shared::replication::components::ReplicationGroup;
@@ -56,7 +57,8 @@ impl TailBundle {
             replicate: Replicate {
                 // prediction_target: NetworkTarget::None,
                 prediction_target: NetworkTarget::Only(vec![id]),
-                interpolation_target: NetworkTarget::AllExcept(vec![id]),
+                interpolation_target: NetworkTarget::None,
+                // interpolation_target: NetworkTarget::AllExcept(vec![id]),
                 // replicate this entity within the same replication group as the parent
                 replication_group: ReplicationGroup::Group(parent.to_bits()),
                 ..default()
@@ -140,7 +142,12 @@ pub struct PlayerParent(pub(crate) Entity);
 
 impl MapEntities for PlayerParent {
     fn map_entities(&mut self, entity_map: &EntityMap) {
+        info!("mapping entity {:?}", self.0);
         self.0.map_entities(entity_map);
+    }
+
+    fn entities(&self) -> EntityHashSet<Entity> {
+        EntityHashSet::from_iter(vec![self.0])
     }
 }
 

--- a/examples/replication_groups/protocol.rs
+++ b/examples/replication_groups/protocol.rs
@@ -1,4 +1,4 @@
-use bevy::prelude::{default, Bundle, Color, Component, Deref, DerefMut, Entity, Vec2};
+use bevy::prelude::{default, Bundle, Color, Component, Deref, DerefMut, Entity, Reflect, Vec2};
 use bevy::utils::EntityHashSet;
 use derive_more::{Add, Mul};
 use lightyear::prelude::*;
@@ -140,10 +140,11 @@ impl TailPoints {
 #[message(custom_map)]
 pub struct PlayerParent(pub(crate) Entity);
 
-impl MapEntities for PlayerParent {
-    fn map_entities(&mut self, entity_map: &EntityMap) {
-        info!("mapping entity {:?}", self.0);
-        self.0.map_entities(entity_map);
+impl<'a> MapEntities<'a> for PlayerParent {
+    fn map_entities(&mut self, entity_mapper: Box<dyn EntityMapper + 'a>) {
+        info!("mapping parent entity {:?}", self.0);
+        self.0.map_entities(entity_mapper);
+        info!("After mapping: {:?}", self.0);
     }
 
     fn entities(&self) -> EntityHashSet<Entity> {

--- a/examples/replication_groups/protocol.rs
+++ b/examples/replication_groups/protocol.rs
@@ -95,7 +95,7 @@ impl PlayerPosition {
                 }
             } else {
                 if b.y <= self.y && self.y <= a.y {
-                    return Some((self.y - b.y) / (a.y - b.y));
+                    return Some((a.y - self.y) / (a.y - b.y));
                 } else {
                     return None;
                 }
@@ -112,7 +112,7 @@ impl PlayerPosition {
                 }
             } else {
                 if b.x <= self.x && self.x <= a.x {
-                    return Some((self.x - b.x) / (a.x - b.x));
+                    return Some((a.x - self.x) / (a.x - b.x));
                 } else {
                     return None;
                 }

--- a/examples/replication_groups/protocol.rs
+++ b/examples/replication_groups/protocol.rs
@@ -84,6 +84,9 @@ impl PlayerPosition {
     /// Will return None if it's not in between, otherwise will return where it is between a and b
     pub(crate) fn is_between(&self, a: Vec2, b: Vec2) -> Option<f32> {
         if a.x == b.x {
+            if self.x != a.x {
+                return None;
+            }
             if a.y < b.y {
                 if a.y <= self.y && self.y <= b.y {
                     return Some((self.y - a.y) / (b.y - a.y));
@@ -98,6 +101,9 @@ impl PlayerPosition {
                 }
             }
         } else if a.y == b.y {
+            if self.y != a.y {
+                return None;
+            }
             if a.x < b.x {
                 if a.x <= self.x && self.x <= b.x {
                     return Some((self.x - a.x) / (b.x - a.x));

--- a/examples/replication_groups/protocol.rs
+++ b/examples/replication_groups/protocol.rs
@@ -127,8 +127,12 @@ pub struct TailLength(pub(crate) f32);
 pub struct TailPoints(pub(crate) VecDeque<(Vec2, Direction)>);
 
 pub struct TailPointsInterpolation;
+// TODO: annoyingly, we still need to implement InterpFn for TailPointsInterpolation
+//  even if we completely disable interpolation, because the derive macro demands it.
+//  maybe also add an attribute on the derive macro?
 impl InterpFn<TailPoints> for TailPointsInterpolation {
     fn lerp(start: TailPoints, other: TailPoints, t: f32) -> TailPoints {
+        panic!("hi");
         start
     }
 }

--- a/examples/replication_groups/protocol.rs
+++ b/examples/replication_groups/protocol.rs
@@ -35,8 +35,8 @@ impl PlayerBundle {
             replicate: Replicate {
                 // prediction_target: NetworkTarget::None,
                 prediction_target: NetworkTarget::Only(vec![id]),
-                interpolation_target: NetworkTarget::None,
-                // interpolation_target: NetworkTarget::AllExcept(vec![id]),
+                // interpolation_target: NetworkTarget::None,
+                interpolation_target: NetworkTarget::AllExcept(vec![id]),
                 // this is the default: the replication group id is a u64 value generated from the entity (`entity.to_bits()`)
                 replication_group: ReplicationGroup::FromEntity,
                 ..default()
@@ -58,8 +58,8 @@ impl TailBundle {
             replicate: Replicate {
                 // prediction_target: NetworkTarget::None,
                 prediction_target: NetworkTarget::Only(vec![id]),
-                interpolation_target: NetworkTarget::None,
-                // interpolation_target: NetworkTarget::AllExcept(vec![id]),
+                // interpolation_target: NetworkTarget::None,
+                interpolation_target: NetworkTarget::AllExcept(vec![id]),
                 // replicate this entity within the same replication group as the parent
                 replication_group: ReplicationGroup::Group(parent.to_bits()),
                 ..default()
@@ -77,6 +77,44 @@ pub struct PlayerId(ClientId);
     Component, Message, Serialize, Deserialize, Clone, Debug, PartialEq, Deref, DerefMut, Add, Mul,
 )]
 pub struct PlayerPosition(pub(crate) Vec2);
+
+impl PlayerPosition {
+    /// Checks if the position is between two other positions.
+    /// (the positions must have the same x or y)
+    /// Will return None if it's not in between, otherwise will return where it is between a and b
+    pub(crate) fn is_between(&self, a: Vec2, b: Vec2) -> Option<f32> {
+        if a.x == b.x {
+            if a.y < b.y {
+                if a.y <= self.y && self.y <= b.y {
+                    return Some((self.y - a.y) / (b.y - a.y));
+                } else {
+                    return None;
+                }
+            } else {
+                if b.y <= self.y && self.y <= a.y {
+                    return Some((self.y - b.y) / (a.y - b.y));
+                } else {
+                    return None;
+                }
+            }
+        } else if a.y == b.y {
+            if a.x < b.x {
+                if a.x <= self.x && self.x <= b.x {
+                    return Some((self.x - a.x) / (b.x - a.x));
+                } else {
+                    return None;
+                }
+            } else {
+                if b.x <= self.x && self.x <= a.x {
+                    return Some((self.x - b.x) / (a.x - b.x));
+                } else {
+                    return None;
+                }
+            }
+        }
+        unreachable!("a and b should be on the same x or y")
+    }
+}
 
 #[derive(Component, Message, Deserialize, Serialize, Clone, Debug, PartialEq)]
 pub struct PlayerColor(pub(crate) Color);

--- a/examples/replication_groups/server.rs
+++ b/examples/replication_groups/server.rs
@@ -22,8 +22,8 @@ impl Plugin for MyServerPlugin {
             .with_key(KEY);
         let link_conditioner = LinkConditionerConfig {
             incoming_latency: Duration::from_millis(200),
-            incoming_jitter: Duration::from_millis(20),
-            incoming_loss: 0.00,
+            incoming_jitter: Duration::from_millis(40),
+            incoming_loss: 0.05,
         };
         let transport = match self.transport {
             Transports::Udp => TransportConfig::UdpSocket(server_addr),

--- a/examples/replication_groups/server.rs
+++ b/examples/replication_groups/server.rs
@@ -23,7 +23,7 @@ impl Plugin for MyServerPlugin {
         let link_conditioner = LinkConditionerConfig {
             incoming_latency: Duration::from_millis(200),
             incoming_jitter: Duration::from_millis(20),
-            incoming_loss: 0.05,
+            incoming_loss: 0.00,
         };
         let transport = match self.transport {
             Transports::Udp => TransportConfig::UdpSocket(server_addr),
@@ -52,8 +52,8 @@ impl Plugin for MyServerPlugin {
                 .chain()
                 .in_set(FixedUpdateSet::Main),
         );
-        app.add_systems(Update, (handle_connections, send_message));
-        app.add_systems(Update, debug_inputs);
+        app.add_systems(Update, handle_connections);
+        // app.add_systems(Update, debug_inputs);
     }
 }
 
@@ -141,20 +141,6 @@ pub(crate) fn movement(
     }
 }
 
-/// Send messages from server to clients
-pub(crate) fn send_message(mut server: ResMut<Server<MyProtocol>>, input: Res<Input<KeyCode>>) {
-    if input.pressed(KeyCode::M) {
-        // TODO: add way to send message to all
-        let message = Message1(5);
-        info!("Send message: {:?}", message);
-        server
-            .send_to_target::<Channel1, Message1>(Message1(5), NetworkTarget::All)
-            .unwrap_or_else(|e| {
-                error!("Failed to send message: {:?}", e);
-            });
-    }
-}
-
 pub(crate) fn debug_inputs(server: Res<Server<MyProtocol>>) {
-    info!(tick = ?server.tick(), inputs = ?server.get_input_buffer(0), "debug");
+    info!(tick = ?server.tick(), inputs = ?server.get_input_buffer(1), "debug");
 }

--- a/examples/replication_groups/server.rs
+++ b/examples/replication_groups/server.rs
@@ -1,0 +1,153 @@
+use crate::protocol::*;
+use crate::shared::{shared_config, shared_movement_behaviour, shared_tail_behaviour};
+use crate::{shared, Transports, KEY, PROTOCOL_ID};
+use bevy::prelude::*;
+use lightyear::prelude::server::*;
+use lightyear::prelude::*;
+use std::collections::HashMap;
+use std::net::{Ipv4Addr, SocketAddr};
+use std::time::Duration;
+
+pub struct MyServerPlugin {
+    pub(crate) port: u16,
+    pub(crate) transport: Transports,
+}
+
+impl Plugin for MyServerPlugin {
+    fn build(&self, app: &mut App) {
+        let server_addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), self.port);
+        let netcode_config = NetcodeConfig::default()
+            .with_protocol_id(PROTOCOL_ID)
+            .with_key(KEY);
+        let link_conditioner = LinkConditionerConfig {
+            incoming_latency: Duration::from_millis(200),
+            incoming_jitter: Duration::from_millis(20),
+            incoming_loss: 0.05,
+        };
+        let transport = match self.transport {
+            Transports::Udp => TransportConfig::UdpSocket(server_addr),
+            Transports::Webtransport => TransportConfig::WebTransportServer {
+                server_addr,
+                certificate: Certificate::self_signed(&["localhost"]),
+            },
+        };
+        let io = Io::from_config(
+            &IoConfig::from_transport(transport).with_conditioner(link_conditioner),
+        );
+        let config = ServerConfig {
+            shared: shared_config().clone(),
+            netcode: netcode_config,
+            ping: PingConfig::default(),
+        };
+        let plugin_config = PluginConfig::new(config, io, protocol());
+        app.add_plugins(server::ServerPlugin::new(plugin_config));
+        app.add_plugins(shared::SharedPlugin);
+        app.init_resource::<Global>();
+        app.add_systems(Startup, init);
+        // the physics/FixedUpdates systems that consume inputs should be run in this set
+        app.add_systems(
+            FixedUpdate,
+            (movement, shared_tail_behaviour)
+                .chain()
+                .in_set(FixedUpdateSet::Main),
+        );
+        app.add_systems(Update, (handle_connections, send_message));
+    }
+}
+
+#[derive(Resource, Default)]
+pub(crate) struct Global {
+    pub client_id_to_entity_id: HashMap<ClientId, Entity>,
+}
+
+pub(crate) fn init(mut commands: Commands) {
+    commands.spawn(Camera2dBundle::default());
+    commands.spawn(TextBundle::from_section(
+        "Server",
+        TextStyle {
+            font_size: 30.0,
+            color: Color::WHITE,
+            ..default()
+        },
+    ));
+}
+
+/// Server connection system, create a player upon connection
+pub(crate) fn handle_connections(
+    mut connections: EventReader<ConnectEvent>,
+    mut disconnections: EventReader<DisconnectEvent>,
+    mut global: ResMut<Global>,
+    mut commands: Commands,
+) {
+    for connection in connections.read() {
+        let client_id = connection.context();
+        // Generate pseudo random color from client id.
+        let h = (((client_id * 30) % 360) as f32) / 360.0;
+        let s = 0.8;
+        let l = 0.5;
+        let player_position = Vec2::ZERO;
+        let player_entity = commands
+            .spawn(PlayerBundle::new(
+                *client_id,
+                player_position,
+                Color::hsl(h, s, l),
+            ))
+            .id();
+        let tail_length = 300.0;
+        let tail_entity = commands.spawn(TailBundle::new(
+            *client_id,
+            player_entity,
+            player_position,
+            tail_length,
+        ));
+        // Add a mapping from client id to entity id
+        global
+            .client_id_to_entity_id
+            .insert(*client_id, player_entity);
+    }
+    for disconnection in disconnections.read() {
+        let client_id = disconnection.context();
+        if let Some(entity) = global.client_id_to_entity_id.remove(client_id) {
+            commands.entity(entity).despawn();
+        }
+    }
+}
+
+/// Read client inputs and move players
+pub(crate) fn movement(
+    mut position_query: Query<&mut PlayerPosition>,
+    mut input_reader: EventReader<InputEvent<Inputs>>,
+    global: Res<Global>,
+    server: Res<Server<MyProtocol>>,
+) {
+    for input in input_reader.read() {
+        let client_id = input.context();
+        if let Some(input) = input.input() {
+            debug!(
+                "Receiving input: {:?} from client: {:?} on tick: {:?}",
+                input,
+                client_id,
+                server.tick()
+            );
+            if let Some(player_entity) = global.client_id_to_entity_id.get(client_id) {
+                if let Ok(mut position) = position_query.get_mut(*player_entity) {
+                    shared_movement_behaviour(&mut position, input);
+                }
+            }
+        }
+    }
+}
+
+/// Send messages from server to clients
+pub(crate) fn send_message(mut server: ResMut<Server<MyProtocol>>, input: Res<Input<KeyCode>>) {
+    if input.pressed(KeyCode::M) {
+        // TODO: add way to send message to all
+        let message = Message1(5);
+        info!("Send message: {:?}", message);
+        server
+            .send_to_target::<Channel1, Message1>(Message1(5), NetworkTarget::All)
+            .unwrap_or_else(|e| {
+                error!("Failed to send message: {:?}", e);
+            });
+    }
+}

--- a/examples/replication_groups/shared.rs
+++ b/examples/replication_groups/shared.rs
@@ -2,6 +2,7 @@ use crate::protocol::Direction;
 use crate::protocol::*;
 use bevy::prelude::*;
 use bevy_inspector_egui::quick::WorldInspectorPlugin;
+use lightyear::prelude::client::Confirmed;
 use lightyear::prelude::*;
 use std::time::Duration;
 use tracing::Level;
@@ -74,7 +75,7 @@ pub(crate) fn shared_tail_behaviour(
             };
             let new_front_dir = Direction::from_points(inflection_pos, parent_position.0).unwrap();
             points.0.push_front((inflection_pos, new_front_dir));
-            trace!(?points, "new points");
+            info!(?points, "new points");
         }
 
         // Update the back
@@ -87,11 +88,11 @@ pub(crate) fn shared_tail_behaviour(
 /// The components should be replicated from the server to the client
 pub(crate) fn draw_snakes(
     mut gizmos: Gizmos,
-    players: Query<(&PlayerPosition, &PlayerColor)>,
-    tails: Query<(&PlayerParent, &TailPoints)>,
+    players: Query<(&PlayerPosition, &PlayerColor), Without<Confirmed>>,
+    tails: Query<(&PlayerParent, &TailPoints), Without<Confirmed>>,
 ) {
     for (parent, points) in tails.iter() {
-        info!("drawing snake with parent: {:?}", parent.0);
+        debug!("drawing snake with parent: {:?}", parent.0);
         let Ok((position, color)) = players.get(parent.0) else {
             panic!("Tail entity has no parent entity!");
         };

--- a/examples/replication_groups/shared.rs
+++ b/examples/replication_groups/shared.rs
@@ -118,9 +118,17 @@ pub(crate) fn draw_snakes(
         );
         // draw the first line
         gizmos.line_2d(position.0, points.0.front().unwrap().0, color.0);
+        if position.0.x != points.0.front().unwrap().0.x
+            && position.0.y != points.0.front().unwrap().0.y
+        {
+            info!("DIAGONAL");
+        }
         // draw the rest of the lines
         for (start, end) in points.0.iter().zip(points.0.iter().skip(1)) {
             gizmos.line_2d(start.0, end.0, color.0);
+            if start.0.x != end.0.x && start.0.y != end.0.y {
+                info!("DIAGONAL");
+            }
         }
     }
 }

--- a/examples/replication_groups/shared.rs
+++ b/examples/replication_groups/shared.rs
@@ -11,8 +11,8 @@ pub fn shared_config() -> SharedConfig {
     SharedConfig {
         enable_replication: true,
         client_send_interval: Duration::default(),
-        server_send_interval: Duration::from_millis(40),
-        // server_send_interval: Duration::from_millis(100),
+        // server_send_interval: Duration::from_millis(40),
+        server_send_interval: Duration::from_millis(100),
         tick: TickConfig {
             tick_duration: Duration::from_secs_f64(1.0 / 64.0),
         },

--- a/examples/replication_groups/shared.rs
+++ b/examples/replication_groups/shared.rs
@@ -1,0 +1,112 @@
+use crate::protocol::Direction;
+use crate::protocol::*;
+use bevy::prelude::*;
+use bevy_inspector_egui::quick::WorldInspectorPlugin;
+use lightyear::prelude::*;
+use std::time::Duration;
+use tracing::Level;
+
+pub fn shared_config() -> SharedConfig {
+    SharedConfig {
+        enable_replication: true,
+        client_send_interval: Duration::default(),
+        server_send_interval: Duration::from_millis(40),
+        // server_send_interval: Duration::from_millis(100),
+        tick: TickConfig {
+            tick_duration: Duration::from_secs_f64(1.0 / 64.0),
+        },
+        log: LogConfig {
+            level: Level::INFO,
+            filter: "wgpu=error,wgpu_hal=error,naga=warn,bevy_app=info,bevy_render=warn,quinn=warn"
+                .to_string(),
+        },
+    }
+}
+
+pub struct SharedPlugin;
+
+impl Plugin for SharedPlugin {
+    fn build(&self, app: &mut App) {
+        // app.add_plugins(WorldInspectorPlugin::new());
+        app.add_systems(Update, draw_snakes);
+    }
+}
+
+// head
+// snake
+
+// This system defines how we update the player's positions when we receive an input
+pub(crate) fn shared_movement_behaviour(position: &mut PlayerPosition, input: &Inputs) {
+    const MOVE_SPEED: f32 = 10.0;
+    match input {
+        Inputs::Direction(direction) => match direction {
+            Direction::Up => position.y += MOVE_SPEED,
+            Direction::Down => position.y -= MOVE_SPEED,
+            Direction::Left => position.x -= MOVE_SPEED,
+            Direction::Right => position.x += MOVE_SPEED,
+        },
+        _ => {}
+    }
+}
+
+// This system defines how we update the player's tails when we the head is updated
+pub(crate) fn shared_tail_behaviour(
+    player_position: Query<&PlayerPosition>,
+    mut tails: Query<(&mut TailPoints, &PlayerParent, &TailLength)>,
+) {
+    for (mut points, parent, length) in tails.iter_mut() {
+        let Ok(parent_position) = player_position.get(parent.0) else {
+            panic!("Tail entity has no parent entity!");
+        };
+        // Update the front if the head turned
+        let (front_pos, front_dir) = points.0.front().unwrap().clone();
+        // NOTE: we do not deal with diagonal directions in this example
+        let front_direction = Direction::from_points(front_pos, parent_position.0);
+        // if the head is going in a new direction, add a new point to the front
+        if front_direction.map_or(true, |dir| dir != front_dir) {
+            trace!(
+                old_front_dir = ?front_dir,
+                new_front_dir = ?front_direction,
+                "creating new inflection point");
+            let inflection_pos = match front_dir {
+                Direction::Up | Direction::Down => Vec2::new(front_pos.x, parent_position.y),
+                Direction::Left | Direction::Right => Vec2::new(parent_position.x, front_pos.y),
+            };
+            let new_front_dir = Direction::from_points(inflection_pos, parent_position.0).unwrap();
+            points.0.push_front((inflection_pos, new_front_dir));
+            trace!(?points, "new points");
+        }
+
+        // Update the back
+        // remove the back points that are above the length
+        points.shorten_back(parent_position.0, length.0);
+    }
+}
+
+/// System that draws the boxed of the player positions.
+/// The components should be replicated from the server to the client
+pub(crate) fn draw_snakes(
+    mut gizmos: Gizmos,
+    players: Query<(&PlayerPosition, &PlayerColor)>,
+    tails: Query<(&PlayerParent, &TailPoints)>,
+) {
+    for (parent, points) in tails.iter() {
+        let Ok((position, color)) = players.get(parent.0) else {
+            panic!("Tail entity has no parent entity!");
+        };
+        // draw the head
+        gizmos.rect(
+            Vec3::new(position.x, position.y, 0.0),
+            Quat::IDENTITY,
+            Vec2::ONE * 20.0,
+            color.0,
+        );
+        // draw the first line
+        gizmos.line_2d(position.0, points.0.front().unwrap().0, color.0);
+        // draw the rest of the lines
+        for (start, end) in points.0.iter().zip(points.0.iter().skip(1)) {
+            gizmos.line_2d(start.0, end.0, color.0);
+        }
+    }
+    for (position, color) in &players {}
+}

--- a/examples/replication_groups/shared.rs
+++ b/examples/replication_groups/shared.rs
@@ -17,7 +17,7 @@ pub fn shared_config() -> SharedConfig {
             tick_duration: Duration::from_secs_f64(1.0 / 64.0),
         },
         log: LogConfig {
-            level: Level::INFO,
+            level: Level::WARN,
             filter: "wgpu=error,wgpu_hal=error,naga=warn,bevy_app=info,bevy_render=warn,quinn=warn"
                 .to_string(),
         },

--- a/examples/replication_groups/shared.rs
+++ b/examples/replication_groups/shared.rs
@@ -27,7 +27,7 @@ pub struct SharedPlugin;
 
 impl Plugin for SharedPlugin {
     fn build(&self, app: &mut App) {
-        // app.add_plugins(WorldInspectorPlugin::new());
+        app.add_plugins(WorldInspectorPlugin::new());
         app.add_systems(Update, draw_snakes);
     }
 }
@@ -49,7 +49,7 @@ pub(crate) fn shared_movement_behaviour(position: &mut PlayerPosition, input: &I
     }
 }
 
-// This system defines how we update the player's tails when we the head is updated
+// This system defines how we update the player's tails when the head is updated
 pub(crate) fn shared_tail_behaviour(
     player_position: Query<&PlayerPosition>,
     mut tails: Query<(&mut TailPoints, &PlayerParent, &TailLength)>,
@@ -91,6 +91,7 @@ pub(crate) fn draw_snakes(
     tails: Query<(&PlayerParent, &TailPoints)>,
 ) {
     for (parent, points) in tails.iter() {
+        info!("drawing snake with parent: {:?}", parent.0);
         let Ok((position, color)) = players.get(parent.0) else {
             panic!("Tail entity has no parent entity!");
         };

--- a/examples/replication_groups/shared.rs
+++ b/examples/replication_groups/shared.rs
@@ -108,5 +108,4 @@ pub(crate) fn draw_snakes(
             gizmos.line_2d(start.0, end.0, color.0);
         }
     }
-    for (position, color) in &players {}
 }

--- a/examples/simple_box/protocol.rs
+++ b/examples/simple_box/protocol.rs
@@ -1,4 +1,5 @@
 use bevy::prelude::{default, Bundle, Color, Component, Deref, DerefMut, Entity, Vec2};
+use bevy::utils::EntityHashSet;
 use derive_more::{Add, Mul};
 use lightyear::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -50,13 +51,16 @@ pub struct PlayerColor(pub(crate) Color);
 #[message(custom_map)]
 pub struct PlayerParent(Entity);
 
-impl MapEntities for PlayerParent {
-    fn map_entities(&mut self, entity_map: &RemoteEntityMap) {
-        self.0.map_entities(entity_map);
+impl<'a> MapEntities<'a> for PlayerParent {
+    fn map_entities(&mut self, entity_mapper: Box<dyn EntityMapper + 'a>) {
+        self.0.map_entities(entity_mapper);
+    }
+
+    fn entities(&self) -> EntityHashSet<Entity> {
+        EntityHashSet::from_iter(vec![self.0])
     }
 }
 
-// #[component_protocol(protocol = "MyProtocol", derive(Debug))]
 #[component_protocol(protocol = "MyProtocol")]
 pub enum Components {
     #[sync(once)]
@@ -77,7 +81,7 @@ pub struct Channel1;
 #[derive(Message, Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct Message1(pub usize);
 
-#[message_protocol(protocol = "MyProtocol", derive(Debug))]
+#[message_protocol(protocol = "MyProtocol")]
 pub enum Messages {
     Message1(Message1),
 }

--- a/examples/simple_box/protocol.rs
+++ b/examples/simple_box/protocol.rs
@@ -51,7 +51,7 @@ pub struct PlayerColor(pub(crate) Color);
 pub struct PlayerParent(Entity);
 
 impl MapEntities for PlayerParent {
-    fn map_entities(&mut self, entity_map: &EntityMap) {
+    fn map_entities(&mut self, entity_map: &RemoteEntityMap) {
         self.0.map_entities(entity_map);
     }
 }

--- a/examples/src/protocol.rs
+++ b/examples/src/protocol.rs
@@ -27,7 +27,6 @@ pub struct Component2(pub f32);
 #[derive(Component, Message, Serialize, Deserialize, Clone, Debug, PartialEq, Add, Mul)]
 pub struct Component3(pub f32);
 
-// #[component_protocol(protocol = "MyProtocol", derive(Debug))]
 #[component_protocol(protocol = "MyProtocol")]
 pub enum MyComponentsProtocol {
     #[sync(full)]

--- a/examples/src/protocol.rs
+++ b/examples/src/protocol.rs
@@ -11,7 +11,7 @@ pub struct Message1(pub String);
 #[derive(Message, Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct Message2(pub u32);
 
-#[message_protocol(protocol = "MyProtocol", derive(Debug))]
+#[message_protocol(protocol = "MyProtocol")]
 pub enum MyMessageProtocol {
     Message1(Message1),
     Message2(Message2),

--- a/lightyear/Cargo.toml
+++ b/lightyear/Cargo.toml
@@ -13,7 +13,6 @@ license = "MIT OR Apache-2.0"
 exclude = ["/tests"]
 
 [features]
-debug = []
 metrics = [
   "dep:metrics",
   "metrics-util",
@@ -75,6 +74,7 @@ tracing-subscriber = { version = "0.3.17", features = [
 
 # server
 crossbeam-channel = { version = "0.5.8", features = [] }
+#petgraph = "0.6.4"  # for replication
 
 # metrics
 metrics = { version = "0.21", optional = true }

--- a/lightyear/src/client/components.rs
+++ b/lightyear/src/client/components.rs
@@ -16,8 +16,7 @@ pub trait SyncComponent: Component + Clone + PartialEq {
     fn mode() -> ComponentSyncMode;
 }
 
-// TODO: add a default here?
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Default, PartialEq)]
 /// Defines how a predicted or interpolated component will be replicated from confirmed to predicted/interpolated
 ///
 /// We use a single enum instead of 2 separate enums because we want to be able to use the same enum for both predicted and interpolated components
@@ -38,4 +37,8 @@ pub enum ComponentSyncMode {
     /// The component will be copied only-once from the confirmed to the interpolated/predicted entity, and then won't stay in sync
     /// Useful for components that you want to modify yourself on the predicted/interpolated entity
     Once,
+
+    #[default]
+    /// The component is not copied from the Confirmed entity to the interpolated/predicted entity
+    None,
 }

--- a/lightyear/src/client/components.rs
+++ b/lightyear/src/client/components.rs
@@ -16,6 +16,7 @@ pub trait SyncComponent: Component + Clone + PartialEq {
     fn mode() -> ComponentSyncMode;
 }
 
+// TODO: add a default here?
 #[derive(Debug, PartialEq)]
 /// Defines how a predicted or interpolated component will be replicated from confirmed to predicted/interpolated
 ///

--- a/lightyear/src/client/components.rs
+++ b/lightyear/src/client/components.rs
@@ -2,7 +2,10 @@
 Defines components that are used for the client-side prediction and interpolation
 */
 
+use crate::prelude::{Named, TypeNamed};
+use bevy::ecs::component::TableStorage;
 use bevy::prelude::{Component, Entity};
+use std::fmt::{Debug, Formatter};
 
 /// Marks an entity that contains the server-updates that are received from the Server
 /// (this entity is a copy of Predicted that is RTT ticks behind)
@@ -12,7 +15,7 @@ pub struct Confirmed {
     pub interpolated: Option<Entity>,
 }
 
-pub trait SyncComponent: Component + Clone + PartialEq {
+pub trait SyncComponent: Component + Clone + PartialEq + Named {
     fn mode() -> ComponentSyncMode;
 }
 

--- a/lightyear/src/client/connection.rs
+++ b/lightyear/src/client/connection.rs
@@ -65,6 +65,7 @@ impl<P: Protocol> Connection<P> {
         let tick = self.base.recv_packet(reader)?;
         debug!("Received server packet with tick: {:?}", tick);
         if tick >= self.sync_manager.latest_received_server_tick {
+            trace!("new last recv server tick: {:?}", tick);
             self.sync_manager.latest_received_server_tick = tick;
             // TODO: add 'received_new_server_tick' ?
             // we probably actually physically received the packet some time between our last `receive` and now.

--- a/lightyear/src/client/connection.rs
+++ b/lightyear/src/client/connection.rs
@@ -71,7 +71,7 @@ impl<P: Protocol> Connection<P> {
             // Let's add delta / 2 as a compromise
             self.sync_manager.duration_since_latest_received_server_tick = Duration::default();
             // self.sync_manager.duration_since_latest_received_server_tick = time_manager.delta() / 2;
-            self.sync_manager.update_current_server_time(
+            self.sync_manager.update_server_time_estimate(
                 tick_manager.config.tick_duration,
                 self.base.ping_manager.rtt(),
             );

--- a/lightyear/src/client/input.rs
+++ b/lightyear/src/client/input.rs
@@ -188,10 +188,17 @@ fn prepare_input_message<P: Protocol>(mut client: ResMut<Client<P>>) {
                 error!("Error while sending input message: {:?}", err);
             })
     }
+    // NOTE: actually we keep the input values! because they might be needed when we rollback for client prediction
+    // TODO: figure out when we can delete old inputs. Basically when the oldest prediction group tick has passed?
+    //  maybe at interpolation_tick(), since it's before any latest server update we receive?
+
     // delete old input values
-    client
-        .get_mut_input_buffer()
-        .pop(current_tick - (message_len + 1));
+    let interpolation_tick = client
+        .connection
+        .sync_manager
+        .interpolation_tick(&client.tick_manager);
+    client.get_mut_input_buffer().pop(interpolation_tick);
+    // .pop(current_tick - (message_len + 1));
 }
 
 // on the client:

--- a/lightyear/src/client/interpolation/interpolate.rs
+++ b/lightyear/src/client/interpolation/interpolate.rs
@@ -128,7 +128,9 @@ pub(crate) fn update_interpolate_status<C: SyncComponent, P: Protocol>(
             }
         }
 
-        trace!(?current_interpolate_tick,
+        trace!(
+            component = ?component.name(),
+            ?current_interpolate_tick,
             last_received_server_tick = ?client.latest_received_server_tick(),
             start_tick = ?start.as_ref().map(|(tick, _)| tick),
             end_tick = ?end.as_ref().map(|(tick, _) | tick),
@@ -153,6 +155,14 @@ pub(crate) fn interpolate<C: InterpolatedComponent<C>>(
             (&status.start, &status.end)
         {
             // info!(?start_tick, ?end_tick, "doing interpolation!");
+            if status.current == *start_tick {
+                *component = start_value.clone();
+                continue;
+            }
+            if status.current == *end_tick {
+                *component = end_value.clone();
+                continue;
+            }
             if start_tick != end_tick {
                 let t = (status.current - *start_tick) as f32 / (*end_tick - *start_tick) as f32;
                 *component = C::lerp(start_value.clone(), end_value.clone(), t);

--- a/lightyear/src/client/interpolation/interpolate.rs
+++ b/lightyear/src/client/interpolation/interpolate.rs
@@ -145,7 +145,7 @@ pub(crate) fn update_interpolate_status<C: SyncComponent, P: Protocol>(
     }
 }
 
-pub(crate) fn interpolate<C: InterpolatedComponent>(
+pub(crate) fn interpolate<C: InterpolatedComponent<C>>(
     mut query: Query<(&mut C, &InterpolateStatus<C>)>,
 ) {
     for (mut component, status) in query.iter_mut() {

--- a/lightyear/src/client/interpolation/interpolation_history.rs
+++ b/lightyear/src/client/interpolation/interpolation_history.rs
@@ -151,7 +151,7 @@ pub(crate) fn apply_confirmed_update<T: SyncComponent, P: Protocol>(
                                 );
                                 continue;
                             };
-                            trace!(tick = ?channel.latest_tick, "adding confirmed update to history");
+                            info!(component = ?confirmed_component.name(), tick = ?channel.latest_tick, "adding confirmed update to history");
                             // assign the history at the value that the entity currently is
                             // TODO: think about mapping entities!
                             history

--- a/lightyear/src/client/interpolation/interpolation_history.rs
+++ b/lightyear/src/client/interpolation/interpolation_history.rs
@@ -95,7 +95,7 @@ pub(crate) fn add_component_history<T: SyncComponent, P: Protocol>(
                         ComponentSyncMode::Full => {
                             debug!("spawn interpolation history");
                             interpolated_entity_mut.insert((
-                                confirmed_component.deref().clone(),
+                                // confirmed_component.deref().clone(),
                                 history,
                                 InterpolateStatus::<T> {
                                     start: None,
@@ -106,7 +106,7 @@ pub(crate) fn add_component_history<T: SyncComponent, P: Protocol>(
                         }
                         _ => {
                             debug!("copy interpolation component");
-                            interpolated_entity_mut.insert(confirmed_component.deref().clone());
+                            // interpolated_entity_mut.insert(confirmed_component.deref().clone());
                         }
                     }
                 }
@@ -153,13 +153,15 @@ pub(crate) fn apply_confirmed_update<T: SyncComponent, P: Protocol>(
                             };
                             trace!(tick = ?channel.latest_tick, "adding confirmed update to history");
                             // assign the history at the value that the entity currently is
+                            // TODO: think about mapping entities!
                             history
                                 .buffer
                                 .add_item(channel.latest_tick, confirmed_component.deref().clone());
                         }
                         // for sync-components, we just match the confirmed component
                         ComponentSyncMode::Simple => {
-                            *interpolated_component = confirmed_component.deref().clone();
+                            // TODO: think about mapping entities!
+                            // *interpolated_component = confirmed_component.deref().clone();
                         }
                         _ => {}
                     }

--- a/lightyear/src/client/interpolation/interpolation_history.rs
+++ b/lightyear/src/client/interpolation/interpolation_history.rs
@@ -150,7 +150,7 @@ pub(crate) fn apply_confirmed_update<T: SyncComponent, P: Protocol>(
                                 );
                                 continue;
                             };
-                            trace!(component = ?confirmed_component.name(), tick = ?channel.latest_tick, "adding confirmed update to history");
+                            info!(component = ?confirmed_component.name(), tick = ?channel.latest_tick, "adding confirmed update to history");
                             // assign the history at the value that the entity currently is
                             // TODO: think about mapping entities!
                             history

--- a/lightyear/src/client/interpolation/interpolation_history.rs
+++ b/lightyear/src/client/interpolation/interpolation_history.rs
@@ -128,7 +128,7 @@ pub(crate) fn apply_confirmed_update<T: SyncComponent, P: Protocol>(
     for (confirmed_entity, confirmed, confirmed_component) in confirmed_entities.iter() {
         if let Some(p) = confirmed.interpolated {
             if confirmed_component.is_changed() {
-                if let Ok((mut interpolated_component, history_option)) =
+                if let Ok((interpolated_component, history_option)) =
                     interpolated_entities.get_mut(p)
                 {
                     match T::mode() {

--- a/lightyear/src/client/interpolation/interpolation_history.rs
+++ b/lightyear/src/client/interpolation/interpolation_history.rs
@@ -65,7 +65,6 @@ impl<T: SyncComponent> ConfirmedHistory<T> {
     /// Get the value of the component at the specified tick.
     /// Clears the history buffer of all ticks older or equal than the specified tick.
     /// NOTE: doesn't pop the last value!
-    /// Returns None
     /// CAREFUL:
     /// the component history will only contain the ticks where the component got updated, and otherwise
     /// contains gaps. Therefore, we need to always leave a value in the history buffer so that we can
@@ -151,7 +150,7 @@ pub(crate) fn apply_confirmed_update<T: SyncComponent, P: Protocol>(
                                 );
                                 continue;
                             };
-                            info!(component = ?confirmed_component.name(), tick = ?channel.latest_tick, "adding confirmed update to history");
+                            trace!(component = ?confirmed_component.name(), tick = ?channel.latest_tick, "adding confirmed update to history");
                             // assign the history at the value that the entity currently is
                             // TODO: think about mapping entities!
                             history

--- a/lightyear/src/client/interpolation/interpolation_history.rs
+++ b/lightyear/src/client/interpolation/interpolation_history.rs
@@ -161,7 +161,7 @@ pub(crate) fn apply_confirmed_update<T: SyncComponent, P: Protocol>(
                         ComponentSyncMode::Simple => {
                             *interpolated_component = confirmed_component.deref().clone();
                         }
-                        ComponentSyncMode::Once => {}
+                        _ => {}
                     }
                 }
             }

--- a/lightyear/src/client/interpolation/mod.rs
+++ b/lightyear/src/client/interpolation/mod.rs
@@ -8,7 +8,7 @@ pub use interpolate::InterpolateStatus;
 pub use interpolation_history::ConfirmedHistory;
 pub use plugin::{add_interpolation_systems, add_lerp_systems};
 
-use crate::client::components::{Confirmed, SyncComponent};
+use crate::client::components::{ComponentSyncMode, Confirmed, SyncComponent};
 use crate::client::interpolation::despawn::InterpolationMapping;
 use crate::shared::replication::components::ShouldBeInterpolated;
 
@@ -35,28 +35,52 @@ pub mod plugin;
 // TODO: maybe merge this with PredictedComponent?
 //  basically it is a HistoryComponent. And we can have modes for Prediction or Interpolation
 
-// TODO: only require the Add/Mul bounds if we're using the linear lerp function
-pub trait InterpolatedComponent:
-    SyncComponent + Mul<f32, Output = Self> + Add<Self, Output = Self> + Sized
-{
-    /// Which interpolation function to use
-    /// By default, it will be a linear interpolation
-    fn lerp_mode() -> LerpMode<Self>;
+pub trait InterpFn<C> {
+    fn lerp(start: C, other: C, t: f32) -> C;
+}
 
-    fn lerp(start: Self, other: Self, t: f32) -> Self {
-        match Self::lerp_mode() {
-            LerpMode::Linear => start * (1.0 - t) + other * t,
-            LerpMode::Custom(lerp) => lerp(start, other, t),
-        }
+pub struct LinearInterpolation;
+impl<C> InterpFn<C> for LinearInterpolation
+where
+    C: Mul<f32, Output = C> + Add<C, Output = C>,
+{
+    fn lerp(start: C, other: C, t: f32) -> C {
+        start * (1.0 - t) + other * t
     }
 }
 
-#[derive(Debug)]
-pub enum LerpMode<C: InterpolatedComponent> {
-    Linear,
-    // TODO: change this to a trait object?
-    Custom(fn(C, C, f32) -> C),
+pub trait InterpolatedComponent<C>: SyncComponent {
+    type Fn: InterpFn<C>;
+
+    fn lerp(start: C, other: C, t: f32) -> C {
+        Self::Fn::lerp(start, other, t)
+    }
 }
+
+// pub trait InterpolatedComponent<C>: SyncComponent + Sized {
+//     type Fn: InterpFn<C>;
+//     /// Which interpolation function to use
+//     /// By default, it will be a linear interpolation
+//     fn lerp_mode() -> LerpMode<Self>;
+//
+//     fn lerp_linear(start: Self, other: Self, t: f32) -> Self
+//     where
+//         Self: Mul<f32, Output = Self> + Add<Self, Output = Self>,
+//     {
+//         start * (1.0 - t) + other * t
+//     }
+//
+//     fn lerp_custom(start: Self, other: Self, t: f32, lerp: fn(Self, Self, f32) -> Self) -> Self {
+//         lerp(start, other, t)
+//     }
+// }
+
+// #[derive(Debug)]
+// pub enum LerpMode<C: InterpolatedComponent> {
+//     Linear,
+//     // TODO: change this to a trait object?
+//     Custom(fn(C, C, f32) -> C),
+// }
 
 /// Marks an entity that is being interpolated by the client
 #[derive(Component, Debug)]

--- a/lightyear/src/client/interpolation/mod.rs
+++ b/lightyear/src/client/interpolation/mod.rs
@@ -6,7 +6,7 @@ use tracing::info;
 
 pub use interpolate::InterpolateStatus;
 pub use interpolation_history::ConfirmedHistory;
-pub use plugin::{add_interpolation_systems, add_lerp_systems};
+pub use plugin::{add_interpolation_systems, add_prepare_interpolation_systems};
 
 use crate::client::components::{ComponentSyncMode, Confirmed, SyncComponent};
 use crate::client::interpolation::despawn::InterpolationMapping;

--- a/lightyear/src/client/interpolation/mod.rs
+++ b/lightyear/src/client/interpolation/mod.rs
@@ -49,6 +49,15 @@ where
     }
 }
 
+/// Use this if you don't want to use an interpolation function for this component.
+/// (For example if you are running your own interpolation logic)
+pub struct NoInterpolation;
+impl<C> InterpFn<C> for NoInterpolation {
+    fn lerp(start: C, _other: C, _t: f32) -> C {
+        start
+    }
+}
+
 pub trait InterpolatedComponent<C>: SyncComponent {
     type Fn: InterpFn<C>;
 

--- a/lightyear/src/client/interpolation/plugin.rs
+++ b/lightyear/src/client/interpolation/plugin.rs
@@ -209,7 +209,7 @@ impl<P: Protocol> Plugin for InterpolationPlugin<P> {
         app.add_systems(
             PreUpdate,
             (
-                spawn_interpolated_entity.in_set(InterpolationSet::SpawnInterpolation),
+                // spawn_interpolated_entity.in_set(InterpolationSet::SpawnInterpolation),
                 despawn_interpolated.in_set(InterpolationSet::Despawn),
             ),
         );

--- a/lightyear/src/client/interpolation/plugin.rs
+++ b/lightyear/src/client/interpolation/plugin.rs
@@ -2,7 +2,8 @@ use std::marker::PhantomData;
 use std::time::Duration;
 
 use bevy::prelude::{
-    apply_deferred, App, IntoSystemConfigs, IntoSystemSetConfigs, Plugin, PreUpdate, SystemSet,
+    apply_deferred, App, IntoSystemConfigs, IntoSystemSetConfigs, Plugin, PostUpdate, PreUpdate,
+    SystemSet,
 };
 
 use crate::client::components::SyncComponent;
@@ -64,10 +65,10 @@ impl InterpolationDelay {
 /// This should be
 #[derive(Clone)]
 pub struct InterpolationConfig {
-    pub(crate) delay: InterpolationDelay,
+    pub delay: InterpolationDelay,
     /// If true, disable the interpolation logic (but still keep the internal component history buffers)
     /// The user will have to manually implement
-    pub(crate) custom_interpolation_logic: bool,
+    pub custom_interpolation_logic: bool,
     // How long are we keeping the history of the confirmed entities so we can interpolate between them?
     // pub(crate) interpolation_buffer_size: Duration,
 }
@@ -129,7 +130,10 @@ pub enum InterpolationSet {
     /// Set to handle interpolated/confirmed entities/components getting despawned
     Despawn,
     DespawnFlush,
-    /// Update component history, interpolation status, and interpolate between last 2 server states
+    /// Update component history, interpolation status
+    PrepareInterpolation,
+    /// Interpolate between last 2 server states. Has to be overriden if
+    /// `InterpolationConfig.custom_interpolation_logic` is set to true
     Interpolate,
 }
 
@@ -141,10 +145,10 @@ pub enum InterpolationSet {
 //   up to the client tick before we just updated the time. Maybe that's not a problem.. but we do need to keep track of the ticks correctly
 //  the tick we rollback to would not be the current client tick ?
 
-pub fn add_interpolation_systems<C: SyncComponent, P: Protocol>(app: &mut App) {
+pub fn add_prepare_interpolation_systems<C: SyncComponent, P: Protocol>(app: &mut App) {
     // TODO: maybe create an overarching prediction set that contains all others?
     app.add_systems(
-        PreUpdate,
+        PostUpdate,
         (
             (add_component_history::<C, P>).in_set(InterpolationSet::SpawnHistory),
             (removed_components::<C>).in_set(InterpolationSet::Despawn),
@@ -153,24 +157,23 @@ pub fn add_interpolation_systems<C: SyncComponent, P: Protocol>(app: &mut App) {
                 update_interpolate_status::<C, P>,
             )
                 .chain()
-                .in_set(InterpolationSet::Interpolate),
+                .in_set(InterpolationSet::PrepareInterpolation),
         ),
     );
 }
 
 // We add the interpolate system in different function because we don't want the non
-// ComponentSyncMode::Full components to need the InterpolatedComponent bounds (in particular Add/Mul)
-pub fn add_lerp_systems<C: InterpolatedComponent<C>, P: Protocol>(app: &mut App) {
+// ComponentSyncMode::Full components to need the InterpolatedComponent bounds
+pub fn add_interpolation_systems<C: InterpolatedComponent<C>, P: Protocol>(app: &mut App) {
     app.add_systems(
-        PreUpdate,
-        (interpolate::<C>
-            .after(update_interpolate_status::<C, P>)
-            .in_set(InterpolationSet::Interpolate),),
+        PostUpdate,
+        interpolate::<C>.in_set(InterpolationSet::Interpolate),
     );
 }
 
 impl<P: Protocol> Plugin for InterpolationPlugin<P> {
     fn build(&self, app: &mut App) {
+        P::Components::add_prepare_interpolation_systems(app);
         if !self.config.custom_interpolation_logic {
             P::Components::add_interpolation_systems(app);
         }
@@ -179,7 +182,7 @@ impl<P: Protocol> Plugin for InterpolationPlugin<P> {
         app.init_resource::<InterpolationMapping>();
         // SETS
         app.configure_sets(
-            PreUpdate,
+            PostUpdate,
             (
                 MainSet::Receive,
                 InterpolationSet::SpawnInterpolation,
@@ -190,13 +193,14 @@ impl<P: Protocol> Plugin for InterpolationPlugin<P> {
                 InterpolationSet::DespawnFlush,
                 // TODO: maybe run in a schedule in-between FixedUpdate and Update?
                 //  or maybe run during PostUpdate?
+                InterpolationSet::PrepareInterpolation,
                 InterpolationSet::Interpolate,
             )
                 .chain(),
         );
         // SYSTEMS
         app.add_systems(
-            PreUpdate,
+            PostUpdate,
             (
                 // TODO: we want to run these flushes only if something actually happened in the previous set!
                 //  because running the flush-system is expensive (needs exclusive world access)
@@ -207,7 +211,7 @@ impl<P: Protocol> Plugin for InterpolationPlugin<P> {
             ),
         );
         app.add_systems(
-            PreUpdate,
+            PostUpdate,
             (
                 // spawn_interpolated_entity.in_set(InterpolationSet::SpawnInterpolation),
                 despawn_interpolated.in_set(InterpolationSet::Despawn),

--- a/lightyear/src/client/prediction/plugin.rs
+++ b/lightyear/src/client/prediction/plugin.rs
@@ -183,10 +183,11 @@ impl<P: Protocol> Plugin for PredictionPlugin<P> {
             (apply_deferred.in_set(PredictionSet::EntityDespawnFlush),),
         );
 
-        app.add_systems(
-            PreUpdate,
-            spawn_predicted_entity.in_set(PredictionSet::SpawnPrediction),
-        );
+        // no need, since we spawn predicted entities/components in replication
+        // app.add_systems(
+        //     PreUpdate,
+        //     spawn_predicted_entity.in_set(PredictionSet::SpawnPrediction),
+        // );
         // 2. (in prediction_systems) add ComponentHistory and a apply_deferred after
         // 3. (in prediction_systems) Check if we should do rollback, clear histories and snap prediction's history to server-state
         // 4. Potentially do rollback

--- a/lightyear/src/client/prediction/predicted_history.rs
+++ b/lightyear/src/client/prediction/predicted_history.rs
@@ -164,6 +164,11 @@ pub fn add_component_history<T: SyncComponent + Named, P: Protocol>(
                                     ComponentState::Updated(confirmed_component.deref().clone()),
                                 );
                                 predicted_entity_mut.insert(history);
+                                // TODO: we do not insert the component here because we need to map entities!
+                                //  also we already added the component during replication
+                                //  but we might to handle components that are not replicated...
+                                //  for components that are not replicated, no need to apply any mapping!
+                                //  so maybe just check if the component existed already?
                                 // predicted_entity_mut
                                 //     .insert((confirmed_component.deref().clone(), history));
                             }

--- a/lightyear/src/client/prediction/predicted_history.rs
+++ b/lightyear/src/client/prediction/predicted_history.rs
@@ -109,6 +109,8 @@ impl<T: SyncComponent> PredictionHistory<T> {
 
 // Copy component insert/remove from confirmed to predicted
 // Currently we will just copy every PredictedComponent
+// TODO: how to handle components that are synced between confirmed/predicted but are not replicated?
+//  I guess they still need to be added here.
 // TODO: add more options:
 //  - copy component and add component history (for rollback)
 //  - copy component to history and don't add component
@@ -140,7 +142,12 @@ pub fn add_component_history<T: SyncComponent + Named, P: Protocol>(
                     }
                 }
 
-                // component got added on confirmed side:
+                // TODO: need to do entity mapping here as well!
+                // TODO: need to run this only for components that were not replicated; and run this in topological order.
+
+                // component got added on confirmed side
+                //   - via replication -> the component will also be added to predicted, so it's handled above as well..
+                //   - without replication -> need to handle here
                 // - full: sync component and add history
                 // - simple/once: sync component
                 if let Some(confirmed_component) = confirmed_component {
@@ -156,12 +163,13 @@ pub fn add_component_history<T: SyncComponent + Named, P: Protocol>(
                                     client.tick(),
                                     ComponentState::Updated(confirmed_component.deref().clone()),
                                 );
-                                predicted_entity_mut
-                                    .insert((confirmed_component.deref().clone(), history));
+                                predicted_entity_mut.insert(history);
+                                // predicted_entity_mut
+                                //     .insert((confirmed_component.deref().clone(), history));
                             }
                             _ => {
                                 // we only sync the components once, but we don't do rollback so no need for a component history
-                                predicted_entity_mut.insert(confirmed_component.deref().clone());
+                                // predicted_entity_mut.insert(confirmed_component.deref().clone());
                             }
                         }
                     }
@@ -241,6 +249,9 @@ pub fn update_prediction_history<T: SyncComponent, P: Protocol>(
     }
 }
 
+// TODO: again,
+//  for replicated components, we could apply the update at replication time directly (for topological sort)
+//  for non-replicated components, it should be applied here, but we need to query with topological sort.
 /// When we receive a server update, we might want to apply it to the predicted entity
 #[allow(clippy::type_complexity)]
 pub(crate) fn apply_confirmed_update<T: SyncComponent, P: Protocol>(
@@ -271,7 +282,7 @@ pub(crate) fn apply_confirmed_update<T: SyncComponent, P: Protocol>(
                         ComponentSyncMode::Simple => {
                             *predicted_component = confirmed_component.deref().clone();
                         }
-                        ComponentSyncMode::Once => {}
+                        _ => {}
                     }
                 }
             }

--- a/lightyear/src/client/prediction/rollback.rs
+++ b/lightyear/src/client/prediction/rollback.rs
@@ -159,8 +159,8 @@ pub(crate) fn client_rollback_check<C: SyncComponent, P: Protocol>(
                     };
                     if should_rollback {
                         info!(
-                                "Rollback check: mismatch for component between predicted and confirmed {:?}",
-                                confirmed_entity
+                                "Rollback check: mismatch for component between predicted and confirmed {:?} on tick {:?}",
+                                confirmed_entity, tick,
                             );
 
                         // we need to clear the history so we can write a new one
@@ -242,7 +242,7 @@ pub(crate) fn run_rollback<P: Protocol>(world: &mut World) {
     // TODO: might not need to check the state, because we only run this system if we are in rollback
     if let RollbackState::ShouldRollback { current_tick } = rollback.state {
         let num_rollback_ticks = client.tick() - current_tick;
-        debug!(
+        info!(
             "Rollback between {:?} and {:?}",
             current_tick,
             client.tick()

--- a/lightyear/src/client/resource.rs
+++ b/lightyear/src/client/resource.rs
@@ -34,14 +34,14 @@ pub struct Client<P: Protocol> {
     // netcode
     netcode: crate::netcode::Client,
     // connection
-    connection: Connection<P>,
+    pub(crate) connection: Connection<P>,
     // protocol
     protocol: P,
     // events
     events: ConnectionEvents<P>,
     // syncing
     pub(crate) time_manager: TimeManager,
-    tick_manager: TickManager,
+    pub(crate) tick_manager: TickManager,
 }
 
 #[allow(clippy::large_enum_variant)]

--- a/lightyear/src/client/resource.rs
+++ b/lightyear/src/client/resource.rs
@@ -208,7 +208,7 @@ impl<P: Protocol> Client<P> {
     /// Update the sync manager.
     /// We run this at PostUpdate because:
     /// - client prediction time is computed from ticks, which haven't been updated yet at PreUpdate
-    /// - server prediction time is computed from time, which has been update via delta
+    /// - server prediction time is computed from time, which has been updated via delta
     /// Also server sends the tick after FixedUpdate, so it makes sense that we would compare to the client tick after FixedUpdate
     /// So instead we update the sync manager at PostUpdate, after both ticks/time have been updated
     pub(crate) fn sync_update(&mut self) {

--- a/lightyear/src/client/sync.rs
+++ b/lightyear/src/client/sync.rs
@@ -46,7 +46,7 @@ pub struct SyncConfig {
     pub speedup_factor: f32,
 
     // Integration
-    current_server_time_smoothing: f32,
+    server_time_estimate_smoothing: f32,
 }
 
 impl Default for SyncConfig {
@@ -58,7 +58,7 @@ impl Default for SyncConfig {
             stats_buffer_duration: Duration::from_secs(2),
             error_margin: 1.0,
             speedup_factor: 1.03,
-            current_server_time_smoothing: 0.1,
+            server_time_estimate_smoothing: 0.1,
         }
     }
 }
@@ -91,7 +91,7 @@ pub struct SyncManager {
     pub(crate) synced: bool,
 
     // time
-    current_server_time: WrappedTime,
+    server_time_estimate: WrappedTime,
     pub(crate) interpolation_time: WrappedTime,
     interpolation_speed_ratio: f32,
 
@@ -113,7 +113,7 @@ impl SyncManager {
             config: config.clone(),
             synced: false,
             // time
-            current_server_time: WrappedTime::default(),
+            server_time_estimate: WrappedTime::default(),
             interpolation_time: WrappedTime::default(),
             interpolation_speed_ratio: 1.0,
             // server tick
@@ -136,7 +136,7 @@ impl SyncManager {
         server_send_interval: Duration,
     ) {
         self.duration_since_latest_received_server_tick += time_manager.delta();
-        self.current_server_time += time_manager.delta();
+        self.server_time_estimate += time_manager.delta();
         self.interpolation_time += time_manager.delta().mul_f32(self.interpolation_speed_ratio);
 
         // check if we are ready to finalize the handshake
@@ -185,40 +185,38 @@ impl SyncManager {
     }
 
     /// current server time from server's point of view (using server tick)
-    pub(crate) fn current_server_time(&self) -> WrappedTime {
-        // TODO: instead of just using the latest_received_server_tick, there should be some sort
-        //  of integration/smoothing
-        self.current_server_time
+    pub(crate) fn server_time_estimate(&self) -> WrappedTime {
+        self.server_time_estimate
     }
 
     /// Everytime we receive a new server update:
     /// Update the estimated current server time, computed from the time elapsed since the
     /// latest received server tick, and our estimate of the RTT
-    pub(crate) fn update_current_server_time(&mut self, tick_duration: Duration, rtt: Duration) {
-        let new_current_server_time_estimate = WrappedTime::from_duration(
+    pub(crate) fn update_server_time_estimate(&mut self, tick_duration: Duration, rtt: Duration) {
+        let new_server_time_estimate = WrappedTime::from_duration(
             self.latest_received_server_tick.0 as u32 * tick_duration
-                + self.duration_since_latest_received_server_tick
-                + rtt / 2,
+                + self.duration_since_latest_received_server_tick,
+            // TODO: the server_time_estimate uses rtt / 2, but we remove it for now so we can
+            //  use this estimate for both prediction and interpolation
+            // + rtt / 2,
         );
-        // instead of just using the latest_received_server_tick, there should be some sort
-        // of integration/smoothing
+        // instead of just using the latest_received_server_tick, we apply some smoothing
         // (in case the latest server tick is wildly off-base)
-        if self.current_server_time == WrappedTime::default() {
-            self.current_server_time = new_current_server_time_estimate;
+        if self.server_time_estimate == WrappedTime::default() {
+            self.server_time_estimate = new_server_time_estimate;
         } else {
-            self.current_server_time = self.current_server_time
-                * self.config.current_server_time_smoothing
-                + new_current_server_time_estimate
-                    * (1.0 - self.config.current_server_time_smoothing);
+            self.server_time_estimate = self.server_time_estimate
+                * self.config.server_time_estimate_smoothing
+                + new_server_time_estimate * (1.0 - self.config.server_time_estimate_smoothing);
         }
     }
 
     /// time at which the server would receive a packet we send now
     fn predicted_server_receive_time(&self, rtt: Duration) -> WrappedTime {
-        self.current_server_time() + rtt / 2
+        self.server_time_estimate() + rtt
     }
 
-    /// how far ahead of the server should I be?
+    /// how far ahead of the server should I be? (for prediction)
     fn client_ahead_minimum(&self, tick_duration: Duration, jitter: Duration) -> Duration {
         self.config.jitter_multiple_margin as u32 * jitter
             + self.config.tick_margin as u32 * tick_duration
@@ -236,13 +234,12 @@ impl SyncManager {
         server_send_interval: Duration,
         tick_manager: &TickManager,
     ) -> WrappedTime {
-        // We want the interpolation time to be just a little bit behind the latest server time
-        // We add `duration_since_latest_received_server_tick` because we receive them intermittently
-        // TODO: maybe integrate because of jitter?
-        let objective_time = WrappedTime::from_duration(
-            self.latest_received_server_tick.0 as u32 * tick_manager.config.tick_duration
-                + self.duration_since_latest_received_server_tick,
-        );
+        // // TODO: maybe integrate because of jitter?
+        // let objective_time = WrappedTime::from_duration(
+        //     self.latest_received_server_tick.0 as u32 * tick_manager.config.tick_duration
+        //         + self.duration_since_latest_received_server_tick,
+        // );
+        let objective_time = self.server_time_estimate();
         // how much we want interpolation time to be behind the latest received server tick?
         // TODO: use a specified config margin + add std of time_between_server_updates?
         let objective_delta =
@@ -368,8 +365,8 @@ impl SyncManager {
         let tick_duration = tick_manager.config.tick_duration;
         let rtt = ping_manager.rtt();
         let jitter = ping_manager.jitter();
-        // recompute the current server time (using the rtt we just computed)
-        self.update_current_server_time(tick_duration, rtt);
+        // recompute the server time estimate (using the rtt we just computed)
+        self.update_server_time_estimate(tick_duration, rtt);
 
         // Compute how many ticks the client must be compared to server
         let client_ideal_time = self.predicted_server_receive_time(rtt)

--- a/lightyear/src/connection/message.rs
+++ b/lightyear/src/connection/message.rs
@@ -3,7 +3,7 @@ Provides a [`ProtocolMessage`] enum that is a wrapper around all the possible me
 */
 use crate::_reexport::{InputMessage, ShouldBeInterpolated, ShouldBePredicted, TickManager};
 use crate::connection::events::ConnectionEvents;
-use crate::prelude::{EntityMap, MapEntities, Tick};
+use crate::prelude::{EntityMapper, MapEntities, RemoteEntityMap, Tick};
 use crate::protocol::channel::ChannelKind;
 use crate::protocol::Protocol;
 use crate::shared::ping::message::SyncMessage;
@@ -31,30 +31,6 @@ pub enum ProtocolMessage<P: Protocol> {
     // the reason why we include sync here instead of doing another MessageManager is so that
     // the sync messages can be added to packets that have other messages
     Sync(SyncMessage),
-}
-
-impl<P: Protocol> MapEntities for ProtocolMessage<P> {
-    fn map_entities(&mut self, entity_map: &EntityMap) {
-        match self {
-            ProtocolMessage::Message(x) => {
-                x.map_entities(entity_map);
-            }
-            ProtocolMessage::Replication(x) => {
-                x.map_entities(entity_map);
-            }
-            ProtocolMessage::Sync(x) => {
-                x.map_entities(entity_map);
-            }
-        }
-    }
-
-    fn entities(&self) -> EntityHashSet<Entity> {
-        match self {
-            ProtocolMessage::Message(x) => x.entities(),
-            ProtocolMessage::Replication(x) => x.entities(),
-            ProtocolMessage::Sync(x) => x.entities(),
-        }
-    }
 }
 
 impl<P: Protocol> ProtocolMessage<P> {

--- a/lightyear/src/connection/message.rs
+++ b/lightyear/src/connection/message.rs
@@ -10,6 +10,8 @@ use crate::shared::ping::message::SyncMessage;
 use crate::shared::replication::{ReplicationMessage, ReplicationMessageData};
 use crate::shared::time_manager::TimeManager;
 use crate::utils::named::Named;
+use bevy::prelude::Entity;
+use bevy::utils::EntityHashSet;
 use serde::{Deserialize, Serialize};
 use tracing::{info, info_span, trace, trace_span};
 
@@ -22,8 +24,7 @@ use tracing::{info, info_span, trace, trace_span};
 //     ShouldBeInterpolated(ShouldBeInterpolated),
 // }
 
-#[cfg_attr(feature = "debug", derive(Debug))]
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 pub enum ProtocolMessage<P: Protocol> {
     Message(P::Message),
     Replication(ReplicationMessage<P::Components, P::ComponentKinds>),
@@ -44,6 +45,14 @@ impl<P: Protocol> MapEntities for ProtocolMessage<P> {
             ProtocolMessage::Sync(x) => {
                 x.map_entities(entity_map);
             }
+        }
+    }
+
+    fn entities(&self) -> EntityHashSet<Entity> {
+        match self {
+            ProtocolMessage::Message(x) => x.entities(),
+            ProtocolMessage::Replication(x) => x.entities(),
+            ProtocolMessage::Sync(x) => x.entities(),
         }
     }
 }

--- a/lightyear/src/connection/mod.rs
+++ b/lightyear/src/connection/mod.rs
@@ -146,7 +146,9 @@ impl<P: Protocol> Connection<P> {
                     match message {
                         ProtocolMessage::Message(mut message) => {
                             // map any entities inside the message
-                            message.map_entities(&self.replication_manager.entity_map);
+                            message.map_entities(Box::new(
+                                &self.replication_manager.remote_entity_map,
+                            ));
                             // buffer the message
                             self.events.push_message(channel_kind, message);
                         }

--- a/lightyear/src/connection/mod.rs
+++ b/lightyear/src/connection/mod.rs
@@ -134,13 +134,19 @@ impl<P: Protocol> Connection<P> {
 
             if !messages.is_empty() {
                 trace!(?channel_name, "Received messages");
-                for (tick, mut message) in messages.into_iter() {
+                for (tick, message) in messages.into_iter() {
+                    // TODO: we shouldn't map the entities here!
+                    //  - we should: order the entities in a group by topological sort (use MapEntities to check dependencies between entities).
+                    //  - apply map_entities when we're in the stage of applying to the world.
+                    //    - because then we read the first entity in the group; spawn it, and the next component that refers to that entity can be mapped successfully!
                     // map entities from remote to local
-                    message.map_entities(&self.replication_manager.entity_map);
+                    // message.map_entities(&self.replication_manager.entity_map);
 
                     // other message-handling logic
                     match message {
-                        ProtocolMessage::Message(message) => {
+                        ProtocolMessage::Message(mut message) => {
+                            // map any entities inside the message
+                            message.map_entities(&self.replication_manager.entity_map);
                             // buffer the message
                             self.events.push_message(channel_kind, message);
                         }

--- a/lightyear/src/lib.rs
+++ b/lightyear/src/lib.rs
@@ -24,10 +24,10 @@ pub mod _reexport {
     pub use crate::channel::builder::{
         EntityActionsChannel, EntityUpdatesChannel, InputChannel, PingChannel,
     };
-    pub use crate::client::interpolation::LinearInterpolation;
     pub use crate::client::interpolation::{
         add_interpolation_systems, add_prepare_interpolation_systems, InterpolatedComponent,
     };
+    pub use crate::client::interpolation::{LinearInterpolation, NoInterpolation};
     pub use crate::client::prediction::add_prediction_systems;
     pub use crate::connection::events::{
         IterComponentInsertEvent, IterComponentRemoveEvent, IterComponentUpdateEvent,

--- a/lightyear/src/lib.rs
+++ b/lightyear/src/lib.rs
@@ -24,6 +24,7 @@ pub mod _reexport {
     pub use crate::channel::builder::{
         EntityActionsChannel, EntityUpdatesChannel, InputChannel, PingChannel,
     };
+    pub use crate::client::interpolation::LinearInterpolation;
     pub use crate::inputs::input_buffer::InputMessage;
     pub use crate::protocol::component::{
         ComponentBehaviour, ComponentKindBehaviour, ComponentProtocol, ComponentProtocolKind,
@@ -65,7 +66,7 @@ pub mod prelude {
     pub use crate::shared::replication::components::{
         NetworkTarget, Replicate, ReplicationGroup, ReplicationMode,
     };
-    pub use crate::shared::replication::entity_map::{EntityMap, MapEntities};
+    pub use crate::shared::replication::entity_map::{EntityMapper, MapEntities, RemoteEntityMap};
     pub use crate::shared::sets::{FixedUpdateSet, MainSet, ReplicationSet};
     pub use crate::shared::tick_manager::{Tick, TickConfig};
     pub use crate::transport::conditioner::LinkConditionerConfig;
@@ -83,7 +84,9 @@ pub mod prelude {
         pub use crate::client::input::{InputConfig, InputSystemSet};
         pub use crate::client::interpolation::interpolation_history::ConfirmedHistory;
         pub use crate::client::interpolation::plugin::{InterpolationConfig, InterpolationDelay};
-        pub use crate::client::interpolation::{InterpolateStatus, Interpolated, LerpMode};
+        pub use crate::client::interpolation::{
+            InterpFn, InterpolateStatus, Interpolated, InterpolatedComponent,
+        };
         pub use crate::client::plugin::{ClientPlugin, PluginConfig};
         pub use crate::client::prediction::plugin::PredictionConfig;
         pub use crate::client::prediction::predicted_history::{ComponentState, PredictionHistory};

--- a/lightyear/src/lib.rs
+++ b/lightyear/src/lib.rs
@@ -25,6 +25,13 @@ pub mod _reexport {
         EntityActionsChannel, EntityUpdatesChannel, InputChannel, PingChannel,
     };
     pub use crate::client::interpolation::LinearInterpolation;
+    pub use crate::client::interpolation::{
+        add_interpolation_systems, add_prepare_interpolation_systems, InterpolatedComponent,
+    };
+    pub use crate::client::prediction::add_prediction_systems;
+    pub use crate::connection::events::{
+        IterComponentInsertEvent, IterComponentRemoveEvent, IterComponentUpdateEvent,
+    };
     pub use crate::inputs::input_buffer::InputMessage;
     pub use crate::protocol::component::{
         ComponentBehaviour, ComponentKindBehaviour, ComponentProtocol, ComponentProtocolKind,
@@ -36,8 +43,15 @@ pub mod _reexport {
     pub use crate::serialize::wordbuffer::reader::ReadWordBuffer;
     pub use crate::serialize::wordbuffer::writer::WriteWordBuffer;
     pub use crate::serialize::writer::WriteBuffer;
+    pub use crate::shared::events::{
+        ComponentInsertEvent, ComponentRemoveEvent, ComponentUpdateEvent,
+    };
     pub use crate::shared::replication::components::{ShouldBeInterpolated, ShouldBePredicted};
+    pub use crate::shared::replication::systems::add_per_component_replication_send_systems;
     pub use crate::shared::replication::ReplicationSend;
+    pub use crate::shared::systems::events::{
+        push_component_insert_events, push_component_remove_events, push_component_update_events,
+    };
     pub use crate::shared::tick_manager::TickManager;
     pub use crate::shared::time_manager::{TimeManager, WrappedTime};
     pub use crate::utils::ready_buffer::ReadyBuffer;

--- a/lightyear/src/lib.rs
+++ b/lightyear/src/lib.rs
@@ -62,7 +62,9 @@ pub mod prelude {
     pub use crate::shared::log::LogConfig;
     pub use crate::shared::ping::manager::PingConfig;
     pub use crate::shared::plugin::SharedPlugin;
-    pub use crate::shared::replication::components::{NetworkTarget, Replicate, ReplicationMode};
+    pub use crate::shared::replication::components::{
+        NetworkTarget, Replicate, ReplicationGroup, ReplicationMode,
+    };
     pub use crate::shared::replication::entity_map::{EntityMap, MapEntities};
     pub use crate::shared::sets::{FixedUpdateSet, MainSet, ReplicationSet};
     pub use crate::shared::tick_manager::{Tick, TickConfig};

--- a/lightyear/src/packet/message.rs
+++ b/lightyear/src/packet/message.rs
@@ -345,7 +345,7 @@ impl MessageContainer {
 }
 
 // TODO: for now messages must be able to be used as events, since we output them in our message events
-pub trait Message: EventContext + Named + MapEntities {}
+pub trait Message: EventContext + Named + for<'a> MapEntities<'a> {}
 
 #[cfg(test)]
 mod tests {

--- a/lightyear/src/protocol/component.rs
+++ b/lightyear/src/protocol/component.rs
@@ -56,6 +56,11 @@ pub trait ComponentProtocol:
     );
 
     fn add_prediction_systems(app: &mut App);
+
+    /// Add all component systems for the PrepareInterpolation SystemSet
+    fn add_prepare_interpolation_systems(app: &mut App);
+
+    /// Add all component systems for the Interpolation SystemSet
     fn add_interpolation_systems(app: &mut App);
 
     /// Get the sync mode for the component

--- a/lightyear/src/protocol/component.rs
+++ b/lightyear/src/protocol/component.rs
@@ -1,6 +1,7 @@
 use std::fmt::Debug;
 use std::hash::Hash;
 
+use crate::client::components::{ComponentSyncMode, SyncComponent};
 use bevy::prelude::{App, Component, EntityWorldMut, World};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
@@ -23,7 +24,7 @@ pub trait ComponentProtocol:
     BitSerializable
     + Serialize
     + DeserializeOwned
-    + MapEntities
+    + for<'a> MapEntities<'a>
     + ComponentBehaviour
     + Debug
     + Send
@@ -56,6 +57,9 @@ pub trait ComponentProtocol:
 
     fn add_prediction_systems(app: &mut App);
     fn add_interpolation_systems(app: &mut App);
+
+    /// Get the sync mode for the component
+    fn mode(&self) -> ComponentSyncMode;
 }
 
 // TODO: enum_delegate doesn't work with generics + cannot be used multiple times since it derives a bunch of Into/From traits
@@ -99,7 +103,7 @@ pub trait ComponentProtocolKind:
     BitSerializable
     + Serialize
     + DeserializeOwned
-    + MapEntities
+    + for<'a> MapEntities<'a>
     + PartialEq
     + Eq
     + Hash

--- a/lightyear/src/protocol/message.rs
+++ b/lightyear/src/protocol/message.rs
@@ -1,4 +1,5 @@
 use std::any::TypeId;
+use std::fmt::Debug;
 
 use bevy::prelude::{App, World};
 use serde::de::DeserializeOwned;
@@ -24,6 +25,7 @@ pub trait MessageProtocol:
     + MapEntities
     + MessageBehaviour
     + Named
+    + Debug
     + Send
     + Sync
     + From<InputMessage<<<Self as MessageProtocol>::Protocol as Protocol>::Input>>

--- a/lightyear/src/protocol/message.rs
+++ b/lightyear/src/protocol/message.rs
@@ -22,7 +22,7 @@ pub trait MessageProtocol:
     + Serialize
     + DeserializeOwned
     + Clone
-    + MapEntities
+    + for<'a> MapEntities<'a>
     + MessageBehaviour
     + Named
     + Debug

--- a/lightyear/src/server/connection.rs
+++ b/lightyear/src/server/connection.rs
@@ -24,7 +24,11 @@ use crate::shared::time_manager::TimeManager;
 /// (handling client inputs)
 pub struct Connection<P: Protocol> {
     pub(crate) base: crate::connection::Connection<P>,
+    /// Stores the inputs that we have received from the client.
     pub(crate) input_buffer: InputBuffer<P::Input>,
+    /// Stores the last input we have received from the client.
+    /// In case we are missing the client input for a tick, we will fallback to using this.
+    pub(crate) last_input: Option<P::Input>,
 }
 
 impl<P: Protocol> Connection<P> {
@@ -32,6 +36,7 @@ impl<P: Protocol> Connection<P> {
         Self {
             base: crate::connection::Connection::new(channel_registry, ping_config),
             input_buffer: InputBuffer::default(),
+            last_input: None,
         }
     }
 

--- a/lightyear/src/server/resource.rs
+++ b/lightyear/src/server/resource.rs
@@ -12,6 +12,7 @@ use crossbeam_channel::Sender;
 use tracing::{debug, debug_span, info, trace, trace_span};
 
 use crate::channel::builder::Channel;
+use crate::inputs::input_buffer::InputBuffer;
 use crate::netcode::{generate_key, ClientId, ConnectToken};
 use crate::packet::message::Message;
 use crate::protocol::channel::ChannelKind;
@@ -130,6 +131,13 @@ impl<P: Protocol> Server<P> {
     }
 
     // INPUTS
+
+    // TODO: exposed only for debugging
+    pub fn get_input_buffer(&self, client_id: ClientId) -> Option<&InputBuffer<P::Input>> {
+        self.user_connections
+            .get(&client_id)
+            .map(|connection| &connection.input_buffer)
+    }
 
     /// Get the inputs for all clients for the given tick
     pub fn pop_inputs(&mut self) -> impl Iterator<Item = (Option<P::Input>, ClientId)> + '_ {

--- a/lightyear/src/server/room.rs
+++ b/lightyear/src/server/room.rs
@@ -595,7 +595,7 @@ mod tests {
             .connection()
             .base()
             .replication_manager
-            .entity_map
+            .remote_entity_map
             .get_local(server_entity)
             .unwrap();
 
@@ -752,7 +752,7 @@ mod tests {
             .connection()
             .base()
             .replication_manager
-            .entity_map
+            .remote_entity_map
             .get_local(server_entity)
             .unwrap();
 

--- a/lightyear/src/shared/ping/manager.rs
+++ b/lightyear/src/shared/ping/manager.rs
@@ -26,7 +26,7 @@ pub struct PingConfig {
 impl Default for PingConfig {
     fn default() -> Self {
         PingConfig {
-            ping_interval: Duration::from_millis(100),
+            ping_interval: Duration::from_millis(40),
             stats_buffer_duration: Duration::from_secs(4),
         }
     }
@@ -214,6 +214,7 @@ impl PingManager {
             // round-trip-delay
             let rtt = received_time - ping_sent_time;
             let server_process_time = pong.pong_sent_time - pong.ping_received_time;
+            trace!(?rtt, ?received_time, ?ping_sent_time, ?server_process_time, ?pong.pong_sent_time, ?pong.ping_received_time, "process pong");
             let round_trip_delay = (rtt - server_process_time).to_std().unwrap();
 
             // update stats buffer

--- a/lightyear/src/shared/ping/manager.rs
+++ b/lightyear/src/shared/ping/manager.rs
@@ -270,7 +270,10 @@ mod tests {
 
     #[test]
     fn test_send_pings() {
-        let config = PingConfig::default();
+        let config = PingConfig {
+            ping_interval: Duration::from_millis(100),
+            stats_buffer_duration: Duration::from_secs(4),
+        };
         let mut ping_manager = PingManager::new(&config);
         let mut time_manager = TimeManager::new(Duration::default());
 

--- a/lightyear/src/shared/ping/message.rs
+++ b/lightyear/src/shared/ping/message.rs
@@ -30,11 +30,3 @@ pub enum SyncMessage {
     Ping(Ping),
     Pong(Pong),
 }
-
-impl MapEntities for SyncMessage {
-    fn map_entities(&mut self, _entity_map: &crate::prelude::EntityMap) {}
-
-    fn entities(&self) -> EntityHashSet<Entity> {
-        EntityHashSet::default()
-    }
-}

--- a/lightyear/src/shared/ping/message.rs
+++ b/lightyear/src/shared/ping/message.rs
@@ -1,5 +1,7 @@
 //! Defines the actual ping/pong messages
 use crate::prelude::MapEntities;
+use bevy::prelude::Entity;
+use bevy::utils::EntityHashSet;
 use serde::{Deserialize, Serialize};
 
 use crate::shared::ping::store::PingId;
@@ -31,4 +33,8 @@ pub enum SyncMessage {
 
 impl MapEntities for SyncMessage {
     fn map_entities(&mut self, _entity_map: &crate::prelude::EntityMap) {}
+
+    fn entities(&self) -> EntityHashSet<Entity> {
+        EntityHashSet::default()
+    }
 }

--- a/lightyear/src/shared/ping/store.rs
+++ b/lightyear/src/shared/ping/store.rs
@@ -6,7 +6,7 @@ use crate::utils::wrapping_id::wrapping_id;
 
 wrapping_id!(PingId);
 
-const PING_BUFFER_SIZE: usize = 32;
+const PING_BUFFER_SIZE: usize = 128;
 
 /// Data structure to store the latest pings sent to remote
 pub struct PingStore {

--- a/lightyear/src/shared/replication/components.rs
+++ b/lightyear/src/shared/replication/components.rs
@@ -1,10 +1,12 @@
 //! Components used for replication
 use crate::channel::builder::{Channel, EntityActionsChannel, EntityUpdatesChannel};
+use crate::client::components::{ComponentSyncMode, SyncComponent};
 use crate::netcode::ClientId;
+use crate::prelude::{EntityMapper, MapEntities};
 use crate::protocol::channel::ChannelKind;
 use crate::server::room::{ClientVisibility, RoomId};
 use bevy::prelude::{Component, Entity};
-use bevy::utils::{HashMap, HashSet};
+use bevy::utils::{EntityHashSet, HashMap, HashSet};
 use lightyear_macros::MessageInternal;
 use serde::{Deserialize, Serialize};
 
@@ -140,13 +142,47 @@ impl NetworkTarget {
 //  that's pretty dangerous because it's now hard for the user to derive new traits.
 //  let's think of another approach later.
 #[derive(Component, MessageInternal, Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[message(custom_map)]
 pub struct ShouldBeInterpolated;
+
+impl SyncComponent for ShouldBeInterpolated {
+    fn mode() -> ComponentSyncMode {
+        ComponentSyncMode::None
+    }
+}
+
+impl<'a> MapEntities<'a> for ShouldBeInterpolated {
+    fn map_entities(&mut self, entity_mapper: Box<dyn EntityMapper + 'a>) {}
+
+    fn entities(&self) -> EntityHashSet<Entity> {
+        EntityHashSet::default()
+    }
+}
 
 // TODO: Right now we use the approach that we add an extra component to the Protocol of components to be replicated.
 //  that's pretty dangerous because it's now hard for the user to derive new traits.
 //  let's think of another approach later.
 #[derive(Component, MessageInternal, Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[message(custom_map)]
 pub struct ShouldBePredicted;
+
+// NOTE: need to define this here because otherwise we get the error
+// "impl doesn't use only types from inside the current crate"
+// TODO: does this mean that we cannot use existing types such as Transform?
+//  might need a list of pre-existing types?
+impl SyncComponent for ShouldBePredicted {
+    fn mode() -> ComponentSyncMode {
+        ComponentSyncMode::None
+    }
+}
+
+impl<'a> MapEntities<'a> for ShouldBePredicted {
+    fn map_entities(&mut self, entity_mapper: Box<dyn EntityMapper + 'a>) {}
+
+    fn entities(&self) -> EntityHashSet<Entity> {
+        EntityHashSet::default()
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/lightyear/src/shared/replication/components.rs
+++ b/lightyear/src/shared/replication/components.rs
@@ -28,6 +28,7 @@ pub struct Replicate {
     //  or force users to use `Replicate::default().with...`?
     /// List of clients that we the entity is currently replicated to.
     /// Will be updated before the other replication systems
+    #[doc(hidden)]
     pub replication_clients_cache: HashMap<ClientId, ClientVisibility>,
     pub replication_mode: ReplicationMode,
     // TODO: currently, if the host removes Replicate, then the entity is not removed in the remote

--- a/lightyear/src/shared/replication/manager.rs
+++ b/lightyear/src/shared/replication/manager.rs
@@ -608,7 +608,7 @@ impl<P: Protocol> ReplicationManager<P> {
                         .iter()
                         .map(|c| c.into())
                         .collect::<Vec<P::ComponentKinds>>();
-                    info!(remote_entity = ?entity, ?kinds, "Received UpdateComponent");
+                    debug!(remote_entity = ?entity, ?kinds, "Received UpdateComponent");
                     for mut component in actions.updates {
                         // map any entities inside the component
                         component.map_entities(Box::new(&self.remote_entity_map));

--- a/lightyear/src/shared/replication/manager.rs
+++ b/lightyear/src/shared/replication/manager.rs
@@ -608,7 +608,7 @@ impl<P: Protocol> ReplicationManager<P> {
                         .iter()
                         .map(|c| c.into())
                         .collect::<Vec<P::ComponentKinds>>();
-                    debug!(remote_entity = ?entity, ?kinds, "Received UpdateComponent");
+                    info!(remote_entity = ?entity, ?kinds, "Received UpdateComponent");
                     for mut component in actions.updates {
                         // map any entities inside the component
                         component.map_entities(Box::new(&self.remote_entity_map));

--- a/lightyear/src/tests/protocol.rs
+++ b/lightyear/src/tests/protocol.rs
@@ -33,8 +33,8 @@ pub struct Component3(pub f32);
 #[message(custom_map)]
 pub struct Component4(pub Entity);
 
-impl MapEntities for Component4 {
-    fn map_entities(&mut self, entity_mapper: Box<dyn EntityMapper>) {
+impl<'a> MapEntities<'a> for Component4 {
+    fn map_entities(&mut self, entity_mapper: Box<dyn EntityMapper + 'a>) {
         self.0.map_entities(entity_mapper);
     }
 
@@ -43,7 +43,6 @@ impl MapEntities for Component4 {
     }
 }
 
-// #[component_protocol_internal(protocol = "MyProtocol", derive(Debug))]
 #[component_protocol_internal(protocol = "MyProtocol")]
 pub enum MyComponentsProtocol {
     #[sync(full)]

--- a/lightyear/src/tests/protocol.rs
+++ b/lightyear/src/tests/protocol.rs
@@ -1,4 +1,5 @@
 use bevy::prelude::{Component, Entity};
+use bevy::utils::EntityHashSet;
 use derive_more::{Add, Mul};
 use serde::{Deserialize, Serialize};
 
@@ -12,7 +13,7 @@ pub struct Message1(pub String);
 #[derive(MessageInternal, Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct Message2(pub u32);
 
-#[message_protocol_internal(protocol = "MyProtocol", derive(Debug))]
+#[message_protocol_internal(protocol = "MyProtocol")]
 pub enum MyMessageProtocol {
     Message1(Message1),
     Message2(Message2),
@@ -33,8 +34,12 @@ pub struct Component3(pub f32);
 pub struct Component4(pub Entity);
 
 impl MapEntities for Component4 {
-    fn map_entities(&mut self, entity_map: &EntityMap) {
-        self.0.map_entities(entity_map);
+    fn map_entities(&mut self, entity_mapper: Box<dyn EntityMapper>) {
+        self.0.map_entities(entity_mapper);
+    }
+
+    fn entities(&self) -> EntityHashSet<Entity> {
+        EntityHashSet::from_iter(vec![self.0])
     }
 }
 

--- a/lightyear/src/utils/bevy.rs
+++ b/lightyear/src/utils/bevy.rs
@@ -1,6 +1,7 @@
 //! Implement lightyear traits for some common bevy types
 use crate::prelude::{EntityMap, MapEntities, Message, Named};
-use bevy::prelude::Transform;
+use bevy::prelude::{Entity, Transform};
+use bevy::utils::EntityHashSet;
 
 impl Named for Transform {
     fn name(&self) -> String {
@@ -10,6 +11,10 @@ impl Named for Transform {
 
 impl MapEntities for Transform {
     fn map_entities(&mut self, entity_map: &EntityMap) {}
+
+    fn entities(&self) -> EntityHashSet<Entity> {
+        EntityHashSet::default()
+    }
 }
 
 impl Message for Transform {}
@@ -25,6 +30,10 @@ cfg_if::cfg_if! {
 
         impl MapEntities for Color {
             fn map_entities(&mut self, entity_map: &EntityMap) {}
+
+            fn entities(&self) -> EntityHashSet<Entity> {
+                EntityHashSet::default()
+            }
         }
 
         impl Message for Color {}
@@ -37,6 +46,10 @@ cfg_if::cfg_if! {
 
         impl MapEntities for Visibility {
             fn map_entities(&mut self, entity_map: &EntityMap) {}
+
+            fn entities(&self) -> EntityHashSet<Entity> {
+                EntityHashSet::default()
+            }
         }
 
         impl Message for Visibility {}

--- a/lightyear/src/utils/bevy.rs
+++ b/lightyear/src/utils/bevy.rs
@@ -1,5 +1,5 @@
 //! Implement lightyear traits for some common bevy types
-use crate::prelude::{EntityMap, MapEntities, Message, Named};
+use crate::prelude::{EntityMapper, MapEntities, Message, Named, RemoteEntityMap};
 use bevy::prelude::{Entity, Transform};
 use bevy::utils::EntityHashSet;
 
@@ -9,8 +9,8 @@ impl Named for Transform {
     }
 }
 
-impl MapEntities for Transform {
-    fn map_entities(&mut self, entity_map: &EntityMap) {}
+impl<'a> MapEntities<'a> for Transform {
+    fn map_entities(&mut self, entity_mapper: Box<dyn EntityMapper + 'a>) {}
 
     fn entities(&self) -> EntityHashSet<Entity> {
         EntityHashSet::default()
@@ -28,8 +28,8 @@ cfg_if::cfg_if! {
             }
         }
 
-        impl MapEntities for Color {
-            fn map_entities(&mut self, entity_map: &EntityMap) {}
+        impl<'a> MapEntities<'a> for Color {
+            fn map_entities(&mut self, entity_mapper: Box<dyn EntityMapper + 'a>) {}
 
             fn entities(&self) -> EntityHashSet<Entity> {
                 EntityHashSet::default()
@@ -44,8 +44,8 @@ cfg_if::cfg_if! {
             }
         }
 
-        impl MapEntities for Visibility {
-            fn map_entities(&mut self, entity_map: &EntityMap) {}
+        impl<'a> MapEntities<'a> for Visibility {
+            fn map_entities(&mut self, entity_mapper: Box<dyn EntityMapper + 'a>) {}
 
             fn entities(&self) -> EntityHashSet<Entity> {
                 EntityHashSet::default()

--- a/lightyear/src/utils/named.rs
+++ b/lightyear/src/utils/named.rs
@@ -4,6 +4,8 @@
 // - derive Reflect for Messages
 // - require to derive Reflect for Components ?
 
+use std::fmt::{Debug, Formatter};
+
 pub trait TypeNamed {
     fn name() -> String;
 }

--- a/macros/src/component.rs
+++ b/macros/src/component.rs
@@ -488,11 +488,16 @@ fn delegate_method(input: &ItemEnum, enum_kind_name: &Ident) -> TokenStream {
     let enum_name = &input.ident;
     let variants = input.variants.iter().map(|v| v.ident.clone());
     let mut map_entities_body = quote! {};
+    let mut entities_body = quote! {};
     for variant in input.variants.iter() {
         let ident = &variant.ident;
         map_entities_body = quote! {
             #map_entities_body
             #enum_name::#ident(ref mut x) => x.map_entities(entity_map),
+        };
+        entities_body = quote! {
+            #entities_body
+            #enum_name::#ident(ref mut x) => x.entities(entity_map),
         };
     }
 
@@ -503,9 +508,17 @@ fn delegate_method(input: &ItemEnum, enum_kind_name: &Ident) -> TokenStream {
                     #map_entities_body
                 }
             }
+            fn entities(&self) -> EntityHashSet<Entity> {
+                match self {
+                    #entities_body
+                }
+            }
         }
         impl MapEntities for #enum_kind_name {
             fn map_entities(&mut self, entity_map: &EntityMap) {}
+            fn entities(&self) -> EntityHashSet<Entity> {
+                EntityHashSet::default()
+            }
         }
     }
 }

--- a/macros/src/component.rs
+++ b/macros/src/component.rs
@@ -163,7 +163,8 @@ pub fn component_protocol_impl(
             use #shared_crate_name::_reexport::*;
             use #shared_crate_name::prelude::*;
             use #shared_crate_name::prelude::client::*;
-            use bevy::prelude::{App, IntoSystemConfigs, EntityWorldMut, World};
+            use bevy::prelude::{App, Entity, IntoSystemConfigs, EntityWorldMut, World};
+            use bevy::utils::{EntityHashMap, EntityHashSet};
             use #shared_crate_name::shared::replication::systems::add_per_component_replication_send_systems;
             use #shared_crate_name::connection::events::{IterComponentInsertEvent, IterComponentRemoveEvent, IterComponentUpdateEvent};
             use #shared_crate_name::shared::systems::events::{
@@ -497,7 +498,7 @@ fn delegate_method(input: &ItemEnum, enum_kind_name: &Ident) -> TokenStream {
         };
         entities_body = quote! {
             #entities_body
-            #enum_name::#ident(ref mut x) => x.entities(entity_map),
+            #enum_name::#ident(ref x) => x.entities(),
         };
     }
 

--- a/macros/src/message.rs
+++ b/macros/src/message.rs
@@ -233,7 +233,7 @@ fn delegate_method(input: &ItemEnum) -> TokenStream {
         };
         entities_body = quote! {
             #entities_body
-            #enum_name::#ident(ref mut x) => x.entities(entity_map),
+            #enum_name::#ident(ref x) => x.entities(),
         };
     }
 

--- a/macros/src/message.rs
+++ b/macros/src/message.rs
@@ -5,7 +5,10 @@ use darling::{Error, FromDeriveInput, FromMeta};
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::{format_ident, quote};
 use std::ops::Deref;
-use syn::{parse_macro_input, parse_quote, DeriveInput, Field, Fields, ItemEnum, LitStr};
+use syn::{
+    parse_macro_input, parse_quote, parse_quote_spanned, DeriveInput, Field, Fields, GenericParam,
+    Generics, ItemEnum, LifetimeParam, LitStr,
+};
 
 #[derive(Debug, FromDeriveInput)]
 #[darling(attributes(message))]
@@ -56,13 +59,29 @@ pub fn message_impl(
     proc_macro::TokenStream::from(gen)
 }
 
+// Add the MapEntities trait for the message.
+// Need to combine the generics from the message with the generics from the trait
 fn map_entities_trait(input: &DeriveInput, ident_map: bool) -> TokenStream {
-    let (impl_generics, type_generics, where_clause) = input.generics.split_for_impl();
+    // combined generics
+    let mut gen_clone = input.generics.clone();
+    let lt: LifetimeParam = parse_quote_spanned! {Span::mixed_site() => 'a};
+    gen_clone.params.push(GenericParam::from(lt));
+    let (impl_generics, _, _) = gen_clone.split_for_impl();
+
+    // type generics
+    let (_, type_generics, where_clause) = input.generics.split_for_impl();
+
+    // trait generics (MapEntities)
+    let mut map_entities_generics = Generics::default();
+    let lt: LifetimeParam = parse_quote_spanned! {Span::mixed_site() => 'a};
+    map_entities_generics.params.push(GenericParam::from(lt));
+    let (_, type_generics_map, _) = map_entities_generics.split_for_impl();
+
     let struct_name = &input.ident;
     if ident_map {
         quote! {
-            impl #impl_generics MapEntities for #struct_name #type_generics #where_clause {
-                fn map_entities(&mut self, entity_map: &EntityMap) {}
+            impl #impl_generics MapEntities #type_generics_map for #struct_name #type_generics #where_clause {
+                fn map_entities(&mut self, entity_mapper: Box<dyn EntityMapper + 'a>) {}
                 fn entities(&self) -> EntityHashSet<Entity> {
                     EntityHashSet::default()
                 }
@@ -229,7 +248,7 @@ fn delegate_method(input: &ItemEnum) -> TokenStream {
         };
         map_entities_body = quote! {
             #map_entities_body
-            #enum_name::#ident(ref mut x) => x.map_entities(entity_map),
+            #enum_name::#ident(ref mut x) => x.map_entities(entity_mapper),
         };
         entities_body = quote! {
             #entities_body
@@ -245,8 +264,8 @@ fn delegate_method(input: &ItemEnum) -> TokenStream {
                 }
             }
         }
-        impl MapEntities for #enum_name {
-            fn map_entities(&mut self, entity_map: &EntityMap) {
+        impl<'a> MapEntities<'a> for #enum_name {
+            fn map_entities(&mut self, entity_mapper: Box<dyn EntityMapper + 'a>) {
                 match self {
                     #map_entities_body
                 }

--- a/macros/tests/derive_component.rs
+++ b/macros/tests/derive_component.rs
@@ -3,14 +3,24 @@ pub mod some_component {
     use derive_more::{Add, Mul};
     use serde::{Deserialize, Serialize};
 
+    use lightyear::prelude::client::InterpFn;
     use lightyear::prelude::*;
     use lightyear_macros::{component_protocol, message_protocol};
 
     #[derive(Component, Message, Serialize, Deserialize, Debug, PartialEq, Clone, Add, Mul)]
     pub struct Component1(pub f32);
 
-    #[derive(Component, Message, Serialize, Deserialize, Debug, PartialEq, Clone, Add, Mul)]
+    #[derive(Component, Message, Serialize, Deserialize, Debug, PartialEq, Clone)]
     pub struct Component2(pub f32);
+
+    #[derive(Component, Message, Serialize, Deserialize, Debug, PartialEq, Clone)]
+    pub struct Component3(String);
+
+    #[derive(Component, Message, Serialize, Deserialize, Debug, PartialEq, Clone)]
+    pub struct Component4(String);
+
+    #[derive(Component, Message, Serialize, Deserialize, Debug, PartialEq, Clone)]
+    pub struct Component5(pub f32);
 
     #[component_protocol(protocol = "MyProtocol")]
     pub enum MyComponentProtocol {
@@ -18,13 +28,25 @@ pub mod some_component {
         Component1(Component1),
         #[sync(simple)]
         Component2(Component2),
+        #[sync(once)]
+        Component3(Component3),
+        Component4(Component4),
+        #[sync(full, lerp = "MyCustom")]
+        Component5(Component5),
+    }
+
+    // custom interpolation logic
+    pub struct MyCustom;
+    impl<C> InterpFn<C> for MyCustom {
+        fn lerp(start: C, _other: C, _t: f32) -> C {
+            start
+        }
     }
 
     #[derive(Message, Serialize, Deserialize, Debug, PartialEq, Clone)]
     pub struct Message1(pub u32);
 
     #[message_protocol(protocol = "MyProtocol")]
-    #[derive(Debug)]
     pub enum MyMessageProtocol {
         Message1(Message1),
     }
@@ -38,6 +60,7 @@ pub mod some_component {
 
 #[cfg(test)]
 mod tests {
+    use lightyear::client::interpolation::InterpolatedComponent;
     use lightyear::protocol::BitSerializable;
     use lightyear::serialize::reader::ReadBuffer;
     use lightyear::serialize::wordbuffer::reader::ReadWordBuffer;
@@ -56,6 +79,19 @@ mod tests {
         let mut reader = ReadWordBuffer::start_read(bytes);
         let copy = MyComponentProtocol::decode(&mut reader)?;
         assert_eq!(component1, copy);
+
+        // check interpolation
+        let component5 = Component5(0.1);
+        assert_eq!(
+            component5.clone(),
+            Component5::lerp(component5, Component5(0.0), 0.5)
+        );
+
+        let component1 = Component1(0.0);
+        assert_eq!(
+            Component1(0.5),
+            Component1::lerp(component1, Component1(1.0), 0.5)
+        );
 
         Ok(())
     }

--- a/macros/tests/derive_message.rs
+++ b/macros/tests/derive_message.rs
@@ -11,10 +11,7 @@ pub mod some_message {
     #[derive(Message, Serialize, Deserialize, Debug, PartialEq, Clone)]
     pub struct Message2(pub u32);
 
-    // #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
-    // #[derive(Debug, PartialEq)]
-    #[message_protocol(protocol = "MyProtocol", derive(Debug))]
-    // #[derive(EnumAsInner)]
+    #[message_protocol(protocol = "MyProtocol")]
     pub enum MyMessageProtocol {
         Message1(Message1),
         Message2(Message2),


### PR DESCRIPTION
# Summary

This PR:
- greatly improves the replication of Messages and Components that contain Entities
- greatly improves the stability of client-prediction and snapshot-interpolation
- adds a more involved example showing how to use custom interpolation logic, and components that contain Entities


# Changelog
## Added

- Added an example `ReplicationGroups` that showcases:
  - the concept of `ReplicationGroups`: where multiple entities are guaranteed to be replicated in a single message, so will always be in sync with each other
  - how replicating components that refer to other entities works (via the `MapEntities` trait)
  - how to execute a complex custom snapshot interpolation logic: the interpolation is not a simple linear interpolation. The interpolated will stay on the "path" of the snake, and never do any diagonal movement 
  - showcases how prediction/interpolation performs with bad connections; the example default settings are with 400ms RTT, 40ms jitter and 10% packet loss


## Updated

- Handle entity mappings more rigorourously now! By `Entity Mapping` I mean Messages or Components that contain references to other entities, such as `HasParent(Entity)`. The entity in the message is from the server's World, and it needs to be mapped to the client's World.
  - refactored the `MapEntities` trait to be more flexible
  - introduced also entity mapping between the Confirmed entities and the Predicted/Interpolated entities (i.e. a component with `HasParent(Entity)` on the Confirmed entity will be synced with the correct mapping on the Predicted/Interpolated entities)
  - A Replication Group will be **guaranteed** to be replicated with an entity order that respects any dependencies between the entities: for example if you have two entities A and B and B depends on A (maybe because it contains a component `HasParent(A)`, B will be replicated **after** A has finished replicating.
  
- Updated the Input handling logic to get rid of some jitter around client prediction:
  - clients now **must** send inputs every tick (even if there are no inputs), so that the server can distinguish between "no input" and "lost input"
  - For a lost input, the server uses the last received input as a fallback estimate
  - this helps reduce prediction errors by a huge amount; client prediction should be more robust now!
  
- Refactored some of the interpolation logic:
  - a Component only needs to implement `Add` and `Mul` if it uses `LinearInterpolation`, not if it uses a custom interpolation function
  - added an option to give the user complete freedom to implement their interpolation logic
  
## Fixed

- Fixed an issue that was causing some instability during client-prediction: the client inputs were not buffered for long enough, so the input buffer was sometimes empty during rollback
- Fixed some issues that were causing instability/jitter during snapshot-interpolation: the interpolation start and end ticks were sometimes not computed correctly, which would cause the interpolation to 'jitter'. Snapshot interpolation should be much smoother now
- Fixed an issue where the ping buffer was sometimes too small and would panic, especially if the ping send_interval was short

# Migration guide

- Clients must now send inputs **every** tick, even if the user isn't doing any action. Practically, this means that you need to add a `None` variant in your Input enum, like so:
```
pub enum Inputs {
    Direction(Direction),
    Delete,
    Spawn,
    // *new*: inputs must be sent every tick, even if there is no action
    NoAction,
}
```

- The MapEntities trait has been modified; all old implementors must be updated to match the new trait:
```
/// Trait that Messages or Components must implement to be able to map entities
pub trait MapEntities<'a> {
    /// Map the entities inside the message or component from the remote World to the local World
    fn map_entities(&mut self, entity_mapper: Box<dyn EntityMapper + 'a>);

    /// Get all the entities that are present in that message or component
    fn entities(&self) -> EntityHashSet<Entity>;
}
```

# Future TODOs / remaining bugs

- Sometimes the player goes to the left by itself at the beginning; probably a bug in the `InputBuffer`
- I've seen cases where the parent's current interpolation tick wasn't the same as the tail's current interpolation tick. This should be impossible since tail/parent are in the same replication group
- Interpolation time (and maybe server time) take a while to sync properly and take on the right value. Normally the correct interpolation time should be computed very quickly.