### PR TITLE
despawn recursive predicted/interpolated entities

### DIFF
--- a/lightyear/src/client/interpolation/despawn.rs
+++ b/lightyear/src/client/interpolation/despawn.rs
@@ -1,4 +1,4 @@
-use bevy::prelude::{Commands, EventReader, Query, RemovedComponents, ResMut};
+use bevy::prelude::{Commands, DespawnRecursiveExt, EventReader, Query, RemovedComponents, ResMut};
 
 use crate::client::components::{Confirmed, SyncComponent};
 use crate::client::interpolation::interpolate::InterpolateStatus;
@@ -43,7 +43,7 @@ pub(crate) fn despawn_interpolated(
             .remove(&confirmed_entity)
         {
             if let Some(mut entity_mut) = commands.get_entity(interpolated) {
-                entity_mut.despawn();
+                entity_mut.despawn_recursive();
             }
         }
     }

--- a/lightyear/src/client/prediction/despawn.rs
+++ b/lightyear/src/client/prediction/despawn.rs
@@ -2,8 +2,8 @@ use std::marker::PhantomData;
 
 use bevy::ecs::system::{Command, EntityCommands};
 use bevy::prelude::{
-    Commands, Component, Entity, Query, Reflect, RemovedComponents, Res, ResMut, With, Without,
-    World,
+    Commands, Component, DespawnRecursiveExt, Entity, Query, Reflect, RemovedComponents, Res,
+    ResMut, With, Without, World,
 };
 use tracing::{debug, error, trace};
 
@@ -100,7 +100,7 @@ pub(crate) fn despawn_confirmed(
             .remove(&confirmed_entity)
         {
             if let Some(mut entity_mut) = commands.get_entity(predicted) {
-                entity_mut.despawn();
+                entity_mut.despawn_recursive();
             }
         }
     }


### PR DESCRIPTION
When the remote entity gets despawned, we run `despawn_recursive` for the `Confirmed` entity;
however we were then only calling `despawn` on the `Predicted` and `Interpolated` entities.

Changing it to `despawn_recursive`