### PR TITLE
Add batch write for replication receive

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,6 @@ lightyear_examples_common = { path = "./examples/common", default-features = fal
 lightyear = { path = "./lightyear", version = "0.19.0", default-features = false }
 
 # utils
-
 anyhow = { version = "1.0.75", features = [] }
 clap = { version = "4.5.4", features = ["derive"] }
 chrono = "0.4.38"

--- a/lightyear/src/client/connection.rs
+++ b/lightyear/src/client/connection.rs
@@ -69,7 +69,6 @@ use super::sync::SyncManager;
 /// ```
 #[derive(Resource, Debug)]
 pub struct ConnectionManager {
-    pub(crate) component_registry: ComponentRegistry,
     pub(crate) message_registry: MessageRegistry,
     pub(crate) message_manager: MessageManager,
     pub(crate) delta_manager: DeltaManager,
@@ -105,7 +104,6 @@ impl Default for ConnectionManager {
         );
         let replication_receiver = ReplicationReceiver::new();
         Self {
-            component_registry: ComponentRegistry::default(),
             message_registry: MessageRegistry::default(),
             message_manager: MessageManager::new(
                 &ChannelRegistry::default(),
@@ -130,7 +128,6 @@ impl Default for ConnectionManager {
 impl ConnectionManager {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
-        component_registry: &ComponentRegistry,
         message_registry: &MessageRegistry,
         channel_registry: &ChannelRegistry,
         client_config: &ClientConfig,
@@ -162,7 +159,6 @@ impl ConnectionManager {
         );
         let replication_receiver = ReplicationReceiver::new();
         Self {
-            component_registry: component_registry.clone(),
             message_registry: message_registry.clone(),
             message_manager,
             delta_manager: DeltaManager::default(),
@@ -370,8 +366,9 @@ impl ConnectionManager {
     pub(crate) fn receive(
         &mut self,
         world: &mut World,
-        // TODO: pass the `ComponentRegistry`/`MessageRegistry` as arguments instead of storing a copy
+        // TODO: pass the MessageRegistry` as arguments instead of storing a copy
         //  in the `ConnectionManager`
+        component_registry: &mut ComponentRegistry,
         time_manager: &TimeManager,
         tick_manager: &TickManager,
     ) -> Result<(), ClientError> {
@@ -464,7 +461,7 @@ impl ConnectionManager {
             self.replication_receiver.apply_world(
                 world,
                 None,
-                &self.component_registry,
+                component_registry,
                 tick_manager.tick(),
                 &mut self.events,
             );

--- a/lightyear/src/client/networking.rs
+++ b/lightyear/src/client/networking.rs
@@ -182,12 +182,15 @@ pub(crate) fn receive(world: &mut World) {
     //  these resources
     let mut connection_manager =
         unsafe { unsafe_world.get_resource_mut::<ConnectionManager>() }.unwrap();
+    let mut component_registry =
+        unsafe { unsafe_world.get_resource_mut::<ComponentRegistry>() }.unwrap();
     let time_manager = unsafe { unsafe_world.get_resource::<TimeManager>() }.unwrap();
     let tick_manager = unsafe { unsafe_world.get_resource::<TickManager>() }.unwrap();
     // RECEIVE: read messages and parse them into events
     let _ = connection_manager
         .receive(
             unsafe { unsafe_world.world_mut() },
+            component_registry.as_mut(),
             time_manager,
             tick_manager,
         )
@@ -453,7 +456,6 @@ fn rebuild_client_connection(world: &mut World) {
 
     // insert a new connection manager (to reset sync, priority, message numbers, etc.)
     let connection_manager = ConnectionManager::new(
-        world.resource::<ComponentRegistry>(),
         world.resource::<MessageRegistry>(),
         world.resource::<ChannelRegistry>(),
         &client_config,

--- a/lightyear/src/client/prediction/prespawn.rs
+++ b/lightyear/src/client/prediction/prespawn.rs
@@ -7,12 +7,11 @@ use tracing::{debug, trace};
 
 use crate::client::components::Confirmed;
 use crate::client::connection::ConnectionManager;
-use crate::client::events::ComponentInsertEvent;
 use crate::client::prediction::resource::PredictionManager;
 use crate::client::prediction::rollback::Rollback;
 use crate::client::prediction::Predicted;
 use crate::prelude::client::PredictionSet;
-use crate::prelude::{ComponentRegistry, Replicated, Replicating, ShouldBePredicted, TickManager};
+use crate::prelude::{ComponentRegistry, Replicated, ShouldBePredicted, TickManager};
 
 use crate::shared::replication::prespawn::compute_default_hash;
 use crate::shared::sets::{ClientMarker, InternalReplicationSet};
@@ -568,9 +567,9 @@ mod tests {
     ///
     #[test]
     fn test_prespawn_success() {
-        tracing_subscriber::FmtSubscriber::builder()
-            .with_max_level(tracing::Level::ERROR)
-            .init();
+        // tracing_subscriber::FmtSubscriber::builder()
+        //     .with_max_level(tracing::Level::ERROR)
+        //     .init();
         let mut stepper = BevyStepper::default();
 
         let client_prespawn = stepper

--- a/lightyear/src/protocol/component.rs
+++ b/lightyear/src/protocol/component.rs
@@ -594,6 +594,9 @@ mod replication {
         /// Store the component's raw bytes into a temporary buffer so that we can get an OwningPtr to it
         /// This function is called for all components that will be added to an entity, so that we can
         /// insert them all at once using `entity_world_mut.insert_by_ids`
+        ///
+        /// SAFETY:
+        /// - the component C must match the `component_id `
         pub(crate) unsafe fn buffer_insert_raw_ptrs<C: Component>(&mut self, mut component: C, component_id: ComponentId) {
             let layout = Layout::new::<C>();
             let ptr = NonNull::new_unchecked(&mut component).cast::<u8>();

--- a/lightyear/src/protocol/delta.rs
+++ b/lightyear/src/protocol/delta.rs
@@ -32,6 +32,7 @@ unsafe fn erased_diff<C: Diffable>(
         delta_type: DeltaType::Normal { previous_tick },
         delta,
     };
+    // TODO: Box::leak seems incorrect here; use Box::into_raw()
     let leaked_data = Box::leak(Box::new(delta_message));
     NonNull::from(leaked_data).cast()
 }

--- a/lightyear/src/protocol/serialize.rs
+++ b/lightyear/src/protocol/serialize.rs
@@ -81,7 +81,6 @@ unsafe fn erased_serialize_fn<M: Message>(
     }
 }
 
-
 /// Default serialize function using bincode
 fn default_serialize<M: Message + Serialize>(
     message: &M,

--- a/lightyear/src/protocol/serialize.rs
+++ b/lightyear/src/protocol/serialize.rs
@@ -6,10 +6,7 @@ use bevy::ecs::entity::MapEntities;
 use bevy::ptr::{Ptr, PtrMut};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
-use std::alloc::Layout;
 use std::any::TypeId;
-use std::ptr::NonNull;
-use tracing::trace;
 
 /// Stores function pointers related to serialization and deserialization
 #[derive(Clone, Debug, PartialEq)]
@@ -20,7 +17,6 @@ pub struct ErasedSerializeFns {
     pub serialize: unsafe fn(),
     pub erased_serialize: ErasedSerializeFn,
     pub deserialize: unsafe fn(),
-    pub erased_deserialize_into_fn: ErasedDeserializeIntoFn,
     pub erased_clone: Option<unsafe fn()>,
     pub map_entities: Option<ErasedMapEntitiesFn>,
     pub send_map_entities: Option<ErasedSendMapEntitiesFn>,
@@ -41,14 +37,6 @@ type ErasedSerializeFn = unsafe fn(
     writer: &mut Writer,
     entity_map: Option<&mut SendEntityMap>,
 ) -> Result<(), SerializationError>;
-
-type ErasedDeserializeIntoFn = unsafe fn(
-    erased_serialize_fn: &ErasedSerializeFns,
-    // Will store the raw bytes of the deserialized message
-    raw_bytes: &mut Vec<u8>,
-    reader: &mut Reader,
-    entity_map: &mut ReceiveEntityMap,
-) -> Result<usize, SerializationError>;
 
 /// Type of the serialize function without entity mapping
 type SerializeFn<M> = fn(message: &M, writer: &mut Writer) -> Result<(), SerializationError>;
@@ -93,39 +81,6 @@ unsafe fn erased_serialize_fn<M: Message>(
     }
 }
 
-pub(crate) unsafe fn erased_deserialize_into<M: Message>(
-    erased_serialize_fn: &ErasedSerializeFns,
-    raw_bytes: &mut Vec<u8>,
-    reader: &mut Reader,
-    // TODO: should this be an option?
-    entity_map: &mut ReceiveEntityMap,
-) -> Result<usize, SerializationError> {
-    trace!("Batch insert for {:?}", std::any::type_name::<M>());
-    let typed_deserialize_fns = erased_serialize_fn.typed::<M>();
-    let mut message = (typed_deserialize_fns.deserialize)(reader)?;
-    if let Some(map_entities) = erased_serialize_fn.receive_map_entities {
-        unsafe {
-            map_entities(PtrMut::from(&mut message), entity_map);
-        }
-    };
-    let layout = Layout::new::<M>();
-    let ptr = NonNull::new_unchecked(&mut message).cast::<u8>();
-    // make sure the Drop trait is not called on the message when we exit this function
-    std::mem::forget(message);
-    Ok(push_ptr(raw_bytes, ptr, layout))
-}
-
-// Given a pointer to a value of type M and the layout of the type, push the bytes
-// of the value into the raw_bytes vector
-pub(crate) unsafe fn push_ptr(raw_bytes: &mut Vec<u8>, ptr: NonNull<u8>, layout: Layout) -> usize {
-    let count = layout.size();
-    raw_bytes.reserve(count);
-    let space = NonNull::new_unchecked(raw_bytes.spare_capacity_mut()).cast::<u8>();
-    space.copy_from_nonoverlapping(ptr, count);
-    let length = raw_bytes.len();
-    raw_bytes.set_len(length + count);
-    length
-}
 
 /// Default serialize function using bincode
 fn default_serialize<M: Message + Serialize>(
@@ -189,7 +144,6 @@ impl ErasedSerializeFns {
             type_name: std::any::type_name::<M>(),
             erased_serialize: erased_serialize_fn::<M>,
             serialize: unsafe { std::mem::transmute(serialize_fns.serialize) },
-            erased_deserialize_into_fn: erased_deserialize_into::<M>,
             deserialize: unsafe { std::mem::transmute(serialize_fns.deserialize) },
             erased_clone: None,
             map_entities: None,

--- a/lightyear/src/server/connection.rs
+++ b/lightyear/src/server/connection.rs
@@ -444,7 +444,7 @@ impl ConnectionManager {
     pub(crate) fn receive(
         &mut self,
         world: &mut World,
-        component_registry: &ComponentRegistry,
+        component_registry: &mut ComponentRegistry,
         message_registry: &MessageRegistry,
         time_manager: &TimeManager,
         tick_manager: &TickManager,
@@ -716,7 +716,7 @@ impl Connection {
     pub fn receive(
         &mut self,
         world: &mut World,
-        component_registry: &ComponentRegistry,
+        component_registry: &mut ComponentRegistry,
         message_registry: &MessageRegistry,
         time_manager: &TimeManager,
         tick_manager: &TickManager,

--- a/lightyear/src/server/networking.rs
+++ b/lightyear/src/server/networking.rs
@@ -237,7 +237,8 @@ pub(crate) fn receive(
     //  these resources
     let mut connection_manager =
         unsafe { unsafe_world.get_resource_mut::<ConnectionManager>() }.unwrap();
-    let component_registry = unsafe { unsafe_world.get_resource::<ComponentRegistry>() }.unwrap();
+    let mut component_registry =
+        unsafe { unsafe_world.get_resource_mut::<ComponentRegistry>() }.unwrap();
     let message_registry = unsafe { unsafe_world.get_resource::<MessageRegistry>() }.unwrap();
     let time_manager = unsafe { unsafe_world.get_resource::<TimeManager>() }.unwrap();
     let tick_manager = unsafe { unsafe_world.get_resource::<TickManager>() }.unwrap();
@@ -245,7 +246,7 @@ pub(crate) fn receive(
     connection_manager
         .receive(
             unsafe { unsafe_world.world_mut() },
-            component_registry,
+            component_registry.as_mut(),
             message_registry,
             time_manager,
             tick_manager,

--- a/lightyear/src/server/replication.rs
+++ b/lightyear/src/server/replication.rs
@@ -1658,6 +1658,9 @@ pub(crate) mod send {
 
         #[test]
         fn test_component_insert_delta() {
+            // tracing_subscriber::FmtSubscriber::builder()
+            //     .with_max_level(tracing::Level::DEBUG)
+            //     .init();
             let mut stepper = BevyStepper::default();
 
             // spawn an entity on server
@@ -3070,60 +3073,63 @@ pub(crate) mod send {
         #[derive(Resource, Default)]
         struct Counter(u32);
 
-        /// Check if we send an update with a component that is not equal to the component on the remote,
-        /// then we apply the update to the remote (so we emit a ComponentUpdateEvent)
-        #[test]
-        fn test_not_equal_update_does_not_trigger_change_detection() {
-            let mut stepper = BevyStepper::default();
-
-            // spawn an entity on server
-            let server_entity = stepper
-                .server_app
-                .world_mut()
-                .spawn(ComponentSyncModeFull(2.0))
-                .id();
-            // spawn an entity on the client with the component value
-            let client_entity = stepper
-                .client_app
-                .world_mut()
-                .spawn(ComponentSyncModeFull(1.0))
-                .id();
-
-            stepper.client_app.init_resource::<Counter>();
-            stepper.client_app.add_systems(
-                Update,
-                move |mut events: EventReader<ComponentUpdateEvent<ComponentSyncModeFull>>,
-                      mut counter: ResMut<Counter>| {
-                    for events in events.read() {
-                        counter.0 += 1;
-                        assert_eq!(events.entity(), client_entity);
-                    }
-                },
-            );
-
-            // add replication with a pre-existing target
-            stepper
-                .server_app
-                .world_mut()
-                .entity_mut(server_entity)
-                .insert((
-                    Replicate::default(),
-                    TargetEntity::Preexisting(client_entity),
-                ));
-
-            // check that we did receive an ComponentUpdateEvent
-            stepper.frame_step();
-            stepper.frame_step();
-            assert_eq!(
-                stepper
-                    .client_app
-                    .world()
-                    .get_resource::<Counter>()
-                    .unwrap()
-                    .0,
-                1
-            );
-        }
+        // TODO: this is not valid anymore because now we batch insert the components
+        //  and on Insert we do not check if the receiving entity already have the component
+        //  or not
+        // /// Check if we send an update with a component that is not equal to the component on the remote,
+        // /// then we apply the update to the remote (so we emit a ComponentUpdateEvent)
+        // #[test]
+        // fn test_not_equal_update_does_not_trigger_change_detection() {
+        //     let mut stepper = BevyStepper::default();
+        //
+        //     // spawn an entity on server
+        //     let server_entity = stepper
+        //         .server_app
+        //         .world_mut()
+        //         .spawn(ComponentSyncModeFull(2.0))
+        //         .id();
+        //     // spawn an entity on the client with the component value
+        //     let client_entity = stepper
+        //         .client_app
+        //         .world_mut()
+        //         .spawn(ComponentSyncModeFull(1.0))
+        //         .id();
+        //
+        //     stepper.client_app.init_resource::<Counter>();
+        //     stepper.client_app.add_systems(
+        //         Update,
+        //         move |mut events: EventReader<ComponentUpdateEvent<ComponentSyncModeFull>>,
+        //               mut counter: ResMut<Counter>| {
+        //             for events in events.read() {
+        //                 counter.0 += 1;
+        //                 assert_eq!(events.entity(), client_entity);
+        //             }
+        //         },
+        //     );
+        //
+        //     // add replication with a pre-existing target
+        //     stepper
+        //         .server_app
+        //         .world_mut()
+        //         .entity_mut(server_entity)
+        //         .insert((
+        //             Replicate::default(),
+        //             TargetEntity::Preexisting(client_entity),
+        //         ));
+        //
+        //     // check that we did receive an ComponentUpdateEvent
+        //     stepper.frame_step();
+        //     stepper.frame_step();
+        //     assert_eq!(
+        //         stepper
+        //             .client_app
+        //             .world()
+        //             .get_resource::<Counter>()
+        //             .unwrap()
+        //             .0,
+        //         1
+        //     );
+        // }
 
         /// Make sure that ClientToServer components are not replicated to the client
         #[test]

--- a/lightyear/src/shared/replication/delta.rs
+++ b/lightyear/src/shared/replication/delta.rs
@@ -219,9 +219,9 @@ impl DeltaComponentStore {
 
 #[cfg(test)]
 mod tests {
-    use bevy::prelude::World;
     use super::*;
     use crate::tests::protocol::ComponentDeltaCompression;
+    use bevy::prelude::World;
 
     #[test]
     fn test_add_get_data() {

--- a/lightyear/src/shared/replication/delta.rs
+++ b/lightyear/src/shared/replication/delta.rs
@@ -26,7 +26,7 @@ pub enum DeltaType {
 /// A message that contains a delta between two states (for serializing delta compression)
 // Need repr(C) to be able to cast the pointer to a u8 pointer
 #[repr(C)]
-#[derive(Deserialize, Serialize)]
+#[derive(Component, Deserialize, Serialize)]
 pub struct DeltaMessage<M> {
     pub(crate) delta_type: DeltaType,
     pub(crate) delta: M,
@@ -219,14 +219,16 @@ impl DeltaComponentStore {
 
 #[cfg(test)]
 mod tests {
+    use bevy::prelude::World;
     use super::*;
     use crate::tests::protocol::ComponentDeltaCompression;
 
     #[test]
     fn test_add_get_data() {
+        let mut world = World::default();
         let mut registry = ComponentRegistry::default();
         registry.register_component::<ComponentDeltaCompression>();
-        registry.set_delta_compression::<ComponentDeltaCompression>();
+        registry.set_delta_compression::<ComponentDeltaCompression>(&mut world);
         let mut store = DeltaComponentStore::default();
         let entity = Entity::from_raw(0);
         let tick = Tick(0);
@@ -246,9 +248,10 @@ mod tests {
 
     #[test]
     fn test_delete_old_data() {
+        let mut world = World::default();
         let mut registry = ComponentRegistry::default();
         registry.register_component::<ComponentDeltaCompression>();
-        registry.set_delta_compression::<ComponentDeltaCompression>();
+        registry.set_delta_compression::<ComponentDeltaCompression>(&mut world);
         let mut store = DeltaComponentStore::default();
         let entity = Entity::from_raw(0);
         let tick_1 = Tick(1);

--- a/lightyear/src/shared/replication/receive.rs
+++ b/lightyear/src/shared/replication/receive.rs
@@ -241,7 +241,7 @@ impl ReplicationReceiver {
         // TODO: should we use commands for command batching?
         world: &mut World,
         remote: Option<ClientId>,
-        component_registry: &ComponentRegistry,
+        component_registry: &mut ComponentRegistry,
         current_tick: Tick,
         events: &mut ConnectionEvents,
     ) {
@@ -569,7 +569,7 @@ impl GroupChannel {
         &mut self,
         world: &mut World,
         remote: Option<ClientId>,
-        component_registry: &ComponentRegistry,
+        component_registry: &mut ComponentRegistry,
         remote_tick: Tick,
         message: EntityActionsMessage,
         remote_entity_map: &mut RemoteEntityMap,
@@ -696,36 +696,33 @@ impl GroupChannel {
             // inserts
             // TODO: remove updates that are duplicate for the same component
             trace!(remote_entity = ?entity, "Received InsertComponent");
-            for component in actions.insert {
-                // TODO: reuse a single reader that reads through the entire message
-                let mut reader = Reader::from(component);
-                if let Ok(kind) = component_registry
-                    .raw_write(
-                        &mut reader,
-                        &mut local_entity_mut,
-                        remote_tick,
-                        &mut remote_entity_map.remote_to_local,
-                        events,
-                    )
-                    .inspect_err(|e| error!("could not write the component to the entity: {:?}", e))
-                {
-                    // for pre-predicted, we need to update the local_entities data, because the entity
-                    // is not spawned so the local_entities data is not updated
-                    if kind == ComponentKind::of::<PrePredicted>() {
-                        self.local_entities.insert(local_entity_mut.id());
-                        local_entity_to_group.insert(local_entity_mut.id(), group_id);
-                    }
-                }
+            let _ = component_registry
+                .batch_write(
+                    actions.insert,
+                    &mut local_entity_mut,
+                    remote_tick,
+                    &mut remote_entity_map.remote_to_local,
+                    events,
+                )
+                .inspect_err(|e| error!("could not insert the components to the entity: {:?}", e));
 
-                // TODO: special-case for pre-predicted entities: we receive them from a client, but then we
-                //  we should immediately take ownership of it, so we won't receive a despawn for it
-                //  thus, we should remove it from the entity map right after receiving it!
-                //  Actually, we should figure out a way to cleanup every received entity where the sender
-                //  stopped replicating or didn't replicate the Despawn, as this could just cause memory to accumulate
+            // TODO: find a way to handle this elegantly. Maybe the server should send a Spawn::Reuse
+            //  or Spawn::PrePredicted for this situation?
+            // for pre-predicted, we need to update the local_entities data, because the entity
+            // is not spawned so the local_entities data is not updated
+            // if kind == ComponentKind::of::<PrePredicted>() {
+            //     self.local_entities.insert(local_entity_mut.id());
+            //     local_entity_to_group.insert(local_entity_mut.id(), group_id);
+            // }
 
-                // TODO: maybe if is-server, attach the client-id to the ShouldBePredicted entity
-                //  to know for which client we should do the pre-prediction
-            }
+            // TODO: special-case for pre-predicted entities: we receive them from a client, but then we
+            //  we should immediately take ownership of it, so we won't receive a despawn for it
+            //  thus, we should remove it from the entity map right after receiving it!
+            //  Actually, we should figure out a way to cleanup every received entity where the sender
+            //  stopped replicating or didn't replicate the Despawn, as this could just cause memory to accumulate
+
+            // TODO: maybe if is-server, attach the client-id to the ShouldBePredicted entity
+            //  to know for which client we should do the pre-prediction
 
             // removals
             trace!(remote_entity = ?entity, ?actions.remove, "Received RemoveComponent");
@@ -872,7 +869,11 @@ impl GroupChannel {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::prelude::ServerReplicate;
     use crate::shared::replication::EntityActions;
+    use crate::tests::protocol::{ComponentSyncModeOnce, ComponentSyncModeSimple};
+    use crate::tests::stepper::BevyStepper;
+    use bevy::prelude::{OnAdd, Query, Trigger, With};
 
     /// Test that the UpdatesIterator works correctly, when we want to iterate through
     /// the buffered updates we have received
@@ -1181,7 +1182,7 @@ mod tests {
         let mut world = World::new();
         let remote_entity = Entity::from_raw(1000);
         let local_entity = world.spawn_empty().id();
-        let component_registry = ComponentRegistry::default();
+        let mut component_registry = ComponentRegistry::default();
         let mut events = ConnectionEvents::default();
         let replication = EntityActionsMessage {
             group_id: ReplicationGroupId(0),
@@ -1203,7 +1204,7 @@ mod tests {
         group_channel.apply_actions_message(
             &mut world,
             None,
-            &component_registry,
+            &mut component_registry,
             Tick(0),
             replication,
             &mut manager.remote_entity_map,
@@ -1218,5 +1219,44 @@ mod tests {
             manager.remote_entity_map.get_local(remote_entity).unwrap(),
             local_entity
         );
+    }
+
+    /// Test that receive() inserts multiple components at the same time
+    /// instead of one by one
+    #[test]
+    fn test_batch_actions_write() {
+        let mut stepper = BevyStepper::default_no_init();
+        // make sure that when ComponentSimple is added, ComponentOnce was also added
+        stepper.client_app.add_observer(
+            |trigger: Trigger<OnAdd, ComponentSyncModeSimple>,
+             query: Query<(), With<ComponentSyncModeOnce>>| {
+                assert!(query.get(trigger.entity()).is_ok());
+            },
+        );
+        // make sure that when ComponentOnce is added, ComponentSimple was also added
+        // i.e. both components are added at the same time
+        stepper.client_app.add_observer(
+            |trigger: Trigger<OnAdd, ComponentSyncModeOnce>,
+             query: Query<(), With<ComponentSyncModeSimple>>| {
+                assert!(query.get(trigger.entity()).is_ok());
+            },
+        );
+        stepper.init();
+
+        stepper.server_app.world_mut().spawn((
+            ServerReplicate::default(),
+            ComponentSyncModeOnce(1.0),
+            ComponentSyncModeSimple(1.0),
+        ));
+        stepper.frame_step();
+        stepper.frame_step();
+
+        // check that the components were added
+        assert!(stepper
+            .client_app
+            .world_mut()
+            .query_filtered::<(), (With<ComponentSyncModeOnce>, With<ComponentSyncModeSimple>)>()
+            .get_single(stepper.client_app.world())
+            .is_ok());
     }
 }

--- a/lightyear/src/shared/replication/receive.rs
+++ b/lightyear/src/shared/replication/receive.rs
@@ -5,8 +5,8 @@ use super::entity_map::RemoteEntityMap;
 use super::{EntityActionsMessage, EntityUpdatesMessage, SpawnAction};
 use crate::packet::message::MessageId;
 use crate::prelude::client::Confirmed;
-use crate::prelude::{ClientId, PrePredicted, Tick};
-use crate::protocol::component::{ComponentKind, ComponentRegistry};
+use crate::prelude::{ClientId, Tick};
+use crate::protocol::component::ComponentRegistry;
 use crate::serialize::reader::Reader;
 use crate::shared::events::connection::ConnectionEvents;
 use crate::shared::replication::authority::{AuthorityPeer, HasAuthority};
@@ -697,7 +697,7 @@ impl GroupChannel {
             // TODO: remove updates that are duplicate for the same component
             trace!(remote_entity = ?entity, "Received InsertComponent");
             let _ = component_registry
-                .batch_write(
+                .batch_insert(
                     actions.insert,
                     &mut local_entity_mut,
                     remote_tick,


### PR DESCRIPTION
I've run into several issues using observers because currently components are inserted sequentially during replication-receive.
This means that you cannot rely on observers such as `Trigger<OnAdd, A>` and then expect another component `B` to be present because there are no guarantees on the order that components are inserted.

The solution is to insert all the components at once on the receiving entity, so that the receiving archetype matches an archetype on the server.
(Ideally we would also remove components at the same time, but i'm not sure that it's possible in bevy).


For updates, i think we don't need to try to do a batch apply, because there are no archetype changes so no impact on observers.

TODO:
- add batching for removal
- Should we sort the component_ids? or is there no need because the server will always iterate the archetype components in the same order