### PR TITLE
Allow seamless entity mapping

### DIFF
--- a/examples/client_replication/src/client.rs
+++ b/examples/client_replication/src/client.rs
@@ -247,7 +247,7 @@ pub(crate) fn send_message(
         info!("Send message: {:?}", message);
         // the message will be re-broadcasted by the server to all clients
         client
-            .send_message_to_target::<Channel1, Message1>(&Message1(5), NetworkTarget::All)
+            .send_message_to_target::<Channel1, Message1>(&mut Message1(5), NetworkTarget::All)
             .unwrap_or_else(|e| {
                 error!("Failed to send message: {:?}", e);
             });

--- a/examples/lobby/src/client.rs
+++ b/examples/lobby/src/client.rs
@@ -314,14 +314,17 @@ mod lobby {
                                                             // send a message to join the game
                                                             let _ = connection_manager
                                                                 .send_message::<Channel1, _>(
-                                                                    &StartGame { lobby_id, host },
+                                                                    &mut StartGame {
+                                                                        lobby_id,
+                                                                        host,
+                                                                    },
                                                                 );
                                                         }
                                                     } else {
                                                         if ui.button("Join Lobby").clicked() {
                                                             connection_manager
                                                                 .send_message::<Channel1, _>(
-                                                                    &JoinLobby { lobby_id },
+                                                                    &mut JoinLobby { lobby_id },
                                                                 )
                                                                 .unwrap();
                                                             next_app_state.set(AppState::Lobby {
@@ -397,7 +400,7 @@ mod lobby {
                                 if let Some(lobby_id) = joined_lobby {
                                     if ui.button("Exit lobby").clicked() {
                                         connection_manager
-                                            .send_message::<Channel1, _>(&ExitLobby {
+                                            .send_message::<Channel1, _>(&mut ExitLobby {
                                                 lobby_id: *lobby_id,
                                             })
                                             .unwrap();
@@ -408,7 +411,7 @@ mod lobby {
                                         let host = lobby_table.get_host();
                                         // send a message to server/client to start the game and possibly act as server
                                         let _ = connection_manager.send_message::<Channel1, _>(
-                                            &StartGame {
+                                            &mut StartGame {
                                                 lobby_id: *lobby_id,
                                                 host,
                                             },

--- a/examples/lobby/src/server.rs
+++ b/examples/lobby/src/server.rs
@@ -236,7 +236,7 @@ mod lobby {
                 // send the StartGame message to the client who is trying to join the game
                 let _ = connection_manager.send_message::<Channel1, _>(
                     *client_id,
-                    &StartGame {
+                    &mut StartGame {
                         lobby_id,
                         host: lobby.host,
                     },
@@ -252,7 +252,7 @@ mod lobby {
                 }
                 // redirect the StartGame message to all other clients in the lobby
                 let _ = connection_manager.send_message_to_target::<Channel1, _>(
-                    &StartGame {
+                    &mut StartGame {
                         lobby_id,
                         host: lobby.host,
                     },

--- a/examples/simple_box/src/server.rs
+++ b/examples/simple_box/src/server.rs
@@ -139,7 +139,7 @@ pub(crate) fn send_message(
         let message = Message1(5);
         info!("Send message: {:?}", message);
         server
-            .send_message_to_target::<Channel1, Message1>(&Message1(5), NetworkTarget::All)
+            .send_message_to_target::<Channel1, Message1>(&mut Message1(5), NetworkTarget::All)
             .unwrap_or_else(|e| {
                 error!("Failed to send message: {:?}", e);
             });

--- a/lightyear/Cargo.toml
+++ b/lightyear/Cargo.toml
@@ -17,29 +17,29 @@ exclude = ["/tests"]
 big_messages = []
 trace = []
 metrics = [
-    "dep:metrics",
-    "metrics-util",
-    "metrics-tracing-context",
-    "metrics-exporter-prometheus",
+  "dep:metrics",
+  "metrics-util",
+  "metrics-tracing-context",
+  "metrics-exporter-prometheus",
 ]
 mock_time = ["dep:mock_instant"]
 webtransport = [
-    "dep:wtransport",
-    "dep:xwt-core",
-    "dep:xwt-web-sys",
-    "dep:web-sys",
-    "dep:ring",
-    "dep:wasm-bindgen-futures",
+  "dep:wtransport",
+  "dep:xwt-core",
+  "dep:xwt-web-sys",
+  "dep:web-sys",
+  "dep:ring",
+  "dep:wasm-bindgen-futures",
 ]
 leafwing = ["dep:leafwing-input-manager"]
 avian2d = ["dep:avian2d"]
 avian3d = ["dep:avian3d", "avian3d/3d"]
 websocket = [
-    "dep:tokio-tungstenite",
-    "dep:futures-util",
-    "dep:web-sys",
-    "dep:wasm-bindgen",
-    "dep:wasm-bindgen-futures",
+  "dep:tokio-tungstenite",
+  "dep:futures-util",
+  "dep:web-sys",
+  "dep:wasm-bindgen",
+  "dep:wasm-bindgen-futures",
 ]
 steam = ["dep:steamworks"]
 
@@ -87,8 +87,8 @@ lightyear_macros = { version = "0.16.4", path = "../macros" }
 tracing = "0.1.40"
 tracing-log = "0.2.0"
 tracing-subscriber = { version = "0.3.17", features = [
-    "registry",
-    "env-filter",
+  "registry",
+  "env-filter",
 ] }
 
 # server
@@ -99,19 +99,19 @@ metrics = { version = "0.23", optional = true }
 metrics-util = { version = "0.15", optional = true }
 metrics-tracing-context = { version = "0.15", optional = true }
 metrics-exporter-prometheus = { version = "0.15.1", optional = true, default-features = false, features = [
-    "http-listener",
+  "http-listener",
 ] }
 
 # bevy
 bevy = { version = "0.14", default-features = false, features = [
-    "multi_threaded",
-    "bevy_state",
-    "serialize",
+  "multi_threaded",
+  "bevy_state",
+  "serialize",
 ] }
 
 # compression
 lz4_flex = { version = "0.11", optional = true, default-features = false, features = [
-    "std",
+  "std",
 ] }
 
 # WebSocket
@@ -120,8 +120,8 @@ futures-util = { version = "0.3.30", optional = true }
 # transport
 # we don't need any tokio features, we use only use the tokio channels
 tokio = { version = "1.36", features = [
-    "sync",
-    "macros",
+  "sync",
+  "macros",
 ], default-features = false }
 futures = "0.3.30"
 async-compat = "0.2.3"
@@ -133,14 +133,14 @@ async-channel = "2.2.0"
 steamworks = { version = "0.11", optional = true }
 # webtransport
 wtransport = { version = "=0.1.14", optional = true, features = [
-    "quinn",
-    "self-signed",
-    "dangerous-configuration",
+  "quinn",
+  "self-signed",
+  "dangerous-configuration",
 ] }
 # websocket
 tokio-tungstenite = { version = "0.23.0", optional = true, features = [
-    "connect",
-    "handshake",
+  "connect",
+  "handshake",
 ] }
 # compression
 zstd = { version = "0.13.1", optional = true }
@@ -149,26 +149,26 @@ zstd = { version = "0.13.1", optional = true }
 console_error_panic_hook = { version = "0.1.7" }
 ring = { version = "0.17.8", optional = true, default-features = false }
 web-sys = { version = "0.3", optional = true, features = [
-    "Document",
-    "WebTransport",
-    "WebTransportHash",
-    "WebTransportOptions",
-    "WebTransportBidirectionalStream",
-    "WebTransportSendStream",
-    "WebTransportReceiveStream",
-    "ReadableStreamDefaultReader",
-    "WritableStreamDefaultWriter",
-    "WebTransportDatagramDuplexStream",
-    "WebSocket",
-    "CloseEvent",
-    "ErrorEvent",
-    "MessageEvent",
-    "BinaryType",
+  "Document",
+  "WebTransport",
+  "WebTransportHash",
+  "WebTransportOptions",
+  "WebTransportBidirectionalStream",
+  "WebTransportSendStream",
+  "WebTransportReceiveStream",
+  "ReadableStreamDefaultReader",
+  "WritableStreamDefaultWriter",
+  "WebTransportDatagramDuplexStream",
+  "WebSocket",
+  "CloseEvent",
+  "ErrorEvent",
+  "MessageEvent",
+  "BinaryType",
 ] }
 bevy_web_keepalive = "0.3"
 futures-lite = { version = "2.1.0", optional = true }
 getrandom = { version = "0.2.11", features = [
-    "js", # feature 'js' is required for wasm
+  "js", # feature 'js' is required for wasm
 ] }
 xwt-core = { version = "0.5", optional = true }
 xwt-web-sys = { version = "0.12", optional = true }

--- a/lightyear/src/client/input/leafwing.rs
+++ b/lightyear/src/client/input/leafwing.rs
@@ -650,9 +650,9 @@ fn send_input_messages<A: LeafwingUserAction>(
     mut connection: ResMut<ConnectionManager>,
     mut message_buffer: ResMut<MessageBuffer<A>>,
 ) {
-    for message in message_buffer.0.drain(..) {
+    for mut message in message_buffer.0.drain(..) {
         connection
-            .send_message::<InputChannel, InputMessage<A>>(&message)
+            .send_message::<InputChannel, InputMessage<A>>(&mut message)
             .unwrap_or_else(|err| {
                 error!("Error while sending input message: {:?}", err);
             });

--- a/lightyear/src/client/input/native.rs
+++ b/lightyear/src/client/input/native.rs
@@ -300,7 +300,7 @@ fn prepare_input_message<A: UserAction>(
     //  - buffer an input every frame; and require some redundancy (number of tick per frame)
     //  - or buffer an input only when we are sending, and require more redundancy
     // let message_len = 20 as u16;
-    let message = input_manager
+    let mut message = input_manager
         .input_buffer
         .create_message(tick_manager.tick(), message_len);
     // all inputs are absent
@@ -312,7 +312,7 @@ fn prepare_input_message<A: UserAction>(
             "sending input message: {:?}", message.end_tick
         );
         connection
-            .send_message::<InputChannel, _>(&message)
+            .send_message::<InputChannel, _>(&mut message)
             .unwrap_or_else(|err| {
                 error!("Error while sending input message: {:?}", err);
             })

--- a/lightyear/src/client/message.rs
+++ b/lightyear/src/client/message.rs
@@ -242,7 +242,7 @@ mod tests {
             .server_app
             .world_mut()
             .resource_mut::<crate::prelude::client::ConnectionManager>()
-            .send_message::<Channel1, StringMessage>(&StringMessage("a".to_string()))
+            .send_message::<Channel1, StringMessage>(&mut StringMessage("a".to_string()))
             .unwrap();
         stepper.frame_step();
         stepper.frame_step();

--- a/lightyear/src/lib.rs
+++ b/lightyear/src/lib.rs
@@ -79,7 +79,7 @@ struct MyMessage;
 struct MyChannel;
 
 fn send_message(mut connection_manager: ResMut<ConnectionManager>) {
-    let _ = connection_manager.send_message_to_target::<MyChannel, MyMessage>(&MyMessage, NetworkTarget::All);
+    let _ = connection_manager.send_message_to_target::<MyChannel, MyMessage>(&mut MyMessage, NetworkTarget::All);
 }
 ```
 

--- a/lightyear/src/server/connection.rs
+++ b/lightyear/src/server/connection.rs
@@ -356,7 +356,7 @@ impl ConnectionManager {
     /// Serialize the message and buffer it to be sent in each `Connection`.
     ///
     /// - If the message is not `MapEntities`, we can serialize it once and reuse the same bytes
-    /// for all `Connections`.
+    ///   for all `Connections`.
     /// - If it is `MapEntities`, we need to map it in each connection.
     pub(crate) fn erased_send_message_to_target<M: Message>(
         &mut self,

--- a/lightyear/src/server/connection.rs
+++ b/lightyear/src/server/connection.rs
@@ -141,7 +141,7 @@ impl ConnectionManager {
     /// Queues up a message to be sent to all clients matching the specific [`NetworkTarget`]
     pub fn send_message_to_target<C: Channel, M: Message>(
         &mut self,
-        message: &M,
+        message: &mut M,
         target: NetworkTarget,
     ) -> Result<(), ServerError> {
         self.erased_send_message_to_target(message, ChannelKind::of::<C>(), target)
@@ -150,7 +150,7 @@ impl ConnectionManager {
     /// Send a message to all clients in a room
     pub fn send_message_to_room<C: Channel, M: Message>(
         &mut self,
-        message: &M,
+        message: &mut M,
         room_id: RoomId,
         room_manager: &RoomManager,
     ) -> Result<(), ServerError> {
@@ -165,7 +165,7 @@ impl ConnectionManager {
     pub fn send_message<C: Channel, M: Message>(
         &mut self,
         client_id: ClientId,
-        message: &M,
+        message: &mut M,
     ) -> Result<(), ServerError> {
         self.send_message_to_target::<C, M>(message, NetworkTarget::Single(client_id))
     }
@@ -301,7 +301,7 @@ impl ConnectionManager {
         entity
     }
 
-    pub(crate) fn buffer_message(
+    pub(crate) fn buffer_message_bytes(
         &mut self,
         message: Bytes,
         channel: ChannelKind,
@@ -310,28 +310,69 @@ impl ConnectionManager {
         self.connections
             .iter_mut()
             .filter(|(id, _)| target.targets(id))
-            // NOTE: this clone is O(1), it just increments the reference count
             .try_for_each(|(_, c)| {
                 // for local clients, we don't want to buffer messages in the MessageManager since
                 // there is no io
                 if c.is_local_client() {
                     c.local_messages_to_send.push(message.clone())
                 } else {
+                    // NOTE: this clone is O(1), it just increments the reference count
                     c.buffer_message(message.clone(), channel)?;
                 }
                 Ok::<(), ServerError>(())
             })
     }
 
+    /// Buffer a `MapEntities` message to remote clients.
+    /// We cannot serialize the message once, we need to instead map the message for each client
+    /// using the `EntityMap` of that connection.
+    fn buffer_map_entities_message<M: Message>(
+        &mut self,
+        message: &mut M,
+        channel: ChannelKind,
+        target: NetworkTarget,
+    ) -> Result<(), ServerError> {
+        self.connections
+            .iter_mut()
+            .filter(|(id, _)| target.targets(id))
+            .try_for_each(|(_, c)| {
+                self.message_registry.serialize(
+                    message,
+                    &mut self.writer,
+                    Some(&mut c.replication_receiver.remote_entity_map.local_to_remote),
+                )?;
+                let message_bytes = self.writer.split();
+                // for local clients, we don't want to buffer messages in the MessageManager since
+                // there is no io
+                if c.is_local_client() {
+                    c.local_messages_to_send.push(message_bytes);
+                } else {
+                    c.buffer_message(message_bytes, channel)?;
+                }
+                Ok::<(), ServerError>(())
+            })
+    }
+
+    /// Serialize the message and buffer it to be sent in each `Connection`.
+    ///
+    /// - If the message is not `MapEntities`, we can serialize it once and reuse the same bytes
+    /// for all `Connections`.
+    /// - If it is `MapEntities`, we need to map it in each connection.
     pub(crate) fn erased_send_message_to_target<M: Message>(
         &mut self,
-        message: &M,
+        message: &mut M,
         channel_kind: ChannelKind,
         target: NetworkTarget,
     ) -> Result<(), ServerError> {
-        self.message_registry.serialize(message, &mut self.writer)?;
-        let message_bytes = self.writer.split();
-        self.buffer_message(message_bytes, channel_kind, target)
+        if self.message_registry.is_map_entities::<M>() {
+            self.buffer_map_entities_message(message, channel_kind, target)?;
+        } else {
+            self.message_registry
+                .serialize(message, &mut self.writer, None)?;
+            let message_bytes = self.writer.split();
+            self.buffer_message_bytes(message_bytes, channel_kind, target)?;
+        }
+        Ok(())
     }
 
     /// Buffer all the replication messages to send.
@@ -382,7 +423,7 @@ impl ConnectionManager {
                 Ok::<(), ServerError>(())
             })?;
         for (message, target, channel_kind) in messages_to_rebroadcast {
-            self.buffer_message(message, channel_kind, target)?;
+            self.buffer_message_bytes(message, channel_kind, target)?;
         }
         Ok(())
     }
@@ -396,14 +437,14 @@ impl ConnectionManager {
         group_id: ReplicationGroupId,
         client_id: ClientId,
         component_registry: &ComponentRegistry,
-        data: &C,
+        data: &mut C,
         bevy_tick: BevyTick,
     ) -> Result<(), ServerError> {
         let net_id = component_registry
             .get_net_id::<C>()
             .ok_or::<ServerError>(ComponentError::NotRegistered.into())?;
         // We store the Bytes in a hashmap, maybe more efficient to write the replication message directly?
-        component_registry.serialize(data, &mut self.writer)?;
+        component_registry.serialize(data, &mut self.writer, None)?;
         let raw_data = self.writer.split();
         self.connection_mut(client_id)?
             .replication_sender
@@ -1006,7 +1047,7 @@ impl MessageSend for ConnectionManager {
     type Error = ServerError;
     fn send_message_to_target<C: Channel, M: Message>(
         &mut self,
-        message: &M,
+        message: &mut M,
         target: NetworkTarget,
     ) -> Result<(), ServerError> {
         self.send_message_to_target::<C, M>(message, target)
@@ -1014,7 +1055,7 @@ impl MessageSend for ConnectionManager {
 
     fn erased_send_message_to_target<M: Message>(
         &mut self,
-        message: &M,
+        message: &mut M,
         channel_kind: ChannelKind,
         target: NetworkTarget,
     ) -> Result<(), ServerError> {

--- a/lightyear/src/server/message.rs
+++ b/lightyear/src/server/message.rs
@@ -219,7 +219,7 @@ mod tests {
             .world_mut()
             .resource_mut::<crate::prelude::server::ConnectionManager>()
             .send_message_to_target::<Channel1, StringMessage>(
-                &StringMessage("a".to_string()),
+                &mut StringMessage("a".to_string()),
                 NetworkTarget::All,
             )
             .unwrap();

--- a/lightyear/src/server/replication.rs
+++ b/lightyear/src/server/replication.rs
@@ -589,7 +589,7 @@ pub(crate) mod send {
                         group_id,
                         client_id,
                         component_registry,
-                        &Controlled,
+                        &mut Controlled,
                         system_ticks.this_run(),
                     )?;
                 }
@@ -601,7 +601,7 @@ pub(crate) mod send {
                         group_id,
                         client_id,
                         component_registry,
-                        &ShouldBePredicted,
+                        &mut ShouldBePredicted,
                         system_ticks.this_run(),
                     )?;
                 }
@@ -611,7 +611,7 @@ pub(crate) mod send {
                         group_id,
                         client_id,
                         component_registry,
-                        &ShouldBeInterpolated,
+                        &mut ShouldBeInterpolated,
                         system_ticks.this_run(),
                     )?;
                 }

--- a/lightyear/src/shared/message.rs
+++ b/lightyear/src/shared/message.rs
@@ -8,13 +8,13 @@ pub(crate) trait MessageSend: Resource {
     type Error: Error;
     fn send_message_to_target<C: Channel, M: Message>(
         &mut self,
-        message: &M,
+        message: &mut M,
         target: NetworkTarget,
     ) -> Result<(), Self::Error>;
 
     fn erased_send_message_to_target<M: Message>(
         &mut self,
-        message: &M,
+        message: &mut M,
         channel_kind: ChannelKind,
         target: NetworkTarget,
     ) -> Result<(), Self::Error>;


### PR DESCRIPTION
Currently we only do entity mapping when we deserialize a message, by looking at the `remote_to_local` map.

We didn't do the reverse, which meant that sending a message referring to a local entity on the entity-receiver side was annoying on because the remote is the entity-sender so it wouldn't apply entity mapping.

Now we also apply entity mapping when we serialize a message, by using the `local_to_remote` map.

I didn't implement this previously because of potential conflicts but I think that the risk of those is pretty small. It would require a user to have both client->server and server->client in the same game.
In the long-term I want to solve those conflicts by using pre-defined ID ranges.
In the meantime we can greatly improve ergonomics by enabling this feature.

The conflicts could be for example:
- Server spawns E1 and replicates to client who spawns E2. Client has E1 remote -> E2 local mapping.
- Client spawns E1 and replicates to server who spawns E3, Server has E1 remote -> E3 local mapping.
(basically the conflict happens if the server and client both spawn and replicate an entity with the same `Entity`)

Client sends a message containing E2.
It maps it from local to remote: E1
Server receives the message with E1, it maps it from remote_to_local -> E3. (instead of just using the original E1)

Solutions to avoid these kinds of conflicts:
- avoid replicating in both directions
- predefined entity ranges for networking
- include a bit in the message that indicates that mapping was already done. If the mapping was already done on the sender, we don't do it again on the receiver. Maybe that bit can be included directly in the Entity, similar to what's described in https://ajmmertens.medium.com/doing-a-lot-with-a-little-ecs-identifiers-25a72bd2647
  On the receiving side we would check this bit to know it entity-mapping has already been applied or not?
  (or just 1 bit per message, but that seems expensive)