### PR TITLE
Let the local-client in host-server mode send a message to the Server

### DIFF
--- a/lightyear/src/client/connection.rs
+++ b/lightyear/src/client/connection.rs
@@ -256,13 +256,7 @@ impl ConnectionManager {
         self.message_registry.serialize(message, &mut self.writer)?;
         let message_bytes = self.writer.split();
 
-        // // TODO: i know channel names never change so i should be able to get them as static
-        // let channel_name = self
-        //     .message_manager
-        //     .channel_registry
-        //     .name(&channel_kind)
-        //     .ok_or::<ClientError>(MessageError::NotRegistered.into())?;
-
+        // TODO: emit logs/metrics about the message being buffered?
         self.messages_to_send.push((message_bytes, channel_kind));
         Ok(())
     }
@@ -310,7 +304,6 @@ impl ConnectionManager {
         self.messages_to_send
             .drain(..)
             .try_for_each(|(message_bytes, channel_kind)| {
-                dbg!(&message_bytes);
                 server_manager
                     .connection_mut(local_client_id)?
                     .receive_message(
@@ -359,7 +352,7 @@ impl ConnectionManager {
             .drain(..)
             .try_for_each(|(message_bytes, channel_kind)| {
                 self.message_manager
-                    .buffer_send(message_bytes, ChannelKind::of::<PingChannel>())?;
+                    .buffer_send(message_bytes, channel_kind)?;
                 Ok::<(), ClientError>(())
             })?;
 

--- a/lightyear/src/client/message.rs
+++ b/lightyear/src/client/message.rs
@@ -1,22 +1,16 @@
 //! Defines the [`ClientMessage`] enum used to send messages from the client to the server
-use bevy::prelude::{
-    App, Commands, Event, EventWriter, Events, IntoSystemConfigs, PreUpdate, Res, ResMut, Trigger,
-};
+
+use bevy::prelude::{App, EventWriter, IntoSystemConfigs, PreUpdate, Res, ResMut};
 use byteorder::WriteBytesExt;
 use bytes::Bytes;
 use tracing::error;
 
 use crate::client::connection::ConnectionManager;
 use crate::client::events::MessageEvent;
-use crate::connection::client::ClientConnection;
-use crate::connection::server::ServerConnections;
-use crate::packet::message::SendMessage;
-use crate::prelude::server::ServerConfig;
-use crate::prelude::{client::is_connected, is_host_server, Channel, ChannelKind, Message};
+use crate::prelude::{client::is_connected, Message};
 use crate::protocol::message::{MessageKind, MessageRegistry};
 use crate::serialize::reader::Reader;
 use crate::serialize::{SerializationError, ToBytes};
-use crate::shared::message::MessageSend;
 use crate::shared::replication::network_target::NetworkTarget;
 use crate::shared::sets::{ClientMarker, InternalMainSet};
 
@@ -84,79 +78,6 @@ fn read_message<M: Message>(
     }
 }
 
-#[derive(Event)]
-struct SendMessageTrigger<M: Message> {
-    message: Option<M>,
-    channel_kind: ChannelKind,
-    network_target: Option<NetworkTarget>,
-}
-
-// TODO: maybe it would be cleaner to use events even when sending messages?
-//  and then have a single type-erased system that goes through all events?
-//  in host-server, it would just forward them to the server?
-/// In host-server mode, the client networking plugins (receive/send) are inactive,
-/// so when the client sends a message to the server, we should send it directly as a
-/// MessageEvent to the server
-fn handle_client_to_server_message<M: Message>(
-    mut trigger: Trigger<SendMessageTrigger<M>>,
-    client_connection: Res<ClientConnection>,
-    mut client_manager: ResMut<ConnectionManager>,
-    mut server_events: Option<Events<crate::server::events::MessageEvent<M>>>,
-    server_config: Option<Res<ServerConfig>>,
-    server_connections: Option<Res<ServerConnections>>,
-    mut server_manager: Option<ResMut<crate::server::connection::ConnectionManager>>,
-) {
-    let mut target = std::mem::take(&mut trigger.event_mut().network_target).unwrap();
-    // if we are in host-server mode, we should send the message directly to the server
-    if is_host_server(server_config, server_connections) {
-        let client_id = client_connection.client.id();
-        // rebroadcast the message if needed
-        if trigger.event().network_target != NetworkTarget::None {
-            target.exclude(NetworkTarget::Single(client_id));
-            let _ = server_manager
-                .unwrap()
-                .erased_send_message_to_target::<M>(
-                    trigger.event().message.as_ref().unwrap(),
-                    trigger.event().channel_kind,
-                    target,
-                )
-                .inspect_err(|e| {
-                    error!(
-                        "Could not rebroadcast host-client message to other clients: {:?}",
-                        e
-                    )
-                });
-        }
-        // send the message directly to the server's Events queue
-        if let Some(mut server_events) = server_events {
-            // SAFETY: we know that there is a message in the event
-            // We just had an option to avoid a copy.
-            let message = std::mem::take(&mut trigger.event_mut().message).unwrap();
-            server_events.send(crate::server::events::MessageEvent::new(message, client_id));
-        }
-    } else {
-        // not in host-server mode, serialize and send the message as normal
-        let _ = client_manager
-            .erased_send_message_to_target(
-                trigger.event().message.as_ref().unwrap(),
-                trigger.event().channel_kind,
-                target,
-            )
-            .inspect_err(|e| {
-                error!("Could not send message to server: {:?}", e);
-            });
-    }
-}
-
-/// Send a message from client to server
-///
-/// We use a trigger `SendMessageTrigger<M>` instead of directly serializing the message
-/// in case we are in host-server mode. In that situation, we just add the message directly
-/// the server's Event queue.
-pub(crate) fn add_client_send_message_to_server<M: Message>(app: &mut App) {
-    app.observe(handle_client_to_server_message::<M>);
-}
-
 /// Register a message that can be sent from server to client
 pub(crate) fn add_client_receive_message_from_server<M: Message>(app: &mut App) {
     app.add_event::<MessageEvent<M>>();
@@ -166,7 +87,6 @@ pub(crate) fn add_client_receive_message_from_server<M: Message>(app: &mut App) 
             .in_set(InternalMainSet::<ClientMarker>::EmitEvents)
             .run_if(is_connected),
     );
-    // send messages from client to server in host-server mode
 }
 
 // impl ClientMessage {
@@ -300,8 +220,9 @@ pub(crate) fn add_client_receive_message_from_server<M: Message>(app: &mut App) 
 mod tests {
     use super::*;
     use crate::serialize::writer::Writer;
-    use crate::tests::host_server_stepper::HostServerStepper;
+    use crate::tests::host_server_stepper::{HostServerStepper, Step};
     use crate::tests::protocol::{Channel1, Message1};
+    use bevy::prelude::{EventReader, Resource, Update};
 
     #[test]
     fn client_message_serde() {
@@ -318,9 +239,30 @@ mod tests {
         assert_eq!(data, result);
     }
 
+    #[derive(Resource, Default)]
+    struct Counter(usize);
+
+    /// System to check that we received the message on the server
+    fn count_messages(
+        mut counter: ResMut<Counter>,
+        mut events: EventReader<crate::server::events::MessageEvent<Message1>>,
+    ) {
+        for event in events.read() {
+            assert_eq!(event.message().0, "a".to_string());
+            counter.0 += 1;
+        }
+    }
+
     #[test]
     fn client_send_message_as_host_server() {
+        // tracing_subscriber::FmtSubscriber::builder()
+        //     .with_max_level(tracing::Level::ERROR)
+        //     .init();
         let mut stepper = HostServerStepper::default();
+
+        stepper.server_app.init_resource::<Counter>();
+        stepper.server_app.add_systems(Update, count_messages);
+
         // send a message from the local client to the server
         stepper
             .server_app
@@ -328,5 +270,10 @@ mod tests {
             .resource_mut::<crate::prelude::client::ConnectionManager>()
             .send_message::<Channel1, Message1>(&Message1("a".to_string()))
             .unwrap();
+        stepper.frame_step();
+        stepper.frame_step();
+
+        // verify that the server received the message
+        assert_eq!(stepper.server_app.world().resource::<Counter>().0, 1);
     }
 }

--- a/lightyear/src/client/message.rs
+++ b/lightyear/src/client/message.rs
@@ -190,32 +190,6 @@ pub(crate) fn add_client_receive_message_from_server<M: Message>(app: &mut App) 
 //     }
 // }
 
-// pub struct ClientToServerSendMessageCommand
-//
-// pub trait ClientToServerMessageCommands {
-//     /// Send a [`Message`] to the server using a specific [`Channel`].
-//     ///
-//     /// The server will re-broadcast the message to the clients specified in the [`NetworkTarget`].
-//     fn send_message_with_target<C: Channel, M: Message>(&mut self, message: &M, target: NetworkTarget);
-//
-//     /// Send a [`Message`] to the server using a specific [`Channel`].
-//     fn send_message<C: Channel, M: Message>(&mut self);
-// }
-//
-// impl ClientToServerMessageCommands for Commands<'_, '_> {
-//     fn send_message_with_target<C: Channel, M: Message>(&mut self, message: &M, target: NetworkTarget) {
-//         self.trigger(SendMessageTrigger {
-//             message: Some(message),
-//             channel_kind: ChannelKind::of::<C>(),
-//             network_target: Some(target),
-//         });
-//     }
-//
-//     fn send_message<C: Channel, M: Message>(&mut self) {
-//         todo!()
-//     }
-// }
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/lightyear/src/client/networking.rs
+++ b/lightyear/src/client/networking.rs
@@ -219,7 +219,6 @@ pub(crate) fn send_host_server(
     mut client_manager: ResMut<ConnectionManager>,
     mut server_manager: ResMut<crate::server::connection::ConnectionManager>,
 ) {
-    dbg!("send host server");
     let _ = client_manager
         .send_packets_host_server(netcode.id(), server_manager.as_mut())
         .inspect_err(|e| {

--- a/lightyear/src/client/networking.rs
+++ b/lightyear/src/client/networking.rs
@@ -57,10 +57,10 @@ impl Plugin for ClientNetworkingPlugin {
                 // run sync before send because some send systems need to know if the client is synced
                 // we don't send packets every frame, but on a timer instead
                 (
-                    SyncSet,
+                    SyncSet.run_if(not(is_host_server)),
                     InternalMainSet::<ClientMarker>::Send.in_set(MainSet::Send),
                 )
-                    .run_if(not(is_host_server.or_else(is_disconnected)))
+                    .run_if(not(is_disconnected))
                     .chain(),
             )
             // SYSTEMS
@@ -76,10 +76,15 @@ impl Plugin for ClientNetworkingPlugin {
                 PreUpdate,
                 (listen_io_state, receive).in_set(InternalMainSet::<ClientMarker>::Receive),
             )
+            // TODO: make HostServer a computed state?
             .add_systems(
                 PostUpdate,
                 (
-                    send.in_set(InternalMainSet::<ClientMarker>::Send),
+                    (
+                        send.run_if(not(is_host_server)),
+                        send_host_server.run_if(is_host_server),
+                    )
+                        .in_set(InternalMainSet::<ClientMarker>::Send),
                     // TODO: update virtual time with Time<Real> so we have more accurate time at Send time.
                     sync_update.in_set(SyncSet),
                 ),
@@ -205,6 +210,24 @@ pub(crate) fn send(
 
     // no need to clear the connection, because we already std::mem::take it
     // client.connection.clear();
+}
+
+/// Send messages in host-server mode
+/// We cannot use the normal `send` function because there is no IO available
+pub(crate) fn send_host_server(
+    netcode: Res<ClientConnection>,
+    mut client_manager: ResMut<ConnectionManager>,
+    mut server_manager: ResMut<crate::server::connection::ConnectionManager>,
+) {
+    dbg!("send host server");
+    let _ = client_manager
+        .send_packets_host_server(netcode.id(), server_manager.as_mut())
+        .inspect_err(|e| {
+            error!(
+                "Error sending messages from local client to server in host-server mode: {}",
+                e
+            )
+        });
 }
 
 /// Update the sync manager.
@@ -335,14 +358,16 @@ fn on_connect_host_server(
     mut commands: Commands,
     netcode: Res<ClientConnection>,
     mut metadata: ResMut<HostServerMetadata>,
-    mut server_connect_event_writer: ResMut<Events<crate::server::events::ConnectEvent>>,
+    mut server_manager: ResMut<crate::server::connection::ConnectionManager>,
 ) {
     // spawn an entity for the client
     let client_entity = commands.spawn(ControlledEntities::default()).id();
-    server_connect_event_writer.send(crate::server::events::ConnectEvent {
-        client_id: netcode.id(),
-        entity: client_entity,
-    });
+    // start a server connection for that client (which will also send a ConnectEvent on the server)
+    server_manager.add(netcode.id(), client_entity);
+    server_manager
+        .connection_mut(netcode.id())
+        .unwrap()
+        .set_local_client();
     metadata.client_entity = Some(client_entity);
 }
 

--- a/lightyear/src/protocol/message.rs
+++ b/lightyear/src/protocol/message.rs
@@ -3,9 +3,7 @@ use std::any::TypeId;
 use std::fmt::Debug;
 
 use crate::client::config::ClientConfig;
-use crate::client::message::{
-    add_client_receive_message_from_server, add_client_send_message_to_server,
-};
+use crate::client::message::add_client_receive_message_from_server;
 use crate::prelude::{client, server};
 use bevy::prelude::{App, Resource, TypePath};
 use bevy::utils::HashMap;
@@ -21,9 +19,7 @@ use crate::protocol::serialize::{ErasedSerializeFns, SerializeFns};
 use crate::serialize::reader::Reader;
 use crate::serialize::writer::Writer;
 use crate::serialize::ToBytes;
-use crate::server::message::{
-    add_server_receive_message_from_client, add_server_send_message_to_client,
-};
+use crate::server::message::add_server_receive_message_from_client;
 use crate::shared::replication::entity_map::EntityMap;
 use crate::shared::replication::resources::DespawnResource;
 
@@ -114,14 +110,8 @@ fn register_message_send<M: Message>(app: &mut App, direction: ChannelDirection)
             if is_server {
                 add_server_receive_message_from_client::<M>(app);
             }
-            if is_client {
-                add_client_send_message_to_server::<M>(app);
-            }
         }
         ChannelDirection::ServerToClient => {
-            if is_server {
-                add_server_send_message_to_client::<M>(app);
-            }
             if is_client {
                 add_client_receive_message_from_server::<M>(app);
             }

--- a/lightyear/src/protocol/message.rs
+++ b/lightyear/src/protocol/message.rs
@@ -3,7 +3,9 @@ use std::any::TypeId;
 use std::fmt::Debug;
 
 use crate::client::config::ClientConfig;
-use crate::client::message::add_server_to_client_message;
+use crate::client::message::{
+    add_client_receive_message_from_server, add_client_send_message_to_server,
+};
 use crate::prelude::{client, server};
 use bevy::prelude::{App, Resource, TypePath};
 use bevy::utils::HashMap;
@@ -19,7 +21,9 @@ use crate::protocol::serialize::{ErasedSerializeFns, SerializeFns};
 use crate::serialize::reader::Reader;
 use crate::serialize::writer::Writer;
 use crate::serialize::ToBytes;
-use crate::server::message::add_client_to_server_message;
+use crate::server::message::{
+    add_server_receive_message_from_client, add_server_send_message_to_client,
+};
 use crate::shared::replication::entity_map::EntityMap;
 use crate::shared::replication::resources::DespawnResource;
 
@@ -108,12 +112,18 @@ fn register_message_send<M: Message>(app: &mut App, direction: ChannelDirection)
     match direction {
         ChannelDirection::ClientToServer => {
             if is_server {
-                add_client_to_server_message::<M>(app);
+                add_server_receive_message_from_client::<M>(app);
+            }
+            if is_client {
+                add_client_send_message_to_server::<M>(app);
             }
         }
         ChannelDirection::ServerToClient => {
+            if is_server {
+                add_server_send_message_to_client::<M>(app);
+            }
             if is_client {
-                add_server_to_client_message::<M>(app);
+                add_client_receive_message_from_server::<M>(app);
             }
         }
         ChannelDirection::Bidirectional => {

--- a/lightyear/src/server/input/leafwing.rs
+++ b/lightyear/src/server/input/leafwing.rs
@@ -61,6 +61,7 @@ impl<A: LeafwingUserAction> Plugin for LeafwingInputPlugin<A> {
             (
                 // TODO: ideally we have a Flush between add_action_diff_buffer and Tick?
                 add_action_diff_buffer::<A>.in_set(InputSystemSet::AddBuffers),
+                // TODO: can disable this in host-server mode!
                 receive_input_message::<A>.in_set(InputSystemSet::ReceiveInputs),
             ),
         );

--- a/lightyear/src/server/message.rs
+++ b/lightyear/src/server/message.rs
@@ -1,16 +1,18 @@
 use std::ops::DerefMut;
 
-use bevy::app::{App, PreUpdate};
-use bevy::prelude::{EventWriter, IntoSystemConfigs, Res, ResMut};
-use tracing::{error, trace};
-
-use crate::prelude::{server::is_started, Message};
+use crate::connection::client::ClientConnection;
+use crate::connection::server::ServerConnections;
+use crate::prelude::server::ServerConfig;
+use crate::prelude::{is_host_server, server::is_started, ChannelKind, Message};
 use crate::protocol::message::{MessageKind, MessageRegistry};
 use crate::serialize::reader::Reader;
 use crate::server::connection::ConnectionManager;
 use crate::server::events::MessageEvent;
 use crate::shared::replication::network_target::NetworkTarget;
 use crate::shared::sets::{InternalMainSet, ServerMarker};
+use bevy::app::{App, PreUpdate};
+use bevy::prelude::{Event, EventWriter, Events, IntoSystemConfigs, Res, ResMut, Trigger};
+use tracing::{error, trace};
 
 /// Read the messages received from the clients and emit the MessageEvent event
 fn read_message<M: Message>(
@@ -64,8 +66,88 @@ fn read_message<M: Message>(
     }
 }
 
-/// Register a message that can be sent from server to client
-pub(crate) fn add_client_to_server_message<M: Message>(app: &mut App) {
+/// Observer Trigger to send a message.
+///
+/// If we are running in host-server mode, the messages that are destined to the local client will be
+/// sent directly to the client's Event queue.
+#[derive(Event)]
+struct SendMessageTrigger<M: Message> {
+    message: Option<M>,
+    channel_kind: ChannelKind,
+    network_target: Option<NetworkTarget>,
+}
+
+// TODO: maybe it would be cleaner to use events even when sending messages?
+//  and then have a single type-erased system that goes through all events?
+//  in host-server, it would just forward them to the server?
+/// In host-server mode, the client networking plugins (receive/send) are inactive,
+/// so when the client sends a message to the server, we should send it directly as a
+/// MessageEvent to the server
+fn handle_server_send_message_to_client<M: Message>(
+    mut trigger: Trigger<SendMessageTrigger<M>>,
+    client_connection: Option<Res<ClientConnection>>,
+    mut client_events: Option<Events<crate::client::events::MessageEvent<M>>>,
+    server_config: Option<Res<ServerConfig>>,
+    server_connections: Option<Res<ServerConnections>>,
+    mut server_manager: ResMut<ConnectionManager>,
+) {
+    let mut target = std::mem::take(&mut trigger.event_mut().network_target).unwrap();
+    // if we are in host-server mode, the messages destined to the local client should be
+    // sent directly to the client's Events queue
+    if is_host_server(server_config, server_connections) {
+        let client_id = client_connection
+            .expect("We are running in host-server mode but could not access the client connection")
+            .client
+            .id();
+        let send_to_local_client = target.targets(&client_id);
+        target.exclude(NetworkTarget::Single(client_id));
+        // send the message normally to other clients
+        if !target.is_empty() {
+            let _ = server_manager
+                .erased_send_message_to_target::<M>(
+                    trigger.event().message.as_ref().unwrap(),
+                    trigger.event().channel_kind,
+                    target,
+                )
+                .inspect_err(|e| {
+                    error!(
+                        "Could not rebroadcast host-client message to other clients: {:?}",
+                        e
+                    )
+                });
+        }
+        // send the message directly to the local client's Events queue
+        if let Some(mut client_events) = client_events {
+            // SAFETY: we know that there is a message in the event
+            // We just had an option to avoid a copy.
+            let message = std::mem::take(&mut trigger.event_mut().message).unwrap();
+            client_events.send(crate::client::events::MessageEvent::new(message, ()));
+        }
+    } else {
+        // not in host-server mode, serialize and send the message as normal
+        let _ = server_manager
+            .erased_send_message_to_target(
+                trigger.event().message.as_ref().unwrap(),
+                trigger.event().channel_kind,
+                target,
+            )
+            .inspect_err(|e| {
+                error!("Could not send message to clients: {:?}", e);
+            });
+    }
+}
+
+/// Send a message from server to clients
+///
+/// We use a trigger `SendMessageTrigger<M>` instead of directly serializing the message
+/// in case we are in host-server mode. In that situation, we just add the message directly
+/// the local client's Event queue.
+pub(crate) fn add_server_send_message_to_client<M: Message>(app: &mut App) {
+    app.observe(handle_server_send_message_to_client::<M>);
+}
+
+/// Register a message that can be sent from client to server
+pub(crate) fn add_server_receive_message_from_client<M: Message>(app: &mut App) {
     app.add_event::<MessageEvent<M>>();
     app.add_systems(
         PreUpdate,

--- a/lightyear/src/server/message.rs
+++ b/lightyear/src/server/message.rs
@@ -1,9 +1,6 @@
 use std::ops::DerefMut;
 
-use crate::connection::client::ClientConnection;
-use crate::connection::server::ServerConnections;
-use crate::prelude::server::ServerConfig;
-use crate::prelude::{is_host_server, server::is_started, ChannelKind, Message};
+use crate::prelude::{server::is_started, Message};
 use crate::protocol::message::{MessageKind, MessageRegistry};
 use crate::serialize::reader::Reader;
 use crate::server::connection::ConnectionManager;
@@ -11,7 +8,7 @@ use crate::server::events::MessageEvent;
 use crate::shared::replication::network_target::NetworkTarget;
 use crate::shared::sets::{InternalMainSet, ServerMarker};
 use bevy::app::{App, PreUpdate};
-use bevy::prelude::{Event, EventWriter, Events, IntoSystemConfigs, Res, ResMut, Trigger};
+use bevy::prelude::{EventWriter, IntoSystemConfigs, Res, ResMut};
 use tracing::{error, trace};
 
 /// Read the messages received from the clients and emit the MessageEvent event
@@ -66,85 +63,85 @@ fn read_message<M: Message>(
     }
 }
 
-/// Observer Trigger to send a message.
-///
-/// If we are running in host-server mode, the messages that are destined to the local client will be
-/// sent directly to the client's Event queue.
-#[derive(Event)]
-struct SendMessageTrigger<M: Message> {
-    message: Option<M>,
-    channel_kind: ChannelKind,
-    network_target: Option<NetworkTarget>,
-}
-
-// TODO: maybe it would be cleaner to use events even when sending messages?
-//  and then have a single type-erased system that goes through all events?
-//  in host-server, it would just forward them to the server?
-/// In host-server mode, the client networking plugins (receive/send) are inactive,
-/// so when the client sends a message to the server, we should send it directly as a
-/// MessageEvent to the server
-fn handle_server_send_message_to_client<M: Message>(
-    mut trigger: Trigger<SendMessageTrigger<M>>,
-    client_connection: Option<Res<ClientConnection>>,
-    mut client_events: Option<Events<crate::client::events::MessageEvent<M>>>,
-    server_config: Option<Res<ServerConfig>>,
-    server_connections: Option<Res<ServerConnections>>,
-    mut server_manager: ResMut<ConnectionManager>,
-) {
-    let mut target = std::mem::take(&mut trigger.event_mut().network_target).unwrap();
-    // if we are in host-server mode, the messages destined to the local client should be
-    // sent directly to the client's Events queue
-    if is_host_server(server_config, server_connections) {
-        let client_id = client_connection
-            .expect("We are running in host-server mode but could not access the client connection")
-            .client
-            .id();
-        let send_to_local_client = target.targets(&client_id);
-        target.exclude(NetworkTarget::Single(client_id));
-        // send the message normally to other clients
-        if !target.is_empty() {
-            let _ = server_manager
-                .erased_send_message_to_target::<M>(
-                    trigger.event().message.as_ref().unwrap(),
-                    trigger.event().channel_kind,
-                    target,
-                )
-                .inspect_err(|e| {
-                    error!(
-                        "Could not rebroadcast host-client message to other clients: {:?}",
-                        e
-                    )
-                });
-        }
-        // send the message directly to the local client's Events queue
-        if let Some(mut client_events) = client_events {
-            // SAFETY: we know that there is a message in the event
-            // We just had an option to avoid a copy.
-            let message = std::mem::take(&mut trigger.event_mut().message).unwrap();
-            client_events.send(crate::client::events::MessageEvent::new(message, ()));
-        }
-    } else {
-        // not in host-server mode, serialize and send the message as normal
-        let _ = server_manager
-            .erased_send_message_to_target(
-                trigger.event().message.as_ref().unwrap(),
-                trigger.event().channel_kind,
-                target,
-            )
-            .inspect_err(|e| {
-                error!("Could not send message to clients: {:?}", e);
-            });
-    }
-}
-
-/// Send a message from server to clients
-///
-/// We use a trigger `SendMessageTrigger<M>` instead of directly serializing the message
-/// in case we are in host-server mode. In that situation, we just add the message directly
-/// the local client's Event queue.
-pub(crate) fn add_server_send_message_to_client<M: Message>(app: &mut App) {
-    app.observe(handle_server_send_message_to_client::<M>);
-}
+// /// Observer Trigger to send a message.
+// ///
+// /// If we are running in host-server mode, the messages that are destined to the local client will be
+// /// sent directly to the client's Event queue.
+// #[derive(Event)]
+// struct SendMessageTrigger<M: Message> {
+//     message: Option<M>,
+//     channel_kind: ChannelKind,
+//     network_target: Option<NetworkTarget>,
+// }
+//
+// // TODO: maybe it would be cleaner to use events even when sending messages?
+// //  and then have a single type-erased system that goes through all events?
+// //  in host-server, it would just forward them to the server?
+// /// In host-server mode, the client networking plugins (receive/send) are inactive,
+// /// so when the client sends a message to the server, we should send it directly as a
+// /// MessageEvent to the server
+// fn handle_server_send_message_to_client<M: Message>(
+//     mut trigger: Trigger<SendMessageTrigger<M>>,
+//     client_connection: Option<Res<ClientConnection>>,
+//     mut client_events: Option<Events<crate::client::events::MessageEvent<M>>>,
+//     server_config: Option<Res<ServerConfig>>,
+//     server_connections: Option<Res<ServerConnections>>,
+//     mut server_manager: ResMut<ConnectionManager>,
+// ) {
+//     let mut target = std::mem::take(&mut trigger.event_mut().network_target).unwrap();
+//     // if we are in host-server mode, the messages destined to the local client should be
+//     // sent directly to the client's Events queue
+//     if is_host_server(server_config, server_connections) {
+//         let client_id = client_connection
+//             .expect("We are running in host-server mode but could not access the client connection")
+//             .client
+//             .id();
+//         let send_to_local_client = target.targets(&client_id);
+//         target.exclude(NetworkTarget::Single(client_id));
+//         // send the message normally to other clients
+//         if !target.is_empty() {
+//             let _ = server_manager
+//                 .erased_send_message_to_target::<M>(
+//                     trigger.event().message.as_ref().unwrap(),
+//                     trigger.event().channel_kind,
+//                     target,
+//                 )
+//                 .inspect_err(|e| {
+//                     error!(
+//                         "Could not rebroadcast host-client message to other clients: {:?}",
+//                         e
+//                     )
+//                 });
+//         }
+//         // send the message directly to the local client's Events queue
+//         if let Some(mut client_events) = client_events {
+//             // SAFETY: we know that there is a message in the event
+//             // We just had an option to avoid a copy.
+//             let message = std::mem::take(&mut trigger.event_mut().message).unwrap();
+//             client_events.send(crate::client::events::MessageEvent::new(message, ()));
+//         }
+//     } else {
+//         // not in host-server mode, serialize and send the message as normal
+//         let _ = server_manager
+//             .erased_send_message_to_target(
+//                 trigger.event().message.as_ref().unwrap(),
+//                 trigger.event().channel_kind,
+//                 target,
+//             )
+//             .inspect_err(|e| {
+//                 error!("Could not send message to clients: {:?}", e);
+//             });
+//     }
+// }
+//
+// /// Send a message from server to clients
+// ///
+// /// We use a trigger `SendMessageTrigger<M>` instead of directly serializing the message
+// /// in case we are in host-server mode. In that situation, we just add the message directly
+// /// the local client's Event queue.
+// pub(crate) fn add_server_send_message_to_client<M: Message>(app: &mut App) {
+//     app.observe(handle_server_send_message_to_client::<M>);
+// }
 
 /// Register a message that can be sent from client to server
 pub(crate) fn add_server_receive_message_from_client<M: Message>(app: &mut App) {

--- a/lightyear/src/server/networking.rs
+++ b/lightyear/src/server/networking.rs
@@ -228,6 +228,7 @@ pub(crate) fn send(
     connection_manager
         .connections
         .iter_mut()
+        .filter(|(_, connection)| !connection.is_local_client())
         .try_for_each(|(client_id, connection)| {
             let client_span =
                 info_span!("send_packets_to_client", client_id = ?client_id).entered();

--- a/lightyear/src/shared/run_conditions.rs
+++ b/lightyear/src/shared/run_conditions.rs
@@ -24,14 +24,6 @@ pub fn is_host_server(
     config: Option<Res<ServerConfig>>,
     server: Option<Res<ServerConnections>>,
 ) -> bool {
-    // let b = config.as_ref().map_or(false, |config| {
-    //     matches!(config.shared.mode, Mode::HostServer)
-    // });
-    // let c = server
-    //     .as_ref()
-    //     .map_or(false, |server| server.is_listening());
-    // dbg!(b);
-    // dbg!(c);
     config.map_or(false, |config| {
         matches!(config.shared.mode, Mode::HostServer)
             && server.map_or(false, |server| server.is_listening())

--- a/lightyear/src/shared/run_conditions.rs
+++ b/lightyear/src/shared/run_conditions.rs
@@ -24,6 +24,14 @@ pub fn is_host_server(
     config: Option<Res<ServerConfig>>,
     server: Option<Res<ServerConnections>>,
 ) -> bool {
+    // let b = config.as_ref().map_or(false, |config| {
+    //     matches!(config.shared.mode, Mode::HostServer)
+    // });
+    // let c = server
+    //     .as_ref()
+    //     .map_or(false, |server| server.is_listening());
+    // dbg!(b);
+    // dbg!(c);
     config.map_or(false, |config| {
         matches!(config.shared.mode, Mode::HostServer)
             && server.map_or(false, |server| server.is_listening())

--- a/lightyear/src/tests/host_server_stepper.rs
+++ b/lightyear/src/tests/host_server_stepper.rs
@@ -1,0 +1,319 @@
+//! Stepper to run tests in host-server mode (client and server are in the same app)
+use std::net::SocketAddr;
+use std::str::FromStr;
+
+use bevy::ecs::system::RunSystemOnce;
+use bevy::input::InputPlugin;
+use bevy::prelude::{default, App, Commands, Mut, PluginGroup, Real, Time, World};
+use bevy::state::app::StatesPlugin;
+use bevy::time::TimeUpdateStrategy;
+use bevy::utils::Duration;
+use bevy::MinimalPlugins;
+
+use crate::connection::netcode::generate_key;
+use crate::prelude::client::{
+    Authentication, ClientCommands, ClientConfig, ClientTransport, InterpolationConfig, NetConfig,
+    PredictionConfig, SyncConfig,
+};
+use crate::prelude::server::{NetcodeConfig, ServerCommands, ServerConfig, ServerTransport};
+use crate::prelude::*;
+use crate::shared::time_manager::WrappedTime;
+use crate::tests::protocol::*;
+use crate::transport::LOCAL_SOCKET;
+
+pub const LOCAL_CLIENT_ID: u64 = 111;
+pub const EXTERNAL_CLIENT_ID: u64 = 112;
+
+/// Helpers to setup a bevy app where I can just step the world easily
+pub trait Step {
+    /// Advance both apps by one frame duration
+    fn frame_step(&mut self);
+
+    /// Advance both apps by on fixed timestep duration
+    fn tick_step(&mut self);
+}
+
+pub struct HostServerStepper {
+    // App for another external client
+    pub client_app: App,
+    // App for the host-server (client + server)
+    pub server_app: App,
+    pub frame_duration: Duration,
+    pub tick_duration: Duration,
+    pub current_time: bevy::utils::Instant,
+}
+
+impl Default for HostServerStepper {
+    fn default() -> Self {
+        let frame_duration = Duration::from_millis(10);
+        let tick_duration = Duration::from_millis(10);
+        let shared_config = SharedConfig {
+            tick: TickConfig::new(tick_duration),
+            ..Default::default()
+        };
+        let client_config = ClientConfig::default();
+
+        let mut stepper = Self::new(shared_config, client_config, frame_duration);
+        stepper.init();
+        stepper
+    }
+}
+
+// Do not forget to use --features mock_time when using the LinkConditioner
+impl HostServerStepper {
+    pub fn new(
+        shared_config: SharedConfig,
+        mut client_config: ClientConfig,
+        frame_duration: Duration,
+    ) -> Self {
+        // tracing_subscriber::FmtSubscriber::builder()
+        //     .with_max_level(tracing::Level::INFO)
+        //     .init();
+
+        // Use local channels instead of UDP for testing
+        let addr = LOCAL_SOCKET;
+        // channels to receive a message from/to server
+        let (from_server_send, from_server_recv) = crossbeam_channel::unbounded();
+        let (to_server_send, to_server_recv) = crossbeam_channel::unbounded();
+        let mut client_io = client::IoConfig::from_transport(ClientTransport::LocalChannel {
+            send: to_server_send,
+            recv: from_server_recv,
+        });
+
+        let mut server_io = server::IoConfig::from_transport(ServerTransport::Channels {
+            channels: vec![(addr, to_server_recv, from_server_send)],
+        });
+
+        let NetConfig::Netcode { io, .. } = client_config.net.clone() else {
+            panic!("Only Netcode transport is supported in tests");
+        };
+        if let Some(conditioner) = io.conditioner {
+            server_io = server_io.with_conditioner(conditioner.clone());
+            client_io = client_io.with_conditioner(conditioner.clone());
+        }
+
+        // Shared config
+        let protocol_id = 0;
+        let private_key = generate_key();
+
+        // Setup server
+        let mut server_app = App::new();
+        server_app.add_plugins((MinimalPlugins, StatesPlugin));
+        let net_config = server::NetConfig::Netcode {
+            config: NetcodeConfig::default()
+                .with_protocol_id(protocol_id)
+                .with_key(private_key),
+            io: server_io,
+        };
+        let mut shared_host_server = shared_config.clone();
+        shared_host_server.mode = Mode::HostServer;
+        let config = ServerConfig {
+            shared: shared_config,
+            net: vec![net_config],
+            ping: PingConfig {
+                // send pings every tick, so that the acks are received every frame
+                ping_interval: Duration::default(),
+                ..default()
+            },
+            ..default()
+        };
+        let plugin = server::ServerPlugins::new(config);
+        server_app.add_plugins((plugin, ProtocolPlugin));
+
+        // Add the ClientPlugin to the server_app, to make it host-server mode!
+        let mut host_server_client_config = client_config.clone();
+        host_server_client_config.shared = shared_host_server;
+        host_server_client_config.net = NetConfig::Local {
+            id: LOCAL_CLIENT_ID,
+        };
+        host_server_client_config.ping = PingConfig {
+            // send pings every tick, so that the acks are received every frame
+            ping_interval: Duration::default(),
+            ..default()
+        };
+        server_app.add_plugins(client::ClientPlugins::new(host_server_client_config));
+
+        // Setup external client
+        let mut client_app = App::new();
+        client_app.add_plugins((MinimalPlugins, StatesPlugin));
+        let net_config = NetConfig::Netcode {
+            auth: Authentication::Manual {
+                server_addr: addr,
+                protocol_id,
+                private_key,
+                client_id: EXTERNAL_CLIENT_ID,
+            },
+            config: Default::default(),
+            io: client_io,
+        };
+
+        client_config.shared = shared_config;
+        client_config.ping = PingConfig {
+            // send pings every tick, so that the acks are received every frame
+            ping_interval: Duration::default(),
+            ..default()
+        };
+        client_config.net = net_config;
+
+        let plugin = client::ClientPlugins::new(client_config);
+        client_app.add_plugins((plugin, ProtocolPlugin));
+
+        #[cfg(feature = "leafwing")]
+        {
+            client_app.add_plugins(LeafwingInputPlugin::<LeafwingInput1>::default());
+            client_app.add_plugins(LeafwingInputPlugin::<LeafwingInput2>::default());
+            server_app.add_plugins(LeafwingInputPlugin::<LeafwingInput1>::default());
+            server_app.add_plugins(LeafwingInputPlugin::<LeafwingInput2>::default());
+            client_app.add_plugins(InputPlugin);
+        }
+
+        // Initialize Real time (needed only for the first TimeSystem run)
+        let now = bevy::utils::Instant::now();
+        client_app
+            .world_mut()
+            .get_resource_mut::<Time<Real>>()
+            .unwrap()
+            .update_with_instant(now);
+        server_app
+            .world_mut()
+            .get_resource_mut::<Time<Real>>()
+            .unwrap()
+            .update_with_instant(now);
+
+        Self {
+            client_app,
+            server_app,
+            frame_duration,
+            tick_duration: shared_config.tick.tick_duration,
+            current_time: now,
+        }
+    }
+
+    pub(crate) fn interpolation_tick(&mut self) -> Tick {
+        self.client_app.world_mut().resource_scope(
+            |world: &mut World, manager: Mut<client::ConnectionManager>| {
+                manager
+                    .sync_manager
+                    .interpolation_tick(world.resource::<TickManager>())
+            },
+        )
+    }
+
+    pub(crate) fn set_client_tick(&mut self, tick: Tick) {
+        let new_time = WrappedTime::from_duration(self.tick_duration * (tick.0 as u32));
+
+        self.client_app
+            .world_mut()
+            .resource_mut::<TimeManager>()
+            .set_current_time(new_time);
+        self.client_app
+            .world_mut()
+            .resource_mut::<TickManager>()
+            .set_tick_to(tick);
+    }
+
+    pub(crate) fn set_server_tick(&mut self, tick: Tick) {
+        let new_time = WrappedTime::from_duration(self.tick_duration * (tick.0 as u32));
+
+        self.server_app
+            .world_mut()
+            .resource_mut::<TimeManager>()
+            .set_current_time(new_time);
+        self.server_app
+            .world_mut()
+            .resource_mut::<TickManager>()
+            .set_tick_to(tick);
+    }
+
+    pub(crate) fn client_tick(&self) -> Tick {
+        self.client_app.world().resource::<TickManager>().tick()
+    }
+    pub(crate) fn server_tick(&self) -> Tick {
+        self.server_app.world().resource::<TickManager>().tick()
+    }
+    pub(crate) fn init(&mut self) {
+        self.server_app.finish();
+        self.server_app.cleanup();
+        self.server_app
+            .world_mut()
+            .run_system_once(|mut commands: Commands| commands.start_server());
+        self.client_app.finish();
+        self.client_app.cleanup();
+        self.client_app
+            .world_mut()
+            .run_system_once(|mut commands: Commands| commands.connect_client());
+
+        // Advance the world to let the connection process complete
+        for _ in 0..100 {
+            if self
+                .client_app
+                .world()
+                .resource::<client::ConnectionManager>()
+                .is_synced()
+            {
+                break;
+            }
+            self.frame_step();
+        }
+    }
+
+    pub(crate) fn start(&mut self) {
+        self.server_app
+            .world_mut()
+            .run_system_once(|mut commands: Commands| commands.start_server());
+        self.client_app
+            .world_mut()
+            .run_system_once(|mut commands: Commands| commands.connect_client());
+
+        // Advance the world to let the connection process complete
+        for _ in 0..100 {
+            if self
+                .client_app
+                .world()
+                .resource::<client::ConnectionManager>()
+                .is_synced()
+            {
+                break;
+            }
+            self.frame_step();
+        }
+    }
+
+    pub(crate) fn stop(&mut self) {
+        self.server_app
+            .world_mut()
+            .run_system_once(|mut commands: Commands| commands.stop_server());
+        self.client_app
+            .world_mut()
+            .run_system_once(|mut commands: Commands| commands.disconnect_client());
+
+        // Advance the world to let the disconnection process complete
+        for _ in 0..100 {
+            self.frame_step();
+        }
+    }
+
+    pub(crate) fn advance_time(&mut self, duration: Duration) {
+        self.current_time += duration;
+        self.client_app
+            .insert_resource(TimeUpdateStrategy::ManualInstant(self.current_time));
+        self.server_app
+            .insert_resource(TimeUpdateStrategy::ManualInstant(self.current_time));
+        mock_instant::MockClock::advance(duration);
+    }
+}
+
+impl Step for HostServerStepper {
+    /// Advance the world by one frame duration
+    fn frame_step(&mut self) {
+        self.advance_time(self.frame_duration);
+        self.client_app.update();
+        self.server_app.update();
+    }
+
+    fn tick_step(&mut self) {
+        self.advance_time(self.tick_duration);
+        self.client_app.update();
+        self.server_app.update();
+    }
+}

--- a/lightyear/src/tests/host_server_stepper.rs
+++ b/lightyear/src/tests/host_server_stepper.rs
@@ -105,10 +105,10 @@ impl HostServerStepper {
                 .with_key(private_key),
             io: server_io,
         };
-        let mut shared_host_server = shared_config.clone();
+        let mut shared_host_server = shared_config;
         shared_host_server.mode = Mode::HostServer;
         let config = ServerConfig {
-            shared: shared_config,
+            shared: shared_host_server,
             net: vec![net_config],
             ping: PingConfig {
                 // send pings every tick, so that the acks are received every frame
@@ -236,7 +236,10 @@ impl HostServerStepper {
         self.server_app.cleanup();
         self.server_app
             .world_mut()
-            .run_system_once(|mut commands: Commands| commands.start_server());
+            .run_system_once(|mut commands: Commands| {
+                commands.start_server();
+                commands.connect_client();
+            });
         self.client_app.finish();
         self.client_app.cleanup();
         self.client_app
@@ -260,7 +263,10 @@ impl HostServerStepper {
     pub(crate) fn start(&mut self) {
         self.server_app
             .world_mut()
-            .run_system_once(|mut commands: Commands| commands.start_server());
+            .run_system_once(|mut commands: Commands| {
+                commands.start_server();
+                commands.connect_client();
+            });
         self.client_app
             .world_mut()
             .run_system_once(|mut commands: Commands| commands.connect_client());
@@ -282,7 +288,10 @@ impl HostServerStepper {
     pub(crate) fn stop(&mut self) {
         self.server_app
             .world_mut()
-            .run_system_once(|mut commands: Commands| commands.stop_server());
+            .run_system_once(|mut commands: Commands| {
+                commands.stop_server();
+                commands.disconnect_client();
+            });
         self.client_app
             .world_mut()
             .run_system_once(|mut commands: Commands| commands.disconnect_client());

--- a/lightyear/src/tests/mod.rs
+++ b/lightyear/src/tests/mod.rs
@@ -1,7 +1,10 @@
 #![allow(unused_imports)]
 #![allow(unused_variables)]
 #![allow(dead_code)]
+
+pub(crate) mod host_server_stepper;
 mod integration;
+
 pub(crate) mod multi_stepper;
 pub mod protocol;
 pub(crate) mod stepper;


### PR DESCRIPTION
The networking plugins were completely disabled in host-server mode, which means that the local client could not send messages to the server.

This PR fixes this:

- when sending a message, instead of buffering the message immediately in the MessageManager, we now store the bytes in a local vec
- if running in host-server mode, we take those bytes and 'receive' them immediately on the server (which is running in the same World)
- if not, we just buffer them in the message manager and send them as normal

Also:
- Also adds a unit test in HostServer mode to confirm that the server receives the message
- Now the server also adds a `Connection` for the local client (instead of simply sending a ConnectEvent). This `Connection` has a field `is_local_client` to distinguish it from normal connections

This fixes half of https://github.com/cBournhonesque/lightyear/issues/535. We can now send messages from local client to server; we still want to be able to send messages from server to local client.