### PR TITLE
docs: update resource replication example

### DIFF
--- a/book/src/concepts/replication/replicate.md
+++ b/book/src/concepts/replication/replicate.md
@@ -27,10 +27,36 @@ You can find some of the other usages in the [advanced_replication](../advanced_
 
 ### Replicating resources
 
-You can also replicate bevy `Resources`. This is useful when you want to update a `Resource` on the server and keep synced
+You can also replicate bevy `Resource`s. This is useful when you want to update a `Resource` on the server and keep synced
 copies on the client. This only works for `Resources` that also implement `Clone`, and should be limited to resources which are cheap to clone.
 
-- Then, to replicate a `Resource`, you can use the `commands.replicate_resource::<R>(replicate)` method. You will need to provide
-an instance of the `Replicate` struct to specify how the replication should be done (e.g. to which clients should the resource
-be replicated). To stop replicating a `Resource`, you can use the `commands.stop_replicate_resource::<R>()` method. Note that
-this won't delete the resource from the client, but it will stop updating it.
+To replicate a `Resource`:
+- Ensure that you have a [`Channel`](../reliability/channels.md) that the resource can be replicated over.
+  This can be done by creating a public struct that derives `Channel` and adding it to your protocol.
+- Next, define your resource and register it:
+    ```rust
+    #[derive(Channel)]
+    pub struct Channel1;
+
+    #[derive(Resource, Clone, Serialize, Deserialize)]
+    pub struct MyResource(pub f32);
+
+    pub fn plugin(app: &mut App) {
+        app.add_channel::<Channel1>(ChannelSettings {
+            mode: ChannelMode::OrderedReliable(ReliableSettings::default()),
+            ..Default::default()
+        });
+
+        app.register_resource::<MyResource>(ChannelDirection::ServerToClient);
+    }
+    ```
+- Finally, to replicate the `Resource`, you can use the `commands.replicate_resource::<R>(replicate)` method.
+  You will need to provide the channel and a `NetworkTarget` to specify how the replication should be done
+  (e.g. to which clients should the resource be replicated):
+    ```rust
+    commands.replicate_resource::<MyResource, Channel1>(NetworkTarget::All);
+    // This will be replicated to all clients; any changes to the resource will also be replicated
+    commands.insert_resource(MyResource(1.0));
+    ```
+- To stop replicating a `Resource`, you can use the `commands.stop_replicate_resource::<R>()` method.
+  Note that this won't delete the resource from the client, but it will stop updating it.


### PR DESCRIPTION
Updates the section on resource replication in the book to better reflect how it's done in the current version of Lightyear.