### PR TITLE
Simplify the `protocolize!` macro

### DIFF
--- a/lightyear/src/client/networking.rs
+++ b/lightyear/src/client/networking.rs
@@ -13,7 +13,6 @@ use crate::client::connection::ConnectionManager;
 use crate::client::events::{ConnectEvent, DisconnectEvent, EntityDespawnEvent, EntitySpawnEvent};
 use crate::client::sync::SyncSet;
 use crate::connection::client::{ClientConnection, NetClient, NetConfig};
-use crate::connection::steam::client::CLIENT;
 use crate::prelude::{SharedConfig, TickManager, TimeManager};
 use crate::protocol::component::ComponentProtocol;
 use crate::protocol::message::MessageProtocol;

--- a/lightyear/src/protocol/mod.rs
+++ b/lightyear/src/protocol/mod.rs
@@ -98,10 +98,8 @@ pub trait Protocol: Send + Sync + Clone + Debug + Resource + TypePath + 'static 
 
     fn add_channel<C: Channel>(&mut self, settings: ChannelSettings) -> &mut Self;
     fn channel_registry(&self) -> &ChannelRegistry;
-    fn add_per_component_replication_send_systems<R: ReplicationSend<Self>>(app: &mut App);
 }
 
-// TODO: give an option to change names of types
 /// This macro is used to build the [`Protocol`] struct.
 /// For convenience, it will re-export some types that need to have the Protocol as a generic parameter, so that you
 /// don't have to type `<MyProtocol>` everywhere.
@@ -109,107 +107,16 @@ pub trait Protocol: Send + Sync + Clone + Debug + Resource + TypePath + 'static 
 /// - `Replicate` is a type alias for [`Replicate<Protocol>`](crate::shared::replication::components::Replicate)
 /// - `ClientConnectionManager` is a type alias for [`ConnectionManager<Protocol>`](crate::client::connection::ConnectionManager)
 /// - `ServerConnectionManager` is a type alias for [`ConnectionManager<Protocol>`](crate::server::connection::ConnectionManager)
