### PR TITLE
handle WebTransport client disconnection

### DIFF
--- a/lightyear/src/connection/netcode/error.rs
+++ b/lightyear/src/connection/netcode/error.rs
@@ -1,3 +1,5 @@
+use std::net::SocketAddr;
+use std::fmt;
 use thiserror::Error;
 
 /// The result type for all the public methods that can return an error in this crate.
@@ -24,3 +26,16 @@ pub enum Error {
     #[error(transparent)]
     Io(#[from] std::io::Error),
 }
+
+#[derive(Debug)]
+pub struct DisConnectionError {
+    pub addr: SocketAddr,
+}
+
+impl fmt::Display for DisConnectionError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Error with socket address: {:?}", self.addr)
+    }
+}
+
+impl std::error::Error for DisConnectionError {}

--- a/lightyear/src/connection/netcode/mod.rs
+++ b/lightyear/src/connection/netcode/mod.rs
@@ -125,7 +125,7 @@ loop {
 
 pub use client::{Client, ClientConfig, ClientState, NetcodeClient};
 pub use crypto::{generate_key, try_generate_key, Key};
-pub use error::{Error, Result};
+pub use error::{Error, Result, DisConnectionError};
 pub use server::{Callback, ClientId, NetcodeServer, Server, ServerConfig};
 pub use token::{ConnectToken, ConnectTokenBuilder, InvalidTokenError};
 

--- a/lightyear/src/connection/netcode/server.rs
+++ b/lightyear/src/connection/netcode/server.rs
@@ -819,9 +819,11 @@ impl<Ctx> NetcodeServer<Ctx> {
                     self.recv_packet(buf, now, addr, sender)?;
                 }
                 Err(e) => {
-                    if e.kind() == std::io::ErrorKind::TimedOut {
-                        if let Ok(addr) = SocketAddr::from_str(e.to_string().as_str()) {
-                            self.remove_client(addr);
+                    if e.kind() == std::io::ErrorKind::Other {
+                        if let Some(e) = e.get_ref() {
+                            if let Some(err) = e.downcast_ref::<super::DisConnectionError>() {
+                                self.remove_client(err.addr);
+                            }
                         }
                     }
                     break;

--- a/lightyear/src/connection/netcode/token.rs
+++ b/lightyear/src/connection/netcode/token.rs
@@ -440,6 +440,12 @@ impl ConnectToken {
         })?;
         Ok(buf)
     }
+
+    /// Tries to convert a 2048-byte array into a connect token.
+    pub fn try_from_bytes(bytes: &[u8]) -> Result<Self, InvalidTokenError> {
+        let mut cursor = io::Cursor::new(bytes);
+        Self::read_from(&mut cursor)
+    }
 }
 
 impl Bytes for ConnectToken {


### PR DESCRIPTION
This pull request addresses the issue of removing clients upon disconnection in WebTransport. 
I've introduced a somewhat unconventional method that leverages std::io::Error to extract SocketAddr upon disconnection, enabling the closure of the connection.

This change is minor but not the optimal solution; I aim to provide a direction for other developers.
