### PR TITLE
Support steam p2p sockets

### DIFF
--- a/lightyear/src/connection/steam/client.rs
+++ b/lightyear/src/connection/steam/client.rs
@@ -40,9 +40,13 @@ impl Default for SteamConfig {
     }
 }
 
+/// Steam socket configuration for clients
 #[derive(Debug, Clone)]
 pub enum SocketConfig {
+    /// Connect to a server by IP address. Suitable for dedicated servers.
     Ip { server_addr: SocketAddr },
+    /// Connect to another Steam user hosting a server. Suitable for
+    /// peer-to-peer games.
     P2P { virtual_port: i32, steam_id: u64 },
 }
 

--- a/lightyear/src/connection/steam/client.rs
+++ b/lightyear/src/connection/steam/client.rs
@@ -124,17 +124,19 @@ impl NetClient for Client {
                 virtual_port,
                 steam_id,
             } => {
-                self.steamworks_client
-                    .read()
-                    .expect("could not get steamworks client")
-                    .get_client()
-                    .networking_sockets()
-                    .connect_p2p(
-                        NetworkingIdentity::new_steam_id(SteamId::from_raw(steam_id)),
-                        virtual_port,
-                        vec![],
-                    )
-                    .context("failed to create p2p connection")?;
+                self.connection = Some(
+                    self.steamworks_client
+                        .read()
+                        .expect("could not get steamworks client")
+                        .get_client()
+                        .networking_sockets()
+                        .connect_p2p(
+                            NetworkingIdentity::new_steam_id(SteamId::from_raw(steam_id)),
+                            virtual_port,
+                            vec![],
+                        )
+                        .context("failed to create p2p connection")?,
+                );
             }
         }
         Ok(())

--- a/lightyear/src/connection/steam/mod.rs
+++ b/lightyear/src/connection/steam/mod.rs
@@ -5,8 +5,6 @@ pub(crate) mod client;
 pub(crate) mod server;
 pub(crate) mod steamworks_client;
 
-pub use steamworks_client::SteamworksClient;
-
 pub(crate) fn get_networking_options(
     conditioner: &Option<LinkConditionerConfig>,
 ) -> Vec<NetworkingConfigEntry> {

--- a/lightyear/src/connection/steam/mod.rs
+++ b/lightyear/src/connection/steam/mod.rs
@@ -3,13 +3,9 @@ use steamworks::networking_types::{NetworkingConfigEntry, NetworkingConfigValue}
 
 pub(crate) mod client;
 pub(crate) mod server;
+pub(crate) mod steamworks_client;
 
-// NOTE: it looks like there's SingleClient can actually be called on multiple threads
-// - https://partner.steamgames.com/doc/api/steam_api#SteamAPI_RunCallbacks
-pub(crate) struct SingleClientThreadSafe(steamworks::SingleClient);
-
-unsafe impl Sync for SingleClientThreadSafe {}
-unsafe impl Send for SingleClientThreadSafe {}
+pub use steamworks_client::SteamworksClient;
 
 pub(crate) fn get_networking_options(
     conditioner: &Option<LinkConditionerConfig>,

--- a/lightyear/src/connection/steam/server.rs
+++ b/lightyear/src/connection/steam/server.rs
@@ -59,7 +59,6 @@ pub enum SocketConfig {
     },
     P2P {
         virtual_port: i32,
-        use_relay_network: bool,
     },
 }
 
@@ -150,13 +149,7 @@ impl NetServer for Server {
                 );
                 info!("Steam socket started on {:?}", server_addr);
             }
