### PR TITLE
Improve replication to newly-connected-clients

### DIFF
--- a/lightyear/src/shared/ping/manager.rs
+++ b/lightyear/src/shared/ping/manager.rs
@@ -212,7 +212,7 @@ impl PingManager {
             let rtt = received_time - ping_sent_time;
             let server_process_time = pong.pong_sent_time - pong.ping_received_time;
             trace!(?rtt, ?received_time, ?ping_sent_time, ?server_process_time, ?pong.pong_sent_time, ?pong.ping_received_time, "process pong");
-            let round_trip_delay = (rtt - server_process_time).to_std().unwrap();
+            let round_trip_delay = (rtt - server_process_time).to_std().unwrap_or_default();
 
             // update stats buffer
             self.sync_stats

--- a/lightyear/src/shared/replication/components.rs
+++ b/lightyear/src/shared/replication/components.rs
@@ -134,6 +134,56 @@ impl NetworkTarget {
         }
     }
 
+    /// Compute the intersection of this target with another one (A ∩ B)
+    pub(crate) fn intersection(&mut self, target: NetworkTarget) {
+        match self {
+            NetworkTarget::All => {
+                *self = target;
+            }
+            NetworkTarget::AllExcept(existing_client_ids) => match target {
+                NetworkTarget::None => {
+                    *self = NetworkTarget::None;
+                }
+                NetworkTarget::AllExcept(target_client_ids) => {
+                    let mut new_excluded_ids = HashSet::from_iter(existing_client_ids.clone());
+                    target_client_ids.into_iter().for_each(|id| {
+                        new_excluded_ids.insert(id);
+                    });
+                    *existing_client_ids = Vec::from_iter(new_excluded_ids);
+                }
+                NetworkTarget::All => {}
+                NetworkTarget::Only(target_client_ids) => {
+                    let mut new_included_ids = HashSet::from_iter(target_client_ids.clone());
+                    existing_client_ids.into_iter().for_each(|id| {
+                        new_included_ids.remove(id);
+                    });
+                    *self = NetworkTarget::Only(Vec::from_iter(new_included_ids));
+                }
+            },
+            NetworkTarget::Only(existing_client_ids) => match target {
+                NetworkTarget::None => {
+                    *self = NetworkTarget::None;
+                }
+                NetworkTarget::AllExcept(target_client_ids) => {
+                    let mut new_included_ids = HashSet::from_iter(existing_client_ids.clone());
+                    target_client_ids.into_iter().for_each(|id| {
+                        new_included_ids.remove(&id);
+                    });
+                    *existing_client_ids = Vec::from_iter(new_included_ids);
+                }
+                NetworkTarget::All => {}
+                NetworkTarget::Only(target_client_ids) => {
+                    let mut new_included_ids = HashSet::from_iter(existing_client_ids.clone());
+                    let mut target_included_ids = HashSet::from_iter(target_client_ids.clone());
+                    let intersection = new_included_ids.intersection(&target_included_ids).cloned();
+                    *existing_client_ids = intersection.collect::<Vec<_>>();
+                }
+            },
+            NetworkTarget::None => {}
+        }
+    }
+
+    /// Compute the difference of this target with another one (A - B)
     pub(crate) fn exclude(&mut self, client_ids: Vec<ClientId>) {
         match self {
             NetworkTarget::All => {
@@ -231,6 +281,38 @@ mod tests {
         target = NetworkTarget::None;
         assert!(!target.should_send_to(&0));
         target.exclude(vec![1]);
+        assert_eq!(target, NetworkTarget::None);
+    }
+
+    #[test]
+    fn test_intersection() {
+        let mut target = NetworkTarget::All;
+        target.intersection(NetworkTarget::AllExcept(vec![1, 2]));
+        assert_eq!(target, NetworkTarget::AllExcept(vec![1, 2]));
+
+        target = NetworkTarget::AllExcept(vec![0]);
+        target.intersection(NetworkTarget::AllExcept(vec![0, 1]));
+        assert!(matches!(target, NetworkTarget::AllExcept(_)));
+
+        if let NetworkTarget::AllExcept(ids) = target {
+            assert!(ids.contains(&0));
+            assert!(ids.contains(&1));
+        }
+
+        target = NetworkTarget::AllExcept(vec![0, 1]);
+        target.intersection(NetworkTarget::Only(vec![0, 2]));
+        assert_eq!(target, NetworkTarget::Only(vec![2]));
+
+        target = NetworkTarget::Only(vec![0, 1]);
+        target.intersection(NetworkTarget::Only(vec![0, 2]));
+        assert_eq!(target, NetworkTarget::Only(vec![0]));
+
+        target = NetworkTarget::Only(vec![0, 1]);
+        target.intersection(NetworkTarget::AllExcept(vec![0, 2]));
+        assert_eq!(target, NetworkTarget::Only(vec![1]));
+
+        target = NetworkTarget::None;
+        target.intersection(NetworkTarget::AllExcept(vec![0, 2]));
         assert_eq!(target, NetworkTarget::None);
     }
 }

--- a/lightyear/src/shared/replication/systems.rs
+++ b/lightyear/src/shared/replication/systems.rs
@@ -174,12 +174,16 @@ fn send_entity_spawn<P: Protocol, R: ReplicationSend<P>>(
 
                 let new_connected_clients = sender.new_connected_clients().clone();
                 if !new_connected_clients.is_empty() {
+                    // replicate to the newly connected clients that match our target
+                    let mut new_connected_target = target.clone();
+                    new_connected_target
+                        .intersection(NetworkTarget::Only(new_connected_clients.clone()));
                     // replicate all entities to newly connected clients
                     let _ = sender
                         .prepare_entity_spawn(
                             entity,
                             &replicate,
-                            NetworkTarget::Only(new_connected_clients.clone()),
+                            new_connected_target,
                             system_bevy_ticks.this_run(),
                         )
                         .map_err(|e| {
@@ -291,12 +295,16 @@ fn send_component_update<C: Component + Clone, P: Protocol, R: ReplicationSend<P
                 let new_connected_clients = sender.new_connected_clients().clone();
                 // replicate all components to newly connected clients
                 if !new_connected_clients.is_empty() {
+                    // replicate to the newly connected clients that match our target
+                    let mut new_connected_target = target.clone();
+                    new_connected_target
+                        .intersection(NetworkTarget::Only(new_connected_clients.clone()));
                     let _ = sender
                         .prepare_component_insert(
                             entity,
                             component.clone().into(),
                             replicate,
-                            NetworkTarget::Only(new_connected_clients.clone()),
+                            new_connected_target,
                             system_bevy_ticks.this_run(),
                         )
                         .map_err(|e| {


### PR DESCRIPTION
Current behaviour:
- when a client newly connects, replicate entities to them

New behaviour:
- when a client newly connects, replicate entities to them only if the entities were supposed to be replicated to them (i.e. if they were included via Replicate.replication_target)