### PR TITLE
Fix panic when sending too many messages in one packet

### DIFF
--- a/lightyear/src/client/config.rs
+++ b/lightyear/src/client/config.rs
@@ -33,7 +33,7 @@ impl Default for NetcodeConfig {
         Self {
             num_disconnect_packets: 10,
             keepalive_packet_send_rate: 1.0 / 10.0,
-            client_timeout_secs: 3,
+            client_timeout_secs: -1,
             token_expire_secs: 30,
         }
     }

--- a/lightyear/src/client/networking.rs
+++ b/lightyear/src/client/networking.rs
@@ -270,6 +270,7 @@ pub(crate) fn sync_update(
         // TODO: how to adjust this for replication groups that have a custom send_interval?
         config.shared.server_replication_send_interval,
     ) {
+        debug!("Triggering TickSync event: {tick_event:?}");
         commands.trigger(tick_event);
     }
 
@@ -279,6 +280,7 @@ pub(crate) fn sync_update(
             tick_manager.deref_mut(),
             &connection.ping_manager,
         ) {
+            debug!("Triggering TickSync event: {tick_event:?}");
             commands.trigger(tick_event);
         }
         let relative_speed = time_manager.get_relative_speed();

--- a/lightyear/src/client/prediction/rollback.rs
+++ b/lightyear/src/client/prediction/rollback.rs
@@ -10,7 +10,7 @@ use bevy::prelude::{
 };
 use bevy::reflect::Reflect;
 use parking_lot::RwLock;
-use tracing::{debug, error, info, trace, trace_span};
+use tracing::{debug, error, trace, trace_span};
 
 use crate::client::components::{Confirmed, SyncComponent};
 use crate::client::config::ClientConfig;

--- a/lightyear/src/serialize/reader.rs
+++ b/lightyear/src/serialize/reader.rs
@@ -1,6 +1,7 @@
 use bytes::{Buf, Bytes};
 use std::io::{Cursor, Read, Seek, SeekFrom};
 
+#[derive(Clone)]
 pub struct Reader(Cursor<Bytes>);
 
 impl From<Bytes> for Reader {


### PR DESCRIPTION
Fixes https://github.com/cBournhonesque/lightyear/issues/614

- stop preparing input messages to send when we're in rollback
- don't use varint to serialize the number of messages to send in a packet