### PR TITLE
Some WebTransport improvements

### DIFF
--- a/examples/bullet_prespawn/Cargo.toml
+++ b/examples/bullet_prespawn/Cargo.toml
@@ -35,5 +35,5 @@ tokio = { version = "1.34.0", features = [
   "rt",
   "rt-multi-thread",
   "net",
-  "time"
-]}
+  "time",
+] }

--- a/examples/client_replication/Cargo.toml
+++ b/examples/client_replication/Cargo.toml
@@ -31,8 +31,8 @@ mock_instant = "0.3"
 metrics-exporter-prometheus = { version = "0.13.0", optional = true }
 bevy-inspector-egui = "0.22.1"
 tokio = { version = "1.34.0", features = [
-    "rt",
-    "rt-multi-thread",
-    "net",
-    "time"
-]}
+  "rt",
+  "rt-multi-thread",
+  "net",
+  "time",
+] }

--- a/examples/leafwing_inputs/Cargo.toml
+++ b/examples/leafwing_inputs/Cargo.toml
@@ -37,5 +37,5 @@ tokio = { version = "1.34.0", features = [
   "rt",
   "rt-multi-thread",
   "net",
-  "time"
-]}
+  "time",
+] }

--- a/examples/replication_groups/Cargo.toml
+++ b/examples/replication_groups/Cargo.toml
@@ -31,8 +31,8 @@ mock_instant = "0.3"
 metrics-exporter-prometheus = { version = "0.13.0", optional = true }
 bevy-inspector-egui = "0.22.1"
 tokio = { version = "1.34.0", features = [
-    "rt",
-    "rt-multi-thread",
-    "net",
-    "time"
-]}
+  "rt",
+  "rt-multi-thread",
+  "net",
+  "time",
+] }

--- a/examples/replication_groups/src/protocol.rs
+++ b/examples/replication_groups/src/protocol.rs
@@ -6,7 +6,7 @@ use lightyear::prelude::*;
 use lightyear::shared::replication::components::ReplicationGroup;
 use serde::{Deserialize, Serialize};
 use std::collections::VecDeque;
-use tracing::{info, trace};
+use tracing::{debug, info, trace};
 
 // Player
 #[derive(Bundle)]
