### PR TITLE
Allow not replicating hierarchy

### DIFF
--- a/lightyear/src/shared/replication/components.rs
+++ b/lightyear/src/shared/replication/components.rs
@@ -93,6 +93,8 @@ pub enum TargetEntity {
 #[derive(Component, Clone, Copy, Debug, PartialEq, Reflect)]
 #[reflect(Component)]
 pub struct ReplicateHierarchy {
+    /// If true, the direct [`Children`](bevy::prelude::Children) of this entity will be replicated
+    pub enabled: bool,
     /// If true, recursively add `Replicate` and `ParentSync` components to all children to make sure they are replicated
     ///
     /// If false, you can still replicate hierarchies, but in a more fine-grained manner. You will have to add the `Replicate`
@@ -102,7 +104,10 @@ pub struct ReplicateHierarchy {
 
 impl Default for ReplicateHierarchy {
     fn default() -> Self {
-        Self { recursive: true }
+        Self {
+            enabled: true,
+            recursive: true,
+        }
     }
 }
 


### PR DESCRIPTION
Hierarchy is not replicated if the ReplicateHierarchy component is not present on the entity.

The issue is that ReplicateHierarchy is part of the Replicate bundle, and is a required-component for ReplicationTarget. This makes it hard to not include the component on the entity.

Instead I am adding a 'enabled' field on `ReplicateHierarchy` to enable/disable hierarchy replication