### PR TITLE
Make client connect async

### DIFF
--- a/lightyear/src/connection/client.rs
+++ b/lightyear/src/connection/client.rs
@@ -1,5 +1,6 @@
 use std::net::SocketAddr;
 use std::str::FromStr;
+use std::sync::Arc;
 
 use anyhow::Result;
 use bevy::ecs::system::SystemParam;

--- a/lightyear/src/connection/local/client.rs
+++ b/lightyear/src/connection/local/client.rs
@@ -22,7 +22,7 @@ impl Client {
 }
 
 impl NetClient for Client {
-    fn connect(&mut self) -> Result<()> {
+    async fn connect(&mut self) -> Result<()> {
         self.is_connected = true;
         Ok(())
     }

--- a/lightyear/src/connection/netcode/client.rs
+++ b/lightyear/src/connection/netcode/client.rs
@@ -2,8 +2,10 @@ use bevy::utils::Duration;
 use std::net::{IpAddr, Ipv4Addr};
 use std::{collections::VecDeque, net::SocketAddr};
 
-use anyhow::Context;
+use anyhow::{anyhow, Context};
+use async_compat::Compat;
 use bevy::prelude::Resource;
+use bevy::tasks::IoTaskPool;
 use tracing::{debug, error, info, trace, warn};
 
 use crate::connection::client::NetClient;
@@ -651,9 +653,9 @@ pub struct Client<Ctx> {
 }
 
 impl<Ctx: Send + Sync> NetClient for Client<Ctx> {
-    fn connect(&mut self) -> anyhow::Result<()> {
+    async fn connect(&mut self) -> anyhow::Result<()> {
         let io_config = self.io_config.clone();
-        let io = io_config.connect().context("could not connect io")?;
+        let io = io_config.connect().await.context("could not connect io")?;
         self.io = Some(io);
         self.client.connect();
         Ok(())

--- a/lightyear/src/connection/steam/client.rs
+++ b/lightyear/src/connection/steam/client.rs
@@ -97,7 +97,7 @@ impl Client {
 }
 
 impl NetClient for Client {
-    fn connect(&mut self) -> Result<()> {
+    async fn connect(&mut self) -> Result<()> {
         let options = get_networking_options(&self.conditioner);
         self.connection = Some(
             Self::client()

--- a/lightyear/src/transport/channels.rs
+++ b/lightyear/src/transport/channels.rs
@@ -51,7 +51,7 @@ impl Channels {
 }
 
 impl TransportBuilder for Channels {
-    fn connect(self) -> Result<TransportEnum> {
+    async fn connect(self) -> Result<TransportEnum> {
         Ok(TransportEnum::Channels(self))
     }
 }

--- a/lightyear/src/transport/config.rs
+++ b/lightyear/src/transport/config.rs
@@ -170,8 +170,8 @@ impl IoConfig {
         self
     }
 
-    pub fn connect(self) -> Result<Io> {
-        let transport = self.transport.build().connect()?;
+    pub async fn connect(self) -> Result<Io> {
+        let transport = self.transport.build().connect().await?;
         let local_addr = transport.local_addr();
         let (sender, receiver, close_fn) = transport.split();
         let receiver: BoxedReceiver = if let Some(conditioner_config) = self.conditioner {

--- a/lightyear/src/transport/dummy.rs
+++ b/lightyear/src/transport/dummy.rs
@@ -12,7 +12,7 @@ use super::error::Result;
 pub struct DummyIo;
 
 impl TransportBuilder for DummyIo {
-    fn connect(self) -> Result<TransportEnum> {
+    async fn connect(self) -> Result<TransportEnum> {
         Ok(TransportEnum::Dummy(self))
     }
 }

--- a/lightyear/src/transport/local.rs
+++ b/lightyear/src/transport/local.rs
@@ -18,7 +18,7 @@ pub(crate) struct LocalChannelBuilder {
 }
 
 impl TransportBuilder for LocalChannelBuilder {
-    fn connect(self) -> Result<TransportEnum> {
+    async fn connect(self) -> Result<TransportEnum> {
         Ok(TransportEnum::LocalChannel(LocalChannel {
             sender: LocalChannelSender { send: self.send },
             receiver: LocalChannelReceiver {

--- a/lightyear/src/transport/mod.rs
+++ b/lightyear/src/transport/mod.rs
@@ -76,7 +76,7 @@ pub(crate) trait TransportBuilder: Send + Sync {
     /// Attempt to:
     /// - connect to the remote (for clients)
     /// - listen to incoming connections (for server)
-    fn connect(self) -> Result<TransportEnum>;
+    async fn connect(self) -> Result<TransportEnum>;
 
     // TODO maybe add a `async fn ready() -> bool` function?
 }

--- a/lightyear/src/transport/udp.rs
+++ b/lightyear/src/transport/udp.rs
@@ -16,7 +16,7 @@ pub struct UdpSocketBuilder {
 }
 
 impl TransportBuilder for UdpSocketBuilder {
-    fn connect(self) -> Result<TransportEnum> {
+    async fn connect(self) -> Result<TransportEnum> {
         let udp_socket = std::net::UdpSocket::bind(self.local_addr)?;
         let local_addr = udp_socket.local_addr()?;
         let socket = Arc::new(Mutex::new(udp_socket));

--- a/lightyear/src/transport/websocket/client_wasm.rs
+++ b/lightyear/src/transport/websocket/client_wasm.rs
@@ -28,7 +28,7 @@ pub(crate) struct WebSocketClientSocketBuilder {
 }
 
 impl TransportBuilder for WebSocketClientSocketBuilder {
-    fn connect(self) -> Result<TransportEnum> {
+    async fn connect(self) -> Result<TransportEnum> {
         let (serverbound_tx, serverbound_rx) = unbounded_channel::<Vec<u8>>();
         let (clientbound_tx, clientbound_rx) = unbounded_channel::<Vec<u8>>();
         let (close_tx, mut close_rx) = mpsc::channel(1);

--- a/lightyear/src/transport/websocket/server.rs
+++ b/lightyear/src/transport/websocket/server.rs
@@ -30,7 +30,7 @@ pub(crate) struct WebSocketServerSocketBuilder {
 }
 
 impl TransportBuilder for WebSocketServerSocketBuilder {
-    fn connect(self) -> Result<TransportEnum> {
+    async fn connect(self) -> Result<TransportEnum> {
         let (serverbound_tx, serverbound_rx) = unbounded_channel::<(SocketAddr, Message)>();
         let clientbound_tx_map = ClientBoundTxMap::new(Mutex::new(HashMap::new()));
 
@@ -44,9 +44,7 @@ impl TransportBuilder for WebSocketServerSocketBuilder {
             serverbound_rx,
         };
 
-        let listener = futures_lite::future::block_on(Compat::new(async move {
-            TcpListener::bind(self.server_addr).await
-        }))?;
+        let listener = TcpListener::bind(self.server_addr).await?;
 
         IoTaskPool::get()
             .spawn(Compat::new(async move {

--- a/lightyear/src/transport/webtransport/server.rs
+++ b/lightyear/src/transport/webtransport/server.rs
@@ -30,7 +30,7 @@ pub(crate) struct WebTransportServerSocketBuilder {
 }
 
 impl TransportBuilder for WebTransportServerSocketBuilder {
-    fn connect(self) -> Result<TransportEnum> {
+    async fn connect(self) -> Result<TransportEnum> {
         let (to_client_sender, to_client_receiver) =
             mpsc::unbounded_channel::<(Box<[u8]>, SocketAddr)>();
         let (from_client_sender, from_client_receiver) = mpsc::unbounded_channel();
@@ -40,11 +40,7 @@ impl TransportBuilder for WebTransportServerSocketBuilder {
             .with_bind_address(self.server_addr)
             .with_certificate(self.certificate)
             .build();
-        // need to run this with Compat because it requires the tokio reactor
-        let endpoint = futures_lite::future::block_on(Compat::new(async {
-            let endpoint = wtransport::Endpoint::server(config)?;
-            Ok::<_, Error>(endpoint)
-        }))?;
+        let endpoint = wtransport::Endpoint::server(config)?;
 
         let sender = WebTransportServerSocketSender {
             server_addr: self.server_addr,


### PR DESCRIPTION
This PR aims to fix https://github.com/cBournhonesque/lightyear/issues/247, where the problem is establishing the io can block the client's main thread (especially if the server is not online), which causes the app to be non-responsive.

One solution would be to make the `connect` function of the `NetClient` crate async.

The main issue that I have is to start the task that will start the connection process:
```
    let connection_task = IoTaskPool::get().spawn(Compat::new(async move {
        {
            netclient.connect().await?;
            Ok(netclient)
        }
    }));
```
I have to move the `netclient` inside the task, so I cannot add it as a Resource to the world. This breaks other systems that expect the `ClientConnection` resource to exist, it also makes the connection logic pretty complicated because we need to wait for that task to be ready.

Because of these reasons I don't expect this to be a good approach, at least in the current state; I'm simply opening the PR to not forget about the idea.