### PR TITLE
Replicate entities correctly in all situations

### DIFF
--- a/examples/interest_management/Cargo.toml
+++ b/examples/interest_management/Cargo.toml
@@ -19,7 +19,11 @@ mock_time = ["lightyear/mock_time"]
 
 [dependencies]
 leafwing-input-manager = "0.11.2"
-lightyear = { path = "../../lightyear", features = ["webtransport", "render", "leafwing"] }
+lightyear = { path = "../../lightyear", features = [
+  "webtransport",
+  "render",
+  "leafwing",
+] }
 serde = { version = "1.0.188", features = ["derive"] }
 anyhow = { version = "1.0.75", features = [] }
 tracing = "0.1"

--- a/examples/interest_management/Cargo.toml
+++ b/examples/interest_management/Cargo.toml
@@ -19,7 +19,7 @@ mock_time = ["lightyear/mock_time"]
 
 [dependencies]
 leafwing-input-manager = "0.11.2"
-lightyear = { path = "../../lightyear", features = ["webtransport", "render"] }
+lightyear = { path = "../../lightyear", features = ["webtransport", "render", "leafwing"] }
 serde = { version = "1.0.188", features = ["derive"] }
 anyhow = { version = "1.0.75", features = [] }
 tracing = "0.1"

--- a/examples/interest_management/src/client.rs
+++ b/examples/interest_management/src/client.rs
@@ -119,13 +119,15 @@ pub(crate) fn movement(
 // System to receive messages on the client
 pub(crate) fn add_input_map(
     mut commands: Commands,
-    // players: Query<Entity, (Added<PlayerId>, With<Predicted>)>,
-    players: Query<Entity, Added<PlayerId>>,
+    predicted_players: Query<Entity, (Added<PlayerId>, With<Predicted>)>,
 ) {
-    for player_entity in players.iter() {
-        commands
-            .entity(player_entity)
-            .insert(PlayerBundle::get_input_map());
+    // we don't want to replicate the ActionState from the server to client, because if we have an ActionState
+    // on the Confirmed player it will keep getting replicated to Predicted and will interfere with our inputs
+    for player_entity in predicted_players.iter() {
+        commands.entity(player_entity).insert((
+            PlayerBundle::get_input_map(),
+            ActionState::<Inputs>::default(),
+        ));
     }
 }
 

--- a/examples/interest_management/src/protocol.rs
+++ b/examples/interest_management/src/protocol.rs
@@ -18,7 +18,7 @@ pub(crate) struct PlayerBundle {
     position: Position,
     color: PlayerColor,
     replicate: Replicate,
-    inputs: InputManagerBundle<Inputs>,
+    action_state: ActionState<Inputs>,
 }
 
 impl PlayerBundle {
@@ -34,18 +34,23 @@ impl PlayerBundle {
                 replication_mode: ReplicationMode::Room,
                 ..default()
             },
-            inputs: InputManagerBundle::<Inputs> {
-                action_state: ActionState::default(),
-                input_map: InputMap::new([
-                    (KeyCode::Right, Inputs::Right),
-                    (KeyCode::Left, Inputs::Left),
-                    (KeyCode::Up, Inputs::Up),
-                    (KeyCode::Down, Inputs::Down),
-                    (KeyCode::Delete, Inputs::Delete),
-                    (KeyCode::Space, Inputs::Spawn),
-                ]),
-            },
+            action_state: ActionState::default(),
         }
+    }
+    pub(crate) fn get_input_map() -> InputMap<Inputs> {
+        InputMap::new([
+            (KeyCode::Right, Inputs::Right),
+            (KeyCode::D, Inputs::Right),
+            (KeyCode::Left, Inputs::Left),
+            (KeyCode::A, Inputs::Left),
+            (KeyCode::Up, Inputs::Up),
+            (KeyCode::W, Inputs::Up),
+            (KeyCode::Down, Inputs::Down),
+            (KeyCode::S, Inputs::Down),
+            (KeyCode::Delete, Inputs::Delete),
+            (KeyCode::Space, Inputs::Spawn),
+            (KeyCode::M, Inputs::Message),
+        ])
     }
 }
 
