### PR TITLE
Avoid entity-mapping error log on preprediction

### DIFF
--- a/lightyear/src/client/input/leafwing.rs
+++ b/lightyear/src/client/input/leafwing.rs
@@ -590,6 +590,13 @@ fn prepare_input_message<A: LeafwingUserAction>(
         //  maybe if it's pre-predicted, we send the original entity (pre-predicted), and the server will apply the conversion
         //   on their end?
         if pre_predicted.is_some() {
+            // wait until the client receives the PrePredicted entity confirmation to send inputs
+            // otherwise we get failed entity_map logs
+            // TODO: the problem is that we wait until we have received the server answer. Ideally we would like
+            //  to wait until the server has received the PrePredicted entity
+            if predicted.is_none() {
+                continue;
+            }
             trace!(
                 ?tick,
                 "sending inputs for pre-predicted entity! Local client entity: {:?}",

--- a/lightyear/src/client/prediction/pre_prediction.rs
+++ b/lightyear/src/client/prediction/pre_prediction.rs
@@ -90,7 +90,6 @@ impl PrePredictionPlugin {
                 .as_ref()
                 .unwrap()
         };
-        let confirmed = trigger.entity();
         // PrePredicted was replicated from the server:
         // When we receive an update from the server that confirms a pre-predicted entity,
         // we will add the Predicted component


### PR DESCRIPTION
EntityMapping now returns an error log when the mapping fails.
This causes issues in PrePrediction because we send LeafwingInputMessages that might arrive before the entity has been spawned on the server. Now we wait until we know the entity has been spawned server side