@@ -34,9 +34,9 @@ impl PlayerBundle {
             color: PlayerColor(color),
             replicate: Replicate {
                 // prediction_target: NetworkTarget::None,
-                prediction_target: NetworkTarget::Only(vec![id]),
+                prediction_target: NetworkTarget::Single(id),
                 // interpolation_target: NetworkTarget::None,
-                interpolation_target: NetworkTarget::AllExcept(vec![id]),
+                interpolation_target: NetworkTarget::AllExceptSingle(id),
                 // this is the default: the replication group id is a u64 value generated from the entity (`entity.to_bits()`)
                 replication_group: ReplicationGroup::FromEntity,
                 ..default()
@@ -57,9 +57,9 @@ impl TailBundle {
             length: TailLength(length),
             replicate: Replicate {
                 // prediction_target: NetworkTarget::None,
-                prediction_target: NetworkTarget::Only(vec![id]),
+                prediction_target: NetworkTarget::Single(id),
                 // interpolation_target: NetworkTarget::None,
-                interpolation_target: NetworkTarget::AllExcept(vec![id]),
+                interpolation_target: NetworkTarget::AllExceptSingle(id),
                 // replicate this entity within the same replication group as the parent
                 replication_group: ReplicationGroup::Group(parent.to_bits()),
                 ..default()
@@ -187,9 +187,9 @@ pub struct PlayerParent(pub(crate) Entity);
 
 impl<'a> MapEntities<'a> for PlayerParent {
     fn map_entities(&mut self, entity_mapper: Box<dyn EntityMapper + 'a>) {
-        info!("mapping parent entity {:?}", self.0);
+        debug!("mapping parent entity {:?}", self.0);
         self.0.map_entities(entity_mapper);
-        info!("After mapping: {:?}", self.0);
+        debug!("After mapping: {:?}", self.0);
     }
 
     fn entities(&self) -> EntityHashSet<Entity> {

--- a/examples/simple_box/Cargo.toml
+++ b/examples/simple_box/Cargo.toml
@@ -31,8 +31,8 @@ mock_instant = "0.3"
 metrics-exporter-prometheus = { version = "0.13.0", optional = true }
 bevy-inspector-egui = "0.22.1"
 tokio = { version = "1.34.0", features = [
-    "rt",
-    "rt-multi-thread",
-    "net",
-    "time"
-]}
+  "rt",
+  "rt-multi-thread",
+  "net",
+  "time",
+] }

--- a/lightyear/src/client/interpolation/interpolate.rs
+++ b/lightyear/src/client/interpolation/interpolate.rs
@@ -1,6 +1,6 @@
 use bevy::ecs::system::EntityCommands;
 use bevy::prelude::{Commands, Component, Entity, Mut, Query, Res, ResMut};
-use tracing::{info, trace};
+use tracing::{debug, info, trace};
 
 use crate::_reexport::ComponentProtocol;
 use crate::client::components::{ComponentSyncMode, SyncComponent, SyncMetadata};
@@ -200,17 +200,17 @@ pub(crate) fn interpolate<C: Component + Clone, P: Protocol>(
     };
 
     for (entity, component, status) in query.iter_mut() {
-        info!("checking if we do interpolation");
+        trace!("checking if we do interpolation");
         let entity_commands = commands.entity(entity);
         // NOTE: it is possible that we reach start_tick when end_tick is not set
         if let Some((start_tick, start_value)) = &status.start {
             if status.current == *start_tick {
-                info!(?entity, ?start_tick, "setting component to start value");
+                trace!(?entity, ?start_tick, "setting component to start value");
                 set_value(entity_commands, component, start_value.clone());
                 continue;
             }
             if let Some((end_tick, end_value)) = &status.end {
-                info!(?entity, ?start_tick, interpolate_tick=?status.current, ?end_tick, "doing interpolation!");
+                trace!(?entity, ?start_tick, interpolate_tick=?status.current, ?end_tick, "doing interpolation!");
                 if status.current == *end_tick {
                     set_value(entity_commands, component, end_value.clone());
                     continue;

--- a/lightyear/src/client/interpolation/interpolate.rs
+++ b/lightyear/src/client/interpolation/interpolate.rs
@@ -200,16 +200,17 @@ pub(crate) fn interpolate<C: Component + Clone, P: Protocol>(
     };
 
     for (entity, component, status) in query.iter_mut() {
+        info!("checking if we do interpolation");
         let entity_commands = commands.entity(entity);
         // NOTE: it is possible that we reach start_tick when end_tick is not set
         if let Some((start_tick, start_value)) = &status.start {
             if status.current == *start_tick {
-                trace!(?entity, ?start_tick, "setting component to start value");
+                info!(?entity, ?start_tick, "setting component to start value");
                 set_value(entity_commands, component, start_value.clone());
                 continue;
             }
             if let Some((end_tick, end_value)) = &status.end {
-                trace!(?entity, ?start_tick, interpolate_tick=?status.current, ?end_tick, "doing interpolation!");
+                info!(?entity, ?start_tick, interpolate_tick=?status.current, ?end_tick, "doing interpolation!");
                 if status.current == *end_tick {
                     set_value(entity_commands, component, end_value.clone());
                     continue;

--- a/lightyear/src/client/systems.rs
+++ b/lightyear/src/client/systems.rs
@@ -43,9 +43,11 @@ pub(crate) fn receive<P: Protocol>(world: &mut World) {
                                         // UPDATE: update client state, send keep-alives, receive packets from io, update connection sync state
                                         time_manager.update(delta);
                                         trace!(time = ?time_manager.current_time(), tick = ?tick_manager.tick(), "receive");
-                                        netcode
+                                        let _ = netcode
                                             .try_update(delta.as_secs_f64(), io.deref_mut())
-                                            .unwrap();
+                                            .map_err(|e| {
+                                                error!("Error updating netcode: {}", e);
+                                            });
 
                                         // only start the connection (sending messages, sending pings, starting sync, etc.)
                                         // once we are connected
@@ -152,9 +154,11 @@ pub fn send<P: Protocol>(
         .send_packets(time_manager.as_ref(), tick_manager.as_ref())
         .unwrap();
     for packet_byte in packet_bytes {
-        netcode
+        let _ = netcode
             .send(packet_byte.as_slice(), io.deref_mut())
-            .unwrap();
+            .map_err(|e| {
+                error!("Error sending packet: {}", e);
+            });
     }
 
     // no need to clear the connection, because we already std::mem::take it

--- a/lightyear/src/transport/webtransport/server.rs
+++ b/lightyear/src/transport/webtransport/server.rs
@@ -107,6 +107,7 @@ impl WebTransportServerSocket {
         to_client_channels.lock().unwrap().remove(&client_addr);
         from_client_handle.abort();
         to_client_handle.abort();
+        // TODO: need to disconnect the client in netcode
     }
 }
 


### PR DESCRIPTION
- Remove the use of tokio::select in webtransport-server and instead spawn separate tasks, so that cancelled futures don't introduce issues
- When the quic connection in closed, close the webtransport-server tasks and webtransport-client tasks (for native only, not wasm)