### PR TITLE
Improve rollback parallelism by adding a RwLock around the RollbackState

### DIFF
--- a/examples/bullet_prespawn/src/shared.rs
+++ b/examples/bullet_prespawn/src/shared.rs
@@ -170,12 +170,9 @@ pub(crate) fn fixed_update_log(
     ball: Query<(Entity, &Transform), (With<BallMarker>, Without<Confirmed>)>,
     interpolated_ball: Query<(Entity, &Transform), (With<BallMarker>, With<Interpolated>)>,
 ) {
-    let mut tick = tick_manager.tick();
-    if let Some(rollback) = rollback {
-        if let RollbackState::ShouldRollback { current_tick } = rollback.state {
-            tick = current_tick;
-        }
-    }
+    let tick = rollback.map_or(tick_manager.tick(), |r| {
+        tick_manager.tick_or_rollback_tick(r.as_ref())
+    });
     for (entity, transform) in player.iter() {
         trace!(
         ?tick,

--- a/examples/leafwing_inputs/assets/settings.ron
+++ b/examples/leafwing_inputs/assets/settings.ron
@@ -4,7 +4,7 @@ Settings(
         client_id: 0,
         client_port: 0, // the OS will assign a random open port
         server_addr: "127.0.0.1",
-        input_delay_ticks: 5,
+        input_delay_ticks: 0,
         correction_ticks_factor: 1.5,
         conditioner: Some(Conditioner(
             latency_ms: 75,

--- a/examples/leafwing_inputs/src/shared.rs
+++ b/examples/leafwing_inputs/src/shared.rs
@@ -174,12 +174,9 @@ pub(crate) fn after_physics_log(
     >,
     ball: Query<&Position, (With<BallMarker>, Without<Confirmed>)>,
 ) {
-    let mut tick = tick_manager.tick();
-    if let Some(rollback) = rollback {
-        if let RollbackState::ShouldRollback { current_tick } = rollback.state {
-            tick = current_tick;
-        }
-    }
+    let tick = rollback.map_or(tick_manager.tick(), |r| {
+        tick_manager.tick_or_rollback_tick(r.as_ref())
+    });
     for (entity, position, rotation) in players.iter() {
         debug!(
             ?tick,

--- a/lightyear/src/client/input_leafwing.rs
+++ b/lightyear/src/client/input_leafwing.rs
@@ -480,12 +480,9 @@ fn get_rollback_action_state<A: LeafwingUserAction>(
     mut action_state_query: Query<(Entity, &mut ActionState<A>, &InputBuffer<A>)>,
     rollback: Res<Rollback>,
 ) {
-    let tick = match rollback.state {
-        RollbackState::Default => unreachable!(),
-        RollbackState::ShouldRollback {
-            current_tick: rollback_tick,
-        } => rollback_tick,
-    };
+    let tick = rollback
+        .get_rollback_tick()
+        .expect("we should be in rollback");
     for (entity, mut action_state, input_buffer) in action_state_query.iter_mut() {
         // let state_is_empty = input_buffer.get(tick).is_none();
         // let input_buffer = input_buffer.buffer;


### PR DESCRIPTION
Continuation of https://github.com/cBournhonesque/lightyear/commit/0af28f187b4c845f36cbe02daafd2e2815a2b24c, which was merged to main accidentally