### PR TITLE
update entity map to return Entity::PLACEHOLDER if the mapping fails

### DIFF
--- a/lightyear/src/shared/replication/authority.rs
+++ b/lightyear/src/shared/replication/authority.rs
@@ -45,7 +45,10 @@ pub(crate) struct AuthorityChange {
 
 impl MapEntities for AuthorityChange {
     fn map_entities<M: EntityMapper>(&mut self, entity_mapper: &mut M) {
-        self.entity = entity_mapper.map_entity(self.entity);
+        let mapped = entity_mapper.map_entity(self.entity);
+        if mapped != Entity::PLACEHOLDER {
+            self.entity = mapped;
+        }
     }
 }
 


### PR DESCRIPTION
This makes it more obvious that the mapping failed, instead of using the initial entity