### PR TITLE
Add system order for avian

### DIFF
--- a/lightyear/src/utils/avian2d.rs
+++ b/lightyear/src/utils/avian2d.rs
@@ -4,8 +4,9 @@ use crate::shared::replication::delta::Diffable;
 use crate::shared::sets::{ClientMarker, InternalReplicationSet, ServerMarker};
 use avian2d::math::Scalar;
 use avian2d::prelude::*;
-use bevy::prelude::IntoSystemSetConfigs;
+use bevy::prelude::TransformSystem::TransformPropagate;
 use bevy::prelude::{App, FixedPostUpdate, Plugin};
+use bevy::prelude::{IntoSystemSetConfigs, PostUpdate};
 use tracing::trace;
 
 pub(crate) struct Avian2dPlugin;
@@ -37,6 +38,17 @@ impl Plugin for Avian2dPlugin {
                 InterpolationSet::UpdateVisualInterpolationState,
             )
                 .after(PhysicsSet::Sync),
+        );
+        // if the sync happens in PostUpdate (because the visual interpolated Position/Rotation are updated every frame in
+        // PostUpdate), and we want to sync them every frame because some entities (text, etc.) might depend on Transform
+        app.configure_sets(
+            PostUpdate,
+            (
+                InterpolationSet::VisualInterpolation,
+                PhysicsSet::Sync,
+                TransformPropagate,
+            )
+                .chain(),
         );
     }
 }

--- a/lightyear/src/utils/avian3d.rs
+++ b/lightyear/src/utils/avian3d.rs
@@ -5,7 +5,8 @@ use crate::shared::sets::{ClientMarker, InternalReplicationSet, ServerMarker};
 use avian3d::math::Scalar;
 use avian3d::prelude::*;
 use bevy::app::{App, FixedPostUpdate, Plugin};
-use bevy::prelude::IntoSystemSetConfigs;
+use bevy::prelude::TransformSystem::TransformPropagate;
+use bevy::prelude::{IntoSystemSetConfigs, PostUpdate};
 use tracing::trace;
 
 pub(crate) struct Avian3dPlugin;
@@ -36,6 +37,17 @@ impl Plugin for Avian3dPlugin {
                 InterpolationSet::UpdateVisualInterpolationState,
             )
                 .after(PhysicsSet::Sync),
+        );
+        // if the sync happens in PostUpdate (because the visual interpolated Position/Rotation are updated every frame in
+        // PostUpdate), and we want to sync them every frame because some entities (text, etc.) might depend on Transform
+        app.configure_sets(
+            PostUpdate,
+            (
+                InterpolationSet::VisualInterpolation,
+                PhysicsSet::Sync,
+                TransformPropagate,
+            )
+                .chain(),
         );
     }
 }


### PR DESCRIPTION
We disable the SyncPlugin in FixedPostUpdate and put it in PostUpdate.
That's because the VisualInterpolation plugin updates Position every frame in PostUpdate, and we want the sync from Position->Transform to happen after that, because some entities depend on the Transform (children, etc.)

Note that even with this fix, sometimes the client is very jittery. 
This suggests that some system order constraints are still missing