### PR TITLE
fix space ships host-server

### DIFF
--- a/examples/spaceships/src/client.rs
+++ b/examples/spaceships/src/client.rs
@@ -3,6 +3,7 @@ use bevy::prelude::*;
 use bevy::utils::Duration;
 use bevy_xpbd_2d::prelude::*;
 use leafwing_input_manager::prelude::*;
+use lightyear::inputs::leafwing::input_buffer::InputBuffer;
 use lightyear::prelude::client::*;
 use lightyear::prelude::*;
 use lightyear::shared::replication::components::Controlled;
@@ -27,7 +28,9 @@ impl Plugin for ExampleClientPlugin {
         app.add_systems(
             FixedUpdate,
             (
-                player_movement,
+                // in host-server, we don't want to run the movement logic twice
+                // disable this because we also run the movement logic in the server
+                player_movement.run_if(not(is_host_server)),
                 // we don't spawn bullets during rollback.
                 // if we have the inputs early (so not in rb) then we spawn,
                 // otherwise we rely on normal server replication to spawn them
@@ -167,7 +170,14 @@ fn handle_hit_event(
 
 // only apply movements to predicted entities
 fn player_movement(
-    mut q: Query<ApplyInputsQuery, (With<Player>, With<Predicted>)>,
+    mut q: Query<
+        (
+            &ActionState<PlayerActions>,
+            &InputBuffer<PlayerActions>,
+            ApplyInputsQuery,
+        ),
+        (With<Player>, With<Predicted>),
+    >,
     tick_manager: Res<TickManager>,
     rollback: Option<Res<Rollback>>,
 ) {
@@ -179,12 +189,7 @@ fn player_movement(
         .map(|rb| tick_manager.tick_or_rollback_tick(rb))
         .unwrap_or(tick_manager.tick());
 
-    for mut aiq in q.iter_mut() {
-        let ApplyInputsQueryItem {
-            input_buffer,
-            action: action_state,
-            ..
-        } = aiq;
+    for (action_state, input_buffer, mut aiq) in q.iter_mut() {
         // is the current ActionState for real?
         if input_buffer.get(tick).is_some() {
             // Got an exact input for this tick, staleness = 0, the happy path.

--- a/examples/spaceships/src/server.rs
+++ b/examples/spaceships/src/server.rs
@@ -283,11 +283,11 @@ pub(crate) fn handle_hit_event(
 /// server can't currently detect if an input is missing, since already removed from input buffer.
 /// fixed in 0.14 branch
 pub(crate) fn player_movement(
-    mut q: Query<ApplyInputsQuery, With<Player>>,
+    mut q: Query<(&ActionState<PlayerActions>, ApplyInputsQuery), With<Player>>,
     tick_manager: Res<TickManager>,
 ) {
     let tick = tick_manager.tick();
-    for mut aiq in q.iter_mut() {
+    for (action_state, mut aiq) in q.iter_mut() {
         // if aiq.input_buffer.get(tick).is_none() {
         //     // set to default? needs 0.14 branch.
         // }
@@ -299,6 +299,6 @@ pub(crate) fn player_movement(
         //     );
         // }
         // check for missing inputs, and set them to default? or sustain for 1 tick?
-        apply_action_state_to_player_movement(aiq.action, 0, &mut aiq, tick);
+        apply_action_state_to_player_movement(action_state, 0, &mut aiq, tick);
     }
 }

--- a/examples/spaceships/src/shared.rs
+++ b/examples/spaceships/src/shared.rs
@@ -115,9 +115,7 @@ pub struct ApplyInputsQuery {
     pub ex_force: &'static mut ExternalForce,
     pub ang_vel: &'static mut AngularVelocity,
     pub rot: &'static Rotation,
-    pub action: &'static ActionState<PlayerActions>,
     pub player: &'static Player,
-    pub input_buffer: &'static InputBuffer<PlayerActions>,
 }
 
 /// applies forces based on action state inputs

--- a/lightyear/src/server/input/leafwing.rs
+++ b/lightyear/src/server/input/leafwing.rs
@@ -198,8 +198,10 @@ fn update_action_state<A: LeafwingUserAction>(
 
     for (entity, mut action_state, mut input_buffer) in action_state_query.iter_mut() {
         // the state on the server is only updated from client inputs!
-        *action_state = input_buffer.pop(tick).unwrap_or_default();
-        debug!(?tick, ?entity, pressed = ?action_state.get_pressed(), "action state after update. Input Buffer: {}", input_buffer.as_ref());
+        if let Some(new_action_state) = input_buffer.pop(tick) {
+            debug!(?tick, ?entity, pressed = ?action_state.get_pressed(), "action state after update. Input Buffer: {}", input_buffer.as_ref());
+            *action_state = new_action_state
+        }
     }
 }
 


### PR DESCRIPTION
Inputs were not working in host-server mode for several reasons:
- the `Controlled` component was not added on local-client entities
- the ActionState on the server was updated from the InputBuffer even if the InputBuffer was empty

Also separate `ActionState`, `InputBuffer` and `ApplyInputsQuery` to make things a bit clearer