-            SocketConfig::P2P {
-                virtual_port,
-                use_relay_network,
-            } => {
-                if use_relay_network {
-                    // self.client.networking_utils().init_relay_network_access();
-                }
+            SocketConfig::P2P { virtual_port } => {
                 self.listen_socket = Some(
                     self.steamworks_client
                         .read()

--- a/lightyear/src/connection/steam/server.rs
+++ b/lightyear/src/connection/steam/server.rs
@@ -50,16 +50,17 @@ impl Default for SteamConfig {
     }
 }
 
+/// Steam socket configuration for servers
 #[derive(Debug, Clone)]
 pub enum SocketConfig {
+    /// This server accepts connections via IP address. Suitable for dedicated servers.
     Ip {
         server_ip: Ipv4Addr,
         game_port: u16,
         query_port: u16,
     },
-    P2P {
-        virtual_port: i32,
-    },
+    /// This server accepts Steam P2P connections. Suitable for peer-to-peer games.
+    P2P { virtual_port: i32 },
 }
 
 impl Default for SocketConfig {

--- a/lightyear/src/connection/steam/steamworks_client.rs
+++ b/lightyear/src/connection/steam/steamworks_client.rs
@@ -4,10 +4,13 @@ use bevy::utils::synccell::SyncCell;
 use steamworks::{ClientManager, SingleClient};
 use tracing::info;
 
+/// This wraps the Steamworks client. It must only be created once per
+/// application run. For convenience, Lightyear can automatically create the
+/// client for you, but for more control, you can create it yourself and pass it in to Lightyear.
 pub struct SteamworksClient {
     app_id: u32,
     client: steamworks::Client<ClientManager>,
-    single: SyncCell<SingleClient>,
+    single: SyncCell<SingleClient>, // https://github.com/Noxime/steamworks-rs/issues/159
 }
 
 impl std::fmt::Debug for SteamworksClient {
@@ -19,6 +22,8 @@ impl std::fmt::Debug for SteamworksClient {
 }
 
 impl SteamworksClient {
+    /// Creates and initializes the Steamworks client. This must only be called
+    /// once per application run.
     pub fn new(app_id: u32) -> Self {
         let (client, single) = steamworks::Client::<ClientManager>::init_app(app_id).unwrap();
 
@@ -29,10 +34,14 @@ impl SteamworksClient {
         }
     }
 
+    /// Gets the thread-safe Steamworks client. Most Steamworks API calls live
+    /// under this client.
     pub fn get_client(&self) -> steamworks::Client<ClientManager> {
         self.client.clone()
     }
 
+    /// Gets the non-thread-safe Steamworks client. This is only used to run
+    /// Steamworks callbacks.
     pub fn get_single(&mut self) -> &mut SingleClient<ClientManager> {
         self.single.get()
     }

--- a/lightyear/src/connection/steam/steamworks_client.rs
+++ b/lightyear/src/connection/steam/steamworks_client.rs
@@ -1,0 +1,39 @@
+use std::sync::OnceLock;
+
+use bevy::utils::synccell::SyncCell;
+use steamworks::{ClientManager, SingleClient};
+use tracing::info;
+
+pub struct SteamworksClient {
+    app_id: u32,
+    client: steamworks::Client<ClientManager>,
+    single: SyncCell<SingleClient>,
+}
+
+impl std::fmt::Debug for SteamworksClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SteamworksClient")
+            .field("app_id", &self.app_id)
+            .finish()
+    }
+}
+
+impl SteamworksClient {
+    pub fn new(app_id: u32) -> Self {
+        let (client, single) = steamworks::Client::<ClientManager>::init_app(app_id).unwrap();
+
+        Self {
+            app_id,
+            client,
+            single: SyncCell::new(single),
+        }
+    }
+
+    pub fn get_client(&self) -> steamworks::Client<ClientManager> {
+        self.client.clone()
+    }
+
+    pub fn get_single(&mut self) -> &mut SingleClient<ClientManager> {
+        self.single.get()
+    }
+}

--- a/lightyear/src/lib.rs
+++ b/lightyear/src/lib.rs
@@ -257,7 +257,7 @@ pub mod prelude {
             Authentication, ClientConnection, IoConfig, NetClient, NetConfig,
         };
         #[cfg(all(feature = "steam", not(target_family = "wasm")))]
-        pub use crate::connection::steam::client::SteamConfig;
+        pub use crate::connection::steam::client::{SocketConfig, SteamConfig};
     }
     pub mod server {
         #[cfg(all(feature = "webtransport", not(target_family = "wasm")))]
@@ -287,6 +287,9 @@ pub mod prelude {
         pub use crate::server::visibility::immediate::VisibilityManager;
         pub use crate::server::visibility::room::{RoomId, RoomManager};
     }
+
+    #[cfg(all(feature = "steam", not(target_family = "wasm")))]
+    pub use crate::connection::steam::steamworks_client::SteamworksClient;
 }
 
 use prelude::*;

--- a/lightyear/src/lib.rs
+++ b/lightyear/src/lib.rs
@@ -267,7 +267,7 @@ pub mod prelude {
             IoConfig, NetConfig, NetServer, ServerConnection, ServerConnections,
         };
         #[cfg(all(feature = "steam", not(target_family = "wasm")))]
-        pub use crate::connection::steam::server::SteamConfig;
+        pub use crate::connection::steam::server::{SocketConfig, SteamConfig};
         pub use crate::server::clients::ControlledEntities;
         pub use crate::server::config::{NetcodeConfig, PacketConfig, ServerConfig};
         pub use crate::server::connection::ConnectionManager;


### PR DESCRIPTION
Adds support for Steam P2P sockets. This has been tested by @zwazel and is confirmed to at least work partially, though with some kinks (https://github.com/cBournhonesque/lightyear/issues/243).

I didn't add tests for this since that would require Steam to be installed to run tests.