### PR TITLE
Cleaning old replication group metadata

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -45,11 +45,20 @@
           - actions with lower-message-id are saved. When group is deleted, we transfer them to the new group.
             - PROBLEM = lower-message-id could just be past messages getting duplicated for some reason.
               - we could include a generation number in the group message. Even a u8 or even fewer bits is fine (with cycling)
+              - maybe even just 1 bit, 0 or 1 that we cycle.
               - if we receive a message with a bigger generation number, we just buffer it
               - i.e. we 
               - but at this point why not just use a u32 for the group id? (the first 32 bits of the Entity)
+                - one problem is that Entities are not guaranteed to have separate indexes. You could have multiple entities with the same index.
+                  -  FROM BEVY DOCS
+                  -  /// No two simultaneously-live entities share the same index, but dead entities' indices may collide
+                     /// with both live and dead entities.
                 - Group = FromEntity. Entity gets despawned. We delete the group on server/client. It gets recreated, and we re-use its entity for our GroupId.
                   - its ok to reuse the entity's index and not the gen, because the new entity will have the same index, but a new generation.
+                  - if it uses another index, its ok too. (we just create a new group.)
+                    - can that index already belong to another group?
+                    - but what if: E1 is in group, E2 is in group. Group is named E1. Then E1 is despawned, and we create another entity E3 that has the same 
+                      index as E1? that means we have to use the entire entity as the group id
                   - then the second group would have the same index, but new generation.
                   - We only use index to find channel, etc; We use generation as we said earlier
                 - Group = FromEntity. We send despawn from VisLost. We delete the group on server/client. We recreate the group

