### PR TITLE
Fix 639

### DIFF
--- a/examples/lobby/src/server.rs
+++ b/examples/lobby/src/server.rs
@@ -56,7 +56,6 @@ impl Plugin for ExampleServerPlugin {
     }
 }
 
-
 /// System to start the dedicated server at Startup
 fn start_dedicated_server(mut commands: Commands) {
     commands.replicate_resource::<Lobbies, Channel1>(NetworkTarget::All);
@@ -238,8 +237,7 @@ mod lobby {
                         host: lobby.host,
                     },
                 );
-            }
-            else {
+            } else {
                 if host.is_none() {
                     // one of the players asked for the game to start
                     for player in &lobby.players {

--- a/lightyear/src/client/interpolation/spawn.rs
+++ b/lightyear/src/client/interpolation/spawn.rs
@@ -1,5 +1,5 @@
 use bevy::prelude::{Added, Commands, Entity, Query, Res, ResMut};
-use tracing::trace;
+use tracing::{error, trace};
 
 use crate::client::components::Confirmed;
 use crate::client::config::ClientConfig;
@@ -34,6 +34,10 @@ pub(crate) fn spawn_interpolated_entity(
         } else {
             // get the confirmed tick for the entity
             // if we don't have it, something has gone very wrong
+            error!(
+                "Confirmed entity missing Confirmed component: {:?}",
+                confirmed_entity
+            );
             let confirmed_tick = connection
                 .replication_receiver
                 .get_confirmed_tick(confirmed_entity)

--- a/lightyear/src/client/interpolation/spawn.rs
+++ b/lightyear/src/client/interpolation/spawn.rs
@@ -34,7 +34,10 @@ pub(crate) fn spawn_interpolated_entity(
         } else {
             // get the confirmed tick for the entity
             // if we don't have it, something has gone very wrong
-            error!("Confirmed entity: {confirmed_entity:?}, interpolated_entity: {interpolated:?}");
+            error!(
+                "Confirmed entity missing Confirmed component: {:?}",
+                confirmed_entity
+            );
             let confirmed_tick = connection
                 .replication_receiver
                 .get_confirmed_tick(confirmed_entity)

--- a/lightyear/src/client/interpolation/spawn.rs
+++ b/lightyear/src/client/interpolation/spawn.rs
@@ -34,10 +34,7 @@ pub(crate) fn spawn_interpolated_entity(
         } else {
             // get the confirmed tick for the entity
             // if we don't have it, something has gone very wrong
-            error!(
-                "Confirmed entity missing Confirmed component: {:?}",
-                confirmed_entity
-            );
+            error!("Confirmed entity: {confirmed_entity:?}, interpolated_entity: {interpolated:?}");
             let confirmed_tick = connection
                 .replication_receiver
                 .get_confirmed_tick(confirmed_entity)

--- a/lightyear/src/client/interpolation/spawn.rs
+++ b/lightyear/src/client/interpolation/spawn.rs
@@ -1,5 +1,5 @@
 use bevy::prelude::{Added, Commands, Entity, Query, Res, ResMut};
-use tracing::{error, trace};
+use tracing::trace;
 
 use crate::client::components::Confirmed;
 use crate::client::config::ClientConfig;
@@ -34,7 +34,7 @@ pub(crate) fn spawn_interpolated_entity(
         } else {
             // get the confirmed tick for the entity
             // if we don't have it, something has gone very wrong
-            error!(
+            trace!(
                 "Confirmed entity missing Confirmed component: {:?}",
                 confirmed_entity
             );

--- a/lightyear/src/client/replication.rs
+++ b/lightyear/src/client/replication.rs
@@ -388,18 +388,12 @@ pub(crate) mod send {
     /// - handles TargetEntity if it's a Preexisting entity
     /// - setting the priority
     pub(crate) fn replicate_entity_spawn(
-        mut entity: Entity,
+        entity: Entity,
         group_id: ReplicationGroupId,
         priority: f32,
         target_entity: Option<&TargetEntity>,
         sender: &mut ConnectionManager,
     ) {
-        // convert the entity to a network entity (possibly mapped)
-        // entity = sender
-        //     .replication_receiver
-        //     .remote_entity_map
-        //     .to_remote(entity);
-
         info!(?entity, "Prepare entity spawn to server");
         if let Some(TargetEntity::Preexisting(remote_entity)) = target_entity {
             sender

--- a/lightyear/src/client/replication.rs
+++ b/lightyear/src/client/replication.rs
@@ -388,12 +388,18 @@ pub(crate) mod send {
     /// - handles TargetEntity if it's a Preexisting entity
     /// - setting the priority
     pub(crate) fn replicate_entity_spawn(
-        entity: Entity,
+        mut entity: Entity,
         group_id: ReplicationGroupId,
         priority: f32,
         target_entity: Option<&TargetEntity>,
         sender: &mut ConnectionManager,
     ) {
+        // convert the entity to a network entity (possibly mapped)
+        // entity = sender
+        //     .replication_receiver
+        //     .remote_entity_map
+        //     .to_remote(entity);
+
         info!(?entity, "Prepare entity spawn to server");
         if let Some(TargetEntity::Preexisting(remote_entity)) = target_entity {
             sender

--- a/lightyear/src/client/replication.rs
+++ b/lightyear/src/client/replication.rs
@@ -394,7 +394,16 @@ pub(crate) mod send {
         target_entity: Option<&TargetEntity>,
         sender: &mut ConnectionManager,
     ) {
-        info!(?entity, "Prepare entity spawn to server");
+        // if we had this entity mapped, that means it already exists on the server
+        if let Some(remote_entity) = sender
+            .replication_receiver
+            .remote_entity_map
+            .local_to_remote
+            .get(&entity)
+        {
+            return;
+        }
+        debug!(?entity, "Prepare entity spawn to server");
         if let Some(TargetEntity::Preexisting(remote_entity)) = target_entity {
             sender
                 .replication_sender

--- a/lightyear/src/server/connection.rs
+++ b/lightyear/src/server/connection.rs
@@ -962,6 +962,7 @@ impl ConnectionManager {
         }
         self.connected_targets(actual_target)
             .try_for_each(|client_id| {
+                // convert the entity to a network entity (in case we need to map it)
                 let entity = self
                     .connection_mut(client_id)?
                     .replication_receiver

--- a/lightyear/src/server/replication.rs
+++ b/lightyear/src/server/replication.rs
@@ -3101,12 +3101,16 @@ pub(crate) mod send {
 
 pub(crate) mod commands {
     use crate::channel::builder::AuthorityChannel;
-    use crate::prelude::{ClientId, Replicated, Replicating, ServerConnectionManager};
+    use crate::prelude::server::{ConnectionManager, SyncTarget};
+    use crate::prelude::{
+        ClientId, ComponentRegistry, Replicated, Replicating, ReplicationGroup,
+        ServerConnectionManager, ShouldBePredicted,
+    };
     use crate::shared::replication::authority::{AuthorityChange, AuthorityPeer, HasAuthority};
+    use crate::shared::replication::components::{InitialReplicated, ShouldBeInterpolated};
     use bevy::ecs::system::EntityCommands;
-    use bevy::prelude::{Entity, World};
-    use crate::prelude::server::SyncTarget;
-    use crate::shared::replication::components::InitialReplicated;
+    use bevy::prelude::{Entity, Mut, World};
+    use tracing::{error, warn};
 
     pub trait AuthorityCommandExt {
         /// This command is used to transfer the authority of an entity to a different peer.
@@ -3191,19 +3195,7 @@ pub(crate) mod commands {
                             )
                             .expect("could not send message");
                         // TODO: this is very flimsy, find a better solution? https://github.com/cBournhonesque/lightyear/issues/639
-                        // if the client that had authority was the original owner, then we might want
-                        // to send a message to it to add ShouldBePredicted or ShouldBeInterpolated
-                        if let Some(rep) = world.entity(entity).get::<InitialReplicated>() {
-                            if let Some(from_client) = rep.from {
-                                if from_client == c {
-                                    if let Some(sync_target) = world.entity(entity).get::<SyncTarget>() {
-                                        if sync_target.prediction.targets(c) {
-
-                                        }
-                                    }
-                                }
-                            }
-                        }
+                        send_sync_components(world, entity, c);
                     }
                     (AuthorityPeer::Server, AuthorityPeer::Client(c)) => {
                         world
@@ -3245,6 +3237,8 @@ pub(crate) mod commands {
                                 },
                             )
                             .expect("could not send message");
+                        // TODO: this is very flimsy, find a better solution? https://github.com/cBournhonesque/lightyear/issues/639
+                        send_sync_components(world, entity, c1);
                     }
                     _ => unreachable!(),
                 }
@@ -3261,19 +3255,68 @@ pub(crate) mod commands {
     // - server adds Replicate with SyncTarget{ interpolation: All} (for example) to replicate to other clients
     // - if the authority gets removed from client 1, then the server should spawn a Interpolated or Predicted entity on client 1
     fn send_sync_components(world: &mut World, entity: Entity, client: ClientId) {
-        if let Some(rep) = world.entity(entity).get::<InitialReplicated>() {
-            if let Some(from_client) = rep.from {
-                if from_client == client {
-                    if let Some(sync_target) = world.entity(entity).get::<SyncTarget>() {
-                        if sync_target.prediction.targets(&client) {
-                            world.
-
+        world.resource_scope(|world: &mut World, mut sender: Mut<ConnectionManager>| {
+            if let Some(rep) = world.entity(entity).get::<InitialReplicated>() {
+                if let Some(from_client) = rep.from {
+                    if from_client == client {
+                        if let Some(sync_target) = world.entity(entity).get::<SyncTarget>() {
+                            if sync_target.prediction.targets(&client) {
+                                warn!("Sending ShouldBePredicted to client {client:?} that lost authority");
+                                let group_id = world
+                                    .entity(entity)
+                                    .get::<ReplicationGroup>()
+                                    .unwrap()
+                                    .group_id(Some(entity));
+                                let component_registry = world.resource::<ComponentRegistry>();
+                                if let Ok(connection_mut) = sender.connection_mut(client) {
+                                    // convert the entity to a network entity
+                                    let network_entity = connection_mut
+                                        .replication_receiver
+                                        .remote_entity_map
+                                        .to_remote(entity);
+                                    let res = sender.prepare_typed_component_insert(
+                                        network_entity,
+                                        group_id,
+                                        client,
+                                        component_registry,
+                                        &mut ShouldBePredicted,
+                                    );
+                                    if let Err(e) = res {
+                                        error!("Error sending ShouldBePredicted: {e:?} to client {client:?} that lost authority");
+                                    }
+                                }
+                            }
+                            if sync_target.interpolation.targets(&client) {
+                                warn!("Sending ShouldBeInterpolated to client {client:?} that lost authority");
+                                let group_id = world
+                                    .entity(entity)
+                                    .get::<ReplicationGroup>()
+                                    .unwrap()
+                                    .group_id(Some(entity));
+                                let component_registry = world.resource::<ComponentRegistry>();
+                                if let Ok(connection_mut) = sender.connection_mut(client) {
+                                    // convert the entity to a network entity
+                                    let network_entity = connection_mut
+                                        .replication_receiver
+                                        .remote_entity_map
+                                        .to_remote(entity);
+                                    let res = sender.prepare_typed_component_insert(
+                                        network_entity,
+                                        group_id,
+                                        client,
+                                        component_registry,
+                                        &mut ShouldBeInterpolated,
+                                    );
+                                    if let Err(e) = res {
+                                        error!("Error sending ShouldBePredicted: {e:?} to client {client:?} that lost authority");
+                                    }
+                                }
+                            }
                         }
                     }
                 }
             }
-        }
-
+        });
     }
 
     fn despawn_without_replication(entity: Entity, world: &mut World) {

--- a/lightyear/src/server/replication.rs
+++ b/lightyear/src/server/replication.rs
@@ -430,8 +430,7 @@ pub(crate) mod send {
                 let sync_target = entity_ref.get::<SyncTarget>();
                 let target_entity = entity_ref.get::<TargetEntity>();
                 let controlled_by = entity_ref.get::<ControlledBy>();
-                let authority_peer =
-                    unsafe { entity_ref.get::<AuthorityPeer>().unwrap_unchecked() };
+                let authority_peer = entity_ref.get::<AuthorityPeer>();
                 let initial_replicated = entity_ref.get::<InitialReplicated>();
                 // SAFETY: we know that the entity has the ReplicationTarget component
                 // because the archetype is in replicated_archetypes
@@ -455,22 +454,6 @@ pub(crate) mod send {
                     system_ticks.last_run(),
                     system_ticks.this_run(),
                 );
-                let authority_peer_ticks = unsafe {
-                    entity_ref
-                        .get_change_ticks::<AuthorityPeer>()
-                        .unwrap_unchecked()
-                };
-                let (added_tick, changed_tick) = (
-                    authority_peer_ticks.added_tick(),
-                    authority_peer_ticks.last_changed_tick(),
-                );
-                let authority_peer = Ref::new(
-                    authority_peer,
-                    &added_tick,
-                    &changed_tick,
-                    system_ticks.last_run(),
-                    system_ticks.this_run(),
-                );
 
                 // b. add entity despawns from visibility or target change
                 replicate_entity_despawn(
@@ -478,7 +461,7 @@ pub(crate) mod send {
                     group_id,
                     &replication_target,
                     cached_replication_target,
-                    &authority_peer,
+                    authority_peer,
                     visibility,
                     &mut sender,
                 );
@@ -495,7 +478,7 @@ pub(crate) mod send {
                     controlled_by,
                     sync_target,
                     target_entity,
-                    &authority_peer,
+                    authority_peer,
                     visibility,
                     &mut sender,
                     &system_ticks,
@@ -568,7 +551,7 @@ pub(crate) mod send {
         controlled_by: Option<&ControlledBy>,
         sync_target: Option<&SyncTarget>,
         target_entity: Option<&TargetEntity>,
-        authority_peer: &Ref<AuthorityPeer>,
+        authority_peer: Option<&AuthorityPeer>,
         visibility: Option<&CachedNetworkRelevance>,
         sender: &mut ConnectionManager,
         system_ticks: &SystemChangeTick,
@@ -612,9 +595,7 @@ pub(crate) mod send {
             None => {
                 let mut target = NetworkTarget::None;
                 // only try to replicate if the replicate component was just added
-                // if the authority is changed, we also send a new spawn message, just in case we need
-                // to
-                if replication_target.is_added() || authority_peer.is_changed() {
+                if replication_target.is_added() {
                     trace!(?entity, "send entity spawn");
                     // TODO: avoid this clone!
                     target = replication_target.target.clone();
@@ -644,10 +625,10 @@ pub(crate) mod send {
         if let Some(AuthorityPeer::Client(c)) = authority_peer {
             target.exclude(&NetworkTarget::Single(*c));
         }
-        // // we don't send entity-spawn to the client who originally spawned the entity
-        // if let Some(client_id) = initial_replicated.and_then(|r| r.from) {
-        //     target.exclude(&NetworkTarget::Single(client_id));
-        // };
+        // we don't send entity-spawn to the client who originally spawned the entity
+        if let Some(client_id) = initial_replicated.and_then(|r| r.from) {
+            target.exclude(&NetworkTarget::Single(client_id));
+        };
         if target.is_empty() {
             return;
         }
@@ -768,7 +749,7 @@ pub(crate) mod send {
         group_id: ReplicationGroupId,
         replication_target: &Ref<ReplicationTarget>,
         cached_replication_target: Option<&Cached<ReplicationTarget>>,
-        authority_peer: &Ref<AuthorityPeer>,
+        authority_peer: Option<&AuthorityPeer>,
         visibility: Option<&CachedNetworkRelevance>,
         sender: &mut ConnectionManager,
     ) {
@@ -804,7 +785,7 @@ pub(crate) mod send {
             }
         }
         // 3. we don't send messages to the client that has authority
-        if let AuthorityPeer::Client(c) = authority_peer {
+        if let Some(AuthorityPeer::Client(c)) = authority_peer {
             target.exclude(&NetworkTarget::Single(*c));
         }
 

--- a/lightyear/src/server/replication.rs
+++ b/lightyear/src/server/replication.rs
@@ -369,9 +369,7 @@ pub(crate) mod send {
                 AuthorityPeer::Client(c) => {
                     // immediately transfer authority to the client to make
                     // sure they know that they own it
-                    commands
-                        .entity(entity)
-                        .transfer_authority(authority_peer.clone());
+                    commands.entity(entity).transfer_authority(*authority_peer);
                 }
                 AuthorityPeer::Server => {
                     debug!("Adding HasAuthority to {:?}", entity);

--- a/lightyear/src/shared/replication/authority.rs
+++ b/lightyear/src/shared/replication/authority.rs
@@ -616,6 +616,9 @@ mod tests {
     // - Transfer authority from C2 to C2
     #[test]
     fn test_transfer_authority_with_interpolation() {
+        tracing_subscriber::FmtSubscriber::builder()
+            .with_max_level(tracing::Level::ERROR)
+            .init();
         let mut stepper = MultiBevyStepper::default();
         let client_entity_1 = stepper
             .client_app_1

--- a/lightyear/src/shared/replication/authority.rs
+++ b/lightyear/src/shared/replication/authority.rs
@@ -45,13 +45,15 @@ impl MapEntities for AuthorityChange {
 
 #[cfg(test)]
 mod tests {
-    use crate::prelude::{client, server, ClientId, Replicated};
+    use crate::prelude::client::{Confirmed, Interpolated};
+    use crate::prelude::server::{Replicate, SyncTarget};
+    use crate::prelude::{client, server, ClientId, NetworkTarget, Replicated};
     use crate::server::replication::commands::AuthorityCommandExt;
     use crate::shared::replication::authority::{AuthorityPeer, HasAuthority};
     use crate::tests::multi_stepper::{MultiBevyStepper, TEST_CLIENT_ID_1, TEST_CLIENT_ID_2};
     use crate::tests::protocol::{ComponentMapEntities, ComponentSyncModeSimple};
     use crate::tests::stepper::{BevyStepper, TEST_CLIENT_ID};
-    use bevy::prelude::{default, Entity};
+    use bevy::prelude::{default, Entity, With};
 
     #[test]
     fn test_transfer_authority_server_to_client() {
@@ -606,5 +608,102 @@ mod tests {
                 .0,
             client_entity_1a
         );
+    }
+
+    // Check for https://github.com/cBournhonesque/lightyear/issues/639
+    // - Spawn an entity on C1 and replicate to server
+    // - Server replicated to all with Interpolation enabled
+    // - Transfer authority from C2 to C2
+    #[test]
+    fn test_transfer_authority_with_interpolation() {
+        let mut stepper = MultiBevyStepper::default();
+        let client_entity_1 = stepper
+            .client_app_1
+            .world_mut()
+            .spawn(client::Replicate::default())
+            .id();
+        // TODO: we need to run a couple frames because the server doesn't read the client's updates
+        //  because they are from the future
+        for _ in 0..10 {
+            stepper.frame_step();
+        }
+        let server_entity = stepper
+            .server_app
+            .world()
+            .resource::<server::ConnectionManager>()
+            .connection(ClientId::Netcode(TEST_CLIENT_ID_1))
+            .expect("client connection missing")
+            .replication_receiver
+            .remote_entity_map
+            .get_local(client_entity_1)
+            .expect("entity was not replicated to server");
+        // Add replicate on the server, with interpolation
+        stepper
+            .server_app
+            .world_mut()
+            .entity_mut(server_entity)
+            .insert(Replicate {
+                authority: AuthorityPeer::Client(ClientId::Netcode(TEST_CLIENT_ID_1)),
+                sync: SyncTarget {
+                    prediction: NetworkTarget::None,
+                    interpolation: NetworkTarget::All,
+                },
+                ..default()
+            });
+        stepper.frame_step();
+        stepper.frame_step();
+
+        // entity was replicated to client 2
+        let client_entity_2 = stepper
+            .client_app_2
+            .world()
+            .resource::<client::ConnectionManager>()
+            .replication_receiver
+            .remote_entity_map
+            .get_local(server_entity)
+            .expect("entity was not replicated to server");
+        // check that it has confirmed and interpolated
+        let confirmed_2 = stepper
+            .client_app_2
+            .world()
+            .get::<Confirmed>(client_entity_2)
+            .expect("confirmed missing on client 2");
+        let interpolated_2 = confirmed_2
+            .interpolated
+            .expect("interpolated entity missing on client 2");
+
+        // transfer authority from client 1 to client 2
+        stepper
+            .server_app
+            .world_mut()
+            .commands()
+            .entity(server_entity)
+            .transfer_authority(AuthorityPeer::Client(ClientId::Netcode(TEST_CLIENT_ID_2)));
+        stepper.frame_step();
+        stepper.frame_step();
+        stepper.frame_step();
+
+        // add Replicate on it as well
+        stepper
+            .client_app_2
+            .world_mut()
+            .entity_mut(client_entity_2)
+            .insert(client::Replicate::default());
+
+        // advance frames.
+        for _ in 0..10 {
+            stepper.frame_step();
+        }
+        // Nothing happens, even though we maybe would have expected
+        // an Interpolated entity to be spawned on client 1?
+        // Is it because no
+        let confirmed_1 = stepper
+            .client_app_1
+            .world()
+            .get::<Confirmed>(client_entity_1)
+            .expect("confirmed missing on client 1");
+        let interpolated_1 = confirmed_1
+            .interpolated
+            .expect("interpolated entity missing on client 1");
     }
 }

--- a/lightyear/src/shared/replication/authority.rs
+++ b/lightyear/src/shared/replication/authority.rs
@@ -54,7 +54,6 @@ mod tests {
     use crate::tests::protocol::{ComponentMapEntities, ComponentSyncModeSimple};
     use crate::tests::stepper::{BevyStepper, TEST_CLIENT_ID};
     use bevy::prelude::{default, Entity, With};
-    use tracing::error;
 
     #[test]
     fn test_transfer_authority_server_to_client() {
@@ -414,7 +413,7 @@ mod tests {
     #[test]
     fn test_receive_updates_from_transferred_authority_client_to_client() {
         // tracing_subscriber::FmtSubscriber::builder()
-        //     .with_max_level(tracing::Level::WARN)
+        //     .with_max_level(tracing::Level::ERROR)
         //     .init();
         let mut stepper = MultiBevyStepper::default();
 
@@ -509,7 +508,6 @@ mod tests {
 
         // TODO: resolve this footgun
         // add replicate BEFORE we transfer authority (otherwise when we add client::Replicate, it would add HasAuthority with it...)
-        // also when we add Replicate after the authority transfer, we would send a redundant Spawn
         stepper
             .client_app_2
             .world_mut()
@@ -619,7 +617,7 @@ mod tests {
     #[test]
     fn test_transfer_authority_with_interpolation() {
         tracing_subscriber::FmtSubscriber::builder()
-            .with_max_level(tracing::Level::WARN)
+            .with_max_level(tracing::Level::ERROR)
             .init();
         let mut stepper = MultiBevyStepper::default();
         let client_entity_1 = stepper
@@ -655,8 +653,6 @@ mod tests {
                 },
                 ..default()
             });
-
-        error!("Server received entity: {:?}", server_entity);
         stepper.frame_step();
         stepper.frame_step();
 
@@ -678,7 +674,6 @@ mod tests {
         let interpolated_2 = confirmed_2
             .interpolated
             .expect("interpolated entity missing on client 2");
-        error!("Client 2 received entity: {:?}", client_entity_2);
 
         // transfer authority from client 1 to client 2
         stepper
@@ -687,11 +682,9 @@ mod tests {
             .commands()
             .entity(server_entity)
             .transfer_authority(AuthorityPeer::Client(ClientId::Netcode(TEST_CLIENT_ID_2)));
-        error!("Authority transferred to client 2: {:?}", client_entity_2);
         stepper.frame_step();
         stepper.frame_step();
         stepper.frame_step();
-        error!("Before adding Replicate on client 2");
 
         // add Replicate on it as well
         stepper

--- a/lightyear/src/shared/replication/authority.rs
+++ b/lightyear/src/shared/replication/authority.rs
@@ -54,6 +54,7 @@ mod tests {
     use crate::tests::protocol::{ComponentMapEntities, ComponentSyncModeSimple};
     use crate::tests::stepper::{BevyStepper, TEST_CLIENT_ID};
     use bevy::prelude::{default, Entity, With};
+    use tracing::error;
 
     #[test]
     fn test_transfer_authority_server_to_client() {
@@ -413,7 +414,7 @@ mod tests {
     #[test]
     fn test_receive_updates_from_transferred_authority_client_to_client() {
         // tracing_subscriber::FmtSubscriber::builder()
-        //     .with_max_level(tracing::Level::ERROR)
+        //     .with_max_level(tracing::Level::WARN)
         //     .init();
         let mut stepper = MultiBevyStepper::default();
 
@@ -508,6 +509,7 @@ mod tests {
 
         // TODO: resolve this footgun
         // add replicate BEFORE we transfer authority (otherwise when we add client::Replicate, it would add HasAuthority with it...)
+        // also when we add Replicate after the authority transfer, we would send a redundant Spawn
         stepper
             .client_app_2
             .world_mut()
@@ -617,7 +619,7 @@ mod tests {
     #[test]
     fn test_transfer_authority_with_interpolation() {
         tracing_subscriber::FmtSubscriber::builder()
-            .with_max_level(tracing::Level::ERROR)
+            .with_max_level(tracing::Level::WARN)
             .init();
         let mut stepper = MultiBevyStepper::default();
         let client_entity_1 = stepper
@@ -653,6 +655,8 @@ mod tests {
                 },
                 ..default()
             });
+
+        error!("Server received entity: {:?}", server_entity);
         stepper.frame_step();
         stepper.frame_step();
 
@@ -674,6 +678,7 @@ mod tests {
         let interpolated_2 = confirmed_2
             .interpolated
             .expect("interpolated entity missing on client 2");
+        error!("Client 2 received entity: {:?}", client_entity_2);
 
         // transfer authority from client 1 to client 2
         stepper
@@ -682,9 +687,11 @@ mod tests {
             .commands()
             .entity(server_entity)
             .transfer_authority(AuthorityPeer::Client(ClientId::Netcode(TEST_CLIENT_ID_2)));
+        error!("Authority transferred to client 2: {:?}", client_entity_2);
         stepper.frame_step();
         stepper.frame_step();
         stepper.frame_step();
+        error!("Before adding Replicate on client 2");
 
         // add Replicate on it as well
         stepper

--- a/lightyear/src/shared/replication/authority.rs
+++ b/lightyear/src/shared/replication/authority.rs
@@ -45,7 +45,7 @@ impl MapEntities for AuthorityChange {
 
 #[cfg(test)]
 mod tests {
-    use crate::prelude::client::{Confirmed, Interpolated};
+    use crate::prelude::client::Confirmed;
     use crate::prelude::server::{Replicate, SyncTarget};
     use crate::prelude::{client, server, ClientId, NetworkTarget, Replicated};
     use crate::server::replication::commands::AuthorityCommandExt;
@@ -53,7 +53,7 @@ mod tests {
     use crate::tests::multi_stepper::{MultiBevyStepper, TEST_CLIENT_ID_1, TEST_CLIENT_ID_2};
     use crate::tests::protocol::{ComponentMapEntities, ComponentSyncModeSimple};
     use crate::tests::stepper::{BevyStepper, TEST_CLIENT_ID};
-    use bevy::prelude::{default, Entity, With};
+    use bevy::prelude::{default, Entity};
 
     #[test]
     fn test_transfer_authority_server_to_client() {
@@ -616,9 +616,9 @@ mod tests {
     // - Transfer authority from C2 to C2
     #[test]
     fn test_transfer_authority_with_interpolation() {
-        tracing_subscriber::FmtSubscriber::builder()
-            .with_max_level(tracing::Level::ERROR)
-            .init();
+        // tracing_subscriber::FmtSubscriber::builder()
+        //     .with_max_level(tracing::Level::WARN)
+        //     .init();
         let mut stepper = MultiBevyStepper::default();
         let client_entity_1 = stepper
             .client_app_1
@@ -693,20 +693,21 @@ mod tests {
             .entity_mut(client_entity_2)
             .insert(client::Replicate::default());
 
-        // advance frames.
-        for _ in 0..10 {
-            stepper.frame_step();
-        }
-        // Nothing happens, even though we maybe would have expected
-        // an Interpolated entity to be spawned on client 1?
-        // Is it because no
-        let confirmed_1 = stepper
-            .client_app_1
-            .world()
-            .get::<Confirmed>(client_entity_1)
-            .expect("confirmed missing on client 1");
-        let interpolated_1 = confirmed_1
-            .interpolated
-            .expect("interpolated entity missing on client 1");
+        // TODO: THIS IS NOT FIXED YET! See https://github.com/cBournhonesque/lightyear/pull/642!
+        // // advance frames.
+        // for _ in 0..10 {
+        //     stepper.frame_step();
+        // }
+        // // Nothing happens, even though we maybe would have expected
+        // // an Interpolated entity to be spawned on client 1?
+        // // Is it because no
+        // let confirmed_1 = stepper
+        //     .client_app_1
+        //     .world()
+        //     .get::<Confirmed>(client_entity_1)
+        //     .expect("confirmed missing on client 1");
+        // let interpolated_1 = confirmed_1
+        //     .interpolated
+        //     .expect("interpolated entity missing on client 1");
     }
 }

--- a/lightyear/src/shared/replication/receive.rs
+++ b/lightyear/src/shared/replication/receive.rs
@@ -29,8 +29,11 @@ pub struct ReplicationReceiver {
     /// Map between local and remote entities. (used mostly on client because it's when we receive entity updates)
     pub remote_entity_map: RemoteEntityMap,
 
-    /// Map from remote entity to the replication group-id
-    pub(crate) remote_entity_to_group: EntityHashMap<Entity, ReplicationGroupId>,
+    /// Map from local entity to the replication group-id
+    /// We use the local entity because in some cases we don't have access to the remote entity at all, since the remote
+    /// has pre-done the mapping! (for example C1 spawns 1 and sends to S who spawns 2. Then S transfers authority to C2,
+    /// S will start sending updates to C1, but will pre-map from 2 to 1, so C1 will never see the remote entity!)
+    pub(crate) local_entity_to_group: EntityHashMap<Entity, ReplicationGroupId>,
 
     // BOTH
     /// Buffer to so that we have an ordered receiver per group
@@ -63,7 +66,7 @@ impl ReplicationReceiver {
         Self {
             // RECEIVE
             remote_entity_map: RemoteEntityMap::default(),
-            remote_entity_to_group: Default::default(),
+            local_entity_to_group: Default::default(),
             // BOTH
             group_channels: Default::default(),
         }
@@ -86,14 +89,6 @@ impl ReplicationReceiver {
             trace!(message_id= ?actions.sequence_id, pending_message_id = ?channel.actions_pending_recv_message_id, "message is too old, ignored");
             return;
         }
-        // update the list of entities in the group
-        actions
-            .actions
-            .iter()
-            .map(|(entity, _)| entity)
-            .for_each(|entity| {
-                channel.remote_entities.insert(*entity);
-            });
 
         // add the message to the buffer
         // TODO: I guess this handles potential duplicates?
@@ -179,30 +174,10 @@ impl ReplicationReceiver {
             .and_then(|channel| channel.latest_tick)
     }
 
-    /// Get the replication group id associated with a given local entity
-    pub(crate) fn get_replication_group_id(
-        &self,
-        confirmed_entity: Entity,
-    ) -> Option<ReplicationGroupId> {
-        self.remote_entity_map
-            .get_remote(confirmed_entity)
-            .and_then(|remote_entity| self.remote_entity_to_group.get(&remote_entity))
-            .copied()
-    }
-
-    // USED BY RECEIVE SIDE (SEND SIZE CAN GET THE GROUP_ID EASILY)
-    /// Get the group channel associated with a given entity
+    /// Get the group channel associated with a given local entity
     fn channel_by_local(&self, local_entity: Entity) -> Option<&GroupChannel> {
-        self.remote_entity_map
-            .get_remote(local_entity)
-            .and_then(|remote_entity| self.channel_by_remote(remote_entity))
-    }
-
-    // USED BY RECEIVE SIDE (SEND SIZE CAN GET THE GROUP_ID EASILY)
-    /// Get the group channel associated with a given entity
-    fn channel_by_remote(&self, remote_entity: Entity) -> Option<&GroupChannel> {
-        self.remote_entity_to_group
-            .get(&remote_entity)
+        self.local_entity_to_group
+            .get(&local_entity)
             .and_then(|group_id| self.group_channels.get(group_id))
     }
 
@@ -253,13 +228,13 @@ impl ReplicationReceiver {
             // spawn
             match actions.spawn {
                 SpawnAction::Spawn => {
-                    self.remote_entity_to_group.insert(*remote_entity, group_id);
                     if let Some(local_entity) = self.remote_entity_map.get_local(*remote_entity) {
                         if world.get_entity(local_entity).is_some() {
                             warn!("Received spawn for an entity that already exists");
                             continue;
                         }
                         warn!("Received spawn for an entity that is already in our entity mapping! Not spawning");
+                        self.local_entity_to_group.insert(local_entity, group_id);
                         continue;
                     }
                     // TODO: optimization: spawn the bundle of insert components
@@ -280,6 +255,11 @@ impl ReplicationReceiver {
                         Replicated { from: remote },
                         InitialReplicated { from: remote },
                     ));
+                    if let Some(group) = self.group_channels.get_mut(&group_id) {
+                        group.local_entities.insert(local_entity.id());
+                    }
+                    self.local_entity_to_group
+                        .insert(local_entity.id(), group_id);
                     self.remote_entity_map
                         .insert(*remote_entity, local_entity.id());
                     trace!("Updated remote entity map: {:?}", self.remote_entity_map);
@@ -309,14 +289,14 @@ impl ReplicationReceiver {
                 debug!(remote_entity = ?entity, "Received entity despawn");
                 if let Some(local_entity) = self.remote_entity_map.remove_by_remote(entity) {
                     if let Some(group) = self.group_channels.get_mut(&group_id) {
-                        group.remote_entities.remove(&entity);
+                        group.local_entities.remove(&local_entity);
                     }
                     // TODO: we despawn all children as well right now, but that might not be what we want?
                     if let Some(entity_mut) = world.get_entity_mut(local_entity) {
                         entity_mut.despawn_recursive();
                     }
                     events.push_despawn(local_entity);
-                    self.remote_entity_to_group.remove(&entity);
+                    self.local_entity_to_group.remove(&local_entity);
                 } else {
                     error!("Received despawn for an entity that does not exist")
                 }
@@ -459,10 +439,8 @@ impl ReplicationReceiver {
         // }
 
         if let Some(g) = self.group_channels.get(&group_id) {
-            g.remote_entities.iter().for_each(|remote_entity| {
-                if let Some(mut local_entity_mut) =
-                    self.remote_entity_map.get_by_remote(world, *remote_entity)
-                {
+            g.local_entities.iter().for_each(|local_entity| {
+                if let Some(mut local_entity_mut) = world.get_entity_mut(*local_entity) {
                     trace!(?remote_tick, "updating confirmed tick for entity");
                     if let Some(mut confirmed) = local_entity_mut.get_mut::<Confirmed>() {
                         confirmed.tick = remote_tick;
@@ -554,7 +532,7 @@ impl ReplicationReceiver {
                     remote_tick,
                     message,
                     &mut self.remote_entity_map,
-                    &mut self.remote_entity_to_group,
+                    &mut self.local_entity_to_group,
                     events,
                 );
             });
@@ -600,8 +578,10 @@ impl ReplicationReceiver {
 #[derive(Debug)]
 pub struct GroupChannel {
     // entities
-    // set of remote entities that are part of the same Replication Group
-    remote_entities: HashSet<Entity>,
+    // set of local entities that are part of the same Replication Group
+    // (we use local entities because we might not be aware of the remote entities,
+    //  if the remote is doing pre-mapping)
+    local_entities: HashSet<Entity>,
     // actions
     pub(crate) actions_pending_recv_message_id: MessageId,
     pub(crate) actions_recv_message_buffer: BTreeMap<MessageId, (Tick, EntityActionsMessage)>,
@@ -614,7 +594,7 @@ pub struct GroupChannel {
 impl Default for GroupChannel {
     fn default() -> Self {
         Self {
-            remote_entities: HashSet::default(),
+            local_entities: HashSet::default(),
             actions_pending_recv_message_id: MessageId(0),
             actions_recv_message_buffer: BTreeMap::new(),
             buffered_updates: UpdatesBuffer::default(),
@@ -817,7 +797,7 @@ impl GroupChannel {
         remote_tick: Tick,
         message: EntityActionsMessage,
         remote_entity_map: &mut RemoteEntityMap,
-        remote_entity_to_group: &mut EntityHashMap<Entity, ReplicationGroupId>,
+        local_entity_to_group: &mut EntityHashMap<Entity, ReplicationGroupId>,
         events: &mut ConnectionEvents,
     ) {
         let group_id = message.group_id;
@@ -826,14 +806,10 @@ impl GroupChannel {
         // These components could even form a cycle, for example A.HasWeapon(B) and B.HasHolder(A)
         // Our solution is to first handle spawn for all entities separately.
         for (remote_entity, actions) in message.actions.iter() {
-            debug!(?remote_entity, ?actions, "Received entity actions");
+            error!(?remote_entity, ?actions, "Received entity actions");
             // spawn
             match actions.spawn {
                 SpawnAction::Spawn => {
-                    // TODO: update this to local_entity_to_group??
-                    remote_entity_to_group.insert(*remote_entity, group_id);
-                    // TODO ABOVE
-
                     if let Some(local_entity) = remote_entity_map.get_local(*remote_entity) {
                         if world.get_entity(local_entity).is_some() {
                             warn!(
@@ -843,6 +819,7 @@ impl GroupChannel {
                             );
                             continue;
                         }
+                        local_entity_to_group.insert(local_entity, group_id);
                         warn!("Received spawn for an entity that is already in our entity mapping! Not spawning");
                         continue;
                     }
@@ -869,6 +846,8 @@ impl GroupChannel {
                         Replicated { from: remote },
                         InitialReplicated { from: remote },
                     ));
+                    self.local_entities.insert(local_entity.id());
+                    local_entity_to_group.insert(local_entity.id(), group_id);
                     // if the entity was replicated from a client to the server, update the AuthorityPeer
                     if let Some(client) = remote {
                         local_entity.insert(AuthorityPeer::Client(client));
@@ -901,13 +880,13 @@ impl GroupChannel {
             if actions.spawn == SpawnAction::Despawn {
                 debug!(remote_entity = ?entity, "Received entity despawn");
                 if let Some(local_entity) = remote_entity_map.remove_by_remote(entity) {
-                    self.remote_entities.remove(&entity);
+                    self.local_entities.remove(&local_entity);
                     // TODO: we despawn all children as well right now, but that might not be what we want?
                     if let Some(entity_mut) = world.get_entity_mut(local_entity) {
                         entity_mut.despawn_recursive();
                     }
                     events.push_despawn(local_entity);
-                    remote_entity_to_group.remove(&entity);
+                    local_entity_to_group.remove(&local_entity);
                 } else {
                     error!("Received despawn for an entity that does not exist")
                 }
@@ -980,6 +959,7 @@ impl GroupChannel {
                     });
             }
         }
+
         self.update_confirmed_tick(world, group_id, remote_tick, remote_entity_map);
     }
 
@@ -1074,11 +1054,13 @@ impl GroupChannel {
         //
         // }
 
-        self.remote_entities.iter().for_each(|remote_entity| {
-            if let Some(mut local_entity_mut) =
-                remote_entity_map.get_by_remote(world, *remote_entity)
-            {
-                trace!(?remote_tick, "updating confirmed tick for entity");
+        self.local_entities.iter().for_each(|local_entity| {
+            if let Some(mut local_entity_mut) = world.get_entity_mut(*local_entity) {
+                error!(
+                    ?remote_tick,
+                    ?local_entity,
+                    "updating confirmed tick for entity"
+                );
                 if let Some(mut confirmed) = local_entity_mut.get_mut::<Confirmed>() {
                     confirmed.tick = remote_tick;
                 }

--- a/lightyear/src/shared/replication/receive.rs
+++ b/lightyear/src/shared/replication/receive.rs
@@ -806,6 +806,7 @@ impl GroupChannel {
         // These components could even form a cycle, for example A.HasWeapon(B) and B.HasHolder(A)
         // Our solution is to first handle spawn for all entities separately.
         for (remote_entity, actions) in message.actions.iter() {
+            error!(?remote_entity, ?actions, "Received entity actions");
             // spawn
             match actions.spawn {
                 SpawnAction::Spawn => {
@@ -845,8 +846,6 @@ impl GroupChannel {
                         Replicated { from: remote },
                         InitialReplicated { from: remote },
                     ));
-
-                    error!(?remote, ?remote_entity, local_entity=?local_entity.id(), ?actions, "Received entity actions");
                     self.local_entities.insert(local_entity.id());
                     local_entity_to_group.insert(local_entity.id(), group_id);
                     // if the entity was replicated from a client to the server, update the AuthorityPeer

--- a/lightyear/src/shared/replication/receive.rs
+++ b/lightyear/src/shared/replication/receive.rs
@@ -806,7 +806,7 @@ impl GroupChannel {
         // These components could even form a cycle, for example A.HasWeapon(B) and B.HasHolder(A)
         // Our solution is to first handle spawn for all entities separately.
         for (remote_entity, actions) in message.actions.iter() {
-            error!(?remote_entity, ?actions, "Received entity actions");
+            error!(?remote_entity, ?remote, ?actions, "Received entity actions");
             // spawn
             match actions.spawn {
                 SpawnAction::Spawn => {

--- a/lightyear/src/shared/replication/receive.rs
+++ b/lightyear/src/shared/replication/receive.rs
@@ -806,7 +806,6 @@ impl GroupChannel {
         // These components could even form a cycle, for example A.HasWeapon(B) and B.HasHolder(A)
         // Our solution is to first handle spawn for all entities separately.
         for (remote_entity, actions) in message.actions.iter() {
-            error!(?remote_entity, ?actions, "Received entity actions");
             // spawn
             match actions.spawn {
                 SpawnAction::Spawn => {
@@ -846,6 +845,8 @@ impl GroupChannel {
                         Replicated { from: remote },
                         InitialReplicated { from: remote },
                     ));
+
+                    error!(?remote, ?remote_entity, local_entity=?local_entity.id(), ?actions, "Received entity actions");
                     self.local_entities.insert(local_entity.id());
                     local_entity_to_group.insert(local_entity.id(), group_id);
                     // if the entity was replicated from a client to the server, update the AuthorityPeer


### PR DESCRIPTION
Related to  https://github.com/cBournhonesque/lightyear/issues/639
The problem is that we used to only do entity mapping from the Sender -> Receiver, i.e. the entity map was **only** present on the receiver. With authority transfer we updated entity mapping, and it can be done both on the sending side or on the receiving side.

Some of our existing logic on the receiver (for example: https://github.com/cBournhonesque/lightyear/blob/1e1cbfadc6fcdcfca61a7b6cf091e24ceaf4a0ba/lightyear/src/shared/replication/receive.rs#L196) still work under the expectation that the entity map only exists on the receiver. (and that **every local entity** is present in the entity map. This is not the case anymore, which is why this function fails (https://github.com/cBournhonesque/lightyear/blob/1e1cbfadc6fcdcfca61a7b6cf091e24ceaf4a0ba/lightyear/src/client/interpolation/spawn.rs#L39).
https://github.com/cBournhonesque/lightyear/blob/1e1cbfadc6fcdcfca61a7b6cf091e24ceaf4a0ba/lightyear/src/shared/replication/receive.rs#L177

Potential solutions:
- include the received tick in `Replicated` so that ALL entities have it (not just the ones with prediction/interp). Could work but maybe inefficient?
- In general using the ChannelReceiver to get the confirmed tick seems very 'flimsy'. Maybe use something else?
- Fix the code paths that still expect all entities to be present in the entity map

This PR currently has a unit test but no fix