### PR TITLE
Add missing `reflect(Component)`s

### DIFF
--- a/lightyear/src/client/components.rs
+++ b/lightyear/src/client/components.rs
@@ -3,7 +3,7 @@ Defines components that are used for the client-side prediction and interpolatio
 */
 use std::fmt::Debug;
 
-use bevy::prelude::{Component, Entity};
+use bevy::prelude::{Component, Entity, ReflectComponent};
 use bevy::reflect::Reflect;
 
 use crate::prelude::{Message, Tick};
@@ -15,6 +15,7 @@ use crate::prelude::{Message, Tick};
 /// - an entity that is in the future compared to the confirmed entity, and does prediction with rollback. It will have the marker component [`Predicted`](crate::client::prediction::Predicted)
 /// - an entity that is in the past compared to the confirmed entity and interpolates between multiple server updates. It will have the marker component [`Interpolated`](crate::client::interpolation::Interpolated)
 #[derive(Component, Reflect, Default)]
+#[reflect(Component)]
 pub struct Confirmed {
     /// The corresponding Predicted entity
     pub predicted: Option<Entity>,

--- a/lightyear/src/client/interpolation/mod.rs
+++ b/lightyear/src/client/interpolation/mod.rs
@@ -1,7 +1,7 @@
 //! Handles interpolation of entities between server updates
 use std::ops::{Add, Mul};
 
-use bevy::prelude::{Component, Entity, Reflect};
+use bevy::prelude::{Component, Entity, Reflect, ReflectComponent};
 
 pub use interpolate::InterpolateStatus;
 pub use interpolation_history::ConfirmedHistory;
@@ -32,6 +32,7 @@ where
 
 /// Marker component for an entity that is being interpolated by the client
 #[derive(Component, Debug, Reflect)]
+#[reflect(Component)]
 pub struct Interpolated {
     // TODO: maybe here add an interpolation function?
     pub confirmed_entity: Entity,

--- a/lightyear/src/client/prediction/despawn.rs
+++ b/lightyear/src/client/prediction/despawn.rs
@@ -1,8 +1,8 @@
 use bevy::ecs::system::EntityCommands;
 use bevy::ecs::world::Command;
 use bevy::prelude::{
-    Commands, Component, DespawnRecursiveExt, Entity, OnRemove, Query, Reflect, Res, ResMut,
-    Trigger, With, Without, World,
+    Commands, Component, DespawnRecursiveExt, Entity, OnRemove, Query, Reflect, ReflectComponent,
+    Res, ResMut, Trigger, With, Without, World,
 };
 use tracing::{debug, error, trace};
 
@@ -24,6 +24,7 @@ pub struct PredictionDespawnCommand {
 }
 
 #[derive(Component, PartialEq, Debug, Reflect)]
+#[reflect(Component)]
 pub(crate) struct PredictionDespawnMarker {
     // TODO: do we need this?
     // TODO: it's pub just for integration tests right now

--- a/lightyear/src/client/prediction/mod.rs
+++ b/lightyear/src/client/prediction/mod.rs
@@ -1,5 +1,5 @@
 //! Handles client-side prediction
-use bevy::prelude::{Component, Entity, Reflect};
+use bevy::prelude::{Component, Entity, Reflect, ReflectComponent};
 use std::fmt::Debug;
 
 pub mod correction;
@@ -16,6 +16,7 @@ pub mod spawn;
 
 /// Marks an entity that is being predicted by the client
 #[derive(Component, Debug, Reflect)]
+#[reflect(Component)]
 pub struct Predicted {
     // This is an option because we could spawn pre-predicted entities on the client that exist before we receive
     // the corresponding confirmed entity

--- a/lightyear/src/client/prediction/prespawn.rs
+++ b/lightyear/src/client/prediction/prespawn.rs
@@ -328,6 +328,7 @@ impl PreSpawnedPlayerObjectPlugin {
 /// let custom_hash: u64 = compute_hash();
 /// PreSpawnedPlayerObject::new(hash);
 /// ``````
+#[reflect(Component)]
 pub struct PreSpawnedPlayerObject {
     /// The hash that will identify the spawned entity
     /// By default, if the hash is not set, it will be generated from the entity's archetype (list of components) and spawn tick

--- a/lightyear/src/client/replication.rs
+++ b/lightyear/src/client/replication.rs
@@ -155,6 +155,7 @@ pub(crate) mod send {
     ///
     /// If this component gets removed, we despawn the entity on the server.
     #[derive(Component, Clone, Copy, Default, Debug, PartialEq, Reflect)]
+    #[reflect(Component)]
     pub struct ReplicateToServer;
 
     /// Bundle that indicates how an entity should be replicated. Add this to an entity to start replicating

--- a/lightyear/src/server/relevance/immediate.rs
+++ b/lightyear/src/server/relevance/immediate.rs
@@ -42,6 +42,7 @@ pub(crate) enum ClientRelevance {
 }
 
 #[derive(Component, Clone, Default, PartialEq, Debug, Reflect)]
+#[reflect(Component)]
 pub(crate) struct CachedNetworkRelevance {
     /// List of clients that the entity is currently replicated to.
     /// Will be updated before the other replication systems

--- a/lightyear/src/server/replication.rs
+++ b/lightyear/src/server/replication.rs
@@ -154,6 +154,7 @@ pub(crate) mod send {
 
     /// Component that indicates which clients should predict and interpolate the entity
     #[derive(Component, Default, Clone, Debug, PartialEq, Reflect)]
+    #[reflect(Component)]
     pub struct SyncTarget {
         /// Which clients should predict this entity (unused for client to server replication)
         pub prediction: NetworkTarget,

--- a/lightyear/src/shared/replication/authority.rs
+++ b/lightyear/src/shared/replication/authority.rs
@@ -17,11 +17,13 @@ use bevy::prelude::*;
 /// - a client without Authority won't be sending any replication updates
 /// - a server won't accept replication updates from clients without Authority
 #[derive(Component, Debug, Default, Clone, Copy, PartialEq, Eq, Reflect)]
+#[reflect(Component)]
 pub struct HasAuthority;
 
 #[derive(
     Component, Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Default, Reflect,
 )]
+#[reflect(Component)]
 pub enum AuthorityPeer {
     None,
     #[default]

--- a/lightyear/src/shared/replication/hierarchy.rs
+++ b/lightyear/src/shared/replication/hierarchy.rs
@@ -21,6 +21,7 @@ use crate::shared::sets::{InternalMainSet, InternalReplicationSet};
 /// Updates entity's `Parent` component on change.
 /// Removes the parent if `None`.
 #[derive(Component, Default, Reflect, Clone, Copy, Serialize, Deserialize, Debug, PartialEq)]
+#[reflect(Component)]
 pub struct ParentSync(Option<Entity>);
 
 impl MapEntities for ParentSync {


### PR DESCRIPTION
Several key already-reflectable components didn't have `#[reflect(Component)]` attached, which means that their `ReflectComponent` couldn't be retrieved. I've gone through and added this where appropriate to components that already had `Reflect` derived.