### PR TITLE
Type erase the receive-message and receive-event systems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ which components are disabled. In particular, it is now possible to express 'dis
   - Add an `Event` to the protocol with `register_event`
   - Replicate an event and buffer it in EventWriter with `send_event`
   - Replicate an event and trigger it with `trigger_event`
+- Replaced `MessageEvent.context()` with `MessageContext.from()`, which returns the `ClientId` that send the message
 - State is correctly cleaned up when the server is stopped (the ControlledBy and Client entities are correctly despawned)
 - Parent-Child hierarchy is now synced properly to the Predicted/Interpolated entities
 - Fixed how prediction/interpolation interact with authority transfer.
@@ -17,6 +18,7 @@ which components are disabled. In particular, it is now possible to express 'dis
     a Predicted/Interpolated entities will now get spawned correctly on client 1
 - Fixed some edge cases related to InterestManagement
 - Fixed a bug where ChannelDirection was not respected (a ClientToServer component would still get replicated from the server to the client) 
+- Type-erased the receive-message systems so that we only have one `read_messages` system instead of one system per message type
 
 
 

--- a/examples/avian_3d_character/src/server.rs
+++ b/examples/avian_3d_character/src/server.rs
@@ -101,7 +101,7 @@ pub(crate) fn replicate_inputs(
     mut input_events: ResMut<Events<MessageEvent<InputMessage<CharacterAction>>>>,
 ) {
     for mut event in input_events.drain() {
-        let client_id = *event.context();
+        let client_id = event.from();
         // Rebroadcast the input to other clients.
         connection
             .send_message_to_target::<InputChannel, _>(

--- a/examples/avian_physics/src/server.rs
+++ b/examples/avian_physics/src/server.rs
@@ -93,7 +93,7 @@ pub(crate) fn replicate_inputs(
     mut input_events: ResMut<Events<MessageEvent<InputMessage<PlayerActions>>>>,
 ) {
     for mut event in input_events.drain() {
-        let client_id = *event.context();
+        let client_id = event.from();
 
         // Optional: do some validation on the inputs to check that there's no cheating
 

--- a/examples/client_replication/src/server.rs
+++ b/examples/client_replication/src/server.rs
@@ -38,7 +38,7 @@ pub(crate) fn movement(
     tick_manager: Res<TickManager>,
 ) {
     for input in input_reader.read() {
-        let client_id = input.context();
+        let client_id = input.from();
         if let Some(input) = input.input() {
             if matches!(input, Inputs::None) {
                 continue;
@@ -51,7 +51,7 @@ pub(crate) fn movement(
             );
 
             for (position, player_id) in position_query.iter_mut() {
-                if player_id.0 == *client_id {
+                if player_id.0 == client_id {
                     // NOTE: be careful to directly pass Mut<PlayerPosition>
                     // getting a mutable reference triggers change detection, unless you use `as_deref_mut()`
                     shared_movement_behaviour(position, input);
@@ -67,14 +67,14 @@ fn delete_player(
     query: Query<(Entity, &PlayerId), With<PlayerPosition>>,
 ) {
     for input in input_reader.read() {
-        let client_id = input.context();
+        let client_id = input.from();
         if let Some(input) = input.input() {
             if matches!(input, Inputs::Delete) {
                 debug!("received delete input!");
                 for (entity, player_id) in query.iter() {
                     // NOTE: we could not accept the despawn (server conflict)
                     //  in which case the client would have to rollback to delete
-                    if player_id.0 == *client_id {
+                    if player_id.0 == client_id {
                         // You can try 2 things here:
                         // - either you consider that the client's action is correct, and you despawn the entity. This should get replicated
                         //   to other clients.

--- a/examples/delta_compression/src/server.rs
+++ b/examples/delta_compression/src/server.rs
@@ -102,7 +102,7 @@ fn movement(
     tick_manager: Res<TickManager>,
 ) {
     for input in input_reader.read() {
-        let client_id = input.context();
+        let client_id = input.from();
         if let Some(input) = input.input() {
             trace!(
                 "Receiving input: {:?} from client: {:?} on tick: {:?}",
@@ -111,7 +111,7 @@ fn movement(
                 tick_manager.tick()
             );
 
-            if let Some(player) = entity_map.0.get(client_id) {
+            if let Some(player) = entity_map.0.get(&client_id) {
                 if let Ok(position) = position_query.get_mut(*player) {
                     shared::shared_movement_behaviour(position, input);
                 }

--- a/examples/distributed_authority/src/server.rs
+++ b/examples/distributed_authority/src/server.rs
@@ -83,7 +83,7 @@ pub(crate) fn movement(
     tick_manager: Res<TickManager>,
 ) {
     for input in input_reader.read() {
-        let client_id = input.context();
+        let client_id = input.from();
         if let Some(input) = input.input() {
             trace!(
                 "Receiving input: {:?} from client: {:?} on tick: {:?}",
@@ -94,7 +94,7 @@ pub(crate) fn movement(
             // NOTE: you can define a mapping from client_id to entity_id to avoid iterating through all
             //  entities here
             for (controlled_by, position) in position_query.iter_mut() {
-                if controlled_by.targets(client_id) {
+                if controlled_by.targets(&client_id) {
                     shared::shared_movement_behaviour(position, input);
                 }
             }

--- a/examples/replication_groups/src/server.rs
+++ b/examples/replication_groups/src/server.rs
@@ -60,7 +60,7 @@ pub(crate) fn movement(
     tick_manager: Res<TickManager>,
 ) {
     for input in input_reader.read() {
-        let client_id = input.context();
+        let client_id = input.from();
         if let Some(input) = input.input() {
             debug!(
                 "Receiving input: {:?} from client: {:?} on tick: {:?}",
@@ -71,7 +71,7 @@ pub(crate) fn movement(
             // NOTE: you can define a mapping from client_id to entity_id to avoid iterating through all
             //  entities here
             for (controlled_by, position) in position_query.iter_mut() {
-                if controlled_by.targets(client_id) {
+                if controlled_by.targets(&client_id) {
                     shared::shared_movement_behaviour(position, input);
                 }
             }

--- a/examples/simple_box/src/server.rs
+++ b/examples/simple_box/src/server.rs
@@ -105,7 +105,7 @@ fn movement(
     tick_manager: Res<TickManager>,
 ) {
     for input in input_reader.read() {
-        let client_id = input.context();
+        let client_id = input.from();
         if let Some(input) = input.input() {
             trace!(
                 "Receiving input: {:?} from client: {:?} on tick: {:?}",
@@ -114,7 +114,7 @@ fn movement(
                 tick_manager.tick()
             );
 
-            if let Some(player) = entity_map.0.get(client_id) {
+            if let Some(player) = entity_map.0.get(&client_id) {
                 if let Ok(position) = position_query.get_mut(*player) {
                     shared::shared_movement_behaviour(position, input);
                 }

--- a/examples/spaceships/src/server.rs
+++ b/examples/spaceships/src/server.rs
@@ -100,7 +100,7 @@ pub(crate) fn replicate_inputs(
     mut input_events: ResMut<Events<MessageEvent<InputMessage<PlayerActions>>>>,
 ) {
     for mut event in input_events.drain() {
-        let client_id = *event.context();
+        let client_id = event.from();
 
         // Optional: do some validation on the inputs to check that there's no cheating
         // Inputs for a specific tick should be write *once*. Don't let players change old inputs.

--- a/lightyear/src/client/connection.rs
+++ b/lightyear/src/client/connection.rs
@@ -83,7 +83,6 @@ pub struct ConnectionManager {
     #[cfg(feature = "leafwing")]
     pub(crate) received_leafwing_input_messages: HashMap<NetId, Vec<Bytes>>,
     /// Used to transfer raw bytes to a system that can convert the bytes to the actual type
-    pub(crate) received_events: HashMap<NetId, Vec<Bytes>>,
     pub(crate) received_messages: HashMap<NetId, Vec<Bytes>>,
     pub(crate) writer: Writer,
 
@@ -121,7 +120,6 @@ impl Default for ConnectionManager {
             events: ConnectionEvents::default(),
             #[cfg(feature = "leafwing")]
             received_leafwing_input_messages: HashMap::default(),
-            received_events: HashMap::default(),
             received_messages: HashMap::default(),
             writer: Writer::with_capacity(0),
             messages_to_send: Vec::default(),
@@ -175,7 +173,6 @@ impl ConnectionManager {
             events: ConnectionEvents::default(),
             #[cfg(feature = "leafwing")]
             received_leafwing_input_messages: HashMap::default(),
-            received_events: HashMap::default(),
             received_messages: HashMap::default(),
             writer: Writer::with_capacity(MAX_PACKET_SIZE),
             messages_to_send: Vec::default(),

--- a/lightyear/src/client/connection.rs
+++ b/lightyear/src/client/connection.rs
@@ -436,14 +436,8 @@ impl ConnectionManager {
                             MessageType::NativeInput => {
                                 todo!()
                             }
-                            MessageType::Normal => {
+                            MessageType::Normal | MessageType::Event => {
                                 self.received_messages
-                                    .entry(net_id)
-                                    .or_default()
-                                    .push(single_data);
-                            }
-                            MessageType::Event => {
-                                self.received_events
                                     .entry(net_id)
                                     .or_default()
                                     .push(single_data);
@@ -483,14 +477,8 @@ impl ConnectionManager {
             MessageType::NativeInput => {
                 todo!()
             }
-            MessageType::Normal => {
+            MessageType::Normal | MessageType::Event => {
                 self.received_messages
-                    .entry(net_id)
-                    .or_default()
-                    .push(single_data);
-            }
-            MessageType::Event => {
-                self.received_events
                     .entry(net_id)
                     .or_default()
                     .push(single_data);

--- a/lightyear/src/client/events.rs
+++ b/lightyear/src/client/events.rs
@@ -14,18 +14,13 @@
 //! ```
 
 use crate::client::connection::ConnectionManager;
-use crate::client::run_conditions::is_connected;
 use crate::connection::client::DisconnectReason;
-use crate::prelude::{ClientId, Message, MessageRegistry};
-use crate::protocol::event::EventReplicationMode;
-use crate::protocol::message::{MessageKind, MessageType};
-use crate::serialize::reader::Reader;
+use crate::prelude::ClientId;
 use crate::shared::events::plugin::EventsPlugin;
 use crate::shared::events::systems::push_component_events;
 use crate::shared::sets::{ClientMarker, InternalMainSet};
 use bevy::app::{App, Plugin, PreUpdate};
-use bevy::prelude::{Commands, Component, Event, EventWriter, IntoSystemConfigs, Res, ResMut};
-use tracing::error;
+use bevy::prelude::{Component, Event, IntoSystemConfigs};
 
 /// Plugin that handles generating bevy [`Events`](Event) related to networking and replication
 #[derive(Default)]
@@ -40,67 +35,6 @@ impl Plugin for ClientEventsPlugin {
             // PLUGIN
             .add_plugins(EventsPlugin::<ConnectionManager>::default());
     }
-}
-
-/// Read the message received from the server and emit the MessageEvent event
-fn read_event<E: Event + Message>(
-    mut commands: Commands,
-    message_registry: Res<MessageRegistry>,
-    mut connection: ResMut<ConnectionManager>,
-    // mut message_event: EventWriter<MessageEvent<E>>,
-    mut event_writer: EventWriter<E>,
-) {
-    let kind = MessageKind::of::<E>();
-    let Some(net) = message_registry.kind_map.net_id(&kind).copied() else {
-        error!(
-            "Could not find the network id for the message kind: {:?}",
-            kind
-        );
-        return;
-    };
-    assert_eq!(
-        message_registry.message_type(net),
-        MessageType::Event,
-        "The message must be registered as an event in the protocol by calling `is_event()`"
-    );
-    if let Some(message_list) = connection.received_events.remove(&net) {
-        for message in message_list {
-            let mut reader = Reader::from(message);
-            // we have to re-decode the net id
-            let Ok((message, replication_mode)) = message_registry.deserialize_event::<E>(
-                &mut reader,
-                &mut connection
-                    .replication_receiver
-                    .remote_entity_map
-                    .remote_to_local,
-            ) else {
-                error!("Could not deserialize message");
-                continue;
-            };
-            match replication_mode {
-                // EventReplicationMode::None => {
-                //     message_event.send(MessageEvent::new(message, ()));
-                // }
-                EventReplicationMode::Buffer => {
-                    event_writer.send(message);
-                }
-                EventReplicationMode::Trigger => {
-                    commands.trigger(message);
-                }
-            }
-        }
-    }
-}
-
-/// Register a message that can be sent from server to client
-pub(crate) fn add_client_receive_event_from_server<E: Event + Message>(app: &mut App) {
-    app.add_event::<E>();
-    app.add_systems(
-        PreUpdate,
-        read_event::<E>
-            .in_set(InternalMainSet::<ClientMarker>::EmitEvents)
-            .run_if(is_connected),
-    );
 }
 
 pub(crate) fn emit_replication_events<C: Component>(app: &mut App) {
@@ -149,7 +83,7 @@ pub type ComponentInsertEvent<C> = crate::shared::events::components::ComponentI
 /// Bevy [`Event`] emitted on the client when a ComponentRemove replication message is received
 pub type ComponentRemoveEvent<C> = crate::shared::events::components::ComponentRemoveEvent<C, ()>;
 /// Bevy [`Event`] emitted on the client when a (non-replication) message is received
-pub type MessageEvent<M> = crate::shared::events::components::MessageEvent<M, ()>;
+pub type MessageEvent<M> = crate::shared::events::components::MessageEvent<M>;
 
 #[cfg(test)]
 mod tests {

--- a/lightyear/src/client/plugin.rs
+++ b/lightyear/src/client/plugin.rs
@@ -14,6 +14,7 @@ use bevy::prelude::*;
 use crate::client::diagnostics::ClientDiagnosticsPlugin;
 use crate::client::events::ClientEventsPlugin;
 use crate::client::interpolation::plugin::InterpolationPlugin;
+use crate::client::message::ClientMessagePlugin;
 use crate::client::networking::ClientNetworkingPlugin;
 use crate::client::prediction::plugin::PredictionPlugin;
 use crate::client::replication::{
@@ -56,6 +57,7 @@ impl PluginGroup for ClientPlugins {
             .add(SetupPlugin {
                 config: self.config,
             })
+            .add(ClientMessagePlugin)
             .add(ClientEventsPlugin)
             .add(ClientNetworkingPlugin)
             .add(ClientDiagnosticsPlugin::default())

--- a/lightyear/src/lib.rs
+++ b/lightyear/src/lib.rs
@@ -102,7 +102,7 @@ fn receive_message(mut message_reader: EventReader<MessageEvent<MyMessage>>) {
        // the message itself
        let message = message_event.message();
        // the client who sent the message
-       let client = message_event.context;
+       let client = message_event.from;
     }
 }
 ```
@@ -198,6 +198,7 @@ pub mod prelude {
     pub use crate::packet::message::Message;
     pub use crate::protocol::channel::{AppChannelExt, ChannelKind, ChannelRegistry};
     pub use crate::protocol::component::{AppComponentExt, ComponentRegistry, Linear};
+    pub use crate::protocol::event::AppEventExt;
     pub use crate::protocol::message::{AppMessageExt, MessageRegistry};
     pub use crate::protocol::serialize::AppSerializeExt;
     pub use crate::shared::config::{Mode, SharedConfig};

--- a/lightyear/src/protocol/event.rs
+++ b/lightyear/src/protocol/event.rs
@@ -1,6 +1,21 @@
+use crate::client::config::ClientConfig;
+use crate::prelude::server::ServerConfig;
+use crate::prelude::{ChannelDirection, ClientId, Message, MessageRegistry};
+use crate::protocol::message::{
+    MessageError, MessageKind, MessageMetadata, MessageRegistration, MessageType, ReceiveMessageFn,
+};
+use crate::protocol::registry::NetId;
+use crate::protocol::SerializeFns;
 use crate::serialize::reader::Reader;
+use crate::serialize::writer::Writer;
 use crate::serialize::{SerializationError, ToBytes};
+use crate::shared::replication::entity_map::{ReceiveEntityMap, SendEntityMap};
+use bevy::app::App;
+use bevy::prelude::{Event, Events, World};
 use byteorder::{ReadBytesExt, WriteBytesExt};
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use tracing::debug;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub(crate) enum EventReplicationMode {
@@ -42,5 +57,223 @@ impl ToBytes for EventReplicationMode {
             2 => Ok(EventReplicationMode::Trigger),
             _ => Err(SerializationError::InvalidValue),
         }
+    }
+}
+
+pub(crate) fn register_event_receive<E: Event + Message>(
+    app: &mut App,
+    direction: ChannelDirection,
+) {
+    let is_client = app.world().get_resource::<ClientConfig>().is_some();
+    let is_server = app.world().get_resource::<ServerConfig>().is_some();
+    let register_fn = |app: &mut App| {
+        app.add_event::<E>();
+        app.world_mut()
+            .resource_mut::<MessageRegistry>()
+            .add_receive_event_metadata::<E>();
+    };
+    match direction {
+        ChannelDirection::ClientToServer => {
+            if is_server {
+                register_fn(app);
+            }
+        }
+        ChannelDirection::ServerToClient => {
+            if is_client {
+                register_fn(app);
+            }
+        }
+        ChannelDirection::Bidirectional => {
+            register_event_receive::<E>(app, ChannelDirection::ClientToServer);
+            register_event_receive::<E>(app, ChannelDirection::ServerToClient);
+        }
+    }
+}
+
+impl MessageRegistry {
+    pub(crate) fn add_receive_event_metadata<E: Event>(&mut self) {
+        let message_kind = MessageKind::of::<E>();
+        let send_message_fn: ReceiveMessageFn = Self::receive_event_internal::<E>;
+        self.message_receive_map.insert(
+            message_kind,
+            MessageMetadata {
+                message_type: MessageType::Event,
+                receive_message_fn: send_message_fn,
+            },
+        );
+    }
+    pub(crate) fn serialize_event<E: Event + Message>(
+        &self,
+        event: &E,
+        event_replication_mode: EventReplicationMode,
+        writer: &mut Writer,
+        entity_map: Option<&mut SendEntityMap>,
+    ) -> Result<(), MessageError> {
+        let kind = MessageKind::of::<E>();
+        let erased_fns = self
+            .serialize_fns_map
+            .get(&kind)
+            .ok_or(MessageError::MissingSerializationFns)?;
+        let net_id = self.kind_map.net_id(&kind).unwrap();
+        net_id.to_bytes(writer)?;
+        event_replication_mode.to_bytes(writer)?;
+        // SAFETY: the ErasedSerializeFns was created for the type M
+        unsafe {
+            erased_fns.serialize(event, writer, entity_map)?;
+        }
+        Ok(())
+    }
+
+    pub(crate) fn deserialize_event<E: Event + Message>(
+        &self,
+        reader: &mut Reader,
+        entity_map: &mut ReceiveEntityMap,
+    ) -> Result<(E, EventReplicationMode), MessageError> {
+        let net_id = NetId::from_bytes(reader)?;
+        let event_replication_mode = EventReplicationMode::from_bytes(reader)?;
+        let kind = self
+            .kind_map
+            .kind(net_id)
+            .ok_or(MessageError::NotRegistered)?;
+        let erased_fns = self
+            .serialize_fns_map
+            .get(kind)
+            .ok_or(MessageError::MissingSerializationFns)?;
+        // SAFETY: the ErasedSerializeFns was created for the type M
+        let event = unsafe { erased_fns.deserialize(reader, entity_map) }?;
+        Ok((event, event_replication_mode))
+    }
+    pub(crate) fn add_event_receive_metadata<E: Message + Event>(
+        &mut self,
+        message_type: MessageType,
+    ) {
+        let message_kind = MessageKind::of::<E>();
+        let send_message_fn: ReceiveMessageFn = Self::receive_event_internal::<E>;
+        self.message_receive_map.insert(
+            message_kind,
+            MessageMetadata {
+                message_type,
+                receive_message_fn: send_message_fn,
+            },
+        );
+    }
+
+    fn receive_event_internal<E: Message + Event>(
+        &self,
+        world: &mut World,
+        from: ClientId,
+        reader: &mut Reader,
+        entity_map: &mut ReceiveEntityMap,
+    ) -> Result<(), MessageError> {
+        dbg!("receive_event_internal", std::any::type_name::<E>());
+        let kind = MessageKind::of::<E>();
+        let receive_metadata = self
+            .message_receive_map
+            .get(&kind)
+            .ok_or(MessageError::NotRegistered)?;
+        match receive_metadata.message_type {
+            MessageType::Event => {
+                // we deserialize the message and send an event or trigger the event
+                let (event, mode) = self.deserialize_event::<E>(reader, entity_map)?;
+                match mode {
+                    EventReplicationMode::Buffer => {
+                        let mut events = world.resource_mut::<Events<E>>();
+                        events.send(event);
+                    }
+                    EventReplicationMode::Trigger => {
+                        world.trigger(event);
+                    }
+                }
+            }
+            _ => unreachable!(),
+        }
+        Ok(())
+    }
+}
+
+pub(crate) trait AppEventInternalExt {
+    /// Function used internally to register an Event
+    fn register_event_internal<E: Event + Message + Serialize + DeserializeOwned>(
+        &mut self,
+        direction: ChannelDirection,
+    ) -> MessageRegistration<'_, E>;
+
+    /// Function used internally to register an event
+    /// with a custom [`SerializeFns`] implementation
+    fn register_event_internal_custom_serde<E: Event + Message>(
+        &mut self,
+        direction: ChannelDirection,
+        serialize_fns: SerializeFns<E>,
+    ) -> MessageRegistration<'_, E>;
+}
+
+impl AppEventInternalExt for App {
+    fn register_event_internal<E: Event + Message + Serialize + DeserializeOwned>(
+        &mut self,
+        direction: ChannelDirection,
+    ) -> MessageRegistration<'_, E> {
+        let mut registry = self.world_mut().resource_mut::<MessageRegistry>();
+        if !registry.is_registered::<E>() {
+            registry.add_message::<E>();
+        }
+        debug!("register event {}", std::any::type_name::<E>());
+        register_event_receive::<E>(self, direction);
+        MessageRegistration {
+            app: self,
+            _marker: std::marker::PhantomData,
+        }
+    }
+
+    fn register_event_internal_custom_serde<E: Event + Message>(
+        &mut self,
+        direction: ChannelDirection,
+        serialize_fns: SerializeFns<E>,
+    ) -> MessageRegistration<'_, E> {
+        let mut registry = self.world_mut().resource_mut::<MessageRegistry>();
+        if !registry.is_registered::<E>() {
+            registry.add_message_custom_serde::<E>(serialize_fns);
+        }
+        debug!("register message {}", std::any::type_name::<E>());
+        register_event_receive::<E>(self, direction);
+        MessageRegistration {
+            app: self,
+            _marker: std::marker::PhantomData,
+        }
+    }
+}
+
+pub trait AppEventExt {
+    /// Registers the event in the Registry
+    /// This event can now be sent over the network.
+    fn register_event<E: Event + Message + Serialize + DeserializeOwned>(
+        &mut self,
+        direction: ChannelDirection,
+    ) -> MessageRegistration<'_, E>;
+
+    /// Registers the event in the Registry
+    ///
+    /// This event can now be sent over the network.
+    /// You need to provide your own [`SerializeFns`] for this message
+    fn register_event_custom_serde<E: Event + Message>(
+        &mut self,
+        direction: ChannelDirection,
+        serialize_fns: SerializeFns<E>,
+    ) -> MessageRegistration<'_, E>;
+}
+
+impl AppEventExt for App {
+    fn register_event<E: Event + Message + Serialize + DeserializeOwned>(
+        &mut self,
+        direction: ChannelDirection,
+    ) -> MessageRegistration<'_, E> {
+        self.register_event_internal(direction)
+    }
+
+    fn register_event_custom_serde<E: Event + Message>(
+        &mut self,
+        direction: ChannelDirection,
+        serialize_fns: SerializeFns<E>,
+    ) -> MessageRegistration<'_, E> {
+        self.register_event_internal_custom_serde(direction, serialize_fns)
     }
 }

--- a/lightyear/src/protocol/message.rs
+++ b/lightyear/src/protocol/message.rs
@@ -1,32 +1,31 @@
-use bevy::ecs::entity::MapEntities;
-use std::any::TypeId;
-use std::fmt::Debug;
-
 use crate::client::config::ClientConfig;
-use crate::client::events::add_client_receive_event_from_server;
-use crate::client::message::add_client_receive_message_from_server;
+use crate::inputs::native::InputMessage;
 use crate::packet::message::Message;
 use crate::prelude::server::ServerConfig;
-use crate::prelude::ChannelDirection;
-use crate::prelude::{client, server};
-use crate::protocol::event::EventReplicationMode;
+use crate::prelude::{client, server, ClientId};
+use crate::prelude::{ChannelDirection, UserAction};
 use crate::protocol::registry::{NetId, TypeKind, TypeMapper};
 use crate::protocol::serialize::{ErasedSerializeFns, SerializeFns};
 use crate::serialize::reader::Reader;
 use crate::serialize::writer::Writer;
 use crate::serialize::ToBytes;
-use crate::server::events::add_server_receive_event_from_client;
-use crate::server::message::add_server_receive_message_from_client;
+use crate::server::input::native::InputBuffers;
+use crate::shared::events::components::MessageEvent;
 use crate::shared::replication::entity_map::{ReceiveEntityMap, SendEntityMap};
 use crate::shared::replication::resources::DespawnResource;
-use bevy::prelude::{App, Event, Resource, TypePath};
+use bevy::ecs::entity::MapEntities;
+use bevy::prelude::{App, Events, Resource, TypePath, World};
 use bevy::utils::HashMap;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
-use tracing::{debug, error};
+use std::any::TypeId;
+use std::fmt::Debug;
+use tracing::{debug, error, trace};
 
 #[derive(thiserror::Error, Debug)]
 pub enum MessageError {
+    #[error("the message if of the wrong type")]
+    IncorrectType,
     #[error("message is not registered in the protocol")]
     NotRegistered,
     #[error("missing serialization functions for message")]
@@ -101,49 +100,53 @@ pub(crate) enum MessageType {
 /// ```
 #[derive(Debug, Default, Clone, Resource, PartialEq, TypePath)]
 pub struct MessageRegistry {
-    typed_map: HashMap<MessageKind, MessageType>,
-    serialize_fns_map: HashMap<MessageKind, ErasedSerializeFns>,
+    /// metadata needed to receive a message
+    pub(crate) message_receive_map: HashMap<MessageKind, MessageMetadata>,
+    pub(crate) serialize_fns_map: HashMap<MessageKind, ErasedSerializeFns>,
     pub(crate) kind_map: TypeMapper<MessageKind>,
 }
 
-fn register_message_receive<M: Message>(app: &mut App, direction: ChannelDirection) {
-    let is_client = app.world().get_resource::<ClientConfig>().is_some();
-    let is_server = app.world().get_resource::<ServerConfig>().is_some();
-    match direction {
-        ChannelDirection::ClientToServer => {
-            if is_server {
-                add_server_receive_message_from_client::<M>(app);
-            }
-        }
-        ChannelDirection::ServerToClient => {
-            if is_client {
-                add_client_receive_message_from_server::<M>(app);
-            }
-        }
-        ChannelDirection::Bidirectional => {
-            register_message_receive::<M>(app, ChannelDirection::ClientToServer);
-            register_message_receive::<M>(app, ChannelDirection::ServerToClient);
-        }
-    }
+pub(crate) type ReceiveMessageFn = fn(
+    &MessageRegistry,
+    &mut World,
+    ClientId,
+    &mut Reader,
+    &mut ReceiveEntityMap,
+) -> Result<(), MessageError>;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct MessageMetadata {
+    pub(crate) message_type: MessageType,
+    pub(crate) receive_message_fn: ReceiveMessageFn,
 }
 
-fn register_event_receive<E: Event + Message>(app: &mut App, direction: ChannelDirection) {
+fn register_message_receive<M: Message>(
+    app: &mut App,
+    direction: ChannelDirection,
+    message_type: MessageType,
+) {
     let is_client = app.world().get_resource::<ClientConfig>().is_some();
     let is_server = app.world().get_resource::<ServerConfig>().is_some();
+    let register_fn = |app: &mut App| {
+        app.add_event::<MessageEvent<M>>();
+        app.world_mut()
+            .resource_mut::<MessageRegistry>()
+            .add_receive_message_metadata::<M>(message_type);
+    };
     match direction {
         ChannelDirection::ClientToServer => {
             if is_server {
-                add_server_receive_event_from_client::<E>(app);
+                register_fn(app);
             }
         }
         ChannelDirection::ServerToClient => {
             if is_client {
-                add_client_receive_event_from_server::<E>(app);
+                register_fn(app);
             }
         }
         ChannelDirection::Bidirectional => {
-            register_event_receive::<E>(app, ChannelDirection::ClientToServer);
-            register_event_receive::<E>(app, ChannelDirection::ServerToClient);
+            register_message_receive::<M>(app, ChannelDirection::ClientToServer, message_type);
+            register_message_receive::<M>(app, ChannelDirection::ServerToClient, message_type);
         }
     }
 }
@@ -208,8 +211,8 @@ fn register_resource_send<R: Resource + Message>(app: &mut App, direction: Chann
 }
 
 pub struct MessageRegistration<'a, M> {
-    app: &'a mut App,
-    _marker: std::marker::PhantomData<M>,
+    pub(crate) app: &'a mut App,
+    pub(crate) _marker: std::marker::PhantomData<M>,
 }
 
 impl<M> MessageRegistration<'_, M> {
@@ -241,20 +244,6 @@ pub(crate) trait AppMessageInternalExt {
         message_type: MessageType,
         serialize_fns: SerializeFns<M>,
     ) -> MessageRegistration<'_, M>;
-
-    /// Function used internally to register an Event
-    fn register_event_internal<E: Event + Message + Serialize + DeserializeOwned>(
-        &mut self,
-        direction: ChannelDirection,
-    ) -> MessageRegistration<'_, E>;
-
-    /// Function used internally to register an event
-    /// with a custom [`SerializeFns`] implementation
-    fn register_event_internal_custom_serde<E: Event + Message>(
-        &mut self,
-        direction: ChannelDirection,
-        serialize_fns: SerializeFns<E>,
-    ) -> MessageRegistration<'_, E>;
 }
 
 impl AppMessageInternalExt for App {
@@ -265,10 +254,10 @@ impl AppMessageInternalExt for App {
     ) -> MessageRegistration<'_, M> {
         let mut registry = self.world_mut().resource_mut::<MessageRegistry>();
         if !registry.is_registered::<M>() {
-            registry.add_message::<M>(message_type);
+            registry.add_message::<M>();
         }
         debug!("register message {}", std::any::type_name::<M>());
-        register_message_receive::<M>(self, direction);
+        register_message_receive::<M>(self, direction, message_type);
         MessageRegistration {
             app: self,
             _marker: std::marker::PhantomData,
@@ -283,43 +272,10 @@ impl AppMessageInternalExt for App {
     ) -> MessageRegistration<'_, M> {
         let mut registry = self.world_mut().resource_mut::<MessageRegistry>();
         if !registry.is_registered::<M>() {
-            registry.add_message_custom_serde::<M>(message_type, serialize_fns);
+            registry.add_message_custom_serde::<M>(serialize_fns);
         }
         debug!("register message {}", std::any::type_name::<M>());
-        register_message_receive::<M>(self, direction);
-        MessageRegistration {
-            app: self,
-            _marker: std::marker::PhantomData,
-        }
-    }
-
-    fn register_event_internal<E: Event + Message + Serialize + DeserializeOwned>(
-        &mut self,
-        direction: ChannelDirection,
-    ) -> MessageRegistration<'_, E> {
-        let mut registry = self.world_mut().resource_mut::<MessageRegistry>();
-        if !registry.is_registered::<E>() {
-            registry.add_message::<E>(MessageType::Event);
-        }
-        debug!("register message {}", std::any::type_name::<E>());
-        register_event_receive::<E>(self, direction);
-        MessageRegistration {
-            app: self,
-            _marker: std::marker::PhantomData,
-        }
-    }
-
-    fn register_event_internal_custom_serde<E: Event + Message>(
-        &mut self,
-        direction: ChannelDirection,
-        serialize_fns: SerializeFns<E>,
-    ) -> MessageRegistration<'_, E> {
-        let mut registry = self.world_mut().resource_mut::<MessageRegistry>();
-        if !registry.is_registered::<E>() {
-            registry.add_message_custom_serde::<E>(MessageType::Event, serialize_fns);
-        }
-        debug!("register message {}", std::any::type_name::<E>());
-        register_event_receive::<E>(self, direction);
+        register_message_receive::<M>(self, direction, message_type);
         MessageRegistration {
             app: self,
             _marker: std::marker::PhantomData,
@@ -345,23 +301,6 @@ pub trait AppMessageExt {
         direction: ChannelDirection,
         serialize_fns: SerializeFns<M>,
     ) -> MessageRegistration<'_, M>;
-
-    /// Registers the event in the Registry
-    /// This event can now be sent over the network.
-    fn register_event<E: Event + Message + Serialize + DeserializeOwned>(
-        &mut self,
-        direction: ChannelDirection,
-    ) -> MessageRegistration<'_, E>;
-
-    /// Registers the event in the Registry
-    ///
-    /// This event can now be sent over the network.
-    /// You need to provide your own [`SerializeFns`] for this message
-    fn register_event_custom_serde<E: Event + Message>(
-        &mut self,
-        direction: ChannelDirection,
-        serialize_fns: SerializeFns<E>,
-    ) -> MessageRegistration<'_, E>;
 
     /// Registers the resource in the Registry
     /// This resource can now be sent over the network.
@@ -397,21 +336,6 @@ impl AppMessageExt for App {
         self.register_message_internal_custom_serde(direction, MessageType::Normal, serialize_fns)
     }
 
-    fn register_event<E: Event + Message + Serialize + DeserializeOwned>(
-        &mut self,
-        direction: ChannelDirection,
-    ) -> MessageRegistration<'_, E> {
-        self.register_event_internal(direction)
-    }
-
-    fn register_event_custom_serde<E: Event + Message>(
-        &mut self,
-        direction: ChannelDirection,
-        serialize_fns: SerializeFns<E>,
-    ) -> MessageRegistration<'_, E> {
-        self.register_event_internal_custom_serde(direction, serialize_fns)
-    }
-
     /// Register a resource to be automatically replicated over the network
     fn register_resource<R: Resource + Message + Serialize + DeserializeOwned>(
         &mut self,
@@ -439,36 +363,87 @@ impl MessageRegistry {
         // TODO this unwrap takes down server if client sends invalid netid.
         //      perhaps return a result from this and handle?
         let kind = self.kind_map.kind(net_id).unwrap();
-        self.typed_map
+        self.message_receive_map
             .get(kind)
-            .map_or(MessageType::Normal, |message_type| *message_type)
+            .map_or(MessageType::Normal, |metadata| metadata.message_type)
     }
 
     pub fn is_registered<M: 'static>(&self) -> bool {
         self.kind_map.net_id(&MessageKind::of::<M>()).is_some()
     }
 
-    pub(crate) fn add_message<M: Message + Serialize + DeserializeOwned>(
-        &mut self,
-        message_type: MessageType,
-    ) {
+    pub(crate) fn add_message<M: Message + Serialize + DeserializeOwned>(&mut self) {
         let message_kind = self.kind_map.add::<M>();
         self.serialize_fns_map
             .insert(message_kind, ErasedSerializeFns::new::<M>());
-        self.typed_map.insert(message_kind, message_type);
     }
 
-    pub(crate) fn add_message_custom_serde<M: Message>(
-        &mut self,
-        message_type: MessageType,
-        serialize_fns: SerializeFns<M>,
-    ) {
+    pub(crate) fn add_receive_message_metadata<M: Message>(&mut self, message_type: MessageType) {
+        let message_kind = MessageKind::of::<M>();
+        let send_message_fn: ReceiveMessageFn = Self::receive_message_internal::<M>;
+        self.message_receive_map.insert(
+            message_kind,
+            MessageMetadata {
+                message_type,
+                receive_message_fn: send_message_fn,
+            },
+        );
+    }
+
+    /// Receive a message from the remote
+    /// The message could be:
+    /// - a Normal message, in which case we buffer a MessageEvent
+    /// - a Event message, in which case we buffer the event directly, or we trigger it
+    pub(crate) fn receive_message(
+        &self,
+        net_id: NetId,
+        world: &mut World,
+        from: ClientId,
+        reader: &mut Reader,
+        entity_map: &mut ReceiveEntityMap,
+    ) -> Result<(), MessageError> {
+        let kind = self
+            .kind_map
+            .kind(net_id)
+            .ok_or(MessageError::NotRegistered)?;
+        let metadata = self
+            .message_receive_map
+            .get(kind)
+            .ok_or(MessageError::NotRegistered)?;
+        (metadata.receive_message_fn)(self, world, from, reader, entity_map)
+    }
+
+    /// Internal function of type ReceiveMessageFn (used for type-erasure)
+    fn receive_message_internal<M: Message>(
+        &self,
+        world: &mut World,
+        from: ClientId,
+        reader: &mut Reader,
+        entity_map: &mut ReceiveEntityMap,
+    ) -> Result<(), MessageError> {
+        let kind = MessageKind::of::<M>();
+        let receive_metadata = self
+            .message_receive_map
+            .get(&kind)
+            .ok_or(MessageError::NotRegistered)?;
+        match receive_metadata.message_type {
+            MessageType::Normal => {
+                // we deserialize the message and send a MessageEvent
+                let mut events = world.resource_mut::<Events<MessageEvent<M>>>();
+                let message = self.deserialize::<M>(reader, entity_map)?;
+                events.send(MessageEvent::new(message, from));
+            }
+            _ => unreachable!(),
+        }
+        Ok(())
+    }
+
+    pub(crate) fn add_message_custom_serde<M: Message>(&mut self, serialize_fns: SerializeFns<M>) {
         let message_kind = self.kind_map.add::<M>();
         self.serialize_fns_map.insert(
             message_kind,
             ErasedSerializeFns::new_custom_serde::<M>(serialize_fns),
         );
-        self.typed_map.insert(message_kind, message_type);
     }
 
     pub(crate) fn try_add_map_entities<M: Clone + MapEntities + 'static>(&mut self) {
@@ -495,48 +470,6 @@ impl MessageRegistry {
             .get(&kind)
             .expect("the message is not part of the protocol");
         erased_fns.map_entities.is_some()
-    }
-
-    pub(crate) fn serialize_event<E: Event + Message>(
-        &self,
-        event: &E,
-        event_replication_mode: EventReplicationMode,
-        writer: &mut Writer,
-        entity_map: Option<&mut SendEntityMap>,
-    ) -> Result<(), MessageError> {
-        let kind = MessageKind::of::<E>();
-        let erased_fns = self
-            .serialize_fns_map
-            .get(&kind)
-            .ok_or(MessageError::MissingSerializationFns)?;
-        let net_id = self.kind_map.net_id(&kind).unwrap();
-        net_id.to_bytes(writer)?;
-        event_replication_mode.to_bytes(writer)?;
-        // SAFETY: the ErasedSerializeFns was created for the type M
-        unsafe {
-            erased_fns.serialize(event, writer, entity_map)?;
-        }
-        Ok(())
-    }
-
-    pub(crate) fn deserialize_event<E: Event + Message>(
-        &self,
-        reader: &mut Reader,
-        entity_map: &mut ReceiveEntityMap,
-    ) -> Result<(E, EventReplicationMode), MessageError> {
-        let net_id = NetId::from_bytes(reader)?;
-        let event_replication_mode = EventReplicationMode::from_bytes(reader)?;
-        let kind = self
-            .kind_map
-            .kind(net_id)
-            .ok_or(MessageError::NotRegistered)?;
-        let erased_fns = self
-            .serialize_fns_map
-            .get(kind)
-            .ok_or(MessageError::MissingSerializationFns)?;
-        // SAFETY: the ErasedSerializeFns was created for the type M
-        let event = unsafe { erased_fns.deserialize(reader, entity_map) }?;
-        Ok((event, event_replication_mode))
     }
 
     pub(crate) fn serialize<M: Message>(
@@ -578,6 +511,41 @@ impl MessageRegistry {
     }
 }
 
+mod inputs {
+    use super::*;
+
+    impl MessageRegistry {
+        fn receive_native_input_internal<A: UserAction>(
+            &self,
+            world: &mut World,
+            from: ClientId,
+            reader: &mut Reader,
+            entity_map: &mut ReceiveEntityMap,
+        ) -> Result<(), MessageError> {
+            let kind = MessageKind::of::<InputMessage<A>>();
+            let receive_metadata = self
+                .message_receive_map
+                .get(&kind)
+                .ok_or(MessageError::NotRegistered)?;
+            if receive_metadata.message_type != MessageType::NativeInput {
+                error!("Incorrect message type for InputMessage<A>, should be NativeInput");
+                return Err(MessageError::IncorrectType);
+            }
+            if let Some(mut input_buffers) = world.get_resource_mut::<InputBuffers<A>>() {
+                let message = self.deserialize::<InputMessage<A>>(reader, entity_map)?;
+                trace!("Received input message: {:?}", message);
+                input_buffers
+                    .buffers
+                    .entry(from)
+                    .or_default()
+                    .1
+                    .update_from_message(message);
+            }
+            Ok(())
+        }
+    }
+}
+
 /// [`MessageKind`] is an internal wrapper around the type of the message
 #[derive(Debug, Eq, Hash, Copy, Clone, PartialEq)]
 pub struct MessageKind(TypeId);
@@ -607,7 +575,7 @@ mod tests {
     #[test]
     fn test_serde() {
         let mut registry = MessageRegistry::default();
-        registry.add_message::<Resource1>(MessageType::Normal);
+        registry.add_message::<Resource1>();
 
         let message = Resource1(1.0);
         let mut writer = Writer::default();
@@ -624,7 +592,7 @@ mod tests {
     #[test]
     fn test_serde_map() {
         let mut registry = MessageRegistry::default();
-        registry.add_message::<ComponentMapEntities>(MessageType::Normal);
+        registry.add_message::<ComponentMapEntities>();
         registry.add_map_entities::<ComponentMapEntities>();
 
         let message = ComponentMapEntities(Entity::from_raw(0));
@@ -646,14 +614,11 @@ mod tests {
     #[test]
     fn test_custom_serde() {
         let mut registry = MessageRegistry::default();
-        registry.add_message_custom_serde::<Resource2>(
-            MessageType::Normal,
-            SerializeFns {
-                serialize: serialize_resource2,
-                deserialize: deserialize_resource2,
-                serialize_map_entities: None,
-            },
-        );
+        registry.add_message_custom_serde::<Resource2>(SerializeFns {
+            serialize: serialize_resource2,
+            deserialize: deserialize_resource2,
+            serialize_map_entities: None,
+        });
 
         let message = Resource2(1.0);
         let mut writer = Writer::default();

--- a/lightyear/src/protocol/message.rs
+++ b/lightyear/src/protocol/message.rs
@@ -39,11 +39,11 @@ pub(crate) enum MessageType {
     /// This is a message for a [`LeafwingUserAction`](crate::inputs::leafwing::LeafwingUserAction)
     #[cfg(feature = "leafwing")]
     LeafwingInput,
-    /// This is a message for a [`UserAction`](crate::inputs::native::UserAction)
+    /// This is a message for a [`UserAction`]
     NativeInput,
     /// This is not an input message, but a regular [`Message`]
     Normal,
-    /// This message is an [`Event`], which can get triggered or buffered in an EventWriter on the remote world
+    /// This message is an [`Event`](bevy::prelude::Event), which can get triggered or buffered in an EventWriter on the remote world
     Event,
 }
 

--- a/lightyear/src/server/connection.rs
+++ b/lightyear/src/server/connection.rs
@@ -515,7 +515,6 @@ pub struct Connection {
 
     // TODO: maybe don't do any replication until connection is synced?
     /// Used to transfer raw bytes to a system that can convert the bytes to the actual type
-    pub(crate) received_events: HashMap<NetId, Vec<(Bytes, NetworkTarget, ChannelKind)>>,
     pub(crate) received_messages: HashMap<NetId, Vec<(Bytes, NetworkTarget, ChannelKind)>>,
     pub(crate) received_input_messages: HashMap<NetId, Vec<(Bytes, NetworkTarget, ChannelKind)>>,
     #[cfg(feature = "leafwing")]
@@ -573,7 +572,6 @@ impl Connection {
             replication_receiver,
             ping_manager: PingManager::new(ping_config),
             events: ConnectionEvents::default(),
-            received_events: HashMap::default(),
             received_messages: HashMap::default(),
             received_input_messages: HashMap::default(),
             #[cfg(feature = "leafwing")]

--- a/lightyear/src/server/connection.rs
+++ b/lightyear/src/server/connection.rs
@@ -792,11 +792,8 @@ impl Connection {
                                     .or_default()
                                     .push(data);
                             }
-                            MessageType::Normal => {
+                            MessageType::Normal | MessageType::Event => {
                                 self.received_messages.entry(net_id).or_default().push(data);
-                            }
-                            MessageType::Event => {
-                                self.received_events.entry(net_id).or_default().push(data);
                             }
                         }
                     }
@@ -852,11 +849,8 @@ impl Connection {
                     .or_default()
                     .push(data);
             }
-            MessageType::Normal => {
+            MessageType::Normal | MessageType::Event => {
                 self.received_messages.entry(net_id).or_default().push(data);
-            }
-            MessageType::Event => {
-                self.received_events.entry(net_id).or_default().push(data);
             }
         }
         Ok(())

--- a/lightyear/src/server/events.rs
+++ b/lightyear/src/server/events.rs
@@ -3,14 +3,9 @@
 use bevy::ecs::entity::EntityHash;
 use bevy::prelude::*;
 use bevy::utils::{hashbrown, HashMap};
-use std::ops::DerefMut;
 
 use crate::connection::id::ClientId;
-use crate::prelude::server::is_started;
-use crate::prelude::{ComponentRegistry, Message, MessageRegistry, NetworkTarget};
-use crate::protocol::event::EventReplicationMode;
-use crate::protocol::message::{MessageKind, MessageType};
-use crate::serialize::reader::Reader;
+use crate::prelude::ComponentRegistry;
 use crate::server::connection::ConnectionManager;
 use crate::shared::events::connection::{
     ConnectionEvents, IterComponentInsertEvent, IterComponentRemoveEvent, IterComponentUpdateEvent,
@@ -41,86 +36,6 @@ impl Plugin for ServerEventsPlugin {
                 emit_connect_events.in_set(InternalMainSet::<ServerMarker>::EmitEvents),
             );
     }
-}
-
-/// Read the events received from the clients and emits the MessageEvent event
-fn read_event<E: Event + Message>(
-    mut commands: Commands,
-    message_registry: Res<MessageRegistry>,
-    mut connection_manager: ResMut<ConnectionManager>,
-    // mut message_event: EventWriter<MessageEvent<E>>,
-    mut event_writer: EventWriter<E>,
-) {
-    let kind = MessageKind::of::<E>();
-    let Some(net) = message_registry.kind_map.net_id(&kind).copied() else {
-        error!(
-            "Could not find the network id for the message kind: {:?}",
-            kind
-        );
-        return;
-    };
-    assert_eq!(
-        message_registry.message_type(net),
-        MessageType::Event,
-        "The message must be registered as an event in the protocol by calling `is_event()`"
-    );
-    // re-borrow to allow split borrows
-    let connection_manager = connection_manager.deref_mut();
-    for (client_id, connection) in connection_manager.connections.iter_mut() {
-        if let Some(event_list) = connection.received_events.remove(&net) {
-            for (event_bytes, target, channel_kind) in event_list {
-                let mut reader = Reader::from(event_bytes);
-                match message_registry.deserialize_event::<E>(
-                    &mut reader,
-                    &mut connection
-                        .replication_receiver
-                        .remote_entity_map
-                        .remote_to_local,
-                ) {
-                    Ok((message, event_replication_mode)) => {
-                        // rebroadcast
-                        if target != NetworkTarget::None {
-                            connection.messages_to_rebroadcast.push((
-                                reader.consume(),
-                                target,
-                                channel_kind,
-                            ));
-                        }
-                        trace!("Received message: {:?}", std::any::type_name::<E>());
-                        match event_replication_mode {
-                            // EventReplicationMode::None => {
-                            //     message_event.send(MessageEvent::new(message, *client_id));
-                            // }
-                            EventReplicationMode::Buffer => {
-                                event_writer.send(message);
-                            }
-                            EventReplicationMode::Trigger => {
-                                commands.trigger(message);
-                            }
-                        }
-                    }
-                    Err(e) => {
-                        error!(
-                            "Could not deserialize message {}: {:?}",
-                            std::any::type_name::<E>(),
-                            e
-                        );
-                    }
-                }
-            }
-        }
-    }
-}
-
-/// Register an event that can be sent from client to server
-pub(crate) fn add_server_receive_event_from_client<E: Event + Message>(app: &mut App) {
-    app.add_event::<E>();
-    app.add_systems(
-        PreUpdate,
-        read_event::<E>
-            .in_set(InternalMainSet::<ServerMarker>::EmitEvents)
-            .run_if(is_started),
-    );
 }
 
 /// Emit events related to connections and disconnections
@@ -366,12 +281,12 @@ pub type ComponentRemoveEvent<C> =
     crate::shared::events::components::ComponentRemoveEvent<C, ClientId>;
 
 /// Bevy [`Event`] emitted on the server on the frame where a (non-replication) message is received
-pub type MessageEvent<M> = crate::shared::events::components::MessageEvent<M, ClientId>;
+pub type MessageEvent<M> = crate::shared::events::components::MessageEvent<M>;
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::prelude::Tick;
+    use crate::prelude::{NetworkTarget, Tick};
     use crate::protocol::channel::ChannelKind;
     use crate::shared::events::EventSend;
     use crate::tests::host_server_stepper::HostServerStepper;

--- a/lightyear/src/server/input/native.rs
+++ b/lightyear/src/server/input/native.rs
@@ -21,7 +21,7 @@ pub struct InputPlugin<A: UserAction> {
 pub struct InputBuffers<A> {
     /// The first element stores the last input we have received from the client.
     /// In case we are missing the client input for a tick, we will fallback to using this.
-    buffers: HashMap<ClientId, (Option<A>, InputBuffer<A>)>,
+    pub(crate) buffers: HashMap<ClientId, (Option<A>, InputBuffer<A>)>,
 }
 
 impl<A> Default for InputBuffers<A> {

--- a/lightyear/src/server/message.rs
+++ b/lightyear/src/server/message.rs
@@ -1,11 +1,11 @@
-use crate::prelude::server::is_started;
+use crate::prelude::server::is_stopped;
 use crate::protocol::message::MessageRegistry;
 use crate::serialize::reader::Reader;
 use crate::server::connection::ConnectionManager;
 use crate::shared::replication::network_target::NetworkTarget;
 use crate::shared::sets::{InternalMainSet, ServerMarker};
 use bevy::app::{App, Plugin, PreUpdate};
-use bevy::prelude::{Commands, IntoSystemConfigs, Mut, ResMut, World};
+use bevy::prelude::{not, Commands, IntoSystemConfigs, Mut, ResMut, World};
 use tracing::{error, trace};
 
 /// Plugin that adds functionality related to receiving messages from clients
@@ -18,7 +18,7 @@ impl Plugin for ServerMessagePlugin {
             PreUpdate,
             read_messages
                 .in_set(InternalMainSet::<ServerMarker>::EmitEvents)
-                .run_if(is_started),
+                .run_if(not(is_stopped)),
         );
     }
 }

--- a/lightyear/src/server/message.rs
+++ b/lightyear/src/server/message.rs
@@ -1,77 +1,84 @@
-use std::ops::DerefMut;
-
-use crate::prelude::{server::is_started, Message};
-use crate::protocol::message::{MessageKind, MessageRegistry};
+use crate::prelude::server::is_started;
+use crate::protocol::message::MessageRegistry;
 use crate::serialize::reader::Reader;
 use crate::server::connection::ConnectionManager;
-use crate::server::events::MessageEvent;
 use crate::shared::replication::network_target::NetworkTarget;
 use crate::shared::sets::{InternalMainSet, ServerMarker};
-use bevy::app::{App, PreUpdate};
-use bevy::prelude::{EventWriter, IntoSystemConfigs, Res, ResMut};
+use bevy::app::{App, Plugin, PreUpdate};
+use bevy::prelude::{Commands, IntoSystemConfigs, Mut, ResMut, World};
 use tracing::{error, trace};
 
-/// Read the messages received from the clients and emit the MessageEvent event
-fn read_message<M: Message>(
-    message_registry: Res<MessageRegistry>,
-    mut connection_manager: ResMut<ConnectionManager>,
-    mut event: EventWriter<MessageEvent<M>>,
-) {
-    let kind = MessageKind::of::<M>();
-    let Some(net) = message_registry.kind_map.net_id(&kind).copied() else {
-        error!(
-            "Could not find the network id for the message kind: {:?}",
-            kind
+/// Plugin that adds functionality related to receiving messages from clients
+#[derive(Default)]
+pub struct ServerMessagePlugin;
+
+impl Plugin for ServerMessagePlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(
+            PreUpdate,
+            read_messages
+                .in_set(InternalMainSet::<ServerMarker>::EmitEvents)
+                .run_if(is_started),
         );
-        return;
-    };
-    // re-borrow to allow split borrows
-    let connection_manager = connection_manager.deref_mut();
-    for (client_id, connection) in connection_manager.connections.iter_mut() {
-        if let Some(message_list) = connection.received_messages.remove(&net) {
-            for (message_bytes, target, channel_kind) in message_list {
-                let mut reader = Reader::from(message_bytes);
-                match message_registry.deserialize::<M>(
-                    &mut reader,
-                    &mut connection
-                        .replication_receiver
-                        .remote_entity_map
-                        .remote_to_local,
-                ) {
-                    Ok(message) => {
-                        // rebroadcast
-                        if target != NetworkTarget::None {
-                            connection.messages_to_rebroadcast.push((
-                                reader.consume(),
-                                target,
-                                channel_kind,
-                            ));
-                        }
-                        event.send(MessageEvent::new(message, *client_id));
-                        trace!("Received message: {:?}", std::any::type_name::<M>());
-                    }
-                    Err(e) => {
-                        error!(
-                            "Could not deserialize message {}: {:?}",
-                            std::any::type_name::<M>(),
-                            e
-                        );
-                    }
-                }
-            }
-        }
     }
 }
 
-/// Register a message that can be sent from client to server
-pub(crate) fn add_server_receive_message_from_client<M: Message>(app: &mut App) {
-    app.add_event::<MessageEvent<M>>();
-    app.add_systems(
-        PreUpdate,
-        read_message::<M>
-            .in_set(InternalMainSet::<ServerMarker>::EmitEvents)
-            .run_if(is_started),
-    );
+/// Read the messages received from the clients and emit the MessageEvent events
+/// Also rebroadcast the messages if needed
+fn read_messages(mut commands: Commands, mut connection_manager: ResMut<ConnectionManager>) {
+    // re-borrow to allow split borrows
+    for (client_id, connection) in connection_manager.connections.iter_mut() {
+        connection
+            .received_messages
+            .iter_mut()
+            .for_each(|(net_id, message_list)| {
+                message_list
+                    .drain(..)
+                    .for_each(|(message_bytes, target, channel_kind)| {
+                        let mut reader = Reader::from(message_bytes);
+                        // make copies to avoid `connection_manager` to be moved inside the closure
+                        let net_id = *net_id;
+                        let client_id = *client_id;
+                        commands.queue(move |world: &mut World| {
+                            // NOTE: removing the resources is a bit risky... however we use the world
+                            // only to get the Events<MessageEvent<M>> so it should be ok
+                            world.resource_scope(|world, registry: Mut<MessageRegistry>| {
+                                world.resource_scope(
+                                    |world, mut manager: Mut<ConnectionManager>| {
+                                            let connection =
+                                                manager.connection_mut(client_id).unwrap();
+                                            match registry.receive_message(
+                                                net_id,
+                                                world,
+                                                client_id,
+                                                &mut reader,
+                                                &mut connection
+                                                    .replication_receiver
+                                                    .remote_entity_map
+                                                    .remote_to_local,
+                                            ) {
+                                                Ok(_) => {
+                                                    // rebroadcast
+                                                    if target != NetworkTarget::None {
+                                                        connection.messages_to_rebroadcast.push((
+                                                            reader.consume(),
+                                                            target,
+                                                            channel_kind,
+                                                        ));
+                                                    }
+                                                    trace!("Received message! NetId: {net_id:?}");
+                                                }
+                                                Err(e) => {
+                                                    error!("Could not deserialize message (NetId: {net_id:?}): {e:?}");
+                                                }
+                                            }
+                                    },
+                                )
+                            });
+                        })
+                    })
+            });
+    }
 }
 
 // impl ServerMessage {

--- a/lightyear/src/server/plugin.rs
+++ b/lightyear/src/server/plugin.rs
@@ -13,6 +13,7 @@ use bevy::app::PluginGroupBuilder;
 use bevy::prelude::*;
 
 use crate::server::events::ServerEventsPlugin;
+use crate::server::message::ServerMessagePlugin;
 use crate::server::networking::ServerNetworkingPlugin;
 use crate::server::relevance::immediate::NetworkRelevancePlugin;
 use crate::server::relevance::room::RoomPlugin;
@@ -59,6 +60,7 @@ impl PluginGroup for ServerPlugins {
             .add(SetupPlugin {
                 config: self.config,
             })
+            .add(ServerMessagePlugin)
             .add(ServerEventsPlugin)
             .add(ServerNetworkingPlugin)
             .add(NetworkRelevancePlugin)

--- a/lightyear/src/shared/events/components.rs
+++ b/lightyear/src/shared/events/components.rs
@@ -5,25 +5,29 @@ use std::marker::PhantomData;
 use bevy::prelude::{Component, Entity, Event};
 
 use crate::packet::message::Message;
+use crate::prelude::ClientId;
 
 /// This event is emitted whenever we receive a message from the remote
 #[derive(Event, Debug)]
-pub struct MessageEvent<M: Message, Ctx = ()> {
+pub struct MessageEvent<M: Message> {
     pub message: M,
-    pub context: Ctx,
+    // TODO: this is not ideal. Should we have PeerId that is either ClientId or Server?
+    /// The client that sent the message.
+    /// If the server sent the message, we will just put ClientId::Local(0) here
+    pub from: ClientId,
 }
 
-impl<M: Message, Ctx> MessageEvent<M, Ctx> {
-    pub fn new(message: M, context: Ctx) -> Self {
-        Self { message, context }
+impl<M: Message> MessageEvent<M> {
+    pub fn new(message: M, from: ClientId) -> Self {
+        Self { message, from }
     }
 
     pub fn message(&self) -> &M {
         &self.message
     }
 
-    pub fn context(&self) -> &Ctx {
-        &self.context
+    pub fn from(&self) -> ClientId {
+        self.from
     }
 }
 

--- a/lightyear/src/shared/events/mod.rs
+++ b/lightyear/src/shared/events/mod.rs
@@ -21,7 +21,7 @@ pub trait EventSend: private::InternalEventSend {
         self.erased_send_event_to_target(event, ChannelKind::of::<C>(), target)
     }
 
-    /// Replicate the `event` to the `target` via channel [`C`] and then trigger the event
+    /// Replicate the `event` to the `target` via channel `C` and then trigger the event
     /// in the remote World
     fn trigger_event_to_target<C: Channel, E: Event + Message>(
         &mut self,

--- a/lightyear/src/shared/input/leafwing.rs
+++ b/lightyear/src/shared/input/leafwing.rs
@@ -27,6 +27,8 @@ impl<A: LeafwingUserAction> Plugin for LeafwingInputPlugin<A> {
 
     // we build this in `finish` to be sure that the MessageRegistry, ClientConfig, ServerConfig exists
     fn finish(&self, app: &mut App) {
+        // TODO: this creates a receive_message fn for InputMessage that is never use as we have
+        //  custom handling of LeafwingInputMessage
         // leafwing messages have special handling so we register them as LeafwingInput
         // we still use `add_message_internal` because we want to emit events contain the message
         // so the user can inspect them and re-broadcast them to other players

--- a/lightyear/src/shared/input/native.rs
+++ b/lightyear/src/shared/input/native.rs
@@ -4,7 +4,8 @@ use bevy::app::{App, Plugin};
 
 use crate::client::config::ClientConfig;
 use crate::inputs::native::InputMessage;
-use crate::prelude::{MessageRegistry, UserAction};
+use crate::prelude::{ChannelDirection, UserAction};
+use crate::protocol::message::{AppMessageInternalExt, MessageType};
 use crate::server::config::ServerConfig;
 
 pub struct InputPlugin<A: UserAction> {
@@ -22,11 +23,14 @@ impl<A: UserAction> Default for InputPlugin<A> {
 impl<A: UserAction> Plugin for InputPlugin<A> {
     fn build(&self, app: &mut App) {}
 
+    // build this in finish() to make sure that the ClientConfig and ServerConfig exist
     fn finish(&self, app: &mut App) {
-        app.world_mut()
-            .resource_mut::<MessageRegistry>()
-            .add_message::<InputMessage<A>>();
-        // TODO: add MessageType!
+        // TODO: this adds a receive_message fn that is never used! Because we have custom handling
+        //  of native input message in ConnectionManager.receive()
+        app.register_message_internal::<InputMessage<A>>(
+            ChannelDirection::ClientToServer,
+            MessageType::NativeInput,
+        );
         let is_client = app.world().get_resource::<ClientConfig>().is_some();
         let is_server = app.world().get_resource::<ServerConfig>().is_some();
         if is_client {

--- a/lightyear/src/shared/input/native.rs
+++ b/lightyear/src/shared/input/native.rs
@@ -5,7 +5,6 @@ use bevy::app::{App, Plugin};
 use crate::client::config::ClientConfig;
 use crate::inputs::native::InputMessage;
 use crate::prelude::{MessageRegistry, UserAction};
-use crate::protocol::message::MessageType;
 use crate::server::config::ServerConfig;
 
 pub struct InputPlugin<A: UserAction> {
@@ -26,7 +25,8 @@ impl<A: UserAction> Plugin for InputPlugin<A> {
     fn finish(&self, app: &mut App) {
         app.world_mut()
             .resource_mut::<MessageRegistry>()
-            .add_message::<InputMessage<A>>(MessageType::NativeInput);
+            .add_message::<InputMessage<A>>();
+        // TODO: add MessageType!
         let is_client = app.world().get_resource::<ClientConfig>().is_some();
         let is_server = app.world().get_resource::<ServerConfig>().is_some();
         if is_client {

--- a/lightyear/src/shared/replication/resources.rs
+++ b/lightyear/src/shared/replication/resources.rs
@@ -181,7 +181,6 @@ pub(crate) mod send {
 
 pub(crate) mod receive {
 
-    use crate::protocol::EventContext;
     use crate::shared::events::components::MessageEvent;
     use crate::shared::message::MessageSend;
 
@@ -228,22 +227,22 @@ pub(crate) mod receive {
         if is_bidirectional {
             app.add_systems(
                 PreUpdate,
-                handle_resource_message_bidirectional::<R, S::EventContext>
+                handle_resource_message_bidirectional::<R>
                     .in_set(InternalReplicationSet::<S::SetMarker>::ReceiveResourceUpdates),
             );
         } else {
             app.add_systems(
                 PreUpdate,
-                handle_resource_message::<R, S::EventContext>
+                handle_resource_message::<R>
                     .in_set(InternalReplicationSet::<S::SetMarker>::ReceiveResourceUpdates),
             );
         }
     }
 
-    fn handle_resource_message<R: Resource + Message, Ctx: EventContext>(
+    fn handle_resource_message<R: Resource + Message>(
         mut commands: Commands,
-        mut update_message: ResMut<Events<MessageEvent<R, Ctx>>>,
-        mut remove_message: EventReader<MessageEvent<DespawnResource<R>, Ctx>>,
+        mut update_message: ResMut<Events<MessageEvent<R>>>,
+        mut remove_message: EventReader<MessageEvent<DespawnResource<R>>>,
         mut resource: Option<ResMut<R>>,
     ) {
         for message in update_message.drain() {
@@ -262,10 +261,10 @@ pub(crate) mod receive {
         }
     }
 
-    fn handle_resource_message_bidirectional<R: Resource + Message, Ctx: EventContext>(
+    fn handle_resource_message_bidirectional<R: Resource + Message>(
         mut commands: Commands,
-        mut update_message: ResMut<Events<MessageEvent<R, Ctx>>>,
-        mut remove_message: EventReader<MessageEvent<DespawnResource<R>, Ctx>>,
+        mut update_message: ResMut<Events<MessageEvent<R>>>,
+        mut remove_message: EventReader<MessageEvent<DespawnResource<R>>>,
         mut resource: Option<ResMut<R>>,
     ) {
         for message in update_message.drain() {


### PR DESCRIPTION
Two main benefits:
- we only have one `read_messages` system instead of one system per message-type. There is an overhead in having many systems running (see https://github.com/bevyengine/bevy/pull/12936)
- the read_events/read_messages logic is unified

Fixes https://github.com/cBournhonesque/lightyear/issues/536