### PR TITLE
Add rollback for non-networked components

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1,4 +1,16 @@
-- 
+- Add rollback for non-networked components. We will only consider entities that have `Predicted` (but no `Confirmed`!)
+  - the components will be added to the prediction_registry with mode=FULL?
+  - add a PredictedHistory
+    - !!`add_component_history` needs to be adapted to handle no confirmed entities
+  - component removed on Predicted -> added to history (`apply_component_removal_predicted`)
+  - `check_rollback`: no need to modify, we don't want to check rollback for non-networked components since we don't receive server updates
+  - !!`prepare_rollback`: reset the state to the PredictedHistory state
+  - `update_prediction_history`: works fine, needed for non-networked components
+  - DESPAWN:
+    - `remove_component_for_despawn_predicted`: OK
+
+
+
 - Replication serialization:
   - to improve performance, we want to:
     - entities that don't have SerializationGroup are considered part of SerializationGroup for the PLACEHOLDER entity (this should be ok since the PLACEHOLDER is never instantiated)

--- a/lightyear/src/client/connection.rs
+++ b/lightyear/src/client/connection.rs
@@ -591,7 +591,7 @@ impl ReplicationSend for ConnectionManager {
 #[cfg(test)]
 mod tests {
     use crate::prelude::{client, server, ClientConnectionManager};
-    use crate::tests::protocol::Message2;
+    use crate::tests::protocol::EntityMessage;
     use crate::tests::stepper::{BevyStepper, Step};
 
     /// Check that we can map entities from the local world to the remote world
@@ -632,7 +632,7 @@ mod tests {
             server_entity
         );
 
-        let mut message = Message2(client_entity);
+        let mut message = EntityMessage(client_entity);
         stepper
             .client_app
             .world_mut()

--- a/lightyear/src/client/interpolation/visual_interpolation.rs
+++ b/lightyear/src/client/interpolation/visual_interpolation.rs
@@ -219,20 +219,20 @@ mod tests {
         stepper.client_app.world_mut().insert_resource(Toggle(true));
         stepper
             .client_app
-            .add_plugins(VisualInterpolationPlugin::<Component1>::default());
+            .add_plugins(VisualInterpolationPlugin::<ComponentSyncModeFull>::default());
         let entity = stepper
             .client_app
             .world_mut()
             .spawn((
-                Component1(0.0),
-                VisualInterpolateStatus::<Component1>::default(),
+                ComponentSyncModeFull(0.0),
+                VisualInterpolateStatus::<ComponentSyncModeFull>::default(),
             ))
             .id();
         stepper.build();
         (stepper, entity)
     }
 
-    fn fixed_update_increment(mut query: Query<&mut Component1>, enabled: Res<Toggle>) {
+    fn fixed_update_increment(mut query: Query<&mut ComponentSyncModeFull>, enabled: Res<Toggle>) {
         if enabled.0 {
             for mut component1 in query.iter_mut() {
                 component1.0 += 1.0;
@@ -251,7 +251,7 @@ mod tests {
                 .client_app
                 .world()
                 .entity(entity)
-                .get::<Component1>()
+                .get::<ComponentSyncModeFull>()
                 .unwrap()
                 .0,
             1.0
@@ -261,12 +261,12 @@ mod tests {
                 .client_app
                 .world()
                 .entity(entity)
-                .get::<VisualInterpolateStatus<Component1>>()
+                .get::<VisualInterpolateStatus<ComponentSyncModeFull>>()
                 .unwrap(),
             &VisualInterpolateStatus {
                 trigger_change_detection: false,
                 previous_value: None,
-                current_value: Some(Component1(1.0)),
+                current_value: Some(ComponentSyncModeFull(1.0)),
             }
         );
         assert_relative_eq!(
@@ -285,7 +285,7 @@ mod tests {
                 .client_app
                 .world()
                 .entity(entity)
-                .get::<Component1>()
+                .get::<ComponentSyncModeFull>()
                 .unwrap()
                 .0,
             1.66,
@@ -296,12 +296,12 @@ mod tests {
                 .client_app
                 .world()
                 .entity(entity)
-                .get::<VisualInterpolateStatus<Component1>>()
+                .get::<VisualInterpolateStatus<ComponentSyncModeFull>>()
                 .unwrap(),
             &VisualInterpolateStatus {
                 trigger_change_detection: false,
-                previous_value: Some(Component1(1.0)),
-                current_value: Some(Component1(2.0)),
+                previous_value: Some(ComponentSyncModeFull(1.0)),
+                current_value: Some(ComponentSyncModeFull(2.0)),
             }
         );
         assert_relative_eq!(
@@ -320,7 +320,7 @@ mod tests {
                 .client_app
                 .world()
                 .entity(entity)
-                .get::<Component1>()
+                .get::<ComponentSyncModeFull>()
                 .unwrap()
                 .0,
             3.00,
@@ -331,12 +331,12 @@ mod tests {
                 .client_app
                 .world()
                 .entity(entity)
-                .get::<VisualInterpolateStatus<Component1>>()
+                .get::<VisualInterpolateStatus<ComponentSyncModeFull>>()
                 .unwrap(),
             &VisualInterpolateStatus {
                 trigger_change_detection: false,
-                previous_value: Some(Component1(3.0)),
-                current_value: Some(Component1(4.0)),
+                previous_value: Some(ComponentSyncModeFull(3.0)),
+                current_value: Some(ComponentSyncModeFull(4.0)),
             }
         );
         assert_relative_eq!(
@@ -355,7 +355,7 @@ mod tests {
                 .client_app
                 .world()
                 .entity(entity)
-                .get::<Component1>()
+                .get::<ComponentSyncModeFull>()
                 .unwrap()
                 .0,
             4.33,
@@ -366,12 +366,12 @@ mod tests {
                 .client_app
                 .world()
                 .entity(entity)
-                .get::<VisualInterpolateStatus<Component1>>()
+                .get::<VisualInterpolateStatus<ComponentSyncModeFull>>()
                 .unwrap(),
             &VisualInterpolateStatus {
                 trigger_change_detection: false,
-                previous_value: Some(Component1(4.0)),
-                current_value: Some(Component1(5.0)),
+                previous_value: Some(ComponentSyncModeFull(4.0)),
+                current_value: Some(ComponentSyncModeFull(5.0)),
             }
         );
         assert_relative_eq!(
@@ -396,7 +396,7 @@ mod tests {
                 .client_app
                 .world()
                 .entity(entity)
-                .get::<Component1>()
+                .get::<ComponentSyncModeFull>()
                 .unwrap()
                 .0,
             1.0
@@ -406,12 +406,12 @@ mod tests {
                 .client_app
                 .world()
                 .entity(entity)
-                .get::<VisualInterpolateStatus<Component1>>()
+                .get::<VisualInterpolateStatus<ComponentSyncModeFull>>()
                 .unwrap(),
             &VisualInterpolateStatus {
                 trigger_change_detection: false,
                 previous_value: None,
-                current_value: Some(Component1(1.0)),
+                current_value: Some(ComponentSyncModeFull(1.0)),
             }
         );
         assert_relative_eq!(
@@ -430,7 +430,7 @@ mod tests {
                 .client_app
                 .world()
                 .entity(entity)
-                .get::<Component1>()
+                .get::<ComponentSyncModeFull>()
                 .unwrap()
                 .0,
             1.66,
@@ -441,12 +441,12 @@ mod tests {
                 .client_app
                 .world()
                 .entity(entity)
-                .get::<VisualInterpolateStatus<Component1>>()
+                .get::<VisualInterpolateStatus<ComponentSyncModeFull>>()
                 .unwrap(),
             &VisualInterpolateStatus {
                 trigger_change_detection: false,
-                previous_value: Some(Component1(1.0)),
-                current_value: Some(Component1(2.0)),
+                previous_value: Some(ComponentSyncModeFull(1.0)),
+                current_value: Some(ComponentSyncModeFull(2.0)),
             }
         );
         assert_relative_eq!(
@@ -466,7 +466,7 @@ mod tests {
                 .client_app
                 .world()
                 .entity(entity)
-                .get::<Component1>()
+                .get::<ComponentSyncModeFull>()
                 .unwrap()
                 .0,
             2.00,
@@ -477,11 +477,11 @@ mod tests {
                 .client_app
                 .world()
                 .entity(entity)
-                .get::<VisualInterpolateStatus<Component1>>()
+                .get::<VisualInterpolateStatus<ComponentSyncModeFull>>()
                 .unwrap(),
             &VisualInterpolateStatus {
                 trigger_change_detection: false,
-                previous_value: Some(Component1(2.0)),
+                previous_value: Some(ComponentSyncModeFull(2.0)),
                 current_value: None,
             }
         );
@@ -501,7 +501,7 @@ mod tests {
                 .client_app
                 .world()
                 .entity(entity)
-                .get::<Component1>()
+                .get::<ComponentSyncModeFull>()
                 .unwrap()
                 .0,
             2.0,
@@ -512,11 +512,11 @@ mod tests {
                 .client_app
                 .world()
                 .entity(entity)
-                .get::<VisualInterpolateStatus<Component1>>()
+                .get::<VisualInterpolateStatus<ComponentSyncModeFull>>()
                 .unwrap(),
             &VisualInterpolateStatus {
                 trigger_change_detection: false,
-                previous_value: Some(Component1(2.0)),
+                previous_value: Some(ComponentSyncModeFull(2.0)),
                 current_value: None,
             }
         );
@@ -536,7 +536,7 @@ mod tests {
                 .client_app
                 .world()
                 .entity(entity)
-                .get::<Component1>()
+                .get::<ComponentSyncModeFull>()
                 .unwrap()
                 .0,
             2.66,
@@ -547,12 +547,12 @@ mod tests {
                 .client_app
                 .world()
                 .entity(entity)
-                .get::<VisualInterpolateStatus<Component1>>()
+                .get::<VisualInterpolateStatus<ComponentSyncModeFull>>()
                 .unwrap(),
             &VisualInterpolateStatus {
                 trigger_change_detection: false,
-                previous_value: Some(Component1(2.0)),
-                current_value: Some(Component1(3.0)),
+                previous_value: Some(ComponentSyncModeFull(2.0)),
+                current_value: Some(ComponentSyncModeFull(3.0)),
             }
         );
         assert_relative_eq!(
@@ -576,7 +576,7 @@ mod tests {
                 .client_app
                 .world()
                 .entity(entity)
-                .get::<Component1>()
+                .get::<ComponentSyncModeFull>()
                 .unwrap()
                 .0,
             0.0
@@ -586,7 +586,7 @@ mod tests {
                 .client_app
                 .world()
                 .entity(entity)
-                .get::<VisualInterpolateStatus<Component1>>()
+                .get::<VisualInterpolateStatus<ComponentSyncModeFull>>()
                 .unwrap(),
             &VisualInterpolateStatus {
                 trigger_change_detection: false,
@@ -610,7 +610,7 @@ mod tests {
                 .client_app
                 .world()
                 .entity(entity)
-                .get::<Component1>()
+                .get::<ComponentSyncModeFull>()
                 .unwrap()
                 .0,
             1.0,
@@ -621,12 +621,12 @@ mod tests {
                 .client_app
                 .world()
                 .entity(entity)
-                .get::<VisualInterpolateStatus<Component1>>()
+                .get::<VisualInterpolateStatus<ComponentSyncModeFull>>()
                 .unwrap(),
             &VisualInterpolateStatus {
                 trigger_change_detection: false,
                 previous_value: None,
-                current_value: Some(Component1(1.0)),
+                current_value: Some(ComponentSyncModeFull(1.0)),
             }
         );
         assert_relative_eq!(
@@ -645,7 +645,7 @@ mod tests {
                 .client_app
                 .world()
                 .entity(entity)
-                .get::<Component1>()
+                .get::<ComponentSyncModeFull>()
                 .unwrap()
                 .0,
             1.25,
@@ -656,12 +656,12 @@ mod tests {
                 .client_app
                 .world()
                 .entity(entity)
-                .get::<VisualInterpolateStatus<Component1>>()
+                .get::<VisualInterpolateStatus<ComponentSyncModeFull>>()
                 .unwrap(),
             &VisualInterpolateStatus {
                 trigger_change_detection: false,
-                previous_value: Some(Component1(1.0)),
-                current_value: Some(Component1(2.0)),
+                previous_value: Some(ComponentSyncModeFull(1.0)),
+                current_value: Some(ComponentSyncModeFull(2.0)),
             }
         );
         assert_relative_eq!(
@@ -680,7 +680,7 @@ mod tests {
                 .client_app
                 .world()
                 .entity(entity)
-                .get::<Component1>()
+                .get::<ComponentSyncModeFull>()
                 .unwrap()
                 .0,
             2.0,
@@ -691,12 +691,12 @@ mod tests {
                 .client_app
                 .world()
                 .entity(entity)
-                .get::<VisualInterpolateStatus<Component1>>()
+                .get::<VisualInterpolateStatus<ComponentSyncModeFull>>()
                 .unwrap(),
             &VisualInterpolateStatus {
                 trigger_change_detection: false,
-                previous_value: Some(Component1(2.0)),
-                current_value: Some(Component1(3.0)),
+                previous_value: Some(ComponentSyncModeFull(2.0)),
+                current_value: Some(ComponentSyncModeFull(3.0)),
             }
         );
         assert_relative_eq!(
@@ -715,7 +715,7 @@ mod tests {
                 .client_app
                 .world()
                 .entity(entity)
-                .get::<Component1>()
+                .get::<ComponentSyncModeFull>()
                 .unwrap()
                 .0,
             2.75,
@@ -726,12 +726,12 @@ mod tests {
                 .client_app
                 .world()
                 .entity(entity)
-                .get::<VisualInterpolateStatus<Component1>>()
+                .get::<VisualInterpolateStatus<ComponentSyncModeFull>>()
                 .unwrap(),
             &VisualInterpolateStatus {
                 trigger_change_detection: false,
-                previous_value: Some(Component1(2.0)),
-                current_value: Some(Component1(3.0)),
+                previous_value: Some(ComponentSyncModeFull(2.0)),
+                current_value: Some(ComponentSyncModeFull(3.0)),
             }
         );
         assert_relative_eq!(
@@ -755,7 +755,7 @@ mod tests {
                 .client_app
                 .world()
                 .entity(entity)
-                .get::<Component1>()
+                .get::<ComponentSyncModeFull>()
                 .unwrap()
                 .0,
             0.0
@@ -765,7 +765,7 @@ mod tests {
                 .client_app
                 .world()
                 .entity(entity)
-                .get::<VisualInterpolateStatus<Component1>>()
+                .get::<VisualInterpolateStatus<ComponentSyncModeFull>>()
                 .unwrap(),
             &VisualInterpolateStatus {
                 trigger_change_detection: false,
@@ -789,7 +789,7 @@ mod tests {
                 .client_app
                 .world()
                 .entity(entity)
-                .get::<Component1>()
+                .get::<ComponentSyncModeFull>()
                 .unwrap()
                 .0,
             1.0,
@@ -800,12 +800,12 @@ mod tests {
                 .client_app
                 .world()
                 .entity(entity)
-                .get::<VisualInterpolateStatus<Component1>>()
+                .get::<VisualInterpolateStatus<ComponentSyncModeFull>>()
                 .unwrap(),
             &VisualInterpolateStatus {
                 trigger_change_detection: false,
                 previous_value: None,
-                current_value: Some(Component1(1.0)),
+                current_value: Some(ComponentSyncModeFull(1.0)),
             }
         );
         assert_relative_eq!(
@@ -824,7 +824,7 @@ mod tests {
                 .client_app
                 .world()
                 .entity(entity)
-                .get::<Component1>()
+                .get::<ComponentSyncModeFull>()
                 .unwrap()
                 .0,
             1.25,
@@ -835,12 +835,12 @@ mod tests {
                 .client_app
                 .world()
                 .entity(entity)
-                .get::<VisualInterpolateStatus<Component1>>()
+                .get::<VisualInterpolateStatus<ComponentSyncModeFull>>()
                 .unwrap(),
             &VisualInterpolateStatus {
                 trigger_change_detection: false,
-                previous_value: Some(Component1(1.0)),
-                current_value: Some(Component1(2.0)),
+                previous_value: Some(ComponentSyncModeFull(1.0)),
+                current_value: Some(ComponentSyncModeFull(2.0)),
             }
         );
         assert_relative_eq!(
@@ -860,7 +860,7 @@ mod tests {
                 .client_app
                 .world()
                 .entity(entity)
-                .get::<Component1>()
+                .get::<ComponentSyncModeFull>()
                 .unwrap()
                 .0,
             2.0,
@@ -871,11 +871,11 @@ mod tests {
                 .client_app
                 .world()
                 .entity(entity)
-                .get::<VisualInterpolateStatus<Component1>>()
+                .get::<VisualInterpolateStatus<ComponentSyncModeFull>>()
                 .unwrap(),
             &VisualInterpolateStatus {
                 trigger_change_detection: false,
-                previous_value: Some(Component1(2.0)),
+                previous_value: Some(ComponentSyncModeFull(2.0)),
                 current_value: None,
             }
         );
@@ -895,7 +895,7 @@ mod tests {
                 .client_app
                 .world()
                 .entity(entity)
-                .get::<Component1>()
+                .get::<ComponentSyncModeFull>()
                 .unwrap()
                 .0,
             2.0,
@@ -906,11 +906,11 @@ mod tests {
                 .client_app
                 .world()
                 .entity(entity)
-                .get::<VisualInterpolateStatus<Component1>>()
+                .get::<VisualInterpolateStatus<ComponentSyncModeFull>>()
                 .unwrap(),
             &VisualInterpolateStatus {
                 trigger_change_detection: false,
-                previous_value: Some(Component1(2.0)),
+                previous_value: Some(ComponentSyncModeFull(2.0)),
                 current_value: None,
             }
         );
@@ -931,7 +931,7 @@ mod tests {
                 .client_app
                 .world()
                 .entity(entity)
-                .get::<Component1>()
+                .get::<ComponentSyncModeFull>()
                 .unwrap()
                 .0,
             2.5,
@@ -942,12 +942,12 @@ mod tests {
                 .client_app
                 .world()
                 .entity(entity)
-                .get::<VisualInterpolateStatus<Component1>>()
+                .get::<VisualInterpolateStatus<ComponentSyncModeFull>>()
                 .unwrap(),
             &VisualInterpolateStatus {
                 trigger_change_detection: false,
-                previous_value: Some(Component1(2.0)),
-                current_value: Some(Component1(3.0)),
+                previous_value: Some(ComponentSyncModeFull(2.0)),
+                current_value: Some(ComponentSyncModeFull(3.0)),
             }
         );
         assert_relative_eq!(

--- a/lightyear/src/client/message.rs
+++ b/lightyear/src/client/message.rs
@@ -195,7 +195,7 @@ mod tests {
     use super::*;
     use crate::serialize::writer::Writer;
     use crate::tests::host_server_stepper::{HostServerStepper, Step};
-    use crate::tests::protocol::{Channel1, Message1};
+    use crate::tests::protocol::{Channel1, StringMessage};
     use bevy::prelude::{EventReader, Resource, Update};
 
     #[test]
@@ -219,7 +219,7 @@ mod tests {
     /// System to check that we received the message on the server
     fn count_messages(
         mut counter: ResMut<Counter>,
-        mut events: EventReader<crate::server::events::MessageEvent<Message1>>,
+        mut events: EventReader<crate::server::events::MessageEvent<StringMessage>>,
     ) {
         for event in events.read() {
             assert_eq!(event.message().0, "a".to_string());
@@ -242,7 +242,7 @@ mod tests {
             .server_app
             .world_mut()
             .resource_mut::<crate::prelude::client::ConnectionManager>()
-            .send_message::<Channel1, Message1>(&Message1("a".to_string()))
+            .send_message::<Channel1, StringMessage>(&StringMessage("a".to_string()))
             .unwrap();
         stepper.frame_step();
         stepper.frame_step();

--- a/lightyear/src/client/prediction/plugin.rs
+++ b/lightyear/src/client/prediction/plugin.rs
@@ -1,6 +1,6 @@
 use bevy::prelude::{
-    not, App, Condition, FixedPostUpdate, IntoSystemConfigs, IntoSystemSetConfigs, Plugin,
-    PostUpdate, PreUpdate, Res, SystemSet,
+    not, App, Component, Condition, FixedPostUpdate, IntoSystemConfigs, IntoSystemSetConfigs,
+    Plugin, PostUpdate, PreUpdate, Res, SystemSet,
 };
 use bevy::reflect::Reflect;
 use bevy::transform::TransformSystem;
@@ -180,6 +180,17 @@ pub enum PredictionSet {
 /// Returns true if we are doing rollback
 pub fn is_in_rollback(rollback: Option<Res<Rollback>>) -> bool {
     rollback.is_some_and(|rollback| rollback.is_rollback())
+}
+
+/// Enable rollbacking a component even if the component is not networked
+pub fn add_non_networked_rollback_systems<C: Component + PartialEq + Clone>(app: &mut App) {
+    app.add_systems(
+        PreUpdate,
+        (
+            // handle components being added
+            add_component_history::<C>.in_set(PredictionSet::SpawnHistory),
+        ),
+    );
 }
 
 pub fn add_prediction_systems<C: SyncComponent>(app: &mut App, prediction_mode: ComponentSyncMode) {

--- a/lightyear/src/client/prediction/plugin.rs
+++ b/lightyear/src/client/prediction/plugin.rs
@@ -15,8 +15,9 @@ use crate::client::prediction::despawn::{
     restore_components_if_despawn_rolled_back, PredictionDespawnMarker,
 };
 use crate::client::prediction::predicted_history::{
-    add_prespawned_component_history, apply_component_removal_confirmed,
-    apply_component_removal_predicted, update_prediction_history,
+    add_non_networked_component_history, add_prespawned_component_history,
+    apply_component_removal_confirmed, apply_component_removal_predicted,
+    update_prediction_history,
 };
 use crate::client::prediction::prespawn::{
     PreSpawnedPlayerObjectPlugin, PreSpawnedPlayerObjectSet,
@@ -29,8 +30,8 @@ use crate::shared::sets::{ClientMarker, InternalMainSet};
 use super::pre_prediction::{PrePredictionPlugin, PrePredictionSet};
 use super::predicted_history::{add_component_history, apply_confirmed_update};
 use super::rollback::{
-    check_rollback, increment_rollback_tick, prepare_rollback, prepare_rollback_prespawn,
-    run_rollback, Rollback, RollbackState,
+    check_rollback, increment_rollback_tick, prepare_rollback, prepare_rollback_non_networked,
+    prepare_rollback_prespawn, run_rollback, Rollback, RollbackState,
 };
 use super::spawn::spawn_predicted_entity;
 
@@ -184,12 +185,17 @@ pub fn is_in_rollback(rollback: Option<Res<Rollback>>) -> bool {
 
 /// Enable rollbacking a component even if the component is not networked
 pub fn add_non_networked_rollback_systems<C: Component + PartialEq + Clone>(app: &mut App) {
+    app.observe(apply_component_removal_predicted::<C>);
     app.add_systems(
         PreUpdate,
         (
-            // handle components being added
-            add_component_history::<C>.in_set(PredictionSet::SpawnHistory),
+            add_non_networked_component_history::<C>.in_set(PredictionSet::SpawnHistory),
+            prepare_rollback_non_networked::<C>.in_set(PredictionSet::PrepareRollback),
         ),
+    );
+    app.add_systems(
+        FixedPostUpdate,
+        update_prediction_history::<C>.in_set(PredictionSet::UpdateHistory),
     );
 }
 

--- a/lightyear/src/client/prediction/pre_prediction.rs
+++ b/lightyear/src/client/prediction/pre_prediction.rs
@@ -190,7 +190,9 @@ mod tests {
     use super::*;
     use crate::prelude::server;
     use crate::prelude::{client, ClientId};
-    use crate::tests::protocol::{Component1, Component2, Component3};
+    use crate::tests::protocol::{
+        ComponentSyncModeFull, ComponentSyncModeOnce, ComponentSyncModeSimple,
+    };
     use crate::tests::stepper::{BevyStepper, Step, TEST_CLIENT_ID};
 
     /// Simple preprediction case
@@ -204,7 +206,7 @@ mod tests {
             .world_mut()
             .spawn((
                 client::Replicate::default(),
-                Component1(1.0),
+                ComponentSyncModeFull(1.0),
                 PrePredicted::default(),
             ))
             .id();
@@ -258,12 +260,16 @@ mod tests {
         //     .with_max_level(tracing::Level::DEBUG)
         //     .init();
         let mut stepper = BevyStepper::default();
-        let child = stepper.client_app.world_mut().spawn(Component3(0.0)).id();
+        let child = stepper
+            .client_app
+            .world_mut()
+            .spawn(ComponentSyncModeOnce(0.0))
+            .id();
         let parent = stepper
             .client_app
             .world_mut()
             .spawn((
-                Component2(0.0),
+                ComponentSyncModeSimple(0.0),
                 client::Replicate::default(),
                 PrePredicted::default(),
             ))
@@ -285,13 +291,13 @@ mod tests {
         let server_parent = stepper
             .server_app
             .world_mut()
-            .query_filtered::<Entity, With<Component2>>()
+            .query_filtered::<Entity, With<ComponentSyncModeSimple>>()
             .get_single(stepper.server_app.world())
             .expect("parent entity was not replicated");
         let server_child = stepper
             .server_app
             .world_mut()
-            .query_filtered::<Entity, With<Component3>>()
+            .query_filtered::<Entity, With<ComponentSyncModeOnce>>()
             .get_single(stepper.server_app.world())
             .expect("child entity was not replicated");
         assert_eq!(

--- a/lightyear/src/client/prediction/predicted_history.rs
+++ b/lightyear/src/client/prediction/predicted_history.rs
@@ -27,7 +27,7 @@ pub(crate) enum ComponentState<C> {
 
 /// To know if we need to do rollback, we need to compare the predicted entity's history with the server's state updates
 #[derive(Component, Debug)]
-pub(crate) struct PredictionHistory<C: PartialEq> {
+pub(crate) struct PredictionHistory<C> {
     // TODO: add a max size for the buffer
     // We want to avoid using a SequenceBuffer for optimization (we don't want to store a copy of the component for each history tick)
     // We can afford to use a ReadyBuffer because we will get server updates with monotonically increasing ticks
@@ -45,7 +45,7 @@ impl<C: PartialEq> Default for PredictionHistory<C> {
     }
 }
 
-impl<C: SyncComponent> PartialEq for PredictionHistory<C> {
+impl<C: PartialEq> PartialEq for PredictionHistory<C> {
     fn eq(&self, other: &Self) -> bool {
         let mut self_history: Vec<_> = self.buffer.heap.iter().collect();
         let mut other_history: Vec<_> = other.buffer.heap.iter().collect();
@@ -55,7 +55,7 @@ impl<C: SyncComponent> PartialEq for PredictionHistory<C> {
     }
 }
 
-impl<C: SyncComponent> PredictionHistory<C> {
+impl<C: PartialEq + Clone> PredictionHistory<C> {
     /// Reset the history for this component
     pub(crate) fn clear(&mut self) {
         self.buffer = ReadyBuffer::new();
@@ -222,7 +222,7 @@ fn add_history<C: SyncComponent>(
 /// If ComponentSyncMode::Full, we store every update on the predicted entity in the PredictionHistory
 ///
 /// This system only handles changes, removals are handled in `apply_component_removal`
-pub(crate) fn update_prediction_history<T: SyncComponent>(
+pub(crate) fn update_prediction_history<T: Component + PartialEq + Clone>(
     mut query: Query<(Ref<T>, &mut PredictionHistory<T>)>,
     tick_manager: Res<TickManager>,
     rollback: Res<Rollback>,
@@ -241,7 +241,7 @@ pub(crate) fn update_prediction_history<T: SyncComponent>(
 
 /// If a component is removed on the Predicted entity, and the ComponentSyncMode == FULL
 /// Add the removal to the history (for potential rollbacks)
-pub(crate) fn apply_component_removal_predicted<C: SyncComponent>(
+pub(crate) fn apply_component_removal_predicted<C: Component + PartialEq + Clone>(
     trigger: Trigger<OnRemove, C>,
     tick_manager: Res<TickManager>,
     rollback: Res<Rollback>,
@@ -320,28 +320,28 @@ mod tests {
     /// Test adding and removing updates to the component history
     #[test]
     fn test_component_history() {
-        let mut component_history = PredictionHistory::<Component1>::default();
+        let mut component_history = PredictionHistory::<ComponentSyncModeFull>::default();
 
         // check when we try to access a value when the buffer is empty
         assert_eq!(component_history.pop_until_tick(Tick(0)), None);
 
         // check when we try to access an exact tick
-        component_history.add_update(Tick(1), Component1(1.0));
-        component_history.add_update(Tick(2), Component1(2.0));
+        component_history.add_update(Tick(1), ComponentSyncModeFull(1.0));
+        component_history.add_update(Tick(2), ComponentSyncModeFull(2.0));
         assert_eq!(
             component_history.pop_until_tick(Tick(2)),
-            Some(ComponentState::Updated(Component1(2.0)))
+            Some(ComponentState::Updated(ComponentSyncModeFull(2.0)))
         );
         // check that we cleared older ticks, and that the most recent value still remains
         assert_eq!(component_history.buffer.len(), 1);
         assert!(component_history.buffer.has_item(&Tick(2)));
 
         // check when we try to access a value in-between ticks
-        component_history.add_update(Tick(4), Component1(4.0));
+        component_history.add_update(Tick(4), ComponentSyncModeFull(4.0));
         // we retrieve the most recent value older or equal to Tick(3)
         assert_eq!(
             component_history.pop_until_tick(Tick(3)),
-            Some(ComponentState::Updated(Component1(2.0)))
+            Some(ComponentState::Updated(ComponentSyncModeFull(2.0)))
         );
         assert_eq!(component_history.buffer.len(), 2);
         // check that the most recent value got added back to the buffer at the popped tick
@@ -349,7 +349,7 @@ mod tests {
             component_history.buffer.heap.peek(),
             Some(&ItemWithReadyKey {
                 key: Tick(2),
-                item: ComponentState::Updated(Component1(2.0))
+                item: ComponentState::Updated(ComponentSyncModeFull(2.0))
             })
         );
         assert!(component_history.buffer.has_item(&Tick(4)));
@@ -401,17 +401,17 @@ mod tests {
             .client_app
             .world_mut()
             .entity_mut(confirmed)
-            .insert(Component1(1.0));
+            .insert(ComponentSyncModeFull(1.0));
         stepper.frame_step();
         assert_eq!(
             stepper
                 .client_app
                 .world_mut()
                 .entity_mut(predicted)
-                .get_mut::<PredictionHistory<Component1>>()
+                .get_mut::<PredictionHistory<ComponentSyncModeFull>>()
                 .expect("Expected prediction history to be added")
                 .pop_until_tick(tick),
-            Some(ComponentState::Updated(Component1(1.0))),
+            Some(ComponentState::Updated(ComponentSyncModeFull(1.0))),
             "Expected component value to be added to prediction history"
         );
         assert_eq!(
@@ -419,9 +419,9 @@ mod tests {
                 .client_app
                 .world()
                 .entity(predicted)
-                .get::<Component1>()
+                .get::<ComponentSyncModeFull>()
                 .expect("Expected component to be added to predicted entity"),
-            &Component1(1.0),
+            &ComponentSyncModeFull(1.0),
             "Expected component to be added to predicted entity"
         );
 
@@ -431,17 +431,17 @@ mod tests {
             .client_app
             .world_mut()
             .entity_mut(predicted)
-            .insert(Component5(1.0));
+            .insert(ComponentSyncModeFull2(1.0));
         stepper.frame_step();
         assert_eq!(
             stepper
                 .client_app
                 .world_mut()
                 .entity_mut(predicted)
-                .get_mut::<PredictionHistory<Component5>>()
+                .get_mut::<PredictionHistory<ComponentSyncModeFull2>>()
                 .expect("Expected prediction history to be added")
                 .pop_until_tick(tick),
-            Some(ComponentState::Updated(Component5(1.0))),
+            Some(ComponentState::Updated(ComponentSyncModeFull2(1.0))),
             "Expected component value to be added to prediction history"
         );
         assert_eq!(
@@ -449,9 +449,9 @@ mod tests {
                 .client_app
                 .world()
                 .entity(predicted)
-                .get::<Component5>()
+                .get::<ComponentSyncModeFull2>()
                 .expect("Expected component to be added to predicted entity"),
-            &Component5(1.0),
+            &ComponentSyncModeFull2(1.0),
             "Expected component to be added to predicted entity"
         );
 
@@ -461,14 +461,14 @@ mod tests {
             .client_app
             .world_mut()
             .entity_mut(confirmed)
-            .insert(Component2(1.0));
+            .insert(ComponentSyncModeSimple(1.0));
         stepper.frame_step();
         assert!(
             stepper
                 .client_app
                 .world()
                 .entity(predicted)
-                .get::<PredictionHistory<Component2>>()
+                .get::<PredictionHistory<ComponentSyncModeSimple>>()
                 .is_none(),
             "Expected component value to not be added to prediction history for ComponentSyncMode::Simple"
         );
@@ -477,9 +477,9 @@ mod tests {
                 .client_app
                 .world()
                 .entity(predicted)
-                .get::<Component2>()
+                .get::<ComponentSyncModeSimple>()
                 .expect("Expected component to be added to predicted entity"),
-            &Component2(1.0),
+            &ComponentSyncModeSimple(1.0),
             "Expected component to be added to predicted entity"
         );
 
@@ -489,13 +489,13 @@ mod tests {
             .client_app
             .world_mut()
             .entity_mut(confirmed)
-            .insert(Component3(1.0));
+            .insert(ComponentSyncModeOnce(1.0));
         stepper.frame_step();
         assert!(
             stepper
                 .client_app
                 .world()                .entity(predicted)
-                .get::<PredictionHistory<Component3>>()
+                .get::<PredictionHistory<ComponentSyncModeOnce>>()
                 .is_none(),
             "Expected component value to not be added to prediction history for ComponentSyncMode::Once"
         );
@@ -504,9 +504,9 @@ mod tests {
                 .client_app
                 .world()
                 .entity(predicted)
-                .get::<Component3>()
+                .get::<ComponentSyncModeOnce>()
                 .expect("Expected component to be added to predicted entity"),
-            &Component3(1.0),
+            &ComponentSyncModeOnce(1.0),
             "Expected component to be added to predicted entity"
         );
     }
@@ -548,13 +548,13 @@ mod tests {
             .client_app
             .world_mut()
             .entity_mut(confirmed)
-            .insert(Component1(1.0));
+            .insert(ComponentSyncModeFull(1.0));
         stepper.frame_step();
         stepper
             .client_app
             .world_mut()
             .entity_mut(predicted)
-            .get_mut::<Component1>()
+            .get_mut::<ComponentSyncModeFull>()
             .unwrap()
             .0 = 2.0;
         stepper.frame_step();
@@ -564,10 +564,10 @@ mod tests {
                 .client_app
                 .world_mut()
                 .entity_mut(predicted)
-                .get_mut::<PredictionHistory<Component1>>()
+                .get_mut::<PredictionHistory<ComponentSyncModeFull>>()
                 .expect("Expected prediction history to be added")
                 .pop_until_tick(tick),
-            Some(ComponentState::Updated(Component1(2.0))),
+            Some(ComponentState::Updated(ComponentSyncModeFull(2.0))),
             "Expected component value to be updated in prediction history"
         );
 
@@ -576,13 +576,13 @@ mod tests {
             .client_app
             .world_mut()
             .entity_mut(confirmed)
-            .insert(Component2(1.0));
+            .insert(ComponentSyncModeSimple(1.0));
         stepper.frame_step();
         stepper
             .client_app
             .world_mut()
             .entity_mut(confirmed)
-            .get_mut::<Component2>()
+            .get_mut::<ComponentSyncModeSimple>()
             .unwrap()
             .0 = 2.0;
         let tick = stepper.client_tick();
@@ -592,9 +592,9 @@ mod tests {
                 .client_app
                 .world()
                 .entity(predicted)
-                .get::<Component2>()
+                .get::<ComponentSyncModeSimple>()
                 .expect("Expected component to be added to predicted entity"),
-            &Component2(2.0),
+            &ComponentSyncModeSimple(2.0),
             "Expected ComponentSyncMode::Simple component to be updated in predicted entity"
         );
 
@@ -603,7 +603,7 @@ mod tests {
             .client_app
             .world_mut()
             .entity_mut(predicted)
-            .remove::<Component1>();
+            .remove::<ComponentSyncModeFull>();
         stepper.frame_step();
         let tick = stepper.client_tick();
         assert_eq!(
@@ -611,7 +611,7 @@ mod tests {
                 .client_app
                 .world_mut()
                 .entity_mut(predicted)
-                .get_mut::<PredictionHistory<Component1>>()
+                .get_mut::<PredictionHistory<ComponentSyncModeFull>>()
                 .expect("Expected prediction history to be added")
                 .pop_until_tick(tick),
             Some(ComponentState::Removed),
@@ -623,7 +623,7 @@ mod tests {
             .client_app
             .world_mut()
             .entity_mut(confirmed)
-            .remove::<Component2>();
+            .remove::<ComponentSyncModeSimple>();
         let tick = stepper.client_tick();
         stepper.frame_step();
         assert!(
@@ -631,7 +631,7 @@ mod tests {
                 .client_app
                 .world()
                 .entity(predicted)
-                .get::<Component2>()
+                .get::<ComponentSyncModeSimple>()
                 .is_none(),
             "Expected component value to be removed from predicted entity"
         );
@@ -648,20 +648,20 @@ mod tests {
             .client_app
             .world_mut()
             .entity_mut(predicted)
-            .insert(Component1(3.0));
+            .insert(ComponentSyncModeFull(3.0));
         stepper
             .client_app
             .world_mut()
-            .run_system_once(update_prediction_history::<Component1>);
+            .run_system_once(update_prediction_history::<ComponentSyncModeFull>);
         assert_eq!(
             stepper
                 .client_app
                 .world_mut()
                 .entity_mut(predicted)
-                .get_mut::<PredictionHistory<Component1>>()
+                .get_mut::<PredictionHistory<ComponentSyncModeFull>>()
                 .expect("Expected prediction history to be added")
                 .pop_until_tick(rollback_tick),
-            Some(ComponentState::Updated(Component1(3.0))),
+            Some(ComponentState::Updated(ComponentSyncModeFull(3.0))),
             "Expected component value to be updated in prediction history"
         );
 
@@ -670,17 +670,17 @@ mod tests {
             .client_app
             .world_mut()
             .entity_mut(predicted)
-            .remove::<Component1>();
+            .remove::<ComponentSyncModeFull>();
         stepper
             .client_app
             .world_mut()
-            .run_system_once(update_prediction_history::<Component1>);
+            .run_system_once(update_prediction_history::<ComponentSyncModeFull>);
         assert_eq!(
             stepper
                 .client_app
                 .world_mut()
                 .entity_mut(predicted)
-                .get_mut::<PredictionHistory<Component1>>()
+                .get_mut::<PredictionHistory<ComponentSyncModeFull>>()
                 .expect("Expected prediction history to be added")
                 .pop_until_tick(rollback_tick),
             Some(ComponentState::Removed),

--- a/lightyear/src/client/prediction/prespawn.rs
+++ b/lightyear/src/client/prediction/prespawn.rs
@@ -463,12 +463,18 @@ mod tests {
         let entity_1 = stepper
             .client_app
             .world_mut()
-            .spawn((Component1(1.0), PreSpawnedPlayerObject::default()))
+            .spawn((
+                ComponentSyncModeFull(1.0),
+                PreSpawnedPlayerObject::default(),
+            ))
             .id();
         let entity_2 = stepper
             .client_app
             .world_mut()
-            .spawn((Component1(1.0), PreSpawnedPlayerObject::default()))
+            .spawn((
+                ComponentSyncModeFull(1.0),
+                PreSpawnedPlayerObject::default(),
+            ))
             .id();
         stepper.frame_step();
 
@@ -497,14 +503,14 @@ mod tests {
                 .client_app
                 .world()
                 .entity(entity_1)
-                .get::<PredictionHistory<Component1>>()
+                .get::<PredictionHistory<ComponentSyncModeFull>>()
                 .unwrap()
                 .buffer
                 .heap
                 .peek(),
             Some(&ItemWithReadyKey {
                 key: current_tick,
-                item: ComponentState::Updated(Component1(1.0)),
+                item: ComponentState::Updated(ComponentSyncModeFull(1.0)),
             })
         );
     }

--- a/lightyear/src/client/prediction/rollback.rs
+++ b/lightyear/src/client/prediction/rollback.rs
@@ -755,7 +755,6 @@ mod unit_tests {
 mod integration_tests {
     use super::test_utils::*;
 
-    use crate::client::prediction::predicted_history::PredictionHistory;
     use crate::prelude::client::*;
     use crate::tests::protocol::*;
     use crate::tests::stepper::{BevyStepper, Step};

--- a/lightyear/src/client/replication.rs
+++ b/lightyear/src/client/replication.rs
@@ -536,7 +536,7 @@ pub(crate) mod send {
         use crate::prelude::{
             server, ClientId, DisabledComponent, ReplicateOnceComponent, Replicated, TargetEntity,
         };
-        use crate::tests::protocol::Component1;
+        use crate::tests::protocol::ComponentSyncModeFull;
         use crate::tests::stepper::{BevyStepper, Step, TEST_CLIENT_ID};
 
         #[test]
@@ -754,7 +754,7 @@ pub(crate) mod send {
                 .client_app
                 .world_mut()
                 .entity_mut(client_entity)
-                .insert(Component1(1.0));
+                .insert(ComponentSyncModeFull(1.0));
             for _ in 0..10 {
                 stepper.frame_step();
             }
@@ -765,9 +765,9 @@ pub(crate) mod send {
                     .server_app
                     .world()
                     .entity(server_entity)
-                    .get::<Component1>()
+                    .get::<ComponentSyncModeFull>()
                     .expect("Component missing"),
-                &Component1(1.0)
+                &ComponentSyncModeFull(1.0)
             )
         }
 
@@ -802,7 +802,10 @@ pub(crate) mod send {
                 .client_app
                 .world_mut()
                 .entity_mut(client_entity)
-                .insert((Component1(1.0), DisabledComponent::<Component1>::default()));
+                .insert((
+                    ComponentSyncModeFull(1.0),
+                    DisabledComponent::<ComponentSyncModeFull>::default(),
+                ));
             for _ in 0..10 {
                 stepper.frame_step();
             }
@@ -812,7 +815,7 @@ pub(crate) mod send {
                 .server_app
                 .world()
                 .entity(server_entity)
-                .get::<Component1>()
+                .get::<ComponentSyncModeFull>()
                 .is_none());
         }
 
@@ -826,7 +829,7 @@ pub(crate) mod send {
             let client_entity = stepper
                 .client_app
                 .world_mut()
-                .spawn((Replicate::default(), Component1(1.0)))
+                .spawn((Replicate::default(), ComponentSyncModeFull(1.0)))
                 .id();
             for _ in 0..10 {
                 stepper.frame_step();
@@ -849,7 +852,7 @@ pub(crate) mod send {
                 .client_app
                 .world_mut()
                 .entity_mut(client_entity)
-                .insert(Component1(2.0));
+                .insert(ComponentSyncModeFull(2.0));
             for _ in 0..10 {
                 stepper.frame_step();
             }
@@ -860,9 +863,9 @@ pub(crate) mod send {
                     .server_app
                     .world()
                     .entity(server_entity)
-                    .get::<Component1>()
+                    .get::<ComponentSyncModeFull>()
                     .expect("Component missing"),
-                &Component1(2.0)
+                &ComponentSyncModeFull(2.0)
             )
         }
 
@@ -940,7 +943,7 @@ pub(crate) mod send {
             let client_entity = stepper
                 .client_app
                 .world_mut()
-                .spawn((Replicate::default(), Component1(1.0)))
+                .spawn((Replicate::default(), ComponentSyncModeFull(1.0)))
                 .id();
             for _ in 0..10 {
                 stepper.frame_step();
@@ -962,9 +965,9 @@ pub(crate) mod send {
                     .server_app
                     .world()
                     .entity(server_entity)
-                    .get::<Component1>()
+                    .get::<ComponentSyncModeFull>()
                     .expect("Component missing"),
-                &Component1(1.0)
+                &ComponentSyncModeFull(1.0)
             );
 
             // remove component
@@ -972,7 +975,7 @@ pub(crate) mod send {
                 .client_app
                 .world_mut()
                 .entity_mut(client_entity)
-                .remove::<Component1>();
+                .remove::<ComponentSyncModeFull>();
             for _ in 0..10 {
                 stepper.frame_step();
             }
@@ -982,7 +985,7 @@ pub(crate) mod send {
                 .server_app
                 .world()
                 .entity(server_entity)
-                .get::<Component1>()
+                .get::<ComponentSyncModeFull>()
                 .is_none());
         }
 
@@ -996,8 +999,8 @@ pub(crate) mod send {
                 .world_mut()
                 .spawn((
                     Replicate::default(),
-                    Component1(1.0),
-                    ReplicateOnceComponent::<Component1>::default(),
+                    ComponentSyncModeFull(1.0),
+                    ReplicateOnceComponent::<ComponentSyncModeFull>::default(),
                 ))
                 .id();
             for _ in 0..10 {
@@ -1021,7 +1024,7 @@ pub(crate) mod send {
                 .client_app
                 .world_mut()
                 .entity_mut(client_entity)
-                .insert(Component1(2.0));
+                .insert(ComponentSyncModeFull(2.0));
             for _ in 0..10 {
                 stepper.frame_step();
             }
@@ -1032,9 +1035,9 @@ pub(crate) mod send {
                     .server_app
                     .world()
                     .entity(server_entity)
-                    .get::<Component1>()
+                    .get::<ComponentSyncModeFull>()
                     .expect("Component missing"),
-                &Component1(1.0)
+                &ComponentSyncModeFull(1.0)
             )
         }
 
@@ -1046,7 +1049,7 @@ pub(crate) mod send {
             let client_entity = stepper
                 .client_app
                 .world_mut()
-                .spawn((Replicate::default(), Component1(1.0)))
+                .spawn((Replicate::default(), ComponentSyncModeFull(1.0)))
                 .id();
             for _ in 0..10 {
                 stepper.frame_step();
@@ -1069,7 +1072,10 @@ pub(crate) mod send {
                 .client_app
                 .world_mut()
                 .entity_mut(client_entity)
-                .insert((Component1(2.0), DisabledComponent::<Component1>::default()));
+                .insert((
+                    ComponentSyncModeFull(2.0),
+                    DisabledComponent::<ComponentSyncModeFull>::default(),
+                ));
             for _ in 0..10 {
                 stepper.frame_step();
             }
@@ -1080,9 +1086,9 @@ pub(crate) mod send {
                     .server_app
                     .world()
                     .entity(server_entity)
-                    .get::<Component1>()
+                    .get::<ComponentSyncModeFull>()
                     .expect("Component missing"),
-                &Component1(1.0)
+                &ComponentSyncModeFull(1.0)
             )
         }
     }

--- a/lightyear/src/client/sync.rs
+++ b/lightyear/src/client/sync.rs
@@ -576,7 +576,10 @@ mod tests {
     ) {
         input_manager.add_input(MyInput(0), tick_manager.tick());
     }
-    fn increment(mut query: Query<&mut Component1>, mut ev: EventReader<InputEvent<MyInput>>) {
+    fn increment(
+        mut query: Query<&mut ComponentSyncModeFull>,
+        mut ev: EventReader<InputEvent<MyInput>>,
+    ) {
         for _ in ev.read() {
             for mut c in query.iter_mut() {
                 c.0 += 1.0;
@@ -609,7 +612,7 @@ mod tests {
         let server_entity = stepper
             .server_app
             .world_mut()
-            .spawn((Component1(0.0), Replicate::default()))
+            .spawn((ComponentSyncModeFull(0.0), Replicate::default()))
             .id();
 
         // cross tick boundary
@@ -620,10 +623,13 @@ mod tests {
             .server_app
             .world_mut()
             .entity_mut(server_entity)
-            .insert(Component1(1.0));
+            .insert(ComponentSyncModeFull(1.0));
         dbg!(&stepper.server_tick());
         dbg!(&stepper.client_tick());
-        dbg!(&stepper.server_app.world().get::<Component1>(server_entity));
+        dbg!(&stepper
+            .server_app
+            .world()
+            .get::<ComponentSyncModeFull>(server_entity));
 
         // make sure the client receives the replication message
         for i in 0..5 {
@@ -642,9 +648,9 @@ mod tests {
             stepper
                 .client_app
                 .world()
-                .get::<Component1>(client_entity)
+                .get::<ComponentSyncModeFull>(client_entity)
                 .unwrap(),
-            &Component1(1.0)
+            &ComponentSyncModeFull(1.0)
         );
     }
 }

--- a/lightyear/src/protocol/delta.rs
+++ b/lightyear/src/protocol/delta.rs
@@ -93,16 +93,16 @@ impl ErasedDeltaFns {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tests::protocol::Component6;
+    use crate::tests::protocol::ComponentDeltaCompression;
 
     #[test]
     fn test_erased_clone() {
-        let erased_fns = ErasedDeltaFns::new::<Component6>();
-        let data = Component6(vec![1]);
+        let erased_fns = ErasedDeltaFns::new::<ComponentDeltaCompression>();
+        let data = ComponentDeltaCompression(vec![1]);
         // clone data
         let cloned = unsafe { (erased_fns.clone)(Ptr::from(&data)) };
         // cast the ptr to the original type
-        let casted = cloned.cast::<Component6>();
+        let casted = cloned.cast::<ComponentDeltaCompression>();
         assert_eq!(unsafe { casted.as_ref() }, &data);
         // free the leaked memory
         unsafe { (erased_fns.drop)(casted.cast()) };
@@ -124,9 +124,9 @@ mod tests {
 
     #[test]
     fn test_erased_diff() {
-        let erased_fns = ErasedDeltaFns::new::<Component6>();
-        let old_data = Component6(vec![1]);
-        let new_data = Component6(vec![1, 2]);
+        let erased_fns = ErasedDeltaFns::new::<ComponentDeltaCompression>();
+        let old_data = ComponentDeltaCompression(vec![1]);
+        let new_data = ComponentDeltaCompression(vec![1, 2]);
 
         let diff = old_data.diff(&new_data);
         assert_eq!(diff, vec![2]);
@@ -150,8 +150,8 @@ mod tests {
 
     #[test]
     fn test_erased_from_base_diff() {
-        let erased_fns = ErasedDeltaFns::new::<Component6>();
-        let new_data = Component6(vec![1, 2]);
+        let erased_fns = ErasedDeltaFns::new::<ComponentDeltaCompression>();
+        let new_data = ComponentDeltaCompression(vec![1, 2]);
         let delta = unsafe { (erased_fns.diff_from_base)(Ptr::from(&new_data)) };
         let casted = delta.cast::<DeltaMessage<Vec<usize>>>();
         let delta_message = unsafe { casted.as_ref() };
@@ -165,10 +165,10 @@ mod tests {
 
     #[test]
     fn test_apply_diff() {
-        let erased_fns = ErasedDeltaFns::new::<Component6>();
-        let mut old_data = Component6(vec![1]);
-        let diff: <Component6 as Diffable>::Delta = vec![2];
+        let erased_fns = ErasedDeltaFns::new::<ComponentDeltaCompression>();
+        let mut old_data = ComponentDeltaCompression(vec![1]);
+        let diff: <ComponentDeltaCompression as Diffable>::Delta = vec![2];
         unsafe { (erased_fns.apply_diff)(PtrMut::from(&mut old_data), Ptr::from(&diff)) };
-        assert_eq!(old_data, Component6(vec![1, 2]));
+        assert_eq!(old_data, ComponentDeltaCompression(vec![1, 2]));
     }
 }

--- a/lightyear/src/server/events.rs
+++ b/lightyear/src/server/events.rs
@@ -244,7 +244,9 @@ pub type MessageEvent<M> = crate::shared::events::components::MessageEvent<M, Cl
 mod tests {
     use crate::prelude::Tick;
     use crate::protocol::channel::ChannelKind;
-    use crate::tests::protocol::{Channel1, Channel2, Component1, Component3, Message1};
+    use crate::tests::protocol::{
+        Channel1, Channel2, ComponentSyncModeFull, ComponentSyncModeOnce, StringMessage,
+    };
 
     use super::*;
 
@@ -257,13 +259,13 @@ mod tests {
         let mut events_1 = ConnectionEvents::new();
         let channel_kind_1 = ChannelKind::of::<Channel1>();
         let channel_kind_2 = ChannelKind::of::<Channel2>();
-        let message1_a = Message1("hello".to_string());
-        let message1_b = Message1("world".to_string());
+        let message1_a = StringMessage("hello".to_string());
+        let message1_b = StringMessage("world".to_string());
         let mut component_registry = ComponentRegistry::default();
-        component_registry.register_component::<Component1>();
-        component_registry.register_component::<Component3>();
-        let net_id_1 = component_registry.net_id::<Component1>();
-        let net_id_2 = component_registry.net_id::<Component3>();
+        component_registry.register_component::<ComponentSyncModeFull>();
+        component_registry.register_component::<ComponentSyncModeOnce>();
+        let net_id_1 = component_registry.net_id::<ComponentSyncModeFull>();
+        let net_id_2 = component_registry.net_id::<ComponentSyncModeOnce>();
         events_1.push_remove_component(entity_1, net_id_1, Tick(0));
         events_1.push_remove_component(entity_1, net_id_2, Tick(0));
         events_1.push_remove_component(entity_2, net_id_1, Tick(0));
@@ -276,14 +278,14 @@ mod tests {
 
         // check that we have the correct messages
         let data: Vec<(Entity, ClientId)> = server_events
-            .iter_component_remove::<Component1>(&component_registry)
+            .iter_component_remove::<ComponentSyncModeFull>(&component_registry)
             .collect();
         assert_eq!(data.len(), 2);
         assert!(data.contains(&(entity_1, client_1)));
         assert!(data.contains(&(entity_2, client_1)));
 
         let data: Vec<(Entity, ClientId)> = server_events
-            .iter_component_remove::<Component3>(&component_registry)
+            .iter_component_remove::<ComponentSyncModeOnce>(&component_registry)
             .collect();
         assert_eq!(data.len(), 2);
         assert!(data.contains(&(entity_1, client_1)));

--- a/lightyear/src/server/message.rs
+++ b/lightyear/src/server/message.rs
@@ -182,7 +182,7 @@ pub(crate) fn add_server_receive_message_from_client<M: Message>(app: &mut App) 
 mod tests {
     use crate::prelude::ClientId;
     use crate::tests::host_server_stepper::{HostServerStepper, Step, LOCAL_CLIENT_ID};
-    use crate::tests::protocol::{Channel1, Message1};
+    use crate::tests::protocol::{Channel1, StringMessage};
     use bevy::app::Update;
     use bevy::prelude::{EventReader, ResMut, Resource};
 
@@ -192,7 +192,7 @@ mod tests {
     /// System to check that we received the message on the server
     fn count_messages(
         mut counter: ResMut<Counter>,
-        mut events: EventReader<crate::client::events::MessageEvent<Message1>>,
+        mut events: EventReader<crate::client::events::MessageEvent<StringMessage>>,
     ) {
         for event in events.read() {
             assert_eq!(event.message().0, "a".to_string());
@@ -216,9 +216,9 @@ mod tests {
             .server_app
             .world_mut()
             .resource_mut::<crate::prelude::server::ConnectionManager>()
-            .send_message::<Channel1, Message1>(
+            .send_message::<Channel1, StringMessage>(
                 ClientId::Local(LOCAL_CLIENT_ID),
-                &Message1("a".to_string()),
+                &StringMessage("a".to_string()),
             )
             .unwrap();
         stepper.frame_step();

--- a/lightyear/src/server/replication.rs
+++ b/lightyear/src/server/replication.rs
@@ -1140,7 +1140,11 @@ pub(crate) mod send {
         fn test_entity_spawn_preexisting_target() {
             let mut stepper = BevyStepper::default();
 
-            let client_entity = stepper.client_app.world_mut().spawn(Component1(1.0)).id();
+            let client_entity = stepper
+                .client_app
+                .world_mut()
+                .spawn(ComponentSyncModeFull(1.0))
+                .id();
             stepper.frame_step();
             let server_entity = stepper
                 .server_app
@@ -1173,7 +1177,7 @@ pub(crate) mod send {
             assert!(stepper
                 .client_app
                 .world()
-                .get::<Component1>(client_entity)
+                .get::<ComponentSyncModeFull>(client_entity)
                 .is_some());
         }
 
@@ -1474,7 +1478,7 @@ pub(crate) mod send {
                 .server_app
                 .world_mut()
                 .entity_mut(server_entity)
-                .insert(Component1(1.0));
+                .insert(ComponentSyncModeFull(1.0));
             stepper.frame_step();
             stepper.frame_step();
 
@@ -1484,9 +1488,9 @@ pub(crate) mod send {
                     .client_app
                     .world()
                     .entity(client_entity)
-                    .get::<Component1>()
+                    .get::<ComponentSyncModeFull>()
                     .expect("component missing"),
-                &Component1(1.0)
+                &ComponentSyncModeFull(1.0)
             );
         }
 
@@ -1517,7 +1521,7 @@ pub(crate) mod send {
                 .server_app
                 .world_mut()
                 .entity_mut(server_entity)
-                .insert(Component6(vec![3, 4]));
+                .insert(ComponentDeltaCompression(vec![3, 4]));
             stepper.frame_step();
             stepper.frame_step();
 
@@ -1527,9 +1531,9 @@ pub(crate) mod send {
                     .client_app
                     .world()
                     .entity(client_entity)
-                    .get::<Component6>()
+                    .get::<ComponentDeltaCompression>()
                     .expect("component missing"),
-                &Component6(vec![3, 4])
+                &ComponentDeltaCompression(vec![3, 4])
             );
         }
 
@@ -1543,8 +1547,8 @@ pub(crate) mod send {
                 .world_mut()
                 .spawn((
                     Replicate::default(),
-                    Component6(vec![1, 2]),
-                    DeltaCompression::<Component6>::default(),
+                    ComponentDeltaCompression(vec![1, 2]),
+                    DeltaCompression::<ComponentDeltaCompression>::default(),
                 ))
                 .id();
             stepper.frame_step();
@@ -1564,9 +1568,9 @@ pub(crate) mod send {
                     .client_app
                     .world()
                     .entity(client_entity)
-                    .get::<Component6>()
+                    .get::<ComponentDeltaCompression>()
                     .expect("component missing"),
-                &Component6(vec![1, 2])
+                &ComponentDeltaCompression(vec![1, 2])
             );
             // check that the component value was stored in the delta manager cache
             assert!(stepper
@@ -1578,7 +1582,7 @@ pub(crate) mod send {
                 .get_component_value(
                     server_entity,
                     tick,
-                    ComponentKind::of::<Component6>(),
+                    ComponentKind::of::<ComponentDeltaCompression>(),
                     ReplicationGroupId(server_entity.to_bits())
                 )
                 .is_some());
@@ -1618,7 +1622,7 @@ pub(crate) mod send {
                 .server_app
                 .world_mut()
                 .entity_mut(server_entity)
-                .insert(Component1(1.0));
+                .insert(ComponentSyncModeFull(1.0));
             stepper.frame_step();
             stepper.frame_step();
 
@@ -1628,9 +1632,9 @@ pub(crate) mod send {
                     .client_app
                     .world()
                     .entity(client_entity)
-                    .get::<Component1>()
+                    .get::<ComponentSyncModeFull>()
                     .expect("component missing"),
-                &Component1(1.0)
+                &ComponentSyncModeFull(1.0)
             );
         }
 
@@ -1656,7 +1660,7 @@ pub(crate) mod send {
                 .server_app
                 .world_mut()
                 .entity_mut(server_entity)
-                .insert(Component1(1.0));
+                .insert(ComponentSyncModeFull(1.0));
             stepper
                 .server_app
                 .world_mut()
@@ -1679,9 +1683,9 @@ pub(crate) mod send {
                     .client_app
                     .world()
                     .entity(client_entity)
-                    .get::<Component1>()
+                    .get::<ComponentSyncModeFull>()
                     .expect("component missing"),
-                &Component1(1.0)
+                &ComponentSyncModeFull(1.0)
             );
         }
 
@@ -1711,7 +1715,10 @@ pub(crate) mod send {
                 .server_app
                 .world_mut()
                 .entity_mut(server_entity)
-                .insert((Component1(1.0), DisabledComponent::<Component1>::default()));
+                .insert((
+                    ComponentSyncModeFull(1.0),
+                    DisabledComponent::<ComponentSyncModeFull>::default(),
+                ));
             stepper.frame_step();
             stepper.frame_step();
 
@@ -1720,7 +1727,7 @@ pub(crate) mod send {
                 .client_app
                 .world()
                 .entity(client_entity)
-                .get::<Component1>()
+                .get::<ComponentSyncModeFull>()
                 .is_none());
         }
 
@@ -1734,8 +1741,8 @@ pub(crate) mod send {
                 .world_mut()
                 .spawn((
                     Replicate::default(),
-                    Component1(1.0),
-                    OverrideTargetComponent::<Component1>::new(NetworkTarget::Single(
+                    ComponentSyncModeFull(1.0),
+                    OverrideTargetComponent::<ComponentSyncModeFull>::new(NetworkTarget::Single(
                         ClientId::Netcode(TEST_CLIENT_ID_1),
                     )),
                 ))
@@ -1765,15 +1772,15 @@ pub(crate) mod send {
                     .client_app_1
                     .world()
                     .entity(client_entity_1)
-                    .get::<Component1>()
+                    .get::<ComponentSyncModeFull>()
                     .expect("component missing"),
-                &Component1(1.0)
+                &ComponentSyncModeFull(1.0)
             );
             assert!(stepper
                 .client_app_2
                 .world()
                 .entity(client_entity_2)
-                .get::<Component1>()
+                .get::<ComponentSyncModeFull>()
                 .is_none());
         }
 
@@ -1793,9 +1800,9 @@ pub(crate) mod send {
                         relevance_mode: NetworkRelevanceMode::InterestManagement,
                         ..default()
                     },
-                    Component1(1.0),
+                    ComponentSyncModeFull(1.0),
                     // override target is only client 1
-                    OverrideTargetComponent::<Component1>::new(NetworkTarget::Single(
+                    OverrideTargetComponent::<ComponentSyncModeFull>::new(NetworkTarget::Single(
                         ClientId::Netcode(TEST_CLIENT_ID_1),
                     )),
                 ))
@@ -1832,15 +1839,15 @@ pub(crate) mod send {
                     .client_app_1
                     .world()
                     .entity(client_entity_1)
-                    .get::<Component1>()
+                    .get::<ComponentSyncModeFull>()
                     .expect("component missing"),
-                &Component1(1.0)
+                &ComponentSyncModeFull(1.0)
             );
             assert!(stepper
                 .client_app_2
                 .world()
                 .entity(client_entity_2)
-                .get::<Component1>()
+                .get::<ComponentSyncModeFull>()
                 .is_none());
         }
 
@@ -1852,7 +1859,7 @@ pub(crate) mod send {
             let server_entity = stepper
                 .server_app
                 .world_mut()
-                .spawn((Replicate::default(), Component1(1.0)))
+                .spawn((Replicate::default(), ComponentSyncModeFull(1.0)))
                 .id();
             stepper.frame_step();
             stepper.frame_step();
@@ -1870,7 +1877,7 @@ pub(crate) mod send {
                 .server_app
                 .world_mut()
                 .entity_mut(server_entity)
-                .insert(Component1(2.0));
+                .insert(ComponentSyncModeFull(2.0));
             stepper.frame_step();
             stepper.frame_step();
 
@@ -1880,9 +1887,9 @@ pub(crate) mod send {
                     .client_app
                     .world()
                     .entity(client_entity)
-                    .get::<Component1>()
+                    .get::<ComponentSyncModeFull>()
                     .expect("component missing"),
-                &Component1(2.0)
+                &ComponentSyncModeFull(2.0)
             );
         }
 
@@ -1894,7 +1901,7 @@ pub(crate) mod send {
             let server_entity = stepper
                 .server_app
                 .world_mut()
-                .spawn((Component1(0.0), Replicate::default()))
+                .spawn((ComponentSyncModeFull(0.0), Replicate::default()))
                 .id();
 
             // replicate to client
@@ -1923,7 +1930,7 @@ pub(crate) mod send {
                 .server_app
                 .world_mut()
                 .entity_mut(server_entity)
-                .insert(Component1(1.0));
+                .insert(ComponentSyncModeFull(1.0));
 
             // make sure the client receives the replication message
             stepper.frame_step();
@@ -1942,9 +1949,9 @@ pub(crate) mod send {
                 stepper
                     .client_app
                     .world()
-                    .get::<Component1>(client_entity)
+                    .get::<ComponentSyncModeFull>(client_entity)
                     .unwrap(),
-                &Component1(1.0)
+                &ComponentSyncModeFull(1.0)
             );
         }
 
@@ -1963,7 +1970,7 @@ pub(crate) mod send {
                             .set_send_frequency(Duration::from_millis(40)),
                         ..default()
                     },
-                    Component1(1.0),
+                    ComponentSyncModeFull(1.0),
                 ))
                 .id();
             stepper.frame_step();
@@ -1982,7 +1989,7 @@ pub(crate) mod send {
                 .server_app
                 .world_mut()
                 .entity_mut(server_entity)
-                .insert(Component1(2.0));
+                .insert(ComponentSyncModeFull(2.0));
             stepper.frame_step();
             stepper.frame_step();
 
@@ -1992,9 +1999,9 @@ pub(crate) mod send {
                     .client_app
                     .world()
                     .entity(client_entity)
-                    .get::<Component1>()
+                    .get::<ComponentSyncModeFull>()
                     .expect("component missing"),
-                &Component1(1.0)
+                &ComponentSyncModeFull(1.0)
             );
             // it has been 4 ticks, the component was updated
             stepper.frame_step();
@@ -2004,9 +2011,9 @@ pub(crate) mod send {
                     .client_app
                     .world()
                     .entity(client_entity)
-                    .get::<Component1>()
+                    .get::<ComponentSyncModeFull>()
                     .expect("component missing"),
-                &Component1(2.0)
+                &ComponentSyncModeFull(2.0)
             );
         }
 
@@ -2020,8 +2027,8 @@ pub(crate) mod send {
                 .world_mut()
                 .spawn((
                     Replicate::default(),
-                    Component6(vec![1, 2]),
-                    DeltaCompression::<Component6>::default(),
+                    ComponentDeltaCompression(vec![1, 2]),
+                    DeltaCompression::<ComponentDeltaCompression>::default(),
                 ))
                 .id();
             let group_id = ReplicationGroupId(server_entity.to_bits());
@@ -2042,9 +2049,9 @@ pub(crate) mod send {
                     .client_app
                     .world()
                     .entity(client_entity)
-                    .get::<Component6>()
+                    .get::<ComponentDeltaCompression>()
                     .expect("component missing"),
-                &Component6(vec![1, 2])
+                &ComponentDeltaCompression(vec![1, 2])
             );
             // check that the component value was stored in the delta manager cache
             assert!(stepper
@@ -2056,7 +2063,7 @@ pub(crate) mod send {
                 .get_component_value(
                     server_entity,
                     insert_tick,
-                    ComponentKind::of::<Component6>(),
+                    ComponentKind::of::<ComponentDeltaCompression>(),
                     group_id,
                 )
                 .is_some());
@@ -2066,7 +2073,7 @@ pub(crate) mod send {
                 .server_app
                 .world_mut()
                 .entity_mut(server_entity)
-                .get_mut::<Component6>()
+                .get_mut::<ComponentDeltaCompression>()
                 .unwrap()
                 .0 = vec![1, 2, 3];
             stepper.frame_step();
@@ -2081,7 +2088,7 @@ pub(crate) mod send {
                 .get_component_value(
                     server_entity,
                     insert_tick,
-                    ComponentKind::of::<Component6>(),
+                    ComponentKind::of::<ComponentDeltaCompression>(),
                     group_id,
                 )
                 .is_some());
@@ -2106,9 +2113,9 @@ pub(crate) mod send {
                     .client_app
                     .world()
                     .entity(client_entity)
-                    .get::<Component6>()
+                    .get::<ComponentDeltaCompression>()
                     .expect("component missing"),
-                &Component6(vec![1, 2, 3])
+                &ComponentDeltaCompression(vec![1, 2, 3])
             );
             // check that the component value for the update_tick was stored in the delta manager cache
             assert!(stepper
@@ -2120,7 +2127,7 @@ pub(crate) mod send {
                 .get_component_value(
                     server_entity,
                     update_tick,
-                    ComponentKind::of::<Component6>(),
+                    ComponentKind::of::<ComponentDeltaCompression>(),
                     group_id,
                 )
                 .is_some());
@@ -2135,7 +2142,7 @@ pub(crate) mod send {
                 .get_component_value(
                     server_entity,
                     insert_tick,
-                    ComponentKind::of::<Component6>(),
+                    ComponentKind::of::<ComponentDeltaCompression>(),
                     group_id,
                 )
                 .is_none());
@@ -2165,9 +2172,9 @@ pub(crate) mod send {
                 .world_mut()
                 .spawn((
                     Replicate::default(),
-                    Component1(1.0),
-                    Component6(vec![1, 2]),
-                    DeltaCompression::<Component6>::default(),
+                    ComponentSyncModeFull(1.0),
+                    ComponentDeltaCompression(vec![1, 2]),
+                    DeltaCompression::<ComponentDeltaCompression>::default(),
                 ))
                 .id();
             let group_id = ReplicationGroupId(server_entity.to_bits());
@@ -2189,9 +2196,9 @@ pub(crate) mod send {
                     .client_app
                     .world()
                     .entity(client_entity)
-                    .get::<Component6>()
+                    .get::<ComponentDeltaCompression>()
                     .expect("component missing"),
-                &Component6(vec![1, 2])
+                &ComponentDeltaCompression(vec![1, 2])
             );
             // check that the component value was stored in the delta manager cache
             assert!(stepper
@@ -2203,7 +2210,7 @@ pub(crate) mod send {
                 .get_component_value(
                     server_entity,
                     insert_tick,
-                    ComponentKind::of::<Component6>(),
+                    ComponentKind::of::<ComponentDeltaCompression>(),
                     group_id,
                 )
                 .is_some());
@@ -2213,7 +2220,7 @@ pub(crate) mod send {
                 .server_app
                 .world_mut()
                 .entity_mut(server_entity)
-                .get_mut::<Component1>()
+                .get_mut::<ComponentSyncModeFull>()
                 .unwrap()
                 .0 = 1.0;
             stepper.frame_step();
@@ -2224,7 +2231,7 @@ pub(crate) mod send {
                 .server_app
                 .world_mut()
                 .entity_mut(server_entity)
-                .get_mut::<Component6>()
+                .get_mut::<ComponentDeltaCompression>()
                 .unwrap()
                 .0 = vec![1, 2, 3];
             stepper.frame_step();
@@ -2239,7 +2246,7 @@ pub(crate) mod send {
                 .get_component_value(
                     server_entity,
                     insert_tick,
-                    ComponentKind::of::<Component6>(),
+                    ComponentKind::of::<ComponentDeltaCompression>(),
                     group_id,
                 )
                 .is_some());
@@ -2264,9 +2271,9 @@ pub(crate) mod send {
                     .client_app
                     .world()
                     .entity(client_entity)
-                    .get::<Component6>()
+                    .get::<ComponentDeltaCompression>()
                     .expect("component missing"),
-                &Component6(vec![1, 2, 3])
+                &ComponentDeltaCompression(vec![1, 2, 3])
             );
             // check that the component value for the update_tick was stored in the delta manager cache
             assert!(stepper
@@ -2278,7 +2285,7 @@ pub(crate) mod send {
                 .get_component_value(
                     server_entity,
                     update_tick,
-                    ComponentKind::of::<Component6>(),
+                    ComponentKind::of::<ComponentDeltaCompression>(),
                     group_id,
                 )
                 .is_some());
@@ -2293,7 +2300,7 @@ pub(crate) mod send {
                 .get_component_value(
                     server_entity,
                     insert_tick,
-                    ComponentKind::of::<Component6>(),
+                    ComponentKind::of::<ComponentDeltaCompression>(),
                     group_id,
                 )
                 .is_none());
@@ -2350,8 +2357,8 @@ pub(crate) mod send {
                 .world_mut()
                 .spawn((
                     Replicate::default(),
-                    Component6(vec![1, 2]),
-                    DeltaCompression::<Component6>::default(),
+                    ComponentDeltaCompression(vec![1, 2]),
+                    DeltaCompression::<ComponentDeltaCompression>::default(),
                 ))
                 .id();
             let group_id = ReplicationGroupId(server_entity.to_bits());
@@ -2372,9 +2379,9 @@ pub(crate) mod send {
                     .client_app
                     .world()
                     .entity(client_entity)
-                    .get::<Component6>()
+                    .get::<ComponentDeltaCompression>()
                     .expect("component missing"),
-                &Component6(vec![1, 2])
+                &ComponentDeltaCompression(vec![1, 2])
             );
             // apply update (we haven't received the ack from the client so our diff should be
             // from the base value, aka [2, 3])
@@ -2382,7 +2389,7 @@ pub(crate) mod send {
                 .server_app
                 .world_mut()
                 .entity_mut(server_entity)
-                .get_mut::<Component6>()
+                .get_mut::<ComponentDeltaCompression>()
                 .unwrap()
                 .0 = vec![1, 2, 3];
             stepper.frame_step();
@@ -2409,9 +2416,9 @@ pub(crate) mod send {
                     .client_app
                     .world()
                     .entity(client_entity)
-                    .get::<Component6>()
+                    .get::<ComponentDeltaCompression>()
                     .expect("component missing"),
-                &Component6(vec![1, 2, 3])
+                &ComponentDeltaCompression(vec![1, 2, 3])
             );
             // the insert_tick message hasn't been acked yet
             assert_eq!(
@@ -2446,7 +2453,7 @@ pub(crate) mod send {
                 .server_app
                 .world_mut()
                 .entity_mut(server_entity)
-                .get_mut::<Component6>()
+                .get_mut::<ComponentDeltaCompression>()
                 .unwrap()
                 .0 = vec![1, 2, 3, 4];
             stepper.frame_step();
@@ -2457,7 +2464,7 @@ pub(crate) mod send {
                 .server_app
                 .world_mut()
                 .entity_mut(server_entity)
-                .get_mut::<Component6>()
+                .get_mut::<ComponentDeltaCompression>()
                 .unwrap()
                 .0 = vec![1, 2, 3, 4, 5];
             stepper.frame_step();
@@ -2467,9 +2474,9 @@ pub(crate) mod send {
                     .client_app
                     .world()
                     .entity(client_entity)
-                    .get::<Component6>()
+                    .get::<ComponentDeltaCompression>()
                     .expect("component missing"),
-                &Component6(vec![1, 2, 3, 4])
+                &ComponentDeltaCompression(vec![1, 2, 3, 4])
             );
             stepper.frame_step();
             // the client receives the second update, it still works well because we apply the diff
@@ -2479,9 +2486,9 @@ pub(crate) mod send {
                     .client_app
                     .world()
                     .entity(client_entity)
-                    .get::<Component6>()
+                    .get::<ComponentDeltaCompression>()
                     .expect("component missing"),
-                &Component6(vec![1, 2, 3, 4, 5])
+                &ComponentDeltaCompression(vec![1, 2, 3, 4, 5])
             );
         }
 
@@ -2522,8 +2529,8 @@ pub(crate) mod send {
                 .world_mut()
                 .spawn((
                     Replicate::default(),
-                    Component7(HashSet::from([1])),
-                    DeltaCompression::<Component7>::default(),
+                    ComponentDeltaCompression2(HashSet::from([1])),
+                    DeltaCompression::<ComponentDeltaCompression2>::default(),
                 ))
                 .id();
             let group_id = ReplicationGroupId(server_entity.to_bits());
@@ -2534,7 +2541,7 @@ pub(crate) mod send {
                 .server_app
                 .world_mut()
                 .entity_mut(server_entity)
-                .get_mut::<Component7>()
+                .get_mut::<ComponentDeltaCompression2>()
                 .unwrap()
                 .0 = HashSet::from([2]);
             // replicate and make sure that the server received the client ack
@@ -2558,9 +2565,9 @@ pub(crate) mod send {
                     .client_app
                     .world()
                     .entity(client_entity)
-                    .get::<Component7>()
+                    .get::<ComponentDeltaCompression2>()
                     .expect("component missing"),
-                &Component7(HashSet::from([2]))
+                &ComponentDeltaCompression2(HashSet::from([2]))
             );
             // check that the server received an ack
             assert!(stepper
@@ -2578,7 +2585,7 @@ pub(crate) mod send {
                 .server_app
                 .world_mut()
                 .entity_mut(server_entity)
-                .get_mut::<Component7>()
+                .get_mut::<ComponentDeltaCompression2>()
                 .unwrap()
                 .0 = HashSet::from([3]);
             stepper.frame_step();
@@ -2588,7 +2595,7 @@ pub(crate) mod send {
                 .server_app
                 .world_mut()
                 .entity_mut(server_entity)
-                .get_mut::<Component7>()
+                .get_mut::<ComponentDeltaCompression2>()
                 .unwrap()
                 .0 = HashSet::from([4]);
             stepper.frame_step();
@@ -2598,9 +2605,9 @@ pub(crate) mod send {
                     .client_app
                     .world()
                     .entity(client_entity)
-                    .get::<Component7>()
+                    .get::<ComponentDeltaCompression2>()
                     .expect("component missing"),
-                &Component7(HashSet::from([3]))
+                &ComponentDeltaCompression2(HashSet::from([3]))
             );
             stepper.frame_step();
             // the client receives the second update, and it still works well because we apply the diff
@@ -2610,9 +2617,9 @@ pub(crate) mod send {
                     .client_app
                     .world()
                     .entity(client_entity)
-                    .get::<Component7>()
+                    .get::<ComponentDeltaCompression2>()
                     .expect("component missing"),
-                &Component7(HashSet::from([4]))
+                &ComponentDeltaCompression2(HashSet::from([4]))
             );
             // check that the history still contains the component for the component update
             // (because we only purge when we receive a strictly more recent tick)
@@ -2620,7 +2627,7 @@ pub(crate) mod send {
                 .client_app
                 .world()
                 .entity(client_entity)
-                .get::<DeltaComponentHistory<Component7>>()
+                .get::<DeltaComponentHistory<ComponentDeltaCompression2>>()
                 .expect("component missing")
                 .buffer
                 .contains_key(&update_tick));
@@ -2629,7 +2636,7 @@ pub(crate) mod send {
                 .client_app
                 .world()
                 .entity(client_entity)
-                .get::<DeltaComponentHistory<Component7>>()
+                .get::<DeltaComponentHistory<ComponentDeltaCompression2>>()
                 .expect("component missing")
                 .buffer
                 .contains_key(&insert_tick));
@@ -2645,7 +2652,7 @@ pub(crate) mod send {
             let server_entity = stepper
                 .server_app
                 .world_mut()
-                .spawn((Replicate::default(), Component1(1.0)))
+                .spawn((Replicate::default(), ComponentSyncModeFull(1.0)))
                 .id();
             stepper.frame_step();
             stepper.frame_step();
@@ -2663,7 +2670,7 @@ pub(crate) mod send {
                 .server_app
                 .world_mut()
                 .entity_mut(server_entity)
-                .insert(Component1(2.0))
+                .insert(ComponentSyncModeFull(2.0))
                 .remove::<ReplicationTarget>();
             stepper.frame_step();
             stepper.frame_step();
@@ -2674,9 +2681,9 @@ pub(crate) mod send {
                     .client_app
                     .world()
                     .entity(client_entity)
-                    .get::<Component1>()
+                    .get::<ComponentSyncModeFull>()
                     .expect("component missing"),
-                &Component1(1.0)
+                &ComponentSyncModeFull(1.0)
             );
 
             // re-add the replication_target component
@@ -2693,9 +2700,9 @@ pub(crate) mod send {
                     .client_app
                     .world()
                     .entity(client_entity)
-                    .get::<Component1>()
+                    .get::<ComponentSyncModeFull>()
                     .expect("component missing"),
-                &Component1(2.0)
+                &ComponentSyncModeFull(2.0)
             );
         }
 
@@ -2707,7 +2714,7 @@ pub(crate) mod send {
             let server_entity = stepper
                 .server_app
                 .world_mut()
-                .spawn((Replicate::default(), Component1(1.0)))
+                .spawn((Replicate::default(), ComponentSyncModeFull(1.0)))
                 .id();
             stepper.frame_step();
             stepper.frame_step();
@@ -2725,7 +2732,10 @@ pub(crate) mod send {
                 .server_app
                 .world_mut()
                 .entity_mut(server_entity)
-                .insert((Component1(2.0), DisabledComponent::<Component1>::default()));
+                .insert((
+                    ComponentSyncModeFull(2.0),
+                    DisabledComponent::<ComponentSyncModeFull>::default(),
+                ));
             stepper.frame_step();
             stepper.frame_step();
 
@@ -2735,9 +2745,9 @@ pub(crate) mod send {
                     .client_app
                     .world()
                     .entity(client_entity)
-                    .get::<Component1>()
+                    .get::<ComponentSyncModeFull>()
                     .expect("component missing"),
-                &Component1(1.0)
+                &ComponentSyncModeFull(1.0)
             );
         }
 
@@ -2751,8 +2761,8 @@ pub(crate) mod send {
                 .world_mut()
                 .spawn((
                     Replicate::default(),
-                    Component1(1.0),
-                    ReplicateOnceComponent::<Component1>::default(),
+                    ComponentSyncModeFull(1.0),
+                    ReplicateOnceComponent::<ComponentSyncModeFull>::default(),
                 ))
                 .id();
             stepper.frame_step();
@@ -2771,9 +2781,9 @@ pub(crate) mod send {
                     .client_app
                     .world()
                     .entity(client_entity)
-                    .get::<Component1>()
+                    .get::<ComponentSyncModeFull>()
                     .expect("component missing"),
-                &Component1(1.0)
+                &ComponentSyncModeFull(1.0)
             );
 
             // update component
@@ -2781,7 +2791,7 @@ pub(crate) mod send {
                 .server_app
                 .world_mut()
                 .entity_mut(server_entity)
-                .insert(Component1(2.0));
+                .insert(ComponentSyncModeFull(2.0));
             stepper.frame_step();
             stepper.frame_step();
 
@@ -2791,9 +2801,9 @@ pub(crate) mod send {
                     .client_app
                     .world()
                     .entity(client_entity)
-                    .get::<Component1>()
+                    .get::<ComponentSyncModeFull>()
                     .expect("component missing"),
-                &Component1(1.0)
+                &ComponentSyncModeFull(1.0)
             );
         }
 
@@ -2805,7 +2815,7 @@ pub(crate) mod send {
             let server_entity = stepper
                 .server_app
                 .world_mut()
-                .spawn((Replicate::default(), Component1(1.0)))
+                .spawn((Replicate::default(), ComponentSyncModeFull(1.0)))
                 .id();
             stepper.frame_step();
             stepper.frame_step();
@@ -2822,9 +2832,9 @@ pub(crate) mod send {
                     .client_app
                     .world()
                     .entity(client_entity)
-                    .get::<Component1>()
+                    .get::<ComponentSyncModeFull>()
                     .expect("component missing"),
-                &Component1(1.0)
+                &ComponentSyncModeFull(1.0)
             );
 
             // remove component
@@ -2832,7 +2842,7 @@ pub(crate) mod send {
                 .server_app
                 .world_mut()
                 .entity_mut(server_entity)
-                .remove::<Component1>();
+                .remove::<ComponentSyncModeFull>();
             stepper.frame_step();
             stepper.frame_step();
 
@@ -2841,7 +2851,7 @@ pub(crate) mod send {
                 .client_app
                 .world()
                 .entity(client_entity)
-                .get::<Component1>()
+                .get::<ComponentSyncModeFull>()
                 .is_none());
         }
 
@@ -2901,7 +2911,7 @@ pub(crate) mod send {
 
             stepper.client_app.add_systems(
                 Update,
-                |mut events: EventReader<ComponentUpdateEvent<Component1>>| {
+                |mut events: EventReader<ComponentUpdateEvent<ComponentSyncModeFull>>| {
                     if let Some(event) = events.read().next() {
                         panic!(
                             "ComponentUpdateEvent received for entity: {:?}",
@@ -2912,9 +2922,17 @@ pub(crate) mod send {
             );
 
             // spawn an entity on server
-            let server_entity = stepper.server_app.world_mut().spawn(Component1(1.0)).id();
+            let server_entity = stepper
+                .server_app
+                .world_mut()
+                .spawn(ComponentSyncModeFull(1.0))
+                .id();
             // spawn an entity on the client with the component value
-            let client_entity = stepper.client_app.world_mut().spawn(Component1(1.0)).id();
+            let client_entity = stepper
+                .client_app
+                .world_mut()
+                .spawn(ComponentSyncModeFull(1.0))
+                .id();
 
             // add replication with a pre-existing target
             stepper
@@ -2942,14 +2960,22 @@ pub(crate) mod send {
             let mut stepper = BevyStepper::default();
 
             // spawn an entity on server
-            let server_entity = stepper.server_app.world_mut().spawn(Component1(2.0)).id();
+            let server_entity = stepper
+                .server_app
+                .world_mut()
+                .spawn(ComponentSyncModeFull(2.0))
+                .id();
             // spawn an entity on the client with the component value
-            let client_entity = stepper.client_app.world_mut().spawn(Component1(1.0)).id();
+            let client_entity = stepper
+                .client_app
+                .world_mut()
+                .spawn(ComponentSyncModeFull(1.0))
+                .id();
 
             stepper.client_app.init_resource::<Counter>();
             stepper.client_app.add_systems(
                 Update,
-                move |mut events: EventReader<ComponentUpdateEvent<Component1>>,
+                move |mut events: EventReader<ComponentUpdateEvent<ComponentSyncModeFull>>,
                       mut counter: ResMut<Counter>| {
                     for events in events.read() {
                         counter.0 += 1;
@@ -3025,14 +3051,14 @@ pub(crate) mod commands {
             let entity = stepper
                 .server_app
                 .world_mut()
-                .spawn((Component1(1.0), Replicate::default()))
+                .spawn((ComponentSyncModeFull(1.0), Replicate::default()))
                 .id();
             stepper.frame_step();
             stepper.frame_step();
             let client_entity = stepper
                 .client_app
                 .world_mut()
-                .query_filtered::<Entity, With<Component1>>()
+                .query_filtered::<Entity, With<ComponentSyncModeFull>>()
                 .get_single(stepper.client_app.world())
                 .unwrap();
 
@@ -3050,7 +3076,7 @@ pub(crate) mod commands {
             assert!(stepper
                 .client_app
                 .world_mut()
-                .query::<&Component1>()
+                .query::<&ComponentSyncModeFull>()
                 .get_single(stepper.client_app.world())
                 .is_err());
 
@@ -3058,14 +3084,14 @@ pub(crate) mod commands {
             let entity = stepper
                 .server_app
                 .world_mut()
-                .spawn((Component1(1.0), Replicate::default()))
+                .spawn((ComponentSyncModeFull(1.0), Replicate::default()))
                 .id();
             stepper.frame_step();
             stepper.frame_step();
             assert!(stepper
                 .client_app
                 .world_mut()
-                .query::<&Component1>()
+                .query::<&ComponentSyncModeFull>()
                 .get_single(stepper.client_app.world())
                 .is_ok());
 
@@ -3077,7 +3103,7 @@ pub(crate) mod commands {
             assert!(stepper
                 .client_app
                 .world_mut()
-                .query::<&Component1>()
+                .query::<&ComponentSyncModeFull>()
                 .get_single(stepper.client_app.world())
                 .is_ok());
         }

--- a/lightyear/src/shared/replication/delta.rs
+++ b/lightyear/src/shared/replication/delta.rs
@@ -220,44 +220,44 @@ impl DeltaComponentStore {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tests::protocol::Component6;
+    use crate::tests::protocol::ComponentDeltaCompression;
 
     #[test]
     fn test_add_get_data() {
         let mut registry = ComponentRegistry::default();
-        registry.register_component::<Component6>();
-        registry.set_delta_compression::<Component6>();
+        registry.register_component::<ComponentDeltaCompression>();
+        registry.set_delta_compression::<ComponentDeltaCompression>();
         let mut store = DeltaComponentStore::default();
         let entity = Entity::from_raw(0);
         let tick = Tick(0);
         let replication_group = ReplicationGroupId(0);
-        let component = Component6(vec![1, 2]);
+        let component = ComponentDeltaCompression(vec![1, 2]);
         let ptr = Ptr::from(&component);
-        let kind = ComponentKind::of::<Component6>();
+        let kind = ComponentKind::of::<ComponentDeltaCompression>();
 
         store.store_component_value(entity, tick, kind, ptr, replication_group, &registry);
 
         let retrieved = store
             .get_component_value(entity, tick, kind, replication_group)
             .unwrap();
-        let retrieved_component = unsafe { retrieved.deref::<Component6>() };
+        let retrieved_component = unsafe { retrieved.deref::<ComponentDeltaCompression>() };
         assert_eq!(retrieved_component, &component);
     }
 
     #[test]
     fn test_delete_old_data() {
         let mut registry = ComponentRegistry::default();
-        registry.register_component::<Component6>();
-        registry.set_delta_compression::<Component6>();
+        registry.register_component::<ComponentDeltaCompression>();
+        registry.set_delta_compression::<ComponentDeltaCompression>();
         let mut store = DeltaComponentStore::default();
         let entity = Entity::from_raw(0);
         let tick_1 = Tick(1);
         let tick_2 = Tick(2);
         let tick_3 = Tick(3);
         let replication_group = ReplicationGroupId(0);
-        let component = Component6(vec![1, 2]);
+        let component = ComponentDeltaCompression(vec![1, 2]);
         let ptr = Ptr::from(&component);
-        let kind = ComponentKind::of::<Component6>();
+        let kind = ComponentKind::of::<ComponentDeltaCompression>();
 
         store.store_component_value(entity, tick_1, kind, ptr, replication_group, &registry);
         store.store_component_value(entity, tick_2, kind, ptr, replication_group, &registry);
@@ -271,12 +271,12 @@ mod tests {
         let retrieved = store
             .get_component_value(entity, tick_2, kind, replication_group)
             .unwrap();
-        let retrieved_component = unsafe { retrieved.deref::<Component6>() };
+        let retrieved_component = unsafe { retrieved.deref::<ComponentDeltaCompression>() };
         assert_eq!(retrieved_component, &component);
         let retrieved = store
             .get_component_value(entity, tick_3, kind, replication_group)
             .unwrap();
-        let retrieved_component = unsafe { retrieved.deref::<Component6>() };
+        let retrieved_component = unsafe { retrieved.deref::<ComponentDeltaCompression>() };
         assert_eq!(retrieved_component, &component);
     }
 }

--- a/lightyear/src/shared/replication/entity_map.rs
+++ b/lightyear/src/shared/replication/entity_map.rs
@@ -136,7 +136,7 @@ mod tests {
         let server_entity = stepper
             .server_app
             .world_mut()
-            .spawn((Component1(0.0), Replicate::default()))
+            .spawn((ComponentSyncModeFull(0.0), Replicate::default()))
             .id();
         // we need to step twice because we run client before server
         stepper.frame_step();
@@ -156,16 +156,16 @@ mod tests {
                 .client_app
                 .world()
                 .entity(client_entity)
-                .get::<Component1>()
+                .get::<ComponentSyncModeFull>()
                 .unwrap(),
-            &Component1(0.0)
+            &ComponentSyncModeFull(0.0)
         );
 
         // Create an entity with a component that needs to be mapped
         let server_entity_2 = stepper
             .server_app
             .world_mut()
-            .spawn((Component4(server_entity), Replicate::default()))
+            .spawn((ComponentMapEntities(server_entity), Replicate::default()))
             .id();
         stepper.frame_step();
         stepper.frame_step();
@@ -185,9 +185,9 @@ mod tests {
                 .client_app
                 .world()
                 .entity(client_entity_2)
-                .get::<Component4>()
+                .get::<ComponentMapEntities>()
                 .unwrap(),
-            &Component4(client_entity)
+            &ComponentMapEntities(client_entity)
         );
     }
 }

--- a/lightyear/src/shared/replication/hierarchy.rs
+++ b/lightyear/src/shared/replication/hierarchy.rs
@@ -254,17 +254,21 @@ mod tests {
 
     fn setup_hierarchy() -> (BevyStepper, Entity, Entity, Entity) {
         let mut stepper = BevyStepper::default();
-        let child = stepper.server_app.world_mut().spawn(Component3(0.0)).id();
+        let child = stepper
+            .server_app
+            .world_mut()
+            .spawn(ComponentSyncModeOnce(0.0))
+            .id();
         let parent = stepper
             .server_app
             .world_mut()
-            .spawn(Component2(0.0))
+            .spawn(ComponentSyncModeSimple(0.0))
             .add_child(child)
             .id();
         let grandparent = stepper
             .server_app
             .world_mut()
-            .spawn(Component1(0.0))
+            .spawn(ComponentSyncModeFull(0.0))
             .add_child(parent)
             .id();
         (stepper, grandparent, parent, child)
@@ -298,13 +302,13 @@ mod tests {
         let client_grandparent = stepper
             .client_app
             .world_mut()
-            .query_filtered::<Entity, With<Component1>>()
+            .query_filtered::<Entity, With<ComponentSyncModeFull>>()
             .get_single(stepper.client_app.world())
             .unwrap();
         let (client_parent, client_parent_sync, client_parent_component) = stepper
             .client_app
             .world_mut()
-            .query_filtered::<(Entity, &ParentSync, &Parent), With<Component2>>()
+            .query_filtered::<(Entity, &ParentSync, &Parent), With<ComponentSyncModeSimple>>()
             .get_single(stepper.client_app.world())
             .unwrap();
 
@@ -374,19 +378,19 @@ mod tests {
         let client_grandparent = stepper
             .client_app
             .world_mut()
-            .query_filtered::<Entity, With<Component1>>()
+            .query_filtered::<Entity, With<ComponentSyncModeFull>>()
             .get_single(stepper.client_app.world())
             .unwrap();
         let client_parent = stepper
             .client_app
             .world_mut()
-            .query_filtered::<Entity, With<Component2>>()
+            .query_filtered::<Entity, With<ComponentSyncModeSimple>>()
             .get_single(stepper.client_app.world())
             .unwrap();
         let client_child = stepper
             .client_app
             .world_mut()
-            .query_filtered::<Entity, With<Component3>>()
+            .query_filtered::<Entity, With<ComponentSyncModeOnce>>()
             .get_single(stepper.client_app.world())
             .unwrap();
 
@@ -434,11 +438,15 @@ mod tests {
     #[test]
     fn test_propagate_hierarchy_client_to_server() {
         let mut stepper = BevyStepper::default();
-        let child = stepper.client_app.world_mut().spawn(Component3(0.0)).id();
+        let child = stepper
+            .client_app
+            .world_mut()
+            .spawn(ComponentSyncModeOnce(0.0))
+            .id();
         let parent = stepper
             .client_app
             .world_mut()
-            .spawn((Component2(0.0), client::Replicate::default()))
+            .spawn((ComponentSyncModeSimple(0.0), client::Replicate::default()))
             .add_child(child)
             .id();
 
@@ -450,13 +458,13 @@ mod tests {
         let server_parent = stepper
             .server_app
             .world_mut()
-            .query_filtered::<Entity, With<Component2>>()
+            .query_filtered::<Entity, With<ComponentSyncModeSimple>>()
             .get_single(stepper.server_app.world())
             .expect("parent entity was not replicated");
         let server_child = stepper
             .server_app
             .world_mut()
-            .query_filtered::<Entity, With<Component3>>()
+            .query_filtered::<Entity, With<ComponentSyncModeOnce>>()
             .get_single(stepper.server_app.world())
             .expect("child entity was not replicated");
         assert_eq!(

--- a/lightyear/src/shared/replication/send.rs
+++ b/lightyear/src/shared/replication/send.rs
@@ -770,7 +770,7 @@ mod tests {
     use crate::prelude::ClientId;
     use crate::server::connection::ConnectionManager;
 
-    use crate::tests::protocol::Component1;
+    use crate::tests::protocol::ComponentSyncModeFull;
     use crate::tests::stepper::{BevyStepper, Step, TEST_CLIENT_ID};
     use bevy::prelude::*;
 
@@ -859,7 +859,7 @@ mod tests {
         let server_entity = stepper
             .server_app
             .world_mut()
-            .spawn((Component1(1.0), Replicate::default()))
+            .spawn((ComponentSyncModeFull(1.0), Replicate::default()))
             .id();
         stepper.frame_step();
 
@@ -868,7 +868,7 @@ mod tests {
             .server_app
             .world_mut()
             .entity_mut(server_entity)
-            .get_mut::<Component1>()
+            .get_mut::<ComponentSyncModeFull>()
             .unwrap()
             .0 = 2.0;
         stepper.frame_step();

--- a/lightyear/src/tests/integration/tick_wrapping.rs
+++ b/lightyear/src/tests/integration/tick_wrapping.rs
@@ -11,7 +11,10 @@ use bevy::utils::Duration;
 fn press_input(mut input_manager: ResMut<InputManager<MyInput>>, tick_manager: Res<TickManager>) {
     input_manager.add_input(MyInput(0), tick_manager.tick());
 }
-fn increment(mut query: Query<&mut Component1>, mut ev: EventReader<InputEvent<MyInput>>) {
+fn increment(
+    mut query: Query<&mut ComponentSyncModeFull>,
+    mut ev: EventReader<InputEvent<MyInput>>,
+) {
     for _ in ev.read() {
         for mut c in query.iter_mut() {
             c.0 += 1.0;
@@ -49,7 +52,7 @@ fn test_sync_after_tick_wrap() {
     let server_entity = stepper
         .server_app
         .world_mut()
-        .spawn((Component1(0.0), Replicate::default()))
+        .spawn((ComponentSyncModeFull(0.0), Replicate::default()))
         .id();
 
     // advance 200 ticks to wrap ticks around u16::MAX
@@ -62,7 +65,7 @@ fn test_sync_after_tick_wrap() {
         .server_app
         .world_mut()
         .entity_mut(server_entity)
-        .insert(Component1(1.0));
+        .insert(ComponentSyncModeFull(1.0));
 
     // make sure the client receives the replication message
     for i in 0..5 {
@@ -81,9 +84,9 @@ fn test_sync_after_tick_wrap() {
         stepper
             .client_app
             .world()
-            .get::<Component1>(client_entity)
+            .get::<ComponentSyncModeFull>(client_entity)
             .unwrap(),
-        &Component1(1.0)
+        &ComponentSyncModeFull(1.0)
     );
 }
 
@@ -116,7 +119,7 @@ fn test_sync_after_tick_half_wrap() {
     let server_entity = stepper
         .server_app
         .world_mut()
-        .spawn((Component1(0.0), Replicate::default()))
+        .spawn((ComponentSyncModeFull(0.0), Replicate::default()))
         .id();
 
     for i in 0..200 {
@@ -126,13 +129,13 @@ fn test_sync_after_tick_half_wrap() {
         .server_app
         .world_mut()
         .entity_mut(server_entity)
-        .insert(Component1(1.0));
+        .insert(ComponentSyncModeFull(1.0));
     // dbg!(&stepper.server_tick());
     // dbg!(&stepper.client_tick());
     let server_value = stepper
         .server_app
         .world()
-        .get::<Component1>(server_entity)
+        .get::<ComponentSyncModeFull>(server_entity)
         .unwrap();
 
     // make sure the client receives the replication message
@@ -152,8 +155,8 @@ fn test_sync_after_tick_half_wrap() {
         stepper
             .client_app
             .world()
-            .get::<Component1>(client_entity)
+            .get::<ComponentSyncModeFull>(client_entity)
             .unwrap(),
-        &Component1(1.0)
+        &ComponentSyncModeFull(1.0)
     );
 }

--- a/lightyear/src/utils/ready_buffer.rs
+++ b/lightyear/src/utils/ready_buffer.rs
@@ -7,12 +7,20 @@ use std::{cmp::Ordering, collections::BinaryHeap};
 /// when the key associated with the item is less than or equal to the current key
 ///
 /// The most recent item (by associated key) is returned first
-#[derive(Clone, Default, Debug)]
-pub struct ReadyBuffer<K: Ord, T: PartialEq> {
+#[derive(Clone, Debug)]
+pub struct ReadyBuffer<K, T> {
     // TODO: compare performance with a SequenceBuffer of fixed size
     // TODO: add a maximum size to the buffer. The elements that are farther away from being ready dont' get added?
     /// min heap: we pop the items with smallest key first
     pub heap: BinaryHeap<ItemWithReadyKey<K, T>>,
+}
+
+impl<K: Ord, T: PartialEq> Default for ReadyBuffer<K, T> {
+    fn default() -> Self {
+        Self {
+            heap: BinaryHeap::default(),
+        }
+    }
 }
 
 impl<K: Ord, T: PartialEq> ReadyBuffer<K, T> {
@@ -147,7 +155,7 @@ impl<K: Ord + Clone, T: PartialEq> ReadyBuffer<K, T> {
 }
 
 #[derive(Clone, Debug)]
-pub struct ItemWithReadyKey<K: Ord, T> {
+pub struct ItemWithReadyKey<K, T> {
     pub key: K,
     pub item: T,
 }


### PR DESCRIPTION
You can now use
```app.add_rollback::<C>()``` on a non-networked component (for example a mesh, a sound, etc.)

to make sure that that component is affected by rollback.

It will only work if the component is added on an entity with `Predicted` (which means that the entity is on the predicted timeline).
 
Entities that are predicted from server entities will have the `Predicted` component added automatically. If you have any non-networked entity for which you also want to apply rollback, you will need to add the `Predicted `component yourself.

Fixes https://github.com/cBournhonesque/lightyear/issues/573