### PR TITLE
Add functions `stop` and `disconnect` to the NetServer

### DIFF
--- a/lightyear/src/connection/netcode/server.rs
+++ b/lightyear/src/connection/netcode/server.rs
@@ -1026,6 +1026,21 @@ impl NetServer for Server {
         Ok(())
     }
 
+    fn stop(&mut self) -> anyhow::Result<()> {
+        self.io.close()?;
+        Ok(())
+    }
+
+    fn disconnect(&mut self, client_id: id::ClientId) -> anyhow::Result<()> {
+        match client_id {
+            id::ClientId::Netcode(id) => self
+                .server
+                .disconnect(id, &mut self.io)
+                .context("Could not disconnect client"),
+            _ => Err(anyhow!("the client id must be of type Netcode")),
+        }
+    }
+
     fn connected_client_ids(&self) -> Vec<id::ClientId> {
         self.server
             .connected_client_ids()

--- a/lightyear/src/connection/netcode/server.rs
+++ b/lightyear/src/connection/netcode/server.rs
@@ -1027,13 +1027,17 @@ impl NetServer for Server {
     }
 
     fn stop(&mut self) -> anyhow::Result<()> {
-        let connected_clients = self.server.connected_client_ids().collect::<Vec<_>>();
+        let mut connected_clients = self
+            .server
+            .connected_client_ids()
+            .map(id::ClientId::Netcode)
+            .collect::<Vec<_>>();
         self.server.disconnect_all(&mut self.io)?;
         self.server
             .cfg
             .context
             .disconnections
-            .extend(connected_clients);
+            .append(&mut connected_clients);
         self.io.close()?;
         Ok(())
     }

--- a/lightyear/src/connection/server.rs
+++ b/lightyear/src/connection/server.rs
@@ -170,6 +170,7 @@ impl ServerConnections {
         }
     }
 
