### PR TITLE
Create server-authoritative 3D physics example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -21,9 +21,10 @@ This folder contains various examples that showcase various `lightyear` features
 
 ## Advanced
 
-- `xpbd_physics`: example that shows how to replicate a physics simulation using xpbd.
+- `avian_physics`: example that shows how to replicate a physics simulation using xpbd.
   We also use the `leafwing` feature for a better way to manage inputs.
-- `spaceships`: more advanced version of `xpbd_physics` with player movement based on forces, fully server authoritative, predicted bullet spawning. 
+- `avian_3d_character`: example that shows clients controlling server-authoritative 3D objects simulated using avian.
+- `spaceships`: more advanced version of `avian_physics` with player movement based on forces, fully server authoritative, predicted bullet spawning. 
 - `bullet_prespawn`: example that shows how to spawn player-objects on the Predicted timeline. This is useful
   to avoid having to wait a full round-trip before the object is spawned.
 - `auth`: an example that shows how a client can get a `ConnectToken` to connect to a server

--- a/examples/avian_3d_character/Cargo.toml
+++ b/examples/avian_3d_character/Cargo.toml
@@ -1,0 +1,40 @@
+[package]
+name = "avian_3d_character"
+version = "0.0.0"
+authors = ["Charles Bournhonesque <charlesbour@gmail.com>"]
+edition = "2021"
+rust-version = "1.65"
+publish = false
+
+[features]
+metrics = ["lightyear/metrics", "dep:metrics-exporter-prometheus"]
+
+[dependencies]
+lightyear_examples_common = { path = "../common" }
+bevy_screen_diagnostics = "0.6"
+leafwing-input-manager = "0.15"
+avian3d = { version = "0.1.1", default-features = false, features = [
+    "3d",
+    "f32",
+    "parry-f32",
+    "parallel",
+    "serialize",
+] }
+lightyear = { path = "../../lightyear", features = [
+    "webtransport",
+    "websocket",
+    "leafwing",
+    "avian3d",
+] }
+serde = { version = "1.0.188", features = ["derive"] }
+anyhow = { version = "1.0.75", features = [] }
+tracing = "0.1"
+tracing-subscriber = "0.3.17"
+bevy = { version = "0.14", features = [
+    "multi_threaded",
+    "bevy_state",
+    "serialize",
+] }
+
+rand = "0.8.1"
+metrics-exporter-prometheus = { version = "0.15.1", optional = true }

--- a/examples/avian_3d_character/README.md
+++ b/examples/avian_3d_character/README.md
@@ -1,0 +1,23 @@
+# Avian 3D Character
+
+This is an example of a server containing server-authoritative, physics-based, 3D characters simulated with `avian3d` and clients controlling those characters and predicting their movement.
+
+## Features
+
+* The client will immediately try to connect to the server on start.
+* The server will spawn a new character for each client that connects and give that client control over the character.
+  * A character is a dynamic 3D capsule.
+  * The client can control the character with `W/A/S/D/SPACE`.
+  * Client inputs are converted into physical forces applied to the character.
+  * All clients will predict the position, rotation, and velocity of all characters.
+* The serve will spawn some dynamic blocks and a static floor on start.
+  * All clients will predict the position, rotation, and velocity of all blocks.
+  * The floor is only replicated and not predicted because we do not expect it to move.
+
+## Running the example
+
+- Run the server: `cargo run server`
+- Run client with id 1: `cargo run client -c 1`
+- Run client with id 2: `cargo run client -c 2` (etc.)
+
+You can modify the file `assets/settings.ron` to modify some networking settings.

--- a/examples/avian_3d_character/assets/settings.ron
+++ b/examples/avian_3d_character/assets/settings.ron
@@ -1,0 +1,38 @@
+MySettings(
+  server_replication_send_interval: 50,
+  input_delay_ticks: 4,
+  // do not set a limit on the amount of prediction
+  max_prediction_ticks: 100,
+  correction_ticks_factor: 2.0,
+  show_confirmed: true,
+  common: Settings(
+    client: ClientSettings(
+            inspector: true,
+            client_id: 0,
+            client_port: 0, // the OS will assign a random open port
+            server_addr: "127.0.0.1",
+            conditioner: Some(Conditioner(
+                latency_ms: 50,
+                jitter_ms: 5,
+                packet_loss: 0.02
+            )),
+            server_port: 5000,
+            transport: Udp
+        ),
+        server: ServerSettings(
+            headless: true,
+            inspector: false,
+            conditioner: None,
+            transport: [
+                Udp(
+                    local_port: 5000
+                ),
+            ],
+        ),
+        shared: SharedSettings(
+            protocol_id: 0,
+            private_key: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+            compression: None,
+        )
+    )
+)

