### PR TITLE
Fix steam issues when recreating the client connection

### DIFF
--- a/examples/simple_box/assets/settings.ron
+++ b/examples/simple_box/assets/settings.ron
@@ -9,20 +9,20 @@ Settings(
             jitter_ms: 20,
             packet_loss: 0.05
         )),
-        server_port: 5000,
-        transport: WebTransport(
-            // this is only needed for wasm, the self-signed certificates are only valid for 2 weeks
-            // the server will print the certificate digest on startup
-            certificate_digest: "a71e935276ac0e37db88bfa702b3ece66f30b3ad4f6117c12b782fe0f2817f9f",
-        ),
+        // server_port: 5000,
+        // transport: WebTransport(
+        //     // this is only needed for wasm, the self-signed certificates are only valid for 2 weeks
+        //     // the server will print the certificate digest on startup
+        //     certificate_digest: "a71e935276ac0e37db88bfa702b3ece66f30b3ad4f6117c12b782fe0f2817f9f",
+        // ),
         // server_port: 5001,
         // transport: Udp,
         // server_port: 5002,
         // transport: WebSocket,
-        // server_port: 5003,
-        // transport: Steam(
-        //     app_id: 480,
-        // )
+        server_port: 5003,
+        transport: Steam(
+            app_id: 480,
+        )
     ),
     server: ServerSettings(
         headless: true,
@@ -42,12 +42,12 @@ Settings(
             WebSocket(
                 local_port: 5002
             ),
-            // Steam(
-            //     app_id: 480,
-            //     server_ip: "0.0.0.0",
-            //     game_port: 5003,
-            //     query_port: 27016,
-            // ),
+            Steam(
+                app_id: 480,
+                server_ip: "0.0.0.0",
+                game_port: 5003,
+                query_port: 27016,
+            ),
         ],
     ),
     shared: SharedSettings(

--- a/examples/simple_box/assets/settings.ron
+++ b/examples/simple_box/assets/settings.ron
@@ -9,20 +9,20 @@ Settings(
             jitter_ms: 20,
             packet_loss: 0.05
         )),
-        // server_port: 5000,
-        // transport: WebTransport(
-        //     // this is only needed for wasm, the self-signed certificates are only valid for 2 weeks
-        //     // the server will print the certificate digest on startup
-        //     certificate_digest: "a71e935276ac0e37db88bfa702b3ece66f30b3ad4f6117c12b782fe0f2817f9f",
-        // ),
+        server_port: 5000,
+        transport: WebTransport(
+            // this is only needed for wasm, the self-signed certificates are only valid for 2 weeks
+            // the server will print the certificate digest on startup
+            certificate_digest: "a71e935276ac0e37db88bfa702b3ece66f30b3ad4f6117c12b782fe0f2817f9f",
+        ),
         // server_port: 5001,
         // transport: Udp,
         // server_port: 5002,
         // transport: WebSocket,
