### PR TITLE
Helpers to replicate Resources

### DIFF
--- a/book/src/concepts/replication/replicate.md
+++ b/book/src/concepts/replication/replicate.md
@@ -19,3 +19,16 @@ For example, `per_component_metadata` lets you fine-tune the replication logic f
 from being replicated, etc.)
 
 You can find some of the other usages in the [advanced_replication](../concepts/advanced_replication/title.md) section.
+
+
+### Replicating resources
+
+You can also replicate bevy `Resources`. This is useful when you want to update a `Resource` on the server and keep synced
+copies on the client. This only works for `Resources` that also implement `Clone`, and should be limited to resources which are cheap to clone.
+
+To replicate a `Resource`, you can use the `commands.replicate_resource::<R>(replicate)` method. You will need to provide
+an instance of the `Replicate` struct to specify how the replication should be done (e.g. to which clients should the resource
+be replicated).
+
+To stop replicating a `Resource`, you can use the `commands.stop_replicate_resource::<R>()` method.
+Note that this won't delete the resource from the client, but it will stop updating it.

--- a/book/src/concepts/replication/replicate.md
+++ b/book/src/concepts/replication/replicate.md
@@ -26,9 +26,8 @@ You can find some of the other usages in the [advanced_replication](../concepts/
 You can also replicate bevy `Resources`. This is useful when you want to update a `Resource` on the server and keep synced
 copies on the client. This only works for `Resources` that also implement `Clone`, and should be limited to resources which are cheap to clone.
 
-To replicate a `Resource`, you can use the `commands.replicate_resource::<R>(replicate)` method. You will need to provide
+- First, you will need to add the component `ReplicateResource<R>` to your `ComponentProtocol`
+- Then, to replicate a `Resource`, you can use the `commands.replicate_resource::<R>(replicate)` method. You will need to provide
 an instance of the `Replicate` struct to specify how the replication should be done (e.g. to which clients should the resource
-be replicated).
-
-To stop replicating a `Resource`, you can use the `commands.stop_replicate_resource::<R>()` method.
-Note that this won't delete the resource from the client, but it will stop updating it.
+be replicated). To stop replicating a `Resource`, you can use the `commands.stop_replicate_resource::<R>()` method. Note that
+this won't delete the resource from the client, but it will stop updating it.

--- a/lightyear/src/client/connection.rs
+++ b/lightyear/src/client/connection.rs
@@ -500,7 +500,7 @@ impl<P: Protocol> ReplicationSend<P> for ConnectionManager<P> {
         Ok(())
     }
 
-    fn prepare_entity_update(
+    fn prepare_component_update(
         &mut self,
         entity: Entity,
         component: P::Components,

--- a/lightyear/src/lib.rs
+++ b/lightyear/src/lib.rs
@@ -57,6 +57,9 @@ pub mod _reexport {
         push_component_insert_events, push_component_remove_events, push_component_update_events,
     };
     pub use crate::shared::replication::components::ShouldBeInterpolated;
+    pub use crate::shared::replication::resources::{
+        add_resource_receive_systems, add_resource_send_systems,
+    };
     pub use crate::shared::replication::systems::add_per_component_replication_send_systems;
     pub use crate::shared::replication::ReplicationSend;
     pub use crate::shared::sets::{ClientMarker, ServerMarker};
@@ -92,6 +95,7 @@ pub mod prelude {
     };
     pub use crate::shared::replication::entity_map::{ExternalMapper, RemoteEntityMap};
     pub use crate::shared::replication::hierarchy::ParentSync;
+    pub use crate::shared::replication::resources::ReplicateResource;
     pub use crate::shared::sets::{FixedUpdateSet, MainSet};
     pub use crate::shared::tick_manager::TickManager;
     pub use crate::shared::tick_manager::{Tick, TickConfig};

--- a/lightyear/src/lib.rs
+++ b/lightyear/src/lib.rs
@@ -58,7 +58,7 @@ pub mod _reexport {
     };
     pub use crate::shared::replication::components::ShouldBeInterpolated;
     pub use crate::shared::replication::resources::{
-        add_resource_receive_systems, add_resource_send_systems,
+        receive::add_resource_receive_systems, send::add_resource_send_systems,
     };
     pub use crate::shared::replication::systems::add_per_component_replication_send_systems;
     pub use crate::shared::replication::ReplicationSend;
@@ -95,7 +95,9 @@ pub mod prelude {
     };
     pub use crate::shared::replication::entity_map::{ExternalMapper, RemoteEntityMap};
     pub use crate::shared::replication::hierarchy::ParentSync;
-    pub use crate::shared::replication::resources::ReplicateResource;
+    pub use crate::shared::replication::resources::{
+        ReplicateResource, ReplicateResourceExt, StopReplicateResourceExt,
+    };
     pub use crate::shared::sets::{FixedUpdateSet, MainSet};
     pub use crate::shared::tick_manager::TickManager;
     pub use crate::shared::tick_manager::{Tick, TickConfig};

--- a/lightyear/src/protocol/component.rs
+++ b/lightyear/src/protocol/component.rs
@@ -58,6 +58,12 @@ pub trait ComponentProtocol:
         app: &mut App,
     );
 
+    /// Add systems needed to replicate resources to remote
+    fn add_resource_send_systems<R: ReplicationSend<Self::Protocol>>(app: &mut App);
+
+    /// Add systems needed to receive resources from remote
+    fn add_resource_receive_systems<R: ReplicationSend<Self::Protocol>>(app: &mut App);
+
     /// Adds Component-related events to the app
     fn add_events<Ctx: EventContext>(app: &mut App);
 

--- a/lightyear/src/server/connection.rs
+++ b/lightyear/src/server/connection.rs
@@ -735,7 +735,7 @@ impl<P: Protocol> ReplicationSend<P> for ConnectionManager<P> {
         })
     }
 
