### PR TITLE
Improvements to room logic

### DIFF
--- a/examples/common/src/app.rs
+++ b/examples/common/src/app.rs
@@ -450,7 +450,6 @@ fn window_plugin() -> WindowPlugin {
 fn log_plugin() -> LogPlugin {
     LogPlugin {
         level: Level::INFO,
-        // filter: "wgpu=error,bevy_render=info,bevy_ecs=warn,lightyear::server=debug,lightyear::shared=debug".to_string(),
         filter: "wgpu=error,bevy_render=info,bevy_ecs=warn".to_string(),
         ..default()
     }

--- a/examples/common/src/app.rs
+++ b/examples/common/src/app.rs
@@ -450,6 +450,7 @@ fn window_plugin() -> WindowPlugin {
 fn log_plugin() -> LogPlugin {
     LogPlugin {
         level: Level::INFO,
+        // filter: "wgpu=error,bevy_render=info,bevy_ecs=warn,lightyear::server=debug,lightyear::shared=debug".to_string(),
         filter: "wgpu=error,bevy_render=info,bevy_ecs=warn".to_string(),
         ..default()
     }

--- a/lightyear/src/client/sync.rs
+++ b/lightyear/src/client/sync.rs
@@ -3,7 +3,7 @@
 use bevy::prelude::{Reflect, SystemSet};
 use bevy::utils::Duration;
 use chrono::Duration as ChronoDuration;
-use tracing::{debug, info, trace};
+use tracing::{debug, trace};
 
 use crate::client::interpolation::plugin::InterpolationDelay;
 use crate::packet::packet::PacketId;
@@ -516,7 +516,6 @@ impl SyncManager {
         let jitter = ping_manager.jitter();
         // recompute the input delay using the new rtt estimate
         self.current_input_delay = prediction_config.input_delay_ticks(rtt, tick_duration);
-        info!("New input delay: {}", self.current_input_delay);
         // recompute the server time estimate (using the rtt we just computed)
         self.update_server_time_estimate(tick_duration, rtt);
 
@@ -542,6 +541,7 @@ impl SyncManager {
                 ?rtt,
                 ?jitter,
                 ?delta_tick,
+                ?self.current_input_delay,
                 predicted_server_receive_time = ?self.predicted_server_receive_time(rtt),
                 client_ahead_time = ?self.client_ahead_minimum(tick_duration, jitter),
                 ?client_ideal_time,

--- a/lightyear/src/server/relevance/immediate.rs
+++ b/lightyear/src/server/relevance/immediate.rs
@@ -218,14 +218,14 @@ pub(super) mod systems {
                 .clients_cache
                 .retain(|client_id, relevance| match relevance {
                     ClientRelevance::Gained => {
-                        info!(
+                        trace!(
                             "Relevance for client {client_id:?} and entity {entity:?} goes from gained to maintained"
                         );
                         *relevance = ClientRelevance::Maintained;
                         true
                     }
                     ClientRelevance::Lost => {
-                        info!("remove client {client_id:?} and entity {entity:?} from relevance cache");
+                        trace!("remove client {client_id:?} and entity {entity:?} from relevance cache");
                         false
                     }
                     ClientRelevance::Maintained => true,

--- a/lightyear/src/server/relevance/immediate.rs
+++ b/lightyear/src/server/relevance/immediate.rs
@@ -49,10 +49,37 @@ pub(crate) struct CachedNetworkRelevance {
     pub(crate) clients_cache: HashMap<ClientId, ClientRelevance>,
 }
 
-#[derive(Debug, Default)]
-struct RelevanceEvents {
-    gained: HashMap<ClientId, EntityHashSet>,
-    lost: HashMap<ClientId, EntityHashSet>,
+#[derive(Debug, Default, Reflect)]
+pub(crate) struct RelevanceEvents {
+    pub(crate) gained: HashMap<ClientId, EntityHashSet>,
+    pub(crate) lost: HashMap<ClientId, EntityHashSet>,
+}
+
+impl RelevanceEvents {
+    /// Update the current [`RelevanceEvents`] with the events from another [`RelevanceEvents`]
+    pub(crate) fn update(&mut self, other: &mut Self) {
+        // NOTE: we handle leave room events before join room events so that if an entity leaves room 1 to join room 2
+        //  and the client is in both rooms, the entity does not get despawned
+        other.lost.drain().for_each(|(client_id, entities)| {
+            self.lost.entry(client_id).or_default().extend(entities);
+        });
+        other.gained.drain().for_each(|(client_id, entities)| {
+            self.gained.entry(client_id).or_default().extend(entities);
+        });
+    }
+    pub(crate) fn gain_relevance_internal(&mut self, client: ClientId, entity: Entity) {
+        self.lost.entry(client).and_modify(|set| {
+            set.remove(&entity);
+        });
+        self.gained.entry(client).or_default().insert(entity);
+    }
+
+    pub(crate) fn lose_relevance_internal(&mut self, client: ClientId, entity: Entity) {
+        self.gained.entry(client).and_modify(|set| {
+            set.remove(&entity);
+        });
+        self.lost.entry(client).or_default().insert(entity);
+    }
 }
 
 /// Resource that manages the network relevance of entities for clients
@@ -64,7 +91,7 @@ struct RelevanceEvents {
 /// to update the relevance of an entity for a given client.
 #[derive(Resource, Debug, Default)]
 pub struct RelevanceManager {
-    events: RelevanceEvents,
+    pub(crate) events: RelevanceEvents,
 }
 
 impl RelevanceManager {
@@ -72,19 +99,13 @@ impl RelevanceManager {
     ///
     /// The relevance status gets cached and will be maintained until is it changed.
     pub fn gain_relevance(&mut self, client: ClientId, entity: Entity) -> &mut Self {
-        self.events.lost.entry(client).and_modify(|set| {
-            set.remove(&entity);
-        });
-        self.events.gained.entry(client).or_default().insert(entity);
+        self.events.gain_relevance_internal(client, entity);
         self
     }
 
     /// Lost relevance of an entity for a given client
     pub fn lose_relevance(&mut self, client: ClientId, entity: Entity) -> &mut Self {
-        self.events.gained.entry(client).and_modify(|set| {
-            set.remove(&entity);
-        });
-        self.events.lost.entry(client).or_default().insert(entity);
+        self.events.lose_relevance_internal(client, entity);
         self
     }
 
@@ -136,7 +157,7 @@ pub(super) mod systems {
                     NetworkRelevanceMode::InterestManagement => {
                         // do not overwrite the relevance if it already exists
                         if cached_relevance.is_none() {
-                            debug!("Adding CachedNetworkRelevance component for entity {entity:?}");
+                            trace!("Adding CachedNetworkRelevance component for entity {entity:?}");
                             commands
                                 .entity(entity)
                                 .insert(CachedNetworkRelevance::default());
@@ -197,14 +218,14 @@ pub(super) mod systems {
                 .clients_cache
                 .retain(|client_id, relevance| match relevance {
                     ClientRelevance::Gained => {
-                        trace!(
+                        info!(
                             "Relevance for client {client_id:?} and entity {entity:?} goes from gained to maintained"
                         );
                         *relevance = ClientRelevance::Maintained;
                         true
                     }
                     ClientRelevance::Lost => {
-                        trace!("remove client {client_id:?} and entity {entity:?} from relevance cache");
+                        info!("remove client {client_id:?} and entity {entity:?} from relevance cache");
                         false
                     }
                     ClientRelevance::Maintained => true,
@@ -229,6 +250,8 @@ pub(crate) struct NetworkRelevancePlugin;
 
 impl Plugin for NetworkRelevancePlugin {
     fn build(&self, app: &mut App) {
+        // REFLECT
+        app.register_type::<CachedNetworkRelevance>();
         // RESOURCES
         app.init_resource::<RelevanceManager>();
         // SETS

--- a/lightyear/src/server/relevance/room.rs
+++ b/lightyear/src/server/relevance/room.rs
@@ -72,7 +72,6 @@ impl From<ClientId> for RoomId {
     }
 }
 
-
 #[derive(Resource, Debug, Default)]
 struct VisibilityEvents {
     gained: HashMap<ClientId, Entity>,
@@ -181,6 +180,24 @@ impl RoomManager {
             for room_id in rooms {
                 self.remove_entity_internal(room_id, entity);
             }
+        }
+    }
+
+    /// Remove all clients from a room
+    pub fn remove_clients(&mut self, room_id: RoomId) {
+        if let Some(room) = self.data.rooms.get(&room_id) {
+            room.clients.iter().for_each(|c| {
+                self.remove_client(*c, room_id);
+            });
+        }
+    }
+
+    /// Remove all entities from a room
+    pub fn remove_entities(&mut self, room_id: RoomId) {
+        if let Some(room) = self.data.rooms.get(&room_id) {
+            room.entities.iter().for_each(|e| {
+                self.remove_entity(*e, room_id);
+            });
         }
     }
 
@@ -301,7 +318,6 @@ impl RoomManager {
             .map_or_else(|| false, |room| room.clients.contains(&client_id))
     }
 }
-
 
 pub(super) mod systems {
     use super::*;

--- a/lightyear/src/server/relevance/room.rs
+++ b/lightyear/src/server/relevance/room.rs
@@ -41,15 +41,14 @@ use bevy::app::App;
 use bevy::ecs::entity::EntityHash;
 use bevy::prelude::*;
 use bevy::reflect::Reflect;
-use bevy::utils::{HashMap, HashSet};
+use bevy::utils::{Entry, HashMap, HashSet};
 
 use serde::{Deserialize, Serialize};
-use tracing::trace;
 
 use crate::connection::id::ClientId;
 use crate::prelude::server::is_started;
 
-use crate::server::relevance::immediate::{NetworkRelevanceSet, RelevanceManager};
+use crate::server::relevance::immediate::{NetworkRelevanceSet, RelevanceEvents, RelevanceManager};
 use crate::shared::sets::{InternalReplicationSet, ServerMarker};
 
 use bevy::utils::hashbrown;
@@ -73,19 +72,6 @@ impl From<ClientId> for RoomId {
     }
 }
 
-/// Resource that will track any changes in the rooms
-/// (we cannot use bevy `Events` directly because we don't need to send this every frame.
-/// Also, we only need to keep track of updates for each send_interval frame. That means that if an entity
-/// leaves then re-joins a room within the same send_interval period, we don't need to send any update)
-///
-/// This will be cleared every time the Server sends updates to the Client (every send_interval)
-#[derive(Resource, Debug, Default)]
-struct RoomEvents {
-    client_enter_room: HashMap<ClientId, HashSet<RoomId>>,
-    client_leave_room: HashMap<ClientId, HashSet<RoomId>>,
-    entity_enter_room: EntityHashMap<Entity, HashSet<RoomId>>,
-    entity_leave_room: EntityHashMap<Entity, HashSet<RoomId>>,
-}
 
 #[derive(Resource, Debug, Default)]
 struct VisibilityEvents {
@@ -93,7 +79,7 @@ struct VisibilityEvents {
     lost: HashMap<ClientId, Entity>,
 }
 
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Reflect)]
 struct RoomData {
     /// List of rooms that a client is in
     client_to_rooms: HashMap<ClientId, HashSet<RoomId>>,
@@ -110,7 +96,7 @@ struct RoomData {
 ///
 /// Entities and clients can belong to multiple rooms, they just need to both be present in one room
 /// for the entity to be replicated to the client.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Reflect)]
 pub struct Room {
     /// list of clients that are in the room
     pub clients: HashSet<ClientId>,
@@ -118,10 +104,17 @@ pub struct Room {
     pub entities: EntityHashSet<Entity>,
 }
 
+impl Room {
+    fn is_empty(&self) -> bool {
+        self.clients.is_empty() && self.entities.is_empty()
+    }
+}
+
 /// Manager responsible for handling rooms
-#[derive(Default, Resource)]
+#[derive(Default, Resource, Reflect)]
+#[reflect(Resource)]
 pub struct RoomManager {
-    events: RoomEvents,
+    events: RelevanceEvents,
     data: RoomData,
 }
 
@@ -139,6 +132,8 @@ pub enum RoomSystemSets {
 
 impl Plugin for RoomPlugin {
     fn build(&self, app: &mut App) {
+        // REFLECT
+        app.register_type::<(RoomManager, RoomData)>();
         // RESOURCES
         app.init_resource::<RoomManager>();
         // SETS
@@ -237,13 +232,11 @@ impl RoomManager {
             .entry(client_id)
             .or_default()
             .insert(room_id);
-        self.data
-            .rooms
-            .entry(room_id)
-            .or_default()
-            .clients
-            .insert(client_id);
-        self.events.client_enter_room(room_id, client_id);
+        let room = self.data.rooms.entry(room_id).or_default();
+        room.clients.insert(client_id);
+        room.entities.iter().for_each(|e| {
+            self.events.gain_relevance_internal(client_id, *e);
+        });
     }
 
     fn remove_client_internal(&mut self, room_id: RoomId, client_id: ClientId) {
@@ -252,13 +245,15 @@ impl RoomManager {
             .entry(client_id)
             .or_default()
             .remove(&room_id);
-        self.data
-            .rooms
-            .entry(room_id)
-            .or_default()
-            .clients
-            .remove(&client_id);
-        self.events.client_leave_room(room_id, client_id);
+        if let Entry::Occupied(mut o) = self.data.rooms.entry(room_id) {
+            o.get_mut().clients.remove(&client_id);
+            o.get().entities.iter().for_each(|e| {
+                self.events.lose_relevance_internal(client_id, *e);
+            });
+            if o.get().is_empty() {
+                o.remove();
+            }
+        }
     }
 
     fn add_entity_internal(&mut self, room_id: RoomId, entity: Entity) {
@@ -267,13 +262,11 @@ impl RoomManager {
             .entry(entity)
             .or_default()
             .insert(room_id);
-        self.data
-            .rooms
-            .entry(room_id)
-            .or_default()
-            .entities
-            .insert(entity);
-        self.events.entity_enter_room(room_id, entity);
+        let room = self.data.rooms.entry(room_id).or_default();
+        room.entities.insert(entity);
+        room.clients.iter().for_each(|c| {
+            self.events.gain_relevance_internal(*c, entity);
+        });
     }
 
     fn remove_entity_internal(&mut self, room_id: RoomId, entity: Entity) {
@@ -282,13 +275,15 @@ impl RoomManager {
             .entry(entity)
             .or_default()
             .remove(&room_id);
-        self.data
-            .rooms
-            .entry(room_id)
-            .or_default()
-            .entities
-            .remove(&entity);
-        self.events.entity_leave_room(room_id, entity);
+        if let Entry::Occupied(mut o) = self.data.rooms.entry(room_id) {
+            o.get_mut().entities.remove(&entity);
+            o.get().clients.iter().for_each(|c| {
+                self.events.lose_relevance_internal(*c, entity);
+            });
+            if o.get().is_empty() {
+                o.remove();
+            }
+        }
     }
 
     fn has_entity_internal(&self, room_id: RoomId, entity: Entity) -> bool {
@@ -307,96 +302,6 @@ impl RoomManager {
     }
 }
 
-impl RoomEvents {
-    fn is_empty(&self) -> bool {
-        self.client_enter_room.is_empty()
-            && self.client_leave_room.is_empty()
-            && self.entity_enter_room.is_empty()
-            && self.entity_leave_room.is_empty()
-    }
-
-    fn clear(&mut self) {
-        self.client_enter_room.clear();
-        self.client_leave_room.clear();
-        self.entity_enter_room.clear();
-        self.entity_leave_room.clear();
-    }
-
-    /// A client joined a room
-    pub fn client_enter_room(&mut self, room_id: RoomId, client_id: ClientId) {
-        // if the client had left the room and re-entered, no need to track the enter
-        if !self
-            .client_leave_room
-            .entry(client_id)
-            .or_default()
-            .remove(&room_id)
-        {
-            self.client_enter_room
-                .entry(client_id)
-                .or_default()
-                .insert(room_id);
-        }
-    }
-
-    pub fn client_leave_room(&mut self, room_id: RoomId, client_id: ClientId) {
-        // if the client had entered the room and left, no need to track the leaving
-        if !self
-            .client_enter_room
-            .entry(client_id)
-            .or_default()
-            .remove(&room_id)
-        {
-            self.client_leave_room
-                .entry(client_id)
-                .or_default()
-                .insert(room_id);
-        }
-    }
-
-    pub fn entity_enter_room(&mut self, room_id: RoomId, entity: Entity) {
-        if !self
-            .entity_leave_room
-            .entry(entity)
-            .or_default()
-            .remove(&room_id)
-        {
-            self.entity_enter_room
-                .entry(entity)
-                .or_default()
-                .insert(room_id);
-        }
-    }
-
-    pub fn entity_leave_room(&mut self, room_id: RoomId, entity: Entity) {
-        if !self
-            .entity_enter_room
-            .entry(entity)
-            .or_default()
-            .remove(&room_id)
-        {
-            self.entity_leave_room
-                .entry(entity)
-                .or_default()
-                .insert(room_id);
-        }
-    }
-
-    fn iter_client_enter_room(&self) -> impl Iterator<Item = (&ClientId, &HashSet<RoomId>)> {
-        self.client_enter_room.iter()
-    }
-
-    fn iter_client_leave_room(&self) -> impl Iterator<Item = (&ClientId, &HashSet<RoomId>)> {
-        self.client_leave_room.iter()
-    }
-
-    fn iter_entity_enter_room(&self) -> impl Iterator<Item = (&Entity, &HashSet<RoomId>)> {
-        self.entity_enter_room.iter()
-    }
-
-    fn iter_entity_leave_room(&self) -> impl Iterator<Item = (&Entity, &HashSet<RoomId>)> {
-        self.entity_leave_room.iter()
-    }
-}
 
 pub(super) mod systems {
     use super::*;
@@ -420,57 +325,7 @@ pub(super) mod systems {
         mut room_manager: ResMut<RoomManager>,
         mut relevance_manager: ResMut<RelevanceManager>,
     ) {
-        if !room_manager.events.is_empty() {
-            trace!(?room_manager.events, "Room events");
-        }
-        // enable split borrows by reborrowing Mut
-        let room_manager = &mut *room_manager;
-
-        // NOTE: we handle leave room events before join room events so that if an entity leaves room 1 to join room 2
-        //  and the client is in both rooms, the entity does not get despawned
-
-        // entity left room
-        for (entity, rooms) in room_manager.events.entity_leave_room.drain() {
-            // for each room left, update the entity's client relevance list if the client was in the room
-            rooms.into_iter().for_each(|room_id| {
-                let room = room_manager.data.rooms.get(&room_id).unwrap();
-                room.clients.iter().for_each(|client_id| {
-                    trace!("entity {entity:?} left room {room:?}. Sending lost relevance to client {client_id:?}");
-                    relevance_manager.lose_relevance(*client_id, entity);
-                });
-            });
-        }
-        // entity joined room
-        for (entity, rooms) in room_manager.events.entity_enter_room.drain() {
-            // for each room joined, update the entity's client relevance list
-            rooms.into_iter().for_each(|room_id| {
-                let room = room_manager.data.rooms.get(&room_id).unwrap();
-                room.clients.iter().for_each(|client_id| {
-                    trace!("entity {entity:?} joined room {room:?}. Sending gained relevance to client {client_id:?}");
-                    relevance_manager.gain_relevance(*client_id, entity);
-                });
-            });
-        }
-        // client left room: update all the entities that are in that room
-        for (client_id, rooms) in room_manager.events.client_leave_room.drain() {
-            rooms.into_iter().for_each(|room_id| {
-                let room = room_manager.data.rooms.get(&room_id).unwrap();
-                room.entities.iter().for_each(|entity| {
-                    trace!("client {client_id:?} left room {room:?}. Sending lost relevance to entity {entity:?}");
-                    relevance_manager.lose_relevance(client_id, *entity);
-                });
-            });
-        }
-        // client joined room: update all the entities that are in that room
-        for (client_id, rooms) in room_manager.events.client_enter_room.drain() {
-            rooms.into_iter().for_each(|room_id| {
-                let room = room_manager.data.rooms.get(&room_id).unwrap();
-                room.entities.iter().for_each(|entity| {
-                    trace!("client {client_id:?} joined room {room:?}. Sending gained relevance to entity {entity:?}");
-                    relevance_manager.gain_relevance(client_id, *entity);
-                });
-            });
-        }
+        relevance_manager.events.update(&mut room_manager.events);
     }
 
     /// Clear out the room metadata for any entity that was ever replicated
@@ -549,10 +404,10 @@ mod tests {
             .world()
             .resource::<RoomManager>()
             .events
-            .entity_enter_room
-            .get(&server_entity)
+            .gained
+            .get(&client_id)
             .unwrap()
-            .contains(&room_id));
+            .contains(&server_entity));
         // Run update replication cache once
         let _ = stepper
             .server_app
@@ -629,10 +484,10 @@ mod tests {
             .world()
             .resource::<RoomManager>()
             .events
-            .entity_leave_room
-            .get(&server_entity)
+            .lost
+            .get(&client_id)
             .unwrap()
-            .contains(&room_id));
+            .contains(&server_entity));
         let _ = stepper
             .server_app
             .world_mut()
@@ -725,10 +580,10 @@ mod tests {
             .world()
             .resource::<RoomManager>()
             .events
-            .client_enter_room
+            .gained
             .get(&client_id)
             .unwrap()
-            .contains(&room_id));
+            .contains(&server_entity));
         // Run update replication cache once
         let _ = stepper
             .server_app
@@ -798,10 +653,10 @@ mod tests {
             .world()
             .resource::<RoomManager>()
             .events
-            .client_leave_room
+            .lost
             .get(&client_id)
             .unwrap()
-            .contains(&room_id));
+            .contains(&server_entity));
         let _ = stepper
             .server_app
             .world_mut()
@@ -1161,5 +1016,90 @@ mod tests {
         );
     }
 
+    /// The entity and client are in room A
+    /// Entity,client leave room at the same time
+    ///
+    /// Entity-Client should lose relevance (not in the same room anymore)
+    #[test]
+    fn test_client_entity_both_leave_room() {
+        let mut stepper = BevyStepper::default();
+        let client_id = ClientId::Netcode(111);
+        let room_id = RoomId(0);
+
+        stepper
+            .server_app
+            .world_mut()
+            .resource_mut::<RoomManager>()
+            .add_client(client_id, room_id);
+        // Spawn an entity on server, in room 1
+        let entity = stepper
+            .server_app
+            .world_mut()
+            .spawn(Replicate {
+                relevance_mode: NetworkRelevanceMode::InterestManagement,
+                ..Default::default()
+            })
+            .id();
+        stepper
+            .server_app
+            .world_mut()
+            .resource_mut::<RoomManager>()
+            .add_entity(entity, room_id);
+        let _ = stepper
+            .server_app
+            .world_mut()
+            .run_system_once(add_cached_network_relevance);
+
+        // Run update replication cache once
+        let _ = stepper
+            .server_app
+            .world_mut()
+            .run_system_once(buffer_room_relevance_events);
+        let _ = stepper
+            .server_app
+            .world_mut()
+            .run_system_once(update_relevance_from_events);
+        assert_eq!(
+            stepper
+                .server_app
+                .world()
+                .entity(entity)
+                .get::<CachedNetworkRelevance>()
+                .unwrap()
+                .clients_cache,
+            HashMap::from([(client_id, ClientRelevance::Gained)])
+        );
+
+        // Client and entity leave room
+        stepper
+            .server_app
+            .world_mut()
+            .resource_mut::<RoomManager>()
+            .remove_client(client_id, room_id);
+        stepper
+            .server_app
+            .world_mut()
+            .resource_mut::<RoomManager>()
+            .remove_entity(entity, room_id);
+        let _ = stepper
+            .server_app
+            .world_mut()
+            .run_system_once(buffer_room_relevance_events);
+        let _ = stepper
+            .server_app
+            .world_mut()
+            .run_system_once(update_relevance_from_events);
+        // make sure that visibility is lost
+        assert_eq!(
+            stepper
+                .server_app
+                .world()
+                .entity(entity)
+                .get::<CachedNetworkRelevance>()
+                .unwrap()
+                .clients_cache,
+            HashMap::from([(client_id, ClientRelevance::Lost)])
+        );
+    }
     // TODO: check that entity despawn/client disconnect cleans the room metadata
 }

--- a/lightyear/src/server/replication.rs
+++ b/lightyear/src/server/replication.rs
@@ -401,7 +401,7 @@ pub(crate) mod send {
                     commands.entity(entity).transfer_authority(*authority_peer);
                 }
                 AuthorityPeer::Server => {
-                    debug!("Adding HasAuthority to {:?}", entity);
+                    trace!("Adding HasAuthority to {:?}", entity);
                     commands.entity(entity).insert(HasAuthority);
                 }
                 _ => {}

--- a/lightyear/src/shared/replication/send.rs
+++ b/lightyear/src/shared/replication/send.rs
@@ -647,6 +647,13 @@ impl ReplicationSender {
                     priority,
                 )?
                 .expect("The entity actions channels should always return a message_id");
+            debug!(
+                ?message_id,
+                ?group_id,
+                ?bevy_tick,
+                ?tick,
+                "Send replication action"
+            );
 
             // restore the hashmap that we took out, so that we can reuse the allocated memory
             channel.pending_actions = message.actions;


### PR DESCRIPTION
- Simplify room logic by replacing RoomEvents with RelevanceEvents. This also allows me to handle an edge case correctly: when an entity and client both leave a room at the same time. Previously the loss of visibility was not computed correctly!
- Remove some extra logs
- When rooms are empty (no clients and no entities), remove them