### PR TITLE
Use wasm_bindgen_futures::spawn_local instead of BevyIoTaskPool in wasm

### DIFF
--- a/examples/auth/index.html
+++ b/examples/auth/index.html
@@ -4,5 +4,6 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <title>Bevy game</title>
+    <link data-trunk rel="rust"/>
 </head>
 </html>

--- a/examples/bullet_prespawn/index.html
+++ b/examples/bullet_prespawn/index.html
@@ -4,5 +4,6 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <title>Bevy game</title>
+    <link data-trunk rel="rust"/>
 </head>
 </html>

--- a/examples/client_replication/index.html
+++ b/examples/client_replication/index.html
@@ -4,5 +4,6 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <title>Bevy game</title>
+    <link data-trunk rel="rust"/>
 </head>
 </html>

--- a/examples/common/Cargo.toml
+++ b/examples/common/Cargo.toml
@@ -6,9 +6,9 @@ description = "Common harness for the lightyear examples"
 
 [dependencies]
 lightyear = { path = "../../lightyear", features = [
-  "steam",
-  "webtransport",
-  "websocket",
+    "steam",
+    "webtransport",
+    "websocket",
 ] }
 
 # utils
@@ -17,6 +17,7 @@ async-compat = "0.2.3"
 cfg-if = "1.0.0"
 clap = { version = "4.5.4", features = ["derive"] }
 crossbeam-channel = "0.5.12"
+rand = "0.8.5"
 serde = { version = "1.0.201", features = ["derive"] }
 
 

--- a/examples/common/src/settings.rs
+++ b/examples/common/src/settings.rs
@@ -2,10 +2,8 @@
 #![allow(unused_variables)]
 use std::net::{Ipv4Addr, SocketAddr};
 
-use async_compat::Compat;
 use bevy::asset::ron;
 use bevy::prelude::Resource;
-use bevy::tasks::IoTaskPool;
 use bevy::utils::Duration;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};

--- a/examples/common/src/settings.rs
+++ b/examples/common/src/settings.rs
@@ -8,6 +8,11 @@ use bevy::utils::Duration;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
+#[cfg(not(target_family = "wasm"))]
+use async_compat::Compat;
+#[cfg(not(target_family = "wasm"))]
+use bevy::tasks::IoTaskPool;
+
 use lightyear::prelude::client::Authentication;
 #[cfg(not(target_family = "wasm"))]
 use lightyear::prelude::client::SteamConfig;

--- a/examples/interest_management/index.html
+++ b/examples/interest_management/index.html
@@ -4,5 +4,6 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <title>Bevy game</title>
+    <link data-trunk rel="rust"/>
 </head>
 </html>

--- a/examples/leafwing_inputs/index.html
+++ b/examples/leafwing_inputs/index.html
@@ -4,5 +4,6 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <title>Bevy game</title>
+    <link data-trunk rel="rust"/>
 </head>
 </html>

--- a/examples/lobby/index.html
+++ b/examples/lobby/index.html
@@ -4,5 +4,6 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <title>Bevy game</title>
+    <link data-trunk rel="rust"/>
 </head>
 </html>

--- a/examples/priority/index.html
+++ b/examples/priority/index.html
@@ -4,5 +4,6 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <title>Bevy game</title>
+    <link data-trunk rel="rust"/>
 </head>
 </html>

--- a/examples/replication_groups/index.html
+++ b/examples/replication_groups/index.html
@@ -4,5 +4,6 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <title>Bevy game</title>
+    <link data-trunk rel="rust"/>
 </head>
 </html>

--- a/examples/simple_box/assets/settings.ron
+++ b/examples/simple_box/assets/settings.ron
@@ -9,16 +9,16 @@ Settings(
             jitter_ms: 20,
             packet_loss: 0.05
         )),
-        // server_port: 5000,
-        // transport: WebTransport(
+        server_port: 5000,
+        transport: WebTransport(
             // this is only needed for wasm, the self-signed certificates are only valid for 2 weeks
             // the server will print the certificate digest on startup
-            // certificate_digest: "24:48:ea:6f:13:a4:4f:2f:42:b9:f3:71:3f:79:c5:7a:d1:1d:29:ab:de:b0:03:4d:94:92:7b:84:69:01:85:1d",
-        // ),
+            certificate_digest: "24:48:ea:6f:13:a4:4f:2f:42:b9:f3:71:3f:79:c5:7a:d1:1d:29:ab:de:b0:03:4d:94:92:7b:84:69:01:85:1d",
+        ),
         // server_port: 5001,
         // transport: Udp,
-        server_port: 5002,
-        transport: WebSocket,
+        // server_port: 5002,
+        // transport: WebSocket,
         // server_port: 5003,
         // transport: Steam(
         //     app_id: 480,

