### PR TITLE
Add try_from_bytes method to ConnectToken

### DIFF
--- a/lightyear/src/connection/netcode/token.rs
+++ b/lightyear/src/connection/netcode/token.rs
@@ -440,6 +440,12 @@ impl ConnectToken {
         })?;
         Ok(buf)
     }
+
+    /// Tries to convert a 2048-byte array into a connect token.
+    pub fn try_from_bytes(bytes: &[u8]) -> Result<Self, InvalidTokenError> {
+        let mut cursor = io::Cursor::new(bytes);
+        Self::read_from(&mut cursor)
+    }
 }
 
 impl Bytes for ConnectToken {


### PR DESCRIPTION
This pull request introduces a new public method, try_from_bytes, to the ConnectToken class. 
Previously, the ConnectToken class lacked a public method for deserializing byte sequences, causing difficulties in reconstructing Token objects during network transmission. 