### PR TITLE
Add authority handling natively

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -104,6 +104,19 @@
     - used from client to get authority over an entity. Client to Server msg
       - server can refused if it already got a previous request
       - from client to server: client adds the `HasAuthority` component. It does not accept receiving updates from the server anymore.
+
+TODO:
+- [x]: we receive updates only if (server) the sender has authority, or if (client) we don't have authority.
+- [x]: (on client) we only send updates if we have authority
+- [x]: add TransferAuthority command on the client
+- [ ]: update hierarchy
+- [ ]: receive edge cases:
+  - [x]: server adds AuthorityPeer when a client replicates to it
+  - [ ]: also refuse entity-actions if the sender does not have authority?
+- [ ]: send edge cases:
+  - [ ]: what happens on component removal?
+- [ ]: handle AuthorityChange messages on the clients
+- [ ]: think about what happens in PrePredicted
     
        
 

--- a/NOTES.md
+++ b/NOTES.md
@@ -114,6 +114,7 @@ TODO:
   - [x]: server adds AuthorityPeer when a client replicates to it
   - [ ]: also refuse entity-actions if the sender does not have authority?
 - [ ]: send edge cases:
+  - [ ]: server adds HasAuthority if entity is spawned with AuthorityPeer::Server
   - [ ]: what happens on component removal?
 - [ ]: handle AuthorityChange messages on the clients
 - [ ]: think about what happens in PrePredicted

--- a/NOTES.md
+++ b/NOTES.md
@@ -69,13 +69,14 @@
 
   - Actually we could try this:
     - all components of Replication are shared between clients and server, they are also replicable.
-    - So when you transfer authority, you just replicate the Replicate components to the new owner.
+    - So when you transfer authority, you just replicate the Authority component to the new owner.
     - On the client if you add `ReplicationTarget`, `SyncTarget`, nothing happens, but those get replicated to the Server. The server then uses them for the replication behaviour. One big problem is ReplicationGroup? I guess we can just apply EntityMapping.
     - How do we avoid bidirectional replication? The component `Authority` specifies who is sending updates. You only send updates
       if you have authority. That means that the server and the client both have the `Replicate` bundle but only one of them is sending updates?
     - Case 1: server spawns an entity and has authority
       - the Replicate bundle is added, and is used to define how its replicated. 
       - no need to replicate the Replicate bundle
+      - the Authority component is added, so 
       - Case 3: it transfers authority to a client.
         - 
     - Case 2: client spawns an entity and has authority, it wants to replicate to all other players
@@ -85,6 +86,25 @@
       - the server has an Authority component which tracks which peer has authority (Self or Client). 
       - In particular, it WILL NOT ACCEPT REPLICATION UPDATES FROM A PEER THAT DOES NOT HAVE AUTHORITY!
       - the clients also have this Authority component?
+
+  - Having Authority means:
+    - I don't accept replication updates from another peer
+    - server tracks at all times who has authority over an entity
+    - server does not accept receiving updates from a peer with no authority
+  - TransferAuthority:
+    - used from the server to client to transfer authority on the client
+    - from server to client: (server gives authority to client)
+        - client gains `HasAuthority`
+        - server updates `AuthorityPeer`
+    - from client 1 to client 2: (server takes authority from C1 and gives it to C2)
+      - send a message to both
+      - they update accordingly
+    - from client to server: (server takes authority from client)
+  - GetAuthorityRequest:
+    - used from client to get authority over an entity. Client to Server msg
+      - server can refused if it already got a previous request
+      - from client to server: client adds the `HasAuthority` component. It does not accept receiving updates from the server anymore.
+    
        
 
 - What would P2P look like?

--- a/NOTES.md
+++ b/NOTES.md
@@ -48,7 +48,7 @@
   
 
 
-# Authority Transfer
+# Replication Server
 
 - Introduce a ReplicationServer and a Simulator?
   - the ReplicationServer handles:
@@ -65,6 +65,27 @@
     - ControlledBy: connects/disconnects are sent to every client?
     - ReplicationGroup: ok
     - Hierarchy: ok
+  - transferring authority would then mean: sending all the replication components to the new owner, and removing them from the old owner.
+
+  - Actually we could try this:
+    - all components of Replication are shared between clients and server, they are also replicable.
+    - So when you transfer authority, you just replicate the Replicate components to the new owner.
+    - On the client if you add `ReplicationTarget`, `SyncTarget`, nothing happens, but those get replicated to the Server. The server then uses them for the replication behaviour. One big problem is ReplicationGroup? I guess we can just apply EntityMapping.
+    - How do we avoid bidirectional replication? The component `Authority` specifies who is sending updates. You only send updates
+      if you have authority. That means that the server and the client both have the `Replicate` bundle but only one of them is sending updates?
+    - Case 1: server spawns an entity and has authority
+      - the Replicate bundle is added, and is used to define how its replicated. 
+      - no need to replicate the Replicate bundle
+      - Case 3: it transfers authority to a client.
+        - 
+    - Case 2: client spawns an entity and has authority, it wants to replicate to all other players
+      - the Replicate bundle is added, and is used to define how its replicated. Most of the components are not actually used.
+      - the Replicate bundle is replicated to the server, which then uses it to replicate to all other clients.
+      - Careful to use ReplicationTarget::AllExceptSingle!!! otherwise all hell breaks loose
+      - the server has an Authority component which tracks which peer has authority (Self or Client). 
+      - In particular, it WILL NOT ACCEPT REPLICATION UPDATES FROM A PEER THAT DOES NOT HAVE AUTHORITY!
+      - the clients also have this Authority component?
+       
 
 - What would P2P look like?
   - the ReplicationServer is also the client! Either in different Worlds (to keep visibility, etc.),
@@ -74,6 +95,8 @@
 - ReplicationServer (server) contains the full entity mapping
   - client 1 spawns E1, sends it to the RS which spawns E1*. RS replicates it to other clients/simulators.
 
+# Authority Transfer
+
 ```rust
 enum AuthorityOwner {
     Server,
@@ -82,10 +105,34 @@ enum AuthorityOwner {
     None,
 }
 ```
+- Having authority means that we have the burden of simulating the entity
+  - for example, server has authority and the other clients just receive replication updates
+  - if a client has authority, it simulates it and sends replication updates to the server. The server also sends replication updates.
+  - the component `Authority` symbolises that we have authority over the entity. There can be only 1 peer with authority
+
+- ConnectionManager.request_authority(entity);
+  - if the client requests, the server will route the request to the current owner of the entity (possibly itself)
+  - if the server is requesting, the server will send the request to the current owner of the entity
+- V1: all requests are successful. 
+  - on receiving the request. We return a message that indicate that the transfer is successful.
+  - The entity_maps don't seem like they need to be updated
+  - the previous owner will remove Replicating, and add Replicated? it should also remove ReplicationTarget or ReplicateToServer, but without
+    despawning the entity.
+    - if the entity is transferred from C1 to C2, the server needs to its replication target. Maybe the server can just listen for `SuccessfulTransfer` and then update its replication target accordingly?
+    - if the entity is transferred from C1 to S, the server needs to update its replication target. (i.e. if it notices that it is the new Authority owner)
+      C1 loses ReplicationToServer and Replicating, and adds Replicated.
+      
+    
+  - the new owner receives TransferSuccessful message and adds ReplicationTarget component.
+  
 - commands.transfer_authority(entity, AuthorityOwner):
+  - send transfer 
   - remove Replicate on the entity
   - send a message to the new owner to add the Replicate component
+  - 
 
+
+# Serialization
 
 - Replication serialization:
   - to improve performance, we want to:
