### PR TITLE
Fix sync issues

### DIFF
--- a/examples/bevy_headless.rs
+++ b/examples/bevy_headless.rs
@@ -8,7 +8,6 @@ use tracing_subscriber::fmt::format::FmtSpan;
 
 use lightyear::netcode::generate_key;
 use lightyear::prelude::client::Authentication;
-use lightyear::prelude::*;
 use lightyear_examples::protocol::*;
 
 fn client_init(mut client: ResMut<Client>) {

--- a/examples/bevy_simple.rs
+++ b/examples/bevy_simple.rs
@@ -10,7 +10,6 @@ use tracing_subscriber::fmt::format::FmtSpan;
 
 use lightyear::netcode::generate_key;
 use lightyear::prelude::client::Authentication;
-use lightyear::prelude::*;
 use lightyear_examples::protocol::*;
 
 fn client_init(mut client: ResMut<Client>) {

--- a/examples/src/stepper.rs
+++ b/examples/src/stepper.rs
@@ -137,6 +137,18 @@ impl BevyStepper {
     fn server(&self) -> &Server {
         self.server_app.world.resource::<Server>()
     }
+
+    pub(crate) fn init(&mut self) {
+        self.client_mut().connect();
+
+        // Advance the world to let the connection process complete
+        for _ in 0..100 {
+            if self.client().is_synced() {
+                break;
+            }
+            self.frame_step();
+        }
+    }
 }
 
 impl Step for BevyStepper {

--- a/lightyear/src/client/resource.rs
+++ b/lightyear/src/client/resource.rs
@@ -169,7 +169,7 @@ impl<P: Protocol> Client<P> {
         if self.connection.sync_manager.is_synced() {
             self.connection.sync_manager.update_prediction_time(
                 &mut self.time_manager,
-                &self.tick_manager,
+                &mut self.tick_manager,
                 &self.connection.ping_manager,
             );
             // update bevy's relative speed
@@ -186,7 +186,10 @@ impl<P: Protocol> Client<P> {
     }
 
     pub fn latest_received_server_tick(&self) -> Tick {
-        self.connection.sync_manager.latest_received_server_tick
+        self.connection
+            .sync_manager
+            .latest_received_server_tick
+            .unwrap_or(Tick(0))
     }
 
     pub fn received_new_server_tick(&self) -> bool {
@@ -304,7 +307,7 @@ impl<P: Protocol> TickManaged for Client<P> {
 #[cfg(test)]
 impl<P: Protocol> Client<P> {
     pub fn set_latest_received_server_tick(&mut self, tick: Tick) {
-        self.connection.sync_manager.latest_received_server_tick = tick;
+        self.connection.sync_manager.latest_received_server_tick = Some(tick);
         self.connection
             .sync_manager
             .duration_since_latest_received_server_tick = Duration::default();

--- a/lightyear/src/server/room.rs
+++ b/lightyear/src/server/room.rs
@@ -486,14 +486,7 @@ mod tests {
             link_conditioner,
             frame_duration,
         );
-        stepper.client_mut().connect();
-        stepper.client_mut().set_synced();
-
-        // Advance the world to let the connection process complete
-        for _ in 0..20 {
-            stepper.frame_step();
-        }
-
+        stepper.init();
         stepper
     }
 

--- a/lightyear/src/shared/replication/entity_map.rs
+++ b/lightyear/src/shared/replication/entity_map.rs
@@ -166,7 +166,6 @@ mod tests {
 
     use crate::prelude::client::*;
     use crate::prelude::*;
-    use crate::tests::protocol::Replicate;
     use crate::tests::protocol::*;
     use crate::tests::stepper::{BevyStepper, Step};
 
@@ -198,13 +197,7 @@ mod tests {
             link_conditioner,
             frame_duration,
         );
-        stepper.client_mut().connect();
-        stepper.client_mut().set_synced();
-
-        // Advance the world to let the connection process complete
-        for _ in 0..20 {
-            stepper.frame_step();
-        }
+        stepper.init();
 
         // Create an entity on server
         let server_entity = stepper

--- a/lightyear/src/shared/replication/mod.rs
+++ b/lightyear/src/shared/replication/mod.rs
@@ -199,13 +199,7 @@ mod tests {
             link_conditioner,
             frame_duration,
         );
-        stepper.client_mut().connect();
-        stepper.client_mut().set_synced();
-
-        // Advance the world to let the connection process complete
-        for _ in 0..20 {
-            stepper.frame_step();
-        }
+        stepper.init();
 
         // Create an entity on server
         let server_entity = stepper

--- a/lightyear/src/tests/stepper.rs
+++ b/lightyear/src/tests/stepper.rs
@@ -141,6 +141,18 @@ impl BevyStepper {
     pub(crate) fn server_mut(&mut self) -> Mut<Server> {
         self.server_app.world.resource_mut::<Server>()
     }
+
+    pub(crate) fn init(&mut self) {
+        self.client_mut().connect();
+
+        // Advance the world to let the connection process complete
+        for _ in 0..100 {
+            if self.client().is_synced() {
+                break;
+            }
+            self.frame_step();
+        }
+    }
 }
 
 impl Step for BevyStepper {


### PR DESCRIPTION
# Context

Issue https://github.com/cBournhonesque/lightyear/issues/33 outlined some problems with syncing, that was causing clients to get assigned an incorrect prediction/interpolation time at the start.

This PR resolves this by fixing 2 problems:
- the initial `latest_received_server_tick` but should have been None, as it was breaking the logic of `tick > latest_received_server_tick` if the starter tick was above 32768
- we were applying smoothing on the server_time_estimate before syncing, which was breaking the relationship between server_time and server_tick that we use later to assign the client tick

