### PR TITLE
Handle host-server disconnects correctly

### DIFF
--- a/examples/simple_box/src/server.rs
+++ b/examples/simple_box/src/server.rs
@@ -65,7 +65,7 @@ pub(crate) fn handle_connections(
 ) {
     for connection in connections.read() {
         let client_id = connection.client_id;
-        // server and client are running in the same app, no need to replicate to the local client
+        // in host-server mode, server and client are running in the same app, no need to replicate to the local client
         let replicate = Replicate {
             sync: SyncTarget {
                 prediction: NetworkTarget::Single(client_id),

--- a/lightyear/src/server/clients.rs
+++ b/lightyear/src/server/clients.rs
@@ -1,6 +1,7 @@
 //! The server spawns an entity per connected client to store metadata about them.
 //!
 //! This module contains components and systems to manage the metadata on client entities.
+use crate::prelude::server::NetworkingState;
 use crate::server::clients::systems::handle_controlled_by_remove;
 use crate::server::replication::send::Lifetime;
 use crate::shared::sets::{InternalReplicationSet, ServerMarker};
@@ -129,11 +130,25 @@ mod systems {
                 }
             }
         }
-        // despawn the entity itself
+        // despawn the client entity itself
         if let Some(command) = commands.get_entity(client_entity) {
             command.despawn_recursive();
         };
     }
+
+    // TODO: is this necessary? calling server.stop() should already run the disconnection process
+    //  for all clients
+    // /// When the server gets disconnected, despawn the client entities.
+    // pub(super) fn handle_server_disconnect(
+    //     mut commands: Commands,
+    //     client_query: Query<Entity, With<ControlledEntities>>,
+    // ) {
+    //     for client_entity in client_query.iter() {
+    //         if let Some(command) = commands.get_entity(client_entity) {
+    //             command.despawn_recursive();
+    //         }
+    //     }
+    // }
 }
 
 impl Plugin for ClientsMetadataPlugin {
@@ -149,7 +164,7 @@ impl Plugin for ClientsMetadataPlugin {
         app.observe(systems::handle_client_disconnect);
         // we handle this in the `Last` `SystemSet` to let the user handle the disconnect event
         // however they want first, before the client entity gets despawned
-        // app.add_systems(Last, systems::handle_client_disconnect);
+        // app.add_systems(Last, systems::handle_server_disconnect);
     }
 }
 

--- a/lightyear/src/server/networking.rs
+++ b/lightyear/src/server/networking.rs
@@ -151,6 +151,8 @@ pub(crate) fn receive_packets(
                 }
             })
         }
+        // TODO: handle disconnections in a separate system that listens to ServerDisconnect events
+        //  to avoid duplicate logic for host-server in client/networking.rs
         // disconnects because we received a disconnect message
         for client_id in new_disconnections {
             if netservers.client_server_map.remove(&client_id).is_some() {


### PR DESCRIPTION
When the host-server client disconnects, the disconnection flow is a bit different because no network packets are being sent. 
The disconnection flow was slightly different, and was missing two things:
- the DisconnectEvent event was emitted but not triggered so observers that reacted to it were not firing (notably the ones that cleanup the ControlledEntities)
- the connection was not removed from the ConnectionManager

This PR fixes both.