### PR TITLE
Fix outstanding errors for Bevy 0.13

### DIFF
--- a/lightyear/Cargo.toml
+++ b/lightyear/Cargo.toml
@@ -30,7 +30,7 @@ webtransport = [
   "dep:tokio",
   "dep:ring",
 ]
-leafwing = ["dep:leafwing-input-manager", "lightyear_macros/leafwing"]
+leafwing = ["dep:leafwing-input-manager", "lightyear_macros/leafwing", "bevy/bevy_asset"]
 xpbd_2d = ["dep:bevy_xpbd_2d"]
 websocket = [
   "dep:tokio",

--- a/lightyear/src/client/input_leafwing.rs
+++ b/lightyear/src/client/input_leafwing.rs
@@ -991,7 +991,7 @@ mod tests {
         stepper
             .client_app
             .world
-            .resource_mut::<Input<KeyCode>>()
+            .resource_mut::<ButtonInput<KeyCode>>()
             .press(KeyCode::A);
         stepper.frame_step();
 

--- a/lightyear/src/client/prediction/prespawn.rs
+++ b/lightyear/src/client/prediction/prespawn.rs
@@ -366,7 +366,8 @@ pub(crate) fn spawn_pre_spawned_player_object<P: Protocol>(
 #[cfg(test)]
 mod tests {
     use bevy::prelude::Entity;
-    use bevy::utils::{Duration, EntityHashMap};
+    use bevy::utils::Duration;
+    use hashbrown::HashMap;
 
     use crate::_reexport::ItemWithReadyKey;
     use crate::client::prediction::resource::PredictionManager;
@@ -418,9 +419,9 @@ mod tests {
         let expected_hash: u64 = 11844036307541615334;
         assert_eq!(
             prediction_manager.prespawn_hash_to_entities,
-            EntityHashMap::from_iter(vec![(
+            HashMap::from_iter(vec![(
                 expected_hash,
-                vec![Entity::from_bits(0), Entity::from_bits(1)]
+                vec![Entity::from_bits(4294967296), Entity::from_bits(4294967297)]
             )])
         );
         assert_eq!(
@@ -436,7 +437,7 @@ mod tests {
             stepper
                 .client_app
                 .world
-                .entity(Entity::from_bits(0))
+                .entity(Entity::from_bits(4294967297))
                 .get::<PredictionHistory<Component1>>()
                 .unwrap()
                 .buffer

--- a/lightyear/src/inputs/leafwing/input_buffer.rs
+++ b/lightyear/src/inputs/leafwing/input_buffer.rs
@@ -1,10 +1,11 @@
 use std::collections::VecDeque;
 use std::fmt::{Debug, Formatter};
 
+use bevy::ecs::entity::{EntityHashSet, EntityMapper};
 use bevy::math::Vec2;
 use bevy::prelude::{Component, Entity, Event, FromReflect, Reflect, Resource, TypePath};
 use bevy::reflect::DynamicTypePath;
-use bevy::utils::{EntityHashSet, HashMap};
+use bevy::utils::HashMap;
 use leafwing_input_manager::axislike::DualAxisData;
 use leafwing_input_manager::prelude::ActionState;
 use leafwing_input_manager::Actionlike;
@@ -12,7 +13,7 @@ use serde::{Deserialize, Serialize};
 use tracing::trace;
 
 use crate::prelude::client::SyncComponent;
-use crate::prelude::{EntityMapper, MapEntities, Message, Named};
+use crate::prelude::{LightyearMapEntities, Message, Named};
 use crate::protocol::BitSerializable;
 use crate::shared::tick_manager::Tick;
 
@@ -32,11 +33,8 @@ use super::LeafwingUserAction;
 // - we apply the ticks on the right tick to the entity/resource
 // - no need to maintain our inputbuffer on the server
 
-impl<'a, A: LeafwingUserAction> MapEntities<'a> for ActionState<A> {
-    fn map_entities(&mut self, entity_mapper: Box<dyn EntityMapper + 'a>) {}
-    fn entities(&self) -> EntityHashSet<Entity> {
-        EntityHashSet::default()
-    }
+impl<A: LeafwingUserAction> LightyearMapEntities for ActionState<A> {
+    fn map_entities<M: EntityMapper>(&mut self, entity_mapper: &mut M) {}
 }
 impl<A: LeafwingUserAction> Named for ActionState<A> {
     // const NAME: &'static str = formatcp!("ActionState<{}>", A::short_type_path());
@@ -235,13 +233,13 @@ impl<A: LeafwingUserAction> Named for InputMessage<A> {
     // const NAME: &'static str = <Self as TypePath>::short_type_path();
 }
 
-impl<'a, A: LeafwingUserAction> MapEntities<'a> for InputMessage<A> {
+impl<A: LeafwingUserAction> LightyearMapEntities for InputMessage<A> {
     // NOTE: we do NOT map the entities for input-message because when already convert
     //  the entities on the message to the corresponding client entities when we write them
     //  in the input message
 
     // NOTE: we only map the inputs for the pre-predicted entities
-    fn map_entities(&mut self, entity_mapper: Box<dyn EntityMapper + 'a>) {
+    fn map_entities<M: EntityMapper>(&mut self, entity_mapper: &mut M) {
         self.diffs
             .iter_mut()
             .filter_map(|(entity, _)| {
@@ -256,19 +254,6 @@ impl<'a, A: LeafwingUserAction> MapEntities<'a> for InputMessage<A> {
                     *entity = new_entity;
                 }
             });
-    }
-
-    fn entities(&self) -> EntityHashSet<Entity> {
-        self.diffs
-            .iter()
-            .filter_map(|(entity, _)| {
-                if let InputTarget::PrePredictedEntity(e) = entity {
-                    Some(*e)
-                } else {
-                    None
-                }
-            })
-            .collect()
     }
 }
 

--- a/lightyear/src/server/input_leafwing.rs
+++ b/lightyear/src/server/input_leafwing.rs
@@ -307,7 +307,7 @@ mod tests {
         stepper
             .client_app
             .world
-            .resource_mut::<Input<KeyCode>>()
+            .resource_mut::<ButtonInput<KeyCode>>()
             .press(KeyCode::A);
         stepper.frame_step();
         // client tick when we send the Jump action
@@ -315,7 +315,7 @@ mod tests {
         stepper
             .client_app
             .world
-            .resource_mut::<Input<KeyCode>>()
+            .resource_mut::<ButtonInput<KeyCode>>()
             .release(KeyCode::A);
         stepper.frame_step();
 

--- a/lightyear/src/tests/protocol.rs
+++ b/lightyear/src/tests/protocol.rs
@@ -1,5 +1,5 @@
+use bevy::ecs::entity::{EntityHashSet, EntityMapper, MapEntities};
 use bevy::prelude::{default, Component, Entity, Reflect};
-use bevy::utils::EntityHashSet;
 use cfg_if::cfg_if;
 use derive_more::{Add, Mul};
 use std::ops::Mul;
@@ -43,13 +43,9 @@ pub struct Component3(pub f32);
 #[message(custom_map)]
 pub struct Component4(pub Entity);
 
-impl<'a> MapEntities<'a> for Component4 {
-    fn map_entities(&mut self, entity_mapper: Box<dyn EntityMapper + 'a>) {
-        self.0.map_entities(entity_mapper);
-    }
-
-    fn entities(&self) -> EntityHashSet<Entity> {
-        EntityHashSet::from_iter(vec![self.0])
+impl MapEntities for Component4 {
+    fn map_entities<M: EntityMapper>(&mut self, entity_mapper: &mut M) {
+        self.0 = entity_mapper.map_entity(self.0);
     }
 }
 

--- a/lightyear/src/utils/bevy_xpbd_2d.rs
+++ b/lightyear/src/utils/bevy_xpbd_2d.rs
@@ -1,15 +1,16 @@
 //! Implement lightyear traits for some common bevy types
 use crate::_reexport::LinearInterpolator;
 use crate::client::components::{ComponentSyncMode, LerpFn, SyncComponent};
-use bevy::prelude::Entity;
-use bevy::utils::EntityHashSet;
+use bevy::ecs::entity::{Entity, EntityHashSet, EntityMapper};
 use bevy_xpbd_2d::components::*;
 use std::ops::{Add, Mul};
 use tracing::{info, trace};
 
-use crate::prelude::{EntityMapper, MapEntities, Message, Named};
+use crate::prelude::{LightyearMapEntities, Message, Named};
 
 pub mod position {
+    use crate::prelude::LightyearMapEntities;
+
     use super::*;
     impl Named for Position {
         const NAME: &'static str = "Position";
@@ -31,12 +32,8 @@ pub mod position {
         }
     }
 
-    impl<'a> MapEntities<'a> for Position {
-        fn map_entities(&mut self, entity_mapper: Box<dyn EntityMapper + 'a>) {}
-
-        fn entities(&self) -> EntityHashSet<Entity> {
-            EntityHashSet::default()
-        }
+    impl LightyearMapEntities for Position {
+        fn map_entities<M: EntityMapper>(&mut self, entity_mapper: &mut M) {}
     }
 }
 pub use position::*;
@@ -71,12 +68,8 @@ pub mod rotation {
         }
     }
 
-    impl<'a> MapEntities<'a> for Rotation {
-        fn map_entities(&mut self, entity_mapper: Box<dyn EntityMapper + 'a>) {}
-
-        fn entities(&self) -> EntityHashSet<Entity> {
-            EntityHashSet::default()
-        }
+    impl LightyearMapEntities for Rotation {
+        fn map_entities<M: EntityMapper>(&mut self, entity_mapper: &mut M) {}
     }
 }
 pub use rotation::*;
@@ -103,12 +96,8 @@ pub mod linear_velocity {
         }
     }
 
-    impl<'a> MapEntities<'a> for LinearVelocity {
-        fn map_entities(&mut self, entity_mapper: Box<dyn EntityMapper + 'a>) {}
-
-        fn entities(&self) -> EntityHashSet<Entity> {
-            EntityHashSet::default()
-        }
+    impl LightyearMapEntities for LinearVelocity {
+        fn map_entities<M: EntityMapper>(&mut self, entity_mapper: &mut M) {}
     }
 }
 pub use linear_velocity::*;
@@ -135,12 +124,8 @@ pub mod angular_velocity {
         }
     }
 
-    impl<'a> MapEntities<'a> for AngularVelocity {
-        fn map_entities(&mut self, entity_mapper: Box<dyn EntityMapper + 'a>) {}
-
-        fn entities(&self) -> EntityHashSet<Entity> {
-            EntityHashSet::default()
-        }
+    impl LightyearMapEntities for AngularVelocity {
+        fn map_entities<M: EntityMapper>(&mut self, entity_mapper: &mut M) {}
     }
 }
 pub use angular_velocity::*;
@@ -153,12 +138,8 @@ pub mod mass {
     impl Named for Mass {
         const NAME: &'static str = "Mass";
     }
-    impl<'a> MapEntities<'a> for Mass {
-        fn map_entities(&mut self, entity_mapper: Box<dyn EntityMapper + 'a>) {}
-
-        fn entities(&self) -> EntityHashSet<Entity> {
-            EntityHashSet::default()
-        }
+    impl LightyearMapEntities for Mass {
+        fn map_entities<M: EntityMapper>(&mut self, entity_mapper: &mut M) {}
     }
 }
 pub use mass::*;

--- a/vendor/bitcode/Cargo.toml
+++ b/vendor/bitcode/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bitcode_lightyear_patch"
 authors = ["Cai Bear", "Finn Bear"]
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/SoftbearStudios/bitcode"
@@ -10,7 +10,7 @@ exclude = ["fuzz/"]
 
 [dependencies]
 bitcode_derive = { version = "0.1.4", optional = true }
-bitintr = "0.3.0"
+# bitintr = "0.3.0"
 bytemuck = { version = "1.13", features = ["extern_crate_alloc"] }
 from_bytes_or_zeroed = "0.1"
 residua-zigzag = "0.1.0"

--- a/vendor/bitcode/src/encoding/bit_string/bit_utils.rs
+++ b/vendor/bitcode/src/encoding/bit_string/bit_utils.rs
@@ -1,41 +1,42 @@
 use crate::word::Word;
-use bitintr::{Pdep, Pext};
+// https://github.com/SoftbearStudios/bitcode/issues/17
+// use bitintr::{Pdep, Pext};
 
 #[inline(always)]
 pub fn pack_lsb<const BITS: usize>(word: Word) -> Word {
     let mask = Word::from_le_bytes([(1 << BITS) - 1; 8]);
 
-    if cfg!(all(target_feature = "bmi2", not(miri))) {
-        word.pext(mask)
-    } else {
-        // Mask off bits that we don't care about.
-        let bytes = (word & mask).to_le_bytes();
-        let mut ret1 = 0;
-        for (i, &b) in bytes[..4].iter().enumerate() {
-            ret1 |= (b as u32) << (i * BITS);
-        }
-        let mut ret2 = 0;
-        for (i, &b) in bytes[4..].iter().enumerate() {
-            ret2 |= (b as u32) << (i * BITS);
-        }
-
-        // 2 steps + merge is a tiny bit faster.
-        ret1 as u64 | (ret2 as u64) << (BITS * 4)
+    // if cfg!(all(target_feature = "bmi2", not(miri))) {
+    //     word.pext(mask)
+    // } else {
+    // Mask off bits that we don't care about.
+    let bytes = (word & mask).to_le_bytes();
+    let mut ret1 = 0;
+    for (i, &b) in bytes[..4].iter().enumerate() {
+        ret1 |= (b as u32) << (i * BITS);
     }
+    let mut ret2 = 0;
+    for (i, &b) in bytes[4..].iter().enumerate() {
+        ret2 |= (b as u32) << (i * BITS);
+    }
+
+    // 2 steps + merge is a tiny bit faster.
+    ret1 as u64 | (ret2 as u64) << (BITS * 4)
+    // }
 }
 
 #[inline(always)]
 pub fn unpack_lsb<const BITS: usize>(word: Word) -> Word {
-    if cfg!(all(target_feature = "bmi2", not(miri))) {
-        let mask = Word::from_le_bytes([(1 << BITS) - 1; 8]);
-        word.pdep(mask)
-    } else {
-        let mut bytes = [0u8; 8];
+    // if cfg!(all(target_feature = "bmi2", not(miri))) {
+    //     let mask = Word::from_le_bytes([(1 << BITS) - 1; 8]);
+    //     word.pdep(mask)
+    // } else {
+    let mut bytes = [0u8; 8];
 
-        for (i, b) in bytes.iter_mut().enumerate() {
-            *b = (word >> (i * BITS) & ((1 << BITS) - 1)) as u8;
-        }
-
-        Word::from_le_bytes(bytes)
+    for (i, b) in bytes.iter_mut().enumerate() {
+        *b = (word >> (i * BITS) & ((1 << BITS) - 1)) as u8;
     }
+
+    Word::from_le_bytes(bytes)
+    // }
 }


### PR DESCRIPTION
I've made an attempt to fix up the remaining compilation, linting and testing errors in Lightyear with the Bevy 0.13 update.

However, I think for the Leafwing Input Manager feature to compile, that crate needs to update.