### PR TITLE
Improve input handling

### DIFF
--- a/examples/bullet_prespawn/src/client.rs
+++ b/examples/bullet_prespawn/src/client.rs
@@ -94,10 +94,7 @@ fn update_cursor_state_from_window(
 
 // Get the cursor position relative to the window
 fn window_relative_mouse_position(window: &Window) -> Option<Vec2> {
-    let Some(cursor_pos) = window.cursor_position() else {
-        return None;
-    };
-
+    let cursor_pos = window.cursor_position()?;
     Some(Vec2::new(
         cursor_pos.x - (window.width() / 2.0),
         (cursor_pos.y - (window.height() / 2.0)) * -1.0,

--- a/examples/bullet_prespawn/src/server.rs
+++ b/examples/bullet_prespawn/src/server.rs
@@ -89,11 +89,6 @@ pub(crate) fn replicate_players(
             };
             e.insert((
                 replicate,
-                // We don't want to replicate the ActionState to the original client, since they are updating it with
-                // their own inputs (if you replicate it to the original client, it will be added on the Confirmed entity,
-                // which will keep syncing it to the Predicted entity because the ActionState gets updated every tick)!
-                // We also don't need the inputs of the other clients, because we are not predicting them
-                OverrideTargetComponent::<ActionState<PlayerActions>>::new(NetworkTarget::None),
                 // The PrePredicted component must be replicated only to the original client
                 OverrideTargetComponent::<PrePredicted>::new(NetworkTarget::Single(client_id)),
             ));

--- a/examples/interest_management/src/protocol.rs
+++ b/examples/interest_management/src/protocol.rs
@@ -27,7 +27,6 @@ pub(crate) struct PlayerBundle {
     color: PlayerColor,
     replicate: Replicate,
     action_state: ActionState<Inputs>,
-    action_state_override_target: OverrideTargetComponent<ActionState<Inputs>>,
 }
 
 impl PlayerBundle {
@@ -51,12 +50,6 @@ impl PlayerBundle {
             color: PlayerColor(color),
             replicate,
             action_state: ActionState::default(),
-            // We don't want to replicate the ActionState to the original client, since they are updating it with
-            // their own inputs (if you replicate it to the original client, it will be added on the Confirmed entity,
-            // which will keep syncing it to the Predicted entity because the ActionState gets updated every tick)!
-            action_state_override_target: OverrideTargetComponent::new(
-                NetworkTarget::AllExceptSingle(id),
-            ),
         }
     }
     pub(crate) fn get_input_map() -> InputMap<Inputs> {

--- a/examples/priority/src/protocol.rs
+++ b/examples/priority/src/protocol.rs
@@ -21,7 +21,6 @@ pub(crate) struct PlayerBundle {
     color: PlayerColor,
     replicate: Replicate,
     action_state: ActionState<Inputs>,
-    action_state_target_override: OverrideTargetComponent<ActionState<Inputs>>,
 }
 
 impl PlayerBundle {
@@ -48,12 +47,6 @@ impl PlayerBundle {
             color: PlayerColor(color),
             replicate,
             action_state: ActionState::default(),
-            // We don't want to replicate the ActionState to the original client, since they are updating it with
-            // their own inputs (if you replicate it to the original client, it will be added on the Confirmed entity,
-            // which will keep syncing it to the Predicted entity because the ActionState gets updated every tick)!
-            action_state_target_override: OverrideTargetComponent::new(
-                NetworkTarget::AllExceptSingle(id),
-            ),
         }
     }
     pub(crate) fn get_input_map() -> InputMap<Inputs> {

--- a/examples/xpbd_physics/assets/settings.ron
+++ b/examples/xpbd_physics/assets/settings.ron
@@ -1,5 +1,5 @@
 MySettings(
-  input_delay_ticks: 3,
+  input_delay_ticks: 10,
   correction_ticks_factor: 1.5,
   predict_all: true,
   show_confirmed: false,

--- a/examples/xpbd_physics/src/client.rs
+++ b/examples/xpbd_physics/src/client.rs
@@ -76,16 +76,16 @@ pub(crate) fn handle_connection(
                 (PlayerActions::Right, KeyCode::KeyD),
             ]),
         ));
-        commands.spawn((PlayerBundle::new(
-            client_id,
-            Vec2::new(50.0, y),
-            InputMap::new([
-                (PlayerActions::Up, KeyCode::ArrowUp),
-                (PlayerActions::Down, KeyCode::ArrowDown),
-                (PlayerActions::Left, KeyCode::ArrowLeft),
-                (PlayerActions::Right, KeyCode::ArrowRight),
-            ]),
-        ),));
+        // commands.spawn((PlayerBundle::new(
+        //     client_id,
+        //     Vec2::new(50.0, y),
+        //     InputMap::new([
+        //         (PlayerActions::Up, KeyCode::ArrowUp),
+        //         (PlayerActions::Down, KeyCode::ArrowDown),
+        //         (PlayerActions::Left, KeyCode::ArrowLeft),
+        //         (PlayerActions::Right, KeyCode::ArrowRight),
+        //     ]),
+        // ),));
     }
 }
 

--- a/examples/xpbd_physics/src/server.rs
+++ b/examples/xpbd_physics/src/server.rs
@@ -3,7 +3,6 @@ use bevy::utils::Duration;
 use bevy::utils::HashMap;
 use bevy_xpbd_2d::prelude::*;
 use leafwing_input_manager::prelude::*;
-use lightyear::inputs::leafwing::InputMessage;
 use lightyear::prelude::client::{Confirmed, Predicted};
 use lightyear::prelude::server::*;
 use lightyear::prelude::*;

--- a/examples/xpbd_physics/src/server.rs
+++ b/examples/xpbd_physics/src/server.rs
@@ -153,12 +153,6 @@ pub(crate) fn replicate_players(
             };
             e.insert((
                 replicate,
-                // We don't want to replicate the ActionState to the original client, since they are updating it with
-                // their own inputs (if you replicate it to the original client, it will be added on the Confirmed entity,
-                // which will keep syncing it to the Predicted entity because the ActionState gets updated every tick)!
-                OverrideTargetComponent::<ActionState<PlayerActions>>::new(
-                    NetworkTarget::AllExceptSingle(client_id),
-                ),
                 // if we receive a pre-predicted entity, only send the prepredicted component back
                 // to the original client
                 OverrideTargetComponent::<PrePredicted>::new(NetworkTarget::Single(client_id)),

--- a/lightyear/src/client/input/leafwing.rs
+++ b/lightyear/src/client/input/leafwing.rs
@@ -396,7 +396,7 @@ fn get_delayed_action_state<A: LeafwingUserAction>(
             .unwrap_or(&ActionState::<A>::default())
             .clone();
         let end_tick = input_buffer.end_tick();
-        error!(current_tick = ?tick_manager.tick(), ?end_tick, "restored delayed action state: {:?}", action_state.get_pressed());
+        debug!(current_tick = ?tick_manager.tick(), ?end_tick, "restored delayed action state: {:?}", action_state.get_pressed());
     }
     if let Some(mut action_state) = global_action_state {
         *action_state = global_input_buffer.get_last().unwrap().clone();
@@ -435,19 +435,18 @@ fn buffer_action_state<A: LeafwingUserAction>(
         );
         trace!(?entity, ?tick, "set action state in input buffer");
         input_buffer.set(tick, action_state);
-        error!(
+        // println!(
+        //     "Set ActionState {:?} for tick {:?} in buffer {}",
+        //     action_state.get_pressed(),
+        //     tick,
+        //     input_buffer.as_ref()
+        // );
+        debug!(
             ?entity,
             current_tick = ?tick_manager.tick(),
             buffer_tick = ?tick,
             "set action state in input buffer: {}",
             input_buffer.as_ref()
-        );
-        trace!(
-            ?entity,
-            ?tick,
-            "input buffer. Start tick {:?}, len: {:?}",
-            input_buffer.start_tick,
-            input_buffer.buffer.len()
         );
     }
     // if let Some(action_state) = global_action_state {
@@ -477,7 +476,7 @@ fn get_non_rollback_action_state<A: LeafwingUserAction>(
             .get(tick)
             .unwrap_or(&ActionState::<A>::default())
             .clone();
-        error!(
+        debug!(
             ?entity,
             ?tick,
             "fetched action state {:?} from input buffer: {}",
@@ -535,7 +534,7 @@ fn get_rollback_action_state<A: LeafwingUserAction>(
             input_buffer
         );
         *action_state = input_buffer.get(tick).cloned().unwrap_or_default();
-        error!(
+        debug!(
             ?entity,
             ?tick,
             pressed = ?action_state.get_pressed(),
@@ -544,7 +543,7 @@ fn get_rollback_action_state<A: LeafwingUserAction>(
         );
     }
     for (entity, mut action_state, input_buffer) in remote_player_query.iter_mut() {
-        error!(
+        debug!(
             ?tick,
             ?entity,
             ?input_buffer,
@@ -662,6 +661,10 @@ fn prepare_input_message<A: LeafwingUserAction>(
                     .copied()
                 {
                     debug!("sending input for server entity: {:?}. local entity: {:?}, confirmed: {:?}", server_entity, entity, confirmed);
+                    // println!(
+                    //     "preparing input message using input_buffer: {}",
+                    //     input_buffer
+                    // );
                     message.add_inputs(num_tick, InputTarget::Entity(server_entity), input_buffer);
                 }
             } else {
@@ -679,7 +682,7 @@ fn prepare_input_message<A: LeafwingUserAction>(
     // TODO: should we provide variants of each user-facing function, so that it pushes the error
     //  to the ConnectionEvents?
     // if !message.is_empty() {
-    error!(?tick, ?num_tick, "sending input message: {}", message);
+    debug!(?tick, ?num_tick, "sending input message: {}", message);
     connection
         .send_message::<InputChannel, InputMessage<A>>(&message)
         .unwrap_or_else(|err| {

--- a/lightyear/src/client/interpolation/visual_interpolation.rs
+++ b/lightyear/src/client/interpolation/visual_interpolation.rs
@@ -184,13 +184,12 @@ pub(crate) fn restore_from_visual_interpolation<C: SyncComponent>(
 
 #[cfg(test)]
 mod tests {
+    use crate::client::config::ClientConfig;
     use approx::assert_relative_eq;
     use bevy::prelude::*;
     use bevy::utils::Duration;
 
-    use crate::client::sync::SyncConfig;
-    use crate::prelude::client::{InterpolationConfig, PredictionConfig};
-    use crate::prelude::{LinkConditionerConfig, SharedConfig, TickConfig};
+    use crate::prelude::{SharedConfig, TickConfig};
     use crate::tests::protocol::*;
     use crate::tests::stepper::{BevyStepper, Step};
 
@@ -204,22 +203,8 @@ mod tests {
             tick: TickConfig::new(tick_duration),
             ..Default::default()
         };
-        let link_conditioner = LinkConditionerConfig {
-            incoming_latency: Duration::from_millis(0),
-            incoming_jitter: Duration::from_millis(0),
-            incoming_loss: 0.0,
-        };
-        let sync_config = SyncConfig::default().speedup_factor(1.0);
-        let prediction_config = PredictionConfig::default();
-        let interpolation_config = InterpolationConfig::default();
-        let mut stepper = BevyStepper::new(
-            shared_config,
-            sync_config,
-            prediction_config,
-            interpolation_config,
-            link_conditioner,
-            frame_duration,
-        );
+        // we create the stepper manually to not run init()
+        let mut stepper = BevyStepper::new(shared_config, ClientConfig::default(), frame_duration);
         stepper
             .client_app
             .add_systems(FixedUpdate, fixed_update_increment);

--- a/lightyear/src/client/prediction/rollback.rs
+++ b/lightyear/src/client/prediction/rollback.rs
@@ -510,6 +510,7 @@ pub(crate) fn run_rollback(world: &mut World) {
 
     // run the physics fixed update schedule (which should contain ALL predicted/rollback components)
     for i in 0..num_rollback_ticks {
+        error!("Rollback tick: {:?}", current_rollback_tick + i);
         // TODO: if we are in rollback, there are some FixedUpdate systems that we don't want to re-run ??
         //  for example we only want to run the physics on non-confirmed entities
         world.run_schedule(FixedMain)

--- a/lightyear/src/client/prediction/rollback.rs
+++ b/lightyear/src/client/prediction/rollback.rs
@@ -191,7 +191,7 @@ pub(crate) fn check_rollback<C: SyncComponent>(
                 }),
             };
             if should_rollback {
-                error!(
+                debug!(
                    ?predicted_exist, ?confirmed_exist,
                    "Rollback check: mismatch for component between predicted and confirmed {:?} on tick {:?} for component {:?}. Current tick: {:?}",
                    confirmed_entity, tick, kind, current_tick
@@ -510,7 +510,7 @@ pub(crate) fn run_rollback(world: &mut World) {
 
     // run the physics fixed update schedule (which should contain ALL predicted/rollback components)
     for i in 0..num_rollback_ticks {
-        error!("Rollback tick: {:?}", current_rollback_tick + i);
+        debug!("Rollback tick: {:?}", current_rollback_tick + i);
         // TODO: if we are in rollback, there are some FixedUpdate systems that we don't want to re-run ??
         //  for example we only want to run the physics on non-confirmed entities
         world.run_schedule(FixedMain)

--- a/lightyear/src/client/prediction/rollback.rs
+++ b/lightyear/src/client/prediction/rollback.rs
@@ -191,7 +191,7 @@ pub(crate) fn check_rollback<C: SyncComponent>(
                 }),
             };
             if should_rollback {
-                debug!(
+                error!(
                    ?predicted_exist, ?confirmed_exist,
                    "Rollback check: mismatch for component between predicted and confirmed {:?} on tick {:?} for component {:?}. Current tick: {:?}",
                    confirmed_entity, tick, kind, current_tick

--- a/lightyear/src/client/sync.rs
+++ b/lightyear/src/client/sync.rs
@@ -616,26 +616,8 @@ mod tests {
 
     #[test]
     fn test_sync_after_tick_wrap() {
-        let frame_duration = Duration::from_secs_f32(1.0 / 60.0);
         let tick_duration = Duration::from_millis(10);
-        let shared_config = SharedConfig {
-            tick: TickConfig::new(tick_duration),
-            ..Default::default()
-        };
-        let link_conditioner = LinkConditionerConfig {
-            incoming_latency: Duration::from_millis(20),
-            incoming_jitter: Duration::from_millis(0),
-            incoming_loss: 0.0,
-        };
-        let mut stepper = BevyStepper::new(
-            shared_config,
-            SyncConfig::default(),
-            client::PredictionConfig::default(),
-            client::InterpolationConfig::default(),
-            link_conditioner,
-            frame_duration,
-        );
-        stepper.init();
+        let mut stepper = BevyStepper::default();
 
         // set time to end of wrapping
         let new_tick = Tick(u16::MAX - 1000);

--- a/lightyear/src/inputs/leafwing/action_diff.rs
+++ b/lightyear/src/inputs/leafwing/action_diff.rs
@@ -128,7 +128,6 @@ impl<A: LeafwingUserAction> ActionDiff<A> {
 mod tests {
     use crate::prelude::{Deserialize, Serialize};
     use bevy::prelude::Reflect;
-    use leafwing_input_manager::prelude::ActionState;
     use leafwing_input_manager::Actionlike;
 
     #[derive(

--- a/lightyear/src/inputs/leafwing/action_diff.rs
+++ b/lightyear/src/inputs/leafwing/action_diff.rs
@@ -1,0 +1,272 @@
+use crate::prelude::{Deserialize, LeafwingUserAction, Serialize, Tick};
+use bevy::math::Vec2;
+use bevy::prelude::{Component, Entity, Event, Reflect, Resource};
+use bevy::utils::HashMap;
+use leafwing_input_manager::action_state::ActionState;
+use leafwing_input_manager::axislike::DualAxisData;
+use std::collections::VecDeque;
+
+/// Will store an `ActionDiff` as well as what generated it (either an Entity, or nothing if the
+/// input actions are represented by a `Resource`)
+///
+/// These are typically accessed using the `Events<ActionDiffEvent>` resource.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Event)]
+pub struct ActionDiffEvent<A> {
+    /// If some: the entity that has the `ActionState<A>` component
+    /// If none: `ActionState<A>` is a Resource, not a component
+    pub owner: Option<Entity>,
+    /// The `ActionDiff` that was generated
+    pub action_diff: Vec<ActionDiff<A>>,
+}
+
+/// Stores presses and releases of buttons without timing information
+///
+/// These are typically accessed using the `Events<ActionDiffEvent>` resource.
+/// Uses a minimal storage format, in order to facilitate transport over the network.
+///
+/// An `ActionState` can be fully reconstructed from a stream of `ActionDiff`
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize, Reflect)]
+pub enum ActionDiff<A> {
+    /// The action was pressed
+    Pressed {
+        /// The value of the action
+        action: A,
+    },
+    /// The action was released
+    Released {
+        /// The value of the action
+        action: A,
+    },
+    /// The value of the action changed
+    ValueChanged {
+        /// The value of the action
+        action: A,
+        /// The new value of the action
+        value: f32,
+    },
+    /// The axis pair of the action changed
+    AxisPairChanged {
+        /// The value of the action
+        action: A,
+        /// The new value of the axis
+        axis_pair: Vec2,
+    },
+}
+
+impl<A: LeafwingUserAction> ActionDiff<A> {
+    pub(crate) fn action(&self) -> A {
+        match self {
+            ActionDiff::Pressed { action } => action.clone(),
+            ActionDiff::Released { action } => action.clone(),
+            ActionDiff::ValueChanged { action, value: _ } => action.clone(),
+            ActionDiff::AxisPairChanged {
+                action,
+                axis_pair: _,
+            } => action.clone(),
+        }
+    }
+
+    /// Applies an [`ActionDiff`] (usually received over the network) to the [`ActionState`].
+    ///
+    /// This lets you reconstruct an [`ActionState`] from a stream of [`ActionDiff`]s
+    pub(crate) fn apply(self, action_state: &mut ActionState<A>) {
+        match self {
+            ActionDiff::Pressed { action } => {
+                action_state.press(&action);
+                // Pressing will initialize the ActionData if it doesn't exist
+                action_state.action_data_mut(&action).unwrap().value = 1.0;
+            }
+            ActionDiff::Released { action } => {
+                action_state.release(&action);
+                // Releasing will initialize the ActionData if it doesn't exist
+                let action_data = action_state.action_data_mut(&action).unwrap();
+                action_data.value = 0.;
+                action_data.axis_pair = None;
+            }
+            ActionDiff::ValueChanged { action, value } => {
+                action_state.press(&action);
+                // Pressing will initialize the ActionData if it doesn't exist
+                action_state.action_data_mut(&action).unwrap().value = value;
+            }
+            ActionDiff::AxisPairChanged { action, axis_pair } => {
+                action_state.press(&action);
+                // Pressing will initialize the ActionData if it doesn't exist
+                let action_data = action_state.action_data_mut(&action).unwrap();
+                action_data.axis_pair = Some(DualAxisData::from_xy(axis_pair));
+                action_data.value = axis_pair.length();
+            }
+        };
+    }
+}
+
+/// The `ActionDiffBuffer` stores the ActionDiff received from the client for each tick
+#[derive(Resource, Component, Debug)]
+pub(crate) struct ActionDiffBuffer<A: LeafwingUserAction> {
+    pub(crate) start_tick: Option<Tick>,
+    buffer: VecDeque<HashMap<A, ActionDiff<A>>>,
+}
+
+impl<A: LeafwingUserAction> Default for ActionDiffBuffer<A> {
+    fn default() -> Self {
+        Self {
+            start_tick: None,
+            buffer: VecDeque::new(),
+        }
+    }
+}
+
+impl<A: LeafwingUserAction> ActionDiffBuffer<A> {
+    pub(crate) fn end_tick(&self) -> Tick {
+        self.start_tick.map_or(Tick(0), |start_tick| {
+            start_tick + (self.buffer.len() as i16 - 1)
+        })
+    }
+
+    /// Take the ActionDiff generated in the frame and use them to populate the buffer
+    /// Note that multiple frame can use the same tick, in which case we will use the latest ActionDiff events
+    /// for a given action
+    pub(crate) fn set(&mut self, tick: Tick, diffs: &Vec<ActionDiff<A>>) {
+        let diffs = diffs
+            .iter()
+            .map(|diff| (diff.action(), diff.clone()))
+            .collect();
+        let Some(start_tick) = self.start_tick else {
+            // initialize the buffer
+            self.start_tick = Some(tick);
+            self.buffer.push_back(diffs);
+            return;
+        };
+
+        // cannot set lower values than start_tick
+        if tick < start_tick {
+            return;
+        }
+
+        let end_tick = start_tick + (self.buffer.len() as i16 - 1);
+        if tick > end_tick {
+            // fill the ticks between end_tick and tick with a copy of the current ActionState
+            for _ in 0..(tick - end_tick - 1) {
+                self.buffer.push_back(HashMap::default());
+            }
+            // add a new value to the buffer, which we will override below
+            self.buffer.push_back(diffs);
+            return;
+        }
+        // safety: we are guaranteed that the tick is in the buffer
+        let entry = self.buffer.get_mut((tick - start_tick) as usize).unwrap();
+
+        // we could have multiple ActionDiff events for the same entity, because the events were generated in different frames
+        // in which case we want to merge them
+        // TODO: should we handle when we have multiple ActionDiff that cancel each other? It should be fine
+        //  since we read the ActionDiff in order, so the later one will cancel the earlier one
+        entry.extend(diffs);
+    }
+
+    /// Remove all the diffs that are older than the given tick, then return the diffs
+    /// for the given tick
+    pub(crate) fn pop(&mut self, tick: Tick) -> Vec<ActionDiff<A>> {
+        let Some(start_tick) = self.start_tick else {
+            return vec![];
+        };
+        if tick < start_tick {
+            return vec![];
+        }
+        if tick > start_tick + (self.buffer.len() as i16 - 1) {
+            // pop everything
+            self.buffer = VecDeque::new();
+            self.start_tick = Some(tick + 1);
+            return vec![];
+        }
+
+        for _ in 0..(tick - start_tick) {
+            // front is the oldest value
+            self.buffer.pop_front();
+        }
+        self.start_tick = Some(tick + 1);
+
+        self.buffer
+            .pop_front()
+            .map(|v| v.into_values().collect())
+            .unwrap_or(vec![])
+    }
+
+    /// Get the ActionState for the given tick
+    pub(crate) fn get(&self, tick: Tick) -> Vec<ActionDiff<A>> {
+        let Some(start_tick) = self.start_tick else {
+            return vec![];
+        };
+        if tick < start_tick || tick > start_tick + (self.buffer.len() as i16 - 1) {
+            return vec![];
+        }
+        self.buffer
+            .get((tick - start_tick) as usize)
+            .map(|v| v.values().cloned().collect())
+            .unwrap_or(vec![])
+    }
+    pub(crate) fn update_from_message(&mut self, end_tick: Tick, diffs: &Vec<Vec<ActionDiff<A>>>) {
+        let message_start_tick = end_tick - diffs.len() as u16 + 1;
+        for (delta, diffs_for_tick) in diffs.iter().enumerate() {
+            let tick = message_start_tick + Tick(delta as u16);
+            self.set(tick, diffs_for_tick);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bevy::prelude::Reflect;
+    use leafwing_input_manager::Actionlike;
+
+    use super::*;
+
+    #[derive(
+        Serialize, Deserialize, Copy, Clone, Eq, PartialEq, Debug, Hash, Reflect, Actionlike,
+    )]
+    enum Action {
+        Jump,
+    }
+
+    #[test]
+    fn test_update_from_message() {
+        let mut diff_buffer = ActionDiffBuffer::default();
+
+        let end_tick = Tick(20);
+        let diffs = vec![
+            vec![],
+            vec![ActionDiff::Pressed {
+                action: Action::Jump,
+            }],
+            vec![],
+            vec![],
+            vec![],
+            vec![ActionDiff::Pressed {
+                action: Action::Jump,
+            }],
+            vec![],
+            vec![],
+            vec![],
+        ];
+
+        diff_buffer.update_from_message(end_tick, &diffs);
+
+        assert_eq!(diff_buffer.get(Tick(20)), vec![]);
+        assert_eq!(diff_buffer.get(Tick(19)), vec![]);
+        assert_eq!(diff_buffer.get(Tick(18)), vec![]);
+        assert_eq!(
+            diff_buffer.get(Tick(17)),
+            vec![ActionDiff::Pressed {
+                action: Action::Jump
+            }]
+        );
+        assert_eq!(diff_buffer.get(Tick(16)), vec![]);
+        assert_eq!(diff_buffer.get(Tick(15)), vec![]);
+        assert_eq!(diff_buffer.get(Tick(14)), vec![]);
+        assert_eq!(
+            diff_buffer.get(Tick(13)),
+            vec![ActionDiff::Pressed {
+                action: Action::Jump
+            }]
+        );
+        assert_eq!(diff_buffer.get(Tick(12)), vec![]);
+    }
+}

--- a/lightyear/src/inputs/leafwing/action_diff.rs
+++ b/lightyear/src/inputs/leafwing/action_diff.rs
@@ -63,14 +63,17 @@ impl<A: LeafwingUserAction> ActionDiff<A> {
                                 axis_pair: axis_pair_after.into(),
                             });
                         }
-                    }
-                    if action_data_before.value != action_data_after.value {
+                    } else if action_data_after.value != 1.0
+                        && action_data_after.value != 0.0
+                        && action_data_before.value != action_data_after.value
+                    {
                         diffs.push(ActionDiff::ValueChanged {
                             action: action.clone(),
                             value: action_data_after.value,
                         });
-                    }
-                    if action_data_after.state.pressed() && !action_data_before.state.pressed() {
+                    } else if action_data_after.state.pressed()
+                        && !action_data_before.state.pressed()
+                    {
                         diffs.push(ActionDiff::Pressed {
                             action: action.clone(),
                         });
@@ -82,7 +85,25 @@ impl<A: LeafwingUserAction> ActionDiff<A> {
                         });
                     }
                 } else {
-                    unreachable!("ActionData_before should have been initialized");
+                    if let Some(axis_pair_after) = action_data_after.axis_pair {
+                        diffs.push(ActionDiff::AxisPairChanged {
+                            action: action.clone(),
+                            axis_pair: axis_pair_after.into(),
+                        });
+                    } else if action_data_after.value != 1.0 {
+                        diffs.push(ActionDiff::ValueChanged {
+                            action: action.clone(),
+                            value: action_data_after.value,
+                        });
+                    } else if action_data_after.state.pressed() {
+                        diffs.push(ActionDiff::Pressed {
+                            action: action.clone(),
+                        });
+                    } else if !action_data_after.state.pressed() {
+                        diffs.push(ActionDiff::Released {
+                            action: action.clone(),
+                        });
+                    }
                 }
             } else {
                 unreachable!("ActionData_after should have been initialized");

--- a/lightyear/src/inputs/leafwing/action_diff.rs
+++ b/lightyear/src/inputs/leafwing/action_diff.rs
@@ -99,7 +99,9 @@ impl<A: LeafwingUserAction> ActionDiff<A> {
     }
 }
 
-/// The `ActionDiffBuffer` stores the ActionDiff received from the client for each tick
+/// The `ActionDiffBuffer` stores the ActionDiff generated at each tick on the client.
+///
+/// It is used to send a more compact `InputMessage` to the server.
 #[derive(Resource, Component, Debug)]
 pub(crate) struct ActionDiffBuffer<A: LeafwingUserAction> {
     pub(crate) start_tick: Option<Tick>,

--- a/lightyear/src/inputs/leafwing/action_diff.rs
+++ b/lightyear/src/inputs/leafwing/action_diff.rs
@@ -1,10 +1,8 @@
-use crate::prelude::{Deserialize, LeafwingUserAction, Serialize, Tick};
+use crate::prelude::{Deserialize, LeafwingUserAction, Serialize};
 use bevy::math::Vec2;
-use bevy::prelude::{Component, Entity, Event, Reflect, Resource};
-use bevy::utils::HashMap;
+use bevy::prelude::Reflect;
 use leafwing_input_manager::action_state::ActionState;
 use leafwing_input_manager::axislike::DualAxisData;
-use std::collections::VecDeque;
 
 /// Stores presses and releases of buttons without timing information
 ///
@@ -124,4 +122,32 @@ impl<A: LeafwingUserAction> ActionDiff<A> {
             }
         };
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::prelude::{Deserialize, Serialize};
+    use bevy::prelude::Reflect;
+    use leafwing_input_manager::prelude::ActionState;
+    use leafwing_input_manager::Actionlike;
+
+    #[derive(
+        Serialize, Deserialize, Copy, Clone, Eq, PartialEq, Debug, Hash, Reflect, Actionlike,
+    )]
+    enum Action {
+        Jump,
+    }
+
+    // fn test_diff() {
+    //     let mut action_state = ActionState::new();
+    //     action_state.press(&Action::Jump);
+    //     action_state.action_data_mut(&Action::Jump).unwrap().value = 0.5;
+    //     let mut action_state2 = action_state.clone();
+    //     action_state2.action_data_mut(&Action::Jump).unwrap().value = 0.75;
+    //     let diff = ActionDiff::create(&action_state, &action_state2);
+    //     assert_eq!(diff.len(), 1);
+    //     let mut action_state3 = action_state.clone();
+    //     diff[0].apply(&mut action_state3);
+    //     assert_eq!(action_state2, action_state3);
+    // }
 }

--- a/lightyear/src/inputs/leafwing/action_diff.rs
+++ b/lightyear/src/inputs/leafwing/action_diff.rs
@@ -6,23 +6,10 @@ use leafwing_input_manager::action_state::ActionState;
 use leafwing_input_manager::axislike::DualAxisData;
 use std::collections::VecDeque;
 
-/// Will store an `ActionDiff` as well as what generated it (either an Entity, or nothing if the
-/// input actions are represented by a `Resource`)
-///
-/// These are typically accessed using the `Events<ActionDiffEvent>` resource.
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Event)]
-pub struct ActionDiffEvent<A> {
-    /// If some: the entity that has the `ActionState<A>` component
-    /// If none: `ActionState<A>` is a Resource, not a component
-    pub owner: Option<Entity>,
-    /// The `ActionDiff` that was generated
-    pub action_diff: Vec<ActionDiff<A>>,
-}
-
 /// Stores presses and releases of buttons without timing information
 ///
-/// These are typically accessed using the `Events<ActionDiffEvent>` resource.
-/// Uses a minimal storage format, in order to facilitate transport over the network.
+/// Used to serialize the difference between two `ActionState` in order to send less data
+/// over the network when sending inputs.
 ///
 /// An `ActionState` can be fully reconstructed from a stream of `ActionDiff`
 #[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize, Reflect)]
@@ -54,16 +41,56 @@ pub enum ActionDiff<A> {
 }
 
 impl<A: LeafwingUserAction> ActionDiff<A> {
-    pub(crate) fn action(&self) -> A {
-        match self {
-            ActionDiff::Pressed { action } => action.clone(),
-            ActionDiff::Released { action } => action.clone(),
-            ActionDiff::ValueChanged { action, value: _ } => action.clone(),
-            ActionDiff::AxisPairChanged {
-                action,
-                axis_pair: _,
-            } => action.clone(),
+    /// Creates a list of `ActionDiff` from the difference between two `ActionState`
+    /// Used to have a smaller serialized size when sending inputs over the network
+    pub(crate) fn create(before: &ActionState<A>, after: &ActionState<A>) -> Vec<Self> {
+        let mut diffs = vec![];
+        for action in after.keys().iter() {
+            let action_data_after = after.action_data(action);
+            if let Some(action_data_after) = action_data_after {
+                let action_data_before = before.action_data(action);
+                // TODO: handle 'consume'? handle 'timing'?
+                if let Some(action_data_before) = action_data_before {
+                    if let Some(axis_pair_after) = action_data_after.axis_pair {
+                        if let Some(axis_pair_before) = action_data_before.axis_pair {
+                            if axis_pair_after != axis_pair_before {
+                                diffs.push(ActionDiff::AxisPairChanged {
+                                    action: action.clone(),
+                                    axis_pair: axis_pair_after.into(),
+                                });
+                            }
+                        } else {
+                            diffs.push(ActionDiff::AxisPairChanged {
+                                action: action.clone(),
+                                axis_pair: axis_pair_after.into(),
+                            });
+                        }
+                    }
+                    if action_data_before.value != action_data_after.value {
+                        diffs.push(ActionDiff::ValueChanged {
+                            action: action.clone(),
+                            value: action_data_after.value,
+                        });
+                    }
+                    if action_data_after.state.pressed() && !action_data_before.state.pressed() {
+                        diffs.push(ActionDiff::Pressed {
+                            action: action.clone(),
+                        });
+                    } else if !action_data_after.state.pressed()
+                        && action_data_before.state.pressed()
+                    {
+                        diffs.push(ActionDiff::Released {
+                            action: action.clone(),
+                        });
+                    }
+                } else {
+                    unreachable!("ActionData should have been initialized");
+                }
+            } else {
+                unreachable!("ActionData should have been initialized");
+            }
         }
+        diffs
     }
 
     /// Applies an [`ActionDiff`] (usually received over the network) to the [`ActionState`].
@@ -96,179 +123,5 @@ impl<A: LeafwingUserAction> ActionDiff<A> {
                 action_data.value = axis_pair.length();
             }
         };
-    }
-}
-
-/// The `ActionDiffBuffer` stores the ActionDiff generated at each tick on the client.
-///
-/// It is used to send a more compact `InputMessage` to the server.
-#[derive(Resource, Component, Debug)]
-pub(crate) struct ActionDiffBuffer<A: LeafwingUserAction> {
-    pub(crate) start_tick: Option<Tick>,
-    buffer: VecDeque<HashMap<A, ActionDiff<A>>>,
-}
-
-impl<A: LeafwingUserAction> Default for ActionDiffBuffer<A> {
-    fn default() -> Self {
-        Self {
-            start_tick: None,
-            buffer: VecDeque::new(),
-        }
-    }
-}
-
-impl<A: LeafwingUserAction> ActionDiffBuffer<A> {
-    pub(crate) fn end_tick(&self) -> Tick {
-        self.start_tick.map_or(Tick(0), |start_tick| {
-            start_tick + (self.buffer.len() as i16 - 1)
-        })
-    }
-
-    /// Take the ActionDiff generated in the frame and use them to populate the buffer
-    /// Note that multiple frame can use the same tick, in which case we will use the latest ActionDiff events
-    /// for a given action
-    pub(crate) fn set(&mut self, tick: Tick, diffs: &Vec<ActionDiff<A>>) {
-        let diffs = diffs
-            .iter()
-            .map(|diff| (diff.action(), diff.clone()))
-            .collect();
-        let Some(start_tick) = self.start_tick else {
-            // initialize the buffer
-            self.start_tick = Some(tick);
-            self.buffer.push_back(diffs);
-            return;
-        };
-
-        // cannot set lower values than start_tick
-        if tick < start_tick {
-            return;
-        }
-
-        let end_tick = start_tick + (self.buffer.len() as i16 - 1);
-        if tick > end_tick {
-            // fill the ticks between end_tick and tick with a copy of the current ActionState
-            for _ in 0..(tick - end_tick - 1) {
-                self.buffer.push_back(HashMap::default());
-            }
-            // add a new value to the buffer, which we will override below
-            self.buffer.push_back(diffs);
-            return;
-        }
-        // safety: we are guaranteed that the tick is in the buffer
-        let entry = self.buffer.get_mut((tick - start_tick) as usize).unwrap();
-
-        // we could have multiple ActionDiff events for the same entity, because the events were generated in different frames
-        // in which case we want to merge them
-        // TODO: should we handle when we have multiple ActionDiff that cancel each other? It should be fine
-        //  since we read the ActionDiff in order, so the later one will cancel the earlier one
-        entry.extend(diffs);
-    }
-
-    /// Remove all the diffs that are older than the given tick, then return the diffs
-    /// for the given tick
-    pub(crate) fn pop(&mut self, tick: Tick) -> Vec<ActionDiff<A>> {
-        let Some(start_tick) = self.start_tick else {
-            return vec![];
-        };
-        if tick < start_tick {
-            return vec![];
-        }
-        if tick > start_tick + (self.buffer.len() as i16 - 1) {
-            // pop everything
-            self.buffer = VecDeque::new();
-            self.start_tick = Some(tick + 1);
-            return vec![];
-        }
-
-        for _ in 0..(tick - start_tick) {
-            // front is the oldest value
-            self.buffer.pop_front();
-        }
-        self.start_tick = Some(tick + 1);
-
-        self.buffer
-            .pop_front()
-            .map(|v| v.into_values().collect())
-            .unwrap_or(vec![])
-    }
-
-    /// Get the ActionState for the given tick
-    pub(crate) fn get(&self, tick: Tick) -> Vec<ActionDiff<A>> {
-        let Some(start_tick) = self.start_tick else {
-            return vec![];
-        };
-        if tick < start_tick || tick > start_tick + (self.buffer.len() as i16 - 1) {
-            return vec![];
-        }
-        self.buffer
-            .get((tick - start_tick) as usize)
-            .map(|v| v.values().cloned().collect())
-            .unwrap_or(vec![])
-    }
-    pub(crate) fn update_from_message(&mut self, end_tick: Tick, diffs: &Vec<Vec<ActionDiff<A>>>) {
-        let message_start_tick = end_tick - diffs.len() as u16 + 1;
-        for (delta, diffs_for_tick) in diffs.iter().enumerate() {
-            let tick = message_start_tick + Tick(delta as u16);
-            self.set(tick, diffs_for_tick);
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use bevy::prelude::Reflect;
-    use leafwing_input_manager::Actionlike;
-
-    use super::*;
-
-    #[derive(
-        Serialize, Deserialize, Copy, Clone, Eq, PartialEq, Debug, Hash, Reflect, Actionlike,
-    )]
-    enum Action {
-        Jump,
-    }
-
-    #[test]
-    fn test_update_from_message() {
-        let mut diff_buffer = ActionDiffBuffer::default();
-
-        let end_tick = Tick(20);
-        let diffs = vec![
-            vec![],
-            vec![ActionDiff::Pressed {
-                action: Action::Jump,
-            }],
-            vec![],
-            vec![],
-            vec![],
-            vec![ActionDiff::Pressed {
-                action: Action::Jump,
-            }],
-            vec![],
-            vec![],
-            vec![],
-        ];
-
-        diff_buffer.update_from_message(end_tick, &diffs);
-
-        assert_eq!(diff_buffer.get(Tick(20)), vec![]);
-        assert_eq!(diff_buffer.get(Tick(19)), vec![]);
-        assert_eq!(diff_buffer.get(Tick(18)), vec![]);
-        assert_eq!(
-            diff_buffer.get(Tick(17)),
-            vec![ActionDiff::Pressed {
-                action: Action::Jump
-            }]
-        );
-        assert_eq!(diff_buffer.get(Tick(16)), vec![]);
-        assert_eq!(diff_buffer.get(Tick(15)), vec![]);
-        assert_eq!(diff_buffer.get(Tick(14)), vec![]);
-        assert_eq!(
-            diff_buffer.get(Tick(13)),
-            vec![ActionDiff::Pressed {
-                action: Action::Jump
-            }]
-        );
-        assert_eq!(diff_buffer.get(Tick(12)), vec![]);
     }
 }

--- a/lightyear/src/inputs/leafwing/action_diff.rs
+++ b/lightyear/src/inputs/leafwing/action_diff.rs
@@ -82,10 +82,10 @@ impl<A: LeafwingUserAction> ActionDiff<A> {
                         });
                     }
                 } else {
-                    unreachable!("ActionData should have been initialized");
+                    unreachable!("ActionData_before should have been initialized");
                 }
             } else {
-                unreachable!("ActionData should have been initialized");
+                unreachable!("ActionData_after should have been initialized");
             }
         }
         diffs

--- a/lightyear/src/inputs/leafwing/input_buffer.rs
+++ b/lightyear/src/inputs/leafwing/input_buffer.rs
@@ -40,7 +40,7 @@ impl<A: LeafwingUserAction> std::fmt::Display for InputBuffer<A> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let ty = A::short_type_path();
 
-        let Some(mut tick) = self.start_tick.clone() else {
+        let Some(tick) = self.start_tick.clone() else {
             return write!(f, "EmptyInputBuffer");
         };
 
@@ -58,10 +58,11 @@ impl<A: LeafwingUserAction> std::fmt::Display for InputBuffer<A> {
             })
             .collect::<Vec<String>>()
             .join("");
-        write!(f, "InputBuffer<{:?}>:\n {:?}", ty, buffer_str)
+        write!(f, "InputBuffer<{:?}>:\n {}", ty, buffer_str)
     }
 }
 
+// TODO: is this actually useful?
 // We use this to avoid cloning values in the buffer too much
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 pub(crate) enum BufferItem<T> {
@@ -240,8 +241,6 @@ impl<T: LeafwingUserAction> InputBuffer<T> {
 
 #[cfg(test)]
 mod tests {
-    use crate::inputs::leafwing::input_message::InputTarget;
-    use crate::prelude::InputMessage;
     use bevy::prelude::Reflect;
     use leafwing_input_manager::Actionlike;
 

--- a/lightyear/src/inputs/leafwing/input_buffer.rs
+++ b/lightyear/src/inputs/leafwing/input_buffer.rs
@@ -39,21 +39,26 @@ pub(crate) struct InputBuffer<A: LeafwingUserAction> {
 impl<A: LeafwingUserAction> std::fmt::Display for InputBuffer<A> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let ty = A::short_type_path();
+
+        let Some(mut tick) = self.start_tick.clone() else {
+            return write!(f, "EmptyInputBuffer");
+        };
+
         let buffer_str = self
             .buffer
             .iter()
-            .map(|item| match item {
-                BufferItem::Absent => "Absent".to_string(),
-                BufferItem::SameAsPrecedent => "SameAsPrecedent".to_string(),
-                BufferItem::Data(data) => format!("{:?}", data.get_pressed()),
+            .enumerate()
+            .map(|(i, item)| {
+                let str = match item {
+                    BufferItem::Absent => "Absent".to_string(),
+                    BufferItem::SameAsPrecedent => "SameAsPrecedent".to_string(),
+                    BufferItem::Data(data) => format!("{:?}", data.get_pressed()),
+                };
+                format!("{:?}: {}\n", tick + i as i16, str)
             })
             .collect::<Vec<String>>()
-            .join(", ");
-        write!(
-            f,
-            "InputBuffer<{:?}> = Start tick: {:?}. Buffer: {:?}",
-            ty, self.start_tick, buffer_str
-        )
+            .join("");
+        write!(f, "InputBuffer<{:?}>:\n {:?}", ty, buffer_str)
     }
 }
 

--- a/lightyear/src/inputs/leafwing/input_buffer.rs
+++ b/lightyear/src/inputs/leafwing/input_buffer.rs
@@ -1,11 +1,7 @@
 use std::collections::VecDeque;
 use std::fmt::{Debug, Formatter};
 
-use bevy::ecs::entity::MapEntities;
-use bevy::math::Vec2;
-use bevy::prelude::{Component, Entity, EntityMapper, Event, Reflect, Resource};
-use bevy::utils::HashMap;
-use leafwing_input_manager::axislike::DualAxisData;
+use bevy::prelude::{Component, Resource};
 use leafwing_input_manager::prelude::ActionState;
 use serde::{Deserialize, Serialize};
 use tracing::trace;
@@ -30,6 +26,7 @@ use super::LeafwingUserAction;
 
 // NOTE: right now, for simplicity, we will send all the action-diffs for all entities in one single message.
 // TODO: can we just use History<ActionState> then? why do we need a special component?
+//  maybe because we want to send/store inputs even before we apply them
 /// The InputBuffer contains a history of the ActionState
 // TODO: improve this data structure
 #[derive(Resource, Component, Debug)]
@@ -75,158 +72,12 @@ impl<A: LeafwingUserAction> Default for InputBuffer<A> {
     }
 }
 
-/// Will store an `ActionDiff` as well as what generated it (either an Entity, or nothing if the
-/// input actions are represented by a `Resource`)
-///
-/// These are typically accessed using the `Events<ActionDiffEvent>` resource.
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Event)]
-pub struct ActionDiffEvent<A> {
-    /// If some: the entity that has the `ActionState<A>` component
-    /// If none: `ActionState<A>` is a Resource, not a component
-    pub owner: Option<Entity>,
-    /// The `ActionDiff` that was generated
-    pub action_diff: Vec<ActionDiff<A>>,
-}
-
-/// Stores presses and releases of buttons without timing information
-///
-/// These are typically accessed using the `Events<ActionDiffEvent>` resource.
-/// Uses a minimal storage format, in order to facilitate transport over the network.
-///
-/// An `ActionState` can be fully reconstructed from a stream of `ActionDiff`
-#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize, Reflect)]
-pub enum ActionDiff<A> {
-    /// The action was pressed
-    Pressed {
-        /// The value of the action
-        action: A,
-    },
-    /// The action was released
-    Released {
-        /// The value of the action
-        action: A,
-    },
-    /// The value of the action changed
-    ValueChanged {
-        /// The value of the action
-        action: A,
-        /// The new value of the action
-        value: f32,
-    },
-    /// The axis pair of the action changed
-    AxisPairChanged {
-        /// The value of the action
-        action: A,
-        /// The new value of the axis
-        axis_pair: Vec2,
-    },
-}
-
-impl<A: LeafwingUserAction> ActionDiff<A> {
-    pub(crate) fn action(&self) -> A {
-        match self {
-            ActionDiff::Pressed { action } => action.clone(),
-            ActionDiff::Released { action } => action.clone(),
-            ActionDiff::ValueChanged { action, value: _ } => action.clone(),
-            ActionDiff::AxisPairChanged {
-                action,
-                axis_pair: _,
-            } => action.clone(),
-        }
-    }
-
-    /// Applies an [`ActionDiff`] (usually received over the network) to the [`ActionState`].
-    ///
-    /// This lets you reconstruct an [`ActionState`] from a stream of [`ActionDiff`]s
-    pub(crate) fn apply(self, action_state: &mut ActionState<A>) {
-        match self {
-            ActionDiff::Pressed { action } => {
-                action_state.press(&action);
-                // Pressing will initialize the ActionData if it doesn't exist
-                action_state.action_data_mut(&action).unwrap().value = 1.0;
-            }
-            ActionDiff::Released { action } => {
-                action_state.release(&action);
-                // Releasing will initialize the ActionData if it doesn't exist
-                let action_data = action_state.action_data_mut(&action).unwrap();
-                action_data.value = 0.;
-                action_data.axis_pair = None;
-            }
-            ActionDiff::ValueChanged { action, value } => {
-                action_state.press(&action);
-                // Pressing will initialize the ActionData if it doesn't exist
-                action_state.action_data_mut(&action).unwrap().value = value;
-            }
-            ActionDiff::AxisPairChanged { action, axis_pair } => {
-                action_state.press(&action);
-                // Pressing will initialize the ActionData if it doesn't exist
-                let action_data = action_state.action_data_mut(&action).unwrap();
-                action_data.axis_pair = Some(DualAxisData::from_xy(axis_pair));
-                action_data.value = axis_pair.length();
-            }
-        };
-    }
-}
-
-// TODO: use Mode to specify how to serialize a message (serde vs bitcode)! + can specify custom serialize function as well (similar to interpolation mode)
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug, Reflect)]
-/// We serialize the inputs by sending only the ActionDiffs of the last few ticks
-/// We will store the last N inputs starting from start_tick (in case of packet loss)
-pub struct InputMessage<A> {
-    pub(crate) end_tick: Tick,
-    // first element is tick end_tick-N+1, last element is end_tick
-    pub(crate) diffs: Vec<(InputTarget, Vec<Vec<ActionDiff<A>>>)>,
-}
-
-#[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Debug, Reflect)]
-pub enum InputTarget {
-    /// the input is for a global resource
-    Global,
-    /// the input is for a predicted or confirmed entity: on the client, the server's local entity is mapped to the client's confirmed entity
-    Entity(Entity),
-    /// the input is for a pre-predicted entity: on the server, the server's local entity is mapped to the client's pre-predicted entity
-    PrePredictedEntity(Entity),
-}
-
-impl<A: LeafwingUserAction> MapEntities for InputMessage<A> {
-    // NOTE: we do NOT map the entities for input-message because when already convert
-    //  the entities on the message to the corresponding client entities when we write them
-    //  in the input message
-
-    // NOTE: we only map the inputs for the pre-predicted entities
-    fn map_entities<M: EntityMapper>(&mut self, entity_mapper: &mut M) {
-        self.diffs
-            .iter_mut()
-            .filter_map(|(entity, _)| {
-                if let InputTarget::PrePredictedEntity(e) = entity {
-                    return Some(e);
-                } else {
-                    return None;
-                }
-            })
-            .for_each(|entity| *entity = entity_mapper.map_entity(*entity));
-    }
-}
-
-impl<T: LeafwingUserAction> InputMessage<T> {
-    pub fn new(end_tick: Tick) -> Self {
-        Self {
-            end_tick,
-            diffs: vec![],
-        }
-    }
-
-    // we will always include
-    pub fn is_empty(&self) -> bool {
-        self.diffs
-            .iter()
-            .all(|(_, diffs)| diffs.iter().all(|diffs_per_tick| diffs_per_tick.is_empty()))
-    }
-}
-
 impl<T: LeafwingUserAction> InputBuffer<T> {
     // Note: we expect this to be set every tick?
     //  i.e. there should be an ActionState for every tick, even if the action is None
+    /// Set the ActionState for the given tick in the InputBuffer
+    ///
+    /// This should be called every tick.
     pub(crate) fn set(&mut self, tick: Tick, value: &ActionState<T>) {
         let Some(start_tick) = self.start_tick else {
             // initialize the buffer
@@ -247,8 +98,7 @@ impl<T: LeafwingUserAction> InputBuffer<T> {
 
             // TODO: think about whether this is correct or not, it is correct if we always call set()
             //  with monotonically increasing ticks, which I think is the case
-            //  maybe that's not correct because the timing information should be different? (i.e. I should tick the action-states myself
-            //  and set them)
+            //  maybe that's not correct because the timing information should be different? (i.e. I should tick the action-states myself and set them)
             // fill the ticks between end_tick and tick with a copy of the current ActionState
             for _ in 0..(tick - end_tick - 1) {
                 trace!("fill ticks");
@@ -353,139 +203,6 @@ impl<T: LeafwingUserAction> InputBuffer<T> {
     }
 }
 
-/// The `ActionDiffBuffer` stores the ActionDiff received from the client for each tick
-#[derive(Resource, Component, Debug)]
-pub(crate) struct ActionDiffBuffer<A: LeafwingUserAction> {
-    pub(crate) start_tick: Option<Tick>,
-    buffer: VecDeque<HashMap<A, ActionDiff<A>>>,
-}
-
-impl<A: LeafwingUserAction> Default for ActionDiffBuffer<A> {
-    fn default() -> Self {
-        Self {
-            start_tick: None,
-            buffer: VecDeque::new(),
-        }
-    }
-}
-
-impl<A: LeafwingUserAction> ActionDiffBuffer<A> {
-    pub(crate) fn end_tick(&self) -> Tick {
-        self.start_tick.map_or(Tick(0), |start_tick| {
-            start_tick + (self.buffer.len() as i16 - 1)
-        })
-    }
-
-    /// Take the ActionDiff generated in the frame and use them to populate the buffer
-    /// Note that multiple frame can use the same tick, in which case we will use the latest ActionDiff events
-    /// for a given action
-    pub(crate) fn set(&mut self, tick: Tick, diffs: &Vec<ActionDiff<A>>) {
-        let diffs = diffs
-            .iter()
-            .map(|diff| (diff.action(), diff.clone()))
-            .collect();
-        let Some(start_tick) = self.start_tick else {
-            // initialize the buffer
-            self.start_tick = Some(tick);
-            self.buffer.push_back(diffs);
-            return;
-        };
-
-        // cannot set lower values than start_tick
-        if tick < start_tick {
-            return;
-        }
-
-        let end_tick = start_tick + (self.buffer.len() as i16 - 1);
-        if tick > end_tick {
-            // fill the ticks between end_tick and tick with a copy of the current ActionState
-            for _ in 0..(tick - end_tick - 1) {
-                self.buffer.push_back(HashMap::default());
-            }
-            // add a new value to the buffer, which we will override below
-            self.buffer.push_back(diffs);
-            return;
-        }
-        // safety: we are guaranteed that the tick is in the buffer
-        let entry = self.buffer.get_mut((tick - start_tick) as usize).unwrap();
-
-        // we could have multiple ActionDiff events for the same entity, because the events were generated in different frames
-        // in which case we want to merge them
-        // TODO: should we handle when we have multiple ActionDiff that cancel each other? It should be fine
-        //  since we read the ActionDiff in order, so the later one will cancel the earlier one
-        entry.extend(diffs);
-    }
-
-    /// Remove all the diffs that are older than the given tick, then return the diffs
-    /// for the given tick
-    pub(crate) fn pop(&mut self, tick: Tick) -> Vec<ActionDiff<A>> {
-        let Some(start_tick) = self.start_tick else {
-            return vec![];
-        };
-        if tick < start_tick {
-            return vec![];
-        }
-        if tick > start_tick + (self.buffer.len() as i16 - 1) {
-            // pop everything
-            self.buffer = VecDeque::new();
-            self.start_tick = Some(tick + 1);
-            return vec![];
-        }
-
-        for _ in 0..(tick - start_tick) {
-            // front is the oldest value
-            self.buffer.pop_front();
-        }
-        self.start_tick = Some(tick + 1);
-
-        self.buffer
-            .pop_front()
-            .map(|v| v.into_values().collect())
-            .unwrap_or(vec![])
-    }
-
-    /// Get the ActionState for the given tick
-    pub(crate) fn get(&self, tick: Tick) -> Vec<ActionDiff<A>> {
-        let Some(start_tick) = self.start_tick else {
-            return vec![];
-        };
-        if tick < start_tick || tick > start_tick + (self.buffer.len() as i16 - 1) {
-            return vec![];
-        }
-        self.buffer
-            .get((tick - start_tick) as usize)
-            .map(|v| v.values().cloned().collect())
-            .unwrap_or(vec![])
-    }
-    pub(crate) fn update_from_message(&mut self, end_tick: Tick, diffs: &Vec<Vec<ActionDiff<A>>>) {
-        let message_start_tick = end_tick - diffs.len() as u16 + 1;
-        for (delta, diffs_for_tick) in diffs.iter().enumerate() {
-            let tick = message_start_tick + Tick(delta as u16);
-            self.set(tick, diffs_for_tick);
-        }
-    }
-
-    // Convert the last N ticks up to end_tick included into a compressed message that we can send to the server
-    // Return None if the last N inputs are all Absent
-    pub(crate) fn add_to_message(
-        &self,
-        message: &mut InputMessage<A>,
-        end_tick: Tick,
-        num_ticks: u16,
-        input_target: InputTarget,
-    ) {
-        let mut inputs = Vec::new();
-        // start with the first value
-        let start_tick = Tick(end_tick.0) - num_ticks + 1;
-        for delta in 0..num_ticks {
-            let tick = start_tick + Tick(delta);
-            let diffs = self.get(tick);
-            inputs.push(diffs);
-        }
-        message.diffs.push((input_target, inputs));
-    }
-}
-
 // TODO: update from message
 
 #[cfg(test)]
@@ -537,97 +254,5 @@ mod tests {
         assert_eq!(input_buffer.pop(Tick(7)), Some(a2.clone()));
         assert_eq!(input_buffer.start_tick, Some(Tick(8)));
         assert_eq!(input_buffer.buffer.len(), 0);
-    }
-
-    #[test]
-    fn test_create_message() {
-        let mut diff_buffer = ActionDiffBuffer::default();
-
-        diff_buffer.set(
-            Tick(3),
-            &vec![ActionDiff::Pressed {
-                action: Action::Jump,
-            }],
-        );
-        diff_buffer.set(
-            Tick(7),
-            &vec![ActionDiff::Released {
-                action: Action::Jump,
-            }],
-        );
-
-        let entity = Entity::from_raw(0);
-        let end_tick = Tick(10);
-        let mut message = InputMessage::<Action>::new(end_tick);
-
-        diff_buffer.add_to_message(&mut message, end_tick, 9, InputTarget::Entity(entity));
-        assert_eq!(
-            message,
-            InputMessage {
-                end_tick: Tick(10),
-                diffs: vec![(
-                    InputTarget::Entity(entity),
-                    vec![
-                        vec![],
-                        vec![ActionDiff::Pressed {
-                            action: Action::Jump
-                        }],
-                        vec![],
-                        vec![],
-                        vec![],
-                        vec![ActionDiff::Released {
-                            action: Action::Jump
-                        }],
-                        vec![],
-                        vec![],
-                        vec![],
-                    ]
-                )],
-            }
-        );
-    }
-
-    #[test]
-    fn test_update_from_message() {
-        let mut diff_buffer = ActionDiffBuffer::default();
-
-        let end_tick = Tick(20);
-        let diffs = vec![
-            vec![],
-            vec![ActionDiff::Pressed {
-                action: Action::Jump,
-            }],
-            vec![],
-            vec![],
-            vec![],
-            vec![ActionDiff::Pressed {
-                action: Action::Jump,
-            }],
-            vec![],
-            vec![],
-            vec![],
-        ];
-
-        diff_buffer.update_from_message(end_tick, &diffs);
-
-        assert_eq!(diff_buffer.get(Tick(20)), vec![]);
-        assert_eq!(diff_buffer.get(Tick(19)), vec![]);
-        assert_eq!(diff_buffer.get(Tick(18)), vec![]);
-        assert_eq!(
-            diff_buffer.get(Tick(17)),
-            vec![ActionDiff::Pressed {
-                action: Action::Jump
-            }]
-        );
-        assert_eq!(diff_buffer.get(Tick(16)), vec![]);
-        assert_eq!(diff_buffer.get(Tick(15)), vec![]);
-        assert_eq!(diff_buffer.get(Tick(14)), vec![]);
-        assert_eq!(
-            diff_buffer.get(Tick(13)),
-            vec![ActionDiff::Pressed {
-                action: Action::Jump
-            }]
-        );
-        assert_eq!(diff_buffer.get(Tick(12)), vec![]);
     }
 }

--- a/lightyear/src/inputs/leafwing/input_message.rs
+++ b/lightyear/src/inputs/leafwing/input_message.rs
@@ -1,0 +1,188 @@
+use crate::inputs::leafwing::action_diff::{ActionDiff, ActionDiffBuffer};
+use crate::inputs::leafwing::input_buffer::InputBuffer;
+use crate::prelude::{Deserialize, LeafwingUserAction, Serialize, Tick};
+use bevy::ecs::entity::MapEntities;
+use bevy::prelude::{Entity, EntityMapper, Reflect};
+use leafwing_input_manager::action_state::ActionState;
+use leafwing_input_manager::Actionlike;
+
+// TODO: use Mode to specify how to serialize a message (serde vs bitcode)! + can specify custom serialize function as well (similar to interpolation mode)
+#[derive(Serialize, Deserialize, Clone, PartialEq, Debug, Reflect)]
+/// We serialize the inputs by sending, for each entity:
+/// - the ActionState at a given start tick
+/// - then the ActionDiffs for all the ticks after that, up to end_tick
+///
+/// (We do this to make sure that we can reconstruct the ActionState at any tick,
+/// even if we miss some inputs. This wouldn't be the case if we only send ActionDiffs)
+pub struct InputMessage<A: Actionlike> {
+    pub(crate) end_tick: Tick,
+    // first element is tick end_tick-N+1, last element is end_tick
+    pub(crate) diffs: Vec<(InputTarget, ActionState<A>, Vec<Vec<ActionDiff<A>>>)>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Debug, Reflect)]
+pub enum InputTarget {
+    /// the input is for a global resource
+    Global,
+    /// the input is for a predicted or confirmed entity: on the client, the server's local entity is mapped to the client's confirmed entity
+    Entity(Entity),
+    /// the input is for a pre-predicted entity: on the server, the server's local entity is mapped to the client's pre-predicted entity
+    PrePredictedEntity(Entity),
+}
+
+impl<A: LeafwingUserAction> MapEntities for InputMessage<A> {
+    // NOTE: we do NOT map the entities for input-message because when already convert
+    //  the entities on the message to the corresponding client entities when we write them
+    //  in the input message
+
+    // NOTE: we only map the inputs for the pre-predicted entities
+    fn map_entities<M: EntityMapper>(&mut self, entity_mapper: &mut M) {
+        self.diffs
+            .iter_mut()
+            .filter_map(|(entity, _, _)| {
+                if let InputTarget::PrePredictedEntity(e) = entity {
+                    return Some(e);
+                } else {
+                    return None;
+                }
+            })
+            .for_each(|entity| *entity = entity_mapper.map_entity(*entity));
+    }
+}
+
+impl<A: LeafwingUserAction> InputMessage<A> {
+    pub fn new(end_tick: Tick) -> Self {
+        Self {
+            end_tick,
+            diffs: vec![],
+        }
+    }
+
+    /// Add the inputs for the `num_ticks` ticks starting from `self.end_tick - num_ticks + 1` up to `self.end_tick`
+    ///
+    /// If we don't have a starting `ActionState` from the `input_buffer`, we start from the first tick for which
+    /// we have an `ActionState`.
+    pub(crate) fn add_inputs(
+        &mut self,
+        num_ticks: u16,
+        input_target: InputTarget,
+        action_diff_buffer: &ActionDiffBuffer<A>,
+        input_buffer: &InputBuffer<A>,
+    ) {
+        let mut inputs = Vec::new();
+        // find the first tick for which we have an `ActionState` buffered
+        let mut start_tick = self.end_tick - num_ticks + 1;
+        while start_tick <= self.end_tick {
+            if input_buffer.get(start_tick).is_some() {
+                break;
+            }
+            start_tick += 1;
+        }
+
+        // there are no ticks for which we have an `ActionState` buffered, so we send nothing
+        if start_tick > self.end_tick {
+            return;
+        }
+
+        let start_value = input_buffer.get(start_tick).unwrap().clone();
+        let mut tick = start_tick + 1;
+        while tick <= self.end_tick {
+            let diffs = action_diff_buffer.get(tick);
+            inputs.push(diffs);
+            tick += 1;
+        }
+        let mut diffs = vec![];
+        for delta in 1..num_ticks {
+            let tick = start_tick + Tick(delta);
+            let diffs_for_tick = action_diff_buffer.get(tick);
+            diffs.push(diffs_for_tick);
+        }
+        self.diffs.push((input_target, start_value, inputs));
+    }
+
+    // TODO: do we want to send the inputs if there are no diffs?
+    pub fn is_empty(&self) -> bool {
+        self.diffs
+            .iter()
+            .all(|(_, _, diffs)| diffs.iter().all(|diffs_per_tick| diffs_per_tick.is_empty()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use leafwing_input_manager::Actionlike;
+
+    #[derive(
+        Serialize, Deserialize, Copy, Clone, Eq, PartialEq, Debug, Hash, Reflect, Actionlike,
+    )]
+    enum Action {
+        Jump,
+    }
+
+    #[test]
+    fn test_generate_input_message_no_start_input() {
+        let input_buffer = InputBuffer::default();
+        let action_diff_buffer = ActionDiffBuffer::<Action>::default();
+        let mut input_message = InputMessage::<Action>::new(Tick(10));
+        input_message.add_inputs(5, InputTarget::Global, &action_diff_buffer, &input_buffer);
+        assert_eq!(
+            input_message,
+            InputMessage {
+                end_tick: Tick(10),
+                diffs: vec![],
+            }
+        );
+        assert!(input_message.is_empty());
+    }
+
+    #[test]
+    fn test_create_message() {
+        let mut input_buffer = InputBuffer::default();
+        input_buffer.set(Tick(2), &ActionState::default());
+        let mut diff_buffer = ActionDiffBuffer::default();
+
+        diff_buffer.set(
+            Tick(3),
+            &vec![ActionDiff::Pressed {
+                action: Action::Jump,
+            }],
+        );
+        diff_buffer.set(
+            Tick(7),
+            &vec![ActionDiff::Released {
+                action: Action::Jump,
+            }],
+        );
+
+        let entity = Entity::from_raw(0);
+        let end_tick = Tick(10);
+        let mut message = InputMessage::<Action>::new(end_tick);
+
+        message.add_inputs(9, InputTarget::Entity(entity), &diff_buffer, &input_buffer);
+        assert_eq!(
+            message,
+            InputMessage {
+                end_tick: Tick(10),
+                diffs: vec![(
+                    InputTarget::Entity(entity),
+                    ActionState::default(),
+                    vec![
+                        vec![ActionDiff::Pressed {
+                            action: Action::Jump
+                        }],
+                        vec![],
+                        vec![],
+                        vec![],
+                        vec![ActionDiff::Released {
+                            action: Action::Jump
+                        }],
+                        vec![],
+                        vec![],
+                        vec![],
+                    ]
+                )],
+            }
+        );
+    }
+}

--- a/lightyear/src/inputs/leafwing/mod.rs
+++ b/lightyear/src/inputs/leafwing/mod.rs
@@ -6,9 +6,9 @@ use leafwing_input_manager::Actionlike;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 
-pub use input_buffer::InputMessage;
-
+pub(crate) mod action_diff;
 pub(crate) mod input_buffer;
+pub(crate) mod input_message;
 
 /// An enum that represents a list of user actions.
 ///

--- a/lightyear/src/lib.rs
+++ b/lightyear/src/lib.rs
@@ -191,7 +191,7 @@ pub mod prelude {
     pub use crate::connection::id::ClientId;
     pub use crate::connection::netcode::{generate_key, ConnectToken, Key};
     #[cfg(feature = "leafwing")]
-    pub use crate::inputs::leafwing::{InputMessage, LeafwingUserAction};
+    pub use crate::inputs::leafwing::{input_message::InputMessage, LeafwingUserAction};
     pub use crate::inputs::native::UserAction;
     pub use crate::packet::error::PacketError;
     pub use crate::packet::message::Message;

--- a/lightyear/src/server/input/leafwing.rs
+++ b/lightyear/src/server/input/leafwing.rs
@@ -1,13 +1,14 @@
 //! Handles client-generated inputs
 use std::ops::DerefMut;
 
+use crate::inputs::leafwing::action_diff::ActionDiffBuffer;
+use crate::inputs::leafwing::input_message::InputTarget;
 use bevy::prelude::*;
 use leafwing_input_manager::prelude::*;
 
-use crate::inputs::leafwing::input_buffer::{ActionDiffBuffer, InputTarget};
-use crate::inputs::leafwing::{InputMessage, LeafwingUserAction};
+use crate::inputs::leafwing::LeafwingUserAction;
 use crate::prelude::server::MessageEvent;
-use crate::prelude::{is_started, MessageRegistry, Mode, TickManager};
+use crate::prelude::{is_started, InputMessage, MessageRegistry, Mode, TickManager};
 use crate::protocol::message::MessageKind;
 use crate::serialize::reader::Reader;
 use crate::server::config::ServerConfig;
@@ -130,7 +131,8 @@ fn receive_input_message<A: LeafwingUserAction>(
                 ) {
                     Ok(message) => {
                         debug!(?client_id, action = ?A::short_type_path(), ?message.end_tick, ?message.diffs, "received input message");
-                        for (target, diffs) in &message.diffs {
+                        // TODO: UPDATE THIS
+                        for (target, _, diffs) in &message.diffs {
                             match target {
                                 // - for pre-predicted entities, we already did the mapping on server side upon receiving the message
                                 // (which is possible because the server received the entity)
@@ -219,11 +221,13 @@ fn update_action_state<A: LeafwingUserAction>(
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use crate::inputs::leafwing::action_diff::ActionDiff;
+    use crate::inputs::leafwing::input_buffer::InputBuffer;
     use bevy::input::InputPlugin;
     use bevy::utils::Duration;
     use leafwing_input_manager::prelude::ActionState;
 
-    use crate::inputs::leafwing::input_buffer::{ActionDiff, InputBuffer};
     use crate::prelude::client;
     use crate::prelude::client::{
         InterpolationConfig, LeafwingInputConfig, PredictionConfig, SyncConfig,
@@ -232,8 +236,6 @@ mod tests {
     use crate::prelude::*;
     use crate::tests::protocol::*;
     use crate::tests::stepper::{BevyStepper, Step};
-
-    use super::*;
 
     #[test]
     fn test_leafwing_inputs() {

--- a/lightyear/src/server/input/leafwing.rs
+++ b/lightyear/src/server/input/leafwing.rs
@@ -195,17 +195,10 @@ fn update_action_state<A: LeafwingUserAction>(
 ) {
     let tick = tick_manager.tick();
 
-    for (entity, mut action_state, input_buffer) in action_state_query.iter_mut() {
+    for (entity, mut action_state, mut input_buffer) in action_state_query.iter_mut() {
         // the state on the server is only updated from client inputs!
-        trace!(
-            ?tick,
-            ?entity,
-            ?input_buffer,
-            "action state pressed: {:?}",
-            &action_state.get_pressed(),
-        );
-        *action_state = input_buffer.get(tick).cloned().unwrap_or_default();
-        error!(?tick, ?entity, pressed = ?action_state.get_pressed(), "action state after update. Input Buffer: {}", input_buffer.as_ref());
+        *action_state = input_buffer.pop(tick).unwrap_or_default();
+        debug!(?tick, ?entity, pressed = ?action_state.get_pressed(), "action state after update. Input Buffer: {}", input_buffer.as_ref());
     }
 }
 

--- a/lightyear/src/server/input/leafwing.rs
+++ b/lightyear/src/server/input/leafwing.rs
@@ -185,13 +185,13 @@ fn update_action_state<A: LeafwingUserAction>(
 ) {
     let tick = tick_manager.tick();
 
-    for (entity, mut action_state, mut input_buffer) in action_state_query.iter_mut() {
+    for (entity, mut action_state, input_buffer) in action_state_query.iter_mut() {
         // the state on the server is only updated from client inputs!
         trace!(
             ?tick,
             ?entity,
             ?input_buffer,
-            "action state: {:?}. Latest action diff buffer tick: {:?}",
+            "action state pressed: {:?}",
             &action_state.get_pressed(),
         );
         *action_state = input_buffer.get(tick).cloned().unwrap_or_default();

--- a/lightyear/src/server/replication.rs
+++ b/lightyear/src/server/replication.rs
@@ -2820,7 +2820,6 @@ pub(crate) mod commands {
             let tick_duration = Duration::from_millis(10);
             let frame_duration = Duration::from_millis(10);
             let mut stepper = BevyStepper::default();
-            stepper.init();
 
             let entity = stepper
                 .server_app

--- a/lightyear/src/server/replication.rs
+++ b/lightyear/src/server/replication.rs
@@ -2808,10 +2808,7 @@ pub(crate) mod commands {
     mod tests {
         use bevy::utils::Duration;
 
-        use crate::client::sync::SyncConfig;
-        use crate::prelude::client::{InterpolationConfig, PredictionConfig};
         use crate::prelude::server::Replicate;
-        use crate::prelude::{LinkConditionerConfig, SharedConfig, TickConfig};
         use crate::tests::protocol::*;
         use crate::tests::stepper::{BevyStepper, Step};
 
@@ -2822,26 +2819,7 @@ pub(crate) mod commands {
         fn test_despawn() {
             let tick_duration = Duration::from_millis(10);
             let frame_duration = Duration::from_millis(10);
-            let shared_config = SharedConfig {
-                tick: TickConfig::new(tick_duration),
-                ..Default::default()
-            };
-            let link_conditioner = LinkConditionerConfig {
-                incoming_latency: Duration::from_millis(0),
-                incoming_jitter: Duration::from_millis(0),
-                incoming_loss: 0.0,
-            };
-            let sync_config = SyncConfig::default().speedup_factor(1.0);
-            let prediction_config = PredictionConfig::default();
-            let interpolation_config = InterpolationConfig::default();
-            let mut stepper = BevyStepper::new(
-                shared_config,
-                sync_config,
-                prediction_config,
-                interpolation_config,
-                link_conditioner,
-                frame_duration,
-            );
+            let mut stepper = BevyStepper::default();
             stepper.init();
 
             let entity = stepper

--- a/lightyear/src/shared/input/leafwing.rs
+++ b/lightyear/src/shared/input/leafwing.rs
@@ -5,9 +5,8 @@ use leafwing_input_manager::prelude::ActionState;
 
 use crate::client::config::ClientConfig;
 use crate::client::input::leafwing::LeafwingInputConfig;
-use crate::inputs::leafwing::InputMessage;
 use crate::prelude::client::ComponentSyncMode;
-use crate::prelude::{AppComponentExt, ChannelDirection, LeafwingUserAction};
+use crate::prelude::{AppComponentExt, ChannelDirection, InputMessage, LeafwingUserAction};
 use crate::protocol::message::AppMessageInternalExt;
 use crate::protocol::message::MessageType;
 use crate::server::config::ServerConfig;

--- a/lightyear/src/shared/input/leafwing.rs
+++ b/lightyear/src/shared/input/leafwing.rs
@@ -5,7 +5,6 @@ use leafwing_input_manager::prelude::ActionState;
 
 use crate::client::config::ClientConfig;
 use crate::client::input::leafwing::LeafwingInputConfig;
-use crate::prelude::client::ComponentSyncMode;
 use crate::prelude::{AppComponentExt, ChannelDirection, InputMessage, LeafwingUserAction};
 use crate::protocol::message::AppMessageInternalExt;
 use crate::protocol::message::MessageType;
@@ -39,10 +38,11 @@ impl<A: LeafwingUserAction> Plugin for LeafwingInputPlugin<A> {
         // - server receiving pre-predicted entities
         // - client receiving other players' inputs
         .add_map_entities();
-        // TODO: how can we avoid this?
-        // We still need to replicate the ActionState to the client
-        app.register_component::<ActionState<A>>(ChannelDirection::Bidirectional)
-            .add_prediction(ComponentSyncMode::Simple);
+
+        // Note: this is necessary because
+        // - so that the server entity has an ActionState on the server when the ActionState is added on the client
+        //   (we only replicate it once when ActionState is first added)
+        app.register_component::<ActionState<A>>(ChannelDirection::ClientToServer);
         let is_client = app.world.get_resource::<ClientConfig>().is_some();
         let is_server = app.world.get_resource::<ServerConfig>().is_some();
         if is_client {

--- a/lightyear/src/tests/integration/tick_wrapping.rs
+++ b/lightyear/src/tests/integration/tick_wrapping.rs
@@ -23,26 +23,8 @@ fn increment(mut query: Query<&mut Component1>, mut ev: EventReader<InputEvent<M
 /// is on a new tick generation
 #[test]
 fn test_sync_after_tick_wrap() {
-    let frame_duration = Duration::from_secs_f32(1.0 / 60.0);
     let tick_duration = Duration::from_millis(10);
-    let shared_config = SharedConfig {
-        tick: TickConfig::new(tick_duration),
-        ..Default::default()
-    };
-    let link_conditioner = LinkConditionerConfig {
-        incoming_latency: Duration::from_millis(20),
-        incoming_jitter: Duration::from_millis(0),
-        incoming_loss: 0.0,
-    };
-    let mut stepper = BevyStepper::new(
-        shared_config,
-        SyncConfig::default(),
-        client::PredictionConfig::default(),
-        client::InterpolationConfig::default(),
-        link_conditioner,
-        frame_duration,
-    );
-    stepper.init();
+    let mut stepper = BevyStepper::default();
 
     // set time to end of wrapping
     let new_tick = Tick(u16::MAX - 100);
@@ -109,26 +91,8 @@ fn test_sync_after_tick_wrap() {
 /// is u16::MAX ticks ahead
 #[test]
 fn test_sync_after_tick_half_wrap() {
-    let frame_duration = Duration::from_secs_f32(1.0 / 60.0);
     let tick_duration = Duration::from_millis(10);
-    let shared_config = SharedConfig {
-        tick: TickConfig::new(tick_duration),
-        ..Default::default()
-    };
-    let link_conditioner = LinkConditionerConfig {
-        incoming_latency: Duration::from_millis(20),
-        incoming_jitter: Duration::from_millis(0),
-        incoming_loss: 0.0,
-    };
-    let mut stepper = BevyStepper::new(
-        shared_config,
-        SyncConfig::default(),
-        client::PredictionConfig::default(),
-        client::InterpolationConfig::default(),
-        link_conditioner,
-        frame_duration,
-    );
-    stepper.init();
+    let mut stepper = BevyStepper::default();
 
     // set time to end of wrapping
     let new_tick = Tick(u16::MAX / 2 - 10);

--- a/lightyear/src/tests/stepper.rs
+++ b/lightyear/src/tests/stepper.rs
@@ -2,6 +2,7 @@ use std::net::SocketAddr;
 use std::str::FromStr;
 
 use bevy::ecs::system::RunSystemOnce;
+use bevy::input::InputPlugin;
 use bevy::prelude::{default, App, Commands, Mut, PluginGroup, Real, Time, World};
 use bevy::time::TimeUpdateStrategy;
 use bevy::utils::Duration;
@@ -10,7 +11,7 @@ use bevy::MinimalPlugins;
 use crate::connection::netcode::generate_key;
 use crate::prelude::client::{
     Authentication, ClientCommands, ClientConfig, ClientTransport, InterpolationConfig,
-    PredictionConfig, SyncConfig,
+    LeafwingInputConfig, NetConfig, PredictionConfig, SyncConfig,
 };
 use crate::prelude::server::{NetcodeConfig, ServerCommands, ServerConfig, ServerTransport};
 use crate::prelude::*;
@@ -45,22 +46,9 @@ impl Default for BevyStepper {
             tick: TickConfig::new(tick_duration),
             ..Default::default()
         };
-        let link_conditioner = LinkConditionerConfig {
-            incoming_latency: Duration::from_millis(0),
-            incoming_jitter: Duration::from_millis(0),
-            incoming_loss: 0.0,
-        };
-        let sync_config = SyncConfig::default().speedup_factor(1.0);
-        let prediction_config = PredictionConfig::default();
-        let interpolation_config = InterpolationConfig::default();
-        let mut stepper = Self::new(
-            shared_config,
-            sync_config,
-            prediction_config,
-            interpolation_config,
-            link_conditioner,
-            frame_duration,
-        );
+        let client_config = ClientConfig::default();
+
+        let mut stepper = Self::new(shared_config, client_config, frame_duration);
         stepper.init();
         stepper
     }
@@ -70,10 +58,7 @@ impl Default for BevyStepper {
 impl BevyStepper {
     pub fn new(
         shared_config: SharedConfig,
-        sync_config: SyncConfig,
-        prediction_config: PredictionConfig,
-        interpolation_config: InterpolationConfig,
-        conditioner: LinkConditionerConfig,
+        mut client_config: ClientConfig,
         frame_duration: Duration,
     ) -> Self {
         // tracing_subscriber::FmtSubscriber::builder()
@@ -85,16 +70,22 @@ impl BevyStepper {
         // channels to receive a message from/to server
         let (from_server_send, from_server_recv) = crossbeam_channel::unbounded();
         let (to_server_send, to_server_recv) = crossbeam_channel::unbounded();
-        let client_io = client::IoConfig::from_transport(ClientTransport::LocalChannel {
+        let mut client_io = client::IoConfig::from_transport(ClientTransport::LocalChannel {
             send: to_server_send,
             recv: from_server_recv,
-        })
-        .with_conditioner(conditioner.clone());
+        });
 
-        let server_io = server::IoConfig::from_transport(ServerTransport::Channels {
+        let mut server_io = server::IoConfig::from_transport(ServerTransport::Channels {
             channels: vec![(addr, to_server_recv, from_server_send)],
-        })
-        .with_conditioner(conditioner.clone());
+        });
+
+        let NetConfig::Netcode { io, .. } = client_config.net else {
+            panic!("Only Netcode transport is supported in tests");
+        };
+        if let Some(conditioner) = io.conditioner {
+            server_io = server_io.with_conditioner(conditioner.clone());
+            client_io = client_io.with_conditioner(conditioner.clone());
+        }
 
         // Shared config
         let protocol_id = 0;
@@ -135,21 +126,26 @@ impl BevyStepper {
             config: Default::default(),
             io: client_io,
         };
-        let config = ClientConfig {
-            shared: shared_config.clone(),
-            net: net_config,
-            sync: sync_config,
-            prediction: prediction_config,
-            interpolation: interpolation_config,
-            ping: PingConfig {
-                // send pings every tick, so that the acks are received every frame
-                ping_interval: Duration::default(),
-                ..default()
-            },
+
+        client_config.shared = shared_config.clone();
+        client_config.ping = PingConfig {
+            // send pings every tick, so that the acks are received every frame
+            ping_interval: Duration::default(),
             ..default()
         };
-        let plugin = client::ClientPlugins::new(config);
+        client_config.net = net_config;
+
+        let plugin = client::ClientPlugins::new(client_config);
         client_app.add_plugins((plugin, ProtocolPlugin));
+
+        #[cfg(feature = "leafwing")]
+        {
+            client_app.add_plugins(LeafwingInputPlugin::<LeafwingInput1>::default());
+            client_app.add_plugins(LeafwingInputPlugin::<LeafwingInput2>::default());
+            server_app.add_plugins(LeafwingInputPlugin::<LeafwingInput1>::default());
+            server_app.add_plugins(LeafwingInputPlugin::<LeafwingInput2>::default());
+            client_app.add_plugins(InputPlugin);
+        }
 
         // Initialize Real time (needed only for the first TimeSystem run)
         let now = bevy::utils::Instant::now();

--- a/lightyear/src/tests/stepper.rs
+++ b/lightyear/src/tests/stepper.rs
@@ -10,8 +10,8 @@ use bevy::MinimalPlugins;
 
 use crate::connection::netcode::generate_key;
 use crate::prelude::client::{
-    Authentication, ClientCommands, ClientConfig, ClientTransport, InterpolationConfig,
-    LeafwingInputConfig, NetConfig, PredictionConfig, SyncConfig,
+    Authentication, ClientCommands, ClientConfig, ClientTransport, InterpolationConfig, NetConfig,
+    PredictionConfig, SyncConfig,
 };
 use crate::prelude::server::{NetcodeConfig, ServerCommands, ServerConfig, ServerTransport};
 use crate::prelude::*;


### PR DESCRIPTION
Using remote clients' inputs for improving rollback and prediction was somehow broken, I think the main reason was that we were relying on `ActionState` getting replicated to the client for this remote_player entities to get new data, but this replication is done at sparse intervals, so even when using `input_delay` we would still get rollbacks.

This PR cleans up somewhat input handling:
- removes ActionDiffBuffer, which was used exclusively to generate the `InputMessage`
- the `InputMessage` now also contains a starting `ActionState` on top of the `Vec<ActionDiff>`, so we don't get stuck in weird inputs if we get desynced
- instead of having a system at PreUpdate that generates `ActionDiff` events, we compute ActionDiffs manually from comparing a tick's ActionState with the previous tick's
- we do not replicate `ActionState` bidirectionally anymore, and we don't sync ActionState to the Predicted entity. Instead:
  - for the client entity, ActionState is added directly to the Predicted entity, so no need to sync. We automatically add `ReplicateOnceComponent<ActionState>` to make sure we replicate it once to the server, so that the `ActionState` can be added to the server
  - for the remote players, we add `ActionState` and `InputBuffer` on the client entity if we receive an `InputMessage` for them
  - this means that we can remove the weird rule where we have to be careful not to replicate Inputs back to ourselves
- We use the `InputBuffer` to update the `ActionState` of remote_players **at every tick**! This gives us the most precision possible when predicting remote players since we don't have to wait for the replication of `ActionState`, and since inputs are sent every frame if possible