### PR TITLE
Fix replication not working after tick wrap-around

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -4,14 +4,13 @@
   - use local executors for async, and use one process/thread per core instead of doing multi-threading (more complicated and less performant
   - one server: 1 game room per core?
 
-- ROLLBACK:
-  - why do we have an immediate rollback upon replication saying that predicted_exist=False and confirmed_exist=True?
-  - is it because we receive a component update on the server-timeline, so we NEED to rollback immediately to get the component
-    to reach the client-timeline?
-
 - SYNC:
-  - why is server time not updating correctly?
-  - why is sync breaking after 25000 ticks?
+  - why is sync breaking after 32700 ticks?
+  - if we set the client_tick to something else, then the relationship between time_manager and sync is broken,
+    so the timemanager's overstep is not trustworthy anymore?
+  - time gets updated during the First system, but i need the time at the end of the frame, so i need to run the time-systems myself
+    before PostUpdate!
+  - we must use the overstep only after FixedUpdate, because that's when it's updated
 
 - PHYSICS:
   - A: if I run FixedUpdate::MAIN AFTER PhysicsSets, I have a smooth physics simulation on client

--- a/lightyear/src/client/connection.rs
+++ b/lightyear/src/client/connection.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 
 use anyhow::Result;
 use bevy::ecs::component::Tick as BevyTick;
-use bevy::prelude::{Resource, World};
+use bevy::prelude::{Res, ResMut, Resource, World};
 use serde::Serialize;
 use tracing::{debug, info, trace, trace_span};
 
@@ -43,6 +43,45 @@ pub struct ConnectionManager<P: Protocol> {
     pub(crate) input_buffer: InputBuffer<P::Input>,
     pub(crate) sync_manager: SyncManager,
     // TODO: maybe don't do any replication until connection is synced?
+}
+
+/// Do some regular cleanup on the internals of replication:
+/// - set the latest_tick for every group to
+pub(crate) fn replication_clean<P: Protocol>(
+    mut connection: ResMut<ConnectionManager<P>>,
+    tick_manager: Res<TickManager>,
+) {
+    debug!("Running replication clean");
+    let tick = tick_manager.tick();
+    // if it's been enough time since we last any action for the group, we can set the last_action_tick to None
+    // (meaning that there's no need when we receive the update to check if we have already received a previous action)
+    for group_channel in connection.replication_sender.group_channels.values_mut() {
+        debug!("Checking group channel: {:?}", group_channel);
+        if let Some(last_action_tick) = group_channel.last_action_tick {
+            if tick - last_action_tick > (i16::MAX / 2) {
+                debug!(
+                    ?tick,
+                    ?last_action_tick,
+                    ?group_channel,
+                    "Setting the last_action tick to None because there hasn't been any new actions in a while");
+                group_channel.last_action_tick = None;
+            }
+        }
+    }
+    // if it's been enough time since we last had any update for the group, we update the latest_tick for the group
+    for group_channel in connection.replication_receiver.group_channels.values_mut() {
+        debug!("Checking group channel: {:?}", group_channel);
+        if let Some(latest_tick) = group_channel.latest_tick {
+            if tick - latest_tick > (i16::MAX / 2) {
+                debug!(
+                    ?tick,
+                    ?latest_tick,
+                    ?group_channel,
+                    "Setting the latest_tick tick to tick because there hasn't been any new updates in a while");
+                group_channel.latest_tick = Some(tick);
+            }
+        }
+    }
 }
 
 impl<P: Protocol> ConnectionManager<P> {
@@ -284,12 +323,16 @@ impl<P: Protocol> ConnectionManager<P> {
                                 SyncMessage::Pong(pong) => {
                                     // process the pong
                                     self.ping_manager.process_pong(pong, time_manager);
+                                    // TODO: a bit dangerous because we want:
+                                    // - real time when computing RTT
+                                    // - virtual time when computing the generation
+                                    // - maybe we should just send both in Pong message?
                                     // update the tick generation from the time + tick information
                                     self.sync_manager.server_pong_tick = tick;
                                     self.sync_manager.server_pong_generation = pong
                                         .pong_sent_time
                                         .tick_generation(tick_manager.config.tick_duration, tick);
-                                    trace!(
+                                    info!(
                                         ?tick,
                                         generation = ?self.sync_manager.server_pong_generation,
                                         time = ?pong.pong_sent_time,

--- a/lightyear/src/client/connection.rs
+++ b/lightyear/src/client/connection.rs
@@ -332,7 +332,7 @@ impl<P: Protocol> ConnectionManager<P> {
                                     self.sync_manager.server_pong_generation = pong
                                         .pong_sent_time
                                         .tick_generation(tick_manager.config.tick_duration, tick);
-                                    info!(
+                                    trace!(
                                         ?tick,
                                         generation = ?self.sync_manager.server_pong_generation,
                                         time = ?pong.pong_sent_time,

--- a/lightyear/src/client/input.rs
+++ b/lightyear/src/client/input.rs
@@ -194,7 +194,7 @@ fn prepare_input_message<P: Protocol>(
     if !message.is_empty() {
         // TODO: should we provide variants of each user-facing function, so that it pushes the error
         //  to the ConnectionEvents?
-        trace!("sending input message: {:?}", message);
+        trace!("sending input message: {:?}", message.end_tick);
         connection
             .send_message::<InputChannel, _>(message)
             .unwrap_or_else(|err| {

--- a/lightyear/src/client/prediction/rollback.rs
+++ b/lightyear/src/client/prediction/rollback.rs
@@ -19,258 +19,118 @@ use crate::protocol::Protocol;
 use super::predicted_history::PredictionHistory;
 use super::{Predicted, Rollback, RollbackState};
 
-// TODO (unrelated): pattern for enabling replication-behaviour for a component/entity. (for example don't replicate this component)
-//  Added a ReplicationBehaviour<C>.
-//  And then maybe we can add an EntityCommands extension that adds a ReplicationBehaviour<C>
+#[allow(clippy::type_complexity)]
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn check_rollback<C: SyncComponent, P: Protocol>(
+    // TODO: have a way to only get the updates of entities that are predicted?
+    tick_manager: Res<TickManager>,
+    connection: Res<ConnectionManager<P>>,
 
-// NOTE: for rollback to work, all entities that are predicted need to be replicated on the same tick!
+    // We also snap the value of the component to the server state if we are in rollback
+    // We use Option<> because the predicted component could have been removed while it still exists in Confirmed
+    mut predicted_query: Query<&mut PredictionHistory<C>, (With<Predicted>, Without<Confirmed>)>,
+    confirmed_query: Query<(Entity, Option<&C>, Ref<Confirmed>)>,
+    mut rollback: ResMut<Rollback>,
+) where
+    <P as Protocol>::ComponentKinds: FromType<C>,
+    P::Components: SyncMetadata<C>,
+{
+    let kind = <P::ComponentKinds as FromType<C>>::from_type();
+    // TODO: maybe change this into a run condition so that we don't even run the system (reduces parallelism)
+    if P::Components::mode() != ComponentSyncMode::Full {
+        return;
+    }
 
-// We need:
-// - Removed because we need to know if the component was removed on predicted, but we have to keep the history for the rest of rollback
-// - To be able to handle missing component histories; (if a component suddenly gets added on confirmed for the first time, it won't exist on predicted, so existed wont have a history)
-//   - BUT WE COULD JUST SPAWN A HISTORY FOR PREDICTED AS SOON AS WE RECEIVE THAT EVENT?
-// - Add ComponentHistory if a component gets added on predicted; so we can start accumulating history for future rollbacks
-// - Add ComponentHistory if a component gets added on confirmed; so we can initiate rollback (if predicted didn't have this component)
-// - We don't really need to remove ComponentHistory. We could try to do it as an optimization later on. For now we just keep them around.
+    // TODO: for mode=simple/once, we still need to re-add the component if the entity ends up not being despawned!
+    if !connection.is_synced() || !connection.received_new_server_tick() {
+        return;
+    }
 
-// // TODO: it seems pretty suboptimal to have one system per component, refactor to loop through all components
-// //  ESPECIALLY BECAUSE WE ROLLBACK EVERYTHING IF ONE COMPONENT IS MISPREDICTED!
-// /// Systems that try to see if we should perform rollback for the predicted entity.
-// /// For each component, we compare the confirmed component (server-state) with the history.
-// /// If we need to run rollback, we clear the predicted history and snap the history back to the server-state
-// // TODO: do not rollback if client is not time synced
-// #[allow(clippy::type_complexity)]
-// #[allow(clippy::too_many_arguments)]
-// pub(crate) fn client_rollback_check<C: SyncComponent, P: Protocol>(
-//     // TODO: have a way to only get the updates of entities that are predicted?
-//     mut commands: Commands,
-//     client: Res<Client<P>>,
-//
-//     // mut updates: EventReader<ComponentUpdateEvent<C>>,
-//     // mut inserts: EventReader<ComponentInsertEvent<C>>,
-//     // mut removals: EventReader<ComponentRemoveEvent<C>>,
-//
-//     // We also snap the value of the component to the server state if we are in rollback
-//     // We use Option<> because the predicted component could have been removed while it still exists in Confirmed
-//     mut predicted_query: Query<
-//         (
-//             Entity,
-//             Option<&mut C>,
-//             &mut PredictionHistory<C>,
-//             Option<&mut Correction<C>>,
-//         ),
-//         (With<Predicted>, Without<Confirmed>),
-//     >,
-//     confirmed_query: Query<(Entity, Option<&C>, Ref<Confirmed>)>,
-//     mut rollback: ResMut<Rollback>,
-// ) where
-//     <P as Protocol>::ComponentKinds: FromType<C>,
-//     P::Components: SyncMetadata<C>,
-// {
-//     let kind = <P::ComponentKinds as FromType<C>>::from_type();
-//     // TODO: maybe change this into a run condition so that we don't even run the system (reduces parallelism)
-//     if P::Components::mode() != ComponentSyncMode::Full {
-//         return;
-//     }
-//
-//     // TODO: for mode=simple/once, we still need to re-add the component if the entity ends up not being despawned!
-//     if !client.is_synced() || !client.received_new_server_tick() {
-//         return;
-//     }
-//     // TODO: can just enable bevy spans?
-//     let _span = trace_span!("client rollback check");
-//
-//     // // 0. We want to do a rollback check every time the component for the confirmed entity got modified in any way (removed/added/updated)
-//     // let confirmed_entity_with_updates = updates
-//     //     .read()
-//     //     .map(|event| event.entity())
-//     //     .chain(inserts.read().map(|event| event.entity()))
-//     //     .chain(removals.read().map(|event| event.entity()))
-//     //     .collect::<EntityHashSet<Entity>>();
-//
-//     for (confirmed_entity, confirmed_component, confirmed) in confirmed_query.iter() {
-//         // only check rollback when any entity in the replication group has been updated
-//         // (i.e. the confirmed tick has been updated)
-//         if !confirmed.is_changed() {
-//             continue;
-//         }
-//         // for confirmed_entity in confirmed_entity_with_updates {
-//         //     let Ok((confirmed_component, confirmed)) = confirmed_query.get(confirmed_entity) else {
-//         //         // this could happen if the entity was despawned but we received updates for it.
-//         //         // maybe only send events for an entity if it still exists?
-//         //         debug!(
-//         //             "could not find the confirmed entity: {:?} that received an update",
-//         //             confirmed_entity
-//         //         );
-//         //         continue;
-//         //     };
-//
-//         // TODO: get the tick of the update from context of ComponentUpdateEvent if we switch to that
-//         // let confirmed_entity = event.entity();
-//         // TODO: no need to get the Predicted component because we're not using it right now..
-//         //  we could use it in the future if we add more state in the Predicted Component
-//         // 1. Get the predicted entity, and it's history
-//         if let Some(p) = confirmed.predicted {
-//             let Ok((predicted_entity, predicted_component, mut predicted_history, mut correction)) =
-//                 predicted_query.get_mut(p)
-//             else {
-//                 debug!("Predicted entity {:?} was not found", confirmed.predicted);
-//                 continue;
-//             };
-//
-//             // 2. We will compare the predicted history and the confirmed entity at the current confirmed entity tick
-//             // - Confirmed contains the server state at the tick
-//             // - History contains the history of what we predicted at the tick
-//             // get the tick that the confirmed entity is at
-//             let tick = confirmed.tick;
-//             if tick > client.tick() {
-//                 info!(
-//                     "Confirmed entity {:?} is at a tick in the future: {:?} compared to client timeline. Current tick: {:?}",
-//                     confirmed_entity,
-//                     tick,
-//                     client.tick()
-//                 );
-//                 continue;
-//             }
-//
-//             // Note: it may seem like an optimization to only compare the history/server-state if we are not sure
-//             // that we should rollback (RollbackState::Default)
-//             // That is not the case, because if we do rollback we will need to snap the client entity to the server state
-//             // So either way we will need to do an operation.
-//             let should_rollback = match rollback.state {
-//                 // 3.a We are still not sure if we should do rollback. Compare history against confirmed
-//                 // We rollback if there's no history (newly added predicted entity, or if there is a mismatch)
-//                 RollbackState::Default => {
-//                     // rollback table:
-//                     // - confirm exist. rollback if:
-//                     //    - predicted history exists and is different
-//                     //    - predicted history does not exist
-//                     //    To rollback:
-//                     //    - update the predicted component to the confirmed component if it exists
-//                     //    - insert the confirmed component to the predicted entity if it doesn't exist
-//                     // - confirm does not exist. rollback if:
-//                     //    - predicted history exists and doesn't contain Removed
-//                     //    -
-//                     //    To rollback:
-//                     //    - we remove the component from predicted.
-//
-//                     let history_value = predicted_history.pop_until_tick(tick);
-//                     let predicted_exist = history_value.is_some();
-//                     let confirmed_exist = confirmed_component.is_some();
-//                     let should_rollback = match confirmed_component {
-//                         // TODO: history-value should not be empty here; should we panic if it is?
-//                         // confirm does not exist. rollback if history value is not Removed
-//                         None => history_value.map_or(false, |history_value| {
-//                             history_value != ComponentState::Removed
-//                         }),
-//                         // confirm exist. rollback if history value is different
-//                         Some(c) => {
-//                             history_value.map_or(true, |history_value| match history_value {
-//                                 ComponentState::Updated(history_value) => history_value != *c,
-//                                 ComponentState::Removed => true,
-//                             })
-//                         }
-//                     };
-//                     if should_rollback {
-//                         info!(
-//                             ?predicted_exist, ?confirmed_exist,
-//                                 "Rollback check: mismatch for component between predicted and confirmed {:?} on tick {:?} for component {:?}. Current tick: {:?}",
-//                                 confirmed_entity, tick, kind, client.tick()
-//                         );
-//                         // TODO: try atomic enum update
-//                         rollback.state = RollbackState::ShouldRollback {
-//                             // we already rolled-back the state for the entity's latest_tick
-//                             // after this we will start right away with a physics update, so we need to start taking the inputs from the next tick
-//                             current_tick: tick + 1,
-//                         };
-//                     }
-//                     should_rollback
-//                 }
-//                 // 3.b We already know we should do rollback (because of another entity/component), start the rollback
-//                 RollbackState::ShouldRollback { .. } => {
-//                     trace!(
-//                             "Rollback check: should roll back for component between predicted and confirmed on tick {:?} for component {:?}. Current tick: {:?}",
-//                             tick, kind, client.tick()
-//                     );
-//                     true
-//                 }
-//             };
-//
-//             if !should_rollback {
-//                 continue;
-//             }
-//
-//             // we need to clear the history so we can write a new one
-//             predicted_history.clear();
-//             // SAFETY: we know the predicted entity exists
-//             let mut entity_mut = commands.entity(predicted_entity);
-//
-//             // we update the state to the Corrected state
-//             // NOTE: visually, we will use the CorrectionFn to interpolate between the current Predicted state and the Corrected state
-//             //  even though for other purposes (physics, etc.) we switch directly to the Corrected state
-//             match confirmed_component {
-//                 // confirm does not exist, remove on predicted
-//                 None => {
-//                     predicted_history
-//                         .buffer
-//                         .add_item(tick, ComponentState::Removed);
-//                     entity_mut.remove::<C>();
-//                 }
-//                 // confirm exist, update or insert on predicted
-//                 Some(c) => {
-//                     predicted_history
-//                         .buffer
-//                         .add_item(tick, ComponentState::Updated(c.clone()));
-//                     match predicted_component {
-//                         None => {
-//                             debug!("Re-adding deleted Full component to predicted");
-//                             entity_mut.insert(c.clone());
-//                         }
-//                         Some(mut predicted_component) => {
-//                             // no need to do a correction if the values are the same
-//                             if predicted_component.as_ref() == c {
-//                                 continue;
-//                             }
-//                             // insert the Correction information only if the component exists on both confirmed and predicted
-//                             let correction_ticks = ((client.tick() - tick) as f32
-//                                 * client.config().prediction.correction_ticks_factor)
-//                                 .round() as i16;
-//
-//                             // no need to add the Correction if the correction is instant
-//                             if correction_ticks != 0 && P::Components::has_correction() {
-//                                 let final_correction_tick = client.tick() + correction_ticks;
-//                                 if let Some(correction) = correction.as_mut() {
-//                                     info!("updating existing correction");
-//                                     // if there is a correction, start the correction again from the previous
-//                                     // visual state to avoid glitches
-//                                     correction.original_prediction =
-//                                         std::mem::take(&mut correction.current_visual)
-//                                             .unwrap_or_else(|| predicted_component.clone());
-//                                     correction.original_tick = client.tick();
-//                                     correction.final_correction_tick = final_correction_tick;
-//                                     // TODO: can set this to None, shouldnt make any diff
-//                                     correction.current_correction = Some(c.clone());
-//                                 } else {
-//                                     info!("inserting new correction");
-//                                     entity_mut.insert(Correction {
-//                                         original_prediction: predicted_component.clone(),
-//                                         original_tick: client.tick(),
-//                                         final_correction_tick,
-//                                         current_visual: None,
-//                                         current_correction: None,
-//                                     });
-//                                 }
-//                             }
-//
-//                             // update the component to the corrected value
-//                             *predicted_component = c.clone();
-//                         }
-//                     };
-//                 }
-//             };
-//         }
-//     }
-// }
+    let current_tick = tick_manager.tick();
+    // TODO: can just enable bevy spans?
+    let _span = trace_span!("client rollback check");
+
+    for (confirmed_entity, confirmed_component, confirmed) in confirmed_query.iter() {
+        // 0. only check rollback when any entity in the replication group has been updated
+        // (i.e. the confirmed tick has been updated)
+        if !confirmed.is_changed() {
+            continue;
+        }
+
+        // let confirmed_entity = event.entity();
+        // TODO: no need to get the Predicted component because we're not using it right now..
+        //  we could use it in the future if we add more state in the Predicted Component
+        // 1. Get the predicted entity, and it's history
+        let Some(p) = confirmed.predicted else {
+            continue;
+        };
+        let Ok(mut predicted_history) = predicted_query.get_mut(p) else {
+            debug!("Predicted entity {:?} was not found", confirmed.predicted);
+            continue;
+        };
+
+        // 2. We will compare the predicted history and the confirmed entity at the current confirmed entity tick
+        // - Confirmed contains the server state at the tick
+        // - History contains the history of what we predicted at the tick
+        // get the tick that the confirmed entity is at
+        let tick = confirmed.tick;
+        if tick > current_tick {
+            debug!(
+                "Confirmed entity {:?} is at a tick in the future: {:?} compared to client timeline. Current tick: {:?}",
+                confirmed_entity,
+                tick,
+                current_tick
+            );
+            continue;
+        }
+
+        // Note: it may seem like an optimization to only compare the history/server-state if we are not sure
+        // that we should rollback (RollbackState::Default)
+        // That is not the case, because if we do rollback we will need to snap the client entity to the server state
+        // So either way we will need to do an operation.
+        match rollback.state {
+            // 3.a We are still not sure if we should do rollback. Compare history against confirmed
+            // We rollback if there's no history (newly added predicted entity, or if there is a mismatch)
+            RollbackState::Default => {
+                let history_value = predicted_history.pop_until_tick(tick);
+                let predicted_exist = history_value.is_some();
+                let confirmed_exist = confirmed_component.is_some();
+                let should_rollback = match confirmed_component {
+                    // TODO: history-value should not be empty here; should we panic if it is?
+                    // confirm does not exist. rollback if history value is not Removed
+                    None => history_value.map_or(false, |history_value| {
+                        history_value != ComponentState::Removed
+                    }),
+                    // confirm exist. rollback if history value is different
+                    Some(c) => history_value.map_or(true, |history_value| match history_value {
+                        ComponentState::Updated(history_value) => history_value != *c,
+                        ComponentState::Removed => true,
+                    }),
+                };
+                if should_rollback {
+                    info!(
+                   ?predicted_exist, ?confirmed_exist,
+                   "Rollback check: mismatch for component between predicted and confirmed {:?} on tick {:?} for component {:?}. Current tick: {:?}",
+                   confirmed_entity, tick, kind, current_tick
+                   );
+                    // TODO: try atomic enum update
+                    rollback.state = RollbackState::ShouldRollback {
+                        // we already rolled-back the state for the entity's latest_tick
+                        // after this we will start right away with a physics update, so we need to start taking the inputs from the next tick
+                        current_tick: tick + 1,
+                    };
+                }
+            }
+            // 3.b We already know we should do rollback (because of another entity/component), start the rollback
+            RollbackState::ShouldRollback { .. } => {
+                trace!(
+                   "Rollback check: should roll back for component between predicted and confirmed on tick {:?} for component {:?}. Current tick: {:?}",
+                   tick, kind, current_tick
+                   );
+            }
+        };
+    }
+}
 
 #[allow(clippy::type_complexity)]
 #[allow(clippy::too_many_arguments)]
@@ -396,132 +256,6 @@ pub(crate) fn prepare_rollback<C: SyncComponent, P: Protocol>(
                         *predicted_component = c.clone();
                     }
                 };
-            }
-        };
-    }
-}
-
-#[allow(clippy::type_complexity)]
-#[allow(clippy::too_many_arguments)]
-pub(crate) fn check_rollback<C: SyncComponent, P: Protocol>(
-    // TODO: have a way to only get the updates of entities that are predicted?
-    tick_manager: Res<TickManager>,
-    connection: Res<ConnectionManager<P>>,
-
-    // We also snap the value of the component to the server state if we are in rollback
-    // We use Option<> because the predicted component could have been removed while it still exists in Confirmed
-    mut predicted_query: Query<&mut PredictionHistory<C>, (With<Predicted>, Without<Confirmed>)>,
-    confirmed_query: Query<(Entity, Option<&C>, Ref<Confirmed>)>,
-    mut rollback: ResMut<Rollback>,
-) where
-    <P as Protocol>::ComponentKinds: FromType<C>,
-    P::Components: SyncMetadata<C>,
-{
-    let kind = <P::ComponentKinds as FromType<C>>::from_type();
-    // TODO: maybe change this into a run condition so that we don't even run the system (reduces parallelism)
-    if P::Components::mode() != ComponentSyncMode::Full {
-        return;
-    }
-
-    // TODO: for mode=simple/once, we still need to re-add the component if the entity ends up not being despawned!
-    if !connection.is_synced() || !connection.received_new_server_tick() {
-        return;
-    }
-
-    let current_tick = tick_manager.tick();
-    // TODO: can just enable bevy spans?
-    let _span = trace_span!("client rollback check");
-
-    for (confirmed_entity, confirmed_component, confirmed) in confirmed_query.iter() {
-        // 0. only check rollback when any entity in the replication group has been updated
-        // (i.e. the confirmed tick has been updated)
-        if !confirmed.is_changed() {
-            continue;
-        }
-
-        // let confirmed_entity = event.entity();
-        // TODO: no need to get the Predicted component because we're not using it right now..
-        //  we could use it in the future if we add more state in the Predicted Component
-        // 1. Get the predicted entity, and it's history
-        let Some(p) = confirmed.predicted else {
-            continue;
-        };
-        let Ok(mut predicted_history) = predicted_query.get_mut(p) else {
-            debug!("Predicted entity {:?} was not found", confirmed.predicted);
-            continue;
-        };
-
-        // 2. We will compare the predicted history and the confirmed entity at the current confirmed entity tick
-        // - Confirmed contains the server state at the tick
-        // - History contains the history of what we predicted at the tick
-        // get the tick that the confirmed entity is at
-        let tick = confirmed.tick;
-        if tick > current_tick {
-            debug!(
-                "Confirmed entity {:?} is at a tick in the future: {:?} compared to client timeline. Current tick: {:?}",
-                confirmed_entity,
-                tick,
-                current_tick
-            );
-            continue;
-        }
-
-        // Note: it may seem like an optimization to only compare the history/server-state if we are not sure
-        // that we should rollback (RollbackState::Default)
-        // That is not the case, because if we do rollback we will need to snap the client entity to the server state
-        // So either way we will need to do an operation.
-        match rollback.state {
-            // 3.a We are still not sure if we should do rollback. Compare history against confirmed
-            // We rollback if there's no history (newly added predicted entity, or if there is a mismatch)
-            RollbackState::Default => {
-                // rollback table:
-                // - confirm exist. rollback if:
-                //    - predicted history exists and is different
-                //    - predicted history does not exist
-                //    To rollback:
-                //    - update the predicted component to the confirmed component if it exists
-                //    - insert the confirmed component to the predicted entity if it doesn't exist
-                // - confirm does not exist. rollback if:
-                //    - predicted history exists and doesn't contain Removed
-                //    -
-                //    To rollback:
-                //    - we remove the component from predicted.
-
-                let history_value = predicted_history.pop_until_tick(tick);
-                let predicted_exist = history_value.is_some();
-                let confirmed_exist = confirmed_component.is_some();
-                let should_rollback = match confirmed_component {
-                    // TODO: history-value should not be empty here; should we panic if it is?
-                    // confirm does not exist. rollback if history value is not Removed
-                    None => history_value.map_or(false, |history_value| {
-                        history_value != ComponentState::Removed
-                    }),
-                    // confirm exist. rollback if history value is different
-                    Some(c) => history_value.map_or(true, |history_value| match history_value {
-                        ComponentState::Updated(history_value) => history_value != *c,
-                        ComponentState::Removed => true,
-                    }),
-                };
-                if should_rollback {
-                    debug!(
-                   ?predicted_exist, ?confirmed_exist,
-                   "Rollback check: mismatch for component between predicted and confirmed {:?} on tick {:?} for component {:?}. Current tick: {:?}",
-                   confirmed_entity, tick, kind, current_tick
-                   );
-                    // TODO: try atomic enum update
-                    rollback.state = RollbackState::ShouldRollback {
-                        // we already rolled-back the state for the entity's latest_tick
-                        // after this we will start right away with a physics update, so we need to start taking the inputs from the next tick
-                        current_tick: tick + 1,
-                    };
-                }
-            }
-            // 3.b We already know we should do rollback (because of another entity/component), start the rollback
-            RollbackState::ShouldRollback { .. } => {
-                trace!(
-                   "Rollback check: should roll back for component between predicted and confirmed on tick {:?} for component {:?}. Current tick: {:?}",
-                   tick, kind, current_tick
-                   );
             }
         };
     }

--- a/lightyear/src/client/resource.rs
+++ b/lightyear/src/client/resource.rs
@@ -73,8 +73,8 @@ pub struct ClientMut<'w, 's, P: Protocol> {
 
 impl<'w, 's, P: Protocol> ClientMut<'w, 's, P> {
     /// Maintain connection with server, queues up any packet received from the server
-    pub(crate) fn update(&mut self, delta: Duration, overstep: Duration) -> Result<()> {
-        self.time_manager.update(delta, overstep);
+    pub(crate) fn update(&mut self, delta: Duration) -> Result<()> {
+        self.time_manager.update(delta);
         self.netcode.try_update(delta.as_secs_f64(), &mut self.io)?;
 
         // only start the connection (sending messages, sending pings, starting sync, etc.)

--- a/lightyear/src/client/sync.rs
+++ b/lightyear/src/client/sync.rs
@@ -195,7 +195,7 @@ impl SyncManager {
         let generation = if (client_tick_raw - self.latest_received_server_tick.unwrap().0 as i32)
             < (i16::MIN as i32)
         {
-            info!("client tick is one generation ahead of server tick");
+            debug!("client tick is one generation ahead of server tick");
             self.server_latest_tick_generation() + 1
         } else {
             self.server_latest_tick_generation()
@@ -222,7 +222,7 @@ impl SyncManager {
     fn server_latest_tick_generation(&self) -> u16 {
         // check if the latest_server_tick has crossed a generation compared to the latest pong tick
         if self.latest_received_server_tick.unwrap().0 < self.server_pong_tick.0 {
-            info!("server tick crossed a generation");
+            debug!("latest server tick is a generation compared to the server pong tick");
             self.server_pong_generation + 1
         } else {
             self.server_pong_generation
@@ -430,7 +430,7 @@ impl SyncManager {
         .unwrap();
 
         if error > max_error_margin_time || error < -max_error_margin_time {
-            info!(
+            debug!(
                 ?rtt,
                 ?jitter,
                 ?current_prediction_time,
@@ -515,7 +515,7 @@ impl SyncManager {
         let delta_tick = client_ideal_tick - tick_manager.tick();
         // Update client ticks
         if rtt != Duration::default() {
-            info!(
+            debug!(
                 buffer_len = ?ping_manager.sync_stats.len(),
                 ?rtt,
                 ?jitter,

--- a/lightyear/src/client/systems.rs
+++ b/lightyear/src/client/systems.rs
@@ -38,10 +38,10 @@ pub(crate) fn receive<P: Protocol>(world: &mut World) {
                                 world.resource_scope(
                                     |world: &mut World, tick_manager: Mut<TickManager>| {
                                         let delta = world.resource::<Time<Virtual>>().delta();
-                                        let overstep = world.resource::<Time<Fixed>>().overstep();
 
                                         // UPDATE: update client state, send keep-alives, receive packets from io, update connection sync state
-                                        time_manager.update(delta, overstep);
+                                        time_manager.update(delta);
+                                        trace!(time = ?time_manager.current_time(), tick = ?tick_manager.tick(), "receive");
                                         netcode
                                             .try_update(delta.as_secs_f64(), io.deref_mut())
                                             .unwrap();

--- a/lightyear/src/inputs/native/input_buffer.rs
+++ b/lightyear/src/inputs/native/input_buffer.rs
@@ -21,7 +21,7 @@ pub struct InputBuffer<T: UserAction> {
 // TODO: add encode directive to encode even more efficiently
 /// We use this structure to efficiently compress the inputs that we send to the server
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
-enum InputData<T: UserAction> {
+pub(crate) enum InputData<T: UserAction> {
     Absent,
     SameAsPrecedent,
     Input(T),
@@ -32,9 +32,9 @@ enum InputData<T: UserAction> {
 /// Message that we use to send the client inputs to the server
 /// We will store the last N inputs starting from start_tick (in case of packet loss)
 pub struct InputMessage<T: UserAction> {
-    end_tick: Tick,
+    pub(crate) end_tick: Tick,
     // first element is tick end_tick-N+1, last element is end_tick
-    inputs: Vec<InputData<T>>,
+    pub(crate) inputs: Vec<InputData<T>>,
 }
 
 impl<T: UserAction> InputMessage<T> {
@@ -132,7 +132,6 @@ impl<T: UserAction> InputBuffer<T> {
         }
         // safety: we are guaranteed that the tick is in the buffer
         *self.buffer.get_mut((tick - start_tick) as usize).unwrap() = value;
-        trace!("buffer: {:?}", self.buffer)
     }
 
     /// We received a new input message from the user, and use it to update the input buffer

--- a/lightyear/src/packet/stats_manager.rs
+++ b/lightyear/src/packet/stats_manager.rs
@@ -140,7 +140,7 @@ mod tests {
         // add some more packet data at a later time
         packet_stats_manager.sent_packet();
         packet_stats_manager.sent_packet_lost();
-        time_manager.update(Duration::from_secs(1), Duration::from_secs(0));
+        time_manager.update(Duration::from_secs(1));
         assert_eq!(
             packet_stats_manager.current_stats,
             PacketStats {
@@ -158,7 +158,7 @@ mod tests {
 
         // add some more packet data at a later time, the older stats should get removed
         packet_stats_manager.sent_packet();
-        time_manager.update(Duration::from_secs(1), Duration::from_secs(0));
+        time_manager.update(Duration::from_secs(1));
         packet_stats_manager.update(&time_manager);
         assert_eq!(packet_stats_manager.current_stats, PacketStats::default());
         assert_eq!(packet_stats_manager.stats_buffer.len(), 2);

--- a/lightyear/src/packet/stats_manager.rs
+++ b/lightyear/src/packet/stats_manager.rs
@@ -122,6 +122,8 @@ mod tests {
     fn test_packet_stats() {
         let mut time_manager = TimeManager::new(Duration::default());
         let mut packet_stats_manager = PacketStatsManager::new(Duration::from_secs(2));
+        // set the time to a value bigger than the stats buffer
+        time_manager.update(Duration::from_secs(3));
 
         // add some packet data
         packet_stats_manager.sent_packet();
@@ -132,6 +134,7 @@ mod tests {
         // update the packet stats
         packet_stats_manager.update(&time_manager);
         assert_eq!(packet_stats_manager.current_stats, PacketStats::default());
+        assert_eq!(packet_stats_manager.stats_buffer.len(), 1);
 
         // compute final stats
         packet_stats_manager.compute_stats();

--- a/lightyear/src/server/connection.rs
+++ b/lightyear/src/server/connection.rs
@@ -487,9 +487,8 @@ impl<P: Protocol> Connection<P> {
                                     self.events.push_input_message(message);
                                 }
                                 InputMessageKind::Native => {
-                                    trace!("update input buffer");
                                     let input_message = message.try_into().unwrap();
-                                    info!("Received input message: {:?}", input_message.end_tick);
+                                    trace!("Received input message: {:?}", input_message.end_tick);
                                     self.input_buffer.update_from_message(input_message);
                                 }
                                 InputMessageKind::None => {

--- a/lightyear/src/server/connection.rs
+++ b/lightyear/src/server/connection.rs
@@ -1,7 +1,7 @@
 //! Specify how a Server sends/receives messages with a Client
 use anyhow::{Context, Result};
 use bevy::ecs::component::Tick as BevyTick;
-use bevy::prelude::{Entity, Resource, World};
+use bevy::prelude::{Entity, Res, ResMut, Resource, World};
 use bevy::utils::{EntityHashMap, Entry, HashMap, HashSet};
 use serde::Serialize;
 use tracing::{debug, debug_span, info, trace, trace_span};
@@ -44,6 +44,47 @@ pub struct ConnectionManager<P: Protocol> {
     // list of clients that connected since the last time we sent replication messages
     // (we want to keep track of them because we need to replicate the entire world state to them)
     pub(crate) new_clients: Vec<ClientId>,
+}
+
+/// Do some regular cleanup on the internals of replication:
+/// - set the latest_tick for every group to
+pub(crate) fn replication_clean<P: Protocol>(
+    mut connection_manager: ResMut<ConnectionManager<P>>,
+    tick_manager: Res<TickManager>,
+) {
+    debug!("Running replication clean");
+    let tick = tick_manager.tick();
+    for connection in connection_manager.connections.values_mut() {
+        // if it's been enough time since we last any action for the group, we can set the last_action_tick to None
+        // (meaning that there's no need when we receive the update to check if we have already received a previous action)
+        for group_channel in connection.replication_sender.group_channels.values_mut() {
+            debug!("Checking group channel: {:?}", group_channel);
+            if let Some(last_action_tick) = group_channel.last_action_tick {
+                if tick - last_action_tick > (i16::MAX / 2) {
+                    debug!(
+                    ?tick,
+                    ?last_action_tick,
+                    ?group_channel,
+                    "Setting the last_action tick to None because there hasn't been any new actions in a while");
+                    group_channel.last_action_tick = None;
+                }
+            }
+        }
+        // if it's been enough time since we last had any update for the group, we update the latest_tick for the group
+        for group_channel in connection.replication_receiver.group_channels.values_mut() {
+            debug!("Checking group channel: {:?}", group_channel);
+            if let Some(latest_tick) = group_channel.latest_tick {
+                if tick - latest_tick > (i16::MAX / 2) {
+                    debug!(
+                    ?tick,
+                    ?latest_tick,
+                    ?group_channel,
+                    "Setting the latest_tick tick to tick because there hasn't been any new updates in a while");
+                    group_channel.latest_tick = Some(tick);
+                }
+            }
+        }
+    }
 }
 
 impl<P: Protocol> ConnectionManager<P> {
@@ -448,7 +489,7 @@ impl<P: Protocol> Connection<P> {
                                 InputMessageKind::Native => {
                                     trace!("update input buffer");
                                     let input_message = message.try_into().unwrap();
-                                    // info!("Received input message: {:?}", input_message);
+                                    info!("Received input message: {:?}", input_message.end_tick);
                                     self.input_buffer.update_from_message(input_message);
                                 }
                                 InputMessageKind::None => {

--- a/lightyear/src/server/plugin.rs
+++ b/lightyear/src/server/plugin.rs
@@ -1,4 +1,5 @@
 //! Defines the server bevy plugin
+use bevy::app::Last;
 use std::ops::DerefMut;
 use std::sync::Mutex;
 
@@ -6,12 +7,14 @@ use bevy::prelude::{
     apply_deferred, App, FixedUpdate, IntoSystemConfigs, IntoSystemSetConfigs,
     Plugin as PluginType, PostUpdate, PreUpdate,
 };
+use bevy::time::common_conditions::on_timer;
 
 use crate::netcode::ClientId;
 use crate::prelude::TimeManager;
 use crate::protocol::component::ComponentProtocol;
 use crate::protocol::message::MessageProtocol;
 use crate::protocol::Protocol;
+use crate::server::connection::replication_clean;
 use crate::server::connection::ConnectionManager;
 use crate::server::events::{ConnectEvent, DisconnectEvent, EntityDespawnEvent, EntitySpawnEvent};
 use crate::server::input::InputPlugin;
@@ -23,7 +26,7 @@ use crate::shared::replication::systems::add_replication_send_systems;
 use crate::shared::sets::ReplicationSet;
 use crate::shared::sets::{FixedUpdateSet, MainSet};
 use crate::shared::systems::tick::increment_tick;
-use crate::shared::time_manager::is_ready_to_send;
+use crate::shared::time_manager::{is_ready_to_send, TimePlugin};
 use crate::transport::io::Io;
 
 use super::config::ServerConfig;
@@ -65,6 +68,10 @@ impl<P: Protocol> PluginType for ServerPlugin<P> {
         let config = self.config.lock().unwrap().deref_mut().take().unwrap();
         let netserver = crate::netcode::Server::new(config.server_config.netcode.clone());
 
+        let tick_duration = config.server_config.shared.tick.tick_duration;
+        // TODO: have better constants for clean_interval?
+        let clean_interval = tick_duration * (i16::MAX as u32 / 3);
+
         // TODO: maybe put those 2 in a ReplicationPlugin?
         add_replication_send_systems::<P, ConnectionManager<P>>(app);
         P::Components::add_per_component_replication_send_systems::<ConnectionManager<P>>(app);
@@ -80,10 +87,10 @@ impl<P: Protocol> PluginType for ServerPlugin<P> {
             })
             .add_plugins(InputPlugin::<P>::default())
             .add_plugins(RoomPlugin::<P>::default())
+            .add_plugins(TimePlugin {
+                send_interval: config.server_config.shared.server_send_interval,
+            })
             // RESOURCES //
-            .insert_resource(TimeManager::new(
-                config.server_config.shared.server_send_interval,
-            ))
             .insert_resource(config.server_config)
             .insert_resource(config.io)
             .insert_resource(netserver)
@@ -146,6 +153,10 @@ impl<P: Protocol> PluginType for ServerPlugin<P> {
                     send::<P>.in_set(MainSet::SendPackets),
                     clear_events::<P>.in_set(MainSet::ClearEvents),
                 ),
+            )
+            .add_systems(
+                Last,
+                replication_clean::<P>.run_if(on_timer(clean_interval)),
             );
     }
 }

--- a/lightyear/src/server/resource.rs
+++ b/lightyear/src/server/resource.rs
@@ -80,7 +80,7 @@ impl<'w, 's, P: Protocol> ServerMut<'w, 's, P> {
     /// Sends keep-alive packets + any non-payload packet needed for netcode
     pub(crate) fn update(&mut self, delta: Duration) -> Result<()> {
         // update time manager
-        self.time_manager.update(delta, Duration::default());
+        self.time_manager.update(delta);
 
         // update netcode server
         let context = self

--- a/lightyear/src/server/systems.rs
+++ b/lightyear/src/server/systems.rs
@@ -31,10 +31,10 @@ pub(crate) fn receive<P: Protocol>(world: &mut World) {
                                     world.resource_scope(
                                         |world: &mut World, mut room_manager: Mut<RoomManager>| {
                                             let delta = world.resource::<Time<Virtual>>().delta();
-                                            let overstep = world.resource::<Time<Fixed>>().overstep();
                                             // UPDATE: update server state, send keep-alives, receive packets from io
                                             // update time manager
-                                            time_manager.update(delta, overstep);
+                                            time_manager.update(delta);
+                                            trace!(time = ?time_manager.current_time(), tick = ?tick_manager.tick(), "receive");
 
                                             // update netcode server
                                             let context = netcode

--- a/lightyear/src/shared/ping/manager.rs
+++ b/lightyear/src/shared/ping/manager.rs
@@ -304,7 +304,7 @@ mod tests {
         assert_eq!(ping_manager.maybe_prepare_ping(&time_manager), None);
 
         let delta = Duration::from_millis(100);
-        time_manager.update(delta, Duration::default());
+        time_manager.update(delta);
         ping_manager.update(&time_manager);
 
         // send pings
@@ -313,12 +313,12 @@ mod tests {
             Some(Ping { id: PingId(0) })
         );
         let delta = Duration::from_millis(60);
-        time_manager.update(delta, Duration::default());
+        time_manager.update(delta);
         ping_manager.update(&time_manager);
 
         // ping timer hasn't gone off yet, send nothing
         assert_eq!(ping_manager.maybe_prepare_ping(&time_manager), None);
-        time_manager.update(delta, Duration::default());
+        time_manager.update(delta);
         ping_manager.update(&time_manager);
         assert_eq!(
             ping_manager.maybe_prepare_ping(&time_manager),
@@ -326,7 +326,7 @@ mod tests {
         );
 
         let delta = Duration::from_millis(100);
-        time_manager.update(delta, Duration::default());
+        time_manager.update(delta);
         ping_manager.update(&time_manager);
         assert_eq!(
             ping_manager.maybe_prepare_ping(&time_manager),

--- a/lightyear/src/shared/ping/manager.rs
+++ b/lightyear/src/shared/ping/manager.rs
@@ -339,15 +339,15 @@ mod tests {
         // check ping store
         assert_eq!(
             ping_manager.ping_store.remove(PingId(0)),
-            Some(WrappedTime::new(100000))
+            Some(WrappedTime::new(100))
         );
         assert_eq!(
             ping_manager.ping_store.remove(PingId(1)),
-            Some(WrappedTime::new(220000))
+            Some(WrappedTime::new(220))
         );
         assert_eq!(
             ping_manager.ping_store.remove(PingId(2)),
-            Some(WrappedTime::new(320000))
+            Some(WrappedTime::new(320))
         );
 
         // receive pongs

--- a/lightyear/src/shared/replication/mod.rs
+++ b/lightyear/src/shared/replication/mod.rs
@@ -76,7 +76,9 @@ pub struct EntityActionMessage<C, K: Hash + Eq> {
 #[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
 pub struct EntityUpdatesMessage<C> {
     /// The last tick for which we sent an EntityActionsMessage for this group
-    last_action_tick: Tick,
+    /// We set this to None after a certain amount of time without any new Actions, to signify on the receiver side
+    /// that there is no ordering constraint with respect to Actions for this group (i.e. the Update can be applied immediately)
+    last_action_tick: Option<Tick>,
     pub(crate) updates: Vec<(Entity, Vec<C>)>,
 }
 

--- a/lightyear/src/shared/replication/send.rs
+++ b/lightyear/src/shared/replication/send.rs
@@ -7,7 +7,7 @@ use bevy::prelude::Entity;
 use bevy::utils::petgraph::data::ElementIterator;
 use bevy::utils::{EntityHashMap, HashMap, HashSet};
 use crossbeam_channel::Receiver;
-use tracing::{debug, error, trace, warn};
+use tracing::{debug, error, info, trace, warn};
 use tracing_subscriber::filter::FilterExt;
 use tracing_subscriber::fmt::writer::MakeWriterExt;
 
@@ -286,7 +286,7 @@ impl<P: Protocol> ReplicationSender<P> {
             let channel = self.group_channels.entry(group_id).or_default();
             let message_id = channel.actions_next_send_message_id;
             channel.actions_next_send_message_id += 1;
-            channel.last_action_tick = tick;
+            channel.last_action_tick = Some(tick);
             messages.push((
                 ChannelKind::of::<EntityActionsChannel>(),
                 group_id,
@@ -305,6 +305,7 @@ impl<P: Protocol> ReplicationSender<P> {
                 ChannelKind::of::<EntityUpdatesChannel>(),
                 group_id,
                 ReplicationMessageData::Updates(EntityUpdatesMessage {
+                    // SAFETY: the last action tick is always set because we send Actions before Updates
                     last_action_tick: channel.last_action_tick,
                     // TODO: maybe we can just send the HashMap directly?
                     updates: Vec::from_iter(updates.into_iter()),
@@ -322,26 +323,23 @@ impl<P: Protocol> ReplicationSender<P> {
     }
 }
 
-/// Channel to keep track of receiving/sending replication messages for a given Group
+/// Channel to keep track of sending replication messages for a given Group
 #[derive(Debug)]
 pub struct GroupChannel {
-    // SEND
     pub actions_next_send_message_id: MessageId,
     // TODO: maybe also keep track of which Tick this bevy-tick corresponds to? (will enable doing diff-compression)
     // bevy tick when we received an ack of an update for this group
     // at the start it's None, and we collect any changes
     pub collect_changes_since_this_tick: Option<BevyTick>,
     // last tick for which we sent an action message
-    pub last_action_tick: Tick,
+    pub last_action_tick: Option<Tick>,
 }
 
 impl Default for GroupChannel {
     fn default() -> Self {
         Self {
             actions_next_send_message_id: MessageId(0),
-            // we start with a very high last_action_tick, so that we need to receive the Actions message
-            // before handling any Updates messages
-            last_action_tick: Tick(0) - 1,
+            last_action_tick: None,
             collect_changes_since_this_tick: None,
         }
     }
@@ -390,7 +388,7 @@ mod tests {
         manager.group_channels.insert(
             group_2,
             GroupChannel {
-                last_action_tick: Tick(3),
+                last_action_tick: Some(Tick(3)),
                 ..Default::default()
             },
         );
@@ -464,7 +462,7 @@ mod tests {
                 ChannelKind::of::<EntityUpdatesChannel>(),
                 group_2,
                 ReplicationMessageData::Updates(EntityUpdatesMessage {
-                    last_action_tick: Tick(3),
+                    last_action_tick: Some(Tick(3)),
                     updates: vec![(
                         entity_3,
                         vec![MyComponentsProtocol::Component3(Component3(5.0))]
@@ -486,7 +484,7 @@ mod tests {
                 .get(&group_1)
                 .unwrap()
                 .last_action_tick,
-            Tick(2)
+            Some(Tick(2))
         );
     }
 }

--- a/lightyear/src/shared/tick_manager.rs
+++ b/lightyear/src/shared/tick_manager.rs
@@ -49,6 +49,7 @@ impl TickManager {
         self.tick = tick;
     }
 
+    /// Get the current tick of the local app
     pub fn tick(&self) -> Tick {
         self.tick
     }

--- a/lightyear/src/shared/time_manager.rs
+++ b/lightyear/src/shared/time_manager.rs
@@ -9,13 +9,16 @@ It will interact with bevy's [`Time`] resource, and potentially change the relat
 The network serialization uses a u32 which can only represent times up to 46 days.
 This module contains some helper functions to compute the difference between two times.
 */
+use bevy::app::{App, RunFixedUpdateLoop};
 use std::cmp::Ordering;
 use std::fmt::Formatter;
 use std::ops::{Add, AddAssign, Mul, Sub, SubAssign};
 use std::time::Duration;
 
 use crate::prelude::Tick;
-use bevy::prelude::{Res, Resource, Time, Timer, TimerMode};
+use bevy::prelude::{IntoSystemConfigs, Plugin, Res, ResMut, Resource, Time, Timer, TimerMode};
+use bevy::time::{Fixed, Virtual};
+use bevy::utils::Instant;
 use chrono::Duration as ChronoDuration;
 use serde::{Deserialize, Serialize};
 
@@ -26,10 +29,35 @@ pub(crate) fn is_ready_to_send(time_manager: Res<TimeManager>) -> bool {
     time_manager.is_ready_to_send()
 }
 
+/// Plugin that will centralize information about the various times (real, virtual, fixed)
+/// as well as track when we should send updates to the remote
+pub(crate) struct TimePlugin {
+    /// Interval at which we send updates to the remote
+    pub(crate) send_interval: Duration,
+}
+
+impl Plugin for TimePlugin {
+    fn build(&self, app: &mut App) {
+        // RESOURCES
+        app.insert_resource(TimeManager::new(self.send_interval));
+        // SYSTEMS
+        app.add_systems(
+            RunFixedUpdateLoop,
+            update_overstep.after(bevy::time::run_fixed_update_schedule),
+        );
+    }
+}
+
+fn update_overstep(mut time_manager: ResMut<TimeManager>, fixed_time: Res<Time<Fixed>>) {
+    time_manager.update_overstep(fixed_time.overstep());
+}
+
 #[derive(Resource)]
 pub struct TimeManager {
-    /// The current time (in ms precision)
+    /// The virtual time
     wrapped_time: WrappedTime,
+    /// The real time
+    real_time: WrappedTime,
     /// The remaining time after running the fixed-update steps
     overstep: Duration,
     /// The time since the last frame; gets update by bevy's Time resource at the start of the frame
@@ -38,9 +66,13 @@ pub struct TimeManager {
     pub base_relative_speed: f32,
     /// Should we speedup or slowdown the simulation to sync the ticks?
     /// >1.0 = speedup, <1.0 = slowdown
+    /// We speed up the virtual time so that our ticks go faster/slower
+    /// Things that depend on real time (ping/pong times), channel/packet managers, send_interval should be unaffected
     pub(crate) sync_relative_speed: f32,
     /// Timer to keep track on we send the next update
     send_timer: Option<Timer>,
+    /// Instant at the start of the frame
+    frame_start: Option<Instant>,
 }
 
 impl TimeManager {
@@ -52,11 +84,13 @@ impl TimeManager {
         };
         Self {
             wrapped_time: WrappedTime::new(0),
+            real_time: WrappedTime::new(0),
             overstep: Duration::default(),
             delta: Duration::default(),
             base_relative_speed: 1.0,
             sync_relative_speed: 1.0,
             send_timer,
+            frame_start: None,
         }
     }
 
@@ -79,17 +113,38 @@ impl TimeManager {
         self.base_relative_speed * self.sync_relative_speed
     }
 
+    // pub fn update_real(&mut self, delta: Duration) {
+    //     self.real_time.elapsed = Instant::now();
+    // }
+
     /// Update the time by applying the latest delta
     /// delta: delta time since last frame
     /// overstep: remaining time after running the fixed-update steps
-    pub fn update(&mut self, delta: Duration, overstep: Duration) {
+    pub(crate) fn update(&mut self, delta: Duration) {
         self.delta = delta;
         self.wrapped_time.elapsed += delta;
-        // set the overstep to the overstep of fixed_time
-        self.overstep = overstep;
+        self.frame_start = Some(Instant::now());
         if let Some(timer) = self.send_timer.as_mut() {
             timer.tick(delta);
         }
+    }
+
+    // TODO: reuse time-real for this?
+    /// Compute the real time elapsed since the start of the frame
+    /// (useful for
+    pub(crate) fn real_time_since_frame_start(&self) -> Duration {
+        self.frame_start
+            .map(|start| Instant::now() - start)
+            .unwrap_or_default()
+    }
+
+    /// Update the overstep (right after the overstep was computed, after RunFixedUpdateLoop)
+    fn update_overstep(&mut self, overstep: Duration) {
+        self.overstep = overstep;
+    }
+
+    fn update_real(&mut self, real_delta: Duration) {
+        self.real_time.elapsed += real_delta;
     }
 
     /// Current time since start, wrapped around 46 days
@@ -371,6 +426,19 @@ mod tests {
         assert_eq!(
             b - WrappedTime::new(2000),
             ChronoDuration::milliseconds(-1000)
+        );
+    }
+
+    #[test]
+    fn test_add() {
+        let a = WrappedTime::new(0);
+        let b = WrappedTime::new(1000);
+
+        assert_eq!(a + b, WrappedTime::new(1000));
+        assert_eq!(b + Duration::from_millis(2000), WrappedTime::new(3000));
+        assert_eq!(
+            b + ChronoDuration::milliseconds(2000),
+            WrappedTime::new(3000)
         );
     }
 


### PR DESCRIPTION
This PR (https://github.com/cBournhonesque/lightyear/pull/80) mainly fixed the sync process between client-server even on tick wrap-around.

However there was still another issue:
- on replication receive, we only accept messages that have `tick > latest_tick` but the latest_tick could be from a long time ago and be wrapped around, so we would have `tick < latest_tick` even for a later tick
- on send side, we would send messages with a `last_action_tick` that could be from a very long time ago, so we would get the same wrap-around problems.

There are 2 potential solutions:
- change Tick to be a u32, which is valid for 2 years without wrap-around with 64Hz.
- run a periodic method (every 5 minutes or so) that:
  - receive-side: updates the `latest_tick` for every group_channel that wasn't updated in a while. If it's been a long-time since we got an update, we know that it's as if that ReplicationGroup has  'applied' latest_tick and is at that state.
  - send-side: updates the `last_action_tick` for every group_chanenl that wasn't updated in a while to None, meaning that there's no more conditions where we need to make sure that the Update is applied after the Action (since the last action was a very long time ago)