### PR TITLE
rename the rollback check fn

### DIFF
--- a/lightyear/src/client/prediction/rollback.rs
+++ b/lightyear/src/client/prediction/rollback.rs
@@ -176,7 +176,7 @@ pub(crate) fn check_rollback<C: SyncComponent>(
                 // confirm exist. rollback if history value is different
                 Some(c) => history_value.map_or(true, |history_value| match history_value {
                     ComponentState::Updated(history_value) => {
-                        !component_registry.rollback_check(&history_value, c)
+                        component_registry.should_rollback(&history_value, c)
                     }
                     ComponentState::Removed => true,
                 }),


### PR DESCRIPTION
Rename the rollback check function to `should_rollback` for clarity.
The function should return `true` if there should be a rollback (i.e. if the predicted value and the confirmed value are very different)

cc @msvbg 