### PR TITLE
Fix priority example

### DIFF
--- a/examples/priority/src/main.rs
+++ b/examples/priority/src/main.rs
@@ -26,7 +26,7 @@ fn main() {
         config.packet = PacketConfig::default()
             .enable_bandwidth_cap()
             // we can set the max bandwidth to 56 KB/s
-            .with_send_bandwidth_bytes_per_second_cap(1500);
+            .with_send_bandwidth_bytes_per_second_cap(3000);
     })
     // add the `ClientPlugins` and `ServerPlugins` plugin groups
     .add_lightyear_plugins()

--- a/examples/priority/src/server.rs
+++ b/examples/priority/src/server.rs
@@ -60,7 +60,7 @@ pub(crate) fn init(mut commands: Commands) {
                     // in case the bandwidth is saturated.
                     // The priority can be sent when the entity is spawned; if multiple entities in the same group have
                     // different priorities, the latest set priority will be used.
-                    // After the entity is spawned, you can update the priority using the ConnectionManager::upate_priority method.
+                    // After the entity is spawned, you can update the priority using the ConnectionManager::update_priority method.
                     group: ReplicationGroup::default().set_priority(1.0 + y.abs() as f32),
                     ..default()
                 },

--- a/examples/xpbd_physics/src/client.rs
+++ b/examples/xpbd_physics/src/client.rs
@@ -76,16 +76,16 @@ pub(crate) fn handle_connection(
                 (PlayerActions::Right, KeyCode::KeyD),
             ]),
         ));
-        // commands.spawn((PlayerBundle::new(
-        //     client_id,
-        //     Vec2::new(50.0, y),
-        //     InputMap::new([
-        //         (PlayerActions::Up, KeyCode::ArrowUp),
-        //         (PlayerActions::Down, KeyCode::ArrowDown),
-        //         (PlayerActions::Left, KeyCode::ArrowLeft),
-        //         (PlayerActions::Right, KeyCode::ArrowRight),
-        //     ]),
-        // ),));
+        commands.spawn((PlayerBundle::new(
+            client_id,
+            Vec2::new(50.0, y),
+            InputMap::new([
+                (PlayerActions::Up, KeyCode::ArrowUp),
+                (PlayerActions::Down, KeyCode::ArrowDown),
+                (PlayerActions::Left, KeyCode::ArrowLeft),
+                (PlayerActions::Right, KeyCode::ArrowRight),
+            ]),
+        ),));
     }
 }
 

--- a/lightyear/src/packet/priority_manager.rs
+++ b/lightyear/src/packet/priority_manager.rs
@@ -180,7 +180,7 @@ impl PriorityManager {
         let mut fragment_data: HashMap<ChannelId, VecDeque<FragmentData>> = HashMap::new();
         let mut bytes_used = 0;
         while let Some(buffered_message) = all_messages.pop() {
-            trace!(channel=?buffered_message.channel_net_id, "Sending message with priority {:?}", buffered_message.priority);
+            error!(channel=?buffered_message.channel_net_id, "Sending message with priority {:?}", buffered_message.priority);
             // we don't use the exact size of the message, but the size of the bytes
             // we will adjust for this later
             let message_bytes = buffered_message.data.len() as u32;

--- a/lightyear/src/shared/replication/send.rs
+++ b/lightyear/src/shared/replication/send.rs
@@ -212,7 +212,7 @@ impl ReplicationSender {
                 }
             } else {
                 error!(?message_id,
-                    "Received an send message-id notification but we know the corresponding group id"
+                    "Received an send message-id notification but we don't know the corresponding group id"
                 );
             }
         }
@@ -547,7 +547,7 @@ impl ReplicationSender {
                     // TODO: send the HashMap directly to avoid extra allocations by cloning into a vec.
                     actions: Vec::from_iter(actions),
                 };
-                debug!("final action messages to send: {:?}", message);
+                error!("final action messages to send: {:?}", message);
 
                 // TODO: we had to put this here because of the borrow checker, but it's not ideal,
                 //  the replication send should normally just an iterator of messages to send

--- a/lightyear/src/shared/replication/send.rs
+++ b/lightyear/src/shared/replication/send.rs
@@ -1,5 +1,4 @@
 //! General struct handling replication
-use bevy::utils::Duration;
 use std::iter::Extend;
 
 use crate::channel::builder::{EntityActionsChannel, EntityUpdatesChannel};
@@ -489,17 +488,28 @@ impl ReplicationSender {
             .collect()
     }
 
+    // TODO: the priority for entity actions should remain the base_priority,
+    //  because the priority will get accumulated in the reliable channel
+    //  For entity updates, we might want to use the multiplier, but not sure
+    //  Maybe we just want to run the accumulate priority system every frame.
     /// Before sending replication messages, we accumulate the priority for all replication groups.
     ///
     /// (the priority starts at 0.0, and is accumulated for each group based on the base priority of the group)
     pub(crate) fn accumulate_priority(&mut self, time_manager: &TimeManager) {
-        let priority_multiplier = if self.replication_config.send_interval == Duration::default() {
-            1.0
-        } else {
-            (self.replication_config.send_interval.as_nanos() / time_manager.delta().as_nanos())
-                as f32
-        };
+        // let priority_multiplier = if self.replication_config.send_interval == Duration::default() {
+        //     1.0
+        // } else {
+        //     (self.replication_config.send_interval.as_nanos() as f32
+        //         / time_manager.delta().as_nanos() as f32)
+        // };
+        let priority_multiplier = 1.0;
         self.group_channels.values_mut().for_each(|channel| {
+            trace!(
+                "in accumulate priority: accumulated={:?} base={:?} multiplier={:?}, send_interval={:?}, time_manager_delta={:?}",
+                channel.accumulated_priority, channel.base_priority, priority_multiplier,
+                self.replication_config.send_interval.as_nanos(),
+                time_manager.delta().as_nanos()
+            );
             channel.accumulated_priority += channel.base_priority * priority_multiplier;
         });
     }
@@ -547,7 +557,7 @@ impl ReplicationSender {
                     // TODO: send the HashMap directly to avoid extra allocations by cloning into a vec.
                     actions: Vec::from_iter(actions),
                 };
-                error!("final action messages to send: {:?}", message);
+                trace!("final action messages to send: {:?}", message);
 
                 // TODO: we had to put this here because of the borrow checker, but it's not ideal,
                 //  the replication send should normally just an iterator of messages to send
@@ -635,7 +645,7 @@ impl ReplicationSender {
                     )?
                     .expect("The entity actions channels should always return a message_id");
 
-                // keep track of the messaage_id -> group mapping, so we can handle receiving an ACK for that message_id later
+                // keep track of the message_id -> group mapping, so we can handle receiving an ACK for that message_id later
                 self.updates_message_id_to_group_id.insert(
                     message_id,
                     UpdateMessageMetadata {


### PR DESCRIPTION
- Add some debug logs
- Raise bandwidth for example
- for now, always priority_multiplier = 1.0 in the replication_sender, because we want the base_priority to be correct