### PR TITLE
Fix duplicate despawn

### DIFF
--- a/examples/simple_box/src/client.rs
+++ b/examples/simple_box/src/client.rs
@@ -262,15 +262,9 @@ pub(crate) fn spawn_connect_button(mut commands: Commands) {
         });
 }
 
-/// Remove all entities when the client disconnect
-fn on_disconnect(
-    mut commands: Commands,
-    player_entities: Query<Entity, With<PlayerId>>,
-    debug_text: Query<Entity, With<ClientIdText>>,
-) {
-    for entity in player_entities.iter() {
-        commands.entity(entity).despawn_recursive();
-    }
+/// Remove the debug text when the client disconnect
+/// (Replicated entities are automatically despawned by lightyear on disconnection)
+fn on_disconnect(mut commands: Commands, debug_text: Query<Entity, With<ClientIdText>>) {
     for entity in debug_text.iter() {
         commands.entity(entity).despawn_recursive();
     }

--- a/lightyear/src/client/networking.rs
+++ b/lightyear/src/client/networking.rs
@@ -402,7 +402,8 @@ fn on_disconnect(
     mut disconnect_event_writer: EventWriter<DisconnectEvent>,
     mut netclient: ResMut<ClientConnection>,
     mut commands: Commands,
-    received_entities: Query<Entity, Or<(With<Replicated>, With<Predicted>, With<Interpolated>)>>,
+    // no need to handle Predicted/Interpolated because there are separate systems that handle these
+    received_entities: Query<Entity, With<Replicated>>,
 ) {
     info!("Running OnDisconnect schedule");
     // despawn any entities that were spawned from replication

--- a/lightyear/src/client/prediction/despawn.rs
+++ b/lightyear/src/client/prediction/despawn.rs
@@ -4,7 +4,7 @@ use bevy::prelude::{
     Commands, Component, DespawnRecursiveExt, Entity, OnRemove, Query, Reflect, ReflectComponent,
     Res, ResMut, Trigger, With, Without, World,
 };
-use tracing::{debug, error, trace};
+use tracing::{debug, error, info, trace};
 
 use crate::client::components::{ComponentSyncMode, Confirmed, SyncComponent};
 use crate::client::config::ClientConfig;


### PR DESCRIPTION
Upon disconnecting the client would often be spammed with annoying log messages such as 
```
2024-12-06T19:22:08.662684Z  WARN bevy_ecs::world: error[B0003]: Could not despawn entity Entity { index: 22, generation: 1 } because it doesn't exist in this World. See: https://bevyengine.org/learn/errors/#b0003
```

This is because there are 2 systems on the client that handle disconnection:
- all replicated+predicted entities are despawned
- all predicted entities are despawned if their confirmed entity is despawned

That means that the entity would try to be despawned twice.

This PR makes sure that the first system only tries to despawn entities that are Replicated.

Let's see if this works (we might want to switch to `InitialReplicated`, or to handle things differently in host-server mode)

Fixes https://github.com/cBournhonesque/lightyear/issues/690 (the warning does not appear anymore for the simple_box example)