### PR TITLE
Make sure ChannelDirection is respected

### DIFF
--- a/examples/common/src/app.rs
+++ b/examples/common/src/app.rs
@@ -450,7 +450,7 @@ fn window_plugin() -> WindowPlugin {
 fn log_plugin() -> LogPlugin {
     LogPlugin {
         level: Level::INFO,
-        filter: "wgpu=error,bevy_render=info,bevy_ecs=warn".to_string(),
+        filter: "wgpu=error,bevy_render=info,bevy_ecs=warn,lightyear::shared=debug,lightyear::server=debug".to_string(),
         ..default()
     }
 }

--- a/lightyear/src/client/input/leafwing.rs
+++ b/lightyear/src/client/input/leafwing.rs
@@ -369,7 +369,7 @@ fn get_delayed_action_state<A: LeafwingUserAction>(
             *action_state = delayed_action_state.clone();
             // dbg!(input_buffer);
             // dbg!(delayed_tick);
-            debug!(
+            trace!(
                 ?entity,
                 ?delayed_tick,
                 "fetched delayed action state {:?} from input buffer: {}",
@@ -412,7 +412,7 @@ fn buffer_action_state<A: LeafwingUserAction>(
     for (entity, action_state, mut input_buffer) in action_state_query.iter_mut() {
         input_buffer.set(tick, action_state);
         // dbg!(tick, action_state);
-        debug!(
+        trace!(
             ?entity,
             current_tick = ?tick_manager.tick(),
             delayed_tick = ?tick,
@@ -447,7 +447,7 @@ fn get_non_rollback_action_state<A: LeafwingUserAction>(
         // This is equivalent to considering that the remote player will keep playing the last action they played.
         if let Some(action) = input_buffer.get(tick) {
             *action_state = action.clone();
-            debug!(
+            trace!(
                 ?entity,
                 ?tick,
                 "fetched action state {:?} from input buffer: {}",
@@ -492,7 +492,7 @@ fn get_rollback_action_state<A: LeafwingUserAction>(
         .expect("we should be in rollback");
     for (entity, mut action_state, input_buffer) in player_action_state_query.iter_mut() {
         *action_state = input_buffer.get(tick).cloned().unwrap_or_default();
-        debug!(
+        trace!(
             ?entity,
             ?tick,
             pressed = ?action_state.get_pressed(),
@@ -503,7 +503,7 @@ fn get_rollback_action_state<A: LeafwingUserAction>(
     for (entity, mut action_state, input_buffer) in remote_player_query.iter_mut() {
         // TODO: should we reuse the existing ActionState as an optimization?
         *action_state = input_buffer.get(tick).cloned().unwrap_or_default();
-        debug!(
+        trace!(
             ?tick,
             ?entity,
             pressed = ?action_state.get_pressed(),
@@ -577,7 +577,7 @@ fn prepare_input_message<A: LeafwingUserAction>(
     num_tick = num_tick * input_config.packet_redundancy;
     let mut message = InputMessage::<A>::new(tick);
     for (entity, input_buffer, predicted, pre_predicted) in input_buffer_query.iter() {
-        debug!(
+        trace!(
             ?tick,
             ?entity,
             "Preparing input message with buffer: {:?}",
@@ -590,9 +590,10 @@ fn prepare_input_message<A: LeafwingUserAction>(
         //  maybe if it's pre-predicted, we send the original entity (pre-predicted), and the server will apply the conversion
         //   on their end?
         if pre_predicted.is_some() {
-            debug!(
+            trace!(
                 ?tick,
-                "sending inputs for pre-predicted entity! Local client entity: {:?}", entity
+                "sending inputs for pre-predicted entity! Local client entity: {:?}",
+                entity
             );
             // TODO: not sure if this whole pre-predicted inputs thing is worth it, because the server won't be able to
             //  to receive the inputs until it receives the pre-predicted spawn message.
@@ -617,7 +618,7 @@ fn prepare_input_message<A: LeafwingUserAction>(
                     .remote_entity_map
                     .get_remote(confirmed)
                 {
-                    debug!("sending input for server entity: {:?}. local entity: {:?}, confirmed: {:?}", server_entity, entity, confirmed);
+                    trace!("sending input for server entity: {:?}. local entity: {:?}, confirmed: {:?}", server_entity, entity, confirmed);
                     // println!(
                     //     "preparing input message using input_buffer: {}",
                     //     input_buffer
@@ -626,12 +627,12 @@ fn prepare_input_message<A: LeafwingUserAction>(
                 }
             } else {
                 // TODO: entity is not predicted or not confirmed? also need to do the conversion, no?
-                debug!("not sending inputs because couldnt find server entity");
+                trace!("not sending inputs because couldnt find server entity");
             }
         }
     }
 
-    debug!(
+    trace!(
         ?tick,
         ?num_tick,
         "sending input message for {:?}: {}",
@@ -672,7 +673,7 @@ fn receive_tick_events<A: LeafwingUserAction>(
         TickEvent::TickSnap { old_tick, new_tick } => {
             if let Some(ref mut global_input_buffer) = global_input_buffer {
                 if let Some(start_tick) = global_input_buffer.start_tick {
-                    trace!(
+                    debug!(
                         "Receive tick snap event {:?}. Updating global input buffer start_tick!",
                         trigger.event()
                     );

--- a/lightyear/src/server/connection.rs
+++ b/lightyear/src/server/connection.rs
@@ -1111,7 +1111,8 @@ impl ConnectionManager {
                 .or_default()
                 .send_tick;
             // send the update for all changes newer than the last send_tick for the group
-            debug!(
+            trace!(
+                name = ?registry.name(kind),
                 ?kind,
                 change_tick = ?component_change_tick,
                 ?send_tick,
@@ -1122,7 +1123,7 @@ impl ConnectionManager {
                 component_change_tick.is_newer_than(tick, system_current_tick)
             }) {
                 num_targets += 1;
-                trace!(
+                debug!(
                     ?entity,
                     ?tick,
                     name = ?registry.name(kind),

--- a/lightyear/src/server/input/leafwing.rs
+++ b/lightyear/src/server/input/leafwing.rs
@@ -121,7 +121,7 @@ fn receive_input_message<A: LeafwingUserAction>(
                         .remote_to_local,
                 ) {
                     Ok(message) => {
-                        debug!(?client_id, action = ?A::short_type_path(), ?message.end_tick, ?message.diffs, "received input message");
+                        trace!(?client_id, action = ?A::short_type_path(), ?message.end_tick, ?message.diffs, "received input message");
                         // TODO: UPDATE THIS
                         for (target, start, diffs) in &message.diffs {
                             match target {
@@ -132,11 +132,11 @@ fn receive_input_message<A: LeafwingUserAction>(
                                 InputTarget::Entity(entity)
                                 | InputTarget::PrePredictedEntity(entity) => {
                                     // TODO Don't update input buffer if inputs arrived too late?
-                                    debug!("received input for entity: {:?}", entity);
+                                    trace!("received input for entity: {:?}", entity);
 
                                     if let Ok(buffer) = query.get_mut(*entity) {
                                         if let Some(mut buffer) = buffer {
-                                            debug!(
+                                            trace!(
                                                 ?target,
                                                 "Update InputBuffer: {} using InputMessage: {}",
                                                 buffer.as_ref(),
@@ -219,7 +219,7 @@ fn update_action_state<A: LeafwingUserAction>(
         // This is equivalent to considering that the player will keep playing the last action they played.
         if let Some(action) = input_buffer.get(tick) {
             *action_state = action.clone();
-            debug!(?tick, ?entity, pressed = ?action_state.get_pressed(), "action state after update. Input Buffer: {}", input_buffer.as_ref());
+            trace!(?tick, ?entity, pressed = ?action_state.get_pressed(), "action state after update. Input Buffer: {}", input_buffer.as_ref());
             // remove all the previous values
             // we keep the current value in the InputBuffer so that if future messages are lost, we can still
             // fallback on the last known value

--- a/lightyear/src/shared/replication/receive.rs
+++ b/lightyear/src/shared/replication/receive.rs
@@ -608,7 +608,7 @@ impl GroupChannel {
         // These components could even form a cycle, for example A.HasWeapon(B) and B.HasHolder(A)
         // Our solution is to first handle spawn for all entities separately.
         for (remote_entity, actions) in message.actions.iter() {
-            debug!(?remote_entity, ?remote, ?actions, "Received entity actions");
+            trace!(?remote_entity, ?remote, ?actions, "Received entity actions");
             // spawn
             match actions.spawn {
                 SpawnAction::Spawn => {
@@ -684,11 +684,11 @@ impl GroupChannel {
         }
 
         for (entity, actions) in message.actions.into_iter() {
-            debug!(remote_entity = ?entity, "Received entity actions");
+            trace!(remote_entity = ?entity, "Received entity actions");
 
             // despawn
             if actions.spawn == SpawnAction::Despawn {
-                debug!(remote_entity = ?entity, "Received entity despawn");
+                trace!(remote_entity = ?entity, "Received entity despawn");
                 if let Some(local_entity) = remote_entity_map.remove_by_remote(entity) {
                     self.local_entities.remove(&local_entity);
                     // TODO: we despawn all children as well right now, but that might not be what we want?
@@ -719,7 +719,7 @@ impl GroupChannel {
 
             // inserts
             // TODO: remove updates that are duplicate for the same component
-            debug!(remote_entity = ?entity, "Received InsertComponent");
+            trace!(remote_entity = ?entity, "Received InsertComponent");
             for component in actions.insert {
                 // TODO: reuse a single reader that reads through the entire message
                 let mut reader = Reader::from(component);
@@ -759,7 +759,7 @@ impl GroupChannel {
             }
 
             // updates
-            debug!(remote_entity = ?entity, "Received UpdateComponent");
+            trace!(remote_entity = ?entity, "Received UpdateComponent");
             for component in actions.updates {
                 let mut reader = Reader::from(component);
                 let _ = component_registry
@@ -821,7 +821,7 @@ impl GroupChannel {
             return;
         }
         for (entity, components) in message.updates.into_iter() {
-            debug!(?components, remote_entity = ?entity, "Received UpdateComponent");
+            trace!(?components, remote_entity = ?entity, "Received UpdateComponent");
             let Some(mut local_entity_mut) = remote_entity_map.get_by_remote(world, entity) else {
                 // we can get a few buffered updates after the entity has been despawned
                 // those are the updates that we received before the despawn action message, but with a tick

--- a/lightyear/src/tests/protocol.rs
+++ b/lightyear/src/tests/protocol.rs
@@ -150,6 +150,9 @@ impl Diffable for ComponentDeltaCompression2 {
 #[derive(Component, Clone, Debug, PartialEq, Reflect)]
 pub struct ComponentRollback(pub f32);
 
+#[derive(Component, Clone, Debug, PartialEq, Reflect, Serialize, Deserialize)]
+pub struct ComponentClientToServer(pub f32);
+
 // Resources
 #[derive(Resource, Serialize, Deserialize, Debug, PartialEq, Clone, Reflect)]
 pub struct Resource1(pub f32);
@@ -247,6 +250,8 @@ impl Plugin for ProtocolPlugin {
             .add_delta_compression();
 
         app.add_rollback::<ComponentRollback>();
+
+        app.register_component::<ComponentClientToServer>(ChannelDirection::ClientToServer);
 
         // resources
         app.register_resource::<Resource1>(ChannelDirection::ServerToClient);


### PR DESCRIPTION
Because of some changes, the ChannelDirection was not respected i.e. ClientToServer components would still get replicated from server to client.

Also changing some of the frequent logs from debug->trace