### PR TITLE
Improve replication logic

### DIFF
--- a/examples/bullet_prespawn/assets/settings.ron
+++ b/examples/bullet_prespawn/assets/settings.ron
@@ -57,7 +57,7 @@ MySettings(
         shared: SharedSettings(
             protocol_id: 0,
             private_key: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
-            compression: Lz4,
+            compression: None,
         )
     )
 )

--- a/examples/xpbd_physics/src/main.rs
+++ b/examples/xpbd_physics/src/main.rs
@@ -21,26 +21,26 @@ fn main() {
     let settings = read_settings::<MySettings>(settings_str);
     // build the bevy app (this adds common plugin such as the DefaultPlugins)
     // and returns the `ClientConfig` and `ServerConfig` so that we can modify them if needed
-    Apps::new(settings.common, cli)
-        // for this example, we will use input delay and a correction function
-        .update_lightyear_client_config(|config| {
-            config.prediction.input_delay_ticks = settings.input_delay_ticks;
-            config.prediction.correction_ticks_factor = settings.correction_ticks_factor;
-        })
-        // add `ClientPlugins` and `ServerPlugins` plugin groups
-        .add_lightyear_plugins()
-        // add our plugins
-        .add_user_plugins(
-            ExampleClientPlugin,
-            ExampleServerPlugin {
-                predict_all: settings.predict_all,
-            },
-            SharedPlugin {
-                show_confirmed: settings.show_confirmed,
-            },
-        )
-        // run the app
-        .run();
+    let mut apps = Apps::new(settings.common, cli);
+    // for this example, we will use input delay and a correction function
+    apps.update_lightyear_client_config(|config| {
+        config.prediction.input_delay_ticks = settings.input_delay_ticks;
+        config.prediction.correction_ticks_factor = settings.correction_ticks_factor;
+    })
+    // add `ClientPlugins` and `ServerPlugins` plugin groups
+    .add_lightyear_plugins()
+    // add our plugins
+    .add_user_plugins(
+        ExampleClientPlugin,
+        ExampleServerPlugin {
+            predict_all: settings.predict_all,
+        },
+        SharedPlugin {
+            show_confirmed: settings.show_confirmed,
+        },
+    );
+    // run the app
+    apps.run();
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/lightyear/Cargo.toml
+++ b/lightyear/Cargo.toml
@@ -133,8 +133,8 @@ wtransport = { version = "=0.1.13", optional = true, features = [
 ] }
 # websocket
 tokio-tungstenite = { version = "0.23.0", optional = true, features = [
-    "connect",
-    "handshake",
+  "connect",
+  "handshake",
 ] }
 # compression
 zstd = { version = "0.13.1", optional = true }

--- a/lightyear/src/channel/builder.rs
+++ b/lightyear/src/channel/builder.rs
@@ -228,6 +228,11 @@ pub struct EntityUpdatesChannel;
 #[derive(ChannelInternal)]
 pub struct PingChannel;
 
+/// Default channel to send pongs. This is a Sequenced Unreliable channel, because
+/// there is no point in getting older pongs.
+#[derive(ChannelInternal)]
+pub struct PongChannel;
+
 #[derive(ChannelInternal)]
 /// Default channel to send inputs from client to server. This is a Sequenced Unreliable channel.
 pub struct InputChannel;

--- a/lightyear/src/client/connection.rs
+++ b/lightyear/src/client/connection.rs
@@ -399,7 +399,7 @@ impl ConnectionManager {
                                 self.received_messages
                                     .entry(net_id)
                                     .or_default()
-                                    .push(single_data.into());
+                                    .push(single_data);
                             }
                         }
                     }

