### PR TITLE
Make examples compatible with a headless server, to test in a real server

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -36,5 +36,7 @@
     - [Interest management](./concepts/advanced_replication/interest_management.md)
     - [Client Replication](./concepts/advanced_replication/client_replication.md)
 
+- [Guides](./guides/title.md)
+  - [Connecting to a remote server](./guides/remote_server.md)
 
 - [Appendix](./appendix/title.md)

--- a/book/src/guides/remote_server.md
+++ b/book/src/guides/remote_server.md
@@ -1,0 +1,40 @@
+# Connecting to a remote server
+
+You've tested your multiplayer locally, and now you want to try connecting to a remote server.
+
+
+This is a quick guide mostly for myself, as I knew nothing about networking and didn't know where to start.
+
+
+## Set up a server
+
+From what I understand you can either:
+- rent a dedicated node with a cloud provider. Smaller cloud providers (Linode, DigitalOcean) seem cheaper than bigger ones (Google Cloud, AWS) unless you have free credits.
+  I used Kamatera, which worked excellently
+- rent a VPS, which is a virtual machine on a dedicated node. I believe this means that you are sharing the resources of the nodes with other customers.
+
+You need to get the public ip address of your server: S-IP.
+
+
+## Connect using UDP
+
+On the client:
+- You will need to create a local UDP socket that binds your **local client ip address**
+  - I believe that when the server receives a packet on their UDP socket, they will receive the **public ip address** of the client.
+    By specifying the local client ip address, you enable the server to do NAT-traversal? I'm not sure.
+  - You can either manually specify your local client ip address, or you can use `0.0.0.0` (INADDR_ANY), which binds
+    to any of the local ip addresses of your machine. I think that if your computer only has 1 network card, then it will
+    bind to that one. (source: [Beej's networking guide](https://beej.us/guide/bgnet/html/index-wide.html#bindman))
+
+
+On the server:
+- Same thing, you will need to create UDP socket that binds to your **local server ip address**.
+  - Again, you can either manually specify your local server ip address, or you can use `0.0.0.0` (INADDR_ANY) if your machine
+    only has 1 network card, or if you don't care which of the local ip addresses the socket binds to
+  - Keep track of the port used for the server: S-P
+- You will need to keep track of the public ip address of your server: S-IP
+- Start the lightyear process on the server, for example with `cargo run --example interest_management -- server --headless`
+
+On the client:
+- connect to the server by specifying the server public ip address and the server port:
+`cargo run --example interest_management -- client -c 1 --server-addr=S-IP --server-port=S-P`

--- a/examples/client_replication/client.rs
+++ b/examples/client_replication/client.rs
@@ -12,22 +12,23 @@ use std::time::Duration;
 
 #[derive(Resource, Clone, Copy)]
 pub struct MyClientPlugin {
-    pub(crate) client_id: ClientId,
+    pub(crate) client_id: u16,
     pub(crate) client_port: u16,
+    pub(crate) server_addr: Ipv4Addr,
     pub(crate) server_port: u16,
     pub(crate) transport: Transports,
 }
 
 impl Plugin for MyClientPlugin {
     fn build(&self, app: &mut App) {
-        let server_addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), self.server_port);
+        let server_addr = SocketAddr::new(self.server_addr.into(), self.server_port);
         let auth = Authentication::Manual {
             server_addr,
-            client_id: self.client_id,
+            client_id: self.client_id as ClientId,
             private_key: KEY,
             protocol_id: PROTOCOL_ID,
         };
-        let client_addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), self.client_port);
+        let client_addr = SocketAddr::new(Ipv4Addr::UNSPECIFIED.into(), self.client_port);
         let link_conditioner = LinkConditionerConfig {
             incoming_latency: Duration::from_millis(900),
             incoming_jitter: Duration::from_millis(20),

--- a/examples/client_replication/client.rs
+++ b/examples/client_replication/client.rs
@@ -12,7 +12,7 @@ use std::time::Duration;
 
 #[derive(Resource, Clone, Copy)]
 pub struct MyClientPlugin {
-    pub(crate) client_id: u16,
+    pub(crate) client_id: ClientId,
     pub(crate) client_port: u16,
     pub(crate) server_addr: Ipv4Addr,
     pub(crate) server_port: u16,
@@ -24,7 +24,7 @@ impl Plugin for MyClientPlugin {
         let server_addr = SocketAddr::new(self.server_addr.into(), self.server_port);
         let auth = Authentication::Manual {
             server_addr,
-            client_id: self.client_id as ClientId,
+            client_id: self.client_id,
             private_key: KEY,
             protocol_id: PROTOCOL_ID,
         };

--- a/examples/client_replication/main.rs
+++ b/examples/client_replication/main.rs
@@ -114,7 +114,7 @@ fn setup(app: &mut App, cli: Cli) {
             transport,
         } => {
             let client_plugin = MyClientPlugin {
-                client_id,
+                client_id: client_id as ClientId,
                 client_port,
                 server_addr,
                 server_port,

--- a/examples/client_replication/main.rs
+++ b/examples/client_replication/main.rs
@@ -3,18 +3,20 @@
 #![allow(dead_code)]
 
 //! Run with
-//! - `cargo run --example bevy_cli server`
-//! - `cargo run --example bevy_cli client`
+//! - `cargo run --example client_replication -- server`
+//! - `cargo run --example client_replication -- client -c 1`
 mod client;
 mod protocol;
 mod server;
 mod shared;
 
+use std::net::Ipv4Addr;
 use std::str::FromStr;
 
 use bevy::log::LogPlugin;
 use bevy::prelude::*;
 use bevy::DefaultPlugins;
+use bevy_inspector_egui::quick::WorldInspectorPlugin;
 use clap::{Parser, ValueEnum};
 use serde::{Deserialize, Serialize};
 use tracing_subscriber::fmt::format::FmtSpan;
@@ -28,13 +30,13 @@ use lightyear::prelude::TransportConfig;
 async fn main() {
     let cli = Cli::parse();
     let mut app = App::new();
-    app.add_plugins(DefaultPlugins.build().disable::<LogPlugin>());
     setup(&mut app, cli);
 
     app.run();
 }
 
-pub const CLIENT_PORT: u16 = 6000;
+// Use a port of 0 to automatically select a port
+pub const CLIENT_PORT: u16 = 0;
 pub const SERVER_PORT: u16 = 5000;
 pub const PROTOCOL_ID: u64 = 0;
 
@@ -50,6 +52,12 @@ pub enum Transports {
 enum Cli {
     SinglePlayer,
     Server {
+        #[arg(long, default_value = "false")]
+        headless: bool,
+
+        #[arg(short, long, default_value = "false")]
+        inspector: bool,
+
         #[arg(short, long, default_value_t = SERVER_PORT)]
         port: u16,
 
@@ -57,11 +65,17 @@ enum Cli {
         transport: Transports,
     },
     Client {
-        #[arg(short, long, default_value_t = ClientId::default())]
-        client_id: ClientId,
+        #[arg(short, long, default_value = "false")]
+        inspector: bool,
+
+        #[arg(short, long, default_value_t = 0)]
+        client_id: u16,
 
         #[arg(long, default_value_t = CLIENT_PORT)]
         client_port: u16,
+
+        #[arg(long, default_value_t = Ipv4Addr::LOCALHOST)]
+        server_addr: Ipv4Addr,
 
         #[arg(short, long, default_value_t = SERVER_PORT)]
         server_port: u16,
@@ -74,22 +88,42 @@ enum Cli {
 fn setup(app: &mut App, cli: Cli) {
     match cli {
         Cli::SinglePlayer => {}
-        Cli::Server { port, transport } => {
+        Cli::Server {
+            headless,
+            inspector,
+            port,
+            transport,
+        } => {
             let server_plugin = MyServerPlugin { port, transport };
+            if !headless {
+                app.add_plugins(DefaultPlugins.build().disable::<LogPlugin>());
+            } else {
+                app.add_plugins(MinimalPlugins);
+            }
+            if inspector {
+                app.add_plugins(WorldInspectorPlugin::new());
+            }
             app.add_plugins(server_plugin);
         }
         Cli::Client {
+            inspector,
             client_id,
             client_port,
+            server_addr,
             server_port,
             transport,
         } => {
             let client_plugin = MyClientPlugin {
                 client_id,
                 client_port,
+                server_addr,
                 server_port,
                 transport,
             };
+            app.add_plugins(DefaultPlugins.build().disable::<LogPlugin>());
+            if inspector {
+                app.add_plugins(WorldInspectorPlugin::new());
+            }
             app.add_plugins(client_plugin);
         }
     }

--- a/examples/client_replication/server.rs
+++ b/examples/client_replication/server.rs
@@ -15,7 +15,7 @@ pub struct MyServerPlugin {
 
 impl Plugin for MyServerPlugin {
     fn build(&self, app: &mut App) {
-        let server_addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), self.port);
+        let server_addr = SocketAddr::new(Ipv4Addr::UNSPECIFIED.into(), self.port);
         let netcode_config = NetcodeConfig::default()
             .with_protocol_id(PROTOCOL_ID)
             .with_key(KEY);

--- a/examples/client_replication/server.rs
+++ b/examples/client_replication/server.rs
@@ -53,7 +53,7 @@ impl Plugin for MyServerPlugin {
             FixedUpdate,
             (movement, delete_player).in_set(FixedUpdateSet::Main),
         );
-        app.add_systems(Update, (handle_disconnections, send_message));
+        app.add_systems(Update, handle_disconnections);
     }
 }
 
@@ -189,19 +189,5 @@ pub(crate) fn replicate_cursors(
                 ..default()
             });
         }
-    }
-}
-
-/// Send messages from server to clients
-pub(crate) fn send_message(mut server: ResMut<Server<MyProtocol>>, input: Res<Input<KeyCode>>) {
-    if input.pressed(KeyCode::M) {
-        // TODO: add way to send message to all
-        let message = Message1(5);
-        debug!("Send message: {:?}", message);
-        server
-            .send_message_to_target::<Channel1, Message1>(Message1(5), NetworkTarget::All)
-            .unwrap_or_else(|e| {
-                error!("Failed to send message: {:?}", e);
-            });
     }
 }

--- a/examples/client_replication/shared.rs
+++ b/examples/client_replication/shared.rs
@@ -1,6 +1,6 @@
 use crate::protocol::*;
 use bevy::prelude::*;
-use bevy_inspector_egui::quick::WorldInspectorPlugin;
+use bevy::render::RenderPlugin;
 use lightyear::prelude::client::Confirmed;
 use lightyear::prelude::*;
 use std::time::Duration;
@@ -27,8 +27,9 @@ pub struct SharedPlugin;
 
 impl Plugin for SharedPlugin {
     fn build(&self, app: &mut App) {
-        app.add_plugins(WorldInspectorPlugin::new());
-        app.add_systems(Update, draw_elements);
+        if app.is_plugin_added::<RenderPlugin>() {
+            app.add_systems(Update, draw_elements);
+        }
     }
 }
 

--- a/examples/interest_management/client.rs
+++ b/examples/interest_management/client.rs
@@ -6,7 +6,7 @@ use bevy::prelude::*;
 use lightyear::_reexport::{ShouldBeInterpolated, ShouldBePredicted};
 use lightyear::prelude::client::*;
 use lightyear::prelude::*;
-use std::net::{Ipv4Addr, SocketAddr};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::str::FromStr;
 use std::time::Duration;
 

--- a/examples/interest_management/client.rs
+++ b/examples/interest_management/client.rs
@@ -12,7 +12,7 @@ use std::time::Duration;
 
 #[derive(Resource, Clone, Copy)]
 pub struct MyClientPlugin {
-    pub(crate) client_id: u16,
+    pub(crate) client_id: ClientId,
     pub(crate) client_port: u16,
     pub(crate) server_addr: Ipv4Addr,
     pub(crate) server_port: u16,
@@ -24,7 +24,7 @@ impl Plugin for MyClientPlugin {
         let server_addr = SocketAddr::new(self.server_addr.into(), self.server_port);
         let auth = Authentication::Manual {
             server_addr,
-            client_id: self.client_id as ClientId,
+            client_id: self.client_id,
             private_key: KEY,
             protocol_id: PROTOCOL_ID,
         };

--- a/examples/interest_management/client.rs
+++ b/examples/interest_management/client.rs
@@ -28,7 +28,7 @@ impl Plugin for MyClientPlugin {
             private_key: KEY,
             protocol_id: PROTOCOL_ID,
         };
-        let client_addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), self.client_port);
+        let client_addr = SocketAddr::new(Ipv4Addr::UNSPECIFIED.into(), self.client_port);
         let link_conditioner = LinkConditionerConfig {
             incoming_latency: Duration::from_millis(100),
             incoming_jitter: Duration::from_millis(10),

--- a/examples/interest_management/client.rs
+++ b/examples/interest_management/client.rs
@@ -14,13 +14,14 @@ use std::time::Duration;
 pub struct MyClientPlugin {
     pub(crate) client_id: u16,
     pub(crate) client_port: u16,
+    pub(crate) server_addr: Ipv4Addr,
     pub(crate) server_port: u16,
     pub(crate) transport: Transports,
 }
 
 impl Plugin for MyClientPlugin {
     fn build(&self, app: &mut App) {
-        let server_addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), self.server_port);
+        let server_addr = SocketAddr::new(self.server_addr.into(), self.server_port);
         let auth = Authentication::Manual {
             server_addr,
             client_id: self.client_id as ClientId,

--- a/examples/interest_management/main.rs
+++ b/examples/interest_management/main.rs
@@ -10,6 +10,7 @@ mod protocol;
 mod server;
 mod shared;
 
+use std::net::Ipv4Addr;
 use std::str::FromStr;
 
 use bevy::log::LogPlugin;
@@ -72,6 +73,9 @@ enum Cli {
         #[arg(long, default_value_t = CLIENT_PORT)]
         client_port: u16,
 
+        #[arg(long, default_value_t = Ipv4Addr::LOCALHOST)]
+        server_addr: Ipv4Addr,
+
         #[arg(short, long, default_value_t = SERVER_PORT)]
         server_port: u16,
 
@@ -104,12 +108,14 @@ fn setup(app: &mut App, cli: Cli) {
             inspector,
             client_id,
             client_port,
+            server_addr,
             server_port,
             transport,
         } => {
             let client_plugin = MyClientPlugin {
                 client_id,
                 client_port,
+                server_addr,
                 server_port,
                 transport,
             };

--- a/examples/interest_management/main.rs
+++ b/examples/interest_management/main.rs
@@ -114,7 +114,7 @@ fn setup(app: &mut App, cli: Cli) {
             transport,
         } => {
             let client_plugin = MyClientPlugin {
-                client_id,
+                client_id: client_id as ClientId,
                 client_port,
                 server_addr,
                 server_port,

--- a/examples/interest_management/main.rs
+++ b/examples/interest_management/main.rs
@@ -3,8 +3,8 @@
 #![allow(dead_code)]
 
 //! Run with
-//! - `cargo run --example bevy_cli server`
-//! - `cargo run --example bevy_cli client`
+//! - `cargo run --example interest_management -- server`
+//! - `cargo run --example interest_management -- client -c 1`
 mod client;
 mod protocol;
 mod server;
@@ -35,7 +35,8 @@ async fn main() {
     app.run();
 }
 
-pub const CLIENT_PORT: u16 = 6000;
+// Use a port of 0 to automatically select a port
+pub const CLIENT_PORT: u16 = 0;
 pub const SERVER_PORT: u16 = 5000;
 pub const PROTOCOL_ID: u64 = 0;
 

--- a/examples/interest_management/server.rs
+++ b/examples/interest_management/server.rs
@@ -23,7 +23,7 @@ const PLAYER_ROOM: RoomId = RoomId(6000);
 
 impl Plugin for MyServerPlugin {
     fn build(&self, app: &mut App) {
-        let server_addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), self.port);
+        let server_addr = SocketAddr::new(Ipv4Addr::UNSPECIFIED.into(), self.port);
         let netcode_config = NetcodeConfig::default()
             .with_protocol_id(PROTOCOL_ID)
             .with_key(KEY);

--- a/examples/interest_management/server.rs
+++ b/examples/interest_management/server.rs
@@ -54,10 +54,7 @@ impl Plugin for MyServerPlugin {
         app.add_systems(Startup, init);
         // the physics/FixedUpdates systems that consume inputs should be run in this set
         app.add_systems(FixedUpdate, movement.in_set(FixedUpdateSet::Main));
-        app.add_systems(
-            Update,
-            (handle_connections, send_message, interest_management, log),
-        );
+        app.add_systems(Update, (handle_connections, interest_management, log));
     }
 }
 
@@ -191,19 +188,5 @@ pub(crate) fn movement(
                 }
             }
         }
-    }
-}
-
-/// Send messages from server to clients
-pub(crate) fn send_message(mut server: ResMut<Server<MyProtocol>>, input: Res<Input<KeyCode>>) {
-    if input.pressed(KeyCode::M) {
-        // TODO: add way to send message to all
-        let message = Message1(5);
-        info!("Send message: {:?}", message);
-        server
-            .send_message_to_target::<Channel1, Message1>(Message1(5), NetworkTarget::All)
-            .unwrap_or_else(|e| {
-                error!("Failed to send message: {:?}", e);
-            });
     }
 }

--- a/examples/interest_management/shared.rs
+++ b/examples/interest_management/shared.rs
@@ -1,6 +1,7 @@
 use crate::protocol::*;
 use bevy::prelude::*;
-use bevy_inspector_egui::quick::WorldInspectorPlugin;
+
+use bevy::render::RenderPlugin;
 use lightyear::prelude::client::Confirmed;
 use lightyear::prelude::*;
 use std::ops::Deref;
@@ -30,8 +31,9 @@ pub struct SharedPlugin;
 
 impl Plugin for SharedPlugin {
     fn build(&self, app: &mut App) {
-        app.add_plugins(WorldInspectorPlugin::new());
-        app.add_systems(Update, (draw_boxes, draw_circles));
+        if app.is_plugin_added::<RenderPlugin>() {
+            app.add_systems(Update, (draw_boxes, draw_circles));
+        }
     }
 }
 

--- a/examples/replication_groups/client.rs
+++ b/examples/replication_groups/client.rs
@@ -15,22 +15,23 @@ use std::time::Duration;
 
 #[derive(Resource, Clone, Copy)]
 pub struct MyClientPlugin {
-    pub(crate) client_id: ClientId,
+    pub(crate) client_id: u16,
     pub(crate) client_port: u16,
+    pub(crate) server_addr: Ipv4Addr,
     pub(crate) server_port: u16,
     pub(crate) transport: Transports,
 }
 
 impl Plugin for MyClientPlugin {
     fn build(&self, app: &mut App) {
-        let server_addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), self.server_port);
+        let server_addr = SocketAddr::new(self.server_addr.into(), self.server_port);
         let auth = Authentication::Manual {
             server_addr,
-            client_id: self.client_id,
+            client_id: self.client_id as ClientId,
             private_key: KEY,
             protocol_id: PROTOCOL_ID,
         };
-        let client_addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), self.client_port);
+        let client_addr = SocketAddr::new(Ipv4Addr::UNSPECIFIED.into(), self.client_port);
         let link_conditioner = LinkConditionerConfig {
             incoming_latency: Duration::from_millis(200),
             incoming_jitter: Duration::from_millis(40),

--- a/examples/replication_groups/client.rs
+++ b/examples/replication_groups/client.rs
@@ -15,7 +15,7 @@ use std::time::Duration;
 
 #[derive(Resource, Clone, Copy)]
 pub struct MyClientPlugin {
-    pub(crate) client_id: u16,
+    pub(crate) client_id: ClientId,
     pub(crate) client_port: u16,
     pub(crate) server_addr: Ipv4Addr,
     pub(crate) server_port: u16,
@@ -27,7 +27,7 @@ impl Plugin for MyClientPlugin {
         let server_addr = SocketAddr::new(self.server_addr.into(), self.server_port);
         let auth = Authentication::Manual {
             server_addr,
-            client_id: self.client_id as ClientId,
+            client_id: self.client_id,
             private_key: KEY,
             protocol_id: PROTOCOL_ID,
         };

--- a/examples/replication_groups/main.rs
+++ b/examples/replication_groups/main.rs
@@ -114,7 +114,7 @@ fn setup(app: &mut App, cli: Cli) {
             transport,
         } => {
             let client_plugin = MyClientPlugin {
-                client_id,
+                client_id: client_id as ClientId,
                 client_port,
                 server_addr,
                 server_port,

--- a/examples/replication_groups/server.rs
+++ b/examples/replication_groups/server.rs
@@ -16,7 +16,7 @@ pub struct MyServerPlugin {
 
 impl Plugin for MyServerPlugin {
     fn build(&self, app: &mut App) {
-        let server_addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), self.port);
+        let server_addr = SocketAddr::new(Ipv4Addr::UNSPECIFIED.into(), self.port);
         let netcode_config = NetcodeConfig::default()
             .with_protocol_id(PROTOCOL_ID)
             .with_key(KEY);

--- a/examples/replication_groups/shared.rs
+++ b/examples/replication_groups/shared.rs
@@ -1,6 +1,7 @@
 use crate::protocol::Direction;
 use crate::protocol::*;
 use bevy::prelude::*;
+use bevy::render::RenderPlugin;
 use bevy_inspector_egui::quick::WorldInspectorPlugin;
 use lightyear::prelude::client::{Confirmed, Interpolated};
 use lightyear::prelude::*;
@@ -28,7 +29,9 @@ pub struct SharedPlugin;
 
 impl Plugin for SharedPlugin {
     fn build(&self, app: &mut App) {
-        app.add_systems(Update, draw_snakes);
+        if app.is_plugin_added::<RenderPlugin>() {
+            app.add_systems(Update, draw_snakes);
+        }
     }
 }
 

--- a/examples/simple_box/client.rs
+++ b/examples/simple_box/client.rs
@@ -11,22 +11,23 @@ use std::time::Duration;
 
 #[derive(Resource, Clone, Copy)]
 pub struct MyClientPlugin {
-    pub(crate) client_id: ClientId,
+    pub(crate) client_id: u16,
     pub(crate) client_port: u16,
+    pub(crate) server_addr: Ipv4Addr,
     pub(crate) server_port: u16,
     pub(crate) transport: Transports,
 }
 
 impl Plugin for MyClientPlugin {
     fn build(&self, app: &mut App) {
-        let server_addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), self.server_port);
+        let server_addr = SocketAddr::new(self.server_addr.into(), self.server_port);
         let auth = Authentication::Manual {
             server_addr,
-            client_id: self.client_id,
+            client_id: self.client_id as ClientId,
             private_key: KEY,
             protocol_id: PROTOCOL_ID,
         };
-        let client_addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), self.client_port);
+        let client_addr = SocketAddr::new(Ipv4Addr::UNSPECIFIED.into(), self.client_port);
         let link_conditioner = LinkConditionerConfig {
             incoming_latency: Duration::from_millis(200),
             incoming_jitter: Duration::from_millis(20),

--- a/examples/simple_box/client.rs
+++ b/examples/simple_box/client.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 
 #[derive(Resource, Clone, Copy)]
 pub struct MyClientPlugin {
-    pub(crate) client_id: u16,
+    pub(crate) client_id: ClientId,
     pub(crate) client_port: u16,
     pub(crate) server_addr: Ipv4Addr,
     pub(crate) server_port: u16,
@@ -23,7 +23,7 @@ impl Plugin for MyClientPlugin {
         let server_addr = SocketAddr::new(self.server_addr.into(), self.server_port);
         let auth = Authentication::Manual {
             server_addr,
-            client_id: self.client_id as ClientId,
+            client_id: self.client_id,
             private_key: KEY,
             protocol_id: PROTOCOL_ID,
         };

--- a/examples/simple_box/main.rs
+++ b/examples/simple_box/main.rs
@@ -3,18 +3,20 @@
 #![allow(dead_code)]
 
 //! Run with
-//! - `cargo run --example bevy_cli server`
-//! - `cargo run --example bevy_cli client`
+//! - `cargo run --example simple_box -- server`
+//! - `cargo run --example simple_box -- client -c 1`
 mod client;
 mod protocol;
 mod server;
 mod shared;
 
+use std::net::Ipv4Addr;
 use std::str::FromStr;
 
 use bevy::log::LogPlugin;
 use bevy::prelude::*;
 use bevy::DefaultPlugins;
+use bevy_inspector_egui::quick::WorldInspectorPlugin;
 use clap::{Parser, ValueEnum};
 use serde::{Deserialize, Serialize};
 use tracing_subscriber::fmt::format::FmtSpan;
@@ -28,13 +30,13 @@ use lightyear::prelude::TransportConfig;
 async fn main() {
     let cli = Cli::parse();
     let mut app = App::new();
-    app.add_plugins(DefaultPlugins.build().disable::<LogPlugin>());
     setup(&mut app, cli);
 
     app.run();
 }
 
-pub const CLIENT_PORT: u16 = 6000;
+// Use a port of 0 to automatically select a port
+pub const CLIENT_PORT: u16 = 0;
 pub const SERVER_PORT: u16 = 5000;
 pub const PROTOCOL_ID: u64 = 0;
 
@@ -50,6 +52,12 @@ pub enum Transports {
 enum Cli {
     SinglePlayer,
     Server {
+        #[arg(long, default_value = "false")]
+        headless: bool,
+
+        #[arg(short, long, default_value = "false")]
+        inspector: bool,
+
         #[arg(short, long, default_value_t = SERVER_PORT)]
         port: u16,
 
@@ -57,11 +65,17 @@ enum Cli {
         transport: Transports,
     },
     Client {
-        #[arg(short, long, default_value_t = ClientId::default())]
-        client_id: ClientId,
+        #[arg(short, long, default_value = "false")]
+        inspector: bool,
+
+        #[arg(short, long, default_value_t = 0)]
+        client_id: u16,
 
         #[arg(long, default_value_t = CLIENT_PORT)]
         client_port: u16,
+
+        #[arg(long, default_value_t = Ipv4Addr::LOCALHOST)]
+        server_addr: Ipv4Addr,
 
         #[arg(short, long, default_value_t = SERVER_PORT)]
         server_port: u16,
@@ -74,22 +88,42 @@ enum Cli {
 fn setup(app: &mut App, cli: Cli) {
     match cli {
         Cli::SinglePlayer => {}
-        Cli::Server { port, transport } => {
+        Cli::Server {
+            headless,
+            inspector,
+            port,
+            transport,
+        } => {
             let server_plugin = MyServerPlugin { port, transport };
+            if !headless {
+                app.add_plugins(DefaultPlugins.build().disable::<LogPlugin>());
+            } else {
+                app.add_plugins(MinimalPlugins);
+            }
+            if inspector {
+                app.add_plugins(WorldInspectorPlugin::new());
+            }
             app.add_plugins(server_plugin);
         }
         Cli::Client {
+            inspector,
             client_id,
             client_port,
+            server_addr,
             server_port,
             transport,
         } => {
             let client_plugin = MyClientPlugin {
                 client_id,
                 client_port,
+                server_addr,
                 server_port,
                 transport,
             };
+            app.add_plugins(DefaultPlugins.build().disable::<LogPlugin>());
+            if inspector {
+                app.add_plugins(WorldInspectorPlugin::new());
+            }
             app.add_plugins(client_plugin);
         }
     }

--- a/examples/simple_box/main.rs
+++ b/examples/simple_box/main.rs
@@ -94,7 +94,11 @@ fn setup(app: &mut App, cli: Cli) {
             port,
             transport,
         } => {
-            let server_plugin = MyServerPlugin { port, transport };
+            let server_plugin = MyServerPlugin {
+                headless,
+                port,
+                transport,
+            };
             if !headless {
                 app.add_plugins(DefaultPlugins.build().disable::<LogPlugin>());
             } else {

--- a/examples/simple_box/main.rs
+++ b/examples/simple_box/main.rs
@@ -118,7 +118,7 @@ fn setup(app: &mut App, cli: Cli) {
             transport,
         } => {
             let client_plugin = MyClientPlugin {
-                client_id,
+                client_id: client_id as ClientId,
                 client_port,
                 server_addr,
                 server_port,

--- a/examples/simple_box/server.rs
+++ b/examples/simple_box/server.rs
@@ -15,7 +15,7 @@ pub struct MyServerPlugin {
 
 impl Plugin for MyServerPlugin {
     fn build(&self, app: &mut App) {
-        let server_addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), self.port);
+        let server_addr = SocketAddr::new(Ipv4Addr::UNSPECIFIED.into(), self.port);
         let netcode_config = NetcodeConfig::default()
             .with_protocol_id(PROTOCOL_ID)
             .with_key(KEY);

--- a/examples/simple_box/shared.rs
+++ b/examples/simple_box/shared.rs
@@ -1,5 +1,6 @@
 use crate::protocol::*;
 use bevy::prelude::*;
+use bevy::render::RenderPlugin;
 use bevy_inspector_egui::quick::WorldInspectorPlugin;
 use lightyear::prelude::*;
 use std::time::Duration;
@@ -26,8 +27,9 @@ pub struct SharedPlugin;
 
 impl Plugin for SharedPlugin {
     fn build(&self, app: &mut App) {
-        // app.add_plugins(WorldInspectorPlugin::new());
-        app.add_systems(Update, draw_boxes);
+        if app.is_plugin_added::<RenderPlugin>() {
+            app.add_systems(Update, draw_boxes);
+        }
     }
 }
 

--- a/lightyear/Cargo.toml
+++ b/lightyear/Cargo.toml
@@ -50,9 +50,6 @@ wtransport = { version = "0.1.9", optional = true }
 bitcode = { version = "0.4.0", package = "bitcode_lightyear_patch", features = [
   "serde",
 ] }
-#bitcode = { git = "https://github.com/cBournhonesque/bitcode.git", branch = "cb/latest", features = [
-#  "serde",
-#] }
 bytes = { version = "1.5", features = ["serde"] }
 self_cell = "1.0"
 serde = { version = "1.0.188", features = ["derive"] }
@@ -74,7 +71,6 @@ tracing-subscriber = { version = "0.3.17", features = [
 
 # server
 crossbeam-channel = { version = "0.5.8", features = [] }
-#petgraph = "0.6.4"  # for replication
 
 # metrics
 metrics = { version = "0.21", optional = true }

--- a/lightyear/src/shared/replication/send.rs
+++ b/lightyear/src/shared/replication/send.rs
@@ -153,6 +153,17 @@ impl<P: Protocol> ReplicationSender<P> {
             .contains(&kind)
             && !force_insert
         {
+            if kind == <P::ComponentKinds as FromType<ShouldBePredicted>>::from_type()
+                && component
+                    .clone()
+                    .try_into()
+                    .is_ok_and(|s| s.client_entity.is_none())
+            {
+                // do not emit a warning if we are trying to insert a ShouldBePredicted component
+                // because of prediction_target, but there already is a ShouldBePredicted component because of
+                // pre-prediction
+                return;
+            }
             warn!(
                 ?group,
                 ?entity,

--- a/lightyear/src/transport/udp.rs
+++ b/lightyear/src/transport/udp.rs
@@ -1,6 +1,7 @@
 use std::io::Result;
 use std::net::SocketAddr;
 use std::sync::{Arc, Mutex};
+use tracing::info;
 
 use crate::transport::{PacketReceiver, PacketSender, Transport};
 
@@ -22,8 +23,8 @@ pub struct UdpSocket {
 
 impl UdpSocket {
     /// Create a non-blocking UDP socket
-    pub fn new(server_addr: &SocketAddr) -> Result<Self> {
-        let udp_socket = std::net::UdpSocket::bind(*server_addr)?;
+    pub fn new(local_addr: &SocketAddr) -> Result<Self> {
+        let udp_socket = std::net::UdpSocket::bind(*local_addr)?;
         let socket = Arc::new(Mutex::new(udp_socket));
         socket.as_ref().lock().unwrap().set_nonblocking(true)?;
         Ok(Self {


### PR DESCRIPTION
After this PR:
- all examples have now been tested over a real connection with a remote server, with both UDP and WebTransport !!!
- fixed some panics that we get if we try to despawn entities for a client who disconnected
- cleaned up some warning logs