### PR TITLE
Emit ConnectEvent correctly on the server in HostServer mode

### DIFF
--- a/lightyear/src/server/connection.rs
+++ b/lightyear/src/server/connection.rs
@@ -503,6 +503,9 @@ impl Connection {
         time_manager: &TimeManager,
         tick_manager: &TickManager,
     ) {
+        if self.is_local_client() {
+            return;
+        }
         self.message_manager
             .update(time_manager, &self.ping_manager, tick_manager);
         self.replication_sender.update(world_tick);

--- a/lightyear/src/server/networking.rs
+++ b/lightyear/src/server/networking.rs
@@ -296,6 +296,7 @@ pub enum NetworkingState {
 /// - the server connection's internal time is up-to-date (otherwise it might not be, since we don't run any server systems while the server is stopped)
 /// - we can take into account any changes to the server config
 fn rebuild_server_connections(world: &mut World) {
+    debug!("Rebuild server connection");
     let server_config = world.resource::<ServerConfig>().clone();
 
     // insert a new connection manager (to reset message numbers, ping manager, etc.)
@@ -327,6 +328,7 @@ fn on_start(world: &mut World) {
         error!("The server is already started. The server can only be started when it is stopped.");
         return;
     }
+
     rebuild_server_connections(world);
     let _ = world
         .resource_mut::<ServerConnections>()

--- a/lightyear/src/shared/events/plugin.rs
+++ b/lightyear/src/shared/events/plugin.rs
@@ -1,12 +1,12 @@
 //! Create the bevy [`Plugin`]
 
 use bevy::app::{App, PreUpdate};
-use bevy::prelude::{IntoSystemConfigs, Plugin, PostUpdate};
+use bevy::prelude::{IntoSystemConfigs, Plugin};
 
 use crate::shared::events::components::{EntityDespawnEvent, EntitySpawnEvent};
 use crate::shared::events::systems::{clear_events, push_entity_events};
 use crate::shared::replication::ReplicationReceive;
-use crate::shared::sets::{InternalMainSet, InternalReplicationSet};
+use crate::shared::sets::InternalMainSet;
 
 pub struct EventsPlugin<R> {
     marker: std::marker::PhantomData<R>,
@@ -31,9 +31,8 @@ impl<R: ReplicationReceive> Plugin for EventsPlugin<R> {
             push_entity_events::<R>.in_set(InternalMainSet::<R::SetMarker>::EmitEvents),
         );
         app.add_systems(
-            PostUpdate,
-            // NOTE: we add this to the All system-set so that this system doesn't run if the host is disconnected
-            clear_events::<R>.in_set(InternalReplicationSet::<R::SetMarker>::All),
+            PreUpdate,
+            clear_events::<R>.after(InternalMainSet::<R::SetMarker>::EmitEvents),
         );
     }
 }

--- a/lightyear/src/shared/sets.rs
+++ b/lightyear/src/shared/sets.rs
@@ -42,6 +42,7 @@ pub enum InternalReplicationSet<M> {
     All,
     _Marker(std::marker::PhantomData<M>),
     SendMessage,
+    EmitEvents,
 }
 
 /// Main SystemSets used by lightyear to receive and send data


### PR DESCRIPTION
The sequence of actions was:

- run PreUpdate
- run StateTransition: client is Connected, state is Started
- server adds a new connection, and adds a ConnectEvent in the buffer
- PostUpdate: ConnectionManager.events are cleared

- run PreUpdate::receive: read from Events, but they were cleared.

Instead we should clear events after we're done reading from them, which is in the `EmitEvents` system set