### PR TITLE
Use observers to handle client disconnect

### DIFF
--- a/examples/auth/Cargo.toml
+++ b/examples/auth/Cargo.toml
@@ -18,16 +18,20 @@ metrics = ["lightyear/metrics", "dep:metrics-exporter-prometheus"]
 [dependencies]
 lightyear_examples_common = { path = "../common" }
 lightyear = { path = "../../lightyear", features = [
-  "steam",
-  "webtransport",
-  "websocket",
+    "steam",
+    "webtransport",
+    "websocket",
 ] }
 async-compat = "0.2.3"
 serde = { version = "1.0.188", features = ["derive"] }
 anyhow = { version = "1.0.75", features = [] }
 tracing = "0.1"
 tracing-subscriber = "0.3.17"
-bevy = { version = "0.13", features = ["bevy_core_pipeline"] }
+bevy = { version = "0.14.0-rc.3", features = [
+    "multi_threaded",
+    "bevy_state",
+    "serialize",
+] }
 bevy_mod_picking = { version = "0.19.1", features = ["backend_bevy_ui"] }
 derive_more = { version = "0.99", features = ["add", "mul"] }
 rand = "0.8.1"

--- a/examples/auth/Cargo.toml
+++ b/examples/auth/Cargo.toml
@@ -18,9 +18,9 @@ metrics = ["lightyear/metrics", "dep:metrics-exporter-prometheus"]
 [dependencies]
 lightyear_examples_common = { path = "../common" }
 lightyear = { path = "../../lightyear", features = [
-    "steam",
-    "webtransport",
-    "websocket",
+  "steam",
+  "webtransport",
+  "websocket",
 ] }
 async-compat = "0.2.3"
 serde = { version = "1.0.188", features = ["derive"] }
@@ -28,9 +28,9 @@ anyhow = { version = "1.0.75", features = [] }
 tracing = "0.1"
 tracing-subscriber = "0.3.17"
 bevy = { version = "0.14.0-rc.3", features = [
-    "multi_threaded",
-    "bevy_state",
-    "serialize",
+  "multi_threaded",
+  "bevy_state",
+  "serialize",
 ] }
 bevy_mod_picking = { version = "0.19.1", features = ["backend_bevy_ui"] }
 derive_more = { version = "0.99", features = ["add", "mul"] }

--- a/lightyear/src/server/input/native.rs
+++ b/lightyear/src/server/input/native.rs
@@ -84,18 +84,16 @@ impl<A: UserAction> Plugin for InputPlugin<A> {
             FixedPostUpdate,
             clear_input_events::<A>.in_set(InputSystemSet::ClearInputEvents),
         );
-        app.add_systems(Last, handle_client_disconnect::<A>);
+        app.observe(handle_client_disconnect::<A>);
     }
 }
 
 /// Remove the client if the client disconnects
 fn handle_client_disconnect<A: UserAction>(
-    mut events: EventReader<DisconnectEvent>,
+    trigger: Trigger<DisconnectEvent>,
     mut input_buffers: ResMut<InputBuffers<A>>,
 ) {
-    for event in events.read() {
-        input_buffers.buffers.remove(&event.client_id);
-    }
+    input_buffers.buffers.remove(&trigger.event().client_id);
 }
 
 /// Read the message received from the client and emit the MessageEvent event

--- a/lightyear/src/server/networking.rs
+++ b/lightyear/src/server/networking.rs
@@ -191,20 +191,20 @@ pub(crate) fn receive(world: &mut World) {
                                             if !connection_manager.events.is_empty() {
                                                 // Connection / Disconnection events
                                                 if connection_manager.events.has_connections() {
-                                                    let mut connect_event_writer =
-                                                        world.get_resource_mut::<Events<ConnectEvent>>().unwrap();
                                                     for connect_event in connection_manager.events.iter_connections() {
                                                         debug!("Client connected event: {}", connect_event.client_id);
-                                                        connect_event_writer.send(connect_event);
+                                                        world.resource_mut::<Events<ConnectEvent>>().send(connect_event);
+                                                        // TODO: trigger all events in batch? https://github.com/bevyengine/bevy/pull/13953
+                                                        world.trigger(connect_event);
                                                     }
                                                 }
 
                                                 if connection_manager.events.has_disconnections() {
-                                                    let mut connect_event_writer =
-                                                        world.get_resource_mut::<Events<DisconnectEvent>>().unwrap();
                                                     for disconnect_event in connection_manager.events.iter_disconnections() {
                                                         debug!("Client disconnected event: {}", disconnect_event.client_id);
-                                                        connect_event_writer.send(disconnect_event);
+                                                        world.resource_mut::<Events<DisconnectEvent>>().send(disconnect_event);
+                                                        // TODO: trigger all events in batch? https://github.com/bevyengine/bevy/pull/13953
+                                                        world.trigger(disconnect_event);
                                                     }
                                                 }
                                             }


### PR DESCRIPTION
This lets us avoid running a system every frame that checks for the `DisconnectEvent` event