### PR TITLE
fix lightyear version for lightyear-benches

### DIFF
--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["game-development", "network-programming"]
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-lightyear = { version = "0.6.0", path = "../lightyear" }
+lightyear = { version = "0.7.0", path = "../lightyear" }
 crossbeam-channel = "0.5.10"
 anyhow = { version = "1.0.75", features = [] }
 bevy = { version = "0.12", features = ["bevy_core_pipeline"] }


### PR DESCRIPTION
This merge fixes the following compilation error:
```
error: failed to select a version for the requirement `lightyear = "^0.6.0"`
candidate versions found which didn't match: 0.7.0
...
```