### PR TITLE
fix client replication example

### DIFF
--- a/examples/client_replication/src/server.rs
+++ b/examples/client_replication/src/server.rs
@@ -102,7 +102,10 @@ fn delete_player(
     }
 }
 
-// Replicate the pre-spawned entities back to the client
+// Replicate the pre-predicted entities back to the client.
+//
+// The objective was to create a normal 'predicted' entity directly in the client timeline, instead
+// of having to create the entity in the server timeline and wait for it to be replicated.
 // Note that this needs to run before FixedUpdate, since we handle client inputs in the FixedUpdate schedule (subject to change)
 // And we want to handle deletion properly
 pub(crate) fn replicate_players(
@@ -123,8 +126,6 @@ pub(crate) fn replicate_players(
                     // we want to replicate back to the original client, since they are using a pre-spawned entity
                     target: NetworkTarget::All,
                 },
-                // keep the authority on the client
-                authority: AuthorityPeer::Client(client_id),
                 sync: SyncTarget {
                     // NOTE: even with a pre-spawned Predicted entity, we need to specify who will run prediction
                     prediction: NetworkTarget::Single(client_id),

--- a/lightyear/src/client/prediction/pre_prediction.rs
+++ b/lightyear/src/client/prediction/pre_prediction.rs
@@ -95,7 +95,7 @@ impl PrePredictionPlugin {
         // we will add the Predicted component
         if let Some(&predicted) = predicted_map.confirmed_to_predicted.get(&trigger.entity()) {
             let confirmed = trigger.entity();
-            debug!("Received PrePredicted entity from server. Confirmed: {confirmed:?}, Predicted: {predicted:?}");
+            info!("Received PrePredicted entity from server. Confirmed: {confirmed:?}, Predicted: {predicted:?}");
             commands.add(move |world: &mut World| {
                 world
                     .entity_mut(predicted)

--- a/lightyear/src/server/prediction.rs
+++ b/lightyear/src/server/prediction.rs
@@ -54,7 +54,10 @@ pub(crate) fn compute_hash(
 }
 
 /// When we receive an entity that a clients wants PrePredicted,
-/// we immediately transfer authority back to the server
+/// we immediately transfer authority back to the server. The server will replicate the PrePredicted
+/// component back to the client. Upon receipt, the client will replace PrePredicted with Predicted.
+///
+/// The entity mapping is done on the client.
 pub(crate) fn handle_pre_predicted(
     trigger: Trigger<OnAdd, PrePredicted>,
     mut commands: Commands,
@@ -63,6 +66,10 @@ pub(crate) fn handle_pre_predicted(
     q: Query<(Entity, &PrePredicted, &Replicated)>,
 ) {
     if let Ok((local_entity, pre_predicted, replicated)) = q.get(trigger.entity()) {
+        debug!(
+            "Received PrePredicted entity from client: {:?}. Transferring authority to server",
+            replicated.from
+        );
         let sending_client = replicated.from.unwrap();
         commands
             .entity(local_entity)


### PR DESCRIPTION
The client replication example has 2 parts:
- showcase client authority. Cursors are spawned on the client and replicated from client to server
- showcase pre-prediction. Players are spawned on the client timeline, and then the authority is transferred to the server).

Somehow for the pre-prediction part the authority was sent back to the client again, which was messing with pre-prediction since pre-prediction relies on the authority being on the server.