### PR TITLE
Add a channel-based local transport

### DIFF
--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -14,7 +14,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 lightyear = { version = "0.5.0", path = "../lightyear" }
-
+crossbeam-channel = "0.5.10"
 anyhow = { version = "1.0.75", features = [] }
 bevy = { version = "0.12", features = ["bevy_core_pipeline"] }
 derive_more = { version = "0.99", features = ["add", "mul"] }

--- a/benches/spawn.rs
+++ b/benches/spawn.rs
@@ -42,6 +42,7 @@ fn spawn_local<const N: usize>(bencher: Bencher) {
                 ..default()
             };
             let mut stepper = LocalBevyStepper::new(
+                1,
                 shared_config,
                 SyncConfig::default(),
                 PredictionConfig::default(),
@@ -67,58 +68,6 @@ fn spawn_local<const N: usize>(bencher: Bencher) {
         .bench_values(|mut stepper| {
             stepper.frame_step();
             stepper.frame_step();
-            assert_eq!(stepper.client_app.world.entities().len(), N as u32);
-            // dbg!(stepper.client().io().stats());
-        });
-}
-
-const FIXED_NUM_ENTITIES: usize = 10;
-
-/// Replicating entity spawns from server to N clients, with a socket io
-#[divan::bench(
-    sample_count = 10,
-    consts = NUM_CLIENTS,
-)]
-fn spawn<const N: usize>(bencher: Bencher) {
-    bencher
-        .with_inputs(|| {
-            let frame_duration = Duration::from_secs_f32(1.0 / 60.0);
-            let tick_duration = Duration::from_millis(10);
-            let shared_config = SharedConfig {
-                tick: TickConfig::new(tick_duration),
-                log: LogConfig {
-                    level: Level::WARN,
-                    ..default()
-                },
-                ..default()
-            };
-            let mut stepper = BevyStepper::new(
-                N,
-                shared_config,
-                SyncConfig::default(),
-                PredictionConfig::default(),
-                InterpolationConfig::default(),
-                frame_duration,
-            );
-            stepper.init();
-
-            let entities = vec![
-                (
-                    Component1(0.0),
-                    Replicate {
-                        replication_target: NetworkTarget::All,
-                        ..default()
-                    },
-                );
-                FIXED_NUM_ENTITIES
-            ];
-
-            stepper.server_app.world.spawn_batch(entities);
-            stepper
-        })
-        .bench_values(|mut stepper| {
-            stepper.frame_step();
-            stepper.frame_step();
             for i in 0..N {
                 let client_id = i as ClientId;
                 assert_eq!(
@@ -129,9 +78,74 @@ fn spawn<const N: usize>(bencher: Bencher) {
                         .world
                         .entities()
                         .len(),
-                    FIXED_NUM_ENTITIES as u32
+                    N as u32
                 );
             }
+            // assert_eq!(stepper.client_app.world.entities().len(), N as u32);
             // dbg!(stepper.client().io().stats());
         });
 }
+
+const FIXED_NUM_ENTITIES: usize = 10;
+
+// /// Replicating entity spawns from server to N clients, with a socket io
+// #[divan::bench(
+//     sample_count = 10,
+//     consts = NUM_CLIENTS,
+// )]
+// fn spawn<const N: usize>(bencher: Bencher) {
+//     bencher
+//         .with_inputs(|| {
+//             let frame_duration = Duration::from_secs_f32(1.0 / 60.0);
+//             let tick_duration = Duration::from_millis(10);
+//             let shared_config = SharedConfig {
+//                 tick: TickConfig::new(tick_duration),
+//                 log: LogConfig {
+//                     level: Level::WARN,
+//                     ..default()
+//                 },
+//                 ..default()
+//             };
+//             let mut stepper = BevyStepper::new(
+//                 N,
+//                 shared_config,
+//                 SyncConfig::default(),
+//                 PredictionConfig::default(),
+//                 InterpolationConfig::default(),
+//                 frame_duration,
+//             );
+//             stepper.init();
+//
+//             let entities = vec![
+//                 (
+//                     Component1(0.0),
+//                     Replicate {
+//                         replication_target: NetworkTarget::All,
+//                         ..default()
+//                     },
+//                 );
+//                 FIXED_NUM_ENTITIES
+//             ];
+//
+//             stepper.server_app.world.spawn_batch(entities);
+//             stepper
+//         })
+//         .bench_values(|mut stepper| {
+//             stepper.frame_step();
+//             stepper.frame_step();
+//             for i in 0..N {
+//                 let client_id = i as ClientId;
+//                 assert_eq!(
+//                     stepper
+//                         .client_apps
+//                         .get(&client_id)
+//                         .unwrap()
+//                         .world
+//                         .entities()
+//                         .len(),
+//                     FIXED_NUM_ENTITIES as u32
+//                 );
+//             }
+//             // dbg!(stepper.client().io().stats());
+//         });
+// }

--- a/benches/spawn.rs
+++ b/benches/spawn.rs
@@ -3,6 +3,7 @@
 
 use bevy::log::info;
 use bevy::prelude::default;
+use bevy::utils::tracing;
 use bevy::utils::tracing::Level;
 use divan::{AllocProfiler, Bencher};
 use lightyear::client::sync::SyncConfig;
@@ -25,7 +26,7 @@ const NUM_CLIENTS: &[usize] = &[0, 1, 2, 4, 8, 16];
 
 /// Replicating N entity spawn from server to channel, with a local io
 #[divan::bench(
-    sample_count = 10,
+    sample_count = 100,
     consts = NUM_ENTITIES,
 )]
 fn spawn_local<const N: usize>(bencher: Bencher) {
@@ -68,6 +69,71 @@ fn spawn_local<const N: usize>(bencher: Bencher) {
         .bench_values(|mut stepper| {
             stepper.frame_step();
             stepper.frame_step();
+
+            let client_id = 0 as ClientId;
+            assert_eq!(
+                stepper
+                    .client_apps
+                    .get(&client_id)
+                    .unwrap()
+                    .world
+                    .entities()
+                    .len(),
+                N as u32
+            );
+            // assert_eq!(stepper.client_app.world.entities().len(), N as u32);
+            // dbg!(stepper.client().io().stats());
+        });
+}
+
+const FIXED_NUM_ENTITIES: usize = 10;
+
+/// Replicating entity spawns from server to N clients, with a socket io
+#[divan::bench(
+    sample_count = 100,
+    consts = NUM_CLIENTS,
+)]
+fn spawn<const N: usize>(bencher: Bencher) {
+    bencher
+        .with_inputs(|| {
+            let frame_duration = Duration::from_secs_f32(1.0 / 60.0);
+            let tick_duration = Duration::from_millis(10);
+            let shared_config = SharedConfig {
+                tick: TickConfig::new(tick_duration),
+                log: LogConfig {
+                    level: Level::WARN,
+                    ..default()
+                },
+                ..default()
+            };
+            let mut stepper = LocalBevyStepper::new(
+                N,
+                shared_config,
+                SyncConfig::default(),
+                PredictionConfig::default(),
+                InterpolationConfig::default(),
+                frame_duration,
+            );
+            stepper.init();
+
+            let entities = vec![
+                (
+                    Component1(0.0),
+                    Replicate {
+                        replication_target: NetworkTarget::All,
+                        ..default()
+                    },
+                );
+                FIXED_NUM_ENTITIES
+            ];
+
+            stepper.server_app.world.spawn_batch(entities);
+            stepper
+        })
+        .bench_values(|mut stepper| {
+            stepper.frame_step();
+            stepper.frame_step();
+
             for i in 0..N {
                 let client_id = i as ClientId;
                 assert_eq!(
@@ -78,74 +144,9 @@ fn spawn_local<const N: usize>(bencher: Bencher) {
                         .world
                         .entities()
                         .len(),
-                    N as u32
+                    FIXED_NUM_ENTITIES as u32
                 );
             }
-            // assert_eq!(stepper.client_app.world.entities().len(), N as u32);
             // dbg!(stepper.client().io().stats());
         });
 }
-
-const FIXED_NUM_ENTITIES: usize = 10;
-
-// /// Replicating entity spawns from server to N clients, with a socket io
-// #[divan::bench(
-//     sample_count = 10,
-//     consts = NUM_CLIENTS,
-// )]
-// fn spawn<const N: usize>(bencher: Bencher) {
-//     bencher
-//         .with_inputs(|| {
-//             let frame_duration = Duration::from_secs_f32(1.0 / 60.0);
-//             let tick_duration = Duration::from_millis(10);
-//             let shared_config = SharedConfig {
-//                 tick: TickConfig::new(tick_duration),
-//                 log: LogConfig {
-//                     level: Level::WARN,
-//                     ..default()
-//                 },
-//                 ..default()
-//             };
-//             let mut stepper = BevyStepper::new(
-//                 N,
-//                 shared_config,
-//                 SyncConfig::default(),
-//                 PredictionConfig::default(),
-//                 InterpolationConfig::default(),
-//                 frame_duration,
-//             );
-//             stepper.init();
-//
-//             let entities = vec![
-//                 (
-//                     Component1(0.0),
-//                     Replicate {
-//                         replication_target: NetworkTarget::All,
-//                         ..default()
-//                     },
-//                 );
-//                 FIXED_NUM_ENTITIES
-//             ];
-//
-//             stepper.server_app.world.spawn_batch(entities);
-//             stepper
-//         })
-//         .bench_values(|mut stepper| {
-//             stepper.frame_step();
-//             stepper.frame_step();
-//             for i in 0..N {
-//                 let client_id = i as ClientId;
-//                 assert_eq!(
-//                     stepper
-//                         .client_apps
-//                         .get(&client_id)
-//                         .unwrap()
-//                         .world
-//                         .entities()
-//                         .len(),
-//                     FIXED_NUM_ENTITIES as u32
-//                 );
-//             }
-//             // dbg!(stepper.client().io().stats());
-//         });
-// }

--- a/benches/src/client.rs
+++ b/benches/src/client.rs
@@ -13,7 +13,7 @@ use crate::protocol::{protocol, MyProtocol};
 pub fn bevy_setup(app: &mut App, auth: Authentication) {
     // create udp-socket based io
     let addr = SocketAddr::from_str("127.0.0.1:0").unwrap();
-    let io = Io::from_config(&IoConfig::from_transport(TransportConfig::UdpSocket(addr)));
+    let io = Io::from_config(IoConfig::from_transport(TransportConfig::UdpSocket(addr)));
     let config = ClientConfig {
         shared: SharedConfig {
             tick: TickConfig::new(Duration::from_millis(10)),

--- a/benches/src/local_stepper.rs
+++ b/benches/src/local_stepper.rs
@@ -19,6 +19,7 @@ use lightyear::prelude::client::{
 use lightyear::prelude::server::{NetcodeConfig, ServerConfig};
 use lightyear::prelude::*;
 use lightyear::server as lightyear_server;
+use lightyear::transport::LOCAL_SOCKET;
 
 use crate::protocol::*;
 
@@ -50,6 +51,8 @@ impl LocalBevyStepper {
         frame_duration: Duration,
     ) -> Self {
         let now = std::time::Instant::now();
+        // Local channels transport only works with server socket = LOCAL_SOCKET
+        let server_addr = LOCAL_SOCKET;
 
         // Shared config
         let protocol_id = 0;
@@ -90,7 +93,7 @@ impl LocalBevyStepper {
                     .build(),
             );
             let auth = Authentication::Manual {
-                server_addr: addr,
+                server_addr,
                 protocol_id,
                 private_key,
                 client_id,

--- a/benches/src/local_stepper.rs
+++ b/benches/src/local_stepper.rs
@@ -188,7 +188,14 @@ impl LocalBevyStepper {
         });
 
         // Advance the world to let the connection process complete
-        for _ in 0..50 {
+        for _ in 0..100 {
+            if self
+                .client_apps
+                .values()
+                .all(|c| c.world.resource::<Client>().is_synced())
+            {
+                return;
+            }
             self.frame_step();
         }
     }

--- a/benches/src/server.rs
+++ b/benches/src/server.rs
@@ -12,7 +12,7 @@ use lightyear::prelude::*;
 
 pub fn bevy_setup(app: &mut App, addr: SocketAddr, protocol_id: u64, private_key: Key) {
     // create udp-socket based io
-    let io = Io::from_config(&IoConfig::from_transport(TransportConfig::UdpSocket(addr)));
+    let io = Io::from_config(IoConfig::from_transport(TransportConfig::UdpSocket(addr)));
     let config = ServerConfig {
         shared: SharedConfig {
             tick: TickConfig::new(Duration::from_millis(10)),

--- a/benches/src/stepper.rs
+++ b/benches/src/stepper.rs
@@ -63,7 +63,7 @@ impl BevyStepper {
         let netcode_config = NetcodeConfig::default()
             .with_protocol_id(protocol_id)
             .with_key(private_key);
-        let io = Io::from_config(&IoConfig::from_transport(TransportConfig::UdpSocket(
+        let io = Io::from_config(IoConfig::from_transport(TransportConfig::UdpSocket(
             local_addr,
         )));
         let server_addr = io.local_addr();
@@ -89,7 +89,7 @@ impl BevyStepper {
                 client_id,
             };
             // let addr = SocketAddr::from_str(&format!("127.0.0.1:{}", i)).unwrap();
-            let io = Io::from_config(&IoConfig::from_transport(TransportConfig::UdpSocket(
+            let io = Io::from_config(IoConfig::from_transport(TransportConfig::UdpSocket(
                 local_addr,
             )));
             let config = ClientConfig {

--- a/examples/client_replication/client.rs
+++ b/examples/client_replication/client.rs
@@ -41,9 +41,8 @@ impl Plugin for MyClientPlugin {
                 server_addr,
             },
         };
-        let io = Io::from_config(
-            &IoConfig::from_transport(transport).with_conditioner(link_conditioner),
-        );
+        let io =
+            Io::from_config(IoConfig::from_transport(transport).with_conditioner(link_conditioner));
         let config = ClientConfig {
             shared: shared_config().clone(),
             input: InputConfig::default(),

--- a/examples/client_replication/server.rs
+++ b/examples/client_replication/server.rs
@@ -31,9 +31,8 @@ impl Plugin for MyServerPlugin {
                 certificate: Certificate::self_signed(&["localhost"]),
             },
         };
-        let io = Io::from_config(
-            &IoConfig::from_transport(transport).with_conditioner(link_conditioner),
-        );
+        let io =
+            Io::from_config(IoConfig::from_transport(transport).with_conditioner(link_conditioner));
         let config = ServerConfig {
             shared: shared_config().clone(),
             netcode: netcode_config,

--- a/examples/interest_management/client.rs
+++ b/examples/interest_management/client.rs
@@ -41,9 +41,8 @@ impl Plugin for MyClientPlugin {
                 server_addr,
             },
         };
-        let io = Io::from_config(
-            &IoConfig::from_transport(transport).with_conditioner(link_conditioner),
-        );
+        let io =
+            Io::from_config(IoConfig::from_transport(transport).with_conditioner(link_conditioner));
         let config = ClientConfig {
             shared: shared_config().clone(),
             input: InputConfig::default(),

--- a/examples/interest_management/server.rs
+++ b/examples/interest_management/server.rs
@@ -39,9 +39,8 @@ impl Plugin for MyServerPlugin {
                 certificate: Certificate::self_signed(&["localhost"]),
             },
         };
-        let io = Io::from_config(
-            &IoConfig::from_transport(transport).with_conditioner(link_conditioner),
-        );
+        let io =
+            Io::from_config(IoConfig::from_transport(transport).with_conditioner(link_conditioner));
         let config = ServerConfig {
             shared: shared_config().clone(),
             netcode: netcode_config,

--- a/examples/replication_groups/client.rs
+++ b/examples/replication_groups/client.rs
@@ -49,9 +49,8 @@ impl Plugin for MyClientPlugin {
                 server_addr,
             },
         };
-        let io = Io::from_config(
-            &IoConfig::from_transport(transport).with_conditioner(link_conditioner),
-        );
+        let io =
+            Io::from_config(IoConfig::from_transport(transport).with_conditioner(link_conditioner));
         let config = ClientConfig {
             shared: shared_config().clone(),
             input: InputConfig::default(),

--- a/examples/replication_groups/server.rs
+++ b/examples/replication_groups/server.rs
@@ -32,9 +32,8 @@ impl Plugin for MyServerPlugin {
                 certificate: Certificate::self_signed(&["localhost"]),
             },
         };
-        let io = Io::from_config(
-            &IoConfig::from_transport(transport).with_conditioner(link_conditioner),
-        );
+        let io =
+            Io::from_config(IoConfig::from_transport(transport).with_conditioner(link_conditioner));
         let config = ServerConfig {
             shared: shared_config().clone(),
             netcode: netcode_config,

--- a/examples/simple_box/client.rs
+++ b/examples/simple_box/client.rs
@@ -40,9 +40,8 @@ impl Plugin for MyClientPlugin {
                 server_addr,
             },
         };
-        let io = Io::from_config(
-            &IoConfig::from_transport(transport).with_conditioner(link_conditioner),
-        );
+        let io =
+            Io::from_config(IoConfig::from_transport(transport).with_conditioner(link_conditioner));
         let config = ClientConfig {
             shared: shared_config().clone(),
             input: InputConfig::default(),

--- a/examples/simple_box/server.rs
+++ b/examples/simple_box/server.rs
@@ -32,9 +32,8 @@ impl Plugin for MyServerPlugin {
                 certificate: Certificate::self_signed(&["localhost"]),
             },
         };
-        let io = Io::from_config(
-            &IoConfig::from_transport(transport).with_conditioner(link_conditioner),
-        );
+        let io =
+            Io::from_config(IoConfig::from_transport(transport).with_conditioner(link_conditioner));
         let config = ServerConfig {
             shared: shared_config().clone(),
             netcode: netcode_config,

--- a/examples/src/client.rs
+++ b/examples/src/client.rs
@@ -12,7 +12,7 @@ use crate::protocol::{protocol, MyProtocol};
 pub fn bevy_setup(app: &mut App, auth: Authentication) {
     // create udp-socket based io
     let addr = SocketAddr::from_str("127.0.0.1:0").unwrap();
-    let io = Io::from_config(&IoConfig::from_transport(TransportConfig::UdpSocket(addr)));
+    let io = Io::from_config(IoConfig::from_transport(TransportConfig::UdpSocket(addr)));
     let config = ClientConfig {
         shared: SharedConfig {
             enable_replication: false,

--- a/examples/src/server.rs
+++ b/examples/src/server.rs
@@ -14,7 +14,7 @@ pub fn bevy_setup(app: &mut App, addr: SocketAddr, protocol_id: u64, private_key
     let netcode_config = NetcodeConfig::default()
         .with_protocol_id(protocol_id)
         .with_key(private_key);
-    let io = Io::from_config(&IoConfig::from_transport(TransportConfig::UdpSocket(addr)));
+    let io = Io::from_config(IoConfig::from_transport(TransportConfig::UdpSocket(addr)));
     let config = ServerConfig {
         shared: SharedConfig {
             enable_replication: false,

--- a/examples/src/stepper.rs
+++ b/examples/src/stepper.rs
@@ -65,7 +65,7 @@ impl BevyStepper {
             .with_protocol_id(protocol_id)
             .with_key(private_key);
         let io = Io::from_config(
-            &IoConfig::from_transport(TransportConfig::UdpSocket(server_addr))
+            IoConfig::from_transport(TransportConfig::UdpSocket(server_addr))
                 .with_conditioner(conditioner.clone()),
         );
         let config = ServerConfig {
@@ -88,7 +88,7 @@ impl BevyStepper {
         };
         let addr = SocketAddr::from_str("127.0.0.1:0").unwrap();
         let io = Io::from_config(
-            &IoConfig::from_transport(TransportConfig::UdpSocket(addr))
+            IoConfig::from_transport(TransportConfig::UdpSocket(addr))
                 .with_conditioner(conditioner.clone()),
         );
         let config = ClientConfig {

--- a/lightyear/Cargo.toml
+++ b/lightyear/Cargo.toml
@@ -44,7 +44,6 @@ ringbuffer = "0.15"
 thiserror = "1.0.50"
 
 # transport
-futures = "0.3.30"
 wtransport = { version = "0.1.9", optional = true }
 
 # serialization

--- a/lightyear/Cargo.toml
+++ b/lightyear/Cargo.toml
@@ -44,6 +44,7 @@ ringbuffer = "0.15"
 thiserror = "1.0.50"
 
 # transport
+futures = "0.3.30"
 wtransport = { version = "0.1.9", optional = true }
 
 # serialization

--- a/lightyear/src/netcode/client.rs
+++ b/lightyear/src/netcode/client.rs
@@ -538,10 +538,11 @@ impl<Ctx> Client<Ctx> {
     /// # use std::time::{Instant, Duration};
     /// # use std::thread;
     /// # use lightyear::prelude::{Io, IoConfig, TransportConfig};
+    /// # let client_addr = SocketAddr::from(([127, 0, 0, 1], 40000));
     /// # let server_addr = SocketAddr::from(([127, 0, 0, 1], 40001));
     /// # let mut server = Server::new(0, [0; 32]).unwrap();
     /// # let token_bytes = server.token(0, server_addr).generate().unwrap().try_into_bytes().unwrap();
-    /// # let mut io = Io::from_config(IoConfig::from_transport(TransportConfig::LocalChannel));
+    /// # let mut io = Io::from_config(IoConfig::from_transport(TransportConfig::UdpSocket(client_addr)));
     /// let mut client = Client::new(&token_bytes).unwrap();
     /// client.connect();
     ///

--- a/lightyear/src/netcode/client.rs
+++ b/lightyear/src/netcode/client.rs
@@ -168,7 +168,7 @@ pub enum ClientState {
 /// # use std::thread;
 /// # use lightyear::prelude::{Io, IoConfig, TransportConfig};
 /// # let addr =  SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 0);
-/// # let mut io = Io::from_config(&IoConfig::from_transport(TransportConfig::UdpSocket(
+/// # let mut io = Io::from_config(IoConfig::from_transport(TransportConfig::UdpSocket(
 /// #    addr))
 /// # );
 /// # let mut server = Server::new(0, [0; 32]).unwrap();
@@ -541,7 +541,7 @@ impl<Ctx> Client<Ctx> {
     /// # let server_addr = SocketAddr::from(([127, 0, 0, 1], 40001));
     /// # let mut server = Server::new(0, [0; 32]).unwrap();
     /// # let token_bytes = server.token(0, server_addr).generate().unwrap().try_into_bytes().unwrap();
-    /// # let mut io = Io::from_config(&IoConfig::from_transport(TransportConfig::LocalChannel));
+    /// # let mut io = Io::from_config(IoConfig::from_transport(TransportConfig::LocalChannel));
     /// let mut client = Client::new(&token_bytes).unwrap();
     /// client.connect();
     ///

--- a/lightyear/src/netcode/mod.rs
+++ b/lightyear/src/netcode/mod.rs
@@ -51,7 +51,7 @@
  use crate::lightyear::transport::io::Io;
 
  // Create an io
- let mut io = Io::from_config(&IoConfig::from_transport(TransportConfig::LocalChannel));
+ let mut io = Io::from_config(IoConfig::from_transport(TransportConfig::LocalChannel));
 
  // Create a server
  let protocol_id = 0x11223344;
@@ -90,7 +90,7 @@ use crate::lightyear::netcode::{generate_key, ConnectToken, Client, MAX_PACKET_S
 use crate::lightyear::transport::io::Io;
 
 // Create an io
-let mut io = Io::from_config(&IoConfig::from_transport(TransportConfig::LocalChannel));
+let mut io = Io::from_config(IoConfig::from_transport(TransportConfig::LocalChannel));
 
 // Generate a connection token for the client
 let protocol_id = 0x11223344;

--- a/lightyear/src/netcode/mod.rs
+++ b/lightyear/src/netcode/mod.rs
@@ -44,14 +44,15 @@
   * Optionally provide a [`ServerConfig`] - a struct that allows you to customize the server's behavior.
 
  ```
- use std::{thread, time::{Instant, Duration}};
+ use std::{thread, time::{Instant, Duration}, net::SocketAddr};
  use crate::lightyear::netcode::{generate_key, Server, MAX_PACKET_SIZE};
 
  use lightyear::prelude::{IoConfig, TransportConfig};
  use crate::lightyear::transport::io::Io;
 
  // Create an io
- let mut io = Io::from_config(IoConfig::from_transport(TransportConfig::LocalChannel));
+ let client_addr = SocketAddr::from(([127, 0, 0, 1], 40000));
+ let mut io = Io::from_config(IoConfig::from_transport(TransportConfig::UdpSocket(client_addr)));
 
  // Create a server
  let protocol_id = 0x11223344;
@@ -84,13 +85,14 @@
   * Optionally provide a [`ClientConfig`] - a struct that allows you to customize the client's behavior.
 
  ```
-use std::{thread, time::{Instant, Duration}};
+use std::{thread, time::{Instant, Duration}, net::SocketAddr};
 use lightyear::prelude::{IoConfig, TransportConfig};
 use crate::lightyear::netcode::{generate_key, ConnectToken, Client, MAX_PACKET_SIZE};
 use crate::lightyear::transport::io::Io;
 
 // Create an io
-let mut io = Io::from_config(IoConfig::from_transport(TransportConfig::LocalChannel));
+let client_addr = SocketAddr::from(([127, 0, 0, 1], 40000));
+let mut io = Io::from_config(IoConfig::from_transport(TransportConfig::UdpSocket(client_addr)));
 
 // Generate a connection token for the client
 let protocol_id = 0x11223344;

--- a/lightyear/src/netcode/server.rs
+++ b/lightyear/src/netcode/server.rs
@@ -771,7 +771,7 @@ impl<Ctx> Server<Ctx> {
     /// # let private_key = [42u8; 32];
     /// # let mut server = Server::new(protocol_id, private_key).unwrap();
     /// # let mut io = Io::from_config(
-    /// #     &IoConfig::from_transport(TransportConfig::UdpSocket(addr))
+    /// #     IoConfig::from_transport(TransportConfig::UdpSocket(addr))
     /// # );
     /// let start = Instant::now();
     /// loop {

--- a/lightyear/src/netcode/server.rs
+++ b/lightyear/src/netcode/server.rs
@@ -304,7 +304,7 @@ impl<Ctx> ServerConfig<Ctx> {
 /// # use std::time::{Instant, Duration};
 /// # use std::thread;
 /// # use lightyear::prelude::{Io, IoConfig, TransportConfig};
-/// let mut io = Io::from_config(&IoConfig::from_transport(TransportConfig::UdpSocket(
+/// let mut io = Io::from_config(IoConfig::from_transport(TransportConfig::UdpSocket(
 ///    SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 0)))
 /// );
 /// let private_key = generate_key();

--- a/lightyear/src/netcode/server.rs
+++ b/lightyear/src/netcode/server.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, VecDeque};
 use std::net::SocketAddr;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use tracing::{debug, error, trace};
+use tracing::{debug, error, info, trace};
 
 use crate::serialize::reader::ReadBuffer;
 use crate::serialize::wordbuffer::reader::ReadWordBuffer;

--- a/lightyear/src/tests/client.rs
+++ b/lightyear/src/tests/client.rs
@@ -10,7 +10,7 @@ use crate::tests::protocol::*;
 
 pub fn setup(auth: Authentication) -> anyhow::Result<Client> {
     let addr = SocketAddr::from_str("127.0.0.1:0")?;
-    let io = Io::from_config(&IoConfig::from_transport(TransportConfig::UdpSocket(addr)));
+    let io = Io::from_config(IoConfig::from_transport(TransportConfig::UdpSocket(addr)));
     let config = ClientConfig {
         shared: SharedConfig {
             enable_replication: false,
@@ -32,7 +32,7 @@ pub fn setup(auth: Authentication) -> anyhow::Result<Client> {
 pub fn bevy_setup(app: &mut App, auth: Authentication) {
     // create udp-socket based io
     let addr = SocketAddr::from_str("127.0.0.1:0").unwrap();
-    let io = Io::from_config(&IoConfig::from_transport(TransportConfig::UdpSocket(addr)));
+    let io = Io::from_config(IoConfig::from_transport(TransportConfig::UdpSocket(addr)));
     let config = ClientConfig {
         shared: SharedConfig {
             enable_replication: false,

--- a/lightyear/src/tests/examples/connection_soak.rs
+++ b/lightyear/src/tests/examples/connection_soak.rs
@@ -32,7 +32,7 @@ fn test_connection_soak() -> anyhow::Result<()> {
         .with_protocol_id(protocol_id)
         .with_key(private_key);
     let io_server = Io::from_config(
-        &IoConfig::from_transport(TransportConfig::UdpSocket(addr)).with_conditioner(
+        IoConfig::from_transport(TransportConfig::UdpSocket(addr)).with_conditioner(
             LinkConditionerConfig {
                 incoming_latency: Duration::from_millis(20),
                 incoming_jitter: Duration::from_millis(10),
@@ -64,7 +64,7 @@ fn test_connection_soak() -> anyhow::Result<()> {
         client_id,
     };
     let io_client = Io::from_config(
-        &IoConfig::from_transport(TransportConfig::UdpSocket(addr)).with_conditioner(
+        IoConfig::from_transport(TransportConfig::UdpSocket(addr)).with_conditioner(
             LinkConditionerConfig {
                 incoming_latency: Duration::from_millis(20),
                 incoming_jitter: Duration::from_millis(10),

--- a/lightyear/src/tests/server.rs
+++ b/lightyear/src/tests/server.rs
@@ -15,7 +15,7 @@ pub fn setup(protocol_id: u64, private_key: Key) -> anyhow::Result<Server> {
     let netcode_config = NetcodeConfig::default()
         .with_protocol_id(protocol_id)
         .with_key(private_key);
-    let io = Io::from_config(&IoConfig::from_transport(TransportConfig::UdpSocket(addr)));
+    let io = Io::from_config(IoConfig::from_transport(TransportConfig::UdpSocket(addr)));
     let config = ServerConfig {
         shared: SharedConfig {
             enable_replication: false,
@@ -35,7 +35,7 @@ pub fn bevy_setup(app: &mut App, addr: SocketAddr, protocol_id: u64, private_key
     let netcode_config = NetcodeConfig::default()
         .with_protocol_id(protocol_id)
         .with_key(private_key);
-    let io = Io::from_config(&IoConfig::from_transport(TransportConfig::UdpSocket(addr)));
+    let io = Io::from_config(IoConfig::from_transport(TransportConfig::UdpSocket(addr)));
     let config = ServerConfig {
         shared: SharedConfig {
             enable_replication: false,

--- a/lightyear/src/tests/stepper.rs
+++ b/lightyear/src/tests/stepper.rs
@@ -50,16 +50,18 @@ impl BevyStepper {
 
         // Use local channels instead of UDP for testing
         let addr = SocketAddr::from_str("127.0.0.1:0").unwrap();
-        let (send, recv) = crossbeam_channel::unbounded();
+        // channels to receive a message from/to server
+        let (from_server_send, from_server_recv) = crossbeam_channel::unbounded();
+        let (to_server_send, to_server_recv) = crossbeam_channel::unbounded();
         let client_io = IoConfig::from_transport(TransportConfig::LocalChannel {
-            send: send.clone(),
-            recv: recv.clone(),
+            send: to_server_send,
+            recv: from_server_recv,
         })
         .with_conditioner(conditioner.clone())
         .get_io();
 
         let server_io = IoConfig::from_transport(TransportConfig::Channels {
-            channels: vec![(addr, recv, send)],
+            channels: vec![(addr, to_server_recv, from_server_send)],
         })
         .with_conditioner(conditioner.clone())
         .get_io();

--- a/lightyear/src/transport/channels.rs
+++ b/lightyear/src/transport/channels.rs
@@ -7,31 +7,20 @@ use crossbeam_channel::{Receiver, Select, Sender};
 use self_cell::self_cell;
 use tracing::info;
 
-use crate::transport::{PacketReceiver, PacketSender, Transport};
+use crate::transport::{PacketReceiver, PacketSender, Transport, LOCAL_SOCKET};
 
 #[derive(Clone)]
 pub struct Channels {
-    addr: SocketAddr,
-    // local receiver channel
-    recv: Receiver<Vec<u8>>,
-    // local sender channel
-    send: Option<Sender<Vec<u8>>>,
     // sender channels from remotes
     remote_recv: HashMap<SocketAddr, Receiver<Vec<u8>>>,
     remote_send: HashMap<SocketAddr, Sender<Vec<u8>>>,
-    buffer: Vec<u8>,
 }
 
 impl Channels {
-    pub(crate) fn new(addr: SocketAddr) -> Self {
-        let (send, recv) = crossbeam_channel::unbounded();
+    pub(crate) fn new() -> Self {
         Channels {
-            addr,
-            recv,
-            send: Some(send),
             remote_recv: HashMap::new(),
             remote_send: HashMap::new(),
-            buffer: vec![],
         }
     }
 
@@ -51,7 +40,7 @@ impl Channels {
 
 impl Transport for Channels {
     fn local_addr(&self) -> SocketAddr {
-        self.addr
+        LOCAL_SOCKET
     }
 
     fn listen(self) -> (Box<dyn PacketSender>, Box<dyn PacketReceiver>) {

--- a/lightyear/src/transport/channels.rs
+++ b/lightyear/src/transport/channels.rs
@@ -56,7 +56,7 @@ impl Transport for Channels {
             let mut id_map = HashMap::new();
             let mut select = Select::new();
             for (addr, recv) in o.recv.iter() {
-                let idx = select.recv(&recv);
+                let idx = select.recv(recv);
                 id_map.insert(idx, *addr);
             }
             ChannelsReceiverDependent {

--- a/lightyear/src/transport/channels.rs
+++ b/lightyear/src/transport/channels.rs
@@ -1,92 +1,142 @@
-// use bevy::utils::HashMap;
-// /// Purely local io for testing
-// /// Messages are sent via channels
-// use std::net::SocketAddr;
-//
-// use crossbeam_channel::{Receiver, Sender};
-//
-// use crate::transport::{PacketReceiver, PacketSender, Transport};
-//
-// #[derive(Clone)]
-// pub struct Channels {
-//     addr: SocketAddr,
-//     // local receiver channel
-//     recv: Receiver<Vec<u8>>,
-//     // local sender channel
-//     send: Option<Sender<Vec<u8>>>,
-//     // sender channels from remotes
-//     remote_recv: HashMap<SocketAddr, Receiver<Vec<u8>>>,
-//     remote_send: HashMap<SocketAddr, Sender<Vec<u8>>>,
-//     buffer: Vec<u8>,
-// }
-//
-// impl Channels {
-//     pub(crate) fn new(addr: SocketAddr) -> Self {
-//         let (send, recv) = crossbeam_channel::unbounded();
-//         Channels {
-//             addr,
-//             recv,
-//             send: Some(send),
-//             remote_recv: HashMap::new(),
-//             remote_send: HashMap::new(),
-//             buffer: vec![],
-//         }
-//     }
-//
-//     pub(crate) fn add_new_remote(&mut self, remote_addr: SocketAddr, remote_send: Sender<Vec<u8>>) {
-//         self.remote_send.insert(remote_addr, remote_send);
-//     }
-// }
-//
-// impl Transport for Channels {
-//     fn local_addr(&self) -> SocketAddr {
-//         self.addr
-//     }
-//
-//     fn listen(&mut self) -> (Box<dyn PacketSender>, Box<dyn PacketReceiver>) {
-//         let sender = LocalChannelSender {
-//             send: self.send.clone(),
-//         };
-//         let receiver = ChannelsReceiver {
-//             buffer: vec![],
-//             recv: self.recv.clone(),
-//         };
-//         (Box::new(sender), Box::new(receiver))
-//     }
-// }
-//
-// struct ChannelsReceiver {
-//     buffer: Vec<u8>,
-//     recv: Receiver<Vec<u8>>,
-// }
-//
-// // TODO: would need an async runtime polling through each of the remote_recv channels
-// impl PacketReceiver for ChannelsReceiver {
-//     fn recv(&mut self) -> std::io::Result<Option<(&mut [u8], SocketAddr)>> {
-//         self.recv.try_recv().map_or_else(
-//             |e| match e {
-//                 crossbeam_channel::TryRecvError::Empty => Ok(None),
-//                 _ => Err(std::io::Error::other(format!(
-//                     "error receiving packet: {:?}",
-//                     e
-//                 ))),
-//             },
-//             |data| {
-//                 self.buffer = data;
-//                 Ok(Some((self.buffer.as_mut_slice(), LOCAL_SOCKET)))
-//             },
-//         )
-//     }
-// }
-//
-// struct LocalChannelSender {
-//     send: Sender<Vec<u8>>,
-// }
-//
-// impl PacketSender for LocalChannelSender {
-//     fn send(&mut self, payload: &[u8], _: &SocketAddr) -> std::io::Result<()> {
-//         self.send
-//             .try_send(payload.to_vec())
-//             .map_err(|_| std::io::Error::other("error sending packet"))
-//     }
-// }
+use bevy::utils::HashMap;
+/// Purely local io for testing
+/// Messages are sent via channels
+use std::net::SocketAddr;
+
+use crossbeam_channel::{Receiver, Select, Sender};
+use self_cell::self_cell;
+use tracing::info;
+
+use crate::transport::{PacketReceiver, PacketSender, Transport};
+
+#[derive(Clone)]
+pub struct Channels {
+    addr: SocketAddr,
+    // local receiver channel
+    recv: Receiver<Vec<u8>>,
+    // local sender channel
+    send: Option<Sender<Vec<u8>>>,
+    // sender channels from remotes
+    remote_recv: HashMap<SocketAddr, Receiver<Vec<u8>>>,
+    remote_send: HashMap<SocketAddr, Sender<Vec<u8>>>,
+    buffer: Vec<u8>,
+}
+
+impl Channels {
+    pub(crate) fn new(addr: SocketAddr) -> Self {
+        let (send, recv) = crossbeam_channel::unbounded();
+        Channels {
+            addr,
+            recv,
+            send: Some(send),
+            remote_recv: HashMap::new(),
+            remote_send: HashMap::new(),
+            buffer: vec![],
+        }
+    }
+
+    /// Add a new remote service that we can send packets to
+    /// - it should provide a Sender (the remote will have the corresponding Receiver)
+    /// - it should provide a Receiver (the remote will have the corresponding Sender)
+    pub(crate) fn add_new_remote(
+        &mut self,
+        remote_addr: SocketAddr,
+        remote_recv: Receiver<Vec<u8>>,
+        remote_send: Sender<Vec<u8>>,
+    ) {
+        self.remote_recv.insert(remote_addr, remote_recv);
+        self.remote_send.insert(remote_addr, remote_send);
+    }
+}
+
+impl Transport for Channels {
+    fn local_addr(&self) -> SocketAddr {
+        self.addr
+    }
+
+    fn listen(self) -> (Box<dyn PacketSender>, Box<dyn PacketReceiver>) {
+        let sender = ChannelsSender {
+            send: self.remote_send,
+        };
+
+        // receiver is a self-referential struct
+        let owner = ChannelsReceiverOwner {
+            recv: self.remote_recv,
+        };
+        let receiver = ChannelsReceiver::new(owner, |o| {
+            let mut id_map = HashMap::new();
+            let mut select = Select::new();
+            for (addr, recv) in o.recv.iter() {
+                let idx = select.recv(&recv);
+                id_map.insert(idx, *addr);
+            }
+            ChannelsReceiverDependent {
+                buffer: vec![],
+                select,
+                id_map,
+            }
+        });
+
+        (Box::new(sender), Box::new(receiver))
+    }
+}
+
+struct ChannelsReceiverOwner {
+    recv: HashMap<SocketAddr, Receiver<Vec<u8>>>,
+}
+struct ChannelsReceiverDependent<'a> {
+    buffer: Vec<u8>,
+    select: Select<'a>,
+    id_map: HashMap<usize, SocketAddr>,
+}
+self_cell!(
+    struct ChannelsReceiver {
+        owner: ChannelsReceiverOwner,
+
+        #[covariant]
+        dependent: ChannelsReceiverDependent,
+    }
+);
+
+impl PacketReceiver for ChannelsReceiver {
+    fn recv(&mut self) -> std::io::Result<Option<(&mut [u8], SocketAddr)>> {
+        self.with_dependent_mut(|owner, dependent| {
+            let op = dependent.select.try_select().map_or_else(
+                |e| Ok(None),
+                |op| {
+                    let addr = dependent.id_map.get(&op.index()).unwrap();
+                    let recv = owner.recv.get(addr).unwrap();
+                    match op.recv(recv) {
+                        Ok(_) => {
+                            dbg!("recv data from client {:?}", addr);
+                            Ok(Some((dependent.buffer.as_mut_slice(), *addr)))
+                        }
+                        Err(e) => Err(std::io::Error::other(format!(
+                            "error receiving packet: {:?}",
+                            e
+                        ))),
+                    }
+                },
+            );
+            op
+        })
+    }
+}
+
+struct ChannelsSender {
+    send: HashMap<SocketAddr, Sender<Vec<u8>>>,
+}
+
+impl PacketSender for ChannelsSender {
+    fn send(&mut self, payload: &[u8], addr: &SocketAddr) -> std::io::Result<()> {
+        dbg!("Server sending packet to {:?}", addr);
+        self.send
+            .get(addr)
+            .ok_or(std::io::Error::other(
+                "could not find remote sender channel for address",
+            ))
+            .unwrap()
+            .try_send(payload.to_vec())
+            .map_err(|_| std::io::Error::other("error sending packet"))
+    }
+}

--- a/lightyear/src/transport/channels.rs
+++ b/lightyear/src/transport/channels.rs
@@ -107,8 +107,8 @@ impl PacketReceiver for ChannelsReceiver {
                     let addr = dependent.id_map.get(&op.index()).unwrap();
                     let recv = owner.recv.get(addr).unwrap();
                     match op.recv(recv) {
-                        Ok(_) => {
-                            dbg!("recv data from client {:?}", addr);
+                        Ok(data) => {
+                            dependent.buffer = data;
                             Ok(Some((dependent.buffer.as_mut_slice(), *addr)))
                         }
                         Err(e) => Err(std::io::Error::other(format!(
@@ -129,7 +129,6 @@ struct ChannelsSender {
 
 impl PacketSender for ChannelsSender {
     fn send(&mut self, payload: &[u8], addr: &SocketAddr) -> std::io::Result<()> {
-        dbg!("Server sending packet to {:?}", addr);
         self.send
             .get(addr)
             .ok_or(std::io::Error::other(

--- a/lightyear/src/transport/conditioner.rs
+++ b/lightyear/src/transport/conditioner.rs
@@ -43,10 +43,10 @@ pub struct ConditionedPacketReceiver<T: PacketReceiver, P: Eq> {
 }
 
 impl<T: PacketReceiver, P: Eq> ConditionedPacketReceiver<T, P> {
-    pub fn new(packet_receiver: T, link_conditioner_config: &LinkConditionerConfig) -> Self {
+    pub fn new(packet_receiver: T, link_conditioner_config: LinkConditionerConfig) -> Self {
         ConditionedPacketReceiver {
             packet_receiver,
-            config: link_conditioner_config.clone(),
+            config: link_conditioner_config,
             time_queue: ReadyBuffer::new(),
             last_packet: None,
         }

--- a/lightyear/src/transport/io.rs
+++ b/lightyear/src/transport/io.rs
@@ -12,7 +12,7 @@ use wtransport::tls::Certificate;
 
 use crate::transport::channels::Channels;
 use crate::transport::conditioner::{ConditionedPacketReceiver, LinkConditionerConfig};
-use crate::transport::local::{LocalChannel, LOCAL_SOCKET};
+use crate::transport::local::LocalChannel;
 use crate::transport::udp::UdpSocket;
 #[cfg(feature = "webtransport")]
 use crate::transport::webtransport::client::WebTransportClientSocket;
@@ -74,7 +74,7 @@ impl TransportConfig {
                 Io::new(addr, sender, receiver)
             }
             TransportConfig::Channels { channels } => {
-                let mut transport = Channels::new(LOCAL_SOCKET);
+                let mut transport = Channels::new();
                 for (addr, remote_recv, remote_send) in channels.into_iter() {
                     transport.add_new_remote(addr, remote_recv, remote_send);
                 }

--- a/lightyear/src/transport/io.rs
+++ b/lightyear/src/transport/io.rs
@@ -1,5 +1,6 @@
 //! Wrapper around a transport, that can perform additional transformations such as
 //! bandwidth monitoring or compression
+use crossbeam_channel::{Receiver, Sender};
 use std::fmt::{Debug, Formatter};
 use std::io::Result;
 use std::net::{IpAddr, SocketAddr};
@@ -9,8 +10,9 @@ use metrics;
 #[cfg(feature = "webtransport")]
 use wtransport::tls::Certificate;
 
+use crate::transport::channels::Channels;
 use crate::transport::conditioner::{ConditionedPacketReceiver, LinkConditionerConfig};
-use crate::transport::local::LocalChannel;
+use crate::transport::local::{LocalChannel, LOCAL_SOCKET};
 use crate::transport::udp::UdpSocket;
 #[cfg(feature = "webtransport")]
 use crate::transport::webtransport::client::WebTransportClientSocket;
@@ -31,31 +33,62 @@ pub enum TransportConfig {
         server_addr: SocketAddr,
         certificate: Certificate,
     },
-    LocalChannel,
+    Channels {
+        channels: Vec<(SocketAddr, Receiver<Vec<u8>>, Sender<Vec<u8>>)>,
+    },
+    LocalChannel {
+        recv: Receiver<Vec<u8>>,
+        send: Sender<Vec<u8>>,
+    },
 }
 
 impl TransportConfig {
-    pub fn get_io(&self) -> Io {
-        let mut transport: Box<dyn Transport> = match self {
-            TransportConfig::UdpSocket(addr) => Box::new(UdpSocket::new(addr).unwrap()),
+    pub fn get_io(self) -> Io {
+        // we don't use `dyn Transport` and instead repeat the code for `transport.listen()` because that function is not
+        // object-safe (we would get "the size of `dyn Transport` cannot be statically determined")
+        match self {
+            TransportConfig::UdpSocket(addr) => {
+                let transport = UdpSocket::new(addr).unwrap();
+                let addr = transport.local_addr();
+                let (sender, receiver) = transport.listen();
+                Io::new(addr, sender, receiver)
+            }
             #[cfg(feature = "webtransport")]
             TransportConfig::WebTransportClient {
                 client_addr,
                 server_addr,
-            } => Box::new(WebTransportClientSocket::new(*client_addr, *server_addr)),
+            } => {
+                let transport = WebTransportClientSocket::new(client_addr, server_addr);
+                let addr = transport.local_addr();
+                let (sender, receiver) = transport.listen();
+                Io::new(addr, sender, receiver)
+            }
             #[cfg(feature = "webtransport")]
             TransportConfig::WebTransportServer {
                 server_addr,
                 certificate,
-            } => Box::new(WebTransportServerSocket::new(
-                *server_addr,
-                certificate.clone(),
-            )),
-            TransportConfig::LocalChannel => Box::new(LocalChannel::new()),
-        };
-        let addr = transport.local_addr();
-        let (sender, receiver) = transport.listen();
-        Io::new(addr, sender, receiver)
+            } => {
+                let transport = WebTransportServerSocket::new(server_addr, certificate);
+                let addr = transport.local_addr();
+                let (sender, receiver) = transport.listen();
+                Io::new(addr, sender, receiver)
+            }
+            TransportConfig::Channels { channels } => {
+                let mut transport = Channels::new(LOCAL_SOCKET);
+                for (addr, remote_recv, remote_send) in channels.into_iter() {
+                    transport.add_new_remote(addr, remote_recv, remote_send);
+                }
+                let addr = transport.local_addr();
+                let (sender, receiver) = transport.listen();
+                Io::new(addr, sender, receiver)
+            }
+            TransportConfig::LocalChannel { recv, send } => {
+                let transport = LocalChannel::new(recv, send);
+                let addr = transport.local_addr();
+                let (sender, receiver) = transport.listen();
+                Io::new(addr, sender, receiver)
+            }
+        }
     }
 }
 
@@ -86,9 +119,9 @@ impl IoConfig {
         self
     }
 
-    pub fn get_io(&self) -> Io {
+    pub fn get_io(self) -> Io {
         let mut io = self.transport.get_io();
-        if let Some(conditioner) = &self.conditioner {
+        if let Some(conditioner) = self.conditioner {
             io = Io::new(
                 io.local_addr,
                 io.sender,
@@ -113,7 +146,7 @@ pub struct IoStats {
 }
 
 impl Io {
-    pub fn from_config(config: &IoConfig) -> Self {
+    pub fn from_config(config: IoConfig) -> Self {
         config.get_io()
     }
 

--- a/lightyear/src/transport/local.rs
+++ b/lightyear/src/transport/local.rs
@@ -60,7 +60,6 @@ impl PacketReceiver for LocalChannelReceiver {
                 ))),
             },
             |data| {
-                dbg!("received data from server");
                 self.buffer = data;
                 Ok(Some((self.buffer.as_mut_slice(), LOCAL_SOCKET)))
             },

--- a/lightyear/src/transport/local.rs
+++ b/lightyear/src/transport/local.rs
@@ -4,28 +4,18 @@ use std::net::SocketAddr;
 
 use crossbeam_channel::{Receiver, Sender};
 
-use crate::transport::{PacketReceiver, PacketSender, Transport};
-
-pub(crate) const LOCAL_SOCKET: SocketAddr = SocketAddr::new(
-    std::net::IpAddr::V4(std::net::Ipv4Addr::new(127, 0, 0, 1)),
-    0,
-);
+use crate::transport::{PacketReceiver, PacketSender, Transport, LOCAL_SOCKET};
 
 // TODO: this is client only; separate client/server transport traits
 #[derive(Clone)]
 pub struct LocalChannel {
     recv: Receiver<Vec<u8>>,
     send: Sender<Vec<u8>>,
-    buffer: Vec<u8>,
 }
 
 impl LocalChannel {
     pub(crate) fn new(recv: Receiver<Vec<u8>>, send: Sender<Vec<u8>>) -> Self {
-        LocalChannel {
-            recv,
-            send,
-            buffer: vec![],
-        }
+        LocalChannel { recv, send }
     }
 }
 

--- a/lightyear/src/transport/mod.rs
+++ b/lightyear/src/transport/mod.rs
@@ -12,7 +12,8 @@ pub(crate) mod local;
 /// The transport is a UDP socket
 pub(crate) mod udp;
 
-// mod channels;
+/// The transport is a map of channels (used for server, during testing)
+pub(crate) mod channels;
 
 /// The transport is using WebTransport
 #[cfg(feature = "webtransport")]
@@ -25,7 +26,7 @@ use std::net::SocketAddr;
 pub trait Transport {
     /// Return the local socket address for this transport
     fn local_addr(&self) -> SocketAddr;
-    fn listen(&mut self) -> (Box<dyn PacketSender>, Box<dyn PacketReceiver>);
+    fn listen(self) -> (Box<dyn PacketSender>, Box<dyn PacketReceiver>);
 
     // fn split(&mut self) -> (Box<dyn PacketReceiver>, Box<dyn PacketSender>);
 }

--- a/lightyear/src/transport/mod.rs
+++ b/lightyear/src/transport/mod.rs
@@ -22,6 +22,11 @@ pub mod webtransport;
 use std::io::Result;
 use std::net::SocketAddr;
 
+pub const LOCAL_SOCKET: SocketAddr = SocketAddr::new(
+    std::net::IpAddr::V4(std::net::Ipv4Addr::new(127, 0, 0, 1)),
+    0,
+);
+
 /// Transport combines a PacketSender and a PacketReceiver
 pub trait Transport {
     /// Return the local socket address for this transport

--- a/lightyear/src/transport/udp.rs
+++ b/lightyear/src/transport/udp.rs
@@ -23,8 +23,8 @@ pub struct UdpSocket {
 
 impl UdpSocket {
     /// Create a non-blocking UDP socket
-    pub fn new(local_addr: &SocketAddr) -> Result<Self> {
-        let udp_socket = std::net::UdpSocket::bind(*local_addr)?;
+    pub fn new(local_addr: SocketAddr) -> Result<Self> {
+        let udp_socket = std::net::UdpSocket::bind(local_addr)?;
         let socket = Arc::new(Mutex::new(udp_socket));
         socket.as_ref().lock().unwrap().set_nonblocking(true)?;
         Ok(Self {
@@ -44,7 +44,7 @@ impl Transport for UdpSocket {
             .expect("error getting local addr")
     }
 
-    fn listen(&mut self) -> (Box<dyn PacketSender>, Box<dyn PacketReceiver>) {
+    fn listen(self) -> (Box<dyn PacketSender>, Box<dyn PacketReceiver>) {
         (Box::new(self.clone()), Box::new(self.clone()))
     }
 }
@@ -97,8 +97,8 @@ mod tests {
         // let the OS assigned a port
         let local_addr = SocketAddr::from_str("127.0.0.1:0")?;
 
-        let mut server_socket = UdpSocket::new(&local_addr)?;
-        let mut client_socket = UdpSocket::new(&local_addr)?;
+        let mut server_socket = UdpSocket::new(local_addr)?;
+        let mut client_socket = UdpSocket::new(local_addr)?;
 
         let server_addr = server_socket.local_addr();
         let client_addr = client_socket.local_addr();
@@ -124,15 +124,15 @@ mod tests {
         // let the OS assigned a port
         let local_addr = SocketAddr::from_str("127.0.0.1:0")?;
 
-        let server_socket = UdpSocket::new(&local_addr)?;
-        let mut client_socket = UdpSocket::new(&local_addr)?;
+        let server_socket = UdpSocket::new(local_addr)?;
+        let mut client_socket = UdpSocket::new(local_addr)?;
 
         let server_addr = server_socket.local_addr();
         let client_addr = client_socket.local_addr();
 
         let mut conditioned_server_receiver = ConditionedPacketReceiver::new(
             server_socket,
-            &LinkConditionerConfig {
+            LinkConditionerConfig {
                 incoming_latency: Duration::from_millis(100),
                 incoming_jitter: Duration::from_millis(0),
                 incoming_loss: 0.0,

--- a/lightyear/src/transport/webtransport/client.rs
+++ b/lightyear/src/transport/webtransport/client.rs
@@ -31,7 +31,7 @@ impl Transport for WebTransportClientSocket {
         self.client_addr
     }
 
-    fn listen(&mut self) -> (Box<dyn PacketSender>, Box<dyn PacketReceiver>) {
+    fn listen(self) -> (Box<dyn PacketSender>, Box<dyn PacketReceiver>) {
         let client_addr = self.client_addr;
         let server_addr = self.server_addr;
         let (to_server_sender, mut to_server_receiver) = mpsc::unbounded_channel();

--- a/lightyear/src/transport/webtransport/mod.rs
+++ b/lightyear/src/transport/webtransport/mod.rs
@@ -27,8 +27,8 @@ mod tests {
         let server_addr = "127.0.0.1:7000".parse().unwrap();
         let client_addr = "127.0.0.1:8000".parse().unwrap();
 
-        let mut client_socket = WebTransportClientSocket::new(client_addr, server_addr);
-        let mut server_socket = WebTransportServerSocket::new(server_addr, certificate);
+        let client_socket = WebTransportClientSocket::new(client_addr, server_addr);
+        let server_socket = WebTransportServerSocket::new(server_addr, certificate);
 
         let (mut server_send, mut server_recv) = server_socket.listen();
         let (mut client_send, mut client_recv) = client_socket.listen();

--- a/lightyear/src/transport/webtransport/server.rs
+++ b/lightyear/src/transport/webtransport/server.rs
@@ -81,10 +81,10 @@ impl Transport for WebTransportServerSocket {
         self.server_addr
     }
 
-    fn listen(&mut self) -> (Box<dyn PacketSender>, Box<dyn PacketReceiver>) {
+    fn listen(self) -> (Box<dyn PacketSender>, Box<dyn PacketReceiver>) {
         // TODO: should i create my own task pool?
         let server_addr = self.server_addr;
-        let certificate = std::mem::take(&mut self.certificate).unwrap();
+        let certificate = self.certificate.unwrap();
         let (to_client_sender, to_client_receiver) =
             mpsc::unbounded_channel::<(Box<[u8]>, SocketAddr)>();
         let (from_client_sender, from_client_receiver) = mpsc::unbounded_channel();


### PR DESCRIPTION
You can use a channel-based local transport for testing by using:
- LocalChannel for clients
- Channels for server

Updated the benchmarks to use the local channels to avoid extra udp latency