### PR TITLE
Add a buffer pool on the network receiver side

### DIFF
--- a/benches/replication.rs
+++ b/benches/replication.rs
@@ -38,7 +38,7 @@ criterion_group!(
 criterion_main!(replication_benches);
 
 // const NUM_ENTITIES: &[usize] = &[0, 10, 100, 1000, 10000];
-const NUM_ENTITIES: &[usize] = &[1000];
+const NUM_ENTITIES: &[usize] = &[10000];
 
 /// Replicating N entity spawn from server to channel, with a local io
 fn send_float_insert_one_client(criterion: &mut Criterion) {

--- a/lightyear/src/client/connection.rs
+++ b/lightyear/src/client/connection.rs
@@ -20,7 +20,7 @@ use crate::client::sync::SyncConfig;
 use crate::inputs::native::input_buffer::InputBuffer;
 use crate::packet::message_manager::MessageManager;
 use crate::packet::packet::Packet;
-use crate::packet::packet_builder::{Payload, PACKET_BUFFER_CAPACITY};
+use crate::packet::packet_builder::{Payload, RecvPayload, PACKET_BUFFER_CAPACITY};
 use crate::prelude::{Channel, ChannelKind, ClientId, Message, ReplicationGroup, TargetEntity};
 use crate::protocol::channel::ChannelRegistry;
 use crate::protocol::component::{ComponentNetId, ComponentRegistry};
@@ -460,12 +460,12 @@ impl ConnectionManager {
 
     pub(crate) fn recv_packet(
         &mut self,
-        packet: Payload,
+        packet: RecvPayload,
         tick_manager: &TickManager,
         component_registry: &ComponentRegistry,
     ) -> Result<(), ClientError> {
         // receive the packets, buffer them, update any sender that were waiting for their sent messages to be acked
-        let tick = self.message_manager.recv_packet(packet)?;
+        let tick = self.message_manager.recv_packet(&packet)?;
         debug!("Received server packet with tick: {:?}", tick);
         if self
             .sync_manager

--- a/lightyear/src/connection/client.rs
+++ b/lightyear/src/connection/client.rs
@@ -15,7 +15,7 @@ use crate::connection::netcode::ConnectToken;
 #[cfg(all(feature = "steam", not(target_family = "wasm")))]
 use crate::connection::steam::{client::SteamConfig, steamworks_client::SteamworksClient};
 use crate::packet::packet::Packet;
-use crate::packet::packet_builder::Payload;
+use crate::packet::packet_builder::{Payload, RecvPayload};
 
 use crate::prelude::client::ClientTransport;
 use crate::prelude::{generate_key, Key, LinkConditionerConfig};
@@ -46,7 +46,7 @@ pub trait NetClient: Send + Sync {
     fn try_update(&mut self, delta_ms: f64) -> Result<(), ConnectionError>;
 
     /// Receive a packet from the server
-    fn recv(&mut self) -> Option<Payload>;
+    fn recv(&mut self) -> Option<RecvPayload>;
 
     /// Send a packet to the server
     fn send(&mut self, buf: &[u8]) -> Result<(), ConnectionError>;
@@ -197,7 +197,7 @@ impl NetClient for ClientConnection {
         self.client.try_update(delta_ms)
     }
 
-    fn recv(&mut self) -> Option<Payload> {
+    fn recv(&mut self) -> Option<RecvPayload> {
         self.client.recv()
     }
 

--- a/lightyear/src/connection/local/client.rs
+++ b/lightyear/src/connection/local/client.rs
@@ -1,7 +1,7 @@
 use crate::client::io::Io;
 use crate::client::networking::NetworkingState;
 use crate::connection::client::{ConnectionError, ConnectionState, NetClient};
-use crate::packet::packet_builder::Payload;
+use crate::packet::packet_builder::{Payload, RecvPayload};
 use crate::prelude::ClientId;
 use crate::transport::LOCAL_SOCKET;
 use std::net::SocketAddr;
@@ -44,7 +44,7 @@ impl NetClient for Client {
         Ok(())
     }
 
-    fn recv(&mut self) -> Option<Payload> {
+    fn recv(&mut self) -> Option<RecvPayload> {
         None
     }
 

--- a/lightyear/src/connection/server.rs
+++ b/lightyear/src/connection/server.rs
@@ -11,7 +11,7 @@ use crate::connection::id::ClientId;
 #[cfg(all(feature = "steam", not(target_family = "wasm")))]
 use crate::connection::steam::{server::SteamConfig, steamworks_client::SteamworksClient};
 use crate::packet::packet::Packet;
-use crate::packet::packet_builder::Payload;
+use crate::packet::packet_builder::{Payload, RecvPayload};
 use crate::prelude::client::ClientTransport;
 use crate::prelude::server::ServerTransport;
 use crate::prelude::LinkConditionerConfig;
@@ -72,7 +72,7 @@ pub trait NetServer: Send + Sync {
     fn try_update(&mut self, delta_ms: f64) -> Result<(), ConnectionError>;
 
     /// Receive a packet from one of the connected clients
-    fn recv(&mut self) -> Option<(Payload, ClientId)>;
+    fn recv(&mut self) -> Option<(RecvPayload, ClientId)>;
 
     /// Send a packet to one of the connected clients
     fn send(&mut self, buf: &[u8], client_id: ClientId) -> Result<(), ConnectionError>;

--- a/lightyear/src/packet/packet_builder.rs
+++ b/lightyear/src/packet/packet_builder.rs
@@ -19,13 +19,14 @@ use crate::serialize::reader::ReadBuffer;
 use crate::serialize::varint::varint_len;
 use crate::serialize::writer::WriteBuffer;
 use crate::serialize::{SerializationError, ToBytes};
-use crate::utils::pool::Reusable;
+use crate::utils::pool::{Reusable, ReusableOwned};
 
 // enough to hold a biggest fragment + writing channel/message_id/etc.
 // pub(crate) const PACKET_BUFFER_CAPACITY: usize = MTU_PAYLOAD_BYTES * (u8::BITS as usize) + 50;
 pub(crate) const PACKET_BUFFER_CAPACITY: usize = MTU_PAYLOAD_BYTES * (u8::BITS as usize);
 
 pub type Payload = Vec<u8>;
+pub type RecvPayload = ReusableOwned<Vec<u8>>;
 
 /// `PacketBuilder` handles the process of creating a packet (writing the header and packing the
 /// messages into packets)

--- a/lightyear/src/server/connection.rs
+++ b/lightyear/src/server/connection.rs
@@ -20,7 +20,7 @@ use crate::connection::id::ClientId;
 use crate::inputs::native::input_buffer::InputBuffer;
 use crate::packet::message_manager::MessageManager;
 use crate::packet::packet::Packet;
-use crate::packet::packet_builder::{Payload, PACKET_BUFFER_CAPACITY};
+use crate::packet::packet_builder::{Payload, RecvPayload, PACKET_BUFFER_CAPACITY};
 use crate::prelude::server::{DisconnectEvent, RoomId, RoomManager};
 use crate::prelude::{
     Channel, ChannelKind, Message, Mode, PreSpawnedPlayerObject, ReplicationGroup,
@@ -703,13 +703,13 @@ impl Connection {
 
     pub fn recv_packet(
         &mut self,
-        packet: Payload,
+        packet: RecvPayload,
         tick_manager: &TickManager,
         component_registry: &ComponentRegistry,
         delta_manager: &mut DeltaManager,
     ) -> Result<(), ServerError> {
         // receive the packets, buffer them, update any sender that were waiting for their sent messages to be acked
-        let tick = self.message_manager.recv_packet(packet)?;
+        let tick = self.message_manager.recv_packet(&packet)?;
         // notify the replication sender that some sent messages were received
         self.replication_sender
             .recv_update_acks(component_registry, delta_manager);


### PR DESCRIPTION
The goal is to avoid allocating when we receive a packet, but instead re-use preallocated vectors that we can copy the packet bytes into.

However when I benchmarked it it didn't make any difference... Maybe because we're not receiving enough packets for it to make a difference in terms of allocations?