### PR TITLE
fix observer panicking with resource missing

### DIFF
--- a/lightyear/src/client/prediction/pre_prediction.rs
+++ b/lightyear/src/client/prediction/pre_prediction.rs
@@ -274,6 +274,13 @@ mod tests {
             stepper.frame_step();
         }
 
+        // check that PrePredicted was also added on the child
+        assert!(stepper
+            .client_app
+            .world()
+            .get::<PrePredicted>(child)
+            .is_some());
+
         // check that both the parent and the child were replicated
         let server_parent = stepper
             .server_app

--- a/lightyear/src/client/prediction/predicted_history.rs
+++ b/lightyear/src/client/prediction/predicted_history.rs
@@ -471,7 +471,8 @@ mod tests {
         assert!(
             stepper
                 .client_app
-                .world()                .entity(predicted)
+                .world()
+                .entity(predicted)
                 .get::<PredictionHistory<Component2>>()
                 .is_none(),
             "Expected component value to not be added to prediction history for ComponentSyncMode::Simple"

--- a/lightyear/src/server/clients.rs
+++ b/lightyear/src/server/clients.rs
@@ -74,30 +74,33 @@ mod systems {
         trigger: Trigger<OnRemove, ControlledBy>,
         query: Query<&ControlledBy>,
         mut client_query: Query<&mut ControlledEntities>,
-        sender: Res<ConnectionManager>,
+        sender: Option<Res<ConnectionManager>>,
     ) {
         // OnRemove observers trigger before the actual removal
         let entity = trigger.entity();
         if let Ok(controlled_by) = query.get(entity) {
-            // TODO: avoid clone
-            sender
-                .connected_targets(controlled_by.target.clone())
-                .for_each(|client_id| {
-                    if let Ok(client_entity) = sender.client_entity(client_id) {
-                        if let Ok(mut controlled_entities) = client_query.get_mut(client_entity) {
-                            // first check if it already contains, to not trigger change detection needlessly
-                            if !controlled_entities.contains_key(&entity) {
-                                return;
+            if let Some(sender) = sender {
+                // TODO: avoid clone
+                sender
+                    .connected_targets(controlled_by.target.clone())
+                    .for_each(|client_id| {
+                        if let Ok(client_entity) = sender.client_entity(client_id) {
+                            if let Ok(mut controlled_entities) = client_query.get_mut(client_entity)
+                            {
+                                // first check if it already contains, to not trigger change detection needlessly
+                                if !controlled_entities.contains_key(&entity) {
+                                    return;
+                                }
+                                trace!(
+                                    "Removing entity {:?} to client {:?}'s controlled entities",
+                                    entity,
+                                    client_id,
+                                );
+                                controlled_entities.remove(&entity);
                             }
-                            trace!(
-                                "Removing entity {:?} to client {:?}'s controlled entities",
-                                entity,
-                                client_id,
-                            );
-                            controlled_entities.remove(&entity);
                         }
-                    }
-                })
+                    })
+            }
         }
     }
 

--- a/lightyear/src/server/networking.rs
+++ b/lightyear/src/server/networking.rs
@@ -203,7 +203,10 @@ pub(crate) fn receive(world: &mut World) {
                                                         debug!("Client connected event: {}", connect_event.client_id);
                                                         world.resource_mut::<Events<ConnectEvent>>().send(connect_event);
                                                         // TODO: trigger all events in batch? https://github.com/bevyengine/bevy/pull/13953
-                                                        world.trigger(connect_event);
+                                                        // NOTE: we don't trigger the event immediately because we're inside world.resource_scope
+                                                        //  so a bunch of Resources have been removed from the World
+                                                        world.commands().trigger(connect_event);
+                                                        // world.trigger(connect_event);
                                                     }
                                                 }
 
@@ -212,7 +215,10 @@ pub(crate) fn receive(world: &mut World) {
                                                         debug!("Client disconnected event: {}", disconnect_event.client_id);
                                                         world.resource_mut::<Events<DisconnectEvent>>().send(disconnect_event);
                                                         // TODO: trigger all events in batch? https://github.com/bevyengine/bevy/pull/13953
-                                                        world.trigger(disconnect_event);
+                                                        // NOTE: we don't trigger the event immediately because we're inside world.resource_scope
+                                                        //  so a bunch of Resources have been removed from the World
+                                                        world.commands().trigger(disconnect_event);
+                                                        // world.trigger(disconnect_event);
                                                     }
                                                 }
                                             }

--- a/lightyear/src/shared/replication/hierarchy.rs
+++ b/lightyear/src/shared/replication/hierarchy.rs
@@ -64,7 +64,7 @@ impl<R: ReplicationSend> HierarchySendPlugin<R> {
             ),
         >,
         children_query: Query<&Children>,
-        child_query: Query<(), With<ParentSync>>,
+        child_query: Query<(), (With<ParentSync>, With<Replicating>)>,
     ) {
         for (
             parent_entity,
@@ -81,7 +81,7 @@ impl<R: ReplicationSend> HierarchySendPlugin<R> {
                 // iterate through all descendents of the entity
                 for child in children_query.iter_descendants(parent_entity) {
                     // TODO: or do we want to propagate any change of any component to the children?
-                    // if the child already has ParentSync, we don't need to add it again
+                    // if the child already has ParentSync and Replicating, we don't need to add it again
                     if child_query.get(child).is_ok() {
                         continue;
                     }


### PR DESCRIPTION
Observers panic in some situations because we call `world.trigger()` inside ` world.resource_scope()`; i.e. the resource has been removed from the world when the observer system runs.

The solution for this is to call `Commands.trigger()` instead of `World.trigger()` so that when the observer runs the resource is available