### PR TITLE
Use dynamic system param for message events

### DIFF
--- a/lightyear/src/client/connection.rs
+++ b/lightyear/src/client/connection.rs
@@ -2,9 +2,9 @@
 use bevy::ecs::component::Tick as BevyTick;
 use bevy::ecs::entity::MapEntities;
 use bevy::prelude::{Event, Resource, World};
+use bevy::utils::Duration;
 #[cfg(feature = "leafwing")]
 use bevy::utils::HashMap;
-use bevy::utils::Duration;
 use bytes::Bytes;
 use tracing::{debug, trace, trace_span};
 

--- a/lightyear/src/client/connection.rs
+++ b/lightyear/src/client/connection.rs
@@ -2,7 +2,9 @@
 use bevy::ecs::component::Tick as BevyTick;
 use bevy::ecs::entity::MapEntities;
 use bevy::prelude::{Event, Resource, World};
-use bevy::utils::{Duration, HashMap};
+#[cfg(feature = "leafwing")]
+use bevy::utils::HashMap;
+use bevy::utils::Duration;
 use bytes::Bytes;
 use tracing::{debug, trace, trace_span};
 
@@ -82,7 +84,7 @@ pub struct ConnectionManager {
     #[cfg(feature = "leafwing")]
     pub(crate) received_leafwing_input_messages: HashMap<NetId, Vec<Bytes>>,
     /// Used to transfer raw bytes to a system that can convert the bytes to the actual type
-    pub(crate) received_messages: HashMap<NetId, Vec<Bytes>>,
+    pub(crate) received_messages: Vec<(NetId, Bytes)>,
     pub(crate) writer: Writer,
 
     /// Internal buffer of the messages that we want to send.
@@ -118,7 +120,7 @@ impl Default for ConnectionManager {
             events: ConnectionEvents::default(),
             #[cfg(feature = "leafwing")]
             received_leafwing_input_messages: HashMap::default(),
-            received_messages: HashMap::default(),
+            received_messages: Vec::default(),
             writer: Writer::with_capacity(0),
             messages_to_send: Vec::default(),
         }
@@ -169,7 +171,7 @@ impl ConnectionManager {
             events: ConnectionEvents::default(),
             #[cfg(feature = "leafwing")]
             received_leafwing_input_messages: HashMap::default(),
-            received_messages: HashMap::default(),
+            received_messages: Vec::default(),
             writer: Writer::with_capacity(MAX_PACKET_SIZE),
             messages_to_send: Vec::default(),
         }
@@ -444,11 +446,9 @@ impl ConnectionManager {
                             MessageType::NativeInput => {
                                 todo!()
                             }
+                            // TODO: should we handle these right here in this system?
                             MessageType::Normal | MessageType::Event => {
-                                self.received_messages
-                                    .entry(net_id)
-                                    .or_default()
-                                    .push(single_data);
+                                self.received_messages.push((net_id, single_data));
                             }
                         }
                     }
@@ -486,10 +486,7 @@ impl ConnectionManager {
                 todo!()
             }
             MessageType::Normal | MessageType::Event => {
-                self.received_messages
-                    .entry(net_id)
-                    .or_default()
-                    .push(single_data);
+                self.received_messages.push((net_id, single_data));
             }
         }
         Ok(())

--- a/lightyear/src/client/input/leafwing.rs
+++ b/lightyear/src/client/input/leafwing.rs
@@ -749,8 +749,8 @@ fn receive_remote_player_input_messages<A: LeafwingUserAction>(
         return;
     };
 
-    if let Some(message_list) = connection.received_leafwing_input_messages.remove(&net) {
-        for message_bytes in message_list {
+    if let Some(message_list) = connection.received_leafwing_input_messages.get_mut(&net) {
+        message_list.drain(..).for_each(|message_bytes| {
             let mut reader = Reader::from(message_bytes);
             match message_registry.deserialize::<InputMessage<A>>(
                 &mut reader,
@@ -829,7 +829,7 @@ fn receive_remote_player_input_messages<A: LeafwingUserAction>(
                     error!(?e, "could not deserialize leafwing input message");
                 }
             }
-        }
+        })
     }
 }
 

--- a/lightyear/src/client/message.rs
+++ b/lightyear/src/client/message.rs
@@ -1,13 +1,19 @@
 //! Defines the [`ClientMessage`] enum used to send messages from the client to the server
 