--- a/examples/avian_3d_character/src/client.rs
+++ b/examples/avian_3d_character/src/client.rs
@@ -1,0 +1,163 @@
+use avian3d::prelude::*;
+use bevy::app::PluginGroupBuilder;
+use bevy::prelude::*;
+use bevy::utils::Duration;
+use leafwing_input_manager::prelude::*;
+use lightyear::inputs::leafwing::input_buffer::InputBuffer;
+use lightyear::prelude::client::*;
+use lightyear::prelude::*;
+use lightyear::shared::replication::components::Controlled;
+use lightyear::shared::tick_manager;
+use lightyear_examples_common::shared::FIXED_TIMESTEP_HZ;
+
+use crate::protocol::*;
+use crate::shared::*;
+
+pub struct ExampleClientPlugin;
+
+impl Plugin for ExampleClientPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(Startup, connect_to_server);
+        app.add_systems(
+            PreUpdate,
+            handle_connection
+                .after(MainSet::Receive)
+                .before(PredictionSet::SpawnPrediction),
+        );
+        app.add_systems(
+            FixedUpdate,
+            // In host-server mode, the server porition is already applying the
+            // character actions and so we don't want to apply the character
+            // actions twice.
+            handle_character_actions
+                .run_if(not(is_host_server))
+                .in_set(FixedSet::Main),
+        );
+        app.add_systems(
+            Update,
+            (handle_new_floor, handle_new_block, handle_new_character),
+        );
+    }
+}
+
+/// Process character actions and apply them to their associated character
+/// entity.
+fn handle_character_actions(
+    time: Res<Time>,
+    spatial_query: SpatialQuery,
+    mut query: Query<
+        (
+            &ActionState<CharacterAction>,
+            &InputBuffer<CharacterAction>,
+            CharacterQuery,
+        ),
+        With<Predicted>,
+    >,
+    tick_manager: Res<TickManager>,
+    rollback: Option<Res<Rollback>>,
+) {
+    // Get the current tick. It may be apart of a rollback.
+    let tick = rollback
+        .as_ref()
+        .map(|rb| tick_manager.tick_or_rollback_tick(rb))
+        .unwrap_or(tick_manager.tick());
+
+    for (action_state, input_buffer, mut character) in &mut query {
+        // Use the current character action if it is.
+        if input_buffer.get(tick).is_some() {
+            apply_character_action(&time, &spatial_query, action_state, &mut character);
+            continue;
+        }
+
+        // If the current character action is not real then use the last real
+        // character action.
+        if let Some((_, prev_action_state)) = input_buffer.get_last_with_tick() {
+            apply_character_action(&time, &spatial_query, prev_action_state, &mut character);
+        } else {
+            // No inputs are in the buffer yet. This can happen during initial
+            // connection. Apply the default input (i.e. nothing pressed).
+            apply_character_action(&time, &spatial_query, action_state, &mut character);
+        }
+    }
+}
+
+pub(crate) fn connect_to_server(mut commands: Commands) {
+    commands.connect_client();
+}
+
+/// Listen for events to know when the client is connected and spawn a text
+/// entity to display the client id.
+pub(crate) fn handle_connection(
+    mut commands: Commands,
+    mut connection_event: EventReader<ConnectEvent>,
+) {
+    for event in connection_event.read() {
+        let client_id = event.client_id();
+        commands.spawn(TextBundle::from_section(
+            format!("Client {}", client_id),
+            TextStyle {
+                font_size: 30.0,
+                color: Color::WHITE,
+                ..default()
+            },
+        ));
+    }
+}
+
+/// Add physics to characters that are newly predicted. If the client controls
+/// the character then add an input component.
+fn handle_new_character(
+    connection: Res<ClientConnection>,
+    mut commands: Commands,
+    mut character_query: Query<
+        (Entity, &ColorComponent, Has<Controlled>),
+        (Added<Predicted>, With<CharacterMarker>),
+    >,
+) {
+    for (entity, color, is_controlled) in &mut character_query {
+        if is_controlled {
+            info!("Adding InputMap to controlled and predicted entity {entity:?}");
+            commands.entity(entity).insert(
+                InputMap::new([(CharacterAction::Jump, KeyCode::Space)])
+                    .with_dual_axis(CharacterAction::Move, KeyboardVirtualDPad::WASD),
+            );
+        } else {
+            info!("Remote character replicated to us: {entity:?}");
+        }
+        let client_id = connection.id();
+        info!(?entity, ?client_id, "Adding physics to character");
+        commands
+            .entity(entity)
+            .insert((CharacterPhysicsBundle::default(),));
+    }
+}
+
+/// Add physics to floors that are newly replicated. The query checks for
+/// replicated floors instead of predicted floors because predicted floors do
+/// not exist since floors aren't predicted.
+fn handle_new_floor(
+    connection: Res<ClientConnection>,
+    mut commands: Commands,
+    character_query: Query<Entity, (Added<Replicated>, With<FloorMarker>)>,
+) {
+    for entity in &character_query {
+        info!(?entity, "Adding physics to floor");
+        commands
+            .entity(entity)
+            .insert(FloorPhysicsBundle::default());
+    }
+}
+
+/// Add physics to blocks that are newly predicted.
+fn handle_new_block(
+    connection: Res<ClientConnection>,
+    mut commands: Commands,
+    character_query: Query<Entity, (Added<Predicted>, With<BlockMarker>)>,
+) {
+    for entity in &character_query {
+        info!(?entity, "Adding physics to block");
+        commands
+            .entity(entity)
+            .insert(BlockPhysicsBundle::default());
+    }
+}

