### PR TITLE
Make ClientPlugin and ServerPlugin PluginGroups

### DIFF
--- a/benches/src/local_stepper.rs
+++ b/benches/src/local_stepper.rs
@@ -151,7 +151,7 @@ impl LocalBevyStepper {
             }],
             ..default()
         };
-        server_app.add_plugins((ServerPlugin::new(config), ProtocolPlugin));
+        server_app.add_plugins((ServerPlugins::new(config), ProtocolPlugin));
 
         // Initialize Real time (needed only for the first TimeSystem run)
         server_app

--- a/benches/src/local_stepper.rs
+++ b/benches/src/local_stepper.rs
@@ -111,7 +111,7 @@ impl LocalBevyStepper {
                 interpolation: interpolation_config.clone(),
                 ..default()
             };
-            client_app.add_plugins((ClientPlugin::new(config), ProtocolPlugin));
+            client_app.add_plugins((ClientPlugins::new(config), ProtocolPlugin));
             // Initialize Real time (needed only for the first TimeSystem run)
             client_app
                 .world

--- a/book/src/concepts/advanced_replication/client_replication.md
+++ b/book/src/concepts/advanced_replication/client_replication.md
@@ -7,6 +7,24 @@ There are different possibilities.
 
 To replicate a client-entity to the server, it is exactly the same as for a server-entity.
 Just add the `Replicate` component to the entity and it will be replicated to the server.
+```rust
+fn handle_connection(
+    mut connection_event: EventReader<ConnectEvent>,
+    mut commands: Commands,
+) {
+    for event in connection_event.read() {
+        let local_client_id = event.client_id();
+        commands.spawn((
+            /* your other components here */
+            Replicate {
+                replication_target: NetworkTarget::All,
+                interpolation_target: NetworkTarget::AllExcept(vec![local_client_id]),
+                ..default()
+            },
+        ));
+    }
+}
+```
 
 Note that `prediction_target` and `interpolation_target` will be unused as the server doesn't do any 
 prediction or interpolation.

