### PR TITLE
Set `send_interval` per Channel instead of globally

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [workspace]
 resolver = "2"
 members = [
-    "lightyear",
-    "macros",
-    # internal
-    "benches",
-    "examples/*",
+  "lightyear",
+  "macros",
+  # internal
+  "benches",
+  "examples/*",
 ]
 default-members = ["lightyear"]
 exclude = ["examples/certificates"]

--- a/examples/common/src/app.rs
+++ b/examples/common/src/app.rs
@@ -15,7 +15,7 @@ use clap::{Parser, ValueEnum};
 use lightyear::prelude::client::ClientConfig;
 use lightyear::prelude::*;
 use lightyear::prelude::{client, server};
-use lightyear::server::config::{ReplicationConfig, ServerConfig};
+use lightyear::server::config::ServerConfig;
 use lightyear::shared::log::add_log_layer;
 use lightyear::transport::LOCAL_SOCKET;
 use serde::{Deserialize, Serialize};

--- a/examples/common/src/app.rs
+++ b/examples/common/src/app.rs
@@ -15,13 +15,13 @@ use clap::{Parser, ValueEnum};
 use lightyear::prelude::client::ClientConfig;
 use lightyear::prelude::*;
 use lightyear::prelude::{client, server};
-use lightyear::server::config::ServerConfig;
+use lightyear::server::config::{ReplicationConfig, ServerConfig};
 use lightyear::shared::log::add_log_layer;
 use lightyear::transport::LOCAL_SOCKET;
 use serde::{Deserialize, Serialize};
 
 use crate::settings::*;
-use crate::shared::shared_config;
+use crate::shared::{shared_config, SERVER_REPLICATION_INTERVAL};
 
 /// CLI options to create an [`App`]
 #[derive(Parser, PartialEq, Debug)]
