### PR TITLE
Add user-provided hook to accept/reject connections

### DIFF
--- a/examples/common/src/settings.rs
+++ b/examples/common/src/settings.rs
@@ -227,6 +227,7 @@ pub(crate) fn get_server_net_configs(settings: &Settings) -> Vec<server::NetConf
                     game_port: *game_port,
                     query_port: *query_port,
                     max_clients: 16,
+                    accept_connection_request_fn: None,
                     version: "1.0".to_string(),
                 },
                 conditioner: settings

--- a/examples/simple_box/src/server.rs
+++ b/examples/simple_box/src/server.rs
@@ -12,6 +12,7 @@ use bevy::utils::HashMap;
 use lightyear::prelude::server::*;
 use lightyear::prelude::*;
 use lightyear::shared::replication::components::ReplicationTarget;
+use std::sync::Arc;
 
 use crate::protocol::*;
 use crate::shared;
@@ -28,7 +29,12 @@ impl Plugin for ExampleServerPlugin {
 }
 
 /// Start the server
-fn start_server(mut commands: Commands) {
+fn start_server(mut config: ResMut<ServerConfig>, mut commands: Commands) {
+    for net_config in &mut config.net {
+        net_config.set_accept_connection_request_fn(Arc::new(|client_id| {
+            client_id != ClientId::Netcode(0)
+        }));
+    }
     commands.start_server();
 }
 

--- a/lightyear/src/connection/netcode/client.rs
+++ b/lightyear/src/connection/netcode/client.rs
@@ -378,9 +378,13 @@ impl<Ctx> NetcodeClient<Ctx> {
         }
         match (packet, self.state) {
             (
-                Packet::Denied(_),
+                Packet::Denied(pkt),
                 ClientState::SendingConnectionRequest | ClientState::SendingChallengeResponse,
             ) => {
+                error!(
+                    "client connection denied by server. Reason: {:?}",
+                    pkt.reason
+                );
                 self.should_disconnect = true;
                 self.should_disconnect_state = ClientState::ConnectionDenied;
             }

--- a/lightyear/src/connection/netcode/packet.rs
+++ b/lightyear/src/connection/netcode/packet.rs
@@ -8,6 +8,7 @@ use chacha20poly1305::XNonce;
 use tracing::debug;
 
 use crate::connection::netcode::ClientId;
+use crate::connection::server::DeniedReason;
 
 use super::{
     bytes::Bytes,
@@ -158,22 +159,95 @@ impl Bytes for RequestPacket {
     }
 }
 
-pub struct DeniedPacket {}
+pub struct DeniedPacket {
+    pub reason: DeniedReason,
+}
 
 impl DeniedPacket {
-    pub fn create() -> Packet<'static> {
-        Packet::Denied(DeniedPacket {})
+    pub fn create(reason: DeniedReason) -> Packet<'static> {
+        Packet::Denied(DeniedPacket { reason })
+    }
+}
+
+impl Bytes for DeniedReason {
+    type Error = io::Error;
+
+    fn write_to(&self, writer: &mut impl WriteBytesExt) -> Result<(), Self::Error> {
+        match self {
+            DeniedReason::ServerFull => {
+                writer.write_u8(0)?;
+            }
+            DeniedReason::Banned => {
+                writer.write_u8(1)?;
+            }
+            DeniedReason::InternalError => {
+                writer.write_u8(2)?;
+            }
+            DeniedReason::AlreadyConnected => {
+                writer.write_u8(3)?;
+            }
+            DeniedReason::TokenAlreadyUsed => {
+                writer.write_u8(4)?;
+            }
+            DeniedReason::InvalidToken => {
+                writer.write_u8(5)?;
+            }
+            DeniedReason::Custom(reason) => {
+                writer.write_u8(6)?;
+                // the reason cannot exceed u8::MAX in size
+                if reason.len() > u8::MAX as usize {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "custom denied reason too long",
+                    ));
+                }
+                writer.write_u8(reason.len() as u8)?;
+                writer.write(reason.as_bytes())?;
+            }
+        }
+        Ok(())
+    }
+
+    fn read_from(reader: &mut impl ReadBytesExt) -> Result<Self, Self::Error> {
+        let variant = reader.read_u8()?;
+        if variant == 0 {
+            Ok(DeniedReason::ServerFull)
+        } else if variant == 1 {
+            Ok(DeniedReason::Banned)
+        } else if variant == 2 {
+            Ok(DeniedReason::InternalError)
+        } else if variant == 3 {
+            Ok(DeniedReason::AlreadyConnected)
+        } else if variant == 4 {
+            Ok(DeniedReason::TokenAlreadyUsed)
+        } else if variant == 5 {
+            Ok(DeniedReason::InvalidToken)
+        } else if variant == 6 {
+            let len = reader.read_u8()? as usize;
+            let mut reason = [0; u8::MAX as usize];
+            reader.read(&mut reason)?;
+            let reason_str = String::from_utf8(reason[..len].to_vec())
+                .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "invalid denied reason"))?;
+            Ok(DeniedReason::Custom(reason_str))
+        } else {
+            Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "invalid denied reason",
+            ))
+        }
     }
 }
 
 impl Bytes for DeniedPacket {
     type Error = io::Error;
-    fn write_to(&self, _writer: &mut impl WriteBytesExt) -> Result<(), Self::Error> {
+    fn write_to(&self, writer: &mut impl WriteBytesExt) -> Result<(), Self::Error> {
+        self.reason.write_to(writer)?;
         Ok(())
     }
 
-    fn read_from(_reader: &mut impl byteorder::ReadBytesExt) -> Result<Self, io::Error> {
-        Ok(Self {})
+    fn read_from(reader: &mut impl byteorder::ReadBytesExt) -> Result<Self, io::Error> {
+        let reason = DeniedReason::read_from(reader)?;
+        Ok(Self { reason })
     }
 }
 
@@ -579,13 +653,15 @@ mod tests {
     }
 
     #[test]
-    fn denied_packet() {
+    fn denied_packet_custom_reason() {
         let packet_key = generate_key();
         let protocol_id = 0x1234_5678_9abc_def0;
         let sequence = 0u64;
         let mut replay_protection = ReplayProtection::new();
 
-        let packet = Packet::Denied(DeniedPacket {});
+        let packet = Packet::Denied(DeniedPacket {
+            reason: DeniedReason::Custom(String::from("a")),
+        });
 
         let mut buf = [0u8; MAX_PKT_BUF_SIZE];
         let size = packet
@@ -602,9 +678,42 @@ mod tests {
         )
         .unwrap();
 
-        let Packet::Denied(_denied_pkt) = packet else {
+        let Packet::Denied(denied_pkt) = packet else {
             panic!("wrong packet type");
         };
+        assert_eq!(denied_pkt.reason, DeniedReason::Custom(String::from("a")));
+    }
+
+    #[test]
+    fn denied_packet() {
+        let packet_key = generate_key();
+        let protocol_id = 0x1234_5678_9abc_def0;
+        let sequence = 0u64;
+        let mut replay_protection = ReplayProtection::new();
+
+        let packet = Packet::Denied(DeniedPacket {
+            reason: DeniedReason::ServerFull,
+        });
+
+        let mut buf = [0u8; MAX_PKT_BUF_SIZE];
+        let size = packet
+            .write(&mut buf, sequence, &packet_key, protocol_id)
+            .unwrap();
+
+        let packet = Packet::read(
+            &mut buf[..size],
+            protocol_id,
+            0,
+            packet_key,
+            Some(&mut replay_protection),
+            0xff,
+        )
+        .unwrap();
+
+        let Packet::Denied(denied_pkt) = packet else {
+            panic!("wrong packet type");
+        };
+        assert_eq!(denied_pkt.reason, DeniedReason::ServerFull);
     }
 
     #[test]

--- a/lightyear/src/connection/netcode/server.rs
+++ b/lightyear/src/connection/netcode/server.rs
@@ -8,7 +8,7 @@ use tracing::{debug, error, trace};
 
 use crate::connection::id;
 use crate::connection::netcode::token::TOKEN_EXPIRE_SEC;
-use crate::connection::server::{IoConfig, NetServer};
+use crate::connection::server::{AcceptConnectionRequestFn, IoConfig, NetServer};
 use crate::serialize::bitcode::reader::BufferPool;
 use crate::serialize::reader::ReadBuffer;
 use crate::server::config::NetcodeConfig;
@@ -246,6 +246,7 @@ pub struct ServerConfig<Ctx> {
     keep_alive_send_rate: f64,
     token_expire_secs: i32,
     client_timeout_secs: i32,
+    handle_connection_request_fn: Option<AcceptConnectionRequestFn>,
     server_addr: SocketAddr,
     context: Ctx,
     on_connect: Option<Callback<Ctx>>,
@@ -259,6 +260,7 @@ impl Default for ServerConfig<()> {
             keep_alive_send_rate: PACKET_SEND_RATE_SEC,
             token_expire_secs: TOKEN_EXPIRE_SEC,
             client_timeout_secs: CLIENT_TIMEOUT_SECS,
+            handle_connection_request_fn: None,
             server_addr: SocketAddr::from(([0, 0, 0, 0], 0)),
             context: (),
             on_connect: None,
@@ -279,6 +281,7 @@ impl<Ctx> ServerConfig<Ctx> {
             keep_alive_send_rate: PACKET_SEND_RATE_SEC,
             token_expire_secs: TOKEN_EXPIRE_SEC,
             client_timeout_secs: CLIENT_TIMEOUT_SECS,
+            handle_connection_request_fn: None,
             server_addr: SocketAddr::from(([0, 0, 0, 0], 0)),
             context: ctx,
             on_connect: None,
@@ -612,6 +615,23 @@ impl<Ctx> NetcodeServer<Ctx> {
             )?;
             return Ok(());
         };
+        if !self
+            .cfg
+            .handle_connection_request_fn
+            .as_mut()
+            .map_or(true, |f| {
+                f(crate::prelude::ClientId::Netcode(token.client_id))
+            })
+        {
+            debug!("server denied connection request. handle_connection_request_fn returned false");
+            self.send_to_addr(
+                DeniedPacket::create(),
+                from_addr,
+                token.server_to_client_key,
+                sender,
+            )?;
+            return Ok(());
+        }
         self.conn_cache.add(
             token.client_id,
             from_addr,
@@ -1136,6 +1156,7 @@ impl Server {
         cfg = cfg.keep_alive_send_rate(config.keep_alive_send_rate);
         cfg = cfg.num_disconnect_packets(config.num_disconnect_packets);
         cfg = cfg.client_timeout_secs(config.client_timeout_secs);
+        cfg.handle_connection_request_fn = config.accept_connection_request_fn;
         let server = NetcodeServer::with_config(config.protocol_id, config.private_key, cfg)
             .expect("Could not create server netcode");
 

--- a/lightyear/src/connection/netcode/server.rs
+++ b/lightyear/src/connection/netcode/server.rs
@@ -10,8 +10,7 @@ use tracing::{debug, error, trace};
 use crate::connection::id;
 use crate::connection::netcode::token::TOKEN_EXPIRE_SEC;
 use crate::connection::server::{
-    AcceptConnectionRequestFn, ConnectionRequestHandler, DefaultConnectionRequestHandler, IoConfig,
-    NetServer,
+    ConnectionRequestHandler, DefaultConnectionRequestHandler, DeniedReason, IoConfig, NetServer,
 };
 use crate::serialize::bitcode::reader::BufferPool;
 use crate::serialize::reader::ReadBuffer;
@@ -612,7 +611,7 @@ impl<Ctx> NetcodeServer<Ctx> {
         if self.num_connected_clients() >= MAX_CLIENTS {
             debug!("server denied connection request. server is full");
             self.send_to_addr(
-                DeniedPacket::create(),
+                DeniedPacket::create(DeniedReason::ServerFull),
                 from_addr,
                 token.server_to_client_key,
                 sender,
@@ -626,7 +625,7 @@ impl<Ctx> NetcodeServer<Ctx> {
         {
             debug!("server denied connection request. handle_connection_request_fn returned false");
             self.send_to_addr(
-                DeniedPacket::create(),
+                DeniedPacket::create(denied_reason),
                 from_addr,
                 token.server_to_client_key,
                 sender,
@@ -683,7 +682,7 @@ impl<Ctx> NetcodeServer<Ctx> {
         if self.num_connected_clients() >= MAX_CLIENTS {
             debug!("server denied connection response. server is full");
             self.send_to_addr(
-                DeniedPacket::create(),
+                DeniedPacket::create(DeniedReason::ServerFull),
                 from_addr,
                 self.conn_cache
                     .clients

--- a/lightyear/src/connection/server.rs
+++ b/lightyear/src/connection/server.rs
@@ -19,6 +19,7 @@ use crate::transport::config::SharedIoConfig;
 /// This function will be run when receiving a connection request.
 ///
 /// This should return true if the connection request is accepted, false otherwise.
+// NOTE: has to use Arc so that the closure can be `Clone`
 pub(crate) type AcceptConnectionRequestFn = Arc<dyn Fn(ClientId) -> bool + Send + Sync>;
 
 #[enum_dispatch]
@@ -82,6 +83,7 @@ pub enum NetConfig {
 }
 
 impl NetConfig {
+    /// Update the `accept_connection_request_fn` field in the config
     pub fn set_accept_connection_request_fn(
         &mut self,
         accept_connection_request_fn: AcceptConnectionRequestFn,

--- a/lightyear/src/connection/server.rs
+++ b/lightyear/src/connection/server.rs
@@ -19,12 +19,7 @@ use crate::server::config::NetcodeConfig;
 use crate::server::io::Io;
 use crate::transport::config::SharedIoConfig;
 
-/// This function will be run when receiving a connection request.
-///
-/// This should return true if the connection request is accepted, false otherwise.
-// NOTE: has to use Arc so that the closure can be `Clone`
-pub(crate) type AcceptConnectionRequestFn = Arc<dyn Fn(ClientId) -> bool + Send + Sync>;
-
+/// Reasons for denying a connection request
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub enum DeniedReason {
     ServerFull,
@@ -33,9 +28,10 @@ pub enum DeniedReason {
     AlreadyConnected,
     TokenAlreadyUsed,
     InvalidToken,
-    Custom(Cow<'static, str>),
+    Custom(String),
 }
 
+/// Trait for handling connection requests from clients.
 pub trait ConnectionRequestHandler: Debug + Send + Sync {
     /// Handle a connection request from a client.
     /// Returns None if the connection is accepted,
@@ -43,6 +39,7 @@ pub trait ConnectionRequestHandler: Debug + Send + Sync {
     fn handle_request(&self, client_id: ClientId) -> Option<DeniedReason>;
 }
 
+/// By default, all connection requests are accepted by the server.
 #[derive(Debug, Clone)]
 pub struct DefaultConnectionRequestHandler;
 

--- a/lightyear/src/connection/steam/server.rs
+++ b/lightyear/src/connection/steam/server.rs
@@ -1,7 +1,7 @@
 use crate::connection::id;
 use crate::connection::id::ClientId;
 use crate::connection::netcode::MAX_PACKET_SIZE;
-use crate::connection::server::NetServer;
+use crate::connection::server::{AcceptConnectionRequestFn, NetServer};
 use crate::packet::packet::Packet;
 use crate::prelude::LinkConditionerConfig;
 use crate::serialize::bitcode::reader::BufferPool;
@@ -21,16 +21,32 @@ use tracing::{error, info};
 
 use super::{get_networking_options, SingleClientThreadSafe};
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct SteamConfig {
     pub app_id: u32,
     pub server_ip: Ipv4Addr,
     pub game_port: u16,
     pub query_port: u16,
     pub max_clients: usize,
+    pub accept_connection_request_fn: Option<AcceptConnectionRequestFn>,
     // pub mode: ServerMode,
     // TODO: name this protocol to match netcode?
     pub version: String,
+}
+
+// Has to be implemented manually because closures are not Debug
+impl ::core::fmt::Debug for SteamConfig {
+    #[inline]
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        f.debug_struct("SteamConfig")
+            .field("app_id", &self.app_id)
+            .field("server_ip", &self.server_ip)
+            .field("game_port", &self.game_port)
+            .field("query_port", &self.query_port)
+            .field("max_clients", &self.max_clients)
+            .field("version", &self.version)
+            .finish()
+    }
 }
 
 impl Default for SteamConfig {
@@ -42,6 +58,7 @@ impl Default for SteamConfig {
             game_port: 27015,
             query_port: 27016,
             max_clients: 16,
+            accept_connection_request_fn: None,
             // mode: ServerMode::NoAuthentication,
             version: "1.0".to_string(),
         }
@@ -184,8 +201,11 @@ impl NetServer for Server {
                         continue;
                     };
                     info!("Client with id: {:?} requesting connection!", steam_id);
-                    // TODO: improve permission check
-                    let permitted = true;
+                    let permitted = self
+                        .config
+                        .accept_connection_request_fn
+                        .as_mut()
+                        .map_or(true, |f| f(ClientId::Steam(steam_id.raw())));
                     if permitted {
                         if let Err(e) = event.accept() {
                             error!("Failed to accept connection from {steam_id:?}: {e}");

--- a/lightyear/src/connection/steam/server.rs
+++ b/lightyear/src/connection/steam/server.rs
@@ -1,7 +1,9 @@
 use crate::connection::id;
 use crate::connection::id::ClientId;
 use crate::connection::netcode::MAX_PACKET_SIZE;
-use crate::connection::server::{AcceptConnectionRequestFn, NetServer};
+use crate::connection::server::{
+    ConnectionRequestHandler, DefaultConnectionRequestHandler, NetServer,
+};
 use crate::packet::packet::Packet;
 use crate::prelude::LinkConditionerConfig;
 use crate::serialize::bitcode::reader::BufferPool;
@@ -21,7 +23,7 @@ use tracing::{error, info};
 
 use super::{get_networking_options, SingleClientThreadSafe};
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct SteamConfig {
     pub app_id: u32,
     pub server_ip: Ipv4Addr,
@@ -29,25 +31,10 @@ pub struct SteamConfig {
     pub query_port: u16,
     pub max_clients: usize,
     /// A closure that will be used to accept or reject incoming connections
-    pub accept_connection_request_fn: Option<AcceptConnectionRequestFn>,
+    pub connection_request_handler: Arc<dyn ConnectionRequestHandler>,
     // pub mode: ServerMode,
     // TODO: name this protocol to match netcode?
     pub version: String,
-}
-
-// Has to be implemented manually because closures are not Debug
-impl ::core::fmt::Debug for SteamConfig {
-    #[inline]
-    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
-        f.debug_struct("SteamConfig")
-            .field("app_id", &self.app_id)
-            .field("server_ip", &self.server_ip)
-            .field("game_port", &self.game_port)
-            .field("query_port", &self.query_port)
-            .field("max_clients", &self.max_clients)
-            .field("version", &self.version)
-            .finish()
-    }
 }
 
 impl Default for SteamConfig {
@@ -59,7 +46,7 @@ impl Default for SteamConfig {
             game_port: 27015,
             query_port: 27016,
             max_clients: 16,
-            accept_connection_request_fn: None,
+            connection_request_handler: Arc::new(DefaultConnectionRequestHandler),
             // mode: ServerMode::NoAuthentication,
             version: "1.0".to_string(),
         }
@@ -202,19 +189,18 @@ impl NetServer for Server {
                         continue;
                     };
                     info!("Client with id: {:?} requesting connection!", steam_id);
-                    let permitted = self
+                    if let Some(denied_reason) = self
                         .config
-                        .accept_connection_request_fn
-                        .as_mut()
-                        .map_or(true, |f| f(ClientId::Steam(steam_id.raw())));
-                    if permitted {
+                        .connection_request_handler
+                        .handle_request(ClientId::Steam(steam_id.raw()))
+                    {
+                        event.reject(NetConnectionEnd::AppGeneric, Some(denied_reason));
+                        continue;
+                    } else {
                         if let Err(e) = event.accept() {
                             error!("Failed to accept connection from {steam_id:?}: {e}");
                         }
                         info!("Accepted connection from client {:?}", steam_id);
-                    } else {
-                        event.reject(NetConnectionEnd::AppGeneric, Some("Not allowed"));
-                        continue;
                     }
                 }
             }

--- a/lightyear/src/connection/steam/server.rs
+++ b/lightyear/src/connection/steam/server.rs
@@ -28,6 +28,7 @@ pub struct SteamConfig {
     pub game_port: u16,
     pub query_port: u16,
     pub max_clients: usize,
+    /// A closure that will be used to accept or reject incoming connections
     pub accept_connection_request_fn: Option<AcceptConnectionRequestFn>,
     // pub mode: ServerMode,
     // TODO: name this protocol to match netcode?

--- a/lightyear/src/server/config.rs
+++ b/lightyear/src/server/config.rs
@@ -4,11 +4,11 @@ use governor::Quota;
 use nonzero_ext::nonzero;
 
 use crate::connection::netcode::{Key, PRIVATE_KEY_BYTES};
-use crate::connection::server::NetConfig;
+use crate::connection::server::{AcceptConnectionRequestFn, NetConfig};
 use crate::shared::config::SharedConfig;
 use crate::shared::ping::manager::PingConfig;
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct NetcodeConfig {
     pub num_disconnect_packets: usize,
     pub keep_alive_send_rate: f64,
@@ -18,6 +18,20 @@ pub struct NetcodeConfig {
     pub client_timeout_secs: i32,
     pub protocol_id: u64,
     pub private_key: Key,
+    pub accept_connection_request_fn: Option<AcceptConnectionRequestFn>,
+}
+// Has to be manually implemented because Closures do not implement Debug
+impl ::core::fmt::Debug for NetcodeConfig {
+    #[inline]
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        f.debug_struct("NetcodeConfig")
+            .field("num_disconnect_packets", &self.num_disconnect_packets)
+            .field("keep_alive_send_rate", &self.keep_alive_send_rate)
+            .field("client_timeout_secs", &self.client_timeout_secs)
+            .field("protocol_id", &self.protocol_id)
+            .field("private_key", &self.private_key)
+            .finish()
+    }
 }
 
 impl Default for NetcodeConfig {
@@ -28,6 +42,7 @@ impl Default for NetcodeConfig {
             client_timeout_secs: 3,
             protocol_id: 0,
             private_key: [0; PRIVATE_KEY_BYTES],
+            accept_connection_request_fn: None,
         }
     }
 }

--- a/lightyear/src/server/config.rs
+++ b/lightyear/src/server/config.rs
@@ -18,6 +18,7 @@ pub struct NetcodeConfig {
     pub client_timeout_secs: i32,
     pub protocol_id: u64,
     pub private_key: Key,
+    /// A closure that will be used to accept or reject incoming connections
     pub accept_connection_request_fn: Option<AcceptConnectionRequestFn>,
 }
 // Has to be manually implemented because Closures do not implement Debug

--- a/lightyear/src/server/config.rs
+++ b/lightyear/src/server/config.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 
 use crate::connection::netcode::{Key, PRIVATE_KEY_BYTES};
 use crate::connection::server::{
-    AcceptConnectionRequestFn, ConnectionRequestHandler, DefaultConnectionRequestHandler, NetConfig,
+    ConnectionRequestHandler, DefaultConnectionRequestHandler, NetConfig,
 };
 use crate::shared::config::SharedConfig;
 use crate::shared::ping::manager::PingConfig;


### PR DESCRIPTION
Fixes https://github.com/cBournhonesque/lightyear/issues/382 
Fixes https://github.com/cBournhonesque/lightyear/issues/381

- Add a field in the `NetConfig` to provide a closure `Fn(ClientId) -> bool` to decide if a connection will get accepted or rejected.
- Add a DeniedReason in the DeniedPacket, which will get showed to the client

TODO:
maybe instead we can pass in a separate object `dyn ConnectionRequestHandler` with
```
trait ConnectionRequestHandler {
   fn accept();
   
   fn reject() -> Reason
}
```
and the user can implement their own?