### PR TITLE
Rollback time resource during rollback

### DIFF
--- a/lightyear/src/client/prediction/predicted_history.rs
+++ b/lightyear/src/client/prediction/predicted_history.rs
@@ -404,7 +404,10 @@ mod tests {
         let confirmed = stepper
             .client_app
             .world_mut()
-            .spawn(Confirmed::default())
+            .spawn(Confirmed {
+                tick,
+                ..Default::default()
+            })
             .id();
         let predicted = stepper
             .client_app
@@ -548,10 +551,14 @@ mod tests {
         let mut stepper = BevyStepper::default();
 
         // add predicted, component
+        let tick = stepper.client_tick();
         let confirmed = stepper
             .client_app
             .world_mut()
-            .spawn(Confirmed::default())
+            .spawn(Confirmed {
+                tick,
+                ..Default::default()
+            })
             .id();
         let predicted = stepper
             .client_app

--- a/lightyear/src/protocol/component.rs
+++ b/lightyear/src/protocol/component.rs
@@ -19,7 +19,6 @@ use crate::client::interpolation::{add_interpolation_systems, add_prepare_interp
 use crate::client::prediction::plugin::{
     add_non_networked_rollback_systems, add_prediction_systems, add_resource_rollback_systems,
 };
-use crate::client::prediction::resource_history::ResourceHistory;
 use crate::prelude::client::SyncComponent;
 use crate::prelude::server::ServerConfig;
 use crate::prelude::{ChannelDirection, Message, Tick};
@@ -1108,10 +1107,10 @@ impl AppComponentExt for App {
         }
     }
 
+    /// Do not use `Time<Fixed>` for `R`. `Time<Fixed>` is already rollbacked.
     fn add_resource_rollback<R: Resource + Clone + Debug>(&mut self) {
         let is_client = self.world().get_resource::<ClientConfig>().is_some();
         if is_client {
-            self.insert_resource(ResourceHistory::<R>::default());
             add_resource_rollback_systems::<R>(self);
         }
     }

--- a/lightyear/src/shared/time_manager.rs
+++ b/lightyear/src/shared/time_manager.rs
@@ -56,7 +56,7 @@ pub struct TimeManager {
     /// The relative speed set by the client.
     pub base_relative_speed: f32,
     /// Should we speedup or slowdown the simulation to sync the ticks?
-    /// >1.0 = speedup, <1.0 = slowdown
+    /// \>1.0 = speedup, <1.0 = slowdown
     /// We speed up the virtual time so that our ticks go faster/slower
     /// Things that depend on real time (ping/pong times), channel/packet managers, send_interval should be unaffected
     pub(crate) sync_relative_speed: f32,


### PR DESCRIPTION
Ensure that the `Fixed<Time>` resource is accurate during a rollback by rollbacking the time resource when a rollback starts and advancing the time after each rollback tick. This is a continuation of https://github.com/cBournhonesque/lightyear/pull/619. This PR takes into account `Time<Fixed>`'s overstep.

I originally thought that using `add_resource_rollback::<Time<Fixed>>()` and running the `RunFixedMainLoop` schedule would be the solution but `RunFixedMainLoop` requires that the real time clock also progress in order to correctly advance the `Time<Fixed>` resource.

Fixes https://github.com/cBournhonesque/lightyear/issues/618