### PR TITLE
Despawn replicated resources on disconnect

### DIFF
--- a/lightyear/src/server/networking.rs
+++ b/lightyear/src/server/networking.rs
@@ -5,8 +5,13 @@ use bevy::prelude::*;
 use tracing::{debug, error, trace, trace_span};
 
 use crate::_reexport::{ComponentProtocol, ServerMarker};
+use crate::client::components::Confirmed;
+use crate::client::config::ClientConfig;
+use crate::client::interpolation::Interpolated;
+use crate::client::prediction::Predicted;
+use crate::connection::client::ClientConnection;
 use crate::connection::server::{NetConfig, NetServer, ServerConnection, ServerConnections};
-use crate::prelude::{TickManager, TimeManager};
+use crate::prelude::{Mode, TickManager, TimeManager};
 use crate::protocol::message::MessageProtocol;
 use crate::protocol::Protocol;
 use crate::server::connection::ConnectionManager;

--- a/lightyear/src/server/networking.rs
+++ b/lightyear/src/server/networking.rs
@@ -5,13 +5,8 @@ use bevy::prelude::*;
 use tracing::{debug, error, trace, trace_span};
 
 use crate::_reexport::{ComponentProtocol, ServerMarker};
-use crate::client::components::Confirmed;
-use crate::client::config::ClientConfig;
-use crate::client::interpolation::Interpolated;
-use crate::client::prediction::Predicted;
-use crate::connection::client::ClientConnection;
 use crate::connection::server::{NetConfig, NetServer, ServerConnection, ServerConnections};
-use crate::prelude::{Mode, TickManager, TimeManager};
+use crate::prelude::{TickManager, TimeManager};
 use crate::protocol::message::MessageProtocol;
 use crate::protocol::Protocol;
 use crate::server::connection::ConnectionManager;

--- a/lightyear/src/shared/replication/receive.rs
+++ b/lightyear/src/shared/replication/receive.rs
@@ -220,7 +220,12 @@ impl<P: Protocol> ReplicationReceiver<P> {
                             continue;
                         }
                         // TODO: optimization: spawn the bundle of insert components
-                        let local_entity = world.spawn_empty();
+                        // we spawn every replicated entity with the `Confirmed` component
+                        let local_entity = world.spawn(Confirmed {
+                            predicted: None,
+                            interpolated: None,
+                            tick,
+                        });
                         self.remote_entity_map.insert(*entity, local_entity.id());
                         trace!("Updated remote entity map: {:?}", self.remote_entity_map);
 


### PR DESCRIPTION
Related to https://github.com/cBournhonesque/lightyear/issues/260

This PR:
- adds a `Confirmed` component on EVERY received replicated entity; those Confirmed entity will get an updated `Tick` every time we receive an update for the corresponding `ReplicationGroup`
- upon disconnection of the **CLIENT**, despawns every Confirmed/Predicted/Interpolated entity
- despawns any replicated resource if the entity gets despawned


TODO: (in a later PR):
- do the same thing on the server side (for received replicated entities)