### PR TITLE
Run client and server inside the same app

### DIFF
--- a/examples/client_replication/src/client.rs
+++ b/examples/client_replication/src/client.rs
@@ -25,6 +25,10 @@ impl ClientPluginGroup {
             net: net_config,
             interpolation: InterpolationConfig::default()
                 .with_delay(InterpolationDelay::default().with_send_interval_ratio(2.0)),
+            replication: ReplicationConfig {
+                // need to specify that we want to turn on client replication
+                enable: true,
+            },
             ..default()
         };
         let plugin_config = PluginConfig::new(config, protocol());

--- a/examples/simple_box/src/server.rs
+++ b/examples/simple_box/src/server.rs
@@ -67,7 +67,6 @@ pub(crate) fn init(mut commands: Commands, mut connections: ResMut<ServerConnect
             error!("Failed to start server: {:?}", e);
         });
     }
-    commands.spawn(Camera2dBundle::default());
     commands.spawn(TextBundle::from_section(
         "Server",
         TextStyle {
@@ -123,7 +122,7 @@ pub(crate) fn movement(
     for input in input_reader.read() {
         let client_id = input.context();
         if let Some(input) = input.input() {
-            debug!(
+            info!(
                 "Receiving input: {:?} from client: {:?} on tick: {:?}",
                 input,
                 client_id,
@@ -138,10 +137,6 @@ pub(crate) fn movement(
     }
 }
 
-// NOTE: you can use either:
-// - ServerMut (which is a wrapper around a bunch of resources used in lightyear)
-// - ResMut<ConnectionManager>, which is the actual resource used to send the message in this case. This is more optimized
-//   because it enables more parallelism
 /// Send messages from server to clients (only in non-headless mode, because otherwise we run with minimal plugins
 /// and cannot do input handling)
 pub(crate) fn send_message(

--- a/examples/simple_box/src/shared.rs
+++ b/examples/simple_box/src/shared.rs
@@ -2,6 +2,7 @@ use bevy::prelude::*;
 use bevy::render::RenderPlugin;
 use bevy::utils::Duration;
 
+use lightyear::prelude::client::*;
 use lightyear::prelude::*;
 
 use crate::protocol::*;
@@ -22,6 +23,7 @@ pub struct SharedPlugin;
 impl Plugin for SharedPlugin {
     fn build(&self, app: &mut App) {
         if app.is_plugin_added::<RenderPlugin>() {
+            app.add_systems(Startup, init);
             app.add_systems(Update, draw_boxes);
             // app.add_plugins(LogDiagnosticsPlugin {
             //     filter: Some(vec![
@@ -32,6 +34,10 @@ impl Plugin for SharedPlugin {
             // });
         }
     }
+}
+
+fn init(mut commands: Commands) {
+    commands.spawn(Camera2dBundle::default());
 }
 
 // This system defines how we update the player's positions when we receive an input
@@ -56,9 +62,15 @@ pub(crate) fn shared_movement_behaviour(mut position: Mut<PlayerPosition>, input
     }
 }
 
-/// System that draws the boxed of the player positions.
+/// System that draws the boxes of the player positions.
 /// The components should be replicated from the server to the client
-pub(crate) fn draw_boxes(mut gizmos: Gizmos, players: Query<(&PlayerPosition, &PlayerColor)>) {
+pub(crate) fn draw_boxes(
+    mut gizmos: Gizmos,
+    players: Query<
+        (&PlayerPosition, &PlayerColor),
+        Or<(With<Confirmed>, With<Predicted>, With<Interpolated>)>,
+    >,
+) {
     for (position, color) in &players {
         gizmos.rect(
             Vec3::new(position.x, position.y, 0.0),

--- a/lightyear/src/client/config.rs
+++ b/lightyear/src/client/config.rs
@@ -6,6 +6,7 @@ use nonzero_ext::nonzero;
 use crate::client::input::InputConfig;
 use crate::client::interpolation::plugin::InterpolationConfig;
 use crate::client::prediction::plugin::PredictionConfig;
+use crate::client::replication::ReplicationConfig;
 use crate::client::sync::SyncConfig;
 use crate::connection::client::NetConfig;
 use crate::shared::config::SharedConfig;
@@ -97,4 +98,5 @@ pub struct ClientConfig {
     pub sync: SyncConfig,
     pub prediction: PredictionConfig,
     pub interpolation: InterpolationConfig,
+    pub replication: ReplicationConfig,
 }

--- a/lightyear/src/client/connection.rs
+++ b/lightyear/src/client/connection.rs
@@ -6,7 +6,7 @@ use bevy::prelude::{Entity, Resource, World};
 use bevy::reflect::Reflect;
 use bevy::utils::Duration;
 use serde::Serialize;
-use tracing::{debug, trace, trace_span};
+use tracing::{debug, info, trace, trace_span};
 
 use crate::_reexport::{EntityUpdatesChannel, PingChannel, ReplicationSend};
 use crate::channel::senders::ChannelSend;
@@ -246,7 +246,7 @@ impl<P: Protocol> ConnectionManager<P> {
         // TODO: issues here: we would like to send the ping/pong messages immediately, otherwise the recorded current time is incorrect
         //   - can give infinity priority to this channel?
         //   - can write directly to io otherwise?
-        if time_manager.is_ready_to_send() {
+        if time_manager.is_client_ready_to_send() {
             // maybe send pings
             // same thing, we want the correct send time for the ping
             // (and not have the delay between when we prepare the ping and when we send the packet)
@@ -423,7 +423,7 @@ impl<P: Protocol> ReplicationSend<P> for ConnectionManager<P> {
         target: NetworkTarget,
         system_current_tick: BevyTick,
     ) -> Result<()> {
-        // trace!(?entity, "Send entity spawn for tick {:?}", self.tick());
+        info!(?entity, "Send entity spawn to server");
         let group_id = replicate.replication_group.group_id(Some(entity));
         let replication_sender = &mut self.replication_sender;
         // update the collect changes tick

--- a/lightyear/src/client/input.rs
+++ b/lightyear/src/client/input.rs
@@ -27,7 +27,7 @@ use bevy::prelude::{
     not, App, EventReader, EventWriter, FixedPostUpdate, FixedPreUpdate, IntoSystemConfigs,
     IntoSystemSetConfigs, Plugin, PostUpdate, Res, ResMut, SystemSet,
 };
-use tracing::{debug, error, trace};
+use tracing::{debug, error, info, trace};
 
 use crate::channel::builder::InputChannel;
 use crate::client::config::ClientConfig;
@@ -248,7 +248,10 @@ fn prepare_input_message<P: Protocol>(
     if !message.is_empty() {
         // TODO: should we provide variants of each user-facing function, so that it pushes the error
         //  to the ConnectionEvents?
-        debug!("sending input message: {:?}", message.end_tick);
+        info!(
+            ?current_tick,
+            "sending input message: {:?}", message.end_tick
+        );
         connection
             .send_message::<InputChannel, _>(message)
             .unwrap_or_else(|err| {

--- a/lightyear/src/client/networking.rs
+++ b/lightyear/src/client/networking.rs
@@ -19,7 +19,7 @@ use crate::protocol::message::MessageProtocol;
 use crate::protocol::Protocol;
 use crate::shared::events::connection::{IterEntityDespawnEvent, IterEntitySpawnEvent};
 use crate::shared::tick_manager::TickEvent;
-use crate::shared::time_manager::is_ready_to_send;
+use crate::shared::time_manager::is_client_ready_to_send;
 
 pub(crate) struct ClientNetworkingPlugin<P: Protocol> {
     marker: std::marker::PhantomData<P>,
@@ -43,7 +43,7 @@ impl<P: Protocol> Plugin for ClientNetworkingPlugin<P> {
                 (
                     // run sync before send because some send systems need to know if the client is synced
                     // we don't send packets every frame, but on a timer instead
-                    (MainSet::Sync, MainSet::Send.run_if(is_ready_to_send)).chain(),
+                    (MainSet::Sync, MainSet::Send.run_if(is_client_ready_to_send)).chain(),
                     MainSet::SendPackets.in_set(MainSet::Send),
                 ),
             )

--- a/lightyear/src/client/plugin.rs
+++ b/lightyear/src/client/plugin.rs
@@ -73,22 +73,26 @@ impl<P: Protocol> Plugin for ClientPlugin<P> {
                 config.client_config.prediction.input_delay_ticks,
             ))
             // PLUGINS //
-            .add_plugins(SharedPlugin::<P> {
-                config: config.client_config.shared.clone(),
-                ..default()
-            })
             .add_plugins(ClientEventsPlugin::<P>::default())
             .add_plugins(ClientNetworkingPlugin::<P>::default())
-            .add_plugins(ClientReplicationPlugin::<P>::new(tick_duration))
             .add_plugins(MetadataPlugin)
             .add_plugins(InputPlugin::<P>::default())
             .add_plugins(PredictionPlugin::<P>::new(config.client_config.prediction))
             .add_plugins(InterpolationPlugin::<P>::new(
                 config.client_config.interpolation.clone(),
             ))
-            .add_plugins(TimePlugin {
-                send_interval: config.client_config.shared.client_send_interval,
-            })
             .add_plugins(ClientDiagnosticsPlugin::<P>::default());
+
+        if config.client_config.replication.enable {
+            app.add_plugins(ClientReplicationPlugin::<P>::new(tick_duration));
+        }
+
+        // check if are running both client and server plugins in the same app
+        if !app.is_plugin_added::<SharedPlugin<P>>() {
+            app.add_plugins(SharedPlugin::<P> {
+                config: config.client_config.shared.clone(),
+                ..default()
+            });
+        }
     }
 }

--- a/lightyear/src/client/replication.rs
+++ b/lightyear/src/client/replication.rs
@@ -3,8 +3,15 @@ use bevy::utils::Duration;
 
 use crate::client::connection::ConnectionManager;
 use crate::client::sync::client_is_synced;
+use crate::prelude::client::InterpolationDelay;
 use crate::prelude::{Protocol, ReplicationSet};
 use crate::shared::replication::plugin::ReplicationPlugin;
+
+#[derive(Clone, Default, Debug)]
+pub struct ReplicationConfig {
+    /// Set to true to enable replicating this client's entities to the server
+    pub enable: bool,
+}
 
 pub struct ClientReplicationPlugin<P: Protocol> {
     tick_duration: Duration,

--- a/lightyear/src/lib.rs
+++ b/lightyear/src/lib.rs
@@ -127,6 +127,7 @@ pub mod prelude {
         pub use crate::client::prediction::plugin::{PredictionConfig, PredictionSet};
         pub use crate::client::prediction::predicted_history::{ComponentState, PredictionHistory};
         pub use crate::client::prediction::{Predicted, PredictionDespawnCommandsExt};
+        pub use crate::client::replication::ReplicationConfig;
         pub use crate::client::sync::SyncConfig;
         pub use crate::connection::client::{
             Authentication, ClientConnection, NetClient, NetConfig,

--- a/lightyear/src/server/config.rs
+++ b/lightyear/src/server/config.rs
@@ -5,6 +5,7 @@ use nonzero_ext::nonzero;
 
 use crate::connection::netcode::Key;
 use crate::connection::server::NetConfig;
+use crate::server::replication::ReplicationConfig;
 use crate::shared::config::SharedConfig;
 use crate::shared::ping::manager::PingConfig;
 
@@ -93,4 +94,5 @@ pub struct ServerConfig {
     pub net: Vec<NetConfig>,
     pub packet: PacketConfig,
     pub ping: PingConfig,
+    pub replication: ReplicationConfig,
 }

--- a/lightyear/src/server/connection.rs
+++ b/lightyear/src/server/connection.rs
@@ -172,6 +172,7 @@ impl<P: Protocol> ConnectionManager<P> {
         self.connections
             .iter_mut()
             .map(move |(client_id, connection)| {
+                trace!(input_buffer = ?connection.input_buffer, ?tick, ?client_id, "input buffer for client");
                 let received_input = connection.input_buffer.pop(tick);
                 let fallback = received_input.is_none();
 
@@ -408,8 +409,8 @@ impl<P: Protocol> Connection<P> {
         //   - can give infinity priority to this channel?
         //   - can write directly to io otherwise?
 
-        // no need to check if `time_manager.is_ready_to_send()` since we only send packets when we are ready to send
-        if time_manager.is_ready_to_send() {
+        // no need to check if `time_manager.is_server_ready_to_send()` since we only send packets when we are ready to send
+        if time_manager.is_server_ready_to_send() {
             // maybe send pings
             // same thing, we want the correct send time for the ping
             // (and not have the delay between when we prepare the ping and when we send the packet)

--- a/lightyear/src/server/networking.rs
+++ b/lightyear/src/server/networking.rs
@@ -14,7 +14,7 @@ use crate::server::events::{ConnectEvent, DisconnectEvent, EntityDespawnEvent, E
 use crate::server::room::RoomManager;
 use crate::shared::events::connection::{IterEntityDespawnEvent, IterEntitySpawnEvent};
 use crate::shared::replication::ReplicationSend;
-use crate::shared::time_manager::is_ready_to_send;
+use crate::shared::time_manager::is_server_ready_to_send;
 
 pub(crate) struct ServerNetworkingPlugin<P: Protocol> {
     config: Vec<NetConfig>,
@@ -48,7 +48,7 @@ impl<P: Protocol> Plugin for ServerNetworkingPlugin<P> {
                 PostUpdate,
                 (
                     // we don't send packets every frame, but on a timer instead
-                    MainSet::Send.run_if(is_ready_to_send),
+                    MainSet::Send.run_if(is_server_ready_to_send),
                     MainSet::SendPackets.in_set(MainSet::Send),
                 ),
             )

--- a/lightyear/src/server/plugin.rs
+++ b/lightyear/src/server/plugin.rs
@@ -65,19 +65,23 @@ impl<P: Protocol> PluginType for ServerPlugin<P> {
                 config.server_config.ping,
             ))
             // PLUGINS
-            .add_plugins(SharedPlugin::<P> {
+            .add_plugins(ServerEventsPlugin::<P>::default())
+            .add_plugins(ServerNetworkingPlugin::<P>::new(config.server_config.net))
+            .add_plugins(ClientMetadataPlugin::<P>::default())
+            .add_plugins(InputPlugin::<P>::default())
+            .add_plugins(RoomPlugin::<P>::default());
+
+        if !config.server_config.replication.disable {
+            app.add_plugins(ServerReplicationPlugin::<P>::new(tick_duration));
+        }
+
+        // check if are running both client and server plugins in the same app
+        if !app.is_plugin_added::<SharedPlugin<P>>() {
+            app.add_plugins(SharedPlugin::<P> {
                 // TODO: move shared config out of server_config?
                 config: config.server_config.shared.clone(),
                 ..default()
-            })
-            .add_plugins(ServerEventsPlugin::<P>::default())
-            .add_plugins(ServerNetworkingPlugin::<P>::new(config.server_config.net))
-            .add_plugins(ServerReplicationPlugin::<P>::new(tick_duration))
-            .add_plugins(ClientMetadataPlugin::<P>::default())
-            .add_plugins(InputPlugin::<P>::default())
-            .add_plugins(RoomPlugin::<P>::default())
-            .add_plugins(TimePlugin {
-                send_interval: config.server_config.shared.server_send_interval,
             });
+        }
     }
 }

--- a/lightyear/src/server/replication.rs
+++ b/lightyear/src/server/replication.rs
@@ -6,6 +6,13 @@ use crate::server::connection::ConnectionManager;
 use crate::server::prediction::compute_hash;
 use crate::shared::replication::plugin::ReplicationPlugin;
 
+/// Configuration related to replicating the server's World to clients
+#[derive(Clone, Default, Debug)]
+pub struct ReplicationConfig {
+    /// Set to true to disable replicating this server's entities to clients
+    pub disable: bool,
+}
+
 pub struct ServerReplicationPlugin<P: Protocol> {
     tick_duration: Duration,
     marker: std::marker::PhantomData<P>,

--- a/lightyear/src/server/room.rs
+++ b/lightyear/src/server/room.rs
@@ -15,7 +15,7 @@ use crate::connection::netcode::ClientId;
 use crate::prelude::ReplicationSet;
 use crate::protocol::Protocol;
 use crate::shared::replication::components::{DespawnTracker, Replicate};
-use crate::shared::time_manager::is_ready_to_send;
+use crate::shared::time_manager::is_server_ready_to_send;
 use crate::utils::wrapping_id::wrapping_id;
 
 type EntityHashMap<K, V> = hashbrown::HashMap<K, V, EntityHash>;
@@ -126,7 +126,7 @@ impl<P: Protocol> Plugin for RoomPlugin<P> {
                     RoomSystemSets::UpdateReplicationCaches,
                     RoomSystemSets::RoomBookkeeping,
                 )
-                    .run_if(is_ready_to_send),
+                    .run_if(is_server_ready_to_send),
             ),
         );
         // SYSTEMS

--- a/lightyear/src/shared/plugin.rs
+++ b/lightyear/src/shared/plugin.rs
@@ -5,10 +5,11 @@ use bevy::prelude::*;
 use replication::hierarchy::HierarchySyncPlugin;
 
 use crate::client::config::ClientConfig;
-use crate::prelude::Protocol;
+use crate::prelude::{Protocol, TimeManager};
 use crate::shared::config::SharedConfig;
 use crate::shared::replication;
 use crate::shared::tick_manager::TickManagerPlugin;
+use crate::shared::time_manager::TimePlugin;
 
 pub struct SharedPlugin<P: Protocol> {
     pub config: SharedConfig,
@@ -52,6 +53,10 @@ impl<P: Protocol> Plugin for SharedPlugin<P> {
         app.add_plugins(HierarchySyncPlugin::<P>::default());
         app.add_plugins(TickManagerPlugin {
             config: self.config.tick.clone(),
+        });
+        app.add_plugins(TimePlugin {
+            server_send_interval: self.config.server_send_interval,
+            client_send_interval: self.config.client_send_interval,
         });
     }
 }

--- a/lightyear/src/shared/tick_manager.rs
+++ b/lightyear/src/shared/tick_manager.rs
@@ -85,6 +85,7 @@ impl TickManager {
     pub(crate) fn set_tick_to(&mut self, tick: Tick) -> TickEvent {
         let old_tick = self.tick;
         self.tick = tick;
+        // info!(?old_tick, new_tick =?tick, "tick snap event");
         TickEvent::TickSnap {
             old_tick,
             new_tick: tick,

--- a/lightyear/src/shared/time_manager.rs
+++ b/lightyear/src/shared/time_manager.rs
@@ -26,22 +26,31 @@ pub use wrapped_time::WrappedTime;
 use crate::prelude::Tick;
 
 // TODO: put this in networking plugin instead?
-/// Run Condition to check if we are ready to send packets
-pub(crate) fn is_ready_to_send(time_manager: Res<TimeManager>) -> bool {
-    time_manager.is_ready_to_send()
+/// Run Condition to check if the server is ready to send packets
+pub(crate) fn is_server_ready_to_send(time_manager: Res<TimeManager>) -> bool {
+    time_manager.is_server_ready_to_send()
+}
+/// Run Condition to check if the client is ready to send packets
+pub(crate) fn is_client_ready_to_send(time_manager: Res<TimeManager>) -> bool {
+    time_manager.is_client_ready_to_send()
 }
 
 /// Plugin that will centralize information about the various times (real, virtual, fixed)
 /// as well as track when we should send updates to the remote
 pub(crate) struct TimePlugin {
-    /// Interval at which we send updates to the remote
-    pub(crate) send_interval: Duration,
+    /// Interval at which the server should send packets to the remote
+    pub(crate) server_send_interval: Duration,
+    /// Interval at which the client should send packets to the remote
+    pub(crate) client_send_interval: Duration,
 }
 
 impl Plugin for TimePlugin {
     fn build(&self, app: &mut App) {
         // RESOURCES
-        app.insert_resource(TimeManager::new(self.send_interval));
+        app.insert_resource(TimeManager::new(
+            self.server_send_interval,
+            self.client_send_interval,
+        ));
         // SYSTEMS
         app.add_systems(
             RunFixedMainLoop,
@@ -71,19 +80,20 @@ pub struct TimeManager {
     /// We speed up the virtual time so that our ticks go faster/slower
     /// Things that depend on real time (ping/pong times), channel/packet managers, send_interval should be unaffected
     pub(crate) sync_relative_speed: f32,
+    /// Timer to keep track of when the server should next send packets
+    server_send_timer: Option<Timer>,
     /// Timer to keep track on we send the next update
-    send_timer: Option<Timer>,
+    client_send_timer: Option<Timer>,
     /// Instant at the start of the frame
     frame_start: Option<Instant>,
 }
 
 impl TimeManager {
-    pub fn new(send_interval: Duration) -> Self {
-        let send_timer = if send_interval == Duration::default() {
-            None
-        } else {
-            Some(Timer::new(send_interval, TimerMode::Repeating))
-        };
+    pub fn new(server_send_interval: Duration, client_send_interval: Duration) -> Self {
+        let server_send_timer = (server_send_interval != Duration::default())
+            .then_some(Timer::new(server_send_interval, TimerMode::Repeating));
+        let client_send_timer = (client_send_interval != Duration::default())
+            .then_some(Timer::new(client_send_interval, TimerMode::Repeating));
         Self {
             wrapped_time: WrappedTime::new(0),
             real_time: WrappedTime::new(0),
@@ -91,13 +101,24 @@ impl TimeManager {
             delta: Duration::default(),
             base_relative_speed: 1.0,
             sync_relative_speed: 1.0,
-            send_timer,
+            server_send_timer,
+            client_send_timer,
             frame_start: None,
         }
     }
 
-    pub(crate) fn is_ready_to_send(&self) -> bool {
-        self.send_timer
+    /// Returns true when the server should send packets
+    /// If there is no timer, send packets every frame
+    pub(crate) fn is_server_ready_to_send(&self) -> bool {
+        self.server_send_timer
+            .as_ref()
+            .map_or(true, |timer| timer.finished())
+    }
+
+    /// Returns true when the client should send packets
+    /// If there is no timer, send packets every frame
+    pub(crate) fn is_client_ready_to_send(&self) -> bool {
+        self.server_send_timer
             .as_ref()
             .map_or(true, |timer| timer.finished())
     }
@@ -117,10 +138,6 @@ impl TimeManager {
         self.base_relative_speed * self.sync_relative_speed
     }
 
-    // pub fn update_real(&mut self, delta: Duration) {
-    //     self.real_time.elapsed = Instant::now();
-    // }
-
     /// Update the time by applying the latest delta
     /// delta: delta time since last frame
     /// overstep: remaining time after running the fixed-update steps
@@ -128,7 +145,10 @@ impl TimeManager {
         self.delta = delta;
         self.wrapped_time.elapsed += delta;
         self.frame_start = Some(Instant::now());
-        if let Some(timer) = self.send_timer.as_mut() {
+        if let Some(timer) = self.server_send_timer.as_mut() {
+            timer.tick(delta);
+        }
+        if let Some(timer) = self.client_send_timer.as_mut() {
             timer.tick(delta);
         }
     }


### PR DESCRIPTION
# Objective

In the current "listen-server" mode, we create 2 Apps (client_app, server_app) that communicate via channels.

This is already pretty good but there are a couple of issues:
- there is a slight input delay even if the latency should be 0 because the inputs from the client will get received by the server on a later tick. Also the client timeline might still be a little different than the server timeline
- there could be an overhead from running 2 Apps, 2 Worlds with similar archetypes, etc.

Instead we could have a model where the `ClientPlugin` and `ServerPlugin` are both running inside the same `App`.

Ideally, there would be as little code change as possible between this mode and the other ways of running lightyear. (dedicated server)
Which means that in a first phase, we will keep the Interpolated/Predicted/Confirmed components even though they aren't actually needed:
- there is no need for prediction, the client could just move directly the server-authoritative entity. (but maybe the client could predict other players? see RocketLeague)
- there is no need for interpolation. Interpolation exists because the server updates are sporadic. In this case the client and server are in the same app so the client has access to the server state every frame!

# Design

I guess there's 2 main options:
A) This is what we'll do in this PR. We create both plugins in the same app connected via local channels. The main changes compared to 2 apps are:
- there is only one TimeManager that is shared between the client and the server . This means that the client operates on the SAME timeline as the server, instead of being ahead (for client-prediction)
- We cannot update the TimeManager's time in the SyncManager because the timeManager's time is the client's prediction time but also the server's time! Also we don't need to do it since the goal of SyncManager is to keep the two timelines in sync, and in this case there are perfectly in sync. We also need to adjust the interpolation time code.
- Change the ClientGlobalMetadata code to only use the client_id received from the server (i.e. without Replicate component)
- For inputs to work with 0 latency, we will send inputs directly via channels to the server's InputEvents receiver (otherwise there would be a one-frame delay because the inputs would be received on the next frame. Also having inputs not being received instantly on the server is incompatible with the unified timeline, since if that's the case the client would have to run slightly ahead of the server.
So basically I have to either:
- separate the TimeManager into a ClientTimeManager and a ServerTimeManager
- or force inputs to have 0 latencies in this unified mode, and use the same timeline.
I think the second option is easier to implement and has other benefits (true 0-delay input latency if running in singleplayer) so let's try this first. (we can keep the second option as fallback).

This has another consequence: **even if there is a link conditioner adding delay, the local client will always have 0 input latency from client -> server.**

B)
- do not use io at all between the server/client, and instead have the client **reuse directly the server entities**
- if a client has ShouldBePredicted, instead of spawning a new Predicted entity we just add a Predicted component
- if a client has ShouldBeInterpolated, instead of spawning a new Interpolated entity, we just add an Interpolated component to the server entity
- either the client doesn't connect to the App (no io needed since they are sharing the same world). This might need a couple of adjustments in the example code.
The problem is that there are some places in the code that expect a client-id, and maybe also a connection?
Can investigate this; maybe we need to create a fixed ClientId for the 'Unified' usecase.
This might be a good long term solution, but might be hard to get working in the short-term (need to let the app run with no io, no netcode, etc.)
I guess in this mode almost nothing related to the ClientPlugin is needed? no need for io, prediction, interpolation, etc. Maybe we could just run with the ServerPlugin? In which case the changes needed are:
- server creates the entity directly (not when a client connects! Maybe we can emit a connection event for a "local" client)
- inputs need to affect that entity



# Blockers

- [ ] Update all examples
- [x] Refactor TimeManager so that it can be shared between ClientPlugin and ServerPlugin
- [x] Register SharedPlugin only once if both ClientPlugin and SharedPlugin are called
- [x] For inputs, do NOT network the client inputs to the server if we are in the same app, instead just directly write to `ServerEventInputs` so that the inputs are read on the same tick by the server
  - [ ] check if it works for leafwing
- [X] Update the `SyncManager` to work correctly
- [ ] Disable sending pings if running in unified mode?

BUGS:
- [ ]: when another client connects, the interpolated entity in the unified app has no components
- [ ]: the interpolation delay on other clients seems very long!