-    fn prepare_entity_update(
+    fn prepare_component_update(
         &mut self,
         entity: Entity,
         component: P::Components,

--- a/lightyear/src/shared/replication/mod.rs
+++ b/lightyear/src/shared/replication/mod.rs
@@ -25,7 +25,7 @@ pub mod entity_map;
 pub(crate) mod hierarchy;
 pub(crate) mod plugin;
 pub(crate) mod receive;
-mod resources;
+pub(crate) mod resources;
 pub(crate) mod send;
 pub mod systems;
 

--- a/lightyear/src/shared/replication/mod.rs
+++ b/lightyear/src/shared/replication/mod.rs
@@ -166,7 +166,7 @@ pub trait ReplicationSend<P: Protocol>: Resource {
         system_current_tick: BevyTick,
     ) -> Result<()>;
 
-    fn prepare_entity_update(
+    fn prepare_component_update(
         &mut self,
         entity: Entity,
         component: P::Components,

--- a/lightyear/src/shared/replication/mod.rs
+++ b/lightyear/src/shared/replication/mod.rs
@@ -25,6 +25,7 @@ pub mod entity_map;
 pub(crate) mod hierarchy;
 pub(crate) mod plugin;
 pub(crate) mod receive;
+mod resources;
 pub(crate) mod send;
 pub mod systems;
 

--- a/lightyear/src/shared/replication/plugin.rs
+++ b/lightyear/src/shared/replication/plugin.rs
@@ -12,6 +12,7 @@ use crate::shared::replication::components::{
 };
 use crate::shared::replication::entity_map::{InterpolatedEntityMap, PredictedEntityMap};
 use crate::shared::replication::hierarchy::{HierarchyReceivePlugin, HierarchySendPlugin};
+use crate::shared::replication::resources::{ResourceReceivePlugin, ResourceSendPlugin};
 use crate::shared::replication::systems::{add_replication_send_systems, cleanup};
 use crate::shared::sets::{InternalMainSet, InternalReplicationSet, MainSet};
 
@@ -63,6 +64,7 @@ impl<P: Protocol, R: ReplicationSend<P>> Plugin for ReplicationPlugin<P, R> {
             );
             // PLUGINS
             app.add_plugins(HierarchyReceivePlugin::<P, R>::default());
+            app.add_plugins(ResourceReceivePlugin::<P, R>::default());
         }
         if self.enable_send {
             app.configure_sets(
@@ -105,6 +107,7 @@ impl<P: Protocol, R: ReplicationSend<P>> Plugin for ReplicationPlugin<P, R> {
             app.add_systems(Last, cleanup::<P, R>.run_if(on_timer(clean_interval)));
             // PLUGINS
             app.add_plugins(HierarchySendPlugin::<P, R>::default());
+            app.add_plugins(ResourceSendPlugin::<P, R>::default());
         }
     }
 }

--- a/lightyear/src/shared/replication/plugin.rs
+++ b/lightyear/src/shared/replication/plugin.rs
@@ -12,7 +12,9 @@ use crate::shared::replication::components::{
 };
 use crate::shared::replication::entity_map::{InterpolatedEntityMap, PredictedEntityMap};
 use crate::shared::replication::hierarchy::{HierarchyReceivePlugin, HierarchySendPlugin};
-use crate::shared::replication::resources::{ResourceReceivePlugin, ResourceSendPlugin};
+use crate::shared::replication::resources::{
+    receive::ResourceReceivePlugin, send::ResourceSendPlugin,
+};
 use crate::shared::replication::systems::{add_replication_send_systems, cleanup};
 use crate::shared::sets::{InternalMainSet, InternalReplicationSet, MainSet};
 

--- a/lightyear/src/shared/replication/plugin.rs
+++ b/lightyear/src/shared/replication/plugin.rs
@@ -79,12 +79,14 @@ impl<P: Protocol, R: ReplicationSend<P>> Plugin for ReplicationPlugin<P, R> {
                 (
                     (
                         InternalReplicationSet::<R::SetMarker>::SendEntityUpdates,
+                        InternalReplicationSet::<R::SetMarker>::SendResourceUpdates,
                         InternalReplicationSet::<R::SetMarker>::SendComponentUpdates,
                         InternalReplicationSet::<R::SetMarker>::SendDespawnsAndRemovals,
                     )
                         .in_set(InternalReplicationSet::<R::SetMarker>::All),
                     (
                         InternalReplicationSet::<R::SetMarker>::SendEntityUpdates,
+                        InternalReplicationSet::<R::SetMarker>::SendResourceUpdates,
                         InternalReplicationSet::<R::SetMarker>::SendComponentUpdates,
                         // NOTE: SendDespawnsAndRemovals is not in MainSet::Send because we need to run them every frame
                         InternalMainSet::<R::SetMarker>::SendPackets,

--- a/lightyear/src/shared/replication/resources.rs
+++ b/lightyear/src/shared/replication/resources.rs
@@ -15,10 +15,10 @@ use serde::{Deserialize, Serialize};
 use std::marker::PhantomData;
 use tracing::error;
 
-pub mod command {
+mod command {
     use super::*;
 
-    /// Extension trait to add the `replicate_resource` method to [`Commands`].
+    /// Extension trait to be able to replicate a resource to remote clients via [`Commands`].
     pub trait ReplicateResourceExt<P: Protocol> {
         /// Start replicating a resource to remote clients.
         ///
@@ -35,7 +35,7 @@ pub mod command {
         }
     }
 
-    pub struct StopReplicateCommand<R> {
+    struct StopReplicateCommand<R> {
         _marker: PhantomData<R>,
     }
 
@@ -50,6 +50,7 @@ pub mod command {
         }
     }
 
+    /// Extension trait to be able to stop replicating a resource to remote clients via [`Commands`].
     pub trait StopReplicateResourceExt {
         /// Stop replicating a resource to remote clients.
         fn stop_replicate_resource<R: Resource + Clone>(&mut self);

--- a/lightyear/src/shared/replication/resources.rs
+++ b/lightyear/src/shared/replication/resources.rs
@@ -206,10 +206,8 @@ pub(crate) mod receive {
                     } else {
                         commands.insert_resource(received_value.clone());
                     }
-                } else {
-                    if let Some(resource) = resource {
-                        commands.remove_resource::<R>();
-                    }
+                } else if let Some(resource) = resource {
+                    commands.remove_resource::<R>();
                 }
             }
         }

--- a/lightyear/src/shared/replication/resources.rs
+++ b/lightyear/src/shared/replication/resources.rs
@@ -6,16 +6,68 @@ use crate::shared::replication::components::Replicate;
 use crate::shared::sets::{InternalMainSet, InternalReplicationSet};
 use async_compat::CompatExt;
 use bevy::app::App;
+use bevy::ecs::system::Command;
 use bevy::prelude::{
     Commands, Component, DetectChanges, Entity, IntoSystemConfigs, IntoSystemSetConfigs, Plugin,
-    PostUpdate, PreUpdate, Query, Ref, Res, ResMut, Resource, SystemSet, With,
+    PostUpdate, PreUpdate, Query, Ref, Res, ResMut, Resource, SystemSet, With, World,
 };
 use serde::{Deserialize, Serialize};
+use std::marker::PhantomData;
 use tracing::error;
+
+pub mod command {
+    use super::*;
+
+    /// Extension trait to add the `replicate_resource` method to [`Commands`].
+    pub trait ReplicateResourceExt<P: Protocol> {
+        /// Start replicating a resource to remote clients.
+        ///
+        /// Any change to the resource will be replicated to the clients.
+        // TODO: we use `Replicate<P>` as argument instead of the simpler `NetworkTarget`
+        //  because it helps with type-inference when calling this method.
+        //  We can switch to `NetworkTarget` if we remove the `P` bound of `Replicate`.
+        fn replicate_resource<R: Resource + Clone>(&mut self, replicate: Replicate<P>);
+    }
+
+    impl<P: Protocol> ReplicateResourceExt<P> for Commands<'_, '_> {
+        fn replicate_resource<R: Resource + Clone>(&mut self, replicate: Replicate<P>) {
+            self.spawn((ReplicateResource::<R>::default(), replicate));
+        }
+    }
+
+    pub struct StopReplicateCommand<R> {
+        _marker: PhantomData<R>,
+    }
+
+    impl<R: Resource + Clone> Command for StopReplicateCommand<R> {
+        fn apply(self, world: &mut World) {
+            if let Ok(entity) = world
+                .query_filtered::<Entity, With<ReplicateResource<R>>>()
+                .get_single(world)
+            {
+                world.despawn(entity);
+            }
+        }
+    }
+
+    pub trait StopReplicateResourceExt {
+        /// Stop replicating a resource to remote clients.
+        fn stop_replicate_resource<R: Resource + Clone>(&mut self);
+    }
+
+    impl StopReplicateResourceExt for Commands<'_, '_> {
+        fn stop_replicate_resource<R: Resource + Clone>(&mut self) {
+            self.add(StopReplicateCommand::<R> {
+                _marker: PhantomData,
+            });
+        }
+    }
+}
+pub use command::{ReplicateResourceExt, StopReplicateResourceExt};
 
 /// This component can be added to an entity to start replicating a [`Resource`] to remote clients.
 ///
-/// Currently resources are cloned to be replicated, so only use this for resources that are
+/// Currently, resources are cloned to be replicated, so only use this for resources that are
 /// cheap-to-clone. (the clone only happens when the resource is modified)
 ///
 /// Only one entity per World should have this component.
@@ -30,118 +82,134 @@ impl<R> Default for ReplicateResource<R> {
     }
 }
 
-pub(crate) struct ResourceSendPlugin<P, R> {
-    _marker: std::marker::PhantomData<(P, R)>,
-}
+pub(crate) mod send {
+    use super::*;
+    pub(crate) struct ResourceSendPlugin<P, R> {
+        _marker: PhantomData<(P, R)>,
+    }
 
-impl<P, R> Default for ResourceSendPlugin<P, R> {
-    fn default() -> Self {
-        Self {
-            _marker: std::marker::PhantomData,
+    impl<P, R> Default for ResourceSendPlugin<P, R> {
+        fn default() -> Self {
+            Self {
+                _marker: std::marker::PhantomData,
+            }
         }
     }
-}
 
-impl<P: Protocol, R: ReplicationSend<P>> Plugin for ResourceSendPlugin<P, R> {
-    fn build(&self, app: &mut App) {
-        app.configure_sets(
+    impl<P: Protocol, R: ReplicationSend<P>> Plugin for ResourceSendPlugin<P, R> {
+        fn build(&self, app: &mut App) {
+            app.configure_sets(
+                PostUpdate,
+                // we need to make sure that the resource data is copied to the component before
+                // we send the component update
+                InternalReplicationSet::<R::SetMarker>::SendResourceUpdates
+                    .before(InternalReplicationSet::<R::SetMarker>::SendComponentUpdates),
+            );
+            P::Components::add_resource_send_systems::<R>(app);
+        }
+    }
+
+    pub fn add_resource_send_systems<P: Protocol, S: ReplicationSend<P>, R: Resource + Clone>(
+        app: &mut App,
+    ) {
+        app.add_systems(
             PostUpdate,
-            // we need to make sure that the resource data is copied to the component before
-            // we send the component update
-            InternalReplicationSet::<R::SetMarker>::SendResourceUpdates
-                .before(InternalReplicationSet::<R::SetMarker>::SendComponentUpdates),
+            copy_send_resource::<P, R>
+                .in_set(InternalReplicationSet::<S::SetMarker>::SendResourceUpdates),
         );
-        P::Components::add_resource_send_systems::<R>(app);
     }
-}
 
-pub fn add_resource_send_systems<P: Protocol, S: ReplicationSend<P>, R: Resource + Clone>(
-    app: &mut App,
-) {
-    app.add_systems(
-        PostUpdate,
-        copy_send_resource::<P, R>
-            .in_set(InternalReplicationSet::<S::SetMarker>::SendResourceUpdates),
-    );
-}
-
-fn copy_send_resource<P: Protocol, R: Resource + Clone>(
-    resource: Option<Res<R>>,
-    mut replicating_entity: Query<&mut ReplicateResource<R>, With<Replicate<P>>>,
-) {
-    let Some(resource) = resource else {
-        return;
-    };
-    if replicating_entity.iter().len() > 1 {
-        error!(
-            "Only one entity per World should have a ReplicateResource<{:?}> component",
-            std::any::type_name::<R>()
-        );
-        return;
-    }
-    if let Ok(mut replicating_entity) = replicating_entity.get_single_mut() {
-        if resource.is_changed() || replicating_entity.is_added() {
-            // TODO: we should be able to avoid this clone? we only need the reference to the resource to serialize it
-            //  - we could directly serialize the data here and store it in the component
-            //  - the component could just be a marker that we need to serialize the resource, and then we have a custom
-            //    serialization function that fetches the resource and serializes it?
-            replicating_entity.resource = Some(resource.clone());
+    fn copy_send_resource<P: Protocol, R: Resource + Clone>(
+        resource: Option<Res<R>>,
+        mut replicating_entity: Query<&mut ReplicateResource<R>, With<Replicate<P>>>,
+    ) {
+        if replicating_entity.iter().len() > 1 {
+            error!(
+                "Only one entity per World should have a ReplicateResource<{:?}> component",
+                std::any::type_name::<R>()
+            );
+            return;
+        }
+        let Some(resource) = resource else {
+            // if the resource was removed, remove it from the entity
+            if let Ok(mut replicating_entity) = replicating_entity.get_single_mut() {
+                if replicating_entity.resource.is_some() {
+                    replicating_entity.resource = None;
+                }
+            }
+            return;
+        };
+        if let Ok(mut replicating_entity) = replicating_entity.get_single_mut() {
+            if resource.is_changed() || replicating_entity.is_added() {
+                // TODO: we should be able to avoid this clone? we only need the reference to the resource to serialize it
+                //  - we could directly serialize the data here and store it in the component
+                //  - the component could just be a marker that we need to serialize the resource, and then we have a custom
+                //    serialization function that fetches the resource and serializes it?
+                replicating_entity.resource = Some(resource.clone());
+            }
         }
     }
 }
 
-pub(crate) struct ResourceReceivePlugin<P, R> {
-    _marker: std::marker::PhantomData<(P, R)>,
-}
+pub(crate) mod receive {
+    use super::*;
+    pub(crate) struct ResourceReceivePlugin<P, R> {
+        _marker: PhantomData<(P, R)>,
+    }
 
-impl<P, R> Default for ResourceReceivePlugin<P, R> {
-    fn default() -> Self {
-        Self {
-            _marker: std::marker::PhantomData,
+    impl<P, R> Default for ResourceReceivePlugin<P, R> {
+        fn default() -> Self {
+            Self {
+                _marker: PhantomData,
+            }
         }
     }
-}
 
-impl<P: Protocol, R: ReplicationSend<P>> Plugin for ResourceReceivePlugin<P, R> {
-    fn build(&self, app: &mut App) {
-        app.configure_sets(
+    impl<P: Protocol, R: ReplicationSend<P>> Plugin for ResourceReceivePlugin<P, R> {
+        fn build(&self, app: &mut App) {
+            app.configure_sets(
+                PreUpdate,
+                InternalReplicationSet::<R::SetMarker>::ReceiveResourceUpdates
+                    .after(InternalMainSet::<R::SetMarker>::Receive),
+            );
+            P::Components::add_resource_receive_systems::<R>(app);
+        }
+    }
+
+    pub fn add_resource_receive_systems<P: Protocol, S: ReplicationSend<P>, R: Resource + Clone>(
+        app: &mut App,
+    ) {
+        app.add_systems(
             PreUpdate,
-            InternalReplicationSet::<R::SetMarker>::ReceiveResourceUpdates
-                .after(InternalMainSet::<R::SetMarker>::Receive),
+            copy_receive_resource::<R>
+                .in_set(InternalReplicationSet::<S::SetMarker>::ReceiveResourceUpdates),
         );
-        P::Components::add_resource_receive_systems::<R>(app);
     }
-}
 
-pub fn add_resource_receive_systems<P: Protocol, S: ReplicationSend<P>, R: Resource + Clone>(
-    app: &mut App,
-) {
-    app.add_systems(
-        PreUpdate,
-        copy_receive_resource::<R>
-            .in_set(InternalReplicationSet::<S::SetMarker>::ReceiveResourceUpdates),
-    );
-}
-
-fn copy_receive_resource<R: Resource + Clone>(
-    mut commands: Commands,
-    replicating_entity: Query<Ref<ReplicateResource<R>>>,
-    resource: Option<ResMut<R>>,
-) {
-    if replicating_entity.iter().len() > 1 {
-        error!(
-            "Only one entity per World should have a ReplicateResource<{:?}> component",
-            std::any::type_name::<R>()
-        );
-        return;
-    }
-    if let Ok(replicating_entity) = replicating_entity.get_single() {
-        if replicating_entity.is_changed() {
-            if let Some(received_value) = &replicating_entity.resource {
-                if let Some(mut resource) = resource {
-                    *resource = received_value.clone();
+    fn copy_receive_resource<R: Resource + Clone>(
+        mut commands: Commands,
+        replicating_entity: Query<Ref<ReplicateResource<R>>>,
+        resource: Option<ResMut<R>>,
+    ) {
+        if replicating_entity.iter().len() > 1 {
+            error!(
+                "Only one entity per World should have a ReplicateResource<{:?}> component",
+                std::any::type_name::<R>()
+            );
+            return;
+        }
+        if let Ok(replicating_entity) = replicating_entity.get_single() {
+            if replicating_entity.is_changed() {
+                if let Some(received_value) = &replicating_entity.resource {
+                    if let Some(mut resource) = resource {
+                        *resource = received_value.clone();
+                    } else {
+                        commands.insert_resource(received_value.clone());
+                    }
                 } else {
-                    commands.insert_resource(received_value.clone());
+                    if let Some(resource) = resource {
+                        commands.remove_resource::<R>();
+                    }
                 }
             }
         }
@@ -150,12 +218,15 @@ fn copy_receive_resource<R: Resource + Clone>(
 
 #[cfg(test)]
 mod tests {
-    use super::ReplicateResource;
+    use super::{ReplicateResource, StopReplicateResourceExt};
+    use crate::prelude::NetworkTarget;
+    use crate::shared::replication::resources::ReplicateResourceExt;
     use crate::tests::protocol::{Component1, Replicate, Resource1};
     use crate::tests::stepper::{BevyStepper, Step};
+    use bevy::prelude::Commands;
 
     #[test]
-    fn test_resource_replication() {
+    fn test_resource_replication_manually() {
         let mut stepper = BevyStepper::default();
 
         // spawn an entity that can replicate a resource
@@ -178,6 +249,7 @@ mod tests {
         stepper.frame_step();
         stepper.frame_step();
 
+        // check that the component was replicated correctly
         let replicated_component = stepper
             .client_app
             .world
@@ -207,5 +279,105 @@ mod tests {
 
         // check that the update was replicated
         assert_eq!(stepper.client_app.world.resource::<Resource1>().0, 2.0);
+
+        // remove the resource
+        stepper.server_app.world.remove_resource::<Resource1>();
+        stepper.frame_step();
+        stepper.frame_step();
+
+        // check that the resource was removed on the client
+        assert!(stepper
+            .client_app
+            .world
+            .get_resource::<Resource1>()
+            .is_none());
+    }
+
+    #[test]
+    fn test_resource_replication_via_commands() {
+        let mut stepper = BevyStepper::default();
+
+        // start replicating a resource via commands (even if the resource doesn't exist yet)
+        let start_replicate_system =
+            stepper
+                .server_app
+                .world
+                .register_system(|mut commands: Commands| {
+                    commands.replicate_resource::<Resource1>(Replicate::default());
+                });
+        let stop_replicate_system =
+            stepper
+                .server_app
+                .world
+                .register_system(|mut commands: Commands| {
+                    commands.stop_replicate_resource::<Resource1>();
+                });
+        let _ = stepper.server_app.world.run_system(start_replicate_system);
+        stepper.frame_step();
+        stepper.frame_step();
+
+        // check that the component was replicated correctly
+        let replicated_component = stepper
+            .client_app
+            .world
+            .query::<&ReplicateResource<Resource1>>()
+            .get_single(&stepper.client_app.world)
+            .unwrap();
+
+        // add the resource
+        stepper.server_app.world.insert_resource(Resource1(1.0));
+        stepper.frame_step();
+        stepper.frame_step();
+
+        let replicated_resource = stepper
+            .client_app
+            .world
+            .query::<&ReplicateResource<Resource1>>()
+            .get_single(&stepper.client_app.world)
+            .unwrap();
+
+        // check that the resource was replicated
+        assert_eq!(stepper.client_app.world.resource::<Resource1>().0, 1.0);
+
+        // update the resource
+        stepper.server_app.world.resource_mut::<Resource1>().0 = 2.0;
+        stepper.frame_step();
+        stepper.frame_step();
+
+        // check that the update was replicated
+        assert_eq!(stepper.client_app.world.resource::<Resource1>().0, 2.0);
+
+        // remove the resource
+        stepper.server_app.world.remove_resource::<Resource1>();
+        stepper.frame_step();
+        stepper.frame_step();
+
+        // check that the resource was removed on the client
+        assert!(stepper
+            .client_app
+            .world
+            .get_resource::<Resource1>()
+            .is_none());
+
+        // re-add the resource
+        stepper.server_app.world.insert_resource(Resource1(1.0));
+        stepper.frame_step();
+        stepper.frame_step();
+
+        // check that the resource was replicated
+        assert_eq!(stepper.client_app.world.resource::<Resource1>().0, 1.0);
+
+        // stop replicating the resource
+        let _ = stepper.server_app.world.run_system(stop_replicate_system);
+        stepper.frame_step();
+        stepper.frame_step();
+
+        // update the resource
+        stepper.server_app.world.resource_mut::<Resource1>().0 = 2.0;
+        stepper.frame_step();
+        stepper.frame_step();
+
+        // check that the resource was not deleted on the client, but also not updated
+        assert_eq!(stepper.client_app.world.resource::<Resource1>().0, 1.0);
     }
 }

--- a/lightyear/src/shared/replication/resources.rs
+++ b/lightyear/src/shared/replication/resources.rs
@@ -1,0 +1,119 @@
+//! Module to handle the replication of bevy [`Resource`]s
+
+use crate::_reexport::ReplicationSend;
+use crate::prelude::{Message, Protocol};
+use crate::shared::sets::{InternalMainSet, InternalReplicationSet};
+use async_compat::CompatExt;
+use bevy::app::App;
+use bevy::prelude::{
+    Commands, Component, DetectChanges, Entity, IntoSystemSetConfigs, Plugin, PostUpdate,
+    PreUpdate, Query, Ref, Res, ResMut, Resource, SystemSet, With,
+};
+use serde::{Deserialize, Serialize};
+use tracing::error;
+
+/// This component can be added to an entity to start replicating a [`Resource`] to remote clients.
+///
+/// Currently resources are cloned to be replicated, so only use this for resources that are
+/// cheap-to-clone. (the clone only happens when the resource is modified)
+///
+/// Only one entity per World should have this component.
+#[derive(Component, Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct ReplicateResource<R: Resource + Message> {
+    resource: R,
+}
+
+struct ResourceSendPlugin<P> {
+    _marker: std::marker::PhantomData<P>,
+}
+
+impl<P> Default for ResourceSendPlugin<P> {
+    fn default() -> Self {
+        Self {
+            _marker: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<P: Protocol, R: ReplicationSend<P>> Plugin for ResourceSendPlugin<P> {
+    fn build(&self, app: &mut App) {
+        app.configure_sets(
+            PostUpdate,
+            // we need to make sure that the resource data is copied to the component before
+            // we send the component update
+            InternalReplicationSet::<R::SetMarker>::SendResourceUpdates
+                .before(InternalReplicationSet::<R::SetMarker>::SendComponentUpdates),
+        );
+        // TODO: call copy_send_resource for every component that is `ReplicateResource` in the `ComponentProtocol`.
+        // app.add_systems(PostUpdate, copy_send_resource())
+    }
+}
+
+fn copy_send_resource<R: Resource + Clone>(
+    resource: Res<R>,
+    mut replicating_entity: Query<&mut ReplicateResource<R>>,
+) {
+    if resource.is_changed() {
+        if replicating_entity.iter().len() > 1 {
+            error!(
+                "Only one entity per World should have a ReplicateResource<{:?}> component",
+                std::any::type_name::<R>()
+            );
+            return;
+        }
+        // TODO: we should be able to avoid this clone? we only need the reference to the resource to serialize it
+        //  - we could directly serialize the data here and store it in the component
+        //  - the component could just be a marker that we need to serialize the resource, and then we have a custom
+        //    serialization function that fetches the resource and serializes it?
+        if let Ok(mut replicating_entity) = replicating_entity.get_single_mut() {
+            replicating_entity.resource = resource.clone();
+        }
+    }
+}
+
+struct ResourceReceivePlugin<P> {
+    _marker: std::marker::PhantomData<P>,
+}
+
+impl<P> Default for ResourceReceivePlugin<P> {
+    fn default() -> Self {
+        Self {
+            _marker: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<P: Protocol, R: ReplicationSend<P>> Plugin for ResourceReceivePlugin<P> {
+    fn build(&self, app: &mut App) {
+        app.configure_sets(
+            PreUpdate,
+            InternalReplicationSet::<R::SetMarker>::ReceiveResourceUpdates
+                .after(InternalMainSet::<R::SetMarker>::Receive),
+        );
+        // TODO: call copy_receive_resource for every component that is `ReplicateResource` in the `ComponentProtocol`.
+        // app.add_systems(PreUpdate, copy_send_resource())
+    }
+}
+
+fn copy_receive_resource<R: Resource + Clone>(
+    mut commands: Commands,
+    replicating_entity: Query<Ref<ReplicateResource<R>>>,
+    resource: Option<ResMut<R>>,
+) {
+    if replicating_entity.iter().len() > 1 {
+        error!(
+            "Only one entity per World should have a ReplicateResource<{:?}> component",
+            std::any::type_name::<R>()
+        );
+        return;
+    }
+    if let Ok(replicating_entity) = replicating_entity.get_single() {
+        if replicating_entity.is_changed() {
+            if let Some(mut resource) = resource {
+                *resource = replicating_entity.resource.clone();
+            } else {
+                commands.insert_resource(replicating_entity.resource.clone());
+            }
+        }
+    }
+}

--- a/lightyear/src/shared/replication/send.rs
+++ b/lightyear/src/shared/replication/send.rs
@@ -353,7 +353,7 @@ impl<P: Protocol> ReplicationSender<P> {
         }
 
         if !messages.is_empty() {
-            debug!(?messages, "Sending replication messages");
+            warn!(?messages, "Sending replication messages");
         }
 
         // clear send buffers

--- a/lightyear/src/shared/sets.rs
+++ b/lightyear/src/shared/sets.rs
@@ -10,6 +10,8 @@ pub struct ServerMarker;
 /// System sets related to Replication
 #[derive(SystemSet, Debug, Hash, PartialEq, Eq, Clone, Copy)]
 pub(crate) enum InternalReplicationSet<M> {
+    /// System that copies the resource data from the entity to the resource in the receiving world
+    ReceiveResourceUpdates,
     /// Set the hash for each entity that is pre-spawned on the client
     /// (has a PreSpawnedPlayerObject component)
     SetPreSpawnedHash,
@@ -22,6 +24,7 @@ pub(crate) enum InternalReplicationSet<M> {
     /// These systems only run once every send_interval
     SendEntityUpdates,
     SendComponentUpdates,
+    SendResourceUpdates,
 
     // SystemSet that encompasses all send replication systems
     All,

--- a/lightyear/src/tests/protocol.rs
+++ b/lightyear/src/tests/protocol.rs
@@ -1,5 +1,5 @@
 use bevy::ecs::entity::MapEntities;
-use bevy::prelude::{default, Component, Entity, EntityMapper, Reflect};
+use bevy::prelude::{default, Component, Entity, EntityMapper, Reflect, Resource};
 use cfg_if::cfg_if;
 use derive_more::{Add, Mul};
 use std::ops::Mul;
@@ -58,7 +58,12 @@ pub enum MyComponentsProtocol {
     Component3(Component3),
     #[protocol(sync(mode = "simple"), map_entities)]
     Component4(Component4),
+    Resource1(ReplicateResource<Resource1>),
 }
+
+// Resources
+#[derive(Resource, Serialize, Deserialize, Debug, PartialEq, Clone, Add, Reflect)]
+pub struct Resource1(pub f32);
 
 // Inputs
 

--- a/lightyear/src/tests/stepper.rs
+++ b/lightyear/src/tests/stepper.rs
@@ -2,6 +2,7 @@ use bevy::utils::Duration;
 use std::net::SocketAddr;
 use std::str::FromStr;
 
+use crate::client::networking::ClientConnectionParam;
 use crate::connection::client::{ClientConnection, NetClient};
 use bevy::ecs::system::SystemState;
 use bevy::prelude::{default, App, Mut, PluginGroup, Real, Time, World};

--- a/macros/src/component.rs
+++ b/macros/src/component.rs
@@ -665,7 +665,9 @@ fn update_method(input: &ItemEnum, fields: &Vec<Field>) -> TokenStream {
             Self::#ident(x) => {
                  if let Some(mut c) = entity.get_mut::<#component_type>() {
                     *c = x;
-                 }
+                 } else {
+                    entity.insert(x);
+                }
             }
         };
         // let is_wrapped = match component_type {

--- a/macros/src/component.rs
+++ b/macros/src/component.rs
@@ -1,4 +1,4 @@
-use crate::shared::{get_fields, strip_attributes};
+use crate::shared::{get_fields, get_inner_generic, strip_attributes};
 use darling::ast::NestedMeta;
 use darling::util::{Flag, PathList};
 use darling::{Error, FromField, FromMeta, FromVariant};
@@ -143,6 +143,8 @@ pub fn component_protocol_impl(
     let sync_component_impl = sync_metadata_impl(&attr_fields, enum_name);
 
     // Methods
+    let add_resource_send_method = add_resource_send_method(&fields, protocol);
+    let add_resource_receive_method = add_resource_receive_method(&fields, protocol);
     let add_systems_method = add_per_component_replication_send_systems_method(&fields, protocol);
     let add_events_method = add_events_method(&fields);
     let push_component_events_method = push_component_events_method(&fields, protocol);
@@ -187,6 +189,8 @@ pub fn component_protocol_impl(
                 #type_ids_method
                 #insert_method
                 #update_method
+                #add_resource_send_method
+                #add_resource_receive_method
                 #add_systems_method
                 #add_events_method
                 #push_component_events_method
@@ -248,6 +252,50 @@ pub fn component_protocol_impl(
     };
 
     proc_macro::TokenStream::from(gen)
+}
+
+fn add_resource_send_method(fields: &Vec<Field>, protocol_name: &Ident) -> TokenStream {
+    let mut body = quote! {};
+    for field in fields {
+        let ty = &field.ty;
+        if !quote!(#ty).to_string().starts_with("ReplicateResource") {
+            continue;
+        }
+        let resource = get_inner_generic(ty)
+            .expect("ReplicateResource must have a generic type: ReplicateResource<R>");
+        body = quote! {
+            #body
+            add_resource_send_systems::<#protocol_name, R, #resource>(app);
+        };
+    }
+    quote! {
+        fn add_resource_send_systems<R: ReplicationSend<#protocol_name>>(app: &mut App)
+        {
+            #body
+        }
+    }
+}
+
+fn add_resource_receive_method(fields: &Vec<Field>, protocol_name: &Ident) -> TokenStream {
+    let mut body = quote! {};
+    for field in fields {
+        let ty = &field.ty;
+        if !quote!(#ty).to_string().starts_with("ReplicateResource") {
+            continue;
+        }
+        let resource = get_inner_generic(ty)
+            .expect("ReplicateResource must have a generic type: ReplicateResource<R>");
+        body = quote! {
+            #body
+            add_resource_receive_systems::<#protocol_name, R, #resource>(app);
+        };
+    }
+    quote! {
+        fn add_resource_receive_systems<R: ReplicationSend<#protocol_name>>(app: &mut App)
+        {
+            #body
+        }
+    }
 }
 
 fn add_per_component_replication_send_systems_method(

--- a/macros/src/shared.rs
+++ b/macros/src/shared.rs
@@ -58,3 +58,23 @@ pub(crate) fn strip_attributes(input: &ItemEnum, attributes_to_remove: &[&str]) 
     }
     input
 }
+
+/// For a type like `XXX<T>`, get the inner type `T`
+pub(crate) fn get_inner_generic(ty: &syn::Type) -> Option<&syn::Type> {
+    if let syn::Type::Path(syn::TypePath { path, .. }) = ty {
+        if path.segments.len() == 1 {
+            if let syn::PathArguments::AngleBracketed(syn::AngleBracketedGenericArguments {
+                args,
+                ..
+            }) = &path.segments.first().unwrap().arguments
+            {
+                if args.len() == 1 {
+                    if let syn::GenericArgument::Type(ty) = args.first().unwrap() {
+                        return Some(ty);
+                    }
+                }
+            }
+        }
+    }
+    None
+}

--- a/macros/tests/derive_component.rs
+++ b/macros/tests/derive_component.rs
@@ -1,6 +1,6 @@
 pub mod some_component {
     use bevy::ecs::entity::MapEntities;
-    use bevy::prelude::{Component, Entity, EntityMapper, Reflect};
+    use bevy::prelude::{Component, Entity, EntityMapper, Reflect, Resource};
     use derive_more::Add;
     use serde::{Deserialize, Serialize};
     use std::ops::Mul;
@@ -8,6 +8,9 @@ pub mod some_component {
     use lightyear::prelude::client::LerpFn;
     use lightyear::prelude::*;
     use lightyear_macros::{component_protocol, message_protocol};
+
+    #[derive(Resource, Serialize, Deserialize, Debug, PartialEq, Clone, Add, Reflect)]
+    pub struct Resource1(pub f32);
 
     #[derive(Component, Serialize, Deserialize, Debug, PartialEq, Clone, Add, Reflect)]
     pub struct Component1(pub f32);
@@ -48,6 +51,7 @@ pub mod some_component {
         Component4(Component4),
         #[protocol(sync(mode = "full", lerp = "MyCustomInterpolator"))]
         Component5(Component5),
+        Resource1(ReplicateResource<Resource1>),
     }
 
     // custom interpolation logic

--- a/macros/tests/derive_message.rs
+++ b/macros/tests/derive_message.rs
@@ -1,6 +1,6 @@
 pub mod some_message {
     use bevy::ecs::entity::MapEntities;
-    use bevy::prelude::{Component, Entity, EntityMapper, Reflect};
+    use bevy::prelude::{Entity, EntityMapper, Reflect};
     use serde::{Deserialize, Serialize};
 
     use lightyear::prelude::*;
@@ -25,13 +25,8 @@ pub mod some_message {
         Message2(Message2),
     }
 
-    #[derive(Component, Serialize, Deserialize, Debug, PartialEq, Clone, Reflect)]
-    pub struct Component1(pub u8);
-
     #[component_protocol(protocol = "MyProtocol")]
-    pub enum MyComponentProtocol {
-        Component1(Component1),
-    }
+    pub enum MyComponentProtocol {}
 
     protocolize! {
         Self = MyProtocol,


### PR DESCRIPTION
- Fixes https://github.com/cBournhonesque/lightyear/issues/58

This PR introduces easily replicating Resources; the idea is to spawn an entity that will contain a `ReplicateResource<R>` component that will get updated whenever the resource gets updated. The `ReplicateResource<R>` component needs to manually get added to the `ComponentProtocol`.

We also provide 2 commands: `replicate_resource::<R>(replicate)` and `stop_replicate_resource::<R>` to easily start/stop replicating a resource.

- Fixes https://github.com/cBournhonesque/lightyear/issues/248 

There was an issue where if we add the `Replicate` component after an entity is already spawned with some components, those components would get replicated as `ComponentUpdate`. This wouldn't insert the components on the remote.
Now we:
- insert the component on the remote even with `ComponentUpdate`
- call `component_insert` if `Replicate` was newly added on an entity.