### PR TITLE
cancel wasm webtransport tasks if the connection is closed

### DIFF
--- a/lightyear/Cargo.toml
+++ b/lightyear/Cargo.toml
@@ -14,31 +14,31 @@ exclude = ["/tests"]
 
 [features]
 metrics = [
-    "dep:metrics",
-    "metrics-util",
-    "metrics-tracing-context",
-    "metrics-exporter-prometheus",
-    "dep:tokio",
+  "dep:metrics",
+  "metrics-util",
+  "metrics-tracing-context",
+  "metrics-exporter-prometheus",
+  "dep:tokio",
 ]
 mock_time = ["dep:mock_instant"]
 render = ["bevy/bevy_render"]
 webtransport = [
-    "dep:wtransport",
-    "dep:xwt-core",
-    "dep:xwt-web-sys",
-    "dep:web-sys",
-    "dep:tokio",
-    "dep:ring",
-    "dep:wasm-bindgen-futures",
+  "dep:wtransport",
+  "dep:xwt-core",
+  "dep:xwt-web-sys",
+  "dep:web-sys",
+  "dep:tokio",
+  "dep:ring",
+  "dep:wasm-bindgen-futures",
 ]
 leafwing = ["dep:leafwing-input-manager", "lightyear_macros/leafwing"]
 xpbd_2d = ["dep:bevy_xpbd_2d"]
 websocket = [
-    "dep:tokio",
-    "dep:tokio-tungstenite",
-    "dep:futures-util",
-    "dep:web-sys",
-    "dep:wasm-bindgen",
+  "dep:tokio",
+  "dep:tokio-tungstenite",
+  "dep:futures-util",
+  "dep:web-sys",
+  "dep:wasm-bindgen",
 ]
 steam = ["dep:steamworks"]
 
@@ -73,7 +73,7 @@ bevy_xpbd_2d = { version = "0.4", optional = true }
 
 # serialization
 bitcode = { version = "0.5.1", package = "bitcode_lightyear_patch", path = "../vendor/bitcode", features = [
-    "serde",
+  "serde",
 ] }
 bytes = { version = "1.5", features = ["serde"] }
 self_cell = "1.0"
@@ -90,8 +90,8 @@ lightyear_macros = { version = "0.13.0", path = "../macros" }
 tracing = "0.1.40"
 tracing-log = "0.2.0"
 tracing-subscriber = { version = "0.3.17", features = [
-    "registry",
-    "env-filter",
+  "registry",
+  "env-filter",
 ] }
 
 # server
@@ -102,12 +102,12 @@ metrics = { version = "0.22", optional = true }
 metrics-util = { version = "0.15", optional = true }
 metrics-tracing-context = { version = "0.15", optional = true }
 metrics-exporter-prometheus = { version = "0.13.0", optional = true, default-features = false, features = [
-    "http-listener",
+  "http-listener",
 ] }
 
 # bevy
 bevy = { version = "0.13", default-features = false, features = [
-    "multi-threaded",
+  "multi-threaded",
 ] }
 
 
@@ -117,7 +117,8 @@ futures-util = { version = "0.3.30", optional = true }
 # transport
 # we don't need any tokio features, we use only use the tokio channels
 tokio = { version = "1.36", features = [
-    "sync", "macros"
+  "sync",
+  "macros",
 ], default-features = false, optional = true }
 futures = "0.3.30"
 async-compat = "0.2.3"
@@ -129,37 +130,37 @@ async-channel = "2.2.0"
 steamworks = { version = "0.11", optional = true }
 # webtransport
 wtransport = { version = "=0.1.11", optional = true, features = [
-    "self-signed",
-    "dangerous-configuration",
+  "self-signed",
+  "dangerous-configuration",
 ] }
 # websocket
 tokio-tungstenite = { version = "0.21.0", optional = true, features = [
-    "connect",
-    "handshake",
+  "connect",
+  "handshake",
 ] }
 
 [target."cfg(target_family = \"wasm\")".dependencies]
 console_error_panic_hook = { version = "0.1.7" }
 ring = { version = "0.17.8", optional = true, default-features = false }
 web-sys = { version = "0.3", optional = true, features = [
-    "WebTransport",
-    "WebTransportHash",
-    "WebTransportOptions",
-    "WebTransportBidirectionalStream",
-    "WebTransportSendStream",
-    "WebTransportReceiveStream",
-    "ReadableStreamDefaultReader",
-    "WritableStreamDefaultWriter",
-    "WebTransportDatagramDuplexStream",
-    "WebSocket",
-    "CloseEvent",
-    "ErrorEvent",
-    "MessageEvent",
-    "BinaryType",
+  "WebTransport",
+  "WebTransportHash",
+  "WebTransportOptions",
+  "WebTransportBidirectionalStream",
+  "WebTransportSendStream",
+  "WebTransportReceiveStream",
+  "ReadableStreamDefaultReader",
+  "WritableStreamDefaultWriter",
+  "WebTransportDatagramDuplexStream",
+  "WebSocket",
+  "CloseEvent",
+  "ErrorEvent",
+  "MessageEvent",
+  "BinaryType",
 ] }
 futures-lite = { version = "2.1.0", optional = true }
 getrandom = { version = "0.2.11", features = [
-    "js", # feature 'js' is required for wasm
+  "js", # feature 'js' is required for wasm
 ] }
 xwt-core = { version = "0.4", optional = true }
 xwt-web-sys = { version = "0.11", optional = true }

