### PR TITLE
Use the parent's ReplicationGroup when propagating it to the children

### DIFF
--- a/lightyear/src/client/prediction/pre_prediction.rs
+++ b/lightyear/src/client/prediction/pre_prediction.rs
@@ -133,7 +133,7 @@ impl PrePredictionPlugin {
                         // tick: Tick(0),
                     })
                     .id();
-                info!("Added PrePredicted on the client. Spawning confirmed entity: {confirmed_entity:?} for pre-rredicted: {predicted_entity:?}");
+                info!("Added PrePredicted on the client. Spawning confirmed entity: {confirmed_entity:?} for pre-predicted: {predicted_entity:?}");
                 world
                     .entity_mut(predicted_entity)
                     .get_mut::<PrePredicted>()

--- a/lightyear/src/client/prediction/pre_prediction.rs
+++ b/lightyear/src/client/prediction/pre_prediction.rs
@@ -95,7 +95,7 @@ impl PrePredictionPlugin {
         // we will add the Predicted component
         if let Some(&predicted) = predicted_map.confirmed_to_predicted.get(&trigger.entity()) {
             let confirmed = trigger.entity();
-            info!("Received PrePredicted entity from server. Confirmed: {confirmed:?}, Predicted: {predicted:?}");
+            debug!("Received PrePredicted entity from server. Confirmed: {confirmed:?}, Predicted: {predicted:?}");
             commands.add(move |world: &mut World| {
                 world
                     .entity_mut(predicted)
@@ -133,7 +133,7 @@ impl PrePredictionPlugin {
                         // tick: Tick(0),
                     })
                     .id();
-                info!("Added PrePredicted on the client. Spawning confirmed entity: {confirmed_entity:?} for pre-predicted: {predicted_entity:?}");
+                debug!("Added PrePredicted on the client. Spawning confirmed entity: {confirmed_entity:?} for pre-predicted: {predicted_entity:?}");
                 world
                     .entity_mut(predicted_entity)
                     .get_mut::<PrePredicted>()

--- a/lightyear/src/client/prediction/pre_prediction.rs
+++ b/lightyear/src/client/prediction/pre_prediction.rs
@@ -95,6 +95,7 @@ impl PrePredictionPlugin {
         // we will add the Predicted component
         if let Some(&predicted) = predicted_map.confirmed_to_predicted.get(&trigger.entity()) {
             let confirmed = trigger.entity();
+            info!("Received PrePredicted entity from server. Confirmed: {confirmed:?}, Predicted: {predicted:?}");
             commands.add(move |world: &mut World| {
                 world
                     .entity_mut(predicted)
@@ -132,6 +133,7 @@ impl PrePredictionPlugin {
                         // tick: Tick(0),
                     })
                     .id();
+                info!("Added PrePredicted on the client. Spawning confirmed entity: {confirmed_entity:?} for pre-rredicted: {predicted_entity:?}");
                 world
                     .entity_mut(predicted_entity)
                     .get_mut::<PrePredicted>()

--- a/lightyear/src/client/prediction/rollback.rs
+++ b/lightyear/src/client/prediction/rollback.rs
@@ -192,7 +192,7 @@ pub(crate) fn check_rollback<C: SyncComponent>(
                 }),
             };
             if should_rollback {
-                debug!(
+                info!(
                    ?predicted_exist, ?confirmed_exist,
                    "Rollback check: mismatch for component between predicted and confirmed {:?} on tick {:?} for component {:?}. Current tick: {:?}",
                    confirmed_entity, tick, kind, current_tick

--- a/lightyear/src/client/prediction/rollback.rs
+++ b/lightyear/src/client/prediction/rollback.rs
@@ -192,7 +192,7 @@ pub(crate) fn check_rollback<C: SyncComponent>(
                 }),
             };
             if should_rollback {
-                info!(
+                debug!(
                    ?predicted_exist, ?confirmed_exist,
                    "Rollback check: mismatch for component between predicted and confirmed {:?} on tick {:?} for component {:?}. Current tick: {:?}",
                    confirmed_entity, tick, kind, current_tick

--- a/lightyear/src/server/replication.rs
+++ b/lightyear/src/server/replication.rs
@@ -367,6 +367,7 @@ pub(crate) mod send {
                     .get::<AuthorityPeer>()
                     .is_some_and(|authority| *authority == AuthorityPeer::Server)
                 {
+                    info!("Adding HasAuthority to {:?}", entity_mut.id());
                     entity_mut.insert(HasAuthority);
                 }
             });

--- a/lightyear/src/server/replication.rs
+++ b/lightyear/src/server/replication.rs
@@ -367,7 +367,7 @@ pub(crate) mod send {
                     .get::<AuthorityPeer>()
                     .is_some_and(|authority| *authority == AuthorityPeer::Server)
                 {
-                    info!("Adding HasAuthority to {:?}", entity_mut.id());
+                    debug!("Adding HasAuthority to {:?}", entity_mut.id());
                     entity_mut.insert(HasAuthority);
                 }
             });

--- a/lightyear/src/shared/replication/hierarchy.rs
+++ b/lightyear/src/shared/replication/hierarchy.rs
@@ -51,6 +51,7 @@ impl<R: ReplicationSend> HierarchySendPlugin<R> {
         parent_query: Query<
             (
                 Entity,
+                &ReplicationGroup,
                 Ref<ReplicateHierarchy>,
                 Option<&PrePredicted>,
                 Option<&ReplicationTarget>,
@@ -65,7 +66,17 @@ impl<R: ReplicationSend> HierarchySendPlugin<R> {
             (
                 Without<Parent>,
                 With<Children>,
-                Or<(Changed<Children>, Changed<ReplicateHierarchy>)>,
+                // TODO also handle when a component is removed, it should be removed for children
+                //   maybe do all this via observers?
+                Or<(
+                    Changed<Children>,
+                    Changed<ReplicateHierarchy>,
+                    Changed<ReplicationTarget>,
+                    Changed<SyncTarget>,
+                    Changed<ControlledBy>,
+                    Changed<NetworkRelevanceMode>,
+                    Changed<AuthorityPeer>,
+                )>,
             ),
         >,
         children_query: Query<&Children>,
@@ -73,6 +84,7 @@ impl<R: ReplicationSend> HierarchySendPlugin<R> {
     ) {
         for (
             parent_entity,
+            parent_group,
             replicate_hierarchy,
             pre_predicted,
             replication_target,
@@ -98,8 +110,8 @@ impl<R: ReplicationSend> HierarchySendPlugin<R> {
                     commands.entity(child).insert((
                         // TODO: should we add replicating?
                         Replicating,
-                        // the entire hierarchy is replicated as a single group, that uses the parent's entity as the group id
-                        ReplicationGroup::new_id(parent_entity.to_bits()),
+                        // the entire hierarchy is replicated as a single group (re-use the parent's replication group id)
+                        parent_group.clone(),
                         ReplicateHierarchy { recursive: true },
                         ParentSync(None),
                     ));
@@ -130,6 +142,9 @@ impl<R: ReplicationSend> HierarchySendPlugin<R> {
                         commands.entity(child).insert(*vis);
                     }
                     if let Some(has_authority) = has_authority {
+                        info!(
+                            "Adding HasAuthority on child: {child:?} (parent: {parent_entity:?})"
+                        );
                         commands.entity(child).insert(*has_authority);
                     }
                     if let Some(authority_peer) = authority_peer {

--- a/lightyear/src/shared/replication/hierarchy.rs
+++ b/lightyear/src/shared/replication/hierarchy.rs
@@ -142,7 +142,7 @@ impl<R: ReplicationSend> HierarchySendPlugin<R> {
                         commands.entity(child).insert(*vis);
                     }
                     if let Some(has_authority) = has_authority {
-                        info!(
+                        debug!(
                             "Adding HasAuthority on child: {child:?} (parent: {parent_entity:?})"
                         );
                         commands.entity(child).insert(*has_authority);

--- a/lightyear/src/shared/replication/hierarchy.rs
+++ b/lightyear/src/shared/replication/hierarchy.rs
@@ -110,8 +110,10 @@ impl<R: ReplicationSend> HierarchySendPlugin<R> {
                     commands.entity(child).insert((
                         // TODO: should we add replicating?
                         Replicating,
-                        // the entire hierarchy is replicated as a single group (re-use the parent's replication group id)
-                        parent_group.clone(),
+                        // the entire hierarchy is replicated as a single group so we re-use the parent's replication group id
+                        parent_group
+                            .clone()
+                            .set_id(parent_group.group_id(Some(parent_entity)).0),
                         ReplicateHierarchy { recursive: true },
                         ParentSync(None),
                     ));


### PR DESCRIPTION
It seems like there could be some replication bugs because the children were using the parent's entity id as replication group, instead of using the parent's replication group directly