--- a/examples/simple_box/assets/settings.ron
+++ b/examples/simple_box/assets/settings.ron
@@ -9,16 +9,16 @@ Settings(
             jitter_ms: 20,
             packet_loss: 0.05
         )),
-        server_port: 5000,
-        transport: WebTransport(
+        // server_port: 5000,
+        // transport: WebTransport(
             // this is only needed for wasm, the self-signed certificates are only valid for 2 weeks
             // the server will print the certificate digest on startup
-            certificate_digest: "24:48:ea:6f:13:a4:4f:2f:42:b9:f3:71:3f:79:c5:7a:d1:1d:29:ab:de:b0:03:4d:94:92:7b:84:69:01:85:1d",
-        ),
+            // certificate_digest: "24:48:ea:6f:13:a4:4f:2f:42:b9:f3:71:3f:79:c5:7a:d1:1d:29:ab:de:b0:03:4d:94:92:7b:84:69:01:85:1d",
+        // ),
         // server_port: 5001,
         // transport: Udp,
-        // server_port: 5002,
-        // transport: WebSocket,
+        server_port: 5002,
+        transport: WebSocket,
         // server_port: 5003,
         // transport: Steam(
         //     app_id: 480,

--- a/examples/simple_box/index.html
+++ b/examples/simple_box/index.html
@@ -4,5 +4,6 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <title>Bevy game</title>
+    <link data-trunk rel="rust"/>
 </head>
 </html>

