### PR TITLE
Simplify wrapping_diff code

### DIFF
--- a/lightyear/src/utils/wrapping_id.rs
+++ b/lightyear/src/utils/wrapping_id.rs
@@ -155,54 +155,11 @@ pub fn wrapping_diff(a: u16, b: u16) -> i16 {
     b.wrapping_sub(a) as i16
 }
 
-// TODO: Remove
-fn wrapping_diff_old(a: u16, b: u16) -> i16 {
-    const MAX: i32 = i16::MAX as i32;
-    const MIN: i32 = i16::MIN as i32;
-    const ADJUST: i32 = (u16::MAX as i32) + 1;
-
-    let a: i32 = i32::from(a);
-    let b: i32 = i32::from(b);
-
-    let mut result = b - a;
-    if (MIN..=MAX).contains(&result) {
-        result as i16
-    } else if b > a {
-        result = b - (a + ADJUST);
-        if (MIN..=MAX).contains(&result) {
-            result as i16
-        } else {
-            panic!("integer overflow, this shouldn't happen")
-        }
-    } else {
-        result = (b + ADJUST) - a;
-        if (MIN..=MAX).contains(&result) {
-            result as i16
-        } else {
-            panic!("integer overflow, this shouldn't happen")
-        }
-    }
-}
-
 #[cfg(test)]
 mod sequence_compare_tests {
     use super::wrapping_id;
 
     wrapping_id!(Id);
-
-    #[ignore]
-    #[test]
-    fn test_wrapping_diff_equivalence() {
-        for a in 0..=u16::MAX {
-            for b in 0..=u16::MAX {
-                assert_eq!(
-                    super::wrapping_diff_old(a, b),
-                    super::wrapping_diff(a, b),
-                    "Mismatch for a={a} and b={b}"
-                );
-            }
-        }
-    }
 
     #[test]
     fn test_ordering() {


### PR DESCRIPTION
`wrapping_diff` can be simplified to `b.wrapping_sub(a) as i16`

I wrote a test to compare the two implementations so a reviewer can convince themselves that they are identical.

The test can be run with:

```sh
cargo test --release -- test_wrapping_diff_equivalence --ignored
```

`--release` is required because it tests all $2^{32}$ inputs.

The wrapping_diff_old can be removed before merge.