### PR TITLE
Fixes https://github.com/cBournhonesque/lightyear/issues/644

### DIFF
--- a/lightyear/src/shared/replication/entity_map.rs
+++ b/lightyear/src/shared/replication/entity_map.rs
@@ -156,8 +156,8 @@ impl RemoteEntityMap {
             let local = Self::mark_unmapped(remote_entity);
             if let Some(remote) = self.local_to_remote.remove(&local) {
                 self.remote_to_local.remove(&remote);
-                return Some(local);
             }
+            return Some(local);
         } else if let Some(local) = self.remote_to_local.remove(&remote_entity) {
             self.local_to_remote.remove(&local);
             return Some(local);


### PR DESCRIPTION
As stated in the comment; if the entity has been pre-mapped by the remote, then we still want to return it in `remove_by_remote` even if not present in `self.local_to_remote`.

