### PR TITLE
Fix `cargo doc`

### DIFF
--- a/lightyear/Cargo.toml
+++ b/lightyear/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lightyear"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Charles Bournhonesque <charlesbour@gmail.com>"]
 edition = "2021"
 rust-version = "1.65"
@@ -47,7 +47,7 @@ thiserror = "1.0.50"
 wtransport = { version = "0.1.9", optional = true }
 
 # serialization
-bitcode = { version = "0.4.0", package = "bitcode_lightyear_patch", features = [
+bitcode = { version = "0.4.1", package = "bitcode_lightyear_patch", path = "../vendor/bitcode", features = [
   "serde",
 ] }
 bytes = { version = "1.5", features = ["serde"] }

--- a/vendor/bitcode/Cargo.toml
+++ b/vendor/bitcode/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bitcode_lightyear_patch"
 authors = ["Cai Bear", "Finn Bear"]
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/SoftbearStudios/bitcode"

--- a/vendor/bitcode/src/encoding/bit_string/mod.rs
+++ b/vendor/bitcode/src/encoding/bit_string/mod.rs
@@ -1,6 +1,5 @@
 use crate::encoding::prelude::*;
-use crate::encoding::{Fixed, Gamma};
-use crate::Encode;
+use crate::encoding::Fixed;
 use std::num::NonZeroUsize;
 
 mod ascii;
@@ -16,7 +15,7 @@ pub struct BitString<C: ByteEncoding>(pub C);
 
 impl<C: ByteEncoding> Encoding for BitString<C> {
     #[inline(always)]
-    fn write_byte_str(self, writer: &mut impl Write, bytes: &[u8]) {
+    fn write_byte_str(self, _writer: &mut impl Write, _bytes: &[u8]) {
         unimplemented!()
         // let n = bytes.len();
         // n.encode(Gamma, writer).unwrap();
@@ -40,7 +39,7 @@ impl<C: ByteEncoding> Encoding for BitString<C> {
     }
 
     #[inline(always)]
-    fn read_bytes(self, reader: &mut impl Read, len: NonZeroUsize) -> Result<&[u8]> {
+    fn read_bytes(self, _reader: &mut impl Read, _len: NonZeroUsize) -> Result<&[u8]> {
         unimplemented!()
         // let is_valid = !reader.read_bit()?;
         // if is_valid {

--- a/vendor/bitcode/src/lib.rs
+++ b/vendor/bitcode/src/lib.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::all)]
-#![cfg_attr(test, feature(test))]
-#![cfg_attr(doc, feature(doc_cfg))]
+// #![cfg_attr(test, feature(test))]
+// #![cfg_attr(doc, feature(doc_cfg))]
 #![forbid(unsafe_code)]
 #![allow(clippy::items_after_test_module)]
 

--- a/vendor/bitcode/src/read.rs
+++ b/vendor/bitcode/src/read.rs
@@ -1,4 +1,3 @@
-use crate::encoding::ByteEncoding;
 use crate::word::Word;
 use crate::Result;
 use std::num::NonZeroUsize;

--- a/vendor/bitcode/src/register_buffer.rs
+++ b/vendor/bitcode/src/register_buffer.rs
@@ -1,4 +1,3 @@
-use crate::encoding::ByteEncoding;
 use crate::read::Read;
 use crate::word::*;
 use crate::write::Write;

--- a/vendor/bitcode/src/serde/mod.rs
+++ b/vendor/bitcode/src/serde/mod.rs
@@ -8,7 +8,7 @@ pub mod ser;
 /// Serializes a `T:` [`Serialize`] into a [`Vec<u8>`].
 ///
 /// **Warning:** The format is incompatible with [`decode`][`crate::decode`] and subject to change between versions.
-#[cfg_attr(doc, doc(cfg(feature = "serde")))]
+// #[cfg_attr(doc, doc(cfg(feature = "serde")))]
 pub fn serialize<T: ?Sized>(t: &T) -> Result<Vec<u8>>
 where
     T: Serialize,
@@ -19,7 +19,7 @@ where
 /// Deserializes a [`&[u8]`][`prim@slice`] into an instance of `T:` [`Deserialize`][`serde::Deserialize`].
 ///
 /// **Warning:** The format is incompatible with [`encode`][`crate::encode`] and subject to change between versions.
-#[cfg_attr(doc, doc(cfg(feature = "serde")))]
+// #[cfg_attr(doc, doc(cfg(feature = "serde")))]
 pub fn deserialize<T>(bytes: &[u8]) -> Result<T>
 where
     T: DeserializeOwned,
@@ -35,7 +35,7 @@ impl Buffer {
     /// [`serialize`].
     ///
     /// **Warning:** The format is incompatible with [`decode`][`Buffer::decode`] and subject to change between versions.
-    #[cfg_attr(doc, doc(cfg(feature = "serde")))]
+    // #[cfg_attr(doc, doc(cfg(feature = "serde")))]
     pub fn serialize<T: ?Sized>(&mut self, t: &T) -> Result<&[u8]>
     where
         T: Serialize,
@@ -47,7 +47,7 @@ impl Buffer {
     /// the buffer's allocations.
     ///
     /// **Warning:** The format is incompatible with [`encode`][`Buffer::encode`] and subject to change between versions.
-    #[cfg_attr(doc, doc(cfg(feature = "serde")))]
+    // #[cfg_attr(doc, doc(cfg(feature = "serde")))]
     pub fn deserialize<T>(&mut self, bytes: &[u8]) -> Result<T>
     where
         T: DeserializeOwned,

--- a/vendor/bitcode/src/word_buffer.rs
+++ b/vendor/bitcode/src/word_buffer.rs
@@ -1,5 +1,4 @@
 use crate::buffer::BufferTrait;
-use crate::encoding::ByteEncoding;
 use crate::nightly::div_ceil;
 use crate::read::Read;
 use crate::word::*;
@@ -9,7 +8,7 @@ use from_bytes_or_zeroed::FromBytesOrZeroed;
 use std::array;
 use std::num::NonZeroUsize;
 
-/// A fast [`Buffer`] that operates on [`Word`]s.
+/// A fast `Buffer` that operates on [`Word`]s.
 #[derive(Debug, Default)]
 pub struct WordBuffer {
     allocation: Allocation,

--- a/vendor/bitcode/src/write.rs
+++ b/vendor/bitcode/src/write.rs
@@ -1,4 +1,3 @@
-use crate::encoding::ByteEncoding;
 use crate::word::Word;
 
 /// Abstracts over writing bits to a buffer.


### PR DESCRIPTION
`cargo doc` was failing because I vendored the `bitcode` crate which seemed to using some nightly features for documentation.

Removed those nightly attributes and released `0.5.1` with the fix