### PR TITLE
Clean up prediction_despawn using Disabled Marker

### DIFF
--- a/examples/fps/src/renderer.rs
+++ b/examples/fps/src/renderer.rs
@@ -8,7 +8,7 @@ use bevy::prelude::*;
 use lightyear::client::interpolation::VisualInterpolationPlugin;
 use lightyear::prelude::client::{Interpolated, Predicted, VisualInterpolateStatus};
 use lightyear::prelude::server::ReplicateToClient;
-use lightyear::prelude::{NetworkIdentity, PreSpawnedPlayerObject, Replicated};
+use lightyear::prelude::{NetworkIdentity, PreSpawned, Replicated};
 use lightyear_avian::prelude::AabbEnvelopeHolder;
 
 #[derive(Clone)]
@@ -90,7 +90,7 @@ pub struct VisibleFilter {
     a: Or<(
         With<Predicted>,
         // to show prespawned entities
-        With<PreSpawnedPlayerObject>,
+        With<PreSpawned>,
         With<Interpolated>,
         With<ReplicateToClient>,
     )>,

--- a/examples/fps/src/shared.rs
+++ b/examples/fps/src/shared.rs
@@ -228,7 +228,7 @@ pub(crate) fn shoot_bullet(
                         // between the two bullets, we add additional information to the hash.
                         // NOTE: if you don't add the salt, the 'left' bullet on the server might get matched with the
                         // 'right' bullet on the client, and vice versa. This is not critical, but it will cause a rollback
-                        PreSpawnedPlayerObject::default_with_salt(salt),
+                        PreSpawned::default_with_salt(salt),
                         Replicate {
                             sync: SyncTarget {
                                 // the bullet is predicted for the client who shot it
@@ -251,7 +251,7 @@ pub(crate) fn shoot_bullet(
                     //  but the server will take authority as soon as the client receives the entity
                     commands.spawn((
                         bullet_bundle,
-                        PreSpawnedPlayerObject::default_with_salt(salt),
+                        PreSpawned::default_with_salt(salt),
                     ));
                 }
             }

--- a/examples/fps/src/shared.rs
+++ b/examples/fps/src/shared.rs
@@ -249,10 +249,7 @@ pub(crate) fn shoot_bullet(
                     // on the client, just spawn the ball
                     // NOTE: the PreSpawnedPlayerObject component indicates that the entity will be spawned on both client and server
                     //  but the server will take authority as soon as the client receives the entity
-                    commands.spawn((
-                        bullet_bundle,
-                        PreSpawned::default_with_salt(salt),
-                    ));
+                    commands.spawn((bullet_bundle, PreSpawned::default_with_salt(salt)));
                 }
             }
         }

--- a/examples/simple_box/src/server.rs
+++ b/examples/simple_box/src/server.rs
@@ -58,7 +58,7 @@ pub(crate) fn handle_connections(
             ControlledBy {
                 target: NetworkTarget::Single(client_id),
                 ..default()
-            }
+            },
         ));
 
         entity_map.0.insert(client_id, entity.id());

--- a/examples/spaceships/src/renderer.rs
+++ b/examples/spaceships/src/renderer.rs
@@ -10,7 +10,7 @@ use bevy::core_pipeline::tonemapping::Tonemapping;
 use bevy::prelude::*;
 use bevy::time::common_conditions::on_timer;
 use leafwing_input_manager::action_state::ActionState;
-use lightyear::client::prediction::prespawn::PreSpawnedPlayerObject;
+use lightyear::client::prediction::prespawn::PreSpawned;
 use lightyear::inputs::leafwing::input_buffer::InputBuffer;
 use lightyear::prelude::client::*;
 use lightyear::prelude::Replicating;
@@ -209,14 +209,14 @@ fn draw_predicted_entities(
             &Rotation,
             &ColorComponent,
             &Collider,
-            Has<PreSpawnedPlayerObject>,
+            Has<PreSpawned>,
             Option<&ActionState<PlayerActions>>,
             Option<&InputBuffer<PlayerActions>>,
         ),
         (
             // skip drawing bullet outlines, since we add a mesh + material to them
             Without<BulletMarker>,
-            Or<(With<PreSpawnedPlayerObject>, With<Predicted>)>,
+            Or<(With<PreSpawned>, With<Predicted>)>,
         ),
     >,
     tick_manager: Res<TickManager>,

