### PR TITLE
Simplify entity mapping for prediction/replication

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -12,10 +12,11 @@
     because start tick or end tick are not updated correctly in some edge cases.
 
 
-- add PredictionGroup and InterpolationGroup.
+- add PredictionGroup and InterpolationGroup?
   - on top of ReplicationGroup?
   - or do we just re-use the replication group id (that usually will have a remote entity id) and use it to see the prediction/interpolation group?
   - then we add the prediction group id on the Confirmed or Predicted components?
+  - when we receive a replicated group with ShouldBePredicted, we udpate the replication graph of the prediction group.
 - Then we don't really need the Confirmed/Predicted components anymore, we could just have resources on the Prediction or Interpolation plugin
 - The resource needs:
   - confirmed<->predicted mapping
@@ -25,7 +26,27 @@
   - for each entity, fetch the confirmed/predicted entity
   - do entity mapping if needed
 - users can add their own entities in the prediction group (even if thre )
+- examples:
+  - a shooter, we shoot bullets. the bullets should be in our prediction group?
+    I guess it's not needed if we don't do rollback for those bullets, i.e. we don't give them a Predicted component.
+    Or we could create the bullet, make it part of the entity group; the server will create the bullet a bit later.
+    When the bullet gets replicated on client; we should be able to map the Confirmed to the predicted bullet; so we don't spawn a new predicted.
+    (in practice, for important stuff, we would just wait for the server replication to spawn the entity (instead of spawning it on client and then deleting it if the server version doesn't spawn it?, and for non-important stuff we would just spawn a short-lived entity that is not predicted.)
+  - a character has HasWeapon(Entity), weapon has HasParent(Entity) which forms a cycle. I guess instead of creating this graph of deps,
+    we should just deal with all spawns first separately! Same for prediction, we first do all spawns first
+  
 
+    
+- TODO: Give an option for rollback to choose how to perform the rollback!
+  - the default option is to snapback instantly to the rollback state.
+  - another option is: snapback to rollback state, perform rollback, then tell the user the previous predicted state and the new predicted state.
+    for example they could choose to lerp over several frames from the [old to new] (i.e correct only 10% of the way).
+    this would cause many consecutive rollback frames, but smoother corrections.
+  - register a component RollbackResult<C> {
+      // use option because the component could have gotten removed
+      old: Option<C>, 
+      new: Option<C>,
+    }
 
 
 - DEBUGGING REPLICATION BOX:

--- a/examples/replication_groups/client.rs
+++ b/examples/replication_groups/client.rs
@@ -278,7 +278,7 @@ pub(crate) fn interpolate(
                 assert_eq!(tail_status.current, parent_status.current);
                 *tail = tail_start_value.clone();
                 *parent_position = pos_start.clone();
-                info!(
+                debug!(
                     ?tail,
                     ?parent_position,
                     "after interpolation; CURRENT = START"
@@ -296,7 +296,7 @@ pub(crate) fn interpolate(
                     assert_eq!(tail_status.current, parent_status.current);
                     *tail = tail_end_value.clone();
                     *parent_position = pos_end.clone();
-                    info!(
+                    debug!(
                         ?tail,
                         ?parent_position,
                         "after interpolation; CURRENT = END"
@@ -324,13 +324,13 @@ pub(crate) fn interpolate(
                             != tail_start_value.0.front().unwrap().0
                         {
                             tail.0.push_front(tail_end_value.0.front().unwrap().clone());
-                            info!("ADD POINT");
+                            debug!("ADD POINT");
                         }
                         // the path is straight! just move the head and adjust the tail
                         *parent_position =
                             PlayerPosition::lerp(pos_start.clone(), pos_end.clone(), t);
                         tail.shorten_back(parent_position.0, tail_length.0);
-                        info!(
+                        debug!(
                             ?tail,
                             ?parent_position,
                             "after interpolation; FIRST SEGMENT"
@@ -371,7 +371,7 @@ pub(crate) fn interpolate(
                     // now move the head by `pos_distance_to_do` while remaining on the tail path
                     for i in (0..segment_idx).rev() {
                         let dist = segment_length(parent_position.0, tail_end_value.0[i].0);
-                        info!(
+                        debug!(
                             ?i,
                             ?dist,
                             ?pos_distance_to_do,
@@ -380,7 +380,7 @@ pub(crate) fn interpolate(
                             "in other segments"
                         );
                         if pos_distance_to_do < 1000.0 * f32::EPSILON {
-                            info!(?tail, ?parent_position, "after interpolation; ON POINT");
+                            debug!(?tail, ?parent_position, "after interpolation; ON POINT");
                             // no need to change anything
                             continue 'outer;
                         }
@@ -406,7 +406,7 @@ pub(crate) fn interpolate(
                                 .1
                                 .get_tail(tail_end_value.0[i].0, dist - pos_distance_to_do);
                             tail.shorten_back(parent_position.0, tail_length.0);
-                            info!(?tail, ?parent_position, "after interpolation; ELSE");
+                            debug!(?tail, ?parent_position, "after interpolation; ELSE");
                             continue 'outer;
                         }
                     }
@@ -419,7 +419,7 @@ pub(crate) fn interpolate(
                         .1
                         .get_tail(pos_end.0, dist - pos_distance_to_do);
                     tail.shorten_back(parent_position.0, tail_length.0);
-                    info!(?tail, ?parent_position, "after interpolation; ELSE FIRST");
+                    debug!(?tail, ?parent_position, "after interpolation; ELSE FIRST");
                 }
             }
         }

--- a/examples/replication_groups/shared.rs
+++ b/examples/replication_groups/shared.rs
@@ -28,13 +28,9 @@ pub struct SharedPlugin;
 
 impl Plugin for SharedPlugin {
     fn build(&self, app: &mut App) {
-        app.add_plugins(WorldInspectorPlugin::new());
         app.add_systems(Update, draw_snakes);
     }
 }
-
-// head
-// snake
 
 // This system defines how we update the player's positions when we receive an input
 pub(crate) fn shared_movement_behaviour(position: &mut PlayerPosition, input: &Inputs) {
@@ -121,13 +117,13 @@ pub(crate) fn draw_snakes(
         if position.0.x != points.0.front().unwrap().0.x
             && position.0.y != points.0.front().unwrap().0.y
         {
-            info!("DIAGONAL");
+            debug!("DIAGONAL");
         }
         // draw the rest of the lines
         for (start, end) in points.0.iter().zip(points.0.iter().skip(1)) {
             gizmos.line_2d(start.0, end.0, color.0);
             if start.0.x != end.0.x && start.0.y != end.0.y {
-                info!("DIAGONAL");
+                debug!("DIAGONAL");
             }
         }
     }

--- a/lightyear/src/channel/builder.rs
+++ b/lightyear/src/channel/builder.rs
@@ -1,6 +1,7 @@
 //! This module contains the [`Channel`] trait
-use lightyear_macros::ChannelInternal;
 use std::time::Duration;
+
+use lightyear_macros::ChannelInternal;
 
 use crate::channel::receivers::ordered_reliable::OrderedReliableReceiver;
 use crate::channel::receivers::sequenced_reliable::SequencedReliableReceiver;

--- a/lightyear/src/channel/receivers/mod.rs
+++ b/lightyear/src/channel/receivers/mod.rs
@@ -1,8 +1,8 @@
-use enum_dispatch::enum_dispatch;
-
-use crate::packet::message::{MessageContainer, SingleData};
+use crate::packet::message::MessageContainer;
+use crate::packet::message::{FragmentData, SingleData};
 use crate::shared::tick_manager::TickManager;
 use crate::shared::time_manager::TimeManager;
+use enum_dispatch::enum_dispatch;
 
 /// Utilities to receive a Message from multiple fragment packets
 pub(crate) mod fragment_receiver;

--- a/lightyear/src/channel/senders/fragment_ack_receiver.rs
+++ b/lightyear/src/channel/senders/fragment_ack_receiver.rs
@@ -1,11 +1,8 @@
-use bevy::utils::HashMap;
-
 use anyhow::Result;
-use bytes::Bytes;
+use bevy::utils::HashMap;
 use tracing::{error, trace};
 
-use crate::packet::message::{FragmentData, FragmentIndex, MessageAck, MessageId, SingleData};
-use crate::packet::packet::FRAGMENT_SIZE;
+use crate::packet::message::{FragmentIndex, MessageId};
 use crate::shared::time_manager::WrappedTime;
 
 /// `FragmentReceiver` is used to reconstruct fragmented messages
@@ -103,8 +100,6 @@ impl FragmentAckTracker {
 
 #[cfg(test)]
 mod tests {
-    use crate::channel::senders::fragment_sender::FragmentSender;
-
     use super::*;
 
     #[test]

--- a/lightyear/src/channel/senders/mod.rs
+++ b/lightyear/src/channel/senders/mod.rs
@@ -1,13 +1,11 @@
-use std::collections::VecDeque;
-
-use bytes::Bytes;
-use crossbeam_channel::Receiver;
-use enum_dispatch::enum_dispatch;
-
 use crate::packet::message::{FragmentData, MessageAck, MessageId, SingleData};
 use crate::shared::ping::manager::PingManager;
 use crate::shared::tick_manager::TickManager;
 use crate::shared::time_manager::TimeManager;
+use bytes::Bytes;
+use crossbeam_channel::Receiver;
+use enum_dispatch::enum_dispatch;
+use std::collections::VecDeque;
 
 pub(crate) mod fragment_ack_receiver;
 pub(crate) mod fragment_sender;

--- a/lightyear/src/channel/senders/reliable.rs
+++ b/lightyear/src/channel/senders/reliable.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use bytes::Bytes;
 use crossbeam_channel::Receiver;
-use tracing::{info, trace};
+use tracing::trace;
 
 use crate::channel::builder::ReliableSettings;
 use crate::channel::senders::fragment_sender::FragmentSender;

--- a/lightyear/src/channel/senders/unordered_unreliable_with_acks.rs
+++ b/lightyear/src/channel/senders/unordered_unreliable_with_acks.rs
@@ -1,16 +1,15 @@
-use bevy::utils::HashMap;
 use std::collections::VecDeque;
 
 use bytes::Bytes;
+use crossbeam_channel::{Receiver, Sender};
 
 use crate::channel::senders::fragment_ack_receiver::FragmentAckReceiver;
 use crate::channel::senders::fragment_sender::FragmentSender;
 use crate::channel::senders::ChannelSend;
-use crate::packet::message::{FragmentData, FragmentIndex, MessageAck, MessageId, SingleData};
+use crate::packet::message::{FragmentData, MessageAck, MessageId, SingleData};
 use crate::shared::ping::manager::PingManager;
 use crate::shared::tick_manager::TickManager;
 use crate::shared::time_manager::{TimeManager, WrappedTime};
-use crossbeam_channel::{Receiver, Sender};
 
 const DISCARD_AFTER: chrono::Duration = chrono::Duration::milliseconds(3000);
 
@@ -130,10 +129,9 @@ impl ChannelSend for UnorderedUnreliableWithAcksSender {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::channel::senders::fragment_ack_receiver::FragmentAckTracker;
     use crate::packet::packet::FRAGMENT_SIZE;
-    use crossbeam_channel::TryRecvError;
+
+    use super::*;
 
     #[test]
     fn test_receive_ack() {

--- a/lightyear/src/client/components.rs
+++ b/lightyear/src/client/components.rs
@@ -1,11 +1,11 @@
 /*!
 Defines components that are used for the client-side prediction and interpolation
 */
+use std::fmt::Debug;
 
-use crate::prelude::{Named, TypeNamed};
-use bevy::ecs::component::TableStorage;
 use bevy::prelude::{Component, Entity};
-use std::fmt::{Debug, Formatter};
+
+use crate::prelude::{MapEntities, Named};
 
 /// Marks an entity that contains the server-updates that are received from the Server
 /// (this entity is a copy of Predicted that is RTT ticks behind)
@@ -15,7 +15,7 @@ pub struct Confirmed {
     pub interpolated: Option<Entity>,
 }
 
-pub trait SyncComponent: Component + Clone + PartialEq + Named {
+pub trait SyncComponent: Component + Clone + PartialEq + Named + for<'a> MapEntities<'a> {
     fn mode() -> ComponentSyncMode;
 }
 

--- a/lightyear/src/client/config.rs
+++ b/lightyear/src/client/config.rs
@@ -6,8 +6,6 @@ use crate::client::interpolation::plugin::InterpolationConfig;
 use crate::client::prediction::plugin::PredictionConfig;
 use crate::client::sync::SyncConfig;
 use crate::shared::config::SharedConfig;
-use crate::transport::io::IoConfig;
-
 use crate::shared::ping::manager::PingConfig;
 
 #[derive(Clone)]

--- a/lightyear/src/client/connection.rs
+++ b/lightyear/src/client/connection.rs
@@ -3,20 +3,14 @@
 use std::time::Duration;
 
 use anyhow::Result;
-use bevy::prelude::World;
-use tracing::{debug, info, trace};
+use tracing::{debug, trace};
 
-use crate::channel::builder::PingChannel;
 use crate::client::sync::SyncConfig;
-use crate::connection::events::ConnectionEvents;
-use crate::connection::message::ProtocolMessage;
 use crate::inputs::input_buffer::InputBuffer;
-use crate::packet::packet_manager::Payload;
-use crate::protocol::channel::{ChannelKind, ChannelRegistry};
+use crate::protocol::channel::ChannelRegistry;
 use crate::protocol::Protocol;
 use crate::serialize::reader::ReadBuffer;
-use crate::shared::ping::manager::{PingConfig, PingManager};
-use crate::shared::ping::message::SyncMessage;
+use crate::shared::ping::manager::PingConfig;
 use crate::shared::tick_manager::Tick;
 use crate::shared::tick_manager::TickManager;
 use crate::shared::time_manager::TimeManager;

--- a/lightyear/src/client/events.rs
+++ b/lightyear/src/client/events.rs
@@ -1,7 +1,6 @@
 //! Wrapper around [`ConnectionEvents`] that adds client-specific functionality
 //!
 use crate::connection::events::ConnectionEvents;
-use crate::prelude::Tick;
 use crate::protocol::Protocol;
 
 pub struct ClientEvents<P: Protocol> {

--- a/lightyear/src/client/input.rs
+++ b/lightyear/src/client/input.rs
@@ -1,5 +1,4 @@
 //! Handles client-generated inputs
-use anyhow::Context;
 use bevy::prelude::{
     not, App, EventReader, EventWriter, FixedUpdate, IntoSystemConfigs, IntoSystemSetConfigs,
     Plugin, PostUpdate, Res, ResMut, SystemSet,

--- a/lightyear/src/client/interpolation/despawn.rs
+++ b/lightyear/src/client/interpolation/despawn.rs
@@ -1,10 +1,9 @@
-use std::collections::HashMap;
-
-use bevy::prelude::{Commands, Entity, EventReader, Query, RemovedComponents, ResMut, Resource};
+use bevy::prelude::{Commands, EventReader, Query, RemovedComponents, ResMut};
 
 use crate::client::components::{Confirmed, SyncComponent};
 use crate::client::interpolation::interpolate::InterpolateStatus;
 use crate::client::interpolation::interpolation_history::ConfirmedHistory;
+use crate::client::interpolation::resource::InterpolationManager;
 use crate::shared::events::ComponentRemoveEvent;
 
 // Despawn logic:
@@ -16,13 +15,6 @@ use crate::shared::events::ComponentRemoveEvent;
 
 // - TODO: despawning another client entity as a consequence from prediction, but we want to roll that back:
 //   - maybe we don't do it, and we wait until we are sure (confirmed despawn) before actually despawning the entity
-
-#[derive(Resource, Default)]
-/// Mapping from confirmed entities to interpolated entities
-/// Needed to despawn interpolated entities when the confirmed entity gets despawned
-pub struct InterpolationMapping {
-    pub confirmed_to_interpolated: HashMap<Entity, Entity>,
-}
 
 /// Remove the component from interpolated entities when it gets removed from confirmed
 pub(crate) fn removed_components<C: SyncComponent>(
@@ -46,12 +38,16 @@ pub(crate) fn removed_components<C: SyncComponent>(
 /// Despawn interpolated entities when the confirmed entity gets despawned
 /// TODO: we should despawn interpolated only when it reaches the latest confirmed snapshot?
 pub(crate) fn despawn_interpolated(
+    mut manager: ResMut<InterpolationManager>,
     mut commands: Commands,
-    mut mapping: ResMut<InterpolationMapping>,
     mut query: RemovedComponents<Confirmed>,
 ) {
-    for entity in query.read() {
-        if let Some(interpolated) = mapping.confirmed_to_interpolated.remove(&entity) {
+    for confirmed_entity in query.read() {
+        if let Some(interpolated) = manager
+            .interpolated_entity_map
+            .remote_to_interpolated
+            .remove(&confirmed_entity)
+        {
             if let Some(mut entity_mut) = commands.get_entity(interpolated) {
                 entity_mut.despawn();
             }

--- a/lightyear/src/client/interpolation/interpolate.rs
+++ b/lightyear/src/client/interpolation/interpolate.rs
@@ -1,5 +1,5 @@
 use bevy::prelude::{Component, Query, ResMut};
-use tracing::{info, trace, warn};
+use tracing::trace;
 
 use crate::client::components::{ComponentSyncMode, SyncComponent};
 use crate::client::interpolation::interpolation_history::ConfirmedHistory;

--- a/lightyear/src/client/interpolation/mod.rs
+++ b/lightyear/src/client/interpolation/mod.rs
@@ -8,32 +8,15 @@ pub use interpolate::InterpolateStatus;
 pub use interpolation_history::ConfirmedHistory;
 pub use plugin::{add_interpolation_systems, add_prepare_interpolation_systems};
 
-use crate::client::components::{ComponentSyncMode, Confirmed, SyncComponent};
-use crate::client::interpolation::despawn::InterpolationMapping;
+use crate::client::components::{Confirmed, SyncComponent};
+use crate::client::interpolation::resource::InterpolationManager;
 use crate::shared::replication::components::ShouldBeInterpolated;
 
 mod despawn;
 mod interpolate;
 pub mod interpolation_history;
 pub mod plugin;
-
-/// This module handles doing snapshot interpolations for entities controlled by other clients.
-///
-/// We want to receive smooth updates for the other players' actions
-/// But we receive their actions at a given timestep that might not match the physics timestep.
-
-/// Which means we can do one of two things:
-/// - apply client prediction for all players
-/// - apply client prediction for the controlled player, and snapshot interpolation for the other players
-
-// TODO:
-// - same thing, add InterpolationTarget on Replicate, which translates into ShouldBeInterpolated.
-// - if we see that on a confirmed entity, then we create a Interpolated entity.
-// - that entity will keep a component history (along with the ticks), and we will interpolate between the last 2 components.
-// - re-use component history ?
-
-// TODO: maybe merge this with PredictedComponent?
-//  basically it is a HistoryComponent. And we can have modes for Prediction or Interpolation
+mod resource;
 
 pub trait InterpFn<C> {
     fn lerp(start: C, other: C, t: f32) -> C;
@@ -66,31 +49,6 @@ pub trait InterpolatedComponent<C>: SyncComponent {
     }
 }
 
-// pub trait InterpolatedComponent<C>: SyncComponent + Sized {
-//     type Fn: InterpFn<C>;
-//     /// Which interpolation function to use
-//     /// By default, it will be a linear interpolation
-//     fn lerp_mode() -> LerpMode<Self>;
-//
-//     fn lerp_linear(start: Self, other: Self, t: f32) -> Self
-//     where
-//         Self: Mul<f32, Output = Self> + Add<Self, Output = Self>,
-//     {
-//         start * (1.0 - t) + other * t
-//     }
-//
-//     fn lerp_custom(start: Self, other: Self, t: f32, lerp: fn(Self, Self, f32) -> Self) -> Self {
-//         lerp(start, other, t)
-//     }
-// }
-
-// #[derive(Debug)]
-// pub enum LerpMode<C: InterpolatedComponent> {
-//     Linear,
-//     // TODO: change this to a trait object?
-//     Custom(fn(C, C, f32) -> C),
-// }
-
 /// Marks an entity that is being interpolated by the client
 #[derive(Component, Debug)]
 pub struct Interpolated {
@@ -100,12 +58,11 @@ pub struct Interpolated {
     //  - despawn immediately all components
     //  - leave the entity alive until the confirmed entity catches up to it and then it gets removed.
     //    - or do this only for certain components (audio, animation, particles..) -> mode on PredictedComponent
-    // rollback_state: RollbackState,
 }
 
 pub fn spawn_interpolated_entity(
+    mut manager: ResMut<InterpolationManager>,
     mut commands: Commands,
-    mut mapping: ResMut<InterpolationMapping>,
     mut confirmed_entities: Query<(Entity, Option<&mut Confirmed>), Added<ShouldBeInterpolated>>,
 ) {
     for (confirmed_entity, confirmed) in confirmed_entities.iter_mut() {
@@ -113,12 +70,15 @@ pub fn spawn_interpolated_entity(
         let interpolated_entity_mut = commands.spawn(Interpolated { confirmed_entity });
         let interpolated = interpolated_entity_mut.id();
 
+        // update the entity mapping
+        manager
+            .interpolated_entity_map
+            .remote_to_interpolated
+            .insert(confirmed_entity, interpolated);
+
         // add Confirmed to the confirmed entity
         // safety: we know the entity exists
         let mut confirmed_entity_mut = commands.get_entity(confirmed_entity).unwrap();
-        mapping
-            .confirmed_to_interpolated
-            .insert(confirmed_entity, interpolated);
         if let Some(mut confirmed) = confirmed {
             confirmed.interpolated = Some(interpolated);
         } else {

--- a/lightyear/src/client/interpolation/plugin.rs
+++ b/lightyear/src/client/interpolation/plugin.rs
@@ -2,15 +2,13 @@ use std::marker::PhantomData;
 use std::time::Duration;
 
 use bevy::prelude::{
-    apply_deferred, App, IntoSystemConfigs, IntoSystemSetConfigs, Plugin, PostUpdate, PreUpdate,
-    SystemSet,
+    apply_deferred, App, IntoSystemConfigs, IntoSystemSetConfigs, Plugin, PostUpdate, SystemSet,
 };
 
 use crate::client::components::SyncComponent;
-use crate::client::interpolation::despawn::{
-    despawn_interpolated, removed_components, InterpolationMapping,
-};
+use crate::client::interpolation::despawn::{despawn_interpolated, removed_components};
 use crate::client::interpolation::interpolate::{interpolate, update_interpolate_status};
+use crate::client::interpolation::resource::InterpolationManager;
 use crate::protocol::component::ComponentProtocol;
 use crate::protocol::Protocol;
 use crate::shared::sets::MainSet;
@@ -179,7 +177,7 @@ impl<P: Protocol> Plugin for InterpolationPlugin<P> {
         }
 
         // RESOURCES
-        app.init_resource::<InterpolationMapping>();
+        app.init_resource::<InterpolationManager>();
         // SETS
         app.configure_sets(
             PostUpdate,
@@ -213,7 +211,7 @@ impl<P: Protocol> Plugin for InterpolationPlugin<P> {
         app.add_systems(
             PostUpdate,
             (
-                // spawn_interpolated_entity.in_set(InterpolationSet::SpawnInterpolation),
+                spawn_interpolated_entity.in_set(InterpolationSet::SpawnInterpolation),
                 despawn_interpolated.in_set(InterpolationSet::Despawn),
             ),
         );

--- a/lightyear/src/client/interpolation/resource.rs
+++ b/lightyear/src/client/interpolation/resource.rs
@@ -1,0 +1,18 @@
+//! Defines bevy resources needed for Interpolation
+use bevy::prelude::Resource;
+
+use crate::shared::replication::entity_map::InterpolatedEntityMap;
+
+#[derive(Resource, Default)]
+pub struct InterpolationManager {
+    /// Map between remote and predicted entities
+    pub interpolated_entity_map: InterpolatedEntityMap,
+}
+
+impl InterpolationManager {
+    pub fn new() -> Self {
+        Self {
+            interpolated_entity_map: Default::default(),
+        }
+    }
+}

--- a/lightyear/src/client/plugin.rs
+++ b/lightyear/src/client/plugin.rs
@@ -2,7 +2,6 @@
 use std::ops::DerefMut;
 use std::sync::Mutex;
 
-use crate::client::resource::{Authentication, Client};
 use bevy::prelude::IntoSystemSetConfigs;
 use bevy::prelude::{
     apply_deferred, not, resource_exists, App, Condition, FixedUpdate, IntoSystemConfigs,
@@ -14,12 +13,12 @@ use crate::client::input::InputPlugin;
 use crate::client::interpolation::plugin::InterpolationPlugin;
 use crate::client::prediction::plugin::{is_in_rollback, PredictionPlugin};
 use crate::client::prediction::Rollback;
+use crate::client::resource::{Authentication, Client};
 use crate::client::systems::{is_ready_to_send, receive, send, sync_update};
 use crate::protocol::component::ComponentProtocol;
 use crate::protocol::message::MessageProtocol;
 use crate::protocol::Protocol;
 use crate::shared::plugin::SharedPlugin;
-use crate::shared::replication::resources::ReplicationData;
 use crate::shared::sets::{FixedUpdateSet, MainSet};
 use crate::shared::systems::tick::increment_tick;
 use crate::transport::io::Io;

--- a/lightyear/src/client/prediction/plugin.rs
+++ b/lightyear/src/client/prediction/plugin.rs
@@ -10,6 +10,7 @@ use crate::client::prediction::despawn::{
     remove_component_for_despawn_predicted, remove_despawn_marker,
 };
 use crate::client::prediction::predicted_history::update_prediction_history;
+use crate::client::prediction::resource::PredictionManager;
 use crate::prelude::Named;
 use crate::protocol::component::ComponentProtocol;
 use crate::protocol::Protocol;
@@ -147,6 +148,7 @@ impl<P: Protocol> Plugin for PredictionPlugin<P> {
         P::Components::add_prediction_systems(app);
 
         // RESOURCES
+        app.init_resource::<PredictionManager>();
         app.insert_resource(Rollback {
             state: RollbackState::Default,
         });
@@ -184,10 +186,10 @@ impl<P: Protocol> Plugin for PredictionPlugin<P> {
         );
 
         // no need, since we spawn predicted entities/components in replication
-        // app.add_systems(
-        //     PreUpdate,
-        //     spawn_predicted_entity.in_set(PredictionSet::SpawnPrediction),
-        // );
+        app.add_systems(
+            PreUpdate,
+            spawn_predicted_entity.in_set(PredictionSet::SpawnPrediction),
+        );
         // 2. (in prediction_systems) add ComponentHistory and a apply_deferred after
         // 3. (in prediction_systems) Check if we should do rollback, clear histories and snap prediction's history to server-state
         // 4. Potentially do rollback

--- a/lightyear/src/client/prediction/resource.rs
+++ b/lightyear/src/client/prediction/resource.rs
@@ -1,0 +1,19 @@
+//! Defines bevy resources needed for Prediction
+
+use bevy::prelude::Resource;
+
+use crate::shared::replication::entity_map::PredictedEntityMap;
+
+#[derive(Resource, Default)]
+pub struct PredictionManager {
+    /// Map between remote and predicted entities
+    pub predicted_entity_map: PredictedEntityMap,
+}
+
+impl PredictionManager {
+    pub fn new() -> Self {
+        Self {
+            predicted_entity_map: Default::default(),
+        }
+    }
+}

--- a/lightyear/src/client/prediction/rollback.rs
+++ b/lightyear/src/client/prediction/rollback.rs
@@ -3,8 +3,8 @@ use std::fmt::Debug;
 use bevy::prelude::{
     Commands, Entity, EventReader, FixedUpdate, Query, Res, ResMut, Without, World,
 };
-use bevy::utils::{EntityHashSet, HashSet};
-use tracing::{debug, error, info, trace, trace_span, warn};
+use bevy::utils::EntityHashSet;
+use tracing::{debug, error, info, trace, trace_span};
 
 use crate::client::components::{ComponentSyncMode, Confirmed, SyncComponent};
 use crate::client::events::{ComponentInsertEvent, ComponentRemoveEvent, ComponentUpdateEvent};

--- a/lightyear/src/client/resource.rs
+++ b/lightyear/src/client/resource.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use anyhow::Result;
 use bevy::prelude::{Resource, Time, Virtual, World};
-use tracing::{debug, trace};
+use tracing::trace;
 
 use crate::channel::builder::Channel;
 use crate::connection::events::ConnectionEvents;
@@ -14,7 +14,6 @@ use crate::netcode::{ConnectToken, Key};
 use crate::packet::message::Message;
 use crate::protocol::channel::ChannelKind;
 use crate::protocol::Protocol;
-use crate::shared::ping::message::SyncMessage;
 use crate::shared::replication::manager::ReplicationManager;
 use crate::shared::tick_manager::TickManager;
 use crate::shared::tick_manager::{Tick, TickManaged};

--- a/lightyear/src/client/sync.rs
+++ b/lightyear/src/client/sync.rs
@@ -1,10 +1,8 @@
 /*! Handles syncing the time between the client and the server
 */
-use std::pin::pin;
 use std::time::Duration;
 
 use bevy::prelude::Res;
-use bevy::time::Stopwatch;
 use tracing::{debug, info, trace};
 
 use crate::client::interpolation::plugin::InterpolationDelay;
@@ -12,8 +10,6 @@ use crate::client::resource::Client;
 use crate::packet::packet::PacketId;
 use crate::protocol::Protocol;
 use crate::shared::ping::manager::PingManager;
-use crate::shared::ping::message::{Ping, Pong};
-use crate::shared::ping::store::{PingId, PingStore};
 use crate::shared::tick_manager::Tick;
 use crate::shared::tick_manager::TickManager;
 use crate::shared::time_manager::{TimeManager, WrappedTime};

--- a/lightyear/src/client/systems.rs
+++ b/lightyear/src/client/systems.rs
@@ -1,8 +1,8 @@
 //! Defines the client bevy systems and run conditions
 use bevy::prelude::{Events, Fixed, Mut, Res, ResMut, Time, Virtual, World};
-use tracing::{debug, info, trace};
+use tracing::trace;
 
-use crate::client::events::{ConnectEvent, DisconnectEvent, EntityDespawnEvent, EntitySpawnEvent};
+use crate::client::events::{EntityDespawnEvent, EntitySpawnEvent};
 use crate::client::resource::Client;
 use crate::connection::events::{IterEntityDespawnEvent, IterEntitySpawnEvent};
 use crate::protocol::component::ComponentProtocol;

--- a/lightyear/src/connection/events.rs
+++ b/lightyear/src/connection/events.rs
@@ -3,8 +3,8 @@
 use std::iter;
 
 use bevy::prelude::{Component, Entity};
-use bevy::utils::{EntityHashMap, HashMap, HashSet};
-use tracing::{info, trace};
+use bevy::utils::HashMap;
+use tracing::trace;
 
 use crate::packet::message::Message;
 use crate::prelude::{Named, Tick};
@@ -12,7 +12,6 @@ use crate::protocol::channel::ChannelKind;
 use crate::protocol::component::IntoKind;
 use crate::protocol::message::{MessageBehaviour, MessageKind};
 use crate::protocol::{EventContext, Protocol};
-use crate::shared::ping::message::{Ping, Pong, SyncMessage};
 
 // TODO: don't make fields pub but instead make accessors
 #[derive(Debug)]
@@ -407,9 +406,9 @@ impl<P: Protocol> IterComponentInsertEvent<P> for ConnectionEvents<P> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use crate::tests::protocol::*;
-    use bevy::utils::HashSet;
+
+    use super::*;
 
     #[test]
     fn test_iter_messages() {

--- a/lightyear/src/connection/message.rs
+++ b/lightyear/src/connection/message.rs
@@ -1,19 +1,13 @@
 /*!
 Provides a [`ProtocolMessage`] enum that is a wrapper around all the possible messages that can be sent over the network
 */
-use crate::_reexport::{InputMessage, ShouldBeInterpolated, ShouldBePredicted, TickManager};
-use crate::connection::events::ConnectionEvents;
-use crate::prelude::{EntityMapper, MapEntities, RemoteEntityMap, Tick};
-use crate::protocol::channel::ChannelKind;
+use serde::{Deserialize, Serialize};
+use tracing::{info_span, trace};
+
 use crate::protocol::Protocol;
 use crate::shared::ping::message::SyncMessage;
 use crate::shared::replication::{ReplicationMessage, ReplicationMessageData};
-use crate::shared::time_manager::TimeManager;
 use crate::utils::named::Named;
-use bevy::prelude::Entity;
-use bevy::utils::EntityHashSet;
-use serde::{Deserialize, Serialize};
-use tracing::{info, info_span, trace, trace_span};
 
 // pub enum InternalMessage<P: Protocol> {
 //     InputMessage(InputMessage<P::Input>),

--- a/lightyear/src/connection/mod.rs
+++ b/lightyear/src/connection/mod.rs
@@ -1,15 +1,10 @@
 /*!  A connection is a wrapper that lets us send message and apply replication
 */
 
-// only public for proc macro
-pub mod events;
-
-pub(crate) mod message;
-
 use anyhow::Result;
-use bevy::prelude::{Entity, World};
+use bevy::prelude::World;
 use serde::{Deserialize, Serialize};
-use tracing::{info, trace, trace_span};
+use tracing::{trace, trace_span};
 
 use crate::channel::builder::{EntityUpdatesChannel, PingChannel};
 use crate::channel::senders::ChannelSend;
@@ -30,6 +25,11 @@ use crate::shared::tick_manager::Tick;
 use crate::shared::tick_manager::TickManager;
 use crate::shared::time_manager::TimeManager;
 use crate::utils::named::Named;
+
+// only public for proc macro
+pub mod events;
+
+pub(crate) mod message;
 
 /// Wrapper to send/receive messages via channels to a remote address
 pub struct Connection<P: Protocol> {
@@ -241,9 +241,6 @@ impl<P: Protocol> Connection<P> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::tests::protocol::*;
-
     // #[test]
     // fn test_notify_ack() -> Result<()> {
     //     let protocol = protocol();

--- a/lightyear/src/inputs/input_buffer.rs
+++ b/lightyear/src/inputs/input_buffer.rs
@@ -4,10 +4,9 @@ use std::fmt::Debug;
 use bevy::prelude::Resource;
 use serde::{Deserialize, Serialize};
 
-use crate::inputs::UserInput;
 use lightyear_macros::MessageInternal;
-use tracing::info;
 
+use crate::inputs::UserInput;
 use crate::protocol::BitSerializable;
 use crate::shared::tick_manager::Tick;
 

--- a/lightyear/src/inputs/mod.rs
+++ b/lightyear/src/inputs/mod.rs
@@ -2,11 +2,12 @@
 Handles dealing with inputs (keyboard presses, mouse clicks) sent from a player (client) to server
 */
 
-/// Defines an [`InputBuffer`](input_buffer::InputBuffer) buffer to store the inputs of a player for each tick
-pub mod input_buffer;
+use std::fmt::Debug;
 
 use crate::protocol::BitSerializable;
-use std::fmt::Debug;
+
+/// Defines an [`InputBuffer`](input_buffer::InputBuffer) buffer to store the inputs of a player for each tick
+pub mod input_buffer;
 
 // TODO: should we request that a user input is a message?
 pub trait UserInput:

--- a/lightyear/src/lib.rs
+++ b/lightyear/src/lib.rs
@@ -15,10 +15,11 @@ You can find more information in the [book](https://cbournhonesque.github.io/lig
 pub mod _reexport {
     pub use enum_delegate;
     pub use enum_dispatch::enum_dispatch;
+    pub use paste::paste;
+
     pub use lightyear_macros::{
         component_protocol_internal, message_protocol_internal, ChannelInternal, MessageInternal,
     };
-    pub use paste::paste;
 
     pub use crate::channel::builder::TickBufferChannel;
     pub use crate::channel::builder::{
@@ -109,6 +110,9 @@ pub mod prelude {
         pub use crate::client::sync::SyncConfig;
     }
     pub mod server {
+        #[cfg(feature = "webtransport")]
+        pub use wtransport::tls::Certificate;
+
         pub use crate::server::config::NetcodeConfig;
         pub use crate::server::config::ServerConfig;
         pub use crate::server::events::{
@@ -118,8 +122,6 @@ pub mod prelude {
         pub use crate::server::plugin::{PluginConfig, ServerPlugin};
         pub use crate::server::resource::Server;
         pub use crate::server::room::{RoomId, RoomMut, RoomRef};
-        #[cfg(feature = "webtransport")]
-        pub use wtransport::tls::Certificate;
     }
 }
 

--- a/lightyear/src/netcode/server.rs
+++ b/lightyear/src/netcode/server.rs
@@ -7,7 +7,7 @@ use tracing::{debug, error, trace};
 use crate::serialize::reader::ReadBuffer;
 use crate::serialize::wordbuffer::reader::ReadWordBuffer;
 use crate::transport::io::Io;
-use crate::transport::{PacketReceiver, PacketSender, Transport};
+use crate::transport::{PacketReceiver, PacketSender};
 
 use super::{
     bytes::Bytes,

--- a/lightyear/src/packet/header.rs
+++ b/lightyear/src/packet/header.rs
@@ -1,15 +1,11 @@
-use derive_more::{AddAssign, SubAssign};
-use std::collections::{HashMap, HashSet};
-use std::thread::current;
-use std::time::{Duration, Instant};
+use std::collections::HashMap;
 
-use crate::_reexport::{ReadyBuffer, TimeManager, WrappedTime};
 use bitcode::{Decode, Encode};
-use chrono::format::ParseErrorKind;
 use ringbuffer::{ConstGenericRingBuffer, RingBuffer};
 use serde::{Deserialize, Serialize};
-use tracing::{info, trace};
+use tracing::trace;
 
+use crate::_reexport::{TimeManager, WrappedTime};
 use crate::packet::packet::PacketId;
 use crate::packet::packet_type::PacketType;
 use crate::packet::stats_manager::PacketStatsManager;

--- a/lightyear/src/packet/message.rs
+++ b/lightyear/src/packet/message.rs
@@ -10,7 +10,6 @@ use crate::serialize::writer::WriteBuffer;
 use crate::shared::replication::entity_map::MapEntities;
 use crate::shared::tick_manager::Tick;
 use crate::utils::named::Named;
-use crate::utils::wrapping_id;
 use crate::utils::wrapping_id::wrapping_id;
 
 // strategies to avoid copying:

--- a/lightyear/src/packet/message_manager.rs
+++ b/lightyear/src/packet/message_manager.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::marker::PhantomData;
 
 use anyhow::{anyhow, Context};
-use tracing::{info, trace};
+use tracing::trace;
 
 use crate::channel::builder::ChannelContainer;
 use crate::channel::receivers::ChannelReceive;
@@ -259,12 +259,7 @@ mod tests {
     use std::collections::HashMap;
     use std::time::Duration;
 
-    use serde::{Deserialize, Serialize};
-
     use crate::_reexport::*;
-    use crate::channel::builder::{
-        ChannelDirection, ChannelMode, ChannelSettings, ReliableSettings,
-    };
     use crate::packet::message::MessageId;
     use crate::packet::packet::FRAGMENT_SIZE;
     use crate::prelude::*;

--- a/lightyear/src/packet/packet_manager.rs
+++ b/lightyear/src/packet/packet_manager.rs
@@ -1,6 +1,5 @@
 use std::collections::{BTreeMap, VecDeque};
 
-use crate::_reexport::TimeManager;
 use bitcode::encoding::Gamma;
 
 use crate::netcode::MAX_PACKET_SIZE;
@@ -616,7 +615,6 @@ impl PacketBuilder {
 #[cfg(test)]
 mod tests {
     use std::collections::{BTreeMap, VecDeque};
-    use std::time::Duration;
 
     use bytes::Bytes;
 

--- a/lightyear/src/packet/stats_manager.rs
+++ b/lightyear/src/packet/stats_manager.rs
@@ -1,8 +1,10 @@
+use std::time::Duration;
+
+use derive_more::{AddAssign, SubAssign};
+use tracing::trace;
+
 use crate::shared::time_manager::{TimeManager, WrappedTime};
 use crate::utils::ready_buffer::ReadyBuffer;
-use derive_more::{AddAssign, SubAssign};
-use std::time::Duration;
-use tracing::{info, trace};
 
 type PacketStatsBuffer = ReadyBuffer<WrappedTime, PacketStats>;
 

--- a/lightyear/src/protocol/component.rs
+++ b/lightyear/src/protocol/component.rs
@@ -1,11 +1,11 @@
 use std::fmt::Debug;
 use std::hash::Hash;
 
-use crate::client::components::{ComponentSyncMode, SyncComponent};
 use bevy::prelude::{App, Component, EntityWorldMut, World};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 
+use crate::client::components::ComponentSyncMode;
 use crate::connection::events::{
     IterComponentInsertEvent, IterComponentRemoveEvent, IterComponentUpdateEvent,
 };

--- a/lightyear/src/protocol/mod.rs
+++ b/lightyear/src/protocol/mod.rs
@@ -5,11 +5,11 @@
 //! Inputs, Messages and Components are all data structures that can be serialized and sent over the network.
 //! Channels are an abstraction over how the data will be sent over the network (reliability, ordering, etc.)
 
+use std::fmt::Debug;
+
 use bevy::prelude::App;
-use lightyear_macros::ChannelInternal;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
-use std::fmt::Debug;
 
 use crate::channel::builder::{Channel, ChannelSettings};
 use crate::inputs::UserInput;

--- a/lightyear/src/server/config.rs
+++ b/lightyear/src/server/config.rs
@@ -4,7 +4,6 @@ use std::time::Duration;
 use crate::netcode::Key;
 use crate::shared::config::SharedConfig;
 use crate::shared::ping::manager::PingConfig;
-use crate::transport::io::IoConfig;
 
 #[derive(Clone)]
 pub struct NetcodeConfig {

--- a/lightyear/src/server/connection.rs
+++ b/lightyear/src/server/connection.rs
@@ -1,23 +1,15 @@
 //! Wrapper around [`crate::connection::Connection`] that adds server-specific functionality
-use std::pin::pin;
-use std::time::Duration;
-
-use crate::_reexport::ReadBuffer;
 use anyhow::Result;
 use bevy::ecs::component::Tick as BevyTick;
 use bevy::prelude::World;
 use tracing::trace;
 
-use crate::channel::builder::PingChannel;
+use crate::_reexport::ReadBuffer;
 use crate::connection::events::{ConnectionEvents, IterMessageEvent};
-use crate::connection::message::ProtocolMessage;
 use crate::inputs::input_buffer::{InputBuffer, InputMessage};
-use crate::packet::packet_manager::Payload;
-use crate::protocol::channel::{ChannelKind, ChannelRegistry};
+use crate::protocol::channel::ChannelRegistry;
 use crate::protocol::Protocol;
-use crate::shared::ping::manager::{PingConfig, PingManager};
-use crate::shared::ping::message::{Ping, Pong, SyncMessage};
-use crate::shared::tick_manager::TickManager;
+use crate::shared::ping::manager::PingConfig;
 use crate::shared::time_manager::TimeManager;
 
 /// Wrapper around a [`crate::connection::Connection`] with server-specific logic

--- a/lightyear/src/server/events.rs
+++ b/lightyear/src/server/events.rs
@@ -9,7 +9,6 @@ use crate::connection::events::{
 use crate::netcode::ClientId;
 use crate::packet::message::Message;
 use crate::protocol::Protocol;
-use crate::shared::ping::message::{Ping, Pong};
 
 pub struct ServerEvents<P: Protocol> {
     // have to handle disconnects separately because the [`ConnectionEvents`] are removed upon disconnection

--- a/lightyear/src/server/plugin.rs
+++ b/lightyear/src/server/plugin.rs
@@ -17,7 +17,6 @@ use crate::server::resource::Server;
 use crate::server::room::RoomPlugin;
 use crate::server::systems::{clear_events, is_ready_to_send};
 use crate::shared::plugin::SharedPlugin;
-use crate::shared::replication::resources::ReplicationData;
 use crate::shared::replication::systems::add_replication_send_systems;
 use crate::shared::sets::ReplicationSet;
 use crate::shared::sets::{FixedUpdateSet, MainSet};

--- a/lightyear/src/server/resource.rs
+++ b/lightyear/src/server/resource.rs
@@ -4,12 +4,12 @@ use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::time::Duration;
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result};
 use bevy::ecs::component::Tick as BevyTick;
 use bevy::prelude::{Entity, Resource, World};
 use bevy::utils::HashSet;
 use crossbeam_channel::Sender;
-use tracing::{debug, debug_span, info, trace, trace_span, warn};
+use tracing::{debug, debug_span, info, trace, trace_span};
 
 use crate::channel::builder::Channel;
 use crate::inputs::input_buffer::InputBuffer;
@@ -18,8 +18,6 @@ use crate::packet::message::Message;
 use crate::protocol::channel::ChannelKind;
 use crate::protocol::Protocol;
 use crate::server::room::{RoomId, RoomManager, RoomMut, RoomRef};
-use crate::shared::ping::manager::PingManager;
-use crate::shared::ping::message::SyncMessage;
 use crate::shared::replication::components::{NetworkTarget, Replicate};
 use crate::shared::replication::components::{ShouldBeInterpolated, ShouldBePredicted};
 use crate::shared::replication::ReplicationSend;

--- a/lightyear/src/server/room.rs
+++ b/lightyear/src/server/room.rs
@@ -1,17 +1,17 @@
-use crate::netcode::ClientId;
-use crate::prelude::{MainSet, Replicate, ReplicationSet};
-use crate::protocol::Protocol;
-use crate::server::resource::Server;
-use crate::server::systems::is_ready_to_send;
-use crate::shared::replication::components::DespawnTracker;
-use crate::utils::wrapping_id::wrapping_id;
 use bevy::app::App;
 use bevy::prelude::{
     Entity, IntoSystemConfigs, IntoSystemSetConfigs, Plugin, PostUpdate, Query, RemovedComponents,
     Res, ResMut, Resource, SystemSet,
 };
 use bevy::utils::{HashMap, HashSet};
-use tracing::info;
+
+use crate::netcode::ClientId;
+use crate::prelude::{Replicate, ReplicationSet};
+use crate::protocol::Protocol;
+use crate::server::resource::Server;
+use crate::server::systems::is_ready_to_send;
+use crate::shared::replication::components::DespawnTracker;
+use crate::utils::wrapping_id::wrapping_id;
 
 // Id for a room, used to perform interest management
 // An entity will be replicated to a client only if they are in the same room
@@ -448,15 +448,18 @@ fn clean_entity_despawns<P: Protocol>(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use std::time::Duration;
+
+    use bevy::ecs::system::RunSystemOnce;
+    use bevy::prelude::Events;
+
     use crate::prelude::client::*;
     use crate::prelude::*;
     use crate::shared::replication::components::ReplicationMode;
     use crate::tests::protocol::*;
     use crate::tests::stepper::{BevyStepper, Step};
-    use bevy::ecs::system::RunSystemOnce;
-    use bevy::prelude::{EventReader, Events};
-    use std::time::Duration;
+
+    use super::*;
 
     fn setup() -> BevyStepper {
         let frame_duration = Duration::from_millis(10);

--- a/lightyear/src/server/systems.rs
+++ b/lightyear/src/server/systems.rs
@@ -1,14 +1,12 @@
 //! Defines the server bevy systems and run conditions
 use bevy::prelude::{Events, Mut, Res, ResMut, Time, World};
-use tracing::{debug, error, info, trace};
+use tracing::{debug, error, trace};
 
 use crate::connection::events::{IterEntityDespawnEvent, IterEntitySpawnEvent};
-use crate::netcode::ClientId;
 use crate::protocol::message::MessageProtocol;
 use crate::protocol::Protocol;
 use crate::server::events::{ConnectEvent, DisconnectEvent, EntityDespawnEvent, EntitySpawnEvent};
 use crate::server::resource::Server;
-use crate::shared::replication::resources::ReplicationData;
 use crate::shared::replication::ReplicationSend;
 
 pub(crate) fn receive<P: Protocol>(world: &mut World) {
@@ -90,6 +88,8 @@ pub(crate) fn send<P: Protocol>(mut server: ResMut<Server<P>>) {
     server.send_packets().unwrap();
 
     server.new_clients.clear();
+
+    // TODO: clear the dependency graph for replication groups send
 }
 
 pub(crate) fn clear_events<P: Protocol>(mut server: ResMut<Server<P>>) {

--- a/lightyear/src/shared/config.rs
+++ b/lightyear/src/shared/config.rs
@@ -2,7 +2,6 @@
 use std::time::Duration;
 
 use crate::shared::log::LogConfig;
-
 use crate::shared::tick_manager::TickConfig;
 
 #[derive(Clone)]

--- a/lightyear/src/shared/log.rs
+++ b/lightyear/src/shared/log.rs
@@ -6,11 +6,8 @@ use bevy::prelude::{App, Plugin};
 use metrics_tracing_context::{MetricsLayer, TracingContextLayer};
 #[cfg(feature = "metrics")]
 use metrics_util::layers::Layer;
-
-use tracing::{warn, Level};
+use tracing::Level;
 use tracing_subscriber::{prelude::*, registry::Registry, EnvFilter};
-
-use tracing_log::LogTracer;
 
 /// Adds logging to Apps.
 ///

--- a/lightyear/src/shared/ping/manager.rs
+++ b/lightyear/src/shared/ping/manager.rs
@@ -1,12 +1,9 @@
 //! Manages sending/receiving pings and computing network statistics
 use std::time::Duration;
 
-use bevy::prelude::Res;
 use bevy::time::Stopwatch;
-use tracing::{debug, error, info, trace};
+use tracing::{error, trace};
 
-use crate::client::resource::Client;
-use crate::packet::packet::PacketId;
 use crate::protocol::Protocol;
 use crate::shared::ping::message::{Ping, Pong, SyncMessage};
 use crate::shared::ping::store::{PingId, PingStore};

--- a/lightyear/src/shared/ping/message.rs
+++ b/lightyear/src/shared/ping/message.rs
@@ -1,11 +1,7 @@
 //! Defines the actual ping/pong messages
-use crate::prelude::MapEntities;
-use bevy::prelude::Entity;
-use bevy::utils::EntityHashSet;
 use serde::{Deserialize, Serialize};
 
 use crate::shared::ping::store::PingId;
-use crate::shared::tick_manager::Tick;
 use crate::shared::time_manager::WrappedTime;
 
 /// Ping message; the remote should response immediately with a pong

--- a/lightyear/src/shared/ping/store.rs
+++ b/lightyear/src/shared/ping/store.rs
@@ -1,7 +1,6 @@
 //! Store the latest pings sent to remote
 use crate::shared::time_manager::WrappedTime;
 use crate::utils::sequence_buffer::SequenceBuffer;
-use crate::utils::wrapping_id;
 use crate::utils::wrapping_id::wrapping_id;
 
 wrapping_id!(PingId);

--- a/lightyear/src/shared/replication/components.rs
+++ b/lightyear/src/shared/replication/components.rs
@@ -1,14 +1,15 @@
 //! Components used for replication
-use crate::channel::builder::{Channel, EntityActionsChannel, EntityUpdatesChannel};
+use bevy::prelude::{Component, Entity};
+use bevy::utils::{EntityHashSet, HashMap, HashSet};
+use serde::{Deserialize, Serialize};
+
+use lightyear_macros::MessageInternal;
+
+use crate::channel::builder::Channel;
 use crate::client::components::{ComponentSyncMode, SyncComponent};
 use crate::netcode::ClientId;
 use crate::prelude::{EntityMapper, MapEntities};
-use crate::protocol::channel::ChannelKind;
-use crate::server::room::{ClientVisibility, RoomId};
-use bevy::prelude::{Component, Entity};
-use bevy::utils::{EntityHashSet, HashMap, HashSet};
-use lightyear_macros::MessageInternal;
-use serde::{Deserialize, Serialize};
+use crate::server::room::ClientVisibility;
 
 /// Component inserted to each replicable entities, to detect when they are despawned
 #[derive(Component, Clone, Copy)]
@@ -187,7 +188,6 @@ impl<'a> MapEntities<'a> for ShouldBePredicted {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::prelude::ClientId;
 
     #[test]
     fn test_network_target() {

--- a/lightyear/src/shared/replication/entity_map.rs
+++ b/lightyear/src/shared/replication/entity_map.rs
@@ -10,6 +10,7 @@ pub trait EntityMapper {
 }
 
 impl<T: EntityMapper> EntityMapper for &T {
+    #[inline]
     fn map(&self, entity: Entity) -> Option<Entity> {
         (*self).map(entity)
     }
@@ -29,6 +30,7 @@ pub struct PredictedEntityMap {
 }
 
 impl EntityMapper for PredictedEntityMap {
+    #[inline]
     fn map(&self, entity: Entity) -> Option<Entity> {
         self.remote_to_predicted.get(&entity).copied()
     }
@@ -41,6 +43,7 @@ pub struct InterpolatedEntityMap {
 }
 
 impl EntityMapper for InterpolatedEntityMap {
+    #[inline]
     fn map(&self, entity: Entity) -> Option<Entity> {
         self.remote_to_interpolated.get(&entity).copied()
     }
@@ -53,10 +56,12 @@ impl RemoteEntityMap {
         self.local_to_remote.insert(local_entity, remote_entity);
     }
 
+    #[inline]
     pub(crate) fn get_local(&self, remote_entity: Entity) -> Option<&Entity> {
         self.remote_to_local.get(&remote_entity)
     }
 
+    #[inline]
     pub(crate) fn get_remote(&self, local_entity: Entity) -> Option<&Entity> {
         self.local_to_remote.get(&local_entity)
     }
@@ -115,6 +120,7 @@ impl RemoteEntityMap {
 }
 
 impl EntityMapper for RemoteEntityMap {
+    #[inline]
     fn map(&self, entity: Entity) -> Option<Entity> {
         self.get_local(entity).copied()
     }
@@ -130,6 +136,7 @@ pub trait MapEntities<'a> {
 }
 
 impl<'a> MapEntities<'a> for Entity {
+    #[inline]
     fn map_entities(&mut self, entity_mapper: Box<dyn EntityMapper + 'a>) {
         if let Some(local) = entity_mapper.map(*self) {
             *self = local;
@@ -141,6 +148,7 @@ impl<'a> MapEntities<'a> for Entity {
         }
     }
 
+    #[inline]
     fn entities(&self) -> EntityHashSet<Entity> {
         EntityHashSet::from_iter(vec![*self])
     }
@@ -148,11 +156,12 @@ impl<'a> MapEntities<'a> for Entity {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use crate::prelude::client::*;
     use crate::prelude::*;
     use crate::tests::protocol::*;
     use crate::tests::stepper::{BevyStepper, Step};
-    use std::time::Duration;
 
     // An entity gets replicated from server to client,
     // then a component gets removed from that entity on server,

--- a/lightyear/src/shared/replication/resources.rs
+++ b/lightyear/src/shared/replication/resources.rs
@@ -1,10 +1,10 @@
 //! Bevy [`bevy::prelude::Resource`]s used for replication
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
-use crate::netcode::ClientId;
-use crate::shared::replication::components::Replicate;
 use bevy::ecs::component::ComponentId;
 use bevy::prelude::{Entity, FromWorld, Resource, World};
+
+use crate::shared::replication::components::Replicate;
 
 #[derive(Resource)]
 /// Internal resource used to keep track of the state of replication

--- a/lightyear/src/shared/replication/systems.rs
+++ b/lightyear/src/shared/replication/systems.rs
@@ -1,20 +1,16 @@
 //! Bevy [`bevy::prelude::System`]s used for replication
-use bevy::ecs::system::SystemChangeTick;
 use std::ops::Deref;
 
-use crate::connection::events::ConnectionEvents;
+use bevy::ecs::system::SystemChangeTick;
 use bevy::prelude::{
-    Added, App, Commands, Component, DetectChanges, Entity, EventReader, IntoSystemConfigs, Mut,
-    PostUpdate, Query, Ref, RemovedComponents, ResMut,
+    Added, App, Commands, Component, DetectChanges, Entity, IntoSystemConfigs, PostUpdate, Query,
+    Ref, RemovedComponents, ResMut,
 };
-use bevy::utils::HashSet;
-use tracing::{debug, info};
+use tracing::debug;
 
-use crate::netcode::ClientId;
 use crate::prelude::NetworkTarget;
 use crate::protocol::component::IntoKind;
 use crate::protocol::Protocol;
-use crate::server::events::ConnectEvent;
 use crate::server::room::ClientVisibility;
 use crate::shared::replication::components::{DespawnTracker, Replicate, ReplicationMode};
 use crate::shared::replication::resources::ReplicationData;

--- a/lightyear/src/tests/examples/connection_soak.rs
+++ b/lightyear/src/tests/examples/connection_soak.rs
@@ -1,11 +1,11 @@
 //! The connection soak test how sending messages/packets works with a real connection, and loss/jitter
 //! We put this test here because it uses some private methods.
-use bevy::ecs::component::Tick as BevyTick;
-use bevy::prelude::World;
 use std::net::SocketAddr;
 use std::str::FromStr;
 use std::time::Duration;
 
+use bevy::ecs::component::Tick as BevyTick;
+use bevy::prelude::World;
 use rand::Rng;
 use tracing::debug;
 

--- a/lightyear/src/tests/stepper.rs
+++ b/lightyear/src/tests/stepper.rs
@@ -5,7 +5,6 @@ use std::time::Duration;
 use bevy::prelude::{App, Mut, PluginGroup, Real, Time};
 use bevy::time::TimeUpdateStrategy;
 use bevy::MinimalPlugins;
-use tracing_subscriber::fmt::format::FmtSpan;
 
 use crate::netcode::generate_key;
 use crate::prelude::client::{
@@ -14,7 +13,6 @@ use crate::prelude::client::{
 };
 use crate::prelude::server::{NetcodeConfig, Server, ServerConfig};
 use crate::prelude::*;
-
 use crate::tests::protocol::{protocol, MyProtocol};
 
 /// Helpers to setup a bevy app where I can just step the world easily

--- a/lightyear/src/transport/io.rs
+++ b/lightyear/src/transport/io.rs
@@ -6,18 +6,17 @@ use std::net::{IpAddr, SocketAddr};
 
 #[cfg(feature = "metrics")]
 use metrics;
+#[cfg(feature = "webtransport")]
+use wtransport::tls::Certificate;
 
 use crate::transport::conditioner::{ConditionedPacketReceiver, LinkConditionerConfig};
-use crate::transport::local::{LocalChannel, LOCAL_SOCKET};
+use crate::transport::local::LocalChannel;
 use crate::transport::udp::UdpSocket;
-
 #[cfg(feature = "webtransport")]
 use crate::transport::webtransport::client::WebTransportClientSocket;
 #[cfg(feature = "webtransport")]
 use crate::transport::webtransport::server::WebTransportServerSocket;
 use crate::transport::{PacketReceiver, PacketSender, Transport};
-#[cfg(feature = "webtransport")]
-use wtransport::tls::Certificate;
 
 #[derive(Clone)]
 pub enum TransportConfig {

--- a/lightyear/src/transport/webtransport/server.rs
+++ b/lightyear/src/transport/webtransport/server.rs
@@ -1,19 +1,20 @@
 //! WebTransport client implementation.
-use crate::transport::webtransport::MTU;
-use crate::transport::{PacketReceiver, PacketSender, Transport};
-use bevy::tasks::{IoTaskPool, TaskPool};
 use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::{Arc, Mutex};
+
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::error::TryRecvError;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
-use tracing::{debug, error, info};
+use tracing::{debug, error};
 use wtransport;
 use wtransport::datagram::Datagram;
 use wtransport::endpoint::IncomingSession;
 use wtransport::tls::Certificate;
-use wtransport::{ClientConfig, ServerConfig};
+use wtransport::ServerConfig;
+
+use crate::transport::webtransport::MTU;
+use crate::transport::{PacketReceiver, PacketSender, Transport};
 
 /// WebTransport client socket
 pub struct WebTransportServerSocket {

--- a/lightyear/src/utils/bevy.rs
+++ b/lightyear/src/utils/bevy.rs
@@ -1,7 +1,8 @@
 //! Implement lightyear traits for some common bevy types
-use crate::prelude::{EntityMapper, MapEntities, Message, Named, RemoteEntityMap};
 use bevy::prelude::{Entity, Transform};
 use bevy::utils::EntityHashSet;
+
+use crate::prelude::{EntityMapper, MapEntities, Message, Named};
 
 impl Named for Transform {
     fn name(&self) -> String {

--- a/lightyear/src/utils/named.rs
+++ b/lightyear/src/utils/named.rs
@@ -4,7 +4,7 @@
 // - derive Reflect for Messages
 // - require to derive Reflect for Components ?
 
-use std::fmt::{Debug, Formatter};
+use std::fmt::Debug;
 
 pub trait TypeNamed {
     fn name() -> String;


### PR DESCRIPTION
- Entity mapping for prediction/replication was done in the replication stage; this introduced unnecessary coupling between replication and prediction/interpolation
- the current approach to deal with entity hierarchies was complicated (creating a graph of dependencies) and could not handle hierarchies. The new approach is much simpler: simply handle spawns for all entities in a group before anything else.