### PR TITLE
Use ComponentHooks to maintain the prediction/confirmed map in sync

### DIFF
--- a/lightyear/src/client/interpolation/despawn.rs
+++ b/lightyear/src/client/interpolation/despawn.rs
@@ -1,9 +1,8 @@
-use bevy::prelude::{Commands, DespawnRecursiveExt, OnRemove, Query, ResMut, Trigger};
+use bevy::prelude::{Commands, DespawnRecursiveExt, OnRemove, Query, Trigger};
 
 use crate::client::components::{Confirmed, SyncComponent};
 use crate::client::interpolation::interpolate::InterpolateStatus;
 use crate::client::interpolation::interpolation_history::ConfirmedHistory;
-use crate::client::interpolation::resource::InterpolationManager;
 
 /// Remove the component from interpolated entities when it gets removed from confirmed
 pub(crate) fn removed_components<C: SyncComponent>(
@@ -26,15 +25,10 @@ pub(crate) fn removed_components<C: SyncComponent>(
 //  not super priority but would be a nice to have
 pub(crate) fn despawn_interpolated(
     trigger: Trigger<OnRemove, Confirmed>,
-    mut manager: ResMut<InterpolationManager>,
+    query: Query<&Confirmed>,
     mut commands: Commands,
 ) {
-    if let Some(interpolated) = manager
-        .interpolated_entity_map
-        .get_mut()
-        .confirmed_to_interpolated
-        .remove(&trigger.entity())
-    {
+    if let Some(interpolated) = query.get(trigger.entity()).unwrap().interpolated {
         if let Some(entity_mut) = commands.get_entity(interpolated) {
             entity_mut.despawn_recursive();
         }

--- a/lightyear/src/client/interpolation/mod.rs
+++ b/lightyear/src/client/interpolation/mod.rs
@@ -1,7 +1,8 @@
 //! Handles interpolation of entities between server updates
-use std::ops::{Add, Mul};
-
+use bevy::ecs::component::StorageType;
+use bevy::ecs::world::DeferredWorld;
 use bevy::prelude::{Component, Entity, Reflect, ReflectComponent};
+use std::ops::{Add, Mul};
 
 pub use interpolate::InterpolateStatus;
 pub use interpolation_history::ConfirmedHistory;
@@ -9,6 +10,7 @@ pub use plugin::{add_interpolation_systems, add_prepare_interpolation_systems};
 pub use visual_interpolation::{VisualInterpolateStatus, VisualInterpolationPlugin};
 
 use crate::client::components::LerpFn;
+use crate::client::interpolation::resource::InterpolationManager;
 
 mod despawn;
 pub mod interpolate;
@@ -31,7 +33,7 @@ where
 }
 
 /// Marker component for an entity that is being interpolated by the client
-#[derive(Component, Debug, Reflect)]
+#[derive(Debug, Reflect)]
 #[reflect(Component)]
 pub struct Interpolated {
     // TODO: maybe here add an interpolation function?
@@ -40,4 +42,44 @@ pub struct Interpolated {
     //  - despawn immediately all components
     //  - leave the entity alive until the confirmed entity catches up to it and then it gets removed.
     //    - or do this only for certain components (audio, animation, particles..) -> mode on PredictedComponent
+}
+
+impl Component for Interpolated {
+    const STORAGE_TYPE: StorageType = StorageType::Table;
+
+    fn register_component_hooks(hooks: &mut bevy::ecs::component::ComponentHooks) {
+        hooks.on_add(
+            |mut deferred_world: DeferredWorld, interpolated: Entity, _component_id| {
+                let confirmed = deferred_world
+                    .get::<Interpolated>(interpolated)
+                    .unwrap()
+                    .confirmed_entity;
+
+                if let Some(mut manager) = deferred_world.get_resource_mut::<InterpolationManager>()
+                {
+                    manager
+                        .interpolated_entity_map
+                        .get_mut()
+                        .confirmed_to_interpolated
+                        .insert(confirmed, interpolated);
+                };
+            },
+        );
+        hooks.on_remove(
+            |mut deferred_world: DeferredWorld, interpolated: Entity, _component_id| {
+                let confirmed = deferred_world
+                    .get::<Interpolated>(interpolated)
+                    .unwrap()
+                    .confirmed_entity;
+                if let Some(mut manager) = deferred_world.get_resource_mut::<InterpolationManager>()
+                {
+                    manager
+                        .interpolated_entity_map
+                        .get_mut()
+                        .confirmed_to_interpolated
+                        .insert(confirmed, interpolated);
+                };
+            },
+        );
+    }
 }

--- a/lightyear/src/client/interpolation/spawn.rs
+++ b/lightyear/src/client/interpolation/spawn.rs
@@ -1,10 +1,9 @@
-use bevy::prelude::{Added, Commands, Entity, Query, Res, ResMut};
+use bevy::prelude::{Added, Commands, Entity, Query, Res};
 use tracing::trace;
 
 use crate::client::components::Confirmed;
 use crate::client::config::ClientConfig;
 use crate::client::connection::ConnectionManager;
-use crate::client::interpolation::resource::InterpolationManager;
 use crate::client::interpolation::Interpolated;
 use crate::prelude::TickManager;
 use crate::shared::replication::components::ShouldBeInterpolated;
@@ -14,7 +13,6 @@ pub(crate) fn spawn_interpolated_entity(
     tick_manager: Res<TickManager>,
     config: Res<ClientConfig>,
     connection: Res<ConnectionManager>,
-    mut manager: ResMut<InterpolationManager>,
     mut commands: Commands,
     mut confirmed_entities: Query<(Entity, Option<&mut Confirmed>), Added<ShouldBeInterpolated>>,
 ) {
@@ -24,13 +22,6 @@ pub(crate) fn spawn_interpolated_entity(
             continue;
         }
         let interpolated = commands.spawn(Interpolated { confirmed_entity }).id();
-
-        // update the entity mapping
-        manager
-            .interpolated_entity_map
-            .get_mut()
-            .confirmed_to_interpolated
-            .insert(confirmed_entity, interpolated);
 
         // add Confirmed to the confirmed entity
         // safety: we know the entity exists

--- a/lightyear/src/client/prediction/mod.rs
+++ b/lightyear/src/client/prediction/mod.rs
@@ -1,4 +1,7 @@
 //! Handles client-side prediction
+use crate::client::prediction::resource::PredictionManager;
+use bevy::ecs::component::StorageType;
+use bevy::ecs::world::DeferredWorld;
 use bevy::prelude::{Component, Entity, Reflect, ReflectComponent};
 use std::fmt::Debug;
 
@@ -15,10 +18,55 @@ pub mod rollback;
 pub mod spawn;
 
 /// Marks an entity that is being predicted by the client
-#[derive(Component, Debug, Reflect)]
+#[derive(Debug, Reflect)]
 #[reflect(Component)]
 pub struct Predicted {
     // This is an option because we could spawn pre-predicted entities on the client that exist before we receive
     // the corresponding confirmed entity
     pub confirmed_entity: Option<Entity>,
+}
+
+impl Component for Predicted {
+    const STORAGE_TYPE: StorageType = StorageType::Table;
+
+    fn register_component_hooks(hooks: &mut bevy::ecs::component::ComponentHooks) {
+        hooks.on_add(
+            |mut deferred_world: DeferredWorld, predicted: Entity, _component_id| {
+                if let Some(confirmed) = deferred_world
+                    .get::<Predicted>(predicted)
+                    .unwrap()
+                    .confirmed_entity
+                {
+                    if let Some(mut manager) =
+                        deferred_world.get_resource_mut::<PredictionManager>()
+                    {
+                        manager
+                            .predicted_entity_map
+                            .get_mut()
+                            .confirmed_to_predicted
+                            .insert(confirmed, predicted);
+                    };
+                }
+            },
+        );
+        hooks.on_remove(
+            |mut deferred_world: DeferredWorld, predicted: Entity, _component_id| {
+                if let Some(confirmed) = deferred_world
+                    .get::<Predicted>(predicted)
+                    .unwrap()
+                    .confirmed_entity
+                {
+                    if let Some(mut manager) =
+                        deferred_world.get_resource_mut::<PredictionManager>()
+                    {
+                        manager
+                            .predicted_entity_map
+                            .get_mut()
+                            .confirmed_to_predicted
+                            .insert(confirmed, predicted);
+                    };
+                }
+            },
+        );
+    }
 }

--- a/lightyear/src/client/prediction/prespawn.rs
+++ b/lightyear/src/client/prediction/prespawn.rs
@@ -212,6 +212,13 @@ impl PreSpawnedPlayerObjectPlugin {
                         .id()
                 };
 
+            // update the predicted entity mapping
+            manager
+                .predicted_entity_map
+                .get_mut()
+                .confirmed_to_predicted
+                .insert(confirmed_entity, predicted_entity);
+
             // 2. assign Confirmed to the server entity's counterpart, and remove PreSpawnedPlayerObject
             // get the confirmed tick for the entity
             // if we don't have it, something has gone very wrong

--- a/lightyear/src/client/prediction/prespawn.rs
+++ b/lightyear/src/client/prediction/prespawn.rs
@@ -1,4 +1,5 @@
 //! Handles spawning entities that are predicted
+
 use bevy::ecs::component::{Components, StorageType};
 use bevy::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -212,13 +213,6 @@ impl PreSpawnedPlayerObjectPlugin {
                         .id()
                 };
 
-            // update the predicted entity mapping
-            manager
-                .predicted_entity_map
-                .get_mut()
-                .confirmed_to_predicted
-                .insert(confirmed_entity, predicted_entity);
-
             // 2. assign Confirmed to the server entity's counterpart, and remove PreSpawnedPlayerObject
             // get the confirmed tick for the entity
             // if we don't have it, something has gone very wrong
@@ -380,7 +374,7 @@ impl Component for PreSpawnedPlayerObject {
                 prespawned_obj.user_salt,
             );
             // update component with the computed hash
-            trace!(
+            debug!(
                 ?entity,
                 ?tick,
                 hash = ?hash,
@@ -486,7 +480,7 @@ mod tests {
     use crate::client::prediction::resource::PredictionManager;
     use bevy::prelude::{default, Entity, With};
 
-    use crate::prelude::client::Confirmed;
+    use crate::prelude::client::{Confirmed, Predicted};
     use crate::prelude::server::{Replicate, SyncTarget};
     use crate::prelude::*;
     use crate::tests::protocol::*;
@@ -554,13 +548,94 @@ mod tests {
     }
 
     /// Client and server run the same system to prespawn an entity
-    /// The pre-spawn somehow fails on the client.
-    /// The server should spawn the entity, it gets spawned to the client.
-    /// The client spawns a Predicted version of the entity.
+    /// Server's should take over authority over the entity
+    ///
+    #[test]
+    fn test_prespawn_success() {
+        // tracing_subscriber::FmtSubscriber::builder()
+        //     .with_max_level(tracing::Level::DEBUG)
+        //     .init();
+        let mut stepper = BevyStepper::default();
+
+        let client_prespawn = stepper
+            .client_app
+            .world_mut()
+            .spawn(PreSpawnedPlayerObject::new(1))
+            .id();
+        let server_prespawn = stepper
+            .server_app
+            .world_mut()
+            .spawn((
+                PreSpawnedPlayerObject::new(1),
+                Replicate {
+                    sync: SyncTarget {
+                        prediction: NetworkTarget::All,
+                        ..default()
+                    },
+                    ..default()
+                },
+            ))
+            .id();
+        stepper.frame_step();
+        stepper.frame_step();
+
+        // thanks to pre-spawning, a Confirmed entity has been spawned on the client
+        // that Confirmed entity is replicate from server_prespawn
+        // and has client_prespawn as predicted entity
+        let predicted = stepper
+            .client_app
+            .world()
+            .get::<Predicted>(client_prespawn)
+            .unwrap();
+        let confirmed = predicted.confirmed_entity.unwrap();
+        assert_eq!(
+            stepper
+                .client_app
+                .world()
+                .get::<Confirmed>(confirmed)
+                .unwrap()
+                .predicted
+                .unwrap(),
+            client_prespawn
+        );
+        assert_eq!(
+            stepper
+                .client_app
+                .world()
+                .resource::<ClientConnectionManager>()
+                .replication_receiver
+                .remote_entity_map
+                .get_local(server_prespawn)
+                .unwrap(),
+            confirmed
+        );
+        // The PreSpawnPlayerObject component has been removed on the client
+        assert!(stepper
+            .client_app
+            .world()
+            .get::<PreSpawnedPlayerObject>(client_prespawn)
+            .is_none());
+
+        // if the Confirmed entity is depsawned, the Predicted entity should also be despawned
+        stepper.client_app.world_mut().despawn(confirmed);
+        stepper.frame_step();
+        assert!(stepper
+            .client_app
+            .world()
+            .get_entity(client_prespawn)
+            .is_err());
+    }
+
+    /// Client and server run the same system to prespawn an entity
+    /// The pre-spawn somehow fails on the client (no matching hash)
+    /// The server entity should just get normally Predicted on the client
+    ///
+    /// If the Confirmed entity is despawned, the Predicted entity should be despawned
     #[test]
     fn test_prespawn_client_missing() {
         let mut stepper = BevyStepper::default();
 
+        // spawn extra entities to check that EntityMapping works correctly with pre-spawning
         let server_entity = stepper
             .server_app
             .world_mut()
@@ -640,5 +715,14 @@ mod tests {
                 .0,
             client_predicted
         );
+
+        // If we despawn the confirmed entity, the predicted entity should also be despawned
+        stepper.client_app.world_mut().despawn(client_confirmed_2);
+        stepper.frame_step();
+        assert!(stepper
+            .client_app
+            .world()
+            .get_entity(client_predicted_2)
+            .is_err());
     }
 }

--- a/lightyear/src/client/prediction/spawn.rs
+++ b/lightyear/src/client/prediction/spawn.rs
@@ -1,10 +1,9 @@
 //! Logic to handle spawning Predicted entities
-use bevy::prelude::{Added, Commands, Entity, Query, Res, ResMut};
+use bevy::prelude::{Added, Commands, Entity, Query, Res};
 use tracing::debug;
 
 use crate::client::components::Confirmed;
 use crate::client::connection::ConnectionManager;
-use crate::client::prediction::resource::PredictionManager;
 use crate::client::prediction::Predicted;
 use crate::prelude::{ShouldBePredicted, TickManager};
 
@@ -15,7 +14,6 @@ use crate::prelude::{ShouldBePredicted, TickManager};
 pub(crate) fn spawn_predicted_entity(
     tick_manager: Res<TickManager>,
     connection: Res<ConnectionManager>,
-    mut manager: ResMut<PredictionManager>,
     mut commands: Commands,
 
     // TODO: instead of listening to the ComponentInsertEvent, should we just directly query on Added<ShouldBePredicted>?
@@ -50,13 +48,6 @@ pub(crate) fn spawn_predicted_entity(
         {
             metrics::counter!("spawn_predicted_entity").increment(1);
         }
-
-        // update the predicted entity mapping
-        manager
-            .predicted_entity_map
-            .get_mut()
-            .confirmed_to_predicted
-            .insert(confirmed_entity, predicted_entity);
 
         // add Confirmed to the confirmed entity
         // safety: we know the entity exists


### PR DESCRIPTION
+ add unit test to make sure that the prediction_map is correctly updated for PreSpawnPlayerObject