### PR TITLE
type-erased the replication systems

### DIFF
--- a/lightyear/Cargo.toml
+++ b/lightyear/Cargo.toml
@@ -17,27 +17,27 @@ exclude = ["/tests"]
 big_messages = []
 trace = []
 metrics = [
-    "dep:metrics",
-    "metrics-util",
-    "metrics-tracing-context",
-    "metrics-exporter-prometheus",
+  "dep:metrics",
+  "metrics-util",
+  "metrics-tracing-context",
+  "metrics-exporter-prometheus",
 ]
 mock_time = ["dep:mock_instant"]
 webtransport = [
-    "dep:wtransport",
-    "dep:xwt-core",
-    "dep:xwt-web-sys",
-    "dep:web-sys",
-    "dep:ring",
-    "dep:wasm-bindgen-futures",
+  "dep:wtransport",
+  "dep:xwt-core",
+  "dep:xwt-web-sys",
+  "dep:web-sys",
+  "dep:ring",
+  "dep:wasm-bindgen-futures",
 ]
 leafwing = ["dep:leafwing-input-manager"]
 xpbd_2d = ["dep:bevy_xpbd_2d"]
 websocket = [
-    "dep:tokio-tungstenite",
-    "dep:futures-util",
-    "dep:web-sys",
-    "dep:wasm-bindgen",
+  "dep:tokio-tungstenite",
+  "dep:futures-util",
+  "dep:web-sys",
+  "dep:wasm-bindgen",
 ]
 steam = ["dep:steamworks"]
 
@@ -84,8 +84,8 @@ lightyear_macros = { version = "0.15.1", path = "../macros" }
 tracing = "0.1.40"
 tracing-log = "0.2.0"
 tracing-subscriber = { version = "0.3.17", features = [
-    "registry",
-    "env-filter",
+  "registry",
+  "env-filter",
 ] }
 
 # server
@@ -96,17 +96,17 @@ metrics = { version = "0.23", optional = true }
 metrics-util = { version = "0.15", optional = true }
 metrics-tracing-context = { version = "0.15", optional = true }
 metrics-exporter-prometheus = { version = "0.13.0", optional = true, default-features = false, features = [
-    "http-listener",
+  "http-listener",
 ] }
 
 # bevy
 bevy = { version = "0.13", default-features = false, features = [
-    "multi-threaded",
+  "multi-threaded",
 ] }
 
 # compression
 lz4_flex = { version = "0.11", optional = true, default-features = false, features = [
-    "std",
+  "std",
 ] }
 
 # WebSocket
@@ -115,8 +115,8 @@ futures-util = { version = "0.3.30", optional = true }
 # transport
 # we don't need any tokio features, we use only use the tokio channels
 tokio = { version = "1.36", features = [
-    "sync",
-    "macros",
+  "sync",
+  "macros",
 ], default-features = false }
 futures = "0.3.30"
 async-compat = "0.2.3"
@@ -128,13 +128,13 @@ async-channel = "2.2.0"
 steamworks = { version = "0.11", optional = true }
 # webtransport
 wtransport = { version = "=0.1.13", optional = true, features = [
-    "self-signed",
-    "dangerous-configuration",
+  "self-signed",
+  "dangerous-configuration",
 ] }
 # websocket
 tokio-tungstenite = { version = "0.23.0", optional = true, features = [
-    "connect",
-    "handshake",
+  "connect",
+  "handshake",
 ] }
 # compression
 zstd = { version = "0.13.1", optional = true }
@@ -143,26 +143,26 @@ zstd = { version = "0.13.1", optional = true }
 console_error_panic_hook = { version = "0.1.7" }
 ring = { version = "0.17.8", optional = true, default-features = false }
 web-sys = { version = "0.3", optional = true, features = [
-    "Document",
-    "WebTransport",
-    "WebTransportHash",
-    "WebTransportOptions",
-    "WebTransportBidirectionalStream",
-    "WebTransportSendStream",
-    "WebTransportReceiveStream",
-    "ReadableStreamDefaultReader",
-    "WritableStreamDefaultWriter",
-    "WebTransportDatagramDuplexStream",
-    "WebSocket",
-    "CloseEvent",
-    "ErrorEvent",
-    "MessageEvent",
-    "BinaryType",
+  "Document",
+  "WebTransport",
+  "WebTransportHash",
+  "WebTransportOptions",
+  "WebTransportBidirectionalStream",
+  "WebTransportSendStream",
+  "WebTransportReceiveStream",
+  "ReadableStreamDefaultReader",
+  "WritableStreamDefaultWriter",
+  "WebTransportDatagramDuplexStream",
+  "WebSocket",
+  "CloseEvent",
+  "ErrorEvent",
+  "MessageEvent",
+  "BinaryType",
 ] }
 bevy_web_keepalive = "0.3"
 futures-lite = { version = "2.1.0", optional = true }
 getrandom = { version = "0.2.11", features = [
-    "js", # feature 'js' is required for wasm
+  "js", # feature 'js' is required for wasm
 ] }
 xwt-core = { version = "0.4", optional = true }
 xwt-web-sys = { version = "0.11", optional = true }
@@ -185,14 +185,14 @@ approx = "0.5.1"
 # we cannot use all-features = true, because we need to provide additional features for bevy_xpbd_2d
 # when building the docs
 features = [
-    "metrics",
-    "webtransport",
-    "leafwing",
-    "xpbd_2d",
-    "websocket",
-    "steam",
-    "zstd",
-    "bevy_xpbd_2d/2d",
-    "bevy_xpbd_2d/f32",
+  "metrics",
+  "webtransport",
+  "leafwing",
+  "xpbd_2d",
+  "websocket",
+  "steam",
+  "zstd",
+  "bevy_xpbd_2d/2d",
+  "bevy_xpbd_2d/f32",
 ]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/lightyear/src/client/prediction/pre_prediction.rs
+++ b/lightyear/src/client/prediction/pre_prediction.rs
@@ -9,10 +9,13 @@ use crate::client::events::ComponentInsertEvent;
 use crate::client::prediction::prespawn::PreSpawnedPlayerObjectSet;
 use crate::client::prediction::resource::PredictionManager;
 use crate::client::prediction::Predicted;
+use crate::client::replication::send::ReplicateToServer;
 use crate::client::sync::client_is_synced;
 use crate::connection::client::NetClient;
 use crate::prelude::client::{ClientConnection, PredictionSet};
-use crate::prelude::{ReplicateHierarchy, ReplicationGroup, ReplicationTarget, ShouldBePredicted};
+use crate::prelude::{
+    ReplicateHierarchy, Replicating, ReplicationGroup, ReplicationTarget, ShouldBePredicted,
+};
 use crate::shared::replication::components::PrePredicted;
 use crate::shared::sets::{ClientMarker, InternalReplicationSet};
 
