### PR TITLE
Order lightyear plugins w.r.t avian plugins

### DIFF
--- a/lightyear/src/shared/plugin.rs
+++ b/lightyear/src/shared/plugin.rs
@@ -105,6 +105,12 @@ impl Plugin for SharedPlugin {
             .register_type::<LinkConditionerConfig>()
             .register_type::<CompressionConfig>();
 
+        // PLUGINS
+        #[cfg(feature = "avian2d")]
+        app.add_plugins(crate::utils::avian2d::Avian2dPlugin);
+        #[cfg(feature = "avian3d")]
+        app.add_plugins(crate::utils::avian3d::Avian3dPlugin);
+
         // RESOURCES
         // the SharedPlugin is called after the ClientConfig is inserted
         let input_send_interval =

--- a/lightyear/src/shared/replication/receive.rs
+++ b/lightyear/src/shared/replication/receive.rs
@@ -25,7 +25,7 @@ type EntityHashMap<K, V> = hashbrown::HashMap<K, V, EntityHash>;
 type EntityHashSet<K> = hashbrown::HashSet<K, EntityHash>;
 
 #[derive(Debug)]
-pub(crate) struct ReplicationReceiver {
+pub struct ReplicationReceiver {
     /// Map between local and remote entities. (used mostly on client because it's when we receive entity updates)
     pub remote_entity_map: RemoteEntityMap,
 

--- a/lightyear/src/utils/avian2d.rs
+++ b/lightyear/src/utils/avian2d.rs
@@ -1,8 +1,37 @@
 //! Implement lightyear traits for some common bevy types
+use crate::prelude::client::{InterpolationSet, PredictionSet};
 use crate::shared::replication::delta::Diffable;
+use crate::shared::sets::{ClientMarker, InternalReplicationSet, ServerMarker};
 use avian2d::math::Scalar;
 use avian2d::prelude::*;
+use bevy::prelude::{App, FixedPostUpdate, IntoSystemSetConfigs, Plugin};
 use tracing::trace;
+
+pub(crate) struct Avian2dPlugin;
+
+impl Plugin for Avian2dPlugin {
+    fn build(&self, app: &mut App) {
+        app.configure_sets(
+            FixedPostUpdate,
+            (
+                PhysicsSet::Prepare,
+                PhysicsSet::StepSimulation,
+                PhysicsSet::Sync,
+            )
+                .before((
+                    PredictionSet::UpdateHistory,
+                    PredictionSet::IncrementRollbackTick,
+                    InterpolationSet::UpdateVisualInterpolationState,
+                ))
+                // run physics after setting the PreSpawned hash to avoid any physics interaction affecting the hash
+                // TODO: maybe use observers so that we don't have any ordering requirements?
+                .after((
+                    InternalReplicationSet::<ClientMarker>::SetPreSpawnedHash,
+                    InternalReplicationSet::<ServerMarker>::SetPreSpawnedHash,
+                )),
+        );
+    }
+}
 
 pub mod position {
     use super::*;


### PR DESCRIPTION
Avian has a PR (https://github.com/Jondolf/avian/pull/457) where their plugin will run inside FixedPostUpdate.

We want to order our plugins w.r.t to that:
- avian must run before storing component values in the PredictionHistory
- avian must run before we update the stored value for VisualInterpolation
- avian must run **after** we compute the PreSpawnedObject hash (because we don't want the hash to change because of some collision)