### PR TITLE
Fixed example floor not being rendered

### DIFF
--- a/examples/avian_3d_character/src/renderer.rs
+++ b/examples/avian_3d_character/src/renderer.rs
@@ -154,7 +154,7 @@ fn add_character_cosmetics(
 /// do not exist since floors aren't predicted.
 fn add_floor_cosmetics(
     mut commands: Commands,
-    floor_query: Query<Entity, (Added<Replicated>, With<FloorMarker>)>,
+    floor_query: Query<Entity, Added<FloorMarker>>,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {


### PR DESCRIPTION
The floor is not being rendered in the avian_3d_character example when run in host-server mode.

The issue was due to cosmetics being applied to the floor with a `Replicated` component, which can only be present on the client. The fix is to apply cosmetics to the floor unconditionally.

Fixes #686 