@@ -167,7 +170,13 @@ impl PrePredictionPlugin {
             debug!(?entity, "removing replicate from pre-predicted entity");
             commands
                 .entity(entity)
-                .remove::<(ReplicationTarget, ReplicationGroup, ReplicateHierarchy)>()
+                .remove::<(
+                    ReplicationTarget,
+                    ReplicateToServer,
+                    Replicating,
+                    ReplicationGroup,
+                    ReplicateHierarchy,
+                )>()
                 .insert((Predicted {
                     confirmed_entity: None,
                 },));

--- a/lightyear/src/client/replication.rs
+++ b/lightyear/src/client/replication.rs
@@ -514,7 +514,7 @@ pub(crate) mod send {
                             group_id,
                             component_kind,
                             component_data,
-                            &component_registry,
+                            component_registry,
                             writer,
                             &mut sender.delta_manager,
                             current_tick,

--- a/lightyear/src/client/replication.rs
+++ b/lightyear/src/client/replication.rs
@@ -50,6 +50,7 @@ pub(crate) mod receive {
 
 pub(crate) mod send {
     use super::*;
+    use bevy::ecs::component::ComponentTicks;
 
     use crate::connection::client::ClientConnection;
 
@@ -57,12 +58,13 @@ pub(crate) mod send {
 
     use crate::prelude::{
         is_connected, is_host_server, ComponentRegistry, DisabledComponent, ReplicateHierarchy,
-        ReplicateOnceComponent, Replicated, ReplicationGroup, TargetEntity, TickManager,
+        Replicated, ReplicationGroup, TargetEntity, Tick, TickManager,
     };
     use crate::protocol::component::ComponentKind;
 
-    use crate::shared::replication::components::{DeltaCompression, DespawnTracker, Replicating};
+    use crate::shared::replication::components::{DespawnTracker, Replicating, ReplicationGroupId};
 
+    use crate::shared::replication::archetypes::{get_erased_component, ReplicatedArchetypes};
     use bevy::ecs::entity::Entities;
     use bevy::ecs::system::SystemChangeTick;
     use bevy::ptr::Ptr;
@@ -105,8 +107,9 @@ pub(crate) mod send {
                         // NOTE: we make sure to update the replicate_cache before we make use of it in `send_entity_despawn`
                         handle_replicating_remove
                             .in_set(InternalReplicationSet::<ClientMarker>::BeforeBuffer),
-                        send_entity_spawn
-                            .in_set(InternalReplicationSet::<ClientMarker>::BufferEntityUpdates),
+                        replicate
+                            .in_set(InternalReplicationSet::<ClientMarker>::BufferEntityUpdates)
+                            .in_set(InternalReplicationSet::<ClientMarker>::BufferComponentUpdates),
                         send_entity_despawn.in_set(
                             InternalReplicationSet::<ClientMarker>::BufferDespawnsAndRemovals,
                         ),
@@ -232,38 +235,150 @@ pub(crate) mod send {
         }
     }
 
+    pub(crate) fn replicate(
+        tick_manager: Res<TickManager>,
+        component_registry: Res<ComponentRegistry>,
+        mut replicated_archetypes: Local<ReplicatedArchetypes<ReplicateToServer>>,
+        system_ticks: SystemChangeTick,
+        mut set: ParamSet<(&World, ResMut<ConnectionManager>)>,
+    ) {
+        // 1. update the list of replicated archetypes
+        replicated_archetypes.update(set.p0(), &component_registry);
+
+        let mut sender = std::mem::take(&mut *set.p1());
+        let world = set.p0();
+
+        // 2. go through all the archetypes that should be replicated
+        for replicated_archetype in replicated_archetypes.archetypes.iter() {
+            // SAFETY: update() makes sure that we have a valid archetype
+            let archetype = unsafe {
+                world
+                    .archetypes()
+                    .get(replicated_archetype.id)
+                    .unwrap_unchecked()
+            };
+            let table = unsafe {
+                world
+                    .storages()
+                    .tables
+                    .get(archetype.table_id())
+                    .unwrap_unchecked()
+            };
+
+            // a. add all entity despawns from entities that were despawned locally
+            // (done in a separate system)
+            // replicate_entity_local_despawn(&mut despawn_removed, &mut set.p1());
+
+            // 3. go through all entities of that archetype
+            for entity in archetype.entities() {
+                let entity_ref = world.entity(entity.id());
+                // SAFETY: we know that the entity has the ReplicationTarget component
+                // because the archetype is in replicated_archetypes
+                let replication_target =
+                    unsafe { entity_ref.get::<ReplicateToServer>().unwrap_unchecked() };
+                let replication_target_ticks = unsafe {
+                    entity_ref
+                        .get_change_ticks::<ReplicateToServer>()
+                        .unwrap_unchecked()
+                };
+                let (added_tick, changed_tick) = (
+                    replication_target_ticks.added_tick(),
+                    replication_target_ticks.last_changed_tick(),
+                );
+                // entity_ref::get_ref() does not do what we want (https://github.com/bevyengine/bevy/issues/13735)
+                // so create the ref manually
+                let replication_target = Ref::new(
+                    replication_target,
+                    &added_tick,
+                    &changed_tick,
+                    system_ticks.last_run(),
+                    system_ticks.this_run(),
+                );
+                let group = entity_ref.get::<ReplicationGroup>();
+                let group_id = group.map_or(ReplicationGroupId::default(), |g| {
+                    g.group_id(Some(entity.id()))
+                });
+                let priority = group.map_or(1.0, |g| g.priority());
+                let target_entity = entity_ref.get::<TargetEntity>();
+
+                // b. add entity despawns from ReplicateToServer component being removed
+                // replicate_entity_despawn(
+                //     entity.id(),
+                //     group_id,
+                //     &replication_target,
+                //     visibility,
+                //     &mut sender,
+                // );
+
+                // c. add entity spawns
+                if replication_target.is_changed() {
+                    replicate_entity_spawn(
+                        entity.id(),
+                        group_id,
+                        priority,
+                        target_entity,
+                        &mut sender,
+                    );
+                }
+
+                // d. all components that were added or changed
+                for replicated_component in replicated_archetype.components.iter() {
+                    let (data, component_ticks) = unsafe {
+                        get_erased_component(
+                            table,
+                            &world.storages().sparse_sets,
+                            entity,
+                            replicated_component.storage_type,
+                            replicated_component.id,
+                        )
+                    };
+                    replicate_component_update(
+                        tick_manager.tick(),
+                        &component_registry,
+                        entity.id(),
+                        replicated_component.kind,
+                        data,
+                        component_ticks,
+                        &replication_target,
+                        group_id,
+                        replicated_component.delta_compression,
+                        replicated_component.replicate_once,
+                        &system_ticks,
+                        &mut sender,
+                    );
+                }
+            }
+        }
+
+        // restore the ConnectionManager
+        *set.p1() = sender;
+    }
+
     /// Send entity spawn replication messages to server when the ReplicationTarget component is added
     /// Also handles:
     /// - handles TargetEntity if it's a Preexisting entity
     /// - setting the priority
-    pub(crate) fn send_entity_spawn(
-        query: Query<
-            (Entity, &ReplicationGroup, Option<&TargetEntity>),
-            (With<Replicating>, Changed<ReplicateToServer>),
-        >,
-        mut sender: ResMut<ConnectionManager>,
+    pub(crate) fn replicate_entity_spawn(
+        entity: Entity,
+        group_id: ReplicationGroupId,
+        priority: f32,
+        target_entity: Option<&TargetEntity>,
+        sender: &mut ConnectionManager,
     ) {
-        query.iter().for_each(|(entity, group, target_entity)| {
-            trace!(?entity, "Prepare entity spawn to server");
-            let group_id = group.group_id(Some(entity));
-            if let Some(TargetEntity::Preexisting(remote_entity)) = target_entity {
-                sender.replication_sender.prepare_entity_spawn_reuse(
-                    entity,
-                    group_id,
-                    *remote_entity,
-                );
-            } else {
-                sender
-                    .replication_sender
-                    .prepare_entity_spawn(entity, group_id);
-            }
-            // TODO: should the priority be a component on the entity? but it should be shared between a group
-            //  should a GroupChannel be a separate entity?
-            // also set the priority for the group when we spawn it
+        trace!(?entity, "Prepare entity spawn to server");
+        if let Some(TargetEntity::Preexisting(remote_entity)) = target_entity {
             sender
                 .replication_sender
-                .update_base_priority(group_id, group.priority());
-        });
+                .prepare_entity_spawn_reuse(entity, group_id, *remote_entity);
+        } else {
+            sender
+                .replication_sender
+                .prepare_entity_spawn(entity, group_id);
+        }
+        // also set the priority for the group when we spawn it
+        sender
+            .replication_sender
+            .update_base_priority(group_id, priority);
     }
 
     /// Send entity despawn if:
@@ -311,135 +426,116 @@ pub(crate) mod send {
     /// - last time we sent an update for that group which got acked.
     ///
     /// NOTE: cannot use ConnectEvents because they are reset every frame
-    pub(crate) fn send_component_update<C: Component>(
-        tick_manager: Res<TickManager>,
-        registry: Res<ComponentRegistry>,
-        query: Query<
-            (
-                Entity,
-                Ref<C>,
-                Ref<ReplicateToServer>,
-                &ReplicationGroup,
-                Has<DeltaCompression<C>>,
-                Has<DisabledComponent<C>>,
-                Has<ReplicateOnceComponent<C>>,
-            ),
-            With<Replicating>,
-        >,
-        system_bevy_ticks: SystemChangeTick,
-        mut connection: ResMut<ConnectionManager>,
+    fn replicate_component_update(
+        current_tick: Tick,
+        component_registry: &ComponentRegistry,
+        entity: Entity,
+        component_kind: ComponentKind,
+        component_data: Ptr,
+        component_ticks: ComponentTicks,
+        replication_target: &Ref<ReplicateToServer>,
+        group_id: ReplicationGroupId,
+        delta_compression: bool,
+        replicate_once: bool,
+        system_ticks: &SystemChangeTick,
+        sender: &mut ConnectionManager,
     ) {
-        let tick = tick_manager.tick();
-        let kind = ComponentKind::of::<C>();
-        // enable split borrows
-        let connection = &mut *connection;
-        query.iter().for_each(
-            |(entity, component, target, group, delta_compression, disabled, replicate_once)| {
-                // do not replicate components that are disabled
-                if disabled {
-                    return;
-                }
-                let (mut insert, mut update) = (false, false);
+        let (mut insert, mut update) = (false, false);
 
-                // send a component_insert for components that were newly added
-                // or if we start replicating the entity
-                // TODO: ideally we would use target.is_added(), but we do the trick of setting all the
-                //  ReplicateToServer components to `changed` on connection so that we replicate existing entities to
-                //  the server
-                if component.is_added() || target.is_changed() {
-                    trace!("component is added or replication_target is added");
-                    insert = true;
-                } else {
-                    // do not send updates for these components, only inserts/removes
-                    if replicate_once {
-                        trace!(?entity,
-                        "not replicating updates for {:?} because it is marked as replicate_once",
-                        kind
-                    );
-                        return;
+        // send a component_insert for components that were newly added
+        // or if we start replicating the entity
+        // TODO: ideally we would use target.is_added(), but we do the trick of setting all the
+        //  ReplicateToServer components to `changed` when the client first connects so that we replicate existing entities to the server
+        if component_ticks.is_added(system_ticks.last_run(), system_ticks.this_run())
+            || replication_target.is_changed()
+        {
+            trace!("component is added or replication_target is added");
+            insert = true;
+        } else {
+            // do not send updates for these components, only inserts/removes
+            if replicate_once {
+                trace!(
+                    ?entity,
+                    "not replicating updates for {:?} because it is marked as replicate_once",
+                    component_kind
+                );
+                return;
+            }
+            // otherwise send an update for all components that changed since the
+            // last update we have ack-ed
+            update = true;
+        }
+        if insert || update {
+            let writer = &mut sender.writer;
+            if insert {
+                if delta_compression {
+                    // SAFETY: the component_data corresponds to the kind
+                    unsafe {
+                        component_registry
+                            .serialize_diff_from_base_value(component_data, writer, component_kind)
+                            .expect("could not serialize delta")
                     }
-                    // otherwise send an update for all components that changed since the
-                    // last update we have ack-ed
-                    update = true;
-                }
-                if insert || update {
-                    let group_id = group.group_id(Some(entity));
-                    let component_data = Ptr::from(component.as_ref());
-                    let writer = &mut connection.writer;
-                    if insert {
-                        if delta_compression {
-                            // SAFETY: the component_data corresponds to the kind
-                            unsafe {
-                                registry
-                                    .serialize_diff_from_base_value(component_data, writer, kind)
-                                    .expect("could not serialize delta")
-                            }
-                        } else {
-                            registry
-                                .erased_serialize(component_data, writer, kind)
-                                .expect("could not serialize component")
-                        };
+                } else {
+                    component_registry
+                        .erased_serialize(component_data, writer, component_kind)
+                        .expect("could not serialize component")
+                };
+                let raw_data = writer.split();
+                sender.replication_sender.prepare_component_insert(
+                    entity,
+                    group_id,
+                    raw_data,
+                    system_ticks.this_run(),
+                );
+            } else {
+                let send_tick = sender
+                    .replication_sender
+                    .group_channels
+                    .entry(group_id)
+                    .or_default()
+                    .send_tick;
+
+                // send the update for all changes newer than the last send bevy tick for the group
+                if send_tick.map_or(true, |c| {
+                    component_ticks
+                        .last_changed_tick()
+                        .is_newer_than(c, system_ticks.this_run())
+                }) {
+                    trace!(
+                        change_tick = ?component_ticks.last_changed_tick(),
+                        ?send_tick,
+                        current_tick = ?system_ticks.this_run(),
+                        "prepare entity update changed check"
+                    );
+                    // trace!(
+                    //     ?entity,
+                    //     component = ?kind,
+                    //     tick = ?self.tick_manager.tick(),
+                    //     "Updating single component"
+                    // );
+                    if !delta_compression {
+                        component_registry
+                            .erased_serialize(component_data, writer, component_kind)
+                            .expect("could not serialize component");
                         let raw_data = writer.split();
-                        connection.replication_sender.prepare_component_insert(
+                        sender
+                            .replication_sender
+                            .prepare_component_update(entity, group_id, raw_data);
+                    } else {
+                        sender.replication_sender.prepare_delta_component_update(
                             entity,
                             group_id,
-                            raw_data,
-                            system_bevy_ticks.this_run(),
+                            component_kind,
+                            component_data,
+                            &component_registry,
+                            writer,
+                            &mut sender.delta_manager,
+                            current_tick,
                         );
-                    } else {
-                        // TODO: should we have additional state tracking so that we know we are in the process of sending this entity to clients?
-                        let send_tick = connection
-                            .replication_sender
-                            .group_channels
-                            .entry(group_id)
-                            .or_default()
-                            .send_tick;
-
-                        // send the update for all changes newer than the last ack bevy tick for the group
-                        if send_tick.map_or(true, |c| {
-                            component
-                                .last_changed()
-                                .is_newer_than(c, system_bevy_ticks.this_run())
-                        }) {
-                            trace!(
-                                change_tick = ?component.last_changed(),
-                                ?send_tick,
-                                current_tick = ?system_bevy_ticks.this_run(),
-                                "prepare entity update changed check"
-                            );
-                            // trace!(
-                            //     ?entity,
-                            //     component = ?kind,
-                            //     tick = ?self.tick_manager.tick(),
-                            //     "Updating single component"
-                            // );
-                            if !delta_compression {
-                                registry
-                                    .erased_serialize(component_data, writer, kind)
-                                    .expect("could not serialize component");
-                                let raw_data = writer.split();
-                                connection
-                                    .replication_sender
-                                    .prepare_component_update(entity, group_id, raw_data);
-                            } else {
-                                connection
-                                    .replication_sender
-                                    .prepare_delta_component_update(
-                                        entity,
-                                        group_id,
-                                        kind,
-                                        component_data,
-                                        &registry,
-                                        writer,
-                                        &mut connection.delta_manager,
-                                        tick,
-                                    );
-                            }
-                        }
                     }
                 }
-            },
-        );
+            }
+        }
     }
 
     /// Send component remove
@@ -478,21 +574,22 @@ pub(crate) mod send {
                 //  It is ok to run it every frame because it creates at most one message per despawn
                 send_component_removed::<C>
                     .in_set(InternalReplicationSet::<ClientMarker>::BufferDespawnsAndRemovals),
-                // NOTE: we run this system once every `send_interval` because we don't want to send too many Update messages
-                //  and use up all the bandwidth
-                send_component_update::<C>
-                    .in_set(InternalReplicationSet::<ClientMarker>::BufferComponentUpdates),
             ),
         );
     }
 
     #[cfg(test)]
     mod tests {
-        use crate::prelude::{client, server, ClientId};
+        use crate::client::replication::send::ReplicateToServer;
+        use crate::prelude::client::Replicate;
+        use crate::prelude::{
+            server, ClientId, DisabledComponent, ReplicateOnceComponent, Replicated, TargetEntity,
+        };
+        use crate::tests::protocol::Component1;
         use crate::tests::stepper::{BevyStepper, Step, TEST_CLIENT_ID};
 
         #[test]
-        fn test_entity_spawn_client_to_server() {
+        fn test_entity_spawn() {
             let mut stepper = BevyStepper::default();
 
             // spawn an entity on server with visibility::All
@@ -505,7 +602,7 @@ pub(crate) mod send {
                 .client_app
                 .world
                 .entity_mut(client_entity)
-                .insert(client::Replicate::default());
+                .insert(Replicate::default());
             // TODO: we need to run a couple frames because the server doesn't read the client's updates
             //  because they are from the future
             for _ in 0..10 {
@@ -523,6 +620,433 @@ pub(crate) mod send {
                 .remote_entity_map
                 .get_local(client_entity)
                 .expect("entity was not replicated to server");
+        }
+
+        #[test]
+        fn test_multi_entity_spawn() {
+            let mut stepper = BevyStepper::default();
+            let server_entities = stepper.server_app.world.entities().len();
+
+            // spawn an entity on server
+            stepper
+                .client_app
+                .world
+                .spawn_batch(vec![Replicate::default(); 2]);
+            for _ in 0..10 {
+                stepper.frame_step();
+            }
+
+            // check that the entities were spawned
+            assert_eq!(
+                stepper.server_app.world.entities().len(),
+                server_entities + 2
+            );
+        }
+
+        #[test]
+        fn test_entity_spawn_preexisting_target() {
+            let mut stepper = BevyStepper::default();
+
+            let server_entity = stepper.server_app.world.spawn_empty().id();
+            stepper.frame_step();
+            let client_entity = stepper
+                .client_app
+                .world
+                .spawn((
+                    Replicate::default(),
+                    TargetEntity::Preexisting(server_entity),
+                ))
+                .id();
+            for _ in 0..10 {
+                stepper.frame_step();
+            }
+
+            // check that the entity was replicated on the server entity
+            assert_eq!(
+                stepper
+                    .server_app
+                    .world
+                    .resource::<server::ConnectionManager>()
+                    .connection(ClientId::Netcode(TEST_CLIENT_ID))
+                    .unwrap()
+                    .replication_receiver
+                    .remote_entity_map
+                    .get_local(client_entity)
+                    .unwrap(),
+                &server_entity
+            );
+            assert!(stepper
+                .server_app
+                .world
+                .get::<Replicated>(server_entity)
+                .is_some());
+        }
+
+        /// Check that if we remove ReplicationToServer
+        /// the entity gets despawned on the server
+        #[test]
+        fn test_entity_spawn_replication_target_update() {
+            let mut stepper = BevyStepper::default();
+
+            let client_entity = stepper.client_app.world.spawn_empty().id();
+            stepper.frame_step();
+            stepper.frame_step();
+
+            // add replicate
+            stepper
+                .client_app
+                .world
+                .entity_mut(client_entity)
+                .insert(Replicate::default());
+            // TODO: we need to run a couple frames because the server doesn't read the client's updates
+            //  because they are from the future
+            for _ in 0..10 {
+                stepper.frame_step();
+            }
+
+            // check that the entity was spawned
+            let server_entity = *stepper
+                .server_app
+                .world
+                .resource::<server::ConnectionManager>()
+                .connection(ClientId::Netcode(TEST_CLIENT_ID))
+                .expect("client connection missing")
+                .replication_receiver
+                .remote_entity_map
+                .get_local(client_entity)
+                .expect("entity was not replicated to server");
+
+            // remove the ReplicateToServer component
+            stepper
+                .client_app
+                .world
+                .entity_mut(client_entity)
+                .remove::<ReplicateToServer>();
+            for _ in 0..10 {
+                stepper.frame_step();
+            }
+            assert!(stepper.server_app.world.get_entity(server_entity).is_none());
+        }
+
+        #[test]
+        fn test_entity_despawn() {
+            let mut stepper = BevyStepper::default();
+
+            // spawn an entity on client
+            let client_entity = stepper.client_app.world.spawn(Replicate::default()).id();
+            for _ in 0..10 {
+                stepper.frame_step();
+            }
+
+            // check that the entity was spawned
+            let server_entity = *stepper
+                .server_app
+                .world
+                .resource::<server::ConnectionManager>()
+                .connection(ClientId::Netcode(TEST_CLIENT_ID))
+                .unwrap()
+                .replication_receiver
+                .remote_entity_map
+                .get_local(client_entity)
+                .expect("entity was not replicated to client");
+
+            // despawn
+            stepper.client_app.world.despawn(client_entity);
+            for _ in 0..10 {
+                stepper.frame_step();
+            }
+
+            // check that the entity was despawned
+            assert!(stepper.server_app.world.get_entity(server_entity).is_none());
+        }
+
+        #[test]
+        fn test_component_insert() {
+            let mut stepper = BevyStepper::default();
+
+            // spawn an entity on client
+            let client_entity = stepper.client_app.world.spawn(Replicate::default()).id();
+            for _ in 0..10 {
+                stepper.frame_step();
+            }
+
+            // check that the entity was spawned
+            let server_entity = *stepper
+                .server_app
+                .world
+                .resource::<server::ConnectionManager>()
+                .connection(ClientId::Netcode(TEST_CLIENT_ID))
+                .unwrap()
+                .replication_receiver
+                .remote_entity_map
+                .get_local(client_entity)
+                .expect("entity was not replicated to client");
+
+            // add component
+            stepper
+                .client_app
+                .world
+                .entity_mut(client_entity)
+                .insert(Component1(1.0));
+            for _ in 0..10 {
+                stepper.frame_step();
+            }
+
+            // check that the component was replicated
+            assert_eq!(
+                stepper
+                    .server_app
+                    .world
+                    .entity(server_entity)
+                    .get::<Component1>()
+                    .expect("Component missing"),
+                &Component1(1.0)
+            )
+        }
+
+        #[test]
+        fn test_component_insert_disabled() {
+            let mut stepper = BevyStepper::default();
+
+            // spawn an entity on client
+            let client_entity = stepper.client_app.world.spawn(Replicate::default()).id();
+            for _ in 0..10 {
+                stepper.frame_step();
+            }
+
+            // check that the entity was spawned
+            let server_entity = *stepper
+                .server_app
+                .world
+                .resource::<server::ConnectionManager>()
+                .connection(ClientId::Netcode(TEST_CLIENT_ID))
+                .unwrap()
+                .replication_receiver
+                .remote_entity_map
+                .get_local(client_entity)
+                .expect("entity was not replicated to client");
+
+            // add component
+            stepper
+                .client_app
+                .world
+                .entity_mut(client_entity)
+                .insert((Component1(1.0), DisabledComponent::<Component1>::default()));
+            for _ in 0..10 {
+                stepper.frame_step();
+            }
+
+            // check that the component was not  replicated
+            assert!(stepper
+                .server_app
+                .world
+                .entity(server_entity)
+                .get::<Component1>()
+                .is_none());
+        }
+
+        // TODO: check that component insert for a component that doesn't have ClientToServer is not replicated!
+
+        #[test]
+        fn test_component_update() {
+            let mut stepper = BevyStepper::default();
+
+            // spawn an entity on client
+            let client_entity = stepper
+                .client_app
+                .world
+                .spawn((Replicate::default(), Component1(1.0)))
+                .id();
+            for _ in 0..10 {
+                stepper.frame_step();
+            }
+
+            // check that the entity was spawned
+            let server_entity = *stepper
+                .server_app
+                .world
+                .resource::<server::ConnectionManager>()
+                .connection(ClientId::Netcode(TEST_CLIENT_ID))
+                .unwrap()
+                .replication_receiver
+                .remote_entity_map
+                .get_local(client_entity)
+                .expect("entity was not replicated to client");
+
+            // update component
+            stepper
+                .client_app
+                .world
+                .entity_mut(client_entity)
+                .insert(Component1(2.0));
+            for _ in 0..10 {
+                stepper.frame_step();
+            }
+
+            // check that the component was updated
+            assert_eq!(
+                stepper
+                    .server_app
+                    .world
+                    .entity(server_entity)
+                    .get::<Component1>()
+                    .expect("Component missing"),
+                &Component1(2.0)
+            )
+        }
+
+        #[test]
+        fn test_component_update_disabled() {
+            let mut stepper = BevyStepper::default();
+
+            // spawn an entity on client
+            let client_entity = stepper
+                .client_app
+                .world
+                .spawn((Replicate::default(), Component1(1.0)))
+                .id();
+            for _ in 0..10 {
+                stepper.frame_step();
+            }
+
+            // check that the entity was spawned
+            let server_entity = *stepper
+                .server_app
+                .world
+                .resource::<server::ConnectionManager>()
+                .connection(ClientId::Netcode(TEST_CLIENT_ID))
+                .unwrap()
+                .replication_receiver
+                .remote_entity_map
+                .get_local(client_entity)
+                .expect("entity was not replicated to client");
+            assert_eq!(
+                stepper
+                    .server_app
+                    .world
+                    .entity(server_entity)
+                    .get::<Component1>()
+                    .expect("Component missing"),
+                &Component1(1.0)
+            );
+
+            // remove component
+            stepper
+                .client_app
+                .world
+                .entity_mut(client_entity)
+                .remove::<Component1>();
+            for _ in 0..10 {
+                stepper.frame_step();
+            }
+
+            // check that the component was removed
+            assert!(stepper
+                .server_app
+                .world
+                .entity(server_entity)
+                .get::<Component1>()
+                .is_none());
+        }
+
+        #[test]
+        fn test_component_update_replicate_once() {
+            let mut stepper = BevyStepper::default();
+
+            // spawn an entity on client
+            let client_entity = stepper
+                .client_app
+                .world
+                .spawn((
+                    Replicate::default(),
+                    Component1(1.0),
+                    ReplicateOnceComponent::<Component1>::default(),
+                ))
+                .id();
+            for _ in 0..10 {
+                stepper.frame_step();
+            }
+
+            // check that the entity was spawned
+            let server_entity = *stepper
+                .server_app
+                .world
+                .resource::<server::ConnectionManager>()
+                .connection(ClientId::Netcode(TEST_CLIENT_ID))
+                .unwrap()
+                .replication_receiver
+                .remote_entity_map
+                .get_local(client_entity)
+                .expect("entity was not replicated to client");
+
+            // update component
+            stepper
+                .client_app
+                .world
+                .entity_mut(client_entity)
+                .insert(Component1(2.0));
+            for _ in 0..10 {
+                stepper.frame_step();
+            }
+
+            // check that the component was not updated
+            assert_eq!(
+                stepper
+                    .server_app
+                    .world
+                    .entity(server_entity)
+                    .get::<Component1>()
+                    .expect("Component missing"),
+                &Component1(1.0)
+            )
+        }
+
+        #[test]
+        fn test_component_remove() {
+            let mut stepper = BevyStepper::default();
+
+            // spawn an entity on client
+            let client_entity = stepper
+                .client_app
+                .world
+                .spawn((Replicate::default(), Component1(1.0)))
+                .id();
+            for _ in 0..10 {
+                stepper.frame_step();
+            }
+
+            // check that the entity was spawned
+            let server_entity = *stepper
+                .server_app
+                .world
+                .resource::<server::ConnectionManager>()
+                .connection(ClientId::Netcode(TEST_CLIENT_ID))
+                .unwrap()
+                .replication_receiver
+                .remote_entity_map
+                .get_local(client_entity)
+                .expect("entity was not replicated to client");
+
+            // update component
+            stepper
+                .client_app
+                .world
+                .entity_mut(client_entity)
+                .insert((Component1(2.0), DisabledComponent::<Component1>::default()));
+            for _ in 0..10 {
+                stepper.frame_step();
+            }
+
+            // check that the component was not updated
+            assert_eq!(
+                stepper
+                    .server_app
+                    .world
+                    .entity(server_entity)
+                    .get::<Component1>()
+                    .expect("Component missing"),
+                &Component1(1.0)
+            )
         }
     }
 }

--- a/lightyear/src/protocol/component.rs
+++ b/lightyear/src/protocol/component.rs
@@ -144,7 +144,6 @@ pub struct ComponentRegistry {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct ReplicationMetadata {
-    pub direction: ChannelDirection,
     pub component_id: ComponentId,
     pub delta_compression_id: ComponentId,
     pub replicate_once_id: ComponentId,
@@ -500,18 +499,13 @@ mod replication {
     use crate::serialize::ToBytes;
 
     impl ComponentRegistry {
-        pub(crate) fn set_replication_fns<C: Component + PartialEq>(
-            &mut self,
-            world: &mut World,
-            direction: ChannelDirection,
-        ) {
+        pub(crate) fn set_replication_fns<C: Component + PartialEq>(&mut self, world: &mut World) {
             let kind = ComponentKind::of::<C>();
             let write: RawWriteFn = Self::write::<C>;
             let remove: RawRemoveFn = Self::remove::<C>;
             self.replication_map.insert(
                 kind,
                 ReplicationMetadata {
-                    direction,
                     component_id: world.init_component::<C>(),
                     delta_compression_id: world.init_component::<DeltaCompression<C>>(),
                     replicate_once_id: world.init_component::<ReplicateOnceComponent<C>>(),
@@ -621,11 +615,9 @@ mod delta {
             // (since the serialized message will contain the delta component's net_id)
             // update the write function to use the delta compression logic
             let write: RawWriteFn = Self::write_delta::<C>;
-            let direction = self.replication_map.get(&kind).unwrap().direction;
             self.replication_map.insert(
                 delta_kind,
                 ReplicationMetadata {
-                    direction,
                     // NOTE: we set these to 0 because they are never used for the DeltaMessage component
                     component_id: ComponentId::new(0),
                     delta_compression_id: ComponentId::new(0),
@@ -986,7 +978,7 @@ impl AppComponentExt for App {
                 if !registry.is_registered::<C>() {
                     registry.register_component::<C>();
                 }
-                registry.set_replication_fns::<C>(world, direction);
+                registry.set_replication_fns::<C>(world);
                 debug!("register component {}", std::any::type_name::<C>());
             });
         register_component_send::<C>(self, direction);

--- a/lightyear/src/protocol/registry.rs
+++ b/lightyear/src/protocol/registry.rs
@@ -65,6 +65,16 @@ impl<K: TypeKind> TypeMapper<K> {
         kind
     }
 
+    pub fn add_manual<T: 'static>(&mut self, net_id: NetId) -> K {
+        let kind = K::from(TypeId::of::<T>());
+        if self.kind_map.contains_key(&kind) {
+            panic!("Type {:?} already registered", std::any::type_name::<T>());
+        }
+        self.kind_map.insert(kind, net_id);
+        self.id_map.insert(net_id, kind);
+        kind
+    }
+
     pub fn kind(&self, net_id: NetId) -> Option<&K> {
         self.id_map.get(&net_id)
     }

--- a/lightyear/src/protocol/registry.rs
+++ b/lightyear/src/protocol/registry.rs
@@ -65,16 +65,6 @@ impl<K: TypeKind> TypeMapper<K> {
         kind
     }
 
-    pub fn add_manual<T: 'static>(&mut self, net_id: NetId) -> K {
-        let kind = K::from(TypeId::of::<T>());
-        if self.kind_map.contains_key(&kind) {
-            panic!("Type {:?} already registered", std::any::type_name::<T>());
-        }
-        self.kind_map.insert(kind, net_id);
-        self.id_map.insert(net_id, kind);
-        kind
-    }
-
     pub fn kind(&self, net_id: NetId) -> Option<&K> {
         self.id_map.get(&net_id)
     }

--- a/lightyear/src/server/connection.rs
+++ b/lightyear/src/server/connection.rs
@@ -81,6 +81,19 @@ pub struct ConnectionManager {
     ping_config: PingConfig,
 }
 
+// This is useful in cases where we need to temporarily store a fake ConnectionManager
+impl Default for ConnectionManager {
+    fn default() -> Self {
+        Self::new(
+            MessageRegistry::default(),
+            ChannelRegistry::default(),
+            ReplicationConfig::default(),
+            PacketConfig::default(),
+            PingConfig::default(),
+        )
+    }
+}
+
 impl ConnectionManager {
     pub(crate) fn new(
         message_registry: MessageRegistry,
@@ -675,10 +688,9 @@ impl ConnectionManager {
     pub(crate) fn prepare_entity_despawn(
         &mut self,
         entity: Entity,
-        group: &ReplicationGroup,
+        group_id: ReplicationGroupId,
         target: NetworkTarget,
     ) -> Result<(), ServerError> {
-        let group_id = group.group_id(Some(entity));
         self.apply_replication(target).try_for_each(|client_id| {
             // trace!(
             //     ?entity,
@@ -725,16 +737,14 @@ impl ConnectionManager {
         kind: ComponentKind,
         component_data: Ptr,
         component_registry: &ComponentRegistry,
-        replication_target: &ReplicationTarget,
         prediction_target: Option<&NetworkTarget>,
-        group: &ReplicationGroup,
+        group_id: ReplicationGroupId,
         target: NetworkTarget,
         delta_compression: bool,
         tick: Tick,
         bevy_tick: BevyTick,
     ) -> Result<(), ServerError> {
         // TODO: first check that the target is not empty!
-        let group_id = group.group_id(Some(entity));
 
         // TODO: think about this. this feels a bit clumsy
         // TODO: this might not be required anymore since we separated ShouldBePredicted from PrePredicted
@@ -813,7 +823,7 @@ impl ConnectionManager {
         kind: ComponentKind,
         component: Ptr,
         registry: &ComponentRegistry,
-        group: &ReplicationGroup,
+        group_id: ReplicationGroupId,
         target: NetworkTarget,
         component_change_tick: BevyTick,
         system_current_tick: BevyTick,
@@ -827,8 +837,6 @@ impl ConnectionManager {
             ?system_current_tick,
             "Prepare entity update"
         );
-
-        let group_id = group.group_id(Some(entity));
         let mut raw_data: Bytes = Bytes::new();
         if !delta_compression {
             // we serialize once and re-use the result for all clients

--- a/lightyear/src/server/connection.rs
+++ b/lightyear/src/server/connection.rs
@@ -43,7 +43,7 @@ use crate::shared::events::connection::ConnectionEvents;
 use crate::shared::message::MessageSend;
 use crate::shared::ping::manager::{PingConfig, PingManager};
 use crate::shared::ping::message::{Ping, Pong};
-use crate::shared::replication::components::{ReplicationGroupId, ReplicationTarget};
+use crate::shared::replication::components::ReplicationGroupId;
 use crate::shared::replication::delta::DeltaManager;
 use crate::shared::replication::network_target::NetworkTarget;
 use crate::shared::replication::receive::ReplicationReceiver;

--- a/lightyear/src/server/replication.rs
+++ b/lightyear/src/server/replication.rs
@@ -747,7 +747,7 @@ pub(crate) mod send {
         // TODO: maybe iterate through all the connected clients instead, to avoid allocations?
         // use the overriden target if present
         let target = override_target.map_or(&replication_target.target, |override_target| {
-            &override_target
+            override_target
         });
         let (insert_target, mut update_target): (NetworkTarget, NetworkTarget) = match visibility {
             Some(visibility) => {

--- a/lightyear/src/shared/replication/archetypes.rs
+++ b/lightyear/src/shared/replication/archetypes.rs
@@ -1,0 +1,172 @@
+//! Keep track of the archetypes that should be replicated
+use std::mem;
+
+use crate::prelude::ComponentRegistry;
+use crate::protocol::component::{ComponentKind, ComponentNetId};
+use bevy::ecs::archetype::ArchetypeEntity;
+use bevy::ecs::component::{ComponentTicks, StorageType};
+use bevy::ecs::storage::{SparseSets, Table};
+use bevy::ptr::Ptr;
+use bevy::{
+    ecs::{
+        archetype::{ArchetypeGeneration, ArchetypeId},
+        component::ComponentId,
+    },
+    prelude::*,
+};
+
+/// Cached information about all replicated archetypes.
+///
+/// The generic component is the component that is used to identify if the archetype is used for Replication.
+/// This is the [`ReplicateToServer`] or [`ReplicationTarget`] component.
+/// (not the [`Replicating`], which just indicates if we are in the process of replicating.
+pub(crate) struct ReplicatedArchetypes<C: Component> {
+    /// ID of the component identifying if the archetype is used for Replication.
+    /// This is the [`ReplicateToServer`] or [`ReplicationTarget`] component.
+    /// (not the [`Replicating`], which just indicates if we are in the process of replicating.
+    replication_component_id: ComponentId,
+    /// Highest processed archetype ID.
+    generation: ArchetypeGeneration,
+
+    /// Archetypes marked as replicated.
+    pub(crate) archetypes: Vec<ReplicatedArchetype>,
+    marker: std::marker::PhantomData<C>,
+}
+
+impl<C: Component> FromWorld for ReplicatedArchetypes<C> {
+    fn from_world(world: &mut World) -> Self {
+        Self {
+            replication_component_id: world.init_component::<C>(),
+            generation: ArchetypeGeneration::initial(),
+            archetypes: Vec::new(),
+            marker: std::marker::PhantomData,
+        }
+    }
+}
+
+/// An archetype that should have some components replicated
+pub(crate) struct ReplicatedArchetype {
+    pub(crate) id: ArchetypeId,
+    pub(crate) components: Vec<ReplicatedComponent>,
+}
+
+pub(crate) struct ReplicatedComponent {
+    pub(crate) delta_compression: bool,
+    pub(crate) replicate_once: bool,
+    pub(crate) override_target: Option<ComponentId>,
+    pub(crate) id: ComponentId,
+    pub(crate) kind: ComponentKind,
+    pub(crate) storage_type: StorageType,
+}
+
+/// Get the component data as a [`Ptr`] and its change ticks
+///
+/// # Safety
+///
+/// Component should be present in the Table or SparseSet
+pub(crate) unsafe fn get_erased_component<'w>(
+    table: &'w Table,
+    sparse_sets: &'w SparseSets,
+    entity: &ArchetypeEntity,
+    storage_type: StorageType,
+    component_id: ComponentId,
+) -> (Ptr<'w>, ComponentTicks) {
+    match storage_type {
+        StorageType::Table => {
+            let column = table.get_column(component_id).unwrap_unchecked();
+            let component = column.get_data_unchecked(entity.table_row());
+            let ticks = column.get_ticks_unchecked(entity.table_row());
+
+            (component, ticks)
+        }
+        StorageType::SparseSet => {
+            let sparse_set = sparse_sets.get(component_id).unwrap_unchecked();
+            let component = sparse_set.get(entity.id()).unwrap_unchecked();
+            let ticks = sparse_set.get_ticks(entity.id()).unwrap_unchecked();
+
+            (component, ticks)
+        }
+    }
+}
+
+impl<C: Component> ReplicatedArchetypes<C> {
+    /// Update the list of archetypes that should be replicated.
+    pub(crate) fn update(&mut self, world: &World, registry: &ComponentRegistry) {
+        let old_generation = mem::replace(&mut self.generation, world.archetypes().generation());
+
+        let kinds = registry.kind_map.kind_map.keys().collect::<Vec<_>>();
+
+        // iterate through the newly added archetypes
+        for archetype in world.archetypes()[old_generation..]
+            .iter()
+            .filter(|archetype| archetype.contains(self.replication_component_id))
+        {
+            let mut replicated_archetype = ReplicatedArchetype {
+                id: archetype.id(),
+                components: Vec::new(),
+            };
+            // add all components of the archetype that are present in the ComponentRegistry, and:
+            // - ignore component if the component is disabled (DisabledComponent<C>) is present
+            // - check if delta-compression is enabled
+            archetype.components().for_each(|component| {
+                let info = unsafe { world.components().get_info(component).unwrap_unchecked() };
+                // if the component has a type_id (i.e. is a rust type)
+                if let Some(kind) = info.type_id().map(|t| ComponentKind(t)) {
+                    // the component is not registered in the ComponentProtocol
+                    if registry.kind_map.net_id(&kind).is_none() {
+                        return;
+                    }
+
+                    // check per component metadata
+                    let disabled = registry.replication_map.get(&kind).map_or(false, |info| {
+                        archetype.components().any(|c| c == info.disabled_id)
+                    });
+                    // we do not replicate the component
+                    if disabled {
+                        return;
+                    }
+                    // TODO: should we store the components in a hashmap for faster lookup?
+                    let delta_compression =
+                        registry.replication_map.get(&kind).map_or(false, |info| {
+                            archetype
+                                .components()
+                                .any(|c| c == info.delta_compression_id)
+                        });
+                    let replicate_once =
+                        registry.replication_map.get(&kind).map_or(false, |info| {
+                            archetype.components().any(|c| c == info.replicate_once_id)
+                        });
+                    let override_target = registry
+                        .replication_map
+                        .get(&kind)
+                        .map_or(false, |info| {
+                            archetype.components().any(|c| c == info.override_target_id)
+                        })
+                        .then(|| {
+                            registry
+                                .replication_map
+                                .get(&kind)
+                                .unwrap()
+                                .override_target_id
+                        });
+
+                    let disabled = registry.replication_map.get(&kind).map_or(false, |info| {
+                        archetype.components().any(|c| c == info.disabled_id)
+                    });
+                    // SAFETY: component ID obtained from this archetype.
+                    let storage_type =
+                        unsafe { archetype.get_storage_type(component).unwrap_unchecked() };
+                    replicated_archetype.components.push(ReplicatedComponent {
+                        delta_compression,
+                        replicate_once,
+                        override_target,
+                        id: component,
+                        kind: kind,
+                        storage_type,
+                    });
+                }
+            });
+            self.archetypes.push(replicated_archetype);
+        }
+    }
+}

--- a/lightyear/src/shared/replication/mod.rs
+++ b/lightyear/src/shared/replication/mod.rs
@@ -24,6 +24,7 @@ use crate::shared::replication::components::ReplicationGroupId;
 
 pub mod components;
 
+pub(crate) mod archetypes;
 pub mod delta;
 pub mod entity_map;
 pub(crate) mod hierarchy;

--- a/lightyear/src/shared/replication/receive.rs
+++ b/lightyear/src/shared/replication/receive.rs
@@ -859,7 +859,7 @@ impl GroupChannel {
 
             // safety: we know by this point that the entity exists
             let Some(mut local_entity_mut) = remote_entity_map.get_by_remote(world, entity) else {
-                error!("cannot find entity");
+                error!(?entity, "cannot find entity");
                 continue;
             };
 

--- a/lightyear/src/tests/protocol.rs
+++ b/lightyear/src/tests/protocol.rs
@@ -164,7 +164,7 @@ impl Plugin for ProtocolPlugin {
         // inputs
         app.add_plugins(InputPlugin::<MyInput>::default());
         // components
-        app.register_component::<Component1>(ChannelDirection::ServerToClient)
+        app.register_component::<Component1>(ChannelDirection::Bidirectional)
             .add_prediction(ComponentSyncMode::Full)
             .add_interpolation(ComponentSyncMode::Full)
             .add_linear_interpolation_fn();


### PR DESCRIPTION
# Context

Currently we have 1 replication system per component. It is fairly expensive to run because we have to maintain one query/one system per component.

This PR switches to a single system for replication that iterates through every archetype, similar to what replicon does (credit to them!).

The new approach iterates through each archetype that we know has the `ReplicateToTarget` component.
Is it actually more efficient? I'm not sure, since data in bevy is stored in a column-order, so fetching data per column is probably much faster. Maybe with queries as entities, once we have a ComponentIndex and a more efficient way of updating queries the old approach will be better?

For serialization, maybe we might want to serialize data component-per-component? (e.g. by column instead of by row). Seems like it would give better compression results.
i.e. maybe the serialization would be something like:
- write all the entities that are despawned
- write all entities in the archetype and serialize them in a row
- write their spawn status (None, Spawn, SpawnReuse)
- for each component C, 
  - write a bitmap that indicates for each entity if it's an include/insert/or None. (https://arrow.apache.org/docs/format/Columnar.html#validity-bitmaps)
  - write all the values 1 by 1. In particular we fetch the data in column format, so we should have better cache-lines, etc.?
- write removals separetely
