### PR TITLE
Create TickEvent to update the input-buffer ticks upon tick snap

### DIFF
--- a/.idea/bevy_lightyear.iml
+++ b/.idea/bevy_lightyear.iml
@@ -35,6 +35,7 @@
       <sourceFolder url="file://$MODULE_DIR$/examples/replication_groups/src" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/examples/simple_box/src" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/examples/stepper/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/lightyear/tests" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/vendor/wtransport/wtransport/src" isTestSource="false" />
       <excludeFolder url="file://$MODULE_DIR$/examples/leafwing_inputs/target" />
       <excludeFolder url="file://$MODULE_DIR$/target" />

--- a/lightyear/src/client/input.rs
+++ b/lightyear/src/client/input.rs
@@ -3,7 +3,7 @@ use bevy::prelude::{
     not, App, EventReader, EventWriter, FixedUpdate, IntoSystemConfigs, IntoSystemSetConfigs,
     Plugin, PostUpdate, Res, ResMut, SystemSet,
 };
-use tracing::{error, info, trace};
+use tracing::{debug, error, info, trace};
 
 use crate::channel::builder::InputChannel;
 use crate::client::config::ClientConfig;
@@ -17,6 +17,7 @@ use crate::inputs::native::UserAction;
 use crate::prelude::TickManager;
 use crate::protocol::Protocol;
 use crate::shared::sets::{FixedUpdateSet, MainSet};
