### PR TITLE
Fix duplicate entities in PrePrediction

### DIFF
--- a/examples/avian_physics/src/client.rs
+++ b/examples/avian_physics/src/client.rs
@@ -48,19 +48,13 @@ pub(crate) fn init(mut commands: Commands) {
     commands.connect_client();
 }
 
-/// Listen for events to know when the client is connected, and spawn a text entity
-/// to display the client id
+/// Listen for events to know when the client is connected, and spawn player entities
 pub(crate) fn handle_connection(
     mut commands: Commands,
     mut connection_event: EventReader<ConnectEvent>,
 ) {
     for event in connection_event.read() {
         let client_id = event.client_id();
-        commands.spawn((
-            Text(format!("Client {}", client_id)),
-            TextColor(Color::WHITE),
-            TextFont::from_font_size(30.0),
-        ));
         let y = (client_id.to_bits() as f32 * 50.0) % 500.0 - 250.0;
         // we will spawn two cubes per player, once is controlled with WASD, the other with arrows
         commands.spawn(PlayerBundle::new(

--- a/examples/avian_physics/src/server.rs
+++ b/examples/avian_physics/src/server.rs
@@ -118,7 +118,9 @@ pub(crate) fn replicate_players(
 ) {
     for (entity, replicated) in query.iter() {
         let client_id = replicated.client_id();
-        info!("received player spawn event from client {client_id:?}");
+        info!(
+            "Received player spawn event from client {client_id:?}. Replicating back to all clients"
+        );
 
         // for all player entities we have received, add a Replicate component so that we can start replicating it
         // to other clients

--- a/examples/avian_physics/src/shared.rs
+++ b/examples/avian_physics/src/shared.rs
@@ -24,13 +24,6 @@ pub struct SharedPlugin;
 impl Plugin for SharedPlugin {
     fn build(&self, app: &mut App) {
         app.add_plugins(ProtocolPlugin);
-        app.add_plugins(LogDiagnosticsPlugin {
-            filter: Some(vec![
-                IoDiagnosticsPlugin::BYTES_IN,
-                IoDiagnosticsPlugin::BYTES_OUT,
-            ]),
-            ..default()
-        });
         // bundles
         app.add_systems(Startup, init);
 

--- a/lightyear/src/client/prediction/pre_prediction.rs
+++ b/lightyear/src/client/prediction/pre_prediction.rs
@@ -52,7 +52,7 @@ impl Plugin for PrePredictionPlugin {
 }
 
 impl PrePredictionPlugin {
-    /// For pre-spawned entities, we want to stop replicating as soon as the initial spawn message has been sent to the
+    /// For pre-predicted entities, we want to stop replicating as soon as the initial spawn message has been sent to the
     /// server (to save bandwidth).
     /// The server will refuse those other updates anyway because it will take authority over the entity.
     /// Therefore we will remove the `Replicate` component right after the first time we've sent a replicating message to the
@@ -95,7 +95,7 @@ impl PrePredictionPlugin {
         // we will add the Predicted component
         if let Some(&predicted) = predicted_map.confirmed_to_predicted.get(&trigger.entity()) {
             let confirmed = trigger.entity();
-            info!("Received PrePredicted entity from server. Confirmed: {confirmed:?}, Predicted: {predicted:?}");
+            debug!("Received PrePredicted entity from server. Confirmed: {confirmed:?}, Predicted: {predicted:?}");
             commands.queue(move |world: &mut World| {
                 world
                     .entity_mut(predicted)

--- a/lightyear/src/client/replication.rs
+++ b/lightyear/src/client/replication.rs
@@ -69,6 +69,7 @@ pub(crate) mod receive {
         for message_event in messages.drain() {
             let message = message_event.message;
             let entity = message.entity;
+            debug!("Received authority change for entity {entity:?}");
             if entities.get(entity).is_some() {
                 if message.gain_authority {
                     commands.queue(move |world: &mut World| {

--- a/lightyear/src/server/prediction.rs
+++ b/lightyear/src/server/prediction.rs
@@ -67,10 +67,6 @@ pub(crate) fn handle_pre_predicted(
     q: Query<(Entity, &PrePredicted, &Replicated)>,
 ) {
     if let Ok((local_entity, pre_predicted, replicated)) = q.get(trigger.entity()) {
-        debug!(
-            "Received PrePredicted entity from client: {:?}. Transferring authority to server",
-            replicated.from
-        );
         let sending_client = replicated.from.unwrap();
         let confirmed_entity = pre_predicted.confirmed_entity.unwrap();
         // update the mapping so that when we send updates, the server entity gets mapped
@@ -81,6 +77,12 @@ pub(crate) fn handle_pre_predicted(
             .replication_receiver
             .remote_entity_map
             .insert(confirmed_entity, local_entity);
+        debug!(
+            ?confirmed_entity,
+            ?local_entity,
+            "Received PrePredicted entity from client: {:?}. Transferring authority to server",
+            replicated.from
+        );
         commands
             .entity(local_entity)
             .transfer_authority(AuthorityPeer::Server);

--- a/lightyear/src/shared/replication/entity_map.rs
+++ b/lightyear/src/shared/replication/entity_map.rs
@@ -2,7 +2,7 @@
 use bevy::ecs::entity::{EntityHashMap, EntityMapper};
 use bevy::prelude::{Deref, DerefMut, Entity, EntityWorldMut, World};
 use bevy::reflect::Reflect;
-use tracing::error;
+use tracing::{error, trace};
 
 const MARKED: u64 = 1 << 62;
 
@@ -28,6 +28,7 @@ impl EntityMapper for SendEntityMap {
         // if we have the entity in our mapping, map it and mark it as mapped
         // so that on the receive side we don't map it again
         if let Some(mapped) = self.0.get(&entity) {
+            trace!("Mapping entity {entity:?} to {mapped:?} in SendEntityMap!");
             RemoteEntityMap::mark_mapped(*mapped)
         } else {
             // otherwise just send the entity as is, and the receiver will map it
@@ -93,6 +94,7 @@ impl RemoteEntityMap {
     pub(crate) fn get_local(&self, remote_entity: Entity) -> Option<Entity> {
         let unmapped = Self::mark_unmapped(remote_entity);
         if Self::is_mapped(remote_entity) {
+            trace!("Received entity {unmapped:?} was already mapped, returning it as is");
             // the remote_entity is actually local, because it has already been mapped!
             // just remove the mapping bit
             return Some(unmapped);

--- a/lightyear/src/shared/replication/receive.rs
+++ b/lightyear/src/shared/replication/receive.rs
@@ -620,10 +620,9 @@ impl GroupChannel {
                         // (e.g client spawned an entity and then transfer the authority to the server.
                         //  The server will then send a spawn message)
                         if world.get_entity(local_entity).is_ok() {
-                            warn!(
-                                ?remote_entity,
+                            debug!(
                                 ?local_entity,
-                                "Received spawn for an entity that already exists. This might be because of an authority transfer."
+                                "Received spawn for entity {local_entity:?} that already exists. This might be because of an authority transfer or pre-prediction."
                             );
                             // we still need to update the local entity to group mapping on the receiver
                             self.local_entities.insert(local_entity);
@@ -666,7 +665,6 @@ impl GroupChannel {
 
                     remote_entity_map.insert(*remote_entity, local_entity.id());
                     trace!("Updated remote entity map: {:?}", remote_entity_map);
-
                     debug!("Received entity spawn for remote entity {remote_entity:?}. Spawned local entity {:?}", local_entity.id());
                     events.push_spawn(local_entity.id());
                 }


### PR DESCRIPTION
The server::replicate_entity_spawn system was not applying entity-mapping for newly replicated entities.
This was causing duplicate entities to be replicated, since the server already received an entity-mapping update due to pre-prediction 

Fixes https://github.com/cBournhonesque/lightyear/issues/790