### PR TITLE
fix mesleading names in readme.

### DIFF
--- a/examples/leafwing_inputs/README.md
+++ b/examples/leafwing_inputs/README.md
@@ -3,7 +3,7 @@
 - multiple entities with a leafwing ActionState (i.e. 2 entities are controlled by action state)
 - a global action-state (with a different ActionLike) for chat
 - chat displayed on screen
-- each player controls 2 cubes (with either WASD or arrows) and there is a ball
+- each player controls 2 squares (with either WASD or arrows) and there is a "ball"
 - they can score
 
 


### PR DESCRIPTION
cubes (3d) -> squares (2d)