### PR TITLE
Add benchmark for packet packing using the new bitcode version

### DIFF
--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -18,8 +18,14 @@ crossbeam-channel = "0.5.10"
 anyhow = { version = "1.0.75", features = [] }
 bevy = { version = "0.13", features = ["bevy_core_pipeline"] }
 derive_more = { version = "0.99", features = ["add", "mul"] }
-divan = "0.1.11"
+divan = "0.1.14"
 serde = { version = "1.0.188", features = ["derive"] }
+
+bitcode = "0.6.0-beta.1"
+rand = "0.8.5"
+rand_chacha = "0.3.1"
+lz4_flex = { version = "0.11.2", default-features = false }
+
 
 [[bench]]
 name = "spawn"

--- a/benches/bitcode_packing.rs
+++ b/benches/bitcode_packing.rs
@@ -1,0 +1,258 @@
+//! Benchmark for how to use bitcode to pack messages into packets of MTU bytes
+#![allow(unused_variables)]
+use bevy::app::App;
+use bevy::prelude::In;
+use divan::counter::ItemsCount;
+use divan::Bencher;
+use rand::distributions::Standard;
+use rand::prelude::*;
+use std::time::Instant;
+
+trait Packer {
+    /// packet the messages into packets (preferably of size <=MAX_SIZE)
+    fn pack(messages: &[Message]) -> Vec<Packet>;
+}
+
+#[derive(bitcode::Encode, bitcode::Decode)]
+enum Message {
+    A(bool),
+    B(u8),
+    C { name: String, x: i16, y: i16 },
+}
+
+impl Distribution<Message> for Standard {
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Message {
+        if rng.gen_bool(0.5) {
+            Message::A(rng.gen_bool(0.1))
+        } else if rng.gen_bool(0.4) {
+            Message::B(rng.gen_range(9..15))
+        } else {
+            Message::C {
+                name: if rng.gen_bool(0.0001) {
+                    // Throw a curveball of an incompressible string larger than a single packet.
+                    let n = rng.gen_range(1300..2000);
+                    (0..n).map(|_| rng.gen_range(b'0'..=b'9') as char).collect()
+                } else {
+                    [
+                        "cow", "sheep", "zombie", "skeleton", "spider", "creeper", "parrot", "bee",
+                    ]
+                    .choose(rng)
+                    .unwrap()
+                    .to_string()
+                },
+                x: rng.gen_range(-100..100),
+                y: rng.gen_range(0..15),
+            }
+        }
+    }
+}
+
+struct Packet(Vec<u8>);
+impl Packet {
+    const MAX_SIZE: usize = 1200;
+}
+
+#[allow(dead_code)]
+fn main() {
+    divan::main();
+}
+
+trait GenMessages: Default {
+    fn gen(&mut self) -> Vec<Message>;
+}
+
+struct RandomGen {
+    rng: rand_chacha::ChaCha20Rng,
+}
+
+impl Default for RandomGen {
+    fn default() -> Self {
+        Self {
+            rng: rand_chacha::ChaCha20Rng::from_seed(Default::default()),
+        }
+    }
+}
+
+impl GenMessages for RandomGen {
+    fn gen(&mut self) -> Vec<Message> {
+        let n = self.rng.gen_range(200..20000);
+        (0..n).map(|_| self.rng.gen()).collect()
+    }
+}
+
+#[divan::bench(
+    types = [NaivePacker, AppendedPacker, ExponentialPacker, InterpolationPacker],
+    sample_count = 10,
+)]
+fn run_packer<P: Packer>(bencher: Bencher) {
+    let mut gen = RandomGen::default();
+    let mut total_bytes = 0;
+    let mut packet_count = 0;
+    let mut packet_extensions = 0;
+    bencher
+        .with_inputs(|| gen.gen())
+        .input_counter(|messages| ItemsCount::of_iter(messages))
+        .bench_local_refs(|messages| {
+            // println!("{}", messages.len());
+            let packets = P::pack(messages);
+            let packet_lens: Vec<_> = packets.iter().map(|p| p.0.len()).collect();
+            // TODO: add as output_counters once it's supported https://github.com/nvzqz/divan/issues/34
+            total_bytes += packet_lens.iter().sum::<usize>();
+            packet_count += packets.len();
+            // number of extra fragments needed
+            packet_extensions += packet_lens
+                .iter()
+                .map(|&len| len.saturating_sub(1) / Packet::MAX_SIZE)
+                .sum::<usize>();
+            // println!("Packet lengths: {packet_lens:?}");
+        });
+    println!(
+        "\n{total_bytes} bytes total, {packet_count} packets, {packet_extensions} extension packets"
+    );
+}
+
+fn encode_compressed(t: &(impl bitcode::Encode + ?Sized)) -> Vec<u8> {
+    let encoded = bitcode::encode(t);
+    // Makes pack_interpolation_search take 33% fewer packets without reducing speed at all.
+    const COMPRESS: bool = true;
+    if COMPRESS {
+        lz4_flex::compress_prepend_size(&encoded)
+    } else {
+        encoded
+    }
+}
+
+struct NaivePacker;
+
+impl Packer for NaivePacker {
+    /// Just call encode_compressed once
+    fn pack(messages: &[Message]) -> Vec<Packet> {
+        vec![Packet(encode_compressed(messages))]
+    }
+}
+
+struct AppendedPacker;
+
+impl Packer for AppendedPacker {
+    /// Encode each packet individually, check the size, and concatenate them up to MAX_SIZE
+    fn pack(messages: &[Message]) -> Vec<Packet> {
+        let mut bytes = vec![];
+        let mut packets = vec![];
+        for m in messages {
+            // Don't use encode_compressed since compression doesn't improve tiny messages.
+            let encoded = bitcode::encode(m);
+            if bytes.len() + encoded.len() > Packet::MAX_SIZE {
+                packets.push(Packet(std::mem::take(&mut bytes)));
+            }
+            bytes.extend_from_slice(&encoded);
+        }
+        if !bytes.is_empty() {
+            packets.push(Packet(bytes));
+        }
+        packets
+    }
+}
+
+struct ExponentialPacker;
+
+impl Packer for ExponentialPacker {
+    // pack messages[0..k] where k is a 2^i up to MAX_SIZE
+    fn pack(mut messages: &[Message]) -> Vec<Packet> {
+        let mut packets = vec![];
+        let mut n = 1;
+        let mut last = None;
+
+        loop {
+            n = n.min(messages.len());
+            let chunk = &messages[..n];
+            let encoded = encode_compressed(chunk);
+            let current = (encoded, n);
+
+            if current.0.len() < Packet::MAX_SIZE && n < messages.len() {
+                last = Some(current);
+                n *= 2;
+                continue;
+            }
+
+            n = 1;
+            // If the current chunk is too big, use the last chunk.
+            let (encoded, n) = last
+                .take()
+                .filter(|_| current.0.len() > Packet::MAX_SIZE)
+                .unwrap_or(current);
+
+            messages = &messages[n..];
+            packets.push(Packet(encoded));
+            if messages.is_empty() {
+                break;
+            }
+        }
+        packets
+    }
+}
+
+struct InterpolationPacker;
+
+impl Packer for InterpolationPacker {
+    fn pack(mut messages: &[Message]) -> Vec<Packet> {
+        const SAMPLE: usize = 32; // Tune based on expected message size and variance.
+        const PRECISION: usize = 30; // More precision will take longer, but get closer to max packet size.
+        const MAX_ATTEMPTS: usize = 4; // Maximum number of attempts before giving up.
+        const TARGET_SIZE: usize = Packet::MAX_SIZE * PRECISION / (PRECISION + 1);
+        const MIN_SIZE: usize = TARGET_SIZE * PRECISION / (PRECISION + 1);
+        const DEBUG: bool = false;
+
+        let mut packets = vec![];
+        let mut message_size = None;
+        // If we run out of attempts, send the largest attempt so far to avoid infinite loop.
+        let mut attempts = 0;
+        let mut largest_so_far = None;
+
+        while !messages.is_empty() {
+            let n = message_size
+                .map(|message_size: f32| (TARGET_SIZE as f32 / message_size).floor() as usize)
+                .unwrap_or(SAMPLE);
+            let n = n.clamp(1, messages.len());
+
+            let chunk = &messages[..n];
+            let encoded = encode_compressed(chunk);
+
+            message_size = Some(encoded.len() as f32 / n as f32);
+            let too_large = encoded.len() > Packet::MAX_SIZE;
+            let too_small = encoded.len() < MIN_SIZE && n != messages.len();
+            let current = (encoded, n);
+
+            let (encoded, n) = if too_large || too_small {
+                if attempts < MAX_ATTEMPTS {
+                    if DEBUG {
+                        println!("skipping {n} messages with {} bytes", current.0.len());
+                    }
+                    if too_small && n > largest_so_far.as_ref().map_or(0, |(_, n)| *n) {
+                        largest_so_far = Some(current);
+                    }
+                    attempts += 1;
+                    continue;
+                }
+                // We ran out of attempts, if the current chunk is too big, use the largest chunk so far.
+                largest_so_far
+                    .take()
+                    .filter(|_| current.0.len() > Packet::MAX_SIZE)
+                    .unwrap_or(current)
+            } else {
+                current
+            };
+
+            attempts = 0;
+            largest_so_far = None;
+
+            if DEBUG {
+                println!("packed {n} messages with {} bytes", encoded.len());
+            }
+            messages = &messages[n..];
+            packets.push(Packet(encoded));
+        }
+
+        // TODO merge tiny packets (caused by single messages > Packet::MAX_SIZE)
+        packets
+    }
+}

