### PR TITLE
Separate new() and new_with_app_id()

### DIFF
--- a/lightyear/src/connection/client.rs
+++ b/lightyear/src/connection/client.rs
@@ -165,7 +165,7 @@ impl NetConfig {
             } => {
                 let client = super::steam::client::Client::new(
                     steamworks_client.unwrap_or_else(|| {
-                        Arc::new(RwLock::new(SteamworksClient::new(config.app_id)))
+                        Arc::new(RwLock::new(SteamworksClient::new_with_app_id(config.app_id)))
                     }),
                     config,
                     conditioner,

--- a/lightyear/src/connection/server.rs
+++ b/lightyear/src/connection/server.rs
@@ -158,7 +158,7 @@ impl NetConfig {
                 // TODO: handle errors
                 let server = super::steam::server::Server::new(
                     steamworks_client.unwrap_or_else(|| {
-                        Arc::new(RwLock::new(SteamworksClient::new(config.app_id)))
+                        Arc::new(RwLock::new(SteamworksClient::new_with_app_id(config.app_id)))
                     }),
                     config,
                     conditioner,

--- a/lightyear/src/connection/steam/steamworks_client.rs
+++ b/lightyear/src/connection/steam/steamworks_client.rs
@@ -19,13 +19,25 @@ impl std::fmt::Debug for SteamworksClient {
 }
 
 impl SteamworksClient {
-    /// Creates and initializes the Steamworks client. This must only be called
-    /// once per application run.
-    pub fn new(app_id: u32) -> Self {
+    /// Creates and initializes the Steamworks client with the specified AppId.
+    /// This must only be called once per application run.
+    pub fn new_with_app_id(app_id: u32) -> Self {
         let (client, single) = steamworks::Client::<ClientManager>::init_app(app_id).unwrap();
 
         Self {
             app_id,
+            client,
+            single: SyncCell::new(single),
+        }
+    }
+
+    /// Creates and initializes the Steamworks client. This must only be called
+    /// once per application run.
+    pub fn new() -> Self {
+        let (client, single) = steamworks::Client::<ClientManager>::init().unwrap();
+
+        Self {
+            app_id: client.utils().app_id(),
             client,
             single: SyncCell::new(single),
         }

--- a/lightyear/src/connection/steam/steamworks_client.rs
+++ b/lightyear/src/connection/steam/steamworks_client.rs
@@ -37,7 +37,7 @@ impl SteamworksClient {
         let (client, single) = steamworks::Client::<ClientManager>::init().unwrap();
 
         Self {
-            app_id: client.utils().app_id(),
+            app_id: client.utils().app_id().0,
             client,
             single: SyncCell::new(single),
         }

--- a/lightyear/src/connection/steam/steamworks_client.rs
+++ b/lightyear/src/connection/steam/steamworks_client.rs
@@ -31,8 +31,10 @@ impl SteamworksClient {
         }
     }
 
-    /// Creates and initializes the Steamworks client. This must only be called
-    /// once per application run.
+    /// Creates and initializes the Steamworks client. If the game isn’t being run through steam
+    /// this can be provided by placing a steam_appid.txt with the ID inside in the current
+    /// working directory.
+    /// This must only be called once per application run.
     pub fn new() -> Self {
         let (client, single) = steamworks::Client::<ClientManager>::init().unwrap();
 


### PR DESCRIPTION
If you call init() on the SteamAPI, it will automatically determine the AppId, otherwise you can call init_app() and provide an explicit AppId.

https://docs.rs/steamworks/latest/steamworks/struct.Client.html#method.init