### PR TITLE
reexport Client<MyProtocol> etc. and the option to not replicate some…

### DIFF
--- a/benches/spawn.rs
+++ b/benches/spawn.rs
@@ -7,7 +7,7 @@ use bevy::utils::tracing::Level;
 use divan::{AllocProfiler, Bencher};
 use lightyear::client::sync::SyncConfig;
 use lightyear::prelude::client::{InterpolationConfig, PredictionConfig};
-use lightyear::prelude::{ClientId, LogConfig, NetworkTarget, Replicate, SharedConfig, TickConfig};
+use lightyear::prelude::{ClientId, LogConfig, NetworkTarget, SharedConfig, TickConfig};
 use lightyear_benches::local_stepper::{LocalBevyStepper, Step as LocalStep};
 use lightyear_benches::protocol::*;
 use lightyear_benches::stepper::{BevyStepper, Step};

--- a/benches/src/local_stepper.rs
+++ b/benches/src/local_stepper.rs
@@ -13,14 +13,13 @@ use bevy::MinimalPlugins;
 use lightyear::client as lightyear_client;
 use lightyear::netcode::generate_key;
 use lightyear::prelude::client::{
-    Authentication, Client, ClientConfig, InputConfig, InterpolationConfig, PredictionConfig,
-    SyncConfig,
+    Authentication, ClientConfig, InputConfig, InterpolationConfig, PredictionConfig, SyncConfig,
 };
-use lightyear::prelude::server::{NetcodeConfig, Server, ServerConfig};
+use lightyear::prelude::server::{NetcodeConfig, ServerConfig};
 use lightyear::prelude::*;
 use lightyear::server as lightyear_server;
 
-use crate::protocol::{protocol, MyProtocol};
+use crate::protocol::*;
 
 pub trait Step {
     /// Advance both apps by one frame duration
@@ -147,16 +146,16 @@ impl LocalBevyStepper {
         }
     }
 
