### PR TITLE
Update HistoryBuffers during client TickEvents

### DIFF
--- a/examples/avian_3d_character/src/renderer.rs
+++ b/examples/avian_3d_character/src/renderer.rs
@@ -1,17 +1,17 @@
-use avian3d::prelude::*;
-use bevy::prelude::*;
-use lightyear::{
-    client::prediction::diagnostics::PredictionDiagnosticsPlugin,
-    prelude::{client::*, *},
-    transport::io::IoDiagnosticsPlugin,
-};
-
 use crate::{
     protocol::{BlockMarker, CharacterMarker, ColorComponent, FloorMarker},
     shared::{
         BLOCK_HEIGHT, BLOCK_WIDTH, CHARACTER_CAPSULE_HEIGHT, CHARACTER_CAPSULE_RADIUS,
         FLOOR_HEIGHT, FLOOR_WIDTH,
     },
+};
+use avian3d::prelude::*;
+use bevy::prelude::*;
+use lightyear::prelude::server::ReplicationTarget;
+use lightyear::{
+    client::prediction::diagnostics::PredictionDiagnosticsPlugin,
+    prelude::{client::*, *},
+    transport::io::IoDiagnosticsPlugin,
 };
 
 pub struct ExampleRendererPlugin;
@@ -96,7 +96,13 @@ fn add_visual_interpolation_components<T: Component>(
 /// want to see the predicted character and not the confirmed character.
 fn add_character_cosmetics(
     mut commands: Commands,
-    character_query: Query<(Entity, &ColorComponent), (Added<Predicted>, With<CharacterMarker>)>,
+    character_query: Query<
+        (Entity, &ColorComponent),
+        (
+            Or<(Added<Predicted>, Added<ReplicationTarget>)>,
+            With<CharacterMarker>,
+        ),
+    >,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
@@ -134,7 +140,13 @@ fn add_floor_cosmetics(
 /// see the predicted block and not the confirmed block.
 fn add_block_cosmetics(
     mut commands: Commands,
-    floor_query: Query<Entity, (Added<Predicted>, With<BlockMarker>)>,
+    floor_query: Query<
+        Entity,
+        (
+            Or<(Added<Predicted>, Added<ReplicationTarget>)>,
+            With<BlockMarker>,
+        ),
+    >,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {

--- a/examples/avian_3d_character/src/settings.rs
+++ b/examples/avian_3d_character/src/settings.rs
@@ -76,6 +76,6 @@ pub(crate) fn get_settings() -> MySettings {
             },
         },
         input_delay_ticks: 0,
-        correction_ticks_factor: 1.0,
+        correction_ticks_factor: 0.0,
     }
 }

--- a/examples/avian_3d_character/src/shared.rs
+++ b/examples/avian_3d_character/src/shared.rs
@@ -137,7 +137,7 @@ pub(crate) fn after_physics_log(
     // info!(?tick, ?collisions, "collisions");
     let is_rollback = rollback.map_or(false, |r| r.is_rollback());
     for (entity, position, rotation, lv, av) in players.iter() {
-        info!(
+        debug!(
             ?is_rollback,
             ?tick,
             ?entity,

--- a/examples/avian_3d_character/src/shared.rs
+++ b/examples/avian_3d_character/src/shared.rs
@@ -7,6 +7,7 @@ use server::ControlledEntities;
 use std::hash::{Hash, Hasher};
 
 use avian3d::prelude::*;
+use bevy::prelude::TransformSystem::TransformPropagate;
 use leafwing_input_manager::prelude::ActionState;
 use lightyear::shared::replication::components::Controlled;
 use tracing::Level;
@@ -100,11 +101,50 @@ impl Plugin for SharedPlugin {
             ..default()
         });
 
-        // We change SyncPlugin to PostUpdate, because we want the visually
-        // interpreted values synced to transform every time, not just when
-        // Fixed schedule runs.
+        app.add_systems(
+            FixedPostUpdate,
+            after_physics_log.after(PhysicsSet::StepSimulation),
+        );
+
+        // // We change SyncPlugin to PostUpdate, because we want the visually
+        // // interpreted values synced to transform every time, not just when
+        // // Fixed schedule runs.
+        // app.add_plugins(PhysicsPlugins::default().build());
         app.add_plugins(PhysicsPlugins::default().build().disable::<SyncPlugin>())
             .add_plugins(SyncPlugin::new(PostUpdate));
+        app.configure_sets(PostUpdate, (PhysicsSet::Sync, TransformPropagate).chain());
+    }
+}
+
+pub(crate) fn after_physics_log(
+    tick_manager: Res<TickManager>,
+    rollback: Option<Res<Rollback>>,
+    players: Query<
+        (
+            Entity,
+            &Position,
+            &Rotation,
+            &LinearVelocity,
+            &AngularVelocity,
+        ),
+        (Without<Confirmed>, With<CharacterMarker>),
+    >,
+) {
+    let tick = rollback.as_ref().map_or(tick_manager.tick(), |r| {
+        tick_manager.tick_or_rollback_tick(r.as_ref())
+    });
+    let is_rollback = rollback.map_or(false, |r| r.is_rollback());
+    for (entity, position, rotation, lv, av) in players.iter() {
+        info!(
+            ?is_rollback,
+            ?tick,
+            ?entity,
+            ?position,
+            ?rotation,
+            ?lv,
+            ?av,
+            "Player after physics update"
+        );
     }
 }
 

--- a/examples/avian_3d_character/src/shared.rs
+++ b/examples/avian_3d_character/src/shared.rs
@@ -119,6 +119,7 @@ impl Plugin for SharedPlugin {
 pub(crate) fn after_physics_log(
     tick_manager: Res<TickManager>,
     rollback: Option<Res<Rollback>>,
+    // collisions: Option<Res<Collisions>>,
     players: Query<
         (
             Entity,
@@ -133,6 +134,7 @@ pub(crate) fn after_physics_log(
     let tick = rollback.as_ref().map_or(tick_manager.tick(), |r| {
         tick_manager.tick_or_rollback_tick(r.as_ref())
     });
+    // info!(?tick, ?collisions, "collisions");
     let is_rollback = rollback.map_or(false, |r| r.is_rollback());
     for (entity, position, rotation, lv, av) in players.iter() {
         info!(

--- a/lightyear/src/client/prediction/despawn.rs
+++ b/lightyear/src/client/prediction/despawn.rs
@@ -269,10 +269,10 @@ pub(crate) fn remove_despawn_marker(
 //         let mut history = PredictionHistory::<Component1>::default();
 //         history
 //             .buffer
-//             .add_item(Tick(0), ComponentState::Updated(Component1(0.0)));
+//             .add_item(Tick(0), HistoryState::Updated(Component1(0.0)));
 //         history
 //             .buffer
-//             .add_item(Tick(1), ComponentState::Updated(Component1(1.0)));
+//             .add_item(Tick(1), HistoryState::Updated(Component1(1.0)));
 //         assert_eq!(
 //             stepper
 //                 .client_app
@@ -315,9 +315,9 @@ pub(crate) fn remove_despawn_marker(
 //         for i in 0..5 {
 //             history
 //                 .buffer
-//                 .add_item(Tick(i), ComponentState::Updated(Component1(i as f32)));
+//                 .add_item(Tick(i), HistoryState::Updated(Component1(i as f32)));
 //         }
-//         history.buffer.add_item(Tick(5), ComponentState::Removed);
+//         history.buffer.add_item(Tick(5), HistoryState::Removed);
 //         assert_eq!(
 //             stepper
 //                 .client_app
@@ -353,7 +353,7 @@ pub(crate) fn remove_despawn_marker(
 //         for i in 3..7 {
 //             history
 //                 .buffer
-//                 .add_item(Tick(i), ComponentState::Updated(Component1(i as f32 - 2.0)));
+//                 .add_item(Tick(i), HistoryState::Updated(Component1(i as f32 - 2.0)));
 //         }
 //         assert_eq!(
 //             stepper
@@ -450,7 +450,7 @@ pub(crate) fn remove_despawn_marker(
 //         let mut history = PredictionHistory::<Component1>::default();
 //         history
 //             .buffer
-//             .add_item(Tick(1), ComponentState::Updated(Component1(1.0)));
+//             .add_item(Tick(1), HistoryState::Updated(Component1(1.0)));
 //         assert_eq!(
 //             stepper
 //                 .client_app

--- a/lightyear/src/client/prediction/history.rs
+++ b/lightyear/src/client/prediction/history.rs
@@ -1,0 +1,188 @@
+use crate::prelude::Tick;
+use bevy::prelude::{Component, Reflect, Resource};
+use bevy::prelude::{ReflectComponent, ReflectResource};
+use std::collections::VecDeque;
+
+/// Stores a past value in the history buffer
+#[derive(Debug, PartialEq, Clone, Default, Reflect)]
+pub(crate) enum HistoryState<R> {
+    // we add a Default implementation simply so that Reflection works
+    #[default]
+    /// the value just got removed
+    Removed,
+    /// the value got updated
+    Updated(R),
+}
+
+/// HistoryBuffer stores past values (usually of a Component or Resource) in a buffer, to allow for rollback
+/// The values must always remain ordered from oldest (front) to most recent (back)
+#[derive(Resource, Component, Debug, Reflect)]
+#[reflect(Component, Resource)]
+pub(crate) struct HistoryBuffer<R> {
+    // Queue containing the history of the resource.
+    // The front contains old elements, the back contains the more recent elements.
+    // We will only store the history for the ticks where the resource got updated
+    // (if the resource doesn't change, we don't store it)
+    //
+    // The ticks might become invalid in case of a TickEvent (the client tick is changed).
+    // In that case we simply handle the TickEvent and update all the ticks inside this buffer.
+    //
+    // Another option would be to store the tick difference between two updates, and only the first (most recent update)
+    // gets updated in case of a TickEvent.
+    pub(crate) buffer: VecDeque<(Tick, HistoryState<R>)>,
+}
+
+impl<R> Default for HistoryBuffer<R> {
+    fn default() -> Self {
+        Self {
+            buffer: VecDeque::new(),
+        }
+    }
+}
+
+// This is mostly present for testing, we only compare the buffer ticks, not the values
+impl<R> PartialEq for HistoryBuffer<R> {
+    fn eq(&self, other: &Self) -> bool {
+        let self_history: Vec<_> = self.buffer.iter().map(|(tick, _)| *tick).collect();
+        let other_history: Vec<_> = other.buffer.iter().map(|(tick, _)| *tick).collect();
+        self_history.eq(&other_history)
+    }
+}
+
+impl<R> HistoryBuffer<R> {
+    /// Reset the history for this resource
+    pub(crate) fn clear(&mut self) {
+        self.buffer.clear();
+    }
+
+    /// Add to the buffer that we received an update for the resource at the given tick
+    /// The tick must be more recent than the most recent update in the buffer
+    pub(crate) fn add_update(&mut self, tick: Tick, value: R) {
+        self.add(tick, Some(value));
+    }
+    /// Add to the buffer that the value got removed at the given tick
+    pub(crate) fn add_remove(&mut self, tick: Tick) {
+        self.add(tick, None);
+    }
+
+    /// Add a value to the history buffer
+    pub(crate) fn add(&mut self, tick: Tick, value: Option<R>) {
+        self.buffer.push_back((
+            tick,
+            match value {
+                Some(value) => HistoryState::Updated(value),
+                None => HistoryState::Removed,
+            },
+        ));
+    }
+
+    /// Peek at the most recent value in the history buffer
+    pub(crate) fn peek(&self) -> Option<&(Tick, HistoryState<R>)> {
+        self.buffer.back()
+    }
+
+    /// In case of a TickEvent where the client tick is changed, we need to update the ticks in the buffer
+    pub(crate) fn update_ticks(&mut self, delta: i16) {
+        self.buffer.iter_mut().for_each(|(tick, _)| {
+            *tick = *tick + delta;
+        });
+    }
+}
+
+impl<R: Clone> HistoryBuffer<R> {
+    /// Clear the history of values strictly older than the specified tick,
+    /// and return the value at the specified tick.
+    ///
+    /// CAREFUL:
+    /// the history will only contain the ticks where the value got updated, and otherwise
+    /// contains gaps. Therefore, we need to always leave a value in the history buffer so that we can
+    /// get the values for the future ticks.
+    /// (i.e. if the buffer contains values at tick 4 and 8. If we pop_until_tick(6),
+    /// we still need to include for tick 4 in the buffer, so that if we call pop_until_tick(7) we still have the correct value
+    pub(crate) fn pop_until_tick(&mut self, tick: Tick) -> Option<HistoryState<R>> {
+        // self.buffer[partition] is the first element where the buffer_tick > tick
+        let partition = self
+            .buffer
+            .partition_point(|(buffer_tick, _)| buffer_tick <= &tick);
+        // all elements are strictly more recent than the tick
+        if partition == 0 {
+            return None;
+        }
+        // remove all elements strictly older than the tick. We need to keep the element at index `partition-1`
+        // because that is the value at tick `tick`
+        self.buffer.drain(0..(partition - 1));
+        let res = self.buffer.pop_front().map(|(_, state)| state);
+        // re-add the value at tick `tick` to the buffer, to make sure that we have a value for ticks
+        // (tick + 1)..(self.buffer[partition].0)
+
+        match res.as_ref() {
+            None | Some(HistoryState::Removed) => {
+                self.buffer.push_front((tick, HistoryState::Removed))
+            }
+            Some(r) => self.buffer.push_front((tick, r.clone())),
+        };
+        res
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Clone, PartialEq, Debug)]
+    struct TestValue(f32);
+
+    /// Test adding and removing updates to the resource history
+    #[test]
+    fn test_add_remove_history() {
+        let mut resource_history = HistoryBuffer::<TestValue>::default();
+
+        // check when we try to access a value when the buffer is empty
+        assert_eq!(resource_history.pop_until_tick(Tick(0)), None);
+
+        // check when we try to access an exact tick
+        resource_history.add_update(Tick(1), TestValue(1.0));
+        resource_history.add_update(Tick(2), TestValue(2.0));
+        assert_eq!(
+            resource_history.pop_until_tick(Tick(2)),
+            Some(HistoryState::Updated(TestValue(2.0)))
+        );
+        // check that we cleared older ticks, and that the most recent value still remains
+        assert_eq!(resource_history.buffer.len(), 1);
+        assert_eq!(
+            resource_history.buffer,
+            VecDeque::from(vec![(Tick(2), HistoryState::Updated(TestValue(2.0)))])
+        );
+
+        // check when we try to access a value in-between ticks
+        resource_history.add_update(Tick(4), TestValue(4.0));
+        // we retrieve the most recent value older or equal to Tick(3)
+        assert_eq!(
+            resource_history.pop_until_tick(Tick(3)),
+            Some(HistoryState::Updated(TestValue(2.0)))
+        );
+        assert_eq!(resource_history.buffer.len(), 2);
+        // check that the most recent value got added back to the buffer at the popped tick
+        assert_eq!(
+            resource_history.buffer,
+            VecDeque::from(vec![
+                (Tick(3), HistoryState::Updated(TestValue(2.0))),
+                (Tick(4), HistoryState::Updated(TestValue(4.0)))
+            ])
+        );
+
+        // check that nothing happens when we try to access a value before any ticks
+        assert_eq!(resource_history.pop_until_tick(Tick(0)), None);
+        assert_eq!(resource_history.buffer.len(), 2);
+
+        resource_history.add_remove(Tick(5));
+        assert_eq!(resource_history.buffer.len(), 3);
+        assert_eq!(
+            resource_history.peek(),
+            Some(&(Tick(5), HistoryState::Removed))
+        );
+
+        resource_history.clear();
+        assert_eq!(resource_history.buffer.len(), 0);
+    }
+}

--- a/lightyear/src/client/prediction/mod.rs
+++ b/lightyear/src/client/prediction/mod.rs
@@ -8,6 +8,7 @@ use std::fmt::Debug;
 pub mod correction;
 pub mod despawn;
 pub mod diagnostics;
+mod history;
 pub mod plugin;
 pub mod pre_prediction;
 pub mod predicted_history;

--- a/lightyear/src/client/prediction/prespawn.rs
+++ b/lightyear/src/client/prediction/prespawn.rs
@@ -483,16 +483,16 @@ impl Component for PreSpawnedPlayerObject {
 
 #[cfg(test)]
 mod tests {
-    use crate::client::prediction::predicted_history::{ComponentState, PredictionHistory};
+    use crate::client::prediction::history::HistoryState;
+    use crate::client::prediction::predicted_history::PredictionHistory;
     use crate::client::prediction::resource::PredictionManager;
-    use bevy::prelude::{default, Entity, With};
-
     use crate::prelude::client::{Confirmed, Predicted};
     use crate::prelude::server::{Replicate, SyncTarget};
     use crate::prelude::*;
     use crate::tests::protocol::*;
     use crate::tests::stepper::BevyStepper;
     use crate::utils::ready_buffer::ItemWithReadyKey;
+    use bevy::prelude::{default, Entity, With};
 
     #[test]
     fn test_compute_hash() {
@@ -544,13 +544,11 @@ mod tests {
                 .entity(entity_1)
                 .get::<PredictionHistory<ComponentSyncModeFull>>()
                 .unwrap()
-                .buffer
-                .heap
                 .peek(),
-            Some(&ItemWithReadyKey {
-                key: current_tick,
-                item: ComponentState::Updated(ComponentSyncModeFull(1.0)),
-            })
+            Some(&(
+                current_tick,
+                HistoryState::Updated(ComponentSyncModeFull(1.0)),
+            ))
         );
     }
 

--- a/lightyear/src/client/prediction/resource_history.rs
+++ b/lightyear/src/client/prediction/resource_history.rs
@@ -1,78 +1,28 @@
 //! There's a lot of overlap with `client::prediction_history` because resources are components in ECS so rollback is going to look similar.
+use crate::prelude::TickManager;
 use bevy::prelude::*;
 
-use crate::{
-    prelude::{Tick, TickManager},
-    utils::ready_buffer::ReadyBuffer,
-};
-
 use super::rollback::Rollback;
+use crate::client::prediction::history::{HistoryBuffer, HistoryState};
+use crate::shared::tick_manager::TickEvent;
 
-/// Stores a past update for a resource
-#[derive(Debug, PartialEq, Clone)]
-pub(crate) enum ResourceState<R> {
-    /// the resource just got removed
-    Removed,
-    /// the resource got updated
-    Updated(R),
-}
+pub(crate) type ResourceHistory<R> = HistoryBuffer<R>;
 
-/// To know if we need to do rollback, we need to compare the resource's history with the server's state updates
-#[derive(Resource, Debug)]
-pub(crate) struct ResourceHistory<R> {
-    // We will only store the history for the ticks where the resource got updated
-    pub buffer: ReadyBuffer<Tick, ResourceState<R>>,
-}
-
-impl<R> Default for ResourceHistory<R> {
-    fn default() -> Self {
-        Self {
-            buffer: ReadyBuffer::new(),
+/// If there is a TickEvent and the client tick suddenly changes, we need
+/// to update the ticks in the history buffer.
+///
+/// The history buffer ticks are only relevant relative to the current client tick.
+/// (i.e. X ticks in the past compared to the current tick)
+pub(crate) fn handle_tick_event_resource_history<R: Resource>(
+    trigger: Trigger<TickEvent>,
+    res: Option<ResMut<ResourceHistory<R>>>,
+) {
+    match *trigger.event() {
+        TickEvent::TickSnap { old_tick, new_tick } => {
+            if let Some(mut history) = res {
+                history.update_ticks(new_tick - old_tick)
+            }
         }
-    }
-}
-
-impl<R> PartialEq for ResourceHistory<R> {
-    fn eq(&self, other: &Self) -> bool {
-        let mut self_history: Vec<_> = self.buffer.heap.iter().collect();
-        let mut other_history: Vec<_> = other.buffer.heap.iter().collect();
-        self_history.sort_by_key(|item| item.key);
-        other_history.sort_by_key(|item| item.key);
-        self_history.eq(&other_history)
-    }
-}
-
-impl<R: Clone> ResourceHistory<R> {
-    /// Reset the history for this resource
-    pub(crate) fn clear(&mut self) {
-        self.buffer = ReadyBuffer::new();
-    }
-
-    /// Add to the buffer that we received an update for the resource at the given tick
-    pub(crate) fn add_update(&mut self, tick: Tick, resource: R) {
-        self.buffer.push(tick, ResourceState::Updated(resource));
-    }
-
-    /// Add to the buffer that the resource got removed at the given tick
-    pub(crate) fn add_remove(&mut self, tick: Tick) {
-        self.buffer.push(tick, ResourceState::Removed);
-    }
-
-    // TODO: check if this logic is necessary/correct?
-    /// Clear the history of values strictly older than the specified tick,
-    /// and return the most recent value that is older or equal to the specified tick.
-    /// NOTE: That value is written back into the buffer
-    ///
-    /// CAREFUL:
-    /// the resource history will only contain the ticks where the resource got updated, and otherwise
-    /// contains gaps. Therefore, we need to always leave a value in the history buffer so that we can
-    /// get the values for the future ticks
-    pub(crate) fn pop_until_tick(&mut self, tick: Tick) -> Option<ResourceState<R>> {
-        self.buffer.pop_until(&tick).map(|(tick, state)| {
-            // TODO: this clone is pretty bad and avoidable. Probably switch to a sequence buffer?
-            self.buffer.push(tick, state.clone());
-            state
-        })
     }
 }
 
@@ -88,12 +38,16 @@ pub(crate) fn update_resource_history<R: Resource + Clone>(
 
     if let Some(resource) = resource {
         if resource.is_changed() {
+            info!(
+                "Resource {:?} changed, adding to history",
+                std::any::type_name::<R>()
+            );
             history.add_update(tick, resource.clone());
         }
     // resource does not exist, it might have been just removed
     } else {
-        match history.buffer.peek_max_item() {
-            Some((_, ResourceState::Removed)) => (),
+        match history.peek() {
+            Some((_, HistoryState::Removed)) => (),
             // if there is no latest item or the latest item isn't a removal then the resource just got removed.
             _ => history.add_remove(tick),
         }
@@ -105,60 +59,12 @@ mod tests {
     use super::*;
     use crate::prelude::client::RollbackState;
     use crate::prelude::AppComponentExt;
+    use crate::prelude::Tick;
     use crate::tests::stepper::BevyStepper;
-    use crate::utils::ready_buffer::ItemWithReadyKey;
     use bevy::ecs::system::RunSystemOnce;
 
     #[derive(Resource, Clone, PartialEq, Debug)]
     struct TestResource(f32);
-
-    /// Test adding and removing updates to the resource history
-    #[test]
-    fn test_resource_history() {
-        let mut resource_history = ResourceHistory::<TestResource>::default();
-
-        // check when we try to access a value when the buffer is empty
-        assert_eq!(resource_history.pop_until_tick(Tick(0)), None);
-
-        // check when we try to access an exact tick
-        resource_history.add_update(Tick(1), TestResource(1.0));
-        resource_history.add_update(Tick(2), TestResource(2.0));
-        assert_eq!(
-            resource_history.pop_until_tick(Tick(2)),
-            Some(ResourceState::Updated(TestResource(2.0)))
-        );
-        // check that we cleared older ticks, and that the most recent value still remains
-        assert_eq!(resource_history.buffer.len(), 1);
-        assert!(resource_history.buffer.has_item(&Tick(2)));
-
-        // check when we try to access a value in-between ticks
-        resource_history.add_update(Tick(4), TestResource(4.0));
-        // we retrieve the most recent value older or equal to Tick(3)
-        assert_eq!(
-            resource_history.pop_until_tick(Tick(3)),
-            Some(ResourceState::Updated(TestResource(2.0)))
-        );
-        assert_eq!(resource_history.buffer.len(), 2);
-        // check that the most recent value got added back to the buffer at the popped tick
-        assert_eq!(
-            resource_history.buffer.heap.peek(),
-            Some(&ItemWithReadyKey {
-                key: Tick(2),
-                item: ResourceState::Updated(TestResource(2.0))
-            })
-        );
-        assert!(resource_history.buffer.has_item(&Tick(4)));
-
-        // check that nothing happens when we try to access a value before any ticks
-        assert_eq!(resource_history.pop_until_tick(Tick(0)), None);
-        assert_eq!(resource_history.buffer.len(), 2);
-
-        resource_history.add_remove(Tick(5));
-        assert_eq!(resource_history.buffer.len(), 3);
-
-        resource_history.clear();
-        assert_eq!(resource_history.buffer.len(), 0);
-    }
 
     /// Test that the history gets updated correctly
     /// 1. Updating the TestResource resource
@@ -190,7 +96,7 @@ mod tests {
                 .get_resource_mut::<ResourceHistory<TestResource>>()
                 .expect("Expected resource history to be added")
                 .pop_until_tick(tick),
-            Some(ResourceState::Updated(TestResource(2.0))),
+            Some(HistoryState::Updated(TestResource(2.0))),
             "Expected resource value to be updated in resource history"
         );
 
@@ -208,7 +114,7 @@ mod tests {
                 .get_resource_mut::<ResourceHistory<TestResource>>()
                 .expect("Expected resource history to be added")
                 .pop_until_tick(tick),
-            Some(ResourceState::Removed),
+            Some(HistoryState::Removed),
             "Expected resource value to be removed in resource history"
         );
 
@@ -235,7 +141,7 @@ mod tests {
                 .get_resource_mut::<ResourceHistory<TestResource>>()
                 .expect("Expected resource history to be added")
                 .pop_until_tick(rollback_tick),
-            Some(ResourceState::Updated(TestResource(3.0))),
+            Some(HistoryState::Updated(TestResource(3.0))),
             "Expected resource value to be updated in resource history"
         );
 
@@ -255,8 +161,71 @@ mod tests {
                 .get_resource_mut::<ResourceHistory<TestResource>>()
                 .expect("Expected resource history to be added")
                 .pop_until_tick(rollback_tick),
-            Some(ResourceState::Removed),
+            Some(HistoryState::Removed),
             "Expected resource value to be removed from resource history"
         );
+    }
+
+    /// Test that the initial resource rollback works correctly even with client sync.
+    /// Case:
+    /// - spawn R on the client
+    /// - client sync
+    /// - rollback is triggered
+    /// Check that the resource is NOT removed, because it existed before the sync.
+    ///
+    /// This is a regression test for a bug where the resource was removed during rollback.
+    /// Since prediction plugins only run after `is_sync`, the resource wasn't inserted in the history buffer
+    /// and was removed during rollback.
+    #[test]
+    fn test_initial_rollback() {
+        // tracing_subscriber::FmtSubscriber::builder()
+        //     .with_max_level(tracing::Level::DEBUG)
+        //     .init();
+        let mut stepper = BevyStepper::default_no_init();
+        stepper.client_app.add_resource_rollback::<TestResource>();
+        stepper.build();
+        stepper.wait_for_connection();
+
+        // insert resource before sync
+        stepper
+            .client_app
+            .world_mut()
+            .insert_resource(TestResource(1.0));
+        stepper.frame_step();
+        info!(
+            "Just added: {:?}",
+            stepper
+                .client_app
+                .world()
+                .resource::<ResourceHistory<TestResource>>()
+        );
+        let client_tick = stepper.client_tick();
+
+        // sync
+        stepper.wait_for_sync();
+        info!(
+            "{:?}",
+            stepper
+                .client_app
+                .world()
+                .resource::<ResourceHistory<TestResource>>()
+        );
+
+        // Initiate rollback
+        let rollback_tick = stepper.server_tick() + 1;
+        stepper
+            .client_app
+            .world_mut()
+            .insert_resource(Rollback::new(RollbackState::ShouldRollback {
+                current_tick: rollback_tick,
+            }));
+        stepper.frame_step();
+
+        // Check that the resource still exists
+        assert!(stepper
+            .client_app
+            .world_mut()
+            .get_resource::<TestResource>()
+            .is_some());
     }
 }

--- a/lightyear/src/client/prediction/resource_history.rs
+++ b/lightyear/src/client/prediction/resource_history.rs
@@ -38,10 +38,6 @@ pub(crate) fn update_resource_history<R: Resource + Clone>(
 
     if let Some(resource) = resource {
         if resource.is_changed() {
-            info!(
-                "Resource {:?} changed, adding to history",
-                std::any::type_name::<R>()
-            );
             history.add_update(tick, resource.clone());
         }
     // resource does not exist, it might have been just removed

--- a/lightyear/src/client/prediction/rollback.rs
+++ b/lightyear/src/client/prediction/rollback.rs
@@ -194,7 +194,7 @@ pub(crate) fn check_rollback<C: SyncComponent>(
                 }),
             };
             if should_rollback {
-                info!(
+                debug!(
                    ?predicted_exist, ?confirmed_exist,
                    "Rollback check: mismatch for component between predicted and confirmed {:?} on tick {:?} for component {:?}. Current tick: {:?}",
                    confirmed_entity, tick, kind, current_tick
@@ -340,10 +340,6 @@ pub(crate) fn prepare_rollback<C: SyncComponent>(
                             }
                         }
 
-                        info!(
-                            "Update predicted component {:?} to match confirmed value",
-                            std::any::type_name::<C>()
-                        );
                         // update the component to the corrected value
                         *predicted_component = rollbacked_predicted_component.clone();
                     }
@@ -549,7 +545,7 @@ pub(crate) fn prepare_rollback_resource<R: Resource + Clone>(
     match history.pop_until_tick(rollback_tick) {
         None | Some(HistoryState::Removed) => {
             if resource.is_some() {
-                info!(
+                debug!(
                     ?kind,
                     "Resource didn't exist at time of rollback, removing it"
                 );

--- a/lightyear/src/client/prediction/rollback.rs
+++ b/lightyear/src/client/prediction/rollback.rs
@@ -11,7 +11,7 @@ use bevy::prelude::{
 use bevy::reflect::Reflect;
 use bevy::time::{Fixed, Time};
 use parking_lot::RwLock;
-use tracing::{debug, error, trace, trace_span};
+use tracing::{debug, error, info, trace, trace_span};
 
 use crate::client::components::{Confirmed, SyncComponent};
 use crate::client::config::ClientConfig;
@@ -194,7 +194,7 @@ pub(crate) fn check_rollback<C: SyncComponent>(
                 }),
             };
             if should_rollback {
-                debug!(
+                info!(
                    ?predicted_exist, ?confirmed_exist,
                    "Rollback check: mismatch for component between predicted and confirmed {:?} on tick {:?} for component {:?}. Current tick: {:?}",
                    confirmed_entity, tick, kind, current_tick

--- a/lightyear/src/client/sync.rs
+++ b/lightyear/src/client/sync.rs
@@ -3,7 +3,7 @@
 use bevy::prelude::{Reflect, SystemSet};
 use bevy::utils::Duration;
 use chrono::Duration as ChronoDuration;
-use tracing::{debug, trace};
+use tracing::{debug, info, trace};
 
 use crate::client::interpolation::plugin::InterpolationDelay;
 use crate::packet::packet::PacketId;
@@ -536,7 +536,7 @@ impl SyncManager {
         let delta_tick = client_ideal_tick - tick_manager.tick();
         // Update client ticks
         if rtt != Duration::default() {
-            debug!(
+            info!(
                 buffer_len = ?ping_manager.sync_stats.len(),
                 ?rtt,
                 ?jitter,

--- a/lightyear/src/client/sync.rs
+++ b/lightyear/src/client/sync.rs
@@ -536,7 +536,7 @@ impl SyncManager {
         let delta_tick = client_ideal_tick - tick_manager.tick();
         // Update client ticks
         if rtt != Duration::default() {
-            info!(
+            debug!(
                 buffer_len = ?ping_manager.sync_stats.len(),
                 ?rtt,
                 ?jitter,

--- a/lightyear/src/tests/stepper.rs
+++ b/lightyear/src/tests/stepper.rs
@@ -1,24 +1,23 @@
 use std::net::SocketAddr;
 use std::str::FromStr;
 
-use bevy::ecs::system::RunSystemOnce;
-use bevy::input::InputPlugin;
-use bevy::prelude::{default, App, Commands, Mut, PluginGroup, Real, Time, World};
-use bevy::state::app::StatesPlugin;
-use bevy::time::TimeUpdateStrategy;
-use bevy::utils::Duration;
-use bevy::MinimalPlugins;
-
 use crate::connection::netcode::generate_key;
 use crate::prelude::client::{
     Authentication, ClientCommands, ClientConfig, ClientTransport, InterpolationConfig, NetConfig,
-    PredictionConfig, SyncConfig,
+    NetworkingState, PredictionConfig, SyncConfig,
 };
 use crate::prelude::server::{NetcodeConfig, ServerCommands, ServerConfig, ServerTransport};
 use crate::prelude::*;
 use crate::shared::time_manager::WrappedTime;
 use crate::tests::protocol::*;
 use crate::transport::LOCAL_SOCKET;
+use bevy::ecs::system::RunSystemOnce;
+use bevy::input::InputPlugin;
+use bevy::prelude::{default, App, Commands, Mut, PluginGroup, Real, State, Time, World};
+use bevy::state::app::StatesPlugin;
+use bevy::time::TimeUpdateStrategy;
+use bevy::utils::Duration;
+use bevy::MinimalPlugins;
 
 pub const TEST_CLIENT_ID: u64 = 111;
 
@@ -33,15 +32,7 @@ pub struct BevyStepper {
 
 impl Default for BevyStepper {
     fn default() -> Self {
-        let frame_duration = Duration::from_millis(10);
-        let tick_duration = Duration::from_millis(10);
-        let shared_config = SharedConfig {
-            tick: TickConfig::new(tick_duration),
-            ..Default::default()
-        };
-        let client_config = ClientConfig::default();
-
-        let mut stepper = Self::new(shared_config, client_config, frame_duration);
+        let mut stepper = Self::default_no_init();
         stepper.init();
         stepper
     }
@@ -162,6 +153,18 @@ impl BevyStepper {
         }
     }
 
+    pub(crate) fn default_no_init() -> Self {
+        let frame_duration = Duration::from_millis(10);
+        let tick_duration = Duration::from_millis(10);
+        let shared_config = SharedConfig {
+            tick: TickConfig::new(tick_duration),
+            ..Default::default()
+        };
+        let client_config = ClientConfig::default();
+
+        Self::new(shared_config, client_config, frame_duration)
+    }
+
     pub(crate) fn interpolation_tick(&mut self) -> Tick {
         self.client_app.world_mut().resource_scope(
             |world: &mut World, manager: Mut<client::ConnectionManager>| {
@@ -210,9 +213,6 @@ impl BevyStepper {
         self.client_app.cleanup();
         self.server_app.finish();
         self.server_app.cleanup();
-    }
-    pub(crate) fn init(&mut self) {
-        self.build();
         let _ = self
             .server_app
             .world_mut()
@@ -221,8 +221,31 @@ impl BevyStepper {
             .client_app
             .world_mut()
             .run_system_once(|mut commands: Commands| commands.connect_client());
+    }
+    pub(crate) fn init(&mut self) {
+        self.build();
+        self.wait_for_connection();
+        self.wait_for_sync();
+    }
 
-        // Advance the world to let the connection process complete
+    // Advance the world until client is connected
+    pub(crate) fn wait_for_connection(&mut self) {
+        for _ in 0..100 {
+            if matches!(
+                self.client_app
+                    .world()
+                    .resource::<State<NetworkingState>>()
+                    .get(),
+                NetworkingState::Connected
+            ) {
+                break;
+            }
+            self.frame_step();
+        }
+    }
+
+    // Advance the world until the client is synced
+    pub(crate) fn wait_for_sync(&mut self) {
         for _ in 0..100 {
             if self
                 .client_app

--- a/lightyear/src/utils/avian2d.rs
+++ b/lightyear/src/utils/avian2d.rs
@@ -40,14 +40,9 @@ impl Plugin for Avian2dPlugin {
             )
                 .after(PhysicsSet::Sync),
         );
-<<<<<<< HEAD
         // if the Avian Sync happens in PostUpdate (because the visual interpolated Position/Rotation are updated
         // every frame in PostUpdate), and we want to sync them every frame because some entities (text, etc.)
         // might depend on Transform
-=======
-        // if the sync happens in PostUpdate (because the visual interpolated Position/Rotation are updated every frame in
-        // PostUpdate), and we want to sync them every frame because some entities (text, etc.) might depend on Transform
->>>>>>> main
         app.configure_sets(
             PostUpdate,
             (
@@ -57,13 +52,10 @@ impl Plugin for Avian2dPlugin {
             )
                 .chain(),
         );
-<<<<<<< HEAD
 
         // Add rollback for some non-replicated resources
         app.add_resource_rollback::<Collisions>();
         app.add_rollback::<CollidingEntities>();
-=======
->>>>>>> main
     }
 }
 

--- a/lightyear/src/utils/avian2d.rs
+++ b/lightyear/src/utils/avian2d.rs
@@ -4,8 +4,9 @@ use crate::shared::replication::delta::Diffable;
 use crate::shared::sets::{ClientMarker, InternalReplicationSet, ServerMarker};
 use avian2d::math::Scalar;
 use avian2d::prelude::*;
-use bevy::prelude::IntoSystemSetConfigs;
+use bevy::prelude::TransformSystem::TransformPropagate;
 use bevy::prelude::{App, FixedPostUpdate, Plugin};
+use bevy::prelude::{IntoSystemSetConfigs, PostUpdate};
 use tracing::trace;
 
 pub(crate) struct Avian2dPlugin;
@@ -37,6 +38,18 @@ impl Plugin for Avian2dPlugin {
                 InterpolationSet::UpdateVisualInterpolationState,
             )
                 .after(PhysicsSet::Sync),
+        );
+        // if the Avian Sync happens in PostUpdate (because the visual interpolated Position/Rotation are updated
+        // every frame in PostUpdate), and we want to sync them every frame because some entities (text, etc.)
+        // might depend on Transform
+        app.configure_sets(
+            PostUpdate,
+            (
+                InterpolationSet::VisualInterpolation,
+                PhysicsSet::Sync,
+                TransformPropagate,
+            )
+                .chain(),
         );
     }
 }

--- a/lightyear/src/utils/avian2d.rs
+++ b/lightyear/src/utils/avian2d.rs
@@ -1,5 +1,6 @@
 //! Implement lightyear traits for some common bevy types
 use crate::prelude::client::{InterpolationSet, PredictionSet};
+use crate::prelude::AppComponentExt;
 use crate::shared::replication::delta::Diffable;
 use crate::shared::sets::{ClientMarker, InternalReplicationSet, ServerMarker};
 use avian2d::math::Scalar;
@@ -51,6 +52,10 @@ impl Plugin for Avian2dPlugin {
             )
                 .chain(),
         );
+
+        // Add rollback for some non-replicated resources
+        app.add_resource_rollback::<Collisions>();
+        app.add_rollback::<CollidingEntities>();
     }
 }
 

--- a/lightyear/src/utils/avian3d.rs
+++ b/lightyear/src/utils/avian3d.rs
@@ -5,7 +5,8 @@ use crate::shared::sets::{ClientMarker, InternalReplicationSet, ServerMarker};
 use avian3d::math::Scalar;
 use avian3d::prelude::*;
 use bevy::app::{App, FixedPostUpdate, Plugin};
-use bevy::prelude::IntoSystemSetConfigs;
+use bevy::prelude::TransformSystem::TransformPropagate;
+use bevy::prelude::{IntoSystemSetConfigs, PostUpdate};
 use tracing::trace;
 
 pub(crate) struct Avian3dPlugin;
@@ -36,6 +37,17 @@ impl Plugin for Avian3dPlugin {
                 InterpolationSet::UpdateVisualInterpolationState,
             )
                 .after(PhysicsSet::Sync),
+        );
+        // if the sync happens in PostUpdate (because the visual interpolated Position/Rotation are updated every frame in
+        // PostUpdate), and we want to sync them every frame because some entities (text, etc.) might depend on Transform
+        app.configure_sets(
+            PostUpdate,
+            (
+                InterpolationSet::VisualInterpolation,
+                PhysicsSet::Sync,
+                TransformPropagate,
+            )
+                .chain(),
         );
     }
 }

--- a/lightyear/src/utils/avian3d.rs
+++ b/lightyear/src/utils/avian3d.rs
@@ -1,5 +1,6 @@
 //! Implement lightyear traits for some common bevy types
 use crate::prelude::client::{InterpolationSet, PredictionSet};
+use crate::prelude::AppComponentExt;
 use crate::shared::replication::delta::Diffable;
 use crate::shared::sets::{ClientMarker, InternalReplicationSet, ServerMarker};
 use avian3d::math::Scalar;
@@ -49,6 +50,10 @@ impl Plugin for Avian3dPlugin {
             )
                 .chain(),
         );
+
+        // Add rollback for some non-replicated resources
+        app.add_resource_rollback::<Collisions>();
+        app.add_rollback::<CollidingEntities>();
     }
 }
 


### PR DESCRIPTION
1) Refactor ResourceHistory and ComponentHistory to use the same HistoryBuffer under the hood. The HistoryBuffer doesn't use a heap anymore but a VecDeque. That's because the updates to the HistoryBuffer are pushed/removed in sequential order.
TODO: the same can be applied to InterpolationHistory since the replication updates are ordered on the receiver side)

2) Make sure that rollback for non-networked resource works correctly.
An issue was that the history was only updated once the client was synced. Therefore we would get in a situation where:
- insert Resource
- client sync (client tick goes from X' to X)
- run history system, so insert Resource in history for tick X
- receive server packet for tick  `X-Rollback`, which triggers a rollback
- the history doesn't contain anything for the resource on tick `X-Rollback`, so the resource gets removed.

My fix is:
- make sure that the HistoryBuffer gets updated when we receive a TickEvent -> all the ticks inside the buffer get updated
- make sure the PredictionPlugin runs if the client is **connected**, not **synced**. This ensures that the resource gets added will be present in the history when the first server packet arrives