### PR TITLE
Write client inputs every tick (FixedUpdate) instead of every frame

### DIFF
--- a/lightyear/src/client/sync.rs
+++ b/lightyear/src/client/sync.rs
@@ -296,6 +296,8 @@ impl SyncManager {
         ChronoDuration::nanoseconds(
             jitter.as_nanos() as i64 * self.config.jitter_multiple_margin as i64
                 // TODO: this should actually be `n * client_input_send_interval`
+                //  in our case we send input messages in FixedUpdate, so roughly every tick_duration
+                //  so this should be fine
                 + tick_duration.as_nanos() as i64 * self.config.tick_margin as i64
                 - input_delay.as_nanos() as i64,
         )


### PR DESCRIPTION
If the simulation is slower than the frame rate, for example simulation speed is 10Hz, then it's a huge waste to write client inputs every frame. Instead what we really want is to send client inputs every tick.

This PR accomplishes this by adding an `InputMessage` in the FixedUpdate schedule instead of in PostUpdate