-        server_port: 5003,
-        transport: Steam(
-            app_id: 480,
-        )
+        // server_port: 5003,
+        // transport: Steam(
+        //     app_id: 480,
+        // )
     ),
     server: ServerSettings(
         headless: true,
@@ -42,12 +42,12 @@ Settings(
             WebSocket(
                 local_port: 5002
             ),
-            Steam(
-                app_id: 480,
-                server_ip: "0.0.0.0",
-                game_port: 5003,
-                query_port: 27016,
-            ),
+            // Steam(
+            //     app_id: 480,
+            //     server_ip: "0.0.0.0",
+            //     game_port: 5003,
+            //     query_port: 27016,
+            // ),
         ],
     ),
     shared: SharedSettings(

--- a/lightyear/Cargo.toml
+++ b/lightyear/Cargo.toml
@@ -14,30 +14,30 @@ exclude = ["/tests"]
 
 [features]
 metrics = [
-    "dep:metrics",
-    "metrics-util",
-    "metrics-tracing-context",
-    "metrics-exporter-prometheus",
-    "dep:tokio",
+  "dep:metrics",
+  "metrics-util",
+  "metrics-tracing-context",
+  "metrics-exporter-prometheus",
+  "dep:tokio",
 ]
 mock_time = ["dep:mock_instant"]
 render = ["bevy/bevy_render"]
 webtransport = [
-    "dep:wtransport",
-    "dep:xwt-core",
-    "dep:xwt-web-sys",
-    "dep:web-sys",
-    "dep:tokio",
-    "dep:ring",
+  "dep:wtransport",
+  "dep:xwt-core",
+  "dep:xwt-web-sys",
+  "dep:web-sys",
+  "dep:tokio",
+  "dep:ring",
 ]
 leafwing = ["dep:leafwing-input-manager", "lightyear_macros/leafwing"]
 xpbd_2d = ["dep:bevy_xpbd_2d"]
 websocket = [
-    "dep:tokio",
-    "dep:tokio-tungstenite",
-    "dep:futures-util",
-    "dep:web-sys",
-    "dep:wasm-bindgen",
+  "dep:tokio",
+  "dep:tokio-tungstenite",
+  "dep:futures-util",
+  "dep:web-sys",
+  "dep:wasm-bindgen",
 ]
 steam = ["dep:steamworks"]
 
@@ -72,7 +72,7 @@ bevy_xpbd_2d = { version = "0.4", optional = true }
 
 # serialization
 bitcode = { version = "0.5.1", package = "bitcode_lightyear_patch", path = "../vendor/bitcode", features = [
-    "serde",
+  "serde",
 ] }
 bytes = { version = "1.5", features = ["serde"] }
 self_cell = "1.0"
@@ -89,8 +89,8 @@ lightyear_macros = { version = "0.13.0", path = "../macros" }
 tracing = "0.1.40"
 tracing-log = "0.2.0"
 tracing-subscriber = { version = "0.3.17", features = [
-    "registry",
-    "env-filter",
+  "registry",
+  "env-filter",
 ] }
 
 # server
@@ -101,12 +101,12 @@ metrics = { version = "0.22", optional = true }
 metrics-util = { version = "0.15", optional = true }
 metrics-tracing-context = { version = "0.15", optional = true }
 metrics-exporter-prometheus = { version = "0.13.0", optional = true, default-features = false, features = [
-    "http-listener",
+  "http-listener",
 ] }
 
 # bevy
 bevy = { version = "0.13", default-features = false, features = [
-    "multi-threaded",
+  "multi-threaded",
 ] }
 
 
@@ -116,7 +116,7 @@ futures-util = { version = "0.3.30", optional = true }
 # transport
 # we don't need any tokio features, we use only use the tokio channels
 tokio = { version = "1.36", features = [
-    "sync",
+  "sync",
 ], default-features = false, optional = true }
 futures = "0.3.30"
 async-compat = "0.2.3"
@@ -127,37 +127,37 @@ async-compat = "0.2.3"
 steamworks = { version = "0.11", optional = true }
 # webtransport
 wtransport = { version = "=0.1.11", optional = true, features = [
-    "self-signed",
-    "dangerous-configuration",
+  "self-signed",
+  "dangerous-configuration",
 ] }
 # websocket
 tokio-tungstenite = { version = "0.21.0", optional = true, features = [
-    "connect",
-    "handshake",
+  "connect",
+  "handshake",
 ] }
 
 [target."cfg(target_family = \"wasm\")".dependencies]
 console_error_panic_hook = { version = "0.1.7" }
 ring = { version = "0.17.7", optional = true }
 web-sys = { version = "0.3", optional = true, features = [
-    "WebTransport",
-    "WebTransportHash",
-    "WebTransportOptions",
-    "WebTransportBidirectionalStream",
-    "WebTransportSendStream",
-    "WebTransportReceiveStream",
-    "ReadableStreamDefaultReader",
-    "WritableStreamDefaultWriter",
-    "WebTransportDatagramDuplexStream",
-    "WebSocket",
-    "CloseEvent",
-    "ErrorEvent",
-    "MessageEvent",
-    "BinaryType",
+  "WebTransport",
+  "WebTransportHash",
+  "WebTransportOptions",
+  "WebTransportBidirectionalStream",
+  "WebTransportSendStream",
+  "WebTransportReceiveStream",
+  "ReadableStreamDefaultReader",
+  "WritableStreamDefaultWriter",
+  "WebTransportDatagramDuplexStream",
+  "WebSocket",
+  "CloseEvent",
+  "ErrorEvent",
+  "MessageEvent",
+  "BinaryType",
 ] }
 futures-lite = { version = "2.1.0", optional = true }
 getrandom = { version = "0.2.11", features = [
-    "js", # feature 'js' is required for wasm
+  "js", # feature 'js' is required for wasm
 ] }
 xwt-core = { version = "0.2", optional = true }
 xwt-web-sys = { version = "0.6", optional = true }

--- a/lightyear/Cargo.toml
+++ b/lightyear/Cargo.toml
@@ -14,30 +14,30 @@ exclude = ["/tests"]
 
 [features]
 metrics = [
-  "dep:metrics",
-  "metrics-util",
-  "metrics-tracing-context",
-  "metrics-exporter-prometheus",
-  "dep:tokio",
+    "dep:metrics",
+    "metrics-util",
+    "metrics-tracing-context",
+    "metrics-exporter-prometheus",
+    "dep:tokio",
 ]
 mock_time = ["dep:mock_instant"]
 render = ["bevy/bevy_render"]
 webtransport = [
-  "dep:wtransport",
-  "dep:xwt-core",
-  "dep:xwt-web-sys",
-  "dep:web-sys",
-  "dep:tokio",
-  "dep:ring",
+    "dep:wtransport",
+    "dep:xwt-core",
+    "dep:xwt-web-sys",
+    "dep:web-sys",
+    "dep:tokio",
+    "dep:ring",
 ]
 leafwing = ["dep:leafwing-input-manager", "lightyear_macros/leafwing"]
 xpbd_2d = ["dep:bevy_xpbd_2d"]
 websocket = [
-  "dep:tokio",
-  "dep:tokio-tungstenite",
-  "dep:futures-util",
-  "dep:web-sys",
-  "dep:wasm-bindgen",
+    "dep:tokio",
+    "dep:tokio-tungstenite",
+    "dep:futures-util",
+    "dep:web-sys",
+    "dep:wasm-bindgen",
 ]
 steam = ["dep:steamworks"]
 
@@ -56,6 +56,7 @@ instant = "0.1.12"
 governor = "0.6.0"
 mock_instant = { version = "0.4.0", optional = true }
 nonzero_ext = "0.3.0"
+once_cell = "1.19.0"
 parking_lot = "0.12.1"
 paste = "1.0"
 rand = "0.8"
@@ -71,7 +72,7 @@ bevy_xpbd_2d = { version = "0.4", optional = true }
 
 # serialization
 bitcode = { version = "0.5.1", package = "bitcode_lightyear_patch", path = "../vendor/bitcode", features = [
-  "serde",
+    "serde",
 ] }
 bytes = { version = "1.5", features = ["serde"] }
 self_cell = "1.0"
@@ -88,8 +89,8 @@ lightyear_macros = { version = "0.13.0", path = "../macros" }
 tracing = "0.1.40"
 tracing-log = "0.2.0"
 tracing-subscriber = { version = "0.3.17", features = [
-  "registry",
-  "env-filter",
+    "registry",
+    "env-filter",
 ] }
 
 # server
@@ -100,12 +101,12 @@ metrics = { version = "0.22", optional = true }
 metrics-util = { version = "0.15", optional = true }
 metrics-tracing-context = { version = "0.15", optional = true }
 metrics-exporter-prometheus = { version = "0.13.0", optional = true, default-features = false, features = [
-  "http-listener",
+    "http-listener",
 ] }
 
 # bevy
 bevy = { version = "0.13", default-features = false, features = [
-  "multi-threaded",
+    "multi-threaded",
 ] }
 
 
@@ -115,7 +116,7 @@ futures-util = { version = "0.3.30", optional = true }
 # transport
 # we don't need any tokio features, we use only use the tokio channels
 tokio = { version = "1.36", features = [
-  "sync",
+    "sync",
 ], default-features = false, optional = true }
 futures = "0.3.30"
 async-compat = "0.2.3"
@@ -126,37 +127,37 @@ async-compat = "0.2.3"
 steamworks = { version = "0.11", optional = true }
 # webtransport
 wtransport = { version = "=0.1.11", optional = true, features = [
-  "self-signed",
-  "dangerous-configuration",
+    "self-signed",
+    "dangerous-configuration",
 ] }
 # websocket
 tokio-tungstenite = { version = "0.21.0", optional = true, features = [
-  "connect",
-  "handshake",
+    "connect",
+    "handshake",
 ] }
 
 [target."cfg(target_family = \"wasm\")".dependencies]
 console_error_panic_hook = { version = "0.1.7" }
 ring = { version = "0.17.7", optional = true }
 web-sys = { version = "0.3", optional = true, features = [
-  "WebTransport",
-  "WebTransportHash",
-  "WebTransportOptions",
-  "WebTransportBidirectionalStream",
-  "WebTransportSendStream",
-  "WebTransportReceiveStream",
-  "ReadableStreamDefaultReader",
-  "WritableStreamDefaultWriter",
-  "WebTransportDatagramDuplexStream",
-  "WebSocket",
-  "CloseEvent",
-  "ErrorEvent",
-  "MessageEvent",
-  "BinaryType",
+    "WebTransport",
+    "WebTransportHash",
+    "WebTransportOptions",
+    "WebTransportBidirectionalStream",
+    "WebTransportSendStream",
+    "WebTransportReceiveStream",
+    "ReadableStreamDefaultReader",
+    "WritableStreamDefaultWriter",
+    "WebTransportDatagramDuplexStream",
+    "WebSocket",
+    "CloseEvent",
+    "ErrorEvent",
+    "MessageEvent",
+    "BinaryType",
 ] }
 futures-lite = { version = "2.1.0", optional = true }
 getrandom = { version = "0.2.11", features = [
-  "js", # feature 'js' is required for wasm
+    "js", # feature 'js' is required for wasm
 ] }
 xwt-core = { version = "0.2", optional = true }
 xwt-web-sys = { version = "0.6", optional = true }

--- a/lightyear/src/client/networking.rs
+++ b/lightyear/src/client/networking.rs
@@ -365,6 +365,9 @@ fn rebuild_net_config<P: Protocol>(world: &mut World) {
     );
     world.insert_resource(connection_manager);
 
+    // drop the previous client connection
+    // (required for some clients, such as steam, where only one client can be active at the same time)
+    world.remove_resource::<ClientConnection>();
     // insert the new client connection
     let netclient = client_config.net.clone().build_client();
     world.insert_resource(netclient);

--- a/lightyear/src/client/networking.rs
+++ b/lightyear/src/client/networking.rs
@@ -108,8 +108,9 @@ impl<P: Protocol> Plugin for ClientNetworkingPlugin<P> {
 
 #[cfg(feature = "steam")]
 fn call_steam_callbacks() {
+    // use steamworks::SingleClient;
     if let Some((_, single)) = CLIENT.get() {
-        single.run_callbacks()
+        single.0.run_callbacks()
     }
 }
 

--- a/lightyear/src/client/networking.rs
+++ b/lightyear/src/client/networking.rs
@@ -368,6 +368,8 @@ fn rebuild_net_config<P: Protocol>(world: &mut World) {
     // drop the previous client connection
     // (required for some clients, such as steam, where only one client can be active at the same time)
     world.remove_resource::<ClientConnection>();
+    // TODO: dropping the Steam Client and recreating it still doesn't work,
+    //  after the client gets recreated, new connection attempts get rejected with the error: RemoteBadCert
     // insert the new client connection
     let netclient = client_config.net.clone().build_client();
     world.insert_resource(netclient);

--- a/lightyear/src/client/plugin.rs
+++ b/lightyear/src/client/plugin.rs
@@ -59,7 +59,6 @@ impl<P: Protocol> ClientPlugin<P> {
 impl<P: Protocol> Plugin for ClientPlugin<P> {
     fn build(&self, app: &mut App) {
         let config = self.config.lock().unwrap().deref_mut().take().unwrap();
-        let netclient = config.client_config.net.clone().build_client();
 
         // in this mode, the server acts as a client
         if config.client_config.shared.mode == Mode::HostServer {

--- a/lightyear/src/connection/steam/client.rs
+++ b/lightyear/src/connection/steam/client.rs
@@ -10,7 +10,7 @@ use anyhow::{anyhow, Context, Result};
 use std::cell::OnceCell;
 use std::collections::VecDeque;
 use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, OnceLock, RwLock};
 use steamworks::networking_sockets::{NetConnection, NetworkingSockets};
 use steamworks::networking_types::{
     NetConnectionEnd, NetConnectionInfo, NetworkingConfigEntry, NetworkingConfigValue,
@@ -43,8 +43,12 @@ impl Default for SteamConfig {
 // and call `init_app` again. However after doing this the client could not connect to the server;
 // the connection gets rejected with reason `RemoteBadCert`.
 // A workaround is to have a static instance of the steamworks clients which is initialized lazily once.
+// struct SteamClient {
+//     client: steamworks::Client<ClientManager>,
+//     single_client: SingleClientThreadSafe,
+// }
 
-static CLIENT: OnceCell<(steamworks::Client<ClientManager>, SingleClient)> = OnceCell::new();
+static CLIENT: OnceLock<(steamworks::Client<ClientManager>, SingleClient)> = OnceLock::new();
 
 pub struct Client {
     // client: OnceCell<steamworks::Client<ClientManager>>,

--- a/lightyear/src/connection/steam/client.rs
+++ b/lightyear/src/connection/steam/client.rs
@@ -106,7 +106,7 @@ impl NetClient for Client {
     fn connect(&mut self) -> Result<()> {
         let options = get_networking_options(&self.conditioner);
         self.connection = Some(
-            self.client()
+            Self::client()
                 .networking_sockets()
                 .connect_by_ip_address(self.config.server_addr, vec![])
                 .context("failed to create connection")?,
@@ -185,7 +185,7 @@ impl NetClient for Client {
     }
 
     fn id(&self) -> ClientId {
-        ClientId::Steam(self.client().user().steam_id().raw())
+        ClientId::Steam(Self::client().user().steam_id().raw())
     }
 
     fn local_addr(&self) -> SocketAddr {

--- a/lightyear/src/connection/steam/client.rs
+++ b/lightyear/src/connection/steam/client.rs
@@ -79,7 +79,7 @@ impl Client {
 
     fn connection_info(&self) -> Option<Result<NetConnectionInfo>> {
         self.connection.as_ref().map(|connection| {
-            self.client()
+            Self::client()
                 .networking_sockets()
                 .get_connection_info(connection)
                 .map_err(|err| anyhow!("could not get connection info"))

--- a/lightyear/src/connection/steam/client.rs
+++ b/lightyear/src/connection/steam/client.rs
@@ -86,7 +86,7 @@ impl NetClient for Client {
         self.connection = Some(
             self.client
                 .networking_sockets()
-                .connect_by_ip_address(self.config.server_addr, options)
+                .connect_by_ip_address(self.config.server_addr, vec![])
                 .context("failed to create connection")?,
         );
         info!(

--- a/lightyear/src/connection/steam/client.rs
+++ b/lightyear/src/connection/steam/client.rs
@@ -93,11 +93,11 @@ impl Client {
             .context("could not get connection state")
     }
 
-    fn client() -> steamworks::Client<ClientManager> {
-        CLIENT.get().unwrap()
+    fn client() -> &'static steamworks::Client<ClientManager> {
+        &CLIENT.get().unwrap().0
     }
 
-    fn single_client() -> &SingleClient {
+    fn single_client() -> &'static SingleClient {
         &CLIENT.get().unwrap().1 .0
     }
 }

--- a/lightyear/src/connection/steam/client.rs
+++ b/lightyear/src/connection/steam/client.rs
@@ -62,6 +62,7 @@ pub struct Client {
 impl Client {
     pub fn new(config: SteamConfig, conditioner: Option<LinkConditionerConfig>) -> Result<Self> {
         CLIENT.get_or_init(|| {
+            info!("Creating new steamworks api client.");
             let (client, single) = steamworks::Client::init_app(config.app_id).unwrap();
             (client, SingleClientThreadSafe(single))
         });

--- a/lightyear/src/connection/steam/client.rs
+++ b/lightyear/src/connection/steam/client.rs
@@ -41,14 +41,9 @@ impl Default for SteamConfig {
 
 // My initial plan was to have the `steamworks::Client` and `SingleClient` be fields of the [`Client`] struct.
 // Everytime we try to reconnect, we could just drop the previous Client (which shutdowns the steam API)
-// and call `init_app` again. However after doing this the client could not connect to the server;
-// the connection gets rejected with reason `RemoteBadCert`.
-// A workaround is to have a static instance of the steamworks clients which is initialized lazily once.
-// struct SteamClient {
-//     client: steamworks::Client<ClientManager>,
-//     single_client: SingleClientThreadSafe,
-// }
-
+// and call `init_app` again. However apparently the Shutdown api does nothing, the api only shuts down
+// when the program ends.
+// Instead, we will initialize lazy a static Client only once per program.
 pub static CLIENT: OnceLock<(steamworks::Client<ClientManager>, SingleClientThreadSafe)> =
     OnceLock::new();
 
@@ -139,7 +134,7 @@ impl NetClient for Client {
     }
 
     fn try_update(&mut self, delta_ms: f64) -> Result<()> {
-        // self.single_client().run_callbacks();
+        Self::single_client().run_callbacks();
 
         // TODO: should I maintain an internal state for the connection? or just rely on `connection_state()` ?
         // update connection state

--- a/lightyear/src/connection/steam/client.rs
+++ b/lightyear/src/connection/steam/client.rs
@@ -48,12 +48,10 @@ impl Default for SteamConfig {
 //     single_client: SingleClientThreadSafe,
 // }
 
-static CLIENT: OnceLock<(steamworks::Client<ClientManager>, SingleClient)> = OnceLock::new();
+static CLIENT: OnceLock<(steamworks::Client<ClientManager>, SingleClientThreadSafe)> =
+    OnceLock::new();
 
 pub struct Client {
-    // client: OnceCell<steamworks::Client<ClientManager>>,
-    // single_client: OnceCell<SingleClientThreadSafe>,
-    // client:
     config: SteamConfig,
     connection: Option<NetConnection<ClientManager>>,
     packet_queue: VecDeque<Packet>,
@@ -65,15 +63,10 @@ impl Client {
     pub fn new(config: SteamConfig, conditioner: Option<LinkConditionerConfig>) -> Result<Self> {
         CLIENT.get_or_init(|| {
             let (client, single) = steamworks::Client::init_app(config.app_id).unwrap();
-            (client, single)
-            // (client, SingleClientThreadSafe(single))
+            (client, SingleClientThreadSafe(single))
         });
-        // let (client, single) = steamworks::Client::init_app(config.app_id)
-        //     .context("could not initialize steam client")?;
 
         Ok(Self {
-            // client,
-            // single_client: SingleClientThreadSafe(single),
             config,
             connection: None,
             packet_queue: VecDeque::new(),
@@ -103,7 +96,7 @@ impl Client {
     }
 
     fn single_client(&self) -> &SingleClient {
-        &CLIENT.get().unwrap().1
+        &CLIENT.get().unwrap().1 .0
     }
 }
 

--- a/lightyear/src/connection/steam/client.rs
+++ b/lightyear/src/connection/steam/client.rs
@@ -8,7 +8,6 @@ use crate::serialize::wordbuffer::reader::BufferPool;
 use crate::transport::LOCAL_SOCKET;
 use anyhow::{anyhow, Context, Result};
 use bevy::tasks::IoTaskPool;
-use std::cell::OnceCell;
 use std::collections::VecDeque;
 use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
 use std::sync::{Arc, OnceLock, RwLock};

--- a/lightyear/src/connection/steam/mod.rs
+++ b/lightyear/src/connection/steam/mod.rs
@@ -19,10 +19,11 @@ pub(crate) fn get_networking_options(
         0,
     )];
     if let Some(ref conditioner) = conditioner {
-        options.push(NetworkingConfigEntry::new_float(
-            NetworkingConfigValue::FakePacketLossRecv,
-            conditioner.incoming_loss * 100.0,
-        ));
+        // TODO: float options are not useable, see https://github.com/Noxime/steamworks-rs/pull/168
+        // options.push(NetworkingConfigEntry::new_float(
+        //     NetworkingConfigValue::FakePacketLossRecv,
+        //     conditioner.incoming_loss * 100.0,
+        // ));
         options.push(NetworkingConfigEntry::new_int32(
             NetworkingConfigValue::FakePacketLagRecv,
             conditioner.incoming_latency.as_millis() as i32,

--- a/lightyear/src/connection/steam/mod.rs
+++ b/lightyear/src/connection/steam/mod.rs
@@ -6,7 +6,7 @@ pub(crate) mod server;
 
 // NOTE: it looks like there's SingleClient can actually be called on multiple threads
 // - https://partner.steamgames.com/doc/api/steam_api#SteamAPI_RunCallbacks
-pub(crate) struct SingleClientThreadSafe(pub(crate) steamworks::SingleClient);
+pub(crate) struct SingleClientThreadSafe(steamworks::SingleClient);
 
 unsafe impl Sync for SingleClientThreadSafe {}
 unsafe impl Send for SingleClientThreadSafe {}

--- a/lightyear/src/connection/steam/mod.rs
+++ b/lightyear/src/connection/steam/mod.rs
@@ -32,10 +32,11 @@ pub(crate) fn get_networking_options(
             NetworkingConfigValue::FakePacketReorderTime,
             conditioner.incoming_jitter.as_millis() as i32,
         ));
-        options.push(NetworkingConfigEntry::new_float(
-            NetworkingConfigValue::FakePacketReorderRecv,
-            100.0,
-        ));
+        // TODO: float options are not useable, see https://github.com/Noxime/steamworks-rs/pull/168
+        // options.push(NetworkingConfigEntry::new_float(
+        //     NetworkingConfigValue::FakePacketReorderRecv,
+        //     100.0,
+        // ));
     }
     options
 }

--- a/lightyear/src/connection/steam/mod.rs
+++ b/lightyear/src/connection/steam/mod.rs
@@ -6,7 +6,7 @@ pub(crate) mod server;
 
 // NOTE: it looks like there's SingleClient can actually be called on multiple threads
 // - https://partner.steamgames.com/doc/api/steam_api#SteamAPI_RunCallbacks
-pub(crate) struct SingleClientThreadSafe(steamworks::SingleClient);
+pub(crate) struct SingleClientThreadSafe(pub(crate) steamworks::SingleClient);
 
 unsafe impl Sync for SingleClientThreadSafe {}
 unsafe impl Send for SingleClientThreadSafe {}

--- a/lightyear/src/connection/steam/server.rs
+++ b/lightyear/src/connection/steam/server.rs
@@ -99,7 +99,7 @@ impl NetServer for Server {
         self.listen_socket = Some(
             self.client
                 .networking_sockets()
-                .create_listen_socket_ip(server_addr, options)
+                .create_listen_socket_ip(server_addr, vec![])
                 .context("could not create server listen socket")?,
         );
         info!("Steam socket started on {:?}", server_addr);

--- a/lightyear/src/connection/steam/server.rs
+++ b/lightyear/src/connection/steam/server.rs
@@ -99,6 +99,7 @@ impl NetServer for Server {
         self.listen_socket = Some(
             self.client
                 .networking_sockets()
+                // TODO: using the NetworkingConfigEntry options seems to cause an issue. See: https://github.com/Noxime/steamworks-rs/issues/169
                 .create_listen_socket_ip(server_addr, vec![])
                 .context("could not create server listen socket")?,
         );


### PR DESCRIPTION
There are several issues with `NetworkingConfigEntry`: 
- https://github.com/Noxime/steamworks-rs/pull/168
- https://github.com/Noxime/steamworks-rs/issues/169

Apart from that:
- Steam works on 0.13.0
- It is broken since the changes where we re-create the `ClientConnection` whenever we try to connect. (it still works if we create the steamworks::client only once during the program)

- What I tried:
  - Dropping the existing ClientConnection (which calls steam api's shutdown) before re-creating the new one. Looks like this doesn't work because steams "shutdown" api pretty much does nothing; steam api is running until the program is shutdown: https://github.com/rlabrecque/Steamworks.NET/issues/187#issuecomment-323700244)
  - tried initializing the steamworks clients only once via OnceCell, the client is able to connect, but is then disconnected immediately with `reason: RemoteBadCert`
  - If I connect immediately when creating the client, it works. It just doesn't work if I delay the connection by connecting only when I click on the 'connect' button. (even if I didn't delete the Client, but I just re-use the same one instead)
  - I tried adding a background system that just runs steam callbacks at all times even if we're not connected, but that didn't help either
  - in the file 'cef_log.previous`, i See logs saying `Error parsing cert retrieved from AIA (as DER). Couldn't read tbsCertificate as SEQUENCE. Failed parsing Certificate`
  - INTERESTING QUIRK: if I connect immediately when starting the client app, then I can disconnect/reconnect at will using the button!!! (meaning that everything works). The issue is that without that initial connection, I get a `RemoteBadCert`
  - If I connect immediately when starting the app, it works
  - If I don't connect immediately; on the first connection attempt I get disconnected with an error `RemoteBadCert`, but future connection attempts work!