### PR TITLE
enable specifying a send_frequency for a ReplicationGroup

### DIFF
--- a/lightyear/src/client/replication.rs
+++ b/lightyear/src/client/replication.rs
@@ -206,7 +206,7 @@ pub(crate) mod send {
             sender.replicate_component_cache.insert(
                 entity,
                 ReplicateCache {
-                    replication_group: *group,
+                    replication_group: group.clone(),
                 },
             );
         }
@@ -272,6 +272,16 @@ pub(crate) mod send {
             // 3. go through all entities of that archetype
             for entity in archetype.entities() {
                 let entity_ref = world.entity(entity.id());
+                let group = entity_ref.get::<ReplicationGroup>();
+                // If the group is not set to send, skip this entity
+                if group.is_some_and(|g| !g.should_send) {
+                    continue;
+                }
+                let group_id = group.map_or(ReplicationGroupId::default(), |g| {
+                    g.group_id(Some(entity.id()))
+                });
+                let priority = group.map_or(1.0, |g| g.priority());
+                let target_entity = entity_ref.get::<TargetEntity>();
                 // SAFETY: we know that the entity has the ReplicationTarget component
                 // because the archetype is in replicated_archetypes
                 let replication_target_ticks = unsafe {
@@ -281,12 +291,6 @@ pub(crate) mod send {
                 };
                 let replication_is_changed = replication_target_ticks
                     .is_changed(system_ticks.last_run(), system_ticks.this_run());
-                let group = entity_ref.get::<ReplicationGroup>();
-                let group_id = group.map_or(ReplicationGroupId::default(), |g| {
-                    g.group_id(Some(entity.id()))
-                });
-                let priority = group.map_or(1.0, |g| g.priority());
-                let target_entity = entity_ref.get::<TargetEntity>();
 
                 // b. add entity despawns from ReplicateToServer component being removed
                 // replicate_entity_despawn(
@@ -881,6 +885,72 @@ pub(crate) mod send {
                 &Component1(2.0)
             )
         }
+
+        // TODO: hard to test because we need to wait a few ticks on the server..
+        //  maybe disable sync for tests?
+        // #[test]
+        // fn test_component_update_send_frequency() {
+        //     let mut stepper = BevyStepper::default();
+        //
+        //     // spawn an entity on server
+        //     let client_entity = stepper
+        //         .client_app
+        //         .world
+        //         .spawn((
+        //             Replicate {
+        //                 // replicate every 4 ticks
+        //                 group: ReplicationGroup::new_from_entity()
+        //                     .set_send_frequency(Duration::from_millis(40)),
+        //                 ..default()
+        //             },
+        //             Component1(1.0),
+        //         ))
+        //         .id();
+        //     stepper.frame_step();
+        //     stepper.frame_step();
+        //     let server_entity = *stepper
+        //         .server_app
+        //         .world
+        //         .resource::<server::ConnectionManager>()
+        //         .connection(ClientId::Netcode(TEST_CLIENT_ID))
+        //         .unwrap()
+        //         .replication_receiver
+        //         .remote_entity_map
+        //         .get_local(client_entity)
+        //         .expect("entity was not replicated to client");
+        //
+        //     // update component
+        //     stepper
+        //         .client_app
+        //         .world
+        //         .entity_mut(client_entity)
+        //         .insert(Component1(2.0));
+        //     stepper.frame_step();
+        //     stepper.frame_step();
+        //
+        //     // check that the component was not updated (because it had been only three ticks)
+        //     assert_eq!(
+        //         stepper
+        //             .server_app
+        //             .world
+        //             .entity(server_entity)
+        //             .get::<Component1>()
+        //             .expect("component missing"),
+        //         &Component1(1.0)
+        //     );
+        //     // it has been 4 ticks, the component was updated
+        //     stepper.frame_step();
+        //     // check that the component was not updated (because it had been only two ticks)
+        //     assert_eq!(
+        //         stepper
+        //             .server_app
+        //             .world
+        //             .entity(server_entity)
+        //             .get::<Component1>()
+        //             .expect("component missing"),
+        //         &Component1(2.0)
+        //     );
+        // }
 
         #[test]
         fn test_component_update_disabled() {


### PR DESCRIPTION
Unreal has a NetUpdateFrequency per actor to determine how often a given entity is replicated: https://docs.unrealengine.com/4.27/en-US/InteractiveExperiences/Networking/Actors/ReplicationFlow/
Coherence has the same concept: https://docs.coherence.io/coherence-sdk-for-unity/optimization/simulation-frequency#per-binding-sampling-frequency

This PR adds the capability to update the send_frequency per replication group. The send_frequency has to be at least the send_frequency of the sender, otherwise we get undefined behavior.

Right now we don't buffer updates exactly at the send_frequency of the entity, we still buffer updates only at the send_frequency of the sender. This makes things easier because we can just keep track of a single send_tick.