### PR TITLE
Add non-networked component to despawned predicted entity test

### DIFF
--- a/lightyear/src/client/prediction/despawn.rs
+++ b/lightyear/src/client/prediction/despawn.rs
@@ -151,28 +151,8 @@ pub(crate) fn restore_components_if_despawn_rolled_back<C: SyncComponent>(
     }
 }
 
-// /// In case we rollback the despawn, we need to restore the removed components
-// /// even if those components are not checking for rollback (SyncComponent != Full)
-// /// For those components, we just re-add them from the cache at the start of rollback
-// pub(crate) fn restore_components_if_despawn_rolled_back<C: SyncComponent>(world: &mut World) {
-//     for (entity, cache) in world
-//         .query_filtered::<(Entity, &RemovedCache<C>), Without<C>>()
-//         .iter(&world)
-//     {
-//         trace!("restoring component after rollback");
-//         let mut entity_mut = world.entity_mut(entity);
-//         if let Some(c) = entity_mut.take::<RemovedCache<C>>() {
-//             entity_mut.insert(c.0);
-//         }
-//         // .remove::<RemovedCache<C>>
-//         // commands
-//         //     .entity(entity)
-//         //     .insert(cache.0.clone())
-//         //     .remove::<RemovedCache<C>>();
-//     }
-// }
-
-/// Remove the despawn marker: if during rollback the components are re-spawned, we don't want to re-despawn them again
+/// Remove the despawn marker: if during rollback the entity are re-spawned, we don't want to re-despawn it again
+/// PredictionDespawnMarker should only be present on the frame where we call `prediction_despawn`
 pub(crate) fn remove_despawn_marker(
     mut commands: Commands,
     query: Query<Entity, With<PredictionDespawnMarker>>,
@@ -187,315 +167,174 @@ pub(crate) fn remove_despawn_marker(
     }
 }
 
