### PR TITLE
Add unit test for client and entities moving rooms

### DIFF
--- a/examples/simple_box/Cargo.toml
+++ b/examples/simple_box/Cargo.toml
@@ -18,10 +18,10 @@ mock_time = ["lightyear/mock_time"]
 
 [dependencies]
 lightyear = { path = "../../lightyear", features = [
-    "steam",
-    "webtransport",
-    "websocket",
-    "render",
+  "steam",
+  "webtransport",
+  "websocket",
+  "render",
 ] }
 async-compat = "0.2.3"
 serde = { version = "1.0.188", features = ["derive"] }

--- a/examples/simple_box/Cargo.toml
+++ b/examples/simple_box/Cargo.toml
@@ -18,10 +18,10 @@ mock_time = ["lightyear/mock_time"]
 
 [dependencies]
 lightyear = { path = "../../lightyear", features = [
-  "steam",
-  "webtransport",
-  "websocket",
-  "render",
+    "steam",
+    "webtransport",
+    "websocket",
+    "render",
 ] }
 async-compat = "0.2.3"
 serde = { version = "1.0.188", features = ["derive"] }

--- a/examples/simple_box/src/main.rs
+++ b/examples/simple_box/src/main.rs
@@ -26,7 +26,6 @@ use crate::settings::*;
 
 mod client;
 mod protocol;
-
 mod server;
 mod settings;
 mod shared;

--- a/examples/simple_box/src/settings.rs
+++ b/examples/simple_box/src/settings.rs
@@ -6,9 +6,13 @@ use async_compat::Compat;
 use bevy::tasks::IoTaskPool;
 use serde::{Deserialize, Serialize};
 
-use lightyear::prelude::client::{Authentication, SteamConfig};
+#[cfg(not(target_family = "wasm"))]
+use lightyear::prelude::client::SteamConfig;
+
+use lightyear::prelude::client::Authentication;
 use lightyear::prelude::{ClientId, IoConfig, LinkConditionerConfig, TransportConfig};
 
+#[cfg(not(target_family = "wasm"))]
 use crate::server::Certificate;
 use crate::{client, server};
 
@@ -20,6 +24,7 @@ pub enum ClientTransports {
         certificate_digest: String,
     },
     WebSocket,
+    #[cfg(not(target_family = "wasm"))]
     Steam {
         app_id: u32,
     },
