### PR TITLE
Fix input delay configuration

### DIFF
--- a/examples/spaceships/src/main.rs
+++ b/examples/spaceships/src/main.rs
@@ -38,11 +38,9 @@ fn main() {
         ));
     // use input delay and a correction function to smooth over rollback errors
     apps.update_lightyear_client_config(|config| {
-        // guarantee that we use this amount of input delay ticks
-        config.prediction.minimum_input_delay_ticks = settings.input_delay_ticks;
-        // TODO: this doesn't work properly for now
-        // config.prediction.maximum_input_delay_before_prediction = settings.input_delay_ticks;
-        config.prediction.maximum_predicted_ticks = settings.max_prediction_ticks;
+        config
+            .prediction
+            .set_fixed_input_delay_ticks(settings.input_delay_ticks);
         config.prediction.correction_ticks_factor = settings.correction_ticks_factor;
     });
     // add `ClientPlugins` and `ServerPlugins` plugin groups

--- a/lightyear/src/client/input/leafwing.rs
+++ b/lightyear/src/client/input/leafwing.rs
@@ -32,14 +32,6 @@
 //! Make sure that all your systems that depend on user inputs are added to the [`FixedUpdate`] [`Schedule`].
 //!
 //! Currently, global inputs (that are stored in a [`Resource`] instead of being attached to a specific [`Entity`] are not supported)
-//!
-//! There are some edge-cases to be careful of:
-//! - the `leafwing_input_manager` crate handles inputs every frame, but `lightyear` needs to store and send inputs for each tick.
-//!   This can cause issues if we have multiple ticks in a single frame, or multiple frames in a single tick.
-//!   For instance, let's say you have a system in the `FixedUpdate` schedule that reacts on a button press when the button was `JustPressed`.
-//!   If we have 2 frames with no FixedUpdate in between (because the framerate is high compared to the tickrate), then on the second frame
-//!   the button won't be `JustPressed` anymore (it will simply be `Pressed`) so your system might not react correctly to it.
-//!
 use std::fmt::Debug;
 use std::marker::PhantomData;
 
@@ -97,8 +89,8 @@ pub struct LeafwingInputConfig<A> {
 ///
 /// We need this because:
 /// - we write the InputMessages during FixedPostUpdate
-/// - we apply the TickUpdateEvents (from doing sync) during PostUpdate. During this phase,
-/// we want to update the tick of the InputMessages that we wrote during FixedPostUpdate.
+/// - we apply the TickUpdateEvents (from doing sync) during PostUpdate, which might affect the ticks from the InputMessages.
+///   During this phase, we want to update the tick of the InputMessages that we wrote during FixedPostUpdate.
 #[derive(Debug, Resource)]
 struct MessageBuffer<A: LeafwingUserAction>(Vec<InputMessage<A>>);
 

--- a/lightyear/src/client/networking.rs
+++ b/lightyear/src/client/networking.rs
@@ -264,6 +264,7 @@ pub(crate) fn sync_update(
         time_manager.deref_mut(),
         tick_manager.deref_mut(),
         &connection.ping_manager,
+        &config.prediction,
         &config.interpolation.delay,
         // TODO: how to adjust this for replication groups that have a custom send_interval?
         config.shared.server_replication_send_interval,
@@ -277,6 +278,7 @@ pub(crate) fn sync_update(
             time_manager.deref_mut(),
             tick_manager.deref_mut(),
             &connection.ping_manager,
+            &config.prediction,
         ) {
             debug!("Triggering TickSync event: {tick_event:?}");
             commands.trigger(tick_event);

--- a/lightyear/src/inputs/leafwing/input_buffer.rs
+++ b/lightyear/src/inputs/leafwing/input_buffer.rs
@@ -1,3 +1,12 @@
+//! The InputBuffer contains a history of the ActionState for each tick.
+//!
+//! It is used for several purposes:
+//! - the client's inputs for tick T must arrive before the server processes tick T, so they are stored
+//!   in the buffer until the server processes them. The InputBuffer can be updated efficiently by receiving
+//!   a list of [`ActionDiff`]s compared from an initial [`ActionState`]
+//! - to implement input-delay, we want a button press at tick t to be processed at tick t + delay on the client.
+//!   Therefore, we will store the computed ActionState at tick t + delay, but then we load the ActionState at tick t
+//!   from the buffer
 use bevy::utils::Instant;
 use std::collections::VecDeque;
 use std::fmt::{Debug, Formatter};


### PR DESCRIPTION
A past PR added extra config options for input-delay:

- minimum_input_delay_ticks
- maximum_input_delay_before_prediction
- maximum_predicted_ticks

These are inspired by SnapNet: https://www.snapnet.dev/docs/core-concepts/input-delay-vs-rollback/
and let you dynamically change the input delay based on the user's latency.

These options could cause issues because the input delay would be updated too frequently which would result in missed inputs or overriden inputs.

Instead we can trust the client's SyncPlugin to make the client timeline stay close to the server timeline even if the RTT fluctuates a bit (by speeding up/down the client time). We only update the input-delay if there was a significant change in RTT.