--- a/lightyear/src/client/io/config.rs
+++ b/lightyear/src/client/io/config.rs
@@ -72,7 +72,7 @@ impl ClientTransport {
                 client_addr,
                 server_addr,
                 certificate_digest,
-            } => TransportBuilderEnum::WebTransportClient(WebTransportClientSocketBuilder {
+            } => ClientTransportBuilderEnum::WebTransportClient(WebTransportClientSocketBuilder {
                 client_addr,
                 server_addr,
                 certificate_digest,

--- a/lightyear/src/client/io/mod.rs
+++ b/lightyear/src/client/io/mod.rs
@@ -22,7 +22,7 @@ impl Io {
         self.state = IoState::Disconnected;
         if let Some(event_sender) = self.context.event_sender.as_mut() {
             event_sender
-                .send_blocking(ClientIoEvent::Disconnected(
+                .try_send(ClientIoEvent::Disconnected(
                     std::io::Error::other("client requested disconnection").into(),
                 ))
                 .map_err(Error::from)?;

--- a/lightyear/src/connection/netcode/server.rs
+++ b/lightyear/src/connection/netcode/server.rs
@@ -1016,7 +1016,7 @@ impl NetServer for Server {
         if let Some(mut io) = self.io.take() {
             if let Some(sender) = &mut self.server.cfg.context.sender {
                 sender
-                    .send_blocking(ServerIoEvent::ServerDisconnected(
+                    .try_send(ServerIoEvent::ServerDisconnected(
                         crate::transport::error::Error::UserRequest,
                     ))
                     .context("Could not send 'ServerStopped' event to io")?;
@@ -1108,7 +1108,7 @@ impl Server {
                 if let Some(sender) = &mut ctx.sender {
                     debug!("Notify the io that client {id:?} got disconnected, so that we can stop the corresponding task");
                     let _ = sender
-                        .send_blocking(ServerIoEvent::ClientDisconnected(addr))
+                        .try_send(ServerIoEvent::ClientDisconnected(addr))
                         .inspect_err(|e| {
                             error!("Error sending 'ClientDisconnected' event to io: {:?}", e)
                         });

--- a/lightyear/src/server/io/config.rs
+++ b/lightyear/src/server/io/config.rs
@@ -11,8 +11,6 @@ use crate::transport::middleware::compression::zstd::compression::ZstdCompressor
 use crate::transport::middleware::compression::zstd::decompression::ZstdDecompressor;
 use crate::transport::middleware::conditioner::LinkConditioner;
 use crate::transport::middleware::{PacketReceiverWrapper, PacketSenderWrapper};
-#[cfg(not(target_family = "wasm"))]
-use crate::transport::udp::UdpSocketBuilder;
 use crate::transport::udp::UdpSocketBuilder;
 #[cfg(all(feature = "websocket", not(target_family = "wasm")))]
 use crate::transport::websocket::server::WebSocketServerSocketBuilder;

--- a/lightyear/src/server/io/config.rs
+++ b/lightyear/src/server/io/config.rs
@@ -13,6 +13,7 @@ use crate::transport::middleware::conditioner::LinkConditioner;
 use crate::transport::middleware::{PacketReceiverWrapper, PacketSenderWrapper};
 #[cfg(not(target_family = "wasm"))]
 use crate::transport::udp::UdpSocketBuilder;
+use crate::transport::udp::UdpSocketBuilder;
 #[cfg(all(feature = "websocket", not(target_family = "wasm")))]
 use crate::transport::websocket::server::WebSocketServerSocketBuilder;
 #[cfg(all(feature = "webtransport", not(target_family = "wasm")))]
@@ -28,7 +29,6 @@ use wtransport::Identity;
 #[derive(Debug, TypePath)]
 pub enum ServerTransport {
     /// Use a [`UdpSocket`](std::net::UdpSocket)
-    #[cfg(not(target_family = "wasm"))]
     UdpSocket(SocketAddr),
     /// Use [`WebTransport`](https://wicg.github.io/web-transport/) as a transport layer
     #[cfg(all(feature = "webtransport", not(target_family = "wasm")))]
@@ -58,7 +58,6 @@ impl Clone for ServerTransport {
     #[inline]
     fn clone(&self) -> ServerTransport {
         match self {
-            #[cfg(not(target_family = "wasm"))]
             ServerTransport::UdpSocket(__self_0) => {
                 ServerTransport::UdpSocket(Clone::clone(__self_0))
             }
@@ -87,7 +86,6 @@ impl Clone for ServerTransport {
 impl ServerTransport {
     fn build(self) -> ServerTransportBuilderEnum {
         match self {
-            #[cfg(not(target_family = "wasm"))]
             ServerTransport::UdpSocket(addr) => {
                 ServerTransportBuilderEnum::UdpSocket(UdpSocketBuilder { local_addr: addr })
             }

--- a/lightyear/src/server/io/mod.rs
+++ b/lightyear/src/server/io/mod.rs
@@ -23,7 +23,7 @@ impl Io {
         self.state = IoState::Disconnected;
         if let Some(event_sender) = self.context.event_sender.as_mut() {
             event_sender
-                .send_blocking(ServerIoEvent::ServerDisconnected(
+                .try_send(ServerIoEvent::ServerDisconnected(
                     std::io::Error::other("server requested disconnection").into(),
                 ))
                 .map_err(Error::from)?;

--- a/lightyear/src/server/io/transport.rs
+++ b/lightyear/src/server/io/transport.rs
@@ -3,8 +3,6 @@ use crate::transport::channels::Channels;
 use crate::transport::dummy::DummyIo;
 use crate::transport::error::Result;
 use crate::transport::io::IoState;
-#[cfg(not(target_family = "wasm"))]
-use crate::transport::udp::{UdpSocket, UdpSocketBuilder};
 use crate::transport::udp::{UdpSocket, UdpSocketBuilder};
 #[cfg(all(feature = "websocket", not(target_family = "wasm")))]
 use crate::transport::websocket::server::{WebSocketServerSocket, WebSocketServerSocketBuilder};

--- a/lightyear/src/server/io/transport.rs
+++ b/lightyear/src/server/io/transport.rs
@@ -5,6 +5,7 @@ use crate::transport::error::Result;
 use crate::transport::io::IoState;
 #[cfg(not(target_family = "wasm"))]
 use crate::transport::udp::{UdpSocket, UdpSocketBuilder};
+use crate::transport::udp::{UdpSocket, UdpSocketBuilder};
 #[cfg(all(feature = "websocket", not(target_family = "wasm")))]
 use crate::transport::websocket::server::{WebSocketServerSocket, WebSocketServerSocketBuilder};
 #[cfg(all(feature = "webtransport", not(target_family = "wasm")))]
@@ -29,7 +30,6 @@ pub(crate) trait ServerTransportBuilder: Send + Sync {
 
 #[enum_dispatch(ServerTransportBuilder)]
 pub(crate) enum ServerTransportBuilderEnum {
-    #[cfg(not(target_family = "wasm"))]
     UdpSocket(UdpSocketBuilder),
     #[cfg(all(feature = "webtransport", not(target_family = "wasm")))]
     WebTransportServer(WebTransportServerSocketBuilder),
@@ -42,7 +42,6 @@ pub(crate) enum ServerTransportBuilderEnum {
 #[allow(clippy::large_enum_variant)]
 #[enum_dispatch(Transport)]
 pub(crate) enum ServerTransportEnum {
-    #[cfg(not(target_family = "wasm"))]
     UdpSocket(UdpSocket),
     #[cfg(all(feature = "webtransport", not(target_family = "wasm")))]
     WebTransportServer(WebTransportServerSocket),

--- a/lightyear/src/transport/dummy.rs
+++ b/lightyear/src/transport/dummy.rs
@@ -4,7 +4,6 @@ use crate::client::io::{ClientIoEventReceiver, ClientNetworkEventSender};
 use crate::server::io::transport::{ServerTransportBuilder, ServerTransportEnum};
 use crate::server::io::{ServerIoEventReceiver, ServerNetworkEventSender};
 use crate::transport::io::IoState;
-use crate::transport::udp::{UdpSocket, UdpSocketBuffer, UdpSocketBuilder};
 use crate::transport::{
     BoxedReceiver, BoxedSender, PacketReceiver, PacketSender, Transport, LOCAL_SOCKET, MTU,
 };

--- a/lightyear/src/transport/error.rs
+++ b/lightyear/src/transport/error.rs
@@ -27,6 +27,14 @@ impl<T> ::core::convert::From<async_channel::SendError<T>> for Error {
 }
 
 #[allow(unused_qualifications)]
+impl<T> ::core::convert::From<async_channel::TrySendError<T>> for Error {
+    #[allow(deprecated)]
+    fn from(source: async_channel::TrySendError<T>) -> Self {
+        Error::Channel(source.to_string())
+    }
+}
+
+#[allow(unused_qualifications)]
 impl<T> ::core::convert::From<crossbeam_channel::SendError<T>> for Error {
     #[allow(deprecated)]
     fn from(source: crossbeam_channel::SendError<T>) -> Self {

--- a/lightyear/src/transport/local.rs
+++ b/lightyear/src/transport/local.rs
@@ -9,7 +9,6 @@ use crate::client::io::{ClientIoEventReceiver, ClientNetworkEventSender};
 use crate::server::io::transport::{ServerTransportBuilder, ServerTransportEnum};
 use crate::server::io::{ServerIoEventReceiver, ServerNetworkEventSender};
 use crate::transport::io::IoState;
-use crate::transport::udp::UdpSocketBuilder;
 use crate::transport::{
     BoxedReceiver, BoxedSender, PacketReceiver, PacketSender, Transport, LOCAL_SOCKET,
 };

--- a/lightyear/src/transport/mod.rs
+++ b/lightyear/src/transport/mod.rs
@@ -13,7 +13,6 @@ use crate::transport::channels::Channels;
 use crate::transport::dummy::DummyIo;
 use crate::transport::io::IoState;
 use crate::transport::local::{LocalChannel, LocalChannelBuilder};
-#[cfg(not(target_family = "wasm"))]
 use crate::transport::udp::{UdpSocket, UdpSocketBuilder};
 #[cfg(feature = "websocket")]
 use crate::transport::websocket::client::{WebSocketClientSocket, WebSocketClientSocketBuilder};
@@ -35,8 +34,6 @@ pub mod io;
 pub(crate) mod local;
 
 /// The transport is a UDP socket
-#[cfg_attr(docsrs, doc(cfg(not(target_family = "wasm"))))]
-#[cfg(not(target_family = "wasm"))]
 pub(crate) mod udp;
 
 /// The transport is a map of channels (used for server, during testing)

--- a/lightyear/src/transport/udp.rs
+++ b/lightyear/src/transport/udp.rs
@@ -36,6 +36,7 @@ impl UdpSocketBuilder {
     }
 }
 
+#[cfg(not(target_family = "wasm"))]
 impl ClientTransportBuilder for UdpSocketBuilder {
     fn connect(
         self,

--- a/lightyear/src/transport/websocket/client_wasm.rs
+++ b/lightyear/src/transport/websocket/client_wasm.rs
@@ -83,7 +83,7 @@ impl ClientTransportBuilder for WebSocketClientSocketBuilder {
         let on_open_callback = Closure::<dyn FnOnce()>::once(move || {
             info!("WebSocket handshake has been successfully completed");
             let serverbound_rx = serverbound_rx.clone();
-            IoTaskPool::get().spawn_local(async move {
+            wasm_bindgen_futures::spawn_local(async move {
                 while let Some(msg) = serverbound_rx.lock().await.recv().await {
                     if ws_clone.ready_state() != 1 {
                         warn!("Tried to send packet through closed websocket connection");
@@ -96,7 +96,7 @@ impl ClientTransportBuilder for WebSocketClientSocketBuilder {
 
         let ws_clone = ws.clone();
         let listen_close_signal_callback = Closure::<dyn FnOnce()>::once(move || {
-            IoTaskPool::get().spawn_local(async move {
+            wasm_bindgen_futures::spawn_local(async move {
                 let _ = close_rx.recv().await;
                 info!("Close websocket connection");
                 ws_clone.close().unwrap();


### PR DESCRIPTION
Try to fix https://github.com/cBournhonesque/lightyear/issues/144

+ fix some other bugs related to the io refactor (the goal of the refactor was that the io tasks get stopped if we are disconnected in netcode (for example if a client requests disconnect). Conversely, if the io task gets disconnected, we want to update the state in netcode to disconnected as well)