### PR TITLE
add a ToggleActions resource on the client to control whether or not …

### DIFF
--- a/lightyear/src/lib.rs
+++ b/lightyear/src/lib.rs
@@ -123,7 +123,9 @@ pub mod prelude {
         pub use crate::connection::client::{ClientConnection, NetClient, NetConfig};
 
         #[cfg(feature = "leafwing")]
-        pub use crate::client::input_leafwing::{LeafwingInputConfig, LeafwingInputPlugin};
+        pub use crate::client::input_leafwing::{
+            LeafwingInputConfig, LeafwingInputPlugin, ToggleActions,
+        };
     }
     pub mod server {
         pub use crate::server::config::{NetcodeConfig, PacketConfig, ServerConfig};


### PR DESCRIPTION
Fixes: https://github.com/cBournhonesque/lightyear/issues/135

This should let the user control whether or not one Leafwing `Actionlike` is active or not.