### PR TITLE
add MTU config for QUIC

### DIFF
--- a/lightyear/src/transport/mod.rs
+++ b/lightyear/src/transport/mod.rs
@@ -61,6 +61,11 @@ pub const LOCAL_SOCKET: SocketAddr = SocketAddr::new(
 /// See: <https://gafferongames.com/post/packet_fragmentation_and_reassembly/>
 pub(crate) const MTU: usize = 1472;
 
+/// Minimum MTU used by QUIC. Any packets bigger than this will error with TooLarge
+/// There is MTU Discovery to potentially allow bigger MTUs, and this is the minimum
+/// the discovery will start from.
+pub(crate) const MIN_MTU: usize = 1300;
+
 pub(crate) type BoxedSender = Box<dyn PacketSender + Send + Sync>;
 pub(crate) type BoxedReceiver = Box<dyn PacketReceiver + Send + Sync>;
 

--- a/lightyear/src/transport/webtransport/client_native.rs
+++ b/lightyear/src/transport/webtransport/client_native.rs
@@ -118,7 +118,6 @@ impl ClientTransportBuilder for WebTransportClientSocketBuilder {
                         loop {
                             if let Some(msg) = to_server_receiver.recv().await {
                                 trace!("send datagram to server: {:?}", &msg);
-                                dbg!(msg.len());
                                 connection_send.send_datagram(msg).unwrap_or_else(|e| {
                                     error!("send_datagram via webtransport error: {:?}", e);
                                 });

--- a/lightyear/src/transport/webtransport/client_native.rs
+++ b/lightyear/src/transport/webtransport/client_native.rs
@@ -17,7 +17,9 @@ use crate::client::io::transport::{ClientTransportBuilder, ClientTransportEnum};
 use crate::client::io::{ClientIoEvent, ClientIoEventReceiver, ClientNetworkEventSender};
 use crate::transport::error::{Error, Result};
 use crate::transport::io::IoState;
-use crate::transport::{BoxedReceiver, BoxedSender, PacketReceiver, PacketSender, Transport, MTU};
+use crate::transport::{
+    BoxedReceiver, BoxedSender, PacketReceiver, PacketSender, Transport, MIN_MTU, MTU,
+};
 
 pub(crate) struct WebTransportClientSocketBuilder {
     pub(crate) client_addr: SocketAddr,
@@ -33,7 +35,7 @@ impl ClientTransportBuilder for WebTransportClientSocketBuilder {
         Option<ClientIoEventReceiver>,
         Option<ClientNetworkEventSender>,
     )> {
-        let (to_server_sender, mut to_server_receiver) = mpsc::unbounded_channel();
+        let (to_server_sender, mut to_server_receiver) = mpsc::unbounded_channel::<Box<[u8]>>();
         let (from_server_sender, from_server_receiver) = mpsc::unbounded_channel();
         // channels used to cancel the task
         let (close_tx, close_rx) = async_channel::bounded(1);
@@ -41,10 +43,17 @@ impl ClientTransportBuilder for WebTransportClientSocketBuilder {
         let (event_tx, event_rx) = async_channel::bounded(1);
 
         IoTaskPool::get().spawn(Compat::new(async move {
-            let config = ClientConfig::builder()
+            let mut config = ClientConfig::builder()
                 .with_bind_address(self.client_addr)
                 .with_no_cert_validation()
                 .build();
+            let mut quic_config = wtransport::quinn::TransportConfig::default();
+            quic_config
+                .initial_mtu(MIN_MTU as u16)
+                .min_mtu(MIN_MTU as u16);
+            config.quic_config_mut().transport_config(
+                Arc::new(quic_config)
+            );
             let server_url = format!("https://{}", self.server_addr);
             info!(
                 "Connecting to server via webtransport at server url: {}",
@@ -109,8 +118,9 @@ impl ClientTransportBuilder for WebTransportClientSocketBuilder {
                         loop {
                             if let Some(msg) = to_server_receiver.recv().await {
                                 trace!("send datagram to server: {:?}", &msg);
+                                dbg!(msg.len());
                                 connection_send.send_datagram(msg).unwrap_or_else(|e| {
-                                    error!("send_datagram error: {:?}", e);
+                                    error!("send_datagram via webtransport error: {:?}", e);
                                 });
                             }
                         }

--- a/lightyear/src/transport/webtransport/server.rs
+++ b/lightyear/src/transport/webtransport/server.rs
@@ -18,7 +18,9 @@ use crate::server::io::transport::{ServerTransportBuilder, ServerTransportEnum};
 use crate::server::io::{ServerIoEvent, ServerIoEventReceiver, ServerNetworkEventSender};
 use crate::transport::error::Result;
 use crate::transport::io::IoState;
-use crate::transport::{BoxedReceiver, BoxedSender, PacketReceiver, PacketSender, Transport, MTU};
+use crate::transport::{
+    BoxedReceiver, BoxedSender, PacketReceiver, PacketSender, Transport, MIN_MTU, MTU,
+};
 
 pub(crate) struct WebTransportServerSocketBuilder {
     pub(crate) server_addr: SocketAddr,
@@ -54,10 +56,17 @@ impl ServerTransportBuilder for WebTransportServerSocketBuilder {
             from_client_receiver,
         };
 
-        let config = ServerConfig::builder()
+        let mut config = ServerConfig::builder()
             .with_bind_address(self.server_addr)
             .with_identity(&self.certificate)
             .build();
+        let mut quic_config = wtransport::quinn::TransportConfig::default();
+        quic_config
+            .initial_mtu(MIN_MTU as u16)
+            .min_mtu(MIN_MTU as u16);
+        config
+            .quic_config_mut()
+            .transport_config(Arc::new(quic_config));
         // need to run this with Compat because it requires the tokio reactor
         IoTaskPool::get()
             .spawn(Compat::new(async move {


### PR DESCRIPTION
The default MTU config for QUIC is 1200 bytes; whereas in Netcode we specify a max payload size of 1200 bytes but a max buffer size (with all the headers, etc.) of 1300 bytes.

I hadn't really seen issues before, because QUIC does MTU discovery and increases the MTU if a higher value is available.
However it can be good to also force QUIC to use a min MTU of 1300 bytes.