### PR TITLE
docs: fix typos, update ring

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -32,7 +32,7 @@ To test the example in wasm, you can run the following commands: `trunk serve`
 You will need a valid SSL certificate to test the example in wasm using webtransport. You will need to run the following
 commands:
 
-- `sh examples/generate.sh` (to generate the temporary SSL certificates, they are only valid for 2 weeks)
+- `sh examples/certificates/generate.sh` (to generate the temporary SSL certificates, they are only valid for 2 weeks)
 - `cargo run -- server` to start the server. The server will print out the certificate digest (something
   like `1fd28860bd2010067cee636a64bcbb492142295b297fd8c480e604b70ce4d644`)
 - You then have to replace the certificate digest in the `assets/settings.ron` file with the one that the server printed

--- a/lightyear/Cargo.toml
+++ b/lightyear/Cargo.toml
@@ -138,7 +138,7 @@ tokio-tungstenite = { version = "0.21.0", optional = true, features = [
 
 [target."cfg(target_family = \"wasm\")".dependencies]
 console_error_panic_hook = { version = "0.1.7" }
-ring = { version = "0.17.7", optional = true }
+ring = { version = "0.17.8", optional = true, default-features = false }
 web-sys = { version = "0.3", optional = true, features = [
   "WebTransport",
   "WebTransportHash",


### PR DESCRIPTION
Changes:
- Fixes a typo for certificate gen
- ring doesn't need features
- Update ring