--- a/examples/avian_3d_character/src/main.rs
+++ b/examples/avian_3d_character/src/main.rs
@@ -1,0 +1,51 @@
+#![allow(unused_imports)]
+#![allow(unused_variables)]
+#![allow(dead_code)]
+use crate::client::ExampleClientPlugin;
+use crate::server::ExampleServerPlugin;
+use crate::shared::SharedPlugin;
+use bevy::prelude::*;
+use lightyear::prelude::client::PredictionConfig;
+use lightyear_examples_common::app::{Apps, Cli};
+use lightyear_examples_common::settings::{read_settings, Settings};
+use serde::{Deserialize, Serialize};
+
+mod client;
+mod protocol;
+mod renderer;
+mod server;
+mod shared;
+
+fn main() {
+    let cli = Cli::default();
+    let settings_str = include_str!("../assets/settings.ron");
+    let settings = read_settings::<MySettings>(settings_str);
+    let mut apps = Apps::new(settings.common, cli);
+    apps.update_lightyear_client_config(|config| {
+        config.prediction.minimum_input_delay_ticks = settings.input_delay_ticks;
+        config.prediction.correction_ticks_factor = settings.correction_ticks_factor;
+    })
+    // Add `ClientPlugins` and `ServerPlugins` plugin groups.
+    .add_lightyear_plugins()
+    .add_user_plugins(ExampleClientPlugin, ExampleServerPlugin, SharedPlugin);
+
+    apps.run();
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct MySettings {
+    pub common: Settings,
+
+    /// By how many ticks an input press will be delayed?
+    /// This can be useful as a tradeoff between input delay and prediction accuracy.
+    /// If the input delay is greater than the RTT, then there won't ever be any mispredictions/rollbacks.
+    /// See [this article](https://www.snapnet.dev/docs/core-concepts/input-delay-vs-rollback/) for more information.
+    pub(crate) input_delay_ticks: u16,
+
+    /// If visual correction is enabled, we don't instantly snapback to the corrected position
+    /// when we need to rollback. Instead we interpolated between the current position and the
+    /// corrected position.
+    /// This controls the duration of the interpolation; the higher it is, the longer the interpolation
+    /// will take
+    pub(crate) correction_ticks_factor: f32,
+}

--- a/examples/avian_3d_character/src/protocol.rs
+++ b/examples/avian_3d_character/src/protocol.rs
@@ -1,0 +1,98 @@
+use avian3d::prelude::*;
+use bevy::prelude::*;
+use bevy::utils::Duration;
+use leafwing_input_manager::prelude::*;
+use lightyear_examples_common::shared::FIXED_TIMESTEP_HZ;
+use serde::{Deserialize, Serialize};
+
+use lightyear::client::components::{ComponentSyncMode, LerpFn};
+use lightyear::client::interpolation::LinearInterpolator;
+use lightyear::prelude::client::{self, LeafwingInputConfig};
+use lightyear::prelude::server::{Replicate, SyncTarget};
+use lightyear::prelude::*;
+use lightyear::utils::avian3d::*;
+use tracing_subscriber::util::SubscriberInitExt;
+
+use crate::shared::color_from_id;
+
+// For prediction, we want everything entity that is predicted to be part of
+// the same replication group This will make sure that they will be replicated
+// in the same message and that all the entities in the group will always be
+// consistent (= on the same tick)
+pub const REPLICATION_GROUP: ReplicationGroup = ReplicationGroup::new_id(1);
+
+// Components
+
+#[derive(Component, Deserialize, Serialize, Clone, Debug, PartialEq)]
+pub struct ColorComponent(pub(crate) Color);
+
+#[derive(Component, Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct CharacterMarker;
+
+#[derive(Component, Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct FloorMarker;
+
+#[derive(Component, Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct BlockMarker;
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Reflect, Serialize, Deserialize)]
+pub enum CharacterAction {
+    Move,
+    Jump,
+}
+
+impl Actionlike for CharacterAction {
+    fn input_control_kind(&self) -> InputControlKind {
+        match self {
+            Self::Move => InputControlKind::DualAxis,
+            Self::Jump => InputControlKind::Button,
+        }
+    }
+}
+
+// Protocol
+pub(crate) struct ProtocolPlugin;
+
+impl Plugin for ProtocolPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_plugins(LeafwingInputPlugin::<CharacterAction>::default());
+
+        app.register_component::<ColorComponent>(ChannelDirection::ServerToClient)
+            .add_prediction(ComponentSyncMode::Once);
+
+        app.register_component::<Name>(ChannelDirection::ServerToClient)
+            .add_prediction(ComponentSyncMode::Once);
+
+        app.register_component::<CharacterMarker>(ChannelDirection::ServerToClient)
+            .add_prediction(ComponentSyncMode::Once);
+
+        app.register_component::<FloorMarker>(ChannelDirection::ServerToClient)
+            .add_prediction(ComponentSyncMode::Once);
+
+        app.register_component::<BlockMarker>(ChannelDirection::ServerToClient)
+            .add_prediction(ComponentSyncMode::Once);
+
+        // Fully replicated, but not visual, so no need for lerp/corrections:
+
+        app.register_component::<LinearVelocity>(ChannelDirection::ServerToClient)
+            .add_prediction(ComponentSyncMode::Full);
+
+        app.register_component::<AngularVelocity>(ChannelDirection::ServerToClient)
+            .add_prediction(ComponentSyncMode::Full);
+
+        // Position and Rotation have a `correction_fn` set, which is used to smear rollback errors
+        // over a few frames, just for the rendering part in postudpate.
+        //
+        // They also set `interpolation_fn` which is used by the VisualInterpolationPlugin to smooth
+        // out rendering between fixedupdate ticks.
+        app.register_component::<Position>(ChannelDirection::ServerToClient)
+            .add_prediction(ComponentSyncMode::Full)
+            .add_interpolation_fn(position::lerp)
+            .add_correction_fn(position::lerp);
+
+        app.register_component::<Rotation>(ChannelDirection::ServerToClient)
+            .add_prediction(ComponentSyncMode::Full)
+            .add_interpolation_fn(rotation::lerp)
+            .add_correction_fn(rotation::lerp);
+    }
+}

