### PR TITLE
Add rollback event for debugging rollback causes

### DIFF
--- a/lightyear/src/client/prediction/plugin.rs
+++ b/lightyear/src/client/prediction/plugin.rs
@@ -32,8 +32,7 @@ use super::predicted_history::{add_component_history, apply_confirmed_update};
 use super::resource_history::{update_resource_history, ResourceHistory};
 use super::rollback::{
     check_rollback, increment_rollback_tick, prepare_rollback, prepare_rollback_non_networked,
-    prepare_rollback_prespawn, prepare_rollback_resource, run_rollback, Rollback, RollbackEvent,
-    RollbackState,
+    prepare_rollback_prespawn, prepare_rollback_resource, run_rollback, Rollback, RollbackState,
 };
 use super::spawn::spawn_predicted_entity;
 
@@ -309,8 +308,6 @@ impl Plugin for PredictionPlugin {
             .register_type::<RollbackState>()
             .register_type::<PredictionDespawnMarker>()
             .register_type::<PredictionConfig>();
-
-        app.add_event::<RollbackEvent>();
 
         // RESOURCES
         app.init_resource::<PredictionManager>();

--- a/lightyear/src/client/prediction/plugin.rs
+++ b/lightyear/src/client/prediction/plugin.rs
@@ -32,7 +32,8 @@ use super::predicted_history::{add_component_history, apply_confirmed_update};
 use super::resource_history::{update_resource_history, ResourceHistory};
 use super::rollback::{
     check_rollback, increment_rollback_tick, prepare_rollback, prepare_rollback_non_networked,
-    prepare_rollback_prespawn, prepare_rollback_resource, run_rollback, Rollback, RollbackState,
+    prepare_rollback_prespawn, prepare_rollback_resource, run_rollback, Rollback, RollbackEvent,
+    RollbackState,
 };
 use super::spawn::spawn_predicted_entity;
 
@@ -308,6 +309,8 @@ impl Plugin for PredictionPlugin {
             .register_type::<RollbackState>()
             .register_type::<PredictionDespawnMarker>()
             .register_type::<PredictionConfig>();
+
+        app.add_event::<RollbackEvent>();
 
         // RESOURCES
         app.init_resource::<PredictionManager>();

--- a/lightyear/src/client/prediction/rollback.rs
+++ b/lightyear/src/client/prediction/rollback.rs
@@ -1,3 +1,4 @@
+use std::any::TypeId;
 use std::fmt::Debug;
 use std::ops::{Deref, DerefMut};
 
@@ -5,8 +6,8 @@ use bevy::app::FixedMain;
 use bevy::ecs::entity::EntityHashSet;
 use bevy::ecs::reflect::ReflectResource;
 use bevy::prelude::{
-    Commands, Component, DespawnRecursiveExt, DetectChanges, Entity, Query, Ref, Res, ResMut,
-    Resource, With, Without, World,
+    Commands, Component, DespawnRecursiveExt, DetectChanges, Entity, Event, EventWriter, Query,
+    Ref, Res, ResMut, Resource, With, Without, World,
 };
 use bevy::reflect::Reflect;
 use bevy::time::{Fixed, Time};
@@ -21,6 +22,7 @@ use crate::client::prediction::diagnostics::PredictionMetrics;
 use crate::client::prediction::predicted_history::ComponentState;
 use crate::client::prediction::resource::PredictionManager;
 use crate::prelude::{ComponentRegistry, PreSpawnedPlayerObject, Tick, TickManager};
+use crate::protocol::component::ComponentKind;
 
 use super::predicted_history::PredictionHistory;
 use super::resource_history::{ResourceHistory, ResourceState};
@@ -36,6 +38,16 @@ pub struct Rollback {
     /// in parallel.
     pub state: RwLock<RollbackState>,
     // pub rollback_groups: EntityHashMap<ReplicationGroupId, RollbackState>,
+}
+
+/// Event that is emitted on the client whenever there's a rollback triggered.
+/// Useful for keeping track of which entities are triggering the rollbacks
+#[derive(Event, Reflect, Debug)]
+pub struct RollbackEvent {
+    /// Entity that triggered the rollback
+    pub entity: Entity,
+    /// Name of the component that triggered the rollback
+    pub component_name: String,
 }
 
 /// Resource that will track whether we should do rollback or not
@@ -113,6 +125,7 @@ pub(crate) fn check_rollback<C: SyncComponent>(
     // We use Option<> because the predicted component could have been removed while it still exists in Confirmed
     confirmed_query: Query<(Entity, Option<&C>, Ref<Confirmed>)>,
     rollback: Res<Rollback>,
+    mut evw_rollback: EventWriter<RollbackEvent>,
 ) {
     // TODO: can just enable bevy spans?
     let _span = trace_span!("client rollback check");
@@ -202,6 +215,13 @@ pub(crate) fn check_rollback<C: SyncComponent>(
                 // we already rolled-back the state for the entity's latest_tick
                 // after this we will start right away with a physics update, so we need to start taking the inputs from the next tick
                 rollback.set_rollback_tick(tick + 1);
+
+                evw_rollback.send(RollbackEvent {
+                    entity: confirmed_entity,
+                    component_name: component_registry
+                        .name(ComponentKind(TypeId::of::<C>()))
+                        .to_string(),
+                });
             }
         } else {
             // 3.b We already know we should do rollback (because of another entity/component), start the rollback

--- a/lightyear/src/protocol/component.rs
+++ b/lightyear/src/protocol/component.rs
@@ -19,6 +19,7 @@ use crate::client::interpolation::{add_interpolation_systems, add_prepare_interp
 use crate::client::prediction::plugin::{
     add_non_networked_rollback_systems, add_prediction_systems, add_resource_rollback_systems,
 };
+use crate::client::prediction::rollback::RollbackEvent;
 use crate::prelude::client::SyncComponent;
 use crate::prelude::server::ServerConfig;
 use crate::prelude::{ChannelDirection, Message, Tick};
@@ -872,6 +873,7 @@ fn register_component_send<C: Component>(app: &mut App, direction: ChannelDirect
                 );
                 crate::server::events::emit_replication_events::<C>(app);
             }
+            app.add_event::<RollbackEvent<C>>();
         }
         ChannelDirection::ServerToClient => {
             if is_server {
@@ -884,6 +886,7 @@ fn register_component_send<C: Component>(app: &mut App, direction: ChannelDirect
                 );
                 crate::client::events::emit_replication_events::<C>(app);
             }
+            app.add_event::<RollbackEvent<C>>();
         }
         ChannelDirection::Bidirectional => {
             register_component_send::<C>(app, ChannelDirection::ServerToClient);


### PR DESCRIPTION
Currently there's no easily accessible way of checking what components are causing rollbacks. 

With this PR, we fire an event whenever a rollback check detects a mismatch which listeners can then aggregate as needed to get statistics on rollback causes.