### PR TITLE
Make io connection async

### DIFF
--- a/lightyear/Cargo.toml
+++ b/lightyear/Cargo.toml
@@ -120,6 +120,7 @@ tokio = { version = "1.36", features = [
 ], default-features = false, optional = true }
 futures = "0.3.30"
 async-compat = "0.2.3"
+async-channel = "2.2.0"
 
 [target."cfg(not(target_family = \"wasm\"))".dependencies]
 # connection

--- a/lightyear/src/connection/client.rs
+++ b/lightyear/src/connection/client.rs
@@ -56,7 +56,7 @@ pub trait NetClient: Send + Sync {
 }
 
 #[enum_dispatch(NetClient)]
-enum NetClientDispatch {
+pub(crate) enum NetClientDispatch {
     Netcode(super::netcode::Client<()>),
     #[cfg(all(feature = "steam", not(target_family = "wasm")))]
     Steam(super::steam::client::Client),

--- a/lightyear/src/connection/client.rs
+++ b/lightyear/src/connection/client.rs
@@ -1,9 +1,11 @@
 use std::net::SocketAddr;
 use std::str::FromStr;
+use std::sync::Arc;
 
 use anyhow::Result;
 use bevy::ecs::system::SystemParam;
 use bevy::prelude::{NextState, Reflect, ResMut, Resource};
+use enum_dispatch::enum_dispatch;
 
 use crate::_reexport::ReadWordBuffer;
 use crate::client::config::NetcodeConfig;
@@ -18,6 +20,7 @@ use crate::packet::packet::Packet;
 use crate::prelude::{generate_key, Io, IoConfig, Key, LinkConditionerConfig};
 
 // TODO: add diagnostics methods?
+#[enum_dispatch]
 pub trait NetClient: Send + Sync {
     // type Error;
 
@@ -52,10 +55,18 @@ pub trait NetClient: Send + Sync {
     fn io_mut(&mut self) -> Option<&mut Io>;
 }
 
+#[enum_dispatch(NetClient)]
+enum NetClientDispatch {
+    Netcode(super::netcode::Client<()>),
+    #[cfg(all(feature = "steam", not(target_family = "wasm")))]
+    Steam(super::steam::client::Client),
+    Local(super::local::client::Client),
+}
+
 /// Resource that holds the client connection
 #[derive(Resource)]
 pub struct ClientConnection {
-    pub(crate) client: Box<dyn NetClient>,
+    pub(crate) client: NetClientDispatch,
 }
 
 #[allow(clippy::large_enum_variant)]
@@ -112,7 +123,7 @@ impl NetConfig {
                     io: None,
                 };
                 ClientConnection {
-                    client: Box::new(client),
+                    client: NetClientDispatch::Netcode(client),
                 }
             }
             #[cfg(all(feature = "steam", not(target_family = "wasm")))]
@@ -124,13 +135,13 @@ impl NetConfig {
                 let client = super::steam::client::Client::new(config, conditioner)
                     .expect("could not create steam client");
                 ClientConnection {
-                    client: Box::new(client),
+                    client: NetClientDispatch::Steam(client),
                 }
             }
             NetConfig::Local { id } => {
                 let client = super::local::client::Client::new(id);
                 ClientConnection {
-                    client: Box::new(client),
+                    client: NetClientDispatch::Local(client),
                 }
             }
         }

--- a/lightyear/src/connection/netcode/client.rs
+++ b/lightyear/src/connection/netcode/client.rs
@@ -660,13 +660,14 @@ impl<Ctx: Send + Sync> NetClient for Client<Ctx> {
     }
 
     fn disconnect(&mut self) -> anyhow::Result<()> {
-        let io = self.io.as_mut().context("io is not initialized")?;
-        self.client
-            .disconnect(io)
-            .context("Error when disconnecting from server")?;
-        // close and drop the io
-        io.close().context("Could not close the io")?;
-        std::mem::take(&mut self.io);
+        if let Some(io) = self.io.as_mut() {
+            self.client
+                .disconnect(io)
+                .context("Error when disconnecting from server")?;
+            // close and drop the io
+            io.close().context("Could not close the io")?;
+            std::mem::take(&mut self.io);
+        }
         Ok(())
     }
 

--- a/lightyear/src/shared/replication/send.rs
+++ b/lightyear/src/shared/replication/send.rs
@@ -105,6 +105,7 @@ impl<P: Protocol> ReplicationSender<P> {
             }
         }
 