@@ -353,6 +353,10 @@ fn server_app(
     let server_config = ServerConfig {
         shared: shared_config(Mode::Separate),
         net: net_configs,
+        replication: ReplicationConfig {
+            send_interval: SERVER_REPLICATION_INTERVAL,
+            ..default()
+        },
         ..default()
     };
     (app, server_config)
@@ -384,6 +388,10 @@ fn combined_app(
     let server_config = ServerConfig {
         shared: shared_config(Mode::HostServer),
         net: net_configs,
+        replication: ReplicationConfig {
+            send_interval: SERVER_REPLICATION_INTERVAL,
+            ..default()
+        },
         ..default()
     };
 

--- a/examples/common/src/shared.rs
+++ b/examples/common/src/shared.rs
@@ -3,12 +3,13 @@ use std::time::Duration;
 
 pub const FIXED_TIMESTEP_HZ: f64 = 64.0;
 
+pub const SERVER_REPLICATION_INTERVAL: Duration = Duration::from_millis(100);
+
 /// The [`SharedConfig`] must be shared between the `ClientConfig` and `ServerConfig`
 pub fn shared_config(mode: Mode) -> SharedConfig {
     SharedConfig {
-        client_send_interval: Duration::default(),
-        // send an update every 100ms
-        server_send_interval: Duration::from_millis(100),
+        // send replication updates every 100ms
+        server_replication_send_interval: SERVER_REPLICATION_INTERVAL,
         tick: TickConfig {
             tick_duration: Duration::from_secs_f64(1.0 / FIXED_TIMESTEP_HZ),
         },

--- a/examples/interest_management/src/server.rs
+++ b/examples/interest_management/src/server.rs
@@ -31,8 +31,8 @@ impl Plugin for ExampleServerPlugin {
             (
                 handle_connections,
                 // we don't have to run interest management every tick, only every time
-                // the server is ready to send packets
-                interest_management.in_set(MainSet::Send),
+                // we are buffering replication messages
+                interest_management.in_set(ReplicationSet::SendMessages),
                 receive_message,
             ),
         );

--- a/examples/simple_setup/src/shared.rs
+++ b/examples/simple_setup/src/shared.rs
@@ -11,8 +11,6 @@ pub const FIXED_TIMESTEP_HZ: f64 = 64.0;
 /// The [`SharedConfig`] must be shared between the `ClientConfig` and `ServerConfig`
 pub fn shared_config(mode: Mode) -> SharedConfig {
     SharedConfig {
-        // send an update every frame
-        client_send_interval: Duration::default(),
         // send an update every 100ms
         server_send_interval: Duration::from_millis(100),
         tick: TickConfig {

--- a/lightyear/src/channel/builder.rs
+++ b/lightyear/src/channel/builder.rs
@@ -82,27 +82,27 @@ impl ChannelContainer {
         match settings.mode {
             ChannelMode::UnorderedUnreliableWithAcks => {
                 receiver = UnorderedUnreliableReceiver::new().into();
-                sender = UnorderedUnreliableWithAcksSender::new().into();
+                sender = UnorderedUnreliableWithAcksSender::new(settings.send_frequency).into();
             }
             ChannelMode::UnorderedUnreliable => {
                 receiver = UnorderedUnreliableReceiver::new().into();
-                sender = UnorderedUnreliableSender::new().into();
+                sender = UnorderedUnreliableSender::new(settings.send_frequency).into();
             }
             ChannelMode::SequencedUnreliable => {
                 receiver = SequencedUnreliableReceiver::new().into();
-                sender = SequencedUnreliableSender::new().into();
+                sender = SequencedUnreliableSender::new(settings.send_frequency).into();
             }
             ChannelMode::UnorderedReliable(reliable_settings) => {
                 receiver = UnorderedReliableReceiver::new().into();
-                sender = ReliableSender::new(reliable_settings).into();
+                sender = ReliableSender::new(reliable_settings, settings.send_frequency).into();
             }
             ChannelMode::SequencedReliable(reliable_settings) => {
                 receiver = SequencedReliableReceiver::new().into();
-                sender = ReliableSender::new(reliable_settings).into();
+                sender = ReliableSender::new(reliable_settings, settings.send_frequency).into();
             }
             ChannelMode::OrderedReliable(reliable_settings) => {
                 receiver = OrderedReliableReceiver::new().into();
-                sender = ReliableSender::new(reliable_settings).into();
+                sender = ReliableSender::new(reliable_settings, settings.send_frequency).into();
             }
         }
         Self {
@@ -119,6 +119,9 @@ impl ChannelContainer {
 #[derive(Clone, Debug, PartialEq)]
 pub struct ChannelSettings {
     pub mode: ChannelMode,
+    /// How often should we try to send messages on this channel.
+    /// Set to `Duration::default()` to send messages every frame if possible.
+    pub send_frequency: Duration,
     pub direction: ChannelDirection,
     /// Sets the priority of the channel. The final priority of a message will be `MessagePriority * ChannelPriority`
     pub priority: f32,
@@ -128,6 +131,7 @@ impl Default for ChannelSettings {
     fn default() -> Self {
         Self {
             mode: ChannelMode::UnorderedUnreliable,
+            send_frequency: Duration::default(),
             direction: ChannelDirection::Bidirectional,
             priority: 1.0,
         }
@@ -236,7 +240,3 @@ pub struct PongChannel;
 #[derive(ChannelInternal)]
 /// Default channel to send inputs from client to server. This is a Sequenced Unreliable channel.
 pub struct InputChannel;
-
-/// Default Unordered Unreliable channel, to send messages as fast as possible without any ordering.
-#[derive(ChannelInternal)]
-pub struct DefaultUnorderedUnreliableChannel;

--- a/lightyear/src/channel/senders/mod.rs
+++ b/lightyear/src/channel/senders/mod.rs
@@ -46,16 +46,8 @@ pub trait ChannelSend {
     /// that can be sent over the network for this channel
     fn send_packet(&mut self) -> (VecDeque<SendMessage>, VecDeque<SendMessage>);
 
-    /// Collect the list of messages that need to be sent
-    /// Either because they have never been sent, or because they need to be resent (for reliability)
-    /// Needs to be called before [`ReliableSender::send_packet`](reliable::ReliableSender::send_packet)
-    fn collect_messages_to_send(&mut self);
-
     /// Called when we receive acknowledgement that a Message has been received
     fn receive_ack(&mut self, message_ack: &MessageAck);
-
-    /// Returns true if there are messages in the buffer that are ready to be sent
-    fn has_messages_to_send(&self) -> bool;
 
     /// Create a new receiver that will receive a message id when a sent message is acked
     fn subscribe_acks(&mut self) -> Receiver<MessageId>;

--- a/lightyear/src/channel/senders/sequenced_unreliable.rs
+++ b/lightyear/src/channel/senders/sequenced_unreliable.rs
@@ -1,3 +1,5 @@
+use bevy::time::{Timer, TimerMode};
+use bevy::utils::Duration;
 use std::collections::VecDeque;
 
 use bytes::Bytes;
@@ -12,7 +14,7 @@ use crate::shared::tick_manager::TickManager;
 use crate::shared::time_manager::TimeManager;
 
 /// A sender that simply sends the messages without checking if they were received
-/// Same as UnorderedUnreliableSender, but includes ordering information
+/// Same as UnorderedUnreliableSender, but includes ordering information (MessageId)
 pub struct SequencedUnreliableSender {
     /// list of single messages that we want to fit into packets and send
     single_messages_to_send: VecDeque<SendMessage>,
@@ -25,22 +27,27 @@ pub struct SequencedUnreliableSender {
     fragment_sender: FragmentSender,
     /// List of senders that want to be notified when a message is lost
     nack_senders: Vec<Sender<MessageId>>,
+    /// Internal timer to determine if the channel is ready to send messages
+    timer: Timer,
 }
 
 impl SequencedUnreliableSender {
-    pub(crate) fn new() -> Self {
+    pub(crate) fn new(send_frequency: Duration) -> Self {
         Self {
             single_messages_to_send: VecDeque::new(),
             fragmented_messages_to_send: VecDeque::new(),
             next_send_message_id: MessageId(0),
             fragment_sender: FragmentSender::new(),
             nack_senders: vec![],
+            timer: Timer::new(send_frequency, TimerMode::Repeating),
         }
     }
 }
 
 impl ChannelSend for SequencedUnreliableSender {
-    fn update(&mut self, _: &TimeManager, _: &PingManager, _: &TickManager) {}
+    fn update(&mut self, time_manager: &TimeManager, _: &PingManager, _: &TickManager) {
+        self.timer.tick(time_manager.delta());
+    }
 
     /// Add a new message to the buffer of messages to be sent.
     /// This is a client-facing function, to be called when you want to send a message
@@ -74,6 +81,9 @@ impl ChannelSend for SequencedUnreliableSender {
     /// Take messages from the buffer of messages to be sent, and build a list of packets
     /// to be sent
     fn send_packet(&mut self) -> (VecDeque<SendMessage>, VecDeque<SendMessage>) {
+        if self.timer.duration() != Duration::default() && !self.timer.finished() {
+            return (VecDeque::new(), VecDeque::new());
+        }
         (
             std::mem::take(&mut self.single_messages_to_send),
             std::mem::take(&mut self.fragmented_messages_to_send),
@@ -84,14 +94,7 @@ impl ChannelSend for SequencedUnreliableSender {
         // self.messages_to_send = remaining_messages_to_send;
     }
 
-    // not necessary for an unreliable sender (all the buffered messages can be sent)
-    fn collect_messages_to_send(&mut self) {}
-
     fn receive_ack(&mut self, _message_ack: &MessageAck) {}
-
-    fn has_messages_to_send(&self) -> bool {
-        !self.single_messages_to_send.is_empty() || !self.fragmented_messages_to_send.is_empty()
-    }
 
     fn subscribe_acks(&mut self) -> Receiver<MessageId> {
         unreachable!()
@@ -115,8 +118,30 @@ impl ChannelSend for SequencedUnreliableSender {
 
 #[cfg(test)]
 mod tests {
-    // #[test]
-    // fn test_sequenced_unreliable_sender_internals() {
-    //     todo!()
-    // }
+    use super::*;
+    use crate::prelude::{PingConfig, TickConfig};
+    #[test]
+    fn test_sequenced_unreliable_sender_internals() {
+        let mut sender = SequencedUnreliableSender::new(Duration::from_secs(1));
+        assert!(!sender.timer.finished());
+
+        sender.buffer_send(Bytes::from("hello"), 1.0).unwrap();
+
+        // we do not send because we didn't reach the timer
+        let (single, _) = sender.send_packet();
+        assert!(single.is_empty());
+
+        // update with a delta of 1 second
+        let mut time_manager = TimeManager::default();
+        time_manager.update(Duration::from_secs(1));
+        sender.update(
+            &time_manager,
+            &PingManager::new(PingConfig::default()),
+            &TickManager::from_config(TickConfig::new(Duration::from_secs(1))),
+        );
+
+        // this time, we send the packet
+        let (single, _) = sender.send_packet();
+        assert_eq!(single.len(), 1);
+    }
 }

--- a/lightyear/src/channel/senders/unordered_unreliable_with_acks.rs
+++ b/lightyear/src/channel/senders/unordered_unreliable_with_acks.rs
@@ -1,3 +1,5 @@
+use bevy::prelude::{Timer, TimerMode};
+use bevy::utils::Duration;
 use std::collections::VecDeque;
 
 use bytes::Bytes;
@@ -36,10 +38,12 @@ pub struct UnorderedUnreliableWithAcksSender {
     /// was acked
     fragment_ack_receiver: FragmentAckReceiver,
     current_time: WrappedTime,
+    /// Internal timer to determine if the channel is ready to send messages
+    timer: Timer,
 }
 
 impl UnorderedUnreliableWithAcksSender {
-    pub(crate) fn new() -> Self {
+    pub(crate) fn new(send_frequency: Duration) -> Self {
         Self {
             single_messages_to_send: VecDeque::new(),
             fragmented_messages_to_send: VecDeque::new(),
@@ -49,6 +53,7 @@ impl UnorderedUnreliableWithAcksSender {
             nack_senders: Vec::new(),
             fragment_ack_receiver: FragmentAckReceiver::new(),
             current_time: WrappedTime::default(),
+            timer: Timer::new(send_frequency, TimerMode::Repeating),
         }
     }
 }
@@ -58,6 +63,7 @@ impl ChannelSend for UnorderedUnreliableWithAcksSender {
         self.current_time = time_manager.current_time();
         self.fragment_ack_receiver
             .cleanup(self.current_time - DISCARD_AFTER);
+        self.timer.tick(time_manager.delta());
     }
 
     /// Add a new message to the buffer of messages to be sent.
@@ -93,6 +99,9 @@ impl ChannelSend for UnorderedUnreliableWithAcksSender {
 
     /// Take messages from the buffer of messages to be sent, and build a list of packets to be sent
     fn send_packet(&mut self) -> (VecDeque<SendMessage>, VecDeque<SendMessage>) {
+        if self.timer.duration() != Duration::default() && !self.timer.finished() {
+            return (VecDeque::new(), VecDeque::new());
+        }
         (
             std::mem::take(&mut self.single_messages_to_send),
             std::mem::take(&mut self.fragmented_messages_to_send),
@@ -102,9 +111,6 @@ impl ChannelSend for UnorderedUnreliableWithAcksSender {
         //     packet_manager.pack_messages_within_channel(messages_to_send);
         // self.messages_to_send = remaining_messages_to_send;
     }
-
-    // not necessary for an unreliable sender (all the buffered messages can be sent)
-    fn collect_messages_to_send(&mut self) {}
 
     /// Notify any subscribers that a message was acked
     fn receive_ack(&mut self, ack: &MessageAck) {
@@ -126,10 +132,6 @@ impl ChannelSend for UnorderedUnreliableWithAcksSender {
                 }
             },
         );
-    }
-
-    fn has_messages_to_send(&self) -> bool {
-        !self.single_messages_to_send.is_empty() || !self.fragmented_messages_to_send.is_empty()
     }
 
     /// Create a new receiver that will receive a message id when a message is acked
@@ -163,7 +165,7 @@ mod tests {
 
     #[test]
     fn test_receive_ack() {
-        let mut sender = UnorderedUnreliableWithAcksSender::new();
+        let mut sender = UnorderedUnreliableWithAcksSender::new(Duration::default());
 
         // create subscriber
         let receiver = sender.subscribe_acks();

--- a/lightyear/src/client/config.rs
+++ b/lightyear/src/client/config.rs
@@ -2,7 +2,6 @@
 use bevy::ecs::reflect::ReflectResource;
 use bevy::prelude::Resource;
 use bevy::reflect::Reflect;
-use bevy::utils::Duration;
 use governor::Quota;
 use nonzero_ext::nonzero;
 
@@ -13,6 +12,7 @@ use crate::client::sync::SyncConfig;
 use crate::connection::client::NetConfig;
 use crate::shared::config::SharedConfig;
 use crate::shared::ping::manager::PingConfig;
+use crate::shared::replication::plugin::ReplicationConfig;
 
 #[derive(Clone, Reflect)]
 /// Config related to the netcode protocol (abstraction of a connection over raw UDP-like transport)
@@ -90,26 +90,6 @@ impl PacketConfig {
         self.bandwidth_cap_enabled = true;
         self
     }
-}
-
-#[derive(Clone, Debug, Default, Reflect)]
-pub struct ReplicationConfig {
-    /// By default, we will send all component updates since the last time we sent an update for a given entity.
-    /// E.g. if the component was updated at tick 3; we will send the update at tick 3, and then at tick 4,
-    /// we won't be sending anything since the component wasn't updated after that.
-    ///
-    /// This helps save bandwidth, but can cause the client to have delayed eventual consistency in the
-    /// case of packet loss.
-    ///
-    /// If this is set to true, we will instead send all updates since the last time we received an ACK from the client.
-    /// E.g. if the component was updated at tick 3; we will send the update at tick 3, and then at tick 4,
-    /// we will send the update again even if the component wasn't updated, because we still haven't
-    /// received an ACK from the client.
-    pub send_updates_since_last_ack: bool,
-    /// How often we send replication updates.
-    ///
-    /// Set to `Duration::default()` to send updates every frame.
-    pub send_interval: Duration,
 }
 
 /// The configuration object that lets you create a `ClientPlugin` with the desired settings.

--- a/lightyear/src/client/config.rs
+++ b/lightyear/src/client/config.rs
@@ -2,6 +2,7 @@
 use bevy::ecs::reflect::ReflectResource;
 use bevy::prelude::Resource;
 use bevy::reflect::Reflect;
+use bevy::utils::Duration;
 use governor::Quota;
 use nonzero_ext::nonzero;
 
@@ -105,6 +106,10 @@ pub struct ReplicationConfig {
     /// we will send the update again even if the component wasn't updated, because we still haven't
     /// received an ACK from the client.
     pub send_updates_since_last_ack: bool,
+    /// How often we send replication updates.
+    ///
+    /// Set to `Duration::default()` to send updates every frame.
+    pub send_interval: Duration,
 }
 
 /// The configuration object that lets you create a `ClientPlugin` with the desired settings.

--- a/lightyear/src/client/input/leafwing.rs
+++ b/lightyear/src/client/input/leafwing.rs
@@ -203,10 +203,9 @@ impl<A: LeafwingUserAction + TypePath> Plugin for LeafwingInputPlugin<A>
                 InputSystemSet::ReceiveTickEvents
                     .run_if(should_run.clone().and_then(client_is_synced)),
                 InputSystemSet::SendInputMessage
-                    .run_if(should_run.clone().and_then(client_is_synced))
-                    .in_set(InternalMainSet::<ClientMarker>::Send),
+                    .run_if(should_run.clone().and_then(client_is_synced)),
                 InputSystemSet::CleanUp.run_if(should_run.clone().and_then(client_is_synced)),
-                InternalMainSet::<ClientMarker>::SendPackets,
+                InternalMainSet::<ClientMarker>::Send,
             )
                 .chain(),
         );

--- a/lightyear/src/client/input/leafwing.rs
+++ b/lightyear/src/client/input/leafwing.rs
@@ -63,7 +63,7 @@ use crate::inputs::leafwing::input_buffer::{
     ActionDiff, ActionDiffBuffer, ActionDiffEvent, InputBuffer, InputMessage, InputTarget,
 };
 use crate::inputs::leafwing::LeafwingUserAction;
-use crate::prelude::{is_host_server, MessageRegistry, TickManager};
+use crate::prelude::{is_host_server, ChannelKind, ChannelRegistry, MessageRegistry, TickManager};
 use crate::protocol::message::MessageKind;
 use crate::serialize::reader::Reader;
 use crate::shared::replication::components::PrePredicted;
@@ -645,6 +645,7 @@ fn clean_buffers<A: LeafwingUserAction>(
 /// Send a message to the server containing the ActionDiffs for the last few ticks
 fn prepare_input_message<A: LeafwingUserAction>(
     mut connection: ResMut<ConnectionManager>,
+    channel_registry: Res<ChannelRegistry>,
     config: Res<ClientConfig>,
     tick_manager: Res<TickManager>,
     // global_action_diff_buffer: Option<Res<ActionDiffBuffer<A>>>,
@@ -664,13 +665,17 @@ fn prepare_input_message<A: LeafwingUserAction>(
     // TODO: instead of redundancy, send ticks up to the latest yet ACK-ed input tick
     //  this means we would also want to track packet->message acks for unreliable channels as well, so we can notify
     //  this system what the latest acked input tick is?
+    let input_send_interval = channel_registry
+        .get_builder_from_kind(&ChannelKind::of::<InputChannel>())
+        .unwrap()
+        .settings
+        .send_frequency;
     // we send redundant inputs, so that if a packet is lost, we can still recover
     // A redundancy of 2 means that we can recover from 1 lost packet
-    let num_tick: u16 = ((config.shared.client_send_interval.as_nanos()
-        / config.shared.tick.tick_duration.as_nanos())
-        + 1)
-    .try_into()
-    .unwrap();
+    let num_tick: u16 =
+        ((input_send_interval.as_nanos() / config.shared.tick.tick_duration.as_nanos()) + 1)
+            .try_into()
+            .unwrap();
     let redundancy = config.input.packet_redundancy;
     let message_len = redundancy * num_tick;
     let mut message = InputMessage::<A>::new(tick);

--- a/lightyear/src/client/input/native.rs
+++ b/lightyear/src/client/input/native.rs
@@ -172,7 +172,6 @@ impl<A: UserAction> Plugin for InputPlugin<A> {
                         // no need to send input messages via io if we are in host-server mode
                         client_is_synced.and_then(not(is_host_server)),
                     ),
-                InternalMainSet::<ClientMarker>::SendPackets,
             )
                 .chain(),
         );

--- a/lightyear/src/client/input/native.rs
+++ b/lightyear/src/client/input/native.rs
@@ -166,12 +166,11 @@ impl<A: UserAction> Plugin for InputPlugin<A> {
                     client_is_synced.and_then(not(is_host_server)),
                 ),
                 // we send inputs only every send_interval
-                InputSystemSet::SendInputMessage
-                    .in_set(InternalMainSet::<ClientMarker>::Send)
-                    .run_if(
-                        // no need to send input messages via io if we are in host-server mode
-                        client_is_synced.and_then(not(is_host_server)),
-                    ),
+                InputSystemSet::SendInputMessage.run_if(
+                    // no need to send input messages via io if we are in host-server mode
+                    client_is_synced.and_then(not(is_host_server)),
+                ),
+                InternalMainSet::<ClientMarker>::Send,
             )
                 .chain(),
         );

--- a/lightyear/src/client/interpolation/interpolate.rs
+++ b/lightyear/src/client/interpolation/interpolate.rs
@@ -65,7 +65,7 @@ pub(crate) fn update_interpolate_status<C: SyncComponent>(
 
     // how many ticks between each interpolation (add 1 to roughly take the ceil)
     let send_interval_delta_tick = (SEND_INTERVAL_TICK_FACTOR
-        * config.shared.server_send_interval.as_secs_f32()
+        * config.shared.server_replication_send_interval.as_secs_f32()
         / config.shared.tick.tick_duration.as_secs_f32()) as i16
         + 1;
 
@@ -222,7 +222,7 @@ pub(crate) fn insert_interpolated_component<C: SyncComponent>(
     // how many ticks between each interpolation update (add 1 to roughly take the ceil)
     // TODO: use something more precise, with the interpolation overstep?
     let send_interval_delta_tick = (SEND_INTERVAL_TICK_FACTOR
-        * config.shared.server_send_interval.as_secs_f32()
+        * config.shared.server_replication_send_interval.as_secs_f32()
         / config.shared.tick.tick_duration.as_secs_f32()) as i16
         + 1;
     for (entity, status) in query.iter_mut() {

--- a/lightyear/src/client/networking.rs
+++ b/lightyear/src/client/networking.rs
@@ -233,7 +233,8 @@ pub(crate) fn sync_update(
         tick_manager.deref_mut(),
         &connection.ping_manager,
         &config.interpolation.delay,
-        config.shared.server_send_interval,
+        // TODO: how to adjust this for replication groups that have a custom send_interval?
+        config.shared.server_replication_send_interval,
     ) {
         tick_events.send(tick_event);
     }

--- a/lightyear/src/client/networking.rs
+++ b/lightyear/src/client/networking.rs
@@ -190,12 +190,6 @@ pub(crate) fn send(
     mut connection: ResMut<ConnectionManager>,
 ) {
     trace!("Send packets to server");
-    // finalize any packets that are needed for replication
-    connection
-        .buffer_replication_messages(tick_manager.tick(), system_change_tick.this_run())
-        .unwrap_or_else(|e| {
-            error!("Error preparing replicate send: {}", e);
-        });
     // SEND_PACKETS: send buffered packets to io
     let packet_bytes = connection
         .send_packets(time_manager.as_ref(), tick_manager.as_ref())

--- a/lightyear/src/client/plugin.rs
+++ b/lightyear/src/client/plugin.rs
@@ -60,7 +60,9 @@ impl PluginGroup for ClientPlugins {
             .add(ClientNetworkingPlugin)
             .add(ClientDiagnosticsPlugin::default())
             .add(ClientReplicationReceivePlugin { tick_interval })
-            .add(ClientReplicationSendPlugin { tick_interval })
+            .add(ClientReplicationSendPlugin {
+                clean_interval: tick_interval,
+            })
             .add(PredictionPlugin)
             .add(InterpolationPlugin::new(interpolation_config));
 

--- a/lightyear/src/client/plugin.rs
+++ b/lightyear/src/client/plugin.rs
@@ -60,9 +60,7 @@ impl PluginGroup for ClientPlugins {
             .add(ClientNetworkingPlugin)
             .add(ClientDiagnosticsPlugin::default())
             .add(ClientReplicationReceivePlugin { tick_interval })
-            .add(ClientReplicationSendPlugin {
-                clean_interval: tick_interval,
-            })
+            .add(ClientReplicationSendPlugin { tick_interval })
             .add(PredictionPlugin)
             .add(InterpolationPlugin::new(interpolation_config));
 

--- a/lightyear/src/client/plugin.rs
+++ b/lightyear/src/client/plugin.rs
@@ -21,7 +21,7 @@ use crate::client::replication::{
 };
 use crate::shared::plugin::SharedPlugin;
 
-use super::config::{ClientConfig, ReplicationConfig};
+use super::config::ClientConfig;
 
 /// A plugin group containing all the client plugins.
 ///
@@ -80,8 +80,6 @@ struct SetupPlugin {
 impl Plugin for SetupPlugin {
     fn build(&self, app: &mut App) {
         app
-            // REFLECTION
-            .register_type::<ReplicationConfig>()
             // RESOURCES //
             .insert_resource(self.config.clone());
 

--- a/lightyear/src/client/replication.rs
+++ b/lightyear/src/client/replication.rs
@@ -71,7 +71,7 @@ pub(crate) mod send {
 
     #[derive(Default)]
     pub struct ClientReplicationSendPlugin {
-        pub clean_interval: Duration,
+        pub tick_interval: Duration,
     }
 
     impl Plugin for ClientReplicationSendPlugin {
@@ -87,7 +87,7 @@ pub(crate) mod send {
                 .register_type::<Replicate>()
                 // PLUGIN
                 .add_plugins(ReplicationSendPlugin::<ConnectionManager>::new(
-                    self.clean_interval,
+                    self.tick_interval,
                     send_interval,
                 ))
                 // SETS

--- a/lightyear/src/client/replication.rs
+++ b/lightyear/src/client/replication.rs
@@ -298,10 +298,7 @@ pub(crate) mod send {
             for entity in archetype.entities() {
                 let entity_ref = world.entity(entity.id());
                 let group = entity_ref.get::<ReplicationGroup>();
-                // If the group is not set to send, skip this entity
-                if group.is_some_and(|g| !g.should_send) {
-                    continue;
-                }
+
                 let group_id = group.map_or(ReplicationGroupId::default(), |g| {
                     g.group_id(Some(entity.id()))
                 });
@@ -335,6 +332,11 @@ pub(crate) mod send {
                         target_entity,
                         &mut sender,
                     );
+                }
+
+                // If the group is not set to send, skip this entity
+                if group.is_some_and(|g| !g.should_send) {
+                    continue;
                 }
 
                 // d. all components that were added or changed

--- a/lightyear/src/client/replication.rs
+++ b/lightyear/src/client/replication.rs
@@ -54,7 +54,7 @@ pub(crate) mod send {
 
     use crate::connection::client::ClientConnection;
 
-    use crate::prelude::client::NetClient;
+    use crate::prelude::client::{ClientConfig, NetClient};
 
     use crate::prelude::{
         is_connected, is_host_server, ComponentRegistry, DisabledComponent, ReplicateHierarchy,
@@ -71,17 +71,24 @@ pub(crate) mod send {
 
     #[derive(Default)]
     pub struct ClientReplicationSendPlugin {
-        pub tick_interval: Duration,
+        pub clean_interval: Duration,
     }
 
     impl Plugin for ClientReplicationSendPlugin {
         fn build(&self, app: &mut App) {
+            let send_interval = app
+                .world
+                .resource::<ClientConfig>()
+                .replication
+                .send_interval;
+
             app
                 // REFLECTION
                 .register_type::<Replicate>()
                 // PLUGIN
                 .add_plugins(ReplicationSendPlugin::<ConnectionManager>::new(
-                    self.tick_interval,
+                    self.clean_interval,
+                    send_interval,
                 ))
                 // SETS
                 .configure_sets(

--- a/lightyear/src/lib.rs
+++ b/lightyear/src/lib.rs
@@ -185,7 +185,7 @@ pub mod prelude {
 
     pub use crate::channel::builder::{
         Channel, ChannelBuilder, ChannelContainer, ChannelDirection, ChannelMode, ChannelSettings,
-        DefaultUnorderedUnreliableChannel, InputChannel, ReliableSettings,
+        InputChannel, ReliableSettings,
     };
     pub use crate::client::prediction::prespawn::PreSpawnedPlayerObject;
     pub use crate::connection::id::ClientId;

--- a/lightyear/src/lib.rs
+++ b/lightyear/src/lib.rs
@@ -288,7 +288,7 @@ pub mod prelude {
         pub use crate::server::replication::commands::DespawnReplicationCommandExt;
         pub use crate::server::replication::{
             send::{ControlledBy, Replicate, ServerFilter, SyncTarget, Visibility},
-            ServerReplicationSet,
+            ReplicationSet, ServerReplicationSet,
         };
         pub use crate::server::visibility::immediate::VisibilityManager;
         pub use crate::server::visibility::room::{RoomId, RoomManager};

--- a/lightyear/src/lib.rs
+++ b/lightyear/src/lib.rs
@@ -213,6 +213,7 @@ pub mod prelude {
     pub use crate::shared::replication::entity_map::RemoteEntityMap;
     pub use crate::shared::replication::hierarchy::ParentSync;
     pub use crate::shared::replication::network_target::NetworkTarget;
+    pub use crate::shared::replication::plugin::ReplicationConfig;
     pub use crate::shared::replication::resources::{
         ReplicateResourceExt, ReplicateResourceMetadata, StopReplicateResourceExt,
     };

--- a/lightyear/src/packet/message_manager.rs
+++ b/lightyear/src/packet/message_manager.rs
@@ -164,15 +164,12 @@ impl MessageManager {
                 .channel_registry
                 .get_net_from_kind(channel_kind)
                 .ok_or(PacketError::ChannelNotFound)?;
-            channel.sender.collect_messages_to_send();
-            if channel.sender.has_messages_to_send() {
-                let (single_data, fragment_data) = channel.sender.send_packet();
+            let (single_data, fragment_data) = channel.sender.send_packet();
 
-                if !single_data.is_empty() || !fragment_data.is_empty() {
-                    trace!(?channel_id, "send message with channel_id");
-                    has_data_to_send = true;
-                }
+            if !single_data.is_empty() || !fragment_data.is_empty() {
+                trace!(?channel_id, "send message with channel_id");
                 data_to_send.push((*channel_id, (single_data, fragment_data)));
+                has_data_to_send = true;
             }
         }
         // return early if there are no messages to send

--- a/lightyear/src/protocol/channel.rs
+++ b/lightyear/src/protocol/channel.rs
@@ -1,5 +1,6 @@
 use bevy::app::App;
 use bevy::prelude::{Resource, TypePath};
+use bevy::utils::Duration;
 use std::any::TypeId;
 use std::collections::HashMap;
 
@@ -7,9 +8,7 @@ use crate::channel::builder::{Channel, ChannelBuilder, ChannelSettings, PongChan
 use crate::channel::builder::{
     ChannelContainer, EntityActionsChannel, EntityUpdatesChannel, InputChannel, PingChannel,
 };
-use crate::prelude::{
-    ChannelDirection, ChannelMode, DefaultUnorderedUnreliableChannel, ReliableSettings,
-};
+use crate::prelude::{ChannelDirection, ChannelMode, ReliableSettings};
 use crate::protocol::registry::{NetId, TypeKind, TypeMapper};
 
 // TODO: derive Reflect once we reach bevy 0.14
@@ -77,36 +76,44 @@ impl ChannelRegistry {
         };
         registry.add_channel::<EntityUpdatesChannel>(ChannelSettings {
             mode: ChannelMode::UnorderedUnreliableWithAcks,
+            // we do not send the send_frequency to `replication_interval` here
+            // because we want to make sure that the entity updates for tick T
+            // are sent on tick T, so we will set the `replication_interval`
+            // directly on the replication_sender
+            send_frequency: Duration::default(),
             direction: ChannelDirection::Bidirectional,
             priority: 1.0,
         });
         registry.add_channel::<EntityActionsChannel>(ChannelSettings {
             mode: ChannelMode::UnorderedReliable(ReliableSettings::default()),
             direction: ChannelDirection::Bidirectional,
+            // we do not send the send_frequency to `replication_interval` here
+            // because we want to make sure that the entity updates for tick T
+            // are sent on tick T, so we will set the `replication_interval`
+            // directly on the replication_sender
+            send_frequency: Duration::default(),
             // we want to send the entity actions as soon as possible
             priority: 10.0,
         });
         registry.add_channel::<PingChannel>(ChannelSettings {
             mode: ChannelMode::SequencedUnreliable,
             direction: ChannelDirection::Bidirectional,
+            send_frequency: Duration::default(),
             // we always want to include the ping in the packet
             priority: 1000.0,
         });
         registry.add_channel::<PongChannel>(ChannelSettings {
             mode: ChannelMode::SequencedUnreliable,
             direction: ChannelDirection::Bidirectional,
+            send_frequency: Duration::default(),
             // we always want to include the ping in the packet
             priority: 1000.0,
         });
         registry.add_channel::<InputChannel>(ChannelSettings {
             mode: ChannelMode::UnorderedUnreliable,
             direction: ChannelDirection::ClientToServer,
+            send_frequency: Duration::default(),
             priority: 3.0,
-        });
-        registry.add_channel::<DefaultUnorderedUnreliableChannel>(ChannelSettings {
-            mode: ChannelMode::UnorderedUnreliable,
-            direction: ChannelDirection::Bidirectional,
-            priority: 1.0,
         });
         registry
     }

--- a/lightyear/src/server/config.rs
+++ b/lightyear/src/server/config.rs
@@ -3,6 +3,7 @@ use bevy::prelude::{Reflect, Resource};
 use governor::Quota;
 use nonzero_ext::nonzero;
 use std::sync::Arc;
+use std::time::Duration;
 
 use crate::connection::netcode::{Key, PRIVATE_KEY_BYTES};
 use crate::connection::server::{
@@ -111,6 +112,10 @@ pub struct ReplicationConfig {
     /// we will send the update again even if the component wasn't updated, because we still haven't
     /// received an ACK from the client.
     pub send_updates_since_last_ack: bool,
+    /// How often we send replication updates.
+    ///
+    /// Set to `Duration::default()` to send updates every frame.
+    pub send_interval: Duration,
 }
 
 /// Configuration for the server plugin.

--- a/lightyear/src/server/config.rs
+++ b/lightyear/src/server/config.rs
@@ -1,14 +1,14 @@
 //! Defines server-specific configuration options
-use bevy::prelude::{Reflect, Resource};
+use bevy::prelude::Resource;
 use governor::Quota;
 use nonzero_ext::nonzero;
 use std::sync::Arc;
-use std::time::Duration;
 
 use crate::connection::netcode::{Key, PRIVATE_KEY_BYTES};
 use crate::connection::server::{
     ConnectionRequestHandler, DefaultConnectionRequestHandler, NetConfig,
 };
+use crate::prelude::ReplicationConfig;
 use crate::shared::config::SharedConfig;
 use crate::shared::ping::manager::PingConfig;
 
@@ -96,26 +96,6 @@ impl PacketConfig {
         self.bandwidth_cap_enabled = true;
         self
     }
-}
-
-#[derive(Clone, Debug, Default, Reflect)]
-pub struct ReplicationConfig {
-    /// By default, we will send all component updates since the last time we sent an update for a given entity.
-    /// E.g. if the component was updated at tick 3; we will send the update at tick 3, and then at tick 4,
-    /// we won't be sending anything since the component wasn't updated after that.
-    ///
-    /// This helps save bandwidth, but can cause the client to have delayed eventual consistency in the
-    /// case of packet loss.
-    ///
-    /// If this is set to true, we will instead send all updates since the last time we received an ACK from the client.
-    /// E.g. if the component was updated at tick 3; we will send the update at tick 3, and then at tick 4,
-    /// we will send the update again even if the component wasn't updated, because we still haven't
-    /// received an ACK from the client.
-    pub send_updates_since_last_ack: bool,
-    /// How often we send replication updates.
-    ///
-    /// Set to `Duration::default()` to send updates every frame.
-    pub send_interval: Duration,
 }
 
 /// Configuration for the server plugin.

--- a/lightyear/src/server/networking.rs
+++ b/lightyear/src/server/networking.rs
@@ -223,13 +223,6 @@ pub(crate) fn send(
     time_manager: Res<TimeManager>,
 ) {
     trace!("Send packets to clients");
-    // finalize any packets that are needed for replication
-    connection_manager
-        .buffer_replication_messages(tick_manager.tick(), change_tick.this_run())
-        .unwrap_or_else(|e| {
-            error!("Error preparing replicate send: {}", e);
-        });
-
     // SEND_PACKETS: send buffered packets to io
     let span = info_span!("send_packets").entered();
     connection_manager

--- a/lightyear/src/server/networking.rs
+++ b/lightyear/src/server/networking.rs
@@ -11,7 +11,6 @@ use crate::server::error::ServerError;
 use crate::server::events::{ConnectEvent, DisconnectEvent};
 use crate::server::io::ServerIoEvent;
 use crate::shared::sets::{InternalMainSet, ServerMarker};
-use crate::shared::time_manager::is_server_ready_to_send;
 use async_channel::TryRecvError;
 use bevy::ecs::system::{RunSystemOnce, SystemChangeTick};
 use bevy::prelude::*;
@@ -46,15 +45,7 @@ impl Plugin for ServerNetworkingPlugin {
             )
             .configure_sets(
                 PostUpdate,
-                (
-                    // we don't send packets every frame, but on a timer instead
-                    InternalMainSet::<ServerMarker>::Send
-                        .in_set(MainSet::Send)
-                        .run_if(is_started.and_then(is_server_ready_to_send)),
-                    InternalMainSet::<ServerMarker>::SendPackets
-                        .in_set(MainSet::SendPackets)
-                        .in_set(InternalMainSet::<ServerMarker>::Send),
-                ),
+                InternalMainSet::<ServerMarker>::Send.in_set(MainSet::Send),
             )
             // SYSTEMS //
             .add_systems(
@@ -63,7 +54,7 @@ impl Plugin for ServerNetworkingPlugin {
             )
             .add_systems(
                 PostUpdate,
-                send.in_set(InternalMainSet::<ServerMarker>::SendPackets),
+                send.in_set(InternalMainSet::<ServerMarker>::Send),
             );
 
         // STARTUP

--- a/lightyear/src/server/networking.rs
+++ b/lightyear/src/server/networking.rs
@@ -247,10 +247,6 @@ pub(crate) fn send(
         .unwrap_or_else(|e: ServerError| {
             error!("Error sending packets: {}", e);
         });
-
-    // clear the list of newly connected clients
-    // (cannot just use the ConnectionEvent because it is cleared after each frame)
-    connection_manager.new_clients.clear();
 }
 
 /// Bevy [`State`] representing the networking state of the server.

--- a/lightyear/src/server/plugin.rs
+++ b/lightyear/src/server/plugin.rs
@@ -59,9 +59,7 @@ impl PluginGroup for ServerPlugins {
             .add(RoomPlugin)
             .add(ClientsMetadataPlugin)
             .add(ServerReplicationReceivePlugin { tick_interval })
-            .add(ServerReplicationSendPlugin {
-                clean_interval: tick_interval,
-            })
+            .add(ServerReplicationSendPlugin { tick_interval })
     }
 }
 

--- a/lightyear/src/server/plugin.rs
+++ b/lightyear/src/server/plugin.rs
@@ -59,7 +59,9 @@ impl PluginGroup for ServerPlugins {
             .add(RoomPlugin)
             .add(ClientsMetadataPlugin)
             .add(ServerReplicationReceivePlugin { tick_interval })
-            .add(ServerReplicationSendPlugin { tick_interval })
+            .add(ServerReplicationSendPlugin {
+                clean_interval: tick_interval,
+            })
     }
 }
 

--- a/lightyear/src/server/plugin.rs
+++ b/lightyear/src/server/plugin.rs
@@ -41,6 +41,11 @@ pub struct ServerPlugins {
 
 impl ServerPlugins {
     pub fn new(config: ServerConfig) -> Self {
+        if config.shared.server_replication_send_interval != config.replication.send_interval {
+            error!(
+                "The config.shared.server_replication_send_interval is different from the config.replication.send_interval. This can cause issues. They should be set to the same value"
+            );
+        }
         Self { config }
     }
 }

--- a/lightyear/src/server/plugin.rs
+++ b/lightyear/src/server/plugin.rs
@@ -21,7 +21,7 @@ use crate::server::visibility::immediate::VisibilityPlugin;
 use crate::server::visibility::room::RoomPlugin;
 use crate::shared::plugin::SharedPlugin;
 
-use super::config::{ReplicationConfig, ServerConfig};
+use super::config::ServerConfig;
 
 /// A plugin group containing all the server plugins.
 ///
@@ -76,8 +76,6 @@ struct SetupPlugin {
 impl Plugin for SetupPlugin {
     fn build(&self, app: &mut App) {
         app
-            // REFLECTION
-            .register_type::<ReplicationConfig>()
             // RESOURCES //
             .insert_resource(self.config.clone());
         // PLUGINS

--- a/lightyear/src/server/replication.rs
+++ b/lightyear/src/server/replication.rs
@@ -21,6 +21,8 @@ pub enum ServerReplicationSet {
     ClientReplication,
 }
 
+pub type ReplicationSet = InternalReplicationSet<ServerMarker>;
+
 pub(crate) mod receive {
     use super::*;
 
@@ -138,7 +140,7 @@ pub(crate) mod send {
             app.add_systems(
                 PostUpdate,
                 add_prediction_interpolation_components
-                    .after(InternalMainSet::<ServerMarker>::Send)
+                    // .after(InternalMainSet::<ServerMarker>::SendMessages)
                     .run_if(is_host_server),
             );
         }

--- a/lightyear/src/server/replication.rs
+++ b/lightyear/src/server/replication.rs
@@ -71,7 +71,7 @@ pub(crate) mod send {
 
     #[derive(Default)]
     pub struct ServerReplicationSendPlugin {
-        pub clean_interval: Duration,
+        pub tick_interval: Duration,
     }
 
     impl Plugin for ServerReplicationSendPlugin {
@@ -87,7 +87,7 @@ pub(crate) mod send {
                 .register_type::<Replicate>()
                 // PLUGIN
                 .add_plugins(ReplicationSendPlugin::<ConnectionManager>::new(
-                    self.clean_interval,
+                    self.tick_interval,
                     send_interval,
                 ))
                 // SYSTEM SETS

--- a/lightyear/src/server/replication.rs
+++ b/lightyear/src/server/replication.rs
@@ -71,19 +71,24 @@ pub(crate) mod send {
 
     #[derive(Default)]
     pub struct ServerReplicationSendPlugin {
-        pub tick_interval: Duration,
+        pub clean_interval: Duration,
     }
 
     impl Plugin for ServerReplicationSendPlugin {
         fn build(&self, app: &mut App) {
-            let config = app.world.resource::<ServerConfig>();
+            let send_interval = app
+                .world
+                .resource::<ServerConfig>()
+                .replication
+                .send_interval;
 
             app
                 // REFLECTION
                 .register_type::<Replicate>()
                 // PLUGIN
                 .add_plugins(ReplicationSendPlugin::<ConnectionManager>::new(
-                    self.tick_interval,
+                    self.clean_interval,
+                    send_interval,
                 ))
                 // SYSTEM SETS
                 .configure_sets(

--- a/lightyear/src/server/visibility/immediate.rs
+++ b/lightyear/src/server/visibility/immediate.rs
@@ -23,7 +23,7 @@ fn my_system(
 */
 use crate::prelude::server::ConnectionManager;
 use crate::prelude::{is_started, ClientId};
-use crate::shared::sets::{InternalMainSet, InternalReplicationSet, ServerMarker};
+use crate::shared::sets::{InternalReplicationSet, ServerMarker};
 use bevy::ecs::entity::EntityHashSet;
 use bevy::prelude::*;
 use bevy::utils::HashMap;
@@ -280,12 +280,12 @@ impl Plugin for VisibilityPlugin {
                 )
                     .run_if(is_started)
                     .chain(),
-                // the room systems can run every send_interval
+                // the visibility systems can run every send_interval
                 (
                     VisibilitySet::UpdateVisibility,
                     VisibilitySet::VisibilityCleanup,
                 )
-                    .in_set(InternalMainSet::<ServerMarker>::Send),
+                    .in_set(InternalReplicationSet::<ServerMarker>::SendMessages),
             ),
         );
         // SYSTEMS

--- a/lightyear/src/server/visibility/room.rs
+++ b/lightyear/src/server/visibility/room.rs
@@ -54,7 +54,7 @@ use crate::prelude::is_started;
 
 use crate::server::visibility::immediate::{VisibilityManager, VisibilitySet};
 use crate::shared::replication::components::DespawnTracker;
-use crate::shared::sets::{InternalMainSet, ServerMarker};
+use crate::shared::sets::{InternalMainSet, InternalReplicationSet, ServerMarker};
 
 type EntityHashMap<K, V> = hashbrown::HashMap<K, V, EntityHash>;
 type EntityHashSet<K> = hashbrown::HashSet<K, EntityHash>;
@@ -163,7 +163,7 @@ impl Plugin for RoomPlugin {
                     RoomSystemSets::UpdateReplicationCaches,
                     RoomSystemSets::RoomBookkeeping,
                 )
-                    .in_set(InternalMainSet::<ServerMarker>::Send), // .run_if(is_server_ready_to_send),
+                    .in_set(InternalReplicationSet::<ServerMarker>::SendMessages), // .run_if(is_server_ready_to_send),
             ),
         );
         // SYSTEMS

--- a/lightyear/src/shared/config.rs
+++ b/lightyear/src/shared/config.rs
@@ -7,12 +7,9 @@ use crate::shared::tick_manager::TickConfig;
 /// Configuration that has to be the same between the server and the client.
 #[derive(Clone, Debug, Reflect)]
 pub struct SharedConfig {
-    /// how often does the client send updates to the server?
-    /// A duration of 0 means that we send updates every frame
-    pub client_send_interval: Duration,
-    /// how often does the server send updates to the client?
-    /// A duration of 0 means that we send updates every frame
-    pub server_send_interval: Duration,
+    /// how often does the server send replication updates to the client?
+    /// A duration of 0 means that we send replication updates every frame
+    pub server_replication_send_interval: Duration,
     /// configuration for the [`FixedUpdate`](bevy::prelude::FixedUpdate) schedule
     pub tick: TickConfig,
     pub mode: Mode,
@@ -45,9 +42,7 @@ pub enum Mode {
 impl Default for SharedConfig {
     fn default() -> Self {
         Self {
-            // 0 means that we send updates every frame
-            client_send_interval: Duration::from_millis(0),
-            server_send_interval: Duration::from_millis(0),
+            server_replication_send_interval: Duration::from_millis(0),
             tick: TickConfig::new(Duration::from_millis(16)),
             mode: Mode::default(),
         }

--- a/lightyear/src/shared/plugin.rs
+++ b/lightyear/src/shared/plugin.rs
@@ -117,10 +117,7 @@ impl Plugin for SharedPlugin {
         app.add_plugins(TickManagerPlugin {
             config: self.config.tick.clone(),
         });
-        app.add_plugins(TimePlugin {
-            server_send_interval: self.config.server_send_interval,
-            client_send_interval: self.config.client_send_interval,
-        });
+        app.add_plugins(TimePlugin);
     }
 
     fn finish(&self, app: &mut App) {

--- a/lightyear/src/shared/replication/hierarchy.rs
+++ b/lightyear/src/shared/replication/hierarchy.rs
@@ -140,7 +140,7 @@ impl<R: ReplicationSend> Plugin for HierarchySendPlugin<R> {
                 Self::removal_system,
             )
                 // we don't need to run these every frame, only every send_interval
-                .in_set(InternalMainSet::<R::SetMarker>::Send)
+                .in_set(InternalReplicationSet::<R::SetMarker>::SendMessages)
                 // run before the replication-send systems
                 .before(InternalReplicationSet::<R::SetMarker>::All),
         );

--- a/lightyear/src/shared/replication/mod.rs
+++ b/lightyear/src/shared/replication/mod.rs
@@ -2,7 +2,6 @@
 use std::fmt::Debug;
 use std::hash::Hash;
 
-use bevy::ecs::component::Tick as BevyTick;
 use bevy::prelude::{Entity, Resource};
 use byteorder::{ReadBytesExt, WriteBytesExt};
 use bytes::Bytes;
@@ -265,23 +264,6 @@ pub(crate) trait ReplicationSend: Resource + ReplicationPeer {
     /// Return the list of clients that connected to the server since we last sent any replication messages
     /// (this is used to send the initial state of the world to new clients)
     fn new_connected_clients(&self) -> Vec<ClientId>;
-
-    /// Get the replication cache
-    fn replication_cache(&mut self) -> &mut Self::ReplicateCache;
-
-    /// Any operation that needs to happen before we can send the replication messages
-    /// (for example collecting the individual single component updates into a single message,
-    ///
-    /// Similarly, we want to collect all ComponentInsert and ComponentRemove into a single message.
-    /// Why? Because if we create separate message for each ComponentInsert (for example when the entity gets spawned)
-    /// Then those 2 component inserts might be stored in different packets, and arrive at different times because of jitter
-    ///
-    /// But the receiving systems might expect both components to be present at the same time.
-    fn buffer_replication_messages(
-        &mut self,
-        tick: Tick,
-        bevy_tick: BevyTick,
-    ) -> Result<(), Self::Error>;
 
     /// Do some regular cleanup on the internals of replication
     /// - account for tick wrapping by resetting some internal ticks for each replication group

--- a/lightyear/src/shared/replication/plugin.rs
+++ b/lightyear/src/shared/replication/plugin.rs
@@ -12,6 +12,26 @@ use bevy::prelude::*;
 use bevy::time::common_conditions::on_timer;
 use bevy::utils::Duration;
 
+#[derive(Clone, Debug, Default, Reflect)]
+pub struct ReplicationConfig {
+    /// By default, we will send all component updates since the last time we sent an update for a given entity.
+    /// E.g. if the component was updated at tick 3; we will send the update at tick 3, and then at tick 4,
+    /// we won't be sending anything since the component wasn't updated after that.
+    ///
+    /// This helps save bandwidth, but can cause the client to have delayed eventual consistency in the
+    /// case of packet loss.
+    ///
+    /// If this is set to true, we will instead send all updates since the last time we received an ACK from the client.
+    /// E.g. if the component was updated at tick 3; we will send the update at tick 3, and then at tick 4,
+    /// we will send the update again even if the component wasn't updated, because we still haven't
+    /// received an ACK from the client.
+    pub send_updates_since_last_ack: bool,
+    /// How often we send replication updates.
+    ///
+    /// Set to `Duration::default()` to send updates every frame.
+    pub send_interval: Duration,
+}
+
 pub(crate) mod receive {
     use super::*;
     pub(crate) struct ReplicationReceivePlugin<R> {
@@ -209,8 +229,8 @@ pub(crate) mod send {
 pub(crate) mod shared {
     use crate::client::replication::send::ReplicateToServer;
     use crate::prelude::{
-        PrePredicted, RemoteEntityMap, ReplicateHierarchy, Replicated, ReplicationGroup,
-        ReplicationTarget, ShouldBePredicted, TargetEntity, VisibilityMode,
+        PrePredicted, RemoteEntityMap, ReplicateHierarchy, Replicated, ReplicationConfig,
+        ReplicationGroup, ReplicationTarget, ShouldBePredicted, TargetEntity, VisibilityMode,
     };
     use crate::shared::replication::components::{
         Controlled, Replicating, ReplicationGroupId, ReplicationGroupIdBuilder,
@@ -234,6 +254,7 @@ pub(crate) mod shared {
                 .register_type::<ReplicateHierarchy>()
                 .register_type::<ReplicationGroupIdBuilder>()
                 .register_type::<ReplicationGroup>()
+                .register_type::<ReplicationConfig>()
                 .register_type::<ReplicationGroupId>()
                 .register_type::<VisibilityMode>()
                 .register_type::<NetworkTarget>()

--- a/lightyear/src/shared/replication/plugin.rs
+++ b/lightyear/src/shared/replication/plugin.rs
@@ -137,7 +137,11 @@ pub(crate) mod send {
                     // only send messages if the timer has finished
                     InternalReplicationSet::<R::SetMarker>::SendMessages.run_if(
                         |timer: Res<SendIntervalTimer<R>>| {
-                            !timer.timer.as_ref().is_some_and(|t| t.finished())
+                            if let Some(timer) = &timer.timer {
+                                timer.finished()
+                            } else {
+                                true
+                            }
                         },
                     ),
                     (

--- a/lightyear/src/shared/replication/send.rs
+++ b/lightyear/src/shared/replication/send.rs
@@ -1,4 +1,5 @@
 //! General struct handling replication
+use bevy::utils::Duration;
 use std::iter::Extend;
 
 use crate::channel::builder::{EntityActionsChannel, EntityUpdatesChannel};
@@ -15,12 +16,13 @@ use tracing::{instrument, Level};
 
 use crate::packet::message::MessageId;
 use crate::packet::message_manager::MessageManager;
-use crate::prelude::{ChannelKind, ComponentRegistry, PacketError, Tick};
+use crate::prelude::{ChannelKind, ComponentRegistry, PacketError, Tick, TimeManager};
 use crate::protocol::component::{ComponentKind, ComponentNetId};
 use crate::serialize::writer::Writer;
 use crate::serialize::{SerializationError, ToBytes};
 use crate::shared::replication::components::ReplicationGroupId;
 use crate::shared::replication::delta::DeltaManager;
+use crate::shared::replication::plugin::ReplicationConfig;
 #[cfg(test)]
 use crate::utils::captures::Captures;
 
@@ -68,18 +70,7 @@ pub(crate) struct ReplicationSender {
     /// We update the `send_tick` only when the message was actually sent.
     pub message_send_receiver: Receiver<MessageId>,
 
-    /// By default, we will send all component updates since the last time we sent an update for a given entity.
-    /// E.g. if the component was updated at tick 3; we will send the update at tick 3, and then at tick 4,
-    /// we won't be sending anything since the component wasn't updated after that.
-    ///
-    /// This helps save bandwidth, but can cause the client to have delayed eventual consistency in the
-    /// case of packet loss.
-    ///
-    /// If this is set to true, we will instead send all updates since the last time we received an ACK from the client.
-    /// E.g. if the component was updated at tick 3; we will send the update at tick 3, and then at tick 4,
-    /// we will send the update again even if the component wasn't updated, because we still haven't
-    /// received an ACK from the client.
-    send_updates_since_last_ack: bool,
+    replication_config: ReplicationConfig,
     bandwidth_cap_enabled: bool,
 }
 
@@ -88,7 +79,7 @@ impl ReplicationSender {
         updates_ack_receiver: Receiver<MessageId>,
         updates_nack_receiver: Receiver<MessageId>,
         message_send_receiver: Receiver<MessageId>,
-        send_updates_since_last_ack: bool,
+        replication_config: ReplicationConfig,
         bandwidth_cap_enabled: bool,
     ) -> Self {
         Self {
@@ -100,7 +91,7 @@ impl ReplicationSender {
             pending_updates: EntityHashMap::default(),
             // pending_unique_components: EntityHashMap::default(),
             group_channels: Default::default(),
-            send_updates_since_last_ack,
+            replication_config,
             // PRIORITY
             message_send_receiver,
             bandwidth_cap_enabled,
@@ -139,7 +130,7 @@ impl ReplicationSender {
     /// We will send all updates that happened after this bevy tick.
     pub(crate) fn get_send_tick(&self, group_id: ReplicationGroupId) -> Option<BevyTick> {
         self.group_channels.get(&group_id).and_then(|channel| {
-            if self.send_updates_since_last_ack {
+            if self.replication_config.send_updates_since_last_ack {
                 channel.ack_bevy_tick
             } else {
                 channel.send_tick
@@ -215,7 +206,7 @@ impl ReplicationSender {
                         "successfully sent message for replication group! Resetting priority"
                     );
                     channel.send_tick = Some(*bevy_tick);
-                    channel.accumulated_priority = Some(0.0);
+                    channel.accumulated_priority = 0.0;
                 } else {
                     error!(?message_id, ?group_id, "Received a send message-id notification but the corresponding group channel does not exist");
                 }
@@ -225,15 +216,6 @@ impl ReplicationSender {
                 );
             }
         }
-
-        // then accumulate the priority for all replication groups
-        self.group_channels.values_mut().for_each(|channel| {
-            channel.accumulated_priority = channel
-                .accumulated_priority
-                .map_or(Some(channel.base_priority), |acc| {
-                    Some(acc + channel.base_priority)
-                });
-        });
     }
 
     // TODO: call this in a system after receive?
@@ -305,12 +287,10 @@ impl ReplicationSender {
 impl ReplicationSender {
     /// Update the base priority for a given group
     pub(crate) fn update_base_priority(&mut self, group_id: ReplicationGroupId, priority: f32) {
-        let channel = self.group_channels.entry(group_id).or_default();
-        channel.base_priority = priority;
-        // if we already have an accumulated priority, don't override it
-        if channel.accumulated_priority.is_none() {
-            channel.accumulated_priority = Some(priority);
-        }
+        self.group_channels
+            .entry(group_id)
+            .or_default()
+            .base_priority = priority;
     }
 
     // TODO: how can I emit metrics here that contain the channel kind?
@@ -490,9 +470,7 @@ impl ReplicationSender {
                 // This is ok to do even if we don't get an actual send notification because EntityActions messages are
                 // guaranteed to be sent at some point. (since the actions channel is reliable)
                 channel.send_tick = Some(bevy_tick);
-                let priority = channel
-                    .accumulated_priority
-                    .unwrap_or(channel.base_priority);
+                let priority = channel.accumulated_priority;
                 let message_id = channel.actions_next_send_message_id;
                 channel.actions_next_send_message_id += 1;
                 channel.last_action_tick = Some(tick);
@@ -509,6 +487,21 @@ impl ReplicationSender {
                 message
             })
             .collect()
+    }
+
+    /// Before sending replication messages, we accumulate the priority for all replication groups.
+    ///
+    /// (the priority starts at 0.0, and is accumulated for each group based on the base priority of the group)
+    pub(crate) fn accumulate_priority(&mut self, time_manager: &TimeManager) {
+        let priority_multiplier = if self.replication_config.send_interval == Duration::default() {
+            1.0
+        } else {
+            (self.replication_config.send_interval.as_nanos() / time_manager.delta().as_nanos())
+                as f32
+        };
+        self.group_channels.values_mut().for_each(|channel| {
+            channel.accumulated_priority += channel.base_priority * priority_multiplier;
+        });
     }
 
     /// Prepare the [`EntityActionsMessage`] messages to send.
@@ -544,9 +537,7 @@ impl ReplicationSender {
                 // This is ok to do even if we don't get an actual send notification because EntityActions messages are
                 // guaranteed to be sent at some point. (since the actions channel is reliable)
                 channel.send_tick = Some(bevy_tick);
-                let priority = channel
-                    .accumulated_priority
-                    .unwrap_or(channel.base_priority);
+                let priority = channel.accumulated_priority;
                 let message_id = channel.actions_next_send_message_id;
                 channel.actions_next_send_message_id += 1;
                 channel.last_action_tick = Some(tick);
@@ -590,9 +581,7 @@ impl ReplicationSender {
         self.pending_updates.drain().map(|(group_id, updates)| {
             trace!(?group_id, "pending updates: {:?}", updates);
             let channel = self.group_channels.entry(group_id).or_default();
-            let priority = channel
-                .accumulated_priority
-                .unwrap_or(channel.base_priority);
+            let priority = channel.accumulated_priority;
             (
                 EntityUpdatesMessage {
                     group_id,
@@ -623,9 +612,7 @@ impl ReplicationSender {
             .try_for_each(|(group_id, updates)| {
                 trace!(?group_id, "pending updates: {:?}", updates);
                 let channel = self.group_channels.entry(group_id).or_default();
-                let priority = channel
-                    .accumulated_priority
-                    .unwrap_or(channel.base_priority);
+                let priority = channel.accumulated_priority;
                 let message = EntityUpdatesMessage {
                     group_id,
                     // TODO: as an optimization, we can use `last_action_tick = tick` to signify
@@ -700,7 +687,7 @@ pub struct GroupChannel {
     /// The priority to send the replication group.
     /// This will be reset to base_priority every time we send network updates, unless we couldn't send a message
     /// for this group because of the bandwidth cap, in which case it will be accumulated.
-    pub accumulated_priority: Option<f32>,
+    pub accumulated_priority: f32,
     pub base_priority: f32,
 }
 
@@ -712,7 +699,7 @@ impl Default for GroupChannel {
             ack_bevy_tick: None,
             ack_tick: None,
             last_action_tick: None,
-            accumulated_priority: None,
+            accumulated_priority: 0.0,
             base_priority: 1.0,
         }
     }
@@ -859,7 +846,13 @@ mod tests {
         let (tx_ack, rx_ack) = crossbeam_channel::unbounded();
         let (tx_nack, rx_nack) = crossbeam_channel::unbounded();
         let (tx_send, rx_send) = crossbeam_channel::unbounded();
-        let mut sender = ReplicationSender::new(rx_ack, rx_nack, rx_send, false, false);
+        let mut sender = ReplicationSender::new(
+            rx_ack,
+            rx_nack,
+            rx_send,
+            ReplicationConfig::default(),
+            false,
+        );
         let group_1 = ReplicationGroupId(0);
         sender
             .group_channels
@@ -952,7 +945,8 @@ mod tests {
         let (tx_ack, rx_ack) = crossbeam_channel::unbounded();
         let (tx_nack, rx_nack) = crossbeam_channel::unbounded();
         let (tx_send, rx_send) = crossbeam_channel::unbounded();
-        let mut sender = ReplicationSender::new(rx_ack, rx_nack, rx_send, false, true);
+        let mut sender =
+            ReplicationSender::new(rx_ack, rx_nack, rx_send, ReplicationConfig::default(), true);
         let group_1 = ReplicationGroupId(0);
         sender
             .group_channels
@@ -999,7 +993,13 @@ mod tests {
         let (tx_ack, rx_ack) = crossbeam_channel::unbounded();
         let (tx_nack, rx_nack) = crossbeam_channel::unbounded();
         let (tx_send, rx_send) = crossbeam_channel::unbounded();
-        let mut manager = ReplicationSender::new(rx_ack, rx_nack, rx_send, false, false);
+        let mut manager = ReplicationSender::new(
+            rx_ack,
+            rx_nack,
+            rx_send,
+            ReplicationConfig::default(),
+            false,
+        );
 
         let entity_1 = Entity::from_raw(0);
         let entity_2 = Entity::from_raw(1);
@@ -1081,7 +1081,7 @@ mod tests {
                     last_action_tick: Some(Tick(3)),
                     updates: vec![(entity_3, vec![raw_4])],
                 },
-                1.0
+                0.0
             )
         );
         assert_eq!(

--- a/lightyear/src/shared/run_conditions.rs
+++ b/lightyear/src/shared/run_conditions.rs
@@ -72,3 +72,17 @@ pub fn is_started(server: Option<Res<ServerConnections>>) -> bool {
 pub fn is_stopped(server: Option<Res<ServerConnections>>) -> bool {
     server.map_or(true, |s| !s.is_listening())
 }
+
+// /// Returns true if we are ready to buffer the server replication messages
+// pub fn is_server_replication_send_ready(
+//     timer: Option<Res<SendIntervalTimer<server::ConnectionManager>>>,
+// ) -> bool {
+//     timer.map_or(false, |t| t.timer.as_ref().map_or(true, |t| t.finished()))
+// }
+//
+// /// Returns true if we are ready to buffer the client replication messages
+// pub fn is_client_replication_send_ready(
+//     timer: Option<Res<SendIntervalTimer<client::ConnectionManager>>>,
+// ) -> bool {
+//     timer.map_or(false, |t| t.timer.as_ref().map_or(true, |t| t.finished()))
+// }

--- a/lightyear/src/shared/sets.rs
+++ b/lightyear/src/shared/sets.rs
@@ -35,6 +35,9 @@ pub(crate) enum InternalReplicationSet<M> {
     Buffer,
     /// System that handles the update of an existing replication component
     AfterBuffer,
+    /// SystemSet where we actually buffer the replication messages.
+    /// Runs every send_interval, not every frame
+    SendMessages,
     /// SystemSet that encompasses all send replication systems
     All,
     _Marker(std::marker::PhantomData<M>),
@@ -52,11 +55,9 @@ pub(crate) enum InternalMainSet<M> {
     /// Runs in `PreUpdate`, after `Receive`
     EmitEvents,
 
-    /// Systems that send data (buffer any data to be sent, and send any buffered packets)
+    /// SystemSet where we actually send packets over the network.
     ///
-    /// Runs in `PostUpdate`.
-    SendPackets,
-    /// System to encompass all send-related systems. Runs only every send_interval
+    /// Runs in `PostUpdate`
     Send,
     _Marker(std::marker::PhantomData<M>),
 }
@@ -72,11 +73,10 @@ pub enum MainSet {
     /// Runs in `PreUpdate`, after `Receive`
     EmitEvents,
 
-    /// Systems that send data (buffer any data to be sent, and send any buffered packets)
+    /// SystemSet where we actually send packets over the network.
+    /// Runs every frame.
     ///
-    /// Runs in `PostUpdate`.
-    SendPackets,
-    /// System to encompass all send-related systems. Runs only every send_interval
+    /// Runs in `PostUpdate`
     Send,
 }
 

--- a/lightyear/src/shared/sets.rs
+++ b/lightyear/src/shared/sets.rs
@@ -9,7 +9,7 @@ pub struct ServerMarker;
 
 /// System sets related to Replication
 #[derive(SystemSet, Debug, Hash, PartialEq, Eq, Clone, Copy)]
-pub(crate) enum InternalReplicationSet<M> {
+pub enum InternalReplicationSet<M> {
     // RECEIVE
     /// System that copies the resource data from the entity to the resource in the receiving world
     ReceiveResourceUpdates,
@@ -41,6 +41,7 @@ pub(crate) enum InternalReplicationSet<M> {
     /// SystemSet that encompasses all send replication systems
     All,
     _Marker(std::marker::PhantomData<M>),
+    SendMessage,
 }
 
 /// Main SystemSets used by lightyear to receive and send data


### PR DESCRIPTION
# Context

Before, we were settings a `send_interval` Duration for the client or the server. The network send systems would only get called every `send_interval`.
This was overly restrictive because in some cases we might want to send messages for a given channel every tick (for example inputs) but send messages for another channel (for example replication messages) less frequently.

This can be useful when predicting other player's actions (GGPO-style) because we want a client to send their inputs to other clients as fast as possible.


This PR:
- gets rid of the global client_send_interval and server_send_interval. The `send_packet` systems now run **every frame**
- every channel now has a `send_interval` setting where you can control how often the channel will actually send their messages
- for replication it's slightly more complicated, we cannot just set the setting on the replication channel themselves, because we want the tick of the packet to be the **same** as the tick of the entity when it was serialized in the packet on the sender. To solve this we have a separate `replication_send_interval` which specifies how often we run the replication systems.

- update the way we do priority accumulation. To remain fair between each channel, we now multiply the priority accumulation value by `send_interval / tick_interval` where send_interval is the send_interval of the channel (or of replication). (because otherwise if a channel runs every 1 second, we would accumulate the priority very slowly, only once every 1 second.)
