### PR TITLE
Add RequiredComponents for replication components

### DIFF
--- a/examples/avian_3d_character/src/settings.rs
+++ b/examples/avian_3d_character/src/settings.rs
@@ -31,9 +31,9 @@ pub(crate) fn get_settings() -> MySettings {
                 headless: false,
                 inspector: true,
                 conditioner: Some(Conditioner {
-                    latency_ms: 150,
-                    jitter_ms: 10,
-                    packet_loss: 0.05,
+                    latency_ms: 50,
+                    jitter_ms: 5,
+                    packet_loss: 0.03,
                 }),
                 transport: vec![
                     ServerTransports::WebTransport {
@@ -76,7 +76,7 @@ pub(crate) fn get_settings() -> MySettings {
                 compression: CompressionConfig::None,
             },
         },
-        input_delay_ticks: 0,
+        input_delay_ticks: 8,
         correction_ticks_factor: 0.0,
     }
 }

--- a/examples/avian_physics/src/protocol.rs
+++ b/examples/avian_physics/src/protocol.rs
@@ -7,7 +7,8 @@ use crate::shared::color_from_id;
 use lightyear::client::components::{ComponentSyncMode, LerpFn};
 use lightyear::client::interpolation::LinearInterpolator;
 use lightyear::prelude::client;
-use lightyear::prelude::server::{Replicate, SyncTarget};
+use lightyear::prelude::client::ReplicateToServer;
+use lightyear::prelude::server::{Replicate, ReplicateToClient, SyncTarget};
 use lightyear::prelude::*;
 use lightyear::utils::avian2d::*;
 use lightyear::utils::bevy::TransformLinearInterpolation;