-use bevy::prelude::{App, Commands, IntoSystemConfigs, Mut, Plugin, PreUpdate, ResMut, World};
+use bevy::ecs::system::{
+    FilteredResourcesMutParamBuilder, ParamBuilder,
+};
+use bevy::prelude::{
+    App, Commands, FilteredResourcesMut, IntoSystemConfigs, Plugin, PreUpdate, ResMut,
+    SystemParamBuilder,
+};
 use byteorder::WriteBytesExt;
 use bytes::Bytes;
 use tracing::error;
 
 use crate::client::connection::ConnectionManager;
 use crate::prelude::{client::is_connected, ClientId};
-use crate::protocol::message::MessageRegistry;
+use crate::protocol::message::{MessageRegistry, MessageType};
 use crate::serialize::reader::Reader;
 use crate::serialize::{SerializationError, ToBytes};
 use crate::shared::replication::network_target::NetworkTarget;
@@ -16,13 +22,39 @@ use crate::shared::sets::{ClientMarker, InternalMainSet};
 pub struct ClientMessagePlugin;
 
 impl Plugin for ClientMessagePlugin {
-    fn build(&self, app: &mut App) {
+    fn build(&self, app: &mut App) {}
+
+    /// Add the system after all messages have been added to the MessageRegistry
+    fn cleanup(&self, app: &mut App) {
+        let message_registry = app.world_mut().remove_resource::<MessageRegistry>().unwrap();
+        // Use FilteredResourceMut SystemParam to register the access dynamically to the
+        // Messages in the MessageRegistry
+        let read_messages = (
+            FilteredResourcesMutParamBuilder::new(|builder| {
+                message_registry
+                    .message_receive_map
+                    .values()
+                    .filter(|metadata| {
+                        metadata.message_type == MessageType::Normal
+                            || metadata.message_type == MessageType::Event
+                    })
+                    .for_each(|metadata| {
+                        builder.add_write_by_id(metadata.component_id);
+                    });
+            }),
+            ParamBuilder,
+            ParamBuilder,
+            ParamBuilder,
+        )
+            .build_state(app.world_mut())
+            .build_system(read_messages);
         app.add_systems(
             PreUpdate,
             read_messages
                 .in_set(InternalMainSet::<ClientMarker>::EmitEvents)
                 .run_if(is_connected),
         );
+        app.insert_resource(message_registry);
     }
 }
 
@@ -60,38 +92,34 @@ impl ToBytes for ClientMessage {
 /// Read the messages received from the server and handle them:
 /// - Messages: send a MessageEvent
 /// - Events: send them to EventWriter or trigger them
-fn read_messages(mut commands: Commands, mut connection: ResMut<ConnectionManager>) {
+fn read_messages(
+    mut events: FilteredResourcesMut,
+    mut commands: Commands,
+    message_registry: ResMut<MessageRegistry>,
+    mut connection: ResMut<ConnectionManager>,
+) {
+    // enable split-borrows
+    let connection = connection.as_mut();
     connection
         .received_messages
-        .iter_mut()
-        .for_each(|(net_id, message_list)| {
-            message_list.drain(..).for_each(|message| {
-                let mut reader = Reader::from(message);
-                // make copies to avoid `connection` to be moved inside the closure
-                let net_id = *net_id;
-                commands.queue(move |world: &mut World| {
-                    // NOTE: removing the resources is a bit risky... however we use the world
-                    // only to get the Events<MessageEvent<M>> so it should be ok
-                    world.resource_scope(|world, registry: Mut<MessageRegistry>| {
-                        world.resource_scope(|world, mut manager: Mut<ConnectionManager>| {
-                            let _ = registry
-                                // we have to re-decode the net id
-                                .receive_message(
-                                    net_id,
-                                    world,
-                                    // TODO: include the client that rebroadcasted the message?
-                                    ClientId::Local(0),
-                                    &mut reader,
-                                    &mut manager
-                                        .replication_receiver
-                                        .remote_entity_map
-                                        .remote_to_local,
-                                )
-                                .inspect_err(|e| error!("Could not deserialize message: {:?}", e));
-                        })
-                    });
-                });
-            })
+        .drain(..)
+        .for_each(|(net_id, message)| {
+            let mut reader = Reader::from(message);
+            let _ = message_registry
+                // we have to re-decode the net id
+                .receive_message(
+                    net_id,
+                    &mut commands,
+                    &mut events,
+                    // TODO: include the client that rebroadcasted the message?
+                    ClientId::Local(0),
+                    &mut reader,
+                    &mut connection
+                        .replication_receiver
+                        .remote_entity_map
+                        .remote_to_local,
+                )
+                .inspect_err(|e| error!("Could not deserialize message: {:?}", e));
         });
 }
 

--- a/lightyear/src/client/message.rs
+++ b/lightyear/src/client/message.rs
@@ -1,8 +1,6 @@
 //! Defines the [`ClientMessage`] enum used to send messages from the client to the server
 
-use bevy::ecs::system::{
-    FilteredResourcesMutParamBuilder, ParamBuilder,
-};
+use bevy::ecs::system::{FilteredResourcesMutParamBuilder, ParamBuilder};
 use bevy::prelude::{
     App, Commands, FilteredResourcesMut, IntoSystemConfigs, Plugin, PreUpdate, ResMut,
     SystemParamBuilder,
@@ -26,7 +24,10 @@ impl Plugin for ClientMessagePlugin {
 
     /// Add the system after all messages have been added to the MessageRegistry
     fn cleanup(&self, app: &mut App) {
-        let message_registry = app.world_mut().remove_resource::<MessageRegistry>().unwrap();
+        let message_registry = app
+            .world_mut()
+            .remove_resource::<MessageRegistry>()
+            .unwrap();
         // Use FilteredResourceMut SystemParam to register the access dynamically to the
         // Messages in the MessageRegistry
         let read_messages = (

--- a/lightyear/src/client/prediction/rollback.rs
+++ b/lightyear/src/client/prediction/rollback.rs
@@ -1039,6 +1039,7 @@ mod integration_tests {
             .register_component::<ComponentWithEntity>(ChannelDirection::Bidirectional)
             .add_prediction(ComponentSyncMode::Full)
             .add_map_entities();
+        stepper.build();
         stepper.init();
 
         // Spawn a remote entity with a `ComponentWithEntity` component that

--- a/lightyear/src/client/prediction/spawn.rs
+++ b/lightyear/src/client/prediction/spawn.rs
@@ -143,7 +143,7 @@ mod tests {
             .remote_entity_map
             .get_local(server_parent)
             .expect("parent entity was not replicated to client");
-        dbg!(confirmed_child, confirmed_parent);
+        // dbg!(confirmed_child, confirmed_parent);
 
         // check that the parent-child hierarchy is maintained
         assert_eq!(

--- a/lightyear/src/server/input/leafwing.rs
+++ b/lightyear/src/server/input/leafwing.rs
@@ -110,8 +110,8 @@ fn receive_input_message<A: LeafwingUserAction>(
     // re-borrow to allow split borrows
     let connection_manager = connection_manager.deref_mut();
     for (client_id, connection) in connection_manager.connections.iter_mut() {
-        if let Some(message_list) = connection.received_leafwing_input_messages.remove(&net) {
-            for (message_bytes, target, channel_kind) in message_list {
+        if let Some(message_list) = connection.received_leafwing_input_messages.get_mut(&net) {
+            message_list.drain(..).for_each(|(message_bytes, target, channel_kind)| {
                 let mut reader = Reader::from(message_bytes);
                 match message_registry.deserialize::<InputMessage<A>>(
                     &mut reader,
@@ -207,7 +207,7 @@ fn receive_input_message<A: LeafwingUserAction>(
                         error!(?e, "could not deserialize leafwing input message");
                     }
                 }
-            }
+            })
         }
     }
 }

--- a/lightyear/src/server/input/native.rs
+++ b/lightyear/src/server/input/native.rs
@@ -111,8 +111,8 @@ fn receive_input_message<A: UserAction>(
         return;
     };
     for (client_id, connection) in connection_manager.connections.iter_mut() {
-        if let Some(message_list) = connection.received_input_messages.remove(&net) {
-            for (message_bytes, target, channel_kind) in message_list {
+        if let Some(message_list) = connection.received_input_messages.get_mut(&net) {
+            message_list.drain(..).for_each(|(message_bytes, target, channel_kind)| {
                 let mut reader = Reader::from(message_bytes);
                 match message_registry.deserialize::<InputMessage<A>>(
                     &mut reader,
@@ -143,7 +143,7 @@ fn receive_input_message<A: UserAction>(
                         error!("Error deserializing input message: {:?}", e);
                     }
                 }
-            }
+            })
         }
     }
 }

--- a/lightyear/src/server/message.rs
+++ b/lightyear/src/server/message.rs
@@ -16,12 +16,14 @@ use tracing::{error, trace};
 pub struct ServerMessagePlugin;
 
 impl Plugin for ServerMessagePlugin {
-    fn build(&self, app: &mut App) {
-    }
+    fn build(&self, app: &mut App) {}
 
     /// Add the system after all messages have been added to the MessageRegistry
     fn cleanup(&self, app: &mut App) {
-        let message_registry = app.world_mut().remove_resource::<MessageRegistry>().unwrap();
+        let message_registry = app
+            .world_mut()
+            .remove_resource::<MessageRegistry>()
+            .unwrap();
         // Use FilteredResourceMut SystemParam to register the access dynamically to the
         // Messages in the MessageRegistry
         let read_messages = (

--- a/lightyear/src/server/message.rs
+++ b/lightyear/src/server/message.rs
@@ -1,11 +1,14 @@
 use crate::prelude::server::is_stopped;
-use crate::protocol::message::MessageRegistry;
+use crate::protocol::message::{MessageRegistry, MessageType};
 use crate::serialize::reader::Reader;
 use crate::server::connection::ConnectionManager;
 use crate::shared::replication::network_target::NetworkTarget;
 use crate::shared::sets::{InternalMainSet, ServerMarker};
 use bevy::app::{App, Plugin, PreUpdate};
-use bevy::prelude::{not, Commands, IntoSystemConfigs, Mut, ResMut, World};
+use bevy::ecs::system::{FilteredResourcesMutParamBuilder, ParamBuilder};
+use bevy::prelude::{
+    not, Commands, FilteredResourcesMut, IntoSystemConfigs, ResMut, SystemParamBuilder,
+};
 use tracing::{error, trace};
 
 /// Plugin that adds functionality related to receiving messages from clients
@@ -14,173 +17,85 @@ pub struct ServerMessagePlugin;
 
 impl Plugin for ServerMessagePlugin {
     fn build(&self, app: &mut App) {
+    }
+
+    /// Add the system after all messages have been added to the MessageRegistry
+    fn cleanup(&self, app: &mut App) {
+        let message_registry = app.world_mut().remove_resource::<MessageRegistry>().unwrap();
+        // Use FilteredResourceMut SystemParam to register the access dynamically to the
+        // Messages in the MessageRegistry
+        let read_messages = (
+            FilteredResourcesMutParamBuilder::new(|builder| {
+                message_registry
+                    .message_receive_map
+                    .values()
+                    .filter(|metadata| {
+                        metadata.message_type == MessageType::Normal
+                            || metadata.message_type == MessageType::Event
+                    })
+                    .for_each(|metadata| {
+                        builder.add_write_by_id(metadata.component_id);
+                    });
+            }),
+            ParamBuilder,
+            ParamBuilder,
+            ParamBuilder,
+        )
+            .build_state(app.world_mut())
+            .build_system(read_messages);
         app.add_systems(
             PreUpdate,
             read_messages
                 .in_set(InternalMainSet::<ServerMarker>::EmitEvents)
                 .run_if(not(is_stopped)),
         );
+        app.world_mut().insert_resource(message_registry);
     }
 }
 
 /// Read the messages received from the clients and emit the MessageEvent events
 /// Also rebroadcast the messages if needed
-fn read_messages(mut commands: Commands, mut connection_manager: ResMut<ConnectionManager>) {
+fn read_messages(
+    mut events: FilteredResourcesMut,
+    mut commands: Commands,
+    message_registry: ResMut<MessageRegistry>,
+    mut connection_manager: ResMut<ConnectionManager>,
+) {
     // re-borrow to allow split borrows
     for (client_id, connection) in connection_manager.connections.iter_mut() {
-        connection
-            .received_messages
-            .iter_mut()
-            .for_each(|(net_id, message_list)| {
-                message_list
-                    .drain(..)
-                    .for_each(|(message_bytes, target, channel_kind)| {
-                        let mut reader = Reader::from(message_bytes);
-                        // make copies to avoid `connection_manager` to be moved inside the closure
-                        let net_id = *net_id;
-                        let client_id = *client_id;
-                        commands.queue(move |world: &mut World| {
-                            // NOTE: removing the resources is a bit risky... however we use the world
-                            // only to get the Events<MessageEvent<M>> so it should be ok
-                            world.resource_scope(|world, registry: Mut<MessageRegistry>| {
-                                world.resource_scope(
-                                    |world, mut manager: Mut<ConnectionManager>| {
-                                            let connection =
-                                                manager.connection_mut(client_id).unwrap();
-                                            match registry.receive_message(
-                                                net_id,
-                                                world,
-                                                client_id,
-                                                &mut reader,
-                                                &mut connection
-                                                    .replication_receiver
-                                                    .remote_entity_map
-                                                    .remote_to_local,
-                                            ) {
-                                                Ok(_) => {
-                                                    // rebroadcast
-                                                    if target != NetworkTarget::None {
-                                                        connection.messages_to_rebroadcast.push((
-                                                            reader.consume(),
-                                                            target,
-                                                            channel_kind,
-                                                        ));
-                                                    }
-                                                    trace!("Received message! NetId: {net_id:?}");
-                                                }
-                                                Err(e) => {
-                                                    error!("Could not deserialize message (NetId: {net_id:?}): {e:?}");
-                                                }
-                                            }
-                                    },
-                                )
-                            });
-                        })
-                    })
-            });
+        connection.received_messages.drain(..).for_each(
+            |(net_id, message_bytes, target, channel_kind)| {
+                let mut reader = Reader::from(message_bytes);
+                match message_registry.receive_message(
+                    net_id,
+                    &mut commands,
+                    &mut events,
+                    *client_id,
+                    &mut reader,
+                    &mut connection
+                        .replication_receiver
+                        .remote_entity_map
+                        .remote_to_local,
+                ) {
+                    Ok(_) => {
+                        // rebroadcast
+                        if target != NetworkTarget::None {
+                            connection.messages_to_rebroadcast.push((
+                                reader.consume(),
+                                target,
+                                channel_kind,
+                            ));
+                        }
+                        trace!("Received message! NetId: {net_id:?}");
+                    }
+                    Err(e) => {
+                        error!("Could not deserialize message (NetId: {net_id:?}): {e:?}");
+                    }
+                }
+            },
+        );
     }
 }
-
-// impl ServerMessage {
-//     pub(crate) fn emit_send_logs(&self, channel_name: &str) {
-//         match self {
-//             ServerMessage::Message(message) => {
-//                 let message_name = message.name();
-//                 trace!(channel = ?channel_name, message = ?message_name, kind = ?message.kind(), "Sending message");
-//                 #[cfg(metrics)]
-//                 metrics::counter!("send_message", "channel" => channel_name, "message" => message_name).increment(1);
-//             }
-//             ServerMessage::Replication(message) => {
-//                 let _span = info_span!("send replication message", channel = ?channel_name, group_id = ?message.group_id);
-//                 #[cfg(metrics)]
-//                 metrics::counter!("send_replication_actions").increment(1);
-//                 match &message.data {
-//                     ReplicationMessageData::Actions(m) => {
-//                         for (entity, actions) in &m.actions {
-//                             let _span = info_span!("send replication actions", ?entity);
-//                             if actions.spawn {
-//                                 trace!("Send entity spawn");
-//                                 #[cfg(metrics)]
-//                                 metrics::counter!("send_entity_spawn").increment(1);
-//                             }
-//                             if actions.despawn {
-//                                 trace!("Send entity despawn");
-//                                 #[cfg(metrics)]
-//                                 metrics::counter!("send_entity_despawn").increment(1);
-//                             }
-//                             if !actions.insert.is_empty() {
-//                                 let components = actions
-//                                     .insert
-//                                     .iter()
-//                                     .map(|c| c.into())
-//                                     .collect::<Vec<P::ComponentKinds>>();
-//                                 trace!(?components, "Sending component insert");
-//                                 #[cfg(metrics)]
-//                                 {
-//                                     for component in components {
-//                                         metrics::counter!("send_component_insert", "component" => kind).increment(1);
-//                                     }
-//                                 }
-//                             }
-//                             if !actions.remove.is_empty() {
-//                                 trace!(?actions.remove, "Sending component remove");
-//                                 #[cfg(metrics)]
-//                                 {
-//                                     for kind in actions.remove {
-//                                         metrics::counter!("send_component_remove", "component" => kind).increment(1);
-//                                     }
-//                                 }
-//                             }
-//                             if !actions.updates.is_empty() {
-//                                 let components = actions
-//                                     .updates
-//                                     .iter()
-//                                     .map(|c| c.into())
-//                                     .collect::<Vec<P::ComponentKinds>>();
-//                                 trace!(?components, "Sending component update");
-//                                 #[cfg(metrics)]
-//                                 {
-//                                     for component in components {
-//                                         metrics::counter!("send_component_update", "component" => kind).increment(1);
-//                                     }
-//                                 }
-//                             }
-//                         }
-//                     }
-//                     ReplicationMessageData::Updates(m) => {
-//                         for (entity, updates) in &m.updates {
-//                             let _span = info_span!("send replication updates", ?entity);
-//                             let components = updates
-//                                 .iter()
-//                                 .map(|c| c.into())
-//                                 .collect::<Vec<P::ComponentKinds>>();
-//                             trace!(?components, "Sending component update");
-//                             #[cfg(metrics)]
-//                             {
-//                                 for component in components {
-//                                     metrics::counter!("send_component_update", "component" => kind)
-//                                         .increment(1);
-//                                 }
-//                             }
-//                         }
-//                     }
-//                 }
-//             }
-//             ServerMessage::Sync(message) => match message {
-//                 SyncMessage::Ping(_) => {
-//                     trace!(channel = ?channel_name, "Sending ping");
-//                     #[cfg(metrics)]
-//                     metrics::counter!("send_ping", "channel" => channel_name).increment(1);
-//                 }
-//                 SyncMessage::Pong(_) => {
-//                     trace!(channel = ?channel_name, "Sending pong");
-//                     #[cfg(metrics)]
-//                     metrics::counter!("send_pong", "channel" => channel_name).increment(1);
-//                 }
-//             },
-//         }
-//     }
-// }
 
 // TODO: another option is to add ClientMessage and ServerMessage to ProtocolMessage
 // then we can keep the shared logic in connection.mod. We just lose 1 bit everytime...

--- a/lightyear/src/shared/input/native.rs
+++ b/lightyear/src/shared/input/native.rs
@@ -21,10 +21,7 @@ impl<A: UserAction> Default for InputPlugin<A> {
 }
 
 impl<A: UserAction> Plugin for InputPlugin<A> {
-    fn build(&self, app: &mut App) {}
-
-    // build this in finish() to make sure that the ClientConfig and ServerConfig exist
-    fn finish(&self, app: &mut App) {
+    fn build(&self, app: &mut App) {
         // TODO: this adds a receive_message fn that is never used! Because we have custom handling
         //  of native input message in ConnectionManager.receive()
         app.register_message_internal::<InputMessage<A>>(
@@ -33,6 +30,7 @@ impl<A: UserAction> Plugin for InputPlugin<A> {
         );
         let is_client = app.world().get_resource::<ClientConfig>().is_some();
         let is_server = app.world().get_resource::<ServerConfig>().is_some();
+        assert!(is_client || is_server, "Either ClientConfig or ServerConfig must be present! Make sure that your SharedPlugin is registered after the ClientPlugins/ServerPlugins");
         if is_client {
             app.add_plugins(crate::client::input::native::InputPlugin::<A>::default());
         }

--- a/lightyear/src/shared/replication/resources.rs
+++ b/lightyear/src/shared/replication/resources.rs
@@ -180,7 +180,6 @@ pub(crate) mod send {
 }
 
 pub(crate) mod receive {
-
     use crate::shared::events::components::MessageEvent;
     use crate::shared::message::MessageSend;
 
@@ -343,7 +342,6 @@ mod tests {
             .server_app
             .world_mut()
             .insert_resource(Resource1(1.0));
-        dbg!("SHOULD SEND RESOURCE MESSAGE");
         stepper.frame_step();
         stepper.frame_step();
 


### PR DESCRIPTION
We were handling received messages by writing a `Command` and passing `World` to the `receive_internal_message` functions.

Instead we can use `FilteredResourcesMut` to create a dynamic system param that requires write access`Events<MessageEvent<E>>`. That means we can write the messages directly in the system instead of pushing a command. 
That system can run in parallel with other systems that are not networking related