### PR TITLE
Fix hashing in bullet-prespawn example

### DIFF
--- a/examples/bullet_prespawn/src/protocol.rs
+++ b/examples/bullet_prespawn/src/protocol.rs
@@ -65,12 +65,7 @@ pub(crate) struct BallBundle {
 }
 
 impl BallBundle {
-    pub(crate) fn new(
-        position: Vec2,
-        rotation_radians: f32,
-        color: Color,
-        predicted: bool,
-    ) -> Self {
+    pub(crate) fn new(position: Vec2, rotation_radians: f32, color: Color) -> Self {
         let mut transform = Transform::from_xyz(position.x, position.y, 0.0);
         transform.rotate_z(rotation_radians);
         Self {

--- a/lightyear/src/client/prediction/prespawn.rs
+++ b/lightyear/src/client/prediction/prespawn.rs
@@ -131,6 +131,18 @@ impl PreSpawnedPlayerObjectPlugin {
                 .entry(hash)
                 .or_default()
                 .push(entity);
+
+            if prediction_manager
+                .prespawn_hash_to_entities
+                .get(&hash)
+                .is_some_and(|v| v.len() > 1)
+            {
+                warn!(
+                    ?hash,
+                    ?entity,
+                    "Multiple pre-spawned entities share the same hash, this might cause extra rollbacks"
+                );
+            }
             // add a timer on the entity so that it gets despawned if the interpolation tick
             // reaches it without matching with any server entity
             prediction_manager.prespawn_tick_to_hash.push(tick, hash);


### PR DESCRIPTION
The bullet-prespawn example spawns 2 PreSpawned objects in the same tick.
These 2 bullets have the same exact hash since they have the same component list + spawn tick.

I think I added this to show that lightyear doesn't panic even with multiple prespawned entities with the same hash exist.

However this was causing a lot of rollbacks since the left bullet on the server might match with the right bullet on the client!
In general we might never want to have this behavior. Maybe it's better to panic if this happens, to let users make sure that the hashes don't collide? For now I'll still support it but issue a warning if this happens.

Fixes https://github.com/cBournhonesque/lightyear/issues/178