--- a/lightyear/src/client/connection.rs
+++ b/lightyear/src/client/connection.rs
@@ -378,6 +378,8 @@ impl ConnectionManager {
                 let net_id = reader
                     .decode::<NetId>(Fixed)
                     .expect("could not decode MessageKind");
+                dbg!(&channel_kind);
+                dbg!(net_id);
                 match message_registry.message_type(net_id) {
                     #[cfg(feature = "leafwing")]
                     MessageType::LeafwingInput => {
@@ -390,6 +392,7 @@ impl ConnectionManager {
                         todo!()
                     }
                     MessageType::Normal => {
+                        dbg!("Normal message");
                         self.received_messages
                             .entry(net_id)
                             .or_default()

--- a/lightyear/src/client/connection.rs
+++ b/lightyear/src/client/connection.rs
@@ -239,7 +239,7 @@ impl ConnectionManager {
         let message = ClientMessage { message, target };
         self.writer.start_write();
         message.encode(&mut self.writer)?;
-        // TODO: doesn't this serialize the bytes twice?
+        // TODO: doesn't this serialize the bytes twice? fix this..
         let message_bytes = self.writer.finish_write().to_vec();
         // message.emit_send_logs(&channel_name);
         self.message_manager.buffer_send(message_bytes, channel)?;

--- a/lightyear/src/client/io/config.rs
+++ b/lightyear/src/client/io/config.rs
@@ -121,6 +121,7 @@ impl SharedIoConfig<ClientTransport> {
             CompressionConfig::None => {}
             #[cfg(feature = "zstd")]
             CompressionConfig::Zstd { level } => {
+                use crate::transport::middleware::PacketSenderWrapper;
                 let compressor = ZstdCompressor::new(level);
                 sender = Box::new(compressor.wrap(sender));
                 let decompressor = ZstdDecompressor::new();
@@ -128,6 +129,7 @@ impl SharedIoConfig<ClientTransport> {
             }
             #[cfg(feature = "lz4")]
             CompressionConfig::Lz4 => {
+                use crate::transport::middleware::PacketSenderWrapper;
                 let compressor =
                     crate::transport::middleware::compression::lz4::Compressor::default();
                 sender = Box::new(compressor.wrap(sender));

--- a/lightyear/src/client/message.rs
+++ b/lightyear/src/client/message.rs
@@ -13,25 +13,14 @@ use crate::protocol::BitSerializable;
 use crate::serialize::reader::ReadBuffer;
 use crate::serialize::writer::WriteBuffer;
 use crate::serialize::RawData;
-use crate::shared::ping::message::{Ping, Pong};
 use crate::shared::replication::network_target::NetworkTarget;
-use crate::shared::replication::ReplicationMessage;
 use crate::shared::sets::{ClientMarker, InternalMainSet};
 
-// ClientMessages can include some extra Metadata
 #[derive(Encode, Decode, Clone, Debug)]
-pub(crate) enum ClientMessage {
-    #[bitcode_hint(frequency = 2)]
-    // #[bitcode(with_serde)]
-    Message(RawData, NetworkTarget),
-    #[bitcode_hint(frequency = 3)]
-    // #[bitcode(with_serde)]
-    Replication(ReplicationMessage),
-    #[bitcode_hint(frequency = 1)]
-    // the reason why we include sync here instead of doing another MessageManager is so that
-    // the sync messages can be added to packets that have other messages
-    Ping(Ping),
-    Pong(Pong),
+pub struct ClientMessage {
+    pub(crate) message: RawData,
+    /// Used if you want to automatically rebroadcast a message to a specific target
+    pub(crate) target: NetworkTarget,
 }
 
 /// Read the message received from the server and emit the MessageEvent event

--- a/lightyear/src/client/prediction/prespawn.rs
+++ b/lightyear/src/client/prediction/prespawn.rs
@@ -498,7 +498,7 @@ mod tests {
 
         let current_tick = stepper.client_app.world.resource::<TickManager>().tick();
         let prediction_manager = stepper.client_app.world.resource::<PredictionManager>();
-        let expected_hash: u64 = 6598339966483644418;
+        let expected_hash: u64 = 17661842671030555484;
         assert_eq!(
             prediction_manager.prespawn_hash_to_entities,
             HashMap::from_iter(vec![(

--- a/lightyear/src/client/prediction/prespawn.rs
+++ b/lightyear/src/client/prediction/prespawn.rs
@@ -498,7 +498,7 @@ mod tests {
 
         let current_tick = stepper.client_app.world.resource::<TickManager>().tick();
         let prediction_manager = stepper.client_app.world.resource::<PredictionManager>();
-        let expected_hash: u64 = 17661842671030555484;
+        let expected_hash: u64 = 6598339966483644418;
         assert_eq!(
             prediction_manager.prespawn_hash_to_entities,
             HashMap::from_iter(vec![(

--- a/lightyear/src/lib.rs
+++ b/lightyear/src/lib.rs
@@ -164,6 +164,7 @@ fn component_inserted(query: Query<Entity, (With<Replicated>, Added<MyComponent>
 [`SharedConfig`]: prelude::SharedConfig
  */
 #![allow(unused_variables)]
+#![allow(clippy::too_many_arguments)]
 #![allow(dead_code)]
 #![allow(clippy::type_complexity)]
 #![allow(rustdoc::private_intra_doc_links)]

--- a/lightyear/src/packet/message_manager.rs
+++ b/lightyear/src/packet/message_manager.rs
@@ -370,7 +370,6 @@ impl MessageManager {
 
     #[cfg(test)]
     pub fn collect_messages(
-        &self,
         messages: impl Iterator<Item = (ChannelKind, (Tick, Bytes))>,
     ) -> HashMap<ChannelKind, Vec<(Tick, Bytes)>> {
         let mut map = HashMap::new();
@@ -475,7 +474,7 @@ mod tests {
             server_message_manager.recv_packet(payload)?;
         }
         let it = server_message_manager.read_messages();
-        let data = server_message_manager.collect_messages(it);
+        let data = MessageManager::collect_messages(it);
 
         assert_eq!(
             data.get(&channel_kind_1).unwrap(),
@@ -488,7 +487,7 @@ mod tests {
 
         // Confirm what happens if we try to receive but there is nothing on the io
         let it = server_message_manager.read_messages();
-        let data = server_message_manager.collect_messages(it);
+        let data = MessageManager::collect_messages(it);
         assert!(data.is_empty());
 
         // Check the state of the packet headers
@@ -568,7 +567,7 @@ mod tests {
             server_message_manager.recv_packet(payload)?;
         }
         let it = server_message_manager.read_messages();
-        let data = server_message_manager.collect_messages(it);
+        let data = MessageManager::collect_messages(it);
         assert_eq!(
             data.get(&channel_kind_1).unwrap(),
             &vec![(Tick(0), message.clone().into())]
@@ -580,7 +579,7 @@ mod tests {
 
         // Confirm what happens if we try to receive but there is nothing on the io
         let it = server_message_manager.read_messages();
-        let data = server_message_manager.collect_messages(it);
+        let data = MessageManager::collect_messages(it);
         assert!(data.is_empty());
 
         // Check the state of the packet headers

--- a/lightyear/src/packet/message_manager.rs
+++ b/lightyear/src/packet/message_manager.rs
@@ -352,7 +352,7 @@ impl MessageManager {
     /// EDIT: Actually, prioritization discards messages that are not sent, so maybe it is guaranteed that the tick
     /// is the remote send tick.
     #[cfg_attr(feature = "trace", instrument(level = Level::INFO, skip_all))]
-    pub fn read_messages(
+    pub(crate) fn read_messages(
         &mut self,
     ) -> impl Iterator<Item = (ChannelKind, (Tick, Bytes))> + Captures<&()> {
         // let mut map = HashMap::new();

--- a/lightyear/src/packet/message_manager.rs
+++ b/lightyear/src/packet/message_manager.rs
@@ -376,8 +376,8 @@ impl MessageManager {
 
     #[cfg(test)]
     pub fn collect_messages(
-        messages: impl Iterator<Item = (ChannelKind, (Tick, Bytes))>,
-    ) -> HashMap<ChannelKind, Vec<(Tick, Bytes)>> {
+        messages: impl Iterator<Item = (ChannelKind, (Tick, bytes::Bytes))>,
+    ) -> HashMap<ChannelKind, Vec<(Tick, bytes::Bytes)>> {
         let mut map = HashMap::new();
         for (channel_kind, (tick, bytes)) in messages {
             map.entry(channel_kind)

--- a/lightyear/src/protocol/channel.rs
+++ b/lightyear/src/protocol/channel.rs
@@ -3,7 +3,7 @@ use bevy::prelude::{Resource, TypePath};
 use std::any::TypeId;
 use std::collections::HashMap;
 
-use crate::channel::builder::{Channel, ChannelBuilder, ChannelSettings};
+use crate::channel::builder::{Channel, ChannelBuilder, ChannelSettings, PongChannel};
 use crate::channel::builder::{
     ChannelContainer, EntityActionsChannel, EntityUpdatesChannel, InputChannel, PingChannel,
 };
@@ -87,6 +87,12 @@ impl ChannelRegistry {
             priority: 10.0,
         });
         registry.add_channel::<PingChannel>(ChannelSettings {
+            mode: ChannelMode::SequencedUnreliable,
+            direction: ChannelDirection::Bidirectional,
+            // we always want to include the ping in the packet
+            priority: 1000.0,
+        });
+        registry.add_channel::<PongChannel>(ChannelSettings {
             mode: ChannelMode::SequencedUnreliable,
             direction: ChannelDirection::Bidirectional,
             // we always want to include the ping in the packet

--- a/lightyear/src/serialize/mod.rs
+++ b/lightyear/src/serialize/mod.rs
@@ -17,6 +17,8 @@ pub enum SerializationError {
     InvalidPacketType,
     #[error("Substraction overflow")]
     SubstractionOverflow,
+    #[error(transparent)]
+    Bitcode(#[from] ::bitcode::Error),
 }
 
 #[allow(clippy::len_without_is_empty)]

--- a/lightyear/src/server/connection.rs
+++ b/lightyear/src/server/connection.rs
@@ -495,33 +495,13 @@ impl Connection {
             &mut self.writer,
             &mut self.message_manager,
         )?;
-
-        self.replication_sender
-            .updates_to_send(tick, bevy_tick)
-            .try_for_each(|(message, priority)| {
-                // message.emit_send_logs("EntityUpdatesChannel");
-                self.writer.start_write();
-                message.encode(&mut self.writer)?;
-                let message_bytes = self.writer.finish_write().to_vec();
-                let message_id = self
-                    .message_manager
-                    // TODO: use const type_id?
-                    .buffer_send_with_priority(
-                        message_bytes,
-                        ChannelKind::of::<EntityUpdatesChannel>(),
-                        priority,
-                    )?
-                    .expect("The entity actions channels should always return a message_id");
-
-                // keep track of the group associated with the message, so we can handle receiving an ACK for that message_id later
-                self.replication_sender.buffer_replication_update_message(
-                    message.group_id,
-                    message_id,
-                    bevy_tick,
-                    tick,
-                );
-                Ok(())
-            })
+        self.replication_sender.send_updates_messages(
+            tick,
+            bevy_tick,
+            &mut self.writer,
+            &mut self.message_manager,
+        )?;
+        Ok(())
     }
 
     fn send_ping(&mut self, ping: Ping) -> Result<(), ServerError> {

--- a/lightyear/src/server/connection.rs
+++ b/lightyear/src/server/connection.rs
@@ -10,7 +10,9 @@ use tracing::{debug, info, info_span, trace, trace_span};
 #[cfg(feature = "trace")]
 use tracing::{instrument, Level};
 
-use crate::channel::builder::{EntityUpdatesChannel, PingChannel};
+use crate::channel::builder::{
+    EntityActionsChannel, EntityUpdatesChannel, PingChannel, PongChannel,
+};
 use bitcode::encoding::Fixed;
 
 use crate::channel::senders::ChannelSend;
@@ -37,7 +39,6 @@ use crate::serialize::RawData;
 use crate::server::config::{PacketConfig, ReplicationConfig};
 use crate::server::error::ServerError;
 use crate::server::events::{ConnectEvent, ServerEvents};
-use crate::server::message::ServerMessage;
 use crate::server::replication::send::ReplicateCache;
 use crate::server::visibility::error::VisibilityError;
 use crate::shared::events::connection::ConnectionEvents;
@@ -49,8 +50,8 @@ use crate::shared::replication::delta::DeltaManager;
 use crate::shared::replication::network_target::NetworkTarget;
 use crate::shared::replication::receive::ReplicationReceiver;
 use crate::shared::replication::send::ReplicationSender;
-use crate::shared::replication::{ReplicationMessage, ReplicationReceive, ReplicationSend};
-use crate::shared::replication::{ReplicationMessageData, ReplicationPeer};
+use crate::shared::replication::{EntityActionsMessage, EntityUpdatesMessage, ReplicationPeer};
+use crate::shared::replication::{ReplicationReceive, ReplicationSend};
 use crate::shared::sets::ServerMarker;
 use crate::shared::tick_manager::Tick;
 use crate::shared::tick_manager::TickManager;
@@ -473,7 +474,6 @@ impl Connection {
             .channel_registry
             .name(&channel)
             .ok_or::<ServerError>(MessageError::NotRegistered.into())?;
-        let message = ServerMessage::Message(message);
         self.writer.start_write();
         message.encode(&mut self.writer)?;
         // TODO: doesn't this serialize the bytes twice?
@@ -490,42 +490,59 @@ impl Connection {
         bevy_tick: BevyTick,
     ) -> Result<(), ServerError> {
         self.replication_sender
-            .finalize(tick, bevy_tick)
-            .into_iter()
-            .try_for_each(|(channel, group_id, message_data, priority)| {
-                let should_track_ack = matches!(message_data, ReplicationMessageData::Updates(_));
-                let channel_name = self
-                    .message_manager
-                    .channel_registry
-                    .name(&channel)
-                    .ok_or::<ServerError>(MessageError::NotRegistered.into())?;
-                let message = ClientMessage::Replication(ReplicationMessage {
-                    group_id,
-                    data: message_data,
-                });
+            .actions_to_send(tick, bevy_tick)
+            .try_for_each(|(message, priority)| {
+                // message.emit_send_logs("EntityActionsChannel");
                 self.writer.start_write();
                 message.encode(&mut self.writer)?;
                 // TODO: doesn't this serialize the bytes twice?
                 let message_bytes = self.writer.finish_write().to_vec();
-                // message.emit_send_logs(&channel_name);
                 let message_id = self
                     .message_manager
-                    .buffer_send_with_priority(message_bytes, channel, priority)?
-                    .expect("The replication channels should always return a message_id");
+                    // TODO: use const type_id?
+                    .buffer_send_with_priority(
+                        message_bytes,
+                        ChannelKind::of::<EntityActionsChannel>(),
+                        priority,
+                    )?
+                    .expect("The entity actions channels should always return a message_id");
+                Ok::<(), ServerError>(())
+            })?;
+
+        let x = self
+            .replication_sender
+            .updates_to_send(tick, bevy_tick)
+            .try_for_each(|(message, priority)| {
+                // message.emit_send_logs("EntityUpdatesChannel");
+                self.writer.start_write();
+                message.encode(&mut self.writer)?;
+                let message_bytes = self.writer.finish_write().to_vec();
+                let message_id = self
+                    .message_manager
+                    // TODO: use const type_id?
+                    .buffer_send_with_priority(
+                        message_bytes,
+                        ChannelKind::of::<EntityUpdatesChannel>(),
+                        priority,
+                    )?
+                    .expect("The entity actions channels should always return a message_id");
 
                 // keep track of the group associated with the message, so we can handle receiving an ACK for that message_id later
-                if should_track_ack {
-                    self.replication_sender
-                        .buffer_replication_update_message(group_id, message_id, bevy_tick, tick);
-                }
+                self.replication_sender.buffer_replication_update_message(
+                    message.group_id,
+                    message_id,
+                    bevy_tick,
+                    tick,
+                );
                 Ok(())
-            })
+            });
+        x
     }
 
     fn send_ping(&mut self, ping: Ping) -> Result<(), ServerError> {
         trace!("Sending ping {:?}", ping);
         self.writer.start_write();
-        ServerMessage::Ping(ping).encode(&mut self.writer)?;
+        self.writer.encode(&ping, Fixed)?;
         let message_bytes = self.writer.finish_write().to_vec();
         self.message_manager
             .buffer_send(message_bytes, ChannelKind::of::<PingChannel>())?;
@@ -535,10 +552,10 @@ impl Connection {
     fn send_pong(&mut self, pong: Pong) -> Result<(), ServerError> {
         trace!("Sending pong {:?}", pong);
         self.writer.start_write();
-        ServerMessage::Pong(pong).encode(&mut self.writer)?;
+        self.writer.encode(&pong, Fixed)?;
         let message_bytes = self.writer.finish_write().to_vec();
         self.message_manager
-            .buffer_send(message_bytes, ChannelKind::of::<PingChannel>())?;
+            .buffer_send(message_bytes, ChannelKind::of::<PongChannel>())?;
         Ok(())
     }
 
@@ -590,104 +607,93 @@ impl Connection {
     ) -> ConnectionEvents {
         let _span = trace_span!("receive").entered();
         let message_registry = world.resource::<MessageRegistry>();
-        for (channel_kind, messages) in self.message_manager.read_messages() {
-            let channel_name = self
-                .message_manager
-                .channel_registry
-                .name(&channel_kind)
-                .unwrap_or("unknown");
-            let _span_channel = trace_span!("channel", channel = channel_name).entered();
+        for (channel_kind, (tick, single_data)) in self.message_manager.read_messages() {
+            // let channel_name = self
+            //     .message_manager
+            //     .channel_registry
+            //     .name(&channel_kind)
+            //     .unwrap_or("unknown");
+            // let _span_channel = trace_span!("channel", channel = channel_name).entered();
 
-            if !messages.is_empty() {
-                trace!(?channel_name, ?messages, "Received messages");
-                for (tick, single_data) in messages.into_iter() {
-                    trace!(?tick, ?single_data, "received message");
-                    // TODO: in this case, it looks like we might not need the pool?
-                    //  we can just have a single buffer, and keep re-using that buffer
-                    let mut reader = self.reader_pool.start_read(single_data.as_ref());
-                    // TODO: maybe just decode a single bit to know if it's message vs replication?
-                    let message = ClientMessage::decode(&mut reader)
-                        .expect("Could not decode server message");
-                    self.reader_pool.attach(reader);
+            trace!(?channel_kind, ?tick, ?single_data, "received message");
+            // TODO: in this case, it looks like we might not need the pool?
+            //  we can just have a single buffer, and keep re-using that buffer
+            let mut reader = self.reader_pool.start_read(single_data.as_ref());
 
-                    match message {
-                        ClientMessage::Message(message, target) => {
-                            let mut reader = self.reader_pool.start_read(message.as_slice());
-                            let net_id = reader
-                                .decode::<NetId>(Fixed)
-                                .expect("could not decode MessageKind");
-                            self.reader_pool.attach(reader);
+            // TODO: get const type ids
+            if channel_kind == ChannelKind::of::<PingChannel>() {
+                let ping = reader.decode::<Ping>(Fixed).expect("Could not decode Ping");
+                // prepare a pong in response (but do not send yet, because we need
+                // to set the correct send time)
+                self.ping_manager
+                    .buffer_pending_pong(&ping, time_manager.current_time());
+                trace!("buffer pong");
+            } else if channel_kind == ChannelKind::of::<PongChannel>() {
+                let pong = reader.decode::<Pong>(Fixed).expect("Could not decode Pong");
+                // process the pong
+                self.ping_manager
+                    .process_pong(&pong, time_manager.current_time());
+            } else if channel_kind == ChannelKind::of::<EntityActionsChannel>() {
+                let actions = EntityActionsMessage::decode(&mut reader)
+                    .expect("Could not decode EntityActionMessage");
+                trace!(?tick, ?actions, "received replication actions message");
+                // buffer the replication message
+                self.replication_receiver.recv_actions(actions, tick);
+            } else if channel_kind == ChannelKind::of::<EntityUpdatesChannel>() {
+                let updates = EntityUpdatesMessage::decode(&mut reader)
+                    .expect("Could not decode EntityUpdatesMessage");
+                trace!(?tick, ?updates, "received replication updates message");
+                // buffer the replication message
+                self.replication_receiver.recv_updates(updates, tick);
+            } else {
+                // TODO: we only get RawData here, does that mean we're deserializing multiple times?
+                //  instead just read the bytes for the target!!
+                let ClientMessage { message, target } =
+                    ClientMessage::decode(&mut reader).expect("Could not decode ClientMessage");
 
-                            // we are also sending target and channel kind so the message can be
-                            // rebroadcasted to other clients after we have converted the entities from the
-                            // client World to the server World
-                            // TODO: but do we have data to convert the entities from the client to the server?
-                            //  I don't think so... maybe the sender should map_entities themselves?
-                            //  or it matters for input messages?
-                            // TODO: avoid clone with Arc<[u8]>?
-                            let data = (message.clone().into(), target.clone(), channel_kind);
+                let mut reader = self.reader_pool.start_read(message.as_slice());
+                let net_id = reader
+                    .decode::<NetId>(Fixed)
+                    .expect("could not decode MessageKind");
+                self.reader_pool.attach(reader);
+                // we are also sending target and channel kind so the message can be
+                // rebroadcasted to other clients after we have converted the entities from the
+                // client World to the server World
+                // TODO: but do we have data to convert the entities from the client to the server?
+                //  I don't think so... maybe the sender should map_entities themselves?
+                //  or it matters for input messages?
+                // TODO: avoid clone with Arc<[u8]>?
+                let data = (message.clone().into(), target.clone(), channel_kind);
 
-                            match message_registry.message_type(net_id) {
-                                #[cfg(feature = "leafwing")]
-                                MessageType::LeafwingInput => self
-                                    .received_leafwing_input_messages
-                                    .entry(net_id)
-                                    .or_default()
-                                    .push(data),
-                                MessageType::NativeInput => {
-                                    self.received_input_messages
-                                        .entry(net_id)
-                                        .or_default()
-                                        .push(data);
-                                }
-                                MessageType::Normal => {
-                                    self.received_messages.entry(net_id).or_default().push(data);
-                                }
-                            }
-                        }
-                        ClientMessage::Replication(replication) => {
-                            trace!(?tick, ?replication, "received replication message");
-                            // buffer the replication message
-                            self.replication_receiver.recv_message(replication, tick);
-                        }
-                        ClientMessage::Ping(ping) => {
-                            // prepare a pong in response (but do not send yet, because we need
-                            // to set the correct send time)
-                            self.ping_manager
-                                .buffer_pending_pong(&ping, time_manager.current_time());
-                            trace!("buffer pong");
-                        }
-                        ClientMessage::Pong(pong) => {
-                            // process the pong
-                            self.ping_manager
-                                .process_pong(&pong, time_manager.current_time());
-                        }
+                match message_registry.message_type(net_id) {
+                    #[cfg(feature = "leafwing")]
+                    MessageType::LeafwingInput => self
+                        .received_leafwing_input_messages
+                        .entry(net_id)
+                        .or_default()
+                        .push(data),
+                    MessageType::NativeInput => {
+                        self.received_input_messages
+                            .entry(net_id)
+                            .or_default()
+                            .push(data);
+                    }
+                    MessageType::Normal => {
+                        self.received_messages.entry(net_id).or_default().push(data);
                     }
                 }
             }
+            self.reader_pool.attach(reader);
         }
 
-        // NOTE: we run this outside `messages.is_empty()` because we might have some messages from a future tick that we can now process
         // Check if we have any replication messages we can apply to the World (and emit events)
-        for (group, replication_list) in
-            self.replication_receiver.read_messages(tick_manager.tick())
-        {
-            trace!(?group, ?replication_list, "read replication messages");
-            replication_list
-                .into_iter()
-                .for_each(|(tick, replication)| {
-                    // TODO: we could include the server tick when this replication_message was sent.
-                    self.replication_receiver.apply_world(
-                        world,
-                        Some(self.client_id),
-                        component_registry,
-                        tick,
-                        replication,
-                        group,
-                        &mut self.events,
-                    );
-                });
-        }
+        self.replication_receiver.apply_world(
+            world,
+            Some(self.client_id),
+            component_registry,
+            tick_manager.tick(),
+            &mut self.events,
+        );
 
         // TODO: do i really need this? I could just create events in this function directly?
         //  why do i need to make events a field of the connection?

--- a/lightyear/src/server/connection.rs
+++ b/lightyear/src/server/connection.rs
@@ -474,12 +474,8 @@ impl Connection {
             .channel_registry
             .name(&channel)
             .ok_or::<ServerError>(MessageError::NotRegistered.into())?;
-        self.writer.start_write();
-        message.encode(&mut self.writer)?;
-        // TODO: doesn't this serialize the bytes twice?
-        let message_bytes = self.writer.finish_write().to_vec();
         // message.emit_send_logs(&channel_name);
-        self.message_manager.buffer_send(message_bytes, channel)?;
+        self.message_manager.buffer_send(message, channel)?;
         Ok(())
     }
 

--- a/lightyear/src/server/connection.rs
+++ b/lightyear/src/server/connection.rs
@@ -489,28 +489,14 @@ impl Connection {
         tick: Tick,
         bevy_tick: BevyTick,
     ) -> Result<(), ServerError> {
-        self.replication_sender
-            .actions_to_send(tick, bevy_tick)
-            .try_for_each(|(message, priority)| {
-                // message.emit_send_logs("EntityActionsChannel");
-                self.writer.start_write();
-                message.encode(&mut self.writer)?;
-                // TODO: doesn't this serialize the bytes twice?
-                let message_bytes = self.writer.finish_write().to_vec();
-                let message_id = self
-                    .message_manager
-                    // TODO: use const type_id?
-                    .buffer_send_with_priority(
-                        message_bytes,
-                        ChannelKind::of::<EntityActionsChannel>(),
-                        priority,
-                    )?
-                    .expect("The entity actions channels should always return a message_id");
-                Ok::<(), ServerError>(())
-            })?;
+        self.replication_sender.send_actions_messages(
+            tick,
+            bevy_tick,
+            &mut self.writer,
+            &mut self.message_manager,
+        )?;
 
-        let x = self
-            .replication_sender
+        self.replication_sender
             .updates_to_send(tick, bevy_tick)
             .try_for_each(|(message, priority)| {
                 // message.emit_send_logs("EntityUpdatesChannel");
@@ -535,8 +521,7 @@ impl Connection {
                     tick,
                 );
                 Ok(())
-            });
-        x
+            })
     }
 
     fn send_ping(&mut self, ping: Ping) -> Result<(), ServerError> {

--- a/lightyear/src/server/io/config.rs
+++ b/lightyear/src/server/io/config.rs
@@ -131,6 +131,7 @@ impl SharedIoConfig<ServerTransport> {
             CompressionConfig::None => {}
             #[cfg(feature = "zstd")]
             CompressionConfig::Zstd { level } => {
+                use crate::transport::middleware::PacketSenderWrapper;
                 let compressor = ZstdCompressor::new(level);
                 sender = Box::new(compressor.wrap(sender));
                 let decompressor = ZstdDecompressor::new();
@@ -138,6 +139,7 @@ impl SharedIoConfig<ServerTransport> {
             }
             #[cfg(feature = "lz4")]
             CompressionConfig::Lz4 => {
+                use crate::transport::middleware::PacketSenderWrapper;
                 let compressor =
                     crate::transport::middleware::compression::lz4::Compressor::default();
                 sender = Box::new(compressor.wrap(sender));

--- a/lightyear/src/server/replication.rs
+++ b/lightyear/src/server/replication.rs
@@ -840,7 +840,7 @@ pub(crate) mod send {
         use crate::client::events::ComponentUpdateEvent;
         use crate::prelude::client::Confirmed;
         use crate::prelude::server::{ControlledBy, NetConfig, Replicate, VisibilityManager};
-        use crate::prelude::{client, server, LinkConditionerConfig, Replicated};
+        use crate::prelude::{client, LinkConditionerConfig, Replicated};
         use crate::server::replication::send::SyncTarget;
         use crate::shared::replication::components::{Controlled, ReplicationGroupId};
         use crate::shared::replication::delta::DeltaComponentHistory;
@@ -875,7 +875,7 @@ pub(crate) mod send {
                 .server_app
                 .world
                 .entity_mut(server_entity)
-                .insert(server::Replicate {
+                .insert(Replicate {
                     sync: SyncTarget {
                         prediction: NetworkTarget::All,
                         interpolation: NetworkTarget::All,
@@ -923,7 +923,7 @@ pub(crate) mod send {
             let server_entity = stepper
                 .server_app
                 .world
-                .spawn(server::Replicate {
+                .spawn(Replicate {
                     visibility: VisibilityMode::InterestManagement,
                     ..default()
                 })
@@ -979,7 +979,7 @@ pub(crate) mod send {
                 .server_app
                 .world
                 .spawn((
-                    server::Replicate::default(),
+                    Replicate::default(),
                     TargetEntity::Preexisting(client_entity),
                 ))
                 .id();
@@ -1016,7 +1016,7 @@ pub(crate) mod send {
             let server_entity = stepper
                 .server_app
                 .world
-                .spawn(server::Replicate {
+                .spawn(Replicate {
                     target: ReplicationTarget {
                         target: NetworkTarget::Single(ClientId::Netcode(TEST_CLIENT_ID_1)),
                     },
@@ -1063,11 +1063,7 @@ pub(crate) mod send {
             let mut stepper = BevyStepper::default();
 
             // spawn an entity on server
-            let server_entity = stepper
-                .server_app
-                .world
-                .spawn(server::Replicate::default())
-                .id();
+            let server_entity = stepper.server_app.world.spawn(Replicate::default()).id();
             stepper.frame_step();
             stepper.frame_step();
 
@@ -1100,7 +1096,7 @@ pub(crate) mod send {
             let server_entity = stepper
                 .server_app
                 .world
-                .spawn(server::Replicate {
+                .spawn(Replicate {
                     visibility: VisibilityMode::InterestManagement,
                     ..default()
                 })
@@ -1149,7 +1145,7 @@ pub(crate) mod send {
             let server_entity_1 = stepper
                 .server_app
                 .world
-                .spawn(server::Replicate {
+                .spawn(Replicate {
                     visibility: VisibilityMode::InterestManagement,
                     group: ReplicationGroup::new_id(1),
                     ..default()
@@ -1158,7 +1154,7 @@ pub(crate) mod send {
             let server_entity_2 = stepper
                 .server_app
                 .world
-                .spawn(server::Replicate {
+                .spawn(Replicate {
                     visibility: VisibilityMode::InterestManagement,
                     group: ReplicationGroup::new_id(1),
                     ..default()
@@ -1231,7 +1227,7 @@ pub(crate) mod send {
             let server_entity = stepper
                 .server_app
                 .world
-                .spawn(server::Replicate {
+                .spawn(Replicate {
                     target: ReplicationTarget {
                         target: NetworkTarget::Single(ClientId::Netcode(TEST_CLIENT_ID)),
                     },
@@ -1270,11 +1266,7 @@ pub(crate) mod send {
             let mut stepper = BevyStepper::default();
 
             // spawn an entity on server
-            let server_entity = stepper
-                .server_app
-                .world
-                .spawn(server::Replicate::default())
-                .id();
+            let server_entity = stepper.server_app.world.spawn(Replicate::default()).id();
             stepper.frame_step();
             stepper.frame_step();
             let client_entity = *stepper
@@ -1313,11 +1305,7 @@ pub(crate) mod send {
             let mut stepper = BevyStepper::default();
 
             // spawn an entity on server
-            let server_entity = stepper
-                .server_app
-                .world
-                .spawn(server::Replicate::default())
-                .id();
+            let server_entity = stepper.server_app.world.spawn(Replicate::default()).id();
             stepper.frame_step();
             stepper.frame_step();
             let client_entity = *stepper
@@ -2390,7 +2378,7 @@ pub(crate) mod send {
                 stepper
                     .server_app
                     .world
-                    .resource::<server::ConnectionManager>()
+                    .resource::<ConnectionManager>()
                     .replicate_component_cache
                     .get(&server_entity)
                     .expect("ReplicateCache missing"),

--- a/lightyear/src/server/replication.rs
+++ b/lightyear/src/server/replication.rs
@@ -916,6 +916,22 @@ pub(crate) mod send {
         }
 
         #[test]
+        fn test_multi_entity_spawn() {
+            let mut stepper = BevyStepper::default();
+
+            // spawn an entity on server
+            stepper
+                .server_app
+                .world
+                .spawn_batch(vec![Replicate::default(); 2]);
+            stepper.frame_step();
+            stepper.frame_step();
+
+            // check that the entities were spawned
+            assert_eq!(stepper.client_app.world.entities().len(), 2);
+        }
+
+        #[test]
         fn test_entity_spawn_visibility() {
             let mut stepper = MultiBevyStepper::default();
 

--- a/lightyear/src/shared/message.rs
+++ b/lightyear/src/shared/message.rs
@@ -3,6 +3,7 @@ use crate::shared::replication::network_target::NetworkTarget;
 use bevy::prelude::Resource;
 use std::error::Error;
 
+/// Shared trait between client and server to send messages to a target
 pub(crate) trait MessageSend: Resource {
     type Error: Error;
     fn send_message_to_target<C: Channel, M: Message>(

--- a/lightyear/src/shared/replication/mod.rs
+++ b/lightyear/src/shared/replication/mod.rs
@@ -67,16 +67,20 @@ impl Default for EntityActions {
 
 // TODO: 99% of the time the ReplicationGroup is the same as the Entity in the hashmap, and there's only 1 entity
 //  have an optimization for that
+/// All the entity actions (Spawn/despawn/inserts/removals) for the entities of a given [`ReplicationGroup`](crate::prelude::ReplicationGroup)
 #[derive(Serialize, Deserialize, Clone, PartialEq, Debug, Encode, Decode)]
-pub struct EntityActionMessage {
+pub struct EntityActionsMessage {
     sequence_id: MessageId,
+    group_id: ReplicationGroupId,
     #[bitcode(with_serde)]
     // we use vec but the order of entities should not matter
     pub(crate) actions: Vec<(Entity, EntityActions)>,
 }
 
+/// All the component updates for the entities of a given [`ReplicationGroup`](crate::prelude::ReplicationGroup)
 #[derive(Serialize, Deserialize, Clone, PartialEq, Debug, Encode, Decode)]
 pub struct EntityUpdatesMessage {
+    pub(crate) group_id: ReplicationGroupId,
     /// The last tick for which we sent an EntityActionsMessage for this group
     /// We set this to None after a certain amount of time without any new Actions, to signify on the receiver side
     /// that there is no ordering constraint with respect to Actions for this group (i.e. the Update can be applied immediately)
@@ -87,20 +91,6 @@ pub struct EntityUpdatesMessage {
     // /// Updates containing diffs with a previous value
     // #[bitcode(with_serde)]
     // diff_updates: Vec<(Entity, Vec<RawData>)>,
-}
-
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug, Encode, Decode)]
-pub enum ReplicationMessageData {
-    /// All the entity actions (Spawn/despawn/inserts/removals) for a given group
-    Actions(EntityActionMessage),
-    /// All the entity updates for a given group
-    Updates(EntityUpdatesMessage),
-}
-
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug, Encode, Decode)]
-pub struct ReplicationMessage {
-    pub(crate) group_id: ReplicationGroupId,
-    pub(crate) data: ReplicationMessageData,
 }
 
 /// Trait for a service that participates in replication.

--- a/lightyear/src/shared/replication/receive.rs
+++ b/lightyear/src/shared/replication/receive.rs
@@ -647,7 +647,7 @@ impl<'a> Iterator for ActionsIterator<'a> {
 }
 
 // TODO: try a sequence buffer?
-/// Stores the EntityUpdatesMessage for a given [`ReplicationGroup`], sorted
+/// Stores the [`EntityUpdatesMessage`] for a given [`ReplicationGroup`](crate::prelude::ReplicationGroup), sorted
 /// in descending remote tick order (the most recent tick first, the oldest tick last)
 #[derive(Debug)]
 pub struct UpdatesBuffer(Vec<(Tick, EntityUpdatesMessage)>);
@@ -689,9 +689,7 @@ impl UpdatesBuffer {
     /// or None if there are None
     fn max_index_to_apply(&self, latest_tick: Option<Tick>) -> Option<usize> {
         // if we haven't applied any latest_tick, we can't apply any updates
-        let Some(latest_tick) = latest_tick else {
-            return None;
-        };
+        let latest_tick = latest_tick?;
 
         let idx = self.0.partition_point(|(_, message)| {
             let Some(last_action_tick) = message.last_action_tick else {
@@ -732,9 +730,7 @@ impl<'a> Iterator for UpdatesIterator<'a> {
 
         // TODO: ideally we do this update only once, when instantiating the iterator?
         // if we cannot apply any updates, return None
-        let Some(max_applicable_idx) = self.max_applicable_idx else {
-            return None;
-        };
+        let max_applicable_idx = self.max_applicable_idx?;
 
         // we have returned all the items that were ready, stop now
         if self.channel.buffered_updates.len() == max_applicable_idx {
@@ -1313,7 +1309,7 @@ mod tests {
         let mut updates = manager.read_updates();
         let update = updates.next().unwrap();
         assert_eq!(update.remote_tick, Tick(5));
-        assert_eq!(update.is_history, false);
+        assert!(!update.is_history);
         assert!(updates.next().is_none());
     }
 

--- a/lightyear/src/shared/replication/receive.rs
+++ b/lightyear/src/shared/replication/receive.rs
@@ -1,6 +1,5 @@
 //! General struct handling replication
 use std::collections::BTreeMap;
-use std::iter::Extend;
 
 use bevy::ecs::entity::EntityHash;
 use bevy::prelude::{DespawnRecursiveExt, Entity, World};
@@ -17,12 +16,10 @@ use crate::serialize::bitcode::reader::BitcodeReader;
 use crate::serialize::reader::ReadBuffer;
 use crate::shared::events::connection::ConnectionEvents;
 use crate::shared::replication::components::{Replicated, ReplicationGroupId};
+use crate::utils::captures::Captures;
 
 use super::entity_map::RemoteEntityMap;
-use super::{
-    EntityActionMessage, EntityUpdatesMessage, ReplicationMessage, ReplicationMessageData,
-    SpawnAction,
-};
+use super::{EntityActionsMessage, EntityUpdatesMessage, SpawnAction};
 
 type EntityHashMap<K, V> = hashbrown::HashMap<K, V, EntityHash>;
 
@@ -53,88 +50,104 @@ impl ReplicationReceiver {
         }
     }
 
-    /// Recv a new replication message and buffer it
+    /// Buffer a received [`EntityActionsMessage`].
+    ///
+    /// The remote_tick is the tick at which the message was buffered and sent by the remote client.
     #[cfg_attr(feature = "trace", instrument(level = Level::INFO, skip_all))]
-    pub(crate) fn recv_message(&mut self, message: ReplicationMessage, remote_tick: Tick) {
-        trace!(?message, ?remote_tick, "Received replication message");
-        let channel = self.group_channels.entry(message.group_id).or_default();
-        match message.data {
-            ReplicationMessageData::Actions(m) => {
-                // if the message is too old, ignore it
-                if m.sequence_id < channel.actions_pending_recv_message_id {
-                    trace!(message_id= ?m.sequence_id, pending_message_id = ?channel.actions_pending_recv_message_id, "message is too old, ignored");
-                    return;
-                }
-                // update the list of entities in the group
-                m.actions
-                    .iter()
-                    .map(|(entity, _)| entity)
-                    .for_each(|entity| {
-                        channel.remote_entities.insert(*entity);
-                    });
+    pub(crate) fn recv_actions(&mut self, actions: EntityActionsMessage, remote_tick: Tick) {
+        trace!(
+            ?actions,
+            ?remote_tick,
+            "Received ReplicationActions message"
+        );
+        let channel = self.group_channels.entry(actions.group_id).or_default();
 
-                // add the message to the buffer
-                // TODO: I guess this handles potential duplicates?
-                channel
-                    .actions_recv_message_buffer
-                    .insert(m.sequence_id, (remote_tick, m));
-            }
-            ReplicationMessageData::Updates(m) => {
-                // NOTE: this is valid instead after tick wrapping because we keep clamping the latest_tick values
-                //  for each channel
-                // if we have already applied a more recent update for this group, no need to keep this one
-                if channel.latest_tick.is_some_and(|t| remote_tick <= t) {
-                    return;
-                }
-
-                // TODO: include somewhere in the update message the m.last_ack_tick since when we compute changes?
-                //  (if we want to do diff compression?
-                // otherwise buffer the update
-                match m.last_action_tick {
-                    None => {
-                        channel
-                            .buffered_updates_without_last_action_tick
-                            .entry(remote_tick)
-                            .or_insert(m);
-                    }
-                    Some(last_action_tick) => {
-                        channel
-                            .buffered_updates_with_last_action_tick
-                            .entry(last_action_tick)
-                            .or_default()
-                            .entry(remote_tick)
-                            .or_insert(m);
-                    }
-                };
-            }
+        // if the message is too old, ignore it
+        if actions.sequence_id < channel.actions_pending_recv_message_id {
+            trace!(message_id= ?actions.sequence_id, pending_message_id = ?channel.actions_pending_recv_message_id, "message is too old, ignored");
+            return;
         }
+        // update the list of entities in the group
+        actions
+            .actions
+            .iter()
+            .map(|(entity, _)| entity)
+            .for_each(|entity| {
+                channel.remote_entities.insert(*entity);
+            });
+
+        // add the message to the buffer
+        // TODO: I guess this handles potential duplicates?
+        channel
+            .actions_recv_message_buffer
+            .insert(actions.sequence_id, (remote_tick, actions));
         trace!(?channel, "group channel after buffering");
     }
 
-    /// Return the list of replication messages that are ready to be applied to the World
-    /// Also include the server_tick when that replication message was emitted
+    /// Buffer a received [`EntityUpdatesMessage`].
     ///
-    /// A message is ready if:
-    /// - actions are read in order
-    /// - updates are read in order, and only if the actions that preceded them have already been read
-    /// - the remote tick is <= the current tick (i.e. we do not read messages from the future)
-    ///
-    ///
-    /// Updates the `latest_tick` for this group
+    /// The remote_tick is the tick at which the message was buffered and sent by the remote client.
     #[cfg_attr(feature = "trace", instrument(level = Level::INFO, skip_all))]
-    pub(crate) fn read_messages(
+    pub(crate) fn recv_updates(&mut self, updates: EntityUpdatesMessage, remote_tick: Tick) {
+        trace!(?updates, ?remote_tick, "Received replication message");
+        let channel = self.group_channels.entry(updates.group_id).or_default();
+
+        // NOTE: this is valid even after tick wrapping because we keep clamping the latest_tick values for each channel
+        // if we have already applied a more recent update for this group, no need to keep this one (or should we keep it for history?)
+        if channel.latest_tick.is_some_and(|t| remote_tick <= t) {
+            return;
+        }
+
+        // TODO: what we want is
+        //  - if the update is for a tick in the past compared to our local state, we can safely ignore immediately
+        //  - make sure that the local state has a `latest_tick` that is bigger than the update's remote tick (i.e.
+        //  we only apply remote ticks if we have reached the last_action_tick for that update)
+        //  - if we have two updates that satisfy those conditions, we don't need to buffer both!
+        //   We can just keep the one with the biggest last_action_tick? since eventually that's the only one we're going to apply.
+        //   Possible exceptions:
+        //   - we want to keep all the intermediary information to put it in a history for interpolation (so that instead of interpolating
+        //     only between the updates we apply that have the highest tick, we interpolate between all updates received. The interpolation
+        //     tick could be much further in the past. Or maybe check the interpolation tick?)
+        //   - we could be delaying some intermediary updates because the update with higher tick also has a higher last_action_tick,
+        //     and we might have some intermediary updates that we could be applying.
+        //     For example `latest_tick` is 5, we receive an update from tick 20 with last_action_tick = 15, and we receive an update
+        //     from tick 10 with last_action tick = 7. Even If we receive the action_tick for tick 7, we wouldn't be able to apply it right away
+        //     because we're waiting for the action_tick for tick 15. So we should keep both updates, and apply them as soon as possible (as soon
+        //     as the smallest last_action_tick is reached)
+        //     However in practice this seems expensive to do, and a rare case. For now, let's just only keep the update with the highest tick?
+        //     TODO: check that this is correct even with delta_compression.
+
+        // TODO: could we use a FreeList here? (SequenceBuffer?) Updates are only buffered until we reach their last_action_tick
+        //  which should be fairly quick, never more than 1-2 sec. (so a buffer of size 64 or 128 seems good). It might need more memory though?
+        //  Benchmark.
+        channel.buffered_updates.insert(updates, remote_tick);
+
+        // TODO: include somewhere in the update message the m.last_ack_tick since when we compute changes?
+        //  (if we want to do diff compression?)
+        trace!(?channel, "group channel after buffering");
+    }
+
+    /// Return all the [`EntityActionsMessage`] from our internal buffer that are ready to be read.
+    /// For each [`ReplicationGroup`], we return the actions in order.
+    ///
+    /// (i.e. if we have sent an action for tick 3 and tick 7, we wait until we receive the one for tick 3 first)
+    #[cfg_attr(feature = "trace", instrument(level = Level::INFO, skip_all))]
+    pub(crate) fn read_actions(
         &mut self,
         current_tick: Tick,
-    ) -> Vec<(ReplicationGroupId, Vec<(Tick, ReplicationMessageData)>)> {
+    ) -> impl Iterator<Item = (Tick, EntityActionsMessage)> + Captures<&()> {
         trace!(?current_tick, ?self.group_channels, "reading replication messages");
         self.group_channels
             .iter_mut()
-            .filter_map(|(group_id, channel)| {
-                channel
-                    .read_messages(current_tick)
-                    .map(|messages| (*group_id, messages))
-            })
-            .collect()
+            .flat_map(move |(group_id, channel)| channel.read_actions(current_tick))
+    }
+
+    #[cfg_attr(feature = "trace", instrument(level = Level::INFO, skip_all))]
+    pub(crate) fn read_updates(&mut self) -> impl Iterator<Item = Update> + Captures<&()> {
+        trace!(?self.group_channels, "reading replication messages");
+        self.group_channels
+            .iter_mut()
+            .flat_map(|(group_id, channel)| channel.read_updates())
     }
 
     /// Gets the tick at which the provided confirmed entity currently is
@@ -197,13 +210,244 @@ impl ReplicationReceiver {
 ///
 /// - all component inserts/removes/updates for an entity to be grouped together in a single message
 impl ReplicationReceiver {
+    pub(crate) fn apply_actions_message(
+        &mut self,
+        world: &mut World,
+        remote: Option<ClientId>,
+        component_registry: &ComponentRegistry,
+        remote_tick: Tick,
+        message: EntityActionsMessage,
+        events: &mut ConnectionEvents,
+    ) {
+        let group_id = message.group_id;
+        debug!(?remote_tick, ?message, "Received replication actions");
+        // NOTE: order matters here, because some components can depend on other entities.
+        // These components could even form a cycle, for example A.HasWeapon(B) and B.HasHolder(A)
+        // Our solution is to first handle spawn for all entities separately.
+        for (remote_entity, actions) in message.actions.iter() {
+            debug!(?remote_entity, "Received entity actions");
+            // spawn
+            match actions.spawn {
+                SpawnAction::Spawn => {
+                    self.remote_entity_to_group.insert(*remote_entity, group_id);
+                    if let Some(local_entity) = self.remote_entity_map.get_local(*remote_entity) {
+                        if world.get_entity(*local_entity).is_some() {
+                            warn!("Received spawn for an entity that already exists");
+                            continue;
+                        }
+                        warn!("Received spawn for an entity that is already in our entity mapping! Not spawning");
+                        continue;
+                    }
+                    // TODO: optimization: spawn the bundle of insert components
+
+                    // TODO: spawning all entities with Confirmed:
+                    //  - is inefficient because we don't need the receive tick in most cases (only for prediction/interpolation)
+                    //  - we can't use Without<Confirmed> queries to display all interpolated/predicted entities, because
+                    //    the entities we receive from other clients all have Confirmed added.
+                    //    Doing Or<(With<Interpolated>, With<Predicted>)> is not ideal; what if we want to see a replicated entity that doesn't have
+                    //    interpolation/prediction? Maybe we should introduce new components ReplicatedFrom<Server> and ReplicatedFrom<Client>.
+                    // // we spawn every replicated entity with the `Confirmed` component
+                    // let local_entity = world.spawn(Confirmed {
+                    //     predicted: None,
+                    //     interpolated: None,
+                    //     tick,
+                    // });
+                    let local_entity = world.spawn(Replicated { from: remote });
+                    self.remote_entity_map
+                        .insert(*remote_entity, local_entity.id());
+                    trace!("Updated remote entity map: {:?}", self.remote_entity_map);
+
+                    debug!(?remote_entity, "Received entity spawn");
+                    events.push_spawn(local_entity.id());
+                }
+                SpawnAction::Reuse(local_entity) => {
+                    let local_entity = Entity::from_bits(local_entity);
+                    let Some(mut entity_mut) = world.get_entity_mut(local_entity) else {
+                        // TODO: ignore the entity in the next steps because it does not exist!
+                        error!("Received ReuseEntity({local_entity:?}) but the entity does not exist in the world");
+                        continue;
+                    };
+                    entity_mut.insert(Replicated { from: remote });
+                    // update the entity mapping
+                    self.remote_entity_map.insert(*remote_entity, local_entity);
+                }
+                _ => {}
+            }
+        }
+
+        for (entity, actions) in message.actions.into_iter() {
+            debug!(remote_entity = ?entity, "Received entity actions");
+
+            // despawn
+            if actions.spawn == SpawnAction::Despawn {
+                debug!(remote_entity = ?entity, "Received entity despawn");
+                if let Some(local_entity) = self.remote_entity_map.remove_by_remote(entity) {
+                    if let Some(group) = self.group_channels.get_mut(&group_id) {
+                        group.remote_entities.remove(&entity);
+                    }
+                    // TODO: we despawn all children as well right now, but that might not be what we want?
+                    if let Some(entity_mut) = world.get_entity_mut(local_entity) {
+                        entity_mut.despawn_recursive();
+                    }
+                    events.push_despawn(local_entity);
+                    self.remote_entity_to_group.remove(&entity);
+                } else {
+                    error!("Received despawn for an entity that does not exist")
+                }
+                continue;
+            }
+
+            // safety: we know by this point that the entity exists
+            let Some(mut local_entity_mut) = self.remote_entity_map.get_by_remote(world, entity)
+            else {
+                error!("cannot find entity");
+                continue;
+            };
+
+            // NOTE: 2 options
+            //  - send the raw data to a separate typed system
+            //  -  or just insert it here via function pointers
+
+            // inserts
+            // TODO: remove updates that are duplicate for the same component
+            debug!(remote_entity = ?entity, "Received InsertComponent");
+            for component in actions.insert {
+                self.reader.reset_read(component.as_slice());
+                let _ = component_registry
+                    .raw_write(
+                        &mut self.reader,
+                        &mut local_entity_mut,
+                        remote_tick,
+                        &mut self.remote_entity_map.remote_to_local,
+                        events,
+                    )
+                    .inspect_err(|e| {
+                        error!("could not write the component to the entity: {:?}", e)
+                    });
+
+                // TODO: special-case for pre-spawned entities: we receive them from a client, but then we
+                //  we should immediately take ownership of it, so we won't receive a despawn for it
+                //  thus, we should remove it from the entity map right after receiving it!
+                //  Actually, we should figure out a way to cleanup every received entity where the sender
+                //  stopped replicating or didn't replicate the Despawn, as this could just cause memory to accumulate
+
+                // TODO: maybe if is-server, attach the client-id to the ShouldBePredicted entity
+                //  to know for which client we should do the pre-prediction
+            }
+
+            // removals
+            trace!(remote_entity = ?entity, ?actions.remove, "Received RemoveComponent");
+            for kind in actions.remove {
+                events.push_remove_component(local_entity_mut.id(), kind, Tick(0));
+                component_registry.raw_remove(kind, &mut local_entity_mut);
+            }
+
+            // updates
+            debug!(remote_entity = ?entity, "Received UpdateComponent");
+            for component in actions.updates {
+                // TODO: re-use buffers via pool?
+                self.reader.reset_read(component.as_slice());
+                let _ = component_registry
+                    .raw_write(
+                        &mut self.reader,
+                        &mut local_entity_mut,
+                        remote_tick,
+                        &mut self.remote_entity_map.remote_to_local,
+                        events,
+                    )
+                    .inspect_err(|e| {
+                        error!("could not write the component to the entity: {:?}", e)
+                    });
+            }
+        }
+        self.update_confirmed_tick(world, group_id, remote_tick);
+    }
+
+    pub(crate) fn apply_updates_message(
+        &mut self,
+        world: &mut World,
+        remote: Option<ClientId>,
+        component_registry: &ComponentRegistry,
+        remote_tick: Tick,
+        is_history: bool,
+        message: EntityUpdatesMessage,
+        events: &mut ConnectionEvents,
+    ) {
+        let group_id = message.group_id;
+        debug!(?remote_tick, ?message, "Received replication updates");
+        // TODO: store this in ConfirmedHistory?
+        if is_history {
+            return;
+        }
+        for (entity, components) in message.updates.into_iter() {
+            debug!(?components, remote_entity = ?entity, "Received UpdateComponent");
+            // update the entity only if it exists
+            if let Some(mut local_entity_mut) = self.remote_entity_map.get_by_remote(world, entity)
+            {
+                for component in components {
+                    self.reader.reset_read(component.as_slice());
+                    let _ = component_registry
+                        .raw_write(
+                            &mut self.reader,
+                            &mut local_entity_mut,
+                            remote_tick,
+                            &mut self.remote_entity_map.remote_to_local,
+                            events,
+                        )
+                        .inspect_err(|e| {
+                            error!("could not write the component to the entity: {:?}", e)
+                        });
+                }
+            } else {
+                // we can get a few buffered updates after the entity has been despawned
+                // those are the updates that we received before the despawn action message, but with a tick
+                // later than the despawn action message
+                debug!("update for entity that doesn't exist?");
+            }
+        }
+        self.update_confirmed_tick(world, group_id, remote_tick);
+    }
+
+    /// Update the Confirmed tick for all entities in the replication group
+    /// so that Predicted/Interpolated entities can be notified
+    ///
+    /// We update it for all entities in the group (even if we received only an update that contains
+    /// updates for E1, it also means that E2 is updated to the same tick, since they are part of the
+    /// same group)
+    pub(crate) fn update_confirmed_tick(
+        &mut self,
+        world: &mut World,
+        group_id: ReplicationGroupId,
+        remote_tick: Tick,
+    ) {
+        // TODO: maybe get the confirmed tick from the apply_world message directly?
+        // // let confirmed_tick = self.group_channels.get(&group_id).unwrap().latest_tick;
+        // if let Some(group_channel) = self.group_channels
+        //     .get(&group_id) {
+        //     grou.remote_entities
+        //
+        // }
+
+        if let Some(g) = self.group_channels.get(&group_id) {
+            g.remote_entities.iter().for_each(|remote_entity| {
+                if let Some(mut local_entity_mut) =
+                    self.remote_entity_map.get_by_remote(world, *remote_entity)
+                {
+                    trace!(?remote_tick, "updating confirmed tick for entity");
+                    if let Some(mut confirmed) = local_entity_mut.get_mut::<Confirmed>() {
+                        confirmed.tick = remote_tick;
+                    }
+                }
+            });
+        }
+    }
+
     // TODO: how can I emit metrics here that contain the channel kind?
     //  use a OnceCell that gets set with the channel name mapping when the protocol is finalized?
     //  the other option is to have wrappers in Connection, but that's pretty ugly
 
-    /// Apply any replication messages to the world, and emit an event
-    /// I think we don't need to emit a tick with the event anymore, because
-    /// we can access the tick via the replication manager
+    /// Read from the buffer the EntityActionsMessage and EntityUpdatesMessage that are ready,
+    /// and apply them to the World
     #[cfg_attr(feature = "trace", instrument(level = Level::INFO, skip_all))]
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn apply_world(
@@ -212,218 +456,33 @@ impl ReplicationReceiver {
         world: &mut World,
         remote: Option<ClientId>,
         component_registry: &ComponentRegistry,
-        tick: Tick,
-        replication: ReplicationMessageData,
-        group_id: ReplicationGroupId,
+        current_tick: Tick,
         events: &mut ConnectionEvents,
     ) {
-        match replication {
-            ReplicationMessageData::Actions(m) => {
-                debug!(?tick, ?m, "Received replication actions");
-                // NOTE: order matters here, because some components can depend on other entities.
-                // These components could even form a cycle, for example A.HasWeapon(B) and B.HasHolder(A)
-                // Our solution is to first handle spawn for all entities separately.
-                for (remote_entity, actions) in m.actions.iter() {
-                    debug!(?remote_entity, "Received entity actions");
-                    // spawn
-                    match actions.spawn {
-                        SpawnAction::Spawn => {
-                            self.remote_entity_to_group.insert(*remote_entity, group_id);
-                            if let Some(local_entity) =
-                                self.remote_entity_map.get_local(*remote_entity)
-                            {
-                                if world.get_entity(*local_entity).is_some() {
-                                    warn!("Received spawn for an entity that already exists");
-                                    continue;
-                                }
-                                warn!("Received spawn for an entity that is already in our entity mapping! Not spawning");
-                                continue;
-                            }
-                            // TODO: optimization: spawn the bundle of insert components
-
-                            // TODO: spawning all entities with Confirmed:
-                            //  - is inefficient because we don't need the receive tick in most cases (only for prediction/interpolation)
-                            //  - we can't use Without<Confirmed> queries to display all interpolated/predicted entities, because
-                            //    the entities we receive from other clients all have Confirmed added.
-                            //    Doing Or<(With<Interpolated>, With<Predicted>)> is not ideal; what if we want to see a replicated entity that doesn't have
-                            //    interpolation/prediction? Maybe we should introduce new components ReplicatedFrom<Server> and ReplicatedFrom<Client>.
-                            // // we spawn every replicated entity with the `Confirmed` component
-                            // let local_entity = world.spawn(Confirmed {
-                            //     predicted: None,
-                            //     interpolated: None,
-                            //     tick,
-                            // });
-                            let local_entity = world.spawn(Replicated { from: remote });
-                            self.remote_entity_map
-                                .insert(*remote_entity, local_entity.id());
-                            trace!("Updated remote entity map: {:?}", self.remote_entity_map);
-
-                            debug!(?remote_entity, "Received entity spawn");
-                            events.push_spawn(local_entity.id());
-                        }
-                        SpawnAction::Reuse(local_entity) => {
-                            let local_entity = Entity::from_bits(local_entity);
-                            let Some(mut entity_mut) = world.get_entity_mut(local_entity) else {
-                                // TODO: ignore the entity in the next steps because it does not exist!
-                                error!("Received ReuseEntity({local_entity:?}) but the entity does not exist in the world");
-                                continue;
-                            };
-                            entity_mut.insert(Replicated { from: remote });
-                            // update the entity mapping
-                            self.remote_entity_map.insert(*remote_entity, local_entity);
-                        }
-                        _ => {}
-                    }
-                }
-
-                for (entity, actions) in m.actions.into_iter() {
-                    debug!(remote_entity = ?entity, "Received entity actions");
-
-                    // despawn
-                    if actions.spawn == SpawnAction::Despawn {
-                        debug!(remote_entity = ?entity, "Received entity despawn");
-                        if let Some(local_entity) = self.remote_entity_map.remove_by_remote(entity)
-                        {
-                            if let Some(group) = self.group_channels.get_mut(&group_id) {
-                                group.remote_entities.remove(&entity);
-                            }
-                            // TODO: we despawn all children as well right now, but that might not be what we want?
-                            if let Some(entity_mut) = world.get_entity_mut(local_entity) {
-                                entity_mut.despawn_recursive();
-                            }
-                            events.push_despawn(local_entity);
-                            self.remote_entity_to_group.remove(&entity);
-                        } else {
-                            error!("Received despawn for an entity that does not exist")
-                        }
-                        continue;
-                    }
-
-                    // safety: we know by this point that the entity exists
-                    let Some(mut local_entity_mut) =
-                        self.remote_entity_map.get_by_remote(world, entity)
-                    else {
-                        error!("cannot find entity");
-                        continue;
-                    };
-
-                    // NOTE: 2 options
-                    //  - send the raw data to a separate typed system
-                    //  -  or just insert it here via function pointers
-                    // inserts
-
-                    // TODO: remove updates that are duplicate for the same component
-                    // let kinds = actions
-                    //     .insert
-                    //     .iter()
-                    //     .map(|c| c.into())
-                    //     .collect::<HashSet<P::ComponentKinds>>();
-                    debug!(remote_entity = ?entity, "Received InsertComponent");
-                    for component in actions.insert {
-                        self.reader.reset_read(component.as_slice());
-                        let _ = component_registry
-                            .raw_write(
-                                &mut self.reader,
-                                &mut local_entity_mut,
-                                tick,
-                                &mut self.remote_entity_map.remote_to_local,
-                                events,
-                            )
-                            .inspect_err(|e| {
-                                error!("could not write the component to the entity: {:?}", e)
-                            });
-
-                        // TODO: special-case for pre-spawned entities: we receive them from a client, but then we
-                        //  we should immediately take ownership of it, so we won't receive a despawn for it
-                        //  thus, we should remove it from the entity map right after receiving it!
-                        //  Actually, we should figure out a way to cleanup every received entity where the sender
-                        //  stopped replicating or didn't replicate the Despawn, as this could just cause memory to accumulate
-
-                        // TODO: maybe if is-server, attach the client-id to the ShouldBePredicted entity
-                        //  to know for which client we should do the pre-prediction
-                    }
-
-                    // removals
-                    trace!(remote_entity = ?entity, ?actions.remove, "Received RemoveComponent");
-                    for kind in actions.remove {
-                        events.push_remove_component(local_entity_mut.id(), kind, Tick(0));
-                        component_registry.raw_remove(kind, &mut local_entity_mut);
-                    }
-
-                    // updates
-                    // let kinds = actions
-                    //     .updates
-                    //     .iter()
-                    //     .map(|c| c.into())
-                    //     .collect::<Vec<P::ComponentKinds>>();
-                    debug!(remote_entity = ?entity, "Received UpdateComponent");
-                    for component in actions.updates {
-                        // TODO: re-use buffers via pool?
-                        self.reader.reset_read(component.as_slice());
-                        let _ = component_registry
-                            .raw_write(
-                                &mut self.reader,
-                                &mut local_entity_mut,
-                                tick,
-                                &mut self.remote_entity_map.remote_to_local,
-                                events,
-                            )
-                            .inspect_err(|e| {
-                                error!("could not write the component to the entity: {:?}", e)
-                            });
-                    }
-                }
-            }
-            ReplicationMessageData::Updates(m) => {
-                debug!(?tick, ?m, "Received replication updates");
-                for (entity, components) in m.updates.into_iter() {
-                    debug!(?components, remote_entity = ?entity, "Received UpdateComponent");
-                    // update the entity only if it exists
-                    if let Some(mut local_entity_mut) =
-                        self.remote_entity_map.get_by_remote(world, entity)
-                    {
-                        for component in components {
-                            self.reader.reset_read(component.as_slice());
-                            let _ = component_registry
-                                .raw_write(
-                                    &mut self.reader,
-                                    &mut local_entity_mut,
-                                    tick,
-                                    &mut self.remote_entity_map.remote_to_local,
-                                    events,
-                                )
-                                .inspect_err(|e| {
-                                    error!("could not write the component to the entity: {:?}", e)
-                                });
-                        }
-                    } else {
-                        // we can get a few buffered updates after the entity has been despawned
-                        // those are the updates that we received before the despawn action message, but with a tick
-                        // later than the despawn action message
-                        debug!("update for entity that doesn't exist?");
-                    }
-                }
-            }
-        }
-
-        // update the Confirmed tick for all entities in the replication group
-        // // TODO: maybe get the confirmed tick from the apply_world message directly?
-        // let confirmed_tick = self.group_channels.get(&group_id).unwrap().latest_tick;
-        self.group_channels
-            .get(&group_id)
-            .map(|g| g.remote_entities.clone())
-            .iter()
-            .flatten()
-            .for_each(|remote_entity| {
-                if let Some(mut local_entity_mut) =
-                    self.remote_entity_map.get_by_remote(world, *remote_entity)
-                {
-                    trace!(?tick, "updating confirmed tick for entity");
-                    if let Some(mut confirmed) = local_entity_mut.get_mut::<Confirmed>() {
-                        confirmed.tick = tick;
-                    }
-                }
+        // apply actions first
+        self.read_actions(current_tick)
+            .for_each(|(remote_tick, actions)| {
+                self.apply_actions_message(
+                    world,
+                    remote,
+                    component_registry,
+                    remote_tick,
+                    actions,
+                    events,
+                )
             });
+        // then updates
+        self.read_updates().for_each(|update| {
+            self.apply_updates_message(
+                world,
+                remote,
+                component_registry,
+                update.remote_tick,
+                update.is_history,
+                update.message,
+                events,
+            )
+        });
     }
 }
 
@@ -435,15 +494,9 @@ pub struct GroupChannel {
     remote_entities: HashSet<Entity>,
     // actions
     pub actions_pending_recv_message_id: MessageId,
-    pub actions_recv_message_buffer: BTreeMap<MessageId, (Tick, EntityActionMessage)>,
+    pub actions_recv_message_buffer: BTreeMap<MessageId, (Tick, EntityActionsMessage)>,
     // updates
-    // map from necessary_last_action_tick to the buffered message
-    // the first tick is the last_action_tick (we can only apply the update if the last action tick has been reached)
-    // the second tick is the update's server tick when it was sent
-    pub buffered_updates_with_last_action_tick:
-        BTreeMap<Tick, BTreeMap<Tick, EntityUpdatesMessage>>,
-    // updates for which there is no condition on the last_action_tick: we can apply them immediately
-    pub buffered_updates_without_last_action_tick: BTreeMap<Tick, EntityUpdatesMessage>,
+    pub buffered_updates: UpdatesBuffer,
     /// remote tick of the latest update/action that we applied to the local group
     pub latest_tick: Option<Tick>,
 }
@@ -454,100 +507,187 @@ impl Default for GroupChannel {
             remote_entities: HashSet::default(),
             actions_pending_recv_message_id: MessageId(0),
             actions_recv_message_buffer: BTreeMap::new(),
-            buffered_updates_with_last_action_tick: Default::default(),
-            buffered_updates_without_last_action_tick: Default::default(),
+            buffered_updates: UpdatesBuffer::default(),
             latest_tick: None,
         }
     }
 }
 
-impl GroupChannel {
-    /// Reads a message from the internal buffer to get its content
-    /// Since we are receiving messages in order, we don't return from the buffer
-    /// until we have received the message we are waiting for (the next expected MessageId)
-    /// This assumes that the sender sends all message ids sequentially.
-    ///
-    /// If had received updates that were waiting on a given action, we also return them
-    #[cfg_attr(feature = "trace", instrument(level = Level::INFO, skip_all))]
-    fn read_action(&mut self, current_tick: Tick) -> Option<(Tick, EntityActionMessage)> {
+/// Iterator that returns all the available EntityActions for the current [`GroupChannel`]
+///
+/// Reads a message from the internal buffer to get its content
+/// Since we are receiving messages in order, we don't return from the buffer
+/// until we have received the message we are waiting for (the next expected MessageId)
+/// This assumes that the sender sends all message ids sequentially.
+///
+/// If had received updates that were waiting on a given action, we also return them
+pub struct ActionsIterator<'a> {
+    channel: &'a mut GroupChannel,
+    current_tick: Tick,
+}
+
+impl<'a> Iterator for ActionsIterator<'a> {
+    /// The message along with the tick at which the remote message was sent
+    type Item = (Tick, EntityActionsMessage);
+
+    fn next(&mut self) -> Option<Self::Item> {
         // TODO: maybe only get the message if our local client tick is >= to it? (so that we don't apply an update from the future)
         let message = self
+            .channel
             .actions_recv_message_buffer
-            .get(&self.actions_pending_recv_message_id)?;
+            .get(&self.channel.actions_pending_recv_message_id)?;
         // if the message is from the future, keep it there
-        if message.0 > current_tick {
-            debug!("message tick {:?} is from the future compared to our current tick {current_tick:?}", message.0);
+        if message.0 > self.current_tick {
+            debug!(
+                "message tick {:?} is from the future compared to our current tick {:?}",
+                message.0, self.current_tick
+            );
             return None;
         }
 
         // We have received the message we are waiting for
         let message = self
+            .channel
             .actions_recv_message_buffer
-            .remove(&self.actions_pending_recv_message_id)
+            .remove(&self.channel.actions_pending_recv_message_id)
             .unwrap();
 
-        self.actions_pending_recv_message_id += 1;
+        self.channel.actions_pending_recv_message_id += 1;
         // Update the latest server tick that we have processed
-        self.latest_tick = Some(message.0);
+        self.channel.latest_tick = Some(message.0);
         Some(message)
     }
+}
 
-    #[cfg_attr(feature = "trace", instrument(level = Level::INFO, skip_all))]
-    fn read_buffered_updates(&mut self) -> Vec<(Tick, EntityUpdatesMessage)> {
-        // if we haven't applied any actions (latest_tick is None) we cannot apply any updates
-        let Some(latest_tick) = self.latest_tick else {
-            return vec![];
-        };
-        // go through all the buffered updates whose last_action_tick has been reached
-        // (the update's last_action_tick <= latest_tick)
-        let not_ready = self
-            .buffered_updates_with_last_action_tick
-            .split_off(&(latest_tick + 1));
+// TODO: try a sequence buffer?
+/// Stores the EntityUpdatesMessage for a given [`ReplicationGroup`], sorted
+/// in descending remote tick order (the most recent tick first, the oldest tick last)
+#[derive(Debug)]
+pub struct UpdatesBuffer(Vec<(Tick, EntityUpdatesMessage)>);
 
-        let mut res = vec![];
-
-        let buffered_updates_to_consider =
-            std::mem::take(&mut self.buffered_updates_with_last_action_tick);
-        for (_, mut updates) in buffered_updates_to_consider.into_iter() {
-            // remove all updates whose tick is <= latest_tick
-            for (tick, update) in updates.split_off(&self.latest_tick.unwrap()) {
-                self.latest_tick = Some(tick);
-                res.push((tick, update));
-            }
-        }
-        // keep updates for which we are waiting for the action_tick
-        self.buffered_updates_with_last_action_tick = not_ready;
-
-        // apply all the updates for the buffered updates that have no last_action_tick
-        // remove all updates whose tick is <= latest_tick
-        let mut buffered_updates_to_consider =
-            std::mem::take(&mut self.buffered_updates_without_last_action_tick);
-        for (tick, update) in buffered_updates_to_consider.split_off(&self.latest_tick.unwrap()) {
-            self.latest_tick = Some(tick);
-            res.push((tick, update));
-        }
-        res
+/// Update that is given to `apply_world`
+struct Update {
+    remote_tick: Tick,
+    message: EntityUpdatesMessage,
+    /// If true, we don't want to apply the update to the world, because we are going
+    /// to apply a more recent one
+    is_history: bool,
+}
+impl Default for UpdatesBuffer {
+    fn default() -> Self {
+        Self(Vec::with_capacity(1))
+    }
+}
+impl UpdatesBuffer {
+    fn clear(&mut self) {
+        self.0.clear();
     }
 
-    #[cfg_attr(feature = "trace", instrument(level = Level::INFO, skip_all))]
-    fn read_messages(&mut self, current_tick: Tick) -> Option<Vec<(Tick, ReplicationMessageData)>> {
-        let mut res = Vec::new();
+    /// Insert a new message in the right position to make sure that the buffer
+    /// is still sorted in descending order
+    fn insert(&mut self, message: EntityUpdatesMessage, remote_tick: Tick) {
+        let index = self.0.partition_point(|(tick, _)| remote_tick < *tick);
+        self.0.insert(index, (remote_tick, message));
+    }
 
-        // check for any actions that are ready to be applied
-        while let Some((tick, actions)) = self.read_action(current_tick) {
-            res.push((tick, ReplicationMessageData::Actions(actions)));
+    /// Number of messages in the buffer
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Get the index of the most recent element in the buffer which has a last_action_tick <= latest_tick,
+    /// i.e. which can be applied that has the highest tick that is less than or equal to the latest_tick
+    ///
+    /// or None if there are None
+    fn max_index_to_apply(&self, latest_tick: Option<Tick>) -> Option<usize> {
+        // if we haven't applied any latest_tick, we can't apply any updates
+        let Some(latest_tick) = latest_tick else {
+            return None;
+        };
+
+        let idx = self.0.partition_point(|(_, message)| {
+            let Some(last_action_tick) = message.last_action_tick else {
+                return true;
+            };
+            last_action_tick > latest_tick
+        });
+        if idx == self.len() {
+            None
+        } else {
+            Some(idx)
+        }
+    }
+    /// Pop the oldest tick from the buffer
+    fn pop_oldest(&mut self) -> Option<(Tick, EntityUpdatesMessage)> {
+        self.0.pop()
+    }
+}
+
+/// Iterator that returns all the available [`EntityUpdatesMessage`] for the current [`GroupChannel`]
+///
+/// We read from the [`UpdatesBuffer`] in ascending remote tick order:
+/// - if we have not reached the last_action_tick for a given update, we stop there
+/// - else, we return all the updates whose last_action_tick is reached, and
+pub struct UpdatesIterator<'a> {
+    channel: &'a mut GroupChannel,
+    /// We iterate until we reach this idx in the buffer
+    max_applicable_idx: Option<usize>,
+}
+
+impl<'a> Iterator for UpdatesIterator<'a> {
+    /// The message along with the tick at which the remote message was sent
+    type Item = Update;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // TODO: NEED TO REIMPLENT THIS TODO!
+        // TODO: maybe only get the message if our local client tick is >= to it? (so that we don't apply an update from the future)
+
+        // TODO: ideally we do this update only once, when instantiating the iterator?
+        // if we cannot apply any updates, return None
+        let Some(max_applicable_idx) = self.max_applicable_idx else {
+            return None;
+        };
+
+        // we have returned all the items that were ready, stop now
+        if self.channel.buffered_updates.len() == max_applicable_idx {
+            return None;
         }
 
-        // TODO: (IMPORTANT): should we try to get the updates in order of tick?
+        // pop the oldest until we reach the max applicable index
+        let (remote_tick, message) = self.channel.buffered_updates.pop_oldest().unwrap();
+        Some(Update {
+            remote_tick,
+            message,
+            is_history: self.channel.buffered_updates.len() - 1 == max_applicable_idx,
+        })
+    }
+}
 
-        // check for any buffered updates that are ready to be applied now that we have applied more actions/updates
-        res.extend(
-            self.read_buffered_updates()
-                .into_iter()
-                .map(|(tick, updates)| (tick, ReplicationMessageData::Updates(updates))),
-        );
+impl GroupChannel {
+    /// Builds an iterator that returns all the available EntityActions for the current [`GroupChannel`]
+    fn read_actions(&mut self, current_tick: Tick) -> ActionsIterator {
+        ActionsIterator {
+            channel: self,
+            current_tick,
+        }
+    }
 
-        (!res.is_empty()).then_some(res)
+    /// Builds an iterator that returns all the available EntityUpdates for the current [`GroupChannel`]
+    /// Needs to run after read_actions for correctness (because we need to update the `latest_tick` of
+    /// the group before we can apply the updates)
+    fn read_updates(&mut self) -> UpdatesIterator {
+        // the buffered_channel is sorted in descending order,
+        // [most_recent_tick, ...,  max_readable_tick (based on last_action_tick), ..., oldest_tick]
+        // What we want is to return (not necessarily in order) [max_readable_tick, ..., oldest_tick]
+        // along with a flag that lets us know if we are the max_readable_tick or not.
+        // (max_readable_tick is the only one we want to actually apply to the world, because the other
+        //  older updates are redundant. The older ticks are included so that we can have a comprehensive
+        //  confirmed history, for example to have a better interpolation)
+        let max_applicable_idx = self.buffered_updates.max_index_to_apply(self.latest_tick);
+        UpdatesIterator {
+            channel: self,
+            max_applicable_idx,
+        }
     }
 }
 
@@ -563,13 +703,11 @@ mod tests {
 
         let group_id = ReplicationGroupId(0);
         // recv an actions message that is too old: should be ignored
-        manager.recv_message(
-            ReplicationMessage {
+        manager.recv_actions(
+            EntityActionsMessage {
                 group_id,
-                data: ReplicationMessageData::Actions(EntityActionMessage {
-                    sequence_id: MessageId(0) - 1,
-                    actions: Default::default(),
-                }),
+                sequence_id: MessageId(0) - 1,
+                actions: Default::default(),
             },
             Tick(0),
         );
@@ -589,13 +727,11 @@ mod tests {
             .is_empty());
 
         // recv an actions message: in order, should be buffered
-        manager.recv_message(
-            ReplicationMessage {
+        manager.recv_actions(
+            EntityActionsMessage {
                 group_id: ReplicationGroupId(0),
-                data: ReplicationMessageData::Actions(EntityActionMessage {
-                    sequence_id: MessageId(0),
-                    actions: Default::default(),
-                }),
+                sequence_id: MessageId(0),
+                actions: Default::default(),
             },
             Tick(0),
         );
@@ -607,85 +743,117 @@ mod tests {
             .contains_key(&MessageId(0)));
 
         // add an updates message
-        manager.recv_message(
-            ReplicationMessage {
+        manager.recv_updates(
+            EntityUpdatesMessage {
                 group_id: ReplicationGroupId(0),
-                data: ReplicationMessageData::Updates(EntityUpdatesMessage {
-                    last_action_tick: Some(Tick(0)),
-                    updates: Default::default(),
-                }),
+                last_action_tick: Some(Tick(0)),
+                updates: Default::default(),
             },
             Tick(1),
         );
-        assert!(manager
-            .group_channels
-            .get(&group_id)
-            .unwrap()
-            .buffered_updates_with_last_action_tick
-            .get(&Tick(0))
-            .unwrap()
-            .get(&Tick(1))
-            .is_some());
+        assert_eq!(
+            manager
+                .group_channels
+                .get(&group_id)
+                .unwrap()
+                .buffered_updates
+                .0,
+            vec![(
+                Tick(1),
+                EntityUpdatesMessage {
+                    group_id: ReplicationGroupId(0),
+                    last_action_tick: Some(Tick(0)),
+                    updates: Default::default(),
+                }
+            )]
+        );
 
         // add updates before actions (last_action_tick is 2)
-        manager.recv_message(
-            ReplicationMessage {
+        manager.recv_updates(
+            EntityUpdatesMessage {
                 group_id: ReplicationGroupId(0),
-                data: ReplicationMessageData::Updates(EntityUpdatesMessage {
-                    last_action_tick: Some(Tick(2)),
-                    updates: Default::default(),
-                }),
+                last_action_tick: Some(Tick(2)),
+                updates: Default::default(),
             },
             Tick(4),
         );
-        assert!(manager
-            .group_channels
-            .get(&group_id)
-            .unwrap()
-            .buffered_updates_with_last_action_tick
-            .get(&Tick(2))
-            .unwrap()
-            .get(&Tick(4))
-            .is_some());
+        assert_eq!(
+            manager
+                .group_channels
+                .get(&group_id)
+                .unwrap()
+                .buffered_updates
+                .0,
+            vec![
+                (
+                    Tick(4),
+                    EntityUpdatesMessage {
+                        group_id: ReplicationGroupId(0),
+                        last_action_tick: Some(Tick(2)),
+                        updates: Default::default(),
+                    }
+                ),
+                (
+                    Tick(1),
+                    EntityUpdatesMessage {
+                        group_id: ReplicationGroupId(0),
+                        last_action_tick: Some(Tick(0)),
+                        updates: Default::default(),
+                    }
+                )
+            ]
+        );
 
         // read messages: only read the first action and update
-        let read_messages = manager.read_messages(Tick(10));
-        let replication_data = &read_messages.first().unwrap().1;
-        assert_eq!(replication_data.get(0).unwrap().0, Tick(0));
-        assert_eq!(replication_data.get(1).unwrap().0, Tick(1));
+        {
+            let mut actions = manager.read_actions(Tick(10));
+            let (tick, _) = actions.next().unwrap();
+            assert_eq!(tick, Tick(0));
+            assert!(actions.next().is_none());
+        }
+        {
+            let mut updates = manager.read_updates();
+            let update = updates.next().unwrap();
+            assert_eq!(update.remote_tick, Tick(1));
+            assert!(updates.next().is_none());
+        }
 
         // recv actions-3: should be buffered, we are still waiting for actions-2
-        manager.recv_message(
-            ReplicationMessage {
+        manager.recv_actions(
+            EntityActionsMessage {
                 group_id: ReplicationGroupId(0),
-                data: ReplicationMessageData::Actions(EntityActionMessage {
-                    sequence_id: MessageId(2),
-                    actions: Default::default(),
-                }),
+                sequence_id: MessageId(2),
+                actions: Default::default(),
             },
             Tick(3),
         );
-        assert!(manager.read_messages(Tick(10)).is_empty());
-
+        assert!(manager.read_updates().next().is_none());
         // recv actions-2: we should now be able to read actions-2, actions-3, updates-4
-        manager.recv_message(
-            ReplicationMessage {
+        manager.recv_actions(
+            EntityActionsMessage {
                 group_id: ReplicationGroupId(0),
-                data: ReplicationMessageData::Actions(EntityActionMessage {
-                    sequence_id: MessageId(1),
-                    actions: Default::default(),
-                }),
+                sequence_id: MessageId(1),
+                actions: Default::default(),
             },
             Tick(2),
         );
-        let read_messages = manager.read_messages(Tick(10));
-        let replication_data = &read_messages.first().unwrap().1;
-        assert_eq!(replication_data.len(), 3);
-        assert_eq!(replication_data.get(0).unwrap().0, Tick(2));
-        assert_eq!(replication_data.get(1).unwrap().0, Tick(3));
-        assert_eq!(replication_data.get(2).unwrap().0, Tick(4));
+        {
+            let mut actions = manager.read_actions(Tick(10));
+            let (tick, _) = actions.next().unwrap();
+            assert_eq!(tick, Tick(2));
+            assert!(actions.next().is_none());
+        }
+        let mut updates = manager.read_updates();
+        let update = updates.next().unwrap();
+        assert_eq!(update.remote_tick, Tick(3));
+        assert_eq!(update.is_history, true);
+        let update = updates.next().unwrap();
+        assert_eq!(update.remote_tick, Tick(4));
+        assert_eq!(update.is_history, false);
+        assert!(updates.next().is_none());
     }
 
+    /// Test applying to the world an EntityActionsMessage that uses SpawnReuse
     #[test]
     fn test_recv_spawn_reuse() {
         let mut manager = ReplicationReceiver::new();
@@ -694,8 +862,8 @@ mod tests {
         let local_entity = world.spawn_empty().id();
         let component_registry = ComponentRegistry::default();
         let mut events = ConnectionEvents::default();
-        let group_id = ReplicationGroupId(0);
-        let replication = ReplicationMessageData::Actions(EntityActionMessage {
+        let replication = EntityActionsMessage {
+            group_id: ReplicationGroupId(0),
             sequence_id: MessageId(0),
             actions: vec![(
                 remote_entity,
@@ -706,14 +874,13 @@ mod tests {
                     updates: vec![],
                 },
             )],
-        });
-        manager.apply_world(
+        };
+        manager.apply_actions_message(
             &mut world,
             None,
             &component_registry,
             Tick(0),
             replication,
-            group_id,
             &mut events,
         );
 

--- a/lightyear/src/shared/replication/resources.rs
+++ b/lightyear/src/shared/replication/resources.rs
@@ -54,11 +54,6 @@ mod command {
 
 /// Metadata indicating how a resource should be replicated.
 /// The resource is only replicated if this resource exists
-///
-/// Currently, resources are cloned to be replicated, so only use this for resources that are
-/// cheap-to-clone. (the clone only happens when the resource is modified)
-///
-/// Only one entity per World should have this component.
 #[derive(Resource, Debug, Clone, PartialEq)]
 pub struct ReplicateResourceMetadata<R> {
     pub target: NetworkTarget,

--- a/lightyear/src/shared/replication/send.rs
+++ b/lightyear/src/shared/replication/send.rs
@@ -500,7 +500,7 @@ impl ReplicationSender {
                         sequence_id: message_id,
                         group_id,
                         // TODO: send the HashMap directly to avoid extra allocations by cloning into a vec.
-                        actions: Vec::from_iter(actions.into_iter()),
+                        actions: Vec::from_iter(actions),
                     },
                     priority,
                 );
@@ -553,7 +553,7 @@ impl ReplicationSender {
                         sequence_id: message_id,
                         group_id,
                         // TODO: send the HashMap directly to avoid extra allocations by cloning into a vec.
-                        actions: Vec::from_iter(actions.into_iter()),
+                        actions: Vec::from_iter(actions),
                     },
                     priority,
                 );
@@ -604,7 +604,7 @@ impl ReplicationSender {
                     // SAFETY: the last action tick is always set because we send Actions before Updates
                     last_action_tick: channel.last_action_tick,
                     // TODO: maybe we can just send the HashMap directly?
-                    updates: Vec::from_iter(updates.into_iter()),
+                    updates: Vec::from_iter(updates),
                 },
                 priority,
             )
@@ -612,7 +612,7 @@ impl ReplicationSender {
         // TODO: also return for each message a list of the components that have delta-compression data?
     }
 
-    /// Buffer the [`EntityUpdateMessage`] to send in the [`MessageManager`]j w
+    /// Buffer the [`EntityUpdatesMessage`] to send in the [`MessageManager`]
     #[cfg_attr(feature = "trace", instrument(level = Level::INFO, skip_all))]
     pub(crate) fn send_updates_messages(
         &mut self,
@@ -636,7 +636,7 @@ impl ReplicationSender {
                     // SAFETY: the last action tick is always set because we send Actions before Updates
                     last_action_tick: channel.last_action_tick,
                     // TODO: maybe we can just send the HashMap directly?
-                    updates: Vec::from_iter(updates.into_iter()),
+                    updates: Vec::from_iter(updates),
                 };
 
                 // message.emit_send_logs("EntityUpdatesChannel");

--- a/lightyear/src/utils/captures.rs
+++ b/lightyear/src/utils/captures.rs
@@ -2,5 +2,5 @@
 //! See https://rust-lang.github.io/rfcs/3498-lifetime-capture-rules-2024.html
 //! and https://www.youtube.com/watch?v=CWiz_RtA1Hw
 
-pub(crate) trait Captures<U> {}
+pub trait Captures<U> {}
 impl<T: ?Sized, U> Captures<U> for T {}

--- a/lightyear/src/utils/captures.rs
+++ b/lightyear/src/utils/captures.rs
@@ -1,0 +1,6 @@
+//! Captures trick to allow for better impl Iterator + 'a
+//! See https://rust-lang.github.io/rfcs/3498-lifetime-capture-rules-2024.html
+//! and https://www.youtube.com/watch?v=CWiz_RtA1Hw
+
+pub(crate) trait Captures<U> {}
+impl<T: ?Sized, U> Captures<U> for T {}

--- a/lightyear/src/utils/captures.rs
+++ b/lightyear/src/utils/captures.rs
@@ -1,6 +1,6 @@
 //! Captures trick to allow for better impl Iterator + 'a
-//! See https://rust-lang.github.io/rfcs/3498-lifetime-capture-rules-2024.html
-//! and https://www.youtube.com/watch?v=CWiz_RtA1Hw
+//! See `<https://rust-lang.github.io/rfcs/3498-lifetime-capture-rules-2024.html>`
+//! and `<https://www.youtube.com/watch?v=CWiz_RtA1Hw>`
 
 pub trait Captures<U> {}
 impl<T: ?Sized, U> Captures<U> for T {}

--- a/lightyear/src/utils/mod.rs
+++ b/lightyear/src/utils/mod.rs
@@ -12,5 +12,6 @@ pub mod bevy;
 #[cfg(feature = "xpbd_2d")]
 pub mod bevy_xpbd_2d;
 
+pub(crate) mod captures;
 pub(crate) mod pool;
 pub mod wrapping_id;


### PR DESCRIPTION
# Context

Start simplifying some of the replication logic.

- No need for a `ReplicationMessage` enum that contains `EntityUpdates` or `EntityActions`, since we already the type of message from the channel
- No need for a `ClientMessage` or `ServerMessage` that encompasses `Replication`,`Ping`, etc. since again we know the type of the message from the channel
- Update the receive/send intermediate logic to use iterators instead of allocating Vecs/Maps

Actually I couldn't use iterators directly because of the borrow-checker so I had to copy the code directly by hand.. not ideal, maybe rust will make this easier in the future


# Perf

Better with lots of entities as expected, as we do fewer intermediate allocations and pass data around directly.
Not clear why it does worse with a small number of entities.

| Benchmark                             | main    | branch  |
|---------------------------------------|---------|---------|
| receive_insert_float/1000/1 group     | 734us   | 541us   |
| receive_insert_float/10000/1 group    | 3.63ms  | 3.52ms  |
| send_insert_float/1000/1 group        | 740us   | 801us   |
| send_insert_float/10000/1 group       | 7.47ms  | 6.64ms  |
| receive_insert_float/1000/many group  | 1.11ms  | 1.17ms  |
| receive_insert_float/10000/many group | 9.68ms  | 8.77ms  |
| send_insert_float/1000/many group     | 1.22ms  | 1.26ms  |
| send_insert_float/10000/may group     | 12.84ms | 11.67ms |