--- a/examples/auth/src/main.rs
+++ b/examples/auth/src/main.rs
@@ -191,7 +191,7 @@ fn server_app(settings: Settings, extra_transport_configs: Vec<TransportConfig>)
         ..default()
     };
     app.add_plugins((
-        server::ServerPlugin::new(server_config),
+        server::ServerPlugins::new(server_config),
         ExampleServerPlugin {
             protocol_id: settings.shared.protocol_id,
             private_key: settings.shared.private_key,
@@ -238,7 +238,7 @@ fn combined_app(
         ..default()
     };
     app.add_plugins((
-        server::ServerPlugin::new(server_config),
+        server::ServerPlugins::new(server_config),
         ExampleServerPlugin {
             protocol_id: settings.shared.protocol_id,
             private_key: settings.shared.private_key,

--- a/examples/auth/src/main.rs
+++ b/examples/auth/src/main.rs
@@ -77,7 +77,7 @@ fn main() {
 /// The cli argument is used to determine if we are running as a client or a server (or listen-server)
 /// Then we build the app and run it.
 ///
-/// To build a lightyear app you will need to add either the [`client::ClientPlugin`] or [`server::ServerPlugin`]
+/// To build a lightyear app you will need to add either the [`client::ClientPlugins`] or [`server::ServerPlugin`]
 /// They can be created by providing a [`client::ClientConfig`] or [`server::ServerConfig`] struct, along with a
 /// shared protocol which defines the messages (Messages, Components, Inputs) that can be sent between client and server.
 fn run(settings: Settings, cli: Cli) {
@@ -150,7 +150,7 @@ fn client_app(settings: Settings, net_config: client::NetConfig) -> App {
         ..default()
     };
     app.add_plugins((
-        client::ClientPlugin::new(client_config),
+        client::ClientPlugins::new(client_config),
         ExampleClientPlugin {
             auth_backend_address: SocketAddr::V4(SocketAddrV4::new(
                 Ipv4Addr::LOCALHOST,
@@ -264,7 +264,7 @@ fn combined_app(
         ..default()
     };
     app.add_plugins((
-        client::ClientPlugin::new(client_config),
+        client::ClientPlugins::new(client_config),
         ExampleClientPlugin {
             auth_backend_address: SocketAddr::V4(SocketAddrV4::new(
                 Ipv4Addr::LOCALHOST,

--- a/examples/bullet_prespawn/assets/settings.ron
+++ b/examples/bullet_prespawn/assets/settings.ron
@@ -55,6 +55,6 @@ Settings(
     shared: SharedSettings(
         protocol_id: 0,
         private_key: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
-        compression: Zstd(level: 0),
+        compression: None,
     )
 )

--- a/examples/bullet_prespawn/src/main.rs
+++ b/examples/bullet_prespawn/src/main.rs
@@ -16,9 +16,7 @@ use bevy_inspector_egui::quick::WorldInspectorPlugin;
 use clap::{Parser, ValueEnum};
 use serde::{Deserialize, Serialize};
 
-use lightyear::prelude::client::{
-    InterpolationConfig, InterpolationDelay, NetConfig, ReplicationConfig,
-};
+use lightyear::prelude::client::{InterpolationConfig, InterpolationDelay, NetConfig};
 use lightyear::prelude::{Mode, TransportConfig};
 use lightyear::shared::log::add_log_layer;
 use lightyear::transport::LOCAL_SOCKET;
@@ -154,10 +152,6 @@ fn client_app(settings: Settings, net_config: client::NetConfig) -> App {
             delay: InterpolationDelay::default().with_send_interval_ratio(2.0),
             ..default()
         },
-        replication: ReplicationConfig {
-            enable_send: true,
-            enable_receive: true,
-        },
         ..default()
     };
     app.add_plugins((
@@ -194,14 +188,10 @@ fn server_app(settings: Settings, extra_transport_configs: Vec<TransportConfig>)
     let server_config = server::ServerConfig {
         shared: shared_config(Mode::Separate),
         net: net_configs,
-        replication: lightyear::server::replication::ReplicationConfig {
-            enable_send: true,
-            enable_receive: true,
-        },
         ..default()
     };
     app.add_plugins((
-        server::ServerPlugin::new(server_config),
+        server::ServerPlugins::new(server_config),
         ExampleServerPlugin,
         SharedPlugin,
     ));
@@ -234,14 +224,10 @@ fn combined_app(
     let server_config = server::ServerConfig {
         shared: shared_config(Mode::HostServer),
         net: net_configs,
-        replication: lightyear::server::replication::ReplicationConfig {
-            enable_send: true,
-            enable_receive: true,
-        },
         ..default()
     };
     app.add_plugins((
-        server::ServerPlugin::new(server_config),
+        server::ServerPlugins::new(server_config),
         ExampleServerPlugin,
     ));
 
@@ -252,10 +238,6 @@ fn combined_app(
         interpolation: InterpolationConfig {
             delay: InterpolationDelay::default().with_send_interval_ratio(2.0),
             ..default()
-        },
-        replication: ReplicationConfig {
-            enable_send: true,
-            enable_receive: true,
         },
         ..default()
     };

--- a/examples/bullet_prespawn/src/main.rs
+++ b/examples/bullet_prespawn/src/main.rs
@@ -161,7 +161,7 @@ fn client_app(settings: Settings, net_config: client::NetConfig) -> App {
         ..default()
     };
     app.add_plugins((
-        client::ClientPlugin::new(client_config),
+        client::ClientPlugins::new(client_config),
         ExampleClientPlugin,
         SharedPlugin,
     ));
@@ -260,7 +260,7 @@ fn combined_app(
         ..default()
     };
     app.add_plugins((
-        client::ClientPlugin::new(client_config),
+        client::ClientPlugins::new(client_config),
         ExampleClientPlugin,
     ));
     // shared plugin

--- a/examples/client_replication/src/main.rs
+++ b/examples/client_replication/src/main.rs
@@ -16,9 +16,7 @@ use bevy_inspector_egui::quick::WorldInspectorPlugin;
 use clap::{Parser, ValueEnum};
 use serde::{Deserialize, Serialize};
 
-use lightyear::prelude::client::{
-    InterpolationConfig, InterpolationDelay, NetConfig, ReplicationConfig,
-};
+use lightyear::prelude::client::{InterpolationConfig, InterpolationDelay, NetConfig};
 use lightyear::prelude::{Mode, TransportConfig};
 use lightyear::shared::log::add_log_layer;
 use lightyear::transport::LOCAL_SOCKET;
@@ -155,10 +153,6 @@ fn client_app(settings: Settings, net_config: client::NetConfig) -> App {
             delay: InterpolationDelay::default().with_send_interval_ratio(2.0),
             ..default()
         },
-        replication: ReplicationConfig {
-            enable_send: true,
-            enable_receive: true,
-        },
         ..default()
     };
     app.add_plugins((
@@ -195,14 +189,10 @@ fn server_app(settings: Settings, extra_transport_configs: Vec<TransportConfig>)
     let server_config = server::ServerConfig {
         shared: shared_config(Mode::Separate),
         net: net_configs,
-        replication: lightyear::server::replication::ReplicationConfig {
-            enable_send: true,
-            enable_receive: true,
-        },
         ..default()
     };
     app.add_plugins((
-        server::ServerPlugin::new(server_config),
+        server::ServerPlugins::new(server_config),
         ExampleServerPlugin,
         SharedPlugin,
     ));
@@ -235,14 +225,10 @@ fn combined_app(
     let server_config = server::ServerConfig {
         shared: shared_config(Mode::HostServer),
         net: net_configs,
-        replication: lightyear::server::replication::ReplicationConfig {
-            enable_send: true,
-            enable_receive: true,
-        },
         ..default()
     };
     app.add_plugins((
-        server::ServerPlugin::new(server_config),
+        server::ServerPlugins::new(server_config),
         ExampleServerPlugin,
     ));
 
@@ -253,10 +239,6 @@ fn combined_app(
         interpolation: InterpolationConfig {
             delay: InterpolationDelay::default().with_send_interval_ratio(2.0),
             ..default()
-        },
-        replication: ReplicationConfig {
-            enable_send: true,
-            enable_receive: true,
         },
         ..default()
     };

--- a/examples/client_replication/src/main.rs
+++ b/examples/client_replication/src/main.rs
@@ -162,7 +162,7 @@ fn client_app(settings: Settings, net_config: client::NetConfig) -> App {
         ..default()
     };
     app.add_plugins((
-        client::ClientPlugin::new(client_config),
+        client::ClientPlugins::new(client_config),
         ExampleClientPlugin,
         SharedPlugin,
     ));
@@ -261,7 +261,7 @@ fn combined_app(
         ..default()
     };
     app.add_plugins((
-        client::ClientPlugin::new(client_config),
+        client::ClientPlugins::new(client_config),
         ExampleClientPlugin,
     ));
     // shared plugin

--- a/examples/interest_management/src/main.rs
+++ b/examples/interest_management/src/main.rs
@@ -158,7 +158,7 @@ fn client_app(settings: Settings, net_config: client::NetConfig) -> App {
         ..default()
     };
     app.add_plugins((
-        client::ClientPlugin::new(client_config),
+        client::ClientPlugins::new(client_config),
         ExampleClientPlugin,
         SharedPlugin,
     ));
@@ -246,7 +246,7 @@ fn combined_app(
         ..default()
     };
     app.add_plugins((
-        client::ClientPlugin::new(client_config),
+        client::ClientPlugins::new(client_config),
         ExampleClientPlugin,
     ));
     // shared plugin

--- a/examples/interest_management/src/main.rs
+++ b/examples/interest_management/src/main.rs
@@ -194,7 +194,7 @@ fn server_app(settings: Settings, extra_transport_configs: Vec<TransportConfig>)
         ..default()
     };
     app.add_plugins((
-        server::ServerPlugin::new(server_config),
+        server::ServerPlugins::new(server_config),
         ExampleServerPlugin,
         SharedPlugin,
     ));
@@ -230,7 +230,7 @@ fn combined_app(
         ..default()
     };
     app.add_plugins((
-        server::ServerPlugin::new(server_config),
+        server::ServerPlugins::new(server_config),
         ExampleServerPlugin,
     ));
 

--- a/examples/leafwing_inputs/src/main.rs
+++ b/examples/leafwing_inputs/src/main.rs
@@ -160,11 +160,6 @@ fn client_app(settings: Settings, net_config: client::NetConfig) -> App {
             delay: InterpolationDelay::default().with_send_interval_ratio(2.0),
             ..default()
         },
-        replication: client::ReplicationConfig {
-            // enable send because we pre-spawn entities on the client
-            enable_send: true,
-            enable_receive: true,
-        },
         ..default()
     };
     app.add_plugins((
@@ -201,14 +196,10 @@ fn server_app(settings: Settings, extra_transport_configs: Vec<TransportConfig>)
     let server_config = server::ServerConfig {
         shared: shared_config(Mode::Separate),
         net: net_configs,
-        replication: lightyear::server::replication::ReplicationConfig {
-            enable_send: true,
-            enable_receive: true,
-        },
         ..default()
     };
     app.add_plugins((
-        server::ServerPlugin::new(server_config),
+        server::ServerPlugins::new(server_config),
         ExampleServerPlugin {
             predict_all: settings.server.predict_all,
         },
@@ -243,14 +234,10 @@ fn combined_app(
     let server_config = server::ServerConfig {
         shared: shared_config(Mode::HostServer),
         net: net_configs,
-        replication: lightyear::server::replication::ReplicationConfig {
-            enable_send: true,
-            enable_receive: true,
-        },
         ..default()
     };
     app.add_plugins((
-        server::ServerPlugin::new(server_config),
+        server::ServerPlugins::new(server_config),
         ExampleServerPlugin {
             predict_all: settings.server.predict_all,
         },
@@ -268,11 +255,6 @@ fn combined_app(
         interpolation: InterpolationConfig {
             delay: InterpolationDelay::default().with_send_interval_ratio(2.0),
             ..default()
-        },
-        replication: client::ReplicationConfig {
-            // enable send because we pre-spawn entities on the client
-            enable_send: true,
-            enable_receive: true,
         },
         ..default()
     };

--- a/examples/leafwing_inputs/src/main.rs
+++ b/examples/leafwing_inputs/src/main.rs
@@ -168,7 +168,7 @@ fn client_app(settings: Settings, net_config: client::NetConfig) -> App {
         ..default()
     };
     app.add_plugins((
-        client::ClientPlugin::new(client_config),
+        client::ClientPlugins::new(client_config),
         ExampleClientPlugin,
         SharedPlugin,
     ));
@@ -277,7 +277,7 @@ fn combined_app(
         ..default()
     };
     app.add_plugins((
-        client::ClientPlugin::new(client_config),
+        client::ClientPlugins::new(client_config),
         ExampleClientPlugin,
     ));
     // shared plugin

--- a/examples/lobby/src/main.rs
+++ b/examples/lobby/src/main.rs
@@ -123,7 +123,7 @@ fn server_app(settings: Settings, extra_transport_configs: Vec<TransportConfig>)
         ..default()
     };
     app.add_plugins((
-        server::ServerPlugin::new(server_config),
+        server::ServerPlugins::new(server_config),
         ExampleServerPlugin,
         SharedPlugin,
     ));
@@ -154,7 +154,7 @@ fn combined_app(settings: Settings, client_net_config: client::NetConfig) -> App
         ..default()
     };
     app.add_plugins((
-        server::ServerPlugin::new(server_config),
+        server::ServerPlugins::new(server_config),
         ExampleServerPlugin,
     ));
 

--- a/examples/lobby/src/main.rs
+++ b/examples/lobby/src/main.rs
@@ -72,7 +72,7 @@ fn main() {
 /// The cli argument is used to determine if we are running as a client or a server (or listen-server)
 /// Then we build the app and run it.
 ///
-/// To build a lightyear app you will need to add either the [`client::ClientPlugin`] or [`server::ServerPlugin`]
+/// To build a lightyear app you will need to add either the [`client::ClientPlugins`] or [`server::ServerPlugin`]
 /// They can be created by providing a [`client::ClientConfig`] or [`server::ServerConfig`] struct, along with a
 /// shared protocol which defines the messages (Messages, Components, Inputs) that can be sent between client and server.
 fn run(mut settings: Settings, cli: Cli) {
@@ -169,7 +169,7 @@ fn combined_app(settings: Settings, client_net_config: client::NetConfig) -> App
         ..default()
     };
     app.add_plugins((
-        client::ClientPlugin::new(client_config),
+        client::ClientPlugins::new(client_config),
         ExampleClientPlugin { settings },
     ));
     // shared plugin

--- a/examples/priority/src/main.rs
+++ b/examples/priority/src/main.rs
@@ -157,7 +157,7 @@ fn client_app(settings: Settings, net_config: client::NetConfig) -> App {
         ..default()
     };
     app.add_plugins((
-        client::ClientPlugin::new(client_config),
+        client::ClientPlugins::new(client_config),
         ExampleClientPlugin,
         SharedPlugin,
     ));
@@ -254,7 +254,7 @@ fn combined_app(
         ..default()
     };
     app.add_plugins((
-        client::ClientPlugin::new(client_config),
+        client::ClientPlugins::new(client_config),
         ExampleClientPlugin,
     ));
     // shared plugin

--- a/examples/replication_groups/src/main.rs
+++ b/examples/replication_groups/src/main.rs
@@ -156,7 +156,7 @@ fn client_app(settings: Settings, net_config: client::NetConfig) -> App {
         ..default()
     };
     app.add_plugins((
-        client::ClientPlugin::new(client_config),
+        client::ClientPlugins::new(client_config),
         ExampleClientPlugin,
         SharedPlugin,
     ));
@@ -243,7 +243,7 @@ fn combined_app(
         ..default()
     };
     app.add_plugins((
-        client::ClientPlugin::new(client_config),
+        client::ClientPlugins::new(client_config),
         ExampleClientPlugin,
     ));
     // shared plugin

--- a/examples/replication_groups/src/main.rs
+++ b/examples/replication_groups/src/main.rs
@@ -192,7 +192,7 @@ fn server_app(settings: Settings, extra_transport_configs: Vec<TransportConfig>)
         ..default()
     };
     app.add_plugins((
-        server::ServerPlugin::new(server_config),
+        server::ServerPlugins::new(server_config),
         ExampleServerPlugin,
         SharedPlugin,
     ));
@@ -228,7 +228,7 @@ fn combined_app(
         ..default()
     };
     app.add_plugins((
-        server::ServerPlugin::new(server_config),
+        server::ServerPlugins::new(server_config),
         ExampleServerPlugin,
     ));
 

--- a/examples/simple_box/src/main.rs
+++ b/examples/simple_box/src/main.rs
@@ -203,7 +203,7 @@ fn server_app(settings: Settings, extra_transport_configs: Vec<TransportConfig>)
         ..default()
     };
     app.add_plugins((
-        server::ServerPlugin::new(server_config),
+        server::ServerPlugins::new(server_config),
         ExampleServerPlugin,
         SharedPlugin,
     ));
@@ -239,7 +239,7 @@ fn combined_app(
         ..default()
     };
     app.add_plugins((
-        server::ServerPlugin::new(server_config),
+        server::ServerPlugins::new(server_config),
         ExampleServerPlugin,
     ));
 

--- a/examples/simple_box/src/main.rs
+++ b/examples/simple_box/src/main.rs
@@ -86,7 +86,7 @@ fn main() {
 /// The cli argument is used to determine if we are running as a client or a server (or listen-server)
 /// Then we build the app and run it.
 ///
-/// To build a lightyear app you will need to add either the [`client::ClientPlugin`] or [`server::ServerPlugin`]
+/// To build a lightyear app you will need to add either the [`client::ClientPlugins`] or [`server::ServerPlugin`]
 /// They can be created by providing a [`client::ClientConfig`] or [`server::ServerConfig`] struct, along with a
 /// shared protocol which defines the messages (Messages, Components, Inputs) that can be sent between client and server.
 fn run(settings: Settings, cli: Cli) {
@@ -167,7 +167,7 @@ fn client_app(settings: Settings, net_config: client::NetConfig) -> App {
         ..default()
     };
     app.add_plugins((
-        client::ClientPlugin::new(client_config),
+        client::ClientPlugins::new(client_config),
         ExampleClientPlugin,
         SharedPlugin,
     ));
@@ -254,7 +254,7 @@ fn combined_app(
         ..default()
     };
     app.add_plugins((
-        client::ClientPlugin::new(client_config),
+        client::ClientPlugins::new(client_config),
         ExampleClientPlugin,
     ));
     // shared plugin

--- a/lightyear/src/client/config.rs
+++ b/lightyear/src/client/config.rs
@@ -8,7 +8,6 @@ use nonzero_ext::nonzero;
 use crate::client::input::InputConfig;
 use crate::client::interpolation::plugin::InterpolationConfig;
 use crate::client::prediction::plugin::PredictionConfig;
-use crate::client::replication::ReplicationConfig;
 use crate::client::sync::SyncConfig;
 use crate::connection::client::NetConfig;
 use crate::shared::config::{Mode, SharedConfig};
@@ -111,5 +110,4 @@ pub struct ClientConfig {
     pub sync: SyncConfig,
     pub prediction: PredictionConfig,
     pub interpolation: InterpolationConfig,
-    pub replication: ReplicationConfig,
 }

--- a/lightyear/src/client/input_leafwing.rs
+++ b/lightyear/src/client/input_leafwing.rs
@@ -963,7 +963,7 @@ mod tests {
             incoming_loss: 0.0,
         };
         let sync_config = SyncConfig::default().speedup_factor(1.0);
-        let prediction_config = PredictionConfig::default().disable(false);
+        let prediction_config = PredictionConfig::default();
         let interpolation_config = InterpolationConfig::default();
         let mut stepper = BevyStepper::new(
             shared_config,

--- a/lightyear/src/client/interpolation/visual_interpolation.rs
+++ b/lightyear/src/client/interpolation/visual_interpolation.rs
@@ -205,7 +205,7 @@ mod tests {
             incoming_loss: 0.0,
         };
         let sync_config = SyncConfig::default().speedup_factor(1.0);
-        let prediction_config = PredictionConfig::default().disable(false);
+        let prediction_config = PredictionConfig::default();
         let interpolation_config = InterpolationConfig::default();
         let mut stepper = BevyStepper::new(
             shared_config,

--- a/lightyear/src/client/plugin.rs
+++ b/lightyear/src/client/plugin.rs
@@ -1,4 +1,13 @@
-//! Defines the client bevy plugin
+//! Defines the [`ClientPlugins`] PluginGroup
+//!
+//! The client consists of multiple different plugins, each with their own responsibilities. These plugins
+//! are grouped into the [`ClientPlugins`] plugin group, which allows you to easily configure and disable
+//! any of the existing plugins.
+//!
+//! This means that users can simply disable existing functionality and replace it with specialized solutions,
+//! while keeping the rest of the features intact.
+//!
+//! Most plugins are truly necessary for the server functionality to work properly, but some could be disabled.
 use bevy::app::PluginGroupBuilder;
 use bevy::prelude::*;
 
@@ -8,7 +17,7 @@ use crate::client::interpolation::plugin::InterpolationPlugin;
 use crate::client::networking::ClientNetworkingPlugin;
 use crate::client::prediction::plugin::PredictionPlugin;
 use crate::client::replication::{ClientReplicationReceivePlugin, ClientReplicationSendPlugin};
-use crate::prelude::server::ServerConfig;
+use crate::prelude::server::{ServerConfig, ServerPlugins};
 use crate::server::events::ServerEventsPlugin;
 use crate::server::networking::ServerNetworkingPlugin;
 use crate::server::replication::{ServerReplicationReceivePlugin, ServerReplicationSendPlugin};

--- a/lightyear/src/client/plugin.rs
+++ b/lightyear/src/client/plugin.rs
@@ -1,4 +1,5 @@
 //! Defines the client bevy plugin
+use bevy::app::PluginGroupBuilder;
 use bevy::prelude::*;
 
 use crate::client::diagnostics::ClientDiagnosticsPlugin;
@@ -6,26 +7,67 @@ use crate::client::events::ClientEventsPlugin;
 use crate::client::interpolation::plugin::InterpolationPlugin;
 use crate::client::networking::ClientNetworkingPlugin;
 use crate::client::prediction::plugin::PredictionPlugin;
-use crate::client::replication::ClientReplicationPlugin;
+use crate::client::replication::{ClientReplicationReceivePlugin, ClientReplicationSendPlugin};
+use crate::prelude::server::ServerConfig;
+use crate::server::events::ServerEventsPlugin;
+use crate::server::networking::ServerNetworkingPlugin;
+use crate::server::replication::{ServerReplicationReceivePlugin, ServerReplicationSendPlugin};
+use crate::server::visibility::immediate::VisibilityPlugin;
+use crate::server::visibility::room::RoomPlugin;
 use crate::shared::config::Mode;
 use crate::shared::plugin::SharedPlugin;
 
 use super::config::ClientConfig;
 
-pub struct ClientPlugin {
+/// A plugin group containing all the client plugins.
+///
+/// By default, the following plugins will be added:
+/// - [`SetupPlugin`]: Adds the [`ClientConfig`] resource and the [`SharedPlugin`] plugin.
+/// - [`ClientEventsPlugin`]: Adds the client network event
+/// - [`ClientNetworkingPlugin`]: Handles the network state (connecting/disconnecting the client, sending/receiving packets)
+/// - [`ClientDiagnosticsPlugin`]: Computes diagnostics about the client connection. Can be disabled if you don't need it.
+/// - [`ClientReplicationReceivePlugin`]: Handles the replication of entities and resources from server to client. This can be
+///   disabled if you don't need server to client replication.
+/// - [`ClientReplicationSendPlugin`]: Handles the replication of entities and resources from client to server. This can be
+///   disabled if you don't need client to server replication.
+/// - [`PredictionPlugin`]: Handles the client-prediction systems. This can be disabled if you don't need it.
+/// - [`InterpolationPlugin`]: Handles the interpolation systems. This can be disabled if you don't need it.
+pub struct ClientPlugins {
     pub config: ClientConfig,
 }
 
-impl ClientPlugin {
+impl ClientPlugins {
     pub fn new(config: ClientConfig) -> Self {
         Self { config }
     }
 }
 
-// TODO: create this as PluginGroup so that users can easily disable sub plugins?
+impl PluginGroup for ClientPlugins {
+    fn build(self) -> PluginGroupBuilder {
+        let builder = PluginGroupBuilder::start::<Self>();
+        let tick_interval = self.config.shared.tick.tick_duration;
+        let interpolation_config = self.config.interpolation.clone();
+        builder
+            .add(SetupPlugin {
+                config: self.config,
+            })
+            .add(ClientEventsPlugin)
+            .add(ClientNetworkingPlugin)
+            .add(ClientDiagnosticsPlugin)
+            .add(ClientReplicationReceivePlugin { tick_interval })
+            .add(ClientReplicationSendPlugin { tick_interval })
+            .add(PredictionPlugin)
+            .add(InterpolationPlugin::new(interpolation_config))
+    }
+}
+
+struct SetupPlugin {
+    config: ClientConfig,
+}
+
 // TODO: override `ready` and `finish` to make sure that the transport/backend is connected
 //  before the plugin is ready
-impl Plugin for ClientPlugin {
+impl Plugin for SetupPlugin {
     fn build(&self, app: &mut App) {
         app
             // RESOURCES //
@@ -40,14 +82,5 @@ impl Plugin for ClientPlugin {
                     config: self.config.shared.clone(),
                 });
         }
-
-        app
-            // PLUGINS //
-            .add_plugins(ClientNetworkingPlugin)
-            .add_plugins(ClientEventsPlugin)
-            .add_plugins(ClientDiagnosticsPlugin)
-            .add_plugins(ClientReplicationPlugin)
-            .add_plugins(PredictionPlugin)
-            .add_plugins(InterpolationPlugin::new(self.config.interpolation.clone()));
     }
 }

--- a/lightyear/src/client/prediction/despawn.rs
+++ b/lightyear/src/client/prediction/despawn.rs
@@ -238,7 +238,7 @@ pub(crate) fn remove_despawn_marker(
 //             incoming_loss: 0.05,
 //         };
 //         let sync_config = SyncConfig::default().speedup_factor(1.0);
-//         let prediction_config = PredictionConfig::default().disable(false);
+//         let prediction_config = PredictionConfig::default();
 //         let interpolation_delay = Duration::from_millis(100);
 //         let interpolation_config = InterpolationConfig::default().with_delay(InterpolationDelay {
 //             min_delay: interpolation_delay,
@@ -428,7 +428,7 @@ pub(crate) fn remove_despawn_marker(
 //             incoming_loss: 0.05,
 //         };
 //         let sync_config = SyncConfig::default().speedup_factor(1.0);
-//         let prediction_config = PredictionConfig::default().disable(false);
+//         let prediction_config = PredictionConfig::default();
 //         let interpolation_delay = Duration::from_millis(100);
 //         let interpolation_config = InterpolationConfig::default().with_delay(InterpolationDelay {
 //             min_delay: interpolation_delay,

--- a/lightyear/src/client/replication.rs
+++ b/lightyear/src/client/replication.rs
@@ -1,3 +1,4 @@
+//! Client replication plugins
 use bevy::prelude::*;
 use bevy::utils::Duration;
 
@@ -7,46 +8,59 @@ use crate::client::networking::is_connected;
 use crate::client::sync::client_is_synced;
 use crate::prelude::client::InterpolationDelay;
 use crate::prelude::SharedConfig;
-use crate::shared::replication::plugin::ReplicationPlugin;
+use crate::shared::replication::plugin::receive::ReplicationReceivePlugin;
+use crate::shared::replication::plugin::send::ReplicationSendPlugin;
 use crate::shared::sets::{ClientMarker, InternalReplicationSet};
 
-#[derive(Clone, Debug, Reflect)]
-pub struct ReplicationConfig {
-    /// Set to true to enable replicating this client's entities to the server
-    pub enable_send: bool,
-    /// Set to true to enable receiving replication updates from the server
-    pub enable_receive: bool,
+#[derive(Default)]
+pub struct ClientReplicationReceivePlugin {
+    pub tick_interval: Duration,
 }
 
-impl Default for ReplicationConfig {
-    fn default() -> Self {
-        Self {
-            enable_send: false,
-            enable_receive: true,
-        }
+impl Plugin for ClientReplicationReceivePlugin {
+    fn build(&self, app: &mut App) {
+        // PLUGIN
+        app.add_plugins(ReplicationReceivePlugin::<ConnectionManager>::new(
+            self.tick_interval,
+        ));
+
+        // TODO: currently we only support pre-spawned entities spawned during the FixedUpdate schedule
+        // // SYSTEM SETS
+        // .configure_sets(
+        //     PostUpdate,
+        //     // on client, the client hash component is not replicated to the server, so there's no ordering constraint
+        //     ReplicationSet::SetPreSpawnedHash.in_set(ReplicationSet::All),
+        // )
+
+        app.configure_sets(
+            PostUpdate,
+            // only replicate entities once client is synced
+            // NOTE: we need is_synced, and not connected. Otherwise the ticks associated with the messages might be incorrect
+            //  and the message might be ignored by the server
+            //  But then pre-predicted entities that are spawned right away will not be replicated?
+            // NOTE: we always need to add this condition if we don't enable replication, because
+            InternalReplicationSet::<ClientMarker>::All.run_if(
+                is_connected
+                    .and_then(client_is_synced)
+                    .and_then(not(SharedConfig::is_host_server_condition)),
+            ),
+        );
     }
 }
 
 #[derive(Default)]
-pub struct ClientReplicationPlugin;
+pub struct ClientReplicationSendPlugin {
+    pub tick_interval: Duration,
+}
 
-impl Plugin for ClientReplicationPlugin {
+impl Plugin for ClientReplicationSendPlugin {
     fn build(&self, app: &mut App) {
-        let config = app.world.resource::<ClientConfig>();
         app
             // PLUGIN
-            .add_plugins(ReplicationPlugin::<ConnectionManager>::new(
-                config.shared.tick.tick_duration,
-                config.replication.enable_send,
-                config.replication.enable_receive,
+            .add_plugins(ReplicationSendPlugin::<ConnectionManager>::new(
+                self.tick_interval,
             ))
-            // TODO: currently we only support pre-spawned entities spawned during the FixedUpdate schedule
-            // // SYSTEM SETS
-            // .configure_sets(
-            //     PostUpdate,
-            //     // on client, the client hash component is not replicated to the server, so there's no ordering constraint
-            //     ReplicationSet::SetPreSpawnedHash.in_set(ReplicationSet::All),
-            // )
+            // SETS
             .configure_sets(
                 PostUpdate,
                 // only replicate entities once client is synced

--- a/lightyear/src/lib.rs
+++ b/lightyear/src/lib.rs
@@ -9,7 +9,7 @@ You can find more information in the [book](https://cbournhonesque.github.io/lig
 
 ### Install the plugins
 
-`lightyear` provides two plugins: [`ServerPlugin`](prelude::server::ServerPlugin) and [`ClientPlugin`](prelude::client::ClientPlugin) that will handle the networking for you.
+`lightyear` provides two plugins: [`ServerPlugin`](prelude::server::ServerPlugins) and [`ClientPlugin`](prelude::client::ClientPlugins) that will handle the networking for you.
 
 ```rust
 use bevy::utils::Duration;
@@ -21,14 +21,14 @@ use lightyear::prelude::server::*;
 fn run_client_app() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugins(ClientPlugin::new(ClientConfig::default()))
+        .add_plugins(ClientPlugins::new(ClientConfig::default()))
         .run()
 }
 
 fn run_server_app() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugins(ServerPlugin::new(ServerConfig::default()))
+        .add_plugins(ServerPlugins::new(ServerConfig::default()))
         .run()
 }
 ```
@@ -228,14 +228,13 @@ pub mod prelude {
             InterpolateStatus, Interpolated, VisualInterpolateStatus, VisualInterpolationPlugin,
         };
         pub use crate::client::networking::{ClientCommands, NetworkingState};
-        pub use crate::client::plugin::ClientPlugin;
+        pub use crate::client::plugin::ClientPlugins;
         pub use crate::client::prediction::correction::Correction;
         pub use crate::client::prediction::despawn::PredictionDespawnCommandsExt;
         pub use crate::client::prediction::plugin::is_in_rollback;
         pub use crate::client::prediction::plugin::{PredictionConfig, PredictionSet};
         pub use crate::client::prediction::rollback::{Rollback, RollbackState};
         pub use crate::client::prediction::Predicted;
-        pub use crate::client::replication::ReplicationConfig;
         pub use crate::client::sync::SyncConfig;
         pub use crate::connection::client::{
             Authentication, ClientConnection, NetClient, NetConfig,
@@ -259,10 +258,8 @@ pub mod prelude {
             DisconnectEvent, EntityDespawnEvent, EntitySpawnEvent, InputEvent, MessageEvent,
         };
         pub use crate::server::networking::{NetworkingState, ServerCommands};
-        pub use crate::server::plugin::ServerPlugin;
-        pub use crate::server::replication::{
-            ReplicationConfig, ServerFilter, ServerReplicationSet,
-        };
+        pub use crate::server::plugin::ServerPlugins;
+        pub use crate::server::replication::{ServerFilter, ServerReplicationSet};
         pub use crate::server::visibility::immediate::VisibilityManager;
         pub use crate::server::visibility::room::{RoomId, RoomManager};
     }

--- a/lightyear/src/protocol/component.rs
+++ b/lightyear/src/protocol/component.rs
@@ -25,7 +25,7 @@ use crate::client::config::ClientConfig;
 use crate::client::interpolation::{add_interpolation_systems, add_prepare_interpolation_systems};
 use crate::client::prediction::plugin::add_prediction_systems;
 use crate::prelude::client::SyncComponent;
-use crate::prelude::server::{ServerConfig, ServerPlugin};
+use crate::prelude::server::{ServerConfig, ServerPlugins};
 use crate::prelude::{
     client, server, AppMessageExt, ChannelDirection, Message, MessageRegistry,
     PreSpawnedPlayerObject, RemoteEntityMap, ReplicateResourceMetadata, Tick,

--- a/lightyear/src/protocol/message.rs
+++ b/lightyear/src/protocol/message.rs
@@ -49,7 +49,7 @@ pub(crate) enum MessageType {
     Normal,
 }
 
-/// A [`Resource`](bevy::prelude::Resource) that will keep track of all the [`Message`]s that can be sent over the network.
+/// A [`Resource`] that will keep track of all the [`Message`]s that can be sent over the network.
 /// A [`Message`] is any type that is serializable and deserializable.
 ///
 ///

--- a/lightyear/src/server/config.rs
+++ b/lightyear/src/server/config.rs
@@ -5,7 +5,6 @@ use nonzero_ext::nonzero;
 
 use crate::connection::netcode::Key;
 use crate::connection::server::NetConfig;
-use crate::server::replication::ReplicationConfig;
 use crate::shared::config::SharedConfig;
 use crate::shared::ping::manager::PingConfig;
 
@@ -95,5 +94,4 @@ pub struct ServerConfig {
     pub net: Vec<NetConfig>,
     pub packet: PacketConfig,
     pub ping: PingConfig,
-    pub replication: ReplicationConfig,
 }

--- a/lightyear/src/server/connection.rs
+++ b/lightyear/src/server/connection.rs
@@ -45,8 +45,8 @@ use crate::shared::replication::components::{
 use crate::shared::replication::receive::ReplicationReceiver;
 use crate::shared::replication::send::ReplicationSender;
 use crate::shared::replication::systems::DespawnMetadata;
-use crate::shared::replication::ReplicationMessageData;
-use crate::shared::replication::{ReplicationMessage, ReplicationSend};
+use crate::shared::replication::{ReplicationMessage, ReplicationReceive, ReplicationSend};
+use crate::shared::replication::{ReplicationMessageData, ReplicationPeer};
 use crate::shared::sets::ServerMarker;
 use crate::shared::tick_manager::Tick;
 use crate::shared::tick_manager::TickManager;
@@ -626,15 +626,26 @@ impl MessageSend for ConnectionManager {
     }
 }
 
-impl ReplicationSend for ConnectionManager {
+impl ReplicationPeer for ConnectionManager {
     type Events = ServerEvents;
     type EventContext = ClientId;
     type SetMarker = ServerMarker;
+}
 
+impl ReplicationReceive for ConnectionManager {
     fn events(&mut self) -> &mut Self::Events {
         &mut self.events
     }
 
+    fn cleanup(&mut self, tick: Tick) {
+        debug!("Running replication receive cleanup");
+        for connection in self.connections.values_mut() {
+            connection.replication_receiver.cleanup(tick);
+        }
+    }
+}
+
+impl ReplicationSend for ConnectionManager {
     fn writer(&mut self) -> &mut BitcodeWriter {
         &mut self.writer
     }
@@ -901,37 +912,9 @@ impl ReplicationSend for ConnectionManager {
     }
 
     fn cleanup(&mut self, tick: Tick) {
-        debug!("Running replication clean");
+        debug!("Running replication send cleanup");
         for connection in self.connections.values_mut() {
-            // if it's been enough time since we last any action for the group, we can set the last_action_tick to None
-            // (meaning that there's no need when we receive the update to check if we have already received a previous action)
-            for group_channel in connection.replication_sender.group_channels.values_mut() {
-                debug!("Checking group channel: {:?}", group_channel);
-                if let Some(last_action_tick) = group_channel.last_action_tick {
-                    if tick - last_action_tick > (i16::MAX / 2) {
-                        debug!(
-                    ?tick,
-                    ?last_action_tick,
-                    ?group_channel,
-                    "Setting the last_action tick to None because there hasn't been any new actions in a while");
-                        group_channel.last_action_tick = None;
-                    }
-                }
-            }
-            // if it's been enough time since we last had any update for the group, we update the latest_tick for the group
-            for group_channel in connection.replication_receiver.group_channels.values_mut() {
-                debug!("Checking group channel: {:?}", group_channel);
-                if let Some(latest_tick) = group_channel.latest_tick {
-                    if tick - latest_tick > (i16::MAX / 2) {
-                        debug!(
-                    ?tick,
-                    ?latest_tick,
-                    ?group_channel,
-                    "Setting the latest_tick tick to tick because there hasn't been any new updates in a while");
-                        group_channel.latest_tick = Some(tick);
-                    }
-                }
-            }
+            connection.replication_sender.cleanup(tick);
         }
     }
 }

--- a/lightyear/src/server/input_leafwing.rs
+++ b/lightyear/src/server/input_leafwing.rs
@@ -271,7 +271,7 @@ mod tests {
             incoming_loss: 0.0,
         };
         let sync_config = SyncConfig::default().speedup_factor(1.0);
-        let prediction_config = PredictionConfig::default().disable(false);
+        let prediction_config = PredictionConfig::default();
         let interpolation_config = InterpolationConfig::default();
         let mut stepper = BevyStepper::new(
             shared_config,

--- a/lightyear/src/server/plugin.rs
+++ b/lightyear/src/server/plugin.rs
@@ -1,26 +1,69 @@
-//! Defines the server bevy plugin
+//! Defines the Server PluginGroup
+//!
+//! The Server consists of multiple different plugins, each with their own responsibilities. These plugins
+//! are grouped into the [`ServerPlugins`] plugin group, which allows you to easily configure and disable
+//! any of the existing plugins.
+//!
+//! This means that users can simply disable existing functionality and replace it with specialized solutions,
+//! while keeping the rest of the features intact.
+//!
+//! Most plugins are truly necessary for the server functionality to work properly, but some could be disabled.
+use bevy::app::PluginGroupBuilder;
 use bevy::prelude::*;
 
 use crate::server::events::ServerEventsPlugin;
 use crate::server::networking::ServerNetworkingPlugin;
-use crate::server::replication::ServerReplicationPlugin;
+use crate::server::replication::{ServerReplicationReceivePlugin, ServerReplicationSendPlugin};
 use crate::server::visibility::immediate::VisibilityPlugin;
 use crate::server::visibility::room::RoomPlugin;
 use crate::shared::plugin::SharedPlugin;
 
 use super::config::ServerConfig;
 
-pub struct ServerPlugin {
+/// A plugin group containing all the server plugins.
+///
+/// By default, the following plugins will be added:
+/// - [`SetupPlugin`]: Adds the [`ServerConfig`] resource and the [`SharedPlugin`] plugin.
+/// - [`ServerEventsPlugin`]: Adds the server network event
+/// - [`ServerNetworkingPlugin`]: Handles the network state (starting/stopping the server, sending/receiving packets)
+/// - [`VisibilityPlugin`]: Handles the visibility system. This can be disabled if you don't need fine-grained interest management.
+/// - [`RoomPlugin`]: Handles the room system, which is an addition to the visibility system. This can be disabled if you don't need rooms.
+/// - [`ServerReplicationReceivePlugin`]: Handles the replication of entities and resources from clients to the server. This can be
+///   disabled if you don't need client to server replication.
+/// - [`ServerReplicationSendPlugin`]: Handles the replication of entities and resources from the server to the client. This can be
+///   disabled if you don't need server to client replication.
+pub struct ServerPlugins {
     config: ServerConfig,
 }
 
-impl ServerPlugin {
+impl ServerPlugins {
     pub fn new(config: ServerConfig) -> Self {
         Self { config }
     }
 }
 
-impl Plugin for ServerPlugin {
+impl PluginGroup for ServerPlugins {
+    fn build(self) -> PluginGroupBuilder {
+        let builder = PluginGroupBuilder::start::<Self>();
+        let tick_interval = self.config.shared.tick.tick_duration;
+        builder
+            .add(SetupPlugin {
+                config: self.config,
+            })
+            .add(ServerEventsPlugin)
+            .add(ServerNetworkingPlugin)
+            .add(VisibilityPlugin)
+            .add(RoomPlugin)
+            .add(ServerReplicationReceivePlugin { tick_interval })
+            .add(ServerReplicationSendPlugin { tick_interval })
+    }
+}
+
+struct SetupPlugin {
+    config: ServerConfig,
+}
+
+impl Plugin for SetupPlugin {
     fn build(&self, app: &mut App) {
         app
             // RESOURCES //
@@ -30,11 +73,6 @@ impl Plugin for ServerPlugin {
             .add_plugins(SharedPlugin {
                 // TODO: move shared config out of server_config?
                 config: self.config.shared.clone(),
-            })
-            .add_plugins(ServerEventsPlugin)
-            .add_plugins(ServerNetworkingPlugin)
-            .add_plugins(VisibilityPlugin)
-            .add_plugins(RoomPlugin)
-            .add_plugins(ServerReplicationPlugin);
+            });
     }
 }

--- a/lightyear/src/server/visibility/immediate.rs
+++ b/lightyear/src/server/visibility/immediate.rs
@@ -1,4 +1,6 @@
-/*! # Visibility
+/*! Main visibility module, where you can immediately update the visibility of an entity for a given client
+
+# Visibility
 
 This module provides a [`VisibilityManager`] resource that allows you to update the visibility of entities in an immediate fashion.
 

--- a/lightyear/src/server/visibility/mod.rs
+++ b/lightyear/src/server/visibility/mod.rs
@@ -1,5 +1,3 @@
-/// Main visibility module, where you can immediately update the visibility of an entity for a given client
 pub mod immediate;
 
-/// Room-based visibility module, where you can use semi-static rooms to manage visibility
 pub mod room;

--- a/lightyear/src/server/visibility/room.rs
+++ b/lightyear/src/server/visibility/room.rs
@@ -1,4 +1,6 @@
-/*! # Room
+/*! Room-based visibility module, where you can use semi-static rooms to manage visibility
+
+# Room
 
 Rooms are used to provide interest management in a semi-static way.
 Entities and Clients can be added to multiple rooms.

--- a/lightyear/src/shared/events/plugin.rs
+++ b/lightyear/src/shared/events/plugin.rs
@@ -7,7 +7,7 @@ use crate::shared::events::components::{
     ConnectEvent, DisconnectEvent, EntityDespawnEvent, EntitySpawnEvent,
 };
 use crate::shared::events::systems::{clear_events, push_entity_events};
-use crate::shared::replication::ReplicationSend;
+use crate::shared::replication::ReplicationReceive;
 use crate::shared::sets::{InternalMainSet, InternalReplicationSet};
 
 pub struct EventsPlugin<R> {
@@ -22,7 +22,7 @@ impl<R> Default for EventsPlugin<R> {
     }
 }
 
-impl<R: ReplicationSend> Plugin for EventsPlugin<R> {
+impl<R: ReplicationReceive> Plugin for EventsPlugin<R> {
     fn build(&self, app: &mut App) {
         // EVENTS
         app.add_event::<ConnectEvent<R::EventContext>>()

--- a/lightyear/src/shared/events/systems.rs
+++ b/lightyear/src/shared/events/systems.rs
@@ -9,10 +9,10 @@ use crate::shared::events::connection::{
     ClearEvents, IterComponentInsertEvent, IterComponentRemoveEvent, IterComponentUpdateEvent,
     IterEntityDespawnEvent, IterEntitySpawnEvent,
 };
-use crate::shared::replication::ReplicationSend;
+use crate::shared::replication::ReplicationReceive;
 
 /// System that gathers the replication events received by the local host and sends them to bevy Events
-pub(crate) fn push_component_events<C: Component, R: ReplicationSend>(
+pub(crate) fn push_component_events<C: Component, R: ReplicationReceive>(
     component_registry: Res<ComponentRegistry>,
     mut connection_manager: ResMut<R>,
     mut component_insert_events: EventWriter<ComponentInsertEvent<C, R::EventContext>>,
@@ -40,7 +40,7 @@ pub(crate) fn push_component_events<C: Component, R: ReplicationSend>(
 }
 
 /// System that gathers the replication events received by the local host and sends them to bevy Events
-pub(crate) fn push_entity_events<R: ReplicationSend>(
+pub(crate) fn push_entity_events<R: ReplicationReceive>(
     mut connection_manager: ResMut<R>,
     mut entity_spawn_events: EventWriter<EntitySpawnEvent<R::EventContext>>,
     mut entity_despawn_events: EventWriter<EntityDespawnEvent<R::EventContext>>,
@@ -59,6 +59,6 @@ pub(crate) fn push_entity_events<R: ReplicationSend>(
     );
 }
 
-pub(crate) fn clear_events<R: ReplicationSend>(mut connection_manager: ResMut<R>) {
+pub(crate) fn clear_events<R: ReplicationReceive>(mut connection_manager: ResMut<R>) {
     connection_manager.events().clear()
 }

--- a/lightyear/src/shared/replication/commands.rs
+++ b/lightyear/src/shared/replication/commands.rs
@@ -58,7 +58,7 @@ mod tests {
             incoming_loss: 0.0,
         };
         let sync_config = SyncConfig::default().speedup_factor(1.0);
-        let prediction_config = PredictionConfig::default().disable(false);
+        let prediction_config = PredictionConfig::default();
         let interpolation_config = InterpolationConfig::default();
         let mut stepper = BevyStepper::new(
             shared_config,

--- a/lightyear/src/shared/replication/components.rs
+++ b/lightyear/src/shared/replication/components.rs
@@ -280,7 +280,7 @@ pub enum VisibilityMode {
     ///
     /// You can use [`gain_visibility`](VisibilityManager::gain_visibility) and [`lose_visibility`](VisibilityManager::lose_visibility)
     /// to control the visibility of entities.
-    /// You can also use the [`RoomManager`](RoomManager)
+    /// You can also use the [`RoomManager`](crate::prelude::server::RoomManager)
     ///
     /// (the client still needs to be included in the [`NetworkTarget`], the room is simply an additional constraint)
     InterestManagement,

--- a/lightyear/src/shared/replication/entity_map.rs
+++ b/lightyear/src/shared/replication/entity_map.rs
@@ -146,7 +146,7 @@ mod tests {
             incoming_loss: 0.0,
         };
         let sync_config = SyncConfig::default().speedup_factor(1.0);
-        let prediction_config = PredictionConfig::default().disable(false);
+        let prediction_config = PredictionConfig::default();
         let interpolation_config = InterpolationConfig::default();
         let mut stepper = BevyStepper::new(
             shared_config,

--- a/lightyear/src/shared/replication/hierarchy.rs
+++ b/lightyear/src/shared/replication/hierarchy.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::prelude::ReplicationGroup;
 use crate::shared::replication::components::Replicate;
-use crate::shared::replication::ReplicationSend;
+use crate::shared::replication::{ReplicationPeer, ReplicationSend};
 use crate::shared::sets::{InternalMainSet, InternalReplicationSet};
 
 /// This component can be added to an entity to replicate the entity's hierarchy to the remote world.
@@ -122,7 +122,7 @@ impl<R> Default for HierarchyReceivePlugin<R> {
     }
 }
 
-impl<R: ReplicationSend> HierarchyReceivePlugin<R> {
+impl<R> HierarchyReceivePlugin<R> {
     /// Update parent/children hierarchy if parent_sync changed
     ///
     /// This only runs on the receiving side
@@ -151,7 +151,7 @@ impl<R: ReplicationSend> HierarchyReceivePlugin<R> {
     }
 }
 
-impl<R: ReplicationSend> Plugin for HierarchyReceivePlugin<R> {
+impl<R: ReplicationPeer> Plugin for HierarchyReceivePlugin<R> {
     fn build(&self, app: &mut App) {
         // REFLECTION
         app.register_type::<ParentSync>();

--- a/lightyear/src/shared/replication/mod.rs
+++ b/lightyear/src/shared/replication/mod.rs
@@ -251,7 +251,7 @@ mod tests {
             incoming_loss: 0.0,
         };
         let sync_config = SyncConfig::default().speedup_factor(1.0);
-        let prediction_config = PredictionConfig::default().disable(false);
+        let prediction_config = PredictionConfig::default();
         let interpolation_config = InterpolationConfig::default();
         let mut stepper = BevyStepper::new(
             shared_config,

--- a/lightyear/src/shared/replication/mod.rs
+++ b/lightyear/src/shared/replication/mod.rs
@@ -105,27 +105,39 @@ pub struct ReplicationMessage {
     pub(crate) data: ReplicationMessageData,
 }
 
-#[doc(hidden)]
-/// Trait for any service that can send replication messages to the remote.
-/// (this trait is used to easily enable both client to server and server to client replication)
-///
-/// The trait is made public because it is needed in the macros
-pub(crate) trait ReplicationSend: Resource {
+/// Trait for a service that participates in replication.
+pub(crate) trait ReplicationPeer: Resource {
     type Events: IterComponentInsertEvent<Self::EventContext>
         + IterComponentRemoveEvent<Self::EventContext>
         + IterComponentUpdateEvent<Self::EventContext>
         + IterEntitySpawnEvent<Self::EventContext>
         + IterEntityDespawnEvent<Self::EventContext>
         + ClearEvents;
-    /// Type of the context associated with the events emitted by this replication plugin
+    /// Type of the context associated with the events emitted/received by this replication peer
     type EventContext: EventContext;
+
     /// Marker to identify the type of the ReplicationSet component
     /// This is mostly relevant in the unified mode, where a ReplicationSet can be added several times
     /// (in the client and the server replication plugins)
     type SetMarker: Debug + Hash + Send + Sync + Eq + Clone;
+}
 
+/// Trait for a service that receives replication messages.
+pub(crate) trait ReplicationReceive: Resource + ReplicationPeer {
+    /// The received events buffer
     fn events(&mut self) -> &mut Self::Events;
 
+    /// Do some regular cleanup on the internals of replication
+    /// - account for tick wrapping by resetting some internal ticks for each replication group
+    fn cleanup(&mut self, tick: Tick);
+}
+
+#[doc(hidden)]
+/// Trait for any service that can send replication messages to the remote.
+/// (this trait is used to easily enable both client to server and server to client replication)
+///
+/// The trait is made public because it is needed in the macros
+pub(crate) trait ReplicationSend: Resource + ReplicationPeer {
     fn writer(&mut self) -> &mut BitcodeWriter;
 
     fn component_registry(&self) -> &ComponentRegistry;

--- a/lightyear/src/shared/replication/resources.rs
+++ b/lightyear/src/shared/replication/resources.rs
@@ -194,6 +194,7 @@ pub(crate) mod receive {
     };
     use crate::shared::message::MessageSend;
     use crate::shared::plugin::Identity;
+    use crate::shared::replication::ReplicationPeer;
     use bevy::prelude::{DetectChangesMut, EventReader, Events, RemovedComponents};
     use tracing::{debug, trace};
 
@@ -211,7 +212,7 @@ pub(crate) mod receive {
         }
     }
 
-    impl<R: ReplicationSend> Plugin for ResourceReceivePlugin<R> {
+    impl<R: ReplicationPeer> Plugin for ResourceReceivePlugin<R> {
         fn build(&self, app: &mut App) {
             app.configure_sets(
                 PreUpdate,

--- a/lightyear/src/shared/replication/systems.rs
+++ b/lightyear/src/shared/replication/systems.rs
@@ -486,11 +486,11 @@ pub(crate) fn send_cleanup<R: ReplicationSend>(
 }
 
 pub(crate) fn receive_cleanup<R: ReplicationReceive>(
-    mut sender: ResMut<R>,
+    mut receiver: ResMut<R>,
     tick_manager: Res<TickManager>,
 ) {
     let tick = tick_manager.tick();
-    sender.cleanup(tick);
+    receiver.cleanup(tick);
 }
 
 #[cfg(test)]

--- a/lightyear/src/shared/replication/systems.rs
+++ b/lightyear/src/shared/replication/systems.rs
@@ -10,7 +10,6 @@ use bevy::prelude::{
 };
 use tracing::{debug, error, info, trace, warn};
 
-use crate::client::replication::ClientReplicationPlugin;
 use crate::prelude::{ClientId, NetworkTarget, ReplicationGroup, ShouldBePredicted, TickManager};
 use crate::protocol::component::ComponentRegistry;
 use crate::server::replication::ServerReplicationSet;
@@ -18,7 +17,7 @@ use crate::server::visibility::immediate::{ClientVisibility, ReplicateVisibility
 use crate::shared::replication::components::{
     DespawnTracker, Replicate, ReplicationGroupId, VisibilityMode,
 };
-use crate::shared::replication::ReplicationSend;
+use crate::shared::replication::{ReplicationReceive, ReplicationSend};
 use crate::shared::sets::{InternalMainSet, InternalReplicationSet};
 
 // TODO: replace this with observers
@@ -34,7 +33,7 @@ pub(crate) struct DespawnMetadata {
 
 /// For every entity that removes their Replicate component but are not despawned, remove the component
 /// from our replicate cache (so that the entity's despawns are no longer replicated)
-fn handle_replicate_remove<R: ReplicationSend>(
+pub(crate) fn handle_replicate_remove<R: ReplicationSend>(
     mut commands: Commands,
     mut sender: ResMut<R>,
     mut query: RemovedComponents<Replicate>,
@@ -79,7 +78,7 @@ pub(crate) fn handle_replicate_add<R: ReplicationSend>(
     }
 }
 
-fn send_entity_despawn<R: ReplicationSend>(
+pub(crate) fn send_entity_despawn<R: ReplicationSend>(
     query: Query<(Entity, &Replicate, Option<&ReplicateVisibility>)>,
     system_bevy_ticks: SystemChangeTick,
     // TODO: ideally we want to send despawns for entities that still had REPLICATE at the time of despawn
@@ -153,7 +152,7 @@ fn send_entity_despawn<R: ReplicationSend>(
     }
 }
 
-fn send_entity_spawn<R: ReplicationSend>(
+pub(crate) fn send_entity_spawn<R: ReplicationSend>(
     system_bevy_ticks: SystemChangeTick,
     component_registry: Res<ComponentRegistry>,
     query: Query<(Entity, Ref<Replicate>, Option<&ReplicateVisibility>)>,
@@ -461,33 +460,6 @@ pub(crate) fn send_component_removed<C: Component, R: ReplicationSend>(
     })
 }
 
-/// add replication systems that are shared between client and server
-pub(crate) fn add_replication_send_systems<R: ReplicationSend>(app: &mut App) {
-    // we need to add despawn trackers immediately for entities for which we add replicate
-    app.add_systems(
-        PreUpdate,
-        handle_replicate_add::<R>.after(ServerReplicationSet::ClientReplication),
-    );
-    app.add_systems(
-        PostUpdate,
-        (
-            // TODO: try to move this to ReplicationSystems as well? entities are spawned only once
-            //  so we can run the system every frame
-            //  putting it here means we might miss entities that are spawned and depspawned within the send_interval? bug or feature?
-            send_entity_spawn::<R>
-                .in_set(InternalReplicationSet::<R::SetMarker>::BufferEntityUpdates),
-            // NOTE: we need to run `send_entity_despawn` once per frame (and not once per send_interval)
-            //  because the RemovedComponents Events are present only for 1 frame and we might miss them if we don't run this every frame
-            //  It is ok to run it every frame because it creates at most one message per despawn
-            // NOTE: we make sure to update the replicate_cache before we make use of it in `send_entity_despawn`
-            (handle_replicate_add::<R>, handle_replicate_remove::<R>)
-                .in_set(InternalReplicationSet::<R::SetMarker>::HandleReplicateUpdate),
-            send_entity_despawn::<R>
-                .in_set(InternalReplicationSet::<R::SetMarker>::BufferDespawnsAndRemovals),
-        ),
-    );
-}
-
 pub(crate) fn register_replicate_component_send<C: Component, R: ReplicationSend>(app: &mut App) {
     app.add_systems(
         PostUpdate,
@@ -495,17 +467,28 @@ pub(crate) fn register_replicate_component_send<C: Component, R: ReplicationSend
             // NOTE: we need to run `send_component_removed` once per frame (and not once per send_interval)
             //  because the RemovedComponents Events are present only for 1 frame and we might miss them if we don't run this every frame
             //  It is ok to run it every frame because it creates at most one message per despawn
-            crate::shared::replication::systems::send_component_removed::<C, R>
+            send_component_removed::<C, R>
                 .in_set(InternalReplicationSet::<R::SetMarker>::BufferDespawnsAndRemovals),
             // NOTE: we run this system once every `send_interval` because we don't want to send too many Update messages
             //  and use up all the bandwidth
-            crate::shared::replication::systems::send_component_update::<C, R>
+            send_component_update::<C, R>
                 .in_set(InternalReplicationSet::<R::SetMarker>::BufferComponentUpdates),
         ),
     );
 }
 
-pub(crate) fn cleanup<R: ReplicationSend>(mut sender: ResMut<R>, tick_manager: Res<TickManager>) {
+pub(crate) fn send_cleanup<R: ReplicationSend>(
+    mut sender: ResMut<R>,
+    tick_manager: Res<TickManager>,
+) {
+    let tick = tick_manager.tick();
+    sender.cleanup(tick);
+}
+
+pub(crate) fn receive_cleanup<R: ReplicationReceive>(
+    mut sender: ResMut<R>,
+    tick_manager: Res<TickManager>,
+) {
     let tick = tick_manager.tick();
     sender.cleanup(tick);
 }

--- a/lightyear/src/tests/integration/multi_transport.rs
+++ b/lightyear/src/tests/integration/multi_transport.rs
@@ -125,7 +125,7 @@ impl MultiBevyStepper {
             ],
             ..default()
         };
-        let plugin = server::ServerPlugin::new(config);
+        let plugin = server::ServerPlugins::new(config);
         server_app.add_plugins((plugin, ProtocolPlugin));
         // Initialize Real time (needed only for the first TimeSystem run)
         server_app
@@ -159,7 +159,7 @@ impl MultiBevyStepper {
                 interpolation: interpolation_config.clone(),
                 ..default()
             };
-            let plugin = client::ClientPlugin::new(config);
+            let plugin = client::ClientPlugins::new(config);
             client_app.add_plugins((plugin, ProtocolPlugin));
             // Initialize Real time (needed only for the first TimeSystem run)
             client_app

--- a/lightyear/src/tests/stepper.rs
+++ b/lightyear/src/tests/stepper.rs
@@ -49,7 +49,7 @@ impl Default for BevyStepper {
             incoming_loss: 0.0,
         };
         let sync_config = SyncConfig::default().speedup_factor(1.0);
-        let prediction_config = PredictionConfig::default().disable(false);
+        let prediction_config = PredictionConfig::default();
         let interpolation_config = InterpolationConfig::default();
         let mut stepper = Self::new(
             shared_config,

--- a/lightyear/src/tests/stepper.rs
+++ b/lightyear/src/tests/stepper.rs
@@ -1,7 +1,6 @@
 use std::net::SocketAddr;
 use std::str::FromStr;
 
-use crate::client::replication::ReplicationConfig;
 use bevy::ecs::system::RunSystemOnce;
 use bevy::prelude::{default, App, Commands, Mut, PluginGroup, Real, Time, World};
 use bevy::time::TimeUpdateStrategy;
@@ -113,13 +112,9 @@ impl BevyStepper {
             shared: shared_config.clone(),
             net: vec![net_config],
             ping: PingConfig::default(),
-            replication: server::ReplicationConfig {
-                enable_send: true,
-                enable_receive: true,
-            },
             ..default()
         };
-        let plugin = server::ServerPlugin::new(config);
+        let plugin = server::ServerPlugins::new(config);
         server_app.add_plugins((plugin, ProtocolPlugin));
 
         // Setup client
@@ -141,13 +136,9 @@ impl BevyStepper {
             sync: sync_config,
             prediction: prediction_config,
             interpolation: interpolation_config,
-            replication: client::ReplicationConfig {
-                enable_send: true,
-                enable_receive: true,
-            },
             ..default()
         };
-        let plugin = client::ClientPlugin::new(config);
+        let plugin = client::ClientPlugins::new(config);
         client_app.add_plugins((plugin, ProtocolPlugin));
 
         // Initialize Real time (needed only for the first TimeSystem run)


### PR DESCRIPTION
In this PR we replace the plugins `ClientPlugin` and `ServerPlugin` 
with the `PluginGroup`s `ClientPlugins` and `ServerPlugins`.

This means that users can use the PluginGroup functionality to disable/replace internal client or server plugins with their own.

This also allows us to remove awkward `enable_send` or `enable_receive` configuration options.
Instead, users can just disable the `ClientReplicationSendPlugin` if they don't need client to server replication.

Fixes https://github.com/cBournhonesque/lightyear/pull/321