+    /// Start listening for client connections on all internal servers
     pub fn start(&mut self) -> Result<()> {
         for server in &mut self.servers {
             server.start()?;
@@ -178,6 +179,16 @@ impl ServerConnections {
         Ok(())
     }
 
+    /// Stop listening for client connections on all internal servers
+    pub fn stop(&mut self) -> Result<()> {
+        for server in &mut self.servers {
+            server.stop()?;
+        }
+        self.is_listening = false;
+        Ok(())
+    }
+
+    pub fn disconnect(&mut self, client_id: ClientId) -> Result<()> {}
     pub(crate) fn is_listening(&self) -> bool {
         self.is_listening
     }

--- a/lightyear/src/connection/server.rs
+++ b/lightyear/src/connection/server.rs
@@ -150,7 +150,7 @@ type ServerConnectionIdx = usize;
 #[derive(Resource)]
 pub struct ServerConnections {
     /// list of the various `ServerConnection`s available. Will be static after first insertion.
-    servers: Vec<ServerConnection>,
+    pub(crate) servers: Vec<ServerConnection>,
     /// Mapping from the connection's [`ClientId`] into the index of the [`ServerConnection`] in the `servers` list
     pub(crate) client_server_map: HashMap<ClientId, ServerConnectionIdx>,
     /// Track whether the server is ready to listen to incoming connections

--- a/lightyear/src/connection/server.rs
+++ b/lightyear/src/connection/server.rs
@@ -11,7 +11,17 @@ use crate::server::config::NetcodeConfig;
 
 pub trait NetServer: Send + Sync {
     /// Start the server
+    /// (i.e. start listening for client connections)
     fn start(&mut self) -> Result<()>;
+
+    /// Stop the server
+    /// (i.e. stop listening for client connections and stop all networking)
+    fn stop(&mut self) -> Result<()>;
+
+    // TODO: should we also have an API for accepting a client? i.e. we receive a connection request
+    //  and we decide whether to accept it or not
+    /// Disconnect a specific client
+    fn disconnect(&mut self, client_id: ClientId) -> Result<()>;
 
     /// Return the list of connected clients
     fn connected_client_ids(&self) -> Vec<ClientId>;
@@ -94,6 +104,14 @@ impl NetServer for ServerConnection {
         self.server.start()
     }
 
+    fn stop(&mut self) -> Result<()> {
+        self.server.stop()
+    }
+
+    fn disconnect(&mut self, client_id: ClientId) -> Result<()> {
+        self.server.disconnect(client_id)
+    }
+
     fn connected_client_ids(&self) -> Vec<ClientId> {
         self.server.connected_client_ids()
     }
@@ -131,7 +149,7 @@ type ServerConnectionIdx = usize;
 #[derive(Resource)]
 pub struct ServerConnections {
     /// list of the various `ServerConnection`s available. Will be static after first insertion.
-    pub servers: Vec<ServerConnection>,
+    servers: Vec<ServerConnection>,
     /// Mapping from the connection's [`ClientId`] into the index of the [`ServerConnection`] in the `servers` list
     pub(crate) client_server_map: HashMap<ClientId, ServerConnectionIdx>,
     /// Track whether the server is ready to listen to incoming connections

--- a/lightyear/src/connection/steam/server.rs
+++ b/lightyear/src/connection/steam/server.rs
@@ -1,4 +1,5 @@
 use crate::_reexport::{ReadBuffer, ReadWordBuffer};
+use crate::connection::id;
 use crate::connection::id::ClientId;
 use crate::connection::netcode::MAX_PACKET_SIZE;
 use crate::connection::server::NetServer;
@@ -16,7 +17,6 @@ use steamworks::networking_types::{
 };
 use steamworks::{ClientManager, Manager, ServerManager, ServerMode, SingleClient, SteamError};
 use tracing::{error, info};
-use crate::connection::id;
 
 use super::{get_networking_options, SingleClientThreadSafe};
 
@@ -108,18 +108,24 @@ impl NetServer for Server {
 
     fn stop(&mut self) -> Result<()> {
         self.listen_socket = None;
+        for (client_id, connection) in self.connections.drain() {
+            let _ = connection.close(NetConnectionEnd::AppGeneric, None, true);
+            self.new_disconnections.push(client_id);
+        }
         info!("Steam socket has been closed.");
+        Ok(())
     }
 
     fn disconnect(&mut self, client_id: ClientId) -> Result<()> {
         match client_id {
-                ClientId::Steam(id) => {
+            ClientId::Steam(id) => {
+                if let Some(connection) = self.connections.remove(&client_id) {
+                    let _ = connection.close(NetConnectionEnd::AppGeneric, None, true);
                     self.new_disconnections.push(client_id);
-                    self.connections.remove(&client_id);
-                    Ok(())
-                },
-                _ => Err(anyhow!("the client id must be of type Steam")),
+                }
+                Ok(())
             }
+            _ => Err(anyhow!("the client id must be of type Steam")),
         }
     }
 

--- a/lightyear/src/connection/steam/server.rs
+++ b/lightyear/src/connection/steam/server.rs
@@ -105,6 +105,15 @@ impl NetServer for Server {
         Ok(())
     }
 
+    fn stop(&mut self) -> Result<()> {
+        self.listen_socket.unwrap(). = None;
+        todo!()
+    }
+
+    fn disconnect(&mut self, client_id: ClientId) -> Result<()> {
+        todo!()
+    }
+
     fn connected_client_ids(&self) -> Vec<ClientId> {
         self.connections.keys().cloned().collect()
     }

--- a/lightyear/src/shared/replication/send.rs
+++ b/lightyear/src/shared/replication/send.rs
@@ -130,7 +130,7 @@ impl<P: Protocol> ReplicationSender<P> {
                     error!("Received an update message-id ack but the corresponding group channel does not exist");
                 }
             } else {
-                error!("Received an update message-id ack but we know the corresponding group id");
+                error!("Received an update message-id ack but we don't know the corresponding group id");
             }
         }
     }


### PR DESCRIPTION
Adds 2 new methods to a NetServer:
- stop: stops the server, all clients are disconnected and the server stops listening for packets
- disconnect: disconnect a specific client


I haven't added unit tests or tested the feature, but I will build an example with some kind of lobby system where the host (i.e. the server) can be changed at runtime to demonstrate this feature.