--- a/lightyear/Cargo.toml
+++ b/lightyear/Cargo.toml
@@ -14,30 +14,31 @@ exclude = ["/tests"]
 
 [features]
 metrics = [
-  "dep:metrics",
-  "metrics-util",
-  "metrics-tracing-context",
-  "metrics-exporter-prometheus",
-  "dep:tokio",
+    "dep:metrics",
+    "metrics-util",
+    "metrics-tracing-context",
+    "metrics-exporter-prometheus",
+    "dep:tokio",
 ]
 mock_time = ["dep:mock_instant"]
 render = ["bevy/bevy_render"]
 webtransport = [
-  "dep:wtransport",
-  "dep:xwt-core",
-  "dep:xwt-web-sys",
-  "dep:web-sys",
-  "dep:tokio",
-  "dep:ring",
+    "dep:wtransport",
+    "dep:xwt-core",
+    "dep:xwt-web-sys",
+    "dep:web-sys",
+    "dep:tokio",
+    "dep:ring",
+    "dep:wasm-bindgen-futures",
 ]
 leafwing = ["dep:leafwing-input-manager", "lightyear_macros/leafwing"]
 xpbd_2d = ["dep:bevy_xpbd_2d"]
 websocket = [
-  "dep:tokio",
-  "dep:tokio-tungstenite",
-  "dep:futures-util",
-  "dep:web-sys",
-  "dep:wasm-bindgen",
+    "dep:tokio",
+    "dep:tokio-tungstenite",
+    "dep:futures-util",
+    "dep:web-sys",
+    "dep:wasm-bindgen",
 ]
 steam = ["dep:steamworks"]
 
@@ -72,7 +73,7 @@ bevy_xpbd_2d = { version = "0.4", optional = true }
 
 # serialization
 bitcode = { version = "0.5.1", package = "bitcode_lightyear_patch", path = "../vendor/bitcode", features = [
-  "serde",
+    "serde",
 ] }
 bytes = { version = "1.5", features = ["serde"] }
 self_cell = "1.0"
@@ -89,8 +90,8 @@ lightyear_macros = { version = "0.13.0", path = "../macros" }
 tracing = "0.1.40"
 tracing-log = "0.2.0"
 tracing-subscriber = { version = "0.3.17", features = [
-  "registry",
-  "env-filter",
+    "registry",
+    "env-filter",
 ] }
 
 # server
@@ -101,12 +102,12 @@ metrics = { version = "0.22", optional = true }
 metrics-util = { version = "0.15", optional = true }
 metrics-tracing-context = { version = "0.15", optional = true }
 metrics-exporter-prometheus = { version = "0.13.0", optional = true, default-features = false, features = [
-  "http-listener",
+    "http-listener",
 ] }
 
 # bevy
 bevy = { version = "0.13", default-features = false, features = [
-  "multi-threaded",
+    "multi-threaded",
 ] }
 
 
@@ -116,7 +117,7 @@ futures-util = { version = "0.3.30", optional = true }
 # transport
 # we don't need any tokio features, we use only use the tokio channels
 tokio = { version = "1.36", features = [
-  "sync",
+    "sync", "macros"
 ], default-features = false, optional = true }
 futures = "0.3.30"
 async-compat = "0.2.3"
@@ -128,41 +129,42 @@ async-channel = "2.2.0"
 steamworks = { version = "0.11", optional = true }
 # webtransport
 wtransport = { version = "=0.1.11", optional = true, features = [
-  "self-signed",
-  "dangerous-configuration",
+    "self-signed",
+    "dangerous-configuration",
 ] }
 # websocket
 tokio-tungstenite = { version = "0.21.0", optional = true, features = [
-  "connect",
-  "handshake",
+    "connect",
+    "handshake",
 ] }
 
 [target."cfg(target_family = \"wasm\")".dependencies]
 console_error_panic_hook = { version = "0.1.7" }
 ring = { version = "0.17.8", optional = true, default-features = false }
 web-sys = { version = "0.3", optional = true, features = [
-  "WebTransport",
-  "WebTransportHash",
-  "WebTransportOptions",
-  "WebTransportBidirectionalStream",
-  "WebTransportSendStream",
-  "WebTransportReceiveStream",
-  "ReadableStreamDefaultReader",
-  "WritableStreamDefaultWriter",
-  "WebTransportDatagramDuplexStream",
-  "WebSocket",
-  "CloseEvent",
-  "ErrorEvent",
-  "MessageEvent",
-  "BinaryType",
+    "WebTransport",
+    "WebTransportHash",
+    "WebTransportOptions",
+    "WebTransportBidirectionalStream",
+    "WebTransportSendStream",
+    "WebTransportReceiveStream",
+    "ReadableStreamDefaultReader",
+    "WritableStreamDefaultWriter",
+    "WebTransportDatagramDuplexStream",
+    "WebSocket",
+    "CloseEvent",
+    "ErrorEvent",
+    "MessageEvent",
+    "BinaryType",
 ] }
 futures-lite = { version = "2.1.0", optional = true }
 getrandom = { version = "0.2.11", features = [
-  "js", # feature 'js' is required for wasm
+    "js", # feature 'js' is required for wasm
 ] }
 xwt-core = { version = "0.4", optional = true }
 xwt-web-sys = { version = "0.11", optional = true }
 wasm-bindgen = { version = "0.2.90", optional = true }
+wasm-bindgen-futures = { version = "0.4.42", optional = true }
 
 
 [dev-dependencies]


### PR DESCRIPTION
Fixes https://github.com/cBournhonesque/lightyear/issues/259

The issue was caused by the two recv/send tasks in wasm; they were not being cancelled even when the webtransport connection was closed, which was causing them to panic.
Now we close those tasks as soon as the connection is closed.

I've tested that we can freely connect/disconnect multiple times in wasm.
