### PR TITLE
Update visibility to allow more immediate visibility updates

### DIFF
--- a/examples/interest_management/Cargo.toml
+++ b/examples/interest_management/Cargo.toml
@@ -18,10 +18,10 @@ metrics = ["lightyear/metrics", "dep:metrics-exporter-prometheus"]
 [dependencies]
 leafwing-input-manager = "0.13"
 lightyear = { path = "../../lightyear", features = [
-    "webtransport",
-    "websocket",
-    "leafwing",
-    "steam",
+  "webtransport",
+  "websocket",
+  "leafwing",
+  "steam",
 ] }
 async-compat = "0.2.3"
 serde = { version = "1.0.188", features = ["derive"] }

--- a/examples/interest_management/Cargo.toml
+++ b/examples/interest_management/Cargo.toml
@@ -14,15 +14,14 @@ publish = false
 
 [features]
 metrics = ["lightyear/metrics", "dep:metrics-exporter-prometheus"]
-mock_time = ["lightyear/mock_time"]
 
 [dependencies]
 leafwing-input-manager = "0.13"
 lightyear = { path = "../../lightyear", features = [
-  "webtransport",
-  "websocket",
-  "leafwing",
-  "steam",
+    "webtransport",
+    "websocket",
+    "leafwing",
+    "steam",
 ] }
 async-compat = "0.2.3"
 serde = { version = "1.0.188", features = ["derive"] }
@@ -33,7 +32,6 @@ bevy = { version = "0.13", features = ["bevy_core_pipeline"] }
 derive_more = { version = "0.99", features = ["add", "mul"] }
 rand = "0.8.5"
 clap = { version = "4.4", features = ["derive"] }
-mock_instant = "0.4"
 metrics-exporter-prometheus = { version = "0.13.0", optional = true }
 bevy-inspector-egui = "0.24"
 cfg-if = "1.0.0"