-    pub fn client(&self) -> &Client<MyProtocol> {
-        self.client_app.world.resource::<Client<MyProtocol>>()
+    pub fn client(&self) -> &Client {
+        self.client_app.world.resource::<Client>()
     }
 
-    pub fn client_mut(&mut self) -> Mut<Client<MyProtocol>> {
-        self.client_app.world.resource_mut::<Client<MyProtocol>>()
+    pub fn client_mut(&mut self) -> Mut<Client> {
+        self.client_app.world.resource_mut::<Client>()
     }
 
-    fn server(&self) -> &Server<MyProtocol> {
-        self.server_app.world.resource::<Server<MyProtocol>>()
+    fn server(&self) -> &Server {
+        self.server_app.world.resource::<Server>()
     }
 
     pub fn init(&mut self) {

--- a/benches/src/stepper.rs
+++ b/benches/src/stepper.rs
@@ -10,14 +10,13 @@ use bevy::MinimalPlugins;
 use lightyear::client as lightyear_client;
 use lightyear::netcode::generate_key;
 use lightyear::prelude::client::{
-    Authentication, Client, ClientConfig, InputConfig, InterpolationConfig, PredictionConfig,
-    SyncConfig,
+    Authentication, ClientConfig, InputConfig, InterpolationConfig, PredictionConfig, SyncConfig,
 };
-use lightyear::prelude::server::{NetcodeConfig, Server, ServerConfig};
+use lightyear::prelude::server::{NetcodeConfig, ServerConfig};
 use lightyear::prelude::*;
 use lightyear::server as lightyear_server;
 
-use crate::protocol::{protocol, MyProtocol};
+use crate::protocol::*;
 
 // Sometimes it takes time for socket to receive all data.
 const SOCKET_WAIT: Duration = Duration::from_millis(5);
@@ -127,32 +126,29 @@ impl BevyStepper {
         }
     }
 
-    pub fn client(&self, client_id: ClientId) -> &Client<MyProtocol> {
+    pub fn client(&self, client_id: ClientId) -> &Client {
         self.client_apps
             .get(&client_id)
             .unwrap()
             .world
-            .resource::<Client<MyProtocol>>()
+            .resource::<Client>()
     }
 
-    pub fn client_mut(&mut self, client_id: ClientId) -> Mut<Client<MyProtocol>> {
+    pub fn client_mut(&mut self, client_id: ClientId) -> Mut<Client> {
         self.client_apps
             .get_mut(&client_id)
             .unwrap()
             .world
-            .resource_mut::<Client<MyProtocol>>()
+            .resource_mut::<Client>()
     }
 
-    fn server(&self) -> &Server<MyProtocol> {
-        self.server_app.world.resource::<Server<MyProtocol>>()
+    fn server(&self) -> &Server {
+        self.server_app.world.resource::<Server>()
     }
 
     pub fn init(&mut self) {
         self.client_apps.values_mut().for_each(|client_app| {
-            client_app
-                .world
-                .resource_mut::<Client<MyProtocol>>()
-                .connect();
+            client_app.world.resource_mut::<Client>().connect();
         });
 
         // Advance the world to let the connection process complete

--- a/examples/bevy_headless.rs
+++ b/examples/bevy_headless.rs
@@ -7,11 +7,11 @@ use tracing::{debug, info};
 use tracing_subscriber::fmt::format::FmtSpan;
 
 use lightyear::netcode::generate_key;
-use lightyear::prelude::client::{Authentication, Client};
+use lightyear::prelude::client::Authentication;
 use lightyear::prelude::*;
-use lightyear_examples::protocol::MyProtocol;
+use lightyear_examples::protocol::*;
 
-fn client_init(mut client: ResMut<Client<MyProtocol>>) {
+fn client_init(mut client: ResMut<Client>) {
     info!("Connecting to server");
     client.connect();
 }

--- a/examples/bevy_simple.rs
+++ b/examples/bevy_simple.rs
@@ -9,11 +9,11 @@ use tracing::{debug, info};
 use tracing_subscriber::fmt::format::FmtSpan;
 
 use lightyear::netcode::generate_key;
-use lightyear::prelude::client::{Authentication, Client};
+use lightyear::prelude::client::Authentication;
 use lightyear::prelude::*;
-use lightyear_examples::protocol::MyProtocol;
+use lightyear_examples::protocol::*;
 
-fn client_init(mut client: ResMut<Client<MyProtocol>>) {
+fn client_init(mut client: ResMut<Client>) {
     info!("Connecting to server");
     client.connect();
 }

--- a/examples/bevy_step.rs
+++ b/examples/bevy_step.rs
@@ -17,10 +17,10 @@ use tracing_subscriber::fmt::format::FmtSpan;
 
 use lightyear::prelude::client::*;
 use lightyear::prelude::*;
-use lightyear_examples::protocol::{protocol, Channel2, MyProtocol};
+use lightyear_examples::protocol::*;
 use lightyear_examples::stepper::{BevyStepper, Step};
 
-fn client_init(mut client: ResMut<Client<MyProtocol>>) {
+fn client_init(mut client: ResMut<Client>) {
     info!("Connecting to server");
     client.connect();
 }

--- a/examples/client_replication/client.rs
+++ b/examples/client_replication/client.rs
@@ -86,7 +86,7 @@ impl Plugin for MyClientPlugin {
 // Startup system for the client
 pub(crate) fn init(
     mut commands: Commands,
-    mut client: ResMut<Client<MyProtocol>>,
+    mut client: ResMut<Client>,
     plugin: Res<MyClientPlugin>,
 ) {
     commands.spawn(Camera2dBundle::default());
@@ -109,7 +109,7 @@ pub(crate) fn init(
 }
 
 // System that reads from peripherals and adds inputs to the buffer
-pub(crate) fn buffer_input(mut client: ResMut<Client<MyProtocol>>, keypress: Res<Input<KeyCode>>) {
+pub(crate) fn buffer_input(mut client: ResMut<Client>, keypress: Res<Input<KeyCode>>) {
     let mut direction = Direction {
         up: false,
         down: false,
@@ -275,7 +275,7 @@ pub(crate) fn receive_message(mut reader: EventReader<MessageEvent<Message1>>) {
 }
 
 /// Send messages from server to clients
-pub(crate) fn send_message(mut client: ResMut<Client<MyProtocol>>, input: Res<Input<KeyCode>>) {
+pub(crate) fn send_message(mut client: ResMut<Client>, input: Res<Input<KeyCode>>) {
     if input.pressed(KeyCode::M) {
         let message = Message1(5);
         info!("Send message: {:?}", message);

--- a/examples/client_replication/server.rs
+++ b/examples/client_replication/server.rs
@@ -89,7 +89,7 @@ pub(crate) fn handle_disconnections(
 pub(crate) fn movement(
     mut position_query: Query<(&mut PlayerPosition, &PlayerId)>,
     mut input_reader: EventReader<InputEvent<Inputs>>,
-    server: Res<Server<MyProtocol>>,
+    server: Res<Server>,
 ) {
     for input in input_reader.read() {
         let client_id = input.context();

--- a/examples/input_buffer_step.rs
+++ b/examples/input_buffer_step.rs
@@ -17,15 +17,13 @@ use bevy::{DefaultPlugins, MinimalPlugins};
 use tracing::{debug, info};
 use tracing_subscriber::fmt::format::FmtSpan;
 
-use lightyear::prelude::client::{
-    Authentication, Client, ClientConfig, InputSystemSet, SyncConfig,
-};
-use lightyear::prelude::server::{NetcodeConfig, Server, ServerConfig};
+use lightyear::prelude::client::{Authentication, ClientConfig, InputSystemSet, SyncConfig};
+use lightyear::prelude::server::{NetcodeConfig, ServerConfig};
 use lightyear::prelude::*;
-use lightyear_examples::protocol::{protocol, Channel2, MyInput, MyProtocol};
+use lightyear_examples::protocol::*;
 use lightyear_examples::stepper::{BevyStepper, Step};
 
-fn client_init(mut client: ResMut<Client<MyProtocol>>) {
+fn client_init(mut client: ResMut<Client>) {
     info!("Connecting to server");
     client.connect();
 }
@@ -38,13 +36,13 @@ fn server_init(mut commands: Commands) {
 }
 
 // System that runs every fixed timestep, and will add an input to the buffer
-fn buffer_client_inputs(mut client: ResMut<Client<MyProtocol>>) {
+fn buffer_client_inputs(mut client: ResMut<Client>) {
     let tick = client.tick();
     client.add_input(MyInput(tick.0 as i16))
 }
 
 fn client_read_input(
-    client: Res<Client<MyProtocol>>,
+    client: Res<Client>,
     mut input_reader: EventReader<client::InputEvent<MyInput>>,
 ) {
     for input in input_reader.read() {
@@ -58,7 +56,7 @@ fn client_read_input(
 
 fn server_read_input(
     // TODO: maybe put the tick in a separate resource? it lowers parallelism to have to fetch the entire server just to get the tick..
-    server: Res<Server<MyProtocol>>,
+    server: Res<Server>,
     mut input_reader: EventReader<server::InputEvent<MyInput>>,
 ) {
     let tick = server.tick();

--- a/examples/interest_management/client.rs
+++ b/examples/interest_management/client.rs
@@ -84,7 +84,7 @@ impl Plugin for MyClientPlugin {
 // Startup system for the client
 pub(crate) fn init(
     mut commands: Commands,
-    mut client: ResMut<Client<MyProtocol>>,
+    mut client: ResMut<Client>,
     plugin: Res<MyClientPlugin>,
 ) {
     commands.spawn(Camera2dBundle::default());
@@ -101,7 +101,7 @@ pub(crate) fn init(
 }
 
 // System that reads from peripherals and adds inputs to the buffer
-pub(crate) fn buffer_input(mut client: ResMut<Client<MyProtocol>>, keypress: Res<Input<KeyCode>>) {
+pub(crate) fn buffer_input(mut client: ResMut<Client>, keypress: Res<Input<KeyCode>>) {
     let mut direction = Direction {
         up: false,
         down: false,
@@ -182,7 +182,7 @@ pub(crate) fn handle_interpolated_spawn(
 }
 
 pub(crate) fn log(
-    client: Res<Client<MyProtocol>>,
+    client: Res<Client>,
     confirmed: Query<&Position, With<Confirmed>>,
     predicted: Query<&Position, (With<Predicted>, Without<Confirmed>)>,
     mut interp_event: EventReader<ComponentInsertEvent<ShouldBeInterpolated>>,

--- a/examples/interest_management/server.rs
+++ b/examples/interest_management/server.rs
@@ -93,7 +93,7 @@ pub(crate) fn init(mut commands: Commands) {
 
 /// Server connection system, create a player upon connection
 pub(crate) fn handle_connections(
-    mut server: ResMut<Server<MyProtocol>>,
+    mut server: ResMut<Server>,
     mut connections: EventReader<ConnectEvent>,
     mut disconnections: EventReader<DisconnectEvent>,
     mut global: ResMut<Global>,
@@ -131,7 +131,7 @@ pub(crate) fn handle_connections(
     }
 }
 
-pub(crate) fn log(server: Res<Server<MyProtocol>>, position: Query<&Position, With<PlayerId>>) {
+pub(crate) fn log(server: Res<Server>, position: Query<&Position, With<PlayerId>>) {
     let server_tick = server.tick();
     for pos in position.iter() {
         debug!(?server_tick, "Confirmed position: {:?}", pos);
@@ -141,7 +141,7 @@ pub(crate) fn log(server: Res<Server<MyProtocol>>, position: Query<&Position, Wi
 /// This is where we perform scope management:
 /// - we will add/remove other entities from the player's room only if they are close
 pub(crate) fn interest_management(
-    mut server: ResMut<Server<MyProtocol>>,
+    mut server: ResMut<Server>,
     player_query: Query<(&PlayerId, Ref<Position>), Without<Circle>>,
     circle_query: Query<(Entity, &Position), With<Circle>>,
 ) {
@@ -170,7 +170,7 @@ pub(crate) fn movement(
     mut position_query: Query<&mut Position>,
     mut input_reader: EventReader<InputEvent<Inputs>>,
     global: Res<Global>,
-    server: Res<Server<MyProtocol>>,
+    server: Res<Server>,
 ) {
     for input in input_reader.read() {
         let client_id = input.context();

--- a/examples/prediction_step.rs
+++ b/examples/prediction_step.rs
@@ -20,10 +20,10 @@ use tracing_subscriber::fmt::format::FmtSpan;
 use lightyear::_reexport::*;
 use lightyear::prelude::client::*;
 use lightyear::prelude::*;
-use lightyear_examples::protocol::{protocol, Channel2, Component1, MyInput, MyProtocol};
+use lightyear_examples::protocol::*;
 use lightyear_examples::stepper::{BevyStepper, Step};
 
-fn client_init(mut client: ResMut<Client<MyProtocol>>) {
+fn client_init(mut client: ResMut<Client>) {
     info!("Connecting to server");
     client.connect();
 }
@@ -40,7 +40,7 @@ fn server_init(mut commands: Commands) {
 }
 
 // System that runs every fixed timestep, and will add an input to the buffer
-fn buffer_client_inputs(mut client: ResMut<Client<MyProtocol>>) {
+fn buffer_client_inputs(mut client: ResMut<Client>) {
     let tick = client.tick();
     let amplitude = 10i16;
     // oscillating value between 0 and 10
@@ -62,7 +62,7 @@ fn shared_behaviour(component1: &mut Component1, input: &MyInput) {
 
 // The client input only gets applied to predicted entities
 fn client_read_input(
-    client: Res<Client<MyProtocol>>,
+    client: Res<Client>,
     mut component1_query: Query<&mut Component1, With<Predicted>>,
     mut input_reader: EventReader<InputEvent<MyInput>>,
 ) {
@@ -83,7 +83,7 @@ fn client_read_input(
 }
 
 fn server_read_input(
-    server: Res<server::Server<MyProtocol>>,
+    server: Res<Server>,
     mut component1_query: Query<&mut Component1>,
     mut input_reader: EventReader<server::InputEvent<MyInput>>,
 ) {

--- a/examples/replication_groups/client.rs
+++ b/examples/replication_groups/client.rs
@@ -110,7 +110,7 @@ impl Plugin for MyClientPlugin {
 // Startup system for the client
 pub(crate) fn init(
     mut commands: Commands,
-    mut client: ResMut<Client<MyProtocol>>,
+    mut client: ResMut<Client>,
     plugin: Res<MyClientPlugin>,
 ) {
     commands.spawn(Camera2dBundle::default());
@@ -127,7 +127,7 @@ pub(crate) fn init(
 }
 
 // System that reads from peripherals and adds inputs to the buffer
-pub(crate) fn buffer_input(mut client: ResMut<Client<MyProtocol>>, keypress: Res<Input<KeyCode>>) {
+pub(crate) fn buffer_input(mut client: ResMut<Client>, keypress: Res<Input<KeyCode>>) {
     if keypress.pressed(KeyCode::W) || keypress.pressed(KeyCode::Up) {
         return client.add_input(Inputs::Direction(Direction::Up));
     }
@@ -191,7 +191,7 @@ pub(crate) fn handle_interpolated_spawn(
 }
 
 pub(crate) fn debug_prediction_pre_rollback(
-    client: Res<Client<MyProtocol>>,
+    client: Res<Client>,
     parent_query: Query<&PredictionHistory<PlayerPosition>>,
     tail_query: Query<(&PlayerParent, &PredictionHistory<TailPoints>)>,
 ) {
@@ -208,7 +208,7 @@ pub(crate) fn debug_prediction_pre_rollback(
 }
 
 pub(crate) fn debug_prediction_post_rollback(
-    client: Res<Client<MyProtocol>>,
+    client: Res<Client>,
     parent_query: Query<&PredictionHistory<PlayerPosition>>,
     tail_query: Query<(&PlayerParent, &PredictionHistory<TailPoints>)>,
 ) {
@@ -223,7 +223,7 @@ pub(crate) fn debug_prediction_post_rollback(
 }
 
 pub(crate) fn debug_interpolate(
-    client: Res<Client<MyProtocol>>,
+    client: Res<Client>,
     parent_query: Query<(
         &InterpolateStatus<PlayerPosition>,
         &ConfirmedHistory<PlayerPosition>,

--- a/examples/replication_groups/server.rs
+++ b/examples/replication_groups/server.rs
@@ -121,7 +121,7 @@ pub(crate) fn movement(
     mut position_query: Query<&mut PlayerPosition>,
     mut input_reader: EventReader<InputEvent<Inputs>>,
     global: Res<Global>,
-    server: Res<Server<MyProtocol>>,
+    server: Res<Server>,
 ) {
     for input in input_reader.read() {
         let client_id = input.context();
@@ -141,6 +141,6 @@ pub(crate) fn movement(
     }
 }
 
-// pub(crate) fn debug_inputs(server: Res<Server<MyProtocol>>) {
+// pub(crate) fn debug_inputs(server: Res<Server>) {
 //     info!(tick = ?server.tick(), inputs = ?server.get_input_buffer(1), "debug");
 // }

--- a/examples/simple_box/client.rs
+++ b/examples/simple_box/client.rs
@@ -80,7 +80,7 @@ impl Plugin for MyClientPlugin {
 // Startup system for the client
 pub(crate) fn init(
     mut commands: Commands,
-    mut client: ResMut<Client<MyProtocol>>,
+    mut client: ResMut<Client>,
     plugin: Res<MyClientPlugin>,
 ) {
     commands.spawn(Camera2dBundle::default());
@@ -97,7 +97,7 @@ pub(crate) fn init(
 }
 
 // System that reads from peripherals and adds inputs to the buffer
-pub(crate) fn buffer_input(mut client: ResMut<Client<MyProtocol>>, keypress: Res<Input<KeyCode>>) {
+pub(crate) fn buffer_input(mut client: ResMut<Client>, keypress: Res<Input<KeyCode>>) {
     let mut direction = Direction {
         up: false,
         down: false,

--- a/examples/simple_box/server.rs
+++ b/examples/simple_box/server.rs
@@ -107,7 +107,7 @@ pub(crate) fn movement(
     mut position_query: Query<&mut PlayerPosition>,
     mut input_reader: EventReader<InputEvent<Inputs>>,
     global: Res<Global>,
-    server: Res<Server<MyProtocol>>,
+    server: Res<Server>,
 ) {
     for input in input_reader.read() {
         let client_id = input.context();
@@ -129,7 +129,7 @@ pub(crate) fn movement(
 
 /// Send messages from server to clients (only in non-headless mode, because otherwise we run with minimal plugins
 /// and cannot do input handling)
-pub(crate) fn send_message(mut server: ResMut<Server<MyProtocol>>, input: Res<Input<KeyCode>>) {
+pub(crate) fn send_message(mut server: ResMut<Server>, input: Res<Input<KeyCode>>) {
     if input.pressed(KeyCode::M) {
         // TODO: add way to send message to all
         let message = Message1(5);

--- a/examples/src/stepper.rs
+++ b/examples/src/stepper.rs
@@ -10,14 +10,13 @@ use tracing_subscriber::fmt::format::FmtSpan;
 use lightyear::client as lightyear_client;
 use lightyear::netcode::generate_key;
 use lightyear::prelude::client::{
-    Authentication, Client, ClientConfig, InputConfig, InterpolationConfig, PredictionConfig,
-    SyncConfig,
+    Authentication, ClientConfig, InputConfig, InterpolationConfig, PredictionConfig, SyncConfig,
 };
-use lightyear::prelude::server::{NetcodeConfig, Server, ServerConfig};
+use lightyear::prelude::server::{NetcodeConfig, ServerConfig};
 use lightyear::prelude::*;
 use lightyear::server as lightyear_server;
 
-use crate::protocol::{protocol, MyProtocol};
+use crate::protocol::*;
 
 /// Helpers to setup a bevy app where I can just step the world easily
 
@@ -127,16 +126,16 @@ impl BevyStepper {
         }
     }
 
-    pub fn client(&self) -> &Client<MyProtocol> {
-        self.client_app.world.resource::<Client<MyProtocol>>()
+    pub fn client(&self) -> &Client {
+        self.client_app.world.resource::<Client>()
     }
 
-    pub fn client_mut(&mut self) -> Mut<Client<MyProtocol>> {
-        self.client_app.world.resource_mut::<Client<MyProtocol>>()
+    pub fn client_mut(&mut self) -> Mut<Client> {
+        self.client_app.world.resource_mut::<Client>()
     }
 
-    fn server(&self) -> &Server<MyProtocol> {
-        self.server_app.world.resource::<Server<MyProtocol>>()
+    fn server(&self) -> &Server {
+        self.server_app.world.resource::<Server>()
     }
 }
 

--- a/lightyear/src/client/plugin.rs
+++ b/lightyear/src/client/plugin.rs
@@ -162,7 +162,7 @@ impl<P: Protocol> PluginType for ClientPlugin<P> {
             .add_systems(
                 PostUpdate,
                 (
-                    (send::<P>, clean_prespawned_entity).in_set(MainSet::SendPackets),
+                    (send::<P>, clean_prespawned_entity::<P>).in_set(MainSet::SendPackets),
                     sync_update::<P>.in_set(MainSet::Sync),
                 ),
             );

--- a/lightyear/src/client/prediction/mod.rs
+++ b/lightyear/src/client/prediction/mod.rs
@@ -14,8 +14,8 @@ pub use predicted_history::{ComponentState, PredictionHistory};
 use crate::client::components::{ComponentSyncMode, Confirmed};
 use crate::client::events::ComponentInsertEvent;
 use crate::client::prediction::resource::PredictionManager;
-use crate::prelude::Replicate;
-use crate::shared::replication::components::ShouldBePredicted;
+use crate::protocol::Protocol;
+use crate::shared::replication::components::{Replicate, ShouldBePredicted};
 use crate::shared::tick_manager::Tick;
 
 mod despawn;
@@ -53,7 +53,7 @@ pub enum RollbackState {
 /// have authority on the entity.
 /// Therefore we will remove the `Replicate` component right after the first time we've sent a replicating message to the
 /// server
-pub(crate) fn clean_prespawned_entity(
+pub(crate) fn clean_prespawned_entity<P: Protocol>(
     mut commands: Commands,
     pre_predicted_entities: Query<Entity, With<ShouldBePredicted>>,
 ) {
@@ -61,7 +61,7 @@ pub(crate) fn clean_prespawned_entity(
         debug!("removing replicate from pre-spawned entity");
         commands
             .entity(entity)
-            .remove::<Replicate>()
+            .remove::<Replicate<P>>()
             .remove::<ShouldBePredicted>()
             .insert(Predicted {
                 confirmed_entity: None,

--- a/lightyear/src/lib.rs
+++ b/lightyear/src/lib.rs
@@ -79,7 +79,7 @@ pub mod prelude {
     pub use crate::shared::ping::manager::PingConfig;
     pub use crate::shared::plugin::SharedPlugin;
     pub use crate::shared::replication::components::{
-        NetworkTarget, Replicate, ReplicationGroup, ReplicationMode,
+        NetworkTarget, ReplicationGroup, ReplicationMode,
     };
     pub use crate::shared::replication::entity_map::{EntityMapper, MapEntities, RemoteEntityMap};
     pub use crate::shared::sets::{FixedUpdateSet, MainSet, ReplicationSet};
@@ -106,7 +106,7 @@ pub mod prelude {
         pub use crate::client::prediction::plugin::PredictionConfig;
         pub use crate::client::prediction::predicted_history::{ComponentState, PredictionHistory};
         pub use crate::client::prediction::{Predicted, PredictionCommandsExt};
-        pub use crate::client::resource::{Authentication, Client};
+        pub use crate::client::resource::Authentication;
         pub use crate::client::sync::SyncConfig;
     }
     pub mod server {
@@ -120,7 +120,6 @@ pub mod prelude {
             DisconnectEvent, EntityDespawnEvent, EntitySpawnEvent, InputEvent, MessageEvent,
         };
         pub use crate::server::plugin::{PluginConfig, ServerPlugin};
-        pub use crate::server::resource::Server;
         pub use crate::server::room::{RoomId, RoomMut, RoomRef};
     }
 }

--- a/lightyear/src/protocol/mod.rs
+++ b/lightyear/src/protocol/mod.rs
@@ -82,11 +82,11 @@ pub trait Protocol: Send + Sync + Clone + Debug + 'static {
 
 /// This macro is used to build the Protocol struct.
 /// For convenience, it will re-export some types that need to have the Protocol as a generic parameter, so that you
-/// don't have to type <MyProtocol> everywhere.
+/// don't have to type `<MyProtocol>` everywhere.
 /// Notably:
-/// - `Replicate` is a type alias for [`Replicate<Protocol>](crate::shared::replication::components::Replicate)
+/// - `Replicate` is a type alias for [`Replicate<Protocol>`](crate::shared::replication::components::Replicate)
 /// - `Client` is a type alias for [`Client<Protocol>`](crate::client::resource::Client)
-/// - `Server` is a type alias for [`Server<Protocol>`](crate::client::resource::Server)
+/// - `Server` is a type alias for [`Server<Protocol>`](crate::server::resource::Server)
 #[macro_export]
 macro_rules! protocolize {
 

--- a/lightyear/src/protocol/mod.rs
+++ b/lightyear/src/protocol/mod.rs
@@ -80,7 +80,13 @@ pub trait Protocol: Send + Sync + Clone + Debug + 'static {
 
 // TODO: give an option to change names of types
 
-/// This macro is used to build the Protocol struct
+/// This macro is used to build the Protocol struct.
+/// For convenience, it will re-export some types that need to have the Protocol as a generic parameter, so that you
+/// don't have to type <MyProtocol> everywhere.
+/// Notably:
+/// - `Replicate` is a type alias for [`Replicate<Protocol>](crate::shared::replication::components::Replicate)
+/// - `Client` is a type alias for [`Client<Protocol>`](crate::client::resource::Client)
+/// - `Server` is a type alias for [`Server<Protocol>`](crate::client::resource::Server)
 #[macro_export]
 macro_rules! protocolize {
 
@@ -158,6 +164,9 @@ macro_rules! protocolize {
             }
         }
         pub use [<$protocol:lower _module>]::$protocol;
+        pub type Replicate = $shared_crate_name::shared::replication::components::Replicate<$protocol>;
+        pub type Client = $shared_crate_name::client::resource::Client<$protocol>;
+        pub type Server = $shared_crate_name::server::resource::Server<$protocol>;
         }
     };
 

--- a/lightyear/src/server/connection.rs
+++ b/lightyear/src/server/connection.rs
@@ -21,15 +21,14 @@ use crate::packet::message_manager::MessageManager;
 use crate::packet::message_receivers::MessageReceiver;
 use crate::packet::message_sender::MessageSender;
 use crate::packet::packet_manager::Payload;
-use crate::prelude::{
-    ChannelKind, DefaultUnorderedUnreliableChannel, MapEntities, NetworkTarget, Replicate,
-};
+use crate::prelude::{ChannelKind, DefaultUnorderedUnreliableChannel, MapEntities};
 use crate::protocol::channel::ChannelRegistry;
 use crate::protocol::Protocol;
 use crate::serialize::reader::ReadBuffer;
 use crate::server::events::ServerEvents;
 use crate::shared::ping::manager::{PingConfig, PingManager};
 use crate::shared::ping::message::SyncMessage;
+use crate::shared::replication::components::{NetworkTarget, Replicate};
 use crate::shared::replication::receive::ReplicationReceiver;
 use crate::shared::replication::send::ReplicationSender;
 use crate::shared::replication::ReplicationMessage;
@@ -46,7 +45,7 @@ pub struct ConnectionManager<P: Protocol> {
     // NOTE: we put this here because we only need one per world, not one per connection
     /// Stores the last `Replicate` component for each replicated entity owned by the current world (the world that sends replication updates)
     /// Needed to know the value of the Replicate component after the entity gets despawned, to know how we replicate the EntityDespawn
-    pub replicate_component_cache: EntityHashMap<Entity, Replicate>,
+    pub replicate_component_cache: EntityHashMap<Entity, Replicate<P>>,
 
     // list of clients that connected since the last time we sent replication messages
     // (we want to keep track of them because we need to replicate the entire world state to them)

--- a/lightyear/src/shared/replication/entity_map.rs
+++ b/lightyear/src/shared/replication/entity_map.rs
@@ -166,6 +166,7 @@ mod tests {
 
     use crate::prelude::client::*;
     use crate::prelude::*;
+    use crate::tests::protocol::Replicate;
     use crate::tests::protocol::*;
     use crate::tests::stepper::{BevyStepper, Step};
 

--- a/lightyear/src/shared/replication/mod.rs
+++ b/lightyear/src/shared/replication/mod.rs
@@ -104,7 +104,7 @@ pub trait ReplicationSend<P: Protocol>: Resource {
     fn prepare_entity_spawn(
         &mut self,
         entity: Entity,
-        replicate: &Replicate,
+        replicate: &Replicate<P>,
         target: NetworkTarget,
         system_current_tick: BevyTick,
     ) -> Result<()>;
@@ -112,7 +112,7 @@ pub trait ReplicationSend<P: Protocol>: Resource {
     fn prepare_entity_despawn(
         &mut self,
         entity: Entity,
-        replicate: &Replicate,
+        replicate: &Replicate<P>,
         target: NetworkTarget,
         system_current_tick: BevyTick,
     ) -> Result<()>;
@@ -121,7 +121,7 @@ pub trait ReplicationSend<P: Protocol>: Resource {
         &mut self,
         entity: Entity,
         component: P::Components,
-        replicate: &Replicate,
+        replicate: &Replicate<P>,
         target: NetworkTarget,
         // bevy_tick for the current system run (we send component updates since the most recent bevy_tick of
         //  last update ack OR last action sent)
@@ -132,7 +132,7 @@ pub trait ReplicationSend<P: Protocol>: Resource {
         &mut self,
         entity: Entity,
         component_kind: P::ComponentKinds,
-        replicate: &Replicate,
+        replicate: &Replicate<P>,
         target: NetworkTarget,
         system_current_tick: BevyTick,
     ) -> Result<()>;
@@ -141,7 +141,7 @@ pub trait ReplicationSend<P: Protocol>: Resource {
         &mut self,
         entity: Entity,
         component: P::Components,
-        replicate: &Replicate,
+        replicate: &Replicate<P>,
         target: NetworkTarget,
         // bevy_tick when the component changes
         component_change_tick: BevyTick,
@@ -159,7 +159,7 @@ pub trait ReplicationSend<P: Protocol>: Resource {
     /// But the receiving systems might expect both components to be present at the same time.
     fn buffer_replication_messages(&mut self) -> Result<()>;
 
-    fn get_mut_replicate_component_cache(&mut self) -> &mut EntityHashMap<Entity, Replicate>;
+    fn get_mut_replicate_component_cache(&mut self) -> &mut EntityHashMap<Entity, Replicate<P>>;
 }
 
 #[cfg(test)]

--- a/lightyear/src/shared/replication/send.rs
+++ b/lightyear/src/shared/replication/send.rs
@@ -17,12 +17,12 @@ use crate::_reexport::{
 };
 use crate::connection::events::ConnectionEvents;
 use crate::packet::message::MessageId;
-use crate::prelude::{MapEntities, Replicate, Tick};
+use crate::prelude::{MapEntities, Tick};
 use crate::protocol::channel::ChannelKind;
 use crate::protocol::component::ComponentProtocol;
 use crate::protocol::component::{ComponentBehaviour, ComponentKindBehaviour};
 use crate::protocol::Protocol;
-use crate::shared::replication::components::ReplicationGroupId;
+use crate::shared::replication::components::{Replicate, ReplicationGroupId};
 
 use super::entity_map::{InterpolatedEntityMap, PredictedEntityMap, RemoteEntityMap};
 use super::{
@@ -36,7 +36,7 @@ pub(crate) struct ReplicationSender<P: Protocol> {
     //  in general, we should have some parts of replication-sender/receiver that are shared across all connections!
     /// Stores the last `Replicate` component for each replicated entity owned by the current world (the world that sends replication updates)
     /// Needed to know the value of the Replicate component after the entity gets despawned, to know how we replicate the EntityDespawn
-    pub replicate_component_cache: EntityHashMap<Entity, Replicate>,
+    pub replicate_component_cache: EntityHashMap<Entity, Replicate<P>>,
     /// Get notified whenever a message-id that was sent has been received by the remote
     pub updates_ack_tracker: Receiver<MessageId>,
     /// Map from message-id to the corresponding group-id that sent this update message

--- a/lightyear/src/tests/client.rs
+++ b/lightyear/src/tests/client.rs
@@ -6,9 +6,9 @@ use bevy::app::App;
 
 use crate::prelude::client::*;
 use crate::prelude::*;
-use crate::tests::protocol::{protocol, MyProtocol};
+use crate::tests::protocol::*;
 
-pub fn setup(auth: Authentication) -> anyhow::Result<Client<MyProtocol>> {
+pub fn setup(auth: Authentication) -> anyhow::Result<Client> {
     let addr = SocketAddr::from_str("127.0.0.1:0")?;
     let io = Io::from_config(&IoConfig::from_transport(TransportConfig::UdpSocket(addr)));
     let config = ClientConfig {

--- a/lightyear/src/tests/examples/connection_soak.rs
+++ b/lightyear/src/tests/examples/connection_soak.rs
@@ -10,8 +10,8 @@ use rand::Rng;
 use tracing::debug;
 
 use crate::connection::events::IterMessageEvent;
-use crate::prelude::client::{Authentication, Client, ClientConfig, SyncConfig};
-use crate::prelude::server::{NetcodeConfig, Server, ServerConfig};
+use crate::prelude::client::{Authentication, ClientConfig, SyncConfig};
+use crate::prelude::server::{NetcodeConfig, ServerConfig};
 use crate::prelude::*;
 use crate::tests::protocol::*;
 

--- a/lightyear/src/tests/server.rs
+++ b/lightyear/src/tests/server.rs
@@ -7,9 +7,9 @@ use bevy::app::App;
 
 use crate::prelude::server::*;
 use crate::prelude::*;
-use crate::tests::protocol::{protocol, MyProtocol};
+use crate::tests::protocol::*;
 
-pub fn setup(protocol_id: u64, private_key: Key) -> anyhow::Result<Server<MyProtocol>> {
+pub fn setup(protocol_id: u64, private_key: Key) -> anyhow::Result<Server> {
     // create udp-socket based io
     let addr = SocketAddr::from_str("127.0.0.1:0")?;
     let netcode_config = NetcodeConfig::default()

--- a/lightyear/src/tests/stepper.rs
+++ b/lightyear/src/tests/stepper.rs
@@ -8,12 +8,11 @@ use bevy::MinimalPlugins;
 
 use crate::netcode::generate_key;
 use crate::prelude::client::{
-    Authentication, Client, ClientConfig, InputConfig, InterpolationConfig, PredictionConfig,
-    SyncConfig,
+    Authentication, ClientConfig, InputConfig, InterpolationConfig, PredictionConfig, SyncConfig,
 };
-use crate::prelude::server::{NetcodeConfig, Server, ServerConfig};
+use crate::prelude::server::{NetcodeConfig, ServerConfig};
 use crate::prelude::*;
-use crate::tests::protocol::{protocol, MyProtocol};
+use crate::tests::protocol::*;
 
 /// Helpers to setup a bevy app where I can just step the world easily
 
@@ -128,19 +127,19 @@ impl BevyStepper {
         }
     }
 
-    pub(crate) fn client(&self) -> &Client<MyProtocol> {
-        self.client_app.world.resource::<Client<MyProtocol>>()
+    pub(crate) fn client(&self) -> &Client {
+        self.client_app.world.resource::<Client>()
     }
 
-    pub(crate) fn client_mut(&mut self) -> Mut<Client<MyProtocol>> {
-        self.client_app.world.resource_mut::<Client<MyProtocol>>()
+    pub(crate) fn client_mut(&mut self) -> Mut<Client> {
+        self.client_app.world.resource_mut::<Client>()
     }
 
-    pub(crate) fn server(&self) -> &Server<MyProtocol> {
-        self.server_app.world.resource::<Server<MyProtocol>>()
+    pub(crate) fn server(&self) -> &Server {
+        self.server_app.world.resource::<Server>()
     }
-    pub(crate) fn server_mut(&mut self) -> Mut<Server<MyProtocol>> {
-        self.server_app.world.resource_mut::<Server<MyProtocol>>()
+    pub(crate) fn server_mut(&mut self) -> Mut<Server> {
+        self.server_app.world.resource_mut::<Server>()
     }
 }
 


### PR DESCRIPTION
- Export type aliases:
```
type Client = Client<MyProtocol>
type Server = Server<MyProtocol>
type Replicate = Replicate<MyProtocol>
```
for convenience.
Solves https://github.com/cBournhonesque/lightyear/issues/38.

- Add the option to not disable replication for individual components of an Entity; you just need to call the following methods on the `Replicate` component which defines how this entity gets replicated:
`replicate.disable_component<Component1>()` to disable replication, and 
`replicate.enable_component<Component1>()` to enable replication.

Note that his should be used careful as it could bring the entity into an invalid state, for example if you replicate that a component was inserted, then disable replication for that component, and then the component gets removed.
The `ComponentRemove` event won't get replicated, and the remote state won't be the same as the local state.

Solves https://github.com/cBournhonesque/lightyear/issues/37 