### PR TITLE
Improve visual interpolation

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -33,6 +33,7 @@
     - [Inputs](./concepts/advanced_replication/inputs.md)
     - [Interpolation](./boncepts/advanced_replication/interpolation.md)
     - [Prediction](./concepts/advanced_replication/prediction.md)
+    - [Visual Interpolation](./concepts/advanced_replication/visual_interpolation.md)
     - [Prespawning](./concepts/advanced_replication/prespawning.md)
     - [ComponentSyncMode](./concepts/advanced_replication/component_sync_mode.md)
     - [Interest management](./concepts/advanced_replication/interest_management.md)

--- a/book/src/concepts/advanced_replication/visual_interpolation.md
+++ b/book/src/concepts/advanced_replication/visual_interpolation.md
@@ -1,0 +1,96 @@
+# Visual Interpolation
+
+Usually, you will want your simulation (physics, etc.) to run during the `FixedUpdate` schedule.
+
+The reason is that if you run this logic during the `Update` schedule, the simulation will run at a rate that is 
+influenced by the frame rate of the client. This can lead to inconsistent results between clients: a beefy machine
+might have a higher FPS, which would translate into a "faster" game/simulation.
+
+This article by GafferOnGames talks a bit more about this: [Fix Your Timestep](https://gafferongames.com/post/fix_your_timestep/)
+
+
+The issue is that this can cause the movement of your entity to appear jittery (if the entity only moves during the FixedUpdate schedule). There could be frames where the FixedUpdate schedule does not run at all, and frames where the FixedUpdate schedule runs multiple times in a row.
+
+To solve this, `lightyear` provides the `VisualInterpolation` plugin.
+
+The plugin will take care of interpolating the position of the entity between the last two `FixedUpdate` ticks, thus making sure that 
+the entity is making smooth progress on every frame.
+
+## How does it work?
+
+There are 3 main systems:
+- during FixedUpdate, we run `update_visual_interpolation_status` after the FixedUpdate::Main set (meaning that the simulation has run).
+  In that system we keep track of the value of the component on the current tick and the previous tick
+- during PostUpdate, we run `visual_interpolation` which will interpolate the value of the component between the last two tick values
+  stored in the `update_visual_interpolation_status` system. We use the `Time<Fixed>::overstep_percentage()` to determine how much to interpolate
+  between the two ticks
+- during PreUpdate, we run `restore_from_visual_interpolation` to restore the component value to what it was before visual interpolation. This is necessary because
+  the interpolated value is not the "real" value of the component for the simulation, it's just a visual representation of the component. We need to restore the real value
+  before the simulation runs again.
+
+Here is an example:
+- you have a component that gets incremented by 1.0 at every fixed update step (and starts at 0.0)
+- the fixed-update step takes 9ms, and the frame takes 12ms
+
+Frame 0:
+- tick is 0, the component is at 0.0
+ 
+Frame 1:
+- We run FixedUpdate once in this frame:
+    - tick is 1
+    - `update_visual_interpolation_status`: set current_value for tick 1 is 1.0, previous_value is None
+- `visual_interpolation`: we do not interpolate because we don't have 2 ticks to interpolate between yet. So the component value is 1.0
+- the time is at 12ms, the overstep_percentage is 0.33
+
+Frame 2:
+- `restore_from_visual_interpolation`: we restore the component to 1.0
+- We run FixedUpdate once in this frame:
+    - tick is 2
+    - `update_visual_interpolation_status`: set current_value for tick 2 is 2.0, previous_value is 1.0
+- `visual_interpolation`: the time is 24ms, the overstep percentage is 0.667, we interpolate between 1.0 and 2.0 so the component is now at 1.667
+
+Frame 3:
+- `restore_from_visual_interpolation`: we restore the component to 2.0
+- We run FixedUpdate twice in this frame:
+    - tick is 3
+    - `update_visual_interpolation_status`: set current_value for tick 3 is 3.0, previous_value is 2.0
+    - tick is 4
+    - `update_visual_interpolation_status`: set current_value for tick 4 is 4.0, previous_value is 3.0
+- `visual_interpolation`: the time is 36, the overstep percentage is 0.0, we interpolate between 3.0 and 4.0 so the component is now at 3.0
+ 
+Frame 4:
+- `restore_from_visual_interpolation`: we restore the component to 4.0
+- We run FixedUpdate once in this frame:
+    - tick is 5
+    - `update_visual_interpolation_status`: set current_value for tick 5 is 5.0, previous_value is 4.0
+- `visual_interpolation`: the time is 48, the overstep percentage is 0.33, we interpolate between 5.0 and 4.0 so the component is now at 4.33
+
+So overall the component value progresses by 1.33 every frame, which is what we expect because a frame duration (12ms) is 1.33 times the fixed update duration (9ms).
+
+## Usage
+
+Visual interpolation is currently only available per component, and you need to enable it by adding a plugin:
+
+```rust,noplayground
+app.add_plugins(VisualInterpolationPlugin::<Component1, MyProtocol>::default());
+```
+
+You will also need to add the `VisualInterpolateState` component to any entity you want to enable visual interpolation for:
+```rust,noplayground
+fn spawn_entity(mut commands: Commands) {
+    commands.spawn().insert(VisualInterpolateState::<Component1>::default());
+}
+```
+
+## Caveats
+
+- The `VisualInterpolationPlugin` is currently only available for components that are present in the protocol. This is because the plugin
+  needs to know how interpolation will be performed. The interpolation function is registered on the protocol directly instead of the component
+  to circumvent the orphan rule (we want users to be able to define a custom interpolation function for external components)
+  - NOTE: This will probably be changed in the future, by letting the user provide a custom interpolation function when creating the plugin.
+ 
+- The interpolation doesn't progress at the same rate at the very beginning, because we wait until there are two ticks available before we start doing the interpolation.
+  (you can see in the example above that on the first frame the component is 1.0, and on the second frame 1.667, so the component value didn't progress by 1.33 like it will
+  in the other frames).
+  - NOTE: it's probably possible to avoid this by just not displaying the component until we have 2 ticks available, but I haven't implemented this yet.
+

--- a/book/src/concepts/advanced_replication/visual_interpolation.md
+++ b/book/src/concepts/advanced_replication/visual_interpolation.md
@@ -16,6 +16,26 @@ To solve this, `lightyear` provides the `VisualInterpolation` plugin.
 The plugin will take care of interpolating the position of the entity between the last two `FixedUpdate` ticks, thus making sure that 
 the entity is making smooth progress on every frame.
 
+There are 3 main ways we can interpolate the component:
+- #1: `lerp(previous_tick_value, current_tick_value, time.overstep_fraction())`: interpolate between the previous tick value and the current tick value.
+  - PROS: relatively simple to implement
+  - CONS:
+    - introduces a visual delay of 1 simulation tick
+    - need to store the previous and current value (so extra component clones)
+- #2: simulate an extra step during FixedUpdate to compute the `future_tick_value`, then interpolate between the `current_tick_value` and the `future_tick_value`
+  `lerp(current_tick_value, future_tick_value, time.overstep_fraction())`
+  - PROS: might be less accurate? (we simulate 1 tick ahead in the future, but maybe that simulation is incorrect because we ran it ahead of when it should have run)
+  - CONS:
+    - need to store the previous and current value (so extra component clones)
+- #3: do not interpolate, but instead run the simulation (FixedUpdate schedule) for one 'partial' tick, i.e. we use (time.overstep_fraction() * fixed_timestep) as the timestep for the simulation.
+  - PROS:
+    - no visual delay, 
+    - no need to store copies of the components 
+  - CONS: 
+    - we might run many extra simulation steps if we run an extra partial step in every frame
+
+Currently lightyear only provides option 1: interpolate between the previous tick value and the current tick value.
+
 ## How does it work?
 
 There are 3 main systems:

--- a/examples/replication_groups/src/client.rs
+++ b/examples/replication_groups/src/client.rs
@@ -6,7 +6,9 @@ use bevy::app::PluginGroupBuilder;
 use bevy::prelude::*;
 use bevy::utils::Duration;
 use lightyear::_reexport::LinearInterpolator;
+use lightyear::client::interpolation::add_visual_interpolation_systems;
 use lightyear::connection::netcode::NetcodeServer;
+use lightyear::prelude::client::InterpolationSet::VisualInterpolation;
 use lightyear::prelude::client::*;
 use lightyear::prelude::*;
 use std::collections::VecDeque;
@@ -132,6 +134,10 @@ impl Plugin for ExampleClientPlugin {
                 .in_set(FixedUpdateSet::Main),
         );
         app.add_systems(Update, (handle_predicted_spawn, handle_interpolated_spawn));
+        add_visual_interpolation_systems::<PlayerPosition, MyProtocol>(app);
+
+        app.add_systems(Update, debug_pre_visual_interpolation);
+        app.add_systems(Last, debug_post_visual_interpolation);
     }
 }
 