@@ -36,6 +41,7 @@ pub enum ServerTransports {
     WebSocket {
         local_port: u16,
     },
+    #[cfg(not(target_family = "wasm"))]
     Steam {
         app_id: u32,
         server_ip: Ipv4Addr,
@@ -57,8 +63,8 @@ pub struct Conditioner {
 impl Conditioner {
     pub fn build(&self) -> LinkConditionerConfig {
         LinkConditionerConfig {
-            incoming_latency: std::time::Duration::from_millis(self.latency_ms as u64),
-            incoming_jitter: std::time::Duration::from_millis(self.jitter_ms as u64),
+            incoming_latency: Duration::from_millis(self.latency_ms as u64),
+            incoming_jitter: Duration::from_millis(self.jitter_ms as u64),
             incoming_loss: self.packet_loss,
         }
     }
@@ -273,7 +279,7 @@ pub fn get_client_net_config(settings: &Settings, client_id: ClientId) -> client
                 client_addr,
                 server_addr,
                 #[cfg(target_family = "wasm")]
-                certificate_digest,
+                certificate_digest: certificate_digest.clone(),
             },
         ),
         ClientTransports::WebSocket => build_client_netcode_config(
@@ -283,6 +289,7 @@ pub fn get_client_net_config(settings: &Settings, client_id: ClientId) -> client
             &settings.shared,
             TransportConfig::WebSocketClient { server_addr },
         ),
+        #[cfg(not(target_family = "wasm"))]
         ClientTransports::Steam { app_id } => client::NetConfig::Steam {
             config: SteamConfig {
                 server_addr,

--- a/lightyear/Cargo.toml
+++ b/lightyear/Cargo.toml
@@ -14,30 +14,30 @@ exclude = ["/tests"]
 
 [features]
 metrics = [
-  "dep:metrics",
-  "metrics-util",
-  "metrics-tracing-context",
-  "metrics-exporter-prometheus",
-  "dep:tokio",
+    "dep:metrics",
+    "metrics-util",
+    "metrics-tracing-context",
+    "metrics-exporter-prometheus",
+    "dep:tokio",
 ]
 mock_time = ["dep:mock_instant"]
 render = ["bevy/bevy_render"]
 webtransport = [
-  "dep:wtransport",
-  "dep:xwt-core",
-  "dep:xwt-web-sys",
-  "dep:web-sys",
-  "dep:tokio",
-  "dep:ring",
+    "dep:wtransport",
+    "dep:xwt-core",
+    "dep:xwt-web-sys",
+    "dep:web-sys",
+    "dep:tokio",
+    "dep:ring",
 ]
 leafwing = ["dep:leafwing-input-manager", "lightyear_macros/leafwing"]
 xpbd_2d = ["dep:bevy_xpbd_2d"]
 websocket = [
-  "dep:tokio",
-  "dep:tokio-tungstenite",
-  "dep:futures-util",
-  "dep:web-sys",
-  "dep:wasm-bindgen",
+    "dep:tokio",
+    "dep:tokio-tungstenite",
+    "dep:futures-util",
+    "dep:web-sys",
+    "dep:wasm-bindgen",
 ]
 steam = ["dep:steamworks"]
 
@@ -70,7 +70,7 @@ bevy_xpbd_2d = { version = "0.4", optional = true }
 
 # serialization
 bitcode = { version = "0.5.1", package = "bitcode_lightyear_patch", path = "../vendor/bitcode", features = [
-  "serde",
+    "serde",
 ] }
 bytes = { version = "1.5", features = ["serde"] }
 object-pool = { version = "0.5.4" }
@@ -88,8 +88,8 @@ lightyear_macros = { version = "0.12.0", path = "../macros" }
 tracing = "0.1.40"
 tracing-log = "0.2.0"
 tracing-subscriber = { version = "0.3.17", features = [
-  "registry",
-  "env-filter",
+    "registry",
+    "env-filter",
 ] }
 
 # server
@@ -100,12 +100,12 @@ metrics = { version = "0.22", optional = true }
 metrics-util = { version = "0.15", optional = true }
 metrics-tracing-context = { version = "0.15", optional = true }
 metrics-exporter-prometheus = { version = "0.13.0", optional = true, default-features = false, features = [
-  "http-listener",
+    "http-listener",
 ] }
 
 # bevy
 bevy = { version = "0.13", default-features = false, features = [
-  "multi-threaded",
+    "multi-threaded",
 ] }
 
 # connection
@@ -117,44 +117,44 @@ futures-util = { version = "0.3.30", optional = true }
 # transport
 # we don't need any tokio features, we use only use the tokio channels
 tokio = { version = "1.36", features = [
-  "sync",
+    "sync",
 ], default-features = false, optional = true }
 async-compat = "0.2.3"
 
 [target."cfg(not(target_family = \"wasm\"))".dependencies]
 # webtransport
-wtransport = { version = "0.1.10", optional = true, features = [
-  "self-signed",
-  "dangerous-configuration",
+wtransport = { version = "=0.1.11", optional = true, features = [
+    "self-signed",
+    "dangerous-configuration",
 ] }
 # websocket
 tokio-tungstenite = { version = "0.21.0", optional = true, features = [
-  "connect",
-  "handshake",
+    "connect",
+    "handshake",
 ] }
 
 [target."cfg(target_family = \"wasm\")".dependencies]
 console_error_panic_hook = { version = "0.1.7" }
 ring = { version = "0.17.7", optional = true }
 web-sys = { version = "0.3", optional = true, features = [
-  "WebTransport",
-  "WebTransportHash",
-  "WebTransportOptions",
-  "WebTransportBidirectionalStream",
-  "WebTransportSendStream",
-  "WebTransportReceiveStream",
-  "ReadableStreamDefaultReader",
-  "WritableStreamDefaultWriter",
-  "WebTransportDatagramDuplexStream",
-  "WebSocket",
-  "CloseEvent",
-  "ErrorEvent",
-  "MessageEvent",
-  "BinaryType",
+    "WebTransport",
+    "WebTransportHash",
+    "WebTransportOptions",
+    "WebTransportBidirectionalStream",
+    "WebTransportSendStream",
+    "WebTransportReceiveStream",
+    "ReadableStreamDefaultReader",
+    "WritableStreamDefaultWriter",
+    "WebTransportDatagramDuplexStream",
+    "WebSocket",
+    "CloseEvent",
+    "ErrorEvent",
+    "MessageEvent",
+    "BinaryType",
 ] }
 futures-lite = { version = "2.1.0", optional = true }
 getrandom = { version = "0.2.11", features = [
-  "js",
+    "js",
 ] } # feature 'js' is required for wasm
 xwt-core = { version = "0.2", optional = true }
 xwt-web-sys = { version = "0.6", optional = true }

--- a/lightyear/Cargo.toml
+++ b/lightyear/Cargo.toml
@@ -14,30 +14,30 @@ exclude = ["/tests"]
 
 [features]
 metrics = [
-    "dep:metrics",
-    "metrics-util",
-    "metrics-tracing-context",
-    "metrics-exporter-prometheus",
-    "dep:tokio",
+  "dep:metrics",
+  "metrics-util",
+  "metrics-tracing-context",
+  "metrics-exporter-prometheus",
+  "dep:tokio",
 ]
 mock_time = ["dep:mock_instant"]
 render = ["bevy/bevy_render"]
 webtransport = [
-    "dep:wtransport",
-    "dep:xwt-core",
-    "dep:xwt-web-sys",
-    "dep:web-sys",
-    "dep:tokio",
-    "dep:ring",
+  "dep:wtransport",
+  "dep:xwt-core",
+  "dep:xwt-web-sys",
+  "dep:web-sys",
+  "dep:tokio",
+  "dep:ring",
 ]
 leafwing = ["dep:leafwing-input-manager", "lightyear_macros/leafwing"]
 xpbd_2d = ["dep:bevy_xpbd_2d"]
 websocket = [
-    "dep:tokio",
-    "dep:tokio-tungstenite",
-    "dep:futures-util",
-    "dep:web-sys",
-    "dep:wasm-bindgen",
+  "dep:tokio",
+  "dep:tokio-tungstenite",
+  "dep:futures-util",
+  "dep:web-sys",
+  "dep:wasm-bindgen",
 ]
 steam = ["dep:steamworks"]
 
@@ -70,7 +70,7 @@ bevy_xpbd_2d = { version = "0.4", optional = true }
 
 # serialization
 bitcode = { version = "0.5.1", package = "bitcode_lightyear_patch", path = "../vendor/bitcode", features = [
-    "serde",
+  "serde",
 ] }
 bytes = { version = "1.5", features = ["serde"] }
 object-pool = { version = "0.5.4" }
@@ -88,8 +88,8 @@ lightyear_macros = { version = "0.12.0", path = "../macros" }
 tracing = "0.1.40"
 tracing-log = "0.2.0"
 tracing-subscriber = { version = "0.3.17", features = [
-    "registry",
-    "env-filter",
+  "registry",
+  "env-filter",
 ] }
 
 # server
@@ -100,12 +100,12 @@ metrics = { version = "0.22", optional = true }
 metrics-util = { version = "0.15", optional = true }
 metrics-tracing-context = { version = "0.15", optional = true }
 metrics-exporter-prometheus = { version = "0.13.0", optional = true, default-features = false, features = [
-    "http-listener",
+  "http-listener",
 ] }
 
 # bevy
 bevy = { version = "0.13", default-features = false, features = [
-    "multi-threaded",
+  "multi-threaded",
 ] }
 
 
@@ -115,7 +115,7 @@ futures-util = { version = "0.3.30", optional = true }
 # transport
 # we don't need any tokio features, we use only use the tokio channels
 tokio = { version = "1.36", features = [
-    "sync",
+  "sync",
 ], default-features = false, optional = true }
 async-compat = "0.2.3"
 
@@ -125,37 +125,37 @@ async-compat = "0.2.3"
 steamworks = { version = "0.11", optional = true }
 # webtransport
 wtransport = { version = "=0.1.11", optional = true, features = [
-    "self-signed",
-    "dangerous-configuration",
+  "self-signed",
+  "dangerous-configuration",
 ] }
 # websocket
 tokio-tungstenite = { version = "0.21.0", optional = true, features = [
-    "connect",
-    "handshake",
+  "connect",
+  "handshake",
 ] }
 
 [target."cfg(target_family = \"wasm\")".dependencies]
 console_error_panic_hook = { version = "0.1.7" }
 ring = { version = "0.17.7", optional = true }
 web-sys = { version = "0.3", optional = true, features = [
-    "WebTransport",
-    "WebTransportHash",
-    "WebTransportOptions",
-    "WebTransportBidirectionalStream",
-    "WebTransportSendStream",
-    "WebTransportReceiveStream",
-    "ReadableStreamDefaultReader",
-    "WritableStreamDefaultWriter",
-    "WebTransportDatagramDuplexStream",
-    "WebSocket",
-    "CloseEvent",
-    "ErrorEvent",
-    "MessageEvent",
-    "BinaryType",
+  "WebTransport",
+  "WebTransportHash",
+  "WebTransportOptions",
+  "WebTransportBidirectionalStream",
+  "WebTransportSendStream",
+  "WebTransportReceiveStream",
+  "ReadableStreamDefaultReader",
+  "WritableStreamDefaultWriter",
+  "WebTransportDatagramDuplexStream",
+  "WebSocket",
+  "CloseEvent",
+  "ErrorEvent",
+  "MessageEvent",
+  "BinaryType",
 ] }
 futures-lite = { version = "2.1.0", optional = true }
 getrandom = { version = "0.2.11", features = [
-    "js", # feature 'js' is required for wasm
+  "js", # feature 'js' is required for wasm
 ] }
 xwt-core = { version = "0.2", optional = true }
 xwt-web-sys = { version = "0.6", optional = true }

--- a/lightyear/Cargo.toml
+++ b/lightyear/Cargo.toml
@@ -108,8 +108,6 @@ bevy = { version = "0.13", default-features = false, features = [
     "multi-threaded",
 ] }
 
-# connection
-steamworks = { version = "0.11", optional = true }
 
 # WebSocket
 futures-util = { version = "0.3.30", optional = true }
@@ -122,6 +120,9 @@ tokio = { version = "1.36", features = [
 async-compat = "0.2.3"
 
 [target."cfg(not(target_family = \"wasm\"))".dependencies]
+# connection
+# steamworks-sys doesn't build on wasm
+steamworks = { version = "0.11", optional = true }
 # webtransport
 wtransport = { version = "=0.1.11", optional = true, features = [
     "self-signed",
@@ -154,8 +155,8 @@ web-sys = { version = "0.3", optional = true, features = [
 ] }
 futures-lite = { version = "2.1.0", optional = true }
 getrandom = { version = "0.2.11", features = [
-    "js",
-] } # feature 'js' is required for wasm
+    "js", # feature 'js' is required for wasm
+] }
 xwt-core = { version = "0.2", optional = true }
 xwt-web-sys = { version = "0.6", optional = true }
 wasm-bindgen = { version = "0.2.90", optional = true }
@@ -171,7 +172,5 @@ approx = "0.5.1"
 
 # docs.rs-specific configuration
 [package.metadata.docs.rs]
-# document all features
 all-features = true
-# defines the configuration attribute `docsrs`
 rustdoc-args = ["--cfg", "docsrs"]

--- a/lightyear/src/channel/receivers/ordered_reliable.rs
+++ b/lightyear/src/channel/receivers/ordered_reliable.rs
@@ -68,12 +68,9 @@ impl ChannelReceive for OrderedReliableReceiver {
     /// This assumes that the sender sends all message ids sequentially.
     fn read_message(&mut self) -> Option<SingleData> {
         // Check if we have received the message we are waiting for
-        let Some(message) = self
+        let message = self
             .recv_message_buffer
-            .remove(&self.pending_recv_message_id)
-        else {
-            return None;
-        };
+            .remove(&self.pending_recv_message_id)?;
 
         // if we have finally received the message we are waiting for, return it and
         // wait for the next one

--- a/lightyear/src/channel/receivers/sequenced_reliable.rs
+++ b/lightyear/src/channel/receivers/sequenced_reliable.rs
@@ -69,9 +69,7 @@ impl ChannelReceive for SequencedReliableReceiver {
     fn read_message(&mut self) -> Option<SingleData> {
         // keep popping messages until we get one that is more recent than the last one we processed
         loop {
-            let Some((message_id, message)) = self.recv_message_buffer.pop_first() else {
-                return None;
-            };
+            let (message_id, message) = self.recv_message_buffer.pop_first()?;
             if message_id >= self.most_recent_message_id {
                 return Some(message);
             }

--- a/lightyear/src/channel/receivers/unordered_reliable.rs
+++ b/lightyear/src/channel/receivers/unordered_reliable.rs
@@ -81,9 +81,7 @@ impl ChannelReceive for UnorderedReliableReceiver {
 
     fn read_message(&mut self) -> Option<SingleData> {
         // return if there are no messages in the buffer
-        let Some((message_id, message)) = self.recv_message_buffer.pop_first() else {
-            return None;
-        };
+        let (message_id, message) = self.recv_message_buffer.pop_first()?;
 
         // this was the message we were waiting for (as a reliable receiver)
         if self.pending_recv_message_id == message_id {

--- a/lightyear/src/connection/client.rs
+++ b/lightyear/src/connection/client.rs
@@ -8,7 +8,7 @@ use crate::_reexport::ReadWordBuffer;
 use crate::client::config::NetcodeConfig;
 use crate::connection::netcode::{ClientId, ConnectToken};
 
-#[cfg(feature = "steam")]
+#[cfg(all(feature = "steam", not(target_family = "wasm")))]
 use crate::connection::steam::client::SteamConfig;
 use crate::packet::packet::Packet;
 
@@ -61,7 +61,7 @@ pub enum NetConfig {
         io: IoConfig,
     },
     // TODO: for steam, we can use a pass-through io that just computes stats?
-    #[cfg(feature = "steam")]
+    #[cfg(all(feature = "steam", not(target_family = "wasm")))]
     Steam {
         config: SteamConfig,
         conditioner: Option<LinkConditionerConfig>,
@@ -103,7 +103,7 @@ impl NetConfig {
                     client: Box::new(client),
                 }
             }
-            #[cfg(feature = "steam")]
+            #[cfg(all(feature = "steam", not(target_family = "wasm")))]
             NetConfig::Steam {
                 config,
                 conditioner,

--- a/lightyear/src/connection/mod.rs
+++ b/lightyear/src/connection/mod.rs
@@ -5,5 +5,6 @@ pub mod netcode;
 
 pub(crate) mod server;
 
+#[cfg_attr(docsrs, doc(cfg(all(feature = "steam", not(target_family = "wasm")))))]
 #[cfg(all(feature = "steam", not(target_family = "wasm")))]
 pub(crate) mod steam;

--- a/lightyear/src/connection/mod.rs
+++ b/lightyear/src/connection/mod.rs
@@ -5,5 +5,5 @@ pub mod netcode;
 
 pub(crate) mod server;
 
-#[cfg(feature = "steam")]
+#[cfg(all(feature = "steam", not(target_family = "wasm")))]
 pub(crate) mod steam;

--- a/lightyear/src/connection/server.rs
+++ b/lightyear/src/connection/server.rs
@@ -6,7 +6,7 @@ use crate::_reexport::ReadWordBuffer;
 use crate::connection::client::ClientConnection;
 use crate::connection::netcode::ClientId;
 
-#[cfg(feature = "steam")]
+#[cfg(all(feature = "steam", not(target_family = "wasm")))]
 use crate::connection::steam::server::SteamConfig;
 use crate::packet::packet::Packet;
 
@@ -50,7 +50,7 @@ pub enum NetConfig {
         config: NetcodeConfig,
         io: IoConfig,
     },
-    #[cfg(feature = "steam")]
+    #[cfg(all(feature = "steam", not(target_family = "wasm")))]
     Steam {
         config: SteamConfig,
         conditioner: Option<LinkConditionerConfig>,
@@ -78,7 +78,7 @@ impl NetConfig {
             }
             // TODO: might want to distinguish between steam with direct ip connections
             //  vs steam with p2p connections
-            #[cfg(feature = "steam")]
+            #[cfg(all(feature = "steam", not(target_family = "wasm")))]
             NetConfig::Steam {
                 config,
                 conditioner,

--- a/lightyear/src/inputs/native/input_buffer.rs
+++ b/lightyear/src/inputs/native/input_buffer.rs
@@ -72,9 +72,7 @@ impl<T: UserAction> InputBuffer<T> {
     /// Remove all the inputs that are older than the given tick, then return the input
     /// for the given tick
     pub(crate) fn pop(&mut self, tick: Tick) -> Option<T> {
-        let Some(start_tick) = self.start_tick else {
-            return None;
-        };
+        let start_tick = self.start_tick?;
         if tick < start_tick {
             return None;
         }
@@ -96,9 +94,7 @@ impl<T: UserAction> InputBuffer<T> {
     }
 
     pub(crate) fn get(&self, tick: Tick) -> Option<&T> {
-        let Some(start_tick) = self.start_tick else {
-            return None;
-        };
+        let start_tick = self.start_tick?;
         if self.buffer.is_empty() {
             return None;
         }

--- a/lightyear/src/lib.rs
+++ b/lightyear/src/lib.rs
@@ -131,7 +131,7 @@ pub mod prelude {
         pub use crate::connection::client::{
             Authentication, ClientConnection, NetClient, NetConfig,
         };
-        #[cfg(feature = "steam")]
+        #[cfg(all(feature = "steam", not(target_family = "wasm")))]
         pub use crate::connection::steam::client::SteamConfig;
     }
     pub mod server {
@@ -147,7 +147,7 @@ pub mod prelude {
         pub use crate::connection::server::{
             NetConfig, NetServer, ServerConnection, ServerConnections,
         };
-        #[cfg(feature = "steam")]
+        #[cfg(all(feature = "steam", not(target_family = "wasm")))]
         pub use crate::connection::steam::server::SteamConfig;
         #[cfg(feature = "leafwing")]
         pub use crate::server::input_leafwing::LeafwingInputPlugin;

--- a/lightyear/src/protocol/mod.rs
+++ b/lightyear/src/protocol/mod.rs
@@ -81,6 +81,9 @@ pub(crate) mod registry;
 ///
 ///# fn main() {}
 /// ```
+///
+/// [`Message`]: crate::prelude::Message
+/// [`Component`]: bevy::prelude::Component
 pub trait Protocol: Send + Sync + Clone + Debug + 'static {
     type Input: crate::inputs::native::UserAction;
     #[cfg(feature = "leafwing")]

--- a/lightyear/src/server/room.rs
+++ b/lightyear/src/server/room.rs
@@ -581,16 +581,20 @@ mod tests {
             .resource_mut::<RoomManager>()
             .room_mut(room_id)
             .add_entity(server_entity);
+        assert!(stepper
+            .server_app
+            .world
+            .resource::<RoomManager>()
+            .events
+            .entity_enter_room
+            .get(&server_entity)
+            .unwrap()
+            .contains(&room_id));
         // Run update replication cache once
         stepper
             .server_app
             .world
             .run_system_once(update_entity_replication_cache::<MyProtocol>);
-        assert!(stepper
-            .server_app
-            .world
-            .resource::<RoomManager>()
-            .has_entity(server_entity, room_id));
         assert_eq!(
             stepper
                 .server_app
@@ -647,10 +651,6 @@ mod tests {
             .resource_mut::<RoomManager>()
             .room_mut(room_id)
             .remove_entity(server_entity);
-        stepper
-            .server_app
-            .world
-            .run_system_once(update_entity_replication_cache::<MyProtocol>);
         assert!(stepper
             .server_app
             .world
@@ -660,6 +660,10 @@ mod tests {
             .get(&server_entity)
             .unwrap()
             .contains(&room_id));
+        stepper
+            .server_app
+            .world
+            .run_system_once(update_entity_replication_cache::<MyProtocol>);
         assert_eq!(
             stepper
                 .server_app
@@ -737,11 +741,6 @@ mod tests {
             .resource_mut::<RoomManager>()
             .room_mut(room_id)
             .add_client(client_id);
-        // Run update replication cache once
-        stepper
-            .server_app
-            .world
-            .run_system_once(update_entity_replication_cache::<MyProtocol>);
         assert!(stepper
             .server_app
             .world
@@ -751,6 +750,11 @@ mod tests {
             .get(&client_id)
             .unwrap()
             .contains(&room_id));
+        // Run update replication cache once
+        stepper
+            .server_app
+            .world
+            .run_system_once(update_entity_replication_cache::<MyProtocol>);
         assert_eq!(
             stepper
                 .server_app
@@ -807,10 +811,6 @@ mod tests {
             .resource_mut::<RoomManager>()
             .room_mut(room_id)
             .remove_client(client_id);
-        stepper
-            .server_app
-            .world
-            .run_system_once(update_entity_replication_cache::<MyProtocol>);
         assert!(stepper
             .server_app
             .world
@@ -820,6 +820,10 @@ mod tests {
             .get(&client_id)
             .unwrap()
             .contains(&room_id));
+        stepper
+            .server_app
+            .world
+            .run_system_once(update_entity_replication_cache::<MyProtocol>);
         assert_eq!(
             stepper
                 .server_app
@@ -935,7 +939,11 @@ mod tests {
             .world
             .resource_mut::<RoomManager>()
             .add_entity(server_entity, new_room_id);
-        stepper.frame_step();
+        // Run update replication cache once
+        stepper
+            .server_app
+            .world
+            .run_system_once(update_entity_replication_cache::<MyProtocol>);
         assert_eq!(
             stepper
                 .server_app

--- a/lightyear/src/server/room.rs
+++ b/lightyear/src/server/room.rs
@@ -9,6 +9,7 @@ use bevy::prelude::{
     Res, ResMut, Resource, SystemSet,
 };
 use bevy::utils::{HashMap, HashSet};
+use tracing::info;
 
 use crate::connection::netcode::ClientId;
 use crate::prelude::ReplicationSet;
@@ -30,7 +31,7 @@ wrapping_id!(RoomId);
 ///
 /// This will be cleared every time the Server sends updates to the Client (every send_interval)
 #[derive(Resource, Debug, Default)]
-pub struct RoomEvents {
+struct RoomEvents {
     client_enter_room: EntityHashMap<ClientId, HashSet<RoomId>>,
     client_leave_room: EntityHashMap<ClientId, HashSet<RoomId>>,
     entity_enter_room: EntityHashMap<Entity, HashSet<RoomId>>,
@@ -38,7 +39,7 @@ pub struct RoomEvents {
 }
 
 #[derive(Default, Debug)]
-pub(crate) struct RoomData {
+struct RoomData {
     /// List of rooms that a client is in
     client_to_rooms: EntityHashMap<ClientId, HashSet<RoomId>>,
     /// List of rooms that an entity is in
@@ -431,6 +432,7 @@ fn update_entity_replication_cache<P: Protocol>(
     mut room_manager: ResMut<RoomManager>,
     mut query: Query<&mut Replicate<P>>,
 ) {
+    info!(?room_manager.events, "Room events");
     // enable split borrows by reborrowing Mut
     let room_manager = &mut *room_manager;
     // entity joined room

--- a/lightyear/src/shared/replication/receive.rs
+++ b/lightyear/src/shared/replication/receive.rs
@@ -413,12 +413,9 @@ impl<P: Protocol> GroupChannel<P> {
         current_tick: Tick,
     ) -> Option<(Tick, EntityActionMessage<P::Components, P::ComponentKinds>)> {
         // TODO: maybe only get the message if our local client tick is >= to it? (so that we don't apply an update from the future)
-        let Some(message) = self
+        let message = self
             .actions_recv_message_buffer
-            .get(&self.actions_pending_recv_message_id)
-        else {
-            return None;
-        };
+            .get(&self.actions_pending_recv_message_id)?;
         // if the message is from the future, keep it there
         if message.0 > current_tick {
             trace!("message tick is from the future compared to our tick");

--- a/lightyear/src/tests/stepper.rs
+++ b/lightyear/src/tests/stepper.rs
@@ -34,6 +34,35 @@ pub struct BevyStepper {
     pub current_time: bevy::utils::Instant,
 }
 
+impl Default for BevyStepper {
+    fn default() -> Self {
+        let frame_duration = Duration::from_millis(10);
+        let tick_duration = Duration::from_millis(10);
+        let shared_config = SharedConfig {
+            tick: TickConfig::new(tick_duration),
+            ..Default::default()
+        };
+        let link_conditioner = LinkConditionerConfig {
+            incoming_latency: Duration::from_millis(0),
+            incoming_jitter: Duration::from_millis(0),
+            incoming_loss: 0.0,
+        };
+        let sync_config = SyncConfig::default().speedup_factor(1.0);
+        let prediction_config = PredictionConfig::default().disable(false);
+        let interpolation_config = InterpolationConfig::default();
+        let mut stepper = Self::new(
+            shared_config,
+            sync_config,
+            prediction_config,
+            interpolation_config,
+            link_conditioner,
+            frame_duration,
+        );
+        stepper.init();
+        stepper
+    }
+}
+
 // Do not forget to use --features mock_time when using the LinkConditioner
 impl BevyStepper {
     pub fn new(


### PR DESCRIPTION
Investigate https://github.com/cBournhonesque/lightyear/issues/198

- Add `add_client`, `remove_client`, `add_entity`, `remove_entity`, `has_entity`, `get_room` APIs directly to the `RoomManager`
- Add a more unit tests for room change logic
- Fixed a bug where the visibility logic would not work properly when an entity changed rooms or a client changed rooms