### PR TITLE
Re-use memory when creating Buffer to decode values

### DIFF
--- a/benches/src/lib.rs
+++ b/benches/src/lib.rs
@@ -5,4 +5,3 @@ pub mod client;
 pub mod local_stepper;
 pub mod protocol;
 pub mod server;
-pub mod stepper;

--- a/lightyear/Cargo.toml
+++ b/lightyear/Cargo.toml
@@ -14,30 +14,30 @@ exclude = ["/tests"]
 
 [features]
 metrics = [
-    "dep:metrics",
-    "metrics-util",
-    "metrics-tracing-context",
-    "metrics-exporter-prometheus",
-    "dep:tokio",
+  "dep:metrics",
+  "metrics-util",
+  "metrics-tracing-context",
+  "metrics-exporter-prometheus",
+  "dep:tokio",
 ]
 mock_time = ["dep:mock_instant"]
 render = ["bevy/bevy_render"]
 webtransport = [
-    "dep:wtransport",
-    "dep:xwt-core",
-    "dep:xwt-web-sys",
-    "dep:web-sys",
-    "dep:tokio",
-    "dep:ring",
+  "dep:wtransport",
+  "dep:xwt-core",
+  "dep:xwt-web-sys",
+  "dep:web-sys",
+  "dep:tokio",
+  "dep:ring",
 ]
 leafwing = ["dep:leafwing-input-manager", "lightyear_macros/leafwing"]
 xpbd_2d = ["dep:bevy_xpbd_2d"]
 websocket = [
-    "dep:tokio",
-    "dep:tokio-tungstenite",
-    "dep:futures-util",
-    "dep:web-sys",
-    "dep:wasm-bindgen",
+  "dep:tokio",
+  "dep:tokio-tungstenite",
+  "dep:futures-util",
+  "dep:web-sys",
+  "dep:wasm-bindgen",
 ]
 steam = ["dep:steamworks"]
 
@@ -70,7 +70,7 @@ bevy_xpbd_2d = { version = "0.4", optional = true }
 
 # serialization
 bitcode = { version = "0.5.1", package = "bitcode_lightyear_patch", path = "../vendor/bitcode", features = [
-    "serde",
+  "serde",
 ] }
 bytes = { version = "1.5", features = ["serde"] }
 object-pool = { version = "0.5.4" }
@@ -88,8 +88,8 @@ lightyear_macros = { version = "0.12.0", path = "../macros" }
 tracing = "0.1.40"
 tracing-log = "0.2.0"
 tracing-subscriber = { version = "0.3.17", features = [
-    "registry",
-    "env-filter",
+  "registry",
+  "env-filter",
 ] }
 
 # server
@@ -100,12 +100,12 @@ metrics = { version = "0.22", optional = true }
 metrics-util = { version = "0.15", optional = true }
 metrics-tracing-context = { version = "0.15", optional = true }
 metrics-exporter-prometheus = { version = "0.13.0", optional = true, default-features = false, features = [
-    "http-listener",
+  "http-listener",
 ] }
 
 # bevy
 bevy = { version = "0.13", default-features = false, features = [
-    "multi-threaded",
+  "multi-threaded",
 ] }
 
 # connection
@@ -117,44 +117,44 @@ futures-util = { version = "0.3.30", optional = true }
 # transport
 # we don't need any tokio features, we use only use the tokio channels
 tokio = { version = "1.36", features = [
-    "sync",
+  "sync",
 ], default-features = false, optional = true }
 async-compat = "0.2.3"
 
 [target."cfg(not(target_family = \"wasm\"))".dependencies]
 # webtransport
 wtransport = { version = "0.1.10", optional = true, features = [
-    "self-signed",
-    "dangerous-configuration",
+  "self-signed",
+  "dangerous-configuration",
 ] }
 # websocket
 tokio-tungstenite = { version = "0.21.0", optional = true, features = [
-    "connect",
-    "handshake",
+  "connect",
+  "handshake",
 ] }
 
 [target."cfg(target_family = \"wasm\")".dependencies]
 console_error_panic_hook = { version = "0.1.7" }
 ring = { version = "0.17.7", optional = true }
 web-sys = { version = "0.3", optional = true, features = [
-    "WebTransport",
-    "WebTransportHash",
-    "WebTransportOptions",
-    "WebTransportBidirectionalStream",
-    "WebTransportSendStream",
-    "WebTransportReceiveStream",
-    "ReadableStreamDefaultReader",
-    "WritableStreamDefaultWriter",
-    "WebTransportDatagramDuplexStream",
-    "WebSocket",
-    "CloseEvent",
-    "ErrorEvent",
-    "MessageEvent",
-    "BinaryType",
+  "WebTransport",
+  "WebTransportHash",
+  "WebTransportOptions",
+  "WebTransportBidirectionalStream",
+  "WebTransportSendStream",
+  "WebTransportReceiveStream",
+  "ReadableStreamDefaultReader",
+  "WritableStreamDefaultWriter",
+  "WebTransportDatagramDuplexStream",
+  "WebSocket",
+  "CloseEvent",
+  "ErrorEvent",
+  "MessageEvent",
+  "BinaryType",
 ] }
 futures-lite = { version = "2.1.0", optional = true }
 getrandom = { version = "0.2.11", features = [
-    "js",
+  "js",
 ] } # feature 'js' is required for wasm
 xwt-core = { version = "0.2", optional = true }
 xwt-web-sys = { version = "0.6", optional = true }

