### PR TITLE
Add client Reflect bounds

### DIFF
--- a/lightyear/src/client/components.rs
+++ b/lightyear/src/client/components.rs
@@ -4,6 +4,7 @@ Defines components that are used for the client-side prediction and interpolatio
 use std::fmt::Debug;
 
 use bevy::prelude::{Component, Entity};
+use bevy::reflect::Reflect;
 
 use crate::prelude::{Message, Tick};
 
@@ -13,7 +14,7 @@ use crate::prelude::{Message, Tick};
 /// - an entity that simply contains the replicated components. It will have the marker component [`Confirmed`]
 /// - an entity that is in the future compared to the confirmed entity, and does prediction with rollback. It will have the marker component [`Predicted`](crate::client::prediction::Predicted)
 /// - an entity that is in the past compared to the confirmed entity and interpolates between multiple server updates. It will have the marker component [`Interpolated`](crate::client::interpolation::Interpolated)
-#[derive(Component)]
+#[derive(Component, Reflect)]
 pub struct Confirmed {
     /// The corresponding Predicted entity
     pub predicted: Option<Entity>,

--- a/lightyear/src/client/config.rs
+++ b/lightyear/src/client/config.rs
@@ -1,5 +1,7 @@
 //! Defines client-specific configuration options
+use bevy::ecs::reflect::ReflectResource;
 use bevy::prelude::Resource;
+use bevy::reflect::Reflect;
 use governor::Quota;
 use nonzero_ext::nonzero;
 
@@ -12,7 +14,7 @@ use crate::connection::client::NetConfig;
 use crate::shared::config::{Mode, SharedConfig};
 use crate::shared::ping::manager::PingConfig;
 
-#[derive(Clone)]
+#[derive(Clone, Reflect)]
 /// Config related to the netcode protocol (abstraction of a connection over raw UDP-like transport)
 pub struct NetcodeConfig {
     pub num_disconnect_packets: usize,
@@ -41,8 +43,10 @@ impl NetcodeConfig {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Reflect)]
+#[reflect(from_reflect = false)]
 pub struct PacketConfig {
+    #[reflect(ignore)]
     /// Number of bytes per second that can be sent to the server
     pub send_bandwidth_cap: Quota,
     /// If false, there is no bandwidth cap and all messages are sent as soon as possible
@@ -88,7 +92,8 @@ impl PacketConfig {
 /// };
 /// let client = ClientPlugin::new(PluginConfig::new(config, io, MyProtocol::default()));
 /// ```
-#[derive(Resource, Clone, Default)]
+#[derive(Resource, Clone, Default, Reflect)]
+#[reflect(Resource, from_reflect = false)]
 pub struct ClientConfig {
     pub shared: SharedConfig,
     pub packet: PacketConfig,

--- a/lightyear/src/client/input.rs
+++ b/lightyear/src/client/input.rs
@@ -28,6 +28,7 @@ use bevy::prelude::{
     not, App, Condition, EventReader, EventWriter, Events, FixedPostUpdate, FixedPreUpdate, In,
     IntoSystemConfigs, IntoSystemSetConfigs, Plugin, PostUpdate, Res, ResMut, Resource, SystemSet,
 };
+use bevy::reflect::Reflect;
 use tracing::{debug, error, info, trace};
 
 use crate::channel::builder::InputChannel;
@@ -47,7 +48,7 @@ use crate::shared::config::Mode;
 use crate::shared::sets::InternalMainSet;
 use crate::shared::tick_manager::TickEvent;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Reflect)]
 pub struct InputConfig {
     /// How many consecutive packets losses do we want to handle?
     /// This is used to compute the redundancy of the input messages.
@@ -126,6 +127,8 @@ pub struct CurrentInput<T: UserAction> {
 
 impl<P: Protocol> Plugin for InputPlugin<P> {
     fn build(&self, app: &mut App) {
+        // REFLECTION
+        app.register_type::<InputConfig>();
         // RESOURCES
         app.init_resource::<InputManager<P::Input>>();
         // EVENT

--- a/lightyear/src/client/interpolation/mod.rs
+++ b/lightyear/src/client/interpolation/mod.rs
@@ -1,7 +1,7 @@
 //! Handles interpolation of entities between server updates
 use std::ops::{Add, Mul};
 
-use bevy::prelude::{Added, Commands, Component, Entity, Query, Res, ResMut};
+use bevy::prelude::{Added, Commands, Component, Entity, Query, Reflect, Res, ResMut};
 use tracing::trace;
 
 pub use interpolate::InterpolateStatus;
@@ -46,7 +46,7 @@ impl<C: Clone> LerpFn<C> for NullInterpolator {
 }
 
 /// Marker component for an entity that is being interpolated by the client
-#[derive(Component, Debug)]
+#[derive(Component, Debug, Reflect)]
 pub struct Interpolated {
     // TODO: maybe here add an interpolation function?
     pub confirmed_entity: Entity,

--- a/lightyear/src/client/interpolation/plugin.rs
+++ b/lightyear/src/client/interpolation/plugin.rs
@@ -12,6 +12,7 @@ use crate::client::interpolation::interpolate::{
 };
 use crate::client::interpolation::resource::InterpolationManager;
 use crate::client::interpolation::spawn::spawn_interpolated_entity;
+use crate::client::interpolation::Interpolated;
 use crate::client::sync::client_is_synced;
 use crate::prelude::{ExternalMapper, Mode};
 use crate::protocol::component::ComponentProtocol;
@@ -22,7 +23,7 @@ use super::interpolation_history::{
 };
 
 // TODO: maybe this is not an enum and user can specify multiple values, and we use the max delay between all of them?
-#[derive(Clone)]
+#[derive(Clone, Reflect)]
 pub struct InterpolationDelay {
     /// The minimum delay that we will apply for interpolation
     /// This should be big enough so that the interpolated entity always has a server snapshot
@@ -64,7 +65,7 @@ impl InterpolationDelay {
 }
 
 /// Config to specify how the snapshot interpolation should behave
-#[derive(Clone)]
+#[derive(Clone, Reflect)]
 pub struct InterpolationConfig {
     pub delay: InterpolationDelay,
     /// If true, disable the interpolation logic (but still keep the internal component history buffers)
@@ -198,6 +199,11 @@ where
 
 impl<P: Protocol> Plugin for InterpolationPlugin<P> {
     fn build(&self, app: &mut App) {
+        // REFLECT
+        app.register_type::<InterpolationConfig>()
+            .register_type::<InterpolationDelay>()
+            .register_type::<Interpolated>();
+
         P::Components::add_prepare_interpolation_systems(app);
         if !self.config.custom_interpolation_logic {
             P::Components::add_interpolation_systems(app);

--- a/lightyear/src/client/interpolation/resource.rs
+++ b/lightyear/src/client/interpolation/resource.rs
@@ -1,9 +1,12 @@
 //! Defines bevy resources needed for Interpolation
+use bevy::ecs::reflect::ReflectResource;
 use bevy::prelude::Resource;
+use bevy::reflect::Reflect;
 
 use crate::shared::replication::entity_map::InterpolatedEntityMap;
 
-#[derive(Resource, Default)]
+#[derive(Resource, Default, Reflect)]
+#[reflect(Resource)]
 pub struct InterpolationManager {
     /// Map between remote and predicted entities
     pub interpolated_entity_map: InterpolatedEntityMap,

--- a/lightyear/src/client/interpolation/visual_interpolation.rs
+++ b/lightyear/src/client/interpolation/visual_interpolation.rs
@@ -64,6 +64,8 @@ where
     P::ComponentKinds: FromType<C>,
 {
     fn build(&self, app: &mut App) {
+        // REFLECTION
+        app.register_type::<VisualInterpolateMarker>();
         // SETS
         app.configure_sets(PreUpdate, InterpolationSet::RestoreVisualInterpolation);
         app.configure_sets(
@@ -120,7 +122,7 @@ impl<C: Component> Default for VisualInterpolateStatus<C> {
 }
 
 /// Marker component to indicate that this entity will be visually interpolated
-#[derive(Component, Debug)]
+#[derive(Component, Debug, Reflect)]
 pub struct VisualInterpolateMarker;
 
 // TODO: explore how we could allow this for non-marker components, user would need to specify the interpolation function?

--- a/lightyear/src/client/plugin.rs
+++ b/lightyear/src/client/plugin.rs
@@ -11,7 +11,8 @@ use crate::client::input::InputPlugin;
 use crate::client::interpolation::plugin::InterpolationPlugin;
 use crate::client::networking::ClientNetworkingPlugin;
 use crate::client::prediction::plugin::PredictionPlugin;
-use crate::client::replication::ClientReplicationPlugin;
+use crate::client::replication::{ClientReplicationPlugin, ReplicationConfig};
+use crate::client::sync::SyncConfig;
 use crate::connection::client::{ClientConnection, NetConfig};
 use crate::protocol::component::ComponentProtocol;
 use crate::protocol::message::MessageProtocol;
@@ -24,7 +25,7 @@ use crate::shared::plugin::SharedPlugin;
 use crate::shared::time_manager::TimePlugin;
 use crate::transport::PacketSender;
 
-use super::config::ClientConfig;
+use super::config::{ClientConfig, PacketConfig};
 
 pub struct PluginConfig<P: Protocol> {
     client_config: ClientConfig,
@@ -58,6 +59,12 @@ impl<P: Protocol> ClientPlugin<P> {
 //  before the plugin is ready
 impl<P: Protocol> Plugin for ClientPlugin<P> {
     fn build(&self, app: &mut App) {
+        // REFLECTION
+        app.register_type::<ClientConfig>()
+            .register_type::<PacketConfig>()
+            .register_type::<SyncConfig>()
+            .register_type::<ReplicationConfig>();
+
         let config = self.config.lock().unwrap().deref_mut().take().unwrap();
         let netclient = config.client_config.net.clone().build_client();
 

--- a/lightyear/src/client/prediction/despawn.rs
+++ b/lightyear/src/client/prediction/despawn.rs
@@ -2,7 +2,7 @@ use std::marker::PhantomData;
 
 use bevy::ecs::system::{Command, EntityCommands};
 use bevy::prelude::{
-    Commands, Component, Entity, Query, RemovedComponents, ResMut, With, Without, World,
+    Commands, Component, Entity, Query, Reflect, RemovedComponents, ResMut, With, Without, World,
 };
 use tracing::{debug, error, trace};
 
@@ -25,7 +25,7 @@ pub struct PredictionDespawnCommand<P: Protocol> {
     _marker: PhantomData<P>,
 }
 
-#[derive(Component, PartialEq, Debug)]
+#[derive(Component, PartialEq, Debug, Reflect)]
 pub(crate) struct PredictionDespawnMarker {
     // TODO: do we need this?
     // TODO: it's pub just for integration tests right now

--- a/lightyear/src/client/prediction/mod.rs
+++ b/lightyear/src/client/prediction/mod.rs
@@ -27,7 +27,7 @@ pub(crate) mod rollback;
 pub mod spawn;
 
 /// Marks an entity that is being predicted by the client
-#[derive(Component, Debug)]
+#[derive(Component, Debug, Reflect)]
 pub struct Predicted {
     // This is an option because we could spawn pre-predicted entities on the client that exist before we receive
     // the corresponding confirmed entity

--- a/lightyear/src/client/prediction/plugin.rs
+++ b/lightyear/src/client/prediction/plugin.rs
@@ -4,17 +4,18 @@ use bevy::prelude::{
     apply_deferred, App, FixedPostUpdate, IntoSystemConfigs, IntoSystemSetConfigs, Plugin,
     PostUpdate, PreUpdate, Res, SystemSet,
 };
+use bevy::reflect::Reflect;
 use bevy::transform::TransformSystem;
 
 use crate::_reexport::{ClientMarker, FromType};
-use crate::client::components::{ComponentSyncMode, SyncComponent, SyncMetadata};
+use crate::client::components::{ComponentSyncMode, Confirmed, SyncComponent, SyncMetadata};
 use crate::client::config::ClientConfig;
 use crate::client::prediction::correction::{
     get_visually_corrected_state, restore_corrected_state,
 };
 use crate::client::prediction::despawn::{
     despawn_confirmed, remove_component_for_despawn_predicted, remove_despawn_marker,
-    restore_components_if_despawn_rolled_back,
+    restore_components_if_despawn_rolled_back, PredictionDespawnMarker,
 };
 use crate::client::prediction::predicted_history::{
     add_prespawned_component_history, update_prediction_history,
@@ -23,9 +24,10 @@ use crate::client::prediction::prespawn::{
     PreSpawnedPlayerObjectPlugin, PreSpawnedPlayerObjectSet,
 };
 use crate::client::prediction::resource::PredictionManager;
+use crate::client::prediction::Predicted;
 use crate::client::sync::client_is_synced;
 use crate::connection::client::{ClientConnection, NetClient};
-use crate::prelude::ExternalMapper;
+use crate::prelude::{ExternalMapper, PreSpawnedPlayerObject};
 use crate::protocol::component::ComponentProtocol;
 use crate::protocol::Protocol;
 use crate::shared::sets::InternalMainSet;
@@ -39,7 +41,7 @@ use super::rollback::{
 use super::spawn::spawn_predicted_entity;
 
 /// Configuration to specify how the prediction plugin should behave
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy, Default, Reflect)]
 pub struct PredictionConfig {
     /// If true, we completely disable the prediction plugin
     pub disable: bool,
@@ -230,6 +232,15 @@ impl<P: Protocol> Plugin for PredictionPlugin<P> {
         if self.config.disable {
             return;
         }
+
+        // REFLECTION
+        app.register_type::<Predicted>()
+            .register_type::<Confirmed>()
+            .register_type::<PreSpawnedPlayerObject>()
+            .register_type::<Rollback>()
+            .register_type::<RollbackState>()
+            .register_type::<PredictionDespawnMarker>()
+            .register_type::<PredictionConfig>();
 
         P::Components::add_prediction_systems(app);
 

--- a/lightyear/src/client/prediction/resource.rs
+++ b/lightyear/src/client/prediction/resource.rs
@@ -2,6 +2,7 @@
 
 use bevy::ecs::entity::EntityHash;
 use bevy::prelude::{Entity, Resource};
+use bevy::reflect::Reflect;
 
 use crate::_reexport::ReadyBuffer;
 use crate::prelude::Tick;

--- a/lightyear/src/client/prediction/rollback.rs
+++ b/lightyear/src/client/prediction/rollback.rs
@@ -2,10 +2,12 @@ use std::fmt::Debug;
 
 use bevy::app::FixedMain;
 use bevy::ecs::entity::EntityHashSet;
+use bevy::ecs::reflect::ReflectResource;
 use bevy::prelude::{
     Commands, DespawnRecursiveExt, DetectChanges, Entity, Query, Ref, Res, ResMut, Resource, With,
     Without, World,
 };
+use bevy::reflect::Reflect;
 use tracing::{debug, error, trace, trace_span};
 
 use crate::_reexport::{ComponentProtocol, FromType};
@@ -23,7 +25,8 @@ use super::predicted_history::PredictionHistory;
 use super::Predicted;
 
 /// Resource that indicates whether we are in a rollback state or not
-#[derive(Resource)]
+#[derive(Default, Resource, Reflect)]
+#[reflect(Resource)]
 pub struct Rollback {
     pub state: RollbackState,
     // pub rollback_groups: EntityHashMap<ReplicationGroupId, RollbackState>,
@@ -31,9 +34,10 @@ pub struct Rollback {
 
 /// Resource that will track whether we should do rollback or not
 /// (We have this as a resource because if any predicted entity needs to be rolled-back; we should roll back all predicted entities)
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Default, Copy, Clone, Reflect)]
 pub enum RollbackState {
     /// We are not in a rollback state
+    #[default]
     Default,
     /// We should do a rollback starting from the current_tick
     ShouldRollback {

--- a/lightyear/src/client/replication.rs
+++ b/lightyear/src/client/replication.rs
@@ -10,7 +10,7 @@ use crate::prelude::Protocol;
 use crate::shared::replication::plugin::ReplicationPlugin;
 use crate::shared::sets::InternalReplicationSet;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Reflect)]
 pub struct ReplicationConfig {
     /// Set to true to enable replicating this client's entities to the server
     pub enable_send: bool,

--- a/lightyear/src/client/sync.rs
+++ b/lightyear/src/client/sync.rs
@@ -1,6 +1,6 @@
 /*! Handles syncing the time between the client and the server
 */
-use bevy::prelude::{Res, SystemSet};
+use bevy::prelude::{Reflect, Res, SystemSet};
 use bevy::utils::Duration;
 use chrono::Duration as ChronoDuration;
 use tracing::{debug, info, trace};
@@ -31,7 +31,7 @@ pub struct SyncSet;
 ///     for tick T sent from the client arrive on the server at tick T
 /// - the interpolation tick/time: this is the interpolation timeline, which runs behind the server time so that interpolation
 ///     always has at least one packet to interpolate towards
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Reflect)]
 pub struct SyncConfig {
     /// How much multiple of jitter do we apply as margin when computing the time
     /// a packet will get received by the server

--- a/lightyear/src/connection/client.rs
+++ b/lightyear/src/connection/client.rs
@@ -2,7 +2,7 @@ use std::net::SocketAddr;
 use std::str::FromStr;
 
 use anyhow::Result;
-use bevy::prelude::Resource;
+use bevy::prelude::{Reflect, Resource};
 
 use crate::_reexport::ReadWordBuffer;
 use crate::client::config::NetcodeConfig;
@@ -57,16 +57,20 @@ pub struct ClientConnection {
 }
 
 #[allow(clippy::large_enum_variant)]
-#[derive(Clone)]
+#[derive(Clone, Reflect)]
+#[reflect(from_reflect = false)]
 pub enum NetConfig {
     Netcode {
+        #[reflect(ignore)]
         auth: Authentication,
         config: NetcodeConfig,
+        #[reflect(ignore)]
         io: IoConfig,
     },
     // TODO: for steam, we can use a pass-through io that just computes stats?
     #[cfg(all(feature = "steam", not(target_family = "wasm")))]
     Steam {
+        #[reflect(ignore)]
         config: SteamConfig,
         conditioner: Option<LinkConditionerConfig>,
     },

--- a/lightyear/src/protocol/channel.rs
+++ b/lightyear/src/protocol/channel.rs
@@ -7,6 +7,7 @@ use crate::channel::builder::ChannelContainer;
 use crate::channel::builder::{Channel, ChannelBuilder, ChannelSettings};
 use crate::protocol::registry::{NetId, TypeKind, TypeMapper};
 
+// TODO: derive Reflect once we reach bevy 0.14
 /// ChannelKind - internal wrapper around the type of the channel
 #[derive(Debug, Eq, Hash, Copy, Clone, PartialEq)]
 pub struct ChannelKind(TypeId);

--- a/lightyear/src/protocol/component.rs
+++ b/lightyear/src/protocol/component.rs
@@ -3,7 +3,8 @@ use std::any::TypeId;
 use std::fmt::{Debug, Display};
 use std::hash::Hash;
 
-use bevy::prelude::{App, Component, Entity, EntityMapper, EntityWorldMut, World};
+use bevy::prelude::{App, Component, Entity, EntityMapper, EntityWorldMut, TypePath, World};
+use bevy::reflect::{FromReflect, GetTypeRegistration};
 use bevy::utils::HashMap;
 use cfg_if::cfg_if;
 
@@ -155,6 +156,9 @@ cfg_if!(
             + Send
             + Sync
             + Display
+            + FromReflect
+            + TypePath
+            + GetTypeRegistration
             + for<'a> From<&'a <Self::Protocol as Protocol>::Components>
             + ComponentKindBehaviour
             + FromType<ShouldBePredicted>
@@ -182,6 +186,9 @@ cfg_if!(
             + Send
             + Sync
             + Display
+            + FromReflect
+            + TypePath
+            + GetTypeRegistration
             + for<'a> From<&'a <Self::Protocol as Protocol>::Components>
             + ComponentKindBehaviour
             + FromType<ShouldBePredicted>

--- a/lightyear/src/protocol/mod.rs
+++ b/lightyear/src/protocol/mod.rs
@@ -9,6 +9,7 @@ use anyhow::Context;
 use std::fmt::Debug;
 
 use bevy::prelude::{App, Resource};
+use bevy::reflect::TypePath;
 use bitcode::encoding::Fixed;
 use bitcode::{Decode, Encode};
 use serde::de::DeserializeOwned;
@@ -84,7 +85,7 @@ pub(crate) mod registry;
 ///
 /// [`Message`]: crate::prelude::Message
 /// [`Component`]: bevy::prelude::Component
-pub trait Protocol: Send + Sync + Clone + Debug + 'static {
+pub trait Protocol: Send + Sync + Clone + Debug + TypePath + 'static {
     type Input: crate::inputs::native::UserAction;
     #[cfg(feature = "leafwing")]
     type LeafwingInput1: crate::inputs::leafwing::LeafwingUserAction;
@@ -125,7 +126,7 @@ macro_rules! protocolize {
             use $shared_crate_name::prelude::*;
             use $shared_crate_name::_reexport::*;
 
-            #[derive(Debug, Clone, Resource, PartialEq)]
+            #[derive(Debug, Clone, Resource, PartialEq, TypePath)]
             pub struct $protocol {
                 channel_registry: ChannelRegistry,
             }

--- a/lightyear/src/server/room.rs
+++ b/lightyear/src/server/room.rs
@@ -8,6 +8,7 @@ use bevy::prelude::{
     Entity, IntoSystemConfigs, IntoSystemSetConfigs, Plugin, PostUpdate, Query, RemovedComponents,
     Res, ResMut, Resource, SystemSet,
 };
+use bevy::reflect::Reflect;
 use bevy::utils::{HashMap, HashSet};
 use tracing::{info, trace};
 
@@ -421,7 +422,7 @@ impl RoomEvents {
 
 // TODO: this should not be public?
 /// Event related to [`Entities`](Entity) which are visible to a client
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Debug, PartialEq, Clone, Copy, Reflect)]
 pub enum ClientVisibility {
     /// the entity was not replicated to the client, but now is
     Gained,

--- a/lightyear/src/shared/config.rs
+++ b/lightyear/src/shared/config.rs
@@ -1,12 +1,13 @@
 //! Configuration that has to be the same between the server and the client.
 use bevy::prelude::Res;
+use bevy::reflect::Reflect;
 use bevy::utils::Duration;
 
 use crate::server::config::ServerConfig;
 use crate::shared::tick_manager::TickConfig;
 
 /// Configuration that has to be the same between the server and the client.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Reflect)]
 pub struct SharedConfig {
     /// how often does the client send updates to the server?
     /// A duration of 0 means that we send updates every frame
@@ -19,7 +20,7 @@ pub struct SharedConfig {
     pub mode: Mode,
 }
 
-#[derive(Default, Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Default, Clone, Copy, Debug, PartialEq, Eq, Reflect)]
 pub enum Mode {
     #[default]
     /// Run the client and server in two different apps

--- a/lightyear/src/shared/ping/manager.rs
+++ b/lightyear/src/shared/ping/manager.rs
@@ -1,4 +1,5 @@
 //! Manages sending/receiving pings and computing network statistics
+use bevy::reflect::Reflect;
 use bevy::time::Stopwatch;
 use bevy::utils::Duration;
 use tracing::{error, trace};
@@ -11,7 +12,7 @@ use crate::utils::ready_buffer::ReadyBuffer;
 
 /// Config for the ping manager, which sends regular pings to the remote machine in order
 /// to compute network statistics (RTT, jitter)
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Reflect)]
 pub struct PingConfig {
     /// The duration to wait before sending a ping message to the remote host,
     /// in order to estimate RTT time

--- a/lightyear/src/shared/plugin.rs
+++ b/lightyear/src/shared/plugin.rs
@@ -2,7 +2,9 @@
 use bevy::ecs::system::SystemParam;
 use bevy::prelude::*;
 
-use crate::prelude::Protocol;
+use crate::prelude::{
+    IoConfig, LinkConditionerConfig, Mode, PingConfig, Protocol, TickConfig, TransportConfig,
+};
 use crate::server::config::ServerConfig;
 use crate::shared::config::SharedConfig;
 use crate::shared::tick_manager::TickManagerPlugin;
@@ -40,6 +42,14 @@ impl<'w, 's> NetworkIdentity<'w, 's> {
 
 impl<P: Protocol> Plugin for SharedPlugin<P> {
     fn build(&self, app: &mut App) {
+        // REFLECTION
+        app.register_type::<Mode>()
+            .register_type::<SharedConfig>()
+            .register_type::<TickConfig>()
+            .register_type::<PingConfig>()
+            .register_type::<LinkConditionerConfig>()
+            .register_type::<IoConfig>();
+
         // RESOURCES
         // NOTE: this tick duration must be the same as any previous existing fixed timesteps
         app.insert_resource(Time::<Fixed>::from_seconds(

--- a/lightyear/src/shared/replication/components.rs
+++ b/lightyear/src/shared/replication/components.rs
@@ -20,7 +20,7 @@ pub struct DespawnTracker;
 
 /// Component that indicates that an entity should be replicated. Added to the entity when it is spawned
 /// in the world that sends replication updates.
-#[derive(Component, Clone, PartialEq, Debug)]
+#[derive(Component, Clone, PartialEq, Debug, Reflect)]
 pub struct Replicate<P: Protocol> {
     /// Which clients should this entity be replicated to
     pub replication_target: NetworkTarget,
@@ -50,7 +50,7 @@ pub struct Replicate<P: Protocol> {
 }
 
 /// This lets you specify how to customize the replication behaviour for a given component
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Reflect)]
 pub struct PerComponentReplicationMetadata {
     /// If true, do not replicate the component. (By default, all components of this entity that are present in the
     /// ComponentProtocol) will be replicated.
@@ -192,7 +192,7 @@ impl<P: Protocol> Replicate<P> {
     }
 }
 
-#[derive(Debug, Default, Copy, Clone, PartialEq)]
+#[derive(Debug, Default, Copy, Clone, PartialEq, Reflect)]
 pub enum ReplicationGroupIdBuilder {
     // the group id is the entity id
     #[default]
@@ -204,7 +204,7 @@ pub enum ReplicationGroupIdBuilder {
     Group(u64),
 }
 
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Reflect)]
 pub struct ReplicationGroup {
     id_builder: ReplicationGroupIdBuilder,
     /// the priority of the accumulation group
@@ -260,10 +260,10 @@ impl ReplicationGroup {
     }
 }
 
-#[derive(Default, Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Default, Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, Reflect)]
 pub struct ReplicationGroupId(pub u64);
 
-#[derive(Clone, Copy, Default, Debug, PartialEq)]
+#[derive(Clone, Copy, Default, Debug, PartialEq, Reflect)]
 pub enum ReplicationMode {
     /// We will replicate this entity only to clients that are in the same room as the entity
     Room,
@@ -301,7 +301,7 @@ impl<P: Protocol> Default for Replicate<P> {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq, Reflect)]
 /// NetworkTarget indicated which clients should receive some message
 pub enum NetworkTarget {
     #[default]

--- a/lightyear/src/shared/replication/entity_map.rs
+++ b/lightyear/src/shared/replication/entity_map.rs
@@ -2,6 +2,7 @@
 use anyhow::Context;
 use bevy::ecs::entity::{EntityHashMap, EntityMapper, MapEntities};
 use bevy::prelude::{Component, Entity, EntityWorldMut, World};
+use bevy::reflect::Reflect;
 use bevy::utils::hashbrown::hash_map::Entry;
 
 /// A trait for structs who can do entity mapping for another type.
@@ -18,14 +19,14 @@ pub trait ExternalMapper<C> {
 //     }
 // }
 
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Reflect)]
 /// Map between local and remote entities. (used mostly on client because it's when we receive entity updates)
 pub struct RemoteEntityMap {
     remote_to_local: EntityHashMap<Entity>,
     local_to_remote: EntityHashMap<Entity>,
 }
 
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Reflect)]
 pub struct PredictedEntityMap {
     // map from the confirmed entity to the predicted entity
     // useful for despawning, as we won't have access to the Confirmed/Predicted components anymore
@@ -41,7 +42,7 @@ impl EntityMapper for PredictedEntityMap {
     }
 }
 
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Reflect)]
 pub struct InterpolatedEntityMap {
     // map from the confirmed entity to the interpolated entity
     // useful for despawning, as we won't have access to the Confirmed/Interpolated components anymore

--- a/lightyear/src/shared/replication/hierarchy.rs
+++ b/lightyear/src/shared/replication/hierarchy.rs
@@ -152,6 +152,9 @@ impl<P: Protocol, R: ReplicationSend<P>> HierarchyReceivePlugin<P, R> {
 
 impl<P: Protocol, R: ReplicationSend<P>> Plugin for HierarchyReceivePlugin<P, R> {
     fn build(&self, app: &mut App) {
+        // REFLECTION
+        app.register_type::<ParentSync>();
+
         // TODO: does this work for client replication? (client replicating to other clients via the server?)
         // when we receive a ParentSync update from the remote, update the hierarchy
         app.add_systems(

--- a/lightyear/src/shared/replication/plugin.rs
+++ b/lightyear/src/shared/replication/plugin.rs
@@ -2,8 +2,15 @@ use bevy::prelude::*;
 use bevy::time::common_conditions::on_timer;
 use bevy::utils::Duration;
 
-use crate::_reexport::{ComponentProtocol, ReplicationSend};
-use crate::prelude::Protocol;
+use crate::_reexport::{ComponentProtocol, ReplicationSend, ShouldBeInterpolated};
+use crate::prelude::{
+    NetworkTarget, PrePredicted, Protocol, RemoteEntityMap, ReplicationGroup, ReplicationMode,
+    ShouldBePredicted,
+};
+use crate::shared::replication::components::{
+    PerComponentReplicationMetadata, Replicate, ReplicationGroupId, ReplicationGroupIdBuilder,
+};
+use crate::shared::replication::entity_map::{InterpolatedEntityMap, PredictedEntityMap};
 use crate::shared::replication::hierarchy::{HierarchyReceivePlugin, HierarchySendPlugin};
 use crate::shared::replication::systems::{add_replication_send_systems, cleanup};
 use crate::shared::sets::{InternalMainSet, InternalReplicationSet, MainSet};
@@ -30,6 +37,23 @@ impl<P: Protocol, R: ReplicationSend<P>> Plugin for ReplicationPlugin<P, R> {
     fn build(&self, app: &mut App) {
         // TODO: have a better constant for clean_interval?
         let clean_interval = self.tick_duration * (i16::MAX as u32 / 3);
+
+        // REFLECTION
+
+        app.register_type::<Replicate<P>>()
+            .register_type::<P::ComponentKinds>()
+            .register_type::<PerComponentReplicationMetadata>()
+            .register_type::<ReplicationGroupIdBuilder>()
+            .register_type::<ReplicationGroup>()
+            .register_type::<ReplicationGroupId>()
+            .register_type::<ReplicationMode>()
+            .register_type::<NetworkTarget>()
+            .register_type::<ShouldBeInterpolated>()
+            .register_type::<PrePredicted>()
+            .register_type::<ShouldBePredicted>()
+            .register_type::<RemoteEntityMap>()
+            .register_type::<PredictedEntityMap>()
+            .register_type::<InterpolatedEntityMap>();
 
         // SYSTEM SETS //
         if self.enable_receive {

--- a/lightyear/src/shared/tick_manager.rs
+++ b/lightyear/src/shared/tick_manager.rs
@@ -47,7 +47,7 @@ impl Plugin for TickManagerPlugin {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Reflect)]
 pub struct TickConfig {
     pub tick_duration: Duration,
 }

--- a/lightyear/src/transport/config.rs
+++ b/lightyear/src/transport/config.rs
@@ -1,3 +1,4 @@
+use bevy::prelude::Reflect;
 use std::fmt::{Debug, Formatter};
 use std::net::{IpAddr, SocketAddr};
 
@@ -116,8 +117,10 @@ impl Debug for TransportConfig {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Reflect)]
+#[reflect(from_reflect = false)]
 pub struct IoConfig {
+    #[reflect(ignore)]
     pub transport: TransportConfig,
     pub conditioner: Option<LinkConditionerConfig>,
 }

--- a/lightyear/src/transport/middleware/conditioner.rs
+++ b/lightyear/src/transport/middleware/conditioner.rs
@@ -1,4 +1,5 @@
 //! Contains the `LinkConditioner` struct which can be used to simulate network conditions
+use bevy::reflect::Reflect;
 use std::net::SocketAddr;
 
 use bevy::utils::Duration;
@@ -20,7 +21,7 @@ cfg_if! {
 }
 
 /// Contains configuration required to initialize a LinkConditioner
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Reflect)]
 pub struct LinkConditionerConfig {
     /// Delay to receive incoming messages in milliseconds (half the RTT)
     pub incoming_latency: Duration,

--- a/macros/src/component.rs
+++ b/macros/src/component.rs
@@ -169,7 +169,7 @@ pub fn component_protocol_impl(
             use #shared_crate_name::prelude::*;
             use #shared_crate_name::prelude::client::*;
             use bevy::ecs::entity::{EntityHashSet, MapEntities, EntityMapper};
-            use bevy::prelude::{App, Entity, IntoSystemConfigs, EntityWorldMut, World};
+            use bevy::prelude::{App, Entity, IntoSystemConfigs, EntityWorldMut, World, Reflect};
             use bevy::utils::HashMap;
             use std::any::TypeId;
             use #shared_crate_name::shared::events::components::{ComponentInsertEvent, ComponentRemoveEvent, ComponentUpdateEvent};
@@ -218,7 +218,7 @@ pub fn component_protocol_impl(
             #sync_component_impl
             #map_entities_method
 
-            #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+            #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Reflect)]
             #[repr(C)]
             #enum_kind
 


### PR DESCRIPTION
Add reflect bounds for most client resources/components for easier debugging via bevy_inspector_egui.
Notably the `ClientConfig` is easily modifiable via reflection during runtime!