### PR TITLE
Replicate hierarchy (including PrePrediction) from client to server

### DIFF
--- a/benches/src/local_stepper.rs
+++ b/benches/src/local_stepper.rs
@@ -227,11 +227,13 @@ impl LocalBevyStepper {
 
     pub fn init(&mut self) {
         self.server_app.finish();
+        self.server_app.cleanup();
         self.server_app
             .world_mut()
             .run_system_once(|mut commands: Commands| commands.start_server());
         self.client_apps.values_mut().for_each(|client_app| {
             client_app.finish();
+            client_app.cleanup();
             let _ = client_app
                 .world_mut()
                 .run_system_once(|mut commands: Commands| commands.connect_client());

--- a/lightyear/src/client/prediction/mod.rs
+++ b/lightyear/src/client/prediction/mod.rs
@@ -6,7 +6,7 @@ pub(crate) mod correction;
 pub(crate) mod despawn;
 pub mod diagnostics;
 pub mod plugin;
-mod pre_prediction;
+pub(crate) mod pre_prediction;
 pub mod predicted_history;
 pub mod prespawn;
 pub(crate) mod resource;

--- a/lightyear/src/client/prediction/prespawn.rs
+++ b/lightyear/src/client/prediction/prespawn.rs
@@ -475,7 +475,7 @@ mod tests {
 
         let current_tick = stepper.client_app.world().resource::<TickManager>().tick();
         let prediction_manager = stepper.client_app.world().resource::<PredictionManager>();
-        let expected_hash: u64 = 14837968436853353711;
+        let expected_hash: u64 = 1572575978495317502;
         assert_eq!(
             prediction_manager.prespawn_hash_to_entities,
             HashMap::from_iter(vec![(

--- a/lightyear/src/server/relevance/immediate.rs
+++ b/lightyear/src/server/relevance/immediate.rs
@@ -327,29 +327,35 @@ mod tests {
     #[test]
     fn test_multiple_relevance_gain() {
         let mut app = App::new();
-        app.world.init_resource::<RelevanceManager>();
-        let entity1 = app.world.spawn(CachedNetworkRelevance::default()).id();
-        let entity2 = app.world.spawn(CachedNetworkRelevance::default()).id();
+        app.world_mut().init_resource::<RelevanceManager>();
+        let entity1 = app
+            .world_mut()
+            .spawn(CachedNetworkRelevance::default())
+            .id();
+        let entity2 = app
+            .world_mut()
+            .spawn(CachedNetworkRelevance::default())
+            .id();
         let client = ClientId::Netcode(1);
 
-        app.world
+        app.world_mut()
             .resource_mut::<RelevanceManager>()
             .gain_relevance(client, entity1);
-        app.world
+        app.world_mut()
             .resource_mut::<RelevanceManager>()
             .gain_relevance(client, entity2);
 
         assert_eq!(
-            app.world
-                .resource_mut::<RelevanceManager>()
+            app.world()
+                .resource::<RelevanceManager>()
                 .events
                 .gained
                 .len(),
             1
         );
         assert_eq!(
-            app.world
-                .resource_mut::<RelevanceManager>()
+            app.world()
+                .resource::<RelevanceManager>()
                 .events
                 .gained
                 .get(&client)
@@ -357,18 +363,18 @@ mod tests {
                 .len(),
             2
         );
-        app.world
+        app.world_mut()
             .run_system_once(systems::update_relevance_from_events);
         assert_eq!(
-            app.world
-                .resource_mut::<RelevanceManager>()
+            app.world()
+                .resource::<RelevanceManager>()
                 .events
                 .gained
                 .len(),
             0
         );
         assert_eq!(
-            app.world
+            app.world()
                 .entity(entity1)
                 .get::<CachedNetworkRelevance>()
                 .unwrap()
@@ -378,7 +384,7 @@ mod tests {
             &ClientRelevance::Gained
         );
         assert_eq!(
-            app.world
+            app.world()
                 .entity(entity2)
                 .get::<CachedNetworkRelevance>()
                 .unwrap()
@@ -391,13 +397,13 @@ mod tests {
         // After we used the relevance events, check how they are updated for bookkeeping
         // - Lost -> removed from cache
         // - Gained -> Maintained
-        app.world
+        app.world_mut()
             .resource_mut::<RelevanceManager>()
             .lose_relevance(client, entity1);
-        app.world
+        app.world_mut()
             .run_system_once(systems::update_relevance_from_events);
         assert_eq!(
-            app.world
+            app.world()
                 .entity(entity1)
                 .get::<CachedNetworkRelevance>()
                 .unwrap()
@@ -407,7 +413,7 @@ mod tests {
             &ClientRelevance::Lost
         );
         assert_eq!(
-            app.world
+            app.world()
                 .entity(entity2)
                 .get::<CachedNetworkRelevance>()
                 .unwrap()
@@ -416,16 +422,17 @@ mod tests {
                 .unwrap(),
             &ClientRelevance::Gained
         );
-        app.world.run_system_once(systems::update_cached_relevance);
+        app.world_mut()
+            .run_system_once(systems::update_cached_relevance);
         assert!(app
-            .world
+            .world()
             .entity(entity1)
             .get::<CachedNetworkRelevance>()
             .unwrap()
             .clients_cache
             .is_empty());
         assert_eq!(
-            app.world
+            app.world()
                 .entity(entity2)
                 .get::<CachedNetworkRelevance>()
                 .unwrap()

--- a/lightyear/src/tests/multi_stepper.rs
+++ b/lightyear/src/tests/multi_stepper.rs
@@ -192,14 +192,17 @@ impl MultiBevyStepper {
 
     pub fn init(&mut self) {
         self.server_app.finish();
+        self.server_app.cleanup();
         self.server_app
             .world_mut()
             .run_system_once(|mut commands: Commands| commands.start_server());
         self.client_app_1.finish();
+        self.client_app_1.cleanup();
         self.client_app_1
             .world_mut()
             .run_system_once(|mut commands: Commands| commands.connect_client());
         self.client_app_2.finish();
+        self.client_app_2.cleanup();
         self.client_app_2
             .world_mut()
             .run_system_once(|mut commands: Commands| commands.connect_client());

--- a/lightyear/src/tests/stepper.rs
+++ b/lightyear/src/tests/stepper.rs
@@ -188,10 +188,12 @@ impl BevyStepper {
     }
     pub(crate) fn init(&mut self) {
         self.server_app.finish();
+        self.server_app.cleanup();
         self.server_app
             .world_mut()
             .run_system_once(|mut commands: Commands| commands.start_server());
         self.client_app.finish();
+        self.client_app.cleanup();
         self.client_app
             .world_mut()
             .run_system_once(|mut commands: Commands| commands.connect_client());


### PR DESCRIPTION
Can now replicate hierarchies properly from client to server, including PrePrediction

Fixes https://github.com/cBournhonesque/lightyear/issues/485