### PR TITLE
fix: register prespawned entity in predicted_entity_map during server…

### DIFF
--- a/lightyear/src/client/prediction/prespawn.rs
+++ b/lightyear/src/client/prediction/prespawn.rs
@@ -212,6 +212,13 @@ impl PreSpawnedPlayerObjectPlugin {
                         .id()
                 };
 
+            // update the predicted entity mapping
+            manager
+                .predicted_entity_map
+                .get_mut()
+                .confirmed_to_predicted
+                .insert(confirmed_entity, predicted_entity);
+
             // 2. assign Confirmed to the server entity's counterpart, and remove PreSpawnedPlayerObject
             // get the confirmed tick for the entity
             // if we don't have it, something has gone very wrong


### PR DESCRIPTION
Currently when a server pre spawned entity is matched with a client one, PreSpawnedPlayerObject is removed and Predicted is added but it does not get added to the predicted_entity_map.

This is an issue because the Predicted entity is not despawned when the confirmed one is despawned (by despawn_confirmed) 

https://github.com/cBournhonesque/lightyear/blob/774e948dcadc2564ea07540b5ea73ed8cbd81368/lightyear/src/client/prediction/despawn.rs#L90 