### PR TITLE
Fix prediction/interpolation interaction with authority transfer

### DIFF
--- a/lightyear/src/client/interpolation/spawn.rs
+++ b/lightyear/src/client/interpolation/spawn.rs
@@ -6,10 +6,12 @@ use crate::client::config::ClientConfig;
 use crate::client::connection::ConnectionManager;
 use crate::client::interpolation::resource::InterpolationManager;
 use crate::client::interpolation::Interpolated;
+use crate::prelude::TickManager;
 use crate::shared::replication::components::ShouldBeInterpolated;
 
 /// Spawn an interpolated entity for each confirmed entity that has the `ShouldBeInterpolated` component added
 pub(crate) fn spawn_interpolated_entity(
+    tick_manager: Res<TickManager>,
     config: Res<ClientConfig>,
     connection: Res<ConnectionManager>,
     mut manager: ResMut<InterpolationManager>,
@@ -17,6 +19,10 @@ pub(crate) fn spawn_interpolated_entity(
     mut confirmed_entities: Query<(Entity, Option<&mut Confirmed>), Added<ShouldBeInterpolated>>,
 ) {
     for (confirmed_entity, confirmed) in confirmed_entities.iter_mut() {
+        // skip if the entity already has an interpolated entity
+        if confirmed.as_ref().is_some_and(|c| c.interpolated.is_some()) {
+            continue;
+        }
         let interpolated = commands.spawn(Interpolated { confirmed_entity }).id();
 
         // update the entity mapping
@@ -35,13 +41,16 @@ pub(crate) fn spawn_interpolated_entity(
             // get the confirmed tick for the entity
             // if we don't have it, something has gone very wrong
             trace!(
-                "Confirmed entity missing Confirmed component: {:?}",
-                confirmed_entity
+                "Adding Confirmed component on entity {:?} after we spawned Interpolated entity {:?}",
+                confirmed_entity, interpolated
             );
             let confirmed_tick = connection
                 .replication_receiver
                 .get_confirmed_tick(confirmed_entity)
-                .unwrap();
+                // in most cases we will have a confirmed tick. The only case where we don't is if
+                // the entity was originally spawned on this client, but then authority was removed
+                // and we not want to add Interpolation
+                .unwrap_or(tick_manager.tick());
             confirmed_entity_mut.insert(Confirmed {
                 interpolated: Some(interpolated),
                 predicted: None,

--- a/lightyear/src/protocol/serialize.rs
+++ b/lightyear/src/protocol/serialize.rs
@@ -309,6 +309,7 @@ mod tests {
     use bevy::prelude::Entity;
     use bevy::ptr::Ptr;
 
+    /// Test serializing/deserializing using the ErasedSerializeFns
     #[test]
     fn test_erased_serde() {
         let mut registry = ErasedSerializeFns::new::<AuthorityChange>();
@@ -317,6 +318,8 @@ mod tests {
         let message = AuthorityChange {
             entity: Entity::from_raw(1),
             gain_authority: true,
+            add_prediction: false,
+            add_interpolation: false,
         };
         let mut writer = Writer::default();
         let _ = unsafe {
@@ -337,6 +340,7 @@ mod tests {
         assert_eq!(new_message, message);
     }
 
+    /// Test serializing/deserializing using the ErasedSerializeFns and applying entity mapping
     #[test]
     fn test_erased_serde_map_entities() {
         let mut registry = ErasedSerializeFns::new::<AuthorityChange>();
@@ -345,6 +349,8 @@ mod tests {
         let message = AuthorityChange {
             entity: Entity::from_raw(1),
             gain_authority: true,
+            add_prediction: false,
+            add_interpolation: false,
         };
         let mut writer = Writer::default();
         let mut entity_map = SendEntityMap::default();
@@ -369,6 +375,8 @@ mod tests {
             AuthorityChange {
                 entity: Entity::from_raw(2),
                 gain_authority: true,
+                add_prediction: false,
+                add_interpolation: false,
             }
         );
     }

--- a/lightyear/src/shared/plugin.rs
+++ b/lightyear/src/shared/plugin.rs
@@ -1,13 +1,10 @@
 //! Bevy [`Plugin`] used by both the server and the client
 use crate::client::config::ClientConfig;
+use crate::connection::client::{ClientConnection, NetClient};
 use crate::connection::server::ServerConnections;
-use bevy::ecs::system::SystemParam;
-use bevy::prelude::*;
-use bevy::utils::Duration;
-
 use crate::prelude::client::ComponentSyncMode;
 use crate::prelude::{
-    AppComponentExt, AppMessageExt, ChannelDirection, ChannelRegistry, ComponentRegistry,
+    AppComponentExt, AppMessageExt, ChannelDirection, ChannelRegistry, ClientId, ComponentRegistry,
     LinkConditionerConfig, MessageRegistry, Mode, ParentSync, PingConfig, PrePredicted,
     PreSpawnedPlayerObject, ShouldBePredicted, TickConfig,
 };
@@ -18,6 +15,9 @@ use crate::shared::tick_manager::TickManagerPlugin;
 use crate::shared::time_manager::TimePlugin;
 use crate::transport::io::{IoState, IoStats};
 use crate::transport::middleware::compression::CompressionConfig;
+use bevy::ecs::system::SystemParam;
+use bevy::prelude::*;
+use bevy::utils::Duration;
 
 #[derive(Default, Debug)]
 pub struct SharedPlugin {
@@ -27,25 +27,29 @@ pub struct SharedPlugin {
 /// You can use this as a SystemParam to identify whether you're running on the client or the server
 #[derive(SystemParam)]
 pub struct NetworkIdentity<'w, 's> {
+    client: Option<Res<'w, ClientConnection>>,
     client_config: Option<Res<'w, ClientConfig>>,
     server: Option<Res<'w, ServerConnections>>,
     _marker: std::marker::PhantomData<&'s ()>,
 }
 
+/// Identifies the network role of the current peer
 #[derive(Debug, PartialEq)]
 pub enum Identity {
     /// This peer is a client.
     /// (note that both the client and server plugins could be running in the same process; but this peer is still acting like a client.
     /// (for example if the server plugin is stopped))
-    Client,
+    ///
+    /// If the client is connected, also contains the client id. If not, contains None.
+    Client(Option<ClientId>),
     /// This peer is a server.
     Server,
     /// This peer is both a server and a client
     HostServer,
 }
 
-impl Identity {
-    pub(crate) fn get_from_world(world: &World) -> Self {
+impl FromWorld for Identity {
+    fn from_world(world: &mut World) -> Self {
         let Some(config) = world.get_resource::<ClientConfig>() else {
             return Identity::Server;
         };
@@ -57,12 +61,18 @@ impl Identity {
         {
             Identity::HostServer
         } else {
-            Identity::Client
+            let client_id = world
+                .get_resource::<ClientConnection>()
+                .as_ref()
+                .and_then(|c| Some(c.client.id()));
+            Identity::Client(client_id)
         }
     }
+}
 
+impl Identity {
     pub fn is_client(&self) -> bool {
-        self == &Identity::Client
+        matches!(self, &Identity::Client(_))
     }
     pub fn is_server(&self) -> bool {
         self == &Identity::Server || self == &Identity::HostServer
@@ -82,7 +92,8 @@ impl NetworkIdentity<'_, '_> {
         {
             Identity::HostServer
         } else {
-            Identity::Client
+            let client_id = self.client.as_ref().and_then(|c| Some(c.client.id()));
+            Identity::Client(client_id)
         }
     }
     pub fn is_client(&self) -> bool {


### PR DESCRIPTION
Fixes https://github.com/cBournhonesque/lightyear/issues/639

Prediction/Interpolation was not working correctly when combined with authority transfer.
An example use case is:
- spawn E1 on client C1
- transfer authority to server S, with prediction/interpolation enabled

How do we make sure that C1 will now spawn a predicted/interpolated entity?

This PR accomplishes this with several changes:
- when the authority is transferred, the new authoritative peer (for example server S) will check if the old authority wants to have prediction/interpolation. If it's the case, we:
  - pass that information directly in the AuthorityChange message. (we cannot send a separate ShouldBePredicted component insert, because that message might arrive before the AuthorityChange message so it will be discarded by C1)
  - send a Spawn message, so that C1 has a receiver GroupChannel and can update the ConfirmedTick (needed for prediction/interpolation). (Another option would be to not have a Spawn message at all but to include the ReplicationGroup in the AuthorityChange message so that upon receipt C1 can create a GroupChannel.) We make sure that on the receiver side, if we receive a Spawn for an existing entity we still update the `local_entity_to_group` for the receiver channel
  - update the sender GroupChannel on S to have an updated `send_tick` so that we don't send redundant component updates to C1, we only send updates since the authority transfer started. (Fixes https://github.com/cBournhonesque/lightyear/issues/758)