### PR TITLE
Simplify HostServer configuration

### DIFF
--- a/examples/auth/src/shared.rs
+++ b/examples/auth/src/shared.rs
@@ -4,10 +4,6 @@
 //! The simulation logic (movement, etc.) should be shared between client and server to guarantee that there won't be
 //! mispredictions/rollbacks.
 use bevy::prelude::*;
-use bevy::utils::Duration;
-
-use lightyear::prelude::*;
-use lightyear::shared::config::Mode;
 
 use crate::protocol::*;
 

--- a/examples/common/src/app.rs
+++ b/examples/common/src/app.rs
@@ -521,7 +521,7 @@ pub fn client_app(settings: Settings, net_config: client::NetConfig) -> (App, Cl
     let app = new_gui_app(settings.client.inspector);
 
     let client_config = ClientConfig {
-        shared: shared_config(lightyear::shared::config::Mode::Separate),
+        shared: shared_config(),
         net: net_config,
         replication: ReplicationConfig {
             send_interval: REPLICATION_INTERVAL,
@@ -555,7 +555,7 @@ pub fn server_app(
     });
     net_configs.extend(extra_net_configs);
     let server_config = ServerConfig {
-        shared: shared_config(lightyear::shared::config::Mode::Separate),
+        shared: shared_config(),
         net: net_configs,
         replication: ReplicationConfig {
             send_interval: REPLICATION_INTERVAL,
@@ -581,7 +581,7 @@ pub fn combined_app(
     });
     net_configs.extend(extra_net_configs);
     let server_config = ServerConfig {
-        shared: shared_config(lightyear::shared::config::Mode::HostServer),
+        shared: shared_config(),
         net: net_configs,
         replication: ReplicationConfig {
             send_interval: REPLICATION_INTERVAL,
@@ -592,7 +592,7 @@ pub fn combined_app(
 
     // client config
     let client_config = ClientConfig {
-        shared: shared_config(lightyear::shared::config::Mode::HostServer),
+        shared: shared_config(),
         net: client_net_config,
         ..default()
     };

--- a/examples/common/src/client_renderer.rs
+++ b/examples/common/src/client_renderer.rs
@@ -127,6 +127,7 @@ pub(crate) fn spawn_connect_button(app: &mut App) {
                             NetworkingState::Connecting | NetworkingState::Connected => {
                                 commands.disconnect_client();
                             }
+                            _ => {}
                         };
                     },
                 );
@@ -148,6 +149,7 @@ pub(crate) fn update_button_text(
             NetworkingState::Connected => {
                 text.0 = "Disconnect".to_string();
             }
+            _ => {}
         };
     }
 }

--- a/examples/common/src/shared.rs
+++ b/examples/common/src/shared.rs
@@ -1,17 +1,16 @@
-use lightyear::prelude::{Mode, SharedConfig, TickConfig};
+use lightyear::prelude::{SharedConfig, TickConfig};
 use std::time::Duration;
 
 pub const FIXED_TIMESTEP_HZ: f64 = 64.0;
 pub const REPLICATION_INTERVAL: Duration = Duration::from_millis(100);
 
 /// The [`SharedConfig`] must be shared between the `ClientConfig` and `ServerConfig`
-pub fn shared_config(mode: Mode) -> SharedConfig {
+pub fn shared_config() -> SharedConfig {
     SharedConfig {
         // send replication updates every 100ms
         server_replication_send_interval: REPLICATION_INTERVAL,
         tick: TickConfig {
             tick_duration: Duration::from_secs_f64(1.0 / FIXED_TIMESTEP_HZ),
         },
-        mode,
     }
 }

--- a/examples/fps/src/renderer.rs
+++ b/examples/fps/src/renderer.rs
@@ -10,8 +10,7 @@ use lightyear::prelude::client::{
     Interpolated, Predicted, VisualInterpolateStatus,
 };
 use lightyear::prelude::server::ReplicationTarget;
-use lightyear::prelude::{PreSpawnedPlayerObject, Replicated};
-use lightyear::shared::identity::NetworkIdentityState;
+use lightyear::prelude::{NetworkIdentity, PreSpawnedPlayerObject, Replicated};
 use lightyear_avian::prelude::AabbEnvelopeHolder;
 
 #[derive(Clone)]
@@ -48,7 +47,7 @@ fn init(mut commands: Commands) {
 struct ScoreText;
 
 #[cfg(feature = "client")]
-fn spawn_score_text(mut commands: Commands, identity: NetworkIdentityState) {
+fn spawn_score_text(mut commands: Commands, identity: NetworkIdentity) {
     if identity.is_client() {
         commands.spawn((
             Text::new("Score: 0"),

--- a/examples/fps/src/renderer.rs
+++ b/examples/fps/src/renderer.rs
@@ -6,9 +6,7 @@ use bevy::color::palettes::css::BLUE;
 use bevy::ecs::query::QueryFilter;
 use bevy::prelude::*;
 use lightyear::client::interpolation::VisualInterpolationPlugin;
-use lightyear::prelude::client::{
-    Interpolated, Predicted, VisualInterpolateStatus,
-};
+use lightyear::prelude::client::{Interpolated, Predicted, VisualInterpolateStatus};
 use lightyear::prelude::server::ReplicationTarget;
 use lightyear::prelude::{NetworkIdentity, PreSpawnedPlayerObject, Replicated};
 use lightyear_avian::prelude::AabbEnvelopeHolder;

--- a/examples/fps/src/renderer.rs
+++ b/examples/fps/src/renderer.rs
@@ -11,7 +11,7 @@ use lightyear::prelude::client::{
 };
 use lightyear::prelude::server::ReplicationTarget;
 use lightyear::prelude::{PreSpawnedPlayerObject, Replicated};
-use lightyear::shared::identity::NetworkIdentity;
+use lightyear::shared::identity::NetworkIdentityState;
 use lightyear_avian::prelude::AabbEnvelopeHolder;
 
 #[derive(Clone)]
@@ -48,7 +48,7 @@ fn init(mut commands: Commands) {
 struct ScoreText;
 
 #[cfg(feature = "client")]
-fn spawn_score_text(mut commands: Commands, identity: NetworkIdentity) {
+fn spawn_score_text(mut commands: Commands, identity: NetworkIdentityState) {
     if identity.is_client() {
         commands.spawn((
             Text::new("Score: 0"),

--- a/examples/fps/src/renderer.rs
+++ b/examples/fps/src/renderer.rs
@@ -5,17 +5,14 @@ use bevy::color::palettes::basic::GREEN;
 use bevy::color::palettes::css::BLUE;
 use bevy::ecs::query::QueryFilter;
 use bevy::prelude::*;
-use bevy::render::primitives::Aabb;
-use bevy::render::RenderPlugin;
-use lightyear::client::components::Confirmed;
 use lightyear::client::interpolation::VisualInterpolationPlugin;
 use lightyear::prelude::client::{
-    Interpolated, InterpolationSet, Predicted, PredictionSet, VisualInterpolateStatus,
+    Interpolated, Predicted, VisualInterpolateStatus,
 };
 use lightyear::prelude::server::ReplicationTarget;
-use lightyear::prelude::{NetworkIdentity, PreSpawnedPlayerObject, Replicated};
-use lightyear::transport::io::IoDiagnosticsPlugin;
-use lightyear_avian::prelude::{AabbEnvelopeHolder, LagCompensationHistory};
+use lightyear::prelude::{PreSpawnedPlayerObject, Replicated};
+use lightyear::shared::identity::NetworkIdentity;
+use lightyear_avian::prelude::AabbEnvelopeHolder;
 
 #[derive(Clone)]
 pub struct ExampleRendererPlugin;

--- a/examples/fps/src/shared.rs
+++ b/examples/fps/src/shared.rs
@@ -14,7 +14,7 @@ use lightyear::prelude::client::*;
 use lightyear::prelude::server::{Replicate, ReplicationTarget, SyncTarget};
 use lightyear::prelude::TickManager;
 use lightyear::prelude::*;
-use lightyear::shared::plugin::Identity;
+use lightyear::shared::identity::Identity;
 use lightyear::transport::io::IoDiagnosticsPlugin;
 
 use crate::protocol::*;

--- a/examples/fps/src/shared.rs
+++ b/examples/fps/src/shared.rs
@@ -14,7 +14,6 @@ use lightyear::prelude::client::*;
 use lightyear::prelude::server::{Replicate, ReplicationTarget, SyncTarget};
 use lightyear::prelude::TickManager;
 use lightyear::prelude::*;
-use lightyear::shared::identity::Identity;
 use lightyear::transport::io::IoDiagnosticsPlugin;
 
 use crate::protocol::*;
@@ -182,7 +181,7 @@ pub(crate) fn fixed_update_log(
 pub(crate) fn shoot_bullet(
     mut commands: Commands,
     tick_manager: Res<TickManager>,
-    identity: NetworkIdentityState,
+    identity: NetworkIdentity,
     mut query: Query<
         (
             &PlayerId,

--- a/examples/fps/src/shared.rs
+++ b/examples/fps/src/shared.rs
@@ -182,7 +182,7 @@ pub(crate) fn fixed_update_log(
 pub(crate) fn shoot_bullet(
     mut commands: Commands,
     tick_manager: Res<TickManager>,
-    identity: NetworkIdentity,
+    identity: NetworkIdentityState,
     mut query: Query<
         (
             &PlayerId,

--- a/examples/lobby/src/shared.rs
+++ b/examples/lobby/src/shared.rs
@@ -5,10 +5,6 @@
 //! mispredictions/rollbacks.
 use bevy::prelude::*;
 
-use lightyear::prelude::client::*;
-use lightyear::prelude::*;
-use lightyear::shared::config::Mode;
-
 use crate::protocol::*;
 
 #[derive(Clone)]

--- a/examples/simple_setup/src/shared.rs
+++ b/examples/simple_setup/src/shared.rs
@@ -21,7 +21,6 @@ pub fn shared_config() -> SharedConfig {
         tick: TickConfig {
             tick_duration: Duration::from_secs_f64(1.0 / FIXED_TIMESTEP_HZ),
         },
-        mode: Mode::Separate,
     }
 }
 

--- a/examples/spaceships/src/server.rs
+++ b/examples/spaceships/src/server.rs
@@ -97,7 +97,7 @@ fn init(mut commands: Commands) {
 
 pub(crate) fn replicate_inputs(
     mut connection: ResMut<ConnectionManager>,
-    mut input_events: ResMut<Events<MessageEvent<InputMessage<PlayerActions>>>>,
+    mut input_events: ResMut<Events<ServerReceiveMessage<InputMessage<PlayerActions>>>>,
 ) {
     for mut event in input_events.drain() {
         let client_id = event.from();

--- a/lightyear/src/client/networking.rs
+++ b/lightyear/src/client/networking.rs
@@ -94,10 +94,6 @@ impl Plugin for ClientNetworkingPlugin {
         );
 
         // DISCONNECTED
-        // app.add_systems(
-        //     OnExit(NetworkingState::Connected),
-        //     on_disconnecting_host_server.run_if(is_host_server),
-        // );
         app.add_systems(
             OnEnter(NetworkingState::Disconnecting),
             (
@@ -302,6 +298,16 @@ pub enum NetworkingState {
     /// The client is connected to the server
     Connected,
 }
+
+// TODO: update this state based on the sync system!
+#[derive(SubStates, Clone, PartialEq, Eq, Hash, Debug, Default)]
+#[source(NetworkingState = NetworkingState::Connected)]
+pub enum ConnectedState {
+    #[default]
+    Unsynced,
+    Synced,
+}
+
 
 /// Listen to [`ClientIoEvent`]s and update the [`IoState`] and [`NetworkingState`] accordingly
 fn listen_io_state(

--- a/lightyear/src/client/networking.rs
+++ b/lightyear/src/client/networking.rs
@@ -11,18 +11,15 @@ use crate::client::config::ClientConfig;
 use crate::client::connection::ConnectionManager;
 use crate::client::events::{ConnectEvent, DisconnectEvent};
 use crate::client::io::ClientIoEvent;
-use crate::client::networking::utils::AppStateExt;
 use crate::client::replication::send::ReplicateToServer;
 use crate::client::run_conditions::is_disconnected;
 use crate::client::sync::SyncSet;
 use crate::connection::client::{ClientConnection, ConnectionError, ConnectionState, NetClient};
 use crate::connection::server::IoConfig;
-use crate::prelude::{
-    is_host_server, ChannelRegistry, MainSet, MessageRegistry, TickManager, TimeManager,
-};
+use crate::prelude::client::NetConfig;
+use crate::prelude::{is_host_server, server, ChannelRegistry, MainSet, MessageRegistry, TickManager, TimeManager};
 use crate::protocol::component::ComponentRegistry;
 use crate::server::clients::ControlledEntities;
-use crate::shared::config::Mode;
 use crate::shared::replication::components::Replicated;
 use crate::shared::sets::{ClientMarker, InternalMainSet};
 use crate::transport::io::IoState;
@@ -36,8 +33,6 @@ impl Plugin for ClientNetworkingPlugin {
             // REFLECTION
             .register_type::<HostServerMetadata>()
             .register_type::<IoConfig>()
-            // STATE
-            .init_state_without_entering(NetworkingState::Disconnected)
             // RESOURCE
             .init_resource::<HostServerMetadata>()
             // SYSTEM SETS
@@ -99,11 +94,15 @@ impl Plugin for ClientNetworkingPlugin {
         );
 
         // DISCONNECTED
+        // app.add_systems(
+        //     OnExit(NetworkingState::Connected),
+        //     on_disconnecting_host_server.run_if(is_host_server),
+        // );
         app.add_systems(
-            OnEnter(NetworkingState::Disconnected),
+            OnEnter(NetworkingState::Disconnecting),
             (
-                on_disconnect.run_if(not(is_host_server)),
-                on_disconnect_host_server.run_if(is_host_server),
+                on_disconnecting.run_if(not(is_host_server)),
+                on_disconnecting_host_server.run_if(is_host_server),
             ),
         );
     }
@@ -146,7 +145,7 @@ pub(crate) fn receive_packets(
 
     if matches!(netclient.state(), ConnectionState::Connected) {
         // we just connected, do a state transition
-        if state.get() != &NetworkingState::Connected {
+        if state.get() == &NetworkingState::Connecting {
             debug!("Setting the networking state to connected");
             next_state.set(NetworkingState::Connected);
         }
@@ -161,8 +160,8 @@ pub(crate) fn receive_packets(
     if let ConnectionState::Disconnected { reason } = netclient.state() {
         netclient.disconnect_reason = reason;
         // we just disconnected, do a state transition
-        if state.get() != &NetworkingState::Disconnected {
-            next_state.set(NetworkingState::Disconnected);
+        if state.get() != &NetworkingState::Disconnecting {
+            next_state.set(NetworkingState::Disconnecting);
         }
     }
 
@@ -291,6 +290,10 @@ pub(crate) fn sync_update(
 /// Bevy [`State`] representing the networking state of the client.
 #[derive(States, Default, Debug, Clone, Copy, PartialEq, Eq, Hash, Reflect)]
 pub enum NetworkingState {
+    // We need this State to have a 1 frame transition so that we can still be in Host-Server mode
+    // while the client is disconnecting. Otherwise as soon as we're Disconnected we are not in
+    // HostServer mode anymore
+    Disconnecting,
     /// The client is disconnected from the server. The receive/send packets systems do not run.
     #[default]
     Disconnected,
@@ -396,15 +399,15 @@ fn on_connect_host_server(
 
 /// System that runs when we enter the Disconnected state
 /// Updates the DisconnectEvent events
-fn on_disconnect(
+fn on_disconnecting(
     mut connection_manager: ResMut<ConnectionManager>,
     mut disconnect_event_writer: EventWriter<DisconnectEvent>,
     mut netclient: ResMut<ClientConnection>,
     mut commands: Commands,
     // no need to handle Predicted/Interpolated because there are separate systems that handle these
     received_entities: Query<Entity, With<Replicated>>,
+    mut networking_state: ResMut<NextState<NetworkingState>>,
 ) {
-    info!("Running OnDisconnect schedule");
     // despawn any entities that were spawned from replication
     received_entities.iter().for_each(|e| {
         if let Some(commands) = commands.get_entity(e) {
@@ -425,19 +428,22 @@ fn on_disconnect(
     // we need to also trigger the event because we sometimes react to it via observers
     commands.trigger(DisconnectEvent { reason: None });
     // TODO: remove ClientConnection and ConnectionManager resources?
+    networking_state.set(NetworkingState::Disconnected);
 }
 
 /// Make sure that the DisconnectEvent is emitted even when the local client disconnects
-fn on_disconnect_host_server(
+fn on_disconnecting_host_server(
     netcode: Res<ClientConnection>,
     mut connection_manager: ResMut<crate::prelude::server::ConnectionManager>,
     mut metadata: ResMut<HostServerMetadata>,
+    mut networking_state: ResMut<NextState<NetworkingState>>,
 ) {
     let client_id = netcode.id();
     if let Some(client_entity) = std::mem::take(&mut metadata.client_entity) {
         // removing the client from the server's connection list also emits the server DisconnectEvent
         connection_manager.remove(client_id);
     }
+    networking_state.set(NetworkingState::Disconnected);
 }
 
 /// This runs only when we enter the [`Connecting`](NetworkingState::Connecting) state.
@@ -448,12 +454,14 @@ fn on_disconnect_host_server(
 /// - we can take into account any changes to the client config
 fn rebuild_client_connection(world: &mut World) {
     let client_config = world.resource::<ClientConfig>().clone();
-    // if client_config.shared.mode == Mode::HostServer {
-    //     assert!(
-    //         matches!(client_config.net, NetConfig::Local { .. }),
-    //         "When running in HostServer mode, the client connection needs to be of type Local"
-    //     );
-    // }
+
+    // if the server is started, that means we're planning to run in host-server mode
+    if world.get_resource::<State<server::NetworkingState>>().is_some_and(|s| s.get() == &server::NetworkingState::Started) {
+            assert!(
+                matches!(client_config.net, NetConfig::Local { .. }),
+                "When running in HostServer mode, the client connection needs to be of type Local"
+            );
+    }
 
     // insert a new connection manager (to reset sync, priority, message numbers, etc.)
     let connection_manager = ConnectionManager::new(
@@ -497,19 +505,6 @@ fn connect(world: &mut World) {
             .resource_mut::<NextState<NetworkingState>>()
             .set(NetworkingState::Disconnected);
     }
-    let config = world.resource::<ClientConfig>();
-    if matches!(
-        world.resource::<ClientConnection>().state(),
-        ConnectionState::Connected
-    ) && config.shared.mode == Mode::HostServer
-    {
-        // TODO: also check if the connection is of type local?
-        // in host server mode, there is no connecting phase, we directly become connected
-        // (because the networking systems don't run so we cannot go through the Connecting state)
-        world
-            .resource_mut::<NextState<NetworkingState>>()
-            .set(NetworkingState::Connected);
-    }
 }
 
 pub trait ClientCommands {
@@ -526,54 +521,32 @@ impl ClientCommands for Commands<'_, '_> {
     }
 
     fn disconnect_client(&mut self) {
-        self.insert_resource(NextState::Pending(NetworkingState::Disconnected));
+        self.insert_resource(NextState::Pending(NetworkingState::Disconnecting));
     }
 }
 
-mod utils {
-    use bevy::app::App;
-    use bevy::prelude::{NextState, State, StateTransition, StateTransitionEvent};
-    use bevy::state::state::{setup_state_transitions_in_world, FreelyMutableState};
 
-    pub(super) trait AppStateExt {
-        // Helper function that runs `init_state::<S>` without entering the state
-        // This is useful for us as we don't want to run OnEnter<NetworkingState::Disconnected> when we start the app
-        fn init_state_without_entering<S: FreelyMutableState>(&mut self, state: S) -> &mut Self;
-    }
-
-    impl AppStateExt for App {
-        fn init_state_without_entering<S: FreelyMutableState>(&mut self, state: S) -> &mut Self {
-            setup_state_transitions_in_world(self.world_mut());
-            self.insert_resource::<State<S>>(State::new(state.clone()))
-                .init_resource::<NextState<S>>()
-                .add_event::<StateTransitionEvent<S>>();
-            let schedule = self.get_schedule_mut(StateTransition).unwrap();
-            S::register_state(schedule);
-            self
-        }
-    }
-}
 
 #[cfg(test)]
 mod tests {
     use bevy::prelude::*;
 
     use crate::{
-        prelude::{client::ClientCommands, server::*},
+        prelude::{client::ClientCommands, server},
         tests::host_server_stepper::HostServerStepper,
     };
 
     #[derive(Resource, Default)]
     struct CheckCounter(usize);
 
-    fn receive_connect_event(mut reader: EventReader<ConnectEvent>, mut res: ResMut<CheckCounter>) {
+    fn receive_connect_event(mut reader: EventReader<server::ConnectEvent>, mut res: ResMut<CheckCounter>) {
         for event in reader.read() {
             res.0 += 1;
         }
     }
 
     fn receive_disconnect_event(
-        mut reader: EventReader<DisconnectEvent>,
+        mut reader: EventReader<server::DisconnectEvent>,
         mut res: ResMut<CheckCounter>,
     ) {
         for event in reader.read() {
@@ -593,6 +566,7 @@ mod tests {
         assert_eq!(stepper.server_app.world().resource::<CheckCounter>().0, 2); // 2 because local client as well as external client connect
     }
 
+    /// Check that a server::Disconnect event is emitted on the server when the local client disconnects
     #[test]
     fn test_host_server_disconnect_event() {
         let mut stepper = HostServerStepper::default();
@@ -603,11 +577,12 @@ mod tests {
             .add_systems(Update, receive_disconnect_event);
         let mut client_world = stepper.client_app.world_mut();
         client_world.commands().disconnect_client();
+        stepper.frame_step();
+        stepper.frame_step();
 
         client_world = stepper.server_app.world_mut();
         client_world.commands().disconnect_client();
 
-        stepper.frame_step();
         stepper.frame_step();
         stepper.frame_step();
         assert_eq!(stepper.server_app.world().resource::<CheckCounter>().0, 2); // 2 because local client as well as external client disconnect

--- a/lightyear/src/client/plugin.rs
+++ b/lightyear/src/client/plugin.rs
@@ -106,9 +106,6 @@ impl Plugin for SetupPlugin {
             // RESOURCES //
             .insert_resource(self.config.clone());
 
-        // TODO: how do we make sure that SharedPlugin is only added once if we want to switch between
-        //  HostServer and Separate mode?
-        // if self.config.shared.mode == Mode::Separate {
         if !app.is_plugin_added::<SharedPlugin>() {
             app
                 // PLUGINS

--- a/lightyear/src/client/prediction/pre_prediction.rs
+++ b/lightyear/src/client/prediction/pre_prediction.rs
@@ -8,7 +8,7 @@ use crate::client::prediction::resource::PredictionManager;
 use crate::client::prediction::Predicted;
 use crate::client::replication::send::ReplicateToServer;
 use crate::prelude::client::is_synced;
-use crate::prelude::{is_host_server, HasAuthority, NetworkIdentity, ReplicateHierarchy, Replicating, ReplicationGroup, ShouldBePredicted, TickManager};
+use crate::prelude::{is_host_server, HasAuthority, NetworkIdentityState, ReplicateHierarchy, Replicating, ReplicationGroup, ShouldBePredicted, TickManager};
 use crate::server::replication::send::ReplicationTarget;
 use crate::shared::replication::components::PrePredicted;
 use crate::shared::sets::{ClientMarker, InternalReplicationSet};
@@ -77,7 +77,7 @@ impl PrePredictionPlugin {
         trigger: Trigger<OnAdd, PrePredicted>,
         mut commands: Commands,
         prediction_manager: Res<PredictionManager>,
-        identity: Option<Res<State<NetworkIdentity>>>,
+        identity: Option<Res<State<NetworkIdentityState>>>,
         // TODO: should we fetch the value of PrePredicted to confirm that it matches what we expect?
     ) {
         let predicted_map = unsafe {

--- a/lightyear/src/client/prediction/pre_prediction.rs
+++ b/lightyear/src/client/prediction/pre_prediction.rs
@@ -8,11 +8,7 @@ use crate::client::prediction::resource::PredictionManager;
 use crate::client::prediction::Predicted;
 use crate::client::replication::send::ReplicateToServer;
 use crate::prelude::client::is_synced;
-use crate::prelude::server::{NetworkingState, ServerConfig};
-use crate::prelude::{
-    is_host_server_ref, HasAuthority, ReplicateHierarchy, Replicating, ReplicationGroup,
-    ShouldBePredicted, TickManager,
-};
+use crate::prelude::{is_host_server, HasAuthority, NetworkIdentity, ReplicateHierarchy, Replicating, ReplicationGroup, ShouldBePredicted, TickManager};
 use crate::server::replication::send::ReplicationTarget;
 use crate::shared::replication::components::PrePredicted;
 use crate::shared::sets::{ClientMarker, InternalReplicationSet};
@@ -81,6 +77,7 @@ impl PrePredictionPlugin {
         trigger: Trigger<OnAdd, PrePredicted>,
         mut commands: Commands,
         prediction_manager: Res<PredictionManager>,
+        identity: Option<Res<State<NetworkIdentity>>>,
         // TODO: should we fetch the value of PrePredicted to confirm that it matches what we expect?
     ) {
         let predicted_map = unsafe {
@@ -106,45 +103,42 @@ impl PrePredictionPlugin {
             });
         } else {
             let predicted_entity = trigger.entity();
-            // PrePredicted was added by the client:
-            // Spawn a Confirmed entity and update the mapping
-            commands.queue(move |world: &mut World| {
-                // TODO: check host_server via sub state
+            if is_host_server(identity) {
                 // for host-server, we don't want to spawn a separate entity because
                 //  the confirmed/predicted/server entity are the same! Instead we just want
                 //  to remove PrePredicted and add Predicted
-                if is_host_server_ref(
-                    world.get_resource_ref::<ServerConfig>(),
-                    world.get_resource_ref::<State<NetworkingState>>(),
-                ) {
+                commands.queue(move |world: &mut World| {
                     // world.entity_mut(predicted_entity).remove::<PrePredicted>();
                     world.entity_mut(predicted_entity).insert(Predicted {
                         confirmed_entity: Some(predicted_entity),
                     });
-                    return;
-                }
-
-                let tick = world.resource::<TickManager>().tick();
-                let confirmed_entity = world
-                    .spawn(Confirmed {
-                        predicted: Some(predicted_entity),
-                        interpolated: None,
-                        tick,
-                    })
-                    .id();
-                debug!("Added PrePredicted on the client. Spawning confirmed entity: {confirmed_entity:?} for pre-predicted: {predicted_entity:?}");
-                world
-                    .entity_mut(predicted_entity)
-                    .get_mut::<PrePredicted>()
-                    .unwrap()
-                    .confirmed_entity = Some(confirmed_entity);
-                world
-                    .resource_mut::<PredictionManager>()
-                    .predicted_entity_map
-                    .get_mut()
-                    .confirmed_to_predicted
-                    .insert(confirmed_entity, predicted_entity);
-            });
+                });
+            } else {
+                // PrePredicted was added by the client:
+                // Spawn a Confirmed entity and update the mapping
+                commands.queue(move |world: &mut World| {
+                    let tick = world.resource::<TickManager>().tick();
+                    let confirmed_entity = world
+                        .spawn(Confirmed {
+                            predicted: Some(predicted_entity),
+                            interpolated: None,
+                            tick,
+                        })
+                        .id();
+                    debug!("Added PrePredicted on the client. Spawning confirmed entity: {confirmed_entity:?} for pre-predicted: {predicted_entity:?}");
+                    world
+                        .entity_mut(predicted_entity)
+                        .get_mut::<PrePredicted>()
+                        .unwrap()
+                        .confirmed_entity = Some(confirmed_entity);
+                    world
+                        .resource_mut::<PredictionManager>()
+                        .predicted_entity_map
+                        .get_mut()
+                        .confirmed_to_predicted
+                        .insert(confirmed_entity, predicted_entity);
+                });
+            }
         }
     }
 }

--- a/lightyear/src/client/run_conditions.rs
+++ b/lightyear/src/client/run_conditions.rs
@@ -3,6 +3,7 @@ use crate::client::connection::ConnectionManager;
 use crate::connection::client::{ClientConnection, ConnectionState, NetClient};
 use bevy::prelude::Res;
 
+
 /// Returns true if the client is connected
 ///
 /// We check the status of the ClientConnection directly instead of using the `State<NetworkingState>`

--- a/lightyear/src/client/sync.rs
+++ b/lightyear/src/client/sync.rs
@@ -14,6 +14,7 @@ use crate::shared::tick_manager::{Tick, TickEvent};
 use crate::shared::time_manager::{TimeManager, WrappedTime};
 use crate::utils::ready_buffer::ReadyBuffer;
 
+
 /// SystemSet that holds systems that update the client's tick/time to match the server's tick/time
 #[derive(SystemSet, Debug, Hash, PartialEq, Eq, Clone, Copy)]
 pub struct SyncSet;

--- a/lightyear/src/lib.rs
+++ b/lightyear/src/lib.rs
@@ -204,7 +204,7 @@ pub mod prelude {
     };
     pub use crate::protocol::serialize::AppSerializeExt;
     pub use crate::shared::config::SharedConfig;
-    pub use crate::shared::identity::{AppIdentityExt, NetworkIdentity};
+    pub use crate::shared::identity::{AppIdentityExt, NetworkIdentity, NetworkIdentityState};
     #[cfg(feature = "leafwing")]
     pub use crate::shared::input::leafwing::LeafwingInputPlugin;
     pub use crate::shared::input::native::InputPlugin;
@@ -288,7 +288,7 @@ pub mod prelude {
         pub use crate::client::io::config::ClientTransport;
         pub use crate::client::io::Io;
         pub use crate::client::message::ReceiveMessage;
-        pub use crate::client::networking::{ClientCommands, NetworkingState};
+        pub use crate::client::networking::{ClientCommands, ConnectedState, NetworkingState};
         pub use crate::client::plugin::ClientPlugins;
         pub use crate::client::prediction::correction::Correction;
         pub use crate::client::prediction::despawn::PredictionDespawnCommandsExt;

--- a/lightyear/src/lib.rs
+++ b/lightyear/src/lib.rs
@@ -203,13 +203,14 @@ pub mod prelude {
         resource::AppResourceExt,
     };
     pub use crate::protocol::serialize::AppSerializeExt;
-    pub use crate::shared::config::{Mode, SharedConfig};
+    pub use crate::shared::config::SharedConfig;
+    pub use crate::shared::identity::{AppIdentityExt, NetworkIdentity};
     #[cfg(feature = "leafwing")]
     pub use crate::shared::input::leafwing::LeafwingInputPlugin;
     pub use crate::shared::input::native::InputPlugin;
     pub use crate::shared::message::MessageSend;
     pub use crate::shared::ping::manager::PingConfig;
-    pub use crate::shared::plugin::{NetworkIdentity, SharedPlugin};
+    pub use crate::shared::plugin::SharedPlugin;
     pub use crate::shared::replication::authority::HasAuthority;
     pub use crate::shared::replication::components::{
         DeltaCompression, DisabledComponents, NetworkRelevanceMode, OverrideTargetComponent,

--- a/lightyear/src/protocol/message/server.rs
+++ b/lightyear/src/protocol/message/server.rs
@@ -3,7 +3,7 @@ use crate::prelude::{
     Channel, ClientId, ClientReceiveMessage, Message, NetworkTarget, ServerConnectionManager,
     ServerReceiveMessage, ServerSendMessage,
 };
-use crate::protocol::message::registry::MessageRegistry;
+use crate::protocol::message::registry::{MessageRegistry, MessageType};
 use crate::protocol::message::trigger::TriggerMessage;
 use crate::protocol::message::MessageError;
 use crate::protocol::registry::NetId;

--- a/lightyear/src/protocol/message/server.rs
+++ b/lightyear/src/protocol/message/server.rs
@@ -3,7 +3,7 @@ use crate::prelude::{
     Channel, ClientId, ClientReceiveMessage, Message, NetworkTarget, ServerConnectionManager,
     ServerReceiveMessage, ServerSendMessage,
 };
-use crate::protocol::message::registry::{MessageRegistry, MessageType};
+use crate::protocol::message::registry::MessageRegistry;
 use crate::protocol::message::trigger::TriggerMessage;
 use crate::protocol::message::MessageError;
 use crate::protocol::registry::NetId;

--- a/lightyear/src/server/input/leafwing.rs
+++ b/lightyear/src/server/input/leafwing.rs
@@ -70,14 +70,15 @@ impl<A: LeafwingUserAction> Plugin for LeafwingInputPlugin<A> {
             FixedPreUpdate,
             update_action_state::<A>.in_set(InputSystemSet::Update),
         );
+    }
 
-        // TODO: register this in Plugin::finish by checking if the client plugin is already registered?
-        if app.world().resource::<ServerConfig>().shared.mode != Mode::HostServer {
-            // we don't want to add this plugin in HostServer mode because it's already added on the client side
-            // Otherwise, we need to add the leafwing server plugin because it ticks Action-States (so just-pressed become pressed)
+    // TODO: this doesn't work! figure out how to make sure that InputManagerPlugin is called
+    fn finish(&self, app: &mut App) {
+        if !app.is_plugin_added::<InputManagerPlugin::<A>>() {
             app.add_plugins(InputManagerPlugin::<A>::server());
         }
     }
+
 }
 
 /// For each entity that has an action-state, insert an InputBuffer, to store

--- a/lightyear/src/server/input/leafwing.rs
+++ b/lightyear/src/server/input/leafwing.rs
@@ -8,11 +8,10 @@ use leafwing_input_manager::prelude::*;
 
 use crate::inputs::leafwing::LeafwingUserAction;
 use crate::prelude::{
-    server::is_started, InputMessage, MessageRegistry, Mode, ServerReceiveMessage, TickManager,
+    server::is_started, InputMessage, MessageRegistry, ServerReceiveMessage, TickManager,
 };
 use crate::protocol::message::MessageKind;
 use crate::serialize::reader::Reader;
-use crate::server::config::ServerConfig;
 use crate::server::connection::ConnectionManager;
 use crate::shared::replication::network_target::NetworkTarget;
 use crate::shared::sets::{InternalMainSet, ServerMarker};

--- a/lightyear/src/server/networking.rs
+++ b/lightyear/src/server/networking.rs
@@ -38,8 +38,6 @@ impl Plugin for ServerNetworkingPlugin {
             // REFLECTION
             .register_type::<IoConfig>()
             .register_type::<NetworkingState>()
-            // STATE
-            .init_state::<NetworkingState>()
             // SYSTEM SETS
             .configure_sets(
                 PreUpdate,
@@ -197,7 +195,7 @@ pub(crate) fn receive_packets(
             {
                 // TODO: convert into packets/bytes per second
                 let packets = 1.0 as u64;
-                let bytes = payload.len() as u64;
+                let bytes = payload.payload.len() as u64;
                 metrics::counter!(format!("transport::{:?}::receive::packets", client_id))
                     .increment(packets);
                 metrics::counter!(format!("transport::{:?}::receive::bytes", client_id))

--- a/lightyear/src/server/plugin.rs
+++ b/lightyear/src/server/plugin.rs
@@ -85,7 +85,6 @@ impl Plugin for SetupPlugin {
         // NOTE: SharedPlugin needs to be added after config
         if !app.is_plugin_added::<SharedPlugin>() {
             app.add_plugins(SharedPlugin {
-                // TODO: move shared config out of server_config?
                 config: self.config.shared,
             });
         }

--- a/lightyear/src/server/prediction.rs
+++ b/lightyear/src/server/prediction.rs
@@ -1,10 +1,7 @@
 //! Handles logic related to prespawning entities
 
-use crate::prelude::server::{AuthorityCommandExt, AuthorityPeer, NetworkingState, ServerConfig};
-use crate::prelude::{
-    is_host_server, ComponentRegistry, PrePredicted, PreSpawnedPlayerObject, Replicated,
-    ServerConnectionManager, TickManager,
-};
+use crate::prelude::server::{AuthorityCommandExt, AuthorityPeer};
+use crate::prelude::{is_host_server, ComponentRegistry, NetworkIdentity, PrePredicted, PreSpawnedPlayerObject, Replicated, ServerConnectionManager, TickManager};
 use crate::shared::replication::prespawn::compute_default_hash;
 use bevy::ecs::component::Components;
 use bevy::prelude::*;
@@ -62,12 +59,11 @@ pub(crate) fn handle_pre_predicted(
     trigger: Trigger<OnAdd, PrePredicted>,
     mut commands: Commands,
     mut manager: ResMut<ServerConnectionManager>,
-    config: Option<Res<ServerConfig>>,
-    server_state: Option<Res<State<NetworkingState>>>,
+    identity: Option<Res<State<NetworkIdentity>>>,
     q: Query<(Entity, &PrePredicted, &Replicated)>,
 ) {
     // no need to do anything in host-server mode, we directly add the `Predicted` component on the client
-    if is_host_server(config, server_state) {
+    if is_host_server(identity) {
         return;
     }
     if let Ok((local_entity, pre_predicted, replicated)) = q.get(trigger.entity()) {

--- a/lightyear/src/server/prediction.rs
+++ b/lightyear/src/server/prediction.rs
@@ -1,7 +1,7 @@
 //! Handles logic related to prespawning entities
 
 use crate::prelude::server::{AuthorityCommandExt, AuthorityPeer};
-use crate::prelude::{is_host_server, ComponentRegistry, NetworkIdentity, PrePredicted, PreSpawnedPlayerObject, Replicated, ServerConnectionManager, TickManager};
+use crate::prelude::{is_host_server, ComponentRegistry, NetworkIdentityState, PrePredicted, PreSpawnedPlayerObject, Replicated, ServerConnectionManager, TickManager};
 use crate::shared::replication::prespawn::compute_default_hash;
 use bevy::ecs::component::Components;
 use bevy::prelude::*;
@@ -59,7 +59,7 @@ pub(crate) fn handle_pre_predicted(
     trigger: Trigger<OnAdd, PrePredicted>,
     mut commands: Commands,
     mut manager: ResMut<ServerConnectionManager>,
-    identity: Option<Res<State<NetworkIdentity>>>,
+    identity: Option<Res<State<NetworkIdentityState>>>,
     q: Query<(Entity, &PrePredicted, &Replicated)>,
 ) {
     // no need to do anything in host-server mode, we directly add the `Predicted` component on the client

--- a/lightyear/src/shared/config.rs
+++ b/lightyear/src/shared/config.rs
@@ -12,38 +12,14 @@ pub struct SharedConfig {
     pub server_replication_send_interval: Duration,
     /// configuration for the [`FixedUpdate`](bevy::prelude::FixedUpdate) schedule
     pub tick: TickConfig,
-    pub mode: Mode,
 }
 
-// TODO: maybe the modes should just be
-//  - server and client are running in separate apps: need to add SharedPlugin on client, etc.
-//  - server and client are running in same app: need to add SharedPlugin on client, need to only add LeafwingInputOnce
-//    - host-server mode activated <> we use LocalTransport on client, server runs some connections <> disable all prediction, etc. on client
-//    - host-server mode non-activate <> we use a non-Local transport on client, server has no connections <> still run all prediction, networking on client; disable server entirely
-
-// TODO: maybe we can figure the mode out directly from the registered plugins and the networking state instead of requiring
-//  the user to specify the mode.
-//  - If we see only the client plugin or the server plugin, we are in Separate mode
-//  - If we see both plugins and we use LocalTransport on Client and the server is started, we are in HostServer mode
-//  - If we see both plugins and we use a non-local transport on client or the server is not started, we are in ClientOnly mode?
-#[derive(Default, Clone, Copy, Debug, PartialEq, Eq, Reflect)]
-pub enum Mode {
-    #[default]
-    /// We will create two bevy Apps: a client app and a server app.
-    /// Data gets passed between the two via channels.
-    Separate,
-    /// Run the app in headless mode
-    /// We have the client and the server running inside the same app.
-    /// The server will also act as a client. (i.e. one client acts as the 'host')
-    HostServer,
-}
 
 impl Default for SharedConfig {
     fn default() -> Self {
         Self {
             server_replication_send_interval: Duration::from_millis(0),
             tick: TickConfig::new(Duration::from_millis(16)),
-            mode: Mode::default(),
         }
     }
 }

--- a/lightyear/src/shared/identity.rs
+++ b/lightyear/src/shared/identity.rs
@@ -1,0 +1,56 @@
+use crate::prelude::{client, server};
+use bevy::prelude::{ComputedStates, State, World};
+
+
+/// State that will contain the current role of the peer. This state is only active if the peer is connected
+#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+pub enum NetworkIdentity {
+    Client,
+    Server,
+    HostServer,
+}
+
+impl ComputedStates for NetworkIdentity {
+    type SourceStates = (Option<client::NetworkingState>, Option<server::NetworkingState>);
+
+    /// We then define the compute function, which takes in the AppState
+    fn compute(sources: Self::SourceStates) -> Option<Self> {
+        match sources {
+            // If client and server states are both present and started, then we must be a HostServer
+            (Some(client::NetworkingState::Connected), Some(server::NetworkingState::Started)) => Some(NetworkIdentity::HostServer),
+            // we include these so that we can run the host_server disconnection systems
+            (Some(client::NetworkingState::Connected), Some(server::NetworkingState::Stopping)) => Some(NetworkIdentity::HostServer),
+            (Some(client::NetworkingState::Disconnecting), Some(server::NetworkingState::Started)) => Some(NetworkIdentity::HostServer),
+            // If only the client is connected, we are a Client
+            (Some(client::NetworkingState::Connected), _) => Some(NetworkIdentity::Client),
+            // If only the server is started, we are a Server
+            (_, Some(server::NetworkingState::Started)) => Some(NetworkIdentity::Server),
+            // If neither client or server are connected, then we don't want the `NetworkIdentity` state to exist
+            _ => None
+        }
+    }
+}
+
+
+pub trait AppIdentityExt {
+    fn is_client(&self) -> bool;
+
+    fn is_server(&self) -> bool;
+
+    fn is_host_server(&self) -> bool;
+
+}
+
+impl AppIdentityExt for World {
+    fn is_client(&self) -> bool {
+        self.get_resource::<State<NetworkIdentity>>().is_some_and(|i| i.get() == &NetworkIdentity::Client)
+    }
+
+    fn is_server(&self) -> bool {
+        self.get_resource::<State<NetworkIdentity>>().is_some_and(|i| i.get() != &NetworkIdentity::Client)
+    }
+
+    fn is_host_server(&self) -> bool {
+        self.get_resource::<State<NetworkIdentity>>().is_some_and(|i| i.get() == &NetworkIdentity::HostServer)
+    }
+}

--- a/lightyear/src/shared/identity.rs
+++ b/lightyear/src/shared/identity.rs
@@ -1,36 +1,54 @@
 use crate::prelude::{client, server};
-use bevy::prelude::{ComputedStates, State, World};
+use bevy::ecs::system::SystemParam;
+use bevy::prelude::{ComputedStates, Res, State, World};
 
 
 /// State that will contain the current role of the peer. This state is only active if the peer is connected
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
-pub enum NetworkIdentity {
+pub enum NetworkIdentityState {
     Client,
     Server,
     HostServer,
 }
 
-impl ComputedStates for NetworkIdentity {
+impl ComputedStates for NetworkIdentityState {
     type SourceStates = (Option<client::NetworkingState>, Option<server::NetworkingState>);
 
     /// We then define the compute function, which takes in the AppState
     fn compute(sources: Self::SourceStates) -> Option<Self> {
         match sources {
             // If client and server states are both present and started, then we must be a HostServer
-            (Some(client::NetworkingState::Connected), Some(server::NetworkingState::Started)) => Some(NetworkIdentity::HostServer),
+            (Some(client::NetworkingState::Connected), Some(server::NetworkingState::Started)) => Some(NetworkIdentityState::HostServer),
             // we include these so that we can run the host_server disconnection systems
-            (Some(client::NetworkingState::Connected), Some(server::NetworkingState::Stopping)) => Some(NetworkIdentity::HostServer),
-            (Some(client::NetworkingState::Disconnecting), Some(server::NetworkingState::Started)) => Some(NetworkIdentity::HostServer),
+            (Some(client::NetworkingState::Connected), Some(server::NetworkingState::Stopping)) => Some(NetworkIdentityState::HostServer),
+            (Some(client::NetworkingState::Disconnecting), Some(server::NetworkingState::Started)) => Some(NetworkIdentityState::HostServer),
             // If only the client is connected, we are a Client
-            (Some(client::NetworkingState::Connected), _) => Some(NetworkIdentity::Client),
+            (Some(client::NetworkingState::Connected), _) => Some(NetworkIdentityState::Client),
             // If only the server is started, we are a Server
-            (_, Some(server::NetworkingState::Started)) => Some(NetworkIdentity::Server),
+            (_, Some(server::NetworkingState::Started)) => Some(NetworkIdentityState::Server),
             // If neither client or server are connected, then we don't want the `NetworkIdentity` state to exist
             _ => None
         }
     }
 }
 
+
+#[derive(SystemParam)]
+pub struct NetworkIdentity<'w> {
+    identity: Option<Res<'w, State<NetworkIdentityState>>>
+}
+
+impl NetworkIdentity<'_> {
+    pub fn is_client(&self) -> bool {
+        self.identity.as_ref().is_some_and(|i| i.get() == &NetworkIdentityState::Client)
+    }
+    pub fn is_server(&self) -> bool {
+        self.identity.as_ref().is_some_and(|i| i.get() != &NetworkIdentityState::Client)
+    }
+    pub fn is_host_server(&self) -> bool {
+        self.identity.as_ref().is_some_and(|i| i.get() == &NetworkIdentityState::HostServer)
+    }
+}
 
 pub trait AppIdentityExt {
     fn is_client(&self) -> bool;
@@ -43,14 +61,14 @@ pub trait AppIdentityExt {
 
 impl AppIdentityExt for World {
     fn is_client(&self) -> bool {
-        self.get_resource::<State<NetworkIdentity>>().is_some_and(|i| i.get() == &NetworkIdentity::Client)
+        self.get_resource::<State<NetworkIdentityState>>().is_some_and(|i| i.get() == &NetworkIdentityState::Client)
     }
 
     fn is_server(&self) -> bool {
-        self.get_resource::<State<NetworkIdentity>>().is_some_and(|i| i.get() != &NetworkIdentity::Client)
+        self.get_resource::<State<NetworkIdentityState>>().is_some_and(|i| i.get() != &NetworkIdentityState::Client)
     }
 
     fn is_host_server(&self) -> bool {
-        self.get_resource::<State<NetworkIdentity>>().is_some_and(|i| i.get() == &NetworkIdentity::HostServer)
+        self.get_resource::<State<NetworkIdentityState>>().is_some_and(|i| i.get() == &NetworkIdentityState::HostServer)
     }
 }

--- a/lightyear/src/shared/mod.rs
+++ b/lightyear/src/shared/mod.rs
@@ -18,3 +18,4 @@ pub mod input;
 pub(crate) mod message;
 pub mod run_conditions;
 pub mod time_manager;
+pub mod identity;

--- a/lightyear/src/shared/plugin.rs
+++ b/lightyear/src/shared/plugin.rs
@@ -1,23 +1,15 @@
 //! Bevy [`Plugin`] used by both the server and the client
 use crate::client::config::ClientConfig;
-use crate::connection::client::{ClientConnection, NetClient};
-use crate::connection::server::ServerConnections;
 use crate::prelude::client::ComponentSyncMode;
-use crate::prelude::server::NetworkingState;
-use crate::prelude::{
-    AppComponentExt, AppMessageExt, ChannelDirection, ChannelRegistry, ClientId, ComponentRegistry,
-    LinkConditionerConfig, MessageRegistry, Mode, ParentSync, PingConfig, PrePredicted,
-    PreSpawnedPlayerObject, ShouldBePredicted, TickConfig,
-};
-use crate::server::run_conditions::is_started_ref;
+use crate::prelude::{client, server, AppComponentExt, AppMessageExt, ChannelDirection, ChannelRegistry, ComponentRegistry, LinkConditionerConfig, MessageRegistry, NetworkIdentity, ParentSync, PingConfig, PrePredicted, PreSpawnedPlayerObject, ShouldBePredicted, TickConfig};
 use crate::shared::config::SharedConfig;
+use crate::shared::plugin::utils::AppStateExt;
 use crate::shared::replication::authority::AuthorityChange;
 use crate::shared::replication::components::{Controlled, ShouldBeInterpolated};
 use crate::shared::tick_manager::TickManagerPlugin;
 use crate::shared::time_manager::TimePlugin;
 use crate::transport::io::{IoState, IoStats};
 use crate::transport::middleware::compression::CompressionConfig;
-use bevy::ecs::system::SystemParam;
 use bevy::prelude::*;
 use bevy::utils::Duration;
 
@@ -26,89 +18,10 @@ pub struct SharedPlugin {
     pub config: SharedConfig,
 }
 
-/// You can use this as a SystemParam to identify whether you're running on the client or the server
-#[derive(SystemParam)]
-pub struct NetworkIdentity<'w, 's> {
-    client: Option<Res<'w, ClientConnection>>,
-    client_config: Option<Res<'w, ClientConfig>>,
-    server: Option<Res<'w, ServerConnections>>,
-    server_state: Option<Res<'w, State<NetworkingState>>>,
-    _marker: std::marker::PhantomData<&'s ()>,
-}
-
-/// Identifies the network role of the current peer
-#[derive(Debug, PartialEq)]
-pub enum Identity {
-    /// This peer is a client.
-    /// (note that both the client and server plugins could be running in the same process; but this peer is still acting like a client.
-    /// (for example if the server plugin is stopped))
-    ///
-    /// If the client is connected, also contains the client id. If not, contains None.
-    Client(Option<ClientId>),
-    /// This peer is a server.
-    Server,
-    /// This peer is both a server and a client
-    HostServer,
-}
-
-impl FromWorld for Identity {
-    fn from_world(world: &mut World) -> Self {
-        let Some(config) = world.get_resource::<ClientConfig>() else {
-            return Identity::Server;
-        };
-        if matches!(config.shared.mode, Mode::HostServer)
-            && is_started_ref(world.get_resource_ref::<State<NetworkingState>>())
-        {
-            Identity::HostServer
-        } else {
-            let client_id = world
-                .get_resource::<ClientConnection>()
-                .as_ref()
-                .map(|c| c.client.id());
-            Identity::Client(client_id)
-        }
-    }
-}
-
-impl Identity {
-    pub fn is_client(&self) -> bool {
-        matches!(self, &Identity::Client(_))
-    }
-    pub fn is_server(&self) -> bool {
-        self == &Identity::Server || self == &Identity::HostServer
-    }
-}
-
-impl NetworkIdentity<'_, '_> {
-    pub fn identity(&self) -> Identity {
-        let Some(config) = &self.client_config else {
-            return Identity::Server;
-        };
-        if matches!(config.shared.mode, Mode::HostServer)
-            && self
-                .server_state
-                .as_ref()
-                .is_some_and(|s| s.get() == &NetworkingState::Started)
-        {
-            Identity::HostServer
-        } else {
-            let client_id = self.client.as_ref().map(|c| c.client.id());
-            Identity::Client(client_id)
-        }
-    }
-    pub fn is_client(&self) -> bool {
-        self.identity().is_client()
-    }
-    pub fn is_server(&self) -> bool {
-        self.identity().is_server()
-    }
-}
-
 impl Plugin for SharedPlugin {
     fn build(&self, app: &mut App) {
         // REFLECTION
-        app.register_type::<Mode>()
-            .register_type::<SharedConfig>()
+        app.register_type::<SharedConfig>()
             .register_type::<TickConfig>()
             .register_type::<PingConfig>()
             .register_type::<IoStats>()
@@ -116,20 +29,7 @@ impl Plugin for SharedPlugin {
             .register_type::<LinkConditionerConfig>()
             .register_type::<CompressionConfig>();
 
-        // PLUGINS
-        #[cfg(feature = "avian2d")]
-        app.add_plugins(crate::utils::avian2d::Avian2dPlugin);
-        #[cfg(feature = "avian3d")]
-        app.add_plugins(crate::utils::avian3d::Avian3dPlugin);
-        #[cfg(feature = "visualizer")]
-        {
-            if !app.is_plugin_added::<bevy_metrics_dashboard::bevy_egui::EguiPlugin>() {
-                app.add_plugins(bevy_metrics_dashboard::bevy_egui::EguiPlugin);
-            }
-            app.add_plugins(bevy_metrics_dashboard::RegistryPlugin::default())
-                .add_plugins(bevy_metrics_dashboard::DashboardPlugin);
-            app.add_systems(Startup, spawn_metrics_visualizer);
-        }
+
 
         // RESOURCES
         // the SharedPlugin is called after the ClientConfig is inserted
@@ -155,9 +55,28 @@ impl Plugin for SharedPlugin {
             config: self.config.tick,
         });
         app.add_plugins(TimePlugin);
+
+        #[cfg(feature = "avian2d")]
+        app.add_plugins(crate::utils::avian2d::Avian2dPlugin);
+        #[cfg(feature = "avian3d")]
+        app.add_plugins(crate::utils::avian3d::Avian3dPlugin);
+        #[cfg(feature = "visualizer")]
+        {
+            if !app.is_plugin_added::<bevy_metrics_dashboard::bevy_egui::EguiPlugin>() {
+                app.add_plugins(bevy_metrics_dashboard::bevy_egui::EguiPlugin);
+            }
+            app.add_plugins(bevy_metrics_dashboard::RegistryPlugin::default())
+                .add_plugins(bevy_metrics_dashboard::DashboardPlugin);
+            app.add_systems(Startup, spawn_metrics_visualizer);
+        }
     }
 
     fn finish(&self, app: &mut App) {
+        // STATES
+        // we need to include both client and server networking states so that the NetworkIdentity ComputedState can be computed correctly
+        app.init_state_without_entering(client::NetworkingState::Disconnected);
+        app.init_state_without_entering(server::NetworkingState::Stopped);
+        app.add_computed_state::<NetworkIdentity>();
         // PROTOCOL
         // we register components here because
         // - the SharedPlugin is built only once in HostServer mode (client and server plugins in the same app)
@@ -190,4 +109,28 @@ fn spawn_metrics_visualizer(mut commands: Commands) {
     commands.spawn(bevy_metrics_dashboard::DashboardWindow::new(
         "Metrics Dashboard",
     ));
+}
+
+pub(super) mod utils {
+    use bevy::app::App;
+    use bevy::prelude::{NextState, State, StateTransition, StateTransitionEvent};
+    use bevy::state::state::{setup_state_transitions_in_world, FreelyMutableState};
+
+    pub(super) trait AppStateExt {
+        // Helper function that runs `init_state::<S>` without entering the state
+        // This is useful for us as we don't want to run OnEnter<NetworkingState::Disconnected> when we start the app
+        fn init_state_without_entering<S: FreelyMutableState>(&mut self, state: S) -> &mut Self;
+    }
+
+    impl AppStateExt for App {
+        fn init_state_without_entering<S: FreelyMutableState>(&mut self, state: S) -> &mut Self {
+            setup_state_transitions_in_world(self.world_mut());
+            self.insert_resource::<State<S>>(State::new(state.clone()))
+                .init_resource::<NextState<S>>()
+                .add_event::<StateTransitionEvent<S>>();
+            let schedule = self.get_schedule_mut(StateTransition).unwrap();
+            S::register_state(schedule);
+            self
+        }
+    }
 }

--- a/lightyear/src/shared/plugin.rs
+++ b/lightyear/src/shared/plugin.rs
@@ -1,7 +1,7 @@
 //! Bevy [`Plugin`] used by both the server and the client
 use crate::client::config::ClientConfig;
 use crate::prelude::client::ComponentSyncMode;
-use crate::prelude::{client, server, AppComponentExt, AppMessageExt, ChannelDirection, ChannelRegistry, ComponentRegistry, LinkConditionerConfig, MessageRegistry, NetworkIdentity, ParentSync, PingConfig, PrePredicted, PreSpawnedPlayerObject, ShouldBePredicted, TickConfig};
+use crate::prelude::{client, server, AppComponentExt, AppMessageExt, ChannelDirection, ChannelRegistry, ComponentRegistry, LinkConditionerConfig, MessageRegistry, NetworkIdentityState, ParentSync, PingConfig, PrePredicted, PreSpawnedPlayerObject, ShouldBePredicted, TickConfig};
 use crate::shared::config::SharedConfig;
 use crate::shared::plugin::utils::AppStateExt;
 use crate::shared::replication::authority::AuthorityChange;
@@ -76,7 +76,8 @@ impl Plugin for SharedPlugin {
         // we need to include both client and server networking states so that the NetworkIdentity ComputedState can be computed correctly
         app.init_state_without_entering(client::NetworkingState::Disconnected);
         app.init_state_without_entering(server::NetworkingState::Stopped);
-        app.add_computed_state::<NetworkIdentity>();
+        app.add_sub_state::<client::ConnectedState>();
+        app.add_computed_state::<NetworkIdentityState>();
         // PROTOCOL
         // we register components here because
         // - the SharedPlugin is built only once in HostServer mode (client and server plugins in the same app)

--- a/lightyear/src/shared/run_conditions.rs
+++ b/lightyear/src/shared/run_conditions.rs
@@ -1,18 +1,15 @@
 //! Common run conditions
-use crate::prelude::server::{is_started, ServerConfig};
-use crate::prelude::{Mode, NetworkIdentity};
-use crate::server::networking::NetworkingState;
-use crate::server::run_conditions::is_started_ref;
-use bevy::prelude::{Ref, Res, State};
+use crate::shared::identity::NetworkIdentity;
+use bevy::prelude::{Res, State};
 
-/// Returns true if the peer is a client
-pub fn is_client(identity: NetworkIdentity) -> bool {
-    identity.is_client()
+/// Returns true if the peer is a client (host-server counts as a server)
+pub fn is_client(identity: Option<Res<State<NetworkIdentity>>>) -> bool {
+    identity.is_some_and(|i| i.get() == &NetworkIdentity::Client)
 }
 
 /// Returns true if the peer is a server
-pub fn is_server(identity: NetworkIdentity) -> bool {
-    identity.is_server()
+pub fn is_server(identity: Option<Res<State<NetworkIdentity>>>) -> bool {
+    identity.is_some_and(|i| i.get() != &NetworkIdentity::Client)
 }
 
 /// Returns true if we are running in host-server mode, i.e. the server is acting as a client
@@ -21,40 +18,6 @@ pub fn is_server(identity: NetworkIdentity) -> bool {
 /// We are in HostServer mode if the mode is set to HostServer AND the server is running.
 /// (checking if the mode is set to HostServer is not enough, it just means that the server plugin
 /// and client plugin are running in the same App)
-pub fn is_host_server(
-    config: Option<Res<ServerConfig>>,
-    server_state: Option<Res<State<NetworkingState>>>,
-) -> bool {
-    config.is_some_and(|config| {
-        matches!(config.shared.mode, Mode::HostServer) && is_started(server_state)
-    })
+pub fn is_host_server(identity: Option<Res<State<NetworkIdentity>>>) -> bool {
+    identity.is_some_and(|i| i.get() == &NetworkIdentity::HostServer)
 }
-
-pub fn is_host_server_ref(
-    config: Option<Ref<ServerConfig>>,
-    server_state: Option<Ref<State<NetworkingState>>>,
-) -> bool {
-    config.is_some_and(|config| {
-        matches!(config.shared.mode, Mode::HostServer) && is_started_ref(server_state)
-    })
-}
-
-/// Returns true if the `SharedConfig` is set to `Mode::Separate`
-/// (i.e. we are not running in HostServer mode)
-pub fn is_mode_separate(config: Option<Res<ServerConfig>>) -> bool {
-    config.map_or(true, |config| config.shared.mode == Mode::Separate)
-}
-
-// /// Returns true if we are ready to buffer the server replication messages
-// pub fn is_server_replication_send_ready(
-//     timer: Option<Res<SendIntervalTimer<server::ConnectionManager>>>,
-// ) -> bool {
-//     timer.map_or(false, |t| t.timer.as_ref().map_or(true, |t| t.finished()))
-// }
-//
-// /// Returns true if we are ready to buffer the client replication messages
-// pub fn is_client_replication_send_ready(
-//     timer: Option<Res<SendIntervalTimer<client::ConnectionManager>>>,
-// ) -> bool {
-//     timer.map_or(false, |t| t.timer.as_ref().map_or(true, |t| t.finished()))
-// }

--- a/lightyear/src/shared/run_conditions.rs
+++ b/lightyear/src/shared/run_conditions.rs
@@ -1,15 +1,15 @@
 //! Common run conditions
-use crate::shared::identity::NetworkIdentity;
+use crate::shared::identity::NetworkIdentityState;
 use bevy::prelude::{Res, State};
 
 /// Returns true if the peer is a client (host-server counts as a server)
-pub fn is_client(identity: Option<Res<State<NetworkIdentity>>>) -> bool {
-    identity.is_some_and(|i| i.get() == &NetworkIdentity::Client)
+pub fn is_client(identity: Option<Res<State<NetworkIdentityState>>>) -> bool {
+    identity.is_some_and(|i| i.get() == &NetworkIdentityState::Client)
 }
 
 /// Returns true if the peer is a server
-pub fn is_server(identity: Option<Res<State<NetworkIdentity>>>) -> bool {
-    identity.is_some_and(|i| i.get() != &NetworkIdentity::Client)
+pub fn is_server(identity: Option<Res<State<NetworkIdentityState>>>) -> bool {
+    identity.is_some_and(|i| i.get() != &NetworkIdentityState::Client)
 }
 
 /// Returns true if we are running in host-server mode, i.e. the server is acting as a client
@@ -18,6 +18,6 @@ pub fn is_server(identity: Option<Res<State<NetworkIdentity>>>) -> bool {
 /// We are in HostServer mode if the mode is set to HostServer AND the server is running.
 /// (checking if the mode is set to HostServer is not enough, it just means that the server plugin
 /// and client plugin are running in the same App)
-pub fn is_host_server(identity: Option<Res<State<NetworkIdentity>>>) -> bool {
-    identity.is_some_and(|i| i.get() == &NetworkIdentity::HostServer)
+pub fn is_host_server(identity: Option<Res<State<NetworkIdentityState>>>) -> bool {
+    identity.is_some_and(|i| i.get() == &NetworkIdentityState::HostServer)
 }

--- a/lightyear/src/tests/host_server_stepper.rs
+++ b/lightyear/src/tests/host_server_stepper.rs
@@ -99,10 +99,8 @@ impl HostServerStepper {
                 .with_key(private_key),
             io: server_io,
         };
-        let mut shared_host_server = shared_config;
-        shared_host_server.mode = Mode::HostServer;
         let config = ServerConfig {
-            shared: shared_host_server,
+            shared: shared_config,
             net: vec![net_config],
             ping: PingConfig {
                 // send pings every tick, so that the acks are received every frame
@@ -115,7 +113,7 @@ impl HostServerStepper {
 
         // Add the ClientPlugin to the server_app, to make it host-server mode!
         let mut host_server_client_config = client_config.clone();
-        host_server_client_config.shared = shared_host_server;
+        host_server_client_config.shared = shared_config;
         host_server_client_config.net = NetConfig::Local {
             id: LOCAL_CLIENT_ID,
         };
@@ -198,7 +196,6 @@ impl HostServerStepper {
 
     pub(crate) fn set_client_tick(&mut self, tick: Tick) {
         let new_time = WrappedTime::from_duration(self.tick_duration * (tick.0 as u32));
-
         self.client_app
             .world_mut()
             .resource_mut::<TimeManager>()
@@ -211,7 +208,6 @@ impl HostServerStepper {
 
     pub(crate) fn set_server_tick(&mut self, tick: Tick) {
         let new_time = WrappedTime::from_duration(self.tick_duration * (tick.0 as u32));
-
         self.server_app
             .world_mut()
             .resource_mut::<TimeManager>()

--- a/lightyear/src/tests/integration/tick_wrapping.rs
+++ b/lightyear/src/tests/integration/tick_wrapping.rs
@@ -1,5 +1,5 @@
 use crate::client::input::native::InputSystemSet;
-use crate::prelude::client::{InputManager, SyncConfig};
+use crate::prelude::client::InputManager;
 use crate::prelude::server::{InputEvent, Replicate};
 use crate::prelude::*;
 use crate::shared::time_manager::WrappedTime;
@@ -59,8 +59,8 @@ fn test_sync_after_tick_wrap() {
     for i in 0..200 {
         stepper.frame_step();
     }
-    dbg!(&stepper.server_tick());
-    dbg!(&stepper.client_tick());
+    // dbg!(&stepper.server_tick());
+    // dbg!(&stepper.client_tick());
     stepper
         .server_app
         .world_mut()

--- a/lightyear/src/transport/webtransport/mod.rs
+++ b/lightyear/src/transport/webtransport/mod.rs
@@ -14,7 +14,6 @@ cfg_if::cfg_if! {
 mod tests {
     use crate::client::io::transport::ClientTransportBuilder;
     use crate::server::io::transport::ServerTransportBuilder;
-    use crate::transport::Transport;
     use bevy::tasks::{IoTaskPool, TaskPoolBuilder};
     use bevy::utils::Duration;
     use wtransport::Identity;
@@ -76,7 +75,6 @@ mod tests {
         };
         assert_eq!(address, server_addr);
         assert_eq!(recv_msg, msg);
-        dbg!(recv_msg);
     }
 }
 
@@ -127,6 +125,5 @@ pub mod wasm_test {
         };
         assert_eq!(address, server_addr);
         assert_eq!(recv_msg, msg);
-        dbg!(recv_msg);
     }
 }


### PR DESCRIPTION
The HostServer configuration was a bit confusing and required the user to both:
- set the ClientTransport to Local
- set the Mode to HostServer

Then the run_condition to check if the app was running in HostServer mode was also fairly complicated.

This PR introduces the `NetworkIdentityState` ComputedState which provides the NetworkIdentity (Client/Server/HostServer) by looking at the client and server NetworkingState. We are in HostServer state if both the client and server are connected.