### PR TITLE
Make the RemoteEntityMap public

### DIFF
--- a/lightyear/src/client/connection.rs
+++ b/lightyear/src/client/connection.rs
@@ -20,7 +20,7 @@ use crate::packet::message_manager::MessageManager;
 use crate::packet::packet_builder::{Payload, RecvPayload};
 use crate::packet::priority_manager::PriorityConfig;
 use crate::prelude::client::PredictionConfig;
-use crate::prelude::{Channel, ChannelKind, ClientId, Message, ReplicationConfig};
+use crate::prelude::{Channel, ChannelKind, ClientId, Message, RemoteEntityMap, ReplicationConfig};
 use crate::protocol::channel::ChannelRegistry;
 use crate::protocol::component::ComponentRegistry;
 use crate::protocol::message::{MessageRegistry, MessageType};
@@ -71,7 +71,7 @@ pub struct ConnectionManager {
     pub(crate) message_manager: MessageManager,
     pub(crate) delta_manager: DeltaManager,
     pub(crate) replication_sender: ReplicationSender,
-    pub(crate) replication_receiver: ReplicationReceiver,
+    pub replication_receiver: ReplicationReceiver,
     pub(crate) events: ConnectionEvents,
     pub ping_manager: PingManager,
     pub(crate) sync_manager: SyncManager,

--- a/lightyear/src/server/connection.rs
+++ b/lightyear/src/server/connection.rs
@@ -460,7 +460,7 @@ pub struct Connection {
     entity: Entity,
     pub message_manager: MessageManager,
     pub(crate) replication_sender: ReplicationSender,
-    pub(crate) replication_receiver: ReplicationReceiver,
+    pub replication_receiver: ReplicationReceiver,
     pub(crate) events: ConnectionEvents,
     pub(crate) ping_manager: PingManager,
 

--- a/lightyear/src/shared/replication/entity_map.rs
+++ b/lightyear/src/shared/replication/entity_map.rs
@@ -67,6 +67,7 @@ pub struct InterpolatedEntityMap {
 }
 
 impl RemoteEntityMap {
+    /// Insert a new mapping between a remote entity and a local entity
     #[inline]
     pub fn insert(&mut self, remote_entity: Entity, local_entity: Entity) {
         self.remote_to_local.insert(remote_entity, local_entity);

--- a/lightyear/src/shared/replication/receive.rs
+++ b/lightyear/src/shared/replication/receive.rs
@@ -30,11 +30,11 @@ pub(crate) struct ReplicationReceiver {
     pub remote_entity_map: RemoteEntityMap,
 
     /// Map from remote entity to the replication group-id
-    pub remote_entity_to_group: EntityHashMap<Entity, ReplicationGroupId>,
+    pub(crate) remote_entity_to_group: EntityHashMap<Entity, ReplicationGroupId>,
 
     // BOTH
     /// Buffer to so that we have an ordered receiver per group
-    pub group_channels: EntityHashMap<ReplicationGroupId, GroupChannel>,
+    pub(crate) group_channels: EntityHashMap<ReplicationGroupId, GroupChannel>,
 }
 
 /// Get `ConnectionEvents` depending on whether we receive from a client or a server


### PR DESCRIPTION
This can be useful if users want to tweak the mappings themselves