### PR TITLE
Send events as server::events::InputEvent instead of client::events:InputEvent  in send_input_directly_to_client_events when using HostServer

### DIFF
--- a/lightyear/src/client/input/leafwing.rs
+++ b/lightyear/src/client/input/leafwing.rs
@@ -975,7 +975,7 @@ mod tests {
         assert!(stepper
             .client_app
             .world()
-            .entity(client_entity)
+            .entity(server_entity)
             .get::<ActionState<LeafwingInput1>>()
             .unwrap()
             .pressed(&LeafwingInput1::Jump));

--- a/lightyear/src/client/input/leafwing.rs
+++ b/lightyear/src/client/input/leafwing.rs
@@ -975,7 +975,7 @@ mod tests {
         assert!(stepper
             .client_app
             .world()
-            .entity(server_entity)
+            .entity(client_entity)
             .get::<ActionState<LeafwingInput1>>()
             .unwrap()
             .pressed(&LeafwingInput1::Jump));


### PR DESCRIPTION
This change simplifies the HostServer mode by not requiring a separate system on the client side for HostServer. 

In apps that do not do client predictions they will be simpler, as there is no need for shared code.

There is also the added benefit that the system only copies input when doing local connection, and could in principal run on all clients (not sure if that's a great idea, but there it is)

I tested it in my app, and ran hostserver for  simple_box, not sure if there are any scenarios it would not work in.