### PR TITLE
Fix certificate generate commands in examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -60,7 +60,8 @@ To test the example in wasm, you can run the following commands: `trunk serve`
 You will need a valid SSL certificate to test the example in wasm using webtransport. You will need to run the following
 commands:
 
-- `sh examples/certificates/generate.sh` (to generate the temporary SSL certificates, they are only valid for 2 weeks)
+- `cd "$(git rev-parse --show-toplevel)" && sh examples/certificates/generate.sh` (to generate the temporary SSL
+  certificates, they are only valid for 2 weeks)
 - `cargo run -- server` to start the server. The server will print out the certificate digest (something
   like `1fd28860bd2010067cee636a64bcbb492142295b297fd8c480e604b70ce4d644`)
 - You then have to replace the certificate digest in the `assets/settings.ron` file with the one that the server printed

--- a/examples/avian_physics/README.md
+++ b/examples/avian_physics/README.md
@@ -55,7 +55,8 @@ To test the example in wasm, you can run the following commands: `trunk serve`
 You will need a valid SSL certificate to test the example in wasm using webtransport. You will need to run the following
 commands:
 
-- `sh examples/generate.sh` (to generate the temporary SSL certificates, they are only valid for 2 weeks)
+- `cd "$(git rev-parse --show-toplevel)" && sh examples/certificates/generate.sh` (to generate the temporary SSL
+  certificates, they are only valid for 2 weeks)
 - `cargo run -- server` to start the server. The server will print out the certificate digest (something
   like `1fd28860bd2010067cee636a64bcbb492142295b297fd8c480e604b70ce4d644`)
 - You then have to replace the certificate digest in the `assets/settings.ron` file with the one that the server printed

--- a/examples/bullet_prespawn/README.md
+++ b/examples/bullet_prespawn/README.md
@@ -37,7 +37,8 @@ To test the example in wasm, you can run the following commands: `trunk serve`
 You will need a valid SSL certificate to test the example in wasm using webtransport. You will need to run the following
 commands:
 
-- `sh examples/generate.sh` (to generate the temporary SSL certificates, they are only valid for 2 weeks)
+- `cd "$(git rev-parse --show-toplevel)" && sh examples/certificates/generate.sh` (to generate the temporary SSL
+  certificates, they are only valid for 2 weeks)
 - `cargo run -- server` to start the server. The server will print out the certificate digest (something
   like `1fd28860bd2010067cee636a64bcbb492142295b297fd8c480e604b70ce4d644`)
 - You then have to replace the certificate digest in the `assets/settings.ron` file with the one that the server printed

--- a/examples/client_replication/README.md
+++ b/examples/client_replication/README.md
@@ -48,7 +48,8 @@ To test the example in wasm, you can run the following commands: `trunk serve`
 You will need a valid SSL certificate to test the example in wasm using webtransport. You will need to run the following
 commands:
 
-- `sh examples/generate.sh` (to generate the temporary SSL certificates, they are only valid for 2 weeks)
+- `cd "$(git rev-parse --show-toplevel)" && sh examples/certificates/generate.sh` (to generate the temporary SSL
+  certificates, they are only valid for 2 weeks)
 - `cargo run -- server` to start the server. The server will print out the certificate digest (something
   like `1fd28860bd2010067cee636a64bcbb492142295b297fd8c480e604b70ce4d644`)
 - You then have to replace the certificate digest in the `assets/settings.ron` file with the one that the server printed

--- a/examples/distributed_authority/README.md
+++ b/examples/distributed_authority/README.md
@@ -41,7 +41,8 @@ To test the example in wasm, you can run the following commands: `trunk serve`
 You will need a valid SSL certificate to test the example in wasm using webtransport. You will need to run the following
 commands:
 
-- `sh examples/generate.sh` (to generate the temporary SSL certificates, they are only valid for 2 weeks)
+- `cd "$(git rev-parse --show-toplevel)" && sh examples/certificates/generate.sh` (to generate the temporary SSL
+  certificates, they are only valid for 2 weeks)
 - `cargo run -- server` to start the server. The server will print out the certificate digest (something
   like `1fd28860bd2010067cee636a64bcbb492142295b297fd8c480e604b70ce4d644`)
 - You then have to replace the certificate digest in the `assets/settings.ron` file with the one that the server printed

