### PR TITLE
Fix despawns for entities created at startup

### DIFF
--- a/lightyear/src/server/networking.rs
+++ b/lightyear/src/server/networking.rs
@@ -278,6 +278,11 @@ fn rebuild_server_connections(world: &mut World) {
         server_config.packet,
         server_config.ping,
     );
+    // // make sure the previous replication metadata is ported over to the new manager
+    // if let Some(mut previous_manager) = world.get_resource_mut::<ConnectionManager>() {
+    //     connection_manager.replicate_component_cache =
+    //         std::mem::take(&mut previous_manager.replicate_component_cache);
+    // }
     world.insert_resource(connection_manager);
 
     // rebuild the server connections and insert them


### PR DESCRIPTION
Despawns were not working correctly because:

- ConnectionManager created at plugin build
- Server starts at Startup
- handle_replicate_add would run in PreUpdate
- then StateTransition happens and we get a new ConnectionManager without `replicate_cache`

This fixes the issue if the server starts at Startup, but it doesn't in the case that the server is started later than startup. All entities added before that would still not be replicated entirely. Maybe restarting the server dynamically is not something we want to support...