--- a/lightyear/Cargo.toml
+++ b/lightyear/Cargo.toml
@@ -14,30 +14,30 @@ exclude = ["/tests"]
 
 [features]
 metrics = [
-  "dep:metrics",
-  "metrics-util",
-  "metrics-tracing-context",
-  "metrics-exporter-prometheus",
-  "dep:tokio",
+    "dep:metrics",
+    "metrics-util",
+    "metrics-tracing-context",
+    "metrics-exporter-prometheus",
+    "dep:tokio",
 ]
 mock_time = ["dep:mock_instant"]
 render = ["bevy/bevy_render"]
 webtransport = [
-  "dep:wtransport",
-  "dep:xwt-core",
-  "dep:xwt-web-sys",
-  "dep:web-sys",
-  "dep:tokio",
-  "dep:ring",
+    "dep:wtransport",
+    "dep:xwt-core",
+    "dep:xwt-web-sys",
+    "dep:web-sys",
+    "dep:tokio",
+    "dep:ring",
 ]
 leafwing = ["dep:leafwing-input-manager", "lightyear_macros/leafwing"]
 xpbd_2d = ["dep:bevy_xpbd_2d"]
 websocket = [
-  "dep:tokio",
-  "dep:tokio-tungstenite",
-  "dep:futures-util",
-  "dep:web-sys",
-  "dep:wasm-bindgen",
+    "dep:tokio",
+    "dep:tokio-tungstenite",
+    "dep:futures-util",
+    "dep:web-sys",
+    "dep:wasm-bindgen",
 ]
 steam = ["dep:steamworks"]
 
@@ -70,9 +70,10 @@ bevy_xpbd_2d = { version = "0.4", optional = true }
 
 # serialization
 bitcode = { version = "0.5.1", package = "bitcode_lightyear_patch", path = "../vendor/bitcode", features = [
-  "serde",
+    "serde",
 ] }
 bytes = { version = "1.5", features = ["serde"] }
+object-pool = { version = "0.5.4" }
 self_cell = "1.0"
 serde = { version = "1.0.193", features = ["derive"] }
 
@@ -87,8 +88,8 @@ lightyear_macros = { version = "0.12.0", path = "../macros" }
 tracing = "0.1.40"
 tracing-log = "0.2.0"
 tracing-subscriber = { version = "0.3.17", features = [
-  "registry",
-  "env-filter",
+    "registry",
+    "env-filter",
 ] }
 
 # server
@@ -99,12 +100,12 @@ metrics = { version = "0.22", optional = true }
 metrics-util = { version = "0.15", optional = true }
 metrics-tracing-context = { version = "0.15", optional = true }
 metrics-exporter-prometheus = { version = "0.13.0", optional = true, default-features = false, features = [
-  "http-listener",
+    "http-listener",
 ] }
 
 # bevy
 bevy = { version = "0.13", default-features = false, features = [
-  "multi-threaded",
+    "multi-threaded",
 ] }
 
 # connection
@@ -116,44 +117,44 @@ futures-util = { version = "0.3.30", optional = true }
 # transport
 # we don't need any tokio features, we use only use the tokio channels
 tokio = { version = "1.36", features = [
-  "sync",
+    "sync",
 ], default-features = false, optional = true }
 async-compat = "0.2.3"
 
 [target."cfg(not(target_family = \"wasm\"))".dependencies]
 # webtransport
 wtransport = { version = "0.1.10", optional = true, features = [
-  "self-signed",
-  "dangerous-configuration",
+    "self-signed",
+    "dangerous-configuration",
 ] }
 # websocket
 tokio-tungstenite = { version = "0.21.0", optional = true, features = [
-  "connect",
-  "handshake",
+    "connect",
+    "handshake",
 ] }
 
 [target."cfg(target_family = \"wasm\")".dependencies]
 console_error_panic_hook = { version = "0.1.7" }
 ring = { version = "0.17.7", optional = true }
 web-sys = { version = "0.3", optional = true, features = [
-  "WebTransport",
-  "WebTransportHash",
-  "WebTransportOptions",
-  "WebTransportBidirectionalStream",
-  "WebTransportSendStream",
-  "WebTransportReceiveStream",
-  "ReadableStreamDefaultReader",
-  "WritableStreamDefaultWriter",
-  "WebTransportDatagramDuplexStream",
-  "WebSocket",
-  "CloseEvent",
-  "ErrorEvent",
-  "MessageEvent",
-  "BinaryType",
+    "WebTransport",
+    "WebTransportHash",
+    "WebTransportOptions",
+    "WebTransportBidirectionalStream",
+    "WebTransportSendStream",
+    "WebTransportReceiveStream",
+    "ReadableStreamDefaultReader",
+    "WritableStreamDefaultWriter",
+    "WebTransportDatagramDuplexStream",
+    "WebSocket",
+    "CloseEvent",
+    "ErrorEvent",
+    "MessageEvent",
+    "BinaryType",
 ] }
 futures-lite = { version = "2.1.0", optional = true }
 getrandom = { version = "0.2.11", features = [
-  "js",
+    "js",
 ] } # feature 'js' is required for wasm
 xwt-core = { version = "0.2", optional = true }
 xwt-web-sys = { version = "0.6", optional = true }

