### PR TITLE
Fix tarpaulin compile error

### DIFF
--- a/lightyear/Cargo.toml
+++ b/lightyear/Cargo.toml
@@ -185,6 +185,10 @@ tracing-subscriber = "0.3.17"
 bitvec = "1.0"
 approx = "0.5.1"
 
+[dev-dependencies.leafwing-input-manager]
+version = "*"
+# Used by tests.
+features = ["keyboard"]
 
 # docs.rs-specific configuration
 [package.metadata.docs.rs]


### PR DESCRIPTION
Enable the "keyboard" flag for the `leafwing-input-manager` dependency when building lightyear for development/non-release.

This prevents `cargo tarpaulin --feature leafwing` from failing to compile. `tarpaulin` fails to compile because the tests within the `lightyear::src::server::input::leafwing` and `lightyear::src::client::input::leafwing` modules require that `bevy_input::KeyCode` implement the `leafwing_input_manager::buttonlike::Buttonlike` trait which is only done if `leafwing-input-manager`'s "keyboard" feature is enabled. This is one of the problems that is preventing lightyear's github repo's `Main/Test` check from passing.

The alternative solution is create a fake button that implements `ButtonLike` and use that instead of `KeyCode` but I wasn't able to get it working.