--- a/examples/interest_management/client.rs
+++ b/examples/interest_management/client.rs
@@ -120,7 +120,7 @@ pub(crate) fn buffer_input(mut client: ResMut<Client<MyProtocol>>, keypress: Res
         direction.right = true;
     }
     if !direction.is_none() {
-        client.add_input(Inputs::Direction(direction));
+        return client.add_input(Inputs::Direction(direction));
     }
     if keypress.pressed(KeyCode::Delete) {
         // currently, inputs is an enum and we can only add one input per tick
@@ -148,8 +148,8 @@ pub(crate) fn movement(
     for input in input_reader.read() {
         if let Some(input) = input.input() {
             debug!(?input, "read input");
-            for mut position in position_query.iter_mut() {
-                shared_movement_behaviour(&mut position, input);
+            for position in position_query.iter_mut() {
+                shared_movement_behaviour(position, input);
             }
         }
     }
@@ -164,7 +164,6 @@ pub(crate) fn receive_message1(mut reader: EventReader<MessageEvent<Message1>>) 
 
 // When the predicted copy of the client-owned entity is spawned, do stuff
 // - assign it a different saturation
-// - keep track of it in the Global resource
 pub(crate) fn handle_predicted_spawn(mut predicted: Query<&mut PlayerColor, Added<Predicted>>) {
     for mut color in predicted.iter_mut() {
         color.0.set_s(0.3);
@@ -173,7 +172,6 @@ pub(crate) fn handle_predicted_spawn(mut predicted: Query<&mut PlayerColor, Adde
 
 // When the predicted copy of the client-owned entity is spawned, do stuff
 // - assign it a different saturation
-// - keep track of it in the Global resource
 pub(crate) fn handle_interpolated_spawn(
     mut interpolated: Query<&mut PlayerColor, Added<Interpolated>>,
 ) {

--- a/examples/interest_management/server.rs
+++ b/examples/interest_management/server.rs
@@ -14,7 +14,7 @@ pub struct MyServerPlugin {
     pub(crate) transport: Transports,
 }
 
-const GRID_SIZE: f32 = 50.0;
+const GRID_SIZE: f32 = 200.0;
 const NUM_CIRCLES: i32 = 10;
 const INTEREST_RADIUS: f32 = 200.0;
 
@@ -122,7 +122,7 @@ pub(crate) fn handle_connections(
         let room_id = RoomId((*client_id) as u16);
         server.room_mut(room_id).add_client(*client_id);
         server.room_mut(PLAYER_ROOM).add_client(*client_id);
-        // also add the player entity to that room
+        // also add the player entity to that room (so that the client can always see their own player)
         server.room_mut(room_id).add_entity(entity.id());
         server.room_mut(PLAYER_ROOM).add_entity(entity.id());
     }
@@ -186,8 +186,8 @@ pub(crate) fn movement(
                 server.tick()
             );
             if let Some(player_entity) = global.client_id_to_entity_id.get(client_id) {
-                if let Ok(mut position) = position_query.get_mut(*player_entity) {
-                    shared_movement_behaviour(&mut position, input);
+                if let Ok(position) = position_query.get_mut(*player_entity) {
+                    shared_movement_behaviour(position, input);
                 }
             }
         }

--- a/examples/interest_management/shared.rs
+++ b/examples/interest_management/shared.rs
@@ -30,13 +30,13 @@ pub struct SharedPlugin;
 
 impl Plugin for SharedPlugin {
     fn build(&self, app: &mut App) {
-        // app.add_plugins(WorldInspectorPlugin::new());
+        app.add_plugins(WorldInspectorPlugin::new());
         app.add_systems(Update, (draw_boxes, draw_circles));
     }
 }
 
 // This system defines how we update the player's positions when we receive an input
-pub(crate) fn shared_movement_behaviour(position: &mut Position, input: &Inputs) {
+pub(crate) fn shared_movement_behaviour(mut position: Mut<Position>, input: &Inputs) {
     const MOVE_SPEED: f32 = 10.0;
     match input {
         Inputs::Direction(direction) => {

--- a/examples/simple_box/client.rs
+++ b/examples/simple_box/client.rs
@@ -116,7 +116,7 @@ pub(crate) fn buffer_input(mut client: ResMut<Client<MyProtocol>>, keypress: Res
         direction.right = true;
     }
     if !direction.is_none() {
-        client.add_input(Inputs::Direction(direction));
+        return client.add_input(Inputs::Direction(direction));
     }
     if keypress.pressed(KeyCode::Delete) {
         // currently, inputs is an enum and we can only add one input per tick

--- a/lightyear/src/client/connection.rs
+++ b/lightyear/src/client/connection.rs
@@ -254,6 +254,7 @@ impl<P: Protocol> Connection<P> {
                             self.replication_receiver.apply_world(
                                 world,
                                 replication,
+                                group,
                                 &mut self.events,
                             );
                         });

--- a/lightyear/src/client/interpolation/interpolation_history.rs
+++ b/lightyear/src/client/interpolation/interpolation_history.rs
@@ -146,9 +146,9 @@ pub(crate) fn apply_confirmed_update<T: SyncComponent, P: Protocol>(
                                 );
                                 continue;
                             };
-                            let Some(channel) = client
+                            let Some(tick) = client
                                 .replication_receiver()
-                                .channel_by_local(confirmed_entity)
+                                .get_confirmed_tick(confirmed_entity)
                             else {
                                 error!(
                                     "Could not find replication channel for entity {:?}",
@@ -159,9 +159,9 @@ pub(crate) fn apply_confirmed_update<T: SyncComponent, P: Protocol>(
                             // map any entities from confirmed to predicted
                             let mut component = confirmed_component.deref().clone();
                             component.map_entities(Box::new(&manager.interpolated_entity_map));
-                            trace!(component = ?component.name(), tick = ?channel.latest_tick, "adding confirmed update to history");
+                            trace!(component = ?component.name(), tick = ?tick, "adding confirmed update to history");
                             // assign the history at the value that the entity currently is
-                            history.buffer.add_item(channel.latest_tick, component);
+                            history.buffer.add_item(tick, component);
                         }
                         // for sync-components, we just match the confirmed component
                         ComponentSyncMode::Simple => {

--- a/lightyear/src/client/prediction/predicted_history.rs
+++ b/lightyear/src/client/prediction/predicted_history.rs
@@ -1,7 +1,9 @@
 use std::ops::Deref;
 
+use crate::_reexport::ShouldBePredicted;
 use bevy::prelude::{
-    Commands, Component, DetectChanges, Entity, Query, Ref, RemovedComponents, Res, With, Without,
+    Commands, Component, DetectChanges, Entity, Or, Query, Ref, RemovedComponents, Res, With,
+    Without,
 };
 use tracing::{error, info};
 
@@ -120,7 +122,13 @@ pub fn add_component_history<C: SyncComponent + Named, P: Protocol>(
     manager: Res<PredictionManager>,
     mut commands: Commands,
     client: Res<Client<P>>,
-    predicted_entities: Query<(Entity, Option<Ref<C>>), Without<PredictionHistory<C>>>,
+    predicted_entities: Query<
+        (Entity, Option<Ref<C>>),
+        (
+            Without<PredictionHistory<C>>,
+            Or<(With<Predicted>, With<ShouldBePredicted>)>,
+        ),
+    >,
     confirmed_entities: Query<(Entity, &Confirmed, Option<Ref<C>>)>,
 ) {
     // add history when a predicted component gets added

--- a/lightyear/src/client/prediction/rollback.rs
+++ b/lightyear/src/client/prediction/rollback.rs
@@ -107,9 +107,9 @@ pub(crate) fn client_rollback_check<C: SyncComponent, P: Protocol>(
             // - Confirmed contains the server state at the tick
             // - History contains the history of what we predicted at the tick
             // get the tick that the confirmed entity is at
-            let Some(channel) = client
+            let Some(tick) = client
                 .replication_receiver()
-                .channel_by_local(confirmed_entity)
+                .get_confirmed_tick(confirmed_entity)
             else {
                 error!(
                     "Could not find replication channel for entity {:?}",
@@ -117,7 +117,6 @@ pub(crate) fn client_rollback_check<C: SyncComponent, P: Protocol>(
                 );
                 continue;
             };
-            let tick = channel.latest_tick;
 
             // Note: it may seem like an optimization to only compare the history/server-state if we are not sure
             // that we should rollback (RollbackState::Default)

--- a/lightyear/src/client/systems.rs
+++ b/lightyear/src/client/systems.rs
@@ -87,6 +87,7 @@ pub(crate) fn send<P: Protocol>(mut client: ResMut<Client<P>>) {
     });
     // send buffered packets to io
     client.send_packets().unwrap();
+    info!(receive_channels = ?client.replication_receiver().group_channels);
 }
 
 pub(crate) fn is_ready_to_send<P: Protocol>(client: Res<Client<P>>) -> bool {

--- a/lightyear/src/server/connection.rs
+++ b/lightyear/src/server/connection.rs
@@ -392,8 +392,12 @@ impl<P: Protocol> Connection<P> {
                     trace!(?group, ?replication_list, "read replication messages");
                     replication_list.into_iter().for_each(|(_, replication)| {
                         // TODO: we could include the server tick when this replication_message was sent.
-                        self.replication_receiver
-                            .apply_world(world, replication, &mut self.events);
+                        self.replication_receiver.apply_world(
+                            world,
+                            replication,
+                            group,
+                            &mut self.events,
+                        );
                     });
                 }
             }

--- a/lightyear/src/shared/replication/entity_map.rs
+++ b/lightyear/src/shared/replication/entity_map.rs
@@ -115,6 +115,10 @@ impl RemoteEntityMap {
         &self.local_to_remote
     }
 
+    pub(crate) fn is_empty(&self) -> bool {
+        self.remote_to_local.is_empty() && self.local_to_remote.is_empty()
+    }
+
     fn clear(&mut self) {
         self.local_to_remote.clear();
         self.remote_to_local.clear();

--- a/lightyear/src/shared/replication/mod.rs
+++ b/lightyear/src/shared/replication/mod.rs
@@ -69,6 +69,10 @@ impl<C, K: Hash + Eq> Default for EntityActions<C, K> {
 #[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
 pub struct EntityActionMessage<C, K: Hash + Eq> {
     sequence_id: MessageId,
+    // used to detect if this was for a new 'generation' of the group
+    // groups change generation whenever all the entities of the group have sent/received a despawn event
+    // The next group that re-uses this entity will have a different generation (the bit is flipped)
+    generation_bit: bool,
     // we use vec but the order of entities should not matter
     pub(crate) actions: Vec<(Entity, EntityActions<C, K>)>,
 }

--- a/lightyear/src/shared/replication/send.rs
+++ b/lightyear/src/shared/replication/send.rs
@@ -304,6 +304,7 @@ impl<P: Protocol> ReplicationSender<P> {
                 group_id,
                 ReplicationMessageData::Actions(EntityActionMessage {
                     sequence_id: message_id,
+                    generation_bit: false,
                     // TODO: maybe we can just send the HashMap directly?
                     actions: Vec::from_iter(actions.into_iter()),
                 }),

--- a/lightyear/src/shared/replication/systems.rs
+++ b/lightyear/src/shared/replication/systems.rs
@@ -69,7 +69,8 @@ fn send_entity_despawn<P: Protocol, R: ReplicationSend<P>>(
                     if replicate.replication_target.should_send_to(client_id)
                         && matches!(visibility, ClientVisibility::Lost)
                     {
-                        debug!("sending entity despawn for entity: {:?}", entity);
+                        trace!("sending entity despawn for entity: {:?}", entity);
+                        // TODO: don't unwrap but handle errors
                         sender
                             .prepare_entity_despawn(
                                 entity,
@@ -122,7 +123,7 @@ fn send_entity_spawn<P: Protocol, R: ReplicationSend<P>>(
                         if replicate.replication_target.should_send_to(client_id) {
                             match visibility {
                                 ClientVisibility::Gained => {
-                                    debug!("send entity spawn to gained");
+                                    trace!("send entity spawn to gained");
                                     sender
                                         .prepare_entity_spawn(
                                             entity,


### PR DESCRIPTION
I wanted to add a system to clean out old replication group metadata once all the entities in the replication group had been despawned.
The crux of the idea was:
- on send/receive: delete a group channel whenever all the entities of the group have a despawn message
- we could have some out-of-order messages for a new group with the same group_id
- to handle them we can:
  - actions: detect actions for the new group either via a generation_bit or if message_id < next_message_id (which cannot happen because we have replay protection). Then we buffer the message in a channel for the future group
  - updates: detect updates for the new group because they will have a last_action_tick that is >= to the tick of one the actions of the new group. Buffer the message in a channel for the future group
- in apply_world: when we delete the old group, we check if we have any updates for the future group, we apply them immediately in apply_world (after the despawn).


Ultimately I decided that this is too complicated and not worth it.

TODO: I will have to think more to see if the current system where we don't cleanup group_channels is problematic.

Also, the group channels don't take much size because:
- all actions should be drained
- only updates from before the despawn, but which arrive after the despawn message might get stored in the group channel indefinitely. 

- we should just add a way to clear all the updates that have tick < the latest action tick. Do it in read_buffered_updates with drain