### PR TITLE
add prediction unit tests and simplify prediction spawn

### DIFF
--- a/lightyear/src/client/connection.rs
+++ b/lightyear/src/client/connection.rs
@@ -136,6 +136,7 @@ impl ConnectionManager {
         self.sync_manager.is_synced()
     }
 
+    /// Returns true if we received a new server packet on this frame
     pub(crate) fn received_new_server_tick(&self) -> bool {
         self.sync_manager.duration_since_latest_received_server_tick == Duration::default()
     }

--- a/lightyear/src/client/prediction/rollback.rs
+++ b/lightyear/src/client/prediction/rollback.rs
@@ -106,32 +106,36 @@ pub(crate) fn check_rollback<C: SyncComponent>(
     tick_manager: Res<TickManager>,
     connection: Res<ConnectionManager>,
     // We also snap the value of the component to the server state if we are in rollback
-    // We use Option<> because the predicted component could have been removed while it still exists in Confirmed
     mut predicted_query: Query<&mut PredictionHistory<C>, (With<Predicted>, Without<Confirmed>)>,
+    // We use Option<> because the predicted component could have been removed while it still exists in Confirmed
     confirmed_query: Query<(Entity, Option<&C>, Ref<Confirmed>)>,
     rollback: Res<Rollback>,
 ) {
+    // TODO: can just enable bevy spans?
+    let _span = trace_span!("client rollback check");
     let kind = std::any::type_name::<C>();
 
     // TODO: for mode=simple/once, we still need to re-add the component if the entity ends up not being despawned!
-    if !connection.is_synced() || !connection.received_new_server_tick() {
+
+    // TODO: maybe we can check if we receive any replication packets?
+    // no need to check for rollback if we didn't receive any packet
+    if !connection.received_new_server_tick() {
         return;
     }
 
     let current_tick = tick_manager.tick();
-    // TODO: can just enable bevy spans?
-    let _span = trace_span!("client rollback check");
-
     for (confirmed_entity, confirmed_component, confirmed) in confirmed_query.iter() {
+        // NOTE: it is not enough to check if we received any ComponentRemoveEvent<C>, ComponentUpdateEvent<C> and ComponentInsertEvent<C>
+        //  because we could have entity A and B in the same ReplicationGroup.
+        //  We receive a message with entity B updates, but no entity A updates, **which means that entity A is still in the same state as before**
+        //  on the confirmed tick! This means that we received an update for entity A, and we still need to check for rollback.
+
         // 0. only check rollback when any entity in the replication group has been updated
         // (i.e. the confirmed tick has been updated)
         if !confirmed.is_changed() {
             continue;
         }
 
-        // let confirmed_entity = event.entity();
-        // TODO: no need to get the Predicted component because we're not using it right now..
-        //  we could use it in the future if we add more state in the Predicted Component
         // 1. Get the predicted entity, and it's history
         let Some(p) = confirmed.predicted else {
             continue;
@@ -339,6 +343,9 @@ pub(crate) fn prepare_rollback_prespawn<C: SyncComponent>(
     mut commands: Commands,
     config: Res<ClientConfig>,
     tick_manager: Res<TickManager>,
+    // TODO: have a way to make these systems run in parallel
+    //  - either by using RwLock in PredictionManager
+    //  - or by using a system that iterates through archetypes, a la replicon?
     mut prediction_manager: ResMut<PredictionManager>,
     // We also snap the value of the component to the server state if we are in rollback
     // We use Option<> because the predicted component could have been removed while it still exists in Confirmed
@@ -504,455 +511,412 @@ pub(crate) fn increment_rollback_tick(rollback: Res<Rollback>) {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
+pub(super) mod test_utils {
+    use crate::client::components::Confirmed;
+    use crate::client::connection::ConnectionManager;
+    use crate::prelude::Tick;
     use crate::tests::stepper::BevyStepper;
+    use bevy::prelude::Entity;
+    use std::time::Duration;
 
+    /// Helper function to simulate that we received a server message
+    pub(super) fn received_confirmed_update(
+        stepper: &mut BevyStepper,
+        confirmed: Entity,
+        tick: Tick,
+    ) {
+        stepper
+            .client_app
+            .world
+            .resource_mut::<ConnectionManager>()
+            .sync_manager
+            .duration_since_latest_received_server_tick = Duration::default();
+        stepper
+            .client_app
+            .world
+            .entity_mut(confirmed)
+            .get_mut::<Confirmed>()
+            .unwrap()
+            .tick = tick;
+    }
+}
+
+#[cfg(test)]
+mod unit_tests {
+    use super::test_utils::*;
+    use super::*;
+    use crate::shared::tick_manager::increment_tick;
+    use crate::tests::protocol::Component1;
+    use crate::tests::stepper::{BevyStepper, Step};
+    use bevy::ecs::system::RunSystemOnce;
+    use std::time::Duration;
+
+    // TODO: check that if A is updated but B is not, and A and B are in the same replication group,
+    //  then we need to check the rollback for B as well!
     /// Check that we enter a rollback state when confirmed entity is updated at tick T and:
     /// 1. Predicted component and Confirmed component are different
     /// 2. Confirmed component does not exist and predicted component exists
     /// 3. Confirmed component exists but predicted component does not exist
+    /// 4. If confirmed component is the same value as what we have in the history for predicted component, we do not rollback
     #[test]
-    fn check_rollback() {
-        let stepper = BevyStepper::default();
+    fn test_check_rollback() {
+        let mut stepper = BevyStepper::default();
+
+        // add predicted/confirmed entities
+        let confirmed = stepper.client_app.world.spawn(Confirmed::default()).id();
+        let predicted = stepper
+            .client_app
+            .world
+            .spawn(Predicted {
+                confirmed_entity: Some(confirmed),
+            })
+            .id();
+        stepper
+            .client_app
+            .world
+            .entity_mut(confirmed)
+            .get_mut::<Confirmed>()
+            .unwrap()
+            .predicted = Some(predicted);
+        stepper
+            .client_app
+            .world
+            .entity_mut(confirmed)
+            .insert(Component1(1.0));
+        stepper.frame_step();
+
+        // 1. Predicted component and confirmed component are different
+        let tick = stepper.client_tick();
+        stepper
+            .client_app
+            .world
+            .entity_mut(confirmed)
+            .get_mut::<Component1>()
+            .unwrap()
+            .0 = 2.0;
+        // simulate that we received a server message for the confirmed entity on tick `tick`
+        received_confirmed_update(&mut stepper, confirmed, tick);
+        stepper
+            .client_app
+            .world
+            .run_system_once(check_rollback::<Component1>);
+        assert_eq!(
+            stepper
+                .client_app
+                .world
+                .resource::<Rollback>()
+                .get_rollback_tick(),
+            Some(tick + 1)
+        );
+
+        // 2. Confirmed component does not exist but predicted component exists
+        // reset rollback state
+        stepper
+            .client_app
+            .world
+            .resource::<Rollback>()
+            .set_non_rollback();
+        stepper
+            .client_app
+            .world
+            .entity_mut(confirmed)
+            .remove::<Component1>();
+        // simulate that we received a server message for the confirmed entity on tick `tick`
+        received_confirmed_update(&mut stepper, confirmed, tick);
+        stepper
+            .client_app
+            .world
+            .run_system_once(check_rollback::<Component1>);
+        assert_eq!(
+            stepper
+                .client_app
+                .world
+                .resource::<Rollback>()
+                .get_rollback_tick(),
+            Some(tick + 1)
+        );
+
+        // 3. Confirmed component exists but predicted component does not exist
+        // reset rollback state
+        stepper
+            .client_app
+            .world
+            .resource::<Rollback>()
+            .set_non_rollback();
+        stepper
+            .client_app
+            .world
+            .entity_mut(predicted)
+            .remove::<Component1>();
+        stepper
+            .client_app
+            .world
+            .entity_mut(confirmed)
+            .insert(Component1(2.0));
+        // simulate that we received a server message for the confirmed entity on tick `tick`
+        received_confirmed_update(&mut stepper, confirmed, tick);
+        stepper
+            .client_app
+            .world
+            .run_system_once(check_rollback::<Component1>);
+        assert_eq!(
+            stepper
+                .client_app
+                .world
+                .resource::<Rollback>()
+                .get_rollback_tick(),
+            Some(tick + 1)
+        );
+
+        // 4. If confirmed component is the same value as what we have in the history for predicted component, we do not rollback
+        // reset rollback state
+        stepper
+            .client_app
+            .world
+            .resource::<Rollback>()
+            .set_non_rollback();
+        stepper
+            .client_app
+            .world
+            .entity_mut(predicted)
+            .get_mut::<PredictionHistory<Component1>>()
+            .unwrap()
+            .add_update(tick, Component1(2.0));
+        // simulate that we received a server message for the confirmed entity on tick `tick`
+        received_confirmed_update(&mut stepper, confirmed, tick);
+        stepper
+            .client_app
+            .world
+            .run_system_once(check_rollback::<Component1>);
+        assert!(!stepper
+            .client_app
+            .world
+            .resource::<Rollback>()
+            .is_rollback());
     }
 }
 
-// #[cfg(test)]
-// mod tests {
-//     use bevy::utils::Duration;
-//
-//     use bevy::prelude::*;
-//     use tracing::{debug, info};
-//
-//     use crate::_reexport::*;
-//     use crate::prelude::client::*;
-//     use crate::prelude::*;
-//     use crate::tests::protocol::*;
-//     use crate::tests::stepper::{BevyStepper, Step};
-//
-//     fn increment_component(
-//         mut commands: Commands,
-//         mut query: Query<(Entity, &mut Component1), With<Predicted>>,
-//     ) {
-//         for (entity, mut component) in query.iter_mut() {
-//             component.0 += 1.0;
-//             if component.0 == 5.0 {
-//                 commands.entity(entity).remove::<Component1>();
-//             }
-//         }
-//     }
-//
-//     fn setup() -> BevyStepper {
-//         let frame_duration = Duration::from_millis(10);
-//         let tick_duration = Duration::from_millis(10);
-//         let shared_config = SharedConfig {
-//             enable_replication: false,
-//             tick: TickConfig::new(tick_duration),
-//             log: LogConfig {
-//                 level: tracing::Level::DEBUG,
-//                 ..Default::default()
-//             },
-//             ..Default::default()
-//         };
-//         let link_conditioner = LinkConditionerConfig {
-//             incoming_latency: Duration::from_millis(40),
-//             incoming_jitter: Duration::from_millis(5),
-//             incoming_loss: 0.05,
-//         };
-//         let sync_config = SyncConfig::default().speedup_factor(1.0);
-//         let prediction_config = PredictionConfig::default().disable(false);
-//         let interpolation_delay = Duration::from_millis(100);
-//         let interpolation_config = InterpolationConfig::default().with_delay(InterpolationDelay {
-//             min_delay: interpolation_delay,
-//             send_interval_ratio: 0.0,
-//         });
-//         let mut stepper = BevyStepper::new(
-//             shared_config,
-//             sync_config,
-//             prediction_config,
-//             interpolation_config,
-//             link_conditioner,
-//             frame_duration,
-//         );
-//         stepper.client_mut().set_synced();
-//         stepper.client_app.add_systems(
-//             FixedUpdate,
-//             increment_component
-//         );
-//         stepper
-//     }
-//
-//     // Test that if a component gets removed from the predicted entity erroneously
-//     // We are still able to rollback properly (the rollback adds the component to the predicted entity)
-//     #[test]
-//     fn test_removed_predicted_component_rollback() -> anyhow::Result<()> {
-//         let mut stepper = setup();
-//
-//         // Create a confirmed entity
-//         let confirmed = stepper
-//             .client_app
-//             .world
-//             .spawn((Component1(0.0), ShouldBePredicted))
-//             .id();
-//
-//         // Tick once
-//         stepper.frame_step();
-//         assert_eq!(stepper.client().tick(), Tick(1));
-//         let predicted = stepper
-//             .client_app
-//             .world
-//             .get::<Confirmed>(confirmed)
-//             .unwrap()
-//             .predicted
-//             .unwrap();
-//
-//         // check that the predicted entity got spawned
-//         assert_eq!(
-//             stepper
-//                 .client_app
-//                 .world
-//                 .get::<Predicted>(predicted)
-//                 .unwrap()
-//                 .confirmed_entity,
-//             confirmed
-//         );
-//
-//         // check that the component history got created
-//         let mut history = PredictionHistory::<Component1>::default();
-//         // this is added during the first rollback call after we create the history
-//         history
-//             .buffer
-//             .add_item(Tick(0), ComponentState::Updated(Component1(0.0)));
-//         history
-//             .buffer
-//             .add_item(Tick(1), ComponentState::Updated(Component1(1.0)));
-//         assert_eq!(
-//             stepper
-//                 .client_app
-//                 .world
-//                 .get::<PredictionHistory<Component1>>(predicted)
-//                 .unwrap(),
-//             &history,
-//         );
-//         // check that the confirmed component got replicated
-//         assert_eq!(
-//             stepper
-//                 .client_app
-//                 .world
-//                 .get::<Component1>(predicted)
-//                 .unwrap(),
-//             &Component1(1.0)
-//         );
-//
-//         // advance five more frames, so that the component gets removed on predicted
-//         for i in 0..5 {
-//             stepper.frame_step();
-//         }
-//         assert_eq!(stepper.client().tick(), Tick(6));
-//
-//         // check that the component got removed on predicted
-//         assert!(stepper
-//             .client_app
-//             .world
-//             .get::<Component1>(predicted)
-//             .is_none());
-//         // check that the component history is still there and that the value of the component history is correct
-//         let mut history = PredictionHistory::<Component1>::default();
-//         for i in 0..5 {
-//             history
-//                 .buffer
-//                 .add_item(Tick(i), ComponentState::Updated(Component1(i as f32)));
-//         }
-//         history.buffer.add_item(Tick(5), ComponentState::Removed);
-//         assert_eq!(
-//             stepper
-//                 .client_app
-//                 .world
-//                 .get::<PredictionHistory<Component1>>(predicted)
-//                 .unwrap(),
-//             &history,
-//         );
-//
-//         // TODO: need to revisit this, a rollback situation is created from receiving a replication update now
-//         // create a rollback situation
-//         stepper.client_mut().set_synced();
-//         stepper
-//             .client_mut()
-//             .set_latest_received_server_tick(Tick(3));
-//         stepper
-//             .client_app
-//             .world
-//             .get_mut::<Component1>(confirmed)
-//             .unwrap()
-//             .0 = 1.0;
-//         // update without incrementing time, because we want to force a rollback check
-//         stepper.client_app.update();
-//
-//         // check that rollback happened
-//         // predicted got the component re-added
-//         stepper
-//             .client_app
-//             .world
-//             .get_mut::<Component1>(predicted)
-//             .unwrap()
-//             .0 = 4.0;
-//         // check that the history is how we expect after rollback
-//         let mut history = PredictionHistory::<Component1>::default();
-//         for i in 3..7 {
-//             history
-//                 .buffer
-//                 .add_item(Tick(i), ComponentState::Updated(Component1(i as f32 - 2.0)));
-//         }
-//         assert_eq!(
-//             stepper
-//                 .client_app
-//                 .world
-//                 .get::<PredictionHistory<Component1>>(predicted)
-//                 .unwrap(),
-//             &history
-//         );
-//
-//         Ok(())
-//     }
-//
-//     // Test that if a component gets added to the predicted entity erroneously but didn't exist on the confirmed entity)
-//     // We are still able to rollback properly (the rollback removes the component from the predicted entity)
-//     #[test]
-//     fn test_added_predicted_component_rollback() -> anyhow::Result<()> {
-//         let mut stepper = setup();
-//
-//         // Create a confirmed entity
-//         let confirmed = stepper.client_app.world.spawn(ShouldBePredicted).id();
-//
-//         // Tick once
-//         stepper.frame_step();
-//         assert_eq!(stepper.client().tick(), Tick(1));
-//         let predicted = stepper
-//             .client_app
-//             .world
-//             .get::<Confirmed>(confirmed)
-//             .unwrap()
-//             .predicted
-//             .unwrap();
-//
-//         // check that the predicted entity got spawned
-//         assert_eq!(
-//             stepper
-//                 .client_app
-//                 .world
-//                 .get::<Predicted>(predicted)
-//                 .unwrap()
-//                 .confirmed_entity,
-//             confirmed
-//         );
-//
-//         // add a new component to Predicted
-//         stepper
-//             .client_app
-//             .world
-//             .entity_mut(predicted)
-//             .insert(Component1(1.0));
-//
-//         // create a rollback situation (confirmed doesn't have a component that predicted has)
-//         stepper.client_mut().set_synced();
-//         stepper
-//             .client_mut()
-//             .set_latest_received_server_tick(Tick(1));
-//         // update without incrementing time, because we want to force a rollback check
-//         stepper.client_app.update();
-//
-//         // check that rollback happened: the component got removed from predicted
-//         assert!(stepper
-//             .client_app
-//             .world
-//             .get::<Component1>(predicted)
-//             .is_none());
-//
-//         // check that history contains the removal
-//         let mut history = PredictionHistory::<Component1>::default();
-//         history.buffer.add_item(Tick(1), ComponentState::Removed);
-//         assert_eq!(
-//             stepper
-//                 .client_app
-//                 .world
-//                 .get::<PredictionHistory<Component1>>(predicted)
-//                 .unwrap(),
-//             &history,
-//         );
-//         Ok(())
-//     }
-//
-//     // Test that if a component gets removed from the confirmed entity
-//     // We are still able to rollback properly (the rollback removes the component from the predicted entity)
-//     #[test]
-//     fn test_removed_confirmed_component_rollback() -> anyhow::Result<()> {
-//         let mut stepper = setup();
-//
-//         // Create a confirmed entity
-//         let confirmed = stepper
-//             .client_app
-//             .world
-//             .spawn((Component1(0.0), ShouldBePredicted))
-//             .id();
-//
-//         // Tick once
-//         stepper.frame_step();
-//         assert_eq!(stepper.client().tick(), Tick(1));
-//         let predicted = stepper
-//             .client_app
-//             .world
-//             .get::<Confirmed>(confirmed)
-//             .unwrap()
-//             .predicted
-//             .unwrap();
-//
-//         // check that the predicted entity got spawned
-//         assert_eq!(
-//             stepper
-//                 .client_app
-//                 .world
-//                 .get::<Predicted>(predicted)
-//                 .unwrap()
-//                 .confirmed_entity,
-//             confirmed
-//         );
-//
-//         // check that the component history got created
-//         let mut history = PredictionHistory::<Component1>::default();
-//         history
-//             .buffer
-//             .add_item(Tick(0), ComponentState::Updated(Component1(0.0)));
-//         history
-//             .buffer
-//             .add_item(Tick(1), ComponentState::Updated(Component1(1.0)));
-//         assert_eq!(
-//             stepper
-//                 .client_app
-//                 .world
-//                 .get::<PredictionHistory<Component1>>(predicted)
-//                 .unwrap(),
-//             &history,
-//         );
-//
-//         // create a rollback situation by removing the component on confirmed
-//         stepper.client_mut().set_synced();
-//         stepper
-//             .client_mut()
-//             .set_latest_received_server_tick(Tick(1));
-//         stepper
-//             .client_app
-//             .world
-//             .entity_mut(confirmed)
-//             .remove::<Component1>();
-//         // update without incrementing time, because we want to force a rollback check
-//         // (need duration_since_latest_received_server_tick = 0)
-//         stepper.client_app.update();
-//
-//         // check that rollback happened
-//         // predicted got the component removed
-//         assert!(stepper
-//             .client_app
-//             .world
-//             .get_mut::<Component1>(predicted)
-//             .is_none());
-//
-//         // check that the history is how we expect after rollback
-//         let mut history = PredictionHistory::<Component1>::default();
-//         history.buffer.add_item(Tick(1), ComponentState::Removed);
-//         assert_eq!(
-//             stepper
-//                 .client_app
-//                 .world
-//                 .get::<PredictionHistory<Component1>>(predicted)
-//                 .unwrap(),
-//             &history
-//         );
-//
-//         Ok(())
-//     }
-//
-//     // Test that if a component gets added to the confirmed entity (but didn't exist on the predicted entity)
-//     // We are still able to rollback properly (the rollback adds the component to the predicted entity)
-//     #[test]
-//     fn test_added_confirmed_component_rollback() -> anyhow::Result<()> {
-//         let mut stepper = setup();
-//
-//         // Create a confirmed entity
-//         let confirmed = stepper.client_app.world.spawn(ShouldBePredicted).id();
-//
-//         // Tick once
-//         stepper.frame_step();
-//         assert_eq!(stepper.client().tick(), Tick(1));
-//         let predicted = stepper
-//             .client_app
-//             .world
-//             .get::<Confirmed>(confirmed)
-//             .unwrap()
-//             .predicted
-//             .unwrap();
-//
-//         // check that the predicted entity got spawned
-//         assert_eq!(
-//             stepper
-//                 .client_app
-//                 .world
-//                 .get::<Predicted>(predicted)
-//                 .unwrap()
-//                 .confirmed_entity,
-//             confirmed
-//         );
-//
-//         // check that the component history did not get created
-//         assert!(stepper
-//             .client_app
-//             .world
-//             .get::<PredictionHistory<Component1>>(predicted)
-//             .is_none());
-//
-//         // advance five more frames, so that the component gets removed on predicted
-//         for i in 0..5 {
-//             stepper.frame_step();
-//         }
-//         assert_eq!(stepper.client().tick(), Tick(6));
-//
-//         // create a rollback situation by adding the component on confirmed
-//         stepper.client_mut().set_synced();
-//         stepper
-//             .client_mut()
-//             .set_latest_received_server_tick(Tick(3));
-//         stepper
-//             .client_app
-//             .world
-//             .entity_mut(confirmed)
-//             .insert(Component1(1.0));
-//         // update without incrementing time, because we want to force a rollback check
-//         stepper.client_app.update();
-//
-//         // check that rollback happened
-//         // predicted got the component re-added
-//         stepper
-//             .client_app
-//             .world
-//             .get_mut::<Component1>(predicted)
-//             .unwrap()
-//             .0 = 4.0;
-//         // check that the history is how we expect after rollback
-//         let mut history = PredictionHistory::<Component1>::default();
-//         for i in 3..7 {
-//             history
-//                 .buffer
-//                 .add_item(Tick(i), ComponentState::Updated(Component1(i as f32 - 2.0)));
-//         }
-//         assert_eq!(
-//             stepper
-//                 .client_app
-//                 .world
-//                 .get::<PredictionHistory<Component1>>(predicted)
-//                 .unwrap(),
-//             &history
-//         );
-//
-//         Ok(())
-//     }
-// }
+/// More general integration tests for rollback
+#[cfg(test)]
+mod integration_tests {
+    use super::test_utils::*;
+
+    use bevy::prelude::*;
+
+    use crate::prelude::client::*;
+    use crate::prelude::*;
+    use crate::tests::protocol::*;
+    use crate::tests::stepper::{BevyStepper, Step};
+
+    fn increment_component(
+        mut commands: Commands,
+        mut query: Query<(Entity, &mut Component1), With<Predicted>>,
+    ) {
+        for (entity, mut component) in query.iter_mut() {
+            component.0 += 1.0;
+            if component.0 == 5.0 {
+                commands.entity(entity).remove::<Component1>();
+            }
+        }
+    }
+
+    fn setup() -> (BevyStepper, Entity, Entity) {
+        let mut stepper = BevyStepper::default();
+        stepper
+            .client_app
+            .add_systems(FixedUpdate, increment_component);
+        // add predicted/confirmed entities
+        let confirmed = stepper.client_app.world.spawn(Confirmed::default()).id();
+        let predicted = stepper
+            .client_app
+            .world
+            .spawn(Predicted {
+                confirmed_entity: Some(confirmed),
+            })
+            .id();
+        stepper
+            .client_app
+            .world
+            .entity_mut(confirmed)
+            .get_mut::<Confirmed>()
+            .unwrap()
+            .predicted = Some(predicted);
+        (stepper, confirmed, predicted)
+    }
+
+    /// Test that:
+    /// - we remove a component from the predicted entity
+    /// - rolling back before the remove should re-add it
+    /// We are still able to rollback properly (the rollback adds the component to the predicted entity)
+    #[test]
+    fn test_removed_predicted_component_rollback() -> anyhow::Result<()> {
+        let (mut stepper, confirmed, predicted) = setup();
+        // insert component on confirmed
+        stepper
+            .client_app
+            .world
+            .entity_mut(confirmed)
+            .insert(Component1(0.0));
+        stepper.frame_step();
+
+        // check that the component got synced
+        assert_eq!(
+            stepper
+                .client_app
+                .world
+                .get::<Component1>(predicted)
+                .unwrap(),
+            &Component1(1.0)
+        );
+
+        // advance five more frames, so that the component gets removed on predicted
+        for i in 0..5 {
+            stepper.frame_step();
+        }
+        // check that the component got removed on predicted
+        assert!(stepper
+            .client_app
+            .world
+            .get::<Component1>(predicted)
+            .is_none());
+
+        // create a rollback situation where the component exists on confirmed but not on predicted
+        let tick = stepper.client_tick();
+        stepper
+            .client_app
+            .world
+            .get_mut::<Component1>(confirmed)
+            .unwrap()
+            .0 = -10.0;
+        received_confirmed_update(&mut stepper, confirmed, tick - 3);
+        stepper.frame_step();
+
+        // check that rollback happened
+        // predicted got the component re-added and that we rolled back 3 ticks and advances by 1 tick
+        assert_eq!(
+            stepper
+                .client_app
+                .world
+                .get_mut::<Component1>(predicted)
+                .unwrap()
+                .0,
+            -6.0
+        );
+        Ok(())
+    }
+
+    /// Test that:
+    /// - a component gets added on Predicted
+    /// - we trigger a rollback, and the confirmed entity does not have the component
+    /// - the rollback removes the component from the predicted entity
+    #[test]
+    fn test_added_predicted_component_rollback() -> anyhow::Result<()> {
+        let (mut stepper, confirmed, predicted) = setup();
+
+        // add a new component to Predicted
+        stepper
+            .client_app
+            .world
+            .entity_mut(predicted)
+            .insert(Component1(1.0));
+        stepper.frame_step();
+
+        // create a rollback situation (confirmed doesn't have a component that predicted has)
+        let tick = stepper.client_tick();
+        received_confirmed_update(&mut stepper, confirmed, tick - 1);
+        stepper.frame_step();
+
+        // check that rollback happened: the component got removed from predicted
+        assert!(stepper
+            .client_app
+            .world
+            .get::<Component1>(predicted)
+            .is_none());
+        Ok(())
+    }
+
+    /// Test that:
+    /// - a component gets removed from the Confirmed entity, triggering a rollback
+    /// - during the rollback, the component gets removed from the Predicted entity
+    #[test]
+    fn test_removed_confirmed_component_rollback() -> anyhow::Result<()> {
+        let (mut stepper, confirmed, predicted) = setup();
+
+        // insert component on confirmed
+        stepper
+            .client_app
+            .world
+            .entity_mut(confirmed)
+            .insert(Component1(0.0));
+        stepper.frame_step();
+
+        // check that the component got synced
+        assert_eq!(
+            stepper
+                .client_app
+                .world
+                .get::<Component1>(predicted)
+                .unwrap(),
+            &Component1(1.0)
+        );
+        // advance a bit more (if we don't then the history contains a component insertion on the first tick,
+        // so the rollback will respawn the component)
+        stepper.frame_step();
+        stepper.frame_step();
+        stepper.frame_step();
+
+        // remove the component on confirmed and create a rollback situation
+        stepper
+            .client_app
+            .world
+            .entity_mut(confirmed)
+            .remove::<Component1>();
+        let tick = stepper.client_tick();
+        received_confirmed_update(&mut stepper, confirmed, tick - 1);
+        stepper.frame_step();
+
+        // check that rollback happened
+        // predicted got the component removed
+        assert!(stepper
+            .client_app
+            .world
+            .get_mut::<Component1>(predicted)
+            .is_none());
+        Ok(())
+    }
+
+    /// Test that:
+    /// - a component gets added to the confirmed entity, triggering rollback
+    /// - the predicted entity did not have the component, so the rollback adds it
+    #[test]
+    fn test_added_confirmed_component_rollback() -> anyhow::Result<()> {
+        let (mut stepper, confirmed, predicted) = setup();
+
+        // check that predicted does not have the component
+        assert!(stepper
+            .client_app
+            .world
+            .get_mut::<Component1>(predicted)
+            .is_none());
+
+        // create a rollback situation (confirmed doesn't have a component that predicted has)
+        stepper
+            .client_app
+            .world
+            .entity_mut(confirmed)
+            .insert(Component1(1.0));
+        let tick = stepper.client_tick();
+        received_confirmed_update(&mut stepper, confirmed, tick - 2);
+        stepper.frame_step();
+
+        // check that rollback happened
+        // predicted got the component re-added
+        stepper
+            .client_app
+            .world
+            .get_mut::<Component1>(predicted)
+            .unwrap()
+            .0 = 4.0;
+        Ok(())
+    }
+}

--- a/lightyear/src/client/prediction/spawn.rs
+++ b/lightyear/src/client/prediction/spawn.rs
@@ -20,66 +20,63 @@ pub(crate) fn spawn_predicted_entity(
     connection: Res<ConnectionManager>,
     mut manager: ResMut<PredictionManager>,
     mut commands: Commands,
+
     // TODO: instead of listening to the ComponentInsertEvent, should we just directly query on Added<ShouldBePredicted>?
     //  maybe listening to the event is more performant, since Added<ShouldBePredicted> queries all entities that have this component?
     //  (which should actually be ok since we remove ShouldBePredicted immediately)
+    //  But maybe this conflicts with PrePrediction and PreSpawning?
     //  Benchmark!
-    // get the list of entities who get ShouldBePredicted replicated from server
-    mut should_be_predicted_added: EventReader<ComponentInsertEvent<ShouldBePredicted>>,
+    // // get the list of entities who get ShouldBePredicted replicated from server
+    // mut should_be_predicted_added: EventReader<ComponentInsertEvent<ShouldBePredicted>>,
+
     // only handle predicted that have ShouldBePredicted
     // (if the entity was handled by prespawn or prepredicted before, ShouldBePredicted gets removed)
-    mut confirmed_entities: Query<Option<&mut Confirmed>, With<ShouldBePredicted>>,
+    mut confirmed_entities: Query<(Entity, Option<&mut Confirmed>), Added<ShouldBePredicted>>,
 ) {
-    for message in should_be_predicted_added.read() {
-        let confirmed_entity = message.entity();
+    for (confirmed_entity, confirmed) in confirmed_entities.iter_mut() {
         debug!("Received entity with ShouldBePredicted from server: {confirmed_entity:?}");
-        if let Ok(confirmed) = confirmed_entities.get_mut(confirmed_entity) {
-            // we need to spawn a predicted entity for this confirmed entity
-            let predicted_entity = commands
-                .spawn(Predicted {
-                    confirmed_entity: Some(confirmed_entity),
-                })
-                .id();
-            debug!(
-                "Spawning predicted entity {:?} for confirmed: {:?}",
-                predicted_entity, confirmed_entity
-            );
-            #[cfg(feature = "metrics")]
-            {
-                metrics::counter!("spawn_predicted_entity").increment(1);
-            }
+        // we need to spawn a predicted entity for this confirmed entity
+        let predicted_entity = commands
+            .spawn(Predicted {
+                confirmed_entity: Some(confirmed_entity),
+            })
+            .id();
+        debug!(
+            "Spawning predicted entity {:?} for confirmed: {:?}",
+            predicted_entity, confirmed_entity
+        );
+        #[cfg(feature = "metrics")]
+        {
+            metrics::counter!("spawn_predicted_entity").increment(1);
+        }
 
-            // update the predicted entity mapping
-            manager
-                .predicted_entity_map
-                .get_mut()
-                .confirmed_to_predicted
-                .insert(confirmed_entity, predicted_entity);
+        // update the predicted entity mapping
+        manager
+            .predicted_entity_map
+            .get_mut()
+            .confirmed_to_predicted
+            .insert(confirmed_entity, predicted_entity);
 
-            // add Confirmed to the confirmed entity
-            // safety: we know the entity exists
-            let mut confirmed_entity_mut = commands.entity(confirmed_entity);
-            confirmed_entity_mut.remove::<ShouldBePredicted>();
-            if let Some(mut confirmed) = confirmed {
-                confirmed.predicted = Some(predicted_entity);
-            } else {
-                // TODO: this is the same as the current tick no? or maybe not because we could have received updates before the spawn
-                //  and they are applied simultaneously
-                // get the confirmed tick for the entity
-                // if we don't have it, something has gone very wrong
-
-                let confirmed_tick = connection
-                    .replication_receiver
-                    .get_confirmed_tick(confirmed_entity)
-                    .unwrap();
-                confirmed_entity_mut.insert(Confirmed {
-                    predicted: Some(predicted_entity),
-                    interpolated: None,
-                    tick: confirmed_tick,
-                });
-            }
+        // add Confirmed to the confirmed entity
+        // safety: we know the entity exists
+        let mut confirmed_entity_mut = commands.entity(confirmed_entity);
+        confirmed_entity_mut.remove::<ShouldBePredicted>();
+        if let Some(mut confirmed) = confirmed {
+            confirmed.predicted = Some(predicted_entity);
         } else {
-            debug!("The confirmed entity {confirmed_entity:?} does not have ShouldBePredicted; it was probably handled by prespawn or prepredicted already");
+            // TODO: this is the same as the current tick no? or maybe not because we could have received updates before the spawn
+            //  and they are applied simultaneously
+            // get the confirmed tick for the entity
+            // if we don't have it, something has gone very wrong
+            let confirmed_tick = connection
+                .replication_receiver
+                .get_confirmed_tick(confirmed_entity)
+                .expect("Confirmed entity should have a confirmed tick");
+            confirmed_entity_mut.insert(Confirmed {
+                predicted: Some(predicted_entity),
+                interpolated: None,
+                tick: confirmed_tick,
+            });
         }
     }
 }

--- a/lightyear/src/shared/tick_manager.rs
+++ b/lightyear/src/shared/tick_manager.rs
@@ -22,7 +22,8 @@ pub enum TickEvent {
     TickSnap { old_tick: Tick, new_tick: Tick },
 }
 
-fn increment_tick(mut tick_manager: ResMut<TickManager>) {
+/// System that increments the tick at the start of FixedUpdate
+pub(crate) fn increment_tick(mut tick_manager: ResMut<TickManager>) {
     tick_manager.increment_tick();
     trace!("increment_tick! new tick: {:?}", tick_manager.tick());
 }


### PR DESCRIPTION
- add unit tests and integration tests for prediction
- spawn Predicted entities based on `Added<ShouldBePredicted>` instead of `ComponentInsertEvent<ShouldBePredicted>`, which should be sufficient