### PR TITLE
Replicate existing entities from client->server when client reconnects to a server

### DIFF
--- a/examples/client_replication/src/server.rs
+++ b/examples/client_replication/src/server.rs
@@ -126,6 +126,9 @@ pub(crate) fn replicate_players(
                     // we want the other clients to apply interpolation for the player
                     interpolation: NetworkTarget::AllExceptSingle(client_id),
                 },
+                controlled_by: ControlledBy {
+                    target: NetworkTarget::Single(client_id),
+                },
                 ..default()
             };
             e.insert((
@@ -157,6 +160,9 @@ pub(crate) fn replicate_cursors(
                     // we want the other clients to apply interpolation for the cursor
                     interpolation: NetworkTarget::AllExceptSingle(client_id),
                     ..default()
+                },
+                controlled_by: ControlledBy {
+                    target: NetworkTarget::Single(client_id),
                 },
                 ..default()
             });

--- a/lightyear/src/server/clients.rs
+++ b/lightyear/src/server/clients.rs
@@ -34,10 +34,9 @@ mod systems {
              client_id: ClientId,
              client_query: &mut Query<&mut ControlledEntities>,
              sender: &ConnectionManager| {
-                trace!(
+                info!(
                     "Adding entity {:?} to client {:?}'s controlled entities",
-                    entity,
-                    client_id
+                    entity, client_id
                 );
                 if let Ok(client_entity) = sender.client_entity(client_id) {
                     if let Ok(mut controlled_entities) = client_query.get_mut(client_entity) {
@@ -78,12 +77,12 @@ mod systems {
         for event in events.read() {
             // despawn all the controlled entities for the disconnected client
             if let Ok(controlled_entities) = client_query.get(event.entity) {
-                debug!(
+                info!(
                     "Despawning all entities controlled by client {:?}",
                     event.client_id
                 );
                 for entity in controlled_entities.iter() {
-                    debug!(
+                    info!(
                         "Despawning entity {entity:?} controlled by client {:?}",
                         event.client_id
                     );

--- a/lightyear/src/server/clients.rs
+++ b/lightyear/src/server/clients.rs
@@ -34,9 +34,10 @@ mod systems {
              client_id: ClientId,
              client_query: &mut Query<&mut ControlledEntities>,
              sender: &ConnectionManager| {
-                info!(
+                trace!(
                     "Adding entity {:?} to client {:?}'s controlled entities",
-                    entity, client_id
+                    entity,
+                    client_id,
                 );
                 if let Ok(client_entity) = sender.client_entity(client_id) {
                     if let Ok(mut controlled_entities) = client_query.get_mut(client_entity) {
@@ -77,12 +78,12 @@ mod systems {
         for event in events.read() {
             // despawn all the controlled entities for the disconnected client
             if let Ok(controlled_entities) = client_query.get(event.entity) {
-                info!(
+                debug!(
                     "Despawning all entities controlled by client {:?}",
                     event.client_id
                 );
                 for entity in controlled_entities.iter() {
-                    info!(
+                    debug!(
                         "Despawning entity {entity:?} controlled by client {:?}",
                         event.client_id
                     );

--- a/lightyear/src/server/networking.rs
+++ b/lightyear/src/server/networking.rs
@@ -22,7 +22,6 @@ use anyhow::{anyhow, Context};
 use async_channel::TryRecvError;
 use bevy::ecs::system::{RunSystemOnce, SystemChangeTick, SystemParam};
 use bevy::prelude::*;
-use futures_util::SinkExt;
 use tracing::{debug, error, trace, trace_span};
 
 /// Plugin handling the server networking systems: sending/receiving packets to clients


### PR DESCRIPTION
Previous logic: when an entity gets spawned on client, replicate it to server.

New logic: when `ReplicateToServer` gets changed, replicate to server.

- When the client reconnects, we set `ReplicateToServer.changed = true` for all entities that were already replicating, so that we re-replicate them!

Fixes https://github.com/cBournhonesque/lightyear/issues/427