### PR TITLE
Rename EventMessage to more specific name

### DIFF
--- a/examples/avian_physics/src/server.rs
+++ b/examples/avian_physics/src/server.rs
@@ -103,7 +103,7 @@ pub(crate) fn movement(
 
 pub(crate) fn replicate_inputs(
     mut connection: ResMut<ConnectionManager>,
-    mut input_events: EventReader<MessageEvent<InputMessage<PlayerActions>>>,
+    mut input_events: EventReader<ServerMessageEvent<InputMessage<PlayerActions>>>,
 ) {
     for event in input_events.read() {
         let inputs = event.message();

--- a/examples/client_replication/src/client.rs
+++ b/examples/client_replication/src/client.rs
@@ -230,7 +230,7 @@ fn window_relative_mouse_position(window: &Window) -> Option<Vec2> {
 }
 
 // System to receive messages on the client
-pub(crate) fn receive_message(mut reader: EventReader<MessageEvent<Message1>>) {
+pub(crate) fn receive_message(mut reader: EventReader<ClientMessageEvent<Message1>>) {
     for event in reader.read() {
         info!("Received message: {:?}", event.message());
     }

--- a/examples/interest_management/src/server.rs
+++ b/examples/interest_management/src/server.rs
@@ -96,7 +96,7 @@ pub(crate) fn handle_connections(
     }
 }
 
-pub(crate) fn receive_message(mut messages: EventReader<MessageEvent<Message1>>) {
+pub(crate) fn receive_message(mut messages: EventReader<ServerMessageEvent<Message1>>) {
     for message in messages.read() {
         info!("recv message");
     }

--- a/examples/lobby/src/client.rs
+++ b/examples/lobby/src/client.rs
@@ -438,7 +438,7 @@ mod lobby {
     /// - set the AppState to Game
     pub(crate) fn receive_start_game_message(
         mut commands: Commands,
-        mut events: EventReader<MessageEvent<StartGame>>,
+        mut events: EventReader<ClientMessageEvent<StartGame>>,
         lobby_table: Res<LobbyTable>,
         mut next_app_state: ResMut<NextState<AppState>>,
         mut config: ResMut<ClientConfig>,

--- a/examples/lobby/src/server.rs
+++ b/examples/lobby/src/server.rs
@@ -162,7 +162,7 @@ mod lobby {
     /// - update the `Lobbies` resource
     /// - add the Client to the room corresponding to the lobby
     pub(super) fn handle_lobby_join(
-        mut events: EventReader<MessageEvent<JoinLobby>>,
+        mut events: EventReader<ServerMessageEvent<JoinLobby>>,
         mut lobbies: ResMut<Lobbies>,
         mut room_manager: ResMut<RoomManager>,
         mut commands: Commands,
@@ -190,7 +190,7 @@ mod lobby {
     /// - update the `Lobbies` resource
     /// - remove the Client from the room corresponding to the lobby
     pub(super) fn handle_lobby_exit(
-        mut events: EventReader<MessageEvent<ExitLobby>>,
+        mut events: EventReader<ServerMessageEvent<ExitLobby>>,
         mut lobbies: ResMut<Lobbies>,
         mut room_manager: ResMut<RoomManager>,
     ) {
@@ -206,7 +206,7 @@ mod lobby {
     /// for each player in the lobby
     pub(super) fn handle_start_game(
         mut connection_manager: ResMut<ConnectionManager>,
-        mut events: EventReader<MessageEvent<StartGame>>,
+        mut events: EventReader<ServerMessageEvent<StartGame>>,
         mut lobbies: ResMut<Lobbies>,
         mut room_manager: ResMut<RoomManager>,
         mut commands: Commands,

--- a/examples/simple_box/src/client.rs
+++ b/examples/simple_box/src/client.rs
@@ -147,7 +147,7 @@ fn player_movement(
 }
 
 /// System to receive messages on the client
-pub(crate) fn receive_message1(mut reader: EventReader<MessageEvent<Message1>>) {
+pub(crate) fn receive_message1(mut reader: EventReader<ClientMessageEvent<Message1>>) {
     for event in reader.read() {
         info!("Received message: {:?}", event.message());
     }

--- a/examples/spaceships/src/server.rs
+++ b/examples/spaceships/src/server.rs
@@ -113,7 +113,7 @@ fn init(mut commands: Commands) {
 
 pub(crate) fn replicate_inputs(
     mut connection: ResMut<ConnectionManager>,
-    mut input_events: EventReader<MessageEvent<InputMessage<PlayerActions>>>,
+    mut input_events: EventReader<ServerMessageEvent<InputMessage<PlayerActions>>>,
 ) {
     for event in input_events.read() {
         let inputs = event.message();

--- a/lightyear/src/client/events.rs
+++ b/lightyear/src/client/events.rs
@@ -84,4 +84,7 @@ pub type ComponentInsertEvent<C> = crate::shared::events::components::ComponentI
 /// Bevy [`Event`] emitted on the client when a ComponentRemove replication message is received
 pub type ComponentRemoveEvent<C> = crate::shared::events::components::ComponentRemoveEvent<C, ()>;
 /// Bevy [`Event`] emitted on the client when a (non-replication) message is received
-pub type MessageEvent<M> = crate::shared::events::components::MessageEvent<M, ()>;
+pub type ClientMessageEvent<M> = crate::shared::events::components::MessageEvent<M, ()>;
+/// Bevy [`Event`] emitted on the client when a (non-replication) message is received
+#[deprecated(note = "Use ClientMessageEvent instead")]
+pub type MessageEvent<M> = ClientMessageEvent<M>;

--- a/lightyear/src/lib.rs
+++ b/lightyear/src/lib.rs
@@ -234,8 +234,8 @@ pub mod prelude {
         pub use crate::client::connection::ConnectionManager;
         pub use crate::client::error::ClientError;
         pub use crate::client::events::{
-            ComponentInsertEvent, ComponentRemoveEvent, ComponentUpdateEvent, ConnectEvent,
-            DisconnectEvent, EntityDespawnEvent, EntitySpawnEvent, InputEvent, MessageEvent,
+            ClientMessageEvent, ComponentInsertEvent, ComponentRemoveEvent, ComponentUpdateEvent,
+            ConnectEvent, DisconnectEvent, EntityDespawnEvent, EntitySpawnEvent, InputEvent,
         };
         #[cfg(feature = "leafwing")]
         pub use crate::client::input::leafwing::LeafwingInputConfig;
@@ -282,7 +282,7 @@ pub mod prelude {
         pub use crate::server::error::ServerError;
         pub use crate::server::events::{
             ComponentInsertEvent, ComponentRemoveEvent, ComponentUpdateEvent, ConnectEvent,
-            DisconnectEvent, EntityDespawnEvent, EntitySpawnEvent, InputEvent, MessageEvent,
+            DisconnectEvent, EntityDespawnEvent, EntitySpawnEvent, InputEvent, ServerMessageEvent,
         };
         pub use crate::server::io::config::ServerTransport;
         pub use crate::server::io::Io;

--- a/lightyear/src/server/events.rs
+++ b/lightyear/src/server/events.rs
@@ -238,7 +238,11 @@ pub type ComponentRemoveEvent<C> =
     crate::shared::events::components::ComponentRemoveEvent<C, ClientId>;
 
 /// Bevy [`Event`] emitted on the server on the frame where a (non-replication) message is received
-pub type MessageEvent<M> = crate::shared::events::components::MessageEvent<M, ClientId>;
+pub type ServerMessageEvent<M> = crate::shared::events::components::MessageEvent<M, ClientId>;
+
+/// Bevy [`Event`] emitted on the server on the frame where a (non-replication) message is received
+#[deprecated(note = "Use `ServerMessageEvent` instead")]
+pub type MessageEvent<M> = ServerMessageEvent<M>;
 
 #[cfg(test)]
 mod tests {

--- a/lightyear/src/server/input/leafwing.rs
+++ b/lightyear/src/server/input/leafwing.rs
@@ -7,7 +7,7 @@ use bevy::prelude::*;
 use leafwing_input_manager::prelude::*;
 
 use crate::inputs::leafwing::LeafwingUserAction;
-use crate::prelude::server::MessageEvent;
+use crate::prelude::server::ServerMessageEvent;
 use crate::prelude::{server::is_started, InputMessage, MessageRegistry, Mode, TickManager};
 use crate::protocol::message::MessageKind;
 use crate::serialize::reader::Reader;
@@ -96,7 +96,7 @@ fn receive_input_message<A: LeafwingUserAction>(
     // TODO: currently we do not handle entities that are controlled by multiple clients
     mut query: Query<Option<&mut InputBuffer<A>>>,
     mut commands: Commands,
-    mut events: EventWriter<MessageEvent<InputMessage<A>>>,
+    mut events: EventWriter<ServerMessageEvent<InputMessage<A>>>,
 ) {
     let kind = MessageKind::of::<InputMessage<A>>();
     let Some(net) = message_registry.kind_map.net_id(&kind).copied() else {
@@ -184,7 +184,7 @@ fn receive_input_message<A: LeafwingUserAction>(
                                 ));
                             }
                         }
-                        events.send(MessageEvent::new(message, *client_id));
+                        events.send(ServerMessageEvent::new(message, *client_id));
                     }
                     Err(e) => {
                         error!(?e, "could not deserialize leafwing input message");


### PR DESCRIPTION
I found myself often have to rename these to avoid import conflict, also when accepting autocomplete I have to look for which module it comes from.
- Rename `MessageEvent` in the client module to `ClientMessageEvent` and in the server module to `ServerMessageEvent` and deprecate the old names to make migration easier.