--- a/examples/priority/README.md
+++ b/examples/priority/README.md
@@ -42,7 +42,8 @@ To test the example in wasm, you can run the following commands: `trunk serve`
 You will need a valid SSL certificate to test the example in wasm using webtransport. You will need to run the following
 commands:
 
-- `sh examples/generate.sh` (to generate the temporary SSL certificates, they are only valid for 2 weeks)
+- `cd "$(git rev-parse --show-toplevel)" && sh examples/certificates/generate.sh` (to generate the temporary SSL
+  certificates, they are only valid for 2 weeks)
 - `cargo run -- server` to start the server. The server will print out the certificate digest (something
   like `1fd28860bd2010067cee636a64bcbb492142295b297fd8c480e604b70ce4d644`)
 - You then have to replace the certificate digest in the `assets/settings.ron` file with the one that the server printed

--- a/examples/replication_groups/README.md
+++ b/examples/replication_groups/README.md
@@ -44,7 +44,8 @@ To test the example in wasm, you can run the following commands: `trunk serve`
 You will need a valid SSL certificate to test the example in wasm using webtransport. You will need to run the following
 commands:
 
-- `sh examples/generate.sh` (to generate the temporary SSL certificates, they are only valid for 2 weeks)
+- `cd "$(git rev-parse --show-toplevel)" && sh examples/certificates/generate.sh` (to generate the temporary SSL
+  certificates, they are only valid for 2 weeks)
 - `cargo run -- server` to start the server. The server will print out the certificate digest (something
   like `1fd28860bd2010067cee636a64bcbb492142295b297fd8c480e604b70ce4d644`)
 - You then have to replace the certificate digest in the `assets/settings.ron` file with the one that the server printed

--- a/examples/simple_box/README.md
+++ b/examples/simple_box/README.md
@@ -36,7 +36,8 @@ To test the example in wasm, you can run the following commands: `trunk serve`
 You will need a valid SSL certificate to test the example in wasm using webtransport. You will need to run the following
 commands:
 
-- `sh examples/generate.sh` (to generate the temporary SSL certificates, they are only valid for 2 weeks)
+- `cd "$(git rev-parse --show-toplevel)" && sh examples/certificates/generate.sh` (to generate the temporary SSL
+  certificates, they are only valid for 2 weeks)
 - `cargo run -- server` to start the server. The server will print out the certificate digest (something
   like `1fd28860bd2010067cee636a64bcbb492142295b297fd8c480e604b70ce4d644`)
 - You then have to replace the certificate digest in the `assets/settings.ron` file with the one that the server printed

--- a/examples/spaceships/README.md
+++ b/examples/spaceships/README.md
@@ -50,7 +50,8 @@ To test the example in wasm, you can run the following commands: `trunk serve`
 You will need a valid SSL certificate to test the example in wasm using webtransport. You will need to run the following
 commands:
 
-- `sh examples/generate.sh` (to generate the temporary SSL certificates, they are only valid for 2 weeks)
+- `cd "$(git rev-parse --show-toplevel)" && sh examples/certificates/generate.sh` (to generate the temporary SSL
+  certificates, they are only valid for 2 weeks)
 - `cargo run -- server` to start the server. The server will print out the certificate digest (something
   like `1fd28860bd2010067cee636a64bcbb492142295b297fd8c480e604b70ce4d644`)
 - You then have to replace the certificate digest in the `assets/settings.ron` file with the one that the server printed


### PR DESCRIPTION
* Prepended a `cd` command because all other commands in each README assume user is in that directory; also the `generate.sh` script assumes user is in the root directory; alternatively consider adding `cd "$(dirname "$(realpath "$0")")"` and removing `$OUT/` in the `generate.sh` and then it could be run from anywhere and the generated keypair would be there (?)
* Used `$(git rev-parse --show-toplevel)` instead of `..` or `../..` for consistency
* Corrected path from `examples/generate.sh` to `examples/certificates/generate.sh`