+#[cfg(feature = "leafwing")]
 #[macro_export]
 macro_rules! protocolize {
-        (
-        Self = $protocol:ident,
-        Message = $message:ty,
-        Component = $components:ty,
-        Input = $input:ty,
-        Crate = $shared_crate_name:ident,
-    ) => {
-        use $shared_crate_name::_reexport::paste;
-        paste! {
-        mod [<$protocol:lower _module>] {
-            use super::*;
-            use bevy::prelude::*;
-            use $shared_crate_name::prelude::*;
-            use $shared_crate_name::_reexport::*;
-
-            #[derive(Debug, Clone, Resource, PartialEq, TypePath)]
-            pub struct $protocol {
-                channel_registry: ChannelRegistry,
-            }
-
-            impl Protocol for $protocol {
-                type Input = $input;
-                type Message = $message;
-                type Components = $components;
-                type ComponentKinds = [<$components Kind>];
-
-                fn add_channel<C: Channel>(&mut self, settings: ChannelSettings) -> &mut Self {
-                    self.channel_registry.add::<C>(settings);
-                    self
-                }
-
-                fn channel_registry(&self) -> &ChannelRegistry {
-                    &self.channel_registry
-                }
-
-                fn add_per_component_replication_send_systems<R: ReplicationSend<Self>>(app: &mut App) {
-                    Self::Components::add_per_component_replication_send_systems::<R>(app);
-                }
-            }
-
-            impl Default for $protocol {
-                fn default() -> Self {
-                    let mut protocol = Self {
-                        channel_registry: ChannelRegistry::default(),
-                    };
-                    protocol.add_channel::<EntityActionsChannel>(ChannelSettings {
-                        mode: ChannelMode::UnorderedReliable(ReliableSettings::default()),
-                        direction: ChannelDirection::Bidirectional,
-                        // we want to send the entity actions as soon as possible
-                        priority: 10.0,
-                    });
-                    protocol.add_channel::<EntityUpdatesChannel>(ChannelSettings {
-                        mode: ChannelMode::UnorderedUnreliableWithAcks,
-                        direction: ChannelDirection::Bidirectional,
-                        priority: 1.0,
-                    });
-                    protocol.add_channel::<PingChannel>(ChannelSettings {
-                        mode: ChannelMode::SequencedUnreliable,
-                        direction: ChannelDirection::Bidirectional,
-                        // we always want to include the ping in the packet
-                        priority: 1000.0,
-                    });
-                    protocol.add_channel::<InputChannel>(ChannelSettings {
-                        // we want to use unordered unreliable because the server has a buffer to re-order the inputs anyway
-                        // Also multiple 'types' of inputs share the same channel
-                        // TODO: maybe we should have a different input channel per input, and use sequenced?
-                        //  because our messages contain the last 10 ticks of input anyway, so we don't need to read older ones.
-                        mode: ChannelMode::UnorderedUnreliable,
-                        direction: ChannelDirection::ClientToServer,
-                        priority: 3.0,
-                    });
-                    protocol.add_channel::<DefaultUnorderedUnreliableChannel>(ChannelSettings {
-                        mode: ChannelMode::UnorderedUnreliable,
-                        direction: ChannelDirection::Bidirectional,
-                        priority: 1.0,
-                    });
-                    protocol.add_channel::<TickBufferChannel>(ChannelSettings {
-                        mode: ChannelMode::TickBuffered,
-                        direction: ChannelDirection::ClientToServer,
-                        priority: 1.0,
-                    });
-                    protocol
-                }
-            }
-        }
-        pub use [<$protocol:lower _module>]::$protocol;
-        pub type Replicate = $shared_crate_name::shared::replication::components::Replicate<$protocol>;
-        pub type ClientConnectionManager = $shared_crate_name::client::connection::ConnectionManager<$protocol>;
-        pub type ServerConnectionManager = $shared_crate_name::server::connection::ConnectionManager<$protocol>;
-        }
-    };
-
     (
         Self = $protocol:ident,
         Message = $message:ty,
         Component = $components:ty,
-        Input = $input:ty,
-        LeafwingInput1 = $leafwing_input_1:ty,
-        LeafwingInput2 = $leafwing_input_2:ty,
+        $(Input = $input:ty,)?
+        $(LeafwingInput1 = $leafwing_input_1:ty,)?
+        $(LeafwingInput2 = $leafwing_input_2:ty,)?
         Crate = $shared_crate_name:ident,
     ) => {
         use $shared_crate_name::_reexport::paste;
@@ -219,7 +126,7 @@ macro_rules! protocolize {
             use bevy::prelude::*;
             use $shared_crate_name::prelude::*;
             use $shared_crate_name::_reexport::*;
-            use $shared_crate_name::inputs::leafwing::{NoAction1, NoAction2};
+            protocolize!(@leafwing_import $shared_crate_name $($leafwing_input_1)?);
 
             #[derive(Debug, Clone, Resource, PartialEq, TypePath)]
             pub struct $protocol {
@@ -227,9 +134,9 @@ macro_rules! protocolize {
             }
 
             impl Protocol for $protocol {
-                type Input = $input;
-                type LeafwingInput1 = $leafwing_input_1;
-                type LeafwingInput2 = $leafwing_input_2;
+                protocolize!(@input $($input)?);
+                protocolize!(@leafwing_input_1 $($leafwing_input_1)?);
+                protocolize!(@leafwing_input_2 $($leafwing_input_2)?);
                 type Message = $message;
                 type Components = $components;
                 type ComponentKinds = [<$components Kind>];
@@ -241,10 +148,6 @@ macro_rules! protocolize {
 
                 fn channel_registry(&self) -> &ChannelRegistry {
                     &self.channel_registry
-                }
-
-                fn add_per_component_replication_send_systems<R: ReplicationSend<Self>>(app: &mut App) {
-                    Self::Components::add_per_component_replication_send_systems::<R>(app);
                 }
             }
 
@@ -295,105 +198,161 @@ macro_rules! protocolize {
         pub type ServerConnectionManager = $shared_crate_name::server::connection::ConnectionManager<$protocol>;
         }
     };
-
     (
         Self = $protocol:ident,
         Message = $message:ty,
         Component = $components:ty,
-        Input = $input:ty,
-        LeafwingInput1 = $leafwing_input_1:ty,
-        LeafwingInput2 = $leafwing_input_2:ty,
+        $(Input = $input:ty,)?
+        $(LeafwingInput1 = $leafwing_input_1:ty,)?
+        $(LeafwingInput2 = $leafwing_input_2:ty,)?
     ) => {
         lightyear::protocolize!{
             Self = $protocol,
             Message = $message,
             Component = $components,
-            Input = $input,
-            LeafwingInput1 = $leafwing_input_1,
-            LeafwingInput2 = $leafwing_input_2,
+            $(Input = $input,)?
+            $(LeafwingInput1 = $leafwing_input_1,)?
+            $(LeafwingInput2 = $leafwing_input_2,)?
             Crate = lightyear,
         }
     };
+    (@leafwing_import $shared_crate_name:ident) => {};
+    (@leafwing_import $shared_crate_name:ident $marker:ty) => {
+        use $shared_crate_name::inputs::leafwing::{NoAction1, NoAction2};
+    };
+    (@input) => {
+        type Input = ();
+    };
+    (@input $input:ty) => {
+        type Input = $input;
+    };
+    (@leafwing_input_1) => {
+        type LeafwingInput1 = NoAction1;
+    };
+    (@leafwing_input_1 $leafwing_input_1:ty) => {
+        type LeafwingInput1 = $leafwing_input_1;
+    };
+    (@leafwing_input_2) => {
+        type LeafwingInput2 = NoAction2;
+    };
+    (@leafwing_input_2 $leafwing_input_2:ty) => {
+        type LeafwingInput2 = $leafwing_input_2;
+    };
+}
 
+/// This macro is used to build the [`Protocol`] struct.
+/// For convenience, it will re-export some types that need to have the Protocol as a generic parameter, so that you
+/// don't have to type `<MyProtocol>` everywhere.
+/// Notably:
+/// - `Replicate` is a type alias for [`Replicate<Protocol>`](crate::shared::replication::components::Replicate)
+/// - `ClientConnectionManager` is a type alias for [`ConnectionManager<Protocol>`](crate::client::connection::ConnectionManager)
+/// - `ServerConnectionManager` is a type alias for [`ConnectionManager<Protocol>`](crate::server::connection::ConnectionManager)
+#[cfg(not(feature = "leafwing"))]
+#[macro_export]
+macro_rules! protocolize {
     (
         Self = $protocol:ident,
         Message = $message:ty,
         Component = $components:ty,
-        LeafwingInput1 = $leafwing_input_1:ty,
-    ) => {
-        lightyear::protocolize!{
-            Self = $protocol,
-            Message = $message,
-            Component = $components,
-            Input = (),
-            LeafwingInput1 = $leafwing_input_1,
-            LeafwingInput2 = NoAction2,
-            Crate = lightyear,
-        }
-    };
-
-    (
-        Self = $protocol:ident,
-        Message = $message:ty,
-        Component = $components:ty,
-        LeafwingInput1 = $leafwing_input_1:ty,
-        LeafwingInput2 = $leafwing_input_2:ty,
-    ) => {
-        lightyear::protocolize!{
-            Self = $protocol,
-            Message = $message,
-            Component = $components,
-            Input = (),
-            LeafwingInput1 = $leafwing_input_1,
-            LeafwingInput2 = $leafwing_input_2,
-            Crate = lightyear,
-        }
-    };
-
-    (
-        Self = $protocol:ident,
-        Message = $message:ty,
-        Component = $components:ty,
+        $(Input = $input:ty,)?
         Crate = $shared_crate_name:ident,
     ) => {
-        $shared_crate_name::protocolize!{
-            Self = $protocol,
-            Message = $message,
-            Component = $components,
-            Input = (),
-            Crate = $shared_crate_name,
+        use $shared_crate_name::_reexport::paste;
+        paste! {
+        mod [<$protocol:lower _module>] {
+            use super::*;
+            use bevy::prelude::*;
+            use $shared_crate_name::prelude::*;
+            use $shared_crate_name::_reexport::*;
+
+            #[derive(Debug, Clone, Resource, PartialEq, TypePath)]
+            pub struct $protocol {
+                channel_registry: ChannelRegistry,
+            }
+
+            impl Protocol for $protocol {
+                protocolize!(@input $($input)?);
+                type Message = $message;
+                type Components = $components;
+                type ComponentKinds = [<$components Kind>];
+
+                fn add_channel<C: Channel>(&mut self, settings: ChannelSettings) -> &mut Self {
+                    self.channel_registry.add::<C>(settings);
+                    self
+                }
+
+                fn channel_registry(&self) -> &ChannelRegistry {
+                    &self.channel_registry
+                }
+            }
+
+            impl Default for $protocol {
+                fn default() -> Self {
+                    let mut protocol = Self {
+                        channel_registry: ChannelRegistry::default(),
+                    };
+                    protocol.add_channel::<EntityActionsChannel>(ChannelSettings {
+                        mode: ChannelMode::UnorderedReliable(ReliableSettings::default()),
+                        direction: ChannelDirection::Bidirectional,
+                        // we want to send the entity actions as soon as possible
+                        priority: 10.0,
+                    });
+                    protocol.add_channel::<EntityUpdatesChannel>(ChannelSettings {
+                        mode: ChannelMode::UnorderedUnreliableWithAcks,
+                        direction: ChannelDirection::Bidirectional,
+                        priority: 1.0,
+                    });
+                    protocol.add_channel::<PingChannel>(ChannelSettings {
+                        mode: ChannelMode::SequencedUnreliable,
+                        direction: ChannelDirection::Bidirectional,
+                        // we always want to include the ping in the packet
+                        priority: 1000.0,
+                    });
+                    protocol.add_channel::<InputChannel>(ChannelSettings {
+                        mode: ChannelMode::UnorderedUnreliable,
+                        direction: ChannelDirection::ClientToServer,
+                        priority: 3.0,
+                    });
+                    protocol.add_channel::<DefaultUnorderedUnreliableChannel>(ChannelSettings {
+                        mode: ChannelMode::UnorderedUnreliable,
+                        direction: ChannelDirection::Bidirectional,
+                        priority: 1.0,
+                    });
+                    protocol.add_channel::<TickBufferChannel>(ChannelSettings {
+                        mode: ChannelMode::TickBuffered,
+                        direction: ChannelDirection::ClientToServer,
+                        priority: 1.0,
+                    });
+                    protocol
+                }
+            }
+        }
+        pub use [<$protocol:lower _module>]::$protocol;
+        pub type Replicate = $shared_crate_name::shared::replication::components::Replicate<$protocol>;
+        pub type ClientConnectionManager = $shared_crate_name::client::connection::ConnectionManager<$protocol>;
+        pub type ServerConnectionManager = $shared_crate_name::server::connection::ConnectionManager<$protocol>;
         }
     };
-
     (
         Self = $protocol:ident,
         Message = $message:ty,
         Component = $components:ty,
-        Input = $input:ty,
+        $(Input = $input:ty,)?
     ) => {
         lightyear::protocolize!{
             Self = $protocol,
             Message = $message,
             Component = $components,
-            Input = $input,
+            $(Input = $input,)?
             Crate = lightyear,
         }
     };
-
-    (
-        Self = $protocol:ident,
-        Message = $message:ty,
-        Component = $components:ty,
-    ) => {
-        lightyear::protocolize!{
-            Self = $protocol,
-            Message = $message,
-            Component = $components,
-            Crate = lightyear,
-        }
+    (@input) => {
+        type Input = ();
     };
-
-
+    (@input $input:ty) => {
+        type Input = $input;
+    };
 }
 
 /// Something that can be serialized bit by bit

--- a/macros/tests/derive_component.rs
+++ b/macros/tests/derive_component.rs
@@ -58,13 +58,8 @@ pub mod some_component {
         }
     }
 
-    #[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Reflect)]
-    pub struct Message1(pub u32);
-
     #[message_protocol(protocol = "MyProtocol")]
-    pub enum MyMessageProtocol {
-        Message1(Message1),
-    }
+    pub enum MyMessageProtocol {}
 
     protocolize! {
         Self = MyProtocol,


### PR DESCRIPTION
The `protocolize!` macro was relying on having one variant for each combination of:
```
Message
Component
Input
LeafwingInput1
LeafwingInput2
```

This meant that there was an exponential number of combinations, which was preventing us from adding more LeafwingInputs, or other protocols such as a ResourceProtocol.
This PR reworks the macro by using the "optional" marker: https://github.com/rust-lang/rfcs/blob/master/text/2298-macro-at-most-once-rep.md
This makes it much easier to add optional variants in the macro.

The only two compulsory arguments currently are `Message` and `Component`, but it should be easy to make it optional.
It is possible to just use empty enums for them if needed.