### PR TITLE
add missing certificate bit to examples' settings.rons

### DIFF
--- a/examples/auth/assets/settings.ron
+++ b/examples/auth/assets/settings.ron
@@ -36,7 +36,11 @@ MySettings(
             )),
             transport: [
                 WebTransport(
-                    local_port: 5000
+                    local_port: 5000,
+                    certificate: FromFile(
+                       cert: "../certificates/cert.pem",
+                       key: "../certificates/key.pem",
+                    )
                 ),
                 Udp(
                     local_port: 5001

--- a/examples/avian_physics/assets/settings.ron
+++ b/examples/avian_physics/assets/settings.ron
@@ -35,7 +35,11 @@ MySettings(
             conditioner: None,
             transport: [
                 WebTransport(
-                    local_port: 5000
+                    local_port: 5000,
+                    certificate: FromFile(
+                       cert: "../certificates/cert.pem",
+                       key: "../certificates/key.pem",
+                    )
                 ),
                 Udp(
                     local_port: 5001

--- a/examples/bullet_prespawn/assets/settings.ron
+++ b/examples/bullet_prespawn/assets/settings.ron
@@ -38,7 +38,11 @@ MySettings(
             )),
             transport: [
                 WebTransport(
-                    local_port: 5000
+                    local_port: 5000,
+                    certificate: FromFile(
+                       cert: "../certificates/cert.pem",
+                       key: "../certificates/key.pem",
+                    )
                 ),
                 Udp(
                     local_port: 5001

--- a/examples/client_replication/assets/settings.ron
+++ b/examples/client_replication/assets/settings.ron
@@ -30,7 +30,11 @@ Settings(
         conditioner: None,
         transport: [
             WebTransport(
-                local_port: 5000
+                local_port: 5000,
+                certificate: FromFile(
+                    cert: "../certificates/cert.pem",
+                    key: "../certificates/key.pem",
+                )
             ),
             Udp(
                 local_port: 5001

--- a/examples/distributed_authority/assets/settings.ron
+++ b/examples/distributed_authority/assets/settings.ron
@@ -34,7 +34,11 @@ Settings(
         )),
         transport: [
             WebTransport(
-                local_port: 5000
+                local_port: 5000,
+                certificate: FromFile(
+                    cert: "../certificates/cert.pem",
+                    key: "../certificates/key.pem",
+                )
             ),
             Udp(
                 local_port: 5001

--- a/examples/interest_management/assets/settings.ron
+++ b/examples/interest_management/assets/settings.ron
@@ -30,7 +30,11 @@ Settings(
         conditioner: None,
         transport: [
             WebTransport(
-                local_port: 5000
+                local_port: 5000,
+                certificate: FromFile(
+                    cert: "../certificates/cert.pem",
+                    key: "../certificates/key.pem",
+                )
             ),
             Udp(
                 local_port: 5001

--- a/examples/lobby/assets/settings.ron
+++ b/examples/lobby/assets/settings.ron
@@ -34,7 +34,11 @@ Settings(
         )),
         transport: [
             WebTransport(
-                local_port: 5000
+                local_port: 5000,
+                certificate: FromFile(
+                    cert: "../certificates/cert.pem",
+                    key: "../certificates/key.pem",
+                )
             ),
             Udp(
                 local_port: 5001

--- a/examples/priority/assets/settings.ron
+++ b/examples/priority/assets/settings.ron
@@ -30,7 +30,11 @@ Settings(
         conditioner: None,
         transport: [
             WebTransport(
-                local_port: 5000
+                local_port: 5000,
+                certificate: FromFile(
+                    cert: "../certificates/cert.pem",
+                    key: "../certificates/key.pem",
+                )
             ),
             Udp(
                 local_port: 5001

--- a/examples/replication_groups/assets/settings.ron
+++ b/examples/replication_groups/assets/settings.ron
@@ -34,7 +34,11 @@ Settings(
         )),
         transport: [
             WebTransport(
-                local_port: 5000
+                local_port: 5000,
+                certificate: FromFile(
+                    cert: "../certificates/cert.pem",
+                    key: "../certificates/key.pem",
+                )
             ),
             Udp(
                 local_port: 5001


### PR DESCRIPTION
restore original examples behaviour of using the certificate pem files, by adding the required bit to settings.ron for examples