### PR TITLE
make private key compulsory on server config

### DIFF
--- a/lightyear/src/server/config.rs
+++ b/lightyear/src/server/config.rs
@@ -3,7 +3,7 @@ use bevy::prelude::Resource;
 use governor::Quota;
 use nonzero_ext::nonzero;
 
-use crate::connection::netcode::Key;
+use crate::connection::netcode::{Key, PRIVATE_KEY_BYTES};
 use crate::connection::server::NetConfig;
 use crate::shared::config::SharedConfig;
 use crate::shared::ping::manager::PingConfig;
@@ -17,7 +17,7 @@ pub struct NetcodeConfig {
     /// The default is 3 seconds. A negative value means no timeout.
     pub client_timeout_secs: i32,
     pub protocol_id: u64,
-    pub private_key: Option<Key>,
+    pub private_key: Key,
 }
 
 impl Default for NetcodeConfig {
@@ -27,7 +27,7 @@ impl Default for NetcodeConfig {
             keep_alive_send_rate: 1.0 / 10.0,
             client_timeout_secs: 3,
             protocol_id: 0,
-            private_key: None,
+            private_key: [0; PRIVATE_KEY_BYTES],
         }
     }
 }
@@ -38,7 +38,7 @@ impl NetcodeConfig {
         self
     }
     pub fn with_key(mut self, key: Key) -> Self {
-        self.private_key = Some(key);
+        self.private_key = key;
         self
     }
 


### PR DESCRIPTION
Since it was `Option<Key>`, some users thought the private key was optional.
I'm changing it to `Key` to make it clear that a private key is required