### PR TITLE
Excessive iteration over query in simple_box example

### DIFF
--- a/examples/simple_box/src/client.rs
+++ b/examples/simple_box/src/client.rs
@@ -139,6 +139,10 @@ fn player_movement(
 ) {
     for input in input_reader.read() {
         if let Some(input) = input.input() {
+            //No need to iterate the position when the input is None
+            if(input == &Inputs::None) {
+                continue;
+            }
             for position in position_query.iter_mut() {
                 shared::shared_movement_behaviour(position, input);
             }


### PR DESCRIPTION
While debugging inputs in HostServer mode it seems excessive iteration of position_query is done when the input is actually none. 

I know this is example code, but programmers (at least one;me) always copy paste, so probably good to fix anyway.