--- a/examples/interest_management/assets/settings.ron
+++ b/examples/interest_management/assets/settings.ron
@@ -27,11 +27,7 @@ Settings(
     server: ServerSettings(
         headless: true,
         inspector: false,
-        conditioner: Some(Conditioner(
-            latency_ms: 200,
-            jitter_ms: 20,
-            packet_loss: 0.05
-        )),
+        conditioner: None,
         transport: [
             WebTransport(
                 local_port: 5000

--- a/examples/interest_management/src/protocol.rs
+++ b/examples/interest_management/src/protocol.rs
@@ -13,7 +13,7 @@ use tracing::info;
 
 use lightyear::client::components::ComponentSyncMode;
 use lightyear::prelude::*;
-use lightyear::shared::replication::components::ReplicationMode;
+use lightyear::shared::replication::components::VisibilityMode;
 use UserAction;
 
 use crate::shared::color_from_id;
@@ -35,7 +35,7 @@ impl PlayerBundle {
             prediction_target: NetworkTarget::Only(vec![id]),
             interpolation_target: NetworkTarget::AllExcept(vec![id]),
             // use rooms for replication
-            replication_mode: ReplicationMode::Room,
+            visibility: VisibilityMode::InterestManagement,
             ..default()
         };
         // We don't want to replicate the ActionState to the original client, since they are updating it with

--- a/examples/lobby/src/server.rs
+++ b/examples/lobby/src/server.rs
@@ -84,10 +84,10 @@ fn spawn_player_entity(
     let replicate = Replicate {
         prediction_target: NetworkTarget::Single(client_id),
         interpolation_target: NetworkTarget::AllExceptSingle(client_id),
-        replication_mode: if dedicated_server {
-            ReplicationMode::Room
+        visibility: if dedicated_server {
+            VisibilityMode::InterestManagement
         } else {
-            ReplicationMode::NetworkTarget
+            VisibilityMode::All
         },
         ..default()
     };
@@ -167,6 +167,7 @@ mod game {
 
 mod lobby {
     use lightyear::server::connection::ConnectionManager;
+    use lightyear::server::visibility::room::RoomManager;
 
     use super::*;
 

--- a/lightyear/src/lib.rs
+++ b/lightyear/src/lib.rs
@@ -190,8 +190,8 @@ pub mod prelude {
     pub use crate::shared::ping::manager::PingConfig;
     pub use crate::shared::plugin::{NetworkIdentity, SharedPlugin};
     pub use crate::shared::replication::components::{
-        NetworkTarget, PrePredicted, Replicate, Replicated, ReplicationGroup, ReplicationMode,
-        ShouldBePredicted, TargetEntity,
+        NetworkTarget, PrePredicted, Replicate, Replicated, ReplicationGroup, ShouldBePredicted,
+        TargetEntity, VisibilityMode,
     };
     pub use crate::shared::replication::entity_map::RemoteEntityMap;
     pub use crate::shared::replication::hierarchy::ParentSync;
@@ -263,7 +263,8 @@ pub mod prelude {
         pub use crate::server::replication::{
             ReplicationConfig, ServerFilter, ServerReplicationSet,
         };
-        pub use crate::server::room::{RoomId, RoomManager, RoomMut, RoomRef};
+        pub use crate::server::visibility::immediate::VisibilityManager;
+        pub use crate::server::visibility::room::{RoomId, RoomManager};
     }
 }
 

--- a/lightyear/src/server/mod.rs
+++ b/lightyear/src/server/mod.rs
@@ -13,8 +13,6 @@ pub mod input;
 
 pub mod plugin;
 
-pub mod room;
-
 #[cfg_attr(docsrs, doc(cfg(feature = "leafwing")))]
 #[cfg(feature = "leafwing")]
 pub mod input_leafwing;
@@ -23,3 +21,4 @@ pub(crate) mod prediction;
 
 pub(crate) mod networking;
 pub mod replication;
+pub mod visibility;

--- a/lightyear/src/server/networking.rs
+++ b/lightyear/src/server/networking.rs
@@ -13,7 +13,7 @@ use crate::protocol::component::ComponentRegistry;
 use crate::server::config::ServerConfig;
 use crate::server::connection::ConnectionManager;
 use crate::server::events::{ConnectEvent, DisconnectEvent, EntityDespawnEvent, EntitySpawnEvent};
-use crate::server::room::RoomManager;
+use crate::server::visibility::room::RoomManager;
 use crate::shared::events::connection::{IterEntityDespawnEvent, IterEntitySpawnEvent};
 use crate::shared::replication::ReplicationSend;
 use crate::shared::sets::{InternalMainSet, ServerMarker};

--- a/lightyear/src/server/plugin.rs
+++ b/lightyear/src/server/plugin.rs
@@ -4,7 +4,8 @@ use bevy::prelude::*;
 use crate::server::events::ServerEventsPlugin;
 use crate::server::networking::ServerNetworkingPlugin;
 use crate::server::replication::ServerReplicationPlugin;
-use crate::server::room::RoomPlugin;
+use crate::server::visibility::immediate::VisibilityPlugin;
+use crate::server::visibility::room::RoomPlugin;
 use crate::shared::plugin::SharedPlugin;
 
 use super::config::ServerConfig;
@@ -32,6 +33,7 @@ impl Plugin for ServerPlugin {
             })
             .add_plugins(ServerEventsPlugin)
             .add_plugins(ServerNetworkingPlugin)
+            .add_plugins(VisibilityPlugin)
             .add_plugins(RoomPlugin)
             .add_plugins(ServerReplicationPlugin);
     }

--- a/lightyear/src/server/replication.rs
+++ b/lightyear/src/server/replication.rs
@@ -37,7 +37,7 @@ pub struct ServerReplicationPlugin;
 
 #[derive(SystemSet, Debug, Hash, PartialEq, Eq, Clone, Copy)]
 pub enum ServerReplicationSet {
-    /// You can use this SystemSet to add Replicate components to entities received from clients (to rebroadcast them to other clients)
+    // You can use this SystemSet to add Replicate components to entities received from clients (to rebroadcast them to other clients)
     ClientReplication,
 }
 

--- a/lightyear/src/server/visibility/immediate.rs
+++ b/lightyear/src/server/visibility/immediate.rs
@@ -1,0 +1,208 @@
+/*! # Visibility
+
+This module provides a [`VisibilityManager`] resource that allows you to update the visibility of entities in an immediate fashion.
+
+Visibilities are cached, so after you set an entity to `visible` for a client, it will remain visible
+until you change the setting again.
+
+```rust
+use bevy::prelude::*;
+use lightyear::prelude::*;
+use lightyear::prelude::server::*;
+
+fn my_system(
+    mut visibility_manager: ResMut<VisibilityManager>,
+) {
+    // you can update the visibility like so
+    visibility_manager.gain_visibility(ClientId::Netcode(1), Entity::PLACEHOLDER);
+    visibility_manager.lose_visibility(ClientId::Netcode(2), Entity::PLACEHOLDER);
+}
+```
+*/
+use crate::prelude::server::ConnectionManager;
+use crate::prelude::ClientId;
+use crate::server::networking::is_started;
+use crate::server::visibility::room::{RoomManager, RoomSystemSets};
+use crate::shared::sets::{InternalMainSet, InternalReplicationSet, ServerMarker};
+use bevy::prelude::*;
+use bevy::utils::HashMap;
+use tracing::trace;
+
+/// Event related to [`Entities`](Entity) which are visible to a client
+#[derive(Debug, PartialEq, Clone, Copy, Reflect)]
+pub(crate) enum ClientVisibility {
+    /// the entity was not replicated to the client, but now is
+    Gained,
+    /// the entity was replicated to the client, but not anymore
+    Lost,
+    /// the entity was already replicated to the client, and still is
+    Maintained,
+}
+
+#[derive(Component, Clone, Default, PartialEq, Debug, Reflect)]
+pub(crate) struct ReplicateVisibility {
+    /// List of clients that the entity is currently replicated to.
+    /// Will be updated before the other replication systems
+    pub(crate) clients_cache: HashMap<ClientId, ClientVisibility>,
+}
+
+#[derive(Debug, Default)]
+struct VisibilityEvents {
+    gained: HashMap<ClientId, Entity>,
+    lost: HashMap<ClientId, Entity>,
+}
+
+#[derive(Resource, Debug, Default)]
+pub struct VisibilityManager {
+    events: VisibilityEvents,
+}
+
+impl VisibilityManager {
+    pub fn gain_visibility(&mut self, client: ClientId, entity: Entity) {
+        self.events.gained.insert(client, entity);
+    }
+
+    pub fn lose_visibility(&mut self, client: ClientId, entity: Entity) {
+        self.events.lost.insert(client, entity);
+    }
+}
+
+pub(super) mod systems {
+    use super::*;
+    use crate::shared::replication::ReplicationSend;
+    use bevy::prelude::DetectChanges;
+
+    /// System that updates the visibility cache of each Entity based on the visibility events.
+    pub fn update_visibility_from_events(
+        mut visibility_events: ResMut<VisibilityManager>,
+        mut visibility: Query<&mut ReplicateVisibility>,
+    ) {
+        if visibility_events.events.gained.is_empty() && visibility_events.events.lost.is_empty() {
+            return;
+        }
+        // NOTE: we handle lost events before gained events so that if one event in the queue
+        //  removes the visibility, and another one gains it, the visibility is maintained
+        for (client, entity) in visibility_events.events.lost.drain() {
+            if let Ok(mut cache) = visibility.get_mut(entity) {
+                error!("Want to lose visibility for entity {entity:?} and client {client:?}. Cache: {cache:?}");
+                if let Some(vis) = cache.clients_cache.get_mut(&client) {
+                    error!("lose visibility for entity {entity:?} and client {client:?}");
+                    *vis = ClientVisibility::Lost;
+                }
+            }
+        }
+        for (client, entity) in visibility_events.events.gained.drain() {
+            if let Ok(mut cache) = visibility.get_mut(entity) {
+                cache
+                    .clients_cache
+                    .entry(client)
+                    .and_modify(|vis| {
+                        // if the visibility was lost above, then that means that the entity was visible
+                        // for this client, so we just maintain it instead
+                        if *vis == ClientVisibility::Lost {
+                            error!("visibility for entity {entity:?} and client {client:?} goes from lost to maintained");
+                            *vis = ClientVisibility::Maintained;
+                        }
+                    })
+                    // if the entity was not visible, the visibility is gained
+                    .or_insert(ClientVisibility::Gained);
+            }
+        }
+    }
+
+    /// After replication, update the Replication Cache:
+    /// - Visibility Gained becomes Visibility Maintained
+    /// - Visibility Lost gets removed from the cache
+    pub fn update_replicate_visibility(mut query: Query<&mut ReplicateVisibility>) {
+        for mut replicate in query.iter_mut() {
+            replicate
+                .clients_cache
+                .retain(|client_id, visibility| match visibility {
+                    ClientVisibility::Gained => {
+                        error!(
+                            "Visibility for client {client_id:?} goes from gained to maintained"
+                        );
+                        *visibility = ClientVisibility::Maintained;
+                        true
+                    }
+                    ClientVisibility::Lost => {
+                        error!("remove client {client_id:?} from room cache");
+                        false
+                    }
+                    ClientVisibility::Maintained => true,
+                });
+        }
+    }
+
+    /// Whenever the visibility of an entity changes, update the despawn metadata cache
+    /// so that we can correctly replicate the despawn to the correct clients
+    pub fn update_despawn_metadata_cache(
+        mut connection_manager: ResMut<ConnectionManager>,
+        mut query: Query<(Entity, &mut ReplicateVisibility)>,
+    ) {
+        for (entity, visibility) in query.iter_mut() {
+            if visibility.is_changed() {
+                if let Some(despawn_metadata) = connection_manager
+                    .get_mut_replicate_despawn_cache()
+                    .get_mut(&entity)
+                {
+                    let new_cache = visibility.clients_cache.keys().copied().collect();
+                    despawn_metadata.replication_clients_cache = new_cache;
+                }
+            }
+        }
+    }
+}
+
+/// System sets related to Rooms
+#[derive(SystemSet, Debug, Hash, PartialEq, Eq, Clone, Copy)]
+pub enum VisibilitySet {
+    /// Update the visibility cache based on the visibility events
+    UpdateVisibility,
+    /// Perform bookkeeping for the visibility caches
+    VisibilityCleanup,
+}
+
+#[derive(Default)]
+pub(crate) struct VisibilityPlugin;
+
+impl Plugin for VisibilityPlugin {
+    fn build(&self, app: &mut App) {
+        // RESOURCES
+        app.init_resource::<VisibilityManager>();
+        // SETS
+        app.configure_sets(
+            PostUpdate,
+            (
+                (
+                    // update replication caches must happen before replication, but after we add ReplicateVisibility
+                    InternalReplicationSet::<ServerMarker>::HandleReplicateUpdate,
+                    VisibilitySet::UpdateVisibility,
+                    InternalReplicationSet::<ServerMarker>::Buffer,
+                    VisibilitySet::VisibilityCleanup,
+                )
+                    .run_if(is_started)
+                    .chain(),
+                // the room systems can run every send_interval
+                (
+                    VisibilitySet::UpdateVisibility,
+                    VisibilitySet::VisibilityCleanup,
+                )
+                    .in_set(InternalMainSet::<ServerMarker>::Send),
+            ),
+        );
+        // SYSTEMS
+        app.add_systems(
+            PostUpdate,
+            (
+                (
+                    systems::update_visibility_from_events,
+                    systems::update_despawn_metadata_cache,
+                )
+                    .chain()
+                    .in_set(VisibilitySet::UpdateVisibility),
+                systems::update_replicate_visibility.in_set(VisibilitySet::VisibilityCleanup),
+            ),
+        );
+    }
+}

--- a/lightyear/src/server/visibility/mod.rs
+++ b/lightyear/src/server/visibility/mod.rs
@@ -1,0 +1,5 @@
+/// Main visibility module, where you can immediately update the visibility of an entity for a given client
+pub mod immediate;
+
+/// Room-based visibility module, where you can use semi-static rooms to manage visibility
+pub mod room;

--- a/lightyear/src/shared/replication/plugin.rs
+++ b/lightyear/src/shared/replication/plugin.rs
@@ -103,13 +103,14 @@ impl<R: ReplicationSend> Plugin for ReplicationPlugin<R> {
                     )
                         .in_set(InternalMainSet::<R::SetMarker>::Send),
                     (
-                        InternalReplicationSet::<R::SetMarker>::HandleReplicateUpdate,
-                        InternalReplicationSet::<R::SetMarker>::Buffer,
-                        InternalMainSet::<R::SetMarker>::SendPackets,
-                    )
-                        .chain(),
-                    (
-                        InternalReplicationSet::<R::SetMarker>::BufferResourceUpdates,
+                        (
+                            (
+                                InternalReplicationSet::<R::SetMarker>::HandleReplicateUpdate,
+                                InternalReplicationSet::<R::SetMarker>::Buffer,
+                            )
+                                .chain(),
+                            InternalReplicationSet::<R::SetMarker>::BufferResourceUpdates,
+                        ),
                         InternalMainSet::<R::SetMarker>::SendPackets,
                     )
                         .chain(),

--- a/lightyear/src/shared/replication/plugin.rs
+++ b/lightyear/src/shared/replication/plugin.rs
@@ -3,8 +3,8 @@ use bevy::time::common_conditions::on_timer;
 use bevy::utils::Duration;
 
 use crate::prelude::{
-    NetworkTarget, PrePredicted, RemoteEntityMap, ReplicationGroup, ReplicationMode,
-    ShouldBePredicted,
+    NetworkTarget, PrePredicted, RemoteEntityMap, ReplicationGroup, ShouldBePredicted,
+    VisibilityMode,
 };
 use crate::shared::replication::components::{
     PerComponentReplicationMetadata, Replicate, ReplicationGroupId, ReplicationGroupIdBuilder,
@@ -49,7 +49,7 @@ impl<R: ReplicationSend> Plugin for ReplicationPlugin<R> {
             .register_type::<ReplicationGroupIdBuilder>()
             .register_type::<ReplicationGroup>()
             .register_type::<ReplicationGroupId>()
-            .register_type::<ReplicationMode>()
+            .register_type::<VisibilityMode>()
             .register_type::<NetworkTarget>()
             .register_type::<ShouldBeInterpolated>()
             .register_type::<PrePredicted>()

--- a/lightyear/src/shared/replication/systems.rs
+++ b/lightyear/src/shared/replication/systems.rs
@@ -98,7 +98,7 @@ fn send_entity_despawn<R: ReplicationSend>(
                     if replicate.replication_target.should_send_to(client_id)
                         && matches!(visibility, ClientVisibility::Lost)
                     {
-                        debug!("sending entity despawn for entity: {:?}", entity);
+                        debug!("sending entity despawn for entity: {:?} because ClientVisibility::Lost", entity);
                         // TODO: don't unwrap but handle errors
                         let group_id = replicate.replication_group.group_id(Some(entity));
                         let _ = sender


### PR DESCRIPTION
# Context

The concept of rooms as semi-static data structures to control visibility could be a bit awkward:
- what if you want to have nested level of rooms? i.e. several 'instances' in a world and then sub-rooms for each instance (for example one room per building)?

The current visibility rules with rooms (especially when client/entities belong to multiple rooms) are not clear, and probably buggy. You could probably make it work by working a RoomId scheme so that you avoid nested rooms.
(for example building 1 of instance 1 is room 1-1, building 1 of instance 2 is room 2-1)

- sometimes you just want to control visibility directly.

# Changes

- I now provide the `VisibilityManager` resource which lets you control the visibility for a given entity directly with the functions `gain_visibility(client_id, entity)` and `lose_visibility(client_id, entity)`.
Those are wrappers to interact with the `ReplicateVisibility` component, which contains a cached list of client_ids that an entity should be visible to.

- The `RoomManager` just becomes a helper that internally uses the `gain_visibility(client_id, entity)` and `lose_visibility(client_id, entity)` methods of the `VisibilityManager` to affect visibility.

- One could imagine having other visibility modes that interact with the `VisibilityManager`:
  - a tag-based system similar to godot or replication_attributes
  - a LOD/distance based system, etc.
  
 # TODO

Note that the interest management example is currently semi-broken, probably because of some subtle ordering bug.
I can fix it later but I want to first get the API changes merged.