### PR TITLE
Reduce buffer copy

### DIFF
--- a/lightyear/src/transport/webtransport/client.rs
+++ b/lightyear/src/transport/webtransport/client.rs
@@ -111,6 +111,7 @@ impl PacketReceiver for WebTransportClientPacketReceiver {
     fn recv(&mut self) -> std::io::Result<Option<(&mut [u8], SocketAddr)>> {
         match self.from_server_receiver.try_recv() {
             Ok(data) => {
+                // Ok(Some((data.payload().as_mut(), self.server_addr)))
                 self.buffer[..data.len()].copy_from_slice(data.payload().as_ref());
                 Ok(Some((&mut self.buffer[..data.len()], self.server_addr)))
             }


### PR DESCRIPTION
Webtransport: we get a Bytes so looks like there's no need to copy the data?