--- a/examples/avian_3d_character/src/renderer.rs
+++ b/examples/avian_3d_character/src/renderer.rs
@@ -1,0 +1,187 @@
+use avian3d::prelude::*;
+use bevy::prelude::*;
+use bevy_screen_diagnostics::{
+    Aggregate, ScreenDiagnostics, ScreenDiagnosticsPlugin, ScreenEntityDiagnosticsPlugin,
+};
+use lightyear::{
+    client::prediction::diagnostics::PredictionDiagnosticsPlugin,
+    prelude::{client::*, *},
+    transport::io::IoDiagnosticsPlugin,
+};
+
+use crate::{
+    protocol::{BlockMarker, CharacterMarker, ColorComponent, FloorMarker},
+    shared::{
+        BLOCK_HEIGHT, BLOCK_WIDTH, CHARACTER_CAPSULE_HEIGHT, CHARACTER_CAPSULE_RADIUS,
+        FLOOR_HEIGHT, FLOOR_WIDTH,
+    },
+};
+
+pub struct ExampleRendererPlugin;
+
+impl Plugin for ExampleRendererPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(Startup, init);
+        app.add_systems(
+            Update,
+            (
+                add_character_cosmetics,
+                add_floor_cosmetics,
+                add_block_cosmetics,
+            ),
+        );
+
+        app.add_plugins(ScreenDiagnosticsPlugin::default());
+        app.add_plugins(ScreenEntityDiagnosticsPlugin);
+
+        // Set up visual interp plugins for Position and Rotation. This doesn't
+        // do anything until you add VisualInterpolationStatus components to
+        // entities.
+        app.add_plugins(VisualInterpolationPlugin::<Position>::default());
+        app.add_plugins(VisualInterpolationPlugin::<Rotation>::default());
+
+        // Observers that add VisualInterpolationStatus components to entities
+        // which receive a Position or Rotation component.
+        app.observe(add_visual_interpolation_components::<Position>);
+        app.observe(add_visual_interpolation_components::<Rotation>);
+    }
+}
+
+fn init(mut commands: Commands, mut onscreen: ResMut<ScreenDiagnostics>) {
+    commands.spawn(Camera3dBundle {
+        transform: Transform::from_xyz(0.0, 4.5, -9.0).looking_at(Vec3::ZERO, Dir3::Y),
+        ..default()
+    });
+
+    commands.spawn(PointLightBundle {
+        point_light: PointLight {
+            shadows_enabled: true,
+            ..default()
+        },
+        transform: Transform::from_xyz(4.0, 8.0, 4.0),
+        ..default()
+    });
+
+    onscreen
+        .add("RB".to_string(), PredictionDiagnosticsPlugin::ROLLBACKS)
+        .aggregate(Aggregate::Value)
+        .format(|v| format!("{v:.0}"));
+    onscreen
+        .add(
+            "RBt".to_string(),
+            PredictionDiagnosticsPlugin::ROLLBACK_TICKS,
+        )
+        .aggregate(Aggregate::Value)
+        .format(|v| format!("{v:.0}"));
+    onscreen
+        .add(
+            "RBd".to_string(),
+            PredictionDiagnosticsPlugin::ROLLBACK_DEPTH,
+        )
+        .aggregate(Aggregate::Value)
+        .format(|v| format!("{v:.1}"));
+    // Screen diagnostics twitches due to layout change when a metric adds or
+    // removes a digit so pad these metrics to 3 digits.
+    onscreen
+        .add("KB_in".to_string(), IoDiagnosticsPlugin::BYTES_IN)
+        .aggregate(Aggregate::Average)
+        .format(|v| format!("{v:0>3.0}"));
+    onscreen
+        .add("KB_out".to_string(), IoDiagnosticsPlugin::BYTES_OUT)
+        .aggregate(Aggregate::Average)
+        .format(|v| format!("{v:0>3.0}"));
+}
+
+/// Add the VisualInterpolateStatus component to non-floor entities with
+/// component `T`. Floors don't need to be visually interpolated because we
+/// don't expect them to move.
+///
+/// We query Without<Confirmed> instead of With<Predicted> so that the server's
+/// gui will also get some visual interpolation. But we're usually just
+/// concerned that the client's Predicted entities get the interpolation
+/// treatment.
+///
+/// Make sure that avian's SyncPlugin is run in PostUpdate in order to
+/// incorporate the changes in pos/rot due to visual interpolation. Entities
+/// rendered based on transforms will then have transforms based on the visual
+/// interpolation.
+fn add_visual_interpolation_components<T: Component>(
+    trigger: Trigger<OnAdd, T>,
+    query: Query<Entity, (With<T>, Without<Confirmed>, Without<FloorMarker>)>,
+    mut commands: Commands,
+) {
+    if !query.contains(trigger.entity()) {
+        return;
+    }
+    debug!("Adding visual interp component to {:?}", trigger.entity());
+    commands
+        .entity(trigger.entity())
+        .insert(VisualInterpolateStatus::<T> {
+            // We must trigger change detection so that the SyncPlugin will
+            // detect and sync changes from Position/Rotation to Transform.
+            //
+            // Without syncing interpolated pos/rot to transform, things like
+            // sprites, meshes, and text which render based on the *Transform*
+            // component (not avian's Position) will be stuttery.
+            trigger_change_detection: true,
+            ..default()
+        });
+}
+
+/// Add components to characters that impact how they are rendered. We only
+/// want to see the predicted character and not the confirmed character.
+fn add_character_cosmetics(
+    mut commands: Commands,
+    character_query: Query<(Entity, &ColorComponent), (Added<Predicted>, With<CharacterMarker>)>,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+) {
+    for (entity, color) in &character_query {
+        info!(?entity, "Adding cosmetics to character {:?}", entity);
+        commands.entity(entity).insert((PbrBundle {
+            mesh: meshes.add(Capsule3d::new(
+                CHARACTER_CAPSULE_RADIUS,
+                CHARACTER_CAPSULE_HEIGHT,
+            )),
+            material: materials.add(color.0),
+            ..default()
+        },));
+    }
+}
+
+/// Add components to floors that impact how they are rendered. We want to see
+/// the replicated floor instead of predicted floors because predicted floors
+/// do not exist since floors aren't predicted.
+fn add_floor_cosmetics(
+    mut commands: Commands,
+    floor_query: Query<Entity, (Added<Replicated>, With<FloorMarker>)>,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+) {
+    for entity in &floor_query {
+        info!(?entity, "Adding cosmetics to floor {:?}", entity);
+        commands.entity(entity).insert(PbrBundle {
+            mesh: meshes.add(Cuboid::new(FLOOR_WIDTH, FLOOR_HEIGHT, FLOOR_WIDTH)),
+            material: materials.add(Color::srgb(1.0, 1.0, 1.0)),
+            ..default()
+        });
+    }
+}
+
+/// Add components to blocks that impact how they are rendered. We only want to
+/// see the predicted block and not the confirmed block.
+fn add_block_cosmetics(
+    mut commands: Commands,
+    floor_query: Query<Entity, (Added<Predicted>, With<BlockMarker>)>,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+) {
+    for entity in &floor_query {
+        info!(?entity, "Adding cosmetics to block {:?}", entity);
+        commands.entity(entity).insert(PbrBundle {
+            mesh: meshes.add(Cuboid::new(BLOCK_WIDTH, BLOCK_HEIGHT, BLOCK_WIDTH)),
+            material: materials.add(Color::srgb(1.0, 0.0, 1.0)),
+            ..default()
+        });
+    }
+}

