### PR TITLE
Fix clippy lint error

### DIFF
--- a/lightyear/src/shared/replication/hierarchy.rs
+++ b/lightyear/src/shared/replication/hierarchy.rs
@@ -549,6 +549,6 @@ mod tests {
             .world_mut()
             .query_filtered::<Entity, With<ComponentSyncModeFull>>()
             .get_single(stepper.server_app.world());
-        assert_eq!(server_child.is_err(), true);
+        assert!(server_child.is_err());
     }
 }


### PR DESCRIPTION
Clippy complains that `assert_eq!(..., true)` statements should be replaced with `assert!()`.