### PR TITLE
Bidirectional resource replication

### DIFF
--- a/examples/client_replication/src/client.rs
+++ b/examples/client_replication/src/client.rs
@@ -251,7 +251,7 @@ pub(crate) fn send_message(
         info!("Send message: {:?}", message);
         // the message will be re-broadcasted by the server to all clients
         client
-            .send_message_to_target::<Channel1, Message1>(Message1(5), NetworkTarget::All)
+            .send_message_to_target::<Channel1, Message1>(&Message1(5), NetworkTarget::All)
             .unwrap_or_else(|e| {
                 error!("Failed to send message: {:?}", e);
             });

--- a/examples/lobby/src/client.rs
+++ b/examples/lobby/src/client.rs
@@ -302,14 +302,14 @@ mod lobby {
                                                             // send a message to join the game
                                                             let _ = connection_manager
                                                                 .send_message::<Channel1, _>(
-                                                                    StartGame { lobby_id, host },
+                                                                    &StartGame { lobby_id, host },
                                                                 );
                                                         }
                                                     } else {
                                                         if ui.button("Join Lobby").clicked() {
                                                             connection_manager
                                                                 .send_message::<Channel1, _>(
-                                                                    JoinLobby { lobby_id },
+                                                                    &JoinLobby { lobby_id },
                                                                 )
                                                                 .unwrap();
                                                             next_app_state.set(AppState::Lobby {
@@ -385,7 +385,7 @@ mod lobby {
                                 if let Some(lobby_id) = joined_lobby {
                                     if ui.button("Exit lobby").clicked() {
                                         connection_manager
-                                            .send_message::<Channel1, _>(ExitLobby {
+                                            .send_message::<Channel1, _>(&ExitLobby {
                                                 lobby_id: *lobby_id,
                                             })
                                             .unwrap();
@@ -396,7 +396,7 @@ mod lobby {
                                         let host = lobby_table.get_host();
                                         // send a message to server/client to start the game and possibly act as server
                                         let _ = connection_manager.send_message::<Channel1, _>(
-                                            StartGame {
+                                            &StartGame {
                                                 lobby_id: *lobby_id,
                                                 host,
                                             },

--- a/examples/lobby/src/client.rs
+++ b/examples/lobby/src/client.rs
@@ -106,6 +106,7 @@ fn on_disconnect(
     for entity in entities.iter() {
         commands.entity(entity).despawn_recursive();
     }
+    commands.remove_resource::<Lobbies>();
 
     // stop the server if it was started (if the player was host)
     commands.stop_server();

--- a/examples/lobby/src/protocol.rs
+++ b/examples/lobby/src/protocol.rs
@@ -197,7 +197,7 @@ impl Plugin for ProtocolPlugin {
         app.add_prediction::<PlayerColor>(ComponentSyncMode::Once);
         app.add_interpolation::<PlayerColor>(ComponentSyncMode::Once);
         // resources
-        app.register_resource::<Lobbies>(ChannelDirection::ServerToClient);
+        app.register_resource::<Lobbies>(ChannelDirection::Bidirectional);
         // channels
         app.add_channel::<Channel1>(ChannelSettings {
             mode: ChannelMode::OrderedReliable(ReliableSettings::default()),

--- a/examples/lobby/src/protocol.rs
+++ b/examples/lobby/src/protocol.rs
@@ -197,7 +197,7 @@ impl Plugin for ProtocolPlugin {
         app.add_prediction::<PlayerColor>(ComponentSyncMode::Once);
         app.add_interpolation::<PlayerColor>(ComponentSyncMode::Once);
         // resources
-        app.register_resource::<Lobbies>(ChannelDirection::Bidirectional);
+        app.register_resource::<Lobbies>(ChannelDirection::ServerToClient);
         // channels
         app.add_channel::<Channel1>(ChannelSettings {
             mode: ChannelMode::OrderedReliable(ReliableSettings::default()),

--- a/examples/lobby/src/server.rs
+++ b/examples/lobby/src/server.rs
@@ -70,7 +70,7 @@ pub(crate) struct Global {
 
 /// System to start the dedicated server at Startup
 fn start_dedicated_server(mut commands: Commands) {
-    commands.replicate_resource::<Lobbies>(Replicate::default());
+    commands.replicate_resource::<Lobbies, Channel1>(NetworkTarget::All);
     commands.start_server();
 }
 
@@ -260,6 +260,7 @@ mod lobby {
                 if host.is_none() {
                     // one of the players asked for the game to start
                     for player in &lobby.players {
+                        error!("Spawning player {player:?} entity for game");
                         let entity =
                             spawn_player_entity(&mut commands, global.reborrow(), *player, true);
                         room_manager.add_entity(entity, room_id);

--- a/lightyear/src/client/connection.rs
+++ b/lightyear/src/client/connection.rs
@@ -446,9 +446,6 @@ impl ConnectionManager {
 }
 
 impl MessageSend for ConnectionManager {
-    // TODO: don't duplicate these but have a super trait instead
-    type EventContext = ();
-    type SetMarker = ClientMarker;
     fn send_message_to_target<C: Channel, M: Message>(
         &mut self,
         message: &M,

--- a/lightyear/src/client/connection.rs
+++ b/lightyear/src/client/connection.rs
@@ -33,6 +33,7 @@ use crate::serialize::writer::WriteBuffer;
 use crate::serialize::RawData;
 use crate::server::message::ServerMessage;
 use crate::shared::events::connection::ConnectionEvents;
+use crate::shared::message::MessageSend;
 use crate::shared::ping::manager::{PingConfig, PingManager};
 use crate::shared::ping::message::{Ping, Pong, SyncMessage};
 use crate::shared::replication::components::{Replicate, ReplicationGroupId};
@@ -41,7 +42,7 @@ use crate::shared::replication::send::ReplicationSender;
 use crate::shared::replication::systems::DespawnMetadata;
 use crate::shared::replication::ReplicationMessageData;
 use crate::shared::replication::{ReplicationMessage, ReplicationSend};
-use crate::shared::sets::ClientMarker;
+use crate::shared::sets::{ClientMarker, ServerMarker};
 use crate::shared::tick_manager::Tick;
 use crate::shared::tick_manager::TickManager;
 use crate::shared::time_manager::TimeManager;
@@ -176,26 +177,27 @@ impl ConnectionManager {
     }
 
     /// Send a message to the server
-    pub fn send_message<C: Channel, M: Message>(&mut self, message: M) -> Result<()> {
+    pub fn send_message<C: Channel, M: Message>(&mut self, message: &M) -> Result<()> {
         self.send_message_to_target::<C, M>(message, NetworkTarget::None)
     }
 
     /// Send a message to the server, the message should be re-broadcasted according to the `target`
     pub fn send_message_to_target<C: Channel, M: Message>(
         &mut self,
-        message: M,
+        message: &M,
         target: NetworkTarget,
     ) -> Result<()> {
-        // TODO: if unified; send message directly to the client's message receiver
-        // TODO: add metrics?
-        // serialize early! then the message manager just focuses on raw bytes + reliability
-        // however we then call serialize many times for small messages, we lose bitcode's compressability
-        let message_bytes = self
-            .message_registry
-            .serialize(&message, &mut self.writer)?;
+        self.erased_send_message_to_target(message, ChannelKind::of::<C>(), target)
+    }
 
-        let channel = ChannelKind::of::<C>();
-        self.buffer_message(message_bytes, channel, target)
+    fn erased_send_message_to_target<M: Message>(
+        &mut self,
+        message: &M,
+        channel_kind: ChannelKind,
+        target: NetworkTarget,
+    ) -> Result<()> {
+        let message_bytes = self.message_registry.serialize(message, &mut self.writer)?;
+        self.buffer_message(message_bytes, channel_kind, target)
     }
 
     pub(crate) fn buffer_message(
@@ -440,6 +442,28 @@ impl ConnectionManager {
         // notify the replication sender that some sent messages were received
         self.replication_sender.recv_update_acks();
         Ok(())
+    }
+}
+
+impl MessageSend for ConnectionManager {
+    // TODO: don't duplicate these but have a super trait instead
+    type EventContext = ();
+    type SetMarker = ClientMarker;
+    fn send_message_to_target<C: Channel, M: Message>(
+        &mut self,
+        message: &M,
+        target: NetworkTarget,
+    ) -> Result<()> {
+        self.send_message_to_target::<C, M>(message, target)
+    }
+
+    fn erased_send_message_to_target<M: Message>(
+        &mut self,
+        message: &M,
+        channel_kind: ChannelKind,
+        target: NetworkTarget,
+    ) -> Result<()> {
+        self.erased_send_message_to_target(message, channel_kind, target)
     }
 }
 

--- a/lightyear/src/client/input.rs
+++ b/lightyear/src/client/input.rs
@@ -300,7 +300,7 @@ fn prepare_input_message<A: UserAction>(
             "sending input message: {:?}", message.end_tick
         );
         connection
-            .send_message::<InputChannel, _>(message)
+            .send_message::<InputChannel, _>(&message)
             .unwrap_or_else(|err| {
                 error!("Error while sending input message: {:?}", err);
             })

--- a/lightyear/src/client/input_leafwing.rs
+++ b/lightyear/src/client/input_leafwing.rs
@@ -673,7 +673,7 @@ fn prepare_input_message<A: LeafwingUserAction>(
             message.diffs
         );
         connection
-            .send_message::<InputChannel, InputMessage<A>>(message)
+            .send_message::<InputChannel, InputMessage<A>>(&message)
             .unwrap_or_else(|err| {
                 error!("Error while sending input message: {:?}", err);
             })

--- a/lightyear/src/lib.rs
+++ b/lightyear/src/lib.rs
@@ -52,7 +52,7 @@ pub mod prelude {
     pub use crate::shared::replication::entity_map::RemoteEntityMap;
     pub use crate::shared::replication::hierarchy::ParentSync;
     pub use crate::shared::replication::resources::{
-        ReplicateResource, ReplicateResourceExt, StopReplicateResourceExt,
+        ReplicateResourceExt, ReplicateResourceMetadata, StopReplicateResourceExt,
     };
     pub use crate::shared::sets::{FixedUpdateSet, MainSet};
     pub use crate::shared::tick_manager::TickManager;

--- a/lightyear/src/lib.rs
+++ b/lightyear/src/lib.rs
@@ -39,6 +39,7 @@ pub mod prelude {
     pub use crate::protocol::channel::{AppChannelExt, ChannelKind, ChannelRegistry};
     pub use crate::protocol::component::{AppComponentExt, ComponentRegistry, Linear};
     pub use crate::protocol::message::{AppMessageExt, MessageRegistry};
+    pub use crate::protocol::serialize::AppSerializeExt;
     pub use crate::shared::config::{Mode, SharedConfig};
     pub use crate::shared::input::InputPlugin;
     #[cfg(feature = "leafwing")]

--- a/lightyear/src/lib.rs
+++ b/lightyear/src/lib.rs
@@ -52,7 +52,7 @@ pub mod prelude {
     pub use crate::shared::replication::entity_map::RemoteEntityMap;
     pub use crate::shared::replication::hierarchy::ParentSync;
     pub use crate::shared::replication::resources::{
-        ReplicateResource, ReplicateResourceExt, StopReplicateCommand, StopReplicateResourceExt,
+        ReplicateResource, ReplicateResourceExt, StopReplicateResourceExt,
     };
     pub use crate::shared::sets::{FixedUpdateSet, MainSet};
     pub use crate::shared::tick_manager::TickManager;

--- a/lightyear/src/packet/message_manager.rs
+++ b/lightyear/src/packet/message_manager.rs
@@ -5,7 +5,7 @@ use bevy::ptr::UnsafeCellDeref;
 use bevy::reflect::Reflect;
 use bytes::Bytes;
 use crossbeam_channel::Receiver;
-use tracing::{info, trace};
+use tracing::{error, info, trace};
 
 use bitcode::buffer::BufferTrait;
 use bitcode::word_buffer::WordBuffer;
@@ -133,6 +133,7 @@ impl MessageManager {
             if channel.sender.has_messages_to_send() {
                 let (single_data, fragment_data) = channel.sender.send_packet();
                 if !single_data.is_empty() || !fragment_data.is_empty() {
+                    trace!(?channel_id, "send message with channel_id");
                     has_data_to_send = true;
                 }
                 data_to_send.push((*channel_id, (single_data, fragment_data)));

--- a/lightyear/src/protocol/component.rs
+++ b/lightyear/src/protocol/component.rs
@@ -7,8 +7,8 @@ use std::hash::Hash;
 use std::ops::{Add, Mul};
 
 use bevy::prelude::{
-    App, Component, Entity, EntityMapper, EntityWorldMut, IntoSystemConfigs, Resource, TypePath,
-    World,
+    App, Component, DetectChangesMut, Entity, EntityMapper, EntityWorldMut, IntoSystemConfigs,
+    Resource, TypePath, World,
 };
 use bevy::reflect::{FromReflect, GetTypeRegistration};
 use bevy::utils::HashMap;
@@ -30,7 +30,7 @@ use crate::prelude::{
     client, server, ChannelDirection, Message, MessageRegistry, PreSpawnedPlayerObject,
     RemoteEntityMap, ReplicateResource, Tick,
 };
-use crate::protocol::message::MessageType;
+use crate::protocol::message::{MessageKind, MessageType};
 use crate::protocol::registry::{NetId, TypeKind, TypeMapper};
 use crate::protocol::serialize::{ErasedSerializeFns, MapEntitiesFn, SerializeFns};
 use crate::protocol::{BitSerializable, EventContext};
@@ -362,6 +362,7 @@ impl ComponentRegistry {
         // TODO: should we send the event based on on the message type (Insert/Update) or based on whether the component was actually inserted?
         if let Some(mut c) = entity_world_mut.get_mut::<C>() {
             events.push_update_component(entity, net_id, tick);
+            // TODO: use set_if_neq for PartialEq
             *c = component;
         } else {
             events.push_insert_component(entity, net_id, tick);

--- a/lightyear/src/protocol/component.rs
+++ b/lightyear/src/protocol/component.rs
@@ -28,7 +28,7 @@ use crate::prelude::client::SyncComponent;
 use crate::prelude::server::{ServerConfig, ServerPlugin};
 use crate::prelude::{
     client, server, ChannelDirection, Message, MessageRegistry, PreSpawnedPlayerObject,
-    RemoteEntityMap, ReplicateResource, Tick,
+    RemoteEntityMap, ReplicateResourceMetadata, Tick,
 };
 use crate::protocol::message::{MessageKind, MessageType};
 use crate::protocol::registry::{NetId, TypeKind, TypeMapper};

--- a/lightyear/src/protocol/component.rs
+++ b/lightyear/src/protocol/component.rs
@@ -151,10 +151,6 @@ impl ComponentRegistry {
             .insert(component_kind, ReplicationMetadata { write, remove });
     }
 
-    pub(crate) fn register_resource<R: Resource + Message>(&mut self) {
-        self.register_component::<ReplicateResource<R>>();
-    }
-
     pub(crate) fn try_add_map_entities<C: MapEntities + 'static>(&mut self) {
         let kind = ComponentKind::of::<C>();
         if let Some(erased_fns) = self.serialize_fns_map.get_mut(&kind) {
@@ -420,45 +416,6 @@ fn register_component_send<C: Component>(app: &mut App, direction: ChannelDirect
     }
 }
 
-fn register_resource_send<R: Resource + Message>(app: &mut App, direction: ChannelDirection) {
-    let is_client = app.world.get_resource::<ClientConfig>().is_some();
-    let is_server = app.world.get_resource::<ServerConfig>().is_some();
-    match direction {
-        ChannelDirection::ClientToServer => {
-            if is_client {
-                crate::shared::replication::resources::send::add_resource_send_systems::<
-                    client::ConnectionManager,
-                    R,
-                >(app);
-            }
-            if is_server {
-                crate::shared::replication::resources::receive::add_resource_receive_systems::<
-                    server::ConnectionManager,
-                    R,
-                >(app);
-            }
-        }
-        ChannelDirection::ServerToClient => {
-            if is_server {
-                crate::shared::replication::resources::send::add_resource_send_systems::<
-                    server::ConnectionManager,
-                    R,
-                >(app);
-            }
-            if is_client {
-                crate::shared::replication::resources::receive::add_resource_receive_systems::<
-                    client::ConnectionManager,
-                    R,
-                >(app);
-            }
-        }
-        ChannelDirection::Bidirectional => {
-            register_resource_send::<R>(app, ChannelDirection::ClientToServer);
-            register_resource_send::<R>(app, ChannelDirection::ServerToClient);
-        }
-    }
-}
-
 /// Add a component to the list of components that can be sent
 pub trait AppComponentExt {
     /// Registers the component in the Registry
@@ -467,14 +424,6 @@ pub trait AppComponentExt {
         &mut self,
         direction: ChannelDirection,
     ) -> ComponentRegistration<'_>;
-
-    /// Registers the resource in the Registry
-    /// This resource can now be sent over the network.
-    fn register_resource<R: Resource + Message>(&mut self, direction: ChannelDirection);
-
-    /// Specify that the component contains entities which should be mapped from the remote world to the local world
-    /// upon deserialization
-    fn add_component_map_entities<C: MapEntities + 'static>(&mut self);
 
     /// Enable prediction systems for this component.
     /// You can specify the prediction [`ComponentSyncMode`]
@@ -509,7 +458,8 @@ impl ComponentRegistration<'_> {
     /// Specify that the component contains entities which should be mapped from the remote world to the local world
     /// upon deserialization
     pub fn add_map_entities<C: MapEntities + 'static>(self) -> Self {
-        self.app.add_component_map_entities::<C>();
+        let mut registry = self.app.world.resource_mut::<ComponentRegistry>();
+        registry.add_map_entities::<C>();
         self
     }
 
@@ -577,16 +527,6 @@ impl AppComponentExt for App {
         debug!("register component {}", std::any::type_name::<C>());
         register_component_send::<C>(self, direction);
         ComponentRegistration { app: self }
-    }
-
-    fn register_resource<R: Resource + Message>(&mut self, direction: ChannelDirection) {
-        self.register_component::<ReplicateResource<R>>(direction);
-        register_resource_send::<R>(self, direction)
-    }
-
-    fn add_component_map_entities<C: MapEntities + 'static>(&mut self) {
-        let mut registry = self.world.resource_mut::<ComponentRegistry>();
-        registry.add_map_entities::<C>();
     }
 
     fn add_prediction<C: SyncComponent>(&mut self, prediction_mode: ComponentSyncMode) {

--- a/lightyear/src/protocol/message.rs
+++ b/lightyear/src/protocol/message.rs
@@ -7,7 +7,8 @@ use std::fmt::Debug;
 use crate::client::config::ClientConfig;
 use crate::client::message::add_server_to_client_message;
 use crate::prelude::{
-    client, server, AppComponentExt, Channel, ComponentRegistry, RemoteEntityMap, ReplicateResource,
+    client, server, AppComponentExt, Channel, ComponentRegistry, RemoteEntityMap,
+    ReplicateResourceMetadata,
 };
 use bevy::prelude::{
     App, Component, EntityMapper, EventWriter, IntoSystemConfigs, ResMut, Resource, TypePath, World,
@@ -35,6 +36,7 @@ use crate::serialize::writer::WriteBuffer;
 use crate::serialize::RawData;
 use crate::server::message::add_client_to_server_message;
 use crate::shared::replication::entity_map::EntityMap;
+use crate::shared::replication::resources::DespawnResource;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub(crate) enum MessageType {
@@ -152,6 +154,7 @@ impl AppMessageExt for App {
     /// Register a resource to be automatically replicated over the network
     fn register_resource<R: Resource + Message>(&mut self, direction: ChannelDirection) {
         self.add_message::<R>(direction);
+        self.add_message::<DespawnResource<R>>(direction);
         register_resource_send::<R>(self, direction)
     }
 }

--- a/lightyear/src/protocol/message.rs
+++ b/lightyear/src/protocol/message.rs
@@ -92,7 +92,7 @@ fn register_resource_send<R: Resource + Message>(app: &mut App, direction: Chann
                 crate::shared::replication::resources::receive::add_resource_receive_systems::<
                     R,
                     server::ConnectionManager,
-                >(app);
+                >(app, false);
             }
         }
         ChannelDirection::ServerToClient => {
@@ -106,12 +106,32 @@ fn register_resource_send<R: Resource + Message>(app: &mut App, direction: Chann
                 crate::shared::replication::resources::receive::add_resource_receive_systems::<
                     R,
                     client::ConnectionManager,
-                >(app);
+                >(app, false);
             }
         }
         ChannelDirection::Bidirectional => {
-            register_resource_send::<R>(app, ChannelDirection::ClientToServer);
-            register_resource_send::<R>(app, ChannelDirection::ServerToClient);
+            if is_server {
+                crate::shared::replication::resources::send::add_resource_send_systems::<
+                    R,
+                    server::ConnectionManager,
+                >(app);
+                crate::shared::replication::resources::receive::add_resource_receive_systems::<
+                    R,
+                    server::ConnectionManager,
+                >(app, true);
+            }
+            if is_client {
+                crate::shared::replication::resources::send::add_resource_send_systems::<
+                    R,
+                    client::ConnectionManager,
+                >(app);
+                crate::shared::replication::resources::receive::add_resource_receive_systems::<
+                    R,
+                    client::ConnectionManager,
+                >(app, true);
+            }
+            // register_resource_send::<R>(app, ChannelDirection::ClientToServer);
+            // register_resource_send::<R>(app, ChannelDirection::ServerToClient);
         }
     }
 }

--- a/lightyear/src/protocol/message.rs
+++ b/lightyear/src/protocol/message.rs
@@ -6,7 +6,9 @@ use std::fmt::Debug;
 
 use crate::client::config::ClientConfig;
 use crate::client::message::add_server_to_client_message;
-use crate::prelude::{client, server, AppComponentExt, Channel, RemoteEntityMap};
+use crate::prelude::{
+    client, server, AppComponentExt, Channel, ComponentRegistry, RemoteEntityMap, ReplicateResource,
+};
 use bevy::prelude::{
     App, Component, EntityMapper, EventWriter, IntoSystemConfigs, ResMut, Resource, TypePath, World,
 };
@@ -73,6 +75,45 @@ fn register_message_send<M: Message>(app: &mut App, direction: ChannelDirection)
     }
 }
 
+fn register_resource_send<R: Resource + Message>(app: &mut App, direction: ChannelDirection) {
+    let is_client = app.world.get_resource::<ClientConfig>().is_some();
+    let is_server = app.world.get_resource::<ServerConfig>().is_some();
+    match direction {
+        ChannelDirection::ClientToServer => {
+            if is_client {
+                crate::shared::replication::resources::send::add_resource_send_systems::<
+                    R,
+                    client::ConnectionManager,
+                >(app);
+            }
+            if is_server {
+                crate::shared::replication::resources::receive::add_resource_receive_systems::<
+                    R,
+                    server::ConnectionManager,
+                >(app);
+            }
+        }
+        ChannelDirection::ServerToClient => {
+            if is_server {
+                crate::shared::replication::resources::send::add_resource_send_systems::<
+                    R,
+                    server::ConnectionManager,
+                >(app);
+            }
+            if is_client {
+                crate::shared::replication::resources::receive::add_resource_receive_systems::<
+                    R,
+                    client::ConnectionManager,
+                >(app);
+            }
+        }
+        ChannelDirection::Bidirectional => {
+            register_resource_send::<R>(app, ChannelDirection::ClientToServer);
+            register_resource_send::<R>(app, ChannelDirection::ServerToClient);
+        }
+    }
+}
+
 pub struct MessageRegistration<'a> {
     app: &'a mut App,
 }
@@ -81,7 +122,8 @@ impl MessageRegistration<'_> {
     /// Specify that the message contains entities which should be mapped from the remote world to the local world
     /// upon deserialization
     pub fn add_map_entities<M: MapEntities + 'static>(self) -> Self {
-        self.app.add_message_map_entities::<M>();
+        let mut registry = self.app.world.resource_mut::<MessageRegistry>();
+        registry.add_map_entities::<M>();
         self
     }
 }
@@ -92,9 +134,9 @@ pub trait AppMessageExt {
     /// This message can now be sent over the network.
     fn add_message<M: Message>(&mut self, direction: ChannelDirection);
 
-    /// Specify that the message contains entities which should be mapped from the remote world to the local world
-    /// upon deserialization
-    fn add_message_map_entities<M: MapEntities + 'static>(&mut self);
+    /// Registers the resource in the Registry
+    /// This resource can now be sent over the network.
+    fn register_resource<R: Resource + Message>(&mut self, direction: ChannelDirection);
 }
 
 impl AppMessageExt for App {
@@ -107,11 +149,10 @@ impl AppMessageExt for App {
         register_message_send::<M>(self, direction);
     }
 
-    /// Specify that the message contains entities which should be mapped from the remote world to the local world
-    /// upon deserialization
-    fn add_message_map_entities<M: MapEntities + 'static>(&mut self) {
-        let mut registry = self.world.resource_mut::<MessageRegistry>();
-        registry.add_map_entities::<M>();
+    /// Register a resource to be automatically replicated over the network
+    fn register_resource<R: Resource + Message>(&mut self, direction: ChannelDirection) {
+        self.add_message::<R>(direction);
+        register_resource_send::<R>(self, direction)
     }
 }
 

--- a/lightyear/src/protocol/mod.rs
+++ b/lightyear/src/protocol/mod.rs
@@ -32,7 +32,7 @@ pub(crate) mod message;
 
 /// Provides a mapping from a type to a unique identifier that can be serialized
 pub(crate) mod registry;
-mod serialize;
+pub(crate) mod serialize;
 
 /// Something that can be serialized bit by bit
 pub trait BitSerializable: Clone {

--- a/lightyear/src/protocol/serialize.rs
+++ b/lightyear/src/protocol/serialize.rs
@@ -1,5 +1,6 @@
 use crate::prelude::{
-    AppMessageExt, ChannelDirection, ComponentRegistry, Message, MessageRegistry, ReplicateResource,
+    AppMessageExt, ChannelDirection, ComponentRegistry, Message, MessageRegistry,
+    ReplicateResourceMetadata,
 };
 use crate::protocol::message::MessageType;
 use crate::protocol::registry::NetId;

--- a/lightyear/src/protocol/serialize.rs
+++ b/lightyear/src/protocol/serialize.rs
@@ -102,9 +102,9 @@ impl ErasedSerializeFns {
 }
 
 pub trait AppSerializeExt {
+    /// Indicate that the type `M` contains Entity references, and that the entities
+    /// should be mapped during deserialization
     fn add_map_entities<M: MapEntities + 'static>(&mut self);
-
-    fn add_resource_map_entities<R: Resource + MapEntities + 'static>(&mut self);
 }
 
 impl AppSerializeExt for App {
@@ -117,9 +117,5 @@ impl AppSerializeExt for App {
         registry.try_add_map_entities::<M>();
         let mut registry = self.world.resource_mut::<ComponentRegistry>();
         registry.try_add_map_entities::<M>();
-    }
-
-    fn add_resource_map_entities<R: Resource + MapEntities + 'static>(&mut self) {
-        self.add_map_entities::<ReplicateResource<R>>();
     }
 }

--- a/lightyear/src/server/connection.rs
+++ b/lightyear/src/server/connection.rs
@@ -36,6 +36,7 @@ use crate::server::config::PacketConfig;
 use crate::server::events::ServerEvents;
 use crate::server::message::ServerMessage;
 use crate::shared::events::connection::ConnectionEvents;
+use crate::shared::message::MessageSend;
 use crate::shared::ping::manager::{PingConfig, PingManager};
 use crate::shared::ping::message::{Ping, Pong, SyncMessage};
 use crate::shared::replication::components::{
@@ -582,6 +583,29 @@ impl Connection {
         self.replication_sender.recv_update_acks();
         debug!("Received server packet with tick: {:?}", tick);
         Ok(())
+    }
+}
+
+impl MessageSend for ConnectionManager {
+    // TODO: don't duplicate these but have a super trait instead
+    type EventContext = ClientId;
+    type SetMarker = ServerMarker;
+
+    fn send_message_to_target<C: Channel, M: Message>(
+        &mut self,
+        message: &M,
+        target: NetworkTarget,
+    ) -> Result<()> {
+        self.send_message_to_target::<C, M>(message, target)
+    }
+
+    fn erased_send_message_to_target<M: Message>(
+        &mut self,
+        message: &M,
+        channel_kind: ChannelKind,
+        target: NetworkTarget,
+    ) -> Result<()> {
+        self.erased_send_message_to_target(message, channel_kind, target)
     }
 }
 

--- a/lightyear/src/server/connection.rs
+++ b/lightyear/src/server/connection.rs
@@ -554,7 +554,7 @@ impl Connection {
         for (group, replication_list) in
             self.replication_receiver.read_messages(tick_manager.tick())
         {
-            error!(?group, ?replication_list, "read replication messages");
+            trace!(?group, ?replication_list, "read replication messages");
             replication_list
                 .into_iter()
                 .for_each(|(tick, replication)| {
@@ -587,10 +587,6 @@ impl Connection {
 }
 
 impl MessageSend for ConnectionManager {
-    // TODO: don't duplicate these but have a super trait instead
-    type EventContext = ClientId;
-    type SetMarker = ServerMarker;
-
     fn send_message_to_target<C: Channel, M: Message>(
         &mut self,
         message: &M,

--- a/lightyear/src/server/connection.rs
+++ b/lightyear/src/server/connection.rs
@@ -527,6 +527,7 @@ impl Connection {
                             }
                         }
                         ClientMessage::Replication(replication) => {
+                            error!(?tick, ?replication, "received replication message");
                             // buffer the replication message
                             self.replication_receiver.recv_message(replication, tick);
                         }
@@ -552,7 +553,7 @@ impl Connection {
         for (group, replication_list) in
             self.replication_receiver.read_messages(tick_manager.tick())
         {
-            trace!(?group, ?replication_list, "read replication messages");
+            error!(?group, ?replication_list, "read replication messages");
             replication_list
                 .into_iter()
                 .for_each(|(tick, replication)| {

--- a/lightyear/src/server/connection.rs
+++ b/lightyear/src/server/connection.rs
@@ -528,7 +528,7 @@ impl Connection {
                             }
                         }
                         ClientMessage::Replication(replication) => {
-                            error!(?tick, ?replication, "received replication message");
+                            trace!(?tick, ?replication, "received replication message");
                             // buffer the replication message
                             self.replication_receiver.recv_message(replication, tick);
                         }

--- a/lightyear/src/server/message.rs
+++ b/lightyear/src/server/message.rs
@@ -82,6 +82,7 @@ fn read_message<M: Message>(
                             }
                         }
                         event.send(MessageEvent::new(message, *client_id));
+                        trace!("Received message: {:?}", std::any::type_name::<M>());
                     }
                     Err(e) => {
                         error!(

--- a/lightyear/src/shared/events/components.rs
+++ b/lightyear/src/shared/events/components.rs
@@ -35,8 +35,8 @@ impl<Ctx> DisconnectEvent<Ctx> {
 /// This event is emitted whenever we receive a message from the remote
 #[derive(Event)]
 pub struct MessageEvent<M: Message, Ctx = ()> {
-    message: M,
-    context: Ctx,
+    pub message: M,
+    pub context: Ctx,
 }
 
 impl<M: Message, Ctx> MessageEvent<M, Ctx> {

--- a/lightyear/src/shared/input_leafwing.rs
+++ b/lightyear/src/shared/input_leafwing.rs
@@ -7,7 +7,8 @@ use crate::client::config::ClientConfig;
 use crate::client::input_leafwing::LeafwingInputConfig;
 use crate::inputs::leafwing::InputMessage;
 use crate::prelude::{
-    AppComponentExt, AppMessageExt, ChannelDirection, LeafwingUserAction, MessageRegistry,
+    AppComponentExt, AppMessageExt, AppSerializeExt, ChannelDirection, LeafwingUserAction,
+    MessageRegistry,
 };
 use crate::protocol::message::MessageType;
 use crate::server::config::ServerConfig;
@@ -32,7 +33,7 @@ impl<A: LeafwingUserAction> Plugin for LeafwingInputPlugin<A> {
         app.world
             .resource_mut::<MessageRegistry>()
             .add_message::<InputMessage<A>>(MessageType::LeafwingInput);
-        app.add_message_map_entities::<InputMessage<A>>();
+        app.add_map_entities::<InputMessage<A>>();
         app.register_component::<ActionState<A>>(ChannelDirection::Bidirectional);
         let is_client = app.world.get_resource::<ClientConfig>().is_some();
         let is_server = app.world.get_resource::<ServerConfig>().is_some();

--- a/lightyear/src/shared/message.rs
+++ b/lightyear/src/shared/message.rs
@@ -5,12 +5,6 @@ use std::fmt::Debug;
 use std::hash::Hash;
 
 pub(crate) trait MessageSend: Resource {
-    /// Type of the context associated with the events emitted by this replication plugin
-    type EventContext: EventContext;
-    /// Marker to identify the type of the ReplicationSet component
-    /// This is mostly relevant in the unified mode, where a ReplicationSet can be added several times
-    /// (in the client and the server replication plugins)
-    type SetMarker: Debug + Hash + Send + Sync + Eq + Clone;
     fn send_message_to_target<C: Channel, M: Message>(
         &mut self,
         message: &M,

--- a/lightyear/src/shared/message.rs
+++ b/lightyear/src/shared/message.rs
@@ -1,0 +1,26 @@
+use crate::prelude::{Channel, ChannelKind, Message, NetworkTarget};
+use crate::protocol::EventContext;
+use bevy::prelude::Resource;
+use std::fmt::Debug;
+use std::hash::Hash;
+
+pub(crate) trait MessageSend: Resource {
+    /// Type of the context associated with the events emitted by this replication plugin
+    type EventContext: EventContext;
+    /// Marker to identify the type of the ReplicationSet component
+    /// This is mostly relevant in the unified mode, where a ReplicationSet can be added several times
+    /// (in the client and the server replication plugins)
+    type SetMarker: Debug + Hash + Send + Sync + Eq + Clone;
+    fn send_message_to_target<C: Channel, M: Message>(
+        &mut self,
+        message: &M,
+        target: NetworkTarget,
+    ) -> anyhow::Result<()>;
+
+    fn erased_send_message_to_target<M: Message>(
+        &mut self,
+        message: &M,
+        channel_kind: ChannelKind,
+        target: NetworkTarget,
+    ) -> anyhow::Result<()>;
+}

--- a/lightyear/src/shared/mod.rs
+++ b/lightyear/src/shared/mod.rs
@@ -20,4 +20,5 @@ pub mod input;
 
 #[cfg(feature = "leafwing")]
 pub mod input_leafwing;
+pub(crate) mod message;
 pub mod time_manager;

--- a/lightyear/src/shared/plugin.rs
+++ b/lightyear/src/shared/plugin.rs
@@ -1,4 +1,6 @@
 //! Bevy [`bevy::prelude::Plugin`] used by both the server and the client
+use crate::client::config::ClientConfig;
+use crate::connection::server::ServerConnections;
 use bevy::ecs::system::SystemParam;
 use bevy::prelude::*;
 
@@ -22,16 +24,44 @@ pub struct SharedPlugin {
 /// You can use this as a SystemParam to identify whether you're running on the client or the server
 #[derive(SystemParam)]
 pub struct NetworkIdentity<'w, 's> {
-    config: Option<Res<'w, ServerConfig>>,
+    client_config: Option<Res<'w, ClientConfig>>,
+    server: Option<Res<'w, ServerConnections>>,
     _marker: std::marker::PhantomData<&'s ()>,
 }
 
+#[derive(Debug, PartialEq)]
+pub enum Identity {
+    /// This peer is a client.
+    /// (note that both the client and server plugins could be running in the same process; but this peer is still acting like a client.
+    /// (for example if the server plugin is stopped))
+    Client,
+    /// This peer is a server.
+    Server,
+    /// This peer is both a server and a client
+    HostServer,
+}
+
 impl<'w, 's> NetworkIdentity<'w, 's> {
+    pub fn identity(&self) -> Identity {
+        let Some(config) = &self.client_config else {
+            return Identity::Server;
+        };
+        if matches!(config.shared.mode, Mode::HostServer)
+            && self
+                .server
+                .as_ref()
+                .map_or(false, |server| server.is_listening())
+        {
+            return Identity::HostServer;
+        } else {
+            return Identity::Client;
+        }
+    }
     pub fn is_client(&self) -> bool {
-        self.config.is_none()
+        self.identity() == Identity::Client
     }
     pub fn is_server(&self) -> bool {
-        self.config.is_some()
+        self.identity() == Identity::Server
     }
 }
 

--- a/lightyear/src/shared/plugin.rs
+++ b/lightyear/src/shared/plugin.rs
@@ -107,8 +107,8 @@ impl Plugin for SharedPlugin {
         app.register_component::<PrePredicted>(ChannelDirection::Bidirectional);
         app.register_component::<ShouldBePredicted>(ChannelDirection::ServerToClient);
         app.register_component::<ShouldBeInterpolated>(ChannelDirection::ServerToClient);
-        app.register_component::<ParentSync>(ChannelDirection::Bidirectional);
-        app.add_component_map_entities::<ParentSync>();
+        app.register_component::<ParentSync>(ChannelDirection::Bidirectional)
+            .add_map_entities::<ParentSync>();
         // check that the protocol was built correctly
         app.world.resource::<ComponentRegistry>().check();
     }

--- a/lightyear/src/shared/plugin.rs
+++ b/lightyear/src/shared/plugin.rs
@@ -52,9 +52,9 @@ impl<'w, 's> NetworkIdentity<'w, 's> {
                 .as_ref()
                 .map_or(false, |server| server.is_listening())
         {
-            return Identity::HostServer;
+            Identity::HostServer
         } else {
-            return Identity::Client;
+            Identity::Client
         }
     }
     pub fn is_client(&self) -> bool {

--- a/lightyear/src/shared/replication/plugin.rs
+++ b/lightyear/src/shared/replication/plugin.rs
@@ -57,11 +57,14 @@ impl<R: ReplicationSend> Plugin for ReplicationPlugin<R> {
             .register_type::<PredictedEntityMap>()
             .register_type::<InterpolatedEntityMap>();
 
+        // TODO: should we put this back into enable_receive?
+        app.add_plugins(ResourceReceivePlugin::<R>::default());
+        app.add_plugins(ResourceSendPlugin::<R>::default());
         // SYSTEM SETS //
         if self.enable_receive {
             // PLUGINS
             app.add_plugins(HierarchyReceivePlugin::<R>::default());
-            app.add_plugins(ResourceReceivePlugin::<R>::default());
+            // app.add_plugins(ResourceReceivePlugin::<R>::default());
         }
         if self.enable_send {
             app.configure_sets(
@@ -113,7 +116,7 @@ impl<R: ReplicationSend> Plugin for ReplicationPlugin<R> {
             add_replication_send_systems::<R>(app);
             // PLUGINS
             app.add_plugins(HierarchySendPlugin::<R>::default());
-            app.add_plugins(ResourceSendPlugin::<R>::default());
+            // app.add_plugins(ResourceSendPlugin::<R>::default());
         }
 
         // TODO: split receive cleanup from send cleanup

--- a/lightyear/src/shared/replication/plugin.rs
+++ b/lightyear/src/shared/replication/plugin.rs
@@ -78,17 +78,18 @@ impl<R: ReplicationSend> Plugin for ReplicationPlugin<R> {
                 (
                     (
                         InternalReplicationSet::<R::SetMarker>::HandleReplicateUpdate,
+                        InternalReplicationSet::<R::SetMarker>::BufferResourceUpdates,
                         InternalReplicationSet::<R::SetMarker>::Buffer,
                     )
                         .in_set(InternalReplicationSet::<R::SetMarker>::All),
                     (
                         InternalReplicationSet::<R::SetMarker>::BufferEntityUpdates,
-                        InternalReplicationSet::<R::SetMarker>::BufferResourceUpdates,
                         InternalReplicationSet::<R::SetMarker>::BufferComponentUpdates,
                         InternalReplicationSet::<R::SetMarker>::BufferDespawnsAndRemovals,
                     )
                         .in_set(InternalReplicationSet::<R::SetMarker>::Buffer),
                     (
+                        InternalReplicationSet::<R::SetMarker>::HandleReplicateUpdate,
                         InternalReplicationSet::<R::SetMarker>::BufferEntityUpdates,
                         InternalReplicationSet::<R::SetMarker>::BufferResourceUpdates,
                         InternalReplicationSet::<R::SetMarker>::BufferComponentUpdates,
@@ -98,6 +99,11 @@ impl<R: ReplicationSend> Plugin for ReplicationPlugin<R> {
                     (
                         InternalReplicationSet::<R::SetMarker>::HandleReplicateUpdate,
                         InternalReplicationSet::<R::SetMarker>::Buffer,
+                        InternalMainSet::<R::SetMarker>::SendPackets,
+                    )
+                        .chain(),
+                    (
+                        InternalReplicationSet::<R::SetMarker>::BufferResourceUpdates,
                         InternalMainSet::<R::SetMarker>::SendPackets,
                     )
                         .chain(),

--- a/lightyear/src/shared/replication/plugin.rs
+++ b/lightyear/src/shared/replication/plugin.rs
@@ -92,10 +92,12 @@ impl<R: ReplicationSend> Plugin for ReplicationPlugin<R> {
                     )
                         .in_set(InternalReplicationSet::<R::SetMarker>::Buffer),
                     (
-                        InternalReplicationSet::<R::SetMarker>::HandleReplicateUpdate,
                         InternalReplicationSet::<R::SetMarker>::BufferEntityUpdates,
                         InternalReplicationSet::<R::SetMarker>::BufferResourceUpdates,
                         InternalReplicationSet::<R::SetMarker>::BufferComponentUpdates,
+                        // TODO: verify this, why does handle-replicate-update need to run every frame?
+                        //  because Removed<Replicate> is cleared every frame?
+                        // NOTE: HandleReplicateUpdate should also run every frame?
                         // NOTE: BufferDespawnsAndRemovals is not in MainSet::Send because we need to run them every frame
                     )
                         .in_set(InternalMainSet::<R::SetMarker>::Send),

--- a/lightyear/src/shared/replication/receive.rs
+++ b/lightyear/src/shared/replication/receive.rs
@@ -432,7 +432,7 @@ impl GroupChannel {
             .get(&self.actions_pending_recv_message_id)?;
         // if the message is from the future, keep it there
         if message.0 > current_tick {
-            trace!("message tick is from the future compared to our tick");
+            error!("message tick {:?} is from the future compared to our current tick {current_tick:?}", message.0);
             return None;
         }
 

--- a/lightyear/src/shared/replication/receive.rs
+++ b/lightyear/src/shared/replication/receive.rs
@@ -432,7 +432,7 @@ impl GroupChannel {
             .get(&self.actions_pending_recv_message_id)?;
         // if the message is from the future, keep it there
         if message.0 > current_tick {
-            error!("message tick {:?} is from the future compared to our current tick {current_tick:?}", message.0);
+            debug!("message tick {:?} is from the future compared to our current tick {current_tick:?}", message.0);
             return None;
         }
 

--- a/lightyear/src/shared/replication/resources.rs
+++ b/lightyear/src/shared/replication/resources.rs
@@ -98,6 +98,9 @@ mod command {
     }
 }
 
+// TODO: serialize the resource directly into the component, instead of cloning it,
+//  but then we need to make sure that the component is serialized with just a memcpy,
+//  since it's already been serialized. Maybe we can implement its BitSerialize ourselves?
 /// This component can be added to an entity to start replicating a [`Resource`] to remote clients.
 ///
 /// Currently, resources are cloned to be replicated, so only use this for resources that are
@@ -125,6 +128,8 @@ impl<R> Default for ReplicateResource<R> {
 
 pub(crate) mod send {
     use super::*;
+    use crate::prelude::NetworkIdentity;
+    use tracing::info;
 
     pub(crate) struct ResourceSendPlugin<R> {
         _marker: PhantomData<R>,
@@ -161,20 +166,22 @@ pub(crate) mod send {
     }
 
     fn copy_send_resource<R: Resource + Clone>(
+        identity: NetworkIdentity,
         resource: Option<Res<R>>,
         mut replicating_entity: Query<&mut ReplicateResource<R>, With<Replicate>>,
     ) {
-        if replicating_entity.iter().len() > 1 {
-            error!(
-                "Only one entity per World should have a ReplicateResource<{:?}> component",
-                std::any::type_name::<R>()
-            );
-            return;
-        }
+        // if replicating_entity.iter().len() > 1 {
+        //     error!(
+        //         "Only one entity per World should have a ReplicateResource<{:?}> component",
+        //         std::any::type_name::<R>()
+        //     );
+        //     return;
+        // }
         let Some(resource) = resource else {
             // if the resource was removed, remove it from the entity
             if let Ok(mut replicating_entity) = replicating_entity.get_single_mut() {
                 if replicating_entity.resource.is_some() {
+                    error!(identity = ?identity.identity(), "Sending removal for resource {:?}", std::any::type_name::<R>());
                     replicating_entity.resource = None;
                 }
             }
@@ -182,6 +189,10 @@ pub(crate) mod send {
         };
         if let Ok(mut replicating_entity) = replicating_entity.get_single_mut() {
             if resource.is_changed() || replicating_entity.is_added() {
+                error!(identity = ?identity.identity(),
+                    "Sending update for resource {:?}",
+                    std::any::type_name::<R>()
+                );
                 // TODO: we should be able to avoid this clone? we only need the reference to the resource to serialize it
                 //  - we could directly serialize the data here and store it in the component
                 //  - the component could just be a marker that we need to serialize the resource, and then we have a custom
@@ -193,7 +204,14 @@ pub(crate) mod send {
 }
 
 pub(crate) mod receive {
-    use bevy::prelude::RemovedComponents;
+    use crate::prelude::{ChannelDirection, ComponentRegistry, NetworkIdentity};
+    use crate::protocol::component::ComponentKind;
+    use crate::protocol::EventContext;
+    use crate::shared::events::components::{
+        ComponentInsertEvent, ComponentRemoveEvent, ComponentUpdateEvent,
+    };
+    use bevy::prelude::{DetectChangesMut, EventReader, RemovedComponents};
+    use tracing::debug;
 
     use super::*;
 
@@ -214,7 +232,7 @@ pub(crate) mod receive {
             app.configure_sets(
                 PreUpdate,
                 InternalReplicationSet::<R::SetMarker>::ReceiveResourceUpdates
-                    .after(InternalMainSet::<R::SetMarker>::Receive),
+                    .after(InternalMainSet::<R::SetMarker>::EmitEvents),
             );
         }
     }
@@ -224,37 +242,91 @@ pub(crate) mod receive {
     ) {
         app.add_systems(
             PreUpdate,
-            (copy_receive_resource::<R>, handle_despawned_entity::<R>)
+            handle_despawned_entity::<R>
+                .in_set(InternalReplicationSet::<S::SetMarker>::ReceiveResourceUpdates),
+        );
+        app.add_systems(
+            PreUpdate,
+            copy_receive_resource::<R, S::EventContext>
                 .in_set(InternalReplicationSet::<S::SetMarker>::ReceiveResourceUpdates),
         );
     }
 
-    fn copy_receive_resource<R: Resource + Clone>(
+    // NOTE: we cannot use directly the value of the resource here inside the ReplicateResource<R> component,
+    //  because in the bidirectional case, we would then be removing the resource immediately since the
+    //  ReplicateResource component doesn't contain the resource in the Receive SystemSet.
+    //  instead, use the replication events.
+    fn copy_receive_resource<R: Resource + Clone, Ctx: EventContext>(
         mut commands: Commands,
+        identity: NetworkIdentity,
+        mut received_inserts: EventReader<ComponentInsertEvent<ReplicateResource<R>, Ctx>>,
+        mut received_updates: EventReader<ComponentUpdateEvent<ReplicateResource<R>, Ctx>>,
         replicating_entity: Query<Ref<ReplicateResource<R>>>,
-        resource: Option<ResMut<R>>,
+        mut resource: Option<ResMut<R>>,
     ) {
-        if replicating_entity.iter().len() > 1 {
-            error!(
-                "Only one entity per World should have a ReplicateResource<{:?}> component",
-                std::any::type_name::<R>()
-            );
-            return;
-        }
-        if let Ok(replicating_entity) = replicating_entity.get_single() {
-            if replicating_entity.is_changed() {
-                if let Some(received_value) = &replicating_entity.resource {
-                    if let Some(mut resource) = resource {
-                        *resource = received_value.clone();
+        for entity in received_inserts
+            .read()
+            .map(|e| e.entity())
+            .chain(received_updates.read().map(|e| e.entity()))
+        {
+            error!(identity = ?identity.identity(), "Received resource replication event");
+            if let Ok(replicating_entity) = replicating_entity.get(entity) {
+                if replicating_entity.is_changed() {
+                    if let Some(received_value) = &replicating_entity.resource {
+                        error!(identity = ?identity.identity(), "Update resource");
+                        if let Some(ref mut resource) = resource {
+                            // write the received value to the resource
+                            // without change detection to avoid an infinite loop
+                            *(resource.bypass_change_detection()) = received_value.clone();
+                        } else {
+                            commands.insert_resource(received_value.clone());
+                        }
                     } else {
-                        commands.insert_resource(received_value.clone());
+                        error!(
+                            is_client = ?identity.is_client(),
+                            "Despawning resource {:?} because the replicating entity doesn't contain it",
+                            std::any::type_name::<R>(),
+                        );
+                        commands.remove_resource::<R>();
                     }
-                } else if let Some(resource) = resource {
-                    commands.remove_resource::<R>();
                 }
             }
         }
     }
+
+    // fn copy_receive_resource<R: Resource + Clone>(
+    //     component_registry: Res<ComponentRegistry>,
+    //     mut commands: Commands,
+    //     replicating_entity: Query<Ref<ReplicateResource<R>>>,
+    //     resource: Option<ResMut<R>>,
+    // ) {
+    //     if replicating_entity.iter().len() > 1 {
+    //         error!(
+    //             "Only one entity per World should have a ReplicateResource<{:?}> component",
+    //             std::any::type_name::<R>()
+    //         );
+    //         return;
+    //     }
+    //     if let Ok(replicating_entity) = replicating_entity.get_single() {
+    //         if replicating_entity.is_changed() {
+    //             if let Some(received_value) = &replicating_entity.resource {
+    //                 if let Some(mut resource) = resource {
+    //                     // TODO: use set_if_neq for PartialEq
+    //                     // resource.set_if_neq(received_value.clone());
+    //                     *resource = received_value.clone();
+    //                 } else {
+    //                     commands.insert_resource(received_value.clone());
+    //                 }
+    //             } else if let Some(resource) = resource {
+    //                 error!(
+    //                     "Despawning resource {:?} because the replicating entity doesn't contain it",
+    //                     std::any::type_name::<R>()
+    //                 );
+    //                 commands.remove_resource::<R>();
+    //             }
+    //         }
+    //     }
+    // }
 
     /// If the entity that was driving the replication of the resource is despawned (usually when the
     /// client disconnects from the server), despawn the resource
@@ -263,6 +335,10 @@ pub(crate) mod receive {
         mut despawned: RemovedComponents<ReplicateResource<R>>,
     ) {
         for despawned_entity in despawned.read() {
+            error!(
+                "Despawning resource {:?} because the entity was despawned",
+                std::any::type_name::<R>()
+            );
             commands.remove_resource::<R>();
         }
     }
@@ -270,12 +346,17 @@ pub(crate) mod receive {
 
 #[cfg(test)]
 mod tests {
-    use bevy::prelude::{Commands, OnEnter};
+    use bevy::ecs::system::RunSystemOnce;
+    use bevy::prelude::{apply_deferred, Commands, OnEnter, Resource};
+    use serde::{Deserialize, Serialize};
+    use std::marker::PhantomData;
+    use tracing::error;
 
     use crate::prelude::client::NetworkingState;
-    use crate::prelude::Replicate;
+    use crate::prelude::{AppComponentExt, Replicate};
+    use crate::shared::replication::resources::command::StartReplicateCommand;
     use crate::shared::replication::resources::ReplicateResourceExt;
-    use crate::tests::protocol::{Component1, Resource1};
+    use crate::tests::protocol::{Component1, Resource1, Resource2};
     use crate::tests::stepper::{BevyStepper, Step};
 
     use super::{ReplicateResource, StopReplicateResourceExt};
@@ -436,6 +517,8 @@ mod tests {
         assert_eq!(stepper.client_app.world.resource::<Resource1>().0, 1.0);
     }
 
+    /// Check that when a client disconnects, every resource that was spawned from replication
+    /// gets despawned.
     #[test]
     fn test_client_disconnect() {
         let mut stepper = BevyStepper::default();
@@ -557,5 +640,69 @@ mod tests {
 
         // check that the deletion hasn't been replicated
         assert_eq!(stepper.client_app.world.resource::<Resource1>().0, 3.0);
+    }
+
+    #[test]
+    fn test_bidirectional_replication() {
+        tracing_subscriber::FmtSubscriber::builder()
+            .with_max_level(tracing::Level::INFO)
+            .init();
+        let mut stepper = BevyStepper::default();
+
+        // start replicating a resource via commands (even if the resource doesn't exist yet)
+        let start_server_replicate_system =
+            stepper
+                .server_app
+                .world
+                .register_system(|mut commands: Commands| {
+                    commands.replicate_resource::<Resource2>(Replicate::default());
+                });
+        let stop_server_replicate_system =
+            stepper
+                .server_app
+                .world
+                .register_system(|mut commands: Commands| {
+                    commands.stop_replicate_resource::<Resource2>();
+                });
+        stepper.server_app.world.insert_resource(Resource2(1.0));
+        error!("resource inserted");
+        let _ = stepper
+            .server_app
+            .world
+            .run_system(start_server_replicate_system);
+        stepper.frame_step();
+        stepper.frame_step();
+
+        // check that the resource was replicated
+        assert_eq!(stepper.client_app.world.resource::<Resource2>().0, 1.0);
+
+        // update the resource on the client
+        // and start replicating the resource to the server
+        let start_client_replicate_system =
+            stepper
+                .client_app
+                .world
+                .register_system(|mut commands: Commands| {
+                    commands.replicate_resource::<Resource2>(Replicate::default());
+                });
+        let stop_client_replicate_system =
+            stepper
+                .server_app
+                .world
+                .register_system(|mut commands: Commands| {
+                    commands.stop_replicate_resource::<Resource2>();
+                });
+
+        let _ = stepper
+            .client_app
+            .world
+            .run_system(start_client_replicate_system);
+        stepper.client_app.world.resource_mut::<Resource2>().0 = 2.0;
+        stepper.frame_step();
+        stepper.frame_step();
+        stepper.frame_step();
+
+        // check that the update was replicated to the server
+        assert_eq!(stepper.server_app.world.resource::<Resource2>().0, 2.0);
     }
 }

--- a/lightyear/src/shared/replication/resources.rs
+++ b/lightyear/src/shared/replication/resources.rs
@@ -15,9 +15,9 @@ use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use tracing::error;
 
-pub use command::{ReplicateResourceExt, StopReplicateCommand, StopReplicateResourceExt};
+pub use command::{ReplicateResourceExt, StopReplicateResourceExt};
 
-use crate::prelude::Message;
+use crate::prelude::{ChannelKind, Message, NetworkTarget};
 use crate::protocol::BitSerializable;
 use crate::shared::replication::components::Replicate;
 use crate::shared::replication::ReplicationSend;
@@ -25,75 +25,37 @@ use crate::shared::sets::{InternalMainSet, InternalReplicationSet};
 
 mod command {
     use super::*;
-
-    pub struct StartReplicateCommand<R> {
-        replicate: Replicate,
-        _marker: PhantomData<R>,
-    }
-
-    impl<R: Resource + Clone> Command for StartReplicateCommand<R> {
-        fn apply(self, world: &mut World) {
-            if let Ok(entity) = world
-                .query_filtered::<Entity, With<ReplicateResource<R>>>()
-                .get_single(world)
-            {
-                world.entity_mut(entity).insert(self.replicate);
-            } else {
-                world.spawn((ReplicateResource::<R>::default(), self.replicate));
-            }
-        }
-    }
+    use crate::prelude::Channel;
 
     /// Extension trait to be able to replicate a resource to remote clients via [`Commands`].
     pub trait ReplicateResourceExt {
         /// Start replicating a resource to remote clients.
         ///
         /// Any change to the resource will be replicated to the clients.
-        fn replicate_resource<R: Resource + Clone>(&mut self, replicate: Replicate);
+        fn replicate_resource<R: Resource, C: Channel>(&mut self, target: NetworkTarget);
     }
 
     impl ReplicateResourceExt for Commands<'_, '_> {
-        fn replicate_resource<R: Resource + Clone>(&mut self, replicate: Replicate) {
-            self.add(StartReplicateCommand::<R> {
-                replicate,
+        fn replicate_resource<R: Resource, C: Channel>(&mut self, target: NetworkTarget) {
+            self.insert_resource(ReplicateResource::<R> {
+                target,
+                channel: ChannelKind::of::<C>(),
                 _marker: PhantomData,
             });
-        }
-    }
-
-    pub struct StopReplicateCommand<R> {
-        _marker: PhantomData<R>,
-    }
-
-    impl<R> Default for StopReplicateCommand<R> {
-        fn default() -> Self {
-            Self {
-                _marker: PhantomData,
-            }
-        }
-    }
-
-    impl<R: Resource + Clone> Command for StopReplicateCommand<R> {
-        fn apply(self, world: &mut World) {
-            if let Ok(entity) = world
-                .query_filtered::<Entity, With<ReplicateResource<R>>>()
-                .get_single(world)
-            {
-                // we do not despawn the entity, because that would delete the resource
-                world.entity_mut(entity).remove::<Replicate>();
-            }
         }
     }
 
     /// Extension trait to be able to stop replicating a resource to remote clients via [`Commands`].
     pub trait StopReplicateResourceExt {
         /// Stop replicating a resource to remote clients.
-        fn stop_replicate_resource<R: Resource + Clone>(&mut self);
+        ///
+        /// This doesn't despawn the resource, it just stops replicating the updates.
+        fn stop_replicate_resource<R: Resource>(&mut self);
     }
 
     impl StopReplicateResourceExt for Commands<'_, '_> {
-        fn stop_replicate_resource<R: Resource + Clone>(&mut self) {
-            self.add(StopReplicateCommand::<R>::default());
+        fn stop_replicate_resource<R: Resource>(&mut self) {
+            self.remove_resource::<ReplicateResource<R>>();
         }
     }
 }
@@ -107,28 +69,32 @@ mod command {
 /// cheap-to-clone. (the clone only happens when the resource is modified)
 ///
 /// Only one entity per World should have this component.
-#[derive(Component, Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Resource, Debug, Clone, PartialEq)]
 pub struct ReplicateResource<R> {
-    resource: Option<R>,
+    pub target: NetworkTarget,
+    pub channel: ChannelKind,
+    _marker: std::marker::PhantomData<R>,
 }
 
-impl<R: MapEntities> MapEntities for ReplicateResource<R> {
-    fn map_entities<M: EntityMapper>(&mut self, entity_mapper: &mut M) {
-        if let Some(r) = self.resource.as_mut() {
-            r.map_entities(entity_mapper);
-        }
-    }
+/// Message that indicates that a resource should be despawned
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct DespawnResource<R> {
+    _marker: std::marker::PhantomData<R>,
 }
 
-impl<R> Default for ReplicateResource<R> {
+impl<R> Default for DespawnResource<R> {
     fn default() -> Self {
-        Self { resource: None }
+        Self {
+            _marker: std::marker::PhantomData,
+        }
     }
 }
 
 pub(crate) mod send {
     use super::*;
     use crate::prelude::NetworkIdentity;
+    use crate::shared::message::MessageSend;
+    use bevy::prelude::resource_removed;
     use tracing::info;
 
     pub(crate) struct ResourceSendPlugin<R> {
@@ -144,60 +110,49 @@ pub(crate) mod send {
     }
 
     impl<R: ReplicationSend> Plugin for ResourceSendPlugin<R> {
-        fn build(&self, app: &mut App) {
-            app.configure_sets(
-                PostUpdate,
-                // we need to make sure that the resource data is copied to the component before
-                // we send the component update
-                InternalReplicationSet::<R::SetMarker>::BufferResourceUpdates
-                    .before(InternalReplicationSet::<R::SetMarker>::BufferComponentUpdates),
-            );
-        }
+        fn build(&self, app: &mut App) {}
     }
 
-    pub(crate) fn add_resource_send_systems<S: ReplicationSend, R: Resource + Clone>(
-        app: &mut App,
-    ) {
+    pub(crate) fn add_resource_send_systems<R: Resource + Message, S: MessageSend>(app: &mut App) {
         app.add_systems(
             PostUpdate,
-            copy_send_resource::<R>
+            (
+                send_resource_removal::<R, S>.run_if(resource_removed::<R>()),
+                send_resource_update::<R, S>,
+            )
                 .in_set(InternalReplicationSet::<S::SetMarker>::BufferResourceUpdates),
         );
     }
 
-    fn copy_send_resource<R: Resource + Clone>(
-        identity: NetworkIdentity,
-        resource: Option<Res<R>>,
-        mut replicating_entity: Query<&mut ReplicateResource<R>, With<Replicate>>,
+    /// Send a message indicating that the resource was removed
+    fn send_resource_removal<R: Resource + Message, S: MessageSend>(
+        mut connection_manager: ResMut<S>,
+        replication_resource: Option<Res<ReplicateResource<R>>>,
     ) {
-        // if replicating_entity.iter().len() > 1 {
-        //     error!(
-        //         "Only one entity per World should have a ReplicateResource<{:?}> component",
-        //         std::any::type_name::<R>()
-        //     );
-        //     return;
-        // }
-        let Some(resource) = resource else {
-            // if the resource was removed, remove it from the entity
-            if let Ok(mut replicating_entity) = replicating_entity.get_single_mut() {
-                if replicating_entity.resource.is_some() {
-                    error!(identity = ?identity.identity(), "Sending removal for resource {:?}", std::any::type_name::<R>());
-                    replicating_entity.resource = None;
+        if let Some(replication_resource) = replication_resource {
+            let _ = connection_manager.erased_send_message_to_target::<DespawnResource<R>>(
+                &DespawnResource::default(),
+                replication_resource.channel,
+                replication_resource.target.clone(),
+            );
+        }
+    }
+
+    /// Send a message when the resource is updated
+    fn send_resource_update<R: Resource + Message, S: MessageSend>(
+        mut connection_manager: ResMut<S>,
+        replication_resource: Option<Res<ReplicateResource<R>>>,
+        resource: Option<Res<R>>,
+    ) {
+        if let Some(resource) = resource {
+            if resource.is_changed() {
+                if let Some(replication_resource) = replication_resource {
+                    let _ = connection_manager.erased_send_message_to_target(
+                        resource.as_ref(),
+                        replication_resource.channel,
+                        replication_resource.target.clone(),
+                    );
                 }
-            }
-            return;
-        };
-        if let Ok(mut replicating_entity) = replicating_entity.get_single_mut() {
-            if resource.is_changed() || replicating_entity.is_added() {
-                error!(identity = ?identity.identity(),
-                    "Sending update for resource {:?}",
-                    std::any::type_name::<R>()
-                );
-                // TODO: we should be able to avoid this clone? we only need the reference to the resource to serialize it
-                //  - we could directly serialize the data here and store it in the component
-                //  - the component could just be a marker that we need to serialize the resource, and then we have a custom
-                //    serialization function that fetches the resource and serializes it?
-                replicating_entity.resource = Some(resource.clone());
             }
         }
     }
@@ -208,9 +163,10 @@ pub(crate) mod receive {
     use crate::protocol::component::ComponentKind;
     use crate::protocol::EventContext;
     use crate::shared::events::components::{
-        ComponentInsertEvent, ComponentRemoveEvent, ComponentUpdateEvent,
+        ComponentInsertEvent, ComponentRemoveEvent, ComponentUpdateEvent, MessageEvent,
     };
-    use bevy::prelude::{DetectChangesMut, EventReader, RemovedComponents};
+    use crate::shared::message::MessageSend;
+    use bevy::prelude::{DetectChangesMut, EventReader, Events, RemovedComponents};
     use tracing::debug;
 
     use super::*;
@@ -237,111 +193,48 @@ pub(crate) mod receive {
         }
     }
 
-    pub(crate) fn add_resource_receive_systems<S: ReplicationSend, R: Resource + Clone>(
+    pub(crate) fn add_resource_receive_systems<R: Resource + Message, S: MessageSend>(
         app: &mut App,
     ) {
         app.add_systems(
             PreUpdate,
-            handle_despawned_entity::<R>
-                .in_set(InternalReplicationSet::<S::SetMarker>::ReceiveResourceUpdates),
-        );
-        app.add_systems(
-            PreUpdate,
-            copy_receive_resource::<R, S::EventContext>
+            handle_resource_message::<R, S::EventContext>
                 .in_set(InternalReplicationSet::<S::SetMarker>::ReceiveResourceUpdates),
         );
     }
 
-    // NOTE: we cannot use directly the value of the resource here inside the ReplicateResource<R> component,
-    //  because in the bidirectional case, we would then be removing the resource immediately since the
-    //  ReplicateResource component doesn't contain the resource in the Receive SystemSet.
-    //  instead, use the replication events.
-    fn copy_receive_resource<R: Resource + Clone, Ctx: EventContext>(
+    fn handle_resource_message<R: Resource + Message, Ctx: EventContext>(
         mut commands: Commands,
-        identity: NetworkIdentity,
-        mut received_inserts: EventReader<ComponentInsertEvent<ReplicateResource<R>, Ctx>>,
-        mut received_updates: EventReader<ComponentUpdateEvent<ReplicateResource<R>, Ctx>>,
-        replicating_entity: Query<Ref<ReplicateResource<R>>>,
+        mut receive_message: ResMut<Events<MessageEvent<R, Ctx>>>,
         mut resource: Option<ResMut<R>>,
     ) {
-        for entity in received_inserts
-            .read()
-            .map(|e| e.entity())
-            .chain(received_updates.read().map(|e| e.entity()))
-        {
-            error!(identity = ?identity.identity(), "Received resource replication event");
-            if let Ok(replicating_entity) = replicating_entity.get(entity) {
-                if replicating_entity.is_changed() {
-                    if let Some(received_value) = &replicating_entity.resource {
-                        error!(identity = ?identity.identity(), "Update resource");
-                        if let Some(ref mut resource) = resource {
-                            // write the received value to the resource
-                            // without change detection to avoid an infinite loop
-                            *(resource.bypass_change_detection()) = received_value.clone();
-                        } else {
-                            commands.insert_resource(received_value.clone());
-                        }
-                    } else {
-                        error!(
-                            is_client = ?identity.is_client(),
-                            "Despawning resource {:?} because the replicating entity doesn't contain it",
-                            std::any::type_name::<R>(),
-                        );
-                        commands.remove_resource::<R>();
-                    }
-                }
+        for message in receive_message.drain() {
+            // TODO: disable change detection only for bidirectional!
+            if let Some(ref mut resource) = resource {
+                // write the received value to the resource
+                // without change detection to avoid an infinite loop
+                *(resource.bypass_change_detection()) = message.message;
+            } else {
+                commands.insert_resource(message.message);
             }
         }
     }
 
-    // fn copy_receive_resource<R: Resource + Clone>(
-    //     component_registry: Res<ComponentRegistry>,
+    // TODO: upon disconnection, despawn the replicated resource?
+    // /// If the entity that was driving the replication of the resource is despawned (usually when the
+    // /// client disconnects from the server), despawn the resource
+    // fn handle_despawned_entity<R: Resource + Clone>(
     //     mut commands: Commands,
-    //     replicating_entity: Query<Ref<ReplicateResource<R>>>,
-    //     resource: Option<ResMut<R>>,
+    //     mut despawned: RemovedComponents<ReplicateResource<R>>,
     // ) {
-    //     if replicating_entity.iter().len() > 1 {
+    //     for despawned_entity in despawned.read() {
     //         error!(
-    //             "Only one entity per World should have a ReplicateResource<{:?}> component",
+    //             "Despawning resource {:?} because the entity was despawned",
     //             std::any::type_name::<R>()
     //         );
-    //         return;
-    //     }
-    //     if let Ok(replicating_entity) = replicating_entity.get_single() {
-    //         if replicating_entity.is_changed() {
-    //             if let Some(received_value) = &replicating_entity.resource {
-    //                 if let Some(mut resource) = resource {
-    //                     // TODO: use set_if_neq for PartialEq
-    //                     // resource.set_if_neq(received_value.clone());
-    //                     *resource = received_value.clone();
-    //                 } else {
-    //                     commands.insert_resource(received_value.clone());
-    //                 }
-    //             } else if let Some(resource) = resource {
-    //                 error!(
-    //                     "Despawning resource {:?} because the replicating entity doesn't contain it",
-    //                     std::any::type_name::<R>()
-    //                 );
-    //                 commands.remove_resource::<R>();
-    //             }
-    //         }
+    //         commands.remove_resource::<R>();
     //     }
     // }
-
-    /// If the entity that was driving the replication of the resource is despawned (usually when the
-    /// client disconnects from the server), despawn the resource
-    fn handle_despawned_entity<R: Resource + Clone>(
-        mut commands: Commands,
-        mut despawned: RemovedComponents<ReplicateResource<R>>,
-    ) {
-        for despawned_entity in despawned.read() {
-            error!(
-                "Despawning resource {:?} because the entity was despawned",
-                std::any::type_name::<R>()
-            );
-            commands.remove_resource::<R>();
-        }
-    }
 }
 
 #[cfg(test)]
@@ -353,81 +246,12 @@ mod tests {
     use tracing::error;
 
     use crate::prelude::client::NetworkingState;
-    use crate::prelude::{AppComponentExt, Replicate};
-    use crate::shared::replication::resources::command::StartReplicateCommand;
+    use crate::prelude::{AppComponentExt, NetworkTarget, Replicate};
     use crate::shared::replication::resources::ReplicateResourceExt;
-    use crate::tests::protocol::{Component1, Resource1, Resource2};
+    use crate::tests::protocol::{Channel1, Component1, Resource1, Resource2};
     use crate::tests::stepper::{BevyStepper, Step};
 
     use super::{ReplicateResource, StopReplicateResourceExt};
-
-    #[test]
-    fn test_resource_replication_manually() {
-        let mut stepper = BevyStepper::default();
-
-        // spawn an entity that can replicate a resource
-        let server_entity = stepper
-            .server_app
-            .world
-            .spawn((ReplicateResource::<Resource1>::default(), Component1(1.0)))
-            .id();
-        // make sure that there is no panic
-        stepper.frame_step();
-        stepper.frame_step();
-
-        // add replicate
-        stepper
-            .server_app
-            .world
-            .entity_mut(server_entity)
-            .insert(Replicate::default());
-        // make sure that there is no panic
-        stepper.frame_step();
-        stepper.frame_step();
-
-        // check that the component was replicated correctly
-        let replicated_component = stepper
-            .client_app
-            .world
-            .query::<&Component1>()
-            .get_single(&stepper.client_app.world)
-            .unwrap();
-
-        // add the resource
-        stepper.server_app.world.insert_resource(Resource1(1.0));
-        stepper.frame_step();
-        stepper.frame_step();
-
-        let replicated_resource = stepper
-            .client_app
-            .world
-            .query::<&ReplicateResource<Resource1>>()
-            .get_single(&stepper.client_app.world)
-            .unwrap();
-
-        // check that the resource was replicated
-        assert_eq!(stepper.client_app.world.resource::<Resource1>().0, 1.0);
-
-        // update the resource
-        stepper.server_app.world.resource_mut::<Resource1>().0 = 2.0;
-        stepper.frame_step();
-        stepper.frame_step();
-
-        // check that the update was replicated
-        assert_eq!(stepper.client_app.world.resource::<Resource1>().0, 2.0);
-
-        // remove the resource
-        stepper.server_app.world.remove_resource::<Resource1>();
-        stepper.frame_step();
-        stepper.frame_step();
-
-        // check that the resource was removed on the client
-        assert!(stepper
-            .client_app
-            .world
-            .get_resource::<Resource1>()
-            .is_none());
-    }
 
     #[test]
     fn test_resource_replication_via_commands() {
@@ -439,7 +263,7 @@ mod tests {
                 .server_app
                 .world
                 .register_system(|mut commands: Commands| {
-                    commands.replicate_resource::<Resource1>(Replicate::default());
+                    commands.replicate_resource::<Resource1, Channel1>(NetworkTarget::All);
                 });
         let stop_replicate_system =
             stepper
@@ -452,25 +276,10 @@ mod tests {
         stepper.frame_step();
         stepper.frame_step();
 
-        // check that the component was replicated correctly
-        let replicated_component = stepper
-            .client_app
-            .world
-            .query::<&ReplicateResource<Resource1>>()
-            .get_single(&stepper.client_app.world)
-            .unwrap();
-
         // add the resource
         stepper.server_app.world.insert_resource(Resource1(1.0));
         stepper.frame_step();
         stepper.frame_step();
-
-        let replicated_resource = stepper
-            .client_app
-            .world
-            .query::<&ReplicateResource<Resource1>>()
-            .get_single(&stepper.client_app.world)
-            .unwrap();
 
         // check that the resource was replicated
         assert_eq!(stepper.client_app.world.resource::<Resource1>().0, 1.0);
@@ -529,7 +338,7 @@ mod tests {
                 .server_app
                 .world
                 .register_system(|mut commands: Commands| {
-                    commands.replicate_resource::<Resource1>(Replicate::default());
+                    commands.replicate_resource::<Resource1, Channel1>(NetworkTarget::All);
                 });
 
         stepper.server_app.world.insert_resource(Resource1(1.0));
@@ -557,7 +366,7 @@ mod tests {
     }
 
     /// Check that:
-    /// - we can stop replicating a resource without despawning the entity/resource
+    /// - we can stop replicating a resource without despawning the resource
     /// - when the replication is stopped, we can despawn the resource on the sender, and the receiver still has the resource
     /// - we can call `start_replicate_resource` even if the replicating entity already exists
     #[test]
@@ -570,7 +379,7 @@ mod tests {
                 .server_app
                 .world
                 .register_system(|mut commands: Commands| {
-                    commands.replicate_resource::<Resource1>(Replicate::default());
+                    commands.replicate_resource::<Resource1, Channel1>(NetworkTarget::All);
                 });
         let stop_replicate_system =
             stepper
@@ -583,25 +392,10 @@ mod tests {
         stepper.frame_step();
         stepper.frame_step();
 
-        // check that the component was replicated correctly
-        let replicated_component = stepper
-            .client_app
-            .world
-            .query::<&ReplicateResource<Resource1>>()
-            .get_single(&stepper.client_app.world)
-            .unwrap();
-
         // add the resource
         stepper.server_app.world.insert_resource(Resource1(1.0));
         stepper.frame_step();
         stepper.frame_step();
-
-        let replicated_resource = stepper
-            .client_app
-            .world
-            .query::<&ReplicateResource<Resource1>>()
-            .get_single(&stepper.client_app.world)
-            .unwrap();
 
         // check that the resource was replicated
         assert_eq!(stepper.client_app.world.resource::<Resource1>().0, 1.0);
@@ -642,67 +436,67 @@ mod tests {
         assert_eq!(stepper.client_app.world.resource::<Resource1>().0, 3.0);
     }
 
-    #[test]
-    fn test_bidirectional_replication() {
-        tracing_subscriber::FmtSubscriber::builder()
-            .with_max_level(tracing::Level::INFO)
-            .init();
-        let mut stepper = BevyStepper::default();
-
-        // start replicating a resource via commands (even if the resource doesn't exist yet)
-        let start_server_replicate_system =
-            stepper
-                .server_app
-                .world
-                .register_system(|mut commands: Commands| {
-                    commands.replicate_resource::<Resource2>(Replicate::default());
-                });
-        let stop_server_replicate_system =
-            stepper
-                .server_app
-                .world
-                .register_system(|mut commands: Commands| {
-                    commands.stop_replicate_resource::<Resource2>();
-                });
-        stepper.server_app.world.insert_resource(Resource2(1.0));
-        error!("resource inserted");
-        let _ = stepper
-            .server_app
-            .world
-            .run_system(start_server_replicate_system);
-        stepper.frame_step();
-        stepper.frame_step();
-
-        // check that the resource was replicated
-        assert_eq!(stepper.client_app.world.resource::<Resource2>().0, 1.0);
-
-        // update the resource on the client
-        // and start replicating the resource to the server
-        let start_client_replicate_system =
-            stepper
-                .client_app
-                .world
-                .register_system(|mut commands: Commands| {
-                    commands.replicate_resource::<Resource2>(Replicate::default());
-                });
-        let stop_client_replicate_system =
-            stepper
-                .server_app
-                .world
-                .register_system(|mut commands: Commands| {
-                    commands.stop_replicate_resource::<Resource2>();
-                });
-
-        let _ = stepper
-            .client_app
-            .world
-            .run_system(start_client_replicate_system);
-        stepper.client_app.world.resource_mut::<Resource2>().0 = 2.0;
-        stepper.frame_step();
-        stepper.frame_step();
-        stepper.frame_step();
-
-        // check that the update was replicated to the server
-        assert_eq!(stepper.server_app.world.resource::<Resource2>().0, 2.0);
-    }
+    // #[test]
+    // fn test_bidirectional_replication() {
+    //     tracing_subscriber::FmtSubscriber::builder()
+    //         .with_max_level(tracing::Level::INFO)
+    //         .init();
+    //     let mut stepper = BevyStepper::default();
+    //
+    //     // start replicating a resource via commands (even if the resource doesn't exist yet)
+    //     let start_server_replicate_system =
+    //         stepper
+    //             .server_app
+    //             .world
+    //             .register_system(|mut commands: Commands| {
+    //                 commands.replicate_resource::<Resource2>(Replicate::default());
+    //             });
+    //     let stop_server_replicate_system =
+    //         stepper
+    //             .server_app
+    //             .world
+    //             .register_system(|mut commands: Commands| {
+    //                 commands.stop_replicate_resource::<Resource2>();
+    //             });
+    //     stepper.server_app.world.insert_resource(Resource2(1.0));
+    //     error!("resource inserted");
+    //     let _ = stepper
+    //         .server_app
+    //         .world
+    //         .run_system(start_server_replicate_system);
+    //     stepper.frame_step();
+    //     stepper.frame_step();
+    //
+    //     // check that the resource was replicated
+    //     assert_eq!(stepper.client_app.world.resource::<Resource2>().0, 1.0);
+    //
+    //     // update the resource on the client
+    //     // and start replicating the resource to the server
+    //     let start_client_replicate_system =
+    //         stepper
+    //             .client_app
+    //             .world
+    //             .register_system(|mut commands: Commands| {
+    //                 commands.replicate_resource::<Resource2>(Replicate::default());
+    //             });
+    //     let stop_client_replicate_system =
+    //         stepper
+    //             .server_app
+    //             .world
+    //             .register_system(|mut commands: Commands| {
+    //                 commands.stop_replicate_resource::<Resource2>();
+    //             });
+    //
+    //     let _ = stepper
+    //         .client_app
+    //         .world
+    //         .run_system(start_client_replicate_system);
+    //     stepper.client_app.world.resource_mut::<Resource2>().0 = 2.0;
+    //     stepper.frame_step();
+    //     stepper.frame_step();
+    //     stepper.frame_step();
+    //
+    //     // check that the update was replicated to the server
+    //     assert_eq!(stepper.server_app.world.resource::<Resource2>().0, 2.0);
+    // }
 }

--- a/lightyear/src/shared/replication/resources.rs
+++ b/lightyear/src/shared/replication/resources.rs
@@ -514,9 +514,9 @@ mod tests {
     /// - resource replication works in both directions
     #[test]
     fn test_bidirectional_replication() {
-        tracing_subscriber::FmtSubscriber::builder()
-            .with_max_level(tracing::Level::ERROR)
-            .init();
+        // tracing_subscriber::FmtSubscriber::builder()
+        //     .with_max_level(tracing::Level::ERROR)
+        //     .init();
         let mut stepper = BevyStepper::default();
 
         // start replicating a resource via commands (even if the resource doesn't exist yet)

--- a/lightyear/src/tests/protocol.rs
+++ b/lightyear/src/tests/protocol.rs
@@ -100,25 +100,26 @@ impl Plugin for ProtocolPlugin {
         // inputs
         app.add_plugins(InputPlugin::<MyInput>::default());
         // components
-        app.register_component::<Component1>(ChannelDirection::ServerToClient);
-        app.add_prediction::<Component1>(ComponentSyncMode::Full);
-        app.add_interpolation::<Component1>(ComponentSyncMode::Full);
-        app.add_linear_interpolation_fn::<Component1>();
+        app.register_component::<Component1>(ChannelDirection::ServerToClient)
+            .add_prediction::<Component1>(ComponentSyncMode::Full)
+            .add_interpolation::<Component1>(ComponentSyncMode::Full)
+            .add_linear_interpolation_fn::<Component1>();
 
-        app.register_component::<Component2>(ChannelDirection::ServerToClient);
-        app.add_prediction::<Component2>(ComponentSyncMode::Simple);
+        app.register_component::<Component2>(ChannelDirection::ServerToClient)
+            .add_prediction::<Component2>(ComponentSyncMode::Simple);
 
-        app.register_component::<Component3>(ChannelDirection::ServerToClient);
-        app.add_prediction::<Component3>(ComponentSyncMode::Once);
+        app.register_component::<Component3>(ChannelDirection::ServerToClient)
+            .add_prediction::<Component3>(ComponentSyncMode::Once);
 
-        app.register_component::<Component4>(ChannelDirection::ServerToClient);
-        app.add_prediction::<Component4>(ComponentSyncMode::Simple);
-        app.add_component_map_entities::<Component4>();
+        app.register_component::<Component4>(ChannelDirection::ServerToClient)
+            .add_prediction::<Component4>(ComponentSyncMode::Simple)
+            .add_map_entities::<Component4>();
 
-        app.register_component::<Component5>(ChannelDirection::ServerToClient);
-        app.add_prediction::<Component5>(ComponentSyncMode::Full);
-        app.add_interpolation::<Component5>(ComponentSyncMode::Full);
-        app.add_linear_interpolation_fn::<Component5>();
+        app.register_component::<Component5>(ChannelDirection::ServerToClient)
+            .add_prediction::<Component5>(ComponentSyncMode::Full)
+            .add_interpolation::<Component5>(ComponentSyncMode::Full)
+            .add_linear_interpolation_fn::<Component5>();
+
         // resources
         app.register_resource::<Resource1>(ChannelDirection::ServerToClient);
         app.register_resource::<Resource2>(ChannelDirection::Bidirectional);

--- a/lightyear/src/tests/protocol.rs
+++ b/lightyear/src/tests/protocol.rs
@@ -58,6 +58,9 @@ impl Mul<f32> for &Component5 {
 #[derive(Resource, Serialize, Deserialize, Debug, PartialEq, Clone, Add, Reflect)]
 pub struct Resource1(pub f32);
 
+#[derive(Resource, Serialize, Deserialize, Debug, PartialEq, Clone, Add, Reflect)]
+pub struct Resource2(pub f32);
+
 // Inputs
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Reflect)]
@@ -116,8 +119,9 @@ impl Plugin for ProtocolPlugin {
         app.add_prediction::<Component5>(ComponentSyncMode::Full);
         app.add_interpolation::<Component5>(ComponentSyncMode::Full);
         app.add_linear_interpolation_fn::<Component5>();
-
+        // resources
         app.register_resource::<Resource1>(ChannelDirection::ServerToClient);
+        app.register_resource::<Resource2>(ChannelDirection::Bidirectional);
         // channels
         app.add_channel::<Channel1>(ChannelSettings {
             mode: ChannelMode::UnorderedUnreliable,

--- a/lightyear/src/tests/stepper.rs
+++ b/lightyear/src/tests/stepper.rs
@@ -1,6 +1,7 @@
 use std::net::SocketAddr;
 use std::str::FromStr;
 
+use crate::client::replication::ReplicationConfig;
 use bevy::ecs::system::RunSystemOnce;
 use bevy::prelude::{default, App, Commands, Mut, PluginGroup, Real, Time, World};
 use bevy::time::TimeUpdateStrategy;
@@ -112,6 +113,10 @@ impl BevyStepper {
             shared: shared_config.clone(),
             net: vec![net_config],
             ping: PingConfig::default(),
+            replication: server::ReplicationConfig {
+                enable_send: true,
+                enable_receive: true,
+            },
             ..default()
         };
         let plugin = server::ServerPlugin::new(config);
@@ -136,6 +141,10 @@ impl BevyStepper {
             sync: sync_config,
             prediction: prediction_config,
             interpolation: interpolation_config,
+            replication: client::ReplicationConfig {
+                enable_send: true,
+                enable_receive: true,
+            },
             ..default()
         };
         let plugin = client::ClientPlugin::new(config);


### PR DESCRIPTION
Fixes https://github.com/cBournhonesque/lightyear/issues/302

Design:
- we now use messages instead of entities to replicate resources
- the resource doesn't need to be clone anymore!
- for bidirectional replication, we bypass change detection on receive to avoid creating an infinite loop
- update the `NetworkIdentity` system param to be more useful