@@ -147,35 +194,7 @@ enum AuthorityOwner {
   - update at tick 10, send_tick = 10, ack_tick = None
   - update at tick
 
-
-
-
   - saves bandwidth because 99% of packets should arrive correctly.
-
-- Add a `Controlled` component to an entity to specify that the player is controlling the entity
-  - field (`controlled_by: NetworkTarget`) on the server `Replicate`
-  - it means that the `Controlled` component gets replicated to the client who has control of this entity.
-  - then the client can filter on `Controlled` to add `Prediction` behaviour, for example. And add Interpolation on non-controlled entities?
-  - server also creates an entity for each connected client. Each client entity has a component indicating the 
-    list of entities under control of the client. `HasControl(EntityHashSet)` (with EntityMapping)
-  - if the player disconnects, we can despawn automatically all entities under their control. (this behavior can be made configurable in the future)
-  - Would `Controlled` be synced to the Predicted entity? Maybe? if we predict other players, it would be nice to know
-    which Predicted entity is under our control.
-  - client->server replication: 
-
-  - PROS:
-    - on the server, users can easily find the list of entities under control of a specific client
-    - on the client, users that receive an entity from the server can quickly check if they have control of it, without
-      having to compare client_ids.
-
-
-
-- Transferring ownership to another client. 
-  - commands.transfer_ownership(entity, new_owner)
-  - sends a message AuthorityTransfer to the new client who should replicate the entity
-  - the new client can spawn an entity
-
-
 
 
 # Interesting links:
@@ -187,11 +206,6 @@ enum AuthorityOwner {
 
 - TODO: create an example related to cheating, where the server can validate inputs
 
-
-- CROSS-TRANSPORT:
-    - TODO:
-        - add unit test on metadata
-        - maybe replace Channels transport with LocalChannels and multi-connection?
 
 - PRESPAWNING:
     - STATUS:
@@ -234,507 +248,3 @@ enum AuthorityOwner {
         - I still frequent rollbacks for the matched entities, weirdly.
         - There are some cases where server/client don't run input on the same tick?
         - Also sometimes we have annoying interpolation freezes..
-
-
-- SYNC:
-    - why is sync breaking after 32700 ticks?
-    - if we set the client_tick to something else, then the relationship between time_manager and sync is broken,
-      so the timemanager's overstep is not trustworthy anymore?
-    - time gets updated during the First system, but i need the time at the end of the frame, so i need to run the
-      time-systems myself
-      before PostUpdate!
-    - we must use the overstep only after FixedUpdate, because that's when it's updated
-
-- PHYSICS:
-    - A: if I run FixedUpdate::MAIN AFTER PhysicsSets, I have a smooth physics simulation on client
-      if I run FixedUpdate::MAIN BEFORE PhysicsSets, it's very jittery. Why? It should be the opposite!
-        - SOLVED: same as C
-    - B: the interpolation of the ball is weirdly jittery
-        - is it because we run the physics simulation on the interpolated entity?
-        - SOLVED: it was because we were running Interpolation at PostUpdate, but drawing at Update.
-    - C: collisions cause weird artifacts when we do rollback. Investigate why.
-        - check tick 1935. On server, we have some values.
-          On client, we have completely different values! After rollback, we get the server values, but only at tick
-            1936.
-          Is there a off-by-one issue?
-          Also the client value was completely different than the server value before the rollback, why?
-        - SOLVED: I think I found the issue, it's because we need to run the physics after applying the Actions, but
-          before
-          we record the ComponentHistory for prediction. This also explains A.
-    - D: the client prediction with the ball seems very slighly jittery. Could it be because we
-      apply `relative_time_updates` to FixedUpdate on client,
-      so we might run a different number of FixedUpdate ticks than on server? Shouln't matter because we still apply
-      inputs on the same ticks?
-        - HYPOTHESIS:
-            1) try interpolating/smoothing the client rollback towards the confirmed output
-            2) predict everything!
-    - E: client prediction for collisions between two predicted entities (player controlled entities) is also jittery.
-      Why?
-      Is it because rotation is not replicated?
-        - SOLVED: that was it, I needed to replicate angular velocity and rotation as well.
-    - F: client is always slightly jittery compared to server.
-        - SOLVED: it's because we are predicting 2 entities so we need to make sure that they are in the same
-          replication group,
-          otherwise the `confirmed_tick` for 1 entity might not be the same as for another entity!
-    - G: why does the simulation go completely bananas if there are a lot of mis-predictions? Is it spiral of death?
-    - H: having a faster send_interval on the server side makes the simulation less good, paradoxically! Why?
-        - do i have an off-by-one error somewhere?
-    - I: how to make good client prediction for other clients?
-        - maybe we replicate the ActionState of other clients, and then we can do some kind of decay on the inputs; or
-          consider
-          that they will still be pressed?
-
-STATUS:
-
-- it looks like there's 0 rollback if we only have 1 client and predict the ball. Smooth
-- goes crazy if I predict the other player
-    - for some reason there was a crazy tick diff. Rollback at tick 934, but client1 was at tick 988!!
-    - then the rollback goes crazy because we predict that the entity is moving at their low velocity for the next 50
-      ticks.
-- I think for proper prediction of other clients we need to know what their latest input was, and then consider that
-  they
-  pressed the same input during the prediction time. We can also decay the inputs over prediction time?
-    - TODO: if we rollback, we ALSO need to restore the other clients inputs to what they were at the rollback tick!!!!
-- Status:
-    - when I press buttons for client 2, the FPS starts dropping. Death spiral?
-    - again, huge tick diff for the rollback (50 ticks) -> WHY???? (only at the start though)
-    - client 1 has some mispredictions but overall seems ok?
-    - sometimes the rotation is completely different?
-    - Not synced during rollback!!!
-- STATUS:
-    - perfect sync if input_delay > RTT, but with initial sync issues
-    - jarring mispredictions if input_delay < RTT
-    - sometimes the state is stuck in a misprediction spiral WHY?
-    - looks like the input wasn't taken into account???? sometimes the release is not handled correctly.
-
-- STATUS: best-settings. Input-delay = 10, Correction = 8.
-
-- Problem 1: if one of the inputs has a correction, all of them should get have it!
-  (after rollback check, iterate through every predicted element in the replication group, and add corrections to those
-  who don't have it.
-  if they don't have it that means their predicted component is already equal to the confirmed component
-
-  Actually I don't think it's an issue maybe? Because if one of the components doesn't have a correction it's because
-  their predicted value was equal to the confirmed value at the time?
-
-- Problem 2: if I set a very high correction-tick number, the movement becomes very saccade for some reason, understand
-  that.
-
-- TODO:
-    - maybe add an option to disable correction for the player-controlled entities (not entities controlled by other
-      players)?
-    - why do i need to not sync the ActionState from server to client for it to work? I guess the problem is that the
-      ActionState on the Confirmed is ticking and being replicated to Predicted all the time...
-    - enable having multiple different rollbacks (with different ticks) for different replication groups
-    - i still get stuck inputs even when sending full diffs!!! why?
-
-
-- TODO: lockstep. All player just see what's happening on the server. that means inputs are not applied on the client (
-  no prediction).
-  the client just uses the confirmed state from server. (with maybe interpolation)
-
-  CONS: delay.
-  PROS: no visual desyncs.
-
-- TODO:
-    - DELAYED INPUTS: on local, our render tick (prediction timeline) is 10. But when we press a button, we will add the
-      button press to the buffer
-      at tick 16, and we immediately send to the server all the actions up to tick 16. The input timeline is in the
-      future compared to the render timeline.
-      That means that on client, we don't use directly the ActionState (which gets updated immediately), but instead we
-      must get the correct ActionState from
-      the buffer of ActionStates. i.e. when we reach tick 16, we get the ActionState from the buffer.
-    - flow is: press input (at client tick 10), update-action-state, store it in buffer for tick 16, then read from
-      buffer at tick 10 to set action set.
-        - if the total RTT is smaller than 6 ticks, then we will never get a rollback because server and client will
-          have run the same sequence of actions!
-    - STATUS:
-        - implemented the delayed inputs. The inputs are actually delayed, but it causes some amount of mispredictions,
-          even
-          with only one client. (which was the opposite of what we wanted lol)
-        - implemented quickening the client-time based on delayed inputs, so that there's a lot less prediction to do!
-        - with sufficient input delay, I get 0 predictions, past an initial period that doesn't work well.
-          For some reason I have some frames where I run a lot of FixedUpdate, and then the client is very desynced.
-          It looks like I have 1 frame that took 0.7 seconds ??
-    - DEBUG:
-        - i'm sending a lot more diffs than necessary. It's because when we fetch the older data from the buffer.
-        - i see a case where an action (release Left) has not been received on the server
-            - why? maybe just send full diffs then, so that we can recover for this case.
-            - absolutely 0 rollbacks with no input delay, so it is related
-            - SOLVED: it's because we need to use the delayed action-state at the start of PreUpdate!
-        - after that, constant rollbacks, even though the later actions are correct
-            - SOLVED: off by 1 error!!!!!!!!!!!!
-    - REMAINING ISSUES:
-        - in general, at the beginning I do a lot of sync adjustements, and after a while not anymore... why?
-        - sometimes at the beginning of sync, I get: "Error too big, snapping prediction time/tick to objective"
-          the current-prediction time was way behind the estimated server time
-            - TODO: understand this!!!
-        - I got a case where immediately after sync, we rollback because the current-tick is further than the
-          latest-received-server-tick.
-            - SOLVED: don't rollback if the server-tick is ahead of client-tick
-        - I got cases where the server-tick on client is ahead of when we should get the input.
-            - that's weird because we should have even more margin because we take care of having the client tick ahead
-              of server tick...
-            - it happens a lot actually!
-            - SOLVED: it's because we don't send an input message with no diffs, and we keep popping from the action
-              diff buffer, so this log is not reliable.
-        - The diffs that the server receives have some duplicate consecutive Pressed. It shouldn't be possible because
-          the diffs should only contain
-          pure changes
-        - with higher tick rate, the frame rate drops to 20.. spiral of death?
-
-
-- TODO: leafwing inputs should be doing something similar as what I do for replication
-    - regularly send full action-state via a reliable channel
-    - the rest of the time send unreliable diffs?
-
-- TODO: if something interacts only with the client entity but not on server. The server does not send an update so
-  we have no rollback! maybe we should check for rollback everytime the confirmed_tick of the group is updated.
-
-- TODO: also the rollback for a replication group is not done correctly. If ANY component of ANY entity the group is
-  rolled back,
-  then we should reset ALL components for ALL ENTITIES the group to the rollback state before doing rollback.
-  Maybe add a component ConfirmedTick to each replicated entity that has prediction, and do rollback if ConfirmedTick is
-  changed.
-    - SOLVED: now we reset all components of ALL entities in the group if we need to do rollback.
-
-- TODO: think about handling alt-tabbing on client, which might slow down frames a lot and fuck some stuff?
-  Could it be ok for the client to run behind the server, if it just buffers the server's updates?
-  i.e. in Receiver we only read the replication messages if the local tick is >= to the remote tick.
-
-- TODO: prediction smoothing. 2 options.
-    - we do rollback, compute the new predicted entity now. And then we interpolate by 'smooth' amount to it instead of
-      just teleporting to it
-      that means that we might do a lot of rollbacks in a row.
-    - we do rollback, compute the new predicted entity in X ticks from now. then we enter RollbackStage::Smooth where we
-      interpolate
-      between now and X+5. We disable checking for rollbacks during that time. Client inputs should affect both the
-      entity now and
-      the entity we are aiming for (X+5)
-
-
-- TODO: also remove ShouldBePredicted or ShouldBeInterpolated on server after we have sent it once
-- TODO: why do I get duplicate ComponentInsertEvent ShouldBePredicted?
-    - SOLVED!
-- TODO: when rollback is initiated, only rollback together the entities that have the same replication_group!!!
-    - this allows the possibility of having separate replication groups for entities that are predicted but don't need
-      to be rolled back together.
-- TODO: should the server send other client' inputs to a client so that they can run client-prediction more accurately
-  on other clients?
-- TODO: physics states might be expensive to network (full f32). What we can do is:
-    - compress the physics on the server before running physics step
-    - then run physics step
-    - and network the compressed physics
-    - then the client/server are working with the same numbers, so fewer desyncs
-- TODO: input decay: https://www.snapnet.dev/blog/netcode-architectures-part-2-rollback/#input-decay
-- TODO: use a sequenced-unreliable channel per actionlike, instead of a global unrealible unordered channel for all
-  inputs
-
-
-- TODO: how to do entity mapping for inputs?
-    - A) inputs on pre-predicted entity. Ok because server maintains mapping between server-local and client-predicted!
-    - B) inputs on confirmed. Ok because server maintains mapping between server-local and client-confirmed!
-    - C) inputs on predicted. How do we do it? Maybe distinguish between Pre-Predicted entities and normal predicted
-      entities?
-      For normal predicted entities, we map the entity to the confirmed one before sending?
-
-QUESTIONS:
-
-- is there a way to make an object purely a 'collider'? It has velocity/position, but the position isn't recomputed by
-  the physics engine
-- when does the syncing between transform and rotation/position happen?
-
-
-- INPUTS:
-    - on client side, we have a ActionStateBuffer for rollback, and a ActionDiffBuffer to generate the message we will
-      send to server
-    - sometimes frames have no fixed-update, so we have a system that runs on PreUpdate after leafwing that generates
-      inputs as events
-      which are only cleared when read
-    - then we keep the diffs in a buffer and we send the last 10 or so to the server
-    - on the server we reconstruct the action-state from the diff.
-    - ISSUES:
-        - if we miss one of the diffs (Pressed/Released) because it arrived too late on the client, our action-state on
-          server is on a bad state.
-            - I do see cases on server where the current-tick is bigger than the latest action-diff-tick we received.
-            - Maybe we should we just send the full action-state every time? (but that's a lot of data)
-            - Maybe we could generate a diff even when the action did not change (i.e. Pressed -> Pressed), so that we
-              still have a smaller msesage
-              but with no timing information
-
-- Since we have multiple Actionlike, how can we send them?
-    - either we add Input1, Input2, etc. in the Protocol
-    - either we make the API work like naia with a non-static protocol
-        - we maintain a map with NetId of each Channel,Message,Input,Component in the protocol
-        - on serialize:
-            - we find the netid of the input
-            - we'll need to pass the ComponentKinds to the serialize function to get the netid
-        - on deserialize:
-            - we pass the ComponentKinds to the deserialize function
-            - we read the netid and get a `dyn ComponentBuilder`
-            - we use the builder to build a `dyn Component`?
-
-
-- CHANGE DETECTION BUG:
-    - What are the consequences of this?
-      "System 'bevy_ecs::event::event_update_system<lightyear::shared::events::MessageEvent<lightyear::inputs::
-      input_buffer::InputMessage<simple_box::protocol::Inputs>,
-      u64>>' has not run for 3258167296 ticks. Changes older than 3258167295 ticks will not be detected."
-
-- SYNC BUGS:
-    - still the problem of converting between 2 modulos, which is not possible. Maybe we can ditch WrappedTime and use
-      the actual time, since
-      we are never sending it over the network?
-    - it looks like sometimes the latest_received_server_tick is always 0, when the sync bug happens
-        - that happens because we start at latest_received_server_tick = 0, and we receive a server tick that is >32k,
-          so it's considered 'smaller'
-        - FIXED
-    - also i've seen a case where client_ideal_tick was lower than server_tick, which is not possible
-        - "2023-12-27T23:01:38.614369Z INFO lightyear::client::sync: Finished syncing! buffer_len=7 latency=199.465125ms
-          jitter=8.13034ms delta_tick=18160 predicted_server_receive_time=WrappedTime { time: 285.611786s }
-          client_ahead_time=40.01602ms client_ideal_time=WrappedTime { time: 285.651802s } client_ideal_tick=Tick(18282)
-          server_tick=Some(Tick(18314)) client_current_tick=Tick(122)"
-        - it seems that the bug is due to using smoothing on the server_time_estimate. It means that the
-          server_time_estimate can not
-          match the server-tick (and be earlier compared to what it would be if we had used the server tick). Temp
-          solution is to
-          remove the smoothing on server_time_estimate for now before syncing. (because syncing depends directly on
-          adding a delta)
-        - TODO:
-            - should i keep it after smoothing? can it have adverse effects?
-
-- BUGS:
-    - client-replication: it seems like the updates are getting accumulated for a given entity while the client is not
-      synced
-        - that's because we don't do the duplicate check anymore, so we keep adding new updates
-        - but our code relies on the assumption that finalize() is called every send_interval (to drain
-          pending-actions/pending-updates) which is not the case anymore.
-        - we still want to accumulate updates early though (before client is synced)
-        - OPTION 1 (SELECTED):
-            - just try sending the updates (which fails because we don't send anything until client is connected). That
-              means
-              we might have a bit of delay to receive the updates at the very beginning (retry_delay).
-        - OPTION 2:
-            - have a more clever way of accumulating updates. Maybe get a HashMap<ComponentKind, latest-tick> for
-              updates?
-            - For actions, we still want to send every update sequentially...
-    - input-events are cleared every fixed-udpate, but we might want to use them every frame. What happens if frames are
-      more frequent
-      than fixed-update? we double-use an input.. I feel like we should just have inputs every frame?
-      Also, only the systems in FixedUpdate get rolled-back, so despawns in Update schedule don't get rolled back.
-      Should we add
-      a schedule in the `Update` schedule that gets rolled-back as well?
-
-
-- add PredictionGroup and InterpolationGroup?
-    - on top of ReplicationGroup?
-    - or do we just re-use the replication group id (that usually will have a remote entity id) and use it to see the
-      prediction/interpolation group?
-    - then we add the prediction group id on the Confirmed or Predicted components?
-    - when we receive a replicated group with ShouldBePredicted, we udpate the replication graph of the prediction
-      group.
-- Then we don't really need the Confirmed/Predicted components anymore, we could just have resources on the Prediction
-  or Interpolation plugin
-- The resource needs:
-    - confirmed<->predicted mapping
-    - for a given prediction-group, the dependency graph of the entities (using confirmed entities?)
-- The prediction systems will:
-    - iterate through the dependency graph of the prediction group
-    - for each entity, fetch the confirmed/predicted entity
-    - do entity mapping if needed
-- users can add their own entities in the prediction group (even if thre )
-- examples:
-    - a shooter, we shoot bullets. the bullets should be in our prediction group?
-      I guess it's not needed if we don't do rollback for those bullets, i.e. we don't give them a Predicted component.
-      Or we could create the bullet, make it part of the entity group; the server will create the bullet a bit later.
-      When the bullet gets replicated on client; we should be able to map the Confirmed to the predicted bullet; so we
-      don't spawn a new predicted.
-      (in practice, for important stuff, we would just wait for the server replication to spawn the entity (instead of
-      spawning it on client and then deleting it if the server version doesn't spawn it?, and for non-important stuff we
-      would just spawn a short-lived entity that is not predicted.)
-    - a character has HasWeapon(Entity), weapon has HasParent(Entity) which forms a cycle. I guess instead of creating
-      this graph of deps,
-      we should just deal with all spawns first separately! Same for prediction, we first do all spawns first
-
-
-- TODO: Give an option for rollback to choose how to perform the rollback!
-    - the default option is to snapback instantly to the rollback state.
-    - another option is: snapback to rollback state, perform rollback, then tell the user the previous predicted state
-      and the new predicted state.
-      for example they could choose to lerp over several frames from the [old to new] (i.e correct only 10% of the way).
-      this would cause many consecutive rollback frames, but smoother corrections.
-    - register a component RollbackResult<C> {
-      // use option because the component could have gotten removed
-      old: Option<C>,
-      new: Option<C>,
-      }
-
-
-- DEBUGGING REPLICATION BOX:
-    - INTERP TIME is sometimes too late; i.e. we receive updates that are way after interp time.
-    - SYNC:
-        - seems to not work well for at the beginning..
-
-- FINAL CHOICE FOR REPLICATION:
-    - send all actions per group on an reliable unordered channel
-        - ordering is done per group, with a sequenced id (1,2,3)
-        - thus we cannot receive a despawn before a spawn, or a component removal before a component insert
-        - actions are still buffered in advance, so that whenever the latest arrives we apply all of them
-        - if there are any actions for an entity, we also send all updates for that entity in the same message!
-    - send all updates per group on an unreliable unordered channel
-        - sequencing is done per group
-        - updates only modify components, do not create them
-        - we send all updates since the last SEND system run for which we received an ACK back.
-            - so that, if we receive update-17, update-18 and we miss 17, we know that by applying 18 we have a correct
-              world state
-            - and we're not missing an update that only happened on 17.
-        - we include in the message the latest tick where we sent actions for that entity
-        - we do not send an update for a component that has an insert
-        - we apply updates immediately for components that exist, and we buffer updates for components/entities that
-          don't exist (this means not in a component)
-            - this means that some components (at insert time), can be stuck behind other components; but it's quickly
-              fixed afterwards. All update components are always on the same tick
-        - prediction:
-            - we store the component history, along with the correct ticks, on the confirmed entity
-            - we check rollback on each action or each update for each entity predicted. We rollback on the oldest
-              rollback tick across all predicted entities.
-              we restore each predicted entity to their latest update tick.
-            - simpler: put all predicted entities in the same group so they have the same tick
-            - even simpler: send all updates+actions for predicted entities in the same packet, so updates AND
-              components are all on the same tick.
-        - interpolation:
-            - we store the component history, along with the correct ticks, on the confirmed entity
-    - groups:
-        - by default, entities are in their own group GroupId = Entity
-        - can specify a group for an entity, and then all entities in that group are in the same group and have their
-          actions / updates sent together
-            - useful for hierarchical entities (parent/children)
-            - need to make sure parents are sent first in groups I think ? for entity mapping
-        - the thing is that groups might be different for each player? not sure if that would ever happen. Not important
-          now
-            - rocket league: predict all player entities + ball -> just put all players and ball in the same group
-            - normal: predict only the player entity -> no need to put them in the same group.
-            - RTS: each player predicts multiple entities -> each player must have their OWN entities in the same group.
-                - still fine to put all a player's entities in the same group
-    - events:
-        - for actions: send an event for each action
-        - for updates: send an event for each component update received (buffer)? or applied? applied would be in order,
-          which be better
-
-
-- interpolation has some lag at the beginning, it looks like the entity isn't moving. Probably because we only got an
-  end but no start?
-    - is it because the start history got deleted? or we should interpolate from current to end?
-    - the problem is that we get regular update roughly every send_interval when the entity is moving. But when it's not
-      the delay between start and end becomes bigger.
-    - when we have start = X, end = None, we should keep pushing start forward at roughly send-interval rate?
-
-- interpolation
-    - how come the interpolation_tick is not behind the latest_server_tick, even after setting the interpolation_delay
-      to 50ms?
-      (server update is 80ms)
-      normally it should be fine because we already make sure that interpolation time is behind the
-      latest_server_tick...
-      need to look into that.
-
-ADD TESTS FOR TRICKY SCENARIOS:
-
-- replication at the beginning while RTT is 0?
-- replication when multiple inserts/removes/updates at same tick
-- replication where the data gets split between multiple packets
-
-ROUGH EDGES:
-
-- the bitcode/Bytes parts are confusing and make extra copies
-- users cannot specify how they serialize messages/components
-
-- SYNC:
-    - sync only works if we send client updates every frame. Otherwise we need to take a LOT more margin on the server
-      to make sure that client packets arrive on time. -> MAKE SYNC COMPATIBLE WITH CLIENT UPDATE_INTERVAL (ADD
-      UPDATE_INTERVAL TO MARGIN?)
-    - Something probably BREAKS BECAUSE OF THE WRAPPING OF TICK AND WRAPPED-TIME, THINK ABOUT HOW IT WORKS
-        - weird wrapping logic in sync manager is probably not correct
-    - can have smarter speedup/down for the sync system
-
-TODO:
-
-- Inputs:
-    - instead of sending the last 15 inputs, send all inputs until the last acked input message (with a max)
-    - also remember to keep around inputs that we might need for prediction!
-    - should we store 1 input per frame instead of 1 input per tick? should we enable rollback of Systems in the Update
-      schedule?
-
-- Serialization:
-    - have a NetworkMessage macro that all network messages must derive (Input, Message, Component)
-        - DONE: all network messages derive Message
-    - all types must be Encode/Decode always. If a type is Serialize/Deserialize, then we can convert it to
-      Encode/Decode ?
-
-- Rooms:
-    - this was done to limit the size of messages, but paradoxically it might increase the size if the entity doesn't
-      get updated a lot
-    - for example, if it's just some background entity, it's better to send them all once, instead of constantly sending
-      them and despawning them
-    - for a mmorpg with fixed instances/rooms; is there need to despawn? maybe better if client just despawns anything
-      in the room, and server just stops replicating stuff outside the main room (without despawning though)
-
-- Prediction:
-    - TODO: output the rollback output. Instead of snapping the entity to the rollback output, provide the rollback
-      output to the user
-      and they can choose themselves how they want to handle it (they could either snap to the rollback output, or lerp
-      from prediction output to rollback output)
-
-    - TODO: handle despawns, spawns
-        - despawn another entity TODO:
-            - we let the user decide
-                - in some cases it's ok to let the created entity despawn
-                - in other cases we would like to only despawn that entity if confirm despawns it (for example a common
-                  object)
-                  -> the user should write their systems so that despawns only happen on the confirmed timeline then
-        - spawn: TODO
-          i.e. we spawn something that depends on the predicted action (like a particle), but actually we rollback,
-          which means that we need to kill the spawned entity.
-            - either we kill immediately if it doesn't get spawned during rollback
-            - either we let it die naturally; either we fade it out?
-              -> same, the user should write their systems so that spawns only happen on the confirmed timeline
-
-    - TODO: 2 ways to create predicted entities
-        - DONE: server-owned: server creates the confirmed entity, when client receives it, it creates a copy which is a
-          predicted entity -> we have this one
-        - TODO: client-owned: client creates the predicted entity. It sends a message to client, which creates the
-          confirmed entity however it wants
-          then when client receives the confirmed entity, it just updates the predicted entity to have a full mapping ->
-          WE DONT HAVE THIS ONE YET
-
-- Replication:
-    - Fix the enable_replication flag, have a better way to enable/disable replication
-    - POSSIBLE TODO: send back messages about entity-actions having been received? (we get this for free with reliable
-      channels, but we need to notify the replication manager)
-
-- Message Manager
-    - TODO: run more extensive soak test. Soak test with multiple clients, replication, connections/disconnections and
-      different send_intervals?
-
-- Packet Manager:
-    - TODO: construct the final Packet from Bytes without using WriteBuffer and ReadBuffer, just concat Bytes to avoid
-      having too many copies
-
-- Channels:
-    - TODO: add channel priority with accumulation. Some channels need infinite priority though (such as pings)
-      with bandwidth limiting. Should be possible, just take the last 1 second to compute the bandwidth used/left.
-    - TODO: actually add a priority per ReplicationGroup. The PRIORITY DEPENDS ON THE CLIENT. (for example distance to
-      client!)
-        - priority
-        - update_period: send_interval for this packet. if 0, then we use the server's send_interval.
-
-- UI:
-    - TODO: UI that lets us see which packets are sent at every system update?
-    - TODO: UI (afte rpriotitization that shows the bandwidth used/priority of each object)
-
-- Metrics/Logs:
-    - add more metrics
-    - think more about log levels. Can we enable sub-level logs via filters? for example enable all prediction logs,
-      etc.
-
-- Reflection:
-    - when can we use this?

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -31,6 +31,7 @@
     - [Server](./concepts/bevy_integration/server.md)
     - [Events](./concepts/bevy_integration/events.md)
   - [Advanced Replication](./concepts/advanced_replication/title.md)
+    - [Authority](./concepts/advanced_replication/authority.md)
     - [Bandwidth Management](./concepts/advanced_replication/bandwidth_management.md)
     - [Replication Logic](./concepts/advanced_replication/replication_logic.md)
     - [Inputs](./concepts/advanced_replication/inputs.md)

--- a/book/src/concepts/advanced_replication/authority.md
+++ b/book/src/concepts/advanced_replication/authority.md
@@ -1,0 +1,65 @@
+# Authority
+
+Networked entities can be simulated on a client or on a server.
+We define by 'Authority' the decision of which **peer is simulating an entity**.
+The authoritative peer (client or server) is the only one that is allowed to send replication updates for an entity, and it won't accept updates from a non-authoritative peer.
+
+Only **one peer** can be the authority over an entity at a given time.
+
+
+### Benefits of distributed client-authority
+
+Client authority means that the client is directly responsible for simulating an entity and sending 
+replication updates for that entity.
+
+Cons:
+  - high exposure to cheating.
+  - lower latency
+Pros:
+  - less CPU load on the server since the client is simulating some entities
+
+
+### How it works
+
+We have 2 components:
+- `HasAuthority`: this is a marker component that you can use as a filter in queries
+  to check if the current peer has authority over the entity.
+  - on clients:
+    - a client will not accept any replication updates from the server if it has `HasAuthority` for an entity
+    - a client will send replication updates for an entity only if it has `HasAuthority` for that entity
+  - on server:
+    - this component is just used as an indicator for convenience, but the server can still send replication
+      updates even if it doesn't have `HasAuthority` for an entity. (because it's broadcasting the updates coming
+      from a client)
+- `AuthorityPeer`: this component is only present on the server, and it indicates to the server which
+  peer currently holds authority over an entity. (`None`, `Server` or a `Client`).
+  The server will only accept replication updates for an entity if the sender matches the `AuthorityPeer`.
+
+### Authority Transfer
+
+On the server, you can use the `EntityCommand` `transfer_authority` to transfer the authority for an entity to a different peer.
+The command is simply `commands.entity(entity).transfer_authority(new_owner)` to transfer the authority of `entity` to the `AuthorityPeer` `new_owner`.
+
+Under the hood, authority transfers do two things:
+- on the server, the transfer is applied immediately (i.e. the `HasAuthority` and `AuthorityPeer` components are updated instantly)
+- than the server sends messages to clients to notify them of an authority change. Upon receiving the message, the client will add or remove the `HasAuthority` component as needed.
+
+### Caveats
+
+- There could be a time where both the client and server have authority at the same time
+  - server is transferring authority from itself to a client: there is a period of time where
+    no peer has authority, which is ok.
+  - server is transferring authority from a client to itself: there is a period of time where
+    both the client and server have authority. The client's updates won't be accepted by the server because it has authority, and the server's updates won't be accepted by the client because it 
+    has authority, so no updates will be applied.
+    
+  - server is transferring authority from client C1 to client C2:
+    - if C1 receives the message first, then for a short period of time no client has authority, which is ok
+    - if C2 receives the message first, then for a short period of time both clients have authority. However the `AuthorityPeer` is immediately updated on the server, so the server will only 
+      accept updates from C2, and will discard the updates from C1.
+
+TODO:
+- maybe let the client always accept updates from the server, even if the client has `HasAuthority`? What is the goal of disallowing the client to accept updates from the server if it has
+`HasAuthority`?
+- maybe include a timestamp/tick to the `ChangeAuthority` messages so that any in-flight replication updates can be handled correctly? 
+  

--- a/book/src/concepts/advanced_replication/authority.md
+++ b/book/src/concepts/advanced_replication/authority.md
@@ -62,4 +62,4 @@ TODO:
 - maybe let the client always accept updates from the server, even if the client has `HasAuthority`? What is the goal of disallowing the client to accept updates from the server if it has
 `HasAuthority`?
 - maybe include a timestamp/tick to the `ChangeAuthority` messages so that any in-flight replication updates can be handled correctly? 
-  
+- maybe have an API `request_authority` where the client requests the authority? and receives a response from the server telling it if the request is accepted or not?

--- a/lightyear/src/channel/builder.rs
+++ b/lightyear/src/channel/builder.rs
@@ -239,3 +239,8 @@ pub struct PongChannel;
 #[derive(ChannelInternal)]
 /// Default channel to send inputs from client to server. This is a Sequenced Unreliable channel.
 pub struct InputChannel;
+
+#[derive(ChannelInternal)]
+/// Channel to send messages related to Authority transfers
+/// This is an Ordered Reliable channel
+pub struct AuthorityChannel;

--- a/lightyear/src/client/connection.rs
+++ b/lightyear/src/client/connection.rs
@@ -1,7 +1,7 @@
 //! Specify how a Client sends/receives messages with a Server
 use bevy::ecs::component::Tick as BevyTick;
 use bevy::ecs::entity::MapEntities;
-use bevy::prelude::{Commands, Resource};
+use bevy::prelude::{Resource, World};
 use bevy::utils::{Duration, HashMap};
 use bytes::Bytes;
 use tracing::{debug, trace, trace_span};
@@ -387,7 +387,7 @@ impl ConnectionManager {
 
     pub(crate) fn receive(
         &mut self,
-        commands: &mut Commands,
+        world: &mut World,
         // TODO: pass the `ComponentRegistry`/`MessageRegistry` as arguments instead of storing a copy
         //  in the `ConnectionManager`
         time_manager: &TimeManager,
@@ -471,7 +471,7 @@ impl ConnectionManager {
         if self.sync_manager.is_synced() {
             // Check if we have any replication messages we can apply to the World (and emit events)
             self.replication_receiver.apply_world(
-                commands,
+                world,
                 None,
                 &self.component_registry,
                 tick_manager.tick(),

--- a/lightyear/src/client/replication.rs
+++ b/lightyear/src/client/replication.rs
@@ -59,7 +59,10 @@ pub(crate) mod send {
 
     use crate::shared::replication::components::{Replicating, ReplicationGroupId};
 
-    use crate::shared::replication::archetypes::{get_erased_component, ReplicatedArchetypes};
+    use crate::shared::replication::archetypes::{
+        get_erased_component, ClientReplicatedArchetypes,
+    };
+    use crate::shared::replication::authority::HasAuthority;
     use crate::shared::replication::error::ReplicationError;
     use bevy::ecs::system::SystemChangeTick;
     use bevy::ptr::Ptr;
@@ -149,6 +152,11 @@ pub(crate) mod send {
         /// Marker indicating that the entity should be replicated to the server.
         /// If this component is removed, the entity will be despawned on the server.
         pub target: ReplicateToServer,
+        /// Marker component that indicates that the client has authority over the entity.
+        /// This means that this client:
+        /// - is allowed to send replication updates for this entity
+        /// - will not accept any replication messages for this entity
+        pub authority: HasAuthority,
         /// The replication group defines how entities are grouped (sent as a single message) for replication.
         ///
         /// After the entity is first replicated, the replication group of the entity should not be modified.
@@ -209,7 +217,7 @@ pub(crate) mod send {
     pub(crate) fn replicate(
         tick_manager: Res<TickManager>,
         component_registry: Res<ComponentRegistry>,
-        mut replicated_archetypes: Local<ReplicatedArchetypes<ReplicateToServer>>,
+        mut replicated_archetypes: Local<ClientReplicatedArchetypes>,
         system_ticks: SystemChangeTick,
         mut set: ParamSet<(&World, ResMut<ConnectionManager>)>,
     ) {

--- a/lightyear/src/protocol/channel.rs
+++ b/lightyear/src/protocol/channel.rs
@@ -4,7 +4,9 @@ use bevy::utils::Duration;
 use std::any::TypeId;
 use std::collections::HashMap;
 
-use crate::channel::builder::{Channel, ChannelBuilder, ChannelSettings, PongChannel};
+use crate::channel::builder::{
+    AuthorityChannel, Channel, ChannelBuilder, ChannelSettings, PongChannel,
+};
 use crate::channel::builder::{
     ChannelContainer, EntityActionsChannel, EntityUpdatesChannel, InputChannel, PingChannel,
 };
@@ -109,6 +111,12 @@ impl ChannelRegistry {
             send_frequency: input_send_interval,
             // we always want to include the inputs in the packet
             priority: f32::INFINITY,
+        });
+        registry.add_channel::<AuthorityChannel>(ChannelSettings {
+            mode: ChannelMode::OrderedReliable(ReliableSettings::default()),
+            send_frequency: Duration::default(),
+            // we want to send the authority transfers as soon as possible
+            priority: 10.0,
         });
         registry
     }

--- a/lightyear/src/protocol/component.rs
+++ b/lightyear/src/protocol/component.rs
@@ -1,14 +1,15 @@
 use bevy::ecs::component::ComponentId;
 use bevy::ecs::entity::MapEntities;
-use bevy::prelude::{App, Commands, Component, Entity, Mut, Resource, TypePath, World};
-use bevy::ptr::Ptr;
-use bevy::utils::HashMap;
-use serde::de::DeserializeOwned;
-use serde::Serialize;
 use std::any::TypeId;
 use std::fmt::Debug;
 use std::hash::Hash;
 use std::ops::{Add, Mul};
+
+use bevy::prelude::{App, Component, EntityWorldMut, Mut, Resource, TypePath, World};
+use bevy::ptr::Ptr;
+use bevy::utils::HashMap;
+use serde::de::DeserializeOwned;
+use serde::Serialize;
 
 use tracing::{debug, error, trace};
 
@@ -20,12 +21,13 @@ use crate::client::prediction::plugin::{
 };
 use crate::prelude::client::SyncComponent;
 use crate::prelude::server::ServerConfig;
-use crate::prelude::{ChannelDirection, ClientId, Message, Tick};
+use crate::prelude::{ChannelDirection, Message, Tick};
 use crate::protocol::delta::ErasedDeltaFns;
 use crate::protocol::registry::{NetId, TypeKind, TypeMapper};
 use crate::protocol::serialize::{ErasedSerializeFns, SerializeFns};
 use crate::serialize::reader::Reader;
 use crate::serialize::SerializationError;
+use crate::shared::events::connection::ConnectionEvents;
 use crate::shared::replication::delta::{DeltaMessage, Diffable};
 use crate::shared::replication::entity_map::EntityMap;
 
@@ -186,16 +188,15 @@ pub struct InterpolationMetadata {
     pub interpolation: Option<unsafe fn()>,
 }
 
-type RawRemoveFn = fn(&ComponentRegistry, &mut Commands, Entity);
+type RawRemoveFn = fn(&ComponentRegistry, &mut EntityWorldMut);
 type RawWriteFn = fn(
     &ComponentRegistry,
     &mut Reader,
     ComponentNetId,
     Tick,
-    &mut Commands,
-    Entity,
+    &mut EntityWorldMut,
     &mut EntityMap,
-    Option<ClientId>,
+    &mut ConnectionEvents,
 ) -> Result<(), ComponentError>;
 
 /// Function used to interpolate from one component state (`start`) to another (`other`)
@@ -534,13 +535,10 @@ mod interpolation {
 mod replication {
     use super::*;
     use crate::prelude::{
-        ClientId, DeltaCompression, DisabledComponent, OverrideTargetComponent,
-        ReplicateOnceComponent,
+        DeltaCompression, DisabledComponent, OverrideTargetComponent, ReplicateOnceComponent,
     };
     use crate::serialize::reader::Reader;
     use crate::serialize::ToBytes;
-    use crate::shared::replication::receive::get_connection_events;
-    use bevy::prelude::{Commands, Entity};
 
     impl ComponentRegistry {
         pub(crate) fn set_replication_fns<C: Component + PartialEq>(&mut self, world: &mut World) {
@@ -565,11 +563,10 @@ mod replication {
         pub(crate) fn raw_write(
             &self,
             reader: &mut Reader,
-            commands: &mut Commands,
-            entity: Entity,
+            entity_world_mut: &mut EntityWorldMut,
             tick: Tick,
             entity_map: &mut EntityMap,
-            remote_id: Option<ClientId>,
+            events: &mut ConnectionEvents,
         ) -> Result<(), ComponentError> {
             let net_id = ComponentNetId::from_bytes(reader).map_err(SerializationError::from)?;
             let kind = self
@@ -581,7 +578,13 @@ mod replication {
                 .get(kind)
                 .ok_or(ComponentError::MissingReplicationFns)?;
             (replication_metadata.write)(
-                self, reader, net_id, tick, commands, entity, entity_map, remote_id,
+                self,
+                reader,
+                net_id,
+                tick,
+                entity_world_mut,
+                entity_map,
+                events,
             )
         }
 
@@ -590,40 +593,31 @@ mod replication {
             reader: &mut Reader,
             net_id: ComponentNetId,
             tick: Tick,
-            commands: &mut Commands,
-            entity: Entity,
+            entity_world_mut: &mut EntityWorldMut,
             entity_map: &mut EntityMap,
-            remote_id: Option<ClientId>,
+            events: &mut ConnectionEvents,
         ) -> Result<(), ComponentError> {
             trace!("Writing component {} to entity", std::any::type_name::<C>());
             let component = self.raw_deserialize::<C>(reader, net_id, entity_map)?;
-
-            commands.add(move |world: &mut World| {
-                let Some(mut entity_world_mut) = world.get_entity_mut(entity) else {
-                    return;
-                };
-                // TODO: should we send the event based on on the message type (Insert/Update) or based on whether the component was actually inserted?
-                if let Some(mut c) = entity_world_mut.get_mut::<C>() {
-                    // only apply the update if the component is different, to not trigger change detection
-                    if c.as_ref() != &component {
-                        *c = component;
-                        get_connection_events(world, remote_id)
-                            .push_update_component(entity, net_id, tick);
-                    }
-                } else {
-                    entity_world_mut.insert(component);
-                    get_connection_events(world, remote_id)
-                        .push_insert_component(entity, net_id, tick);
+            let entity = entity_world_mut.id();
+            // TODO: should we send the event based on on the message type (Insert/Update) or based on whether the component was actually inserted?
+            if let Some(mut c) = entity_world_mut.get_mut::<C>() {
+                // only apply the update if the component is different, to not trigger change detection
+                if c.as_ref() != &component {
+                    events.push_update_component(entity, net_id, tick);
+                    *c = component;
                 }
-            });
+            } else {
+                events.push_insert_component(entity, net_id, tick);
+                entity_world_mut.insert(component);
+            }
             Ok(())
         }
 
         pub(crate) fn raw_remove(
             &self,
             net_id: ComponentNetId,
-            commands: &mut Commands,
-            entity: Entity,
+            entity_world_mut: &mut EntityWorldMut,
         ) {
             let kind = self.kind_map.kind(net_id).expect("unknown component kind");
             let replication_metadata = self
@@ -633,11 +627,11 @@ mod replication {
             let f = replication_metadata
                 .remove
                 .expect("the component does not have a remove function");
-            f(self, commands, entity);
+            f(self, entity_world_mut);
         }
 
-        pub(crate) fn remove<C: Component>(&self, commands: &mut Commands, entity: Entity) {
-            commands.entity(entity).remove::<C>();
+        pub(crate) fn remove<C: Component>(&self, entity_world_mut: &mut EntityWorldMut) {
+            entity_world_mut.remove::<C>();
         }
     }
 }
@@ -648,7 +642,6 @@ mod delta {
     use crate::shared::replication::delta::{DeltaComponentHistory, DeltaType};
 
     use crate::serialize::writer::Writer;
-    use crate::shared::replication::receive::get_connection_events;
     use std::ptr::NonNull;
 
     impl ComponentRegistry {
@@ -756,10 +749,9 @@ mod delta {
             reader: &mut Reader,
             net_id: ComponentNetId,
             tick: Tick,
-            commands: &mut Commands,
-            entity: Entity,
+            entity_world_mut: &mut EntityWorldMut,
             entity_map: &mut EntityMap,
-            remote_id: Option<ClientId>,
+            events: &mut ConnectionEvents,
         ) -> Result<(), ComponentError> {
             trace!(
                 "Writing component delta {} to entity",
@@ -768,92 +760,68 @@ mod delta {
             let delta_net_id = self.net_id::<DeltaMessage<C::Delta>>();
             let delta =
                 self.raw_deserialize::<DeltaMessage<C::Delta>>(reader, delta_net_id, entity_map)?;
+            let entity = entity_world_mut.id();
             // TODO: should we send the event based on on the message type (Insert/Update) or based on whether the component was actually inserted?
-            commands.add(move |world: &mut World| {
-                let Some(mut entity_world_mut) = world.get_entity_mut(entity) else {
-                    return
-                };
-                let mut is_update = false;
-                let mut is_insert = false;
-                match delta.delta_type {
-                    DeltaType::Normal { previous_tick } => {
-                        let Some(mut history) = entity_world_mut.get_mut::<DeltaComponentHistory<C>>()
-                        else {
-                            // TODO: maybe a command that pipes errors somewhere?
-                            error!("Entity {entity:?} does not have a ConfirmedHistory<{}>, but we received a diff for delta-compression",
-                                        std::any::type_name::<C>());
-                            return;
-                            // return Err(ComponentError::DeltaCompressionError(
-                            //     format!("Entity {entity:?} does not have a ConfirmedHistory<{}>, but we received a diff for delta-compression",
-                            //             std::any::type_name::<C>())
-                            // ));
-                        };
-                        let Some(past_value) = history.buffer.get(&previous_tick) else {
-                            error!("Entity {entity:?} does not have a value for tick {previous_tick:?} in the ConfirmedHistory<{}>",
-                                        std::any::type_name::<C>());
-                            return;
-                            // return Err(ComponentError::DeltaCompressionError(
-                            //     format!("Entity {entity:?} does not have a value for tick {previous_tick:?} in the ConfirmedHistory<{}>",
-                            //             std::any::type_name::<C>())
-                            // ));
-                        };
-                        // TODO: is it possible to have one clone instead of 2?
-                        let mut new_value = past_value.clone();
-                        new_value.apply_diff(&delta.delta);
-                        // we can remove all the values strictly older than previous_tick in the component history
-                        // (since we now that server has receive an ack for previous_tick)
-                        history.buffer = history.buffer.split_off(&previous_tick);
-                        // store the new value in the history
-                        history.buffer.insert(tick, new_value.clone());
-                        let Some(mut c) = entity_world_mut.get_mut::<C>() else {
-                            error!("Entity {entity:?} does not have a {} component, but we received a diff for delta-compression",
-                                        std::any::type_name::<C>());
-                            return;
-                            // return Err(ComponentError::DeltaCompressionError(
-                            //     format!("Entity {entity:?} does not have a {} component, but we received a diff for delta-compression",
-                            //             std::any::type_name::<C>())
-                            // ));
-                        };
-                        *c = new_value;
-                        is_update = true;
-                        let events = get_connection_events(world, remote_id);
-                        events.push_update_component(entity, net_id, tick);
-                    }
-                    DeltaType::FromBase => {
-                        let mut new_value = C::base_value();
-                        new_value.apply_diff(&delta.delta);
-                        let value = new_value.clone();
-                        if let Some(mut c) = entity_world_mut.get_mut::<C>() {
-                            // only apply the update if the component is different, to not trigger change detection
-                            if c.as_ref() != &new_value {
-                                *c = new_value;
-                                is_update = true;
-                            }
-                        } else {
-                            entity_world_mut.insert(new_value);
-                            is_insert = true;
-                        }
-                        // store the component value in the delta component history, so that we can compute
-                        // diffs from it
-                        if let Some(mut history) =
-                            entity_world_mut.get_mut::<DeltaComponentHistory<C>>()
-                        {
-                            history.buffer.insert(tick, value);
-                        } else {
-                            // create a DeltaComponentHistory and insert the value
-                            let mut history = DeltaComponentHistory::default();
-                            history.buffer.insert(tick, value);
-                            entity_world_mut.insert(history);
-                        }
-                    }
-                }
-                let events = get_connection_events(world, remote_id);
-                if is_update {
+            match delta.delta_type {
+                DeltaType::Normal { previous_tick } => {
+                    let Some(mut history) = entity_world_mut.get_mut::<DeltaComponentHistory<C>>()
+                    else {
+                        return Err(ComponentError::DeltaCompressionError(
+                            format!("Entity {entity:?} does not have a ConfirmedHistory<{}>, but we received a diff for delta-compression",
+                                    std::any::type_name::<C>())
+                        ));
+                    };
+                    let Some(past_value) = history.buffer.get(&previous_tick) else {
+                        return Err(ComponentError::DeltaCompressionError(
+                            format!("Entity {entity:?} does not have a value for tick {previous_tick:?} in the ConfirmedHistory<{}>",
+                                    std::any::type_name::<C>())
+                        ));
+                    };
+                    // TODO: is it possible to have one clone instead of 2?
+                    let mut new_value = past_value.clone();
+                    new_value.apply_diff(&delta.delta);
+                    // we can remove all the values strictly older than previous_tick in the component history
+                    // (since we now that server has receive an ack for previous_tick)
+                    history.buffer = history.buffer.split_off(&previous_tick);
+                    // store the new value in the history
+                    history.buffer.insert(tick, new_value.clone());
+                    let Some(mut c) = entity_world_mut.get_mut::<C>() else {
+                        return Err(ComponentError::DeltaCompressionError(
+                            format!("Entity {entity:?} does not have a {} component, but we received a diff for delta-compression",
+                            std::any::type_name::<C>())
+                        ));
+                    };
+                    *c = new_value;
                     events.push_update_component(entity, net_id, tick);
-                } else if is_insert {
-                    events.push_insert_component(entity, net_id, tick);
                 }
-            });
+                DeltaType::FromBase => {
+                    let mut new_value = C::base_value();
+                    new_value.apply_diff(&delta.delta);
+                    let value = new_value.clone();
+                    if let Some(mut c) = entity_world_mut.get_mut::<C>() {
+                        // only apply the update if the component is different, to not trigger change detection
+                        if c.as_ref() != &new_value {
+                            *c = new_value;
+                            events.push_update_component(entity, net_id, tick);
+                        }
+                    } else {
+                        entity_world_mut.insert(new_value);
+                        events.push_insert_component(entity, net_id, tick);
+                    }
+                    // store the component value in the delta component history, so that we can compute
+                    // diffs from it
+                    if let Some(mut history) =
+                        entity_world_mut.get_mut::<DeltaComponentHistory<C>>()
+                    {
+                        history.buffer.insert(tick, value);
+                    } else {
+                        // create a DeltaComponentHistory and insert the value
+                        let mut history = DeltaComponentHistory::default();
+                        history.buffer.insert(tick, value);
+                        entity_world_mut.insert(history);
+                    }
+                }
+            }
             Ok(())
         }
     }

--- a/lightyear/src/server/connection.rs
+++ b/lightyear/src/server/connection.rs
@@ -1,7 +1,7 @@
 //! Specify how a Server sends/receives messages with a Client
 use bevy::ecs::component::Tick as BevyTick;
 use bevy::ecs::entity::{EntityHash, MapEntities};
-use bevy::prelude::{Commands, Component, Entity, Resource};
+use bevy::prelude::{Component, Entity, Resource, World};
 use bevy::ptr::Ptr;
 use bevy::utils::{Duration, HashMap};
 use bytes::Bytes;
@@ -394,7 +394,7 @@ impl ConnectionManager {
     #[cfg_attr(feature = "trace", instrument(level = Level::INFO, skip_all))]
     pub(crate) fn receive(
         &mut self,
-        commands: &mut Commands,
+        world: &mut World,
         component_registry: &ComponentRegistry,
         message_registry: &MessageRegistry,
         time_manager: &TimeManager,
@@ -408,7 +408,7 @@ impl ConnectionManager {
                 let _span = trace_span!("receive", ?client_id).entered();
                 // receive events on the connection
                 let events = connection.receive(
-                    commands,
+                    world,
                     component_registry,
                     message_registry,
                     time_manager,
@@ -671,7 +671,7 @@ impl Connection {
 
     pub fn receive(
         &mut self,
-        commands: &mut Commands,
+        world: &mut World,
         component_registry: &ComponentRegistry,
         message_registry: &MessageRegistry,
         time_manager: &TimeManager,
@@ -758,7 +758,7 @@ impl Connection {
 
         // Check if we have any replication messages we can apply to the World (and emit events)
         self.replication_receiver.apply_world(
-            commands,
+            world,
             Some(self.client_id),
             component_registry,
             tick_manager.tick(),

--- a/lightyear/src/server/replication.rs
+++ b/lightyear/src/server/replication.rs
@@ -59,7 +59,10 @@ pub(crate) mod send {
     use crate::protocol::component::ComponentKind;
     use crate::server::error::ServerError;
     use crate::server::relevance::immediate::{CachedNetworkRelevance, ClientRelevance};
-    use crate::shared::replication::archetypes::{get_erased_component, ReplicatedArchetypes};
+    use crate::shared::replication::archetypes::{
+        get_erased_component, ServerReplicatedArchetypes,
+    };
+    use crate::shared::replication::authority::AuthorityPeer;
     use crate::shared::replication::components::{
         Cached, Controlled, Replicating, ReplicationGroupId, ReplicationTarget,
         ShouldBeInterpolated,
@@ -211,6 +214,9 @@ pub(crate) mod send {
     pub struct Replicate {
         /// Which clients should this entity be replicated to?
         pub target: ReplicationTarget,
+        // TODO: if AuthorityPeer::Server is added, need to add HasAuthority (via observer)
+        /// Who has authority over the entity? i.e. who is in charge of simulating the entity and sending replication updates?
+        pub authority: AuthorityPeer,
         /// Which clients should predict/interpolate the entity?
         pub sync: SyncTarget,
         /// How do we control the visibility of the entity?
@@ -345,7 +351,7 @@ pub(crate) mod send {
     pub(crate) fn replicate(
         tick_manager: Res<TickManager>,
         component_registry: Res<ComponentRegistry>,
-        mut replicated_archetypes: Local<ReplicatedArchetypes<ReplicationTarget>>,
+        mut replicated_archetypes: Local<ServerReplicatedArchetypes>,
         system_ticks: SystemChangeTick,
         mut set: ParamSet<(&World, ResMut<ConnectionManager>)>,
     ) {

--- a/lightyear/src/server/replication.rs
+++ b/lightyear/src/server/replication.rs
@@ -3064,7 +3064,7 @@ pub(crate) mod commands {
                         });
 
                 match (current_owner, new_owner) {
-                    (x, y) if x == y => return,
+                    (x, y) if x == y => (),
                     (AuthorityPeer::None, AuthorityPeer::Server) => {
                         world
                             .entity_mut(entity)

--- a/lightyear/src/shared/plugin.rs
+++ b/lightyear/src/shared/plugin.rs
@@ -7,11 +7,12 @@ use bevy::utils::Duration;
 
 use crate::prelude::client::ComponentSyncMode;
 use crate::prelude::{
-    AppComponentExt, ChannelDirection, ChannelRegistry, ComponentRegistry, LinkConditionerConfig,
-    MessageRegistry, Mode, ParentSync, PingConfig, PrePredicted, PreSpawnedPlayerObject,
-    ShouldBePredicted, TickConfig,
+    AppComponentExt, AppMessageExt, ChannelDirection, ChannelRegistry, ComponentRegistry,
+    LinkConditionerConfig, MessageRegistry, Mode, ParentSync, PingConfig, PrePredicted,
+    PreSpawnedPlayerObject, ShouldBePredicted, TickConfig,
 };
 use crate::shared::config::SharedConfig;
+use crate::shared::replication::authority::AuthorityChange;
 use crate::shared::replication::components::{Controlled, ShouldBeInterpolated};
 use crate::shared::tick_manager::TickManagerPlugin;
 use crate::shared::time_manager::TimePlugin;
@@ -146,6 +147,10 @@ impl Plugin for SharedPlugin {
         app.register_component::<Controlled>(ChannelDirection::ServerToClient)
             .add_prediction(ComponentSyncMode::Once)
             .add_interpolation(ComponentSyncMode::Once);
+
+        app.register_message::<AuthorityChange>(ChannelDirection::ServerToClient)
+            .add_map_entities();
+
         // check that the protocol was built correctly
         app.world().resource::<ComponentRegistry>().check();
     }

--- a/lightyear/src/shared/replication/archetypes.rs
+++ b/lightyear/src/shared/replication/archetypes.rs
@@ -20,14 +20,14 @@ use bevy::{
 /// Cached information about all replicated archetypes.
 ///
 /// The generic component is the component that is used to identify if the archetype is used for Replication.
-/// This is the [`ReplicateToServer`](crate::client::replication::send::ReplicateToServer) or [`ReplicationTarget`](crate::prelude::ReplicationTarget) component.
+/// This is the [`ReplicateToServer`] or [`ReplicationTarget`] component.
 /// (not the [`Replicating`], which just indicates if we are in the process of replicating.
 // NOTE: we keep the generic so that we can have both resources in the same world in
 // host-server mode
 #[derive(Resource)]
 pub(crate) struct ReplicatedArchetypes<C: Component> {
     /// ID of the component identifying if the archetype is used for Replication.
-    /// This is the [`ReplicateToServer`](crate::client::replication::send::ReplicateToServer) or [`ReplicationTarget`](crate::prelude::ReplicationTarget) component.
+    /// This is the [`ReplicateToServer`] or [`ReplicationTarget`] component.
     /// (not the [`Replicating`], which just indicates if we are in the process of replicating.
     replication_component_id: ComponentId,
     /// ID of the [`Replicating`] component, which indicates that the entity is being replicated.

--- a/lightyear/src/shared/replication/authority.rs
+++ b/lightyear/src/shared/replication/authority.rs
@@ -54,3 +54,182 @@ pub(crate) struct GetAuthorityRequest {
 pub(crate) struct GetAuthorityResponse {
     success: bool,
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::prelude::{client, server, ClientId};
+    use crate::server::replication::commands::AuthorityCommandExt;
+    use crate::shared::replication::authority::{AuthorityPeer, HasAuthority};
+    use crate::tests::protocol::ComponentSyncModeSimple;
+    use crate::tests::stepper::{BevyStepper, Step, TEST_CLIENT_ID};
+
+    #[test]
+    fn test_transfer_authority_server_to_client() {
+        let mut stepper = BevyStepper::default();
+
+        let server_entity = stepper
+            .server_app
+            .world_mut()
+            .spawn((server::Replicate::default(), ComponentSyncModeSimple(1.0)))
+            .id();
+
+        stepper.flush();
+        // check that HasAuthority was added
+        assert!(stepper
+            .server_app
+            .world()
+            .get::<HasAuthority>(server_entity)
+            .is_some());
+
+        stepper.frame_step();
+        stepper.frame_step();
+        // check that the entity was replicated
+        let client_entity = *stepper
+            .client_app
+            .world()
+            .resource::<client::ConnectionManager>()
+            .replication_receiver
+            .remote_entity_map
+            .get_local(server_entity)
+            .expect("entity was not replicated to client");
+
+        // transfer authority from server to client
+        stepper
+            .server_app
+            .world_mut()
+            .commands()
+            .entity(server_entity)
+            .transfer_authority(AuthorityPeer::Client(ClientId::Netcode(TEST_CLIENT_ID)));
+
+        // check that the authority was transferred correctly
+        stepper.flush();
+        assert!(stepper
+            .server_app
+            .world()
+            .get::<HasAuthority>(server_entity)
+            .is_none());
+        assert_eq!(
+            stepper
+                .server_app
+                .world()
+                .get::<AuthorityPeer>(server_entity)
+                .unwrap(),
+            &AuthorityPeer::Client(ClientId::Netcode(TEST_CLIENT_ID))
+        );
+        stepper.frame_step();
+        stepper.frame_step();
+        stepper.flush();
+        assert!(stepper
+            .client_app
+            .world()
+            .get::<HasAuthority>(client_entity)
+            .is_some());
+
+        // transfer authority from client to none
+        stepper
+            .server_app
+            .world_mut()
+            .commands()
+            .entity(server_entity)
+            .transfer_authority(AuthorityPeer::None);
+        stepper.flush();
+        stepper.frame_step();
+        stepper.frame_step();
+        stepper.flush();
+        assert!(stepper
+            .client_app
+            .world()
+            .get::<HasAuthority>(client_entity)
+            .is_none());
+    }
+
+    #[test]
+    fn test_ignore_updates_from_non_authority() {
+        let mut stepper = BevyStepper::default();
+
+        let client_entity = stepper
+            .client_app
+            .world_mut()
+            .spawn((client::Replicate::default(), ComponentSyncModeSimple(1.0)))
+            .id();
+
+        // TODO: we need to run a couple frames because the server doesn't read the client's updates
+        //  because they are from the future
+        for _ in 0..10 {
+            stepper.frame_step();
+            stepper.frame_step();
+        }
+        // check that the entity was replicated
+        let server_entity = *stepper
+            .server_app
+            .world()
+            .resource::<server::ConnectionManager>()
+            .connection(ClientId::Netcode(TEST_CLIENT_ID))
+            .expect("client connection missing")
+            .replication_receiver
+            .remote_entity_map
+            .get_local(client_entity)
+            .expect("entity was not replicated to server");
+
+        // transfer authority from server to client
+        stepper
+            .server_app
+            .world_mut()
+            .commands()
+            .entity(server_entity)
+            .transfer_authority(AuthorityPeer::Server);
+
+        // check that the authority was transferred correctly
+        stepper.flush();
+        assert!(stepper
+            .server_app
+            .world()
+            .get::<HasAuthority>(server_entity)
+            .is_some());
+        assert_eq!(
+            stepper
+                .server_app
+                .world()
+                .get::<AuthorityPeer>(server_entity)
+                .unwrap(),
+            &AuthorityPeer::Server
+        );
+        stepper.frame_step();
+        stepper.frame_step();
+        stepper.flush();
+        assert!(stepper
+            .client_app
+            .world()
+            .get::<HasAuthority>(client_entity)
+            .is_none());
+
+        // create a conflict situation where the client also gets added `HasAuthority` at the same time as the server (which is what happens when the AuthorityChange message is in flight)
+        // TODO: it does mean that server changes while the client is in the process of getting authority are ignored. Is this what we want? Maybe we make the client always accept remote changes?
+        stepper
+            .client_app
+            .world_mut()
+            .entity_mut(client_entity)
+            .insert(HasAuthority);
+        // update the component
+        stepper
+            .client_app
+            .world_mut()
+            .get_mut::<ComponentSyncModeSimple>(client_entity)
+            .unwrap()
+            .0 = 2.0;
+        for _ in 0..10 {
+            stepper.frame_step();
+            stepper.frame_step();
+        }
+        // check that the server didn't accept the client's update because it believes that it has the authority (AuthorityPeer = Server)
+        assert_eq!(
+            stepper
+                .server_app
+                .world()
+                .get::<ComponentSyncModeSimple>(server_entity)
+                .unwrap()
+                .0,
+            1.0
+        );
+    }
+}

--- a/lightyear/src/shared/replication/authority.rs
+++ b/lightyear/src/shared/replication/authority.rs
@@ -1,0 +1,26 @@
+//! Module related to the concept of `Authority`
+//!
+//! A peer is said to have authority over an entity if it has the burden of simulating the entity.
+//! Note that replicating state to other peers doesn't necessary mean that you have authority:
+//! client C1 could have authority (is simulating the entity), replicated to the server which then replicates to other clients.
+//! In this case C1 has authority even though the server is still replicating some states.
+//!
+use crate::prelude::ClientId;
+use bevy::prelude::*;
+
+#[derive(Component, Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Authority;
+
+pub enum Peer {
+    Server,
+    Client(ClientId),
+}
+
+pub struct AuthorityRequest {
+    pub entity: Entity,
+    pub peer: Peer,
+}
+
+pub struct AuthorityResponse {
+    success: bool,
+}

--- a/lightyear/src/shared/replication/authority.rs
+++ b/lightyear/src/shared/replication/authority.rs
@@ -16,12 +16,15 @@ use bevy::prelude::*;
 /// - a client with Authority won't accept replication updates from the server
 /// - a client without Authority won't be sending any replication updates
 /// - a server won't accept replication updates from clients without Authority
-#[derive(Component, Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Component, Debug, Default, Clone, Copy, PartialEq, Eq, Reflect)]
 pub struct HasAuthority;
 
-#[derive(Component, Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(
+    Component, Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Default, Reflect,
+)]
 pub enum AuthorityPeer {
     None,
+    #[default]
     Server,
     Client(ClientId),
 }

--- a/lightyear/src/shared/replication/authority.rs
+++ b/lightyear/src/shared/replication/authority.rs
@@ -61,7 +61,7 @@ mod tests {
     use crate::server::replication::commands::AuthorityCommandExt;
     use crate::shared::replication::authority::{AuthorityPeer, HasAuthority};
     use crate::tests::protocol::ComponentSyncModeSimple;
-    use crate::tests::stepper::{BevyStepper, Step, TEST_CLIENT_ID};
+    use crate::tests::stepper::{BevyStepper, TEST_CLIENT_ID};
 
     #[test]
     fn test_transfer_authority_server_to_client() {

--- a/lightyear/src/shared/replication/authority.rs
+++ b/lightyear/src/shared/replication/authority.rs
@@ -5,22 +5,49 @@
 //! client C1 could have authority (is simulating the entity), replicated to the server which then replicates to other clients.
 //! In this case C1 has authority even though the server is still replicating some states.
 //!
-use crate::prelude::ClientId;
+
+use crate::prelude::{ClientId, Deserialize, Serialize};
+use bevy::ecs::entity::MapEntities;
 use bevy::prelude::*;
 
+/// Authority is used to define who is in charge of simulating an entity.
+///
+/// In particular:
+/// - a client with Authority won't accept replication updates from the server
+/// - a client without Authority won't be sending any replication updates
+/// - a server won't accept replication updates from clients without Authority
 #[derive(Component, Debug, Clone, Copy, PartialEq, Eq)]
-pub struct Authority;
+pub struct HasAuthority;
 
-pub enum Peer {
+#[derive(Component, Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AuthorityPeer {
+    None,
     Server,
     Client(ClientId),
 }
 
-pub struct AuthorityRequest {
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct TransferAuthority {
     pub entity: Entity,
-    pub peer: Peer,
+    pub peer: AuthorityPeer,
 }
 
-pub struct AuthorityResponse {
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct AuthorityChange {
+    pub entity: Entity,
+    pub gain_authority: bool,
+}
+
+impl MapEntities for AuthorityChange {
+    fn map_entities<M: EntityMapper>(&mut self, entity_mapper: &mut M) {
+        self.entity = entity_mapper.map_entity(self.entity);
+    }
+}
+
+pub(crate) struct GetAuthorityRequest {
+    pub entity: Entity,
+}
+
+pub(crate) struct GetAuthorityResponse {
     success: bool,
 }

--- a/lightyear/src/shared/replication/hierarchy.rs
+++ b/lightyear/src/shared/replication/hierarchy.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 use crate::prelude::server::ControlledBy;
 use crate::prelude::{MainSet, NetworkRelevanceMode, PrePredicted, Replicating, ReplicationGroup};
 use crate::server::replication::send::SyncTarget;
+use crate::shared::replication::authority::{AuthorityPeer, HasAuthority};
 use crate::shared::replication::components::{ReplicateHierarchy, ReplicationTarget};
 use crate::shared::replication::{ReplicationPeer, ReplicationSend};
 use crate::shared::sets::{InternalMainSet, InternalReplicationSet};
@@ -56,6 +57,8 @@ impl<R: ReplicationSend> HierarchySendPlugin<R> {
                 Option<&SyncTarget>,
                 Option<&ControlledBy>,
                 Option<&NetworkRelevanceMode>,
+                Option<&HasAuthority>,
+                Option<&AuthorityPeer>,
             ),
             (
                 Without<Parent>,
@@ -75,6 +78,8 @@ impl<R: ReplicationSend> HierarchySendPlugin<R> {
             sync_target,
             controlled_by,
             visibility_mode,
+            has_authority,
+            authority_peer,
         ) in parent_query.iter()
         {
             if replicate_hierarchy.recursive {
@@ -119,6 +124,12 @@ impl<R: ReplicationSend> HierarchySendPlugin<R> {
                     }
                     if let Some(vis) = visibility_mode {
                         commands.entity(child).insert(*vis);
+                    }
+                    if let Some(has_authority) = has_authority {
+                        commands.entity(child).insert(*has_authority);
+                    }
+                    if let Some(authority_peer) = authority_peer {
+                        commands.entity(child).insert(*authority_peer);
                     }
                 }
             }

--- a/lightyear/src/shared/replication/mod.rs
+++ b/lightyear/src/shared/replication/mod.rs
@@ -26,7 +26,7 @@ use crate::shared::replication::components::ReplicationGroupId;
 pub mod components;
 
 pub(crate) mod archetypes;
-mod authority;
+pub(crate) mod authority;
 pub mod delta;
 pub mod entity_map;
 pub mod error;

--- a/lightyear/src/shared/replication/mod.rs
+++ b/lightyear/src/shared/replication/mod.rs
@@ -26,6 +26,7 @@ use crate::shared::replication::components::ReplicationGroupId;
 pub mod components;
 
 pub(crate) mod archetypes;
+mod authority;
 pub mod delta;
 pub mod entity_map;
 pub mod error;

--- a/lightyear/src/shared/replication/plugin.rs
+++ b/lightyear/src/shared/replication/plugin.rs
@@ -251,6 +251,7 @@ pub(crate) mod shared {
         NetworkRelevanceMode, PrePredicted, RemoteEntityMap, ReplicateHierarchy, Replicated,
         ReplicationConfig, ReplicationGroup, ReplicationTarget, ShouldBePredicted, TargetEntity,
     };
+    use crate::shared::replication::authority::{AuthorityPeer, HasAuthority};
     use crate::shared::replication::components::{
         Controlled, Replicating, ReplicationGroupId, ReplicationGroupIdBuilder,
         ShouldBeInterpolated,
@@ -282,6 +283,8 @@ pub(crate) mod shared {
                 .register_type::<ShouldBePredicted>()
                 .register_type::<RemoteEntityMap>()
                 .register_type::<PredictedEntityMap>()
+                .register_type::<HasAuthority>()
+                .register_type::<AuthorityPeer>()
                 .register_type::<InterpolatedEntityMap>();
         }
     }

--- a/lightyear/src/shared/replication/receive.rs
+++ b/lightyear/src/shared/replication/receive.rs
@@ -11,7 +11,7 @@ use crate::shared::replication::components::{Replicated, ReplicationGroupId};
 #[cfg(test)]
 use crate::utils::captures::Captures;
 use bevy::ecs::entity::EntityHash;
-use bevy::prelude::{Commands, DespawnRecursiveExt, Entity, EntityWorldMut, World};
+use bevy::prelude::{DespawnRecursiveExt, Entity, World};
 use bevy::utils::HashSet;
 use tracing::{debug, error, trace, warn};
 #[cfg(feature = "trace")]
@@ -235,7 +235,7 @@ impl ReplicationReceiver {
     #[cfg(test)]
     pub(crate) fn apply_actions_message(
         &mut self,
-        commands: &mut Commands,
+        world: &mut World,
         remote: Option<ClientId>,
         component_registry: &ComponentRegistry,
         remote_tick: Tick,
@@ -254,7 +254,7 @@ impl ReplicationReceiver {
                 SpawnAction::Spawn => {
                     self.remote_entity_to_group.insert(*remote_entity, group_id);
                     if let Some(local_entity) = self.remote_entity_map.get_local(*remote_entity) {
-                        if commands.get_entity(*local_entity).is_some() {
+                        if world.get_entity(*local_entity).is_some() {
                             warn!("Received spawn for an entity that already exists");
                             continue;
                         }
@@ -275,7 +275,7 @@ impl ReplicationReceiver {
                     //     interpolated: None,
                     //     tick,
                     // });
-                    let local_entity = commands.spawn(Replicated { from: remote });
+                    let local_entity = world.spawn(Replicated { from: remote });
                     self.remote_entity_map
                         .insert(*remote_entity, local_entity.id());
                     trace!("Updated remote entity map: {:?}", self.remote_entity_map);
@@ -284,7 +284,7 @@ impl ReplicationReceiver {
                     events.push_spawn(local_entity.id());
                 }
                 SpawnAction::Reuse(local_entity) => {
-                    let Some(mut entity_mut) = commands.get_entity(local_entity) else {
+                    let Some(mut entity_mut) = world.get_entity_mut(local_entity) else {
                         // TODO: ignore the entity in the next steps because it does not exist!
                         error!("Received ReuseEntity({local_entity:?}) but the entity does not exist in the world");
                         continue;
@@ -307,15 +307,11 @@ impl ReplicationReceiver {
                     if let Some(group) = self.group_channels.get_mut(&group_id) {
                         group.remote_entities.remove(&entity);
                     }
-                    commands.add(move |world: &mut World| {
-                        if let Some(entity_mut) = world.get_entity_mut(local_entity) {
-                            // TODO: we despawn all children as well right now, but that might not be what we want?
-                            entity_mut.despawn_recursive();
-                        }
-                        // TODO: only send the despawn event if the entity actually existed?
-                        get_connection_events(world, remote).push_despawn(local_entity);
-                    });
-                    // TODO: should we update this in the Command or here?
+                    // TODO: we despawn all children as well right now, but that might not be what we want?
+                    if let Some(entity_mut) = world.get_entity_mut(local_entity) {
+                        entity_mut.despawn_recursive();
+                    }
+                    events.push_despawn(local_entity);
                     self.remote_entity_to_group.remove(&entity);
                 } else {
                     error!("Received despawn for an entity that does not exist")
@@ -324,12 +320,11 @@ impl ReplicationReceiver {
             }
 
             // safety: we know by this point that the entity exists
-            let local_entity = self.remote_entity_map.get_local(entity);
-            if local_entity.and_then(|e| commands.get_entity(*e)).is_none() {
-                error!("Cannot find remote entity: {:?}", entity);
+            let Some(mut local_entity_mut) = self.remote_entity_map.get_by_remote(world, entity)
+            else {
+                error!("cannot find entity");
                 continue;
-            }
-            let local_entity = *local_entity.unwrap();
+            };
 
             // NOTE: 2 options
             //  - send the raw data to a separate typed system
@@ -345,11 +340,10 @@ impl ReplicationReceiver {
                 let _ = component_registry
                     .raw_write(
                         &mut reader,
-                        commands,
-                        local_entity,
+                        &mut local_entity_mut,
                         remote_tick,
                         &mut self.remote_entity_map.remote_to_local,
-                        remote,
+                        events,
                     )
                     .inspect_err(|e| {
                         error!("could not write the component to the entity: {:?}", e)
@@ -368,8 +362,8 @@ impl ReplicationReceiver {
             // removals
             trace!(remote_entity = ?entity, ?actions.remove, "Received RemoveComponent");
             for kind in actions.remove {
-                events.push_remove_component(local_entity, kind, Tick(0));
-                component_registry.raw_remove(kind, commands, local_entity);
+                events.push_remove_component(local_entity_mut.id(), kind, Tick(0));
+                component_registry.raw_remove(kind, &mut local_entity_mut);
             }
 
             // updates
@@ -380,24 +374,23 @@ impl ReplicationReceiver {
                 let _ = component_registry
                     .raw_write(
                         &mut reader,
-                        commands,
-                        local_entity,
+                        &mut local_entity_mut,
                         remote_tick,
                         &mut self.remote_entity_map.remote_to_local,
-                        remote,
+                        events,
                     )
                     .inspect_err(|e| {
                         error!("could not write the component to the entity: {:?}", e)
                     });
             }
         }
-        self.update_confirmed_tick(commands, group_id, remote_tick);
+        self.update_confirmed_tick(world, group_id, remote_tick);
     }
 
     #[cfg(test)]
     pub(crate) fn apply_updates_message(
         &mut self,
-        commands: &mut Commands,
+        world: &mut World,
         remote: Option<ClientId>,
         component_registry: &ComponentRegistry,
         remote_tick: Tick,
@@ -415,32 +408,30 @@ impl ReplicationReceiver {
             debug!(?components, remote_entity = ?entity, "Received UpdateComponent");
 
             // update the entity only if it exists
-            let local_entity = self.remote_entity_map.get_local(entity);
-            if local_entity.and_then(|e| commands.get_entity(*e)).is_none() {
+            let Some(mut local_entity_mut) = self.remote_entity_map.get_by_remote(world, entity)
+            else {
                 // we can get a few buffered updates after the entity has been despawned
                 // those are the updates that we received before the despawn action message, but with a tick
                 // later than the despawn action message
                 debug!("update for entity that doesn't exist: {:?}", entity);
                 continue;
-            }
-            let local_entity = *local_entity.unwrap();
+            };
             for component in components {
                 let mut reader = Reader::from(component);
                 let _ = component_registry
                     .raw_write(
                         &mut reader,
-                        commands,
-                        local_entity,
+                        &mut local_entity_mut,
                         remote_tick,
                         &mut self.remote_entity_map.remote_to_local,
-                        remote,
+                        events,
                     )
                     .inspect_err(|e| {
                         error!("could not write the component to the entity: {:?}", e)
                     });
             }
         }
-        self.update_confirmed_tick(commands, group_id, remote_tick);
+        self.update_confirmed_tick(world, group_id, remote_tick);
     }
 
     /// Update the Confirmed tick for all entities in the replication group
@@ -451,7 +442,7 @@ impl ReplicationReceiver {
     /// same group)
     pub(crate) fn update_confirmed_tick(
         &mut self,
-        commands: &mut Commands,
+        world: &mut World,
         group_id: ReplicationGroupId,
         remote_tick: Tick,
     ) {
@@ -465,20 +456,14 @@ impl ReplicationReceiver {
 
         if let Some(g) = self.group_channels.get(&group_id) {
             g.remote_entities.iter().for_each(|remote_entity| {
-                let local_entity = self.remote_entity_map.get_local(*remote_entity);
-                if local_entity.and_then(|e| commands.get_entity(*e)).is_none() {
-                    debug!("update for entity that doesn't exist?");
-                    return;
+                if let Some(mut local_entity_mut) =
+                    self.remote_entity_map.get_by_remote(world, *remote_entity)
+                {
+                    trace!(?remote_tick, "updating confirmed tick for entity");
+                    if let Some(mut confirmed) = local_entity_mut.get_mut::<Confirmed>() {
+                        confirmed.tick = remote_tick;
+                    }
                 }
-                let local_entity = *local_entity.unwrap();
-                commands
-                    .entity(local_entity)
-                    .add(move |mut entity_world_mut: EntityWorldMut| {
-                        trace!(?remote_tick, "updating confirmed tick for entity");
-                        if let Some(mut confirmed) = entity_world_mut.get_mut::<Confirmed>() {
-                            confirmed.tick = remote_tick;
-                        }
-                    });
             });
         }
     }
@@ -493,7 +478,8 @@ impl ReplicationReceiver {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn apply_world(
         &mut self,
-        commands: &mut Commands,
+        // TODO: should we use commands for command batching?
+        world: &mut World,
         remote: Option<ClientId>,
         component_registry: &ComponentRegistry,
         current_tick: Tick,
@@ -558,7 +544,7 @@ impl ReplicationReceiver {
                 channel.latest_tick = Some(remote_tick);
 
                 channel.apply_actions_message(
-                    commands,
+                    world,
                     remote,
                     component_registry,
                     remote_tick,
@@ -592,12 +578,13 @@ impl ReplicationReceiver {
                     let (remote_tick, message) = channel.buffered_updates.pop_oldest().unwrap();
                     let is_history = channel.buffered_updates.len() != max_applicable_idx;
                     channel.apply_updates_message(
-                        commands,
+                        world,
                         remote,
                         component_registry,
                         remote_tick,
                         is_history,
                         message,
+                        events,
                         &mut self.remote_entity_map,
                     );
                 }
@@ -814,7 +801,7 @@ impl GroupChannel {
     /// Apply actions for channel
     pub(crate) fn apply_actions_message(
         &mut self,
-        commands: &mut Commands,
+        world: &mut World,
         remote: Option<ClientId>,
         component_registry: &ComponentRegistry,
         remote_tick: Tick,
@@ -835,7 +822,7 @@ impl GroupChannel {
                 SpawnAction::Spawn => {
                     remote_entity_to_group.insert(*remote_entity, group_id);
                     if let Some(local_entity) = remote_entity_map.get_local(*remote_entity) {
-                        if commands.get_entity(*local_entity).is_some() {
+                        if world.get_entity(*local_entity).is_some() {
                             warn!("Received spawn for an entity that already exists");
                             continue;
                         }
@@ -856,7 +843,9 @@ impl GroupChannel {
                     //     interpolated: None,
                     //     tick,
                     // });
-                    let local_entity = commands.spawn(Replicated { from: remote });
+
+                    // TODO: maybe use command-batching?
+                    let local_entity = world.spawn(Replicated { from: remote });
                     remote_entity_map.insert(*remote_entity, local_entity.id());
                     trace!("Updated remote entity map: {:?}", remote_entity_map);
 
@@ -864,7 +853,7 @@ impl GroupChannel {
                     events.push_spawn(local_entity.id());
                 }
                 SpawnAction::Reuse(local_entity) => {
-                    let Some(mut entity_mut) = commands.get_entity(local_entity) else {
+                    let Some(mut entity_mut) = world.get_entity_mut(local_entity) else {
                         // TODO: ignore the entity in the next steps because it does not exist!
                         error!("Received ReuseEntity({local_entity:?}) but the entity does not exist in the world");
                         continue;
@@ -886,7 +875,7 @@ impl GroupChannel {
                 if let Some(local_entity) = remote_entity_map.remove_by_remote(entity) {
                     self.remote_entities.remove(&entity);
                     // TODO: we despawn all children as well right now, but that might not be what we want?
-                    if let Some(entity_mut) = commands.get_entity(local_entity) {
+                    if let Some(entity_mut) = world.get_entity_mut(local_entity) {
                         entity_mut.despawn_recursive();
                     }
                     events.push_despawn(local_entity);
@@ -898,12 +887,10 @@ impl GroupChannel {
             }
 
             // safety: we know by this point that the entity exists
-            let local_entity = remote_entity_map.get_local(entity);
-            if local_entity.and_then(|e| commands.get_entity(*e)).is_none() {
-                error!("Cannot find remote entity: {:?}", entity);
+            let Some(mut local_entity_mut) = remote_entity_map.get_by_remote(world, entity) else {
+                error!(?entity, "cannot find entity");
                 continue;
-            }
-            let local_entity = *local_entity.unwrap();
+            };
 
             // NOTE: 2 options
             //  - send the raw data to a separate typed system
@@ -918,11 +905,10 @@ impl GroupChannel {
                 let _ = component_registry
                     .raw_write(
                         &mut reader,
-                        commands,
-                        local_entity,
+                        &mut local_entity_mut,
                         remote_tick,
                         &mut remote_entity_map.remote_to_local,
-                        remote,
+                        events,
                     )
                     .inspect_err(|e| {
                         error!("could not write the component to the entity: {:?}", e)
@@ -941,8 +927,8 @@ impl GroupChannel {
             // removals
             trace!(remote_entity = ?entity, ?actions.remove, "Received RemoveComponent");
             for kind in actions.remove {
-                events.push_remove_component(local_entity, kind, Tick(0));
-                component_registry.raw_remove(kind, commands, local_entity);
+                events.push_remove_component(local_entity_mut.id(), kind, Tick(0));
+                component_registry.raw_remove(kind, &mut local_entity_mut);
             }
 
             // updates
@@ -952,28 +938,28 @@ impl GroupChannel {
                 let _ = component_registry
                     .raw_write(
                         &mut reader,
-                        commands,
-                        local_entity,
+                        &mut local_entity_mut,
                         remote_tick,
                         &mut remote_entity_map.remote_to_local,
-                        remote,
+                        events,
                     )
                     .inspect_err(|e| {
                         error!("could not write the component to the entity: {:?}", e)
                     });
             }
         }
-        self.update_confirmed_tick(commands, group_id, remote_tick, remote_entity_map);
+        self.update_confirmed_tick(world, group_id, remote_tick, remote_entity_map);
     }
 
     pub(crate) fn apply_updates_message(
         &mut self,
-        commands: &mut Commands,
+        world: &mut World,
         remote: Option<ClientId>,
         component_registry: &ComponentRegistry,
         remote_tick: Tick,
         is_history: bool,
         message: EntityUpdatesMessage,
+        events: &mut ConnectionEvents,
         remote_entity_map: &mut RemoteEntityMap,
     ) {
         let group_id = message.group_id;
@@ -984,37 +970,29 @@ impl GroupChannel {
         }
         for (entity, components) in message.updates.into_iter() {
             debug!(?components, remote_entity = ?entity, "Received UpdateComponent");
-            // update the entity only if it exists
-            let local_entity = remote_entity_map.get_local(entity);
-            if local_entity
-                .and_then(|local_entity| commands.get_entity(*local_entity))
-                .is_none()
-            {
+            let Some(mut local_entity_mut) = remote_entity_map.get_by_remote(world, entity) else {
                 // we can get a few buffered updates after the entity has been despawned
                 // those are the updates that we received before the despawn action message, but with a tick
                 // later than the despawn action message
                 debug!("update for entity that doesn't exist?");
                 continue;
-            }
-            let local_entity = *local_entity.unwrap();
-
+            };
             for component in components {
                 let mut reader = Reader::from(component);
                 let _ = component_registry
                     .raw_write(
                         &mut reader,
-                        commands,
-                        local_entity,
+                        &mut local_entity_mut,
                         remote_tick,
                         &mut remote_entity_map.remote_to_local,
-                        remote,
+                        events,
                     )
                     .inspect_err(|e| {
                         error!("could not write the component to the entity: {:?}", e)
                     });
             }
         }
-        self.update_confirmed_tick(commands, group_id, remote_tick, remote_entity_map);
+        self.update_confirmed_tick(world, group_id, remote_tick, remote_entity_map);
     }
 
     /// Update the Confirmed tick for all entities in the replication group
@@ -1025,7 +1003,7 @@ impl GroupChannel {
     /// same group)
     pub(crate) fn update_confirmed_tick(
         &mut self,
-        commands: &mut Commands,
+        world: &mut World,
         group_id: ReplicationGroupId,
         remote_tick: Tick,
         remote_entity_map: &mut RemoteEntityMap,
@@ -1039,20 +1017,14 @@ impl GroupChannel {
         // }
 
         self.remote_entities.iter().for_each(|remote_entity| {
-            let local_entity = remote_entity_map.get_local(*remote_entity);
-            if local_entity.and_then(|e| commands.get_entity(*e)).is_none() {
-                debug!("update for entity that doesn't exist?");
-                return;
+            if let Some(mut local_entity_mut) =
+                remote_entity_map.get_by_remote(world, *remote_entity)
+            {
+                trace!(?remote_tick, "updating confirmed tick for entity");
+                if let Some(mut confirmed) = local_entity_mut.get_mut::<Confirmed>() {
+                    confirmed.tick = remote_tick;
+                }
             }
-            let local_entity = *local_entity.unwrap();
-            commands
-                .entity(local_entity)
-                .add(move |mut entity_world_mut: EntityWorldMut| {
-                    trace!(?remote_tick, "updating confirmed tick for entity");
-                    if let Some(mut confirmed) = entity_world_mut.get_mut::<Confirmed>() {
-                        confirmed.tick = remote_tick;
-                    }
-                });
         });
     }
 }
@@ -1385,7 +1357,7 @@ mod tests {
             )],
         };
         manager.apply_actions_message(
-            &mut world.commands(),
+            &mut world,
             None,
             &component_registry,
             Tick(0),

--- a/lightyear/src/tests/stepper.rs
+++ b/lightyear/src/tests/stepper.rs
@@ -287,6 +287,11 @@ impl BevyStepper {
             .insert_resource(TimeUpdateStrategy::ManualInstant(self.current_time));
         mock_instant::global::MockClock::advance(duration);
     }
+
+    pub(crate) fn flush(&mut self) {
+        self.client_app.world_mut().flush();
+        self.server_app.world_mut().flush();
+    }
 }
 
 impl Step for BevyStepper {


### PR DESCRIPTION
For each entity add a component `HasAuthority` which symbolizes which peer is simulating the entity.
The server only accepts replication updates from the entity which currently has authority