### PR TITLE
Avoid panic when using PrePredicted in HostServer mode

### DIFF
--- a/lightyear/src/client/prediction/pre_prediction.rs
+++ b/lightyear/src/client/prediction/pre_prediction.rs
@@ -388,6 +388,5 @@ mod tests {
         for _ in 0..10 {
             stepper.frame_step();
         }
-
     }
 }

--- a/lightyear/src/server/prediction.rs
+++ b/lightyear/src/server/prediction.rs
@@ -1,7 +1,10 @@
 //! Handles logic related to prespawning entities
 
 use crate::prelude::server::{AuthorityCommandExt, AuthorityPeer, NetworkingState, ServerConfig};
-use crate::prelude::{is_host_server, ComponentRegistry, PrePredicted, PreSpawnedPlayerObject, Replicated, ServerConnectionManager, TickManager};
+use crate::prelude::{
+    is_host_server, ComponentRegistry, PrePredicted, PreSpawnedPlayerObject, Replicated,
+    ServerConnectionManager, TickManager,
+};
 use crate::shared::replication::prespawn::compute_default_hash;
 use bevy::ecs::component::Components;
 use bevy::prelude::*;

--- a/lightyear/src/server/prediction.rs
+++ b/lightyear/src/server/prediction.rs
@@ -1,10 +1,7 @@
 //! Handles logic related to prespawning entities
 
-use crate::prelude::server::{AuthorityCommandExt, AuthorityPeer};
-use crate::prelude::{
-    ComponentRegistry, PrePredicted, PreSpawnedPlayerObject, Replicated, ServerConnectionManager,
-    TickManager,
-};
+use crate::prelude::server::{AuthorityCommandExt, AuthorityPeer, NetworkingState, ServerConfig};
+use crate::prelude::{is_host_server, ComponentRegistry, PrePredicted, PreSpawnedPlayerObject, Replicated, ServerConnectionManager, TickManager};
 use crate::shared::replication::prespawn::compute_default_hash;
 use bevy::ecs::component::Components;
 use bevy::prelude::*;
@@ -62,10 +59,14 @@ pub(crate) fn handle_pre_predicted(
     trigger: Trigger<OnAdd, PrePredicted>,
     mut commands: Commands,
     mut manager: ResMut<ServerConnectionManager>,
-    // add `With<Replicated>` bound for host-server mode; so that we don't trigger this system
-    // for local client entities
+    config: Option<Res<ServerConfig>>,
+    server_state: Option<Res<State<NetworkingState>>>,
     q: Query<(Entity, &PrePredicted, &Replicated)>,
 ) {
+    // no need to do anything in host-server mode, we directly add the `Predicted` component on the client
+    if is_host_server(config, server_state) {
+        return;
+    }
     if let Ok((local_entity, pre_predicted, replicated)) = q.get(trigger.entity()) {
         let sending_client = replicated.from.unwrap();
         let confirmed_entity = pre_predicted.confirmed_entity.unwrap();


### PR DESCRIPTION
Fixes https://github.com/cBournhonesque/lightyear/issues/869

We could have a panic because the comment
```
    // add `With<Replicated>` bound for host-server mode; so that we don't trigger this system
    // for local client entities
    q: Query<(Entity, &PrePredicted, &Replicated)>,
```
is incorrect! In HostServer mode we automatically insert the `Replicated` component to local-client spawned entities (so they can be queried), so we need instead to check directly if we're in HostServer mode