### PR TITLE
fixup disconnect events firing, adapt steam disconnections to ConnectionError

### DIFF
--- a/lightyear/src/client/networking.rs
+++ b/lightyear/src/client/networking.rs
@@ -496,7 +496,7 @@ fn connect(world: &mut World) {
             });
             // TODO: how can we also provide a reason here since it's not cloneable?
             // we need to also trigger the event because we sometimes react to it via observers
-            commands.trigger(DisconnectEvent { reason: None });
+            world.trigger(DisconnectEvent { reason: None });
     }
     let config = world.resource::<ClientConfig>();
     if matches!(

--- a/lightyear/src/connection/client.rs
+++ b/lightyear/src/connection/client.rs
@@ -346,4 +346,7 @@ pub enum ConnectionError {
     #[error(transparent)]
     #[cfg(all(feature = "steam", not(target_family = "wasm")))]
     SteamError(#[from] steamworks::SteamError),
+    #[error("client was disconnected")]
+    #[cfg(all(feature = "steam", not(target_family = "wasm")))]
+    SteamDisconnection(steamworks::networking_types::NetConnectionEnd)
 }

--- a/lightyear/src/connection/steam/client.rs
+++ b/lightyear/src/connection/steam/client.rs
@@ -1,4 +1,4 @@
-use crate::connection::client::{ConnectionError, ConnectionState, DisconnectReason, NetClient};
+use crate::connection::client::{ConnectionError, ConnectionState, NetClient};
 use crate::connection::id::ClientId;
 use crate::packet::packet_builder::RecvPayload;
 use crate::prelude::client::Io;
@@ -159,7 +159,7 @@ impl NetClient for Client {
                     .connection_info()
                     .map_or(None, |info| info.ok().map(|i| i.end_reason()))
                     .flatten()
-                    .map(|r| DisconnectReason::Steam(r));
+                    .map(|r| ConnectionError::SteamDisconnection(r));
                 ConnectionState::Disconnected { reason }
             }
         }


### PR DESCRIPTION
Looks like the steamworks `NetConnectionEnd` type was getting mapped to the now removed `DisconnectReason` type. So I just gave it an entry in `ConnectionError`. I can do that differently if you had something else in mind