### PR TITLE
Fix Controlled replication in host-server mode

### DIFF
--- a/lightyear/src/server/replication.rs
+++ b/lightyear/src/server/replication.rs
@@ -271,7 +271,11 @@ pub(crate) mod send {
             // also insert [`Controlled`] on the entity if it's controlled by the local client
             if let Some(controlled_by) = controlled_by {
                 if controlled_by.is_changed() && controlled_by.targets(&local_client) {
-                    commands.entity(entity).insert(Controlled);
+                    commands
+                        .entity(entity)
+                        // NOTE: do not replicate this Controlled to other clients, or they will
+                        // think they control this entity
+                        .insert((Controlled, DisabledComponent::<Controlled>::default()));
                 }
             }
             if (replication_target.is_changed()) && replication_target.target.targets(&local_client)

--- a/lightyear/src/shared/plugin.rs
+++ b/lightyear/src/shared/plugin.rs
@@ -143,7 +143,7 @@ impl Plugin for SharedPlugin {
         app.register_component::<ShouldBeInterpolated>(ChannelDirection::ServerToClient);
         app.register_component::<ParentSync>(ChannelDirection::Bidirectional)
             .add_map_entities();
-        app.register_component::<Controlled>(ChannelDirection::Bidirectional)
+        app.register_component::<Controlled>(ChannelDirection::ServerToClient)
             .add_prediction(ComponentSyncMode::Once)
             .add_interpolation(ComponentSyncMode::Once);
         // check that the protocol was built correctly


### PR DESCRIPTION
In host-server mode, the `Controlled` component is added to the locally controlled entities so that the client systems can work on them.
However this was replicated back to other clients when they connect, so we need to add a `DisabledComponent` to avoid that