### PR TITLE
Split the monolithic Client/Server resources into multiple resources

### DIFF
--- a/examples/client_replication/src/client.rs
+++ b/examples/client_replication/src/client.rs
@@ -3,7 +3,6 @@ use crate::protocol::*;
 use crate::shared::{color_from_id, shared_config, shared_movement_behaviour};
 use crate::{Transports, KEY, PROTOCOL_ID};
 use bevy::prelude::*;
-use lightyear::_reexport::ShouldBePredicted;
 use lightyear::prelude::client::*;
 use lightyear::prelude::*;
 use std::net::{Ipv4Addr, SocketAddr};
@@ -83,11 +82,7 @@ impl Plugin for MyClientPlugin {
 }
 
 // Startup system for the client
-pub(crate) fn init(
-    mut commands: Commands,
-    mut client: ResMut<Client>,
-    plugin: Res<MyClientPlugin>,
-) {
+pub(crate) fn init(mut commands: Commands, mut client: ClientMut, plugin: Res<MyClientPlugin>) {
     commands.spawn(Camera2dBundle::default());
     commands.spawn(TextBundle::from_section(
         format!("Client {}", plugin.client_id),
@@ -108,7 +103,7 @@ pub(crate) fn init(
 }
 
 // System that reads from peripherals and adds inputs to the buffer
-pub(crate) fn buffer_input(mut client: ResMut<Client>, keypress: Res<Input<KeyCode>>) {
+pub(crate) fn buffer_input(mut client: ClientMut, keypress: Res<Input<KeyCode>>) {
     let mut direction = Direction {
         up: false,
         down: false,
@@ -273,7 +268,7 @@ pub(crate) fn receive_message(mut reader: EventReader<MessageEvent<Message1>>) {
 }
 
 /// Send messages from server to clients
-pub(crate) fn send_message(mut client: ResMut<Client>, input: Res<Input<KeyCode>>) {
+pub(crate) fn send_message(mut client: ResMut<Connection>, input: Res<Input<KeyCode>>) {
     if input.pressed(KeyCode::M) {
         let message = Message1(5);
         info!("Send message: {:?}", message);

--- a/examples/client_replication/src/server.rs
+++ b/examples/client_replication/src/server.rs
@@ -88,7 +88,7 @@ pub(crate) fn handle_disconnections(
 pub(crate) fn movement(
     mut position_query: Query<(&mut PlayerPosition, &PlayerId)>,
     mut input_reader: EventReader<InputEvent<Inputs>>,
-    server: Res<Server>,
+    tick_manager: Res<TickManager>,
 ) {
     for input in input_reader.read() {
         let client_id = input.context();
@@ -97,7 +97,7 @@ pub(crate) fn movement(
                 "Receiving input: {:?} from client: {:?} on tick: {:?}",
                 input,
                 client_id,
-                server.tick()
+                tick_manager.tick()
             );
 
             for (position, player_id) in position_query.iter_mut() {

--- a/examples/interest_management/src/client.rs
+++ b/examples/interest_management/src/client.rs
@@ -5,7 +5,7 @@ use bevy::prelude::*;
 use leafwing_input_manager::plugin::InputManagerSystem;
 use leafwing_input_manager::prelude::*;
 use leafwing_input_manager::systems::{run_if_enabled, tick_action_state};
-use lightyear::_reexport::{ShouldBeInterpolated, ShouldBePredicted};
+use lightyear::_reexport::ShouldBeInterpolated;
 use lightyear::prelude::client::*;
 use lightyear::prelude::*;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
@@ -82,11 +82,7 @@ impl Plugin for MyClientPlugin {
 }
 
 // Startup system for the client
-pub(crate) fn init(
-    mut commands: Commands,
-    mut client: ResMut<Client>,
-    plugin: Res<MyClientPlugin>,
-) {
+pub(crate) fn init(mut commands: Commands, mut client: ClientMut, plugin: Res<MyClientPlugin>) {
     commands.spawn(Camera2dBundle::default());
     commands.spawn(TextBundle::from_section(
         format!("Client {}", plugin.client_id),
@@ -150,17 +146,18 @@ pub(crate) fn handle_interpolated_spawn(
 }
 
 pub(crate) fn log(
-    client: Res<Client>,
+    tick_manager: Res<TickManager>,
+    connection: Res<Connection>,
     confirmed: Query<&Position, With<Confirmed>>,
     predicted: Query<&Position, (With<Predicted>, Without<Confirmed>)>,
     mut interp_event: EventReader<ComponentInsertEvent<ShouldBeInterpolated>>,
     mut predict_event: EventReader<ComponentInsertEvent<ShouldBePredicted>>,
 ) {
-    let server_tick = client.latest_received_server_tick();
+    let server_tick = connection.latest_received_server_tick();
     for confirmed_pos in confirmed.iter() {
         debug!(?server_tick, "Confirmed position: {:?}", confirmed_pos);
     }
-    let client_tick = client.tick();
+    let client_tick = tick_manager.tick();
     for predicted_pos in predicted.iter() {
         debug!(?client_tick, "Predicted position: {:?}", predicted_pos);
     }

--- a/examples/leafwing_inputs/src/client.rs
+++ b/examples/leafwing_inputs/src/client.rs
@@ -7,7 +7,6 @@ use bevy_xpbd_2d::parry::shape::ShapeType::Ball;
 use bevy_xpbd_2d::prelude::*;
 use leafwing_input_manager::action_state::ActionDiff;
 use leafwing_input_manager::prelude::*;
-use lightyear::_reexport::ShouldBePredicted;
 use lightyear::inputs::native::input_buffer::InputBuffer;
 use lightyear::prelude::client::LeafwingInputPlugin;
 use lightyear::prelude::client::*;
@@ -113,11 +112,7 @@ impl Plugin for MyClientPlugin {
 }
 
 // Startup system for the client
-pub(crate) fn init(
-    mut commands: Commands,
-    mut client: ResMut<Client>,
-    plugin: Res<MyClientPlugin>,
-) {
+pub(crate) fn init(mut commands: Commands, mut client: ClientMut, plugin: Res<MyClientPlugin>) {
     commands.spawn(Camera2dBundle::default());
     commands.spawn(
         TextBundle::from_section(
@@ -217,7 +212,7 @@ fn add_player_physics(
 // If we were predicting more entities, we would have to only apply movement to the player owned one.
 fn player_movement(
     plugin: Res<MyClientPlugin>,
-    client: Res<Client>,
+    tick_manager: Res<TickManager>,
     mut velocity_query: Query<
         (
             Entity,
@@ -233,7 +228,7 @@ fn player_movement(
         // note that we also apply the input to the other predicted clients!
         // TODO: add input decay?
         shared_movement_behaviour(velocity, action_state);
-        info!(?entity, tick = ?client.tick(), ?position, actions = ?action_state.get_pressed(), "applying movement to predicted player");
+        info!(?entity, tick = ?tick_manager.tick(), ?position, actions = ?action_state.get_pressed(), "applying movement to predicted player");
     }
 }
 

--- a/examples/leafwing_inputs/src/protocol.rs
+++ b/examples/leafwing_inputs/src/protocol.rs
@@ -3,7 +3,6 @@ use bevy::utils::EntityHashSet;
 use bevy_xpbd_2d::prelude::*;
 use derive_more::{Add, Mul};
 use leafwing_input_manager::prelude::*;
-use lightyear::_reexport::ShouldBePredicted;
 use lightyear::client::components::LerpFn;
 use lightyear::prelude::*;
 use lightyear::utils::bevy_xpbd_2d::*;

--- a/examples/leafwing_inputs/src/server.rs
+++ b/examples/leafwing_inputs/src/server.rs
@@ -115,7 +115,7 @@ pub(crate) fn handle_disconnections(
 /// Read client inputs and move players
 /// NOTE: this system can now be run in both client/server!
 pub(crate) fn movement(
-    server: Res<Server>,
+    tick_manager: Res<TickManager>,
     mut action_query: Query<(
         Entity,
         &Position,
@@ -127,7 +127,7 @@ pub(crate) fn movement(
         // NOTE: be careful to directly pass Mut<PlayerPosition>
         // getting a mutable reference triggers change detection, unless you use `as_deref_mut()`
         shared_movement_behaviour(velocity, action);
-        info!(?entity, tick = ?server.tick(), ?position, actions = ?action.get_pressed(), "applying movement to player");
+        info!(?entity, tick = ?tick_manager.tick(), ?position, actions = ?action.get_pressed(), "applying movement to player");
     }
 }
 

--- a/examples/leafwing_inputs/src/shared.rs
+++ b/examples/leafwing_inputs/src/shared.rs
@@ -7,6 +7,7 @@ use bevy_xpbd_2d::parry::shape::Ball;
 use bevy_xpbd_2d::prelude::*;
 use bevy_xpbd_2d::{PhysicsSchedule, PhysicsStepSet};
 use leafwing_input_manager::prelude::ActionState;
+use lightyear::_reexport::TickManager;
 use lightyear::client::prediction::{Rollback, RollbackState};
 use lightyear::prelude::client::*;
 use lightyear::prelude::*;
@@ -172,8 +173,8 @@ pub(crate) fn shared_movement_behaviour(
     *velocity = LinearVelocity(velocity.clamp_length_max(MAX_VELOCITY));
 }
 
-pub(crate) fn after_physics_log<T: TickManaged>(
-    ticker: Res<T>,
+pub(crate) fn after_physics_log(
+    tick_manager: Res<TickManager>,
     rollback: Option<Res<Rollback>>,
     players: Query<
         (Entity, &Position, &Rotation),
@@ -181,7 +182,7 @@ pub(crate) fn after_physics_log<T: TickManaged>(
     >,
     ball: Query<&Position, (With<BallMarker>, Without<Confirmed>)>,
 ) {
-    let mut tick = ticker.tick();
+    let mut tick = tick_manager.tick();
     if let Some(rollback) = rollback {
         if let RollbackState::ShouldRollback { current_tick } = rollback.state {
             tick = current_tick;
@@ -201,8 +202,8 @@ pub(crate) fn after_physics_log<T: TickManaged>(
     }
 }
 
-pub(crate) fn last_log<T: TickManaged>(
-    ticker: Res<T>,
+pub(crate) fn last_log(
+    tick_manager: Res<TickManager>,
     players: Query<
         (
             Entity,
@@ -215,7 +216,7 @@ pub(crate) fn last_log<T: TickManaged>(
     >,
     ball: Query<&Position, (With<BallMarker>, Without<Confirmed>)>,
 ) {
-    let tick = ticker.tick();
+    let tick = tick_manager.tick();
     for (entity, position, rotation, correction, rotation_correction) in players.iter() {
         info!(?tick, ?entity, ?position, ?correction, "Player LAST update");
         info!(

--- a/examples/leafwing_inputs/src/shared.rs
+++ b/examples/leafwing_inputs/src/shared.rs
@@ -7,7 +7,7 @@ use bevy_xpbd_2d::parry::shape::Ball;
 use bevy_xpbd_2d::prelude::*;
 use bevy_xpbd_2d::{PhysicsSchedule, PhysicsStepSet};
 use leafwing_input_manager::prelude::ActionState;
-use lightyear::_reexport::TickManager;
+use lightyear::prelude::TickManager
 use lightyear::client::prediction::{Rollback, RollbackState};
 use lightyear::prelude::client::*;
 use lightyear::prelude::*;

--- a/examples/leafwing_inputs/src/shared.rs
+++ b/examples/leafwing_inputs/src/shared.rs
@@ -7,9 +7,9 @@ use bevy_xpbd_2d::parry::shape::Ball;
 use bevy_xpbd_2d::prelude::*;
 use bevy_xpbd_2d::{PhysicsSchedule, PhysicsStepSet};
 use leafwing_input_manager::prelude::ActionState;
-use lightyear::prelude::TickManager
 use lightyear::client::prediction::{Rollback, RollbackState};
 use lightyear::prelude::client::*;
+use lightyear::prelude::TickManager;
 use lightyear::prelude::*;
 use lightyear::transport::io::IoDiagnosticsPlugin;
 use std::time::Duration;
@@ -91,19 +91,8 @@ impl Plugin for SharedPlugin {
         // add a log at the start of the physics schedule
         app.add_systems(PhysicsSchedule, log.in_set(PhysicsStepSet::BroadPhase));
 
-        if app.world.contains_resource::<Client>() {
-            app.add_systems(
-                FixedUpdate,
-                after_physics_log::<Client>.after(FixedUpdateSet::Main),
-            );
-            app.add_systems(Last, last_log::<Client>);
-        }
-        if app.world.contains_resource::<Server>() {
-            app.add_systems(
-                FixedUpdate,
-                after_physics_log::<Server>.after(FixedUpdateSet::Main),
-            );
-        }
+        app.add_systems(FixedUpdate, after_physics_log.after(FixedUpdateSet::Main));
+        app.add_systems(Last, last_log);
 
         // registry types for reflection
         app.register_type::<PlayerId>();

--- a/examples/replication_groups/src/client.rs
+++ b/examples/replication_groups/src/client.rs
@@ -4,6 +4,7 @@ use crate::shared::{shared_config, shared_movement_behaviour, shared_tail_behavi
 use crate::{Transports, KEY, PROTOCOL_ID};
 use bevy::prelude::*;
 use lightyear::_reexport::LinearInterpolator;
+use lightyear::netcode::NetcodeServer;
 use lightyear::prelude::client::*;
 use lightyear::prelude::*;
 use std::collections::VecDeque;
@@ -107,7 +108,7 @@ impl Plugin for MyClientPlugin {
 // Startup system for the client
 pub(crate) fn init(
     mut commands: Commands,
-    mut client: ResMut<Client>,
+    mut client: ResMut<NetClient>,
     plugin: Res<MyClientPlugin>,
 ) {
     commands.spawn(Camera2dBundle::default());
@@ -124,7 +125,7 @@ pub(crate) fn init(
 }
 
 // System that reads from peripherals and adds inputs to the buffer
-pub(crate) fn buffer_input(mut client: ResMut<Client>, keypress: Res<Input<KeyCode>>) {
+pub(crate) fn buffer_input(mut client: ClientMut, keypress: Res<Input<KeyCode>>) {
     if keypress.pressed(KeyCode::W) || keypress.pressed(KeyCode::Up) {
         return client.add_input(Inputs::Direction(Direction::Up));
     }
@@ -188,11 +189,12 @@ pub(crate) fn handle_interpolated_spawn(
 }
 
 pub(crate) fn debug_prediction_pre_rollback(
-    client: Res<Client>,
+    tick_manager: Res<TickManager>,
+    client: Client,
     parent_query: Query<&PredictionHistory<PlayerPosition>>,
     tail_query: Query<(&PlayerParent, &PredictionHistory<TailPoints>)>,
 ) {
-    info!(tick = ?client.tick(),
+    info!(tick = ?tick_manager.tick(),
         inputs = ?client.get_input_buffer(),
         "prediction pre rollback debug");
     for (parent, tail_history) in tail_query.iter() {
@@ -205,11 +207,11 @@ pub(crate) fn debug_prediction_pre_rollback(
 }
 
 pub(crate) fn debug_prediction_post_rollback(
-    client: Res<Client>,
+    tick_manager: Res<TickManager>,
     parent_query: Query<&PredictionHistory<PlayerPosition>>,
     tail_query: Query<(&PlayerParent, &PredictionHistory<TailPoints>)>,
 ) {
-    info!(tick = ?client.tick(), "prediction post rollback debug");
+    info!(tick = ?tick_manager.tick(), "prediction post rollback debug");
     for (parent, tail_history) in tail_query.iter() {
         let parent_history = parent_query
             .get(parent.0)
@@ -220,7 +222,7 @@ pub(crate) fn debug_prediction_post_rollback(
 }
 
 pub(crate) fn debug_interpolate(
-    client: Res<Client>,
+    tick_manager: Res<TickManager>,
     parent_query: Query<(
         &InterpolateStatus<PlayerPosition>,
         &ConfirmedHistory<PlayerPosition>,
@@ -231,7 +233,7 @@ pub(crate) fn debug_interpolate(
         &ConfirmedHistory<TailPoints>,
     )>,
 ) {
-    info!(tick = ?client.tick(), "interpolation debug");
+    info!(tick = ?tick_manager.tick(), "interpolation debug");
     for (parent, tail_status, tail_history) in tail_query.iter() {
         let (parent_status, parent_history) = parent_query
             .get(parent.0)

--- a/examples/replication_groups/src/server.rs
+++ b/examples/replication_groups/src/server.rs
@@ -119,7 +119,7 @@ pub(crate) fn movement(
     mut position_query: Query<&mut PlayerPosition>,
     mut input_reader: EventReader<InputEvent<Inputs>>,
     global: Res<Global>,
-    server: Res<Server>,
+    tick_manager: Res<TickManager>,
 ) {
     for input in input_reader.read() {
         let client_id = input.context();
@@ -128,7 +128,7 @@ pub(crate) fn movement(
                 "Receiving input: {:?} from client: {:?} on tick: {:?}",
                 input,
                 client_id,
-                server.tick()
+                tick_manager.tick()
             );
             if let Some(player_entity) = global.client_id_to_entity_id.get(client_id) {
                 if let Ok(mut position) = position_query.get_mut(*player_entity) {

--- a/examples/simple_box/src/client.rs
+++ b/examples/simple_box/src/client.rs
@@ -77,11 +77,7 @@ impl Plugin for MyClientPlugin {
 }
 
 // Startup system for the client
-pub(crate) fn init(
-    mut commands: Commands,
-    mut client: ResMut<Client>,
-    plugin: Res<MyClientPlugin>,
-) {
+pub(crate) fn init(mut commands: Commands, mut client: ClientMut, plugin: Res<MyClientPlugin>) {
     commands.spawn(Camera2dBundle::default());
     commands.spawn(TextBundle::from_section(
         format!("Client {}", plugin.client_id),
@@ -96,7 +92,7 @@ pub(crate) fn init(
 }
 
 // System that reads from peripherals and adds inputs to the buffer
-pub(crate) fn buffer_input(mut client: ResMut<Client>, keypress: Res<Input<KeyCode>>) {
+pub(crate) fn buffer_input(mut client: ClientMut, keypress: Res<Input<KeyCode>>) {
     let mut direction = Direction {
         up: false,
         down: false,

--- a/examples/simple_box/src/server.rs
+++ b/examples/simple_box/src/server.rs
@@ -106,7 +106,7 @@ pub(crate) fn movement(
     mut position_query: Query<&mut PlayerPosition>,
     mut input_reader: EventReader<InputEvent<Inputs>>,
     global: Res<Global>,
-    server: Res<Server>,
+    tick_manager: Res<TickManager>,
 ) {
     for input in input_reader.read() {
         let client_id = input.context();
@@ -115,7 +115,7 @@ pub(crate) fn movement(
                 "Receiving input: {:?} from client: {:?} on tick: {:?}",
                 input,
                 client_id,
-                server.tick()
+                tick_manager.tick()
             );
             if let Some(player_entity) = global.client_id_to_entity_id.get(client_id) {
                 if let Ok(position) = position_query.get_mut(*player_entity) {
@@ -126,9 +126,13 @@ pub(crate) fn movement(
     }
 }
 
+// NOTE: you can use either:
+// - ServerMut (which is a wrapper around a bunch of resources used in lightyear)
+// - ResMut<ConnectionManager>, which is the actual resource used to send the message in this case. This is more optimized
+//   because it enables more parallelism
 /// Send messages from server to clients (only in non-headless mode, because otherwise we run with minimal plugins
 /// and cannot do input handling)
-pub(crate) fn send_message(mut server: ResMut<Server>, input: Res<Input<KeyCode>>) {
+pub(crate) fn send_message(mut server: ResMut<ConnectionManager>, input: Res<Input<KeyCode>>) {
     if input.pressed(KeyCode::M) {
         // TODO: add way to send message to all
         let message = Message1(5);

--- a/lightyear/src/channel/receivers/tick_unreliable.rs
+++ b/lightyear/src/channel/receivers/tick_unreliable.rs
@@ -55,7 +55,7 @@ impl TickUnreliableReceiver {
 impl ChannelReceive for TickUnreliableReceiver {
     fn update(&mut self, time_manager: &TimeManager, tick_manager: &TickManager) {
         self.current_time = time_manager.current_time();
-        self.current_tick = tick_manager.current_tick();
+        self.current_tick = tick_manager.tick();
         self.fragment_receiver
             .cleanup(self.current_time - DISCARD_AFTER);
     }

--- a/lightyear/src/channel/senders/tick_unreliable.rs
+++ b/lightyear/src/channel/senders/tick_unreliable.rs
@@ -40,7 +40,7 @@ impl TickUnreliableSender {
 
 impl ChannelSend for TickUnreliableSender {
     fn update(&mut self, _: &TimeManager, _: &PingManager, tick_manager: &TickManager) {
-        self.current_tick = tick_manager.current_tick();
+        self.current_tick = tick_manager.tick();
     }
 
     /// Add a new message to the buffer of messages to be sent.

--- a/lightyear/src/client/config.rs
+++ b/lightyear/src/client/config.rs
@@ -1,4 +1,5 @@
 //! Defines client-specific configuration options
+use bevy::prelude::Resource;
 use std::time::Duration;
 
 use crate::client::input::InputConfig;
@@ -59,7 +60,7 @@ impl PacketConfig {
     }
 }
 
-#[derive(Clone, Default)]
+#[derive(Resource, Clone, Default)]
 pub struct ClientConfig {
     pub shared: SharedConfig,
     pub netcode: NetcodeConfig,

--- a/lightyear/src/client/connection.rs
+++ b/lightyear/src/client/connection.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 
 use anyhow::Result;
 use bevy::ecs::component::Tick as BevyTick;
-use bevy::prelude::World;
+use bevy::prelude::{Resource, World};
 use serde::Serialize;
 use tracing::{debug, trace, trace_span};
 
@@ -15,7 +15,7 @@ use crate::connection::message::{ClientMessage, ServerMessage};
 use crate::inputs::native::input_buffer::InputBuffer;
 use crate::packet::message_manager::MessageManager;
 use crate::packet::packet_manager::Payload;
-use crate::prelude::{ChannelKind, MapEntities, NetworkTarget};
+use crate::prelude::{Channel, ChannelKind, MapEntities, Message, NetworkTarget};
 use crate::protocol::channel::ChannelRegistry;
 use crate::protocol::Protocol;
 use crate::serialize::reader::ReadBuffer;
@@ -32,6 +32,7 @@ use crate::shared::time_manager::TimeManager;
 use super::sync::SyncManager;
 
 /// Wrapper that handles the connection with the server
+#[derive(Resource)]
 pub struct Connection<P: Protocol> {
     pub message_manager: MessageManager,
     pub(crate) replication_sender: ReplicationSender<P>,
@@ -73,6 +74,26 @@ impl<P: Protocol> Connection<P> {
         }
     }
 
+    pub(crate) fn is_synced(&self) -> bool {
+        self.sync_manager.is_synced()
+    }
+
+    pub(crate) fn received_new_server_tick(&self) -> bool {
+        self.sync_manager.duration_since_latest_received_server_tick == Duration::default()
+    }
+
+    pub(crate) fn latest_received_server_tick(&self) -> Tick {
+        self.sync_manager
+            .latest_received_server_tick
+            .unwrap_or(Tick(0))
+    }
+
+    /// Get a cloned version of the input (we might not want to pop from the buffer because we want
+    /// to keep it for rollback)
+    pub(crate) fn get_input(&self, tick: Tick) -> Option<P::Input> {
+        self.input_buffer.get(tick).cloned()
+    }
+
     pub(crate) fn clear(&mut self) {
         self.events.clear();
     }
@@ -89,6 +110,15 @@ impl<P: Protocol> Connection<P> {
 
         // we update the sync manager in POST_UPDATE
         // self.sync_manager.update(time_manager);
+    }
+
+    /// Send a message to the server
+    pub fn send_message<C: Channel, M: Message>(&mut self, message: M) -> Result<()>
+    where
+        P::Message: From<M>,
+    {
+        let channel = ChannelKind::of::<C>();
+        self.buffer_message(message.into(), channel, NetworkTarget::None)
     }
 
     pub(crate) fn buffer_message(
@@ -187,8 +217,7 @@ impl<P: Protocol> Connection<P> {
                     Ok::<(), anyhow::Error>(())
                 })?;
         }
-        self.message_manager
-            .send_packets(tick_manager.current_tick())
+        self.message_manager.send_packets(tick_manager.tick())
     }
 
     pub fn receive(
@@ -247,9 +276,8 @@ impl<P: Protocol> Connection<P> {
                 }
                 // Check if we have any replication messages we can apply to the World (and emit events)
                 if self.sync_manager.is_synced() {
-                    for (group, replication_list) in self
-                        .replication_receiver
-                        .read_messages(tick_manager.current_tick())
+                    for (group, replication_list) in
+                        self.replication_receiver.read_messages(tick_manager.tick())
                     {
                         trace!(?group, ?replication_list, "read replication messages");
                         replication_list

--- a/lightyear/src/client/connection.rs
+++ b/lightyear/src/client/connection.rs
@@ -82,7 +82,7 @@ impl<P: Protocol> Connection<P> {
         self.sync_manager.duration_since_latest_received_server_tick == Duration::default()
     }
 
-    pub(crate) fn latest_received_server_tick(&self) -> Tick {
+    pub fn latest_received_server_tick(&self) -> Tick {
         self.sync_manager
             .latest_received_server_tick
             .unwrap_or(Tick(0))

--- a/lightyear/src/client/connection.rs
+++ b/lightyear/src/client/connection.rs
@@ -121,6 +121,19 @@ impl<P: Protocol> Connection<P> {
         self.buffer_message(message.into(), channel, NetworkTarget::None)
     }
 
+    /// Send a message to the server, the message should be re-broadcasted according to the `target`
+    pub fn send_message_to_target<C: Channel, M: Message>(
+        &mut self,
+        message: M,
+        target: NetworkTarget,
+    ) -> Result<()>
+    where
+        P::Message: From<M>,
+    {
+        let channel = ChannelKind::of::<C>();
+        self.buffer_message(message.into(), channel, target)
+    }
+
     pub(crate) fn buffer_message(
         &mut self,
         message: P::Message,

--- a/lightyear/src/client/diagnostics.rs
+++ b/lightyear/src/client/diagnostics.rs
@@ -17,16 +17,12 @@ impl<P> Default for ClientDiagnosticsPlugin<P> {
     }
 }
 
-fn io_diagnostics_system<P: Protocol>(
-    mut io: ResMut<Io>,
-    time: Res<Time<Real>>,
-    mut diagnostics: Diagnostics,
-) {
+fn io_diagnostics_system(mut io: ResMut<Io>, time: Res<Time<Real>>, mut diagnostics: Diagnostics) {
     IoDiagnosticsPlugin::update_diagnostics(&mut io.stats, &time, &mut diagnostics);
 }
 impl<P: Protocol> Plugin for ClientDiagnosticsPlugin<P> {
     fn build(&self, app: &mut App) {
         app.add_plugins(IoDiagnosticsPlugin);
-        app.add_systems(PostUpdate, io_diagnostics_system::<P>);
+        app.add_systems(PostUpdate, io_diagnostics_system);
     }
 }

--- a/lightyear/src/client/diagnostics.rs
+++ b/lightyear/src/client/diagnostics.rs
@@ -1,5 +1,5 @@
 use crate::client::resource::Client;
-use crate::prelude::Protocol;
+use crate::prelude::{Io, Protocol};
 use crate::transport::io::{IoDiagnosticsPlugin, IoStats};
 use bevy::app::{App, Plugin, PostUpdate};
 use bevy::diagnostic::{Diagnostic, Diagnostics, RegisterDiagnostic};
@@ -18,11 +18,11 @@ impl<P> Default for ClientDiagnosticsPlugin<P> {
 }
 
 fn io_diagnostics_system<P: Protocol>(
-    mut client: ResMut<Client<P>>,
+    mut io: ResMut<Io>,
     time: Res<Time<Real>>,
     mut diagnostics: Diagnostics,
 ) {
-    IoDiagnosticsPlugin::update_diagnostics(&mut client.io.stats, &time, &mut diagnostics);
+    IoDiagnosticsPlugin::update_diagnostics(&mut io.stats, &time, &mut diagnostics);
 }
 impl<P: Protocol> Plugin for ClientDiagnosticsPlugin<P> {
     fn build(&self, app: &mut App) {

--- a/lightyear/src/client/input.rs
+++ b/lightyear/src/client/input.rs
@@ -1,4 +1,5 @@
 //! Handles client-generated inputs
+use crate::_reexport::TickManager;
 use bevy::prelude::{
     not, App, EventReader, EventWriter, FixedUpdate, IntoSystemConfigs, IntoSystemSetConfigs,
     Plugin, PostUpdate, Res, ResMut, SystemSet,
@@ -6,6 +7,8 @@ use bevy::prelude::{
 use tracing::{error, trace};
 
 use crate::channel::builder::InputChannel;
+use crate::client::config::ClientConfig;
+use crate::client::connection::Connection;
 use crate::client::events::InputEvent;
 use crate::client::prediction::plugin::is_in_rollback;
 use crate::client::prediction::{Rollback, RollbackState};
@@ -14,7 +17,6 @@ use crate::client::sync::client_is_synced;
 use crate::inputs::native::UserAction;
 use crate::protocol::Protocol;
 use crate::shared::sets::{FixedUpdateSet, MainSet};
-use crate::shared::tick_manager::TickManaged;
 
 #[derive(Debug, Clone)]
 pub struct InputConfig {
@@ -144,22 +146,27 @@ fn clear_input_events<P: Protocol>(mut input_events: EventReader<InputEvent<P::I
 // The only tricky part is that events are cleared every frame, but we want to clear every tick instead
 // Do it in this system because we want an input for every tick
 fn write_input_event<P: Protocol>(
-    mut client: ResMut<Client<P>>,
+    tick_manager: Res<TickManager>,
+    connection: Res<Connection<P>>,
     mut input_events: EventWriter<InputEvent<P::Input>>,
     rollback: Option<Res<Rollback>>,
 ) {
-    let tick = rollback.map_or(client.tick(), |rollback| match rollback.state {
-        RollbackState::Default => client.tick(),
+    let tick = rollback.map_or(tick_manager.tick(), |rollback| match rollback.state {
+        RollbackState::Default => tick_manager.tick(),
         RollbackState::ShouldRollback {
             current_tick: rollback_tick,
         } => rollback_tick,
     });
-    input_events.send(InputEvent::new(client.get_input(tick).clone(), ()));
+    input_events.send(InputEvent::new(connection.get_input(tick), ()));
 }
 
 // Take the input buffer, and prepare the input message to send to the server
-fn prepare_input_message<P: Protocol>(mut client: ResMut<Client<P>>) {
-    let current_tick = client.tick();
+fn prepare_input_message<P: Protocol>(
+    mut connection: ResMut<Connection<P>>,
+    config: Res<ClientConfig>,
+    tick_manager: Res<TickManager>,
+) {
+    let current_tick = tick_manager.tick();
     // TODO: the number of messages should be in SharedConfig
     trace!(tick = ?current_tick, "prepare_input_message");
     // TODO: instead of 15, send ticks up to the latest yet ACK-ed input tick
@@ -167,10 +174,10 @@ fn prepare_input_message<P: Protocol>(mut client: ResMut<Client<P>>) {
     //  this system what the latest acked input tick is?
 
     // we send redundant inputs, so that if a packet is lost, we can still recover
-    let num_tick = ((client.config().shared.client_send_interval.as_micros()
-        / client.config().shared.tick.tick_duration.as_micros())
+    let num_tick = ((config.shared.client_send_interval.as_micros()
+        / config.shared.tick.tick_duration.as_micros())
         + 1) as u16;
-    let redundancy = client.config().input.packet_redundancy;
+    let redundancy = config.input.packet_redundancy;
     // let redundancy = 3;
     let message_len = redundancy * num_tick;
     // TODO: we can either:
@@ -178,14 +185,14 @@ fn prepare_input_message<P: Protocol>(mut client: ResMut<Client<P>>) {
     //  - buffer an input every frame; and require some redundancy (number of tick per frame)
     //  - or buffer an input only when we are sending, and require more redundancy
     // let message_len = 20 as u16;
-    let message = client
-        .get_input_buffer()
-        .create_message(client.tick(), message_len);
+    let message = connection
+        .input_buffer
+        .create_message(tick_manager.tick(), message_len);
     // all inputs are absent
     if !message.is_empty() {
         // TODO: should we provide variants of each user-facing function, so that it pushes the error
         //  to the ConnectionEvents?
-        client
+        connection
             .send_message::<InputChannel, _>(message)
             .unwrap_or_else(|err| {
                 error!("Error while sending input message: {:?}", err);
@@ -196,11 +203,8 @@ fn prepare_input_message<P: Protocol>(mut client: ResMut<Client<P>>) {
     //  maybe at interpolation_tick(), since it's before any latest server update we receive?
 
     // delete old input values
-    let interpolation_tick = client
-        .connection
-        .sync_manager
-        .interpolation_tick(&client.tick_manager);
-    client.get_mut_input_buffer().pop(interpolation_tick);
+    let interpolation_tick = connection.sync_manager.interpolation_tick(&tick_manager);
+    connection.input_buffer.pop(interpolation_tick);
     // .pop(current_tick - (message_len + 1));
 }
 

--- a/lightyear/src/client/input.rs
+++ b/lightyear/src/client/input.rs
@@ -1,5 +1,4 @@
 //! Handles client-generated inputs
-use crate::_reexport::TickManager;
 use bevy::prelude::{
     not, App, EventReader, EventWriter, FixedUpdate, IntoSystemConfigs, IntoSystemSetConfigs,
     Plugin, PostUpdate, Res, ResMut, SystemSet,
@@ -15,6 +14,7 @@ use crate::client::prediction::{Rollback, RollbackState};
 use crate::client::resource::Client;
 use crate::client::sync::client_is_synced;
 use crate::inputs::native::UserAction;
+use crate::prelude::TickManager;
 use crate::protocol::Protocol;
 use crate::shared::sets::{FixedUpdateSet, MainSet};
 

--- a/lightyear/src/client/input_leafwing.rs
+++ b/lightyear/src/client/input_leafwing.rs
@@ -8,7 +8,6 @@ use leafwing_input_manager::plugin::InputManagerSystem;
 use leafwing_input_manager::prelude::*;
 use tracing::{error, info, trace};
 
-use crate::_reexport::{ShouldBePredicted, TickManager};
 use crate::channel::builder::InputChannel;
 use crate::client::config::ClientConfig;
 use crate::client::connection::Connection;
@@ -20,7 +19,7 @@ use crate::inputs::leafwing::input_buffer::{
     ActionDiff, ActionDiffBuffer, ActionDiffEvent, InputBuffer, InputMessage, InputTarget,
 };
 use crate::inputs::leafwing::LeafwingUserAction;
-use crate::prelude::MapEntities;
+use crate::prelude::{MapEntities, TickManager};
 use crate::protocol::Protocol;
 use crate::shared::replication::components::PrePredicted;
 use crate::shared::sets::{FixedUpdateSet, MainSet};

--- a/lightyear/src/client/interpolation/interpolate.rs
+++ b/lightyear/src/client/interpolation/interpolate.rs
@@ -1,12 +1,13 @@
 use bevy::prelude::{Component, Query, Res, ResMut};
 use tracing::trace;
 
-use crate::_reexport::{ComponentProtocol, TickManager};
+use crate::_reexport::ComponentProtocol;
 use crate::client::components::{ComponentSyncMode, SyncComponent, SyncMetadata};
 use crate::client::config::ClientConfig;
 use crate::client::connection::Connection;
 use crate::client::interpolation::interpolation_history::ConfirmedHistory;
 use crate::client::resource::Client;
+use crate::prelude::TickManager;
 use crate::protocol::Protocol;
 use crate::shared::tick_manager::Tick;
 

--- a/lightyear/src/client/interpolation/interpolate.rs
+++ b/lightyear/src/client/interpolation/interpolate.rs
@@ -1,8 +1,10 @@
-use bevy::prelude::{Component, Query, ResMut};
+use bevy::prelude::{Component, Query, Res, ResMut};
 use tracing::trace;
 
-use crate::_reexport::ComponentProtocol;
+use crate::_reexport::{ComponentProtocol, TickManager};
 use crate::client::components::{ComponentSyncMode, SyncComponent, SyncMetadata};
+use crate::client::config::ClientConfig;
+use crate::client::connection::Connection;
 use crate::client::interpolation::interpolation_history::ConfirmedHistory;
 use crate::client::resource::Client;
 use crate::protocol::Protocol;
@@ -31,7 +33,9 @@ pub struct InterpolateStatus<C: Component> {
 /// At the end of each frame, interpolate the components between the last 2 confirmed server states
 /// Invariant: start_tick <= current_interpolate_tick <= end_tick
 pub(crate) fn update_interpolate_status<C: SyncComponent, P: Protocol>(
-    client: ResMut<Client<P>>,
+    config: Res<ClientConfig>,
+    connection: Res<Connection<P>>,
+    tick_manager: Res<TickManager>,
     mut query: Query<(&mut C, &mut InterpolateStatus<C>, &mut ConfirmedHistory<C>)>,
 ) where
     P::Components: SyncMetadata<C>,
@@ -39,17 +43,19 @@ pub(crate) fn update_interpolate_status<C: SyncComponent, P: Protocol>(
     if P::Components::mode() != ComponentSyncMode::Full {
         return;
     }
-    if !client.is_synced() {
+    if !connection.is_synced() {
         return;
     }
 
     // how many ticks between each interpolation (add 1 to roughly take the ceil)
-    let send_interval_delta_tick =
-        (SEND_INTERVAL_TICK_FACTOR * client.config().shared.server_send_interval.as_secs_f32()
-            / client.config().shared.tick.tick_duration.as_secs_f32()) as i16
-            + 1;
+    let send_interval_delta_tick = (SEND_INTERVAL_TICK_FACTOR
+        * config.shared.server_send_interval.as_secs_f32()
+        / config.shared.tick.tick_duration.as_secs_f32()) as i16
+        + 1;
 
-    let current_interpolate_tick = client.interpolation_tick();
+    let current_interpolate_tick = connection
+        .sync_manager
+        .interpolation_tick(tick_manager.as_ref());
     for (mut component, mut status, mut history) in query.iter_mut() {
         let mut start = status.start.take();
         let mut end = status.end.take();
@@ -149,7 +155,7 @@ pub(crate) fn update_interpolate_status<C: SyncComponent, P: Protocol>(
         trace!(
             component = ?component.name(),
             ?current_interpolate_tick,
-            last_received_server_tick = ?client.latest_received_server_tick(),
+            last_received_server_tick = ?connection.latest_received_server_tick(),
             start_tick = ?start.as_ref().map(|(tick, _)| tick),
             end_tick = ?end.as_ref().map(|(tick, _) | tick),
             "update_interpolate_status");

--- a/lightyear/src/client/interpolation/interpolation_history.rs
+++ b/lightyear/src/client/interpolation/interpolation_history.rs
@@ -1,6 +1,5 @@
 use std::ops::Deref;
 
-use crate::_reexport::TickManager;
 use bevy::prelude::{
     Commands, Component, DetectChanges, Entity, Query, Ref, Res, ResMut, With, Without,
 };
@@ -13,6 +12,7 @@ use crate::client::interpolation::interpolate::InterpolateStatus;
 use crate::client::interpolation::resource::InterpolationManager;
 use crate::client::interpolation::Interpolated;
 use crate::client::resource::Client;
+use crate::prelude::TickManager;
 use crate::protocol::Protocol;
 use crate::shared::tick_manager::Tick;
 use crate::utils::ready_buffer::ReadyBuffer;

--- a/lightyear/src/client/interpolation/interpolation_history.rs
+++ b/lightyear/src/client/interpolation/interpolation_history.rs
@@ -1,5 +1,6 @@
 use std::ops::Deref;
 
+use crate::_reexport::TickManager;
 use bevy::prelude::{
     Commands, Component, DetectChanges, Entity, Query, Ref, Res, ResMut, With, Without,
 };
@@ -7,6 +8,7 @@ use tracing::{debug, error, trace};
 
 use crate::client::components::{ComponentSyncMode, SyncComponent};
 use crate::client::components::{Confirmed, SyncMetadata};
+use crate::client::connection::Connection;
 use crate::client::interpolation::interpolate::InterpolateStatus;
 use crate::client::interpolation::resource::InterpolationManager;
 use crate::client::interpolation::Interpolated;
@@ -77,8 +79,9 @@ impl<T: SyncComponent> ConfirmedHistory<T> {
 // TODO: maybe add the component history on the Confirmed entity instead of Interpolated? would make more sense maybe
 pub(crate) fn add_component_history<C: SyncComponent, P: Protocol>(
     manager: Res<InterpolationManager>,
+    tick_manager: Res<TickManager>,
     mut commands: Commands,
-    client: ResMut<Client<P>>,
+    connection: Res<Connection<P>>,
     interpolated_entities: Query<Entity, (Without<ConfirmedHistory<C>>, With<Interpolated>)>,
     confirmed_entities: Query<(&Confirmed, Ref<C>)>,
 ) where
@@ -105,7 +108,9 @@ pub(crate) fn add_component_history<C: SyncComponent, P: Protocol>(
                                 InterpolateStatus::<C> {
                                     start: None,
                                     end: None,
-                                    current: client.interpolation_tick(),
+                                    current: connection
+                                        .sync_manager
+                                        .interpolation_tick(tick_manager.as_ref()),
                                 },
                             ));
                         }
@@ -125,7 +130,6 @@ pub(crate) fn add_component_history<C: SyncComponent, P: Protocol>(
 /// or update the interpolated component directly if InterpolatedComponentMode::Sync
 pub(crate) fn apply_confirmed_update<C: SyncComponent, P: Protocol>(
     manager: ResMut<InterpolationManager>,
-    client: Res<Client<P>>,
     mut interpolated_entities: Query<
         // TODO: handle missing T?
         (&mut C, Option<&mut ConfirmedHistory<C>>),
@@ -150,16 +154,17 @@ pub(crate) fn apply_confirmed_update<C: SyncComponent, P: Protocol>(
                                 );
                                 continue;
                             };
-                            let Some(tick) = client
-                                .replication_receiver()
-                                .get_confirmed_tick(confirmed_entity)
-                            else {
-                                error!(
-                                    "Could not find replication channel for entity {:?}",
-                                    confirmed_entity
-                                );
-                                continue;
-                            };
+                            let tick = confirmed.tick;
+                            // let Some(tick) = client
+                            //     .replication_receiver()
+                            //     .get_confirmed_tick(confirmed_entity)
+                            // else {
+                            //     error!(
+                            //         "Could not find replication channel for entity {:?}",
+                            //         confirmed_entity
+                            //     );
+                            //     continue;
+                            // };
                             // map any entities from confirmed to predicted
                             let mut component = confirmed_component.deref().clone();
                             component.map_entities(Box::new(&manager.interpolated_entity_map));

--- a/lightyear/src/client/interpolation/mod.rs
+++ b/lightyear/src/client/interpolation/mod.rs
@@ -9,6 +9,7 @@ pub use interpolation_history::ConfirmedHistory;
 pub use plugin::{add_interpolation_systems, add_prepare_interpolation_systems};
 
 use crate::client::components::{Confirmed, LerpFn, SyncComponent};
+use crate::client::connection::Connection;
 use crate::client::interpolation::resource::InterpolationManager;
 use crate::client::resource::Client;
 use crate::protocol::Protocol;
@@ -51,7 +52,7 @@ pub struct Interpolated {
 }
 
 pub fn spawn_interpolated_entity<P: Protocol>(
-    client: Res<Client<P>>,
+    connection: Res<Connection<P>>,
     mut manager: ResMut<InterpolationManager>,
     mut commands: Commands,
     mut confirmed_entities: Query<(Entity, Option<&mut Confirmed>), Added<ShouldBeInterpolated>>,
@@ -75,8 +76,8 @@ pub fn spawn_interpolated_entity<P: Protocol>(
         } else {
             // get the confirmed tick for the entity
             // if we don't have it, something has gone very wrong
-            let confirmed_tick = client
-                .replication_receiver()
+            let confirmed_tick = connection
+                .replication_receiver
                 .get_confirmed_tick(confirmed_entity)
                 .unwrap();
             confirmed_entity_mut.insert(Confirmed {

--- a/lightyear/src/client/plugin.rs
+++ b/lightyear/src/client/plugin.rs
@@ -2,7 +2,6 @@
 use std::ops::DerefMut;
 use std::sync::Mutex;
 
-use crate::_reexport::TimeManager;
 use crate::client::connection::Connection;
 use crate::client::diagnostics::ClientDiagnosticsPlugin;
 use bevy::prelude::IntoSystemSetConfigs;
@@ -20,7 +19,7 @@ use crate::client::prediction::Rollback;
 use crate::client::resource::{Authentication, Client};
 use crate::client::systems::{receive, send, sync_update};
 use crate::connection::events::ConnectionEvents;
-use crate::prelude::ReplicationSet;
+use crate::prelude::{ReplicationSet, TimeManager};
 use crate::protocol::component::ComponentProtocol;
 use crate::protocol::message::MessageProtocol;
 use crate::protocol::Protocol;

--- a/lightyear/src/client/plugin.rs
+++ b/lightyear/src/client/plugin.rs
@@ -2,6 +2,8 @@
 use std::ops::DerefMut;
 use std::sync::Mutex;
 
+use crate::_reexport::TimeManager;
+use crate::client::connection::Connection;
 use crate::client::diagnostics::ClientDiagnosticsPlugin;
 use bevy::prelude::IntoSystemSetConfigs;
 use bevy::prelude::{
@@ -16,7 +18,8 @@ use crate::client::interpolation::plugin::InterpolationPlugin;
 use crate::client::prediction::plugin::{is_connected, is_in_rollback, PredictionPlugin};
 use crate::client::prediction::Rollback;
 use crate::client::resource::{Authentication, Client};
-use crate::client::systems::{is_ready_to_send, receive, send, sync_update};
+use crate::client::systems::{receive, send, sync_update};
+use crate::connection::events::ConnectionEvents;
 use crate::prelude::ReplicationSet;
 use crate::protocol::component::ComponentProtocol;
 use crate::protocol::message::MessageProtocol;
@@ -25,6 +28,7 @@ use crate::shared::plugin::SharedPlugin;
 use crate::shared::replication::systems::add_replication_send_systems;
 use crate::shared::sets::{FixedUpdateSet, MainSet};
 use crate::shared::systems::tick::increment_tick;
+use crate::shared::time_manager::is_ready_to_send;
 use crate::transport::io::Io;
 
 use super::config::ClientConfig;
@@ -64,16 +68,19 @@ impl<P: Protocol> ClientPlugin<P> {
 impl<P: Protocol> PluginType for ClientPlugin<P> {
     fn build(&self, app: &mut App) {
         let config = self.config.lock().unwrap().deref_mut().take().unwrap();
-        let client = Client::new(
-            config.client_config.clone(),
-            config.io,
-            config.auth,
-            config.protocol,
-        );
+
+        let token = config
+            .auth
+            .get_token(config.client_config.netcode.client_timeout_secs)
+            .expect("could not generate token");
+        let token_bytes = token.try_into_bytes().unwrap();
+        let netcode =
+            crate::netcode::Client::with_config(&token_bytes, config.client_config.netcode.build())
+                .expect("could not create netcode client");
         let fixed_timestep = config.client_config.shared.tick.tick_duration;
 
-        add_replication_send_systems::<P, Client<P>>(app);
-        P::Components::add_per_component_replication_send_systems::<Client<P>>(app);
+        add_replication_send_systems::<P, Connection<P>>(app);
+        P::Components::add_per_component_replication_send_systems::<Connection<P>>(app);
         P::Components::add_events::<()>(app);
         // TODO: it's annoying to have to keep that () around...
         //  revisit this.. maybe the into_iter_messages returns directly an object that
@@ -94,7 +101,20 @@ impl<P: Protocol> PluginType for ClientPlugin<P> {
             ))
             .add_plugins(ClientDiagnosticsPlugin::<P>::default())
             // RESOURCES //
-            .insert_resource(client)
+            .insert_resource(config.client_config.clone())
+            .insert_resource(config.io)
+            .insert_resource(netcode)
+            .insert_resource(Connection::<P>::new(
+                config.protocol.channel_registry(),
+                config.client_config.sync,
+                &config.client_config.ping,
+                config.client_config.prediction.input_delay_ticks,
+            ))
+            .insert_resource(TimeManager::new(
+                config.client_config.shared.client_send_interval,
+            ))
+            .insert_resource(ConnectionEvents::<P>::new())
+            .insert_resource(config.protocol)
             // SYSTEM SETS //
             .configure_sets(PreUpdate, (MainSet::Receive, MainSet::ReceiveFlush).chain())
             .configure_sets(
@@ -132,13 +152,13 @@ impl<P: Protocol> PluginType for ClientPlugin<P> {
                     (ReplicationSet::All, MainSet::SendPackets).chain(),
                     // only replicate entities once client is connected
                     // TODO: should it be only when the client is synced? because before that the ticks might be incorrect!
-                    ReplicationSet::All.run_if(is_connected::<P>),
+                    ReplicationSet::All.run_if(is_connected),
                 ),
             )
             .configure_sets(
                 PostUpdate,
                 // run sync before send because some send systems need to know if the client is synced
-                (MainSet::Sync, MainSet::Send.run_if(is_ready_to_send::<P>)).chain(),
+                (MainSet::Sync, MainSet::Send.run_if(is_ready_to_send)).chain(),
             )
             // EVENTS //
             .add_event::<ConnectEvent>()
@@ -151,19 +171,6 @@ impl<P: Protocol> PluginType for ClientPlugin<P> {
                 (
                     (receive::<P>).in_set(MainSet::Receive),
                     apply_deferred.in_set(MainSet::ReceiveFlush),
-                ),
-            )
-            // TODO: a bit of a code-smell that i have to run this here instead of in the shared plugin
-            //  maybe TickManager should be a separate resource not contained in Client/Server?
-            //  and runs Update in PreUpdate before the client/server systems
-            .add_systems(
-                FixedUpdate,
-                (
-                    increment_tick::<Client<P>>
-                        .in_set(FixedUpdateSet::TickUpdate)
-                        // run if there is no rollback resource, or if we are not in rollback
-                        .run_if((not(resource_exists::<Rollback>())).or_else(not(is_in_rollback))),
-                    apply_deferred.in_set(FixedUpdateSet::MainFlush),
                 ),
             )
             // TODO: update virtual time with Time<Real> so we have more accurate time at Send time.

--- a/lightyear/src/client/prediction/correction.rs
+++ b/lightyear/src/client/prediction/correction.rs
@@ -9,11 +9,11 @@
 use bevy::prelude::{Commands, Component, Entity, Query, Res};
 use tracing::{debug, info};
 
-use crate::_reexport::ComponentProtocol;
+use crate::_reexport::{ComponentProtocol, TickManager};
 use crate::client::components::{LerpFn, SyncComponent, SyncMetadata};
 use crate::client::easings::{ease_out_quad, ease_out_quart};
 use crate::client::resource::Client;
-use crate::prelude::{Tick, TickManaged};
+use crate::prelude::Tick;
 use crate::protocol::Protocol;
 
 // TODO: instead of requiring the component to implement the correction, we could have a separate
@@ -84,14 +84,14 @@ pub struct Correction<C: Component> {
 /// Visually update the component to the a value that is interpolated between the original prediction
 /// and the Corrected state
 pub(crate) fn get_visually_corrected_state<C: SyncComponent, P: Protocol>(
-    client: Res<Client<P>>,
+    tick_manager: Res<TickManager>,
     mut commands: Commands,
     mut query: Query<(Entity, &mut C, &mut Correction<C>)>,
 ) where
     P::Components: SyncMetadata<C>,
 {
     for (entity, mut component, mut correction) in query.iter_mut() {
-        let current_tick = client.tick();
+        let current_tick = tick_manager.tick();
         let mut t = (current_tick - correction.original_tick) as f32
             / (correction.final_correction_tick - correction.original_tick) as f32;
         t = t.clamp(0.0, 1.0);

--- a/lightyear/src/client/prediction/correction.rs
+++ b/lightyear/src/client/prediction/correction.rs
@@ -9,11 +9,11 @@
 use bevy::prelude::{Commands, Component, Entity, Query, Res};
 use tracing::{debug, info};
 
-use crate::_reexport::{ComponentProtocol, TickManager};
+use crate::_reexport::ComponentProtocol;
 use crate::client::components::{LerpFn, SyncComponent, SyncMetadata};
 use crate::client::easings::{ease_out_quad, ease_out_quart};
 use crate::client::resource::Client;
-use crate::prelude::Tick;
+use crate::prelude::{Tick, TickManager};
 use crate::protocol::Protocol;
 
 // TODO: instead of requiring the component to implement the correction, we could have a separate

--- a/lightyear/src/client/prediction/despawn.rs
+++ b/lightyear/src/client/prediction/despawn.rs
@@ -6,14 +6,13 @@ use bevy::prelude::{
 };
 use tracing::{debug, error, trace};
 
-use crate::_reexport::ShouldBePredicted;
+use crate::_reexport::{ShouldBePredicted, TickManager};
 use crate::client::components::{ComponentSyncMode, Confirmed, SyncComponent, SyncMetadata};
 use crate::client::prediction::resource::PredictionManager;
 use crate::client::prediction::Predicted;
 use crate::client::resource::Client;
 use crate::protocol::Protocol;
 use crate::shared::tick_manager::Tick;
-use crate::shared::tick_manager::TickManaged;
 
 // - TODO: despawning another client entity as a consequence from prediction, but we want to roll that back:
 //   - maybe we don't do it, and we wait until we are sure (confirmed despawn) before actually despawning the entity
@@ -39,8 +38,8 @@ pub struct PredictionDespawnMarker {
 
 impl<P: Protocol> Command for PredictionDespawnCommand<P> {
     fn apply(self, world: &mut World) {
-        let client = world.get_resource::<Client<P>>().unwrap();
-        let current_tick = client.tick();
+        let tick_manager = world.get_resource::<TickManager>().unwrap();
+        let current_tick = tick_manager.tick();
 
         let mut predicted_entity_to_despawn: Option<Entity> = None;
 

--- a/lightyear/src/client/prediction/despawn.rs
+++ b/lightyear/src/client/prediction/despawn.rs
@@ -6,11 +6,11 @@ use bevy::prelude::{
 };
 use tracing::{debug, error, trace};
 
-use crate::_reexport::{ShouldBePredicted, TickManager};
 use crate::client::components::{ComponentSyncMode, Confirmed, SyncComponent, SyncMetadata};
 use crate::client::prediction::resource::PredictionManager;
 use crate::client::prediction::Predicted;
 use crate::client::resource::Client;
+use crate::prelude::{ShouldBePredicted, TickManager};
 use crate::protocol::Protocol;
 use crate::shared::tick_manager::Tick;
 

--- a/lightyear/src/client/prediction/mod.rs
+++ b/lightyear/src/client/prediction/mod.rs
@@ -190,7 +190,7 @@ pub(crate) fn spawn_predicted_entity<P: Protocol>(
 /// We automatically add the extra needed information to the component.
 /// - client_entity: is needed to know which entity to use as the predicted entity
 /// - client_id: is needed in case the pre-predicted entity is predicted by other players upon replication
-pub(crate) fn handle_pre_prediction<P: Protocol>(
+pub(crate) fn handle_pre_prediction(
     netcode: Res<crate::netcode::Client>,
     mut query: Query<(Entity, &mut ShouldBePredicted), Without<Confirmed>>,
 ) {

--- a/lightyear/src/client/prediction/plugin.rs
+++ b/lightyear/src/client/prediction/plugin.rs
@@ -143,8 +143,8 @@ pub fn is_in_rollback(rollback: Res<Rollback>) -> bool {
 }
 
 /// Returns true if the client is connected
-pub fn is_connected<P: Protocol>(client: Res<Client<P>>) -> bool {
-    client.is_connected()
+pub fn is_connected(netclient: Res<crate::netcode::Client>) -> bool {
+    netclient.is_connected()
 }
 
 pub fn add_prediction_systems<C: SyncComponent, P: Protocol>(app: &mut App)
@@ -179,7 +179,7 @@ where
             app.add_systems(
                 FixedUpdate,
                 // we need to run this during fixed update to know accurately the history for each tick
-                update_prediction_history::<C, P>.in_set(PredictionSet::UpdateHistory),
+                update_prediction_history::<C>.in_set(PredictionSet::UpdateHistory),
             );
             app.add_systems(
                 PostUpdate,
@@ -278,7 +278,7 @@ impl<P: Protocol> Plugin for PredictionPlugin<P> {
                 // clean-up the ShouldBePredicted components after we've sent them
                 clean_prespawned_entity::<P>.after(ReplicationSet::All),
             )
-                .run_if(is_connected::<P>),
+                .run_if(is_connected),
         );
         // 2. (in prediction_systems) add ComponentHistory and a apply_deferred after
         // 3. (in prediction_systems) Check if we should do rollback, clear histories and snap prediction's history to server-state

--- a/lightyear/src/client/prediction/plugin.rs
+++ b/lightyear/src/client/prediction/plugin.rs
@@ -274,7 +274,7 @@ impl<P: Protocol> Plugin for PredictionPlugin<P> {
             PostUpdate,
             (
                 // fill in the client_entity and client_id for pre-predicted entities
-                handle_pre_prediction::<P>.before(ReplicationSet::All),
+                handle_pre_prediction,
                 // clean-up the ShouldBePredicted components after we've sent them
                 clean_prespawned_entity::<P>.after(ReplicationSet::All),
             )
@@ -283,10 +283,7 @@ impl<P: Protocol> Plugin for PredictionPlugin<P> {
         // 2. (in prediction_systems) add ComponentHistory and a apply_deferred after
         // 3. (in prediction_systems) Check if we should do rollback, clear histories and snap prediction's history to server-state
         // 4. Potentially do rollback
-        app.add_systems(
-            PreUpdate,
-            (run_rollback::<P>).in_set(PredictionSet::Rollback),
-        );
+        app.add_systems(PreUpdate, run_rollback.in_set(PredictionSet::Rollback));
 
         // FixedUpdate systems
         // 1. Update client tick (don't run in rollback)

--- a/lightyear/src/client/prediction/predicted_history.rs
+++ b/lightyear/src/client/prediction/predicted_history.rs
@@ -6,12 +6,11 @@ use bevy::prelude::{
 };
 use tracing::{debug, error, info};
 
-use crate::_reexport::{ShouldBePredicted, TickManager};
 use crate::client::components::{SyncComponent, SyncMetadata};
 use crate::client::connection::Connection;
 use crate::client::prediction::resource::PredictionManager;
 use crate::client::resource::Client;
-use crate::prelude::Named;
+use crate::prelude::{Named, ShouldBePredicted, TickManager};
 use crate::protocol::Protocol;
 use crate::shared::tick_manager::Tick;
 use crate::utils::ready_buffer::ReadyBuffer;

--- a/lightyear/src/client/prediction/predicted_history.rs
+++ b/lightyear/src/client/prediction/predicted_history.rs
@@ -6,14 +6,14 @@ use bevy::prelude::{
 };
 use tracing::{debug, error, info};
 
-use crate::_reexport::ShouldBePredicted;
+use crate::_reexport::{ShouldBePredicted, TickManager};
 use crate::client::components::{SyncComponent, SyncMetadata};
+use crate::client::connection::Connection;
 use crate::client::prediction::resource::PredictionManager;
 use crate::client::resource::Client;
 use crate::prelude::Named;
 use crate::protocol::Protocol;
 use crate::shared::tick_manager::Tick;
-use crate::shared::tick_manager::TickManaged;
 use crate::utils::ready_buffer::ReadyBuffer;
 
 use super::{ComponentSyncMode, Confirmed, Predicted, Rollback, RollbackState};
@@ -122,7 +122,7 @@ impl<T: SyncComponent> PredictionHistory<T> {
 pub fn add_component_history<C: SyncComponent, P: Protocol>(
     manager: Res<PredictionManager>,
     mut commands: Commands,
-    client: Res<Client<P>>,
+    tick_manager: Res<TickManager>,
     predicted_entities: Query<
         (Entity, Option<Ref<C>>),
         (
@@ -145,7 +145,7 @@ pub fn add_component_history<C: SyncComponent, P: Protocol>(
                     // insert history, it will be quickly filled by a rollback (since it starts empty before the current client tick)
                     let mut history = PredictionHistory::<C>::default();
                     history.buffer.add_item(
-                        client.tick(),
+                        tick_manager.tick(),
                         ComponentState::Updated(predicted_component.deref().clone()),
                     );
                     commands.entity(predicted_entity).insert(history);
@@ -182,7 +182,7 @@ pub fn add_component_history<C: SyncComponent, P: Protocol>(
                                 // insert history, it will be quickly filled by a rollback (since it starts empty before the current client tick)
                                 let mut history = PredictionHistory::<C>::default();
                                 history.buffer.add_item(
-                                    client.tick(),
+                                    tick_manager.tick(),
                                     ComponentState::Updated(confirmed_component.deref().clone()),
                                 );
                                 predicted_entity_mut.insert((new_component, history));
@@ -246,17 +246,17 @@ pub fn add_component_history<C: SyncComponent, P: Protocol>(
 //    - we remove the component from predicted.
 
 /// After one fixed-update tick, we record the predicted component history for the current tick
-pub fn update_prediction_history<T: SyncComponent, P: Protocol>(
+pub fn update_prediction_history<T: SyncComponent>(
     mut query: Query<(Ref<T>, &mut PredictionHistory<T>)>,
     mut removed_component: RemovedComponents<T>,
     mut removed_entities: Query<&mut PredictionHistory<T>, Without<T>>,
-    client: Res<Client<P>>,
+    tick_manager: Res<TickManager>,
     rollback: Res<Rollback>,
 ) {
     // tick for which we will record the history
     let tick = match rollback.state {
         // if not in rollback, we are recording the history for the current client tick
-        RollbackState::Default => client.tick(),
+        RollbackState::Default => tick_manager.tick(),
         // if in rollback, we are recording the history for the current rollback tick
         RollbackState::ShouldRollback { current_tick } => current_tick,
     };
@@ -285,7 +285,6 @@ pub fn update_prediction_history<T: SyncComponent, P: Protocol>(
 #[allow(clippy::type_complexity)]
 pub(crate) fn apply_confirmed_update<C: SyncComponent, P: Protocol>(
     manager: Res<PredictionManager>,
-    client: Res<Client<P>>,
     mut predicted_entities: Query<
         &mut C,
         (
@@ -298,7 +297,6 @@ pub(crate) fn apply_confirmed_update<C: SyncComponent, P: Protocol>(
 ) where
     P::Components: SyncMetadata<C>,
 {
-    let latest_server_tick = client.latest_received_server_tick();
     for (confirmed_entity, confirmed_component) in confirmed_entities.iter() {
         if let Some(p) = confirmed_entity.predicted {
             if confirmed_component.is_changed() && !confirmed_component.is_added() {

--- a/lightyear/src/client/prediction/rollback.rs
+++ b/lightyear/src/client/prediction/rollback.rs
@@ -5,7 +5,7 @@ use bevy::prelude::{
 };
 use tracing::{debug, info, trace, trace_span};
 
-use crate::_reexport::{ComponentProtocol, FromType, TickManager};
+use crate::_reexport::{ComponentProtocol, FromType};
 use crate::client::components::{ComponentSyncMode, Confirmed, SyncComponent};
 use crate::client::config::ClientConfig;
 use crate::client::connection::Connection;
@@ -13,6 +13,7 @@ use crate::client::prediction::correction::Correction;
 use crate::client::prediction::predicted_history::ComponentState;
 use crate::client::resource::Client;
 use crate::prelude::client::SyncMetadata;
+use crate::prelude::TickManager;
 use crate::protocol::Protocol;
 
 use super::predicted_history::PredictionHistory;

--- a/lightyear/src/client/prediction/rollback.rs
+++ b/lightyear/src/client/prediction/rollback.rs
@@ -527,7 +527,7 @@ pub(crate) fn check_rollback<C: SyncComponent, P: Protocol>(
     }
 }
 
-pub(crate) fn run_rollback<P: Protocol>(world: &mut World) {
+pub(crate) fn run_rollback(world: &mut World) {
     let tick_manager = world.get_resource::<TickManager>().unwrap();
     let rollback = world.get_resource::<Rollback>().unwrap();
 

--- a/lightyear/src/client/resource.rs
+++ b/lightyear/src/client/resource.rs
@@ -258,7 +258,7 @@ impl<'w, 's, P: Protocol> Client<'w, 's, P> {
 
 // Access some internals for tests
 #[cfg(test)]
-impl<P: Protocol> Client<P> {
+impl<'w, 's, P: Protocol> Client<'w, 's, P> {
     // pub fn set_latest_received_server_tick(&mut self, tick: Tick) {
     //     self.connection.sync_manager.latest_received_server_tick = Some(tick);
     //     self.connection

--- a/lightyear/src/client/systems.rs
+++ b/lightyear/src/client/systems.rs
@@ -7,13 +7,13 @@ use bevy_xpbd_2d::prelude::PhysicsTime;
 use std::ops::DerefMut;
 use tracing::{error, info, trace};
 
-use crate::_reexport::{ReplicationSend, TickManager, TimeManager};
+use crate::_reexport::ReplicationSend;
 use crate::client::config::ClientConfig;
 use crate::client::connection::Connection;
 use crate::client::events::{EntityDespawnEvent, EntitySpawnEvent};
 use crate::client::resource::{Client, ClientMut};
 use crate::connection::events::{IterEntityDespawnEvent, IterEntitySpawnEvent};
-use crate::prelude::Io;
+use crate::prelude::{Io, TickManager, TimeManager};
 use crate::protocol::component::ComponentProtocol;
 use crate::protocol::message::MessageProtocol;
 use crate::protocol::Protocol;
@@ -160,7 +160,7 @@ pub fn send<P: Protocol>(
 pub(crate) fn sync_update<P: Protocol>(
     config: Res<ClientConfig>,
     netclient: Res<crate::netcode::Client>,
-    mut connection: ResMut<Connection<P>>,
+    connection: ResMut<Connection<P>>,
     mut time_manager: ResMut<TimeManager>,
     mut tick_manager: ResMut<TickManager>,
     mut virtual_time: ResMut<Time<Virtual>>,

--- a/lightyear/src/connection/events.rs
+++ b/lightyear/src/connection/events.rs
@@ -2,7 +2,7 @@
 */
 use std::iter;
 
-use bevy::prelude::{Component, Entity};
+use bevy::prelude::{Component, Entity, Resource};
 use bevy::utils::HashMap;
 use tracing::trace;
 
@@ -16,7 +16,7 @@ use crate::protocol::message::MessageKind;
 use crate::protocol::{EventContext, Protocol};
 
 // TODO: don't make fields pub but instead make accessors
-#[derive(Debug)]
+#[derive(Debug, Resource)]
 pub struct ConnectionEvents<P: Protocol> {
     // netcode
     // we put disconnections outside of there because `ConnectionEvents` gets removed upon disconnection

--- a/lightyear/src/lib.rs
+++ b/lightyear/src/lib.rs
@@ -48,14 +48,13 @@ pub mod _reexport {
     pub use crate::shared::events::{
         ComponentInsertEvent, ComponentRemoveEvent, ComponentUpdateEvent,
     };
-    pub use crate::shared::replication::components::{ShouldBeInterpolated, ShouldBePredicted};
+    pub use crate::shared::replication::components::ShouldBeInterpolated;
     pub use crate::shared::replication::systems::add_per_component_replication_send_systems;
     pub use crate::shared::replication::ReplicationSend;
     pub use crate::shared::systems::events::{
         push_component_insert_events, push_component_remove_events, push_component_update_events,
     };
-    pub use crate::shared::tick_manager::TickManager;
-    pub use crate::shared::time_manager::{TimeManager, WrappedTime};
+    pub use crate::shared::time_manager::WrappedTime;
     pub use crate::utils::ready_buffer::ReadyBuffer;
     pub use crate::utils::sequence_buffer::SequenceBuffer;
 }
@@ -82,11 +81,13 @@ pub mod prelude {
     pub use crate::shared::ping::manager::PingConfig;
     pub use crate::shared::plugin::SharedPlugin;
     pub use crate::shared::replication::components::{
-        NetworkTarget, ReplicationGroup, ReplicationMode,
+        NetworkTarget, ReplicationGroup, ReplicationMode, ShouldBePredicted,
     };
     pub use crate::shared::replication::entity_map::{EntityMapper, MapEntities, RemoteEntityMap};
     pub use crate::shared::sets::{FixedUpdateSet, MainSet, ReplicationSet};
+    pub use crate::shared::tick_manager::TickManager;
     pub use crate::shared::tick_manager::{Tick, TickConfig};
+    pub use crate::shared::time_manager::TimeManager;
     pub use crate::transport::conditioner::LinkConditionerConfig;
     pub use crate::transport::io::{Io, IoConfig, TransportConfig};
     pub use crate::utils::named::Named;
@@ -129,7 +130,7 @@ pub mod prelude {
             DisconnectEvent, EntityDespawnEvent, EntitySpawnEvent, InputEvent, MessageEvent,
         };
         pub use crate::server::plugin::{PluginConfig, ServerPlugin};
-        pub use crate::server::room::{RoomId, RoomMut, RoomRef};
+        pub use crate::server::room::{RoomId, RoomManager, RoomMut, RoomRef};
 
         #[cfg(feature = "leafwing")]
         pub use crate::server::input_leafwing::LeafwingInputPlugin;

--- a/lightyear/src/lib.rs
+++ b/lightyear/src/lib.rs
@@ -86,7 +86,7 @@ pub mod prelude {
     };
     pub use crate::shared::replication::entity_map::{EntityMapper, MapEntities, RemoteEntityMap};
     pub use crate::shared::sets::{FixedUpdateSet, MainSet, ReplicationSet};
-    pub use crate::shared::tick_manager::{Tick, TickConfig, TickManaged};
+    pub use crate::shared::tick_manager::{Tick, TickConfig};
     pub use crate::transport::conditioner::LinkConditionerConfig;
     pub use crate::transport::io::{Io, IoConfig, TransportConfig};
     pub use crate::utils::named::Named;

--- a/lightyear/src/lib.rs
+++ b/lightyear/src/lib.rs
@@ -115,6 +115,7 @@ pub mod prelude {
         pub use crate::client::prediction::{Predicted, PredictionCommandsExt};
         pub use crate::client::resource::Authentication;
         pub use crate::client::sync::SyncConfig;
+        pub use crate::netcode::Client as NetClient;
 
         #[cfg(feature = "leafwing")]
         pub use crate::client::input_leafwing::{LeafwingInputConfig, LeafwingInputPlugin};
@@ -134,6 +135,8 @@ pub mod prelude {
 
         #[cfg(feature = "leafwing")]
         pub use crate::server::input_leafwing::LeafwingInputPlugin;
+
+        pub use crate::netcode::Server as NetServer;
     }
 }
 

--- a/lightyear/src/netcode/client.rs
+++ b/lightyear/src/netcode/client.rs
@@ -1,3 +1,4 @@
+use bevy::prelude::Resource;
 use std::{
     collections::VecDeque,
     net::SocketAddr,
@@ -176,6 +177,8 @@ pub enum ClientState {
 /// let mut client = Client::new(&token_bytes).unwrap();
 /// client.connect();
 /// ```
+
+#[derive(Resource)]
 pub struct Client<Ctx = ()> {
     id: ClientId,
     state: ClientState,

--- a/lightyear/src/netcode/client.rs
+++ b/lightyear/src/netcode/client.rs
@@ -34,10 +34,10 @@ type Callback<Ctx> = Box<dyn FnMut(ClientState, ClientState, &mut Ctx) + Send + 
 /// # Example
 /// ```
 /// # struct MyContext;
-/// # use crate::lightyear::netcode::{generate_key, Server};
+/// # use crate::lightyear::netcode::{generate_key, NetcodeServer};
 /// # let addr = std::net::SocketAddr::from(([127, 0, 0, 1], 40007));
 /// # let private_key = generate_key();
-/// # let token = Server::new(0x11223344, private_key).unwrap().token(123u64, addr).generate().unwrap();
+/// # let token = NetcodeServer::new(0x11223344, private_key).unwrap().token(123u64, addr).generate().unwrap();
 /// # let token_bytes = token.try_into_bytes().unwrap();
 /// use crate::lightyear::netcode::{Client, ClientConfig, ClientState};
 ///
@@ -163,7 +163,7 @@ pub enum ClientState {
 ///
 /// # Example
 /// ```
-/// use crate::lightyear::netcode::{ConnectToken, Client, ClientConfig, ClientState, Server};
+/// use crate::lightyear::netcode::{ConnectToken, Client, ClientConfig, ClientState, NetcodeServer};
 /// # use std::net::{Ipv4Addr, SocketAddr};
 /// # use std::time::{Instant, Duration};
 /// # use std::thread;
@@ -172,7 +172,7 @@ pub enum ClientState {
 /// # let mut io = Io::from_config(IoConfig::from_transport(TransportConfig::UdpSocket(
 /// #    addr))
 /// # );
-/// # let mut server = Server::new(0, [0; 32]).unwrap();
+/// # let mut server = NetcodeServer::new(0, [0; 32]).unwrap();
 /// # let token_bytes = server.token(0, addr).generate().unwrap().try_into_bytes().unwrap();
 /// let mut client = Client::new(&token_bytes).unwrap();
 /// client.connect();
@@ -545,13 +545,13 @@ impl<Ctx> Client<Ctx> {
     /// # Example
     /// ```
     /// # use std::net::SocketAddr;
-    /// # use crate::lightyear::netcode::{ConnectToken, Client, ClientConfig, ClientState, Server};
+    /// # use crate::lightyear::netcode::{ConnectToken, Client, ClientConfig, ClientState, NetcodeServer};
     /// # use std::time::{Instant, Duration};
     /// # use std::thread;
     /// # use lightyear::prelude::{Io, IoConfig, TransportConfig};
     /// # let client_addr = SocketAddr::from(([127, 0, 0, 1], 40000));
     /// # let server_addr = SocketAddr::from(([127, 0, 0, 1], 40001));
-    /// # let mut server = Server::new(0, [0; 32]).unwrap();
+    /// # let mut server = NetcodeServer::new(0, [0; 32]).unwrap();
     /// # let token_bytes = server.token(0, server_addr).generate().unwrap().try_into_bytes().unwrap();
     /// # let mut io = Io::from_config(IoConfig::from_transport(TransportConfig::UdpSocket(client_addr)));
     /// let mut client = Client::new(&token_bytes).unwrap();

--- a/lightyear/src/netcode/mod.rs
+++ b/lightyear/src/netcode/mod.rs
@@ -126,7 +126,7 @@ loop {
 pub use client::{Client, ClientConfig, ClientState};
 pub use crypto::{generate_key, try_generate_key, Key};
 pub use error::{Error, Result};
-pub use server::{Callback, ClientId, Server, ServerConfig};
+pub use server::{Callback, ClientId, NetServer as Server, ServerConfig};
 pub use token::{ConnectToken, ConnectTokenBuilder, InvalidTokenError};
 
 mod bytes;

--- a/lightyear/src/netcode/mod.rs
+++ b/lightyear/src/netcode/mod.rs
@@ -45,7 +45,7 @@
 
  ```
  use std::{thread, time::{Instant, Duration}, net::SocketAddr};
- use crate::lightyear::netcode::{generate_key, Server, MAX_PACKET_SIZE};
+ use crate::lightyear::netcode::{generate_key, NetcodeServer, MAX_PACKET_SIZE};
 
  use lightyear::prelude::{IoConfig, TransportConfig};
  use crate::lightyear::transport::io::Io;
@@ -57,7 +57,7 @@
  // Create a server
  let protocol_id = 0x11223344;
  let private_key = generate_key(); // you can also provide your own key
- let mut server = Server::new(protocol_id, private_key).unwrap();
+ let mut server = NetcodeServer::new(protocol_id, private_key).unwrap();
 
  // Run the server at 60Hz
  let start = Instant::now();
@@ -126,7 +126,7 @@ loop {
 pub use client::{Client, ClientConfig, ClientState};
 pub use crypto::{generate_key, try_generate_key, Key};
 pub use error::{Error, Result};
-pub use server::{Callback, ClientId, NetServer as Server, ServerConfig};
+pub use server::{Callback, ClientId, NetcodeServer, Server, ServerConfig};
 pub use token::{ConnectToken, ConnectTokenBuilder, InvalidTokenError};
 
 mod bytes;

--- a/lightyear/src/netcode/token.rs
+++ b/lightyear/src/netcode/token.rs
@@ -303,7 +303,7 @@ impl Bytes for ChallengeToken {
 /// assert_eq!(token_bytes.len(), CONNECT_TOKEN_BYTES);
 /// ```
 ///
-/// Alternatively, you can use [`Server::token`](crate::netcode::server::Server::token) to generate a connect token from an already existing [`Server`](crate::netcode::server::Server).
+/// Alternatively, you can use [`Server::token`](crate::netcode::server::NetcodeServer::token) to generate a connect token from an already existing [`Server`](crate::netcode::server::NetcodeServer).
 #[derive(Clone)]
 pub struct ConnectToken {
     pub(crate) version_info: [u8; NETCODE_VERSION.len()],

--- a/lightyear/src/packet/header.rs
+++ b/lightyear/src/packet/header.rs
@@ -6,10 +6,11 @@ use tracing::trace;
 
 use bitcode::{Decode, Encode};
 
-use crate::_reexport::{TimeManager, WrappedTime};
+use crate::_reexport::WrappedTime;
 use crate::packet::packet::PacketId;
 use crate::packet::packet_type::PacketType;
 use crate::packet::stats_manager::PacketStatsManager;
+use crate::prelude::TimeManager;
 use crate::shared::tick_manager::Tick;
 
 /// Header included at the start of all packets

--- a/lightyear/src/protocol/mod.rs
+++ b/lightyear/src/protocol/mod.rs
@@ -108,7 +108,7 @@ macro_rules! protocolize {
             use $shared_crate_name::prelude::*;
             use $shared_crate_name::_reexport::*;
 
-            #[derive(Debug, Clone)]
+            #[derive(Debug, Clone, Resource)]
             pub struct $protocol {
                 channel_registry: ChannelRegistry,
             }
@@ -172,8 +172,12 @@ macro_rules! protocolize {
         }
         pub use [<$protocol:lower _module>]::$protocol;
         pub type Replicate = $shared_crate_name::shared::replication::components::Replicate<$protocol>;
-        pub type Client = $shared_crate_name::client::resource::Client<$protocol>;
-        pub type Server = $shared_crate_name::server::resource::Server<$protocol>;
+        pub type Client<'w, 's> = $shared_crate_name::client::resource::Client<'w, 's, $protocol>;
+        pub type Server<'w, 's> = $shared_crate_name::server::resource::Server<'w, 's, $protocol>;
+        pub type ClientMut<'w, 's> = $shared_crate_name::client::resource::ClientMut<'w, 's, $protocol>;
+        pub type ServerMut<'w, 's> = $shared_crate_name::server::resource::ServerMut<'w, 's, $protocol>;
+        pub type Connection = $shared_crate_name::client::connection::Connection<$protocol>;
+        pub type ConnectionManager = $shared_crate_name::server::connection::ConnectionManager<$protocol>;
         }
     };
 
@@ -195,7 +199,7 @@ macro_rules! protocolize {
             use $shared_crate_name::_reexport::*;
             use $shared_crate_name::inputs::leafwing::{NoAction1, NoAction2};
 
-            #[derive(Debug, Clone)]
+            #[derive(Debug, Clone, Resource)]
             pub struct $protocol {
                 channel_registry: ChannelRegistry,
             }
@@ -257,8 +261,12 @@ macro_rules! protocolize {
         }
         pub use [<$protocol:lower _module>]::$protocol;
         pub type Replicate = $shared_crate_name::shared::replication::components::Replicate<$protocol>;
-        pub type Client = $shared_crate_name::client::resource::Client<$protocol>;
-        pub type Server = $shared_crate_name::server::resource::Server<$protocol>;
+        pub type Client<'w, 's> = $shared_crate_name::client::resource::Client<'w, 's, $protocol>;
+        pub type Server<'w, 's> = $shared_crate_name::server::resource::Server<'w, 's, $protocol>;
+        pub type ClientMut<'w, 's> = $shared_crate_name::client::resource::ClientMut<'w, 's, $protocol>;
+        pub type ServerMut<'w, 's> = $shared_crate_name::server::resource::ServerMut<'w, 's, $protocol>;
+        pub type Connection = $shared_crate_name::client::connection::Connection<$protocol>;
+        pub type ConnectionManager = $shared_crate_name::server::connection::ConnectionManager<$protocol>;
         }
     };
 

--- a/lightyear/src/protocol/mod.rs
+++ b/lightyear/src/protocol/mod.rs
@@ -7,7 +7,7 @@
 
 use std::fmt::Debug;
 
-use bevy::prelude::App;
+use bevy::prelude::{App, Resource};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 
@@ -66,7 +66,7 @@ pub(crate) mod registry;
 ///
 ///# fn main() {}
 /// ```
-pub trait Protocol: Send + Sync + Clone + Debug + 'static {
+pub trait Protocol: Send + Sync + Clone + Debug + Resource + 'static {
     type Input: crate::inputs::native::UserAction;
     #[cfg(feature = "leafwing")]
     type LeafwingInput1: crate::inputs::leafwing::LeafwingUserAction;

--- a/lightyear/src/server/config.rs
+++ b/lightyear/src/server/config.rs
@@ -1,4 +1,5 @@
 //! Defines server-specific configuration options
+use bevy::prelude::Resource;
 use std::time::Duration;
 
 use crate::netcode::Key;
@@ -66,7 +67,7 @@ impl PacketConfig {
     }
 }
 
-#[derive(Clone, Default)]
+#[derive(Clone, Default, Resource)]
 pub struct ServerConfig {
     pub shared: SharedConfig,
     pub netcode: NetcodeConfig,

--- a/lightyear/src/server/connection.rs
+++ b/lightyear/src/server/connection.rs
@@ -61,8 +61,9 @@ impl<P: Protocol> ConnectionManager<P> {
     pub(crate) fn apply_replication(
         &mut self,
         target: NetworkTarget,
-    ) -> Box<dyn Iterator<Item = ClientId> + '_> {
-        let connected_clients = self.connections.keys().copied();
+    ) -> Box<dyn Iterator<Item = ClientId>> {
+        // TODO: avoid this vec allocation
+        let connected_clients: Vec<ClientId> = self.connections.keys().copied().collect();
         match target {
             NetworkTarget::All => {
                 // TODO: maybe only send stuff when the client is time-synced ?

--- a/lightyear/src/server/connection.rs
+++ b/lightyear/src/server/connection.rs
@@ -61,7 +61,7 @@ impl<P: Protocol> ConnectionManager<P> {
     pub(crate) fn apply_replication(
         &mut self,
         target: NetworkTarget,
-    ) -> Box<dyn Iterator<Item = ClientId>> {
+    ) -> Box<dyn Iterator<Item = ClientId> + '_> {
         let connected_clients = self.connections.keys().copied();
         match target {
             NetworkTarget::All => {

--- a/lightyear/src/server/input.rs
+++ b/lightyear/src/server/input.rs
@@ -1,11 +1,11 @@
 //! Handles client-generated inputs
-use crate::_reexport::TickManager;
 use bevy::prelude::{
     App, EventReader, EventWriter, FixedUpdate, IntoSystemConfigs, IntoSystemSetConfigs, Plugin,
     Res, ResMut, SystemSet,
 };
 
 use crate::netcode::ClientId;
+use crate::prelude::TickManager;
 use crate::protocol::Protocol;
 use crate::server::connection::ConnectionManager;
 use crate::server::resource::Server;

--- a/lightyear/src/server/input_leafwing.rs
+++ b/lightyear/src/server/input_leafwing.rs
@@ -1,14 +1,13 @@
 //! Handles client-generated inputs
 use std::ops::DerefMut;
 
-use crate::_reexport::TickManager;
 use bevy::prelude::*;
 use leafwing_input_manager::prelude::*;
 
 use crate::connection::events::IterInputMessageEvent;
 use crate::inputs::leafwing::input_buffer::{ActionDiffBuffer, InputBuffer, InputTarget};
 use crate::inputs::leafwing::{InputMessage, LeafwingUserAction};
-use crate::prelude::MainSet;
+use crate::prelude::{MainSet, TickManager};
 use crate::protocol::Protocol;
 use crate::server::connection::ConnectionManager;
 use crate::server::events::InputMessageEvent;
@@ -270,8 +269,9 @@ mod tests {
 
         // check that the entity is replicated, including the ActionState component
         let client_entity = *stepper
-            .client()
-            .connection()
+            .client_app
+            .world
+            .resource::<Connection>()
             .replication_receiver
             .remote_entity_map
             .get_local(server_entity)
@@ -298,7 +298,7 @@ mod tests {
             .press(KeyCode::A);
         stepper.frame_step();
         // client tick when we send the Jump action
-        let client_tick = stepper.client().tick();
+        let client_tick = stepper.client_tick();
         stepper
             .client_app
             .world

--- a/lightyear/src/server/mod.rs
+++ b/lightyear/src/server/mod.rs
@@ -5,7 +5,7 @@
 
 pub mod config;
 
-mod connection;
+pub mod connection;
 
 pub mod events;
 

--- a/lightyear/src/server/plugin.rs
+++ b/lightyear/src/server/plugin.rs
@@ -2,13 +2,13 @@
 use std::ops::DerefMut;
 use std::sync::Mutex;
 
-use crate::_reexport::TimeManager;
 use bevy::prelude::{
     apply_deferred, App, FixedUpdate, IntoSystemConfigs, IntoSystemSetConfigs,
     Plugin as PluginType, PostUpdate, PreUpdate,
 };
 
 use crate::netcode::ClientId;
+use crate::prelude::TimeManager;
 use crate::protocol::component::ComponentProtocol;
 use crate::protocol::message::MessageProtocol;
 use crate::protocol::Protocol;

--- a/lightyear/src/server/resource.rs
+++ b/lightyear/src/server/resource.rs
@@ -242,22 +242,6 @@ impl<'w, 's, P: Protocol> Server<'w, 's, P> {
     //         .get(&client_id)
     //         .map(|connection| &connection.input_buffer)
     // }
-
-    // REPLICATION
-
-    /// Send packets that are ready from the message manager through the transport layer
-    pub fn send_packets(&mut self) -> Result<()> {
-        let span = trace_span!("send_packets").entered();
-        for (client_idx, connection) in &mut self.connection_manager.connections.iter_mut() {
-            let client_span =
-                trace_span!("send_packets_to_client", client_id = ?client_idx).entered();
-            for packet_byte in connection.send_packets(&self.time_manager, &self.tick_manager)? {
-                self.netcode
-                    .send(packet_byte.as_slice(), *client_idx, &mut self.io)?;
-            }
-        }
-        Ok(())
-    }
 }
 
 pub struct ServerContext {

--- a/lightyear/src/server/resource.rs
+++ b/lightyear/src/server/resource.rs
@@ -4,7 +4,8 @@ use std::time::Duration;
 
 use anyhow::{Context, Result};
 use bevy::ecs::component::Tick as BevyTick;
-use bevy::prelude::{Entity, Resource, World};
+use bevy::ecs::system::SystemParam;
+use bevy::prelude::{Entity, Res, ResMut, Resource, World};
 use bevy::utils::{EntityHashMap, HashSet};
 use crossbeam_channel::Sender;
 use tracing::{debug, debug_span, error, info, trace, trace_span};
@@ -19,8 +20,8 @@ use crate::server::room::{RoomId, RoomManager, RoomMut, RoomRef};
 use crate::shared::replication::components::{NetworkTarget, Replicate};
 use crate::shared::replication::components::{ShouldBeInterpolated, ShouldBePredicted};
 use crate::shared::replication::ReplicationSend;
+use crate::shared::tick_manager::Tick;
 use crate::shared::tick_manager::TickManager;
-use crate::shared::tick_manager::{Tick, TickManaged};
 use crate::shared::time_manager::TimeManager;
 use crate::transport::io::Io;
 use crate::transport::{PacketSender, Transport};
@@ -29,87 +30,155 @@ use super::config::ServerConfig;
 use super::connection::ConnectionManager;
 use super::events::ServerEvents;
 
-#[derive(Resource)]
-pub struct Server<P: Protocol> {
+#[derive(SystemParam)]
+pub struct Server<'w, 's, P: Protocol> {
     // Config
-    config: ServerConfig,
+    config: Res<'w, ServerConfig>,
     // Io
-    io: Io,
+    io: Res<'w, Io>,
     // Netcode
-    netcode: crate::netcode::Server<NetcodeServerContext>,
-    context: ServerContext,
+    netcode: Res<'w, crate::netcode::Server>,
     // Connections
-    pub(crate) connection_manager: ConnectionManager<P>,
+    pub(crate) connection_manager: Res<'w, ConnectionManager<P>>,
     // Protocol
-    pub protocol: P,
+    pub protocol: Res<'w, P>,
     // Rooms
-    pub(crate) room_manager: RoomManager,
+    pub(crate) room_manager: Res<'w, RoomManager>,
     // Time
-    time_manager: TimeManager,
-    pub(crate) tick_manager: TickManager,
+    time_manager: Res<'w, TimeManager>,
+    pub(crate) tick_manager: Res<'w, TickManager>,
+    _marker: std::marker::PhantomData<&'s ()>,
 }
 
-pub struct NetcodeServerContext {
-    pub connections: Sender<ClientId>,
-    pub disconnections: Sender<ClientId>,
+#[derive(SystemParam)]
+pub struct ServerMut<'w, 's, P: Protocol> {
+    // Config
+    config: ResMut<'w, ServerConfig>,
+    // Io
+    io: ResMut<'w, Io>,
+    // Netcode
+    netcode: ResMut<'w, crate::netcode::Server>,
+    // Connections
+    pub(crate) connection_manager: ResMut<'w, ConnectionManager<P>>,
+    // Protocol
+    pub protocol: ResMut<'w, P>,
+    // Rooms
+    pub(crate) room_manager: ResMut<'w, RoomManager>,
+    // Time
+    time_manager: ResMut<'w, TimeManager>,
+    pub(crate) tick_manager: ResMut<'w, TickManager>,
+    _marker: std::marker::PhantomData<&'s ()>,
 }
 
-impl<P: Protocol> Server<P> {
-    pub fn new(config: ServerConfig, io: Io, protocol: P) -> Self {
-        // create netcode server
-        let private_key = config.netcode.private_key.unwrap_or(generate_key());
-        let (connections_tx, connections_rx) = crossbeam_channel::unbounded();
-        let (disconnections_tx, disconnections_rx) = crossbeam_channel::unbounded();
-        let server_context = NetcodeServerContext {
-            connections: connections_tx,
-            disconnections: disconnections_tx,
-        };
-        let mut cfg = crate::netcode::ServerConfig::with_context(server_context)
-            .on_connect(|id, ctx| {
-                ctx.connections.send(id).unwrap();
-            })
-            .on_disconnect(|id, ctx| {
-                ctx.disconnections.send(id).unwrap();
-            });
-        cfg = cfg.keep_alive_send_rate(config.netcode.keep_alive_send_rate);
-        cfg = cfg.num_disconnect_packets(config.netcode.num_disconnect_packets);
+impl<'w, 's, P: Protocol> ServerMut<'w, 's, P> {
+    /// Return the server's received events since last frame
+    pub(crate) fn events(&mut self) -> &mut ServerEvents<P> {
+        &mut self.connection_manager.events
+    }
 
-        let netcode =
-            crate::netcode::Server::with_config(config.netcode.protocol_id, private_key, cfg)
-                .expect("Could not create server netcode");
-        let context = ServerContext {
-            connections: connections_rx,
-            disconnections: disconnections_rx,
-        };
-        Self {
-            config: config.clone(),
-            io,
-            netcode,
-            context,
-            // TODO: avoid clone
-            connection_manager: ConnectionManager::new(protocol.channel_registry().clone()),
-            protocol,
-            room_manager: RoomManager::default(),
-            time_manager: TimeManager::new(config.shared.server_send_interval),
-            tick_manager: TickManager::from_config(config.shared.tick),
+    /// Update the server's internal state, queues up in a buffer any packets received from clients
+    /// Sends keep-alive packets + any non-payload packet needed for netcode
+    pub(crate) fn update(&mut self, delta: Duration) -> Result<()> {
+        // update time manager
+        self.time_manager.update(delta, Duration::default());
+
+        // update netcode server
+        let context = self
+            .netcode
+            .try_update(delta.as_secs_f64(), &mut self.io)
+            .context("Error updating netcode server")?;
+
+        // update connections
+        self.connection_manager
+            .update(&self.time_manager, &self.tick_manager);
+
+        // handle connection
+        for client_id in context.connections.iter().copied() {
+            // let client_addr = self.netcode.client_addr(client_id).unwrap();
+            // info!("New connection from {} (id: {})", client_addr, client_id);
+            self.connection_manager.add(client_id, &self.config.ping);
         }
+
+        // handle disconnections
+        for client_id in context.disconnections.iter().copied() {
+            self.connection_manager.remove(client_id);
+            self.room_manager.client_disconnect(client_id);
+        }
+        Ok(())
     }
 
-    /// Generate a connect token for a client with id `client_id`
-    pub fn token(&mut self, client_id: ClientId) -> ConnectToken {
-        self.netcode
-            .token(client_id, self.local_addr())
-            .timeout_seconds(self.config.netcode.client_timeout_secs)
-            .generate()
-            .unwrap()
+    /// Receive packets from the transport layer and buffer them with the message manager
+    pub(crate) fn recv_packets(&mut self) -> Result<()> {
+        while let Some((mut reader, client_id)) = self.netcode.recv() {
+            // TODO: use connection to apply on BOTH message manager and replication manager
+            self.connection_manager
+                .connection_mut(client_id)?
+                .recv_packet(&mut reader, &self.tick_manager)?;
+        }
+        Ok(())
     }
+
+    /// Receive messages from each connection, and update the events buffer
+    pub(crate) fn receive(&mut self, world: &mut World) {
+        self.connection_manager
+            .receive(world, &self.time_manager, &self.tick_manager)
+            .unwrap_or_else(|e| {
+                error!("Error during receive: {}", e);
+            });
+    }
+}
+
+impl<'w, 's, P: Protocol> Server<'w, 's, P> {
+    // pub fn new(config: ServerConfig, io: Io, protocol: P) -> Self {
+    //     // create netcode server
+    //     let private_key = config.netcode.private_key.unwrap_or(generate_key());
+    //     let (connections_tx, connections_rx) = crossbeam_channel::unbounded();
+    //     let (disconnections_tx, disconnections_rx) = crossbeam_channel::unbounded();
+    //     let server_context = NetcodeServerContext {
+    //         connections: connections_tx,
+    //         disconnections: disconnections_tx,
+    //     };
+    //     let mut cfg = crate::netcode::ServerConfig::with_context(server_context)
+    //         .on_connect(|id, ctx| {
+    //             ctx.connections.send(id).unwrap();
+    //         })
+    //         .on_disconnect(|id, ctx| {
+    //             ctx.disconnections.send(id).unwrap();
+    //         });
+    //     cfg = cfg.keep_alive_send_rate(config.netcode.keep_alive_send_rate);
+    //     cfg = cfg.num_disconnect_packets(config.netcode.num_disconnect_packets);
+    //
+    //     let netcode =
+    //         crate::netcode::Server::with_config(config.netcode.protocol_id, private_key, cfg)
+    //             .expect("Could not create server netcode");
+    //     let context = ServerContext {
+    //         connections: connections_rx,
+    //         disconnections: disconnections_rx,
+    //     };
+    //     Self {
+    //         config: config.clone(),
+    //         io,
+    //         netcode,
+    //         context,
+    //         // TODO: avoid clone
+    //         connection_manager: ConnectionManager::new(protocol.channel_registry().clone()),
+    //         protocol,
+    //         room_manager: RoomManager::default(),
+    //         time_manager: TimeManager::new(config.shared.server_send_interval),
+    //         tick_manager: TickManager::from_config(config.shared.tick),
+    //     }
+
+    // /// Generate a connect token for a client with id `client_id`
+    // pub fn token(&mut self, client_id: ClientId) -> ConnectToken {
+    //     self.netcode
+    //         .token(client_id, self.local_addr())
+    //         .timeout_seconds(self.config.netcode.client_timeout_secs)
+    //         .generate()
+    //         .unwrap()
+    // }
 
     pub fn local_addr(&self) -> SocketAddr {
         self.io.local_addr()
-    }
-
-    pub fn client_ids(&self) -> impl Iterator<Item = ClientId> + '_ {
-        self.netcode.client_ids()
     }
 
     // IO
@@ -137,57 +206,7 @@ impl<P: Protocol> Server<P> {
     //         .map(|connection| &connection.input_buffer)
     // }
 
-    // TIME
-
-    #[doc(hidden)]
-    pub(crate) fn is_ready_to_send(&self) -> bool {
-        self.time_manager.is_ready_to_send()
-    }
-
-    #[doc(hidden)]
-    pub fn set_base_relative_speed(&mut self, relative_speed: f32) {
-        self.time_manager.base_relative_speed = relative_speed;
-    }
-
     // REPLICATION
-    /// Find the list of clients that should receive the replication message
-    fn apply_replication(&mut self, target: NetworkTarget) -> Box<dyn Iterator<Item = ClientId>> {
-        match target {
-            NetworkTarget::All => {
-                // TODO: maybe only send stuff when the client is time-synced ?
-                Box::new(self.netcode.connected_client_ids().into_iter())
-            }
-            NetworkTarget::AllExceptSingle(client_id) => Box::new(
-                self.netcode
-                    .connected_client_ids()
-                    .into_iter()
-                    .filter(move |id| *id != client_id),
-            ),
-            NetworkTarget::AllExcept(client_ids) => {
-                let client_ids: HashSet<ClientId> = HashSet::from_iter(client_ids);
-                Box::new(
-                    self.netcode
-                        .connected_client_ids()
-                        .into_iter()
-                        .filter(move |id| !client_ids.contains(id)),
-                )
-            }
-            NetworkTarget::Single(client_id) => {
-                if self.connection_manager.connections.contains_key(&client_id) {
-                    Box::new(std::iter::once(client_id))
-                } else {
-                    Box::new(std::iter::empty())
-                }
-            }
-            NetworkTarget::Only(client_ids) => Box::new(
-                self.netcode
-                    .connected_client_ids()
-                    .into_iter()
-                    .filter(move |id| client_ids.contains(id)),
-            ),
-            NetworkTarget::None => Box::new(std::iter::empty()),
-        }
-    }
 
     // MESSAGES
 
@@ -221,45 +240,6 @@ impl<P: Protocol> Server<P> {
         self.send_message_to_target::<C, M>(message, NetworkTarget::Only(vec![client_id]))
     }
 
-    /// Update the server's internal state, queues up in a buffer any packets received from clients
-    /// Sends keep-alive packets + any non-payload packet needed for netcode
-    pub(crate) fn update(&mut self, delta: Duration) -> Result<()> {
-        // update time manager
-        self.time_manager.update(delta, Duration::default());
-
-        // update netcode server
-        self.netcode
-            .try_update(delta.as_secs_f64(), &mut self.io)
-            .context("Error updating netcode server")?;
-
-        // update connections
-        self.connection_manager
-            .update(&self.time_manager, &self.tick_manager);
-
-        // handle connections
-        for client_id in self.context.connections.try_iter() {
-            let client_addr = self.netcode.client_addr(client_id).unwrap();
-            info!("New connection from {} (id: {})", client_addr, client_id);
-            self.connection_manager.add(client_id, &self.config.ping);
-        }
-
-        // handle disconnections
-        for client_id in self.context.disconnections.try_iter() {
-            self.connection_manager.remove(client_id);
-            self.room_manager.client_disconnect(client_id);
-        }
-        Ok(())
-    }
-
-    /// Receive messages from each connection, and update the events buffer
-    pub fn receive(&mut self, world: &mut World) {
-        self.connection_manager
-            .receive(world, &self.time_manager, &self.tick_manager)
-            .unwrap_or_else(|e| {
-                error!("Error during receive: {}", e);
-            });
-    }
-
     /// Send packets that are ready from the message manager through the transport layer
     pub fn send_packets(&mut self) -> Result<()> {
         let span = trace_span!("send_packets").entered();
@@ -270,17 +250,6 @@ impl<P: Protocol> Server<P> {
                 self.netcode
                     .send(packet_byte.as_slice(), *client_idx, &mut self.io)?;
             }
-        }
-        Ok(())
-    }
-
-    /// Receive packets from the transport layer and buffer them with the message manager
-    pub fn recv_packets(&mut self) -> Result<()> {
-        while let Some((mut reader, client_id)) = self.netcode.recv() {
-            // TODO: use connection to apply on BOTH message manager and replication manager
-            self.connection_manager
-                .connection_mut(client_id)?
-                .recv_packet(&mut reader, &self.tick_manager)?;
         }
         Ok(())
     }
@@ -305,9 +274,9 @@ pub struct ServerContext {
     pub disconnections: crossbeam_channel::Receiver<ClientId>,
 }
 
-impl<P: Protocol> ReplicationSend<P> for Server<P> {
+impl<P: Protocol> ReplicationSend<P> for ConnectionManager<P> {
     fn new_connected_clients(&self) -> Vec<ClientId> {
-        self.connection_manager.new_clients.clone()
+        self.new_clients.clone()
     }
 
     fn prepare_entity_spawn(
@@ -321,16 +290,13 @@ impl<P: Protocol> ReplicationSend<P> for Server<P> {
         // debug!(?entity, "Spawning entity");
         // TODO: should we have additional state tracking so that we know we are in the process of sending this entity to clients?
         self.apply_replication(target).try_for_each(|client_id| {
-            trace!(
-                ?client_id,
-                ?entity,
-                "Send entity spawn for tick {:?}",
-                self.tick_manager.current_tick()
-            );
-            let replication_sender = &mut self
-                .connection_manager
-                .connection_mut(client_id)?
-                .replication_sender;
+            // trace!(
+            //     ?client_id,
+            //     ?entity,
+            //     "Send entity spawn for tick {:?}",
+            //     self.tick_manager.tick()
+            // );
+            let replication_sender = &mut self.connection_mut(client_id)?.replication_sender;
             // update the collect changes tick
             replication_sender
                 .group_channels
@@ -366,16 +332,13 @@ impl<P: Protocol> ReplicationSend<P> for Server<P> {
     ) -> Result<()> {
         let group = replicate.group_id(Some(entity));
         self.apply_replication(target).try_for_each(|client_id| {
-            trace!(
-                ?entity,
-                ?client_id,
-                "Send entity despawn for tick {:?}",
-                self.tick_manager.current_tick()
-            );
-            let replication_sender = &mut self
-                .connection_manager
-                .connection_mut(client_id)?
-                .replication_sender;
+            // trace!(
+            //     ?entity,
+            //     ?client_id,
+            //     "Send entity despawn for tick {:?}",
+            //     self.tick_manager.tick()
+            // );
+            let replication_sender = &mut self.connection_mut(client_id)?.replication_sender;
             // update the collect changes tick
             replication_sender
                 .group_channels
@@ -418,16 +381,13 @@ impl<P: Protocol> ReplicationSend<P> for Server<P> {
         let group = replicate.group_id(Some(entity));
         self.apply_replication(actual_target)
             .try_for_each(|client_id| {
-                trace!(
-                    ?entity,
-                    component = ?kind,
-                    tick = ?self.tick_manager.current_tick(),
-                    "Inserting single component"
-                );
-                let replication_sender = &mut self
-                    .connection_manager
-                    .connection_mut(client_id)?
-                    .replication_sender;
+                // trace!(
+                //     ?entity,
+                //     component = ?kind,
+                //     tick = ?self.tick_manager.tick(),
+                //     "Inserting single component"
+                // );
+                let replication_sender = &mut self.connection_mut(client_id)?.replication_sender;
                 // update the collect changes tick
                 replication_sender
                     .group_channels
@@ -450,10 +410,7 @@ impl<P: Protocol> ReplicationSend<P> for Server<P> {
         debug!(?entity, ?component_kind, "Sending RemoveComponent");
         let group = replicate.group_id(Some(entity));
         self.apply_replication(target).try_for_each(|client_id| {
-            let replication_sender = &mut self
-                .connection_manager
-                .connection_mut(client_id)?
-                .replication_sender;
+            let replication_sender = &mut self.connection_mut(client_id)?.replication_sender;
             replication_sender
                 .group_channels
                 .entry(group)
@@ -478,10 +435,7 @@ impl<P: Protocol> ReplicationSend<P> for Server<P> {
         let group = replicate.group_id(Some(entity));
         self.apply_replication(target).try_for_each(|client_id| {
             // TODO: should we have additional state tracking so that we know we are in the process of sending this entity to clients?
-            let replication_sender = &mut self
-                .connection_manager
-                .connection_mut(client_id)?
-                .replication_sender;
+            let replication_sender = &mut self.connection_mut(client_id)?.replication_sender;
             let collect_changes_since_this_tick = replication_sender
                 .group_channels
                 .entry(group)
@@ -504,12 +458,12 @@ impl<P: Protocol> ReplicationSend<P> for Server<P> {
                     current_tick = ?system_current_tick,
                     "prepare entity update changed check"
                 );
-                trace!(
-                    ?entity,
-                    component = ?kind,
-                    tick = ?self.tick_manager.current_tick(),
-                    "Updating single component"
-                );
+                // trace!(
+                //     ?entity,
+                //     component = ?kind,
+                //     tick = ?self.tick_manager.tick(),
+                //     "Updating single component"
+                // );
                 replication_sender.prepare_entity_update(entity, group, component.clone());
             }
             Ok(())
@@ -517,22 +471,11 @@ impl<P: Protocol> ReplicationSend<P> for Server<P> {
     }
 
     /// Buffer the replication messages
-    fn buffer_replication_messages(&mut self, bevy_tick: BevyTick) -> Result<()> {
-        self.connection_manager
-            .buffer_replication_messages(self.tick_manager.current_tick(), bevy_tick)
+    fn buffer_replication_messages(&mut self, tick: Tick, bevy_tick: BevyTick) -> Result<()> {
+        self.buffer_replication_messages(tick, bevy_tick)
     }
 
     fn get_mut_replicate_component_cache(&mut self) -> &mut EntityHashMap<Entity, Replicate<P>> {
-        &mut self.connection_manager.replicate_component_cache
-    }
-}
-
-impl<P: Protocol> TickManaged for Server<P> {
-    fn tick(&self) -> Tick {
-        self.tick_manager.current_tick()
-    }
-
-    fn increment_tick(&mut self) {
-        self.tick_manager.increment_tick();
+        &mut self.replicate_component_cache
     }
 }

--- a/lightyear/src/server/systems.rs
+++ b/lightyear/src/server/systems.rs
@@ -5,11 +5,11 @@ use std::ops::DerefMut;
 use std::time::Duration;
 use tracing::{debug, error, trace, trace_span};
 
-use crate::_reexport::{ComponentProtocol, TickManager, TimeManager};
+use crate::_reexport::ComponentProtocol;
 use crate::client::connection::Connection;
 use crate::client::resource::ClientMut;
 use crate::connection::events::{IterEntityDespawnEvent, IterEntitySpawnEvent};
-use crate::prelude::Io;
+use crate::prelude::{Io, TickManager, TimeManager};
 use crate::protocol::message::MessageProtocol;
 use crate::protocol::Protocol;
 use crate::server::config::ServerConfig;
@@ -157,7 +157,7 @@ pub(crate) fn send<P: Protocol>(
             error!("Error preparing replicate send: {}", e);
         });
 
-    // send buffered packets to io
+    // SEND_PACKETS: send buffered packets to io
     let span = trace_span!("send_packets").entered();
     connection_manager
         .connections

--- a/lightyear/src/shared/plugin.rs
+++ b/lightyear/src/shared/plugin.rs
@@ -1,8 +1,7 @@
 //! Bevy [`bevy::prelude::Plugin`] used by both the server and the client
-use crate::_reexport::{TickManager, TimeManager};
 use crate::client::prediction::plugin::is_in_rollback;
 use crate::client::prediction::Rollback;
-use crate::prelude::FixedUpdateSet;
+use crate::prelude::{FixedUpdateSet, TickManager};
 use bevy::app::FixedUpdate;
 use bevy::prelude::*;
 

--- a/lightyear/src/shared/plugin.rs
+++ b/lightyear/src/shared/plugin.rs
@@ -1,8 +1,14 @@
 //! Bevy [`bevy::prelude::Plugin`] used by both the server and the client
-use bevy::prelude::{App, Fixed, Plugin, Time};
+use crate::_reexport::{TickManager, TimeManager};
+use crate::client::prediction::plugin::is_in_rollback;
+use crate::client::prediction::Rollback;
+use crate::prelude::FixedUpdateSet;
+use bevy::app::FixedUpdate;
+use bevy::prelude::*;
 
 use crate::shared::config::SharedConfig;
 use crate::shared::log;
+use crate::shared::systems::tick::increment_tick;
 
 pub struct SharedPlugin {
     pub config: SharedConfig,
@@ -15,11 +21,24 @@ impl Plugin for SharedPlugin {
         app.insert_resource(Time::<Fixed>::from_seconds(
             self.config.tick.tick_duration.as_secs_f64(),
         ));
+        app.insert_resource(TickManager::from_config(self.config.tick.clone()));
 
-        // SYSTEMS
+        // PLUGINS
         // TODO: increment_tick should be shared
         // app.add_systems(FixedUpdate, increment_tick);
         let log_config = self.config.log.clone();
         app.add_plugins(log::LogPlugin { config: log_config });
+
+        // SYSTEMS
+        app.add_systems(
+            FixedUpdate,
+            (
+                increment_tick
+                    .in_set(FixedUpdateSet::TickUpdate)
+                    // run if there is no rollback resource, or if we are not in rollback
+                    .run_if(not(resource_exists::<Rollback>()).or_else(not(is_in_rollback))),
+                apply_deferred.in_set(FixedUpdateSet::MainFlush),
+            ),
+        );
     }
 }

--- a/lightyear/src/shared/replication/entity_map.rs
+++ b/lightyear/src/shared/replication/entity_map.rs
@@ -227,8 +227,9 @@ mod tests {
 
         // Check that the entity is replicated to client
         let client_entity = *stepper
-            .client()
-            .connection()
+            .client_app
+            .world
+            .resource::<Connection>()
             .replication_receiver
             .remote_entity_map
             .get_local(server_entity)
@@ -254,8 +255,9 @@ mod tests {
 
         // Check that this entity was replicated correctly, and that the component got mapped
         let client_entity_2 = *stepper
-            .client()
-            .connection()
+            .client_app
+            .world
+            .resource::<Connection>()
             .replication_receiver
             .remote_entity_map
             .get_local(server_entity_2)

--- a/lightyear/src/shared/replication/mod.rs
+++ b/lightyear/src/shared/replication/mod.rs
@@ -157,7 +157,7 @@ pub trait ReplicationSend<P: Protocol>: Resource {
     /// Then those 2 component inserts might be stored in different packets, and arrive at different times because of jitter
     ///
     /// But the receiving systems might expect both components to be present at the same time.
-    fn buffer_replication_messages(&mut self, bevy_tick: BevyTick) -> Result<()>;
+    fn buffer_replication_messages(&mut self, tick: Tick, bevy_tick: BevyTick) -> Result<()>;
 
     fn get_mut_replicate_component_cache(&mut self) -> &mut EntityHashMap<Entity, Replicate<P>>;
 }

--- a/lightyear/src/shared/replication/mod.rs
+++ b/lightyear/src/shared/replication/mod.rs
@@ -213,8 +213,9 @@ mod tests {
 
         // Check that the entity is replicated to client
         let client_entity = *stepper
-            .client()
-            .connection()
+            .client_app
+            .world
+            .resource::<Connection>()
             .replication_receiver
             .remote_entity_map
             .get_local(server_entity)

--- a/lightyear/src/shared/replication/send.rs
+++ b/lightyear/src/shared/replication/send.rs
@@ -11,9 +11,9 @@ use tracing::{debug, error, trace, warn};
 use tracing_subscriber::filter::FilterExt;
 use tracing_subscriber::fmt::writer::MakeWriterExt;
 
-use crate::_reexport::{EntityActionsChannel, EntityUpdatesChannel, FromType, ShouldBePredicted};
+use crate::_reexport::{EntityActionsChannel, EntityUpdatesChannel, FromType};
 use crate::packet::message::MessageId;
-use crate::prelude::{MapEntities, Tick};
+use crate::prelude::{MapEntities, ShouldBePredicted, Tick};
 use crate::protocol::channel::ChannelKind;
 use crate::protocol::component::ComponentProtocol;
 use crate::protocol::component::{ComponentBehaviour, ComponentKindBehaviour};

--- a/lightyear/src/shared/systems/tick.rs
+++ b/lightyear/src/shared/systems/tick.rs
@@ -1,9 +1,8 @@
+use crate::_reexport::TickManager;
 use bevy::prelude::ResMut;
 use tracing::trace;
 
-use crate::shared::tick_manager::TickManaged;
-
-pub fn increment_tick<T: TickManaged>(mut service: ResMut<T>) {
-    service.increment_tick();
-    trace!("increment_tick! new tick: {:?}", service.tick());
+pub fn increment_tick(mut tick_manager: ResMut<TickManager>) {
+    tick_manager.increment_tick();
+    trace!("increment_tick! new tick: {:?}", tick_manager.tick());
 }

--- a/lightyear/src/shared/systems/tick.rs
+++ b/lightyear/src/shared/systems/tick.rs
@@ -1,4 +1,4 @@
-use crate::_reexport::TickManager;
+use crate::prelude::TickManager;
 use bevy::prelude::ResMut;
 use tracing::trace;
 

--- a/lightyear/src/shared/tick_manager.rs
+++ b/lightyear/src/shared/tick_manager.rs
@@ -9,11 +9,6 @@ use crate::utils::wrapping_id::wrapping_id;
 // Internal id that tracks the Tick value for the server and the client
 wrapping_id!(Tick);
 
-pub trait TickManaged: Resource {
-    fn tick(&self) -> Tick;
-    fn increment_tick(&mut self);
-}
-
 #[derive(Clone)]
 pub struct TickConfig {
     pub tick_duration: Duration,
@@ -53,7 +48,7 @@ impl TickManager {
         self.tick = tick;
     }
 
-    pub fn current_tick(&self) -> Tick {
+    pub fn tick(&self) -> Tick {
         self.tick
     }
 }

--- a/lightyear/src/shared/time_manager.rs
+++ b/lightyear/src/shared/time_manager.rs
@@ -13,7 +13,7 @@ use std::fmt::Formatter;
 use std::ops::{Add, AddAssign, Mul, Sub, SubAssign};
 use std::time::Duration;
 
-use bevy::prelude::{Time, Timer, TimerMode};
+use bevy::prelude::{Res, Resource, Time, Timer, TimerMode};
 use chrono::Duration as ChronoDuration;
 use serde::{Deserialize, Serialize};
 
@@ -22,6 +22,12 @@ use bitcode::{Decode, Encode};
 /// Time wraps after u32::MAX in microseconds (a bit over an hour)
 pub const WRAPPING_TIME_US: u32 = u32::MAX;
 
+/// Run Condition to check if we are ready to send packets
+pub(crate) fn is_ready_to_send(time_manager: Res<TimeManager>) -> bool {
+    time_manager.is_ready_to_send()
+}
+
+#[derive(Resource)]
 pub struct TimeManager {
     /// The current time
     wrapped_time: WrappedTime,

--- a/lightyear/src/tests/client.rs
+++ b/lightyear/src/tests/client.rs
@@ -8,27 +8,6 @@ use crate::prelude::client::*;
 use crate::prelude::*;
 use crate::tests::protocol::*;
 
-pub fn setup(auth: Authentication) -> anyhow::Result<Client> {
-    let addr = SocketAddr::from_str("127.0.0.1:0")?;
-    let io = Io::from_config(IoConfig::from_transport(TransportConfig::UdpSocket(addr)));
-    let config = ClientConfig {
-        shared: SharedConfig {
-            enable_replication: false,
-            tick: TickConfig::new(Duration::from_millis(10)),
-            ..Default::default()
-        },
-        input: InputConfig::default(),
-        netcode: Default::default(),
-        ping: PingConfig::default(),
-        sync: SyncConfig::default(),
-        prediction: PredictionConfig::default(),
-        interpolation: InterpolationConfig::default(),
-    };
-
-    // create lightyear client
-    Ok(Client::new(config, io, auth, protocol()))
-}
-
 pub fn bevy_setup(app: &mut App, auth: Authentication) {
     // create udp-socket based io
     let addr = SocketAddr::from_str("127.0.0.1:0").unwrap();

--- a/lightyear/src/tests/examples/connection_soak.rs
+++ b/lightyear/src/tests/examples/connection_soak.rs
@@ -15,131 +15,132 @@ use crate::prelude::server::{NetcodeConfig, ServerConfig};
 use crate::prelude::*;
 use crate::tests::protocol::*;
 
+// TODO: rework connection_soak, we need to create bevy plugins now to be able to use the rest of the library
 #[test]
 #[ignore]
 fn test_connection_soak() -> anyhow::Result<()> {
-    tracing_subscriber::FmtSubscriber::builder()
-        .with_max_level(tracing::Level::DEBUG)
-        .init();
-
-    // common
-    let protocol_id = 0;
-    let private_key = generate_key();
-
-    // Create server
-    let addr = SocketAddr::from_str("127.0.0.1:0")?;
-    let netcode_config = NetcodeConfig::default()
-        .with_protocol_id(protocol_id)
-        .with_key(private_key);
-    let io_server = Io::from_config(
-        IoConfig::from_transport(TransportConfig::UdpSocket(addr)).with_conditioner(
-            LinkConditionerConfig {
-                incoming_latency: Duration::from_millis(20),
-                incoming_jitter: Duration::from_millis(10),
-                incoming_loss: 0.10,
-            },
-        ),
-    );
-    let fixed_timestep = Duration::from_millis(10);
-    // TODO: link conditioner doesn't work with virtual time
-    let shared_config = SharedConfig {
-        enable_replication: false,
-        tick: TickConfig::new(fixed_timestep),
-        ..Default::default()
-    };
-    let config = ServerConfig {
-        shared: shared_config.clone(),
-        netcode: netcode_config,
-        ping: Default::default(),
-    };
-    let mut server = Server::new(config, io_server, protocol());
-    debug!("Created server with local address: {}", server.local_addr());
-
-    // create client
-    let client_id = 111;
-    let auth = Authentication::Manual {
-        server_addr: server.local_addr(),
-        protocol_id,
-        private_key,
-        client_id,
-    };
-    let io_client = Io::from_config(
-        IoConfig::from_transport(TransportConfig::UdpSocket(addr)).with_conditioner(
-            LinkConditionerConfig {
-                incoming_latency: Duration::from_millis(20),
-                incoming_jitter: Duration::from_millis(10),
-                incoming_loss: 0.10,
-            },
-        ),
-    );
-    let config = ClientConfig {
-        shared: shared_config.clone(),
-        netcode: Default::default(),
-        ping: Default::default(),
-        sync: SyncConfig::default(),
-        ..Default::default()
-    };
-    let mut client = Client::new(config, io_client, auth, protocol());
-    debug!("Created client with local address: {}", client.local_addr());
-
-    // Start the connection
-    client.connect();
-
-    let start = std::time::Instant::now();
-    let tick_rate_secs = Duration::from_secs_f64(1.0 / 30.0);
-
-    // Run the server and client in parallel
-    let server_thread = std::thread::spawn(move || -> anyhow::Result<()> {
-        debug!("Starting server thread");
-        let mut world = World::default();
-        let mut rng = rand::thread_rng();
-        loop {
-            server.update(start.elapsed())?;
-            server.recv_packets()?;
-            server.send_packets()?;
-            server.receive(&mut world);
-
-            let num_message = rng.gen_range(0..2);
-            // let num_message = 0;
-            for _ in 0..num_message {
-                // TODO: use geometric distribution? use multiple of FRAGMENT_SIZE?
-
-                // TODO: there is a problem with fragments, issues only appear with fragments
-                let message_length = rng.gen_range(0..1300);
-                let s: String = (&mut rng)
-                    .sample_iter(rand::distributions::Alphanumeric)
-                    .take(message_length)
-                    .map(char::from)
-                    .collect();
-                let message = Message1(s);
-                debug!("Sending message {message:?}");
-                server.send_message_to_target::<Channel1, Message1>(message, NetworkTarget::All)?;
-            }
-            std::thread::sleep(tick_rate_secs);
-        }
-    });
-    let client_thread = std::thread::spawn(move || -> anyhow::Result<()> {
-        let mut world = World::default();
-        debug!("Starting client thread");
-        loop {
-            // can use 0 overstep if not in Bevy
-            client.update(start.elapsed(), Duration::default())?;
-            client.recv_packets()?;
-            client.send_packets()?;
-
-            if client.is_connected() {
-                let mut events = client.receive(&mut world);
-                if !events.is_empty() {
-                    debug!("events received: {:?}", events);
-                    for (message, _) in events.into_iter_messages::<Message1>() {
-                        debug!("Received message {message:?}");
-                    }
-                }
-            }
-            std::thread::sleep(tick_rate_secs);
-        }
-    });
-    client_thread.join().expect("client thread has panicked")?;
-    server_thread.join().expect("server thread has panicked")?;
+    // tracing_subscriber::FmtSubscriber::builder()
+    //     .with_max_level(tracing::Level::DEBUG)
+    //     .init();
+    //
+    // // common
+    // let protocol_id = 0;
+    // let private_key = generate_key();
+    //
+    // // Create server
+    // let addr = SocketAddr::from_str("127.0.0.1:0")?;
+    // let netcode_config = NetcodeConfig::default()
+    //     .with_protocol_id(protocol_id)
+    //     .with_key(private_key);
+    // let io_server = Io::from_config(
+    //     IoConfig::from_transport(TransportConfig::UdpSocket(addr)).with_conditioner(
+    //         LinkConditionerConfig {
+    //             incoming_latency: Duration::from_millis(20),
+    //             incoming_jitter: Duration::from_millis(10),
+    //             incoming_loss: 0.10,
+    //         },
+    //     ),
+    // );
+    // let fixed_timestep = Duration::from_millis(10);
+    // // TODO: link conditioner doesn't work with virtual time
+    // let shared_config = SharedConfig {
+    //     enable_replication: false,
+    //     tick: TickConfig::new(fixed_timestep),
+    //     ..Default::default()
+    // };
+    // let config = ServerConfig {
+    //     shared: shared_config.clone(),
+    //     netcode: netcode_config,
+    //     ping: Default::default(),
+    // };
+    // let mut server = Server::new(config, io_server, protocol());
+    // debug!("Created server with local address: {}", server.local_addr());
+    //
+    // // create client
+    // let client_id = 111;
+    // let auth = Authentication::Manual {
+    //     server_addr: server.local_addr(),
+    //     protocol_id,
+    //     private_key,
+    //     client_id,
+    // };
+    // let io_client = Io::from_config(
+    //     IoConfig::from_transport(TransportConfig::UdpSocket(addr)).with_conditioner(
+    //         LinkConditionerConfig {
+    //             incoming_latency: Duration::from_millis(20),
+    //             incoming_jitter: Duration::from_millis(10),
+    //             incoming_loss: 0.10,
+    //         },
+    //     ),
+    // );
+    // let config = ClientConfig {
+    //     shared: shared_config.clone(),
+    //     netcode: Default::default(),
+    //     ping: Default::default(),
+    //     sync: SyncConfig::default(),
+    //     ..Default::default()
+    // };
+    // let mut client = Client::new(config, io_client, auth, protocol());
+    // debug!("Created client with local address: {}", client.local_addr());
+    //
+    // // Start the connection
+    // client.connect();
+    //
+    // let start = std::time::Instant::now();
+    // let tick_rate_secs = Duration::from_secs_f64(1.0 / 30.0);
+    //
+    // // Run the server and client in parallel
+    // let server_thread = std::thread::spawn(move || -> anyhow::Result<()> {
+    //     debug!("Starting server thread");
+    //     let mut world = World::default();
+    //     let mut rng = rand::thread_rng();
+    //     loop {
+    //         server.update(start.elapsed())?;
+    //         server.recv_packets()?;
+    //         server.send_packets()?;
+    //         server.receive(&mut world);
+    //
+    //         let num_message = rng.gen_range(0..2);
+    //         // let num_message = 0;
+    //         for _ in 0..num_message {
+    //             // TODO: use geometric distribution? use multiple of FRAGMENT_SIZE?
+    //
+    //             // TODO: there is a problem with fragments, issues only appear with fragments
+    //             let message_length = rng.gen_range(0..1300);
+    //             let s: String = (&mut rng)
+    //                 .sample_iter(rand::distributions::Alphanumeric)
+    //                 .take(message_length)
+    //                 .map(char::from)
+    //                 .collect();
+    //             let message = Message1(s);
+    //             debug!("Sending message {message:?}");
+    //             server.send_message_to_target::<Channel1, Message1>(message, NetworkTarget::All)?;
+    //         }
+    //         std::thread::sleep(tick_rate_secs);
+    //     }
+    // });
+    // let client_thread = std::thread::spawn(move || -> anyhow::Result<()> {
+    //     let mut world = World::default();
+    //     debug!("Starting client thread");
+    //     loop {
+    //         // can use 0 overstep if not in Bevy
+    //         client.update(start.elapsed(), Duration::default())?;
+    //         client.recv_packets()?;
+    //         client.send_packets()?;
+    //
+    //         if client.is_connected() {
+    //             let mut events = client.receive(&mut world);
+    //             if !events.is_empty() {
+    //                 debug!("events received: {:?}", events);
+    //                 for (message, _) in events.into_iter_messages::<Message1>() {
+    //                     debug!("Received message {message:?}");
+    //                 }
+    //             }
+    //         }
+    //         std::thread::sleep(tick_rate_secs);
+    //     }
+    // });
+    // client_thread.join().expect("client thread has panicked")?;
+    // server_thread.join().expect("server thread has panicked")?;
     Ok(())
 }

--- a/lightyear/src/tests/server.rs
+++ b/lightyear/src/tests/server.rs
@@ -9,27 +9,6 @@ use crate::prelude::server::*;
 use crate::prelude::*;
 use crate::tests::protocol::*;
 
-pub fn setup(protocol_id: u64, private_key: Key) -> anyhow::Result<Server> {
-    // create udp-socket based io
-    let addr = SocketAddr::from_str("127.0.0.1:0")?;
-    let netcode_config = NetcodeConfig::default()
-        .with_protocol_id(protocol_id)
-        .with_key(private_key);
-    let io = Io::from_config(IoConfig::from_transport(TransportConfig::UdpSocket(addr)));
-    let config = ServerConfig {
-        shared: SharedConfig {
-            enable_replication: false,
-            tick: TickConfig::new(Duration::from_millis(10)),
-            ..Default::default()
-        },
-        netcode: netcode_config,
-        ping: PingConfig::default(),
-    };
-
-    // create lightyear server
-    Ok(Server::new(config, io, protocol()))
-}
-
 pub fn bevy_setup(app: &mut App, addr: SocketAddr, protocol_id: u64, private_key: Key) {
     // create udp-socket based io
     let netcode_config = NetcodeConfig::default()

--- a/lightyear/src/tests/stepper.rs
+++ b/lightyear/src/tests/stepper.rs
@@ -2,6 +2,7 @@ use std::net::SocketAddr;
 use std::str::FromStr;
 use std::time::Duration;
 
+use bevy::ecs::system::SystemState;
 use bevy::prelude::{App, Mut, PluginGroup, Real, Time};
 use bevy::time::TimeUpdateStrategy;
 use bevy::{DefaultPlugins, MinimalPlugins};
@@ -130,27 +131,21 @@ impl BevyStepper {
         }
     }
 
-    pub(crate) fn client(&self) -> &Client {
-        self.client_app.world.resource::<Client>()
+    pub(crate) fn client_tick(&self) -> Tick {
+        self.client_app.world.resource::<TickManager>().tick()
     }
-
-    pub(crate) fn client_mut(&mut self) -> Mut<Client> {
-        self.client_app.world.resource_mut::<Client>()
+    pub(crate) fn server_tick(&self) -> Tick {
+        self.server_app.world.resource::<TickManager>().tick()
     }
-
-    pub(crate) fn server(&self) -> &Server {
-        self.server_app.world.resource::<Server>()
-    }
-    pub(crate) fn server_mut(&mut self) -> Mut<Server> {
-        self.server_app.world.resource_mut::<Server>()
-    }
-
     pub(crate) fn init(&mut self) {
-        self.client_mut().connect();
+        self.client_app
+            .world
+            .resource_mut::<crate::netcode::Client>()
+            .connect();
 
         // Advance the world to let the connection process complete
         for _ in 0..100 {
-            if self.client().is_synced() {
+            if self.client_app.world.resource::<Connection>().is_synced() {
                 break;
             }
             self.frame_step();

--- a/lightyear/src/transport/io.rs
+++ b/lightyear/src/transport/io.rs
@@ -2,7 +2,7 @@
 //! bandwidth monitoring or compression
 use bevy::app::{App, Plugin};
 use bevy::diagnostic::{Diagnostic, DiagnosticId, Diagnostics, RegisterDiagnostic};
-use bevy::prelude::{Real, Res, Time};
+use bevy::prelude::{Real, Res, Resource, Time};
 use crossbeam_channel::{Receiver, Sender};
 use std::fmt::{Debug, Formatter};
 use std::io::Result;
@@ -136,6 +136,7 @@ impl IoConfig {
     }
 }
 
+#[derive(Resource)]
 pub struct Io {
     local_addr: SocketAddr,
     sender: Box<dyn PacketSender>,

--- a/macros/tests/derive_component.rs
+++ b/macros/tests/derive_component.rs
@@ -3,7 +3,7 @@ pub mod some_component {
     use derive_more::{Add, Mul};
     use serde::{Deserialize, Serialize};
 
-    use lightyear::prelude::client::InterpFn;
+    use lightyear::prelude::client::{InterpFn, LerpFn};
     use lightyear::prelude::*;
     use lightyear_macros::{component_protocol, message_protocol};
 
@@ -37,7 +37,7 @@ pub mod some_component {
 
     // custom interpolation logic
     pub struct MyCustomInterpolator;
-    impl<C> InterpFn<C> for MyCustomInterpolator {
+    impl<C> LerpFn<C> for MyCustomInterpolator {
         fn lerp(start: C, _other: C, _t: f32) -> C {
             start
         }


### PR DESCRIPTION
1) We had a single Resource called `Client` or `Server`, which was limiting parallelism between our systems because every single networking function needed access to that resource.

Instead I now split this main resource into multiple:
- TickManager
- TimeManager
- Protocol
- ClientConfig / ServerConfig
- NetClient / NetServer (for netcode)
- Io
- ConnectionManager -> handles inputs, replication, sending messages (the connection-manager can probably still be split up into multiple parts.

This should improve parallelism, and is just better practice in general.

2) Also simplified the NetcodeServer logic by removing the use of channels to get the list of newly-connected clients


TODO:
- clean up docs
- think about what to do with the `Client/ClientMut` and `Server/ServerMut` `SystemParam`s