### PR TITLE
Support bevy_xpbd with double precision

### DIFF
--- a/lightyear/Cargo.toml
+++ b/lightyear/Cargo.toml
@@ -72,7 +72,7 @@ zstd = { version = "0.13.1", optional = true }
 leafwing-input-manager = { version = "0.13", optional = true }
 
 # physics
-bevy_xpbd_2d = { version = "0.4", optional = true }
+bevy_xpbd_2d = { version = "0.4", optional = true, default-features = false }
 
 # serialization
 bitcode = { version = "0.5.1", package = "bitcode_lightyear_patch", path = "../vendor/bitcode", features = [

--- a/lightyear/src/utils/bevy_xpbd_2d.rs
+++ b/lightyear/src/utils/bevy_xpbd_2d.rs
@@ -3,6 +3,7 @@ use std::ops::{Add, Mul};
 
 use bevy::prelude::EntityMapper;
 use bevy_xpbd_2d::components::*;
+use bevy_xpbd_2d::math::Scalar;
 use tracing::trace;
 
 use crate::client::components::{LerpFn, SyncComponent};
@@ -18,7 +19,8 @@ pub mod position {
     use super::*;
 
     pub fn lerp(start: &Position, other: &Position, t: f32) -> Position {
-        let res = Position::new(start.0 * (1.0 - t) + other.0 * t);
+        let u = Scalar::from(t);
+        let res = Position::new(start.0 * (1.0 - u) + other.0 * u);
         trace!(
             "position lerp: start: {:?} end: {:?} t: {} res: {:?}",
             start,
@@ -35,9 +37,10 @@ pub mod rotation {
     use super::*;
 
     pub fn lerp(start: &Rotation, other: &Rotation, t: f32) -> Rotation {
+        let u = Scalar::from(t);
         let shortest_angle =
             ((((other.as_degrees() - start.as_degrees()) % 360.0) + 540.0) % 360.0) - 180.0;
-        let res = Rotation::from_degrees(start.as_degrees() + shortest_angle * t);
+        let res = Rotation::from_degrees(start.as_degrees() + shortest_angle * u);
         // // as_radians() returns a value between -Pi and Pi
         // // add Pi to get positive values, for interpolation
         // let res = Rotation::from_radians(
@@ -60,7 +63,8 @@ pub mod linear_velocity {
     use super::*;
 
     pub fn lerp(start: &LinearVelocity, other: &LinearVelocity, t: f32) -> LinearVelocity {
-        let res = LinearVelocity(start.0 * (1.0 - t) + other.0 * t);
+        let u = Scalar::from(t);
+        let res = LinearVelocity(start.0 * (1.0 - u) + other.0 * u);
         trace!(
             "linear velocity lerp: start: {:?} end: {:?} t: {} res: {:?}",
             start,
@@ -77,7 +81,8 @@ pub mod angular_velocity {
     use super::*;
 
     pub fn lerp(start: &AngularVelocity, other: &AngularVelocity, t: f32) -> AngularVelocity {
-        let res = AngularVelocity(start.0 * (1.0 - t) + other.0 * t);
+        let u = Scalar::from(t);
+        let res = AngularVelocity(start.0 * (1.0 - u) + other.0 * u);
         trace!(
             "angular velocity lerp: start: {:?} end: {:?} t: {} res: {:?}",
             start,


### PR DESCRIPTION
I use bevy_xpbd with f64 scalars, which doesn't work with lightyear currently since it assumes f32. I initially tried making `LerpFn` generic over the float type, but this gets a little hairy and I figured that it was easier to just keep lightyear's base interpolation logic as f32 and convert convert f32 to f64 as needed in the lerp utilities.