@@ -190,8 +196,8 @@ pub(crate) fn movement(
     }
     for input in input_reader.read() {
         if let Some(input) = input.input() {
-            for mut position in position_query.iter_mut() {
-                shared_movement_behaviour(&mut position, input);
+            for position in position_query.iter_mut() {
+                shared_movement_behaviour(position, input);
             }
         }
     }
@@ -200,10 +206,22 @@ pub(crate) fn movement(
 // When the predicted copy of the client-owned entity is spawned, do stuff
 // - assign it a different saturation
 // - keep track of it in the Global resource
-pub(crate) fn handle_predicted_spawn(mut predicted: Query<&mut PlayerColor, Added<Predicted>>) {
-    for mut color in predicted.iter_mut() {
+pub(crate) fn handle_predicted_spawn(
+    mut commands: Commands,
+    mut predicted_heads: Query<(Entity, &mut PlayerColor), Added<Predicted>>,
+    predicted_tails: Query<Entity, (With<PlayerParent>, Added<Predicted>)>,
+) {
+    for (entity, mut color) in predicted_heads.iter_mut() {
         color.0.set_s(0.3);
+        commands
+            .entity(entity)
+            .insert(VisualInterpolateStatus::<PlayerPosition>::default());
     }
+    // for entity in predicted_tails.iter() {
+    //     commands
+    //         .entity(entity)
+    //         .insert(VisualInterpolateStatus::<TailPoints>::default())
+    // }
 }
 
 // When the predicted copy of the client-owned entity is spawned, do stuff
@@ -247,6 +265,36 @@ pub(crate) fn debug_prediction_post_rollback(
             .expect("Tail entity has no parent entity!");
         info!(?parent_history, "parent");
         info!(?tail_history, "tail");
+    }
+}
+
+pub(crate) fn debug_pre_visual_interpolation(
+    tick_manager: Res<TickManager>,
+    query: Query<(&PlayerPosition, &VisualInterpolateStatus<PlayerPosition>)>,
+) {
+    let tick = tick_manager.tick();
+    for (position, interpolate_status) in query.iter() {
+        info!(
+            ?tick,
+            ?position,
+            ?interpolate_status,
+            "pre visual interpolation"
+        );
+    }
+}
+
+pub(crate) fn debug_post_visual_interpolation(
+    tick_manager: Res<TickManager>,
+    query: Query<(&PlayerPosition, &VisualInterpolateStatus<PlayerPosition>)>,
+) {
+    let tick = tick_manager.tick();
+    for (position, interpolate_status) in query.iter() {
+        info!(
+            ?tick,
+            ?position,
+            ?interpolate_status,
+            "post visual interpolation"
+        );
     }
 }
 
@@ -303,44 +351,19 @@ pub(crate) fn interpolate(
                 continue;
             }
             let pos_start = &parent_status.start.as_ref().unwrap().1;
-            if tail_status.current == *start_tick {
-                assert_eq!(tail_status.current, parent_status.current);
-                *tail = tail_start_value.clone();
-                *parent_position = pos_start.clone();
-                debug!(
-                    ?tail,
-                    ?parent_position,
-                    "after interpolation; CURRENT = START"
-                );
-                continue;
-            }
-
             if let Some((end_tick, tail_end_value)) = &tail_status.end {
                 if parent_status.end.is_none() {
                     // the parent component has not been confirmed yet, so we can't interpolate
                     continue;
                 }
                 let pos_end = &parent_status.end.as_ref().unwrap().1;
-                if tail_status.current == *end_tick {
-                    assert_eq!(tail_status.current, parent_status.current);
-                    *tail = tail_end_value.clone();
-                    *parent_position = pos_end.clone();
-                    debug!(
-                        ?tail,
-                        ?parent_position,
-                        "after interpolation; CURRENT = END"
-                    );
-                    continue;
-                }
                 if start_tick != end_tick {
                     // the new tail will be similar to the old tail, with some added points at the front
                     *tail = tail_start_value.clone();
                     *parent_position = pos_start.clone();
 
                     // interpolation ratio
-                    let t = (tail_status.current - *start_tick) as f32
-                        / (*end_tick - *start_tick) as f32;
-
+                    let t = tail_status.interpolation_fraction().unwrap();
                     let mut tail_diff_length = 0.0;
                     // find in which end tail segment the previous head_position is
 
@@ -356,8 +379,7 @@ pub(crate) fn interpolate(
                             debug!("ADD POINT");
                         }
                         // the path is straight! just move the head and adjust the tail
-                        *parent_position =
-                            LinearInterpolator::lerp(pos_start.clone(), pos_end.clone(), t);
+                        *parent_position = LinearInterpolator::lerp(pos_start, pos_end, t);
                         tail.shorten_back(parent_position.0, tail_length.0);
                         debug!(
                             ?tail,

--- a/examples/replication_groups/src/protocol.rs
+++ b/examples/replication_groups/src/protocol.rs
@@ -6,6 +6,7 @@ use lightyear::prelude::*;
 use lightyear::shared::replication::components::ReplicationGroup;
 use serde::{Deserialize, Serialize};
 use std::collections::VecDeque;
+use std::ops::Mul;
 use tracing::{debug, info, trace};
 
 // Player
@@ -74,9 +75,17 @@ impl TailBundle {
 pub struct PlayerId(ClientId);
 
 #[derive(
-    Component, Message, Serialize, Deserialize, Clone, Debug, PartialEq, Deref, DerefMut, Add, Mul,
+    Component, Message, Serialize, Deserialize, Clone, Debug, PartialEq, Deref, DerefMut, Add,
 )]
 pub struct PlayerPosition(pub(crate) Vec2);
+
+impl Mul<f32> for &PlayerPosition {
+    type Output = PlayerPosition;
+
+    fn mul(self, rhs: f32) -> Self::Output {
+        PlayerPosition(self.0 * rhs)
+    }
+}
 
 impl PlayerPosition {
     /// Checks if the position is between two other positions.

--- a/examples/replication_groups/src/server.rs
+++ b/examples/replication_groups/src/server.rs
@@ -171,8 +171,8 @@ pub(crate) fn movement(
                 tick_manager.tick()
             );
             if let Some((player_entity, _)) = global.client_id_to_entity_id.get(client_id) {
-                if let Ok(mut position) = position_query.get_mut(*player_entity) {
-                    shared_movement_behaviour(&mut position, input);
+                if let Ok(position) = position_query.get_mut(*player_entity) {
+                    shared_movement_behaviour(position, input);
                 }
             }
         }

--- a/examples/replication_groups/src/shared.rs
+++ b/examples/replication_groups/src/shared.rs
@@ -39,15 +39,12 @@ impl Plugin for SharedPlugin {
 pub(crate) fn shared_movement_behaviour(mut position: Mut<PlayerPosition>, input: &Inputs) {
     const MOVE_SPEED: f32 = 10.0;
     match input {
-        Inputs::Direction(direction) => {
-            info!("moving head!");
-            match direction {
-                Direction::Up => position.y += MOVE_SPEED,
-                Direction::Down => position.y -= MOVE_SPEED,
-                Direction::Left => position.x -= MOVE_SPEED,
-                Direction::Right => position.x += MOVE_SPEED,
-            }
-        }
+        Inputs::Direction(direction) => match direction {
+            Direction::Up => position.y += MOVE_SPEED,
+            Direction::Down => position.y -= MOVE_SPEED,
+            Direction::Left => position.x -= MOVE_SPEED,
+            Direction::Right => position.x += MOVE_SPEED,
+        },
         _ => {}
     }
 }

--- a/examples/replication_groups/src/shared.rs
+++ b/examples/replication_groups/src/shared.rs
@@ -36,15 +36,18 @@ impl Plugin for SharedPlugin {
 }
 
 // This system defines how we update the player's positions when we receive an input
-pub(crate) fn shared_movement_behaviour(position: &mut PlayerPosition, input: &Inputs) {
+pub(crate) fn shared_movement_behaviour(mut position: Mut<PlayerPosition>, input: &Inputs) {
     const MOVE_SPEED: f32 = 10.0;
     match input {
-        Inputs::Direction(direction) => match direction {
-            Direction::Up => position.y += MOVE_SPEED,
-            Direction::Down => position.y -= MOVE_SPEED,
-            Direction::Left => position.x -= MOVE_SPEED,
-            Direction::Right => position.x += MOVE_SPEED,
-        },
+        Inputs::Direction(direction) => {
+            info!("moving head!");
+            match direction {
+                Direction::Up => position.y += MOVE_SPEED,
+                Direction::Down => position.y -= MOVE_SPEED,
+                Direction::Left => position.x -= MOVE_SPEED,
+                Direction::Right => position.x += MOVE_SPEED,
+            }
+        }
         _ => {}
     }
 }

--- a/lightyear/Cargo.toml
+++ b/lightyear/Cargo.toml
@@ -162,6 +162,7 @@ derive_more = { version = "0.99", features = ["add", "mul"] }
 mock_instant = { version = "0.3.1" }
 tracing-subscriber = "0.3.17"
 bitvec = "1.0"
+approx = "0.5.1"
 
 # docs.rs-specific configuration
 [package.metadata.docs.rs]

--- a/lightyear/src/client/components.rs
+++ b/lightyear/src/client/components.rs
@@ -33,7 +33,7 @@ impl<T> SyncComponent for T where T: Component + Clone + PartialEq + Named + for
 
 /// Function that will interpolated between two values
 pub trait LerpFn<C> {
-    fn lerp(start: C, other: C, t: f32) -> C;
+    fn lerp(start: &C, other: &C, t: f32) -> C;
 }
 
 /// Defines how to do interpolation/correction for the component

--- a/lightyear/src/client/interpolation/interpolate.rs
+++ b/lightyear/src/client/interpolation/interpolate.rs
@@ -36,20 +36,16 @@ pub struct InterpolateStatus<C: Component> {
 
 impl<C: Component> InterpolateStatus<C> {
     pub fn interpolation_fraction(&self) -> Option<f32> {
-        self.start
-            .as_ref()
-            .map(|(start_tick, _)| {
-                self.end.as_ref().map(|(end_tick, _)| {
-                    if *start_tick != *end_tick {
-                        let t = ((self.current_tick - *start_tick) as f32 + self.current_overstep)
-                            / (*end_tick - *start_tick) as f32;
-                        t
-                    } else {
-                        0.0
-                    }
-                })
+        self.start.as_ref().and_then(|(start_tick, _)| {
+            self.end.as_ref().map(|(end_tick, _)| {
+                if *start_tick != *end_tick {
+                    ((self.current_tick - *start_tick) as f32 + self.current_overstep)
+                        / (*end_tick - *start_tick) as f32
+                } else {
+                    0.0
+                }
             })
-            .flatten()
+        })
     }
 }
 

--- a/lightyear/src/client/interpolation/interpolation_history.rs
+++ b/lightyear/src/client/interpolation/interpolation_history.rs
@@ -86,6 +86,12 @@ pub(crate) fn add_component_history<C: SyncComponent, P: Protocol>(
 ) where
     P::Components: SyncMetadata<C>,
 {
+    let current_tick = connection
+        .sync_manager
+        .interpolation_tick(tick_manager.as_ref());
+    let current_overstep = connection
+        .sync_manager
+        .interpolation_overstep(tick_manager.as_ref());
     for (confirmed_entity, confirmed_component) in confirmed_entities.iter() {
         if let Some(p) = confirmed_entity.interpolated {
             if let Ok(interpolated_entity) = interpolated_entities.get(p) {
@@ -109,9 +115,8 @@ pub(crate) fn add_component_history<C: SyncComponent, P: Protocol>(
                                 InterpolateStatus::<C> {
                                     start: None,
                                     end: None,
-                                    current: connection
-                                        .sync_manager
-                                        .interpolation_tick(tick_manager.as_ref()),
+                                    current_tick,
+                                    current_overstep,
                                 },
                             ));
                         }

--- a/lightyear/src/client/interpolation/mod.rs
+++ b/lightyear/src/client/interpolation/mod.rs
@@ -6,7 +6,10 @@ use tracing::trace;
 
 pub use interpolate::InterpolateStatus;
 pub use interpolation_history::ConfirmedHistory;
-pub use plugin::{add_interpolation_systems, add_prepare_interpolation_systems};
+pub use plugin::{
+    add_interpolation_systems, add_prepare_interpolation_systems, add_visual_interpolation_systems,
+};
+pub use visual_interpolation::VisualInterpolateStatus;
 
 use crate::client::components::{Confirmed, LerpFn, SyncComponent};
 use crate::client::connection::ConnectionManager;
@@ -19,14 +22,16 @@ mod interpolate;
 pub mod interpolation_history;
 pub mod plugin;
 mod resource;
+mod visual_interpolation;
 
 /// Interpolator that performs linear interpolation.
 pub struct LinearInterpolator;
 impl<C> LerpFn<C> for LinearInterpolator
 where
-    C: Mul<f32, Output = C> + Add<C, Output = C>,
+    for<'a> &'a C: Mul<f32, Output = C>,
+    C: Add<C, Output = C>,
 {
-    fn lerp(start: C, other: C, t: f32) -> C {
+    fn lerp(start: &C, other: &C, t: f32) -> C {
         start * (1.0 - t) + other * t
     }
 }
@@ -34,9 +39,9 @@ where
 /// Use this if you don't want to use an interpolation function for this component.
 /// (For example if you are running your own interpolation logic)
 pub struct NullInterpolator;
-impl<C> LerpFn<C> for NullInterpolator {
-    fn lerp(start: C, _other: C, _t: f32) -> C {
-        start
+impl<C: Clone> LerpFn<C> for NullInterpolator {
+    fn lerp(start: &C, _other: &C, _t: f32) -> C {
+        start.clone()
     }
 }
 

--- a/lightyear/src/client/interpolation/mod.rs
+++ b/lightyear/src/client/interpolation/mod.rs
@@ -6,10 +6,8 @@ use tracing::trace;
 
 pub use interpolate::InterpolateStatus;
 pub use interpolation_history::ConfirmedHistory;
-pub use plugin::{
-    add_interpolation_systems, add_prepare_interpolation_systems, add_visual_interpolation_systems,
-};
-pub use visual_interpolation::VisualInterpolateStatus;
+pub use plugin::{add_interpolation_systems, add_prepare_interpolation_systems};
+pub use visual_interpolation::{VisualInterpolateStatus, VisualInterpolationPlugin};
 
 use crate::client::components::{Confirmed, LerpFn, SyncComponent};
 use crate::client::connection::ConnectionManager;

--- a/lightyear/src/client/interpolation/plugin.rs
+++ b/lightyear/src/client/interpolation/plugin.rs
@@ -152,32 +152,6 @@ pub enum InterpolationSet {
 // - a PROBLEM is that ideally we would like to rollback the physics simulation
 //   up to the client tick before we just updated the time. Maybe that's not a problem.. but we do need to keep track of the ticks correctly
 //  the tick we rollback to would not be the current client tick ?
-
-pub fn add_visual_interpolation_systems<C: SyncComponent, P: Protocol>(app: &mut App)
-where
-    P::Components: SyncMetadata<C>,
-{
-    match P::Components::mode() {
-        ComponentSyncMode::Full => {
-            app.add_systems(
-                PreUpdate,
-                restore_from_visual_interpolation::<C>
-                    .in_set(InterpolationSet::RestoreVisualInterpolation),
-            );
-            app.add_systems(
-                FixedUpdate,
-                update_visual_interpolation_status::<C>
-                    .in_set(InterpolationSet::UpdateVisualInterpolationState),
-            );
-            app.add_systems(
-                PostUpdate,
-                visual_interpolation::<C, P>.in_set(InterpolationSet::VisualInterpolation),
-            );
-        }
-        _ => {}
-    }
-}
-
 pub fn add_prepare_interpolation_systems<C: SyncComponent, P: Protocol>(app: &mut App)
 where
     P::Components: SyncMetadata<C>,
@@ -238,11 +212,6 @@ impl<P: Protocol> Plugin for InterpolationPlugin<P> {
         // RESOURCES
         app.init_resource::<InterpolationManager>();
         // SETS
-        app.configure_sets(PreUpdate, InterpolationSet::RestoreVisualInterpolation);
-        app.configure_sets(
-            FixedUpdate,
-            InterpolationSet::UpdateVisualInterpolationState.after(FixedUpdateSet::MainFlush),
-        );
         app.configure_sets(
             Update,
             (
@@ -257,7 +226,6 @@ impl<P: Protocol> Plugin for InterpolationPlugin<P> {
             )
                 .chain(),
         );
-        app.configure_sets(PostUpdate, InterpolationSet::VisualInterpolation);
         // SYSTEMS
         app.add_systems(
             Update,

--- a/lightyear/src/client/interpolation/visual_interpolation.rs
+++ b/lightyear/src/client/interpolation/visual_interpolation.rs
@@ -1,0 +1,140 @@
+//! This module is not related to the interpolating between server updates.
+//! Instead it is responsible for interpolating between FixedUpdate ticks during the Update state.
+//!
+//! Usually, the simulation is run during the FixedUpdate schedule so that it doesn't depend on frame rate.
+//! This can cause some visual inconsistencies (jitter) because the frames (Update schedule) don't correspond exactly to
+//! the FixedUpdate schedule: there can be frames with several fixed-update ticks, and some frames with no fixed-update ticks.
+//!
+//! To solve this, we will visually display the state of the game with 1 tick of delay
+//! For example if on the Update state we have an overstep of 0.7 and the current tick is 10,
+//! we will display the state of the game interpolated at 0.7 between tick 9 and tick 10.
+//!
+//! Another way to solve this would to run an extra 'partial' simulation step with 0.7 dt and use this for the visual state.
+
+// TODO: in post-update, interpolate the visual state of the game between with 1 tick of delay.
+// - we need to store the component values of the previous tick
+// - then in PostUpdate (visual interpolation) we interpolate between the previous tick and the current tick using the overstep
+// - in PreUpdate, we restore the component value to the previous tick values
+
+use crate::_reexport::ComponentProtocol;
+use crate::client::components::{SyncComponent, SyncMetadata};
+use crate::prelude::{Protocol, Tick, TickManager, TimeManager};
+use bevy::prelude::{Component, DetectChanges, DetectChangesMut, Query, Ref, Res};
+use tracing::info;
+
+// TODO: we might want to add this automatically to some entities that are predicted?
+/// Component that stores the previous value of a component for visual interpolation
+/// For now we will only use this to interpolate components that are updated during the FixedUpdate schedule.
+/// Hence, some values are not included in the struct:
+/// - start_tick = current_tick - 1
+/// - start_value = previous_value
+/// - end_tick = current_tick
+/// - end_value = current_value
+/// - overstep = Time<Fixed>.overstep_percentage() = TimeManager.overstep()
+#[derive(Component, PartialEq, Debug)]
+pub struct VisualInterpolateStatus<C: Component> {
+    /// Value of the component at the previous tick
+    pub previous_value: Option<C>,
+    /// Value of the component at the current tick
+    pub current_value: Option<C>,
+}
+
+// Manual implementation because we don't want to force `Component` to have a `Default` bound
+impl<C: Component> Default for VisualInterpolateStatus<C> {
+    fn default() -> Self {
+        Self {
+            previous_value: None,
+            current_value: None,
+        }
+    }
+}
+
+// TODO: test the visual interpolation in 2 settings
+//  - multiple ticks in one frame
+//  - no ticks in one frame
+// T1 T2 F  F T3 T4 F
+
+// F T1 T2 F T3 F T4 T5 F
+
+/// Marker component to indicate that this entity will be visually interpolated
+#[derive(Component, Debug)]
+pub struct VisualInterpolateMarker;
+
+// TODO: explore how we could allow this for non-marker components, user would need to specify the interpolation function?
+//  (to avoid orphan rule)
+/// Currently we will only support components that are present in the protocol and have a SyncMetadata implementation
+pub(crate) fn visual_interpolation<C: SyncComponent, P: Protocol>(
+    tick_manager: Res<TickManager>,
+    time_manager: Res<TimeManager>,
+    mut query: Query<(&mut C, &VisualInterpolateStatus<C>)>,
+) where
+    P::Components: SyncMetadata<C>,
+{
+    let kind = C::type_name();
+    let tick = tick_manager.tick();
+    let overstep = time_manager.overstep();
+    for (mut component, mut interpolate_status) in query.iter_mut() {
+        // TODO: think about how we can avoid running this all the time if the component is not changed
+        // if !component.is_changed() {
+        //     info!(
+        //         ?kind,
+        //         "Component is not changed, skipping visual interpolation"
+        //     );
+        //     continue;
+        // }
+        let Some(previous_value) = &interpolate_status.previous_value else {
+            info!(?kind, "No previous value, skipping visual interpolation");
+            continue;
+        };
+        let Some(current_value) = &interpolate_status.current_value else {
+            info!(?kind, "No current value, skipping visual interpolation");
+            continue;
+        };
+        info!(
+            ?kind,
+            ?tick,
+            ?overstep,
+            // ?previous_value,
+            // current_value = ?component.as_ref(),
+            "Visual interpolation of fixed-update component!"
+        );
+        *component.bypass_change_detection() =
+            P::Components::lerp(previous_value, current_value, overstep);
+        // interpolate_status.previous_value = Some(current_value);
+    }
+}
+
+// TODO: handle edge states
+/// Update the previous and current tick values.
+/// Runs in FixedUpdate after FixedUpdate::Main (where the component values are updated)
+pub(crate) fn update_visual_interpolation_status<C: SyncComponent>(
+    mut query: Query<(Ref<C>, &mut VisualInterpolateStatus<C>)>,
+) {
+    for (component, mut interpolate_status) in query.iter_mut() {
+        if !component.is_changed() {
+            info!("not updating interpolate status because component did not change");
+            continue;
+        }
+        info!("updating interpolate status");
+        if let Some(current_value) = interpolate_status.current_value.take() {
+            interpolate_status.previous_value = Some(current_value);
+        }
+        interpolate_status.current_value = Some(component.clone());
+    }
+}
+
+/// Restore the component value to the non-interpolated value
+pub(crate) fn restore_from_visual_interpolation<C: SyncComponent>(
+    mut query: Query<(&mut C, &mut VisualInterpolateStatus<C>)>,
+) {
+    let kind = C::type_name();
+    for (mut component, mut interpolate_status) in query.iter_mut() {
+        // TODO: do this only if we actually did visual interpolation
+        // if interpolate_status.is_changed() {
+        if let Some(current_value) = &interpolate_status.current_value {
+            info!(?kind, "Restoring visual interpolation");
+            *component.bypass_change_detection() = current_value.clone();
+        }
+        // }
+    }
+}

--- a/lightyear/src/client/interpolation/visual_interpolation.rs
+++ b/lightyear/src/client/interpolation/visual_interpolation.rs
@@ -22,7 +22,7 @@
 //! app.add_plugins(VisualInterpolationPlugin::<Component1, MyProtocol>::default());
 //! ```
 //! - To enable VisualInterpolation on a given entity, you need to add the `VisualInterpolateStatus` component to it manually
-//! ```rust,no_run_ignore
+//! ```rust,no_run,ignore
 //! fn spawn_entity(mut commands: Commands) {
 //!     commands.spawn().insert(VisualInterpolateState::<Component1>::default());
 //! }
@@ -72,24 +72,21 @@ where
         app.configure_sets(PostUpdate, InterpolationSet::VisualInterpolation);
 
         // SYSTEMS
-        match P::Components::mode() {
-            ComponentSyncMode::Full => {
-                app.add_systems(
-                    PreUpdate,
-                    restore_from_visual_interpolation::<C>
-                        .in_set(InterpolationSet::RestoreVisualInterpolation),
-                );
-                app.add_systems(
-                    FixedUpdate,
-                    update_visual_interpolation_status::<C>
-                        .in_set(InterpolationSet::UpdateVisualInterpolationState),
-                );
-                app.add_systems(
-                    PostUpdate,
-                    visual_interpolation::<C, P>.in_set(InterpolationSet::VisualInterpolation),
-                );
-            }
-            _ => {}
+        if P::Components::mode() == ComponentSyncMode::Full {
+            app.add_systems(
+                PreUpdate,
+                restore_from_visual_interpolation::<C>
+                    .in_set(InterpolationSet::RestoreVisualInterpolation),
+            );
+            app.add_systems(
+                FixedUpdate,
+                update_visual_interpolation_status::<C>
+                    .in_set(InterpolationSet::UpdateVisualInterpolationState),
+            );
+            app.add_systems(
+                PostUpdate,
+                visual_interpolation::<C, P>.in_set(InterpolationSet::VisualInterpolation),
+            );
         }
     }
 }
@@ -102,7 +99,7 @@ where
 /// - start_value = previous_value
 /// - end_tick = current_tick
 /// - end_value = current_value
-/// - overstep = Time<Fixed>.overstep_percentage() = TimeManager.overstep()
+/// - overstep = `Time<Fixed>`.overstep_percentage() = TimeManager.overstep()
 #[derive(Component, PartialEq, Debug)]
 pub struct VisualInterpolateStatus<C: Component> {
     /// Value of the component at the previous tick

--- a/lightyear/src/client/prediction/prespawn.rs
+++ b/lightyear/src/client/prediction/prespawn.rs
@@ -367,7 +367,6 @@ pub(crate) fn spawn_pre_spawned_player_object<P: Protocol>(
 mod tests {
     use bevy::prelude::Entity;
     use bevy::utils::{Duration, EntityHashMap};
-    use tracing_subscriber::fmt::format::FmtSpan;
 
     use crate::_reexport::ItemWithReadyKey;
     use crate::client::prediction::resource::PredictionManager;

--- a/lightyear/src/client/prediction/rollback.rs
+++ b/lightyear/src/client/prediction/rollback.rs
@@ -5,7 +5,7 @@ use bevy::prelude::{
     With, Without, World,
 };
 use bevy::utils::EntityHashSet;
-use tracing::{debug, error, trace, trace_span};
+use tracing::{debug, error, info, trace, trace_span};
 
 use crate::_reexport::{ComponentProtocol, FromType};
 use crate::client::components::{ComponentSyncMode, Confirmed, SyncComponent};
@@ -169,6 +169,7 @@ pub(crate) fn prepare_rollback<C: SyncComponent, P: Protocol>(
         return;
     }
     let _span = trace_span!("client rollback prepare");
+    info!("in prepare rollback");
 
     let current_tick = tick_manager.tick();
     for (confirmed_entity, confirmed_component, confirmed) in confirmed_query.iter() {

--- a/lightyear/src/client/prediction/rollback.rs
+++ b/lightyear/src/client/prediction/rollback.rs
@@ -169,7 +169,7 @@ pub(crate) fn prepare_rollback<C: SyncComponent, P: Protocol>(
         return;
     }
     let _span = trace_span!("client rollback prepare");
-    info!("in prepare rollback");
+    debug!("in prepare rollback");
 
     let current_tick = tick_manager.tick();
     for (confirmed_entity, confirmed_component, confirmed) in confirmed_query.iter() {

--- a/lightyear/src/lib.rs
+++ b/lightyear/src/lib.rs
@@ -112,7 +112,7 @@ pub mod prelude {
             InterpolationConfig, InterpolationDelay, InterpolationSet,
         };
         pub use crate::client::interpolation::{
-            InterpolateStatus, Interpolated, VisualInterpolateStatus,
+            InterpolateStatus, Interpolated, VisualInterpolateStatus, VisualInterpolationPlugin,
         };
         pub use crate::client::plugin::{ClientPlugin, PluginConfig};
         pub use crate::client::prediction::correction::Correction;

--- a/lightyear/src/lib.rs
+++ b/lightyear/src/lib.rs
@@ -111,7 +111,9 @@ pub mod prelude {
         pub use crate::client::interpolation::plugin::{
             InterpolationConfig, InterpolationDelay, InterpolationSet,
         };
-        pub use crate::client::interpolation::{InterpolateStatus, Interpolated};
+        pub use crate::client::interpolation::{
+            InterpolateStatus, Interpolated, VisualInterpolateStatus,
+        };
         pub use crate::client::plugin::{ClientPlugin, PluginConfig};
         pub use crate::client::prediction::correction::Correction;
         pub use crate::client::prediction::plugin::is_in_rollback;

--- a/lightyear/src/protocol/component.rs
+++ b/lightyear/src/protocol/component.rs
@@ -103,14 +103,14 @@ pub trait ComponentProtocol:
     }
 
     /// Get the sync mode for the component
-    fn lerp<C>(start: C, other: C, t: f32) -> C
+    fn lerp<C>(start: &C, other: &C, t: f32) -> C
     where
         Self: SyncMetadata<C>,
     {
         <Self as SyncMetadata<C>>::Interpolator::lerp(start, other, t)
     }
 
-    fn correct<C>(predicted: C, corrected: C, t: f32) -> C
+    fn correct<C>(predicted: &C, corrected: &C, t: f32) -> C
     where
         Self: SyncMetadata<C>,
     {

--- a/lightyear/src/shared/replication/receive.rs
+++ b/lightyear/src/shared/replication/receive.rs
@@ -8,8 +8,6 @@ use bevy::reflect::Reflect;
 use bevy::utils::petgraph::data::ElementIterator;
 use bevy::utils::{EntityHashMap, HashSet};
 use tracing::{debug, error, trace, trace_span, warn};
-use tracing_subscriber::filter::FilterExt;
-use tracing_subscriber::fmt::writer::MakeWriterExt;
 
 use crate::packet::message::MessageId;
 use crate::prelude::client::Confirmed;

--- a/lightyear/src/shared/replication/send.rs
+++ b/lightyear/src/shared/replication/send.rs
@@ -8,8 +8,6 @@ use bevy::utils::petgraph::data::ElementIterator;
 use bevy::utils::{EntityHashMap, HashMap, HashSet};
 use crossbeam_channel::Receiver;
 use tracing::{debug, error, trace, warn};
-use tracing_subscriber::filter::FilterExt;
-use tracing_subscriber::fmt::writer::MakeWriterExt;
 
 use crate::_reexport::{EntityActionsChannel, EntityUpdatesChannel, FromType};
 use crate::packet::message::MessageId;

--- a/lightyear/src/tests/protocol.rs
+++ b/lightyear/src/tests/protocol.rs
@@ -2,6 +2,7 @@ use bevy::prelude::{default, Component, Entity, Reflect};
 use bevy::utils::EntityHashSet;
 use cfg_if::cfg_if;
 use derive_more::{Add, Mul};
+use std::ops::Mul;
 
 use serde::{Deserialize, Serialize};
 
@@ -24,6 +25,13 @@ pub enum MyMessageProtocol {
 // Components
 #[derive(Component, MessageInternal, Serialize, Deserialize, Clone, Debug, PartialEq, Add, Mul)]
 pub struct Component1(pub f32);
+
+impl Mul<f32> for &Component1 {
+    type Output = Component1;
+    fn mul(self, rhs: f32) -> Self::Output {
+        Component1(self.0 * rhs)
+    }
+}
 
 #[derive(Component, MessageInternal, Serialize, Deserialize, Clone, Debug, PartialEq, Add, Mul)]
 pub struct Component2(pub f32);

--- a/lightyear/src/tests/stepper.rs
+++ b/lightyear/src/tests/stepper.rs
@@ -175,17 +175,21 @@ impl BevyStepper {
             self.frame_step();
         }
     }
+
+    pub(crate) fn advance_time(&mut self, duration: Duration) {
+        self.current_time += duration;
+        self.client_app
+            .insert_resource(TimeUpdateStrategy::ManualInstant(self.current_time));
+        self.server_app
+            .insert_resource(TimeUpdateStrategy::ManualInstant(self.current_time));
+        mock_instant::MockClock::advance(duration);
+    }
 }
 
 impl Step for BevyStepper {
     /// Advance the world by one frame duration
     fn frame_step(&mut self) {
-        self.current_time += self.frame_duration;
-        self.client_app
-            .insert_resource(TimeUpdateStrategy::ManualInstant(self.current_time));
-        self.server_app
-            .insert_resource(TimeUpdateStrategy::ManualInstant(self.current_time));
-        mock_instant::MockClock::advance(self.frame_duration);
+        self.advance_time(self.frame_duration);
         self.client_app.update();
         // sleep a bit to make sure that local io receives the packets
         // std::thread::sleep(Duration::from_millis(1));
@@ -194,12 +198,7 @@ impl Step for BevyStepper {
     }
 
     fn tick_step(&mut self) {
-        self.current_time += self.tick_duration;
-        self.client_app
-            .insert_resource(TimeUpdateStrategy::ManualInstant(self.current_time));
-        self.server_app
-            .insert_resource(TimeUpdateStrategy::ManualInstant(self.current_time));
-        mock_instant::MockClock::advance(self.tick_duration);
+        self.advance_time(self.tick_duration);
         self.client_app.update();
         self.server_app.update();
     }

--- a/lightyear/src/transport/websocket/mod.rs
+++ b/lightyear/src/transport/websocket/mod.rs
@@ -20,7 +20,6 @@ mod tests {
     use bevy::tasks::{IoTaskPool, TaskPoolBuilder};
     use bevy::utils::Duration;
     use tracing::info;
-    use tracing_subscriber::fmt::format::FmtSpan;
 
     #[cfg(not(target_family = "wasm"))]
     #[tokio::test]

--- a/lightyear/src/transport/webtransport/mod.rs
+++ b/lightyear/src/transport/webtransport/mod.rs
@@ -22,7 +22,6 @@ mod tests {
     use bevy::tasks::{IoTaskPool, TaskPoolBuilder};
     use bevy::utils::Duration;
     use tracing::info;
-    use tracing_subscriber::fmt::format::FmtSpan;
     use wtransport::tls::Certificate;
 
     #[cfg(not(target_family = "wasm"))]

--- a/lightyear/src/utils/bevy.rs
+++ b/lightyear/src/utils/bevy.rs
@@ -18,9 +18,9 @@ impl Named for Transform {
 pub struct TransformLinearInterpolation;
 
 impl LerpFn<Transform> for TransformLinearInterpolation {
-    fn lerp(start: Transform, other: Transform, t: f32) -> Transform {
+    fn lerp(start: &Transform, other: &Transform, t: f32) -> Transform {
         let translation = start.translation * (1.0 - t) + other.translation * t;
-        let rotation = start.rotation.lerp(other.rotation, t);
+        let rotation = start.rotation.slerp(other.rotation, t);
         let scale = start.scale * (1.0 - t) + other.scale * t;
         let res = Transform {
             translation,


### PR DESCRIPTION
Improve interpolation behaviour by:
- using the interpolation overstep percentage for Interpolated entity
- adding the concept of a `VisualInterpolationPlugin` to visually interpolate entities that are only updated during FixedUpdate
- provide an `interpolation_fraction` function to automatically compute the interpolation percentage
- Update LerpFn to take references as input instead of the actual values


Migration guide:
- if you use `derive_more` to derive `Mul<f32>` automatically on your interpolated struct, you might have to instead derive `Mul<f32>` for `&C` directly:
```
impl Mul<f32> for &Component1 {
    type Output = Component1;
    fn mul(self, rhs: f32) -> Self::Output {
        Component1(self.0 * rhs)
    }
}
```