### PR TITLE
Re-use allocations during write

### DIFF
--- a/benches/replication.rs
+++ b/benches/replication.rs
@@ -38,7 +38,7 @@ criterion_group!(
 criterion_main!(replication_benches);
 
 // const NUM_ENTITIES: &[usize] = &[0, 10, 100, 1000, 10000];
-const NUM_ENTITIES: &[usize] = &[1000, 10000];
+const NUM_ENTITIES: &[usize] = &[10000];
 
 /// Replicating N entity spawn from server to channel, with a local io
 fn send_float_insert_one_client(criterion: &mut Criterion) {

--- a/benches/src/local_stepper.rs
+++ b/benches/src/local_stepper.rs
@@ -118,7 +118,7 @@ impl LocalBevyStepper {
             let mut client_app = App::new();
             client_app.add_plugins((
                 MinimalPlugins,
-                #[cfg(feature = "bevy/trace_tracy")]
+                // #[cfg(feature = "bevy/trace_tracy")]
                 LogPlugin::default(),
             ));
             let auth = Authentication::Manual {
@@ -157,7 +157,7 @@ impl LocalBevyStepper {
         let mut server_app = App::new();
         server_app.add_plugins((
             MinimalPlugins,
-            #[cfg(feature = "bevy/trace_tracy")]
+            // #[cfg(feature = "bevy/trace_tracy")]
             LogPlugin::default(),
         ));
         let config = ServerConfig {

--- a/lightyear/src/server/connection.rs
+++ b/lightyear/src/server/connection.rs
@@ -499,9 +499,8 @@ impl Connection {
 
     fn send_ping(&mut self, ping: Ping) -> Result<(), ServerError> {
         trace!("Sending ping {:?}", ping);
-        let mut writer = Writer::with_capacity(ping.len());
-        ping.to_bytes(&mut writer)?;
-        let message_bytes = writer.to_bytes();
+        ping.to_bytes(&mut self.writer)?;
+        let message_bytes = self.writer.split();
         self.message_manager
             .buffer_send(message_bytes, ChannelKind::of::<PingChannel>())?;
         Ok(())
@@ -509,9 +508,8 @@ impl Connection {
 
     fn send_pong(&mut self, pong: Pong) -> Result<(), ServerError> {
         trace!("Sending pong {:?}", pong);
-        let mut writer = Writer::with_capacity(pong.len());
-        pong.to_bytes(&mut writer)?;
-        let message_bytes = writer.to_bytes();
+        pong.to_bytes(&mut self.writer)?;
+        let message_bytes = self.writer.split();
         self.message_manager
             .buffer_send(message_bytes, ChannelKind::of::<PongChannel>())?;
         Ok(())
@@ -762,7 +760,6 @@ impl ConnectionManager {
 
         // even with delta-compression enabled
         // the diff can be shared for every client since we're inserting
-        let mut writer = Writer::default();
         if delta_compression {
             // store the component value in a storage shared between all connections, so that we can compute diffs
             // NOTE: we don't update the ack data because we only receive acks for ReplicationUpdate messages
@@ -777,15 +774,15 @@ impl ConnectionManager {
             // SAFETY: the component_data corresponds to the kind
             unsafe {
                 component_registry
-                    .serialize_diff_from_base_value(component_data, &mut writer, kind)
+                    .serialize_diff_from_base_value(component_data, &mut self.writer, kind)
                     .expect("could not serialize delta")
             }
         } else {
             component_registry
-                .erased_serialize(component_data, &mut writer, kind)
+                .erased_serialize(component_data, &mut self.writer, kind)
                 .expect("could not serialize component")
         };
-        let raw_data = writer.to_bytes();
+        let raw_data = self.writer.split();
         self.apply_replication(actual_target)
             .try_for_each(|client_id| {
                 // trace!(
@@ -834,10 +831,9 @@ impl ConnectionManager {
         let group_id = group.group_id(Some(entity));
         let mut raw_data: Bytes = Bytes::new();
         if !delta_compression {
-            let mut writer = Writer::default();
             // we serialize once and re-use the result for all clients
-            registry.erased_serialize(component, &mut writer, kind)?;
-            raw_data = writer.to_bytes();
+            registry.erased_serialize(component, &mut self.writer, kind)?;
+            raw_data = self.writer.split();
         }
         let mut num_targets = 0;
         self.apply_replication(target).try_for_each(|client_id| {

--- a/lightyear/src/server/replication.rs
+++ b/lightyear/src/server/replication.rs
@@ -690,7 +690,6 @@ pub(crate) mod send {
                 };
                 if !insert_target.is_empty() || !update_target.is_empty() {
                     let component_data = Ptr::from(component.as_ref());
-                    let writer = sender.writer();
                     if !insert_target.is_empty() {
                         let _ = sender
                             .prepare_component_insert(


### PR DESCRIPTION
After the serialization refactor, we were creating one new `Writer` every time we needed to serialize, which meant that we were doing a new allocation every time.

Instead, we now reuuse internally the same `BytesMut` to write the various individual messages.
When we finish the write for a message, we call `BytesMut::split` which creates a `Bytes` pointing to the amount of memory.
Once all the messages are sent and the ref count for those messages are dropped, new calls to `BytesMut::write` will attempt to reuse the memory at the start of the buffer.

TODO:
- we still need think about how to reuse memory for the reliable sender. The optimization happens only if all other refs have been dropped (https://docs.rs/bytes/latest/bytes/struct.BytesMut.html#method.reserve), but reliable senders keep their bytes in storage