### PR TITLE
Remove extra rollbacks from Avian

### DIFF
--- a/examples/avian_physics/src/shared.rs
+++ b/examples/avian_physics/src/shared.rs
@@ -1,3 +1,4 @@
+use avian2d::dynamics::solver::SolverConfig;
 use avian2d::prelude::*;
 use bevy::color::palettes::css;
 use bevy::diagnostic::LogDiagnosticsPlugin;
@@ -71,8 +72,14 @@ impl Plugin for SharedPlugin {
         app.add_plugins(
             PhysicsPlugins::new(FixedUpdate)
                 .build()
+                .disable::<SleepingPlugin>()
                 .disable::<ColliderHierarchyPlugin>(),
         )
+        .insert_resource(SubstepCount(12))
+        .insert_resource(SolverConfig {
+            warm_start_coefficient: 0.0,
+            ..default()
+        })
         .insert_resource(Time::new_with(Physics::fixed_once_hz(FIXED_TIMESTEP_HZ)))
         .insert_resource(Gravity(Vec2::ZERO));
         app.configure_sets(


### PR DESCRIPTION
With the move from XPBD to Avian, we noticed that even with a single player we have rollbacks, especially on contacts/collisions.
This should not happen normally because the client/server have access to the same inputs and the simulations are deterministic.

It seems to be because Avian maintains some stateful data:
- **sleeping**: the entity is sleeping and is ignored by the physics engine
- **warm start**: the collision solver use the previous frame's collisions

We have 2 solutions:
- remove sleeping and disable warm start
- add rollback for xpbd stateful resources, like `Collisions` and `Sleeping`