--- a/examples/avian_3d_character/src/server.rs
+++ b/examples/avian_3d_character/src/server.rs
@@ -1,0 +1,183 @@
+use std::f32::consts::TAU;
+
+use avian3d::prelude::*;
+use bevy::color::palettes::css;
+use bevy::math::VectorSpace;
+use bevy::prelude::*;
+use bevy::time::common_conditions::on_timer;
+use bevy::utils::Duration;
+use bevy::utils::HashMap;
+use client::Rollback;
+use leafwing_input_manager::action_diff::ActionDiff;
+use leafwing_input_manager::prelude::*;
+use lightyear::client::connection;
+use lightyear::prelude::client::{Confirmed, Predicted};
+use lightyear::prelude::server::*;
+use lightyear::prelude::*;
+use lightyear::shared::tick_manager;
+use lightyear_examples_common::shared::FIXED_TIMESTEP_HZ;
+
+use crate::protocol::*;
+use crate::shared;
+use crate::shared::apply_character_action;
+use crate::shared::BlockPhysicsBundle;
+use crate::shared::CharacterPhysicsBundle;
+use crate::shared::CharacterQuery;
+use crate::shared::FixedSet;
+use crate::shared::FloorPhysicsBundle;
+use crate::shared::CHARACTER_CAPSULE_HEIGHT;
+use crate::shared::CHARACTER_CAPSULE_RADIUS;
+use crate::shared::FLOOR_HEIGHT;
+use crate::shared::FLOOR_WIDTH;
+
+// Plugin for server-specific logic
+pub struct ExampleServerPlugin;
+
+impl Plugin for ExampleServerPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(Startup, init);
+        app.add_systems(
+            PreUpdate,
+            // This system will replicate the inputs of a client to other
+            // clients so that a client can predict other clients.
+            replicate_inputs.after(MainSet::EmitEvents),
+        );
+        // The physics/FixedUpdates systems that consume inputs should be run
+        // in `FixedSet::Main`.
+        app.add_systems(FixedUpdate, handle_character_actions.in_set(FixedSet::Main));
+        app.add_systems(Update, handle_connections);
+    }
+}
+
+fn handle_character_actions(
+    time: Res<Time>,
+    spatial_query: SpatialQuery,
+    mut query: Query<(&ActionState<CharacterAction>, CharacterQuery)>,
+) {
+    for (action_state, mut character) in &mut query {
+        apply_character_action(&time, &spatial_query, action_state, &mut character);
+    }
+}
+
+fn init(mut commands: Commands) {
+    commands.start_server();
+
+    commands.spawn((
+        Name::new("Floor"),
+        FloorPhysicsBundle::default(),
+        FloorMarker,
+        Position::new(Vec3::ZERO),
+        // Floors don't need to be predicted since they will never move.
+        Replicate::default(),
+    ));
+
+    // Blocks need to be predicted because their position, rotation, velocity
+    // may change.
+    let block_replicate_component = Replicate {
+        sync: SyncTarget {
+            prediction: NetworkTarget::All,
+            ..default()
+        },
+        // Make sure that all entities that are predicted are part of the
+        // same replication group
+        group: REPLICATION_GROUP,
+        ..default()
+    };
+    commands.spawn((
+        Name::new("Block"),
+        BlockPhysicsBundle::default(),
+        BlockMarker,
+        Position::new(Vec3::new(1.0, 1.0, 0.0)),
+        block_replicate_component.clone(),
+    ));
+    commands.spawn((
+        Name::new("Block"),
+        BlockPhysicsBundle::default(),
+        BlockMarker,
+        Position::new(Vec3::new(-1.0, 1.0, 0.0)),
+        block_replicate_component.clone(),
+    ));
+}
+
+pub(crate) fn replicate_inputs(
+    mut connection: ResMut<ConnectionManager>,
+    mut input_events: ResMut<Events<MessageEvent<InputMessage<CharacterAction>>>>,
+) {
+    for mut event in input_events.drain() {
+        let client_id = *event.context();
+        // Rebroadcast the input to other clients.
+        connection
+            .send_message_to_target::<InputChannel, _>(
+                &mut event.message,
+                NetworkTarget::AllExceptSingle(client_id),
+            )
+            .unwrap()
+    }
+}
+
+/// Spawn a character whenever a new client has connected.
+pub(crate) fn handle_connections(
+    mut connections: EventReader<ConnectEvent>,
+    mut commands: Commands,
+    character_query: Query<Entity, With<CharacterMarker>>,
+) {
+    // Track the number of characters in order to pick colors and starting
+    // positions.
+    let mut num_characters = character_query.iter().count();
+    for connection in connections.read() {
+        let client_id = connection.client_id;
+        info!("Client connected with client-id {client_id:?}. Spawning character entity.");
+        // Replicate newly connected clients to all players
+        let replicate = Replicate {
+            sync: SyncTarget {
+                prediction: NetworkTarget::All,
+                ..default()
+            },
+            controlled_by: ControlledBy {
+                target: NetworkTarget::Single(client_id),
+                ..default()
+            },
+            // Make sure that all entities that are predicted are part of the
+            // same replication group
+            group: REPLICATION_GROUP,
+            ..default()
+        };
+
+        // Pick color and position for player.
+        let available_colors = [
+            css::LIMEGREEN,
+            css::PINK,
+            css::YELLOW,
+            css::AQUA,
+            css::CRIMSON,
+            css::GOLD,
+            css::ORANGE_RED,
+            css::SILVER,
+            css::SALMON,
+            css::YELLOW_GREEN,
+            css::WHITE,
+            css::RED,
+        ];
+        let color = available_colors[num_characters % available_colors.len()];
+        let angle: f32 = num_characters as f32 * 5.0;
+        let x = 2.0 * angle.cos();
+        let z = 2.0 * angle.sin();
+
+        // Spawn the character with ActionState. The client will add their own
+        // InputMap.
+        let character = commands
+            .spawn((
+                Name::new("Character"),
+                ActionState::<CharacterAction>::default(),
+                Position(Vec3::new(x, 3.0, z)),
+                replicate,
+                CharacterPhysicsBundle::default(),
+                ColorComponent(color.into()),
+                CharacterMarker,
+            ))
+            .id();
+
+        info!("Created entity {character:?} for client {client_id:?}");
+        num_characters += 1;
+    }
+}