@@ -117,7 +122,7 @@ pub enum Messages {
 // Inputs
 
 #[derive(
-    Serialize, Deserialize, Debug, Default, PartialEq, Eq, Hash, Reflect, Clone, Actionlike,
+    Serialize, Deserialize, Debug, Default, PartialEq, Eq, Hash, Reflect, Clone, Copy, Actionlike,
 )]
 pub enum Inputs {
     Up,
@@ -131,27 +136,7 @@ pub enum Inputs {
     None,
 }
 
-impl Inputs {
-    /// Get the mapping from keycodes to inputs
-    pub(crate) fn get_input_map() -> InputMap<Inputs> {
-        use KeyCode::*;
-        InputMap::new([
-            (Right, Inputs::Right),
-            (D, Inputs::Right),
-            (Left, Inputs::Left),
-            (A, Inputs::Left),
-            (Up, Inputs::Up),
-            (W, Inputs::Up),
-            (Down, Inputs::Down),
-            (S, Inputs::Down),
-            (Delete, Inputs::Delete),
-            (Space, Inputs::Spawn),
-            (M, Inputs::Message),
-        ])
-    }
-}
-
-impl UserAction for Inputs {}
+impl LeafwingUserAction for Inputs {}
 
 // Protocol
 
@@ -159,7 +144,7 @@ protocolize! {
     Self = MyProtocol,
     Message = Messages,
     Component = Components,
-    Input = Inputs,
+    LeafwingInput1 = Inputs,
 }
 
 pub(crate) fn protocol() -> MyProtocol {

--- a/examples/interest_management/src/shared.rs
+++ b/examples/interest_management/src/shared.rs
@@ -2,6 +2,7 @@ use crate::protocol::*;
 use bevy::prelude::*;
 
 use bevy::render::RenderPlugin;
+use leafwing_input_manager::action_state::ActionState;
 use lightyear::prelude::client::Confirmed;
 use lightyear::prelude::*;
 use std::ops::Deref;
@@ -38,22 +39,19 @@ impl Plugin for SharedPlugin {
 }
 
 // This system defines how we update the player's positions when we receive an input
-pub(crate) fn shared_movement_behaviour(mut position: Mut<Position>, input: &Inputs) {
+pub(crate) fn shared_movement_behaviour(mut position: Mut<Position>, input: &ActionState<Inputs>) {
     const MOVE_SPEED: f32 = 10.0;
-    match input {
-        Inputs::Up => {
-            position.y += MOVE_SPEED;
-        }
-        Inputs::Down => {
-            position.y -= MOVE_SPEED;
-        }
-        Inputs::Left => {
-            position.x -= MOVE_SPEED;
-        }
-        Inputs::Right => {
-            position.x += MOVE_SPEED;
-        }
-        _ => {}
+    if input.pressed(Inputs::Up) {
+        position.y += MOVE_SPEED;
+    }
+    if input.pressed(Inputs::Down) {
+        position.y -= MOVE_SPEED;
+    }
+    if input.pressed(Inputs::Left) {
+        position.x -= MOVE_SPEED;
+    }
+    if input.pressed(Inputs::Right) {
+        position.x += MOVE_SPEED;
     }
 }
 
@@ -62,7 +60,8 @@ pub(crate) fn shared_movement_behaviour(mut position: Mut<Position>, input: &Inp
 /// This time we will only draw the predicted/interpolated entities
 pub(crate) fn draw_boxes(
     mut gizmos: Gizmos,
-    players: Query<(&Position, &PlayerColor), Without<Confirmed>>,
+    // players: Query<(&Position, &PlayerColor), Without<Confirmed>>,
+    players: Query<(&Position, &PlayerColor)>,
 ) {
     for (position, color) in &players {
         gizmos.rect(

--- a/examples/leafwing_inputs/src/client.rs
+++ b/examples/leafwing_inputs/src/client.rs
@@ -135,19 +135,19 @@ pub(crate) fn init(
     );
     let y = (plugin.client_id as f32 * 50.0) % 500.0 - 250.0;
     // we will spawn two cubes per player, once is controlled with WASD, the other with arrows
-    if plugin.client_id == 2 {
-        commands.spawn(PlayerBundle::new(
-            plugin.client_id,
-            Vec2::new(-50.0, y),
-            color_from_id(plugin.client_id),
-            InputMap::new([
-                (KeyCode::W, PlayerActions::Up),
-                (KeyCode::S, PlayerActions::Down),
-                (KeyCode::A, PlayerActions::Left),
-                (KeyCode::D, PlayerActions::Right),
-            ]),
-        ));
-    }
+    // if plugin.client_id == 2 {
+    commands.spawn(PlayerBundle::new(
+        plugin.client_id,
+        Vec2::new(-50.0, y),
+        color_from_id(plugin.client_id),
+        InputMap::new([
+            (KeyCode::W, PlayerActions::Up),
+            (KeyCode::S, PlayerActions::Down),
+            (KeyCode::A, PlayerActions::Left),
+            (KeyCode::D, PlayerActions::Right),
+        ]),
+    ));
+    // }
     // commands.spawn(PlayerBundle::new(
     //     plugin.client_id,
     //     Vec2::new(50.0, y),

--- a/examples/leafwing_inputs/src/client.rs
+++ b/examples/leafwing_inputs/src/client.rs
@@ -17,7 +17,7 @@ use std::str::FromStr;
 use std::time::Duration;
 
 pub const INPUT_DELAY_TICKS: u16 = 0;
-pub const CORRECTION_TICKS_FACTOR: f32 = 1.0;
+pub const CORRECTION_TICKS_FACTOR: f32 = 1.5;
 
 #[derive(Resource, Clone, Copy)]
 pub struct MyClientPlugin {
@@ -148,17 +148,17 @@ pub(crate) fn init(
         ]),
     ));
     // }
-    // commands.spawn(PlayerBundle::new(
-    //     plugin.client_id,
-    //     Vec2::new(50.0, y),
-    //     color_from_id(plugin.client_id),
-    //     InputMap::new([
-    //         (KeyCode::Up, PlayerActions::Up),
-    //         (KeyCode::Down, PlayerActions::Down),
-    //         (KeyCode::Left, PlayerActions::Left),
-    //         (KeyCode::Right, PlayerActions::Right),
-    //     ]),
-    // ));
+    commands.spawn(PlayerBundle::new(
+        plugin.client_id,
+        Vec2::new(50.0, y),
+        color_from_id(plugin.client_id),
+        InputMap::new([
+            (KeyCode::Up, PlayerActions::Up),
+            (KeyCode::Down, PlayerActions::Down),
+            (KeyCode::Left, PlayerActions::Left),
+            (KeyCode::Right, PlayerActions::Right),
+        ]),
+    ));
     client.connect();
 }
 

--- a/examples/leafwing_inputs/src/server.rs
+++ b/examples/leafwing_inputs/src/server.rs
@@ -88,12 +88,12 @@ pub(crate) fn init(mut commands: Commands, plugin: Res<MyServerPlugin>) {
     );
 
     // the ball is server-authoritative
-    // commands.spawn(BallBundle::new(
-    //     Vec2::new(0.0, 0.0),
-    //     Color::AZURE,
-    //     // if true, we predict the ball on clients
-    //     plugin.predict_all,
-    // ));
+    commands.spawn(BallBundle::new(
+        Vec2::new(0.0, 0.0),
+        Color::AZURE,
+        // if true, we predict the ball on clients
+        plugin.predict_all,
+    ));
 }
 
 /// Server disconnection system, delete all player entities upon disconnection
@@ -162,9 +162,9 @@ pub(crate) fn replicate_players(
             ]));
             if plugin.predict_all {
                 replicate.prediction_target = NetworkTarget::All;
-                // if we predict other players, we need to replicate their actions to all clients other than the original one
-                // (the original client will apply the actions locally)
-                replicate.disable_replicate_once::<ActionState<PlayerActions>>();
+                // // if we predict other players, we need to replicate their actions to all clients other than the original one
+                // // (the original client will apply the actions locally)
+                // replicate.disable_replicate_once::<ActionState<PlayerActions>>();
             } else {
                 // NOTE: even with a pre-spawned Predicted entity, we need to specify who will run prediction
                 replicate.prediction_target = NetworkTarget::Only(vec![*client_id]);

--- a/examples/leafwing_inputs/src/shared.rs
+++ b/examples/leafwing_inputs/src/shared.rs
@@ -29,7 +29,7 @@ pub fn shared_config() -> SharedConfig {
             tick_duration: Duration::from_secs_f64(1.0 / FIXED_TIMESTEP_HZ),
         },
         log: LogConfig {
-            level: Level::INFO,
+            level: Level::WARN,
             filter: "wgpu=error,wgpu_hal=error,naga=warn,bevy_app=info,bevy_render=warn,quinn=warn"
                 .to_string(),
         },

--- a/lightyear/src/client/diagnostics.rs
+++ b/lightyear/src/client/diagnostics.rs
@@ -26,7 +26,7 @@ fn io_diagnostics_system<P: Protocol>(
 }
 impl<P: Protocol> Plugin for ClientDiagnosticsPlugin<P> {
     fn build(&self, app: &mut App) {
-        app.add_plugins(IoDiagnosticsPlugin::default());
+        app.add_plugins(IoDiagnosticsPlugin);
         app.add_systems(PostUpdate, io_diagnostics_system::<P>);
     }
 }

--- a/lightyear/src/client/input_leafwing.rs
+++ b/lightyear/src/client/input_leafwing.rs
@@ -14,10 +14,12 @@ use crate::client::prediction::{Predicted, Rollback, RollbackState};
 use crate::client::resource::Client;
 use crate::client::sync::client_is_synced;
 use crate::inputs::leafwing::input_buffer::{
-    ActionDiff, ActionDiffBuffer, ActionDiffEvent, InputBuffer, InputMessage,
+    ActionDiff, ActionDiffBuffer, ActionDiffEvent, InputBuffer, InputMessage, InputTarget,
 };
 use crate::inputs::leafwing::LeafwingUserAction;
+use crate::prelude::MapEntities;
 use crate::protocol::Protocol;
+use crate::shared::replication::components::PrePredicted;
 use crate::shared::sets::{FixedUpdateSet, MainSet};
 use crate::shared::tick_manager::TickManaged;
 
@@ -205,9 +207,12 @@ where
         //   'set' will apply SameAsPrecedent for TB.
         app.add_systems(
             PostUpdate,
-            prepare_input_message::<P, A>
-                .in_set(InputSystemSet::SendInputMessage)
-                .run_if(client_is_synced::<P>),
+            (
+                prepare_input_message::<P, A>
+                    .in_set(InputSystemSet::SendInputMessage)
+                    .run_if(client_is_synced::<P>),
+                add_action_state_buffer_added_input_map::<A>,
+            ),
         );
     }
 }
@@ -222,6 +227,21 @@ pub enum InputSystemSet {
     SendInputMessage,
 }
 
+fn add_action_state_buffer_added_input_map<A: LeafwingUserAction>(
+    mut commands: Commands,
+    entities: Query<Entity, (With<ActionState<A>>, Added<InputMap<A>>)>,
+) {
+    // TODO: find a way to add input-buffer/action-diff-buffer only for controlled entity
+    //  maybe provide the "controlled" component? or just use With<InputMap>?
+
+    for entity in entities.iter() {
+        commands.entity(entity).insert((
+            InputBuffer::<A>::default(),
+            ActionDiffBuffer::<A>::default(),
+        ));
+    }
+}
+
 /// For each entity that has an action-state, insert an action-state-buffer
 /// that will store the value of the action-state for the last few ticks
 fn add_action_state_buffer<A: LeafwingUserAction>(
@@ -232,17 +252,17 @@ fn add_action_state_buffer<A: LeafwingUserAction>(
         (
             Added<ActionState<A>>,
             With<InputMap<A>>,
-            Or<(With<Predicted>, With<ShouldBePredicted>)>,
+            // Or<(With<Predicted>, With<ShouldBePredicted>)>,
         ),
     >,
-    other_entities: Query<
-        Entity,
-        (
-            Added<ActionState<A>>,
-            Without<Predicted>,
-            Without<ShouldBePredicted>,
-        ),
-    >,
+    // other_entities: Query<
+    //     Entity,
+    //     (
+    //         Added<ActionState<A>>,
+    //         Without<Predicted>,
+    //         Without<ShouldBePredicted>,
+    //     ),
+    // >,
 ) {
     // TODO: find a way to add input-buffer/action-diff-buffer only for controlled entity
     //  maybe provide the "controlled" component? or just use With<InputMap>?
@@ -420,7 +440,12 @@ fn prepare_input_message<P: Protocol, A: LeafwingUserAction>(
     mut client: ResMut<Client<P>>,
     global_action_diff_buffer: Option<ResMut<ActionDiffBuffer<A>>>,
     global_input_buffer: Option<ResMut<InputBuffer<A>>>,
-    mut action_diff_buffer_query: Query<(Entity, Option<&Predicted>, &mut ActionDiffBuffer<A>)>,
+    mut action_diff_buffer_query: Query<(
+        Entity,
+        Option<&Predicted>,
+        &mut ActionDiffBuffer<A>,
+        Option<&PrePredicted>,
+    )>,
     mut input_buffer_query: Query<(Entity, &mut InputBuffer<A>)>,
 ) where
     P::Message: From<InputMessage<A>>,
@@ -452,27 +477,64 @@ fn prepare_input_message<P: Protocol, A: LeafwingUserAction>(
         interpolation_tick
     );
 
-    for (entity, predicted, mut action_diff_buffer) in action_diff_buffer_query.iter_mut() {
+    for (entity, predicted, mut action_diff_buffer, pre_predicted) in
+        action_diff_buffer_query.iter_mut()
+    {
         trace!(
             ?tick,
             ?entity,
             "Preparing input message with buffer: {:?}",
             action_diff_buffer.as_ref()
         );
-        action_diff_buffer.add_to_message(&mut message, tick, message_len, Some(entity));
 
-        // TODO: make this better, this is a bit awkward.
-        //  also does that mean that inputs before we receive the confirmation on client are not mapped?
-        // TODO: actually we don't need this, because the remote_entity_map on server contains the Predicted entity!
-        // Convert the entity in the message from the Predicted tot he Confirmed, so that the server
-        // can map to their own local entity
-        // if let Some(predicted) = predicted {
-        //     info!("has predicted!!");
-        //     if let Some(confirmed) = predicted.confirmed_entity {
-        //         info!("mapping the entity in the input message from Predicted to Confirmed");
-        //         message.per_entity_diffs.last_mut().unwrap().0 = confirmed
-        //     }
-        // }
+        // Make sure that server can read the inputs correctly
+        // TODO: currently we are not sending inputs for pre-predicted entities until we receive the confirmation from the server
+        //  could we find a way to do it?
+        //  maybe if it's pre-predicted, we send the original entity (pre-predicted), and the server will apply the conversion
+        //   on their end?
+
+        if pre_predicted.is_some() {
+            warn!(
+                "sending inputs for pre-predicted entity! Local client entity: {:?}",
+                entity
+            );
+            // TODO: not sure if this whole pre-predicted inputs thing is worth it, because the server won't be able to
+            //  to receive the inputs until it receives the pre-predicted spawn message.
+            //  so all the inputs sent between pre-predicted spawn and server-receives-pre-predicted will be lost
+
+            // TODO: I feel like pre-predicted inputs work well only for global-inputs, because then the server can know
+            // for which client the inputs were!
+
+            // 0. the entity is pre-predicted
+            action_diff_buffer.add_to_message(
+                &mut message,
+                tick,
+                message_len,
+                InputTarget::PrePredictedEntity(entity),
+            );
+        } else {
+            // 1.if the entity is confirmed, we need to convert the entity to the server's entity
+            // 2. the entity is predicted.
+            // We need to first convert the entity to confirmed, and then from confirmed to remote
+            if let Some(confirmed) = predicted.map_or(Some(entity), |p| p.confirmed_entity) {
+                if let Some(server_entity) = client
+                    .replication_receiver()
+                    .remote_entity_map
+                    .get_remote(confirmed)
+                    .copied()
+                {
+                    warn!("sending input for server entity: {:?}. local entity: {:?}, confirmed: {:?}", server_entity, entity, confirmed);
+                    action_diff_buffer.add_to_message(
+                        &mut message,
+                        tick,
+                        message_len,
+                        InputTarget::Entity(server_entity),
+                    );
+                }
+            } else {
+                warn!("not sending inputs because couldnt find server entity");
+            }
+        }
 
         action_diff_buffer.pop(interpolation_tick);
     }
@@ -487,7 +549,7 @@ fn prepare_input_message<P: Protocol, A: LeafwingUserAction>(
         trace!("input buffer len: {:?}", input_buffer.buffer.len());
     }
     if let Some(mut action_diff_buffer) = global_action_diff_buffer {
-        action_diff_buffer.add_to_message(&mut message, tick, message_len, None);
+        action_diff_buffer.add_to_message(&mut message, tick, message_len, InputTarget::Global);
         action_diff_buffer.pop(interpolation_tick);
     }
     if let Some(mut input_buffer) = global_input_buffer {
@@ -498,11 +560,11 @@ fn prepare_input_message<P: Protocol, A: LeafwingUserAction>(
     // TODO: should we provide variants of each user-facing function, so that it pushes the error
     //  to the ConnectionEvents?
     if !message.is_empty() {
-        debug!(
+        warn!(
             action = ?A::short_type_path(),
             ?tick,
             "sending input message: {:?}",
-            message.per_entity_diffs
+            message.diffs
         );
         client
             .send_message::<InputChannel, InputMessage<A>>(message)
@@ -647,7 +709,7 @@ pub fn generate_action_diffs<A: LeafwingUserAction>(
         }
 
         if !diffs.is_empty() {
-            debug!(?maybe_entity, "writing action diffs: {:?}", diffs);
+            warn!(?maybe_entity, "writing action diffs: {:?}", diffs);
             action_diffs.send(ActionDiffEvent {
                 owner: maybe_entity,
                 action_diff: diffs,

--- a/lightyear/src/client/prediction/mod.rs
+++ b/lightyear/src/client/prediction/mod.rs
@@ -13,7 +13,7 @@ use crate::client::events::ComponentInsertEvent;
 use crate::client::prediction::resource::PredictionManager;
 use crate::client::resource::Client;
 use crate::protocol::Protocol;
-use crate::shared::replication::components::{Replicate, ShouldBePredicted};
+use crate::shared::replication::components::{PrePredicted, Replicate, ShouldBePredicted};
 use crate::shared::tick_manager::Tick;
 
 pub(crate) mod correction;
@@ -63,10 +63,15 @@ pub(crate) fn clean_prespawned_entity<P: Protocol>(
         commands
             .entity(entity)
             .remove::<Replicate<P>>()
+            // don't remove should-be-predicted, so that we can know which entities were pre-predicted
             .remove::<ShouldBePredicted>()
-            .insert(Predicted {
-                confirmed_entity: None,
-            });
+            .insert((
+                Predicted {
+                    confirmed_entity: None,
+                },
+                // TODO: add this if we want to send inputs for pre-predicted entities before we receive the confirmed entity
+                // PrePredicted,
+            ));
     }
 }
 
@@ -179,6 +184,7 @@ pub(crate) fn spawn_predicted_entity<P: Protocol>(
     }
 }
 
+// TODO: should we run this only when Added<ShouldBePredicted>?
 /// If a client adds `ShouldBePredicted` to an entity to perform pre-Prediction.
 /// We automatically add the extra needed information to the component.
 /// - client_entity: is needed to know which entity to use as the predicted entity

--- a/lightyear/src/client/prediction/mod.rs
+++ b/lightyear/src/client/prediction/mod.rs
@@ -70,7 +70,7 @@ pub(crate) fn clean_prespawned_entity<P: Protocol>(
                     confirmed_entity: None,
                 },
                 // TODO: add this if we want to send inputs for pre-predicted entities before we receive the confirmed entity
-                // PrePredicted,
+                PrePredicted,
             ));
     }
 }

--- a/lightyear/src/shared/replication/components.rs
+++ b/lightyear/src/shared/replication/components.rs
@@ -408,6 +408,10 @@ pub struct ShouldBeInterpolated;
 //  that's pretty dangerous because it's now hard for the user to derive new traits.
 //  let's think of another approach later.
 // NOTE: we do not map entities for this component, we want to receive the entities as is
+
+/// Indicates that an entity was pre-predicted
+#[derive(Component)]
+pub struct PrePredicted;
 #[derive(Component, MessageInternal, Serialize, Deserialize, Clone, Debug, Default, PartialEq)]
 pub struct ShouldBePredicted {
     // TODO: rename this?

--- a/lightyear/src/shared/replication/components.rs
+++ b/lightyear/src/shared/replication/components.rs
@@ -229,18 +229,18 @@ impl<P: Protocol> Default for Replicate<P> {
             replication_group: Default::default(),
             per_component_metadata: HashMap::default(),
         };
-        // those metadata components can be only replicated once
+        // those metadata components should only be replicated once
         replicate.enable_replicate_once::<ShouldBePredicted>();
         replicate.enable_replicate_once::<ShouldBeInterpolated>();
-        cfg_if! {
-            // the ActionState components are replicated only once when the entity is spawned
-            // then they get updated by the user inputs, not by replication!
-            if #[cfg(feature = "leafwing")] {
-                use leafwing_input_manager::prelude::ActionState;
-                replicate.enable_replicate_once::<ActionState<P::LeafwingInput1>>();
-                replicate.enable_replicate_once::<ActionState<P::LeafwingInput2>>();
-            }
-        }
+        // cfg_if! {
+        //     // the ActionState components are replicated only once when the entity is spawned
+        //     // then they get updated by the user inputs, not by replication!
+        //     if #[cfg(feature = "leafwing")] {
+        //         use leafwing_input_manager::prelude::ActionState;
+        //         replicate.enable_replicate_once::<ActionState<P::LeafwingInput1>>();
+        //         replicate.enable_replicate_once::<ActionState<P::LeafwingInput2>>();
+        //     }
+        // }
         replicate
     }
 }

--- a/lightyear/src/shared/replication/entity_map.rs
+++ b/lightyear/src/shared/replication/entity_map.rs
@@ -16,6 +16,13 @@ impl<T: EntityMapper> EntityMapper for &T {
     }
 }
 
+impl EntityMapper for EntityHashMap<Entity, Entity> {
+    #[inline]
+    fn map(&self, entity: Entity) -> Option<Entity> {
+        self.get(&entity).copied()
+    }
+}
+
 #[derive(Default, Debug)]
 /// Map between local and remote entities. (used mostly on client because it's when we receive entity updates)
 pub struct RemoteEntityMap {
@@ -56,6 +63,15 @@ impl RemoteEntityMap {
     pub fn insert(&mut self, remote_entity: Entity, local_entity: Entity) {
         self.remote_to_local.insert(remote_entity, local_entity);
         self.local_to_remote.insert(local_entity, remote_entity);
+    }
+
+    pub(crate) fn get_to_remote_mapper(&self) -> Box<dyn EntityMapper + '_> {
+        Box::new(&self.local_to_remote)
+    }
+
+    // TODO: makke sure all calls to remote entity map use this to get the exact mapper
+    pub(crate) fn get_to_local_mapper(&self) -> Box<dyn EntityMapper + '_> {
+        Box::new(&self.remote_to_local)
     }
 
     #[inline]

--- a/lightyear/src/transport/io.rs
+++ b/lightyear/src/transport/io.rs
@@ -225,7 +225,6 @@ impl PacketSender for Io {
     }
 }
 
-#[derive(Default)]
 pub struct IoDiagnosticsPlugin;
 
 impl IoDiagnosticsPlugin {


### PR DESCRIPTION
We now replicate entities correctly in all situations:

- pre-predicted entity: we send the client-entity, and the server does the mapping using their entity-map
- Predicted entity: we convert the entity to the corresponding confirmed entity, and then to the corresponding remote entity and we send this to server
- Confirmed entity: we convert the entity to the corresponding cofirmed entity and then we send that to the server


Note that there are important footguns with Inputs:
- if you are using Predicted entities, you CANNOT replicate ActionState on the Confirmed entity, or else the ActionState will keep getting synced to the Predicted entity. Maybe I can add a PerComponentSyncMode to know which components need to have their ActionState synced to Predicted. (it's the case for other clients, but not for the player-controlled one)


Added a marker component `PrePredicted` that lets us identify entities that were Pre-Predicted