+        // TODO: don't accumulate priority if priority is not enabled
         // then accumulate the priority for all replication groups
         self.group_channels.values_mut().for_each(|channel| {
             channel.accumulated_priority = channel
@@ -353,7 +354,7 @@ impl<P: Protocol> ReplicationSender<P> {
         }
 
         if !messages.is_empty() {
-            warn!(?messages, "Sending replication messages");
+            debug!(?messages, "Sending replication messages");
         }
 
         // clear send buffers

--- a/lightyear/src/tests/stepper.rs
+++ b/lightyear/src/tests/stepper.rs
@@ -5,7 +5,7 @@ use std::str::FromStr;
 use crate::client::networking::ClientConnectionParam;
 use crate::connection::client::{ClientConnection, NetClient};
 use bevy::ecs::system::SystemState;
-use bevy::prelude::{default, App, Mut, PluginGroup, Real, Time, World};
+use bevy::prelude::{default, App, Mut, NextState, PluginGroup, Real, State, Time, World};
 use bevy::time::TimeUpdateStrategy;
 use bevy::{DefaultPlugins, MinimalPlugins};
 use tracing_subscriber::fmt::format::FmtSpan;
@@ -13,7 +13,8 @@ use tracing_subscriber::fmt::format::FmtSpan;
 use crate::connection::netcode::generate_key;
 use crate::connection::server::{NetServer, ServerConnection, ServerConnections};
 use crate::prelude::client::{
-    Authentication, ClientConfig, InputConfig, InterpolationConfig, PredictionConfig, SyncConfig,
+    Authentication, ClientConfig, InputConfig, InterpolationConfig, NetworkingState,
+    PredictionConfig, SyncConfig,
 };
 use crate::prelude::server::{NetcodeConfig, ServerConfig};
 use crate::prelude::*;
@@ -192,9 +193,8 @@ impl BevyStepper {
             .expect("could not start server");
         self.client_app
             .world
-            .resource_mut::<ClientConnection>()
-            .connect()
-            .expect("could not connect client");
+            .resource_mut::<NextState<NetworkingState>>()
+            .set(NetworkingState::Connecting);
 
         // Advance the world to let the connection process complete
         for _ in 0..100 {

--- a/lightyear/src/transport/channels.rs
+++ b/lightyear/src/transport/channels.rs
@@ -7,6 +7,7 @@ use crossbeam_channel::{Receiver, Select, Sender};
 use self_cell::self_cell;
 use tracing::info;
 
+use crate::transport::io::IoState;
 use crate::transport::{
     BoxedCloseFn, BoxedReceiver, BoxedSender, PacketReceiver, PacketSender, Transport,
     TransportBuilder, TransportEnum, LOCAL_SOCKET,
@@ -51,8 +52,8 @@ impl Channels {
 }
 
 impl TransportBuilder for Channels {
-    fn connect(self) -> Result<TransportEnum> {
-        Ok(TransportEnum::Channels(self))
+    fn connect(self) -> Result<(TransportEnum, IoState)> {
+        Ok((TransportEnum::Channels(self), IoState::Connected))
     }
 }
 

--- a/lightyear/src/transport/config.rs
+++ b/lightyear/src/transport/config.rs
@@ -171,7 +171,7 @@ impl IoConfig {
     }
 
     pub fn connect(self) -> Result<Io> {
-        let transport = self.transport.build().connect()?;
+        let (transport, state) = self.transport.build().connect()?;
         let local_addr = transport.local_addr();
         let (sender, receiver, close_fn) = transport.split();
         let receiver: BoxedReceiver = if let Some(conditioner_config) = self.conditioner {
@@ -185,6 +185,7 @@ impl IoConfig {
             sender,
             receiver,
             close_fn,
+            state,
             stats: IoStats::default(),
         })
     }

--- a/lightyear/src/transport/dummy.rs
+++ b/lightyear/src/transport/dummy.rs
@@ -1,6 +1,7 @@
 //! Dummy io for connections that provide their own way of sending and receiving raw bytes (for example steamworks).
 use std::net::SocketAddr;
 
+use crate::transport::io::IoState;
 use crate::transport::{
     BoxedCloseFn, BoxedReceiver, BoxedSender, PacketReceiver, PacketSender, Transport,
     TransportBuilder, TransportEnum, LOCAL_SOCKET,
@@ -12,8 +13,8 @@ use super::error::Result;
 pub struct DummyIo;
 
 impl TransportBuilder for DummyIo {
-    fn connect(self) -> Result<TransportEnum> {
-        Ok(TransportEnum::Dummy(self))
+    fn connect(self) -> Result<(TransportEnum, IoState)> {
+        Ok((TransportEnum::Dummy(self), IoState::Connected))
     }
 }
 

--- a/lightyear/src/transport/io.rs
+++ b/lightyear/src/transport/io.rs
@@ -174,7 +174,7 @@ impl Plugin for IoDiagnosticsPlugin {
 /// Tracks the state of creating the Io
 pub(crate) enum IoState {
     Connecting {
-        error_channel: tokio::sync::mpsc::Receiver<Option<Error>>,
+        error_channel: async_channel::Receiver<Option<Error>>,
     },
     Connected,
     Disconnected,

--- a/lightyear/src/transport/io.rs
+++ b/lightyear/src/transport/io.rs
@@ -18,7 +18,7 @@ use crate::transport::middleware::conditioner::{
 use crate::transport::middleware::PacketReceiverWrapper;
 use crate::transport::{PacketReceiver, PacketSender, Transport};
 
-use super::error::Result;
+use super::error::{Error, Result};
 use super::{
     BoxedCloseFn, BoxedReceiver, BoxedSender, TransportBuilder, TransportBuilderEnum, LOCAL_SOCKET,
 };
@@ -30,6 +30,7 @@ pub struct Io {
     pub(crate) sender: BoxedSender,
     pub(crate) receiver: BoxedReceiver,
     pub(crate) close_fn: Option<BoxedCloseFn>,
+    pub(crate) state: IoState,
     pub(crate) stats: IoStats,
 }
 
@@ -168,4 +169,13 @@ impl Plugin for IoDiagnosticsPlugin {
                 .with_max_history_length(IoDiagnosticsPlugin::DIAGNOSTIC_HISTORY_LEN),
         );
     }
+}
+
+/// Tracks the state of creating the Io
+pub(crate) enum IoState {
+    Connecting {
+        error_channel: tokio::sync::mpsc::Receiver<Option<Error>>,
+    },
+    Connected,
+    Disconnected,
 }

--- a/lightyear/src/transport/local.rs
+++ b/lightyear/src/transport/local.rs
@@ -4,6 +4,7 @@ use std::net::SocketAddr;
 
 use crossbeam_channel::{Receiver, Sender};
 
+use crate::transport::io::IoState;
 use crate::transport::{
     BoxedCloseFn, BoxedReceiver, BoxedSender, PacketReceiver, PacketSender, Transport,
     TransportBuilder, TransportEnum, LOCAL_SOCKET,
@@ -18,14 +19,17 @@ pub(crate) struct LocalChannelBuilder {
 }
 
 impl TransportBuilder for LocalChannelBuilder {
-    fn connect(self) -> Result<TransportEnum> {
-        Ok(TransportEnum::LocalChannel(LocalChannel {
-            sender: LocalChannelSender { send: self.send },
-            receiver: LocalChannelReceiver {
-                buffer: vec![],
-                recv: self.recv,
-            },
-        }))
+    fn connect(self) -> Result<(TransportEnum, IoState)> {
+        Ok((
+            TransportEnum::LocalChannel(LocalChannel {
+                sender: LocalChannelSender { send: self.send },
+                receiver: LocalChannelReceiver {
+                    buffer: vec![],
+                    recv: self.recv,
+                },
+            }),
+            IoState::Connected,
+        ))
     }
 }
 

--- a/lightyear/src/transport/mod.rs
+++ b/lightyear/src/transport/mod.rs
@@ -8,6 +8,7 @@ use error::Result;
 
 use crate::transport::channels::Channels;
 use crate::transport::dummy::DummyIo;
+use crate::transport::io::IoState;
 use crate::transport::local::{LocalChannel, LocalChannelBuilder};
 #[cfg(not(target_family = "wasm"))]
 use crate::transport::udp::{UdpSocket, UdpSocketBuilder};
@@ -76,7 +77,7 @@ pub(crate) trait TransportBuilder: Send + Sync {
     /// Attempt to:
     /// - connect to the remote (for clients)
     /// - listen to incoming connections (for server)
-    fn connect(self) -> Result<TransportEnum>;
+    fn connect(self) -> Result<(TransportEnum, IoState)>;
 
     // TODO maybe add a `async fn ready() -> bool` function?
 }

--- a/lightyear/src/transport/udp.rs
+++ b/lightyear/src/transport/udp.rs
@@ -112,13 +112,13 @@ mod tests {
     fn test_udp_socket() -> Result<(), anyhow::Error> {
         // let the OS assign a port
         let local_addr = SocketAddr::from_str("127.0.0.1:0")?;
-        let client_socket = UdpSocketBuilder { local_addr }
+        let (client_socket, _) = UdpSocketBuilder { local_addr }
             .connect()
             .context("could not connect to socket")?;
         let client_addr = client_socket.local_addr();
         let (mut client_sender, _, _) = client_socket.split();
 
-        let server_socket = UdpSocketBuilder { local_addr }
+        let (server_socket, _) = UdpSocketBuilder { local_addr }
             .connect()
             .context("could not connect to socket")?;
         let server_addr = server_socket.local_addr();
@@ -145,13 +145,13 @@ mod tests {
         // let the OS assign a port
         let local_addr = SocketAddr::from_str("127.0.0.1:0")?;
 
-        let client_socket = UdpSocketBuilder { local_addr }
+        let (client_socket, _) = UdpSocketBuilder { local_addr }
             .connect()
             .context("could not connect to socket")?;
         let client_addr = client_socket.local_addr();
         let (mut client_sender, _, _) = client_socket.split();
 
-        let server_socket = UdpSocketBuilder { local_addr }
+        let (server_socket, _) = UdpSocketBuilder { local_addr }
             .connect()
             .context("could not connect to socket")?;
         let server_addr = server_socket.local_addr();

--- a/lightyear/src/transport/udp.rs
+++ b/lightyear/src/transport/udp.rs
@@ -4,6 +4,7 @@ use std::sync::{Arc, Mutex};
 
 use anyhow::Context;
 
+use crate::transport::io::IoState;
 use crate::transport::{
     BoxedCloseFn, BoxedReceiver, BoxedSender, PacketReceiver, PacketSender, Transport,
     TransportBuilder, TransportEnum, MTU,
@@ -16,7 +17,7 @@ pub struct UdpSocketBuilder {
 }
 
 impl TransportBuilder for UdpSocketBuilder {
-    fn connect(self) -> Result<TransportEnum> {
+    fn connect(self) -> Result<(TransportEnum, IoState)> {
         let udp_socket = std::net::UdpSocket::bind(self.local_addr)?;
         let local_addr = udp_socket.local_addr()?;
         let socket = Arc::new(Mutex::new(udp_socket));
@@ -26,11 +27,14 @@ impl TransportBuilder for UdpSocketBuilder {
             buffer: [0; MTU],
         };
         let receiver = sender.clone();
-        Ok(TransportEnum::UdpSocket(UdpSocket {
-            local_addr,
-            sender,
-            receiver,
-        }))
+        Ok((
+            TransportEnum::UdpSocket(UdpSocket {
+                local_addr,
+                sender,
+                receiver,
+            }),
+            IoState::Connected,
+        ))
     }
 }
 

--- a/lightyear/src/transport/websocket/client_native.rs
+++ b/lightyear/src/transport/websocket/client_native.rs
@@ -44,7 +44,7 @@ impl TransportBuilder for WebSocketClientSocketBuilder {
         let (clientbound_tx, clientbound_rx) = unbounded_channel::<Message>();
         let (close_tx, mut close_rx) = mpsc::channel(1);
         // channels used to check the status of the io task
-        let (status_tx, status_rx) = mpsc::channel(1);
+        let (status_tx, status_rx) = async_channel::bounded(1);
 
         let sender = WebSocketClientSocketSender { serverbound_tx };
         let receiver = WebSocketClientSocketReceiver {

--- a/lightyear/src/transport/websocket/client_native.rs
+++ b/lightyear/src/transport/websocket/client_native.rs
@@ -28,6 +28,7 @@ use tracing::{debug, info, trace};
 use tracing_log::log::error;
 
 use crate::transport::error::{Error, Result};
+use crate::transport::io::IoState;
 use crate::transport::{
     BoxedCloseFn, BoxedReceiver, BoxedSender, PacketReceiver, PacketSender, Transport,
     TransportBuilder, TransportEnum, LOCAL_SOCKET, MTU,
@@ -38,10 +39,12 @@ pub(crate) struct WebSocketClientSocketBuilder {
 }
 
 impl TransportBuilder for WebSocketClientSocketBuilder {
-    fn connect(self) -> Result<TransportEnum> {
+    fn connect(self) -> Result<(TransportEnum, IoState)> {
         let (serverbound_tx, mut serverbound_rx) = unbounded_channel::<Message>();
         let (clientbound_tx, clientbound_rx) = unbounded_channel::<Message>();
         let (close_tx, mut close_rx) = mpsc::channel(1);
+        // channels used to check the status of the io task
+        let (status_tx, status_rx) = mpsc::channel(1);
 
         let sender = WebSocketClientSocketSender { serverbound_tx };
         let receiver = WebSocketClientSocketReceiver {
@@ -50,60 +53,67 @@ impl TransportBuilder for WebSocketClientSocketBuilder {
             clientbound_rx,
         };
 
-        // TODO: make connect async?
-        // connect to the server
-        let (ws_stream, _) = IoTaskPool::get()
-            .scope(|scope| {
-                scope.spawn(Compat::new(async move {
-                    connect_async_with_config(format!("ws://{}/", self.server_addr), None, true)
-                        .await
-                }))
-            })
-            .pop()
-            .unwrap()?;
-        info!("WebSocket handshake has been successfully completed");
-        let (mut write, mut read) = ws_stream.split();
-
-        let send_handle = IoTaskPool::get().spawn(Compat::new(async move {
-            while let Some(msg) = read.next().await {
-                let msg = msg
-                    .map_err(|e| {
-                        error!("Error while receiving websocket msg: {}", e);
-                    })
-                    .unwrap();
-
-                clientbound_tx
-                    .send(msg)
-                    .expect("Unable to propagate the read websocket message to the receiver");
-            }
-            // when we reach this point, the stream is closed
-        }));
-        let recv_handle = IoTaskPool::get().spawn(Compat::new(async move {
-            while let Some(msg) = serverbound_rx.recv().await {
-                write
-                    .send(msg)
-                    .await
-                    .map_err(|e| {
-                        error!("Encountered error while sending websocket msg: {}", e);
-                    })
-                    .unwrap();
-            }
-        }));
-        // wait for a signal that the io should be closed
         IoTaskPool::get()
-            .spawn(async move {
+            .spawn(Compat::new(async move {
+                let ws_stream = match connect_async_with_config(
+                    format!("ws://{}/", self.server_addr),
+                    None,
+                    true,
+                )
+                .await
+                {
+                    Ok((ws_stream, _)) => ws_stream,
+                    Err(e) => {
+                        status_tx.send(Some(e.into())).await.unwrap();
+                        return;
+                    }
+                };
+                info!("WebSocket handshake has been successfully completed");
+                let (mut write, mut read) = ws_stream.split();
+
+                let send_handle = IoTaskPool::get().spawn(Compat::new(async move {
+                    while let Some(msg) = read.next().await {
+                        let msg = msg
+                            .map_err(|e| {
+                                error!("Error while receiving websocket msg: {}", e);
+                            })
+                            .unwrap();
+
+                        clientbound_tx.send(msg).expect(
+                            "Unable to propagate the read websocket message to the receiver",
+                        );
+                    }
+                    // when we reach this point, the stream is closed
+                }));
+                let recv_handle = IoTaskPool::get().spawn(Compat::new(async move {
+                    while let Some(msg) = serverbound_rx.recv().await {
+                        write
+                            .send(msg)
+                            .await
+                            .map_err(|e| {
+                                error!("Encountered error while sending websocket msg: {}", e);
+                            })
+                            .unwrap();
+                    }
+                }));
+                // wait for a signal that the io should be closed
                 close_rx.recv().await;
                 info!("Close websocket connection");
                 send_handle.cancel().await;
                 recv_handle.cancel().await;
-            })
+            }))
             .detach();
-        Ok(TransportEnum::WebSocketClient(WebSocketClientSocket {
-            local_addr: self.server_addr,
-            sender,
-            receiver,
-            close_sender: close_tx,
-        }))
+        Ok((
+            TransportEnum::WebSocketClient(WebSocketClientSocket {
+                local_addr: self.server_addr,
+                sender,
+                receiver,
+                close_sender: close_tx,
+            }),
+            IoState::Connecting {
+                error_channel: status_rx,
+            },
+        ))
     }
 }
 

--- a/lightyear/src/transport/websocket/server.rs
+++ b/lightyear/src/transport/websocket/server.rs
@@ -11,6 +11,7 @@ use futures_util::{
     stream::{SplitSink, TryStreamExt},
     SinkExt, StreamExt, TryFutureExt,
 };
+use tokio::sync::mpsc;
 use tokio::{
     net::{TcpListener, TcpStream},
     sync::mpsc::{error::TryRecvError, unbounded_channel, UnboundedReceiver, UnboundedSender},
@@ -20,6 +21,7 @@ use tracing::{info, trace};
 use tracing_log::log::error;
 
 use crate::transport::error::{Error, Result};
+use crate::transport::io::IoState;
 use crate::transport::{
     BoxedCloseFn, BoxedReceiver, BoxedSender, PacketReceiver, PacketSender, Transport,
     TransportBuilder, TransportEnum, MTU,
@@ -30,9 +32,11 @@ pub(crate) struct WebSocketServerSocketBuilder {
 }
 
 impl TransportBuilder for WebSocketServerSocketBuilder {
-    fn connect(self) -> Result<TransportEnum> {
+    fn connect(self) -> Result<(TransportEnum, IoState)> {
         let (serverbound_tx, serverbound_rx) = unbounded_channel::<(SocketAddr, Message)>();
         let clientbound_tx_map = ClientBoundTxMap::new(Mutex::new(HashMap::new()));
+        // channels used to check the status of the io task
+        let (status_tx, status_rx) = mpsc::channel(1);
 
         let sender = WebSocketServerSocketSender {
             server_addr: self.server_addr,
@@ -44,12 +48,15 @@ impl TransportBuilder for WebSocketServerSocketBuilder {
             serverbound_rx,
         };
 
-        let listener = futures_lite::future::block_on(Compat::new(async move {
-            TcpListener::bind(self.server_addr).await
-        }))?;
-
-        IoTaskPool::get()
+        let listener = IoTaskPool::get()
             .spawn(Compat::new(async move {
+                let listener = match TcpListener::bind(self.server_addr).await {
+                    Ok(l) => l,
+                    Err(e) => {
+                        status_tx.send(Some(e.into())).await.unwrap();
+                        return;
+                    }
+                };
                 info!("Starting server websocket task");
                 while let Ok((stream, addr)) = listener.accept().await {
                     let clientbound_tx_map = clientbound_tx_map.clone();
@@ -108,11 +115,16 @@ impl TransportBuilder for WebSocketServerSocketBuilder {
                 }
             }))
             .detach();
-        Ok(TransportEnum::WebSocketServer(WebSocketServerSocket {
-            local_addr: self.server_addr,
-            sender,
-            receiver,
-        }))
+        Ok((
+            TransportEnum::WebSocketServer(WebSocketServerSocket {
+                local_addr: self.server_addr,
+                sender,
+                receiver,
+            }),
+            IoState::Connecting {
+                error_channel: status_rx,
+            },
+        ))
     }
 }
 

--- a/lightyear/src/transport/websocket/server.rs
+++ b/lightyear/src/transport/websocket/server.rs
@@ -36,7 +36,7 @@ impl TransportBuilder for WebSocketServerSocketBuilder {
         let (serverbound_tx, serverbound_rx) = unbounded_channel::<(SocketAddr, Message)>();
         let clientbound_tx_map = ClientBoundTxMap::new(Mutex::new(HashMap::new()));
         // channels used to check the status of the io task
-        let (status_tx, status_rx) = mpsc::channel(1);
+        let (status_tx, status_rx) = async_channel::bounded(1);
 
         let sender = WebSocketServerSocketSender {
             server_addr: self.server_addr,

--- a/lightyear/src/transport/webtransport/client_native.rs
+++ b/lightyear/src/transport/webtransport/client_native.rs
@@ -48,6 +48,7 @@ impl TransportBuilder for WebTransportClientSocketBuilder {
             let endpoint = match wtransport::Endpoint::client(config) {
                 Ok(e) => {e}
                 Err(e) => {
+                    error!("Error creating webtransport endpoint: {:?}", e);
                     status_tx.send(Some(e.into())).await.unwrap();
                     return
                 }
@@ -55,10 +56,12 @@ impl TransportBuilder for WebTransportClientSocketBuilder {
             let connection = match endpoint.connect(&server_url).await {
                 Ok(c) => {c}
                 Err(e) => {
+                    error!("Error creating webtransport connection: {:?}", e);
                     status_tx.send(Some(e.into())).await.unwrap();
                     return
                 }
             };
+            // signal that the io is connected
             status_tx.send(None).await.unwrap();
             info!("Connected.");
 

--- a/lightyear/src/transport/webtransport/client_wasm.rs
+++ b/lightyear/src/transport/webtransport/client_wasm.rs
@@ -32,7 +32,7 @@ impl TransportBuilder for WebTransportClientSocketBuilder {
         // channels used to cancel the task
         let (close_tx, mut close_rx) = mpsc::channel(1);
         // channels used to check the status of the io task
-        let (status_tx, status_rx) = mpsc::channel(1);
+        let (status_tx, status_rx) = async_channel::bounded(1);
 
         let server_url = format!("https://{}", self.server_addr);
         info!(

--- a/lightyear/src/transport/webtransport/client_wasm.rs
+++ b/lightyear/src/transport/webtransport/client_wasm.rs
@@ -12,6 +12,7 @@ use tracing::{debug, error, info, trace};
 use xwt_core::prelude::*;
 
 use crate::transport::error::{Error, Result};
+use crate::transport::io::IoState;
 use crate::transport::{
     BoxedCloseFn, BoxedReceiver, BoxedSender, PacketReceiver, PacketSender, Transport,
     TransportBuilder, TransportEnum, MTU,
@@ -24,12 +25,14 @@ pub struct WebTransportClientSocketBuilder {
 }
 
 impl TransportBuilder for WebTransportClientSocketBuilder {
-    fn connect(self) -> Result<TransportEnum> {
+    fn connect(self) -> Result<(TransportEnum, IoState)> {
         // TODO: This can exhaust all available memory unless there is some other way to limit the amount of in-flight data in place
         let (to_server_sender, mut to_server_receiver) = mpsc::unbounded_channel();
         let (from_server_sender, from_server_receiver) = mpsc::unbounded_channel();
         // channels used to cancel the task
         let (close_tx, mut close_rx) = mpsc::channel(1);
+        // channels used to check the status of the io task
+        let (status_tx, status_rx) = mpsc::channel(1);
 
         let server_url = format!("https://{}", self.server_addr);
         info!(
@@ -54,16 +57,37 @@ impl TransportBuilder for WebTransportClientSocketBuilder {
         IoTaskPool::get().spawn_local(async move {
             info!("Starting webtransport io thread");
 
-            let connecting = endpoint
-                .connect(&server_url)
-                .await
-                .map_err(|e| std::io::Error::other(format!("failed to connect to server: {:?}", e)))
-                .expect("failed to connect to server");
-            let connection = connecting
-                .wait_connect()
-                .await
-                .map_err(|e| std::io::Error::other(format!("failed to connect to server: {:?}", e)))
-                .expect("failed to connect to server");
+            let connecting = match endpoint.connect(&server_url).await {
+                Ok(e) => e,
+                Err(e) => {
+                    error!("Error creating webtransport connection: {:?}", e);
+                    status_tx
+                        .send(Some(
+                            std::io::Error::other("error creating webtransport connection").into(),
+                        ))
+                        .await
+                        .unwrap();
+                    return;
+                }
+            };
+            let connection = match connecting.wait_connect().await {
+                Ok(c) => c,
+                Err(e) => {
+                    error!("Error connecting to server: {:?}", e);
+                    status_tx
+                        .send(Some(
+                            std::io::Error::other(
+                                "error connecting webtransport endpoint to server",
+                            )
+                            .into(),
+                        ))
+                        .await
+                        .unwrap();
+                    return;
+                }
+            };
+            // signal that the io is connected
+            status_tx.send(None).await.unwrap();
             let connection = Rc::new(connection);
             send.send(connection.clone()).unwrap();
             send2.send(connection.clone()).unwrap();
@@ -79,7 +103,9 @@ impl TransportBuilder for WebTransportClientSocketBuilder {
         //   cancelled
         IoTaskPool::get()
             .spawn(async move {
-                let connection = recv.await.expect("could not get connection");
+                let Ok(connection) = recv.await else {
+                    return;
+                };
                 loop {
                     match connection.receive_datagram().await {
                         Ok(data) => {
@@ -95,7 +121,9 @@ impl TransportBuilder for WebTransportClientSocketBuilder {
             .detach();
         IoTaskPool::get()
             .spawn(async move {
-                let connection = recv2.await.expect("could not get connection");
+                let Ok(connection) = recv2.await else {
+                    return;
+                };
                 loop {
                     if let Some(msg) = to_server_receiver.recv().await {
                         trace!("send datagram to server: {:?}", &msg);
@@ -108,7 +136,9 @@ impl TransportBuilder for WebTransportClientSocketBuilder {
             .detach();
         IoTaskPool::get()
             .spawn(async move {
-                let connection = recv3.await.expect("could not get connection");
+                let Ok(connection) = recv3.await else {
+                    return;
+                };
                 // Wait for a close signal from the close channel, or for the quic connection to be closed
                 close_rx.recv().await;
                 info!("WebTransport connection closed.");
@@ -124,12 +154,15 @@ impl TransportBuilder for WebTransportClientSocketBuilder {
             from_server_receiver,
             buffer: [0; MTU],
         };
-        Ok(TransportEnum::WebTransportClient(
-            WebTransportClientSocket {
+        Ok((
+            TransportEnum::WebTransportClient(WebTransportClientSocket {
                 local_addr: self.client_addr,
                 sender,
                 receiver,
                 close_sender: close_tx,
+            }),
+            IoState::Connecting {
+                error_channel: status_rx,
             },
         ))
     }

--- a/lightyear/src/transport/webtransport/server.rs
+++ b/lightyear/src/transport/webtransport/server.rs
@@ -36,7 +36,7 @@ impl TransportBuilder for WebTransportServerSocketBuilder {
             mpsc::unbounded_channel::<(Box<[u8]>, SocketAddr)>();
         let (from_client_sender, from_client_receiver) = mpsc::unbounded_channel();
         // channels used to check the status of the io task
-        let (status_tx, status_rx) = mpsc::channel(1);
+        let (status_tx, status_rx) = async_channel::bounded(1);
         let to_client_senders = Arc::new(Mutex::new(HashMap::new()));
 
         let sender = WebTransportServerSocketSender {
@@ -73,6 +73,7 @@ impl TransportBuilder for WebTransportServerSocketBuilder {
                     // new client connecting
                     let incoming_session = endpoint.accept().await;
 
+                    // TODO: when a client disconnects (i.e. the connection is closed), close the task here as well
                     IoTaskPool::get()
                         .spawn(Compat::new(WebTransportServerSocket::handle_client(
                             incoming_session,

--- a/lightyear/src/transport/webtransport/server.rs
+++ b/lightyear/src/transport/webtransport/server.rs
@@ -19,6 +19,7 @@ use wtransport::ServerConfig;
 use wtransport::{Connection, Endpoint};
 
 use crate::transport::error::{Error, Result};
+use crate::transport::io::IoState;
 use crate::transport::{
     BoxedCloseFn, BoxedReceiver, BoxedSender, PacketReceiver, PacketSender, Transport,
     TransportBuilder, TransportEnum, MTU,
@@ -30,21 +31,13 @@ pub(crate) struct WebTransportServerSocketBuilder {
 }
 
 impl TransportBuilder for WebTransportServerSocketBuilder {
-    fn connect(self) -> Result<TransportEnum> {
+    fn connect(self) -> Result<(TransportEnum, IoState)> {
         let (to_client_sender, to_client_receiver) =
             mpsc::unbounded_channel::<(Box<[u8]>, SocketAddr)>();
         let (from_client_sender, from_client_receiver) = mpsc::unbounded_channel();
+        // channels used to check the status of the io task
+        let (status_tx, status_rx) = mpsc::channel(1);
         let to_client_senders = Arc::new(Mutex::new(HashMap::new()));
-
-        let config = ServerConfig::builder()
-            .with_bind_address(self.server_addr)
-            .with_certificate(self.certificate)
-            .build();
-        // need to run this with Compat because it requires the tokio reactor
-        let endpoint = futures_lite::future::block_on(Compat::new(async {
-            let endpoint = wtransport::Endpoint::server(config)?;
-            Ok::<_, Error>(endpoint)
-        }))?;
 
         let sender = WebTransportServerSocketSender {
             server_addr: self.server_addr,
@@ -56,8 +49,21 @@ impl TransportBuilder for WebTransportServerSocketBuilder {
             from_client_receiver,
         };
 
+        let config = ServerConfig::builder()
+            .with_bind_address(self.server_addr)
+            .with_certificate(self.certificate)
+            .build();
+        // need to run this with Compat because it requires the tokio reactor
         IoTaskPool::get()
             .spawn(Compat::new(async move {
+                let endpoint = match wtransport::Endpoint::server(config) {
+                    Ok(e) => e,
+                    Err(e) => {
+                        status_tx.send(Some(e.into())).await.unwrap();
+                        return;
+                    }
+                };
+
                 info!("Starting server webtransport task");
                 loop {
                     // clone the channel for each client
@@ -78,11 +84,14 @@ impl TransportBuilder for WebTransportServerSocketBuilder {
             }))
             .detach();
 
-        Ok(TransportEnum::WebTransportServer(
-            WebTransportServerSocket {
+        Ok((
+            TransportEnum::WebTransportServer(WebTransportServerSocket {
                 local_addr: self.server_addr,
                 sender,
                 receiver,
+            }),
+            IoState::Connecting {
+                error_channel: status_rx,
             },
         ))
     }


### PR DESCRIPTION
Similar to https://github.com/cBournhonesque/lightyear/pull/255
This PR aims to fix https://github.com/cBournhonesque/lightyear/issues/247, where the problem is establishing the io can block the client's main thread (especially if the server is not online), which causes the app to be non-responsive.

The solution here is to start the io connection process in a detached background task, and maintain an `IoState` which lets us know if the io is connected or not. The IoState gets updated via channels.

TESTED:
- trying to connect when there is no server now returns early (doesn't freeze the app) and logs an error message

TODO:
- [x] upon disconnection, should we call close() on the ClientConnection and then remove it, to delete any underlying io task?

- [ ] disconnecting in wasm freezes the app