@@ -26,7 +27,7 @@ pub(crate) struct PlayerBundle {
     id: PlayerId,
     position: Position,
     color: ColorComponent,
-    replicate: client::Replicate,
+    replicate: ReplicateToServer,
     physics: PhysicsBundle,
     inputs: InputManagerBundle<PlayerActions>,
     // IMPORTANT: this lets the server know that the entity is pre-predicted
@@ -43,7 +44,7 @@ impl PlayerBundle {
             id: PlayerId(id),
             position: Position(position),
             color: ColorComponent(color),
-            replicate: client::Replicate::default(),
+            replicate: ReplicateToServer::default(),
             physics: PhysicsBundle::player(),
             inputs: InputManagerBundle::<PlayerActions> {
                 action_state: ActionState::default(),

--- a/examples/common/src/app.rs
+++ b/examples/common/src/app.rs
@@ -547,7 +547,7 @@ pub fn server_app(
     };
     #[cfg(not(feature = "gui"))]
     let app = new_headless_app();
-    info!("server_app. gui={}", cfg!(feature = "gui"));
+    info!("server_app. gui={}", cfg!(feature = "gui") && enable_gui);
     // configure the network configuration
     let mut net_configs = get_server_net_configs(&settings);
     let extra_net_configs = extra_transport_configs.into_iter().map(|c| {

--- a/examples/simple_box/src/server.rs
+++ b/examples/simple_box/src/server.rs
@@ -48,19 +48,18 @@ pub(crate) fn handle_connections(
 ) {
     for connection in connections.read() {
         let client_id = connection.client_id;
-        // in host-server mode, server and client are running in the same app, no need to replicate to the local client
-        let replicate = Replicate {
-            sync: SyncTarget {
+        let entity = commands.spawn((
+            PlayerBundle::new(client_id, Vec2::ZERO),
+            ReplicateToClient::default(),
+            SyncTarget {
                 prediction: NetworkTarget::Single(client_id),
                 interpolation: NetworkTarget::AllExceptSingle(client_id),
             },
-            controlled_by: ControlledBy {
+            ControlledBy {
                 target: NetworkTarget::Single(client_id),
                 ..default()
-            },
-            ..default()
-        };
-        let entity = commands.spawn((PlayerBundle::new(client_id, Vec2::ZERO), replicate));
+            }
+        ));
 
         entity_map.0.insert(client_id, entity.id());
 

--- a/lightyear/src/client/prediction/plugin.rs
+++ b/lightyear/src/client/prediction/plugin.rs
@@ -21,9 +21,7 @@ use crate::client::prediction::predicted_history::{
     apply_component_removal_predicted, handle_tick_event_prediction_history,
     update_prediction_history,
 };
-use crate::client::prediction::prespawn::{
-    PreSpawnedPlayerObjectPlugin, PreSpawnedPlayerObjectSet,
-};
+use crate::client::prediction::prespawn::PreSpawnedPlayerObjectPlugin;
 use crate::client::prediction::resource::PredictionManager;
 use crate::client::prediction::Predicted;
 use crate::prelude::{is_host_server, PreSpawnedPlayerObject};
@@ -403,12 +401,12 @@ impl Plugin for PredictionPlugin {
         app.add_systems(
             PreUpdate,
             (
-                // - we first check if the entity has a matching PreSpawnedPlayerObject. If match, remove PrePredicted/ShouldBePredicted
-                // - then we check if it is a PrePredicted entity. If match, remove ShouldBePredicted
-                // - then we check if we should spawn a new predicted entity
-                spawn_predicted_entity
-                    .after(PreSpawnedPlayerObjectSet::Spawn)
-                    .in_set(PredictionSet::SpawnPrediction),
+                // - we first check via observer if:
+                //   - the entity has a matching PreSpawnedPlayerObject. If match, remove PrePredicted/ShouldBePredicted.
+                //     If no match we do nothing and treat this as a normal-predicted entity
+                //   - the entity has a PrePredicted component. If it does, remove ShouldBePredicted to not trigger normal prediction-spawn system
+                // - then we check via a system if we should spawn a new predicted entity
+                spawn_predicted_entity.in_set(PredictionSet::SpawnPrediction),
                 run_rollback.in_set(PredictionSet::Rollback),
                 #[cfg(feature = "metrics")]
                 super::rollback::no_rollback

--- a/lightyear/src/client/prediction/prespawn.rs
+++ b/lightyear/src/client/prediction/prespawn.rs
@@ -56,7 +56,7 @@ impl PreSpawnedPlayerObjectPlugin {
         rollback: Res<Rollback>,
         components: &Components,
     ) {
-        let entity = trigger.entity();
+        let entity = trigger.target();
         if let Ok(prespawn) = query.get(entity) {
             // get the rollback tick if the pre-spawned entity is being recreated during rollback!
             let tick = tick_manager.tick_or_rollback_tick(rollback.as_ref());
@@ -114,7 +114,7 @@ impl PreSpawnedPlayerObjectPlugin {
             Added<Replicated>,
         >,
     ) {
-        let confirmed_entity = trigger.entity();
+        let confirmed_entity = trigger.target();
         if let Ok(server_prespawn) = query.get(confirmed_entity) {
             // we handle the PreSpawnedPlayerObject hash in this system and don't need it afterwards
             commands

--- a/lightyear/src/client/prediction/prespawn.rs
+++ b/lightyear/src/client/prediction/prespawn.rs
@@ -14,18 +14,12 @@ use crate::prelude::client::PredictionSet;
 use crate::prelude::{ComponentRegistry, Replicated, ShouldBePredicted, TickManager};
 
 use crate::shared::replication::prespawn::compute_default_hash;
-use crate::shared::sets::{ClientMarker, InternalReplicationSet};
 
 #[derive(Default)]
 pub(crate) struct PreSpawnedPlayerObjectPlugin;
 
 #[derive(SystemSet, Debug, Hash, PartialEq, Eq, Clone, Copy)]
 pub enum PreSpawnedPlayerObjectSet {
-    // PreUpdate Sets
-    /// When we receive an entity from the server that contains the [`PreSpawnedPlayerObject`] component,
-    /// that means that it was already spawned on the client.
-    /// Do the matching process to find the corresponding client entity
-    Spawn,
     // PostUpdate Sets
     /// Add the necessary information to the PrePrediction component (before replication)
     /// Clean up the PreSpawnedPlayerObject entities for which we couldn't find a mapped server entity
@@ -35,51 +29,14 @@ pub enum PreSpawnedPlayerObjectSet {
 impl Plugin for PreSpawnedPlayerObjectPlugin {
     fn build(&self, app: &mut App) {
         app.configure_sets(
-            PreUpdate,
-            PreSpawnedPlayerObjectSet::Spawn.in_set(PredictionSet::SpawnPrediction),
-        );
-        app.configure_sets(
             PostUpdate,
             PreSpawnedPlayerObjectSet::CleanUp.in_set(PredictionSet::All),
         );
-        app.configure_sets(
-            FixedPostUpdate,
-            // we run the prespawn hash at FixedUpdate AND PostUpdate (to handle entities spawned during Update)
-            // TODO: entities spawned during update might have a tick that is off by 1 or more...
-            //  account for this when setting the hash?
-            // NOTE: we need to call this before SpawnHistory otherwise the history would affect the hash.
-            // TODO: find a way to exclude predicted history from the hash
-            InternalReplicationSet::<ClientMarker>::SetPreSpawnedHash
-                .in_set(PredictionSet::All)
-                .before(PredictionSet::Sync),
-        );
-
-        app.add_systems(
-            PreUpdate,
-            // we first try to see if the entity was a PreSpawnedPlayerObject
-            // if we couldn't match it then the component gets removed and then should we try the normal spawn-prediction flow
-            // TODO: or should we just consider that there was an error, and not go through the normal prediction flow?
-            (Self::match_with_received_server_entity, ApplyDeferred)
-                .chain()
-                .in_set(PreSpawnedPlayerObjectSet::Spawn),
-        );
-        app.add_systems(
-            FixedPostUpdate,
-            // adds new prespawn hashes to the prediction manager
-            Self::register_prespawn_hashes
-                .in_set(InternalReplicationSet::<ClientMarker>::SetPreSpawnedHash),
-        );
-
+        app.add_observer(Self::match_with_received_server_entity);
+        app.add_observer(Self::register_prespawn_hashes);
         app.add_systems(
             PostUpdate,
-            (
-                Self::pre_spawned_player_object_cleanup.in_set(PreSpawnedPlayerObjectSet::CleanUp),
-                // TODO: right now we only support pre-spawning during FixedUpdate::Main because we need the exact
-                //  tick to compute the hash
-                // compute hashes for all pre-spawned player objects
-                // Self::compute_prespawn_hash
-                //     .in_set(InternalReplicationSet::<ClientMarker>::SetPreSpawnedHash),
-            ),
+            Self::pre_spawned_player_object_cleanup.in_set(PreSpawnedPlayerObjectSet::CleanUp),
         );
     }
 }
@@ -87,30 +44,22 @@ impl Plugin for PreSpawnedPlayerObjectPlugin {
 impl PreSpawnedPlayerObjectPlugin {
     /// For all newly added prespawn hashes, register them in the prediction manager
     pub(crate) fn register_prespawn_hashes(
-        // ignore replicated entities, we only want to iterate through entities spawned on the client
-        // directly
-        // we need a param-set because of https://github.com/bevyengine/bevy/issues/7255
-        // (entity-mut conflicts with resources)
-        mut set: ParamSet<(
-            Query<
-                (Entity, &PreSpawnedPlayerObject),
-                (
-                    Without<Replicated>,
-                    Without<Confirmed>,
-                    Added<PreSpawnedPlayerObject>,
-                ),
-            >,
-            ResMut<PredictionManager>,
-        )>,
+        trigger: Trigger<OnAdd, PreSpawnedPlayerObject>,
+        query: Query<
+            &PreSpawnedPlayerObject,
+            // run this only when the component was added on a client-spawned entity (not server-replicated)
+            Without<Replicated>,
+        >,
+        mut prediction_manager: ResMut<PredictionManager>,
         component_registry: Res<ComponentRegistry>,
         tick_manager: Res<TickManager>,
         rollback: Res<Rollback>,
         components: &Components,
     ) {
-        let mut prediction_manager = std::mem::take(&mut *set.p1());
-        // get the rollback tick if the pre-spawned entity is being recreated during rollback!
-        let tick = tick_manager.tick_or_rollback_tick(rollback.as_ref());
-        for (entity, prespawn) in set.p0().iter() {
+        let entity = trigger.entity();
+        if let Ok(prespawn) = query.get(entity) {
+            // get the rollback tick if the pre-spawned entity is being recreated during rollback!
+            let tick = tick_manager.tick_or_rollback_tick(rollback.as_ref());
             // the hash can be None when PreSpawnedPlayerObject is inserted, but the component
             // hook will calculate it, so it can't be None here.
             let hash = prespawn
@@ -145,21 +94,7 @@ impl PreSpawnedPlayerObjectPlugin {
             // add a timer on the entity so that it gets despawned if the interpolation tick
             // reaches it without matching with any server entity
             prediction_manager.prespawn_tick_to_hash.push(tick, hash);
-            // predicted_entities.push(entity);
         }
-
-        *set.p1() = prediction_manager;
-
-        // NOTE: originally I wanted to remove PreSpawnedPlayerObject here because I wanted to call `compute_hash`
-        // at PostUpdate, which would run twice (at the end of FixedUpdate and at PostUpdate)
-        // But actually we need the component to be present so that we spawn a ComponentHistory
-
-        // for entity in predicted_entities {
-        //     info!("remove PreSpawnedPlayerObject");
-        //     // we stored the relevant information in the PredictionManager resource
-        //     // so we can remove the component here
-        //     world.entity_mut(entity).remove::<PreSpawnedPlayerObject>();
-        // }
     }
 
     // TODO: should we require that ShouldBePredicted is present on the entity?
@@ -168,15 +103,19 @@ impl PreSpawnedPlayerObjectPlugin {
     /// Try to match which client entity it is and take authority over it.
     /// TODO WARNING see duplicated logic in server/prediction.rs compute_hash
     pub(crate) fn match_with_received_server_entity(
+        trigger: Trigger<OnAdd, PreSpawnedPlayerObject>,
         mut commands: Commands,
         connection: Res<ConnectionManager>,
         mut manager: ResMut<PredictionManager>,
         query: Query<
-            (Entity, &PreSpawnedPlayerObject),
-            (Added<Replicated>, Added<PreSpawnedPlayerObject>),
+            &PreSpawnedPlayerObject,
+            // only trigger this when the entity is received on the client via server-replication
+            // (this is valid because Replicated is added before the components are inserted
+            Added<Replicated>,
         >,
     ) {
-        query.iter().for_each(|(confirmed_entity, server_prespawn)| {
+        let confirmed_entity = trigger.entity();
+        if let Ok(server_prespawn) = query.get(confirmed_entity) {
             // we handle the PreSpawnedPlayerObject hash in this system and don't need it afterwards
             commands
                 .entity(confirmed_entity)
@@ -188,6 +127,10 @@ impl PreSpawnedPlayerObjectPlugin {
             let Some(mut client_entity_list) =
                 manager.prespawn_hash_to_entities.remove(&server_hash)
             else {
+                #[cfg(feature = "metrics")]
+                {
+                    metrics::counter!("prespawn::no_match").increment(1);
+                }
                 debug!(?server_hash, "Received a PreSpawnedPlayerObject entity from the server with a hash that does not match any client entity");
                 // remove the PreSpawnedPlayerObject so that the entity can be normal-predicted
                 commands
@@ -205,6 +148,10 @@ impl PreSpawnedPlayerObjectPlugin {
             //  and add a Predicted component to it
             let predicted_entity =
                 if let Some(mut entity_commands) = commands.get_entity(client_entity) {
+                    #[cfg(feature = "metrics")]
+                    {
+                        metrics::counter!("prespawn::match::found").increment(1);
+                    }
                     debug!("re-using existing entity");
                     entity_commands
                         .remove::<PreSpawnedPlayerObject>()
@@ -213,6 +160,10 @@ impl PreSpawnedPlayerObjectPlugin {
                         });
                     client_entity
                 } else {
+                    #[cfg(feature = "metrics")]
+                    {
+                        metrics::counter!("prespawn::match::missing").increment(1);
+                    }
                     debug!("spawning new entity");
                     // 1.b if the client_entity does not exist, re-create it (because server has authority)
                     commands
@@ -256,7 +207,7 @@ impl PreSpawnedPlayerObjectPlugin {
                     .prespawn_hash_to_entities
                     .insert(server_hash, client_entity_list);
             }
-        });
+        }
     }
 
     /// Cleanup the client prespawned entities for which we couldn't find a mapped server entity
@@ -310,6 +261,12 @@ impl PreSpawnedPlayerObjectPlugin {
 #[derive(Serialize, Deserialize, Default, Debug, Copy, Clone, PartialEq, Eq, Reflect)]
 /// Added to indicate the client has prespawned the predicted version of this entity.
 ///
+/// The server should spawn a similar component and replicate it to the client, when the
+/// client receive that replicated entity, it will try to match it with the prespawned entity
+/// using the hash value.
+///
+/// Prespawned entities must be spawned in the `FixedMain` schedule.
+///
 /// ```rust,ignore
 /// // Default hashing implementation: (tick + components)
 /// PreSpawnedPlayerObject::default();
@@ -334,8 +291,6 @@ pub struct PreSpawnedPlayerObject {
     /// distinguish between bullets spawned on the same tick, but by different players.
     #[serde(skip)]
     pub user_salt: Option<u64>,
-    //
-    // pub conflict_resolution: ConflictResolution,
 }
 
 impl PreSpawnedPlayerObject {
@@ -370,7 +325,8 @@ impl Component for PreSpawnedPlayerObject {
                 .entity(entity)
                 .get::<PreSpawnedPlayerObject>()
                 .unwrap();
-            // The user may have provided the hash for us, in which case do nothing.
+            // The user may have provided the hash for us, or the hash is already present because the component
+            // has been replicated from the server, in which case do nothing.
             if prespawned_obj.hash.is_some() {
                 return;
             }
@@ -408,91 +364,6 @@ impl Component for PreSpawnedPlayerObject {
         });
     }
 }
-
-// pub enum ClientNoMatchHandling {
-//     /// If we don't get any server-entity that matches this prespawned player object, then we despawn it on the client
-//     /// Once we are sure that we won't get any more server updates for that entity
-//     /// (i.e. once interpolation_tick is reached)
-//     Despawn,
-//
-//     /// Even if we don't get any server-entity that matches this prespawned player object, we don't bother despawning it
-//     /// and we just leave it as is
-//     Allow,
-// }
-//
-// pub enum ServerNoMatchHandling {
-//     /// If the server sends an entity that doesn't match any existing client prespawned player object, we consider that the server
-//     /// entity is still valid and we spawn a Predicted entity for it.
-//     ForcePrediction,
-// }
-
-// pub enum ConflictResolution {
-//     /// If we don't get any server-entity that matches this prespawned player object, then we despawn it on the client
-//     /// Once we are sure that we won't get any more server updates for that entity
-//     /// (i.e. once interpolation_tick is reached)
-//     DespawnClient,
-//     /// If the server sends us an entity that doesn't match any client prespawned player object, we consider that the entity
-//     /// should still be predicted normally.
-//     AllowDuplicate,
-// }
-
-// TODO: maybe provide a prediction_spawn command instead of running the `compute_hash` in both FixedUpdate and PostUpdate?
-
-// /// This command must be used to spawn predicted entities
-// /// - It will insert the
-// /// - If the entity is confirmed, we despawn both the predicted and confirmed entities
-// pub struct PredictionSpawnCommand {
-//     entity: Entity,
-//     _marker: PhantomData,
-// }
-//
-// impl Command for PredictionSpawnCommand {
-//     fn apply(self, world: &mut World) {
-//         todo!()
-//     }
-// }
-//
-// pub trait PredictionSpawnCommandsExt {
-//     fn prediction_spawn(&mut self);
-//
-// }
-// impl PredictionSpawnCommandsExt for EntityCommands<'_, '_, '_> {
-//     fn prediction_spawn(&mut self, pre) {
-//         let entity = self.id();
-//         self.commands().add(PredictionDespawnCommand {
-//             entity,
-//             _marker: PhantomData::,
-//         })
-//     }
-// }
-
-// At the end of Update, maintain a HashMap from hash -> entity for the client-side pre-spawned entities
-// when we get a server entity with PreSpawned
-
-// pub enum PredictedMode {
-//     /// The entity is spawned on the server and then replicated to the client, which will spawn a Confirmed and a Predicted entity
-//     FromServer,
-//     /// The entity is spawned on the client, which will send a message to the server to tell it to spawn an entity.
-
-//     /// The client can predict-spawn an entity, and it expects the server to also spawn the same entity when it receives
-//     /// the information about the first entity.
-//     /// Then the server replicates back its spawned entity to the client, and grabs authority over the entity.
-//     /// All inputs that act on the entity after its spawned will be sent to the server.
-//     PreSpawnedUserControlled {
-//         /// the client entity that was pre-spawned and will be sent to the server
-//         client_entity: Option<Entity>,
-//         /// this is set by the server to know which client did the pre-prediction (in case the client is running
-//         /// prediction for other client's entities as well)
-//         client_id: Option<ClientId>,
-//     },
-//     /// The entity is created on both the client (in the predicted-timeline) and server side, preferably with the same system.
-//     /// (for example a bullet that is shot by the player)
-//     /// When the server replicates the bullet to the client, it finds the corresponding client prespawned entity and takes authority over it.
-//     PreSpawnedPlayerObject {
-//         /// Hash that will identify the entity
-//         hash: u64,
-//     },
-// }
 
 #[cfg(test)]
 mod tests {
@@ -545,7 +416,10 @@ mod tests {
         assert_eq!(
             prediction_manager.prespawn_tick_to_hash.heap.peek(),
             Some(&ItemWithReadyKey {
-                key: current_tick,
+                // NOTE: in this test we have to add + 1 here because the `register_prespawn_hashes` observer
+                //  runs outside of the FixedUpdate schedule so the entity is registered with the previous tick
+                //  in a real situation the entity would be spawned inside FixedUpdate so the hash would be correct
+                key: current_tick - 1,
                 item: expected_hash,
             })
         );

--- a/lightyear/src/client/replication.rs
+++ b/lightyear/src/client/replication.rs
@@ -151,7 +151,7 @@ pub(crate) mod send {
         InitialReplicated, Replicating, ReplicationGroupId,
     };
 
-    
+
     use crate::shared::replication::archetypes::{
         get_erased_component, ClientReplicatedArchetypes,
     };
@@ -757,7 +757,6 @@ pub(crate) mod send {
     #[cfg(test)]
     mod tests {
         use crate::client::replication::send::ReplicateToServer;
-        use crate::prelude::client::Replicate;
         use crate::prelude::{
             server, ChannelDirection, ClientId, ComponentRegistry, DisabledComponents,
             ReplicateOnceComponent, Replicated, TargetEntity,
@@ -786,7 +785,7 @@ pub(crate) mod send {
                 .client_app
                 .world_mut()
                 .entity_mut(client_entity)
-                .insert(Replicate::default());
+                .insert(ReplicateToServer);
             // TODO: we need to run a couple frames because the server doesn't read the client's updates
             //  because they are from the future
             for _ in 0..10 {
@@ -826,7 +825,7 @@ pub(crate) mod send {
             let client_entity = stepper
                 .client_app
                 .world_mut()
-                .spawn(Replicate::default())
+                .spawn(ReplicateToServer)
                 .id();
 
             stepper.frame_step();
@@ -837,7 +836,7 @@ pub(crate) mod send {
                 .client_app
                 .world_mut()
                 .entity_mut(client_entity)
-                .insert(Replicate::default());
+                .insert(ReplicateToServer);
             // TODO: we need to run a couple frames because the server doesn't read the client's updates
             //  because they are from the future
             for _ in 0..10 {
@@ -886,7 +885,7 @@ pub(crate) mod send {
             stepper
                 .client_app
                 .world_mut()
-                .spawn_batch(vec![Replicate::default(); 2]);
+                .spawn_batch(vec![ReplicateToServer; 2]);
             for _ in 0..10 {
                 stepper.frame_step();
             }
@@ -908,7 +907,7 @@ pub(crate) mod send {
                 .client_app
                 .world_mut()
                 .spawn((
-                    Replicate::default(),
+                    ReplicateToServer,
                     TargetEntity::Preexisting(server_entity),
                 ))
                 .id();
@@ -952,7 +951,7 @@ pub(crate) mod send {
                 .client_app
                 .world_mut()
                 .entity_mut(client_entity)
-                .insert(Replicate::default());
+                .insert(ReplicateToServer);
             // TODO: we need to run a couple frames because the server doesn't read the client's updates
             //  because they are from the future
             for _ in 0..10 {
@@ -995,7 +994,7 @@ pub(crate) mod send {
             let client_entity = stepper
                 .client_app
                 .world_mut()
-                .spawn(Replicate::default())
+                .spawn(ReplicateToServer)
                 .id();
             let client_child = stepper
                 .client_app
@@ -1054,7 +1053,7 @@ pub(crate) mod send {
             let client_entity = stepper
                 .client_app
                 .world_mut()
-                .spawn(Replicate::default())
+                .spawn(ReplicateToServer)
                 .id();
             let client_child = stepper
                 .client_app
@@ -1095,7 +1094,7 @@ pub(crate) mod send {
             let client_entity = stepper
                 .client_app
                 .world_mut()
-                .spawn(Replicate::default())
+                .spawn(ReplicateToServer)
                 .id();
             for _ in 0..10 {
                 stepper.frame_step();
@@ -1143,7 +1142,7 @@ pub(crate) mod send {
             let client_entity = stepper
                 .client_app
                 .world_mut()
-                .spawn(Replicate::default())
+                .spawn(ReplicateToServer)
                 .id();
             for _ in 0..10 {
                 stepper.frame_step();
@@ -1193,7 +1192,7 @@ pub(crate) mod send {
             let client_entity = stepper
                 .client_app
                 .world_mut()
-                .spawn((Replicate::default(), ComponentSyncModeFull(1.0)))
+                .spawn((ReplicateToServer, ComponentSyncModeFull(1.0)))
                 .id();
             for _ in 0..10 {
                 stepper.frame_step();
@@ -1307,7 +1306,7 @@ pub(crate) mod send {
             let client_entity = stepper
                 .client_app
                 .world_mut()
-                .spawn((Replicate::default(), ComponentSyncModeFull(1.0)))
+                .spawn((ReplicateToServer, ComponentSyncModeFull(1.0)))
                 .id();
             for _ in 0..10 {
                 stepper.frame_step();
@@ -1362,7 +1361,7 @@ pub(crate) mod send {
                 .client_app
                 .world_mut()
                 .spawn((
-                    Replicate::default(),
+                    ReplicateToServer,
                     ComponentSyncModeFull(1.0),
                     ReplicateOnceComponent::<ComponentSyncModeFull>::default(),
                 ))
@@ -1413,7 +1412,7 @@ pub(crate) mod send {
             let client_entity = stepper
                 .client_app
                 .world_mut()
-                .spawn((Replicate::default(), ComponentSyncModeFull(1.0)))
+                .spawn((ReplicateToServer, ComponentSyncModeFull(1.0)))
                 .id();
             let client_child = stepper
                 .client_app
@@ -1511,7 +1510,7 @@ pub(crate) mod send {
             let client_entity = stepper
                 .client_app
                 .world_mut()
-                .spawn((Replicate::default(), ComponentSyncModeOnce(1.0)))
+                .spawn((ReplicateToServer, ComponentSyncModeOnce(1.0)))
                 .id();
             for _ in 0..10 {
                 stepper.frame_step();

--- a/lightyear/src/lib.rs
+++ b/lightyear/src/lib.rs
@@ -243,7 +243,9 @@ pub mod prelude {
         pub use crate::client::events::EntityDespawnEvent as ClientEntityDespawnEvent;
         pub use crate::client::events::EntitySpawnEvent as ClientEntitySpawnEvent;
         pub use crate::client::message::ReceiveMessage as ClientReceiveMessage;
+        pub use crate::client::message::ReceiveMessage as FromServer;
         pub use crate::client::message::SendMessage as ClientSendMessage;
+        pub use crate::client::message::SendMessage as ToServer;
         pub use crate::client::replication::send::Replicate as ClientReplicate;
 
         pub use crate::client::connection::ConnectionManager as ClientConnectionManager;
@@ -256,7 +258,9 @@ pub mod prelude {
         pub use crate::server::events::EntityDespawnEvent as ServerEntityDespawnEvent;
         pub use crate::server::events::EntitySpawnEvent as ServerEntitySpawnEvent;
         pub use crate::server::message::ReceiveMessage as ServerReceiveMessage;
+        pub use crate::server::message::ReceiveMessage as FromClients;
         pub use crate::server::message::SendMessage as ServerSendMessage;
+        pub use crate::server::message::SendMessage as ToClients;
 
         pub use crate::server::connection::ConnectionManager as ServerConnectionManager;
 

--- a/lightyear/src/server/networking.rs
+++ b/lightyear/src/server/networking.rs
@@ -195,7 +195,7 @@ pub(crate) fn receive_packets(
             {
                 // TODO: convert into packets/bytes per second
                 let packets = 1.0 as u64;
-                let bytes = payload.payload.len() as u64;
+                let bytes = payload.len() as u64;
                 metrics::counter!(format!("transport::{:?}::receive::packets", client_id))
                     .increment(packets);
                 metrics::counter!(format!("transport::{:?}::receive::bytes", client_id))

--- a/lightyear/src/server/prediction.rs
+++ b/lightyear/src/server/prediction.rs
@@ -1,57 +1,8 @@
 //! Handles logic related to prespawning entities
 
 use crate::prelude::server::{AuthorityCommandExt, AuthorityPeer};
-use crate::prelude::{
-    is_host_server, ComponentRegistry, NetworkIdentityState, PrePredicted, PreSpawnedPlayerObject,
-    Replicated, ServerConnectionManager, TickManager,
-};
-use crate::shared::replication::prespawn::compute_default_hash;
-use bevy::ecs::component::Components;
+use crate::prelude::{PrePredicted, Replicated, ServerConnectionManager};
 use bevy::prelude::*;
-
-/// Compute the hash of the spawned entity by hashing the NetId of all its components along with the tick at which it was created
-/// 1. Client spawns an entity and adds the PreSpawnedPlayerObject component
-/// 2. Client will compute the hash of the entity and store it internally
-/// 3. Server (later) spawns the entity, computes the hash and replicates the PreSpawnedPlayerObject component
-/// 4. When the client receives the PreSpawnedPlayerObject component, it will compare the hash with the one it computed
-pub(crate) fn compute_hash(
-    // we need a param-set because of https://github.com/bevyengine/bevy/issues/7255
-    // (entity-mut conflicts with resources)
-    mut set: ParamSet<(
-        Query<EntityMut, Added<PreSpawnedPlayerObject>>,
-        // TODO: avoid this
-        ResMut<ComponentRegistry>,
-        Res<TickManager>,
-    )>,
-    components: &Components,
-) {
-    let tick = set.p2().tick();
-    let component_registry = std::mem::take(&mut *set.p1());
-
-    // get the list of entities that need to have a new hash computed, along with the hash
-    for mut entity_mut in set.p0().iter_mut() {
-        let entity = entity_mut.id();
-        // the hash has already been computed by the user
-        let prespawn = entity_mut.get::<PreSpawnedPlayerObject>().unwrap();
-        if prespawn.hash.is_some() {
-            trace!("Hash for pre-spawned player object was already computed!");
-            continue;
-        }
-        let hash = compute_default_hash(
-            &component_registry,
-            components,
-            entity_mut.archetype(),
-            tick,
-            prespawn.user_salt,
-        );
-        debug!(?entity, ?tick, ?hash, "computed spawn hash for entity");
-        let mut prespawn = entity_mut.get_mut::<PreSpawnedPlayerObject>().unwrap();
-        prespawn.hash = Some(hash);
-    }
-
-    // put the resources back
-    *set.p1() = component_registry;
-}
 
 /// When we receive an entity that a clients wants PrePredicted,
 /// we immediately transfer authority back to the server. The server will replicate the PrePredicted
@@ -62,15 +13,15 @@ pub(crate) fn handle_pre_predicted(
     trigger: Trigger<OnAdd, PrePredicted>,
     mut commands: Commands,
     mut manager: ResMut<ServerConnectionManager>,
-    identity: Option<Res<State<NetworkIdentityState>>>,
     q: Query<(Entity, &PrePredicted, &Replicated)>,
 ) {
-    // no need to do anything in host-server mode, we directly add the `Predicted` component on the client
-    if is_host_server(identity) {
-        return;
-    }
     if let Ok((local_entity, pre_predicted, replicated)) = q.get(trigger.target()) {
         let sending_client = replicated.from.unwrap();
+        // if the client who created the PrePredicted entity is the local client, no need to do anything!
+        // (the client Observer already adds Predicted on the entity)
+        if sending_client.is_local() {
+            return;
+        }
         let confirmed_entity = pre_predicted.confirmed_entity.unwrap();
         // update the mapping so that when we send updates, the server entity gets mapped
         // to the client's confirmed entity

--- a/lightyear/src/server/replication.rs
+++ b/lightyear/src/server/replication.rs
@@ -10,7 +10,6 @@ use crate::prelude::client::ClientConnection;
 use crate::prelude::{server::is_started, PrePredicted};
 use crate::server::config::ServerConfig;
 use crate::server::connection::ConnectionManager;
-use crate::server::prediction::compute_hash;
 use crate::shared::replication::plugin::receive::ReplicationReceivePlugin;
 use crate::shared::replication::plugin::send::ReplicationSendPlugin;
 use crate::shared::sets::{InternalMainSet, InternalReplicationSet, ServerMarker};
@@ -101,19 +100,7 @@ pub(crate) mod send {
                 // SYSTEM SETS
                 .configure_sets(
                     PostUpdate,
-                    // on server: we need to set the hash value before replicating the component
-                    InternalReplicationSet::<ServerMarker>::SetPreSpawnedHash
-                        .before(InternalReplicationSet::<ServerMarker>::BufferComponentUpdates)
-                        .in_set(InternalReplicationSet::<ServerMarker>::All),
-                )
-                .configure_sets(
-                    PostUpdate,
                     InternalReplicationSet::<ServerMarker>::All.run_if(is_started),
-                )
-                // SYSTEMS
-                .add_systems(
-                    PostUpdate,
-                    compute_hash.in_set(InternalReplicationSet::<ServerMarker>::SetPreSpawnedHash),
                 );
             // SYSTEMS
             app.add_systems(

--- a/lightyear/src/shared/replication/components.rs
+++ b/lightyear/src/shared/replication/components.rs
@@ -343,6 +343,8 @@ impl ToBytes for ReplicationGroupId {
     }
 }
 
+// NOTE: we don't add a #[require(ReplicateToClient)] attribute here
+//  so that it's possible to override the NetworkRelevanceMode for a ReplicateLike entity
 #[derive(Component, Clone, Copy, Default, Debug, PartialEq, Reflect)]
 #[reflect(Component)]
 pub enum NetworkRelevanceMode {

--- a/lightyear/src/shared/replication/entity_map.rs
+++ b/lightyear/src/shared/replication/entity_map.rs
@@ -26,6 +26,10 @@ impl EntityMapper for EntityMap {
             entity
         })
     }
+
+    fn set_mapped(&mut self, source: Entity, target: Entity) {
+        self.0.set_mapped(source, target);
+    }
 }
 
 #[derive(Default, Debug, Reflect, Deref, DerefMut)]
@@ -43,6 +47,10 @@ impl EntityMapper for SendEntityMap {
             // otherwise just send the entity as is, and the receiver will map it
             entity
         }
+    }
+
+    fn set_mapped(&mut self, source: Entity, target: Entity) {
+        self.0.insert(source, target);
     }
 }
 
@@ -63,6 +71,10 @@ impl EntityMapper for ReceiveEntityMap {
                 Entity::PLACEHOLDER
             })
         }
+    }
+
+    fn set_mapped(&mut self, source: Entity, target: Entity) {
+        self.0.insert(source, target);
     }
 }
 

--- a/lightyear/src/shared/sets.rs
+++ b/lightyear/src/shared/sets.rs
@@ -15,9 +15,6 @@ pub enum InternalReplicationSet<M> {
     ReceiveResourceUpdates,
 
     // SEND
-    /// Set the hash for each entity that is pre-spawned on the client
-    /// (has a PreSpawnedPlayerObject component)
-    SetPreSpawnedHash,
     /// System that handles the addition/removal of the `Replicate` component
     BeforeBuffer,
 

--- a/lightyear/src/utils/avian2d.rs
+++ b/lightyear/src/utils/avian2d.rs
@@ -1,7 +1,6 @@
 //! Implement lightyear traits for some common bevy types
 use crate::prelude::client::{InterpolationSet, PredictionSet};
 use crate::shared::replication::delta::Diffable;
-use crate::shared::sets::{ClientMarker, InternalReplicationSet, ServerMarker};
 use avian2d::math::Scalar;
 use avian2d::prelude::*;
 use bevy::app::{RunFixedMainLoop, RunFixedMainLoopSystem};
@@ -14,16 +13,6 @@ pub(crate) struct Avian2dPlugin;
 
 impl Plugin for Avian2dPlugin {
     fn build(&self, app: &mut App) {
-        app.configure_sets(
-            FixedPostUpdate,
-            // Ensure PreSpawned hash calculated before physics runs, to avoid any physics interaction affecting it
-            // TODO: maybe use observers so that we don't have any ordering requirements?
-            (
-                InternalReplicationSet::<ClientMarker>::SetPreSpawnedHash,
-                InternalReplicationSet::<ServerMarker>::SetPreSpawnedHash,
-            )
-                .before(PhysicsSet::Prepare), // Runs right before physics.
-        );
         // NB: the three main physics sets in FixedPostUpdate run in this order:
         // pub enum PhysicsSet {
         //     Prepare,

--- a/lightyear/src/utils/avian3d.rs
+++ b/lightyear/src/utils/avian3d.rs
@@ -1,7 +1,6 @@
 //! Implement lightyear traits for some common bevy types
 use crate::prelude::client::{InterpolationSet, PredictionSet};
 use crate::shared::replication::delta::Diffable;
-use crate::shared::sets::{ClientMarker, InternalReplicationSet, ServerMarker};
 use avian3d::math::Scalar;
 use avian3d::prelude::*;
 use bevy::app::{App, FixedPostUpdate, Plugin};
@@ -12,16 +11,6 @@ use tracing::trace;
 pub(crate) struct Avian3dPlugin;
 impl Plugin for Avian3dPlugin {
     fn build(&self, app: &mut App) {
-        app.configure_sets(
-            FixedPostUpdate,
-            // Ensure PreSpawned hash set before physics runs, to avoid any physics interaction affecting it
-            // TODO: maybe use observers so that we don't have any ordering requirements?
-            (
-                InternalReplicationSet::<ClientMarker>::SetPreSpawnedHash,
-                InternalReplicationSet::<ServerMarker>::SetPreSpawnedHash,
-            )
-                .before(PhysicsSet::Prepare), // Runs right before physics.
-        );
         // NB: the three main physics sets in FixedPostUpdate run in this order:
         // pub enum PhysicsSet {
         //     Prepare,


### PR DESCRIPTION
You can now spawn all necessary components starting from `ReplicateToClients` and `ReplicateToServer` instead of using the `Replicate` bundle, which spawns some uncessary components.

I might actually deprecate the Replicate bundles entirely