### PR TITLE
Improve the server stop logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ## [Unreleased]
 
+- Simplified the examples
 - Removed `DisabledComponent::<C>` in favor of `DisabledComponents` to have more control over
 which components are disabled. In particular, it is now possible to express 'disable all components except these'.
 - Enabled replicating events directly!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ which components are disabled. In particular, it is now possible to express 'dis
   - Add an `Event` to the protocol with `register_event`
   - Replicate an event and buffer it in EventWriter with `send_event`
   - Replicate an event and trigger it with `trigger_event`
+- State is correctly cleaned up when the server is stopped (the ControlledBy and Client entities are correctly despawned)
+- Fixed how prediction/interpolation interact with authority transfer.
+  - For example in the use case where we spawn an entity on Client 1, replicate it to the server, then give the server authority over the entity,
+    a Predicted/Interpolated entities will now get spawned correctly on client 1
+- Fixed some edge cases related to InterestManagement
+- Fixed a bug where ChannelDirection was not respected (a ClientToServer component would still get replicated from the server to the client) 
+
 
 
 ## 0.18.0 - 2024-12-24

--- a/examples/common/src/app.rs
+++ b/examples/common/src/app.rs
@@ -450,7 +450,8 @@ fn window_plugin() -> WindowPlugin {
 fn log_plugin() -> LogPlugin {
     LogPlugin {
         level: Level::INFO,
-        filter: "wgpu=error,bevy_render=info,bevy_ecs=warn".to_string(),
+        filter: "wgpu=error,bevy_render=info,bevy_ecs=warn,bevy_time=warn,lightyear=debug"
+            .to_string(),
         ..default()
     }
 }

--- a/examples/common/src/app.rs
+++ b/examples/common/src/app.rs
@@ -450,8 +450,7 @@ fn window_plugin() -> WindowPlugin {
 fn log_plugin() -> LogPlugin {
     LogPlugin {
         level: Level::INFO,
-        filter: "wgpu=error,bevy_render=info,bevy_ecs=warn,bevy_time=warn,lightyear=debug"
-            .to_string(),
+        filter: "wgpu=error,bevy_render=info,bevy_ecs=warn,bevy_time=warn".to_string(),
         ..default()
     }
 }

--- a/examples/simple_box/src/server.rs
+++ b/examples/simple_box/src/server.rs
@@ -24,7 +24,10 @@ impl Plugin for ExampleServerPlugin {
         app.add_systems(Startup, start_server);
         // the physics/FixedUpdates systems that consume inputs should be run in this set.
         app.add_systems(FixedUpdate, movement);
-        app.add_systems(Update, (send_message, handle_connections));
+        app.add_systems(
+            Update,
+            (send_message, handle_connections, server_start_stop),
+        );
     }
 }
 
@@ -121,6 +124,20 @@ fn movement(
                     client_id
                 )
             }
+        }
+    }
+}
+
+pub(crate) fn server_start_stop(
+    mut commands: Commands,
+    state: Res<State<NetworkingState>>,
+    input: Option<Res<ButtonInput<KeyCode>>>,
+) {
+    if input.is_some_and(|input| input.just_pressed(KeyCode::KeyS)) {
+        if state.get() == &NetworkingState::Stopped {
+            commands.start_server();
+        } else {
+            commands.stop_server();
         }
     }
 }

