### PR TITLE
Map entities when rollbacking predicted component

### DIFF
--- a/lightyear/src/client/prediction/predicted_history.rs
+++ b/lightyear/src/client/prediction/predicted_history.rs
@@ -122,8 +122,8 @@ pub(crate) fn add_component_history<C: SyncComponent>(
     manager: Res<PredictionManager>,
     mut commands: Commands,
     tick_manager: Res<TickManager>,
-    predicted_entities: Query<
-        (Entity, Option<Ref<C>>),
+    predicted_components: Query<
+        Option<Ref<C>>,
         (
             Without<PredictionHistory<C>>,
             // for all types of predicted entities, we want to add the component history to enable them to be rolled-back
@@ -135,8 +135,8 @@ pub(crate) fn add_component_history<C: SyncComponent>(
     let kind = std::any::type_name::<C>();
     let tick = tick_manager.tick();
     for (confirmed_entity, confirmed, confirmed_component) in confirmed_entities.iter() {
-        if let Some(p) = confirmed.predicted {
-            if let Ok((predicted_entity, predicted_component)) = predicted_entities.get(p) {
+        if let Some(predicted_entity) = confirmed.predicted {
+            if let Ok(predicted_component) = predicted_components.get(predicted_entity) {
                 // if component got added on predicted side, add history
                 add_history::<C>(
                     component_registry.as_ref(),

--- a/lightyear/src/client/prediction/rollback.rs
+++ b/lightyear/src/client/prediction/rollback.rs
@@ -226,7 +226,6 @@ pub(crate) fn prepare_rollback<C: SyncComponent>(
     // We use Option<> because the predicted component could have been removed while it still exists in Confirmed
     mut predicted_query: Query<
         (
-            Entity,
             Option<&mut C>,
             &mut PredictionHistory<C>,
             Option<&mut Correction<C>>,
@@ -258,13 +257,13 @@ pub(crate) fn prepare_rollback<C: SyncComponent>(
         // // careful, we added 1 to the tick in the check_rollback stage...
         // let tick = Tick(*current_tick - 1);
 
-        let Some(p) = confirmed.predicted else {
+        let Some(predicted_entity) = confirmed.predicted else {
             continue;
         };
 
         // 1. Get the predicted entity, and it's history
-        let Ok((predicted_entity, predicted_component, mut predicted_history, mut correction)) =
-            predicted_query.get_mut(p)
+        let Ok((predicted_component, mut predicted_history, mut correction)) =
+            predicted_query.get_mut(predicted_entity)
         else {
             debug!(
                 "Predicted entity {:?} was not found when preparing rollback for {:?}",

--- a/lightyear/src/client/prediction/rollback.rs
+++ b/lightyear/src/client/prediction/rollback.rs
@@ -879,10 +879,16 @@ mod integration_tests {
 
     use super::test_utils::*;
 
-    use crate::prelude::client::*;
+    use crate::client::prediction::resource::PredictionManager;
+    use crate::prelude::server::SyncTarget;
+    use crate::prelude::{
+        client::*, AppComponentExt, ChannelDirection, NetworkTarget, SharedConfig, TickConfig,
+    };
     use crate::tests::protocol::*;
     use crate::tests::stepper::BevyStepper;
+    use bevy::ecs::entity::MapEntities;
     use bevy::prelude::*;
+    use serde::{Deserialize, Serialize};
 
     fn setup(increment_component: bool) -> (BevyStepper, Entity, Entity) {
         fn increment_component_system(
@@ -929,6 +935,142 @@ mod integration_tests {
             .predicted = Some(predicted);
         stepper.frame_step();
         (stepper, confirmed, predicted)
+    }
+
+    /// Test that the entities within a predicted component marked as to be
+    /// entity-mapped are mapped when rollbacked.
+    #[test]
+    fn test_rollback_entity_mapping() {
+        #[derive(Component, Serialize, Deserialize, Clone, Copy, PartialEq)]
+        struct ComponentWithEntity(Entity);
+
+        impl MapEntities for ComponentWithEntity {
+            fn map_entities<M: bevy::prelude::EntityMapper>(&mut self, entity_mapper: &mut M) {
+                self.0 = entity_mapper.map_entity(self.0);
+            }
+        }
+
+        let frame_duration = Duration::from_millis(10);
+        let tick_duration = Duration::from_millis(10);
+        let shared_config = SharedConfig {
+            tick: TickConfig::new(tick_duration),
+            ..Default::default()
+        };
+        let mut stepper = BevyStepper::new(shared_config, ClientConfig::default(), frame_duration);
+        // Make `ComponentWithEntity` fully predictable and entity-mappable.
+        stepper
+            .client_app
+            .register_component::<ComponentWithEntity>(ChannelDirection::Bidirectional)
+            .add_prediction(ComponentSyncMode::Full)
+            .add_map_entities();
+        stepper
+            .server_app
+            .register_component::<ComponentWithEntity>(ChannelDirection::Bidirectional)
+            .add_prediction(ComponentSyncMode::Full)
+            .add_map_entities();
+        stepper.init();
+
+        // Spawn a remote entity with a `ComponentWithEntity` component that
+        // points to the remote entity. This entity will be replicated to the
+        // client and predicted by the client.
+        let remote_entity = stepper.server_app.world_mut().spawn_empty().id();
+        stepper
+            .server_app
+            .world_mut()
+            .entity_mut(remote_entity)
+            .insert((
+                ComponentWithEntity(remote_entity),
+                crate::server::replication::send::Replicate {
+                    sync: SyncTarget {
+                        prediction: NetworkTarget::All,
+                        ..default()
+                    },
+                    ..default()
+                },
+            ));
+
+        // Wait for server to send replicated component to client.
+        for _ in 0..100 {
+            stepper.frame_step();
+        }
+
+        // Get the confirmed and predicted entities associated with `remote_entity`.
+        let confirmed_entity = *stepper
+            .client_app
+            .world_mut()
+            .resource::<ConnectionManager>()
+            .replication_receiver
+            .remote_entity_map
+            .remote_to_local
+            .get(&remote_entity)
+            .unwrap();
+        let predicted_entity = *stepper
+            .client_app
+            .world_mut()
+            .resource_mut::<PredictionManager>()
+            .predicted_entity_map
+            .get_mut()
+            .confirmed_to_predicted
+            .get(&confirmed_entity)
+            .unwrap();
+
+        // Modify `predicted_entity`'s `ComponentWithEntity` to point to some
+        // incorrect value, perform a rollback, and verify that
+        // `predicted_entity`'s `ComponentWithEntity` points to
+        // `predicted_entity`.
+        stepper
+            .client_app
+            .world_mut()
+            .entity_mut(predicted_entity)
+            .get_mut::<ComponentWithEntity>()
+            .unwrap()
+            .0 = Entity::PLACEHOLDER;
+        let tick = stepper.client_tick();
+        stepper
+            .client_app
+            .world_mut()
+            .resource_mut::<Rollback>()
+            .set_rollback_tick(tick);
+        stepper.tick_step();
+        assert_eq!(
+            stepper
+                .client_app
+                .world()
+                .entity(predicted_entity)
+                .get::<ComponentWithEntity>()
+                .unwrap()
+                .0,
+            predicted_entity,
+            "Expected predicted component to point to predicted entity"
+        );
+
+        // Delete `predicted_entity`'s `ComponentWithEntity`, perform a
+        // rollback, and verify that `predicted_entity`'s
+        // `ComponentWithEntity` gets re-created and points to
+        // `predicted_entity`.
+        stepper
+            .client_app
+            .world_mut()
+            .entity_mut(predicted_entity)
+            .remove::<ComponentWithEntity>();
+        let tick = stepper.client_tick();
+        stepper
+            .client_app
+            .world_mut()
+            .resource_mut::<Rollback>()
+            .set_rollback_tick(tick);
+        stepper.tick_step();
+        assert_eq!(
+            stepper
+                .client_app
+                .world_mut()
+                .entity_mut(predicted_entity)
+                .get_mut::<ComponentWithEntity>()
+                .unwrap()
+                .0,
+            predicted_entity,
+            "Expected predicted component to point to predicted entity"
+        );
     }
 
     /// Test that:


### PR DESCRIPTION
Map the entities within a predicted component when it is rollbacked. If they are not mapped then the predicted component's entities will be the same as its confirmed component counterpart when a rollback starts which may not be desired.