### PR TITLE
Use sparse set storage for corrections

### DIFF
--- a/lightyear/src/client/prediction/correction.rs
+++ b/lightyear/src/client/prediction/correction.rs
@@ -60,6 +60,7 @@ pub struct InterpolatedCorrector;
 // }
 
 #[derive(Component, Debug)]
+#[component(storage = "SparseSet")]
 pub struct Correction<C: Component> {
     /// This is what the original predicted value was before any correction was applied
     pub original_prediction: C,


### PR DESCRIPTION
It looks like `Correction` is added and removed frequently, which means that it should probably use [sparse set ECS storage](https://bevy-cheatbook.github.io/patterns/component-storage.html) to stop the ECS from moving entities between archetypes too frequently.

I'm not really sure how to bench this just yet due to not being experienced enough with the code base, but this probably deserves a benchmark.