### PR TITLE
Remove unneeded import

### DIFF
--- a/lightyear/src/transport/websocket/server.rs
+++ b/lightyear/src/transport/websocket/server.rs
@@ -24,7 +24,6 @@ use crate::server::io::transport::{ServerTransportBuilder, ServerTransportEnum};
 use crate::server::io::{ServerIoEvent, ServerIoEventReceiver, ServerNetworkEventSender};
 use crate::transport::error::{Error, Result};
 use crate::transport::io::IoState;
-use crate::transport::webtransport::server::WebTransportServerSocket;
 use crate::transport::{BoxedReceiver, BoxedSender, PacketReceiver, PacketSender, Transport, MTU};
 
 pub(crate) struct WebSocketServerSocketBuilder {


### PR DESCRIPTION
If I don't include the web transport feature, then I get an error when building my project because this is imported on all configurations, and it's not used in the file.