### PR TITLE
fix: Remove `ring` to fix wasm32 web builds

### DIFF
--- a/lightyear/Cargo.toml
+++ b/lightyear/Cargo.toml
@@ -28,7 +28,6 @@ webtransport = [
   "dep:xwt-core",
   "dep:xwt-web",
   "dep:web-sys",
-  "dep:ring",
   "dep:wasm-bindgen-futures",
 ]
 leafwing = ["dep:leafwing-input-manager"]
@@ -147,7 +146,6 @@ zstd = { version = "0.13.1", optional = true }
 
 [target."cfg(target_family = \"wasm\")".dependencies]
 console_error_panic_hook = { version = "0.1.7" }
-ring = { version = "0.17.8", optional = true, default-features = false }
 web-sys = { version = "0.3", optional = true, features = [
   "Document",
   "WebTransport",

--- a/lightyear/src/transport/webtransport/client_wasm.rs
+++ b/lightyear/src/transport/webtransport/client_wasm.rs
@@ -18,6 +18,36 @@ use crate::transport::error::{Error, Result};
 use crate::transport::io::IoState;
 use crate::transport::{BoxedReceiver, BoxedSender, PacketReceiver, PacketSender, Transport, MTU};
 
+// Adapted from https://github.com/briansmith/ring/blob/befdc87ac7cbca615ab5d68724f4355434d3a620/src/test.rs#L364-L393
+pub fn from_hex(hex_str: &str) -> std::result::Result<Vec<u8>, String> {
+    if hex_str.len() % 2 != 0 {
+        return Err(String::from(
+            "Hex string does not have an even number of digits",
+        ));
+    }
+
+    let mut result = Vec::with_capacity(hex_str.len() / 2);
+    for digits in hex_str.as_bytes().chunks(2) {
+        let hi = from_hex_digit(digits[0])?;
+        let lo = from_hex_digit(digits[1])?;
+        result.push((hi * 0x10) | lo);
+    }
+    Ok(result)
+}
+
+fn from_hex_digit(d: u8) -> std::result::Result<u8, String> {
+    use core::ops::RangeInclusive;
+    const DECIMAL: (u8, RangeInclusive<u8>) = (0, b'0'..=b'9');
+    const HEX_LOWER: (u8, RangeInclusive<u8>) = (10, b'a'..=b'f');
+    const HEX_UPPER: (u8, RangeInclusive<u8>) = (10, b'A'..=b'F');
+    for (offset, range) in &[DECIMAL, HEX_LOWER, HEX_UPPER] {
+        if range.contains(&d) {
+            return Ok(d - range.start() + offset);
+        }
+    }
+    Err(format!("Invalid hex digit '{}'", d as char))
+}
+
 pub struct WebTransportClientSocketBuilder {
     pub(crate) client_addr: SocketAddr,
     pub(crate) server_addr: SocketAddr,
@@ -50,7 +80,7 @@ impl ClientTransportBuilder for WebTransportClientSocketBuilder {
         let options = xwt_web::WebTransportOptions {
             server_certificate_hashes: vec![xwt_web::CertificateHash {
                 algorithm: xwt_web::HashAlgorithm::Sha256,
-                value: ring::test::from_hex(&self.certificate_digest).unwrap(),
+                value: from_hex(&self.certificate_digest).unwrap(),
             }],
             ..Default::default()
         };


### PR DESCRIPTION
Fixes #684 

This is admittedly a blunt solution to the problem. For uncertain reasons, the `ring` dependency does not seem compatible with `wasm32-unknown-unknown`/`wasm-bindgen` builds. But: `ring` only seems to be used for this ~25 line utility function. So, the fix proposed here is to remove the `ring` dependency and inline the utility function. Submitted for your consideration!