### PR TITLE
Enable overriding the rollback check function with a custom equality check function

### DIFF
--- a/lightyear/src/client/prediction/rollback.rs
+++ b/lightyear/src/client/prediction/rollback.rs
@@ -102,6 +102,7 @@ impl Rollback {
 #[allow(clippy::type_complexity)]
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn check_rollback<C: SyncComponent>(
+    component_registry: Res<ComponentRegistry>,
     // TODO: have a way to only get the updates of entities that are predicted?
     tick_manager: Res<TickManager>,
     connection: Res<ConnectionManager>,
@@ -174,7 +175,9 @@ pub(crate) fn check_rollback<C: SyncComponent>(
                 }),
                 // confirm exist. rollback if history value is different
                 Some(c) => history_value.map_or(true, |history_value| match history_value {
-                    ComponentState::Updated(history_value) => history_value != *c,
+                    ComponentState::Updated(history_value) => {
+                        !component_registry.rollback_check(&history_value, c)
+                    }
                     ComponentState::Removed => true,
                 }),
             };

--- a/lightyear/src/protocol/component.rs
+++ b/lightyear/src/protocol/component.rs
@@ -410,6 +410,20 @@ impl ComponentRegistry {
             .context("the component is not part of the protocol")
             .map_or(false, |metadata| metadata.correction.is_some())
     }
+
+    /// Perform a rollback check to determine if a rollback is needed.
+    pub(crate) fn rollback_check<C: Component>(&self, this: &C, that: &C) -> bool {
+        let kind = ComponentKind::of::<C>();
+        let prediction_metadata = self
+            .prediction_map
+            .get(&kind)
+            .context("the component is not part of the protocol")
+            .unwrap();
+        let rollback_check_fn: RollbackCheckFn<C> =
+            unsafe { std::mem::transmute(prediction_metadata.rollback_check) };
+        rollback_check_fn(this, that)
+    }
+
     pub(crate) fn correct<C: Component>(&self, predicted: &C, corrected: &C, t: f32) -> C {
         let kind = ComponentKind::of::<C>();
         let prediction_metadata = self


### PR DESCRIPTION
Fixes https://github.com/cBournhonesque/lightyear/issues/334

I still require a `PartialEq` bound on `SyncComponent` for convenience for now.

An alternative would be to not require the bound, and let users do `add_default_rollback_check_fn()` if their component is `PartialEq`, but that seems overly verbose since 99% of the time the rollback component would implement PartiaLEq