### PR TITLE
Improve visual interpolation for examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 .DS_Store
 /examples/target/
 /examples/Cargo.lock
+.aider*

--- a/examples/avian_3d_character/src/protocol.rs
+++ b/examples/avian_3d_character/src/protocol.rs
@@ -5,15 +5,15 @@ use leafwing_input_manager::prelude::*;
 use lightyear_examples_common::shared::FIXED_TIMESTEP_HZ;
 use serde::{Deserialize, Serialize};
 
+use crate::shared::color_from_id;
 use lightyear::client::components::{ComponentSyncMode, LerpFn};
 use lightyear::client::interpolation::LinearInterpolator;
 use lightyear::prelude::client::{self, LeafwingInputConfig};
 use lightyear::prelude::server::{Replicate, SyncTarget};
 use lightyear::prelude::*;
 use lightyear::utils::avian3d::{position, rotation};
+use lightyear::utils::bevy::TransformLinearInterpolation;
 use tracing_subscriber::util::SubscriberInitExt;
-
-use crate::shared::color_from_id;
 
 // For prediction, we want everything entity that is predicted to be part of
 // the same replication group This will make sure that they will be replicated
@@ -105,5 +105,11 @@ impl Plugin for ProtocolPlugin {
             .add_prediction(ComponentSyncMode::Full)
             .add_interpolation_fn(rotation::lerp)
             .add_correction_fn(rotation::lerp);
+
+        // do not replicate Transform but make sure to register an interpolation function
+        // for it so that we can do visual interpolation
+        // (another option would be to replicate transform and not use Position/Rotation at all)
+        app.add_interpolation::<Transform>(ComponentSyncMode::None);
+        app.add_interpolation_fn::<Transform>(TransformLinearInterpolation::lerp);
     }
 }

--- a/examples/avian_3d_character/src/server.rs
+++ b/examples/avian_3d_character/src/server.rs
@@ -85,20 +85,20 @@ fn init(mut commands: Commands) {
         group: REPLICATION_GROUP,
         ..default()
     };
