### PR TITLE
clarify connect token docs

### DIFF
--- a/book/src/concepts/connection/title.md
+++ b/book/src/concepts/connection/title.md
@@ -11,25 +11,44 @@ To establish that connection, that needs to be some machinery that runs on top o
 - storing the list of connected remote peers
 - etc.
 
-In lightyear, it is possible to use different connection types, via the two traits
-`NetClient` and `NetServer`.
+`lightyear` uses the traits `NetClient` and `NetServer` to abstract over the connection logic.
 
 Multiple implementations are provided:
 - Netcode
 - Steam
+- Local
 
 
 ## Netcode
 
 This implementation is based on the [netcode.io](https://github.com/networkprotocol/netcode/blob/master/STANDARD.md) standard created
 by Glenn Fiedler (of GafferOnGames fame). It describes a protocol to establish a secure connection between two peers, provided
-that there is a transport layer to exchange packets.
+that there is an unoredered unreliable transport layer to exchange packets.
 
 For my purpose I am using [this](https://github.com/benny-n/netcode) Rust implementation of the standard.
 
 You can use the Netcode connection by using the `NetcodeClient` and `NetcodeServer` structs, coupled with any of the available
 transports (Udp, WebTransport, etc.)
 
+To connect to a game server, the client needs to send a `ConnectToken` to the game server to start the connection process.
+
+There are several ways to obtain a `ConnectToken`:
+- the client can request a `ConnectToken` via a secure (e.g. HTTPS) connection from a backend server.
+The server must use the same `protocol_id` and `private_key` as the game servers.
+The backend server could be a dedicated webserver; or the game server itself, if it has a way to
+establish secure connection.
+- when testing, it can be convenient for the client to create its own `ConnectToken` manually.
+You can use `Authentication::Manual` for those cases.
+
+Currently `lightyear` does not provide any functionality to let a game server send a `ConnectToken` securely to a client.
+You will have to handle this logic youself.
+
+
 ## Steam
 
 This implementation is based on the Steamworks SDK. 
+
+## Local
+
+Local connections are used when running in host-server mode: the server and the client are running in the same bevy App.
+No packets are actually sent over the network since the client and server share the same `World`.

--- a/lightyear/src/connection/client.rs
+++ b/lightyear/src/connection/client.rs
@@ -62,7 +62,8 @@ pub(crate) enum NetClientDispatch {
     Local(super::local::client::Client),
 }
 
-/// Resource that holds the client connection
+/// Resource that holds a [`NetClient`] instance.
+/// (either a Netcode, Steam, or Local client)
 #[derive(Resource)]
 pub struct ClientConnection {
     pub(crate) client: NetClientDispatch,
@@ -191,11 +192,32 @@ impl NetClient for ClientConnection {
 
 #[derive(Resource, Default, Clone)]
 #[allow(clippy::large_enum_variant)]
-/// Struct used to authenticate with the server when using the netcode connection
+/// Struct used to authenticate with the server when using the Netcode connection.
+///
+/// Netcode is a standard to establish secure connections between clients and game servers on top of
+/// an unreliable unordered transport such as UDP.
+/// You can read more about it here: https://github.com/mas-bandwidth/netcode/blob/main/STANDARD.md
+///
+/// The client sends a `ConnectToken` to the game server to start the connection process.
+///
+/// There are several ways to obtain a `ConnectToken`:
+/// - the client can request a `ConnectToken` via a secure (e.g. HTTPS) connection from a backend server.
+/// The server must use the same `protocol_id` and `private_key` as the game servers.
+/// The backend server could be a dedicated webserver; or the game server itself, if it has a way to
+/// establish secure connection.
+/// - when testing, it can be convenient for the client to create its own `ConnectToken` manually.
+/// You can use `Authentication::Manual` for those cases.
 pub enum Authentication {
-    /// Use a `ConnectToken` that was already received (usually from a secure-connection to a webserver)
+    /// Use a `ConnectToken` to authenticate with the game server.
+    ///
+    /// The client must have already received the `ConnectToken` from the backend.
+    /// (The backend will generate a new `client_id` for the user, and use that to generate the
+    /// `ConnectToken`)
     Token(ConnectToken),
-    /// Or build a `ConnectToken` manually from the given parameters
+    /// The client can build a `ConnectToken` manually.
+    ///
+    /// This is only useful for testing purposes. In production, the client should not have access
+    /// to the `private_key`.
     Manual {
         server_addr: SocketAddr,
         client_id: u64,
@@ -203,8 +225,11 @@ pub enum Authentication {
         protocol_id: u64,
     },
     #[default]
-    /// Request a connect token from the backend
-    RequestConnectToken,
+    /// The client has no `ConnectToken`, so it cannot connect to the game server yet.
+    ///
+    /// This is provided so that you can still build a [`ClientConnection`] `Resource` while waiting
+    /// to receive a `ConnectToken` from the backend.
+    None,
 }
 
 impl Authentication {
@@ -225,8 +250,8 @@ impl Authentication {
                 .expire_seconds(token_expire_secs)
                 .generate()
                 .ok(),
-            Authentication::RequestConnectToken => {
-                // create a fake connect token so that we have a NetcodeClient
+            Authentication::None => {
+                // create a fake connect token so that we can build a NetcodeClient
                 ConnectToken::build(
                     SocketAddr::from_str("0.0.0.0:0").unwrap(),
                     0,


### PR DESCRIPTION
Fixes https://github.com/cBournhonesque/lightyear/issues/307

Adds more documentation about the netcode standard and how to use ConnectTokens.