--- a/examples/avian_3d_character/src/shared.rs
+++ b/examples/avian_3d_character/src/shared.rs
@@ -1,0 +1,243 @@
+use bevy::diagnostic::LogDiagnosticsPlugin;
+use bevy::ecs::query::QueryData;
+use bevy::math::VectorSpace;
+use bevy::prelude::*;
+use bevy::render::RenderPlugin;
+use bevy::utils::Duration;
+use lightyear::inputs::leafwing::input_buffer::InputBuffer;
+use server::ControlledEntities;
+use std::hash::{Hash, Hasher};
+
+use avian3d::prelude::*;
+use leafwing_input_manager::prelude::ActionState;
+use lightyear::shared::replication::components::Controlled;
+use tracing::Level;
+
+use lightyear::prelude::client::*;
+use lightyear::prelude::TickManager;
+use lightyear::prelude::*;
+use lightyear::shared::ping::diagnostics::PingDiagnosticsPlugin;
+use lightyear::transport::io::IoDiagnosticsPlugin;
+use lightyear_examples_common::shared::FIXED_TIMESTEP_HZ;
+
+use crate::protocol::*;
+use crate::renderer::ExampleRendererPlugin;
+
+pub const FLOOR_WIDTH: f32 = 100.0;
+pub const FLOOR_HEIGHT: f32 = 1.0;
+
+pub const BLOCK_WIDTH: f32 = 1.0;
+pub const BLOCK_HEIGHT: f32 = 1.0;
+
+pub const CHARACTER_CAPSULE_RADIUS: f32 = 0.5;
+pub const CHARACTER_CAPSULE_HEIGHT: f32 = 0.5;
+
+#[derive(Bundle)]
+pub(crate) struct CharacterPhysicsBundle {
+    collider: Collider,
+    rigid_body: RigidBody,
+    external_force: ExternalForce,
+    external_impulse: ExternalImpulse,
+    lock_axes: LockedAxes,
+    friction: Friction,
+}
+
+impl Default for CharacterPhysicsBundle {
+    fn default() -> Self {
+        Self {
+            collider: Collider::capsule(CHARACTER_CAPSULE_RADIUS, CHARACTER_CAPSULE_HEIGHT),
+            rigid_body: RigidBody::Dynamic,
+            external_force: ExternalForce::ZERO.with_persistence(false),
+            external_impulse: ExternalImpulse::ZERO.with_persistence(false),
+            lock_axes: LockedAxes::default()
+                .lock_rotation_x()
+                .lock_rotation_y()
+                .lock_rotation_z(),
+            friction: Friction::new(0.0).with_combine_rule(CoefficientCombine::Min),
+        }
+    }
+}
+
+#[derive(Bundle)]
+pub(crate) struct FloorPhysicsBundle {
+    collider: Collider,
+    rigid_body: RigidBody,
+}
+
+impl Default for FloorPhysicsBundle {
+    fn default() -> Self {
+        Self {
+            collider: Collider::cuboid(FLOOR_WIDTH, FLOOR_HEIGHT, FLOOR_WIDTH),
+            rigid_body: RigidBody::Static,
+        }
+    }
+}
+
+#[derive(Bundle)]
+pub(crate) struct BlockPhysicsBundle {
+    collider: Collider,
+    rigid_body: RigidBody,
+}
+
+impl Default for BlockPhysicsBundle {
+    fn default() -> Self {
+        Self {
+            collider: Collider::cuboid(BLOCK_WIDTH, BLOCK_HEIGHT, BLOCK_WIDTH),
+            rigid_body: RigidBody::Dynamic,
+        }
+    }
+}
+
+#[derive(SystemSet, Debug, Hash, PartialEq, Eq, Clone, Copy)]
+pub enum FixedSet {
+    // Main fixed update systems (i.e. handle inputs).
+    Main,
+    // Apply physics steps.
+    Physics,
+}
+
+#[derive(Clone)]
+pub struct SharedPlugin;
+
+impl Plugin for SharedPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_plugins(ProtocolPlugin);
+        if app.is_plugin_added::<RenderPlugin>() {
+            app.add_plugins(ExampleRendererPlugin);
+        }
+
+        // Physics
+
+        // Position and Rotation are the primary source of truth so no need to
+        // sync changes from Transform to Position.
+        app.insert_resource(avian3d::sync::SyncConfig {
+            transform_to_position: false,
+            position_to_transform: true,
+        });
+
+        // We change SyncPlugin to PostUpdate, because we want the visually
+        // interpreted values synced to transform every time, not just when
+        // Fixed schedule runs.
+        app.add_plugins(
+            PhysicsPlugins::new(FixedUpdate)
+                .build()
+                .disable::<SyncPlugin>(),
+        )
+        .add_plugins(SyncPlugin::new(PostUpdate));
+
+        app.insert_resource(Time::new_with(Physics::fixed_once_hz(FIXED_TIMESTEP_HZ)));
+
+        app.configure_sets(
+            FixedUpdate,
+            (
+                // Make sure that any physics simulation happens after the Main
+                // SystemSet (i.e. where we apply user's actions).
+                (
+                    PhysicsSet::Prepare,
+                    PhysicsSet::StepSimulation,
+                    PhysicsSet::Sync,
+                )
+                    .in_set(FixedSet::Physics),
+                (FixedSet::Main, FixedSet::Physics).chain(),
+            ),
+        );
+    }
+}
+
+/// Generate pseudo-random color based on `client_id`.
+pub(crate) fn color_from_id(client_id: ClientId) -> Color {
+    let h = (((client_id.to_bits().wrapping_mul(30)) % 360) as f32) / 360.0;
+    let s = 1.0;
+    let l = 0.5;
+    Color::hsl(h, s, l)
+}
+
+#[derive(QueryData)]
+#[query_data(mutable, derive(Debug))]
+pub struct CharacterQuery {
+    pub external_force: &'static mut ExternalForce,
+    pub external_impulse: &'static mut ExternalImpulse,
+    pub linear_velocity: &'static LinearVelocity,
+    pub mass: &'static Mass,
+    pub position: &'static Position,
+    pub entity: Entity,
+}
+
+/// Apply the character actions `action_state` to the character entity `character`.
+pub fn apply_character_action(
+    time: &Res<Time>,
+    spatial_query: &SpatialQuery,
+    action_state: &ActionState<CharacterAction>,
+    character: &mut CharacterQueryItem,
+) {
+    const MAX_SPEED: f32 = 5.0;
+    const MAX_ACCELERATION: f32 = 20.0;
+
+    // How much velocity can change in a single tick given the max acceleration.
+    let max_velocity_delta_per_tick = MAX_ACCELERATION * time.delta_seconds();
+
+    // Handle jumping.
+    if action_state.pressed(&CharacterAction::Jump) {
+        let ray_cast_origin = character.position.0
+            + Vec3::new(
+                0.0,
+                -CHARACTER_CAPSULE_HEIGHT / 2.0 - CHARACTER_CAPSULE_RADIUS,
+                0.0,
+            );
+
+        // Only jump if the character is on the ground.
+        //
+        // Check if we are touching the ground by sending a ray from the bottom
+        // of the character downwards.
+        if spatial_query
+            .cast_ray(
+                ray_cast_origin,
+                Dir3::NEG_Y,
+                0.01,
+                true,
+                SpatialQueryFilter::from_excluded_entities([character.entity]),
+            )
+            .is_some()
+        {
+            character
+                .external_impulse
+                .apply_impulse(Vec3::new(0.0, 5.0, 0.0));
+        }
+    }
+
+    // Handle moving.
+    let move_dir = action_state
+        .axis_pair(&CharacterAction::Move)
+        .clamp_length_max(1.0);
+    let move_dir = Vec3::new(-move_dir.x, 0.0, move_dir.y);
+
+    // Linear velocity of the character ignoring vertical speed.
+    let ground_linear_velocity = Vec3::new(
+        character.linear_velocity.x,
+        0.0,
+        character.linear_velocity.z,
+    );
+
+    let desired_ground_linear_velocity = move_dir * MAX_SPEED;
+
+    let new_ground_linear_velocity = ground_linear_velocity
+        .move_towards(desired_ground_linear_velocity, max_velocity_delta_per_tick);
+
+    // Acceleration required to change the linear velocity from
+    // `ground_linear_velocity` to `new_ground_linear_velocity` in the duration
+    // of a single tick.
+    //
+    // There is no need to clamp the acceleration's length to
+    // `MAX_ACCELERATION`. The difference between `ground_linear_velocity` and
+    // `new_ground_linear_velocity` is never great enough to require more than
+    // `MAX_ACCELERATION` in a single tick, This is because
+    // `new_ground_linear_velocity` is calculated using
+    // `max_velocity_delta_per_tick` which restricts how much the velocity can
+    // change in a single tick based on `MAX_ACCELERATION`.
+    let required_acceleration =
+        (new_ground_linear_velocity - ground_linear_velocity) / time.delta_seconds();
+
+    character
+        .external_force
+        .apply_force(required_acceleration * character.mass.0);
+}


### PR DESCRIPTION
I've created an example of clients controlling server-authoritative, 3D physics objects. The spaceships example also showcases clients controlling server-authoritative physics but it has a lot of extra features such as pre-spawning and wasm that make it more difficult to follow. This is intended to be a more streamlined example. Plus, it demonstrates 3D physics which is neat.

[avian_3d_physics_demo.webm](https://github.com/user-attachments/assets/4d89e18d-2f08-434d-9d3b-4c701afa5fa5)