--- a/examples/spaceships/src/shared.rs
+++ b/examples/spaceships/src/shared.rs
@@ -245,7 +245,7 @@ pub fn shared_player_firing(
 
         // the default hashing algorithm uses the tick and component list. in order to disambiguate
         // between two players spawning a bullet on the same tick, we add client_id to the mix.
-        let prespawned = PreSpawnedPlayerObject::default_with_salt(player.client_id.to_bits());
+        let prespawned = PreSpawned::default_with_salt(player.client_id.to_bits());
 
         let bullet_entity = commands
             .spawn((

--- a/lightyear/src/client/components.rs
+++ b/lightyear/src/client/components.rs
@@ -26,8 +26,11 @@ pub struct Confirmed {
     pub tick: Tick,
 }
 
-pub trait SyncComponent: Component<Mutability = Mutable> + Clone + PartialEq + Message {}
-impl<T> SyncComponent for T where T: Component<Mutability = Mutable> + Clone + PartialEq + Message {}
+pub(crate) trait MutComponent: Component<Mutability=Mutable> {}
+
+impl<T> MutComponent for T where T: Component<Mutability=Mutable> {}
+pub trait SyncComponent: MutComponent + Clone + PartialEq + Message {}
+impl<T> SyncComponent for T where T: MutComponent + Clone + PartialEq + Message {}
 
 /// Function that will interpolate between two values
 pub trait LerpFn<C> {

--- a/lightyear/src/client/components.rs
+++ b/lightyear/src/client/components.rs
@@ -26,9 +26,9 @@ pub struct Confirmed {
     pub tick: Tick,
 }
 
-pub(crate) trait MutComponent: Component<Mutability=Mutable> {}
+pub(crate) trait MutComponent: Component<Mutability = Mutable> {}
 
-impl<T> MutComponent for T where T: Component<Mutability=Mutable> {}
+impl<T> MutComponent for T where T: Component<Mutability = Mutable> {}
 pub(crate) trait SyncComponent: MutComponent + Clone + PartialEq + Message {}
 impl<T> SyncComponent for T where T: MutComponent + Clone + PartialEq + Message {}
 

--- a/lightyear/src/client/components.rs
+++ b/lightyear/src/client/components.rs
@@ -29,7 +29,7 @@ pub struct Confirmed {
 pub(crate) trait MutComponent: Component<Mutability=Mutable> {}
 
 impl<T> MutComponent for T where T: Component<Mutability=Mutable> {}
-pub trait SyncComponent: MutComponent + Clone + PartialEq + Message {}
+pub(crate) trait SyncComponent: MutComponent + Clone + PartialEq + Message {}
 impl<T> SyncComponent for T where T: MutComponent + Clone + PartialEq + Message {}
 
 /// Function that will interpolate between two values

--- a/lightyear/src/client/input/leafwing.rs
+++ b/lightyear/src/client/input/leafwing.rs
@@ -51,7 +51,10 @@ use crate::client::sync::SyncSet;
 use crate::inputs::leafwing::input_buffer::InputBuffer;
 use crate::inputs::leafwing::input_message::InputTarget;
 use crate::inputs::leafwing::LeafwingUserAction;
-use crate::prelude::{is_host_server, ChannelKind, ChannelRegistry, ClientReceiveMessage, InputMessage, MessageRegistry, ReplicateOnceComponent, ServerReceiveMessage, TickManager, TimeManager};
+use crate::prelude::{
+    is_host_server, ChannelKind, ChannelRegistry, ClientReceiveMessage, InputMessage,
+    MessageRegistry, ReplicateOnceComponent, ServerReceiveMessage, TickManager, TimeManager,
+};
 use crate::protocol::message::MessageKind;
 use crate::serialize::reader::Reader;
 use crate::shared::replication::components::PrePredicted;
@@ -1092,7 +1095,6 @@ mod tests {
         assert_eq!(delay.delay_ms, 20);
     }
 
-
     pub(crate) fn replicate_inputs(
         mut receive_inputs: ResMut<Events<ServerReceiveMessage<InputMessage<LeafwingInput1>>>>,
         mut send_inputs: EventWriter<ServerSendMessage<InputMessage<LeafwingInput1>>>,
@@ -1111,7 +1113,10 @@ mod tests {
     fn test_receive_inputs_other_clients() {
         let mut stepper = MultiBevyStepper::default();
         // server propagate inputs to other clients
-        stepper.server_app.add_systems(PreUpdate, replicate_inputs.after(crate::server::input::leafwing::InputSystemSet::ReceiveInputs));
+        stepper.server_app.add_systems(
+            PreUpdate,
+            replicate_inputs.after(crate::server::input::leafwing::InputSystemSet::ReceiveInputs),
+        );
         let server_entity = stepper
             .server_app
             .world_mut()
@@ -1123,7 +1128,7 @@ mod tests {
                         interpolation: None,
                     },
                     ..default()
-                }
+                },
             ))
             .id();
 
@@ -1146,17 +1151,29 @@ mod tests {
             .remote_entity_map
             .get_local(server_entity)
             .expect("entity was not replicated to client");
-        stepper.client_app_2.world_mut().entity_mut(client_entity_2).insert(
-            InputMap::<LeafwingInput1>::new([(
+        stepper
+            .client_app_2
+            .world_mut()
+            .entity_mut(client_entity_2)
+            .insert(InputMap::<LeafwingInput1>::new([(
                 LeafwingInput1::Jump,
                 KeyCode::KeyA,
-            )])
-        );
+            )]));
         stepper.frame_step();
         stepper.frame_step();
 
         // client 1 should have received the InputMessage from client 2 which was broadcasted by the client
-        assert!(stepper.client_app_1.world().get::<ActionState<LeafwingInput1>>(client_entity_1).is_some());
-        assert!(stepper.client_app_1.world().get::<InputBuffer<LeafwingInput1>>(client_entity_1).unwrap().end_tick().is_some());
+        assert!(stepper
+            .client_app_1
+            .world()
+            .get::<ActionState<LeafwingInput1>>(client_entity_1)
+            .is_some());
+        assert!(stepper
+            .client_app_1
+            .world()
+            .get::<InputBuffer<LeafwingInput1>>(client_entity_1)
+            .unwrap()
+            .end_tick()
+            .is_some());
     }
 }

--- a/lightyear/src/client/interpolation/plugin.rs
+++ b/lightyear/src/client/interpolation/plugin.rs
@@ -73,7 +73,7 @@ impl Default for InterpolationConfig {
     fn default() -> Self {
         Self {
             min_delay: Duration::from_millis(0),
-            send_interval_ratio: 2.0,
+            send_interval_ratio: 1.2,
         }
     }
 }

--- a/lightyear/src/client/prediction/despawn.rs
+++ b/lightyear/src/client/prediction/despawn.rs
@@ -1,14 +1,13 @@
 use bevy::ecs::entity_disabling::Disabled;
 use bevy::ecs::system::EntityCommands;
 use bevy::prelude::*;
-use tracing::{debug, error, trace};
+use tracing::{error, trace};
 
-use crate::client::components::{ComponentSyncMode, Confirmed, SyncComponent};
+use crate::client::components::Confirmed;
 use crate::client::prediction::Predicted;
 use crate::prelude::{
-    AppIdentityExt, ComponentRegistry, PreSpawned, ShouldBePredicted, TickManager,
+    AppIdentityExt, PreSpawned, ShouldBePredicted, TickManager,
 };
-use crate::shared::tick_manager::Tick;
 
 
 /// This command must be used to despawn Predicted entities.

--- a/lightyear/src/client/prediction/despawn.rs
+++ b/lightyear/src/client/prediction/despawn.rs
@@ -126,7 +126,6 @@ mod tests {
             ))
             .id();
         stepper.frame_step();
-        dbg!("server about to replicate");
         stepper.frame_step();
         let confirmed_entity = stepper
             .client_app
@@ -144,7 +143,23 @@ mod tests {
             .get::<Confirmed>()
             .expect("Confirmed component missing");
         let predicted_entity = confirmed.predicted.unwrap();
-        dbg!(&confirmed_entity, &predicted_entity);
+        // check that a rollback occurred to add the components on the predicted entity
+        assert_eq!(
+            stepper
+                .client_app
+                .world()
+                .get::<ComponentSyncModeFull>(predicted_entity)
+                .unwrap(),
+            &ComponentSyncModeFull(1.0)
+        );
+        assert_eq!(
+            stepper
+                .client_app
+                .world()
+                .get::<ComponentSyncModeSimple>(predicted_entity)
+                .unwrap(),
+            &ComponentSyncModeSimple(1.0)
+        );
         // try adding a non-protocol component (which could be some rendering component)
         stepper
             .client_app
@@ -153,7 +168,6 @@ mod tests {
             .insert(TestComponent(1));
 
         // despawn the predicted entity locally
-        dbg!("prediction despawn");
         stepper
             .client_app
             .world_mut()

--- a/lightyear/src/client/prediction/despawn.rs
+++ b/lightyear/src/client/prediction/despawn.rs
@@ -5,10 +5,7 @@ use tracing::{error, trace};
 
 use crate::client::components::Confirmed;
 use crate::client::prediction::Predicted;
-use crate::prelude::{
-    AppIdentityExt, PreSpawned, ShouldBePredicted, TickManager,
-};
-
+use crate::prelude::{AppIdentityExt, PreSpawned, ShouldBePredicted, TickManager};
 
 /// This command must be used to despawn Predicted entities.
 /// The reason is that we might want to not completely despawn the entity in case it gets 'restored' during a rollback.
@@ -210,6 +207,7 @@ mod tests {
                 .unwrap(),
             &ComponentSyncModeFull(2.0)
         );
+        // non-Full components are also present
         assert_eq!(
             stepper
                 .client_app

--- a/lightyear/src/client/prediction/plugin.rs
+++ b/lightyear/src/client/prediction/plugin.rs
@@ -25,7 +25,6 @@ use crate::prelude::client::is_connected;
 use crate::prelude::{is_host_server, PreSpawned};
 use crate::shared::sets::{ClientMarker, InternalMainSet};
 use bevy::ecs::component::Mutable;
-use bevy::ecs::entity_disabling::DefaultQueryFilters;
 use bevy::prelude::*;
 use bevy::reflect::Reflect;
 use bevy::transform::TransformSystem;

--- a/lightyear/src/client/prediction/plugin.rs
+++ b/lightyear/src/client/prediction/plugin.rs
@@ -3,16 +3,17 @@ use super::predicted_history::apply_confirmed_update;
 use super::resource_history::{
     handle_tick_event_resource_history, update_resource_history, ResourceHistory,
 };
-use super::rollback::{check_rollback, increment_rollback_tick, prepare_rollback, prepare_rollback_non_networked, prepare_rollback_prespawn, prepare_rollback_resource, remove_prediction_disable,
-                      run_rollback, Rollback, RollbackState};
+use super::rollback::{
+    check_rollback, increment_rollback_tick, prepare_rollback, prepare_rollback_non_networked,
+    prepare_rollback_prespawn, prepare_rollback_resource, remove_prediction_disable, run_rollback,
+    Rollback, RollbackState,
+};
 use super::spawn::spawn_predicted_entity;
 use crate::client::components::{ComponentSyncMode, Confirmed, SyncComponent};
 use crate::client::prediction::correction::{
     get_visually_corrected_state, restore_corrected_state,
 };
-use crate::client::prediction::despawn::{
-    despawn_confirmed, PredictionDisable,
-};
+use crate::client::prediction::despawn::{despawn_confirmed, PredictionDisable};
 use crate::client::prediction::predicted_history::{
     add_prediction_history, add_sync_systems, apply_component_removal_confirmed,
     apply_component_removal_predicted, handle_tick_event_prediction_history,
@@ -427,9 +428,7 @@ impl Plugin for PredictionPlugin {
         );
         app.add_systems(
             FixedPostUpdate,
-            (
-                increment_rollback_tick.in_set(PredictionSet::IncrementRollbackTick),
-            ),
+            (increment_rollback_tick.in_set(PredictionSet::IncrementRollbackTick),),
         );
 
         // PostUpdate systems

--- a/lightyear/src/client/prediction/plugin.rs
+++ b/lightyear/src/client/prediction/plugin.rs
@@ -3,18 +3,15 @@ use super::predicted_history::apply_confirmed_update;
 use super::resource_history::{
     handle_tick_event_resource_history, update_resource_history, ResourceHistory,
 };
-use super::rollback::{
-    check_rollback, increment_rollback_tick, prepare_rollback, prepare_rollback_non_networked,
-    prepare_rollback_prespawn, prepare_rollback_resource, run_rollback, Rollback, RollbackState,
-};
+use super::rollback::{check_rollback, increment_rollback_tick, prepare_rollback, prepare_rollback_non_networked, prepare_rollback_prespawn, prepare_rollback_resource, remove_prediction_disable,
+                      run_rollback, Rollback, RollbackState};
 use super::spawn::spawn_predicted_entity;
 use crate::client::components::{ComponentSyncMode, Confirmed, SyncComponent};
 use crate::client::prediction::correction::{
     get_visually_corrected_state, restore_corrected_state,
 };
 use crate::client::prediction::despawn::{
-    despawn_confirmed, remove_component_for_despawn_predicted, remove_despawn_marker,
-    restore_components_if_despawn_rolled_back, PredictionDespawnMarker,
+    despawn_confirmed, PredictionDisable,
 };
 use crate::client::prediction::predicted_history::{
     add_prediction_history, add_sync_systems, apply_component_removal_confirmed,
@@ -24,15 +21,15 @@ use crate::client::prediction::predicted_history::{
 use crate::client::prediction::prespawn::PreSpawnedPlayerObjectPlugin;
 use crate::client::prediction::resource::PredictionManager;
 use crate::client::prediction::Predicted;
-use crate::prelude::{is_host_server, PreSpawnedPlayerObject};
+use crate::prelude::client::is_connected;
+use crate::prelude::{is_host_server, PreSpawned};
 use crate::shared::sets::{ClientMarker, InternalMainSet};
 use bevy::ecs::component::Mutable;
+use bevy::ecs::entity_disabling::DefaultQueryFilters;
 use bevy::prelude::*;
 use bevy::reflect::Reflect;
 use bevy::transform::TransformSystem;
 use core::time::Duration;
-
-use crate::prelude::client::is_connected;
 
 /// Configuration to specify how the prediction plugin should behave
 #[derive(Debug, Clone, Copy, Reflect)]
@@ -187,6 +184,11 @@ pub enum PredictionSet {
     RestoreVisualCorrection,
     /// Check if rollback is needed
     CheckRollback,
+
+    // ROLLBACK
+    /// If any Predicted entity was marked as despawned, instead of despawning them we simply disabled the entity.
+    /// If we do a rollback we want to restore those entities.
+    RemoveDisable,
     /// Prepare rollback by snapping the current state to the confirmed state and clearing histories
     /// For pre-spawned entities, we just roll them back to their historical state.
     /// If they didn't exist in the rollback tick, despawn them
@@ -325,28 +327,11 @@ pub fn add_prediction_systems<C: SyncComponent>(app: &mut App, prediction_mode: 
                 (
                     // for SyncMode::Simple, just copy the confirmed components
                     apply_confirmed_update::<C>.in_set(PredictionSet::CheckRollback),
-                    // if we are rolling back (maybe because the predicted entity despawn is getting cancelled, restore components)
-                    restore_components_if_despawn_rolled_back::<C>
-                        // .before(run_rollback::)
-                        .in_set(PredictionSet::PrepareRollback),
                 ),
-            );
-        }
-        ComponentSyncMode::Once => {
-            app.add_systems(
-                PreUpdate,
-                // if we are rolling back (maybe because the predicted entity despawn is getting cancelled, restore components)
-                restore_components_if_despawn_rolled_back::<C>
-                    // .before(run_rollback::)
-                    .in_set(PredictionSet::PrepareRollback),
             );
         }
         _ => {}
     };
-    app.add_systems(
-        FixedPostUpdate,
-        remove_component_for_despawn_predicted::<C>.in_set(PredictionSet::EntityDespawn),
-    );
 }
 
 impl Plugin for PredictionPlugin {
@@ -362,10 +347,10 @@ impl Plugin for PredictionPlugin {
         // REFLECTION
         app.register_type::<Predicted>()
             .register_type::<Confirmed>()
-            .register_type::<PreSpawnedPlayerObject>()
+            .register_type::<PreSpawned>()
             .register_type::<Rollback>()
             .register_type::<RollbackState>()
-            .register_type::<PredictionDespawnMarker>()
+            .register_type::<PredictionDisable>()
             .register_type::<PredictionConfig>();
 
         // RESOURCES
@@ -386,6 +371,7 @@ impl Plugin for PredictionPlugin {
                     PredictionSet::Sync,
                     PredictionSet::RestoreVisualCorrection,
                     PredictionSet::CheckRollback,
+                    PredictionSet::RemoveDisable.run_if(is_in_rollback),
                     PredictionSet::PrepareRollback.run_if(is_in_rollback),
                     PredictionSet::Rollback.run_if(is_in_rollback),
                 )
@@ -407,6 +393,7 @@ impl Plugin for PredictionPlugin {
                 //   - the entity has a PrePredicted component. If it does, remove ShouldBePredicted to not trigger normal prediction-spawn system
                 // - then we check via a system if we should spawn a new predicted entity
                 spawn_predicted_entity.in_set(PredictionSet::SpawnPrediction),
+                remove_prediction_disable.in_set(PredictionSet::RemoveDisable),
                 run_rollback.in_set(PredictionSet::Rollback),
                 #[cfg(feature = "metrics")]
                 super::rollback::no_rollback
@@ -442,7 +429,6 @@ impl Plugin for PredictionPlugin {
         app.add_systems(
             FixedPostUpdate,
             (
-                remove_despawn_marker.in_set(PredictionSet::EntityDespawn),
                 increment_rollback_tick.in_set(PredictionSet::IncrementRollbackTick),
             ),
         );
@@ -462,6 +448,7 @@ impl Plugin for PredictionPlugin {
     }
 
     // We run this after `build` and `finish` to make sure that all components were registered before we create the observer
+    // that will trigger on all predicted components
     fn cleanup(&self, app: &mut App) {
         add_sync_systems(app);
     }

--- a/lightyear/src/client/prediction/predicted_history.rs
+++ b/lightyear/src/client/prediction/predicted_history.rs
@@ -10,9 +10,7 @@ use crate::client::prediction::resource::PredictionManager;
 use crate::client::prediction::rollback::Rollback;
 use crate::client::prediction::Predicted;
 use crate::prelude::client::PredictionSet;
-use crate::prelude::{
-    ComponentRegistry, HistoryBuffer, PrePredicted, PreSpawned, TickManager,
-};
+use crate::prelude::{ComponentRegistry, HistoryBuffer, PrePredicted, PreSpawned, TickManager};
 use crate::shared::tick_manager::TickEvent;
 
 pub(crate) type PredictionHistory<C> = HistoryBuffer<C>;
@@ -168,11 +166,7 @@ pub(crate) fn add_prediction_history<C: Component>(
         (),
         (
             Without<PredictionHistory<C>>,
-            Or<(
-                With<Predicted>,
-                With<PrePredicted>,
-                With<PreSpawned>,
-            )>,
+            Or<(With<Predicted>, With<PrePredicted>, With<PreSpawned>)>,
         ),
     >,
 ) {

--- a/lightyear/src/client/prediction/predicted_history.rs
+++ b/lightyear/src/client/prediction/predicted_history.rs
@@ -5,7 +5,7 @@ use bevy::ecs::component::ComponentId;
 use bevy::prelude::*;
 use std::ops::Deref;
 
-use crate::client::components::{ComponentSyncMode, Confirmed, MutComponent, SyncComponent};
+use crate::client::components::{ComponentSyncMode, Confirmed, SyncComponent};
 use crate::client::prediction::resource::PredictionManager;
 use crate::client::prediction::rollback::Rollback;
 use crate::client::prediction::Predicted;

--- a/lightyear/src/client/prediction/predicted_history.rs
+++ b/lightyear/src/client/prediction/predicted_history.rs
@@ -155,10 +155,11 @@ fn apply_predicted_sync(world: &mut World) {
 /// If a ComponentSyncMode::Full gets added to [`PrePredicted`] or [`PreSpawned`] entity,
 /// add a PredictionHistory component.
 ///
-/// We don't need to run this for [`Predicted`] entities because the confirmed->sync observers already
-/// instead a PredictionHistory component if it's missing on the Predicted entity.
+
 ///
 /// We don't put any value in the history because the `update_history` systems will add the value.
+// TODO: We could not run this for [`Predicted`] entities and instead have the confirmed->sync observers already
+//  add a PredictionHistory component if it's missing on the Predicted entity.
 pub(crate) fn add_prediction_history<C: Component>(
     trigger: Trigger<OnAdd, C>,
     mut commands: Commands,
@@ -168,6 +169,7 @@ pub(crate) fn add_prediction_history<C: Component>(
         (
             Without<PredictionHistory<C>>,
             Or<(
+                With<Predicted>,
                 With<PrePredicted>,
                 With<PreSpawned>,
             )>,

--- a/lightyear/src/client/prediction/predicted_history.rs
+++ b/lightyear/src/client/prediction/predicted_history.rs
@@ -5,13 +5,13 @@ use bevy::ecs::component::ComponentId;
 use bevy::prelude::*;
 use std::ops::Deref;
 
-use crate::client::components::{ComponentSyncMode, Confirmed, SyncComponent};
+use crate::client::components::{ComponentSyncMode, Confirmed, MutComponent, SyncComponent};
 use crate::client::prediction::resource::PredictionManager;
 use crate::client::prediction::rollback::Rollback;
 use crate::client::prediction::Predicted;
 use crate::prelude::client::PredictionSet;
 use crate::prelude::{
-    ComponentRegistry, HistoryBuffer, PrePredicted, PreSpawnedPlayerObject, TickManager,
+    ComponentRegistry, HistoryBuffer, PrePredicted, PreSpawned, TickManager,
 };
 use crate::shared::tick_manager::TickEvent;
 
@@ -20,7 +20,7 @@ pub(crate) type PredictionHistory<C> = HistoryBuffer<C>;
 /// If ComponentSyncMode::Full, we store every update on the predicted entity in the PredictionHistory
 ///
 /// This system only handles changes, removals are handled in `apply_component_removal`
-pub(crate) fn update_prediction_history<T: Component + PartialEq + Clone>(
+pub(crate) fn update_prediction_history<T: Component + Clone>(
     mut query: Query<(Ref<T>, &mut PredictionHistory<T>)>,
     tick_manager: Res<TickManager>,
     rollback: Res<Rollback>,
@@ -57,7 +57,7 @@ pub(crate) fn handle_tick_event_prediction_history<C: Component>(
 
 /// If a component is removed on the Predicted entity, and the ComponentSyncMode == FULL
 /// Add the removal to the history (for potential rollbacks)
-pub(crate) fn apply_component_removal_predicted<C: Component + PartialEq + Clone>(
+pub(crate) fn apply_component_removal_predicted<C: Component>(
     trigger: Trigger<OnRemove, C>,
     tick_manager: Res<TickManager>,
     rollback: Res<Rollback>,
@@ -75,7 +75,7 @@ pub(crate) fn apply_component_removal_predicted<C: Component + PartialEq + Clone
 /// - if the ComponentSyncMode == ONCE, do nothing (we only care about replicating the component once)
 /// - if the ComponentSyncMode == SIMPLE, remove the component from the Predicted entity
 /// - if the ComponentSyncMode == FULL, do nothing. We might get a rollback by comparing with the history.
-pub(crate) fn apply_component_removal_confirmed<C: SyncComponent>(
+pub(crate) fn apply_component_removal_confirmed<C: Component>(
     trigger: Trigger<OnRemove, C>,
     mut commands: Commands,
     confirmed_query: Query<&Confirmed>,
@@ -152,11 +152,14 @@ fn apply_predicted_sync(world: &mut World) {
     });
 }
 
-/// If a ComponentSyncMode::Full gets added to a Predicted, PrePredicted or PreSpawned entity,
+/// If a ComponentSyncMode::Full gets added to [`PrePredicted`] or [`PreSpawned`] entity,
 /// add a PredictionHistory component.
 ///
-/// We don't put any value in the history because the `update_history` systems will add the value
-pub(crate) fn add_prediction_history<C: SyncComponent>(
+/// We don't need to run this for [`Predicted`] entities because the confirmed->sync observers already
+/// instead a PredictionHistory component if it's missing on the Predicted entity.
+///
+/// We don't put any value in the history because the `update_history` systems will add the value.
+pub(crate) fn add_prediction_history<C: Component>(
     trigger: Trigger<OnAdd, C>,
     mut commands: Commands,
     // TODO: should we also have With<ShouldBePredicted>?
@@ -165,9 +168,8 @@ pub(crate) fn add_prediction_history<C: SyncComponent>(
         (
             Without<PredictionHistory<C>>,
             Or<(
-                With<Predicted>,
                 With<PrePredicted>,
-                With<PreSpawnedPlayerObject>,
+                With<PreSpawned>,
             )>,
         ),
     >,
@@ -182,10 +184,10 @@ pub(crate) fn add_prediction_history<C: SyncComponent>(
 /// When the Confirmed component is added, sync components to the Predicted entity
 ///
 /// This is needed in two cases:
-/// - when an entity is replicated, the components are added onto the Confirmed entity before the Confirmed
+/// - when an entity is replicated, the components are replicated onto the Confirmed entity before the Confirmed
 ///   component is added
 /// - when a client spawned on the client transfers authority to the server, the Confirmed
-///   component can be added even though the entity already had components
+///   component can be added even though the entity already had existing components
 ///
 /// We have some ordering constraints related to syncing hierarchy so we don't want to sync components
 /// immediately here (because the ParentSync component might not be able to get mapped properly since the parent entity

--- a/lightyear/src/client/prediction/prespawn.rs
+++ b/lightyear/src/client/prediction/prespawn.rs
@@ -117,9 +117,7 @@ impl PreSpawnedPlayerObjectPlugin {
         let confirmed_entity = trigger.target();
         if let Ok(server_prespawn) = query.get(confirmed_entity) {
             // we handle the PreSpawnedPlayerObject hash in this system and don't need it afterwards
-            commands
-                .entity(confirmed_entity)
-                .remove::<PreSpawned>();
+            commands.entity(confirmed_entity).remove::<PreSpawned>();
             let Some(server_hash) = server_prespawn.hash else {
                 error!("Received a PreSpawnedPlayerObject entity from the server without a hash");
                 return;
@@ -133,9 +131,7 @@ impl PreSpawnedPlayerObjectPlugin {
                 }
                 debug!(?server_hash, "Received a PreSpawnedPlayerObject entity from the server with a hash that does not match any client entity");
                 // remove the PreSpawnedPlayerObject so that the entity can be normal-predicted
-                commands
-                    .entity(confirmed_entity)
-                    .remove::<PreSpawned>();
+                commands.entity(confirmed_entity).remove::<PreSpawned>();
                 return;
             };
 
@@ -153,11 +149,9 @@ impl PreSpawnedPlayerObjectPlugin {
                         metrics::counter!("prespawn::match::found").increment(1);
                     }
                     debug!("re-using existing entity");
-                    entity_commands
-                        .remove::<PreSpawned>()
-                        .insert(Predicted {
-                            confirmed_entity: Some(confirmed_entity),
-                        });
+                    entity_commands.remove::<PreSpawned>().insert(Predicted {
+                        confirmed_entity: Some(confirmed_entity),
+                    });
                     client_entity
                 } else {
                     #[cfg(feature = "metrics")]
@@ -321,10 +315,7 @@ impl Component for PreSpawned {
     fn register_component_hooks(hooks: &mut bevy::ecs::component::ComponentHooks) {
         hooks.on_add(|mut deferred_world, context: HookContext| {
             let entity = context.entity;
-            let prespawned_obj = deferred_world
-                .entity(entity)
-                .get::<PreSpawned>()
-                .unwrap();
+            let prespawned_obj = deferred_world.entity(entity).get::<PreSpawned>().unwrap();
             // The user may have provided the hash for us, or the hash is already present because the component
             // has been replicated from the server, in which case do nothing.
             if prespawned_obj.hash.is_some() {
@@ -388,18 +379,12 @@ mod tests {
         let entity_1 = stepper
             .client_app
             .world_mut()
-            .spawn((
-                ComponentSyncModeFull(1.0),
-                PreSpawned::default(),
-            ))
+            .spawn((ComponentSyncModeFull(1.0), PreSpawned::default()))
             .id();
         let entity_2 = stepper
             .client_app
             .world_mut()
-            .spawn((
-                ComponentSyncModeFull(1.0),
-                PreSpawned::default(),
-            ))
+            .spawn((ComponentSyncModeFull(1.0), PreSpawned::default()))
             .id();
         stepper.frame_step();
 

--- a/lightyear/src/client/prediction/rollback.rs
+++ b/lightyear/src/client/prediction/rollback.rs
@@ -107,7 +107,10 @@ pub(crate) fn check_rollback<C: SyncComponent>(
     tick_manager: Res<TickManager>,
     connection: Res<ConnectionManager>,
     // we include Disabled in the filter to also check rollback for predicted despawn entities
-    mut predicted_query: Query<(Option<&mut PredictionHistory<C>>, Has<Disabled>), (With<Predicted>, Without<Confirmed>)>,
+    mut predicted_query: Query<
+        (Option<&mut PredictionHistory<C>>, Has<Disabled>),
+        (With<Predicted>, Without<Confirmed>),
+    >,
     // We use Option<> because the predicted component could have been removed while it still exists in Confirmed
     confirmed_query: Query<(Entity, Option<&C>, Ref<Confirmed>)>,
     rollback: Res<Rollback>,
@@ -284,7 +287,7 @@ pub(crate) fn check_rollback<C: SyncComponent>(
 pub(crate) fn remove_prediction_disable(
     mut commands: Commands,
     // TODO: use our own custom Disable marker when this is possible
-    query: Query<Entity, (With<Predicted>, With<Disabled>)>
+    query: Query<Entity, (With<Predicted>, With<Disabled>)>,
 ) {
     query.iter().for_each(|e| {
         commands.entity(e).remove::<Disabled>();
@@ -308,11 +311,7 @@ pub(crate) fn prepare_rollback<C: SyncComponent>(
             &mut PredictionHistory<C>,
             Option<&mut Correction<C>>,
         ),
-        (
-            With<Predicted>,
-            Without<Confirmed>,
-            Without<PreSpawned>,
-        ),
+        (With<Predicted>, Without<Confirmed>, Without<PreSpawned>),
     >,
     confirmed_query: Query<(Entity, Option<&C>, Ref<Confirmed>)>,
     rollback: Res<Rollback>,
@@ -448,11 +447,7 @@ pub(crate) fn prepare_rollback_prespawn<C: SyncComponent>(
     // We use Option<> because the predicted component could have been removed while it still exists in Confirmed
     mut predicted_query: Query<
         (Entity, Option<&mut C>, &mut PredictionHistory<C>),
-        (
-            With<PreSpawned>,
-            Without<Confirmed>,
-            Without<Predicted>,
-        ),
+        (With<PreSpawned>, Without<Confirmed>, Without<Predicted>),
     >,
     rollback: Res<Rollback>,
 ) {

--- a/lightyear/src/client/prediction/rollback.rs
+++ b/lightyear/src/client/prediction/rollback.rs
@@ -10,14 +10,12 @@ use bevy::prelude::*;
 use bevy::reflect::Reflect;
 use bevy::time::{Fixed, Time};
 use parking_lot::RwLock;
-use smallvec::SmallVec;
 use tracing::{debug, error, trace, trace_span};
 
 use crate::client::components::{Confirmed, SyncComponent};
 use crate::client::config::ClientConfig;
 use crate::client::connection::ConnectionManager;
 use crate::client::prediction::correction::Correction;
-use crate::client::prediction::despawn::PredictionDisable;
 use crate::client::prediction::diagnostics::PredictionMetrics;
 use crate::client::prediction::resource::PredictionManager;
 use crate::prelude::{ComponentRegistry, HistoryState, PreSpawned, Tick, TickManager};
@@ -153,7 +151,7 @@ pub(crate) fn check_rollback<C: SyncComponent>(
 
         let tick = confirmed.tick;
         // This will happen if the entity has been marked as PredictionDisable
-        let Ok((mut predicted_history, _)) = predicted_query.get_mut(p) else {
+        let Ok((predicted_history, _)) = predicted_query.get_mut(p) else {
             // TODO: we could try using a PredictedDisableMarker marker, for now we consider that there's a rollback if we
             //  cannot find the entity
             debug!(

--- a/lightyear/src/client/prediction/spawn.rs
+++ b/lightyear/src/client/prediction/spawn.rs
@@ -44,6 +44,7 @@ pub(crate) fn spawn_predicted_entity(
             "Spawning predicted entity {:?} for confirmed: {:?}",
             predicted_entity, confirmed_entity
         );
+        dbg!("Spawn", &predicted_entity, &confirmed_entity);
         #[cfg(feature = "metrics")]
         {
             metrics::counter!("prediction::pre_predicted_spawn").increment(1);

--- a/lightyear/src/client/prediction/spawn.rs
+++ b/lightyear/src/client/prediction/spawn.rs
@@ -44,7 +44,6 @@ pub(crate) fn spawn_predicted_entity(
             "Spawning predicted entity {:?} for confirmed: {:?}",
             predicted_entity, confirmed_entity
         );
-        dbg!("Spawn", &predicted_entity, &confirmed_entity);
         #[cfg(feature = "metrics")]
         {
             metrics::counter!("prediction::pre_predicted_spawn").increment(1);

--- a/lightyear/src/client/replication.rs
+++ b/lightyear/src/client/replication.rs
@@ -151,7 +151,6 @@ pub(crate) mod send {
         InitialReplicated, Replicating, ReplicationGroupId,
     };
 
-
     use crate::shared::replication::archetypes::{
         get_erased_component, ClientReplicatedArchetypes,
     };
@@ -822,11 +821,7 @@ pub(crate) mod send {
             let mut stepper = BevyStepper::default();
 
             // spawn an entity on server with visibility::All
-            let client_entity = stepper
-                .client_app
-                .world_mut()
-                .spawn(ReplicateToServer)
-                .id();
+            let client_entity = stepper.client_app.world_mut().spawn(ReplicateToServer).id();
 
             stepper.frame_step();
             stepper.frame_step();
@@ -906,10 +901,7 @@ pub(crate) mod send {
             let client_entity = stepper
                 .client_app
                 .world_mut()
-                .spawn((
-                    ReplicateToServer,
-                    TargetEntity::Preexisting(server_entity),
-                ))
+                .spawn((ReplicateToServer, TargetEntity::Preexisting(server_entity)))
                 .id();
             for _ in 0..10 {
                 stepper.frame_step();
@@ -991,11 +983,7 @@ pub(crate) mod send {
             let mut stepper = BevyStepper::default();
 
             // spawn an entity on client
-            let client_entity = stepper
-                .client_app
-                .world_mut()
-                .spawn(ReplicateToServer)
-                .id();
+            let client_entity = stepper.client_app.world_mut().spawn(ReplicateToServer).id();
             let client_child = stepper
                 .client_app
                 .world_mut()
@@ -1050,11 +1038,7 @@ pub(crate) mod send {
             let mut stepper = BevyStepper::default();
 
             // spawn an entity on client
-            let client_entity = stepper
-                .client_app
-                .world_mut()
-                .spawn(ReplicateToServer)
-                .id();
+            let client_entity = stepper.client_app.world_mut().spawn(ReplicateToServer).id();
             let client_child = stepper
                 .client_app
                 .world_mut()
@@ -1091,11 +1075,7 @@ pub(crate) mod send {
             let mut stepper = BevyStepper::default();
 
             // spawn an entity on client
-            let client_entity = stepper
-                .client_app
-                .world_mut()
-                .spawn(ReplicateToServer)
-                .id();
+            let client_entity = stepper.client_app.world_mut().spawn(ReplicateToServer).id();
             for _ in 0..10 {
                 stepper.frame_step();
             }
@@ -1139,11 +1119,7 @@ pub(crate) mod send {
             let mut stepper = BevyStepper::default();
 
             // spawn an entity on client
-            let client_entity = stepper
-                .client_app
-                .world_mut()
-                .spawn(ReplicateToServer)
-                .id();
+            let client_entity = stepper.client_app.world_mut().spawn(ReplicateToServer).id();
             for _ in 0..10 {
                 stepper.frame_step();
             }

--- a/lightyear/src/connection/steam/server.rs
+++ b/lightyear/src/connection/steam/server.rs
@@ -110,7 +110,7 @@ impl Server {
             server,
             config,
             listen_socket: None,
-            connections: HashMap::new(),
+            connections: HashMap::default(),
             packet_queue: VecDeque::new(),
             new_connections: Vec::new(),
             new_disconnections: Vec::new(),

--- a/lightyear/src/lib.rs
+++ b/lightyear/src/lib.rs
@@ -188,7 +188,7 @@ pub mod prelude {
         Channel, ChannelBuilder, ChannelContainer, ChannelDirection, ChannelMode, ChannelSettings,
         InputChannel, ReliableSettings,
     };
-    pub use crate::client::prediction::prespawn::PreSpawnedPlayerObject;
+    pub use crate::client::prediction::prespawn::PreSpawned;
     pub use crate::connection::id::ClientId;
     pub use crate::connection::netcode::{generate_key, ConnectToken, Key};
     #[cfg(feature = "leafwing")]

--- a/lightyear/src/lib.rs
+++ b/lightyear/src/lib.rs
@@ -269,9 +269,7 @@ pub mod prelude {
     pub use rename::*;
 
     pub mod client {
-        pub use crate::client::components::{
-            ComponentSyncMode, Confirmed, LerpFn, SyncMetadata,
-        };
+        pub use crate::client::components::{ComponentSyncMode, Confirmed, LerpFn, SyncMetadata};
         pub use crate::client::config::{ClientConfig, NetcodeConfig, PacketConfig};
         pub use crate::client::connection::ConnectionManager;
         pub use crate::client::error::ClientError;

--- a/lightyear/src/lib.rs
+++ b/lightyear/src/lib.rs
@@ -270,7 +270,7 @@ pub mod prelude {
 
     pub mod client {
         pub use crate::client::components::{
-            ComponentSyncMode, Confirmed, LerpFn, SyncComponent, SyncMetadata,
+            ComponentSyncMode, Confirmed, LerpFn, SyncMetadata,
         };
         pub use crate::client::config::{ClientConfig, NetcodeConfig, PacketConfig};
         pub use crate::client::connection::ConnectionManager;

--- a/lightyear/src/protocol/component.rs
+++ b/lightyear/src/protocol/component.rs
@@ -634,6 +634,7 @@ mod prediction {
             predicted: Entity,
             world: &mut World,
         ) {
+            dbg!("batch sync", &confirmed, &predicted);
             // clone each component to be synced into a temporary buffer
             component_ids.iter().for_each(|component_id| {
                 let kind = self.component_id_to_kind.get(component_id).unwrap();
@@ -668,6 +669,7 @@ mod prediction {
                 // if the predicted entity already had a PredictionHistory component (for example
                 // if the entity was PreSpawned entity), we don't want to overwrite it.
                 if world.get::<PredictionHistory<C>>(predicted).is_none() {
+                    dbg!(std::any::type_name::<PredictionHistory<C>>());
                     unsafe {
                         self.temp_write_buffer.buffer_insert_raw_ptrs(
                             PredictionHistory::<C>::default(),
@@ -767,9 +769,9 @@ mod replication {
     use crate::serialize::ToBytes;
     use crate::shared::replication::entity_map::ReceiveEntityMap;
     use bevy::ecs::component::Mutable;
-    
+
     use bytes::Bytes;
-    
+
 
     impl ComponentRegistry {
         pub(crate) fn direction(&self, kind: ComponentKind) -> Option<ChannelDirection> {

--- a/lightyear/src/protocol/component.rs
+++ b/lightyear/src/protocol/component.rs
@@ -770,7 +770,6 @@ mod replication {
 
     use bytes::Bytes;
 
-
     impl ComponentRegistry {
         pub(crate) fn direction(&self, kind: ComponentKind) -> Option<ChannelDirection> {
             self.replication_map

--- a/lightyear/src/protocol/component.rs
+++ b/lightyear/src/protocol/component.rs
@@ -16,13 +16,12 @@ use std::ptr::NonNull;
 
 use tracing::{debug, error, trace};
 
-use crate::client::components::ComponentSyncMode;
+use crate::client::components::{ComponentSyncMode, SyncComponent};
 use crate::client::config::ClientConfig;
 use crate::client::interpolation::{add_interpolation_systems, add_prepare_interpolation_systems};
 use crate::client::prediction::plugin::{
     add_non_networked_rollback_systems, add_prediction_systems, add_resource_rollback_systems,
 };
-use crate::prelude::client::SyncComponent;
 use crate::prelude::server::ServerConfig;
 use crate::prelude::{ChannelDirection, Message, Tick};
 use crate::protocol::delta::ErasedDeltaFns;

--- a/lightyear/src/server/connection.rs
+++ b/lightyear/src/server/connection.rs
@@ -23,8 +23,7 @@ use crate::packet::message_manager::MessageManager;
 use crate::packet::packet_builder::{Payload, RecvPayload};
 use crate::prelude::server::DisconnectEvent;
 use crate::prelude::{
-    ChannelKind, Message, PreSpawned, ReplicationConfig, ReplicationGroup,
-    ShouldBePredicted,
+    ChannelKind, Message, PreSpawned, ReplicationConfig, ReplicationGroup, ShouldBePredicted,
 };
 use crate::protocol::channel::ChannelRegistry;
 use crate::protocol::component::{

--- a/lightyear/src/server/connection.rs
+++ b/lightyear/src/server/connection.rs
@@ -23,7 +23,7 @@ use crate::packet::message_manager::MessageManager;
 use crate::packet::packet_builder::{Payload, RecvPayload};
 use crate::prelude::server::DisconnectEvent;
 use crate::prelude::{
-    ChannelKind, Message, PreSpawnedPlayerObject, ReplicationConfig, ReplicationGroup,
+    ChannelKind, Message, PreSpawned, ReplicationConfig, ReplicationGroup,
     ShouldBePredicted,
 };
 use crate::protocol::channel::ChannelRegistry;
@@ -795,7 +795,7 @@ impl ConnectionManager {
         // same thing for PreSpawnedPlayerObject: that component should only be replicated to prediction_target
         let mut actual_target = target;
         let should_be_predicted_kind = ComponentKind::of::<ShouldBePredicted>();
-        let pre_spawned_player_object_kind = ComponentKind::of::<PreSpawnedPlayerObject>();
+        let pre_spawned_player_object_kind = ComponentKind::of::<PreSpawned>();
         if kind == should_be_predicted_kind || kind == pre_spawned_player_object_kind {
             actual_target = prediction_target.unwrap().clone();
         }

--- a/lightyear/src/server/replication.rs
+++ b/lightyear/src/server/replication.rs
@@ -1511,11 +1511,9 @@ pub(crate) mod send {
             let server_entity = stepper
                 .server_app
                 .world_mut()
-                .spawn(
-                    ReplicateToClient {
-                        target: NetworkTarget::Single(ClientId::Netcode(TEST_CLIENT_ID_1)),
-                    }
-                )
+                .spawn(ReplicateToClient {
+                    target: NetworkTarget::Single(ClientId::Netcode(TEST_CLIENT_ID_1)),
+                })
                 .id();
             stepper.frame_step();
             stepper.frame_step();
@@ -1537,7 +1535,8 @@ pub(crate) mod send {
                 .world_mut()
                 .entity_mut(server_entity)
                 .get_mut::<ReplicateToClient>()
-                .unwrap().target = NetworkTarget::All;
+                .unwrap()
+                .target = NetworkTarget::All;
             stepper.frame_step();
             stepper.frame_step();
 
@@ -1787,11 +1786,9 @@ pub(crate) mod send {
             let server_entity = stepper
                 .server_app
                 .world_mut()
-                .spawn(
-                    ReplicateToClient {
-                        target: NetworkTarget::Single(ClientId::Netcode(TEST_CLIENT_ID)),
-                    },
-                )
+                .spawn(ReplicateToClient {
+                    target: NetworkTarget::Single(ClientId::Netcode(TEST_CLIENT_ID)),
+                })
                 .id();
             stepper.frame_step();
             stepper.frame_step();
@@ -3327,11 +3324,9 @@ pub(crate) mod send {
             let server_entity = stepper
                 .server_app
                 .world_mut()
-                .spawn(
-                    ReplicateToClient {
-                        target: NetworkTarget::None,
-                    },
-                )
+                .spawn(ReplicateToClient {
+                    target: NetworkTarget::None,
+                })
                 .id();
             stepper.frame_step();
             stepper.frame_step();

--- a/lightyear/src/shared/replication/plugin.rs
+++ b/lightyear/src/shared/replication/plugin.rs
@@ -255,7 +255,7 @@ pub(crate) mod shared {
     use crate::client::replication::send::ReplicateToServer;
     use crate::prelude::{
         AppComponentExt, AppMessageExt, ChannelDirection, ComponentRegistry, NetworkRelevanceMode,
-        PrePredicted, PreSpawnedPlayerObject, RelationshipSync, RemoteEntityMap, Replicated,
+        PrePredicted, PreSpawned, RelationshipSync, RemoteEntityMap, Replicated,
         ReplicationConfig, ReplicationGroup, ShouldBePredicted, TargetEntity,
     };
     use crate::server::replication::send::ReplicateToClient;
@@ -304,7 +304,7 @@ pub(crate) mod shared {
             // - we need to run this in `finish` so that all plugins have been built (so ClientPlugin and ServerPlugin
             // both exists)
             // - the replication::SharedPlugin should only be added once, even when running in host-server mode
-            app.register_component::<PreSpawnedPlayerObject>(ChannelDirection::Bidirectional);
+            app.register_component::<PreSpawned>(ChannelDirection::Bidirectional);
             app.register_component::<PrePredicted>(ChannelDirection::Bidirectional);
             app.register_component::<ShouldBePredicted>(ChannelDirection::ServerToClient);
             app.register_component::<ShouldBeInterpolated>(ChannelDirection::ServerToClient);

--- a/lightyear/src/shared/replication/plugin.rs
+++ b/lightyear/src/shared/replication/plugin.rs
@@ -255,8 +255,8 @@ pub(crate) mod shared {
     use crate::client::replication::send::ReplicateToServer;
     use crate::prelude::{
         AppComponentExt, AppMessageExt, ChannelDirection, ComponentRegistry, NetworkRelevanceMode,
-        PrePredicted, PreSpawned, RelationshipSync, RemoteEntityMap, Replicated,
-        ReplicationConfig, ReplicationGroup, ShouldBePredicted, TargetEntity,
+        PrePredicted, PreSpawned, RelationshipSync, RemoteEntityMap, Replicated, ReplicationConfig,
+        ReplicationGroup, ShouldBePredicted, TargetEntity,
     };
     use crate::server::replication::send::ReplicateToClient;
     use crate::shared::replication::authority::{AuthorityChange, AuthorityPeer, HasAuthority};

--- a/lightyear/src/shared/replication/prespawn.rs
+++ b/lightyear/src/shared/replication/prespawn.rs
@@ -1,8 +1,6 @@
 //! Shared logic to handle prespawning entities
 
-use crate::prelude::{
-    ComponentRegistry, PrePredicted, PreSpawned, ShouldBePredicted, Tick,
-};
+use crate::prelude::{ComponentRegistry, PrePredicted, PreSpawned, ShouldBePredicted, Tick};
 use crate::protocol::component::ComponentKind;
 use crate::shared::replication::components::{Controlled, ShouldBeInterpolated};
 use crate::shared::replication::hierarchy::ReplicateLike;

--- a/lightyear/src/shared/replication/prespawn.rs
+++ b/lightyear/src/shared/replication/prespawn.rs
@@ -1,7 +1,7 @@
 //! Shared logic to handle prespawning entities
 
 use crate::prelude::{
-    ComponentRegistry, PrePredicted, PreSpawnedPlayerObject, ShouldBePredicted, Tick,
+    ComponentRegistry, PrePredicted, PreSpawned, ShouldBePredicted, Tick,
 };
 use crate::protocol::component::ComponentKind;
 use crate::shared::replication::components::{Controlled, ShouldBeInterpolated};
@@ -45,7 +45,7 @@ pub(crate) fn compute_default_hash(
             if let Some(type_id) = components.get_info(component_id).unwrap().type_id() {
                 // ignore some book-keeping components that are included in the component registry
                 if type_id != TypeId::of::<PrePredicted>()
-                    && type_id != TypeId::of::<PreSpawnedPlayerObject>()
+                    && type_id != TypeId::of::<PreSpawned>()
                     && type_id != TypeId::of::<ShouldBePredicted>()
                     && type_id != TypeId::of::<ShouldBeInterpolated>()
                     && type_id != TypeId::of::<Controlled>()

--- a/lightyear/src/transport/websocket/server.rs
+++ b/lightyear/src/transport/websocket/server.rs
@@ -40,12 +40,12 @@ impl ServerTransportBuilder for WebSocketServerSocketBuilder {
         Option<ServerNetworkEventSender>,
     )> {
         let (serverbound_tx, serverbound_rx) = unbounded_channel::<(SocketAddr, Message)>();
-        let clientbound_tx_map = ClientBoundTxMap::new(Mutex::new(HashMap::new()));
+        let clientbound_tx_map = ClientBoundTxMap::new(Mutex::new(HashMap::default()));
         // channels used to cancel the task
         let (close_tx, close_rx) = async_channel::unbounded();
         // channels used to check the status of the io task
         let (status_tx, status_rx) = async_channel::unbounded();
-        let addr_to_task = Arc::new(Mutex::new(HashMap::new()));
+        let addr_to_task = Arc::new(Mutex::new(HashMap::default()));
 
         let sender = WebSocketServerSocketSender {
             server_addr: self.server_addr,

--- a/lightyear/src/transport/webtransport/server.rs
+++ b/lightyear/src/transport/webtransport/server.rs
@@ -43,8 +43,8 @@ impl ServerTransportBuilder for WebTransportServerSocketBuilder {
         let (close_tx, close_rx) = async_channel::unbounded();
         // channels used to check the status of the io task
         let (status_tx, status_rx) = async_channel::unbounded();
-        let to_client_senders = Arc::new(Mutex::new(HashMap::new()));
-        let addr_to_task = Arc::new(Mutex::new(HashMap::new()));
+        let to_client_senders = Arc::new(Mutex::new(HashMap::default()));
+        let addr_to_task = Arc::new(Mutex::new(HashMap::default()));
 
         let sender = WebTransportServerSocketSender {
             server_addr: self.server_addr,


### PR DESCRIPTION
When a client despawns a Predicted component, we used to have a weird workaround where we cached all their components temporarily until either there is a rollback or the Confirmed entity gets despawned. We can now simplify this logic since `Disabled` component has been merged in bevy.