### PR TITLE
Fix pre-prediction example

### DIFF
--- a/examples/avian_physics/src/server.rs
+++ b/examples/avian_physics/src/server.rs
@@ -1,3 +1,6 @@
+use crate::protocol::*;
+use crate::shared;
+use crate::shared::{color_from_id, shared_movement_behaviour, FixedSet};
 use avian2d::prelude::*;
 use bevy::color::palettes::css;
 use bevy::prelude::*;
@@ -7,10 +10,7 @@ use leafwing_input_manager::prelude::*;
 use lightyear::prelude::client::{Confirmed, Predicted};
 use lightyear::prelude::server::*;
 use lightyear::prelude::*;
-
-use crate::protocol::*;
-use crate::shared;
-use crate::shared::{color_from_id, shared_movement_behaviour, FixedSet};
+use lightyear::shared::replication::components::InitialReplicated;
 
 // Plugin for server-specific logic
 pub struct ExampleServerPlugin {
@@ -123,10 +123,13 @@ pub(crate) fn replicate_inputs(
 }
 
 // Replicate the pre-predicted entities back to the client
+// We have to use `InitialReplicated` instead of `Replicated`, because
+// the server has already assumed authority over the entity so the `Replicated` component
+// has been removed
 pub(crate) fn replicate_players(
     global: Res<Global>,
     mut commands: Commands,
-    query: Query<(Entity, &Replicated), (Added<Replicated>, With<PlayerId>)>,
+    query: Query<(Entity, &InitialReplicated), (Added<InitialReplicated>, With<PlayerId>)>,
 ) {
     for (entity, replicated) in query.iter() {
         let client_id = replicated.client_id();

--- a/examples/bullet_prespawn/src/server.rs
+++ b/examples/bullet_prespawn/src/server.rs
@@ -2,13 +2,13 @@ use bevy::prelude::*;
 use bevy::utils::Duration;
 use leafwing_input_manager::prelude::*;
 
-use lightyear::client::prediction::Predicted;
-use lightyear::prelude::server::*;
-use lightyear::prelude::*;
-
 use crate::protocol::*;
 use crate::shared;
 use crate::shared::{color_from_id, shared_player_movement};
+use lightyear::client::prediction::Predicted;
+use lightyear::prelude::server::*;
+use lightyear::prelude::*;
+use lightyear::shared::replication::components::InitialReplicated;
 
 // Plugin for server-specific logic
 pub struct ExampleServerPlugin;
@@ -58,9 +58,15 @@ pub(crate) fn init(mut commands: Commands) {
 // }
 
 // Replicate the pre-spawned entities back to the client
+// We have to use `InitialReplicated` instead of `Replicated`, because
+// the server has already assumed authority over the entity so the `Replicated` component
+// has been removed
 pub(crate) fn replicate_players(
     mut commands: Commands,
-    replicated_players: Query<(Entity, &Replicated), (Added<Replicated>, With<PlayerId>)>,
+    replicated_players: Query<
+        (Entity, &InitialReplicated),
+        (Added<InitialReplicated>, With<PlayerId>),
+    >,
 ) {
     for (entity, replicated) in replicated_players.iter() {
         let client_id = replicated.client_id();

--- a/examples/client_replication/src/server.rs
+++ b/examples/client_replication/src/server.rs
@@ -1,15 +1,15 @@
 use bevy::prelude::*;
 use bevy::utils::Duration;
 
+use crate::protocol::*;
+use crate::shared;
+use crate::shared::{color_from_id, shared_movement_behaviour};
 use lightyear::client::components::Confirmed;
 use lightyear::client::interpolation::Interpolated;
 use lightyear::client::prediction::Predicted;
 use lightyear::prelude::server::*;
 use lightyear::prelude::*;
-
-use crate::protocol::*;
-use crate::shared;
-use crate::shared::{color_from_id, shared_movement_behaviour};
+use lightyear::shared::replication::components::InitialReplicated;
 
 // Plugin for server-specific logic
 pub struct ExampleServerPlugin;
@@ -107,7 +107,10 @@ fn delete_player(
 // And we want to handle deletion properly
 pub(crate) fn replicate_players(
     mut commands: Commands,
-    replicated_players: Query<(Entity, &Replicated), (With<PlayerPosition>, Added<Replicated>)>,
+    replicated_players: Query<
+        (Entity, &InitialReplicated),
+        (With<PlayerPosition>, Added<InitialReplicated>),
+    >,
 ) {
     for (entity, replicated) in replicated_players.iter() {
         let client_id = replicated.client_id();
@@ -146,7 +149,10 @@ pub(crate) fn replicate_players(
 
 pub(crate) fn replicate_cursors(
     mut commands: Commands,
-    replicated_cursor: Query<(Entity, &Replicated), (With<CursorPosition>, Added<Replicated>)>,
+    replicated_cursor: Query<
+        (Entity, &InitialReplicated),
+        (With<CursorPosition>, Added<InitialReplicated>),
+    >,
 ) {
     for (entity, replicated) in replicated_cursor.iter() {
         let client_id = replicated.client_id();

--- a/examples/simple_box/src/server.rs
+++ b/examples/simple_box/src/server.rs
@@ -17,10 +17,7 @@ use std::sync::Arc;
 use crate::protocol::*;
 use crate::shared;
 
-
-
 pub struct ExampleServerPlugin;
-
 
 impl Plugin for ExampleServerPlugin {
     fn build(&self, app: &mut App) {
@@ -32,11 +29,10 @@ impl Plugin for ExampleServerPlugin {
     }
 }
 
-
 /// A simple resource map that tell me  the corresponding server entity of that client
 /// Important for O(n) acess
-#[derive(Resource,Default)]
-pub struct ClientEntityMap(HashMap<ClientId,Entity>);
+#[derive(Resource, Default)]
+pub struct ClientEntityMap(HashMap<ClientId, Entity>);
 
 /// Start the server
 fn start_server(mut commands: Commands) {
@@ -139,12 +135,14 @@ fn movement(
                     shared::shared_movement_behaviour(position, input);
                 }
             } else {
-                error!("Couldnt find this player in map which means I cant move him")
+                debug!(
+                    "Couldnt find player in client entity map for client_id: {:?}",
+                    client_id
+                )
             }
         }
     }
 }
-
 
 /// Send messages from server to clients (only in non-headless mode, because otherwise we run with minimal plugins
 /// and cannot do input handling)

--- a/lightyear/src/shared/replication/components.rs
+++ b/lightyear/src/shared/replication/components.rs
@@ -22,6 +22,13 @@ pub struct InitialReplicated {
     pub from: Option<ClientId>,
 }
 
+impl InitialReplicated {
+    /// For client->server replication, identify the client that replicated this entity to the server
+    pub fn client_id(&self) -> ClientId {
+        self.from.expect("expected a client id")
+    }
+}
+
 /// Marker component that indicates that the entity is being replicated
 /// from a remote world.
 ///


### PR DESCRIPTION
There is a subtle bug introduced by updating the pre-prediction logic.

I recently distinguish between `Replicated` (an entity that is currently being replicated from the remote) and `InitialReplicated`(an entity that was initially spawned from a remote).
In the case of pre-prediction, the current ordering is:
- client spawns entity with `PrePredicted`
- server receives it and adds `Replicated` and `InitialReplicated` (upon replication)
- server observer notices the `PrePredicted` and transfer the authority from client to server, removing the `Replicated`component (since the entity is now owned by the server)
- the system in server.rs queries on Replicated, but the component does not exist anymore.

The solution is for now to update it to use `InitialReplicated`. It's a bit confusing, annoying and not ideal but I don't see an easier fix right now

Fixes https://github.com/cBournhonesque/lightyear/issues/701 