### PR TITLE
Use a hook on PreSpawnedPlayerObject component to compute missing hashes

### DIFF
--- a/book/src/concepts/advanced_replication/prespawning.md
+++ b/book/src/concepts/advanced_replication/prespawning.md
@@ -39,6 +39,10 @@ That's it!
 ## In-depth
 
 The various system-sets for prespawning are:
+
+- PreSpawnedPlayerObject Component Hook, on_add:
+  - Unless a hash is provided, computes the hash of the prespawned entity based on its archetype (only the components that are present in the ComponentProtocol) + spawn tick.
+
 - PreUpdate schedule:
   - `PredictionSet::SpawnPrediction`: we first run the prespawn match system to match the pre-spawned entities with their corresponding server entity.
     If there is a match, we remove the PreSpawnedPlayerObject component and add the Predicted/Confirmed components.
@@ -47,8 +51,7 @@ The various system-sets for prespawning are:
 
 - FixedUpdate schedule:
   - FixedUpdate::Main: prespawn the entity
-  - FixedUpdate::SetPreSpawnedHash: we compute the hash of the prespawned entity based on its archetype (only the components that are present in the ComponentProtocol) + spawn tick.
-     We store the hash and the spawn tick in the `PredictionManager` (not in the `PreSpawnedPlayerObject` component).
+  - FixedUpdate::SetPreSpawnedHash: we store all new hashes and the spawn tick in the `PredictionManager` (not in the `PreSpawnedPlayerObject` component).
   - FixedUpdate::SpawnHistory: add a PredictionHistory for each component of the pre-spawned entity. We need this to:
     - not rollback immediately when we get the corresponding server entity
     - do rollbacks correctly for pre-spawned entities


### PR DESCRIPTION
After changing my bullet decorator from a system to an observer, i was seeing an ordering discrepency between server/clients, causing a different hash to be computed.

By changing compute_hash step to run as a component hook, it enforces consistency and makes it easier to reason about what components will take part in the hash calculation – anything added up to point when `PreSpawnPlayerObject` is inserted will be seen in the hook.

This has the side effect of computing the hash one tick earlier in some situations, which is why I had to update the hash in the test case.

* Added a component hook to `PreSpawnPlayerObject` which does compute_hash if a hash wasn't provided.
* Changed the system ~`compute_prespawn_hash`~ to `register_prespawn_hashes`, to add them to PredictionManager