+use crate::shared::tick_manager::TickEvent;
 
 #[derive(Debug, Clone)]
 pub struct InputConfig {
@@ -72,7 +73,7 @@ impl<P: Protocol> Plugin for InputPlugin<P> {
         // SETS
         app.configure_sets(
             FixedUpdate,
-            ((
+            (
                 FixedUpdateSet::TickUpdate,
                 // no need to keep buffering inputs during rollback
                 InputSystemSet::BufferInputs.run_if(not(is_in_rollback)),
@@ -80,13 +81,19 @@ impl<P: Protocol> Plugin for InputPlugin<P> {
                 FixedUpdateSet::Main,
                 InputSystemSet::ClearInputEvent,
             )
-                .chain(),),
+                .chain(),
         );
         app.configure_sets(
             PostUpdate,
-            // we send inputs only every send_interval
             (
-                InputSystemSet::SendInputMessage.in_set(MainSet::Send),
+                // handle tick events from sync before sending the message
+                InputSystemSet::ReceiveTickEvents
+                    .after(MainSet::Sync)
+                    .run_if(client_is_synced::<P>),
+                // we send inputs only every send_interval
+                InputSystemSet::SendInputMessage
+                    .in_set(MainSet::Send)
+                    .run_if(client_is_synced::<P>),
                 MainSet::SendPackets,
             )
                 .chain(),
@@ -106,15 +113,17 @@ impl<P: Protocol> Plugin for InputPlugin<P> {
         // app.add_systems(PostUpdate, clear_input_events::<P>);
         app.add_systems(
             PostUpdate,
-            prepare_input_message::<P>
-                .in_set(InputSystemSet::SendInputMessage)
-                .run_if(client_is_synced::<P>),
+            (
+                prepare_input_message::<P>.in_set(InputSystemSet::SendInputMessage),
+                receive_tick_events::<P>.in_set(InputSystemSet::ReceiveTickEvents),
+            ),
         );
     }
 }
 
 #[derive(SystemSet, Debug, Hash, PartialEq, Eq, Clone, Copy)]
 pub enum InputSystemSet {
+    // FIXED UPDATE
     /// System Set to write the input events to the input buffer.
     /// The User should add their system here!!
     BufferInputs,
@@ -122,7 +131,11 @@ pub enum InputSystemSet {
     WriteInputEvent,
     /// System Set to clear the input events (otherwise bevy clears events every frame, not every tick)
     ClearInputEvent,
-    /// System Set to prepare the input message
+
+    // POST UPDATE
+    /// In case we suddenly changed the ticks during sync, we need to update out input buffers to the new ticks
+    ReceiveTickEvents,
+    /// System Set to prepare the input message (in Send SystemSet)
     SendInputMessage,
 }
 
@@ -160,6 +173,26 @@ fn write_input_event<P: Protocol>(
     input_events.send(InputEvent::new(connection.get_input(tick), ()));
 }
 
+fn receive_tick_events<P: Protocol>(
+    mut tick_events: EventReader<TickEvent>,
+    mut connection: ResMut<ConnectionManager<P>>,
+) {
+    for tick_event in tick_events.read() {
+        match tick_event {
+            TickEvent::TickSnap { old_tick, new_tick } => {
+                // if the tick got updated, update our inputs to match our new ticks
+                connection.input_buffer.start_tick.map(|start_tick| {
+                    info!(
+                        "Receive tick snap event {:?}. Updating input buffer start_tick!",
+                        tick_event
+                    );
+                    connection.input_buffer.start_tick = Some(start_tick + (*new_tick - *old_tick))
+                });
+            }
+        }
+    }
+}
+
 // Take the input buffer, and prepare the input message to send to the server
 fn prepare_input_message<P: Protocol>(
     mut connection: ResMut<ConnectionManager<P>>,
@@ -194,7 +227,7 @@ fn prepare_input_message<P: Protocol>(
     if !message.is_empty() {
         // TODO: should we provide variants of each user-facing function, so that it pushes the error
         //  to the ConnectionEvents?
-        trace!("sending input message: {:?}", message.end_tick);
+        debug!("sending input message: {:?}", message.end_tick);
         connection
             .send_message::<InputChannel, _>(message)
             .unwrap_or_else(|err| {
@@ -210,15 +243,3 @@ fn prepare_input_message<P: Protocol>(
     connection.input_buffer.pop(interpolation_tick);
     // .pop(current_tick - (message_len + 1));
 }
-
-// on the client:
-// - FixedUpdate: before physics but after increment tick,
-//   - rollback: we get the input from the history -> HERE GIVE THE USER AN OPPORTUNITY TO CUSTOMIZE.
-//        BY DEFAULT WE JUST TAKE THE INPUT FOR THE TICK, BUT MAYBE WE WANT TO DO SOMETHING ELSE?
-//        SLIGHTLY MODIFY THE INPUT? IF NONE, REPEAT THE PREVIOUS ONE?
-//   - non rollback:
-//         we get the input from keyboard/mouse and store it in the InputBuffer
-//         use input for predicted entities
-//   - can use system piping?
-// - Send:
-//   - we read the

--- a/lightyear/src/client/plugin.rs
+++ b/lightyear/src/client/plugin.rs
@@ -24,7 +24,6 @@ use crate::protocol::Protocol;
 use crate::shared::plugin::SharedPlugin;
 use crate::shared::replication::systems::add_replication_send_systems;
 use crate::shared::sets::{FixedUpdateSet, MainSet};
-use crate::shared::systems::tick::increment_tick;
 use crate::shared::time_manager::{is_ready_to_send, TimePlugin};
 use crate::transport::io::Io;
 
@@ -141,6 +140,7 @@ impl<P: Protocol> Plugin for ClientPlugin<P> {
                     (
                         ReplicationSet::SendEntityUpdates,
                         ReplicationSet::SendComponentUpdates,
+                        // NOTE: SendDespawnsAndRemovals is not in MainSet::Send because we need to run them every frame
                         MainSet::SendPackets,
                     )
                         .in_set(MainSet::Send)
@@ -167,7 +167,7 @@ impl<P: Protocol> Plugin for ClientPlugin<P> {
             .add_systems(
                 PreUpdate,
                 (
-                    (receive::<P>).in_set(MainSet::Receive),
+                    receive::<P>.in_set(MainSet::Receive),
                     apply_deferred.in_set(MainSet::ReceiveFlush),
                 ),
             )

--- a/lightyear/src/server/connection.rs
+++ b/lightyear/src/server/connection.rs
@@ -488,7 +488,7 @@ impl<P: Protocol> Connection<P> {
                                 }
                                 InputMessageKind::Native => {
                                     let input_message = message.try_into().unwrap();
-                                    trace!("Received input message: {:?}", input_message.end_tick);
+                                    debug!("Received input message: {:?}", input_message.end_tick);
                                     self.input_buffer.update_from_message(input_message);
                                 }
                                 InputMessageKind::None => {

--- a/lightyear/src/server/plugin.rs
+++ b/lightyear/src/server/plugin.rs
@@ -25,7 +25,6 @@ use crate::shared::plugin::SharedPlugin;
 use crate::shared::replication::systems::add_replication_send_systems;
 use crate::shared::sets::ReplicationSet;
 use crate::shared::sets::{FixedUpdateSet, MainSet};
-use crate::shared::systems::tick::increment_tick;
 use crate::shared::time_manager::{is_ready_to_send, TimePlugin};
 use crate::transport::io::Io;
 

--- a/lightyear/src/shared/replication/receive.rs
+++ b/lightyear/src/shared/replication/receive.rs
@@ -196,7 +196,7 @@ impl<P: Protocol> ReplicationReceiver<P> {
         let _span = trace_span!("Apply received replication message to world").entered();
         match replication {
             ReplicationMessageData::Actions(m) => {
-                trace!(?tick, ?m, "Received replication actions");
+                debug!(?tick, ?m, "Received replication actions");
                 // NOTE: order matters here, because some components can depend on other entities.
                 // These components could even form a cycle, for example A.HasWeapon(B) and B.HasHolder(A)
                 // Our solution is to first handle spawn for all entities separately.
@@ -308,7 +308,7 @@ impl<P: Protocol> ReplicationReceiver<P> {
                 }
             }
             ReplicationMessageData::Updates(m) => {
-                trace!(?tick, ?m, "Received replication updates");
+                debug!(?tick, ?m, "Received replication updates");
                 for (entity, components) in m.updates.into_iter() {
                     debug!(?components, remote_entity = ?entity, "Received UpdateComponent");
                     // update the entity only if it exists

--- a/lightyear/src/shared/replication/send.rs
+++ b/lightyear/src/shared/replication/send.rs
@@ -314,7 +314,7 @@ impl<P: Protocol> ReplicationSender<P> {
         }
 
         if !messages.is_empty() {
-            trace!(?messages, "Sending replication messages");
+            debug!(?messages, "Sending replication messages");
         }
 
         // clear send buffers

--- a/lightyear/src/shared/systems/mod.rs
+++ b/lightyear/src/shared/systems/mod.rs
@@ -1,3 +1,2 @@
 //! Bevy [`System`](bevy::prelude::System) that are shared between the server and client
 pub mod events;
-pub mod tick;

--- a/lightyear/src/shared/systems/tick.rs
+++ b/lightyear/src/shared/systems/tick.rs
@@ -1,8 +1,0 @@
-use crate::prelude::TickManager;
-use bevy::prelude::ResMut;
-use tracing::trace;
-
-pub fn increment_tick(mut tick_manager: ResMut<TickManager>) {
-    tick_manager.increment_tick();
-    trace!("increment_tick! new tick: {:?}", tick_manager.tick());
-}

--- a/lightyear/src/shared/tick_manager.rs
+++ b/lightyear/src/shared/tick_manager.rs
@@ -1,14 +1,54 @@
 //! Module to handle the [`Tick`], a sequence number incremented at each [`bevy::prelude::FixedUpdate`] schedule run
-use std::time::Duration;
+use bevy::utils::Duration;
 
 use crate::_reexport::WrappedTime;
-use bevy::prelude::Resource;
+use crate::client::prediction::plugin::is_in_rollback;
+use crate::client::prediction::Rollback;
+use crate::prelude::FixedUpdateSet;
+use bevy::prelude::*;
 use tracing::{info, trace};
 
 use crate::utils::wrapping_id::wrapping_id;
 
 // Internal id that tracks the Tick value for the server and the client
 wrapping_id!(Tick);
+
+pub struct TickManagerPlugin {
+    pub(crate) config: TickConfig,
+}
+
+// TODO: we actually don't need this on server-side..
+#[derive(Event, Debug)]
+pub enum TickEvent {
+    TickSnap { old_tick: Tick, new_tick: Tick },
+}
+
+fn increment_tick(mut tick_manager: ResMut<TickManager>) {
+    tick_manager.increment_tick();
+    trace!("increment_tick! new tick: {:?}", tick_manager.tick());
+}
+
+impl Plugin for TickManagerPlugin {
+    fn build(&self, app: &mut App) {
+        app
+            // EVENTS
+            .add_event::<TickEvent>()
+            // RESOURCES
+            // TODO: avoid clone
+            .insert_resource(TickManager::from_config(self.config.clone()))
+            // SYSTEMS
+            .add_systems(
+                FixedUpdate,
+                (
+                    increment_tick
+                        .in_set(FixedUpdateSet::TickUpdate)
+                        // run if there is no rollback resource, or if we are not in rollback
+                        .run_if(not(resource_exists::<Rollback>()).or_else(not(is_in_rollback))),
+                    apply_deferred.in_set(FixedUpdateSet::MainFlush),
+                ),
+            );
+    }
+}
 
 #[derive(Clone)]
 pub struct TickConfig {
@@ -45,8 +85,13 @@ impl TickManager {
         self.tick += 1;
         trace!(new_tick = ?self.tick, "incremented tick")
     }
-    pub(crate) fn set_tick_to(&mut self, tick: Tick) {
+    pub(crate) fn set_tick_to(&mut self, tick: Tick) -> TickEvent {
+        let old_tick = self.tick;
         self.tick = tick;
+        TickEvent::TickSnap {
+            old_tick,
+            new_tick: tick,
+        }
     }
 
     /// Get the current tick of the local app

--- a/lightyear/src/shared/time_manager.rs
+++ b/lightyear/src/shared/time_manager.rs
@@ -151,6 +151,11 @@ impl TimeManager {
     pub fn current_time(&self) -> WrappedTime {
         self.wrapped_time
     }
+
+    #[cfg(test)]
+    pub(crate) fn set_current_time(&mut self, time: WrappedTime) {
+        self.wrapped_time = time;
+    }
 }
 
 mod wrapped_time {

--- a/lightyear/src/tests/integration/mod.rs
+++ b/lightyear/src/tests/integration/mod.rs
@@ -1,0 +1,1 @@
+mod tick_wrapping;

--- a/lightyear/src/tests/integration/tick_wrapping.rs
+++ b/lightyear/src/tests/integration/tick_wrapping.rs
@@ -1,0 +1,207 @@
+use crate::_reexport::WrappedTime;
+use crate::prelude::client::{InputSystemSet, SyncConfig};
+use crate::prelude::server::InputEvent;
+use crate::prelude::*;
+use crate::tests::protocol::*;
+use crate::tests::stepper::{BevyStepper, Step};
+use bevy::prelude::*;
+use std::time::Duration;
+
+fn press_input(mut connection: ResMut<ClientConnectionManager>, tick_manager: Res<TickManager>) {
+    connection.add_input(MyInput(0), tick_manager.tick());
+}
+fn increment(mut query: Query<&mut Component1>, mut ev: EventReader<InputEvent<MyInput>>) {
+    for _ in ev.read() {
+        for mut c in query.iter_mut() {
+            c.0 += 1.0;
+        }
+    }
+}
+
+/// This test checks that input handling and replication still works if the client connect when the server
+/// is on a new tick generation
+#[test]
+fn test_sync_after_tick_wrap() {
+    let frame_duration = Duration::from_secs_f32(1.0 / 60.0);
+    let tick_duration = Duration::from_millis(10);
+    let shared_config = SharedConfig {
+        enable_replication: false,
+        tick: TickConfig::new(tick_duration),
+        ..Default::default()
+    };
+    let link_conditioner = LinkConditionerConfig {
+        incoming_latency: Duration::from_millis(20),
+        incoming_jitter: Duration::from_millis(0),
+        incoming_loss: 0.0,
+    };
+    let mut stepper = BevyStepper::new(
+        shared_config,
+        SyncConfig::default(),
+        client::PredictionConfig::default(),
+        client::InterpolationConfig::default(),
+        link_conditioner,
+        frame_duration,
+    );
+
+    // set time to end of wrapping
+    let new_tick = Tick(u16::MAX - 100);
+    let new_time = WrappedTime::from_duration(tick_duration * (new_tick.0 as u32));
+    stepper
+        .server_app
+        .world
+        .resource_mut::<TimeManager>()
+        .set_current_time(new_time);
+    stepper
+        .server_app
+        .world
+        .resource_mut::<TickManager>()
+        .set_tick_to(new_tick);
+
+    stepper.client_app.add_systems(
+        FixedUpdate,
+        press_input.in_set(InputSystemSet::BufferInputs),
+    );
+    stepper
+        .server_app
+        .add_systems(FixedUpdate, increment.in_set(FixedUpdateSet::Main));
+
+    let server_entity = stepper
+        .server_app
+        .world
+        .spawn((
+            Component1(0.0),
+            Replicate {
+                replication_target: NetworkTarget::All,
+                ..default()
+            },
+        ))
+        .id();
+
+    for i in 0..200 {
+        stepper.frame_step();
+    }
+    stepper.init();
+    dbg!(&stepper.server_tick());
+    dbg!(&stepper.client_tick());
+    let server_value = stepper
+        .server_app
+        .world
+        .get::<Component1>(server_entity)
+        .unwrap();
+
+    // make sure the client receives the replication message
+    for i in 0..5 {
+        stepper.frame_step();
+    }
+
+    let client_entity = *stepper
+        .client_app
+        .world
+        .resource::<ClientConnectionManager>()
+        .replication_receiver
+        .remote_entity_map
+        .get_local(server_entity)
+        .unwrap();
+    assert_eq!(
+        stepper
+            .client_app
+            .world
+            .get::<Component1>(client_entity)
+            .unwrap(),
+        &Component1(47.0)
+    );
+}
+
+/// This test checks that input handling and replication still works if the client connect when the server
+/// is u16::MAX ticks ahead
+#[test]
+fn test_sync_after_tick_half_wrap() {
+    let frame_duration = Duration::from_secs_f32(1.0 / 60.0);
+    let tick_duration = Duration::from_millis(10);
+    let shared_config = SharedConfig {
+        enable_replication: false,
+        tick: TickConfig::new(tick_duration),
+        ..Default::default()
+    };
+    let link_conditioner = LinkConditionerConfig {
+        incoming_latency: Duration::from_millis(20),
+        incoming_jitter: Duration::from_millis(0),
+        incoming_loss: 0.0,
+    };
+    let mut stepper = BevyStepper::new(
+        shared_config,
+        SyncConfig::default(),
+        client::PredictionConfig::default(),
+        client::InterpolationConfig::default(),
+        link_conditioner,
+        frame_duration,
+    );
+
+    // set time to end of wrapping
+    let new_tick = Tick(u16::MAX / 2 - 10);
+    let new_time = WrappedTime::from_duration(tick_duration * (new_tick.0 as u32));
+    stepper
+        .server_app
+        .world
+        .resource_mut::<TimeManager>()
+        .set_current_time(new_time);
+    stepper
+        .server_app
+        .world
+        .resource_mut::<TickManager>()
+        .set_tick_to(new_tick);
+
+    stepper.client_app.add_systems(
+        FixedUpdate,
+        press_input.in_set(InputSystemSet::BufferInputs),
+    );
+    stepper
+        .server_app
+        .add_systems(FixedUpdate, increment.in_set(FixedUpdateSet::Main));
+
+    let server_entity = stepper
+        .server_app
+        .world
+        .spawn((
+            Component1(0.0),
+            Replicate {
+                replication_target: NetworkTarget::All,
+                ..default()
+            },
+        ))
+        .id();
+
+    for i in 0..200 {
+        stepper.frame_step();
+    }
+    stepper.init();
+    dbg!(&stepper.server_tick());
+    dbg!(&stepper.client_tick());
+    let server_value = stepper
+        .server_app
+        .world
+        .get::<Component1>(server_entity)
+        .unwrap();
+
+    // make sure the client receives the replication message
+    for i in 0..5 {
+        stepper.frame_step();
+    }
+
+    let client_entity = *stepper
+        .client_app
+        .world
+        .resource::<ClientConnectionManager>()
+        .replication_receiver
+        .remote_entity_map
+        .get_local(server_entity)
+        .unwrap();
+    assert_eq!(
+        stepper
+            .client_app
+            .world
+            .get::<Component1>(client_entity)
+            .unwrap(),
+        &Component1(47.0)
+    );
+}

--- a/lightyear/src/tests/mod.rs
+++ b/lightyear/src/tests/mod.rs
@@ -3,6 +3,7 @@
 #![allow(dead_code)]
 pub mod client;
 mod examples;
+mod integration;
 pub mod protocol;
 pub mod server;
 pub mod stepper;


### PR DESCRIPTION
This PR:
- adds a TickEvent during the sync stage when the client tick snaps forward/back.
- the InputBuffer will update the existing buffer ticks when a TickSnap occurs
- added integration tests for correct input-handling/replication after server tick reached 33k, or 66k ticks
- created a TickManagerPlugin to centralize all tick-related systems