### PR TITLE
Add wasm-bindgen-futures Dependency to websocket Feature

### DIFF
--- a/lightyear/Cargo.toml
+++ b/lightyear/Cargo.toml
@@ -38,6 +38,7 @@ websocket = [
   "dep:futures-util",
   "dep:web-sys",
   "dep:wasm-bindgen",
+  "dep:wasm-bindgen-futures",
 ]
 steam = ["dep:steamworks"]
 


### PR DESCRIPTION
Sorry for the tiny PRs. :sweat_smile: 

I was just working on integrating lightyear into my wasm client that uses the WebSocket transport.

I got a compile errors at:
https://github.com/cBournhonesque/lightyear/blob/main/lightyear/src/transport/websocket/client_wasm.rs#L86
https://github.com/cBournhonesque/lightyear/blob/main/lightyear/src/transport/websocket/client_wasm.rs#L99

```
86 |             wasm_bindgen_futures::spawn_local(async move {
   |             ^^^^^^^^^^^^^^^^^^^^ use of undeclared crate or module `wasm_bindgen_futures`
```

I looked at Cargo.toml, and sure enough, we've got `dep:wasm_bindgen_futures` in the `webtransport` feature, but not for the `websocket` feature.

This PR just adds the missing dependency.