--- a/benches/spawn.rs
+++ b/benches/spawn.rs
@@ -1,6 +1,8 @@
 //! Benchmark to measure the performance of replicating Entity spawns
 #![allow(unused_imports)]
 
+mod bitcode_packing;
+
 use bevy::log::info;
 use bevy::prelude::default;
 use bevy::utils::tracing;
@@ -12,7 +14,6 @@ use lightyear::prelude::client::{InterpolationConfig, PredictionConfig};
 use lightyear::prelude::{ClientId, NetworkTarget, SharedConfig, TickConfig};
 use lightyear_benches::local_stepper::{LocalBevyStepper, Step as LocalStep};
 use lightyear_benches::protocol::*;
-use lightyear_benches::stepper::{BevyStepper, Step};
 
 fn main() {
     divan::main()


### PR DESCRIPTION
Thanks to @finnbear for contributing an awesome benchmark on using bitcode 0.6.0 and packing the resulting serialized messages into packets of size MAX_SIZE.

The reason for this benchmark is that with the previous bitcode version 0.5.0; we could serialize each individual packet separately and track the number of bits written in an internal buffer. We could use this to try to serialize as many small messages as possible into packets of size MTU.

With bitcode 0.6.0, some APIs related to counting the number of bits written in the internal buffer have been removed; but it's still possible to apply several message-packing strategies to serialize various messages into packets of size MTU.

<img width="834" alt="image" src="https://github.com/cBournhonesque/lightyear/assets/8112632/1bcb5b5a-69c6-450a-b91b-e89d9afbcc5b">


The benchmark shows that the best strategy is to use the `BinarySearchPacker`;
it only has a 2X time overhead compared to the naive packer (which doesn't do any packing) but it seems to very rarely create extra fragments beyond the MTU size.