### PR TITLE
Small replication improvements

### DIFF
--- a/examples/interest_management/client.rs
+++ b/examples/interest_management/client.rs
@@ -120,7 +120,7 @@ pub(crate) fn buffer_input(mut client: ResMut<Client<MyProtocol>>, keypress: Res
         direction.right = true;
     }
     if !direction.is_none() {
-        client.add_input(Inputs::Direction(direction));
+        return client.add_input(Inputs::Direction(direction));
     }
     if keypress.pressed(KeyCode::Delete) {
         // currently, inputs is an enum and we can only add one input per tick
@@ -148,8 +148,8 @@ pub(crate) fn movement(
     for input in input_reader.read() {
         if let Some(input) = input.input() {
             debug!(?input, "read input");
-            for mut position in position_query.iter_mut() {
-                shared_movement_behaviour(&mut position, input);
+            for position in position_query.iter_mut() {
+                shared_movement_behaviour(position, input);
             }
         }
     }
@@ -164,7 +164,6 @@ pub(crate) fn receive_message1(mut reader: EventReader<MessageEvent<Message1>>) 
 
 // When the predicted copy of the client-owned entity is spawned, do stuff
 // - assign it a different saturation
-// - keep track of it in the Global resource
 pub(crate) fn handle_predicted_spawn(mut predicted: Query<&mut PlayerColor, Added<Predicted>>) {
     for mut color in predicted.iter_mut() {
         color.0.set_s(0.3);
@@ -173,7 +172,6 @@ pub(crate) fn handle_predicted_spawn(mut predicted: Query<&mut PlayerColor, Adde
 
 // When the predicted copy of the client-owned entity is spawned, do stuff
 // - assign it a different saturation
-// - keep track of it in the Global resource
 pub(crate) fn handle_interpolated_spawn(
     mut interpolated: Query<&mut PlayerColor, Added<Interpolated>>,
 ) {

--- a/examples/interest_management/server.rs
+++ b/examples/interest_management/server.rs
@@ -14,7 +14,7 @@ pub struct MyServerPlugin {
     pub(crate) transport: Transports,
 }
 
-const GRID_SIZE: f32 = 50.0;
+const GRID_SIZE: f32 = 200.0;
 const NUM_CIRCLES: i32 = 10;
 const INTEREST_RADIUS: f32 = 200.0;
 
@@ -122,7 +122,7 @@ pub(crate) fn handle_connections(
         let room_id = RoomId((*client_id) as u16);
         server.room_mut(room_id).add_client(*client_id);
         server.room_mut(PLAYER_ROOM).add_client(*client_id);
-        // also add the player entity to that room
+        // also add the player entity to that room (so that the client can always see their own player)
         server.room_mut(room_id).add_entity(entity.id());
         server.room_mut(PLAYER_ROOM).add_entity(entity.id());
     }
@@ -186,8 +186,8 @@ pub(crate) fn movement(
                 server.tick()
             );
             if let Some(player_entity) = global.client_id_to_entity_id.get(client_id) {
-                if let Ok(mut position) = position_query.get_mut(*player_entity) {
-                    shared_movement_behaviour(&mut position, input);
+                if let Ok(position) = position_query.get_mut(*player_entity) {
+                    shared_movement_behaviour(position, input);
                 }
             }
         }

--- a/examples/interest_management/shared.rs
+++ b/examples/interest_management/shared.rs
@@ -30,13 +30,13 @@ pub struct SharedPlugin;
 
 impl Plugin for SharedPlugin {
     fn build(&self, app: &mut App) {
-        // app.add_plugins(WorldInspectorPlugin::new());
+        app.add_plugins(WorldInspectorPlugin::new());
         app.add_systems(Update, (draw_boxes, draw_circles));
     }
 }
 
 // This system defines how we update the player's positions when we receive an input
-pub(crate) fn shared_movement_behaviour(position: &mut Position, input: &Inputs) {
+pub(crate) fn shared_movement_behaviour(mut position: Mut<Position>, input: &Inputs) {
     const MOVE_SPEED: f32 = 10.0;
     match input {
         Inputs::Direction(direction) => {

--- a/examples/simple_box/client.rs
+++ b/examples/simple_box/client.rs
@@ -116,7 +116,7 @@ pub(crate) fn buffer_input(mut client: ResMut<Client<MyProtocol>>, keypress: Res
         direction.right = true;
     }
     if !direction.is_none() {
-        client.add_input(Inputs::Direction(direction));
+        return client.add_input(Inputs::Direction(direction));
     }
     if keypress.pressed(KeyCode::Delete) {
         // currently, inputs is an enum and we can only add one input per tick

--- a/lightyear/src/client/connection.rs
+++ b/lightyear/src/client/connection.rs
@@ -254,6 +254,7 @@ impl<P: Protocol> Connection<P> {
                             self.replication_receiver.apply_world(
                                 world,
                                 replication,
+                                group,
                                 &mut self.events,
                             );
                         });

--- a/lightyear/src/client/interpolation/interpolation_history.rs
+++ b/lightyear/src/client/interpolation/interpolation_history.rs
@@ -146,9 +146,9 @@ pub(crate) fn apply_confirmed_update<T: SyncComponent, P: Protocol>(
                                 );
                                 continue;
                             };
-                            let Some(channel) = client
+                            let Some(tick) = client
                                 .replication_receiver()
-                                .channel_by_local(confirmed_entity)
+                                .get_confirmed_tick(confirmed_entity)
                             else {
                                 error!(
                                     "Could not find replication channel for entity {:?}",
@@ -159,9 +159,9 @@ pub(crate) fn apply_confirmed_update<T: SyncComponent, P: Protocol>(
                             // map any entities from confirmed to predicted
                             let mut component = confirmed_component.deref().clone();
                             component.map_entities(Box::new(&manager.interpolated_entity_map));
-                            trace!(component = ?component.name(), tick = ?channel.latest_tick, "adding confirmed update to history");
+                            trace!(component = ?component.name(), tick = ?tick, "adding confirmed update to history");
                             // assign the history at the value that the entity currently is
-                            history.buffer.add_item(channel.latest_tick, component);
+                            history.buffer.add_item(tick, component);
                         }
                         // for sync-components, we just match the confirmed component
                         ComponentSyncMode::Simple => {

--- a/lightyear/src/client/prediction/predicted_history.rs
+++ b/lightyear/src/client/prediction/predicted_history.rs
@@ -1,7 +1,9 @@
 use std::ops::Deref;
 
+use crate::_reexport::ShouldBePredicted;
 use bevy::prelude::{
-    Commands, Component, DetectChanges, Entity, Query, Ref, RemovedComponents, Res, With, Without,
+    Commands, Component, DetectChanges, Entity, Or, Query, Ref, RemovedComponents, Res, With,
+    Without,
 };
 use tracing::{error, info};
 
@@ -120,7 +122,13 @@ pub fn add_component_history<C: SyncComponent + Named, P: Protocol>(
     manager: Res<PredictionManager>,
     mut commands: Commands,
     client: Res<Client<P>>,
-    predicted_entities: Query<(Entity, Option<Ref<C>>), Without<PredictionHistory<C>>>,
+    predicted_entities: Query<
+        (Entity, Option<Ref<C>>),
+        (
+            Without<PredictionHistory<C>>,
+            Or<(With<Predicted>, With<ShouldBePredicted>)>,
+        ),
+    >,
     confirmed_entities: Query<(Entity, &Confirmed, Option<Ref<C>>)>,
 ) {
     // add history when a predicted component gets added

--- a/lightyear/src/client/prediction/rollback.rs
+++ b/lightyear/src/client/prediction/rollback.rs
@@ -107,9 +107,9 @@ pub(crate) fn client_rollback_check<C: SyncComponent, P: Protocol>(
             // - Confirmed contains the server state at the tick
             // - History contains the history of what we predicted at the tick
             // get the tick that the confirmed entity is at
-            let Some(channel) = client
+            let Some(tick) = client
                 .replication_receiver()
-                .channel_by_local(confirmed_entity)
+                .get_confirmed_tick(confirmed_entity)
             else {
                 error!(
                     "Could not find replication channel for entity {:?}",
@@ -117,7 +117,6 @@ pub(crate) fn client_rollback_check<C: SyncComponent, P: Protocol>(
                 );
                 continue;
             };
-            let tick = channel.latest_tick;
 
             // Note: it may seem like an optimization to only compare the history/server-state if we are not sure
             // that we should rollback (RollbackState::Default)

--- a/lightyear/src/server/connection.rs
+++ b/lightyear/src/server/connection.rs
@@ -392,8 +392,12 @@ impl<P: Protocol> Connection<P> {
                     trace!(?group, ?replication_list, "read replication messages");
                     replication_list.into_iter().for_each(|(_, replication)| {
                         // TODO: we could include the server tick when this replication_message was sent.
-                        self.replication_receiver
-                            .apply_world(world, replication, &mut self.events);
+                        self.replication_receiver.apply_world(
+                            world,
+                            replication,
+                            group,
+                            &mut self.events,
+                        );
                     });
                 }
             }

--- a/lightyear/src/shared/replication/entity_map.rs
+++ b/lightyear/src/shared/replication/entity_map.rs
@@ -115,6 +115,10 @@ impl RemoteEntityMap {
         &self.local_to_remote
     }
 
+    pub(crate) fn is_empty(&self) -> bool {
+        self.remote_to_local.is_empty() && self.local_to_remote.is_empty()
+    }
+
     fn clear(&mut self) {
         self.local_to_remote.clear();
         self.remote_to_local.clear();

--- a/lightyear/src/shared/replication/send.rs
+++ b/lightyear/src/shared/replication/send.rs
@@ -312,9 +312,9 @@ pub struct GroupChannel {
     // SEND
     pub actions_next_send_message_id: MessageId,
     // TODO: maybe also keep track of which Tick this bevy-tick corresponds to? (will enable doing diff-compression)
-    // TODO: maybe this should be an Option, so that we make sure that when we need it's always is_some()
     // bevy tick when we received an ack of an update for this group
-    pub collect_changes_since_this_tick: BevyTick,
+    // at the start it's None, and we collect any changes
+    pub collect_changes_since_this_tick: Option<BevyTick>,
     // last tick for which we sent an action message
     pub last_action_tick: Tick,
 }
@@ -326,7 +326,7 @@ impl Default for GroupChannel {
             // we start with a very high last_action_tick, so that we need to receive the Actions message
             // before handling any Updates messages
             last_action_tick: Tick(0) - 1,
-            collect_changes_since_this_tick: BevyTick::new(0),
+            collect_changes_since_this_tick: None,
         }
     }
 }
@@ -338,7 +338,7 @@ impl GroupChannel {
 
         // if bevy_tick is bigger than current tick, set current_tick to bevy_tick
         // if bevy_tick.is_newer_than(self.collect_changes_since_this_tick, BevyTick::MAX) {
-        self.collect_changes_since_this_tick = bevy_tick;
+        self.collect_changes_since_this_tick = Some(bevy_tick);
         // }
     }
 }

--- a/lightyear/src/shared/replication/systems.rs
+++ b/lightyear/src/shared/replication/systems.rs
@@ -70,6 +70,7 @@ fn send_entity_despawn<P: Protocol, R: ReplicationSend<P>>(
                         && matches!(visibility, ClientVisibility::Lost)
                     {
                         debug!("sending entity despawn for entity: {:?}", entity);
+                        // TODO: don't unwrap but handle errors
                         sender
                             .prepare_entity_despawn(
                                 entity,


### PR DESCRIPTION
- Fixed the interest_management/simple_box examples
- Removed the concept of replication-group-deletion, as this was more complicated to handle than I thought
- Only add a PredictionHistory to Predicted entities