### PR TITLE
Add interpolation component if enough time has passed

### DIFF
--- a/examples/replication_groups/src/protocol.rs
+++ b/examples/replication_groups/src/protocol.rs
@@ -218,7 +218,7 @@ pub enum Components {
     TailLength(TailLength),
     // we set the interpolation function to NoInterpolation because we are using our own custom interpolation logic
     // (by default it would use LinearInterpolator, which requires Add and Mul bounds on this component)
-    #[protocol(sync(mode = "once", lerp = "NullInterpolator"))]
+    #[protocol(sync(mode = "full", lerp = "NullInterpolator"))]
     TailPoints(TailPoints),
     // we specify `map_entities` because the entity contained in this component needs to be mapped
     #[protocol(sync(mode = "once"), map_entities)]

--- a/lightyear/src/client/interpolation/interpolate.rs
+++ b/lightyear/src/client/interpolation/interpolate.rs
@@ -16,6 +16,7 @@ use crate::shared::tick_manager::Tick;
 // - lower values (with a minimum of 1.0) will make the interpolation look better when we receive an update,
 //   but will also make it more likely to have a wrong interpolation when we have packet loss
 // - however we can combat packet loss by having a bigger delay
+// TODO: this value should depend on jitter I think
 const SEND_INTERVAL_TICK_FACTOR: f32 = 1.5;
 
 // TODO: the inner fields are pub just for integration testing.
@@ -51,7 +52,7 @@ impl<C: Component> InterpolateStatus<C> {
 }
 
 /// At the end of each frame, interpolate the components between the last 2 confirmed server states
-/// Invariant: start_tick <= current_interpolate_tick <= end_tick
+/// Invariant: start_tick <= current_interpolate_tick + overstep < end_tick
 pub(crate) fn update_interpolate_status<C: SyncComponent, P: Protocol>(
     config: Res<ClientConfig>,
     connection: Res<ConnectionManager<P>>,
@@ -67,9 +68,6 @@ pub(crate) fn update_interpolate_status<C: SyncComponent, P: Protocol>(
     P::ComponentKinds: FromType<C>,
 {
     let kind = P::ComponentKinds::from_type();
-    if !connection.is_synced() {
-        return;
-    }
 
     // how many ticks between each interpolation (add 1 to roughly take the ceil)
     let send_interval_delta_tick = (SEND_INTERVAL_TICK_FACTOR
@@ -209,38 +207,59 @@ pub(crate) fn update_interpolate_status<C: SyncComponent, P: Protocol>(
     }
 }
 
-/// Only sync the component from the Confirmed to the Interpolated entity
-/// after we have at least 2 confirmed updates, otherwise if the server send rate is low
-/// the component could be stuck at the 'start_tick' value until we have another update to interpolate towards
+/// Insert the component on the `Interpolated` entity.
+/// We do not insert the component immediately on `Interpolated` when the component gets added on the `Confirmed` entity,
+/// because then the component value would be constant (= to the starting value) until we get another component update,
+/// and then it starts moving. This can be jarring if the server send rate is low (then for example a bullet is frozen for a bit
+/// before it starts moving).
+/// Instead we will insert the component after either:
+/// - we have received 2 updates on the Confirmed entity (so we can interpolate between them)
+/// - or at least SEND_INTERVAL_TICK_FACTOR * send_interval has passed. (this is to deal with the case where we only receive
+/// one update; for example if we spawn the player and then they don't move. If we didn't do this the interpolated entity would
+/// simply not appear)
 pub(crate) fn insert_interpolated_component<C: SyncComponent, P: Protocol>(
+    config: Res<ClientConfig>,
+    tick_manager: Res<TickManager>,
     mut commands: Commands,
     mut query: Query<(Entity, &InterpolateStatus<C>), Without<C>>,
 ) where
     P::Components: SyncMetadata<C>,
 {
+    let tick = tick_manager.tick();
+    // how many ticks between each interpolation update (add 1 to roughly take the ceil)
+    // TODO: use something more precise, with the interpolation overstep?
+    let send_interval_delta_tick = (SEND_INTERVAL_TICK_FACTOR
+        * config.shared.server_send_interval.as_secs_f32()
+        / config.shared.tick.tick_duration.as_secs_f32()) as i16
+        + 1;
     for (entity, status) in query.iter_mut() {
-        trace!("checking if we do interpolation");
+        trace!("checking if we need to insert the component on the Interpolated entity");
         let mut entity_commands = commands.entity(entity);
         // NOTE: it is possible that we reach start_tick when end_tick is not set
         if let Some((start_tick, start_value)) = &status.start {
-            // TODO: maybe that's not correct? we only want to insert the component if we are interpolating
-            //  between two values!
-            // if status.current_ == *start_tick {
-            //     debug!(?entity, ?start_tick, "setting component to start value");
-            //     entity_commands.insert(start_value.clone());
-            //     continue;
-            // }
+            // we have two updates!, add the component
             if let Some((end_tick, end_value)) = &status.end {
+                assert!(status.current_tick < *end_tick);
+                assert_ne!(start_tick, end_tick);
                 trace!(?entity, ?start_tick, interpolate_tick=?status.current_tick, ?end_tick, "doing interpolation!");
                 if status.current_tick == *end_tick {
+                    info!("insert comp value curr=end");
                     entity_commands.insert(end_value.clone());
                     continue;
                 }
                 if start_tick != end_tick {
+                    info!("insert comp value ");
                     let t = status.interpolation_fraction().unwrap();
                     let value = P::Components::lerp(start_value, end_value, t);
                     entity_commands.insert(value);
                 } else {
+                    info!("insert comp value start=end");
+                    entity_commands.insert(start_value.clone());
+                }
+            } else {
+                // we only have one update, but enough time has passed that we should add the component anyway
+                if tick - *start_tick >= send_interval_delta_tick {
+                    info!("insert interpolated comp value, enough time");
                     entity_commands.insert(start_value.clone());
                 }
             }

--- a/lightyear/src/client/interpolation/interpolation_history.rs
+++ b/lightyear/src/client/interpolation/interpolation_history.rs
@@ -24,7 +24,7 @@ pub struct ConfirmedHistory<T: SyncComponent> {
 
     // TODO: add a max size for the buffer
     // We want to avoid using a SequenceBuffer for optimization (we don't want to store a copy of the component for each history tick)
-    // We can afford to use a ReadyBuffer because we will get server updates with monotically increasing ticks
+    // We can afford to use a ReadyBuffer because we will get server updates with monotonically increasing ticks
     // therefore we can get rid of the old ticks before the server update
 
     // We will only store the history for the ticks where the component got updated
@@ -115,7 +115,8 @@ pub(crate) fn add_component_history<C: SyncComponent, P: Protocol>(
                             trace!(?interpolated_entity, tick=?tick_manager.tick(),  "spawn interpolation history");
                             interpolated_entity_mut.insert((
                                 // NOTE: we probably do NOT want to insert the component right away, instead we want to wait until we have two updates
-                                //  we can interpolate between. Otherwise it will look jarring if send_interval is low.
+                                //  we can interpolate between. Otherwise it will look jarring if send_interval is low. (because the entity will
+                                //  stay fixed until we get the next update, then it will start moving)
                                 // new_component,
                                 history,
                                 InterpolateStatus::<C> {

--- a/lightyear/src/client/interpolation/interpolation_history.rs
+++ b/lightyear/src/client/interpolation/interpolation_history.rs
@@ -120,7 +120,7 @@ pub(crate) fn add_component_history<C: SyncComponent, P: Protocol>(
                                 // new_component,
                                 history,
                                 InterpolateStatus::<C> {
-                                    start: None,
+                                    start: Some((current_tick, new_component)),
                                     end: None,
                                     current_tick,
                                     current_overstep,

--- a/lightyear/src/client/interpolation/plugin.rs
+++ b/lightyear/src/client/interpolation/plugin.rs
@@ -12,6 +12,7 @@ use crate::client::interpolation::interpolate::{
 };
 use crate::client::interpolation::resource::InterpolationManager;
 use crate::client::interpolation::spawn::spawn_interpolated_entity;
+use crate::client::sync::client_is_synced;
 use crate::prelude::{ExternalMapper, Mode};
 use crate::protocol::component::ComponentProtocol;
 use crate::protocol::Protocol;
@@ -163,7 +164,7 @@ where
                 Update,
                 (
                     apply_confirmed_update_mode_full::<C, P>,
-                    update_interpolate_status::<C, P>,
+                    update_interpolate_status::<C, P>.run_if(client_is_synced::<P>),
                     // TODO: that means we could insert the component twice, here and then in interpolate...
                     //  need to optimize this
                     insert_interpolated_component::<C, P>,


### PR DESCRIPTION
Previously, we only added interpolated components if we received two server updates.
The reason is if the send_interval was low, the component would be constant (equal to the start value) until we receive an update. For objects that are always moving, like bullets, it is weird: the bullet appears to be frozen for a split second before moving.

The problem is that if the spawned entity is not  updating after the initial spawn, we wouldn't add any component (since we need 2 updates).

Now, we insert the component if:
- we received 2 component updates (so we can interpolate between)
- at least 1.3 * send_interval has passed, in which case we consider that the entity will not get updated and we can spawn the component.

The `replication_groups` example exhibits the new behaviour 