-// TODO: revisit this; rollbacks happen when we receive a replication message now
-// #[cfg(test)]
-// mod tests {
-//     use crate::_reexport::*;
-//     use crate::prelude::client::*;
-//     use crate::prelude::*;
-//     use crate::tests::protocol::*;
-//     use crate::tests::stepper::{BevyStepper};
-//     use bevy::prelude::*;
-//     use bevy::utils::Duration;
-//
-//     fn increment_component_and_despawn(
-//         mut commands: Commands,
-//         mut query: Query<(Entity, &mut Component1), With<Predicted>>,
-//     ) {
-//         for (entity, mut component) in query.iter_mut() {
-//             component.0 += 1.0;
-//             if component.0 == 5.0 {
-//                 commands.entity(entity).prediction_despawn::<MyProtocol>();
-//             }
-//         }
-//     }
-//
-//     // Test that if a predicted entity gets despawned erroneously
-//     // We are still able to rollback properly (the rollback re-adds the predicted entity, or prevents it from despawning)
-//     #[test]
-//     fn test_despawned_predicted_rollback() -> anyhow::Result<()> {
-//         let frame_duration = Duration::from_millis(10);
-//         let tick_duration = Duration::from_millis(10);
-//         let shared_config = SharedConfig {
-//             enable_replication: false,
-//             tick: TickConfig::new(tick_duration),
-//             ..Default::default()
-//         };
-//         let link_conditioner = LinkConditionerConfig {
-//             incoming_latency: Duration::from_millis(40),
-//             incoming_jitter: Duration::from_millis(5),
-//             incoming_loss: 0.05,
-//         };
-//         let sync_config = SyncConfig::default().speedup_factor(1.0);
-//         let prediction_config = PredictionConfig::default();
-//         let interpolation_delay = Duration::from_millis(100);
-//         let interpolation_config = InterpolationConfig::default().with_delay(InterpolationDelay {
-//             min_delay: interpolation_delay,
-//             send_interval_ratio: 0.0,
-//         });
-//         let mut stepper = BevyStepper::new(
-//             shared_config,
-//             sync_config,
-//             prediction_config,
-//             interpolation_config,
-//             link_conditioner,
-//             frame_duration,
-//         );
-//         stepper.client_mut().set_synced();
-//         stepper.client_app.add_systems(
-//             FixedUpdate,
-//             increment_component_and_despawn
-//         );
-//
-//         // Create a confirmed entity
-//         let confirmed = stepper
-//             .client_app
-//             .world_mut()
-//             .spawn((Component1(0.0), ShouldBePredicted))
-//             .id();
-//
-//         // Tick once
-//         stepper.frame_step();
-//         assert_eq!(stepper.client().tick(), Tick(1));
-//         let predicted = stepper
-//             .client_app
-//             .world()//             .get::<Confirmed>(confirmed)
-//             .unwrap()
-//             .predicted
-//             .unwrap();
-//
-//         // check that the predicted entity got spawned
-//         assert_eq!(
-//             stepper
-//                 .client_app
-//                 .world()//                 .get::<Predicted>(predicted)
-//                 .unwrap()
-//                 .confirmed_entity,
-//             confirmed
-//         );
-//
-//         // check that the component history got created
-//         let mut history = PredictionHistory::<Component1>::default();
-//         history
-//             .buffer
-//             .add_item(Tick(0), HistoryState::Updated(Component1(0.0)));
-//         history
-//             .buffer
-//             .add_item(Tick(1), HistoryState::Updated(Component1(1.0)));
-//         assert_eq!(
-//             stepper
-//                 .client_app
-//                 .world()//                 .get::<PredictionHistory<Component1>>(predicted)
-//                 .unwrap(),
-//             &history,
-//         );
-//         // check that the confirmed component got replicated
-//         assert_eq!(
-//             stepper
-//                 .client_app
-//                 .world()//                 .get::<Component1>(predicted)
-//                 .unwrap(),
-//             &Component1(1.0)
-//         );
-//
-//         // advance five more frames, so that the component gets removed on predicted
-//         for i in 0..5 {
-//             stepper.frame_step();
-//         }
-//         assert_eq!(stepper.client().tick(), Tick(6));
-//
-//         // check that the component got removed on predicted
-//         assert!(stepper
-//             .client_app
-//             .world()//             .get::<Component1>(predicted)
-//             .is_none());
-//         // // check that predicted has the despawn marker
-//         // assert_eq!(
-//         //     stepper
-//         //         .client_app
-//         //         .world()//         //         .get::<PredictionDespawnMarker>(predicted)
-//         //         .unwrap(),
-//         //     &PredictionDespawnMarker {
-//         //         death_tick: Tick(5)
-//         //     }
-//         // );
-//         // check that the component history is still there and that the value of the component history is correct
-//         let mut history = PredictionHistory::<Component1>::default();
-//         for i in 0..5 {
-//             history
-//                 .buffer
-//                 .add_item(Tick(i), HistoryState::Updated(Component1(i as f32)));
-//         }
-//         history.buffer.add_item(Tick(5), HistoryState::Removed);
-//         assert_eq!(
-//             stepper
-//                 .client_app
-//                 .world()//                 .get::<PredictionHistory<Component1>>(predicted)
-//                 .unwrap(),
-//             &history,
-//         );
-//
-//         // create a rollback situation
-//         stepper.client_mut().set_synced();
-//         stepper
-//             .client_mut()
-//             .set_latest_received_server_tick(Tick(3));
-//         stepper
-//             .client_app
-//             .world_mut()
-//             .get_mut::<Component1>(confirmed)
-//             .unwrap()
-//             .0 = 1.0;
-//         // update without incrementing time, because we want to force a rollback check
-//         stepper.client_app.update();
-//
-//         // check that rollback happened
-//         // predicted exists, and got the component re-added
-//         stepper
-//             .client_app
-//             .world_mut()
-//             .get_mut::<Component1>(predicted)
-//             .unwrap()
-//             .0 = 4.0;
-//         // check that the history is how we expect after rollback
-//         let mut history = PredictionHistory::<Component1>::default();
-//         for i in 3..7 {
-//             history
-//                 .buffer
-//                 .add_item(Tick(i), HistoryState::Updated(Component1(i as f32 - 2.0)));
-//         }
-//         assert_eq!(
-//             stepper
-//                 .client_app
-//                 .world()//                 .get::<PredictionHistory<Component1>>(predicted)
-//                 .unwrap(),
-//             &history
-//         );
-//         Ok(())
-//     }
-//
-//     // Test that if another entity gets added during prediction,
-//     // - either it should get despawned if there is a rollback that doesn't add it anymore
-//     // - or we should just let it live? (imagine it's audio, etc.)
-//
-//     fn increment_component_and_despawn_both(
-//         mut commands: Commands,
-//         mut query: Query<(Entity, &mut Component1)>,
-//     ) {
-//         for (entity, mut component) in query.iter_mut() {
-//             component.0 += 1.0;
-//             if component.0 == 5.0 {
-//                 commands.entity(entity).prediction_despawn::<MyProtocol>();
-//             }
-//         }
-//     }
-//
-//     // Test that if a confirmed entity gets despawned,
-//     // the corresponding predicted entity gets despawned as well
-//     // Test that if a predicted entity gets despawned erroneously
-//     // We are still able to rollback properly (the rollback re-adds the predicted entity, or prevents it from despawning)
-//     #[test]
-//     fn test_despawned_confirmed_rollback() -> anyhow::Result<()> {
-//         let frame_duration = Duration::from_millis(10);
-//         let tick_duration = Duration::from_millis(10);
-//         let shared_config = SharedConfig {
-//             enable_replication: false,
-//             tick: TickConfig::new(tick_duration),
-//             ..Default::default()
-//         };
-//         let link_conditioner = LinkConditionerConfig {
-//             incoming_latency: Duration::from_millis(40),
-//             incoming_jitter: Duration::from_millis(5),
-//             incoming_loss: 0.05,
-//         };
-//         let sync_config = SyncConfig::default().speedup_factor(1.0);
-//         let prediction_config = PredictionConfig::default();
-//         let interpolation_delay = Duration::from_millis(100);
-//         let interpolation_config = InterpolationConfig::default().with_delay(InterpolationDelay {
-//             min_delay: interpolation_delay,
-//             send_interval_ratio: 0.0,
-//         });
-//         let mut stepper = BevyStepper::new(
-//             shared_config,
-//             sync_config,
-//             prediction_config,
-//             interpolation_config,
-//             link_conditioner,
-//             frame_duration,
-//         );
-//         stepper.client_app.add_systems(
-//             FixedUpdate,
-//             increment_component_and_despawn_both
-//         );
-//
-//         // Create a confirmed entity
-//         let confirmed = stepper
-//             .client_app
-//             .world_mut()
-//             .spawn((Component1(0.0), ShouldBePredicted))
-//             .id();
-//
-//         // Tick once
-//         stepper.frame_step();
-//         assert_eq!(stepper.client().tick(), Tick(1));
-//         let predicted = stepper
-//             .client_app
-//             .world()//             .get::<Confirmed>(confirmed)
-//             .unwrap()
-//             .predicted
-//             .unwrap();
-//
-//         // check that the predicted entity got spawned
-//         assert_eq!(
-//             stepper
-//                 .client_app
-//                 .world()//                 .get::<Predicted>(predicted)
-//                 .unwrap()
-//                 .confirmed_entity,
-//             confirmed
-//         );
-//
-//         // check that the component history got created
-//         let mut history = PredictionHistory::<Component1>::default();
-//         history
-//             .buffer
-//             .add_item(Tick(1), HistoryState::Updated(Component1(1.0)));
-//         assert_eq!(
-//             stepper
-//                 .client_app
-//                 .world()//                 .get::<PredictionHistory<Component1>>(predicted)
-//                 .unwrap(),
-//             &history,
-//         );
-//         // check that the confirmed component got replicated
-//         assert_eq!(
-//             stepper
-//                 .client_app
-//                 .world()//                 .get::<Component1>(predicted)
-//                 .unwrap(),
-//             &Component1(1.0)
-//         );
-//
-//         // create a situation where the confirmed entity gets despawned during FixedUpdate::Main
-//         stepper.client_mut().set_synced();
-//         stepper
-//             .client_mut()
-//             .set_latest_received_server_tick(Tick(0));
-//         // we set it to 5 so that it gets despawned during FixedUpdate::Main
-//         stepper
-//             .client_app
-//             .world_mut()
-//             .get_mut::<Component1>(confirmed)
-//             .unwrap()
-//             .0 = 4.0;
-//         // update without incrementing time, because we want to force a rollback check
-//         stepper.frame_step();
-//
-//         // check that rollback happened
-//         // confirmed and predicted both got despawned
-//         assert!(stepper.client_app.world().get_entity(confirmed).is_none());
-//         assert!(stepper.client_app.world().get_entity(predicted).is_none());
-//
-//         Ok(())
-//     }
-// }
+#[cfg(test)]
+mod tests {
+    use crate::client::prediction::despawn::PredictionDespawnMarker;
+    use crate::client::prediction::resource::PredictionManager;
+    use crate::prelude::client::{Confirmed, PredictionDespawnCommandsExt};
+    use crate::prelude::server::SyncTarget;
+    use crate::prelude::{client, server, NetworkTarget};
+    use crate::tests::protocol::{ComponentSyncModeFull, ComponentSyncModeSimple};
+    use crate::tests::stepper::BevyStepper;
+    use bevy::prelude::default;
+
+    /// Test that if a predicted entity gets despawned erroneously
+    /// The rollback re-adds the predicted entity.
+    #[test]
+    fn test_despawned_predicted_rollback() {
+        let mut stepper = BevyStepper::default();
+
+        let server_entity = stepper
+            .server_app
+            .world_mut()
+            .spawn((
+                ComponentSyncModeFull(1.0),
+                ComponentSyncModeSimple(1.0),
+                server::Replicate {
+                    sync: SyncTarget {
+                        prediction: NetworkTarget::All,
+                        ..default()
+                    },
+                    ..default()
+                },
+            ))
+            .id();
+        stepper.frame_step();
+        stepper.frame_step();
+        let confirmed_entity = stepper
+            .client_app
+            .world()
+            .resource::<client::ConnectionManager>()
+            .replication_receiver
+            .remote_entity_map
+            .get_local(server_entity)
+            .expect("entity was not replicated to client");
+        // check that prediction, interpolation, controlled was handled correctly
+        let confirmed = stepper
+            .client_app
+            .world()
+            .entity(confirmed_entity)
+            .get::<Confirmed>()
+            .expect("Confirmed component missing");
+        let predicted_entity = confirmed.predicted.unwrap();
+
+        // despawn the predicted entity locally
+        stepper
+            .client_app
+            .world_mut()
+            .commands()
+            .entity(predicted_entity)
+            .prediction_despawn();
+        stepper.frame_step();
+        // make sure that all components have been removed
+        assert!(stepper
+            .client_app
+            .world()
+            .get::<ComponentSyncModeFull>(predicted_entity)
+            .is_none());
+        assert!(stepper
+            .client_app
+            .world()
+            .get::<ComponentSyncModeSimple>(predicted_entity)
+            .is_none());
+        // the despawn marker should be removed immediately
+        assert!(stepper
+            .client_app
+            .world()
+            .get::<PredictionDespawnMarker>(predicted_entity)
+            .is_none());
+
+        // update the server entity to trigger a rollback where the predicted entity should be 're-spawned'
+        stepper
+            .server_app
+            .world_mut()
+            .get_mut::<ComponentSyncModeFull>(server_entity)
+            .unwrap()
+            .0 = 2.0;
+        stepper.frame_step();
+        stepper.frame_step();
+
+        assert_eq!(
+            stepper
+                .client_app
+                .world()
+                .get::<ComponentSyncModeFull>(predicted_entity)
+                .unwrap(),
+            &ComponentSyncModeFull(2.0)
+        );
+        // the non-Full components should also get restored
+        assert_eq!(
+            stepper
+                .client_app
+                .world()
+                .get::<ComponentSyncModeSimple>(predicted_entity)
+                .unwrap(),
+            &ComponentSyncModeSimple(1.0)
+        );
+    }
+
+    /// Check that when the confirmed entity gets despawned, the predicted entity gets despawned as well
+    #[test]
+    fn test_despawned_confirmed() {
+        let mut stepper = BevyStepper::default();
+
+        let server_entity = stepper
+            .server_app
+            .world_mut()
+            .spawn((
+                ComponentSyncModeFull(1.0),
+                ComponentSyncModeSimple(1.0),
+                server::Replicate {
+                    sync: SyncTarget {
+                        prediction: NetworkTarget::All,
+                        ..default()
+                    },
+                    ..default()
+                },
+            ))
+            .id();
+        stepper.frame_step();
+        stepper.frame_step();
+        let confirmed_entity = stepper
+            .client_app
+            .world()
+            .resource::<client::ConnectionManager>()
+            .replication_receiver
+            .remote_entity_map
+            .get_local(server_entity)
+            .expect("entity was not replicated to client");
+        // check that prediction, interpolation, controlled was handled correctly
+        let confirmed = stepper
+            .client_app
+            .world()
+            .entity(confirmed_entity)
+            .get::<Confirmed>()
+            .expect("Confirmed component missing");
+        let predicted_entity = confirmed.predicted.unwrap();
+
+        // despawn the confirmed entity
+        stepper.client_app.world_mut().despawn(confirmed_entity);
+        stepper.frame_step();
+
+        // check that the predicted entity got despawned
+        assert!(stepper
+            .client_app
+            .world()
+            .get_entity(predicted_entity)
+            .is_err());
+        // check that the confirmed to predicted map got updated
+        unsafe {
+            assert!(stepper
+                .client_app
+                .world()
+                .resource::<PredictionManager>()
+                .predicted_entity_map
+                .get()
+                .as_ref()
+                .unwrap()
+                .confirmed_to_predicted
+                .get(&confirmed_entity)
+                .is_none());
+        }
+    }
+}

--- a/lightyear/src/client/prediction/mod.rs
+++ b/lightyear/src/client/prediction/mod.rs
@@ -64,7 +64,7 @@ impl Component for Predicted {
                             .predicted_entity_map
                             .get_mut()
                             .confirmed_to_predicted
-                            .insert(confirmed, predicted);
+                            .remove(&confirmed);
                     };
                 }
             },


### PR DESCRIPTION
The test still doesn't pass but hopefully we can remember to handle this case in the future