-    commands.spawn((
-        Name::new("Block"),
-        BlockPhysicsBundle::default(),
-        BlockMarker,
-        Position::new(Vec3::new(1.0, 1.0, 0.0)),
-        block_replicate_component.clone(),
-    ));
-    commands.spawn((
-        Name::new("Block"),
-        BlockPhysicsBundle::default(),
-        BlockMarker,
-        Position::new(Vec3::new(-1.0, 1.0, 0.0)),
-        block_replicate_component.clone(),
-    ));
+    // commands.spawn((
+    //     Name::new("Block"),
+    //     BlockPhysicsBundle::default(),
+    //     BlockMarker,
+    //     Position::new(Vec3::new(1.0, 1.0, 0.0)),
+    //     block_replicate_component.clone(),
+    // ));
+    // commands.spawn((
+    //     Name::new("Block"),
+    //     BlockPhysicsBundle::default(),
+    //     BlockMarker,
+    //     Position::new(Vec3::new(-1.0, 1.0, 0.0)),
+    //     block_replicate_component.clone(),
+    // ));
 }
 
 pub(crate) fn replicate_inputs(

--- a/examples/avian_3d_character/src/shared.rs
+++ b/examples/avian_3d_character/src/shared.rs
@@ -95,6 +95,7 @@ impl Plugin for SharedPlugin {
 
         // Position and Rotation are the primary source of truth so no need to
         // sync changes from Transform to Position.
+        // (we are not applying manual updates to Transform)
         app.insert_resource(avian3d::sync::SyncConfig {
             transform_to_position: false,
             position_to_transform: true,
@@ -111,18 +112,14 @@ impl Plugin for SharedPlugin {
             after_physics_log.after(PhysicsSet::StepSimulation),
         );
 
-        // We change SyncPlugin to PostUpdate, because we want the visually
-        // interpreted values synced to transform every time, not just when
-        // Fixed schedule runs.
         app.add_plugins(
             PhysicsPlugins::default()
                 .build()
-                .disable::<SyncPlugin>()
-                .disable::<PhysicsInterpolationPlugin>(), // disable Sleeping plugin as it can mess up physics rollbacks
-                                                          // TODO: disabling sleeping plugin causes the player to fall through the floor
-                                                          // .disable::<SleepingPlugin>(),
-        )
-        .add_plugins(SyncPlugin::new(PostUpdate));
+                .disable::<PhysicsInterpolationPlugin>(),
+            // disable Sleeping plugin as it can mess up physics rollbacks
+            // TODO: disabling sleeping plugin causes the player to fall through the floor
+            // .disable::<SleepingPlugin>(),
+        );
     }
 }
 

--- a/examples/avian_physics/src/client.rs
+++ b/examples/avian_physics/src/client.rs
@@ -95,8 +95,6 @@ fn add_ball_physics(
         Entity,
         (
             With<BallMarker>,
-            // insert the physics components on the ball that is displayed on screen
-            // (either interpolated or predicted)
             Or<(Added<Interpolated>, Added<Predicted>)>,
         ),
     >,

--- a/examples/avian_physics/src/protocol.rs
+++ b/examples/avian_physics/src/protocol.rs
@@ -3,14 +3,14 @@ use bevy::prelude::*;
 use leafwing_input_manager::prelude::*;
 use serde::{Deserialize, Serialize};
 
+use crate::shared::color_from_id;
 use lightyear::client::components::{ComponentSyncMode, LerpFn};
 use lightyear::client::interpolation::LinearInterpolator;
 use lightyear::prelude::client;
 use lightyear::prelude::server::{Replicate, SyncTarget};
 use lightyear::prelude::*;
 use lightyear::utils::avian2d::*;
-
-use crate::shared::color_from_id;
+use lightyear::utils::bevy::TransformLinearInterpolation;
 
 pub const BALL_SIZE: f32 = 15.0;
 pub const PLAYER_SIZE: f32 = 40.0;

--- a/examples/avian_physics/src/shared.rs
+++ b/examples/avian_physics/src/shared.rs
@@ -33,7 +33,6 @@ impl Plugin for SharedPlugin {
                 .build()
                 .disable::<ColliderHierarchyPlugin>(),
         )
-        .insert_resource(Time::<Fixed>::from_hz(FIXED_TIMESTEP_HZ))
         .insert_resource(Gravity(Vec2::ZERO));
 
         // add a log at the start of the physics schedule

--- a/examples/spaceships/src/protocol.rs
+++ b/examples/spaceships/src/protocol.rs
@@ -5,15 +5,15 @@ use leafwing_input_manager::prelude::*;
 use lightyear_examples_common::shared::FIXED_TIMESTEP_HZ;
 use serde::{Deserialize, Serialize};
 
+use crate::shared::color_from_id;
 use lightyear::client::components::{ComponentSyncMode, LerpFn};
 use lightyear::client::interpolation::LinearInterpolator;
 use lightyear::prelude::client::{self, LeafwingInputConfig};
 use lightyear::prelude::server::{Replicate, SyncTarget};
 use lightyear::prelude::*;
 use lightyear::utils::avian2d::*;
+use lightyear::utils::bevy::TransformLinearInterpolation;
 use tracing_subscriber::util::SubscriberInitExt;
-
-use crate::shared::color_from_id;
 
 pub const BULLET_SIZE: f32 = 1.5;
 pub const SHIP_WIDTH: f32 = 19.0;
@@ -286,5 +286,11 @@ impl Plugin for ProtocolPlugin {
             .add_prediction(ComponentSyncMode::Full)
             .add_interpolation_fn(rotation::lerp)
             .add_correction_fn(rotation::lerp);
+
+        // do not replicate Transform but make sure to register an interpolation function
+        // for it so that we can do visual interpolation
+        // (another option would be to replicate transform and not use Position/Rotation at all)
+        app.add_interpolation::<Transform>(ComponentSyncMode::None);
+        app.add_interpolation_fn::<Transform>(TransformLinearInterpolation::lerp);
     }
 }

--- a/examples/spaceships/src/shared.rs
+++ b/examples/spaceships/src/shared.rs
@@ -49,10 +49,8 @@ impl Plugin for SharedPlugin {
         });
         // We change SyncPlugin to PostUpdate, because we want the visually interpreted values
         // synced to transform every time, not just when Fixed schedule runs.
-        app.add_plugins(PhysicsPlugins::default().build().disable::<SyncPlugin>())
-            .add_plugins(SyncPlugin::new(PostUpdate));
+        app.add_plugins(PhysicsPlugins::default().build());
 
-        app.insert_resource(Time::<Fixed>::from_hz(FIXED_TIMESTEP_HZ));
         app.insert_resource(Gravity(Vec2::ZERO));
         // our systems run in FixedUpdate, avian's systems run in FixedPostUpdate.
         app.add_systems(

--- a/lightyear/src/protocol/component.rs
+++ b/lightyear/src/protocol/component.rs
@@ -537,6 +537,7 @@ mod interpolation {
                 )
             });
         }
+
         pub(crate) fn interpolation_mode<C: Component>(&self) -> ComponentSyncMode {
             let kind = ComponentKind::of::<C>();
             self.interpolation_map


### PR DESCRIPTION
The current flow of visual interpolation for examples is:
- visually interpolate Position/Rotation
- to make sure that changes in Position are reflected in Transform, we:
  - put the avian SyncPlugin in PostUpdate (so that even if FixedUpdate doesn't run, we still have visual interpolation run, and then the Position/Rotation gets synced to Transform)
  - add the ordering in `PostUpdate`: VisualInterpolation -> Sync -> TransformPropagate
  - make sure that `UpdateVisualInterpolation` runs after PhysicsSet::Simulation in FixedPostUpdate
  
  All of this is pretty convoluted and very error-prone, instead what we want todo:
  - visually interpolate Transform (for this we need to make sure that an interpolation fn has been registered for Transform)
  - we don't need to touch the SyncPlugin; Pos/Rot are synced to transform in PostUpdate

This is much simpler!
As an extra optimization we can move SyncPlugin to RunFixedMainLoop so that it doesn't run on rollbacks.

Also add visual_interpolation to avian_physics example.