--- a/lightyear/src/client/connection.rs
+++ b/lightyear/src/client/connection.rs
@@ -507,7 +507,7 @@ impl ConnectionManager {
     ) -> Result<(), ClientError> {
         // receive the packets, buffer them, update any sender that were waiting for their sent messages to be acked
         let tick = self.message_manager.recv_packet(packet)?;
-        debug!("Received server packet with tick: {:?}", tick);
+        trace!("Received server packet with tick: {:?}", tick);
         if self
             .sync_manager
             .latest_received_server_tick

--- a/lightyear/src/client/input/native.rs
+++ b/lightyear/src/client/input/native.rs
@@ -309,9 +309,10 @@ fn prepare_input_message<A: UserAction>(
     if !message.is_empty() {
         // TODO: should we provide variants of each user-facing function, so that it pushes the error
         //  to the ConnectionEvents?
-        debug!(
+        trace!(
             ?current_tick,
-            "sending input message: {:?}", message.end_tick
+            "sending input message: {:?}",
+            message.end_tick
         );
         connection
             .send_message::<InputChannel, _>(&message)

--- a/lightyear/src/client/input/native.rs
+++ b/lightyear/src/client/input/native.rs
@@ -46,7 +46,7 @@
 use bevy::prelude::*;
 use bevy::reflect::Reflect;
 use bevy::utils::Duration;
-use tracing::{debug, error, trace};
+use tracing::{error, trace};
 
 use crate::client::config::ClientConfig;
 use crate::client::connection::ConnectionManager;

--- a/lightyear/src/client/prediction/pre_prediction.rs
+++ b/lightyear/src/client/prediction/pre_prediction.rs
@@ -8,7 +8,7 @@ use crate::client::prediction::resource::PredictionManager;
 use crate::client::prediction::Predicted;
 use crate::client::replication::send::ReplicateToServer;
 use crate::prelude::client::is_synced;
-use crate::prelude::server::{ServerConfig, ServerConnections};
+use crate::prelude::server::{NetworkingState, ServerConfig};
 use crate::prelude::{
     is_host_server_ref, HasAuthority, ReplicateHierarchy, Replicating, ReplicationGroup,
     ShouldBePredicted, TickManager,
@@ -116,7 +116,7 @@ impl PrePredictionPlugin {
                 //  to remove PrePredicted and add Predicted
                 if is_host_server_ref(
                     world.get_resource_ref::<ServerConfig>(),
-                    world.get_resource_ref::<ServerConnections>(),
+                    world.get_resource_ref::<State<NetworkingState>>(),
                 ) {
                     // world.entity_mut(predicted_entity).remove::<PrePredicted>();
                     world.entity_mut(predicted_entity).insert(Predicted {

--- a/lightyear/src/connection/netcode/server.rs
+++ b/lightyear/src/connection/netcode/server.rs
@@ -954,7 +954,6 @@ impl<Ctx> NetcodeServer<Ctx> {
         debug!("server disconnecting client {client_id}");
         self.on_disconnect(client_id, addr);
         for _ in 0..self.cfg.num_disconnect_packets {
-            // self.send_to_client(DisconnectPacket::create(), client_id, io)?;
             // we do not use ? here because we want to continue even if the send fails
             let _ = self
                 .send_to_client(DisconnectPacket::create(), client_id, io)
@@ -1027,7 +1026,6 @@ pub(crate) mod connection {
     use super::*;
     use crate::connection::server::ConnectionError;
     use core::result::Result;
-    use tracing::info;
 
     #[derive(Default)]
     pub(crate) struct NetcodeServerContext {

--- a/lightyear/src/connection/server.rs
+++ b/lightyear/src/connection/server.rs
@@ -205,8 +205,6 @@ impl ServerConnections {
         for server in &mut self.servers {
             server.stop()?;
         }
-        // since is_listening is false, the `receive_packets` function won't be called and
-        // we won't finish the disconnection process (cleaning up the Connections in the ConnectionManager)
         Ok(())
     }
 

--- a/lightyear/src/lib.rs
+++ b/lightyear/src/lib.rs
@@ -327,7 +327,7 @@ pub mod prelude {
             },
             ReplicationSet, ServerReplicationSet,
         };
-        pub use crate::server::run_conditions::{is_started, is_stopped, NetworkingStateExt};
+        pub use crate::server::run_conditions::{is_started, is_stopped};
         pub use crate::shared::replication::authority::AuthorityPeer;
     }
 

--- a/lightyear/src/lib.rs
+++ b/lightyear/src/lib.rs
@@ -327,7 +327,7 @@ pub mod prelude {
             },
             ReplicationSet, ServerReplicationSet,
         };
-        pub use crate::server::run_conditions::{is_started, is_stopped};
+        pub use crate::server::run_conditions::{is_started, is_stopped, NetworkingStateExt};
         pub use crate::shared::replication::authority::AuthorityPeer;
     }
 

--- a/lightyear/src/server/connection.rs
+++ b/lightyear/src/server/connection.rs
@@ -332,6 +332,7 @@ impl ConnectionManager {
         metrics::gauge!("connected_clients").decrement(1.0);
         info!("Client {} disconnected", client_id);
         if let Ok(entity) = self.client_entity(client_id) {
+            debug!("Sending Client DisconnectEvent");
             self.events
                 .add_disconnect_event(DisconnectEvent { client_id, entity });
         }

--- a/lightyear/src/server/input/native.rs
+++ b/lightyear/src/server/input/native.rs
@@ -122,7 +122,7 @@ fn receive_input_message<A: UserAction>(
                         .remote_to_local,
                 ) {
                     Ok(message) => {
-                        debug!("Received input message: {:?}", message);
+                        trace!("Received input message: {:?}", message);
                         input_buffers
                             .buffers
                             .entry(*client_id)
@@ -161,7 +161,7 @@ fn write_input_event<A: UserAction>(
         .buffers
         .iter_mut()
         .for_each(move |(client_id, (last_input, input_buffer))| {
-            debug!(?input_buffer, ?tick, ?client_id, "input buffer for client");
+            trace!(?input_buffer, ?tick, ?client_id, "input buffer for client");
             let received_input = input_buffer.pop(tick);
             let fallback = received_input.is_none();
 
@@ -176,7 +176,7 @@ fn write_input_event<A: UserAction>(
             };
             if fallback {
                 // TODO: do not log this while clients are syncing..
-                debug!(
+                trace!(
                 ?client_id,
                 ?tick,
                 fallback_input = ?&input,

--- a/lightyear/src/server/networking.rs
+++ b/lightyear/src/server/networking.rs
@@ -345,7 +345,7 @@ fn rebuild_server_connections(world: &mut World) {
 /// - rebuild the server connection manager
 /// - start listening on the server connections
 fn on_start(world: &mut World) {
-    if world.resource::<ServerConnections>().is_listening() {
+    if is_started(world.get::<Res<State<NetworkingState::>>>()) {
         error!("The server is already started. The server can only be started when it is stopped.");
         return;
     }

--- a/lightyear/src/server/run_conditions.rs
+++ b/lightyear/src/server/run_conditions.rs
@@ -1,19 +1,37 @@
 //! Common server-related run conditions
 use crate::connection::server::ServerConnections;
-use bevy::prelude::Res;
+use crate::prelude::server::NetworkingState;
+use bevy::prelude::{Res, State, World};
 
 /// Returns true if the server is started.
 ///
 /// We check the status of the `ServerConnections` directly instead of using the `State<NetworkingState>`
 /// to avoid having a frame of delay since the `StateTransition` schedule runs after the `PreUpdate` schedule
-pub fn is_started(server: Option<Res<ServerConnections>>) -> bool {
-    server.map_or(false, |s| s.is_listening())
+pub fn is_started(server: Option<Res<State<NetworkingState>>>) -> bool {
+    server.map_or(false, |s| s.get() != &NetworkingState::Stopped)
 }
 
 /// Returns true if the server is stopped.
 ///
 /// We check the status of the `ServerConnections` directly instead of using the `State<NetworkingState>`
 /// to avoid having a frame of delay since the `StateTransition` schedule runs after the `PreUpdate` schedule
-pub fn is_stopped(server: Option<Res<ServerConnections>>) -> bool {
-    server.map_or(true, |s| !s.is_listening())
+pub fn is_stopped(server: Option<Res<State<NetworkingState>>>) -> bool {
+    server.map_or(true, |s| s.get() == &NetworkingState::Stopped)
+}
+
+pub(crate) trait NetworkingStateExt {
+    fn is_started(&self) -> bool;
+    fn is_stopped(&self) -> bool;
+}
+
+impl NetworkingStateExt for &World {
+    fn is_started(&self) -> bool {
+        self.get_resource::<State<NetworkingState>>()
+            .map_or(false, |s| s.get() != &NetworkingState::Stopped)
+    }
+
+    fn is_stopped(&self) -> bool {
+        self.get_resource::<State<NetworkingState>>()
+            .map_or(true, |s| s.get() == &NetworkingState::Stopped)
+    }
 }

--- a/lightyear/src/server/run_conditions.rs
+++ b/lightyear/src/server/run_conditions.rs
@@ -1,14 +1,13 @@
 //! Common server-related run conditions
-use crate::connection::server::ServerConnections;
 use crate::prelude::server::NetworkingState;
-use bevy::prelude::{Res, State, World};
+use bevy::prelude::{Ref, Res, State};
 
 /// Returns true if the server is started.
 ///
 /// We check the status of the `ServerConnections` directly instead of using the `State<NetworkingState>`
 /// to avoid having a frame of delay since the `StateTransition` schedule runs after the `PreUpdate` schedule
 pub fn is_started(server: Option<Res<State<NetworkingState>>>) -> bool {
-    server.map_or(false, |s| s.get() != &NetworkingState::Stopped)
+    server.map_or(false, |s| s.get() == &NetworkingState::Started)
 }
 
 /// Returns true if the server is stopped.
@@ -19,19 +18,9 @@ pub fn is_stopped(server: Option<Res<State<NetworkingState>>>) -> bool {
     server.map_or(true, |s| s.get() == &NetworkingState::Stopped)
 }
 
-pub(crate) trait NetworkingStateExt {
-    fn is_started(&self) -> bool;
-    fn is_stopped(&self) -> bool;
+pub(crate) fn is_started_ref(server: Option<Ref<State<NetworkingState>>>) -> bool {
+    server.map_or(false, |s| s.get() == &NetworkingState::Started)
 }
-
-impl NetworkingStateExt for &World {
-    fn is_started(&self) -> bool {
-        self.get_resource::<State<NetworkingState>>()
-            .map_or(false, |s| s.get() != &NetworkingState::Stopped)
-    }
-
-    fn is_stopped(&self) -> bool {
-        self.get_resource::<State<NetworkingState>>()
-            .map_or(true, |s| s.get() == &NetworkingState::Stopped)
-    }
+pub(crate) fn is_stopped_ref(server: Option<Ref<State<NetworkingState>>>) -> bool {
+    server.map_or(true, |s| s.get() == &NetworkingState::Stopped)
 }

--- a/lightyear/src/shared/plugin.rs
+++ b/lightyear/src/shared/plugin.rs
@@ -3,11 +3,13 @@ use crate::client::config::ClientConfig;
 use crate::connection::client::{ClientConnection, NetClient};
 use crate::connection::server::ServerConnections;
 use crate::prelude::client::ComponentSyncMode;
+use crate::prelude::server::NetworkingState;
 use crate::prelude::{
     AppComponentExt, AppMessageExt, ChannelDirection, ChannelRegistry, ClientId, ComponentRegistry,
     LinkConditionerConfig, MessageRegistry, Mode, ParentSync, PingConfig, PrePredicted,
     PreSpawnedPlayerObject, ShouldBePredicted, TickConfig,
 };
+use crate::server::run_conditions::NetworkingStateExt;
 use crate::shared::config::SharedConfig;
 use crate::shared::replication::authority::AuthorityChange;
 use crate::shared::replication::components::{Controlled, ShouldBeInterpolated};
@@ -30,6 +32,7 @@ pub struct NetworkIdentity<'w, 's> {
     client: Option<Res<'w, ClientConnection>>,
     client_config: Option<Res<'w, ClientConfig>>,
     server: Option<Res<'w, ServerConnections>>,
+    server_state: Option<Res<'w, State<NetworkingState>>>,
     _marker: std::marker::PhantomData<&'s ()>,
 }
 
@@ -53,12 +56,7 @@ impl FromWorld for Identity {
         let Some(config) = world.get_resource::<ClientConfig>() else {
             return Identity::Server;
         };
-        if matches!(config.shared.mode, Mode::HostServer)
-            && world
-                .get_resource::<ServerConnections>()
-                .as_ref()
-                .map_or(false, |server| server.is_listening())
-        {
+        if matches!(config.shared.mode, Mode::HostServer) && world.is_started() {
             Identity::HostServer
         } else {
             let client_id = world
@@ -86,9 +84,9 @@ impl NetworkIdentity<'_, '_> {
         };
         if matches!(config.shared.mode, Mode::HostServer)
             && self
-                .server
+                .server_state
                 .as_ref()
-                .map_or(false, |server| server.is_listening())
+                .map_or(false, |s| s.get() == &NetworkingState::Started)
         {
             Identity::HostServer
         } else {

--- a/lightyear/src/shared/plugin.rs
+++ b/lightyear/src/shared/plugin.rs
@@ -9,7 +9,7 @@ use crate::prelude::{
     LinkConditionerConfig, MessageRegistry, Mode, ParentSync, PingConfig, PrePredicted,
     PreSpawnedPlayerObject, ShouldBePredicted, TickConfig,
 };
-use crate::server::run_conditions::NetworkingStateExt;
+use crate::server::run_conditions::is_started_ref;
 use crate::shared::config::SharedConfig;
 use crate::shared::replication::authority::AuthorityChange;
 use crate::shared::replication::components::{Controlled, ShouldBeInterpolated};
@@ -56,7 +56,9 @@ impl FromWorld for Identity {
         let Some(config) = world.get_resource::<ClientConfig>() else {
             return Identity::Server;
         };
-        if matches!(config.shared.mode, Mode::HostServer) && world.is_started() {
+        if matches!(config.shared.mode, Mode::HostServer)
+            && is_started_ref(world.get_resource_ref::<State<NetworkingState>>())
+        {
             Identity::HostServer
         } else {
             let client_id = world

--- a/lightyear/src/shared/run_conditions.rs
+++ b/lightyear/src/shared/run_conditions.rs
@@ -1,8 +1,8 @@
 //! Common run conditions
-use crate::connection::server::ServerConnections;
 use crate::prelude::server::{is_started, ServerConfig};
 use crate::prelude::{Mode, NetworkIdentity};
 use crate::server::networking::NetworkingState;
+use crate::server::run_conditions::is_started_ref;
 use bevy::prelude::{Ref, Res, State};
 
 /// Returns true if the peer is a client
@@ -32,10 +32,10 @@ pub fn is_host_server(
 
 pub fn is_host_server_ref(
     config: Option<Ref<ServerConfig>>,
-    server_state: Option<Res<State<NetworkingState>>>,
+    server_state: Option<Ref<State<NetworkingState>>>,
 ) -> bool {
     config.map_or(false, |config| {
-        matches!(config.shared.mode, Mode::HostServer) && is_started(server_state)
+        matches!(config.shared.mode, Mode::HostServer) && is_started_ref(server_state)
     })
 }
 

--- a/lightyear/src/shared/run_conditions.rs
+++ b/lightyear/src/shared/run_conditions.rs
@@ -1,8 +1,9 @@
 //! Common run conditions
 use crate::connection::server::ServerConnections;
-use crate::prelude::server::ServerConfig;
+use crate::prelude::server::{is_started, ServerConfig};
 use crate::prelude::{Mode, NetworkIdentity};
-use bevy::prelude::{Ref, Res};
+use crate::server::networking::NetworkingState;
+use bevy::prelude::{Ref, Res, State};
 
 /// Returns true if the peer is a client
 pub fn is_client(identity: NetworkIdentity) -> bool {
@@ -22,21 +23,19 @@ pub fn is_server(identity: NetworkIdentity) -> bool {
 /// and client plugin are running in the same App)
 pub fn is_host_server(
     config: Option<Res<ServerConfig>>,
-    server: Option<Res<ServerConnections>>,
+    server_state: Option<Res<State<NetworkingState>>>,
 ) -> bool {
     config.map_or(false, |config| {
-        matches!(config.shared.mode, Mode::HostServer)
-            && server.map_or(false, |server| server.is_listening())
+        matches!(config.shared.mode, Mode::HostServer) && is_started(server_state)
     })
 }
 
 pub fn is_host_server_ref(
     config: Option<Ref<ServerConfig>>,
-    server: Option<Ref<ServerConnections>>,
+    server_state: Option<Res<State<NetworkingState>>>,
 ) -> bool {
     config.map_or(false, |config| {
-        matches!(config.shared.mode, Mode::HostServer)
-            && server.map_or(false, |server| server.is_listening())
+        matches!(config.shared.mode, Mode::HostServer) && is_started(server_state)
     })
 }
 

--- a/lightyear/src/transport/webtransport/server.rs
+++ b/lightyear/src/transport/webtransport/server.rs
@@ -88,7 +88,8 @@ impl ServerTransportBuilder for WebTransportServerSocketBuilder {
                         Ok(event) = close_rx.recv() => {
                             match event {
                                 ServerIoEvent::ServerDisconnected(e) => {
-                                    debug!("Stopping webtransport io task. Reason: {:?}", e);
+                                    debug!("Stopping all webtransport io tasks. Reason: {:?}", e);
+                                    // drop all tasks so that they can be cleaned up
                                     drop(addr_to_task);
                                     return;
                                 }


### PR DESCRIPTION
- Stop relying on a `is_listening` flag on the server and instead use the server::NetworkingState directly
- Introduce `NetworkingState::Starting` and `NetworkingState::Stopping` so that we can run logic during the temporary states. In particular this means that we can run `receive_packets` once while the server is stopping. `receive_packets` handles the disconnection logic by sending DisconnectEvent messages and removing the connection from the ConnectionManager, so this was needed for correct behaviour
- Add a unit test to make sure that on server_stop the Client entities are despawned and the connection gets removed from the ConnectionManager.

Fixes https://github.com/cBournhonesque/lightyear/issues/603