### PR TITLE
Fix listen-server commands in examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -41,7 +41,7 @@ There are different 'modes' of operation:
   separate threads.
   They will communicate via channels (so with almost 0 latency)
 - as a listen server with `cargo run -- host-server`. This will launch a single bevy app, where the server will also act
-  as a client. Functionally, it is similar to the "listen-server" mode, but you have a single bevy `World` instead of
+  as a client. Functionally, it is similar to the "client-and-server" mode, but you have a single bevy `World` instead of
   separate client and server `Worlds`s.
 
 Then you can launch clients with the commands:

--- a/examples/auth/README.md
+++ b/examples/auth/README.md
@@ -20,11 +20,11 @@ to the client. The client can then use the `ConnectToken` to start the `lightyea
 There are different 'modes' of operation:
 
 - as a dedicated server with `cargo run -- server`
-- as a listen server with `cargo run -- listen-server`. This will launch 2 independent bevy apps (client and server) in
+- as a listen server with `cargo run -- client-and-server`. This will launch 2 independent bevy apps (client and server) in
   separate threads.
   They will communicate via channels (so with almost 0 latency)
 - as a listen server with `cargo run -- host-server`. This will launch a single bevy app, where the server will also act
-  as a client. Functionally, it is similar to the "listen-server" mode, but you have a single bevy `World` instead of
+  as a client. Functionally, it is similar to the "client-and-server" mode, but you have a single bevy `World` instead of
   separate client and server `Worlds`s.
 
 Then you can launch clients with the commands:

--- a/examples/avian_physics/README.md
+++ b/examples/avian_physics/README.md
@@ -32,11 +32,11 @@ enabled.*
 There are different 'modes' of operation:
 
 - as a dedicated server with `cargo run -- server`
-- as a listen server with `cargo run -- listen-server`. This will launch 2 independent bevy apps (client and server) in
-  separate threads.
+- as a listen server with `cargo run -- client-and-server`. This will launch 2 independent bevy apps (client and server)
+  in separate threads.
   They will communicate via channels (so with almost 0 latency)
 - as a listen server with `cargo run -- host-server`. This will launch a single bevy app, where the server will also act
-  as a client. Functionally, it is similar to the "listen-server" mode, but you have a single bevy `World` instead of
+  as a client. Functionally, it is similar to the "client-and-server" mode, but you have a single bevy `World` instead of
   separate client and server `Worlds`s.
 
 Then you can launch clients with the commands:

--- a/examples/bullet_prespawn/README.md
+++ b/examples/bullet_prespawn/README.md
@@ -14,11 +14,11 @@ https://github.com/cBournhonesque/lightyear/assets/8112632/ee547c32-1f14-4bdc-9e
 There are different 'modes' of operation:
 
 - as a dedicated server with `cargo run -- server`
-- as a listen server with `cargo run -- listen-server`. This will launch 2 independent bevy apps (client and server) in
+- as a listen server with `cargo run -- client-and-server`. This will launch 2 independent bevy apps (client and server) in
   separate threads.
   They will communicate via channels (so with almost 0 latency)
 - as a listen server with `cargo run -- host-server`. This will launch a single bevy app, where the server will also act
-  as a client. Functionally, it is similar to the "listen-server" mode, but you have a single bevy `World` instead of
+  as a client. Functionally, it is similar to the "client-and-server" mode, but you have a single bevy `World` instead of
   separate client and server `Worlds`s.
 
 Then you can launch clients with the commands:

--- a/examples/client_replication/README.md
+++ b/examples/client_replication/README.md
@@ -25,11 +25,11 @@ https://github.com/cBournhonesque/lightyear/assets/8112632/718bfa44-80b5-4d83-a3
 There are different 'modes' of operation:
 
 - as a dedicated server with `cargo run -- server`
-- as a listen server with `cargo run -- listen-server`. This will launch 2 independent bevy apps (client and server) in
+- as a listen server with `cargo run -- client-and-server`. This will launch 2 independent bevy apps (client and server) in
   separate threads.
   They will communicate via channels (so with almost 0 latency)
 - as a listen server with `cargo run -- host-server`. This will launch a single bevy app, where the server will also act
-  as a client. Functionally, it is similar to the "listen-server" mode, but you have a single bevy `World` instead of
+  as a client. Functionally, it is similar to the "client-and-server" mode, but you have a single bevy `World` instead of
   separate client and server `Worlds`s.
 
 Then you can launch clients with the commands:

--- a/examples/distributed_authority/README.md
+++ b/examples/distributed_authority/README.md
@@ -17,11 +17,11 @@ https://github.com/user-attachments/assets/ee987fce-7a0d-4e76-a010-bc35b71e24cf
 There are different 'modes' of operation:
 
 - as a dedicated server with `cargo run -- server`
-- as a listen server with `cargo run -- listen-server`. This will launch 2 independent bevy apps (client and server) in
+- as a listen server with `cargo run -- client-and-server`. This will launch 2 independent bevy apps (client and server) in
   separate threads.
   They will communicate via channels (so with almost 0 latency)
 - as a listen server with `cargo run -- host-server`. This will launch a single bevy app, where the server will also act
-  as a client. Functionally, it is similar to the "listen-server" mode, but you have a single bevy `World` instead of
+  as a client. Functionally, it is similar to the "client-and-server" mode, but you have a single bevy `World` instead of
   separate client and server `Worlds`s.
 
 Then you can launch clients with the commands:

--- a/examples/distributed_authority/src/main.rs
+++ b/examples/distributed_authority/src/main.rs
@@ -1,7 +1,7 @@
 //! This example showcases how to use Lightyear with Bevy, to easily get replication along with prediction/interpolation working.
 //!
 //! There is a lot of setup code, but it's mostly to have the examples work in all possible configurations of transport.
-//! (all transports are supported, as well as running the example in listen-server or host-server mode)
+//! (all transports are supported, as well as running the example in client-and-server or host-server mode)
 //!
 //!
 //! Run with

--- a/examples/interest_management/README.md
+++ b/examples/interest_management/README.md
@@ -14,11 +14,11 @@ https://github.com/cBournhonesque/lightyear/assets/8112632/41a6d102-77a1-4a44-89
 There are different 'modes' of operation:
 
 - as a dedicated server with `cargo run -- server`
-- as a listen server with `cargo run -- listen-server`. This will launch 2 independent bevy apps (client and server) in
+- as a listen server with `cargo run -- client-and-server`. This will launch 2 independent bevy apps (client and server) in
   separate threads.
   They will communicate via channels (so with almost 0 latency)
 - as a listen server with `cargo run -- host-server`. This will launch a single bevy app, where the server will also act
-  as a client. Functionally, it is similar to the "listen-server" mode, but you have a single bevy `World` instead of
+  as a client. Functionally, it is similar to the "client-and-server" mode, but you have a single bevy `World` instead of
   separate client and server `Worlds`s.
 
 Then you can launch clients with the commands:

--- a/examples/lobby/src/main.rs
+++ b/examples/lobby/src/main.rs
@@ -1,7 +1,7 @@
 //! This example showcases how to use Lightyear with Bevy, to easily get replication along with prediction/interpolation working.
 //!
 //! There is a lot of setup code, but it's mostly to have the examples work in all possible configurations of transport.
-//! (all transports are supported, as well as running the example in listen-server or host-server mode)
+//! (all transports are supported, as well as running the example in client-and-server or host-server mode)
 //!
 //!
 //! Run with

--- a/examples/priority/README.md
+++ b/examples/priority/README.md
@@ -19,11 +19,11 @@ https://github.com/cBournhonesque/lightyear/assets/8112632/0efcd974-b181-4910-93
 There are different 'modes' of operation:
 
 - as a dedicated server with `cargo run -- server`
-- as a listen server with `cargo run -- listen-server`. This will launch 2 independent bevy apps (client and server) in
+- as a listen server with `cargo run -- client-and-server`. This will launch 2 independent bevy apps (client and server) in
   separate threads.
   They will communicate via channels (so with almost 0 latency)
 - as a listen server with `cargo run -- host-server`. This will launch a single bevy app, where the server will also act
-  as a client. Functionally, it is similar to the "listen-server" mode, but you have a single bevy `World` instead of
+  as a client. Functionally, it is similar to the "client-and-server" mode, but you have a single bevy `World` instead of
   separate client and server `Worlds`s.
 
 Then you can launch clients with the commands:

--- a/examples/replication_groups/README.md
+++ b/examples/replication_groups/README.md
@@ -21,11 +21,11 @@ https://github.com/cBournhonesque/lightyear/assets/8112632/e7625286-a167-4f50-aa
 There are different 'modes' of operation:
 
 - as a dedicated server with `cargo run -- server`
-- as a listen server with `cargo run -- listen-server`. This will launch 2 independent bevy apps (client and server) in
+- as a listen server with `cargo run -- client-and-server`. This will launch 2 independent bevy apps (client and server) in
   separate threads.
   They will communicate via channels (so with almost 0 latency)
 - as a listen server with `cargo run -- host-server`. This will launch a single bevy app, where the server will also act
-  as a client. Functionally, it is similar to the "listen-server" mode, but you have a single bevy `World` instead of
+  as a client. Functionally, it is similar to the "client-and-server" mode, but you have a single bevy `World` instead of
   separate client and server `Worlds`s.
 
 Then you can launch clients with the commands:

--- a/examples/simple_box/README.md
+++ b/examples/simple_box/README.md
@@ -13,11 +13,11 @@ https://github.com/cBournhonesque/lightyear/assets/8112632/7b57d48a-d8b0-4cdd-a1
 There are different 'modes' of operation:
 
 - as a dedicated server with `cargo run -- server`
-- as a listen server with `cargo run -- listen-server`. This will launch 2 independent bevy apps (client and server) in
+- as a listen server with `cargo run -- client-and-server`. This will launch 2 independent bevy apps (client and server) in
   separate threads.
   They will communicate via channels (so with almost 0 latency)
 - as a listen server with `cargo run -- host-server`. This will launch a single bevy app, where the server will also act
-  as a client. Functionally, it is similar to the "listen-server" mode, but you have a single bevy `World` instead of
+  as a client. Functionally, it is similar to the "client-and-server" mode, but you have a single bevy `World` instead of
   separate client and server `Worlds`s.
 
 Then you can launch clients with the commands:

--- a/examples/simple_box/src/main.rs
+++ b/examples/simple_box/src/main.rs
@@ -1,7 +1,7 @@
 //! This example showcases how to use Lightyear with Bevy, to easily get replication along with prediction/interpolation working.
 //!
 //! There is a lot of setup code, but it's mostly to have the examples work in all possible configurations of transport.
-//! (all transports are supported, as well as running the example in listen-server or host-server mode)
+//! (all transports are supported, as well as running the example in client-and-server or host-server mode)
 //!
 //!
 //! Run with


### PR DESCRIPTION
AFAICT, the `listen-server` command was renamed to `client-and-server` in https://github.com/cBournhonesque/lightyear/commit/0f9947b24a81948bd6aac6cc1f6b1ac234b18dfb ... this PR intends to update all the dangling mentions of the no longer valid `listen-server` command.