### PR TITLE
Use `Commands` instead of `World` to apply replication updates

### DIFF
--- a/lightyear/src/client/prediction/predicted_history.rs
+++ b/lightyear/src/client/prediction/predicted_history.rs
@@ -243,21 +243,16 @@ pub(crate) fn update_prediction_history<T: SyncComponent>(
 /// Add the removal to the history (for potential rollbacks)
 pub(crate) fn apply_component_removal_predicted<C: SyncComponent>(
     trigger: Trigger<OnRemove, C>,
-    // TODO: why do I need these options? why are these resources not present when the observer runs?
-    tick_manager: Option<Res<TickManager>>,
-    rollback: Option<Res<Rollback>>,
+    tick_manager: Res<TickManager>,
+    rollback: Res<Rollback>,
     mut predicted_query: Query<&mut PredictionHistory<C>>,
 ) {
     // TODO: do not run this if component-sync-mode != FULL
     // if the component was removed from the Predicted entity, add the Removal to the history
     if let Ok(mut history) = predicted_query.get_mut(trigger.entity()) {
-        if let Some(tick_manager) = tick_manager {
-            if let Some(rollback) = rollback {
-                // tick for which we will record the history (either the current client tick or the current rollback tick)
-                let tick = tick_manager.tick_or_rollback_tick(rollback.as_ref());
-                history.add_remove(tick);
-            }
-        }
+        // tick for which we will record the history (either the current client tick or the current rollback tick)
+        let tick = tick_manager.tick_or_rollback_tick(rollback.as_ref());
+        history.add_remove(tick);
     }
 }
 

--- a/lightyear/src/client/replication.rs
+++ b/lightyear/src/client/replication.rs
@@ -501,10 +501,8 @@ pub(crate) mod send {
     /// Send component remove
     pub(crate) fn send_component_removed<C: Component>(
         trigger: Trigger<OnRemove, C>,
-        // TODO: despawn/respawn the observers if we are not connected/ready to send?
-        // need to use options because this system could get triggered when those resources don't exist
-        registry: Option<Res<ComponentRegistry>>,
-        sender: Option<ResMut<ConnectionManager>>,
+        registry: Res<ComponentRegistry>,
+        mut sender: ResMut<ConnectionManager>,
         // only remove the component for entities that are being actively replicated
         query: Query<
             (&ReplicationGroup, Has<DisabledComponent<C>>),
@@ -519,14 +517,10 @@ pub(crate) mod send {
             }
             let group_id = group.group_id(Some(entity));
             trace!(?entity, kind = ?std::any::type_name::<C>(), "Sending RemoveComponent");
-            if let Some(registry) = registry {
-                if let Some(mut sender) = sender {
-                    let kind = registry.net_id::<C>();
-                    sender
-                        .replication_sender
-                        .prepare_component_remove(entity, group_id, kind);
-                }
-            }
+            let kind = registry.net_id::<C>();
+            sender
+                .replication_sender
+                .prepare_component_remove(entity, group_id, kind);
         }
     }
 

--- a/lightyear/src/protocol/component.rs
+++ b/lightyear/src/protocol/component.rs
@@ -1,15 +1,15 @@
 use bevy::ecs::component::ComponentId;
 use bevy::ecs::entity::MapEntities;
-use std::any::TypeId;
-use std::fmt::Debug;
-use std::hash::Hash;
-use std::ops::{Add, Mul};
-
+use bevy::ecs::system::EntityCommands;
 use bevy::prelude::{App, Component, EntityWorldMut, Mut, Resource, TypePath, World};
 use bevy::ptr::Ptr;
 use bevy::utils::HashMap;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
+use std::any::TypeId;
+use std::fmt::Debug;
+use std::hash::Hash;
+use std::ops::{Add, Mul};
 
 use tracing::{debug, error, trace};
 
@@ -186,13 +186,13 @@ pub struct InterpolationMetadata {
     pub interpolation: Option<unsafe fn()>,
 }
 
-type RawRemoveFn = fn(&ComponentRegistry, &mut EntityWorldMut);
+type RawRemoveFn = fn(&ComponentRegistry, &mut EntityCommands);
 type RawWriteFn = fn(
     &ComponentRegistry,
     &mut Reader,
     ComponentNetId,
     Tick,
-    &mut EntityWorldMut,
+    &mut EntityCommands,
     &mut EntityMap,
     &mut ConnectionEvents,
 ) -> Result<(), ComponentError>;
@@ -531,11 +531,25 @@ mod interpolation {
 
 mod replication {
     use super::*;
-    use crate::prelude::{
-        DeltaCompression, DisabledComponent, OverrideTargetComponent, ReplicateOnceComponent,
-    };
+    use crate::prelude::{ClientId, DeltaCompression, DisabledComponent, OverrideTargetComponent, ReplicateOnceComponent};
     use crate::serialize::reader::Reader;
     use crate::serialize::ToBytes;
+    use bevy::ecs::system::EntityCommands;
+    use bevy::prelude::{Commands, Entity};
+    use crate::client::connection::ConnectionManager;
+
+    /// Get `ConnectionEvents` depending on whether we receive from a client or a server
+    fn get_events(world: &mut World, remote_id: Option<ClientId>) -> &mut ConnectionEvents {
+        // SAFETY: the ConnectionEvents resource is always present
+        let events = remote_id.map_or(
+            &mut world.get_mut::<ConnectionManager>().unwrap(),
+            |id| &mut world.get_mut::<ConnectionEvents>().unwrap().for_client(id),
+        );
+        events
+
+    }
+    let events = remote_id.map_or(
+    &mut world.get_mut::<ConnectionManager>().unwrap(), |id| &mut world.get_mut::<ConnectionEvents>().unwrap().for_client(id));
 
     impl ComponentRegistry {
         pub(crate) fn set_replication_fns<C: Component + PartialEq>(&mut self, world: &mut World) {
@@ -560,10 +574,11 @@ mod replication {
         pub(crate) fn raw_write(
             &self,
             reader: &mut Reader,
-            entity_world_mut: &mut EntityWorldMut,
+            commands: &mut Commands,
+            entity: Entity,
             tick: Tick,
             entity_map: &mut EntityMap,
-            events: &mut ConnectionEvents,
+            remote_id: Option<ClientId>,
         ) -> Result<(), ComponentError> {
             let net_id = ComponentNetId::from_bytes(reader).map_err(SerializationError::from)?;
             let kind = self
@@ -575,13 +590,7 @@ mod replication {
                 .get(kind)
                 .ok_or(ComponentError::MissingReplicationFns)?;
             (replication_metadata.write)(
-                self,
-                reader,
-                net_id,
-                tick,
-                entity_world_mut,
-                entity_map,
-                events,
+                self, reader, net_id, tick, commands, entity, entity_map, remote_id,
             )
         }
 
@@ -590,31 +599,38 @@ mod replication {
             reader: &mut Reader,
             net_id: ComponentNetId,
             tick: Tick,
-            entity_world_mut: &mut EntityWorldMut,
+            commands: &mut Commands,
+            entity: Entity,
             entity_map: &mut EntityMap,
-            events: &mut ConnectionEvents,
+            remote_id: Option<ClientId>,
         ) -> Result<(), ComponentError> {
             trace!("Writing component {} to entity", std::any::type_name::<C>());
             let component = self.raw_deserialize::<C>(reader, net_id, entity_map)?;
-            let entity = entity_world_mut.id();
-            // TODO: should we send the event based on on the message type (Insert/Update) or based on whether the component was actually inserted?
-            if let Some(mut c) = entity_world_mut.get_mut::<C>() {
-                // only apply the update if the component is different, to not trigger change detection
-                if c.as_ref() != &component {
-                    events.push_update_component(entity, net_id, tick);
-                    *c = component;
+
+            commands.add(move |world: &mut World| {
+
+
+
+
+                // TODO: should we send the event based on on the message type (Insert/Update) or based on whether the component was actually inserted?
+                if let Some(mut c) = entity_world_mut.get_mut::<C>() {
+                    // only apply the update if the component is different, to not trigger change detection
+                    if c.as_ref() != &component {
+                        events.push_update_component(entity, net_id, tick);
+                        *c = component;
+                    }
+                } else {
+                    events.push_insert_component(entity, net_id, tick);
+                    entity_world_mut.insert(component);
                 }
-            } else {
-                events.push_insert_component(entity, net_id, tick);
-                entity_world_mut.insert(component);
-            }
+            });
             Ok(())
         }
 
         pub(crate) fn raw_remove(
             &self,
             net_id: ComponentNetId,
-            entity_world_mut: &mut EntityWorldMut,
+            entity_commands: &mut EntityCommands,
         ) {
             let kind = self.kind_map.kind(net_id).expect("unknown component kind");
             let replication_metadata = self
@@ -624,11 +640,11 @@ mod replication {
             let f = replication_metadata
                 .remove
                 .expect("the component does not have a remove function");
-            f(self, entity_world_mut);
+            f(self, entity_commands);
         }
 
-        pub(crate) fn remove<C: Component>(&self, entity_world_mut: &mut EntityWorldMut) {
-            entity_world_mut.remove::<C>();
+        pub(crate) fn remove<C: Component>(&self, entity_commands: &mut EntityCommands) {
+            entity_commands.remove::<C>();
         }
     }
 }
@@ -746,7 +762,7 @@ mod delta {
             reader: &mut Reader,
             net_id: ComponentNetId,
             tick: Tick,
-            entity_world_mut: &mut EntityWorldMut,
+            entity_commands: &mut EntityCommands,
             entity_map: &mut EntityMap,
             events: &mut ConnectionEvents,
         ) -> Result<(), ComponentError> {
@@ -757,68 +773,80 @@ mod delta {
             let delta_net_id = self.net_id::<DeltaMessage<C::Delta>>();
             let delta =
                 self.raw_deserialize::<DeltaMessage<C::Delta>>(reader, delta_net_id, entity_map)?;
-            let entity = entity_world_mut.id();
             // TODO: should we send the event based on on the message type (Insert/Update) or based on whether the component was actually inserted?
-            match delta.delta_type {
-                DeltaType::Normal { previous_tick } => {
-                    let Some(mut history) = entity_world_mut.get_mut::<DeltaComponentHistory<C>>()
-                    else {
-                        return Err(ComponentError::DeltaCompressionError(
-                            format!("Entity {entity:?} does not have a ConfirmedHistory<{}>, but we received a diff for delta-compression",
-                                    std::any::type_name::<C>())
-                        ));
-                    };
-                    let Some(past_value) = history.buffer.get(&previous_tick) else {
-                        return Err(ComponentError::DeltaCompressionError(
-                            format!("Entity {entity:?} does not have a value for tick {previous_tick:?} in the ConfirmedHistory<{}>",
-                                    std::any::type_name::<C>())
-                        ));
-                    };
-                    // TODO: is it possible to have one clone instead of 2?
-                    let mut new_value = past_value.clone();
-                    new_value.apply_diff(&delta.delta);
-                    // we can remove all the values strictly older than previous_tick in the component history
-                    // (since we now that server has receive an ack for previous_tick)
-                    history.buffer = history.buffer.split_off(&previous_tick);
-                    // store the new value in the history
-                    history.buffer.insert(tick, new_value.clone());
-                    let Some(mut c) = entity_world_mut.get_mut::<C>() else {
-                        return Err(ComponentError::DeltaCompressionError(
-                            format!("Entity {entity:?} does not have a {} component, but we received a diff for delta-compression",
-                            std::any::type_name::<C>())
-                        ));
-                    };
-                    *c = new_value;
-                    events.push_update_component(entity, net_id, tick);
-                }
-                DeltaType::FromBase => {
-                    let mut new_value = C::base_value();
-                    new_value.apply_diff(&delta.delta);
-                    let value = new_value.clone();
-                    if let Some(mut c) = entity_world_mut.get_mut::<C>() {
-                        // only apply the update if the component is different, to not trigger change detection
-                        if c.as_ref() != &new_value {
-                            *c = new_value;
-                            events.push_update_component(entity, net_id, tick);
+            entity_commands.add(|mut entity_world_mut: EntityWorldMut| {
+                let entity = entity_world_mut.id();
+                match delta.delta_type {
+                    DeltaType::Normal { previous_tick } => {
+                        let Some(mut history) = entity_world_mut.get_mut::<DeltaComponentHistory<C>>()
+                        else {
+                            // TODO: maybe a command that pipes errors somewhere?
+                            error!("Entity {entity:?} does not have a ConfirmedHistory<{}>, but we received a diff for delta-compression",
+                                        std::any::type_name::<C>());
+                            return;
+                            // return Err(ComponentError::DeltaCompressionError(
+                            //     format!("Entity {entity:?} does not have a ConfirmedHistory<{}>, but we received a diff for delta-compression",
+                            //             std::any::type_name::<C>())
+                            // ));
+                        };
+                        let Some(past_value) = history.buffer.get(&previous_tick) else {
+                            error!("Entity {entity:?} does not have a value for tick {previous_tick:?} in the ConfirmedHistory<{}>",
+                                        std::any::type_name::<C>());
+                            return;
+                            // return Err(ComponentError::DeltaCompressionError(
+                            //     format!("Entity {entity:?} does not have a value for tick {previous_tick:?} in the ConfirmedHistory<{}>",
+                            //             std::any::type_name::<C>())
+                            // ));
+                        };
+                        // TODO: is it possible to have one clone instead of 2?
+                        let mut new_value = past_value.clone();
+                        new_value.apply_diff(&delta.delta);
+                        // we can remove all the values strictly older than previous_tick in the component history
+                        // (since we now that server has receive an ack for previous_tick)
+                        history.buffer = history.buffer.split_off(&previous_tick);
+                        // store the new value in the history
+                        history.buffer.insert(tick, new_value.clone());
+                        let Some(mut c) = entity_world_mut.get_mut::<C>() else {
+                            error!("Entity {entity:?} does not have a {} component, but we received a diff for delta-compression",
+                                        std::any::type_name::<C>());
+                            return;
+                            // return Err(ComponentError::DeltaCompressionError(
+                            //     format!("Entity {entity:?} does not have a {} component, but we received a diff for delta-compression",
+                            //             std::any::type_name::<C>())
+                            // ));
+                        };
+                        *c = new_value;
+                        events.push_update_component(entity, net_id, tick);
+                    }
+                    DeltaType::FromBase => {
+                        let mut new_value = C::base_value();
+                        new_value.apply_diff(&delta.delta);
+                        let value = new_value.clone();
+                        if let Some(mut c) = entity_world_mut.get_mut::<C>() {
+                            // only apply the update if the component is different, to not trigger change detection
+                            if c.as_ref() != &new_value {
+                                *c = new_value;
+                                events.push_update_component(entity, net_id, tick);
+                            }
+                        } else {
+                            entity_world_mut.insert(new_value);
+                            events.push_insert_component(entity, net_id, tick);
                         }
-                    } else {
-                        entity_world_mut.insert(new_value);
-                        events.push_insert_component(entity, net_id, tick);
-                    }
-                    // store the component value in the delta component history, so that we can compute
-                    // diffs from it
-                    if let Some(mut history) =
-                        entity_world_mut.get_mut::<DeltaComponentHistory<C>>()
-                    {
-                        history.buffer.insert(tick, value);
-                    } else {
-                        // create a DeltaComponentHistory and insert the value
-                        let mut history = DeltaComponentHistory::default();
-                        history.buffer.insert(tick, value);
-                        entity_world_mut.insert(history);
+                        // store the component value in the delta component history, so that we can compute
+                        // diffs from it
+                        if let Some(mut history) =
+                            entity_world_mut.get_mut::<DeltaComponentHistory<C>>()
+                        {
+                            history.buffer.insert(tick, value);
+                        } else {
+                            // create a DeltaComponentHistory and insert the value
+                            let mut history = DeltaComponentHistory::default();
+                            history.buffer.insert(tick, value);
+                            entity_world_mut.insert(history);
+                        }
                     }
                 }
-            }
+            });
             Ok(())
         }
     }

--- a/lightyear/src/server/clients.rs
+++ b/lightyear/src/server/clients.rs
@@ -157,13 +157,13 @@ impl Plugin for ClientsMetadataPlugin {
 mod tests {
     use crate::client::networking::ClientCommands;
     use crate::prelude::server::{ConnectionManager, ControlledBy, Replicate};
-    use crate::prelude::{ClientId, NetworkTarget};
+    use crate::prelude::{client, ClientId, NetworkTarget, Replicated, ReplicationTarget};
     use crate::server::clients::ControlledEntities;
     use crate::server::replication::send::Lifetime;
     use crate::tests::multi_stepper::{MultiBevyStepper, TEST_CLIENT_ID_1, TEST_CLIENT_ID_2};
     use crate::tests::stepper::{BevyStepper, Step, TEST_CLIENT_ID};
     use bevy::ecs::entity::EntityHashMap;
-    use bevy::prelude::default;
+    use bevy::prelude::{default, Entity, With};
 
     /// Check that the Client Entities are updated after ControlledBy is added
     #[test]
@@ -337,5 +337,51 @@ mod tests {
             .world()
             .get_entity(server_entity_2)
             .is_some());
+    }
+
+    /// The owning client despawns the entity that they control.
+    /// The server should receive the despawn. This will trigger the
+    /// OnRemove<ControlledBy>, which should not panic
+    /// See: https://github.com/cBournhonesque/lightyear/issues/546
+    #[test]
+    fn test_owning_client_despawns_entity() {
+        let mut stepper = BevyStepper::default();
+        let client_entity = stepper
+            .client_app
+            .world_mut()
+            .spawn(client::Replicate::default())
+            .id();
+        // make sure the server replicated the entity
+        for _ in 0..10 {
+            stepper.frame_step();
+        }
+        let server_entity = stepper
+            .server_app
+            .world_mut()
+            .query_filtered::<Entity, With<Replicated>>()
+            .single(stepper.server_app.world());
+        // add ControlledBy on the entity
+        stepper
+            .server_app
+            .world_mut()
+            .entity_mut(server_entity)
+            .insert(Replicate {
+                target: ReplicationTarget {
+                    target: NetworkTarget::None,
+                },
+                controlled_by: ControlledBy {
+                    target: NetworkTarget::Single(ClientId::Netcode(TEST_CLIENT_ID)),
+                    ..default()
+                },
+                ..default()
+            });
+
+        // despawn the entity on the client
+        stepper.client_app.world_mut().despawn(client_entity);
+        // as described in https://github.com/cBournhonesque/lightyear/issues/546,
+        // when the observer is triggered the `ConnectionManager` is not available
+        for _ in 0..10 {
+            stepper.frame_step();
+        }
     }
 }

--- a/lightyear/src/server/clients.rs
+++ b/lightyear/src/server/clients.rs
@@ -379,7 +379,8 @@ mod tests {
         // despawn the entity on the client
         stepper.client_app.world_mut().despawn(client_entity);
         // as described in https://github.com/cBournhonesque/lightyear/issues/546,
-        // when the observer is triggered the `ConnectionManager` is not available
+        // when the observer is triggered the `ConnectionManager` is not available if we use
+        // world.resource_scope during `receive`, so the function panics
         for _ in 0..10 {
             stepper.frame_step();
         }

--- a/lightyear/src/shared/replication/entity_map.rs
+++ b/lightyear/src/shared/replication/entity_map.rs
@@ -1,6 +1,7 @@
 //! Map between local and remote entities
 use bevy::ecs::entity::{EntityHashMap, EntityMapper};
-use bevy::prelude::{Deref, DerefMut, Entity, EntityWorldMut, World};
+use bevy::ecs::system::EntityCommands;
+use bevy::prelude::{Commands, Deref, DerefMut, Entity, EntityWorldMut, World};
 use bevy::reflect::Reflect;
 use bevy::utils::hashbrown::hash_map::Entry;
 
@@ -69,6 +70,16 @@ impl RemoteEntityMap {
     ) -> Option<EntityWorldMut<'a>> {
         self.get_local(remote_entity)
             .and_then(|e| world.get_entity_mut(*e))
+    }
+
+    /// Get the corresponding local entity for a given remote entity, or create it if it doesn't exist.
+    pub(super) fn get_by_remote_commands(
+        &mut self,
+        commands: &mut Commands,
+        remote_entity: Entity,
+    ) -> Option<EntityCommands> {
+        self.get_local(remote_entity)
+            .and_then(|e| commands.get_entity(*e))
     }
 
     /// Get the corresponding local entity for a given remote entity, or create it if it doesn't exist.

--- a/lightyear/src/shared/replication/entity_map.rs
+++ b/lightyear/src/shared/replication/entity_map.rs
@@ -1,7 +1,6 @@
 //! Map between local and remote entities
 use bevy::ecs::entity::{EntityHashMap, EntityMapper};
-use bevy::ecs::system::EntityCommands;
-use bevy::prelude::{Commands, Deref, DerefMut, Entity, EntityWorldMut, World};
+use bevy::prelude::{Deref, DerefMut, Entity, EntityWorldMut, World};
 use bevy::reflect::Reflect;
 use bevy::utils::hashbrown::hash_map::Entry;
 
@@ -70,16 +69,6 @@ impl RemoteEntityMap {
     ) -> Option<EntityWorldMut<'a>> {
         self.get_local(remote_entity)
             .and_then(|e| world.get_entity_mut(*e))
-    }
-
-    /// Get the corresponding local entity for a given remote entity, or create it if it doesn't exist.
-    pub(super) fn get_by_remote_commands(
-        &mut self,
-        commands: &mut Commands,
-        remote_entity: Entity,
-    ) -> Option<EntityCommands> {
-        self.get_local(remote_entity)
-            .and_then(|e| commands.get_entity(*e))
     }
 
     /// Get the corresponding local entity for a given remote entity, or create it if it doesn't exist.


### PR DESCRIPTION
Fixes https://github.com/cBournhonesque/lightyear/issues/550 and https://github.com/cBournhonesque/lightyear/issues/546

There was a pretty important bug because:
- we use a lot of `world.resource_scope` in `networking::receive` to apply networking updates, which removes a bunch of important resources from the world temporarily.
- we switched to using observers to handle some events, primarily a bunch of `OnRemove` triggers

The problem was that those observers were triggered during `networking::receive`, when some resources such as `ConnectionManager` were not available, which would cause panics.

This PR switches our receive logic to use `Commands` instead of `World`. The updates are not applied immediately but are now pushed to a CommandQueue. The observers are triggered when the CommandQueue is executed.