### PR TITLE
finish + remake packet if no room for channel id. fixes #455

### DIFF
--- a/lightyear/src/packet/packet_builder.rs
+++ b/lightyear/src/packet/packet_builder.rs
@@ -240,9 +240,17 @@ impl PacketBuilder {
             }
 
             let mut packet = self.current_packet.take().unwrap();
+
             // we need to call this to preassign the channel_id
             if !packet.can_fit_channel(*channel_id) {
-                unreachable!();
+                self.current_packet = Some(packet);
+                packets.push(self.finish_packet());
+                self.build_new_single_packet(current_tick)?;
+                packet = self.current_packet.take().unwrap();
+                if !packet.can_fit_channel(*channel_id) {
+                    // channel will always fit in a new packet
+                    unreachable!();
+                }
             }
             // number of messages for this channel that we will write
             // (we wait until we know the full number, because we want to write that)


### PR DESCRIPTION
i was getting crashes, presumably due to not enough room left in packet to fit the channel bytes.

in that case, i now finish+remake a new packet, and carry on.