### PR TITLE
Rollback improvements

### DIFF
--- a/examples/avian_3d_character/src/client.rs
+++ b/examples/avian_3d_character/src/client.rs
@@ -103,7 +103,7 @@ fn handle_new_character(
         info!(?entity, ?client_id, "Adding physics to character");
         commands
             .entity(entity)
-            .insert((CharacterPhysicsBundle::default(),));
+            .insert(CharacterPhysicsBundle::default());
     }
 }
 

--- a/examples/avian_3d_character/src/protocol.rs
+++ b/examples/avian_3d_character/src/protocol.rs
@@ -73,11 +73,16 @@ impl Plugin for ProtocolPlugin {
             .add_prediction(ComponentSyncMode::Once);
 
         // Fully replicated, but not visual, so no need for lerp/corrections:
-
         app.register_component::<LinearVelocity>(ChannelDirection::ServerToClient)
             .add_prediction(ComponentSyncMode::Full);
 
         app.register_component::<AngularVelocity>(ChannelDirection::ServerToClient)
+            .add_prediction(ComponentSyncMode::Full);
+
+        app.register_component::<ExternalForce>(ChannelDirection::ServerToClient)
+            .add_prediction(ComponentSyncMode::Full);
+
+        app.register_component::<ExternalImpulse>(ChannelDirection::ServerToClient)
             .add_prediction(ComponentSyncMode::Full);
 
         // Position and Rotation have a `correction_fn` set, which is used to smear rollback errors

--- a/examples/avian_3d_character/src/renderer.rs
+++ b/examples/avian_3d_character/src/renderer.rs
@@ -71,13 +71,18 @@ fn init(mut commands: Commands) {
 /// interpolation.
 fn add_visual_interpolation_components<T: Component>(
     trigger: Trigger<OnAdd, T>,
-    query: Query<Entity, (With<T>, Without<Confirmed>, Without<FloorMarker>)>,
+    // TODO: how to guarantee that Predicted has been added before the component gets added?
+    query: Query<Entity, (With<T>, With<Predicted>, Without<FloorMarker>)>,
     mut commands: Commands,
 ) {
     if !query.contains(trigger.entity()) {
         return;
     }
-    debug!("Adding visual interp component to {:?}", trigger.entity());
+    debug!(
+        "Adding visual interp component for {:?} to {:?}",
+        std::any::type_name::<T>(),
+        trigger.entity()
+    );
     commands
         .entity(trigger.entity())
         .insert(VisualInterpolateStatus::<T> {

--- a/examples/avian_3d_character/src/server.rs
+++ b/examples/avian_3d_character/src/server.rs
@@ -65,7 +65,12 @@ fn init(mut commands: Commands) {
         FloorMarker,
         Position::new(Vec3::ZERO),
         // Floors don't need to be predicted since they will never move.
-        Replicate::default(),
+        // We put it in the same replication group to avoid having the players be replicated before the floor
+        // and falling infinitely
+        Replicate {
+            group: REPLICATION_GROUP,
+            ..default()
+        },
     ));
 
     // Blocks need to be predicted because their position, rotation, velocity
@@ -80,20 +85,20 @@ fn init(mut commands: Commands) {
         group: REPLICATION_GROUP,
         ..default()
     };
-    commands.spawn((
-        Name::new("Block"),
-        BlockPhysicsBundle::default(),
-        BlockMarker,
-        Position::new(Vec3::new(1.0, 1.0, 0.0)),
-        block_replicate_component.clone(),
-    ));
-    commands.spawn((
-        Name::new("Block"),
-        BlockPhysicsBundle::default(),
-        BlockMarker,
-        Position::new(Vec3::new(-1.0, 1.0, 0.0)),
-        block_replicate_component.clone(),
-    ));
+    // commands.spawn((
+    //     Name::new("Block"),
+    //     BlockPhysicsBundle::default(),
+    //     BlockMarker,
+    //     Position::new(Vec3::new(1.0, 1.0, 0.0)),
+    //     block_replicate_component.clone(),
+    // ));
+    // commands.spawn((
+    //     Name::new("Block"),
+    //     BlockPhysicsBundle::default(),
+    //     BlockMarker,
+    //     Position::new(Vec3::new(-1.0, 1.0, 0.0)),
+    //     block_replicate_component.clone(),
+    // ));
 }
 
 pub(crate) fn replicate_inputs(

--- a/lightyear/src/client/interpolation/visual_interpolation.rs
+++ b/lightyear/src/client/interpolation/visual_interpolation.rs
@@ -37,7 +37,7 @@ use bevy::transform::TransformSystem::TransformPropagate;
 
 use crate::client::components::SyncComponent;
 use crate::prelude::client::{InterpolationSet, PredictionSet};
-use crate::prelude::{ComponentRegistry, TickManager, TimeManager};
+use crate::prelude::{ComponentRegistry, MainSet, TickManager, TimeManager};
 
 pub struct VisualInterpolationPlugin<C: SyncComponent> {
     _marker: std::marker::PhantomData<C>,
@@ -69,7 +69,10 @@ impl<C: SyncComponent> Plugin for VisualInterpolationPlugin<C> {
         );
         app.configure_sets(
             PostUpdate,
-            InterpolationSet::VisualInterpolation.before(TransformPropagate),
+            InterpolationSet::VisualInterpolation
+                .before(TransformPropagate)
+                // we don't want the visual interpolation value to be the one replicated!
+                .after(MainSet::Send),
         );
 
         // SYSTEMS


### PR DESCRIPTION
1) If visual-interpolation runs in PostUpdate before Send, then the server might send visually-interpolated values (if VisualInterpolation is enabled). This will mess up rollback on the client, so we add an ordering constraints

2) Disable Sleeping on the client in avian3d as this messes up with rollback

3) Add ExternalForce and ExternalImpulse to rollback as those are used in the player movement


This configuration has no rollbacks, but rollbacks happen if the Block rigid bodies are added