### PR TITLE
Expose and document `SerializeFns`

### DIFF
--- a/lightyear/src/protocol/message.rs
+++ b/lightyear/src/protocol/message.rs
@@ -267,7 +267,7 @@ pub trait AppMessageExt {
     /// Registers the message in the Registry
     ///
     /// This message can now be sent over the network.
-    /// You need to provide your own SerializationFns for this message
+    /// You need to provide your own [`SerializeFns`] for this message
     fn register_message_custom_serde<M: Message>(
         &mut self,
         direction: ChannelDirection,
@@ -284,7 +284,7 @@ pub trait AppMessageExt {
     /// Registers the resource in the Registry
     ///
     /// This resource can now be sent over the network.
-    /// You need to provide your own SerializationFns for this message
+    /// You need to provide your own [`SerializeFns`] for this message
     fn register_resource_custom_serde<R: Resource + Message>(
         &mut self,
         direction: ChannelDirection,

--- a/lightyear/src/protocol/mod.rs
+++ b/lightyear/src/protocol/mod.rs
@@ -23,6 +23,7 @@ pub(crate) mod delta;
 /// Provides a mapping from a type to a unique identifier that can be serialized
 pub(crate) mod registry;
 pub(crate) mod serialize;
+pub use serialize::SerializeFns;
 
 /// Data that can be used in an Event
 /// Same as `Event`, but we implement it automatically for all compatible types

--- a/lightyear/src/protocol/serialize.rs
+++ b/lightyear/src/protocol/serialize.rs
@@ -23,9 +23,16 @@ pub struct ErasedSerializeFns {
     pub receive_map_entities: Option<ErasedReceiveMapEntitiesFn>,
 }
 
+/// Controls how a type (resources/components/messages) is serialized and deserialized
 pub struct SerializeFns<M> {
+    /// Called to serialize the type into the writer
     pub serialize: SerializeFn<M>,
+    /// Called to deserialize the type from the reader
     pub deserialize: DeserializeFn<M>,
+    /// Called to serialize the type into the writer with entity mapping.
+    ///
+    /// Can be set to [`None`] if entity mapping is not required, but *will*
+    /// be assumed to exist and be called if mapping is enabled.
     pub serialize_map_entities: Option<SerializeMapEntitiesFn<M>>,
 }
 


### PR DESCRIPTION
While trying to use `register_component_serialize_fns`, I noticed that `SerializeFns` was not exposed. I've fixed this and also added some basic comments to explain its use.