--- a/lightyear/src/channel/builder.rs
+++ b/lightyear/src/channel/builder.rs
@@ -42,7 +42,7 @@ pub trait Channel: 'static + Named {
 #[doc(hidden)]
 #[derive(Clone, Debug, PartialEq)]
 pub struct ChannelBuilder {
-    pub(crate) settings: ChannelSettings,
+    pub settings: ChannelSettings,
 }
 
 impl ChannelBuilder {

--- a/lightyear/src/client/connection.rs
+++ b/lightyear/src/client/connection.rs
@@ -14,6 +14,7 @@ use crate::client::message::ClientMessage;
 use crate::client::sync::SyncConfig;
 use crate::inputs::native::input_buffer::InputBuffer;
 use crate::packet::message_manager::MessageManager;
+use crate::packet::packet::Packet;
 use crate::packet::packet_manager::Payload;
 use crate::prelude::{Channel, ChannelKind, LightyearMapEntities, Message, NetworkTarget};
 use crate::protocol::channel::ChannelRegistry;
@@ -367,13 +368,9 @@ impl<P: Protocol> ConnectionManager<P> {
         std::mem::replace(&mut self.events, ConnectionEvents::new())
     }
 
-    pub(crate) fn recv_packet(
-        &mut self,
-        reader: &mut impl ReadBuffer,
-        tick_manager: &TickManager,
-    ) -> Result<()> {
+    pub(crate) fn recv_packet(&mut self, packet: Packet, tick_manager: &TickManager) -> Result<()> {
         // receive the packets, buffer them, update any sender that were waiting for their sent messages to be acked
-        let tick = self.message_manager.recv_packet(reader)?;
+        let tick = self.message_manager.recv_packet(packet)?;
         debug!("Received server packet with tick: {:?}", tick);
         if self
             .sync_manager

--- a/lightyear/src/client/networking.rs
+++ b/lightyear/src/client/networking.rs
@@ -105,9 +105,9 @@ pub(crate) fn receive<P: Protocol>(world: &mut World) {
                                         }
 
                                         // RECV PACKETS: buffer packets into message managers
-                                        while let Some(mut reader) = netcode.recv() {
+                                        while let Some(packet) = netcode.recv() {
                                             connection
-                                                .recv_packet(&mut reader, tick_manager.as_ref())
+                                                .recv_packet(packet, tick_manager.as_ref())
                                                 .unwrap();
                                         }
 

--- a/lightyear/src/client/resource.rs
+++ b/lightyear/src/client/resource.rs
@@ -100,22 +100,6 @@ impl<'w, 's, P: Protocol> ClientMut<'w, 's, P> {
         Ok(())
     }
 
-    /// Receive messages from the server
-    pub(crate) fn receive(&mut self, world: &mut World) -> ConnectionEvents<P> {
-        trace!("Receive server packets");
-        self.connection
-            .receive(world, &self.time_manager, &self.tick_manager)
-    }
-
-    /// Receive packets from the transport layer and buffer them with the message manager
-    pub(crate) fn recv_packets(&mut self) -> Result<()> {
-        while let Some(mut reader) = self.netcode.recv() {
-            self.connection
-                .recv_packet(&mut reader, &self.tick_manager)?;
-        }
-        Ok(())
-    }
-
     // NETCODE
 
     /// Start the connection process with the server

--- a/lightyear/src/connection/client.rs
+++ b/lightyear/src/connection/client.rs
@@ -9,6 +9,7 @@ use crate::connection::netcode::ClientId;
 
 #[cfg(feature = "steam")]
 use crate::connection::steam::client::SteamConfig;
+use crate::packet::packet::Packet;
 
 use crate::prelude::client::Authentication;
 use crate::prelude::{Io, IoConfig, LinkConditionerConfig};
@@ -27,7 +28,7 @@ pub trait NetClient: Send + Sync {
     fn try_update(&mut self, delta_ms: f64) -> Result<()>;
 
     /// Receive a packet from the server
-    fn recv(&mut self) -> Option<ReadWordBuffer>;
+    fn recv(&mut self) -> Option<Packet>;
 
     /// Send a packet to the server
     fn send(&mut self, buf: &[u8]) -> Result<()>;
@@ -131,7 +132,7 @@ impl NetClient for ClientConnection {
         self.client.try_update(delta_ms)
     }
 
-    fn recv(&mut self) -> Option<ReadWordBuffer> {
+    fn recv(&mut self) -> Option<Packet> {
         self.client.recv()
     }
 

--- a/lightyear/src/connection/netcode/packet.rs
+++ b/lightyear/src/connection/netcode/packet.rs
@@ -38,6 +38,8 @@ pub enum Error {
     TokenExpired,
     #[error("sequence {0} already received")]
     AlreadyReceived(u64),
+    #[error("invalid packet payload")]
+    InvalidPayload,
 }
 
 trait WriteSequence {

--- a/lightyear/src/connection/server.rs
+++ b/lightyear/src/connection/server.rs
@@ -8,6 +8,7 @@ use crate::connection::netcode::ClientId;
 
 #[cfg(feature = "steam")]
 use crate::connection::steam::server::SteamConfig;
+use crate::packet::packet::Packet;
 
 use crate::prelude::{Io, IoConfig, LinkConditionerConfig};
 use crate::server::config::NetcodeConfig;
@@ -24,7 +25,7 @@ pub trait NetServer: Send + Sync {
     fn try_update(&mut self, delta_ms: f64) -> Result<()>;
 
     /// Receive a packet from one of the connected clients
-    fn recv(&mut self) -> Option<(ReadWordBuffer, ClientId)>;
+    fn recv(&mut self) -> Option<(Packet, ClientId)>;
 
     /// Send a packet to one of the connected clients
     fn send(&mut self, buf: &[u8], client_id: ClientId) -> Result<()>;
@@ -106,7 +107,7 @@ impl NetServer for ServerConnection {
         self.server.try_update(delta_ms)
     }
 
-    fn recv(&mut self) -> Option<(ReadWordBuffer, ClientId)> {
+    fn recv(&mut self) -> Option<(Packet, ClientId)> {
         self.server.recv()
     }
 

--- a/lightyear/src/packet/message_manager.rs
+++ b/lightyear/src/packet/message_manager.rs
@@ -291,7 +291,7 @@ impl MessageManager {
                 trace!(?channel_kind, "reading message: {:?}", single_data);
                 // TODO: in this case, it looks like we might not need the pool?
                 //  we can just have a single buffer, and keep re-using that buffer
-                info!(pool_len = ?self.reader_pool.0.len(), "read from message manager");
+                trace!(pool_len = ?self.reader_pool.0.len(), "read from message manager");
                 let mut reader = self.reader_pool.start_read(single_data.bytes.as_ref());
                 let message = M::decode(&mut reader).expect("Could not decode message");
                 // return the buffer to the pool
@@ -366,7 +366,7 @@ mod tests {
 
         // server: receive bytes from the sent messages, then process them into messages
         for packet_byte in packet_bytes.iter_mut() {
-            let packet = ReadWordBuffer::start_read(packet_byte.as_slice())?;
+            let packet = Packet::decode(&mut ReadWordBuffer::start_read(packet_byte.as_slice()))?;
             server_message_manager.recv_packet(packet)?;
         }
         let mut data = server_message_manager.read_messages();
@@ -403,7 +403,7 @@ mod tests {
 
         // On client side: keep looping to receive bytes on the network, then process them into messages
         for packet_byte in packet_bytes.iter_mut() {
-            let packet = ReadWordBuffer::start_read(packet_byte.as_slice())?;
+            let packet = Packet::decode(&mut ReadWordBuffer::start_read(packet_byte.as_slice()))?;
             client_message_manager.recv_packet(packet)?;
         }
 
@@ -469,7 +469,7 @@ mod tests {
 
         // server: receive bytes from the sent messages, then process them into messages
         for packet_byte in packet_bytes.iter_mut() {
-            let packet = ReadWordBuffer::start_read(packet_byte.as_slice())?;
+            let packet = Packet::decode(&mut ReadWordBuffer::start_read(packet_byte.as_slice()))?;
             server_message_manager.recv_packet(packet)?;
         }
         let mut data = server_message_manager.read_messages();
@@ -514,7 +514,7 @@ mod tests {
 
         // On client side: keep looping to receive bytes on the network, then process them into messages
         for packet_byte in packet_bytes.iter_mut() {
-            let packet = ReadWordBuffer::start_read(packet_byte.as_slice())?;
+            let packet = Packet::decode(&mut ReadWordBuffer::start_read(packet_byte.as_slice()))?;
             client_message_manager.recv_packet(packet)?;
         }
 
@@ -564,7 +564,7 @@ mod tests {
 
         // server: receive bytes from the sent messages, then process them into messages
         for packet_byte in payloads.iter_mut() {
-            let packet = ReadWordBuffer::start_read(packet_byte.as_slice())?;
+            let packet = Packet::decode(&mut ReadWordBuffer::start_read(packet_byte.as_slice()))?;
             server_message_manager.recv_packet(packet)?;
         }
 
@@ -575,7 +575,7 @@ mod tests {
 
         // On client side: keep looping to receive bytes on the network, then process them into messages
         for packet_byte in packet_bytes.iter_mut() {
-            let packet = ReadWordBuffer::start_read(packet_byte.as_slice())?;
+            let packet = Packet::decode(&mut ReadWordBuffer::start_read(packet_byte.as_slice()))?;
             client_message_manager.recv_packet(packet)?;
         }
 

--- a/lightyear/src/packet/packet.rs
+++ b/lightyear/src/packet/packet.rs
@@ -269,7 +269,7 @@ impl PacketData {
 }
 
 #[derive(Debug)]
-pub(crate) struct Packet {
+pub struct Packet {
     pub(crate) header: PacketHeader,
     pub(crate) data: PacketData,
 }

--- a/lightyear/src/packet/packet.rs
+++ b/lightyear/src/packet/packet.rs
@@ -317,7 +317,7 @@ impl Packet {
     }
 
     // #[cfg(test)]
-    pub fn header(&self) -> &PacketHeader {
+    pub(crate) fn header(&self) -> &PacketHeader {
         &self.header
     }
 
@@ -350,7 +350,7 @@ impl Packet {
         }
     }
 
-    pub fn message_acks(&self) -> HashMap<ChannelId, Vec<MessageAck>> {
+    pub(crate) fn message_acks(&self) -> HashMap<ChannelId, Vec<MessageAck>> {
         match &self.data {
             PacketData::Single(single_packet) => single_packet.message_acks(),
             PacketData::Fragmented(fragmented_packet) => fragmented_packet.message_acks(),

--- a/lightyear/src/packet/packet_manager.rs
+++ b/lightyear/src/packet/packet_manager.rs
@@ -1,6 +1,7 @@
 use std::collections::{BTreeMap, VecDeque};
 
 use bitcode::encoding::Gamma;
+use bitcode::word_buffer::WordBuffer;
 
 use crate::connection::netcode::MAX_PACKET_SIZE;
 use crate::packet::header::PacketHeaderManager;
@@ -75,13 +76,6 @@ impl PacketBuilder {
         // packet.encode(&mut self.write_buffer)?;
         // let bytes = self.write_buffer.finish_write();
         // Ok(bytes)
-    }
-
-    /// Decode a packet from raw bytes
-    // TODO: the reader buffer will be created from the io (we copy the io bytes into a buffer)
-    // Should we decode the packet and get ChannelKinds directly?
-    pub(crate) fn decode_packet(&mut self, reader: &mut impl ReadBuffer) -> anyhow::Result<Packet> {
-        Packet::decode(reader)
     }
 
     /// Start building new packet, we start with an empty packet

--- a/lightyear/src/serialize/reader.rs
+++ b/lightyear/src/serialize/reader.rs
@@ -6,9 +6,7 @@ use bitcode::word::Word;
 use bitcode::Decode;
 use serde::de::DeserializeOwned;
 
-pub trait ReadBuffer: BitRead {
-    fn capacity(&self) -> usize;
-
+pub trait ReadBuffer {
     /// Deserialize from the buffer using serde
     fn deserialize<T: DeserializeOwned>(&mut self) -> Result<T>;
 
@@ -20,21 +18,4 @@ pub trait ReadBuffer: BitRead {
 
     /// Check for errors such as Eof and ExpectedEof
     fn finish_read(&mut self) -> Result<()>;
-}
-
-/// Abstracts over reading bits from a buffer.
-pub trait BitRead {
-    /// Advances any amount of bits. Must never fail.
-    fn advance(&mut self, bits: usize);
-    /// Peeks 64 bits without reading them. Bits after EOF are zeroed.
-    fn peek_bits(&mut self) -> Result<Word>;
-
-    // Reads 1 bit.
-    fn read_bit(&mut self) -> Result<bool>;
-    /// Reads up to 64 bits. `bits` must be in range `1..=64`.
-    fn read_bits(&mut self, bits: usize) -> Result<Word>;
-    /// Reads `len` bytes.
-    fn read_bytes(&mut self, len: NonZeroUsize) -> Result<&[u8]>;
-    /// Ensures that at least `bits` remain. Never underreports remaining bits.
-    fn reserve_bits(&self, bits: usize) -> Result<()>;
 }

--- a/lightyear/src/serialize/wordbuffer/reader.rs
+++ b/lightyear/src/serialize/wordbuffer/reader.rs
@@ -50,7 +50,7 @@ impl BufferPool {
 
     pub fn start_read(&self, bytes: &[u8]) -> ReadWordBuffer {
         trace!("buffer pool length: {}", self.0.len());
-        let mut buffer = self.0.pull(new_buffer);
+        let buffer = self.0.pull(new_buffer);
         // let (reader, context) = buffer.start_read(bytes);
         // ReadWordBuffer { reader, context }
         let (_, buffer) = buffer.detach();

--- a/lightyear/src/serialize/wordbuffer/reader.rs
+++ b/lightyear/src/serialize/wordbuffer/reader.rs
@@ -3,6 +3,7 @@ use std::num::NonZeroUsize;
 use std::ops::Deref;
 use std::sync::{Arc, Mutex, RwLock};
 
+use crate::packet::packet::MTU_PAYLOAD_BYTES;
 use anyhow::Context;
 use bevy::ptr::UnsafeCellDeref;
 use bitcode::buffer::BufferTrait;
@@ -13,8 +14,11 @@ use bitcode::word_buffer::{WordBuffer, WordContext, WordReader};
 use bitcode::Decode;
 use self_cell::self_cell;
 use serde::de::DeserializeOwned;
+use tracing::{info, trace};
 
-use crate::serialize::reader::{BitRead, ReadBuffer};
+use crate::serialize::reader::ReadBuffer;
+
+pub const READER_BUFFER_POOL_SIZE: usize = 1;
 
 #[derive(Default)]
 pub struct Reader<'a>(Option<(WordReader<'a>, WordContext)>);
@@ -25,6 +29,44 @@ struct OnlyGammaDecode<T: DeserializeOwned>(#[bitcode(with_serde)] T);
 
 unsafe impl Send for ReadWordBuffer {}
 unsafe impl Sync for ReadWordBuffer {}
+
+pub(crate) struct BufferPool(pub(crate) object_pool::Pool<WordBuffer>);
+
+fn new_buffer() -> WordBuffer {
+    trace!("Allocating new buffer for ReadWordBuffer");
+    WordBuffer::with_capacity(MTU_PAYLOAD_BYTES)
+}
+
+impl Default for BufferPool {
+    fn default() -> Self {
+        Self::new(READER_BUFFER_POOL_SIZE)
+    }
+}
+
+impl BufferPool {
+    pub fn new(cap: usize) -> Self {
+        Self(object_pool::Pool::new(cap, new_buffer))
+    }
+
+    pub fn start_read(&self, bytes: &[u8]) -> ReadWordBuffer {
+        trace!("buffer pool length: {}", self.0.len());
+        let mut buffer = self.0.pull(new_buffer);
+        // let (reader, context) = buffer.start_read(bytes);
+        // ReadWordBuffer { reader, context }
+        let (_, buffer) = buffer.detach();
+        ReadWordBuffer::start_read_with_buffer(bytes, buffer)
+    }
+
+    pub fn attach(&self, reader: ReadWordBuffer) {
+        // return to the pool the buffer associated to the reader
+        self.0.attach(reader.into_owner().into_inner());
+    }
+}
+
+// pub struct ReadWordBuffer<'buffer> {
+//     reader: WordReader<'buffer>,
+//     context: WordContext,
+// }
 
 // We use self_cell because the reader contains a reference to the WordBuffer
 // (it will take ownership of the buffer's contents to write into)
@@ -38,18 +80,29 @@ self_cell!(
 );
 
 impl ReadBuffer for ReadWordBuffer {
-    fn capacity(&self) -> usize {
-        unsafe { self.borrow_owner().deref().capacity() }
-    }
-
     // fn deserialize<T: DeserializeOwned>(&mut self) -> anyhow::Result<T> {
-    //     self.with_dependent_mut(|buffer, reader| {
-    //         let reader = reader
-    //             .0
-    //             .as_mut()
-    //             .map_or_else(|| panic!("no reader"), |(reader, _)| reader);
-    //         deserialize_compat(Fixed, reader).context("error deserializing")
-    //     })
+    //     let with_gamma =
+    //         OnlyGammaDecode::<T>::decode(Fixed, &mut self.reader).context("error deserializing")?;
+    //     Ok(with_gamma.0)
+    // }
+    //
+    // fn decode<T: Decode>(&mut self, encoding: impl Encoding) -> anyhow::Result<T> {
+    //     T::decode(encoding, &mut self.reader).context("error decoding")
+    // }
+    //
+    // fn start_read(bytes: &[u8]) -> Self {
+    //     let mut buffer = WordBuffer::with_capacity(bytes.len());
+    //     let (reader, context) = buffer.start_read(bytes);
+    //     ReadWordBuffer { reader, context }
+    // }
+    //
+    // fn finish_read(&mut self) -> anyhow::Result<()> {
+    //     todo!();
+    //     // WordBuffer::finish_read(self.reader, self.context).context("error finishing read");
+    //     // self.with_dependent_mut(|_, reader| {
+    //     //     let (reader, context) = std::mem::take(reader).0.context("no reader")?;
+    //     //     WordBuffer::finish_read(reader, context).context("error finishing read")
+    //     // })
     // }
 
     fn deserialize<T: DeserializeOwned>(&mut self) -> anyhow::Result<T> {
@@ -96,34 +149,15 @@ impl ReadBuffer for ReadWordBuffer {
     }
 }
 
-impl BitRead for ReadWordBuffer {
-    fn advance(&mut self, _bits: usize) {
-        todo!()
-    }
-
-    fn peek_bits(&mut self) -> anyhow::Result<Word> {
-        todo!()
-    }
-
-    fn read_bit(&mut self) -> anyhow::Result<bool> {
-        todo!()
-    }
-
-    fn read_bits(&mut self, _bits: usize) -> anyhow::Result<Word> {
-        todo!()
-    }
-
-    fn read_bytes(&mut self, len: NonZeroUsize) -> anyhow::Result<&[u8]> {
-        self.with_dependent_mut(|_buffer, reader| {
-            let reader = reader
-                .0
-                .as_mut()
-                .map_or_else(|| panic!("no reader"), |(reader, _)| reader);
-            reader.read_bytes(len).context("error reading bytes")
+impl ReadWordBuffer {
+    pub(crate) fn start_read_with_buffer(bytes: &[u8], buffer: WordBuffer) -> Self {
+        ReadWordBuffer::new(UnsafeCell::new(buffer), |buffer| {
+            // safety: we just created the buffer and nothing else had access to it
+            // we need to get a mutable reference to the buffer to take ownership of it
+            unsafe {
+                let (reader, context) = buffer.deref_mut().start_read(bytes);
+                Reader(Some((reader, context)))
+            }
         })
-    }
-
-    fn reserve_bits(&self, _bits: usize) -> anyhow::Result<()> {
-        todo!()
     }
 }

--- a/lightyear/src/serialize/wordbuffer/writer.rs
+++ b/lightyear/src/serialize/wordbuffer/writer.rs
@@ -6,7 +6,7 @@ use bitcode::write::Write;
 use bitcode::Encode;
 use serde::Serialize;
 
-use crate::serialize::writer::{BitWrite, WriteBuffer};
+use crate::serialize::writer::WriteBuffer;
 
 // strategy for message/channels
 
@@ -49,10 +49,6 @@ impl WriteBuffer for WriteWordBuffer {
             .context("error encoding")
     }
 
-    fn capacity(&self) -> usize {
-        self.buffer.capacity()
-    }
-
     fn with_capacity(capacity: usize) -> Self {
         let mut buffer = WordBuffer::with_capacity(capacity);
         let writer = buffer.start_write();
@@ -89,20 +85,6 @@ impl WriteBuffer for WriteWordBuffer {
 
     fn set_reserved_bits(&mut self, num_bits: usize) {
         self.max_bits = num_bits;
-    }
-}
-
-impl BitWrite for WriteWordBuffer {
-    fn write_bit(&mut self, bit: bool) {
-        self.writer.write_bit(bit)
-    }
-
-    fn write_bits(&mut self, _bits: u32) {
-        todo!()
-    }
-
-    fn write_bytes(&mut self, bytes: &[u8]) {
-        self.writer.write_bytes(bytes)
     }
 }
 

--- a/lightyear/src/serialize/writer.rs
+++ b/lightyear/src/serialize/writer.rs
@@ -3,9 +3,7 @@ use bitcode::Encode;
 use serde::Serialize;
 
 /// Buffer to facilitate writing bits
-pub trait WriteBuffer: BitWrite {
-    // type Writer: BitWrite;
-
+pub trait WriteBuffer {
     /// Serialize the given value into the buffer
     /// There is no padding when we serialize a value (i.e. it's possible to add a single bit
     /// to the buffer)
@@ -14,7 +12,6 @@ pub trait WriteBuffer: BitWrite {
 
     fn encode<T: Encode + ?Sized>(&mut self, t: &T, encoding: impl Encoding) -> anyhow::Result<()>;
 
-    fn capacity(&self) -> usize;
     fn with_capacity(capacity: usize) -> Self;
 
     /// Clears the buffer.
@@ -36,10 +33,4 @@ pub trait WriteBuffer: BitWrite {
 
     /// Set the number of bits that can be written to this buffer
     fn set_reserved_bits(&mut self, num_bits: usize);
-}
-
-pub trait BitWrite {
-    fn write_bit(&mut self, bit: bool);
-    fn write_bits(&mut self, bits: u32);
-    fn write_bytes(&mut self, bytes: &[u8]);
 }

--- a/lightyear/src/server/connection.rs
+++ b/lightyear/src/server/connection.rs
@@ -14,6 +14,7 @@ use crate::client::message::ClientMessage;
 use crate::connection::netcode::ClientId;
 use crate::inputs::native::input_buffer::InputBuffer;
 use crate::packet::message_manager::MessageManager;
+use crate::packet::packet::Packet;
 use crate::packet::packet_manager::Payload;
 use crate::prelude::{Channel, ChannelKind, LightyearMapEntities, Message};
 use crate::protocol::channel::ChannelRegistry;
@@ -535,13 +536,9 @@ impl<P: Protocol> Connection<P> {
         std::mem::replace(&mut self.events, ConnectionEvents::new())
     }
 
-    pub fn recv_packet(
-        &mut self,
-        reader: &mut impl ReadBuffer,
-        tick_manager: &TickManager,
-    ) -> Result<()> {
+    pub fn recv_packet(&mut self, packet: Packet, tick_manager: &TickManager) -> Result<()> {
         // receive the packets, buffer them, update any sender that were waiting for their sent messages to be acked
-        let tick = self.message_manager.recv_packet(reader)?;
+        let tick = self.message_manager.recv_packet(packet)?;
         // notify the replication sender that some sent messages were received
         self.replication_sender.recv_update_acks();
         debug!("Received server packet with tick: {:?}", tick);

--- a/lightyear/src/server/networking.rs
+++ b/lightyear/src/server/networking.rs
@@ -110,13 +110,13 @@ pub(crate) fn receive<P: Protocol>(world: &mut World) {
 
                                             // RECV_PACKETS: buffer packets into message managers
                                             for (server_idx, netserver) in netservers.servers.iter_mut().enumerate() {
-                                                while let Some((mut reader, client_id)) = netserver.recv() {
+                                                while let Some((packet, client_id)) = netserver.recv() {
                                                     if let Some(global_id) = netservers.global_id_map.get_global(server_idx, client_id) {
                                                         // TODO: use connection to apply on BOTH message manager and replication manager
                                                         connection_manager
                                                             .connection_mut(global_id)
                                                             .expect("connection not found")
-                                                            .recv_packet(&mut reader, tick_manager.as_ref())
+                                                            .recv_packet(packet, tick_manager.as_ref())
                                                             .expect("could not recv packet");
                                                     } else {
                                                         error!("Global client id was not found!");

--- a/lightyear/src/server/resource.rs
+++ b/lightyear/src/server/resource.rs
@@ -101,26 +101,6 @@ impl<'w, 's, P: Protocol> ServerMut<'w, 's, P> {
         Ok(())
     }
 
-    /// Receive packets from the transport layer and buffer them with the message manager
-    pub(crate) fn recv_packets(&mut self) -> Result<()> {
-        while let Some((mut reader, client_id)) = self.netcode.recv() {
-            // TODO: use connection to apply on BOTH message manager and replication manager
-            self.connection_manager
-                .connection_mut(client_id)?
-                .recv_packet(&mut reader, &self.tick_manager)?;
-        }
-        Ok(())
-    }
-
-    /// Receive messages from each connection, and update the events buffer
-    pub(crate) fn receive(&mut self, world: &mut World) {
-        self.connection_manager
-            .receive(world, &self.time_manager, &self.tick_manager)
-            .unwrap_or_else(|e| {
-                error!("Error during receive: {}", e);
-            });
-    }
-
     // MESSAGES
 
     /// Queues up a message to be sent to all clients

--- a/vendor/bitcode/src/word_buffer.rs
+++ b/vendor/bitcode/src/word_buffer.rs
@@ -10,6 +10,7 @@ use std::num::NonZeroUsize;
 
 /// A fast `Buffer` that operates on [`Word`]s.
 #[derive(Debug, Default)]
+
 pub struct WordBuffer {
     allocation: Allocation,
     read_bytes_buf: Box<[Word]>,


### PR DESCRIPTION
This PR introduces 2 changes:
- when we receive bytes from the network, we would create a new buffer, copy the bytes in there, and then create a ReadWordBuffer which would allow us to deserialize the data. We would then pass the ReadWordBuffer around, to eventually deserialize the data. This level of indirection was a bit unwieldy and not very useful, instead we just directly deserialize the data into a `Packet` object
- to re-use the memory and avoid allocating a new buffer on every packet receive, we introduce an `object_pool::Pool` of `WordBuffer`. In practice, we don't really need the pool and could probably just use `Option<WordBuffer>`, but maybe it will be useful in the future. Now, when we receive a new packet, we copy the bytes into the pre-allocated buffer from the pool, and we immediately decode into a `Packet`. 

(where does the memory for the `Packet` live? the stack?)

TODO: 
- add safeguards/limitations on the size of this buffer? (it could grow indefinitely!) I know renet has memory limits on the size of buffers per channel



Fixes https://github.com/cBournhonesque/lightyear/issues/43