### PR TITLE
Replace `ReplicateOnce<C>` with `ReplicateOnce`

### DIFF
--- a/examples/delta_compression/src/protocol.rs
+++ b/examples/delta_compression/src/protocol.rs
@@ -22,7 +22,7 @@ use tracing::{info, trace};
 pub(crate) struct PlayerBundle {
     id: PlayerId,
     position: PlayerPosition,
-    delta: DeltaCompression<PlayerPosition>,
+    delta: DeltaCompression,
     color: PlayerColor,
 }
 
@@ -36,7 +36,7 @@ impl PlayerBundle {
         Self {
             id: PlayerId(id),
             position: PlayerPosition(position),
-            delta: DeltaCompression::default(),
+            delta: DeltaCompression::default().add::<PlayerPosition>(),
             color: PlayerColor(color),
         }
     }

--- a/lightyear/src/client/components.rs
+++ b/lightyear/src/client/components.rs
@@ -26,10 +26,10 @@ pub struct Confirmed {
     pub tick: Tick,
 }
 
-pub(crate) trait MutComponent: Component<Mutability = Mutable> {}
+pub trait MutComponent: Component<Mutability = Mutable> {}
 
 impl<T> MutComponent for T where T: Component<Mutability = Mutable> {}
-pub(crate) trait SyncComponent: MutComponent + Clone + PartialEq + Message {}
+pub trait SyncComponent: MutComponent + Clone + PartialEq + Message {}
 impl<T> SyncComponent for T where T: MutComponent + Clone + PartialEq + Message {}
 
 /// Function that will interpolate between two values

--- a/lightyear/src/client/input/leafwing.rs
+++ b/lightyear/src/client/input/leafwing.rs
@@ -332,9 +332,13 @@ fn add_action_state_buffer<A: LeafwingUserAction>(
         // but don't replicate any updates after we replicated the initial component spawn
         //
         // Be careful to not overwrite an existing ReplicateOnce if present
-        commands.entity(entity).entry::<ReplicateOnce>()
+        commands
+            .entity(entity)
+            .entry::<ReplicateOnce>()
             .or_default()
-            .and_modify(|mut v| {v.add_mut::<ActionState<A>>();});
+            .and_modify(|mut v| {
+                v.add_mut::<ActionState<A>>();
+            });
         if !has_action_state {
             commands.entity(entity).insert(ActionState::<A>::default());
         }

--- a/lightyear/src/client/replication.rs
+++ b/lightyear/src/client/replication.rs
@@ -140,11 +140,7 @@ pub(crate) mod send {
 
     use crate::prelude::client::{ClientConfig, NetClient};
 
-    use crate::prelude::{
-        client::{is_connected, is_synced},
-        is_host_server, ComponentRegistry, DisabledComponents, ReplicateLike, Replicated,
-        ReplicationGroup, TargetEntity, Tick, TickManager, TimeManager,
-    };
+    use crate::prelude::{client::{is_connected, is_synced}, is_host_server, ComponentRegistry, DeltaCompression, DisabledComponents, ReplicateLike, ReplicateOnce, Replicated, ReplicationGroup, TargetEntity, Tick, TickManager, TimeManager};
     use crate::protocol::component::ComponentKind;
 
     use crate::shared::replication::components::{
@@ -352,6 +348,8 @@ pub(crate) mod send {
                     group_ready,
                     target_entity,
                     disabled_components,
+                    delta_compression,
+                    replicate_once,
                     replication_target_ticks,
                     is_replicate_like_added,
                 ) = if let Some(replicate_like) =
@@ -390,6 +388,12 @@ pub(crate) mod send {
                         entity_ref
                             .get::<DisabledComponents>()
                             .or_else(|| query_entity_ref.get()),
+                        entity_ref
+                            .get::<DeltaCompression>()
+                            .or_else(|| query_entity_ref.get()),
+                        entity_ref
+                            .get::<ReplicateOnce>()
+                            .or_else(|| query_entity_ref.get()),
                         // SAFETY: we know that the entity has the ReplicateToServer component
                         // because the archetype is in replicated_archetypes
                         unsafe {
@@ -419,6 +423,8 @@ pub(crate) mod send {
                         group_ready,
                         entity_ref.get::<TargetEntity>(),
                         entity_ref.get::<DisabledComponents>(),
+                        entity_ref.get::<DeltaCompression>(),
+                        entity_ref.get::<ReplicateOnce>(),
                         // SAFETY: we know that the entity has the ReplicateToServer component
                         // because the archetype is in replicated_archetypes
                         unsafe {
@@ -474,6 +480,10 @@ pub(crate) mod send {
                             replicated_component.id,
                         )
                     };
+                    // TODO: maybe the old method was faster because we had-precached the delta-compression data
+                    //  for the archetype?
+                    let delta_compression = delta_compression.is_some_and(|d| d.enabled_kind(replicated_component.kind));
+                    let replicate_once = replicate_once.is_some_and(|r| r.enabled_kind(replicated_component.kind));
                     let _ = replicate_component_update(
                         tick_manager.tick(),
                         &component_registry,
@@ -483,8 +493,8 @@ pub(crate) mod send {
                         component_ticks,
                         replication_is_changed,
                         group_id,
-                        replicated_component.delta_compression,
-                        replicated_component.replicate_once,
+                        delta_compression,
+                        replicate_once,
                         &system_ticks,
                         &mut sender,
                     )
@@ -758,7 +768,7 @@ pub(crate) mod send {
         use crate::client::replication::send::ReplicateToServer;
         use crate::prelude::{
             server, ChannelDirection, ClientId, ComponentRegistry, DisabledComponents,
-            ReplicateOnceComponent, Replicated, TargetEntity,
+            ReplicateOnce, Replicated, TargetEntity,
         };
         use crate::protocol::component::ComponentKind;
         use crate::tests::protocol::{ComponentSyncModeFull, ComponentSyncModeOnce};
@@ -1339,7 +1349,7 @@ pub(crate) mod send {
                 .spawn((
                     ReplicateToServer,
                     ComponentSyncModeFull(1.0),
-                    ReplicateOnceComponent::<ComponentSyncModeFull>::default(),
+                    ReplicateOnce::default().add::<ComponentSyncModeFull>(),
                 ))
                 .id();
             for _ in 0..10 {

--- a/lightyear/src/client/replication.rs
+++ b/lightyear/src/client/replication.rs
@@ -140,7 +140,11 @@ pub(crate) mod send {
 
     use crate::prelude::client::{ClientConfig, NetClient};
 
-    use crate::prelude::{client::{is_connected, is_synced}, is_host_server, ComponentRegistry, DeltaCompression, DisabledComponents, ReplicateLike, ReplicateOnce, Replicated, ReplicationGroup, TargetEntity, Tick, TickManager, TimeManager};
+    use crate::prelude::{
+        client::{is_connected, is_synced},
+        is_host_server, ComponentRegistry, DeltaCompression, DisabledComponents, ReplicateLike,
+        ReplicateOnce, Replicated, ReplicationGroup, TargetEntity, Tick, TickManager, TimeManager,
+    };
     use crate::protocol::component::ComponentKind;
 
     use crate::shared::replication::components::{
@@ -482,8 +486,10 @@ pub(crate) mod send {
                     };
                     // TODO: maybe the old method was faster because we had-precached the delta-compression data
                     //  for the archetype?
-                    let delta_compression = delta_compression.is_some_and(|d| d.enabled_kind(replicated_component.kind));
-                    let replicate_once = replicate_once.is_some_and(|r| r.enabled_kind(replicated_component.kind));
+                    let delta_compression = delta_compression
+                        .is_some_and(|d| d.enabled_kind(replicated_component.kind));
+                    let replicate_once =
+                        replicate_once.is_some_and(|r| r.enabled_kind(replicated_component.kind));
                     let _ = replicate_component_update(
                         tick_manager.tick(),
                         &component_registry,

--- a/lightyear/src/lib.rs
+++ b/lightyear/src/lib.rs
@@ -214,7 +214,7 @@ pub mod prelude {
     pub use crate::shared::replication::authority::HasAuthority;
     pub use crate::shared::replication::components::{
         DeltaCompression, DisableReplicateHierarchy, DisabledComponents, NetworkRelevanceMode,
-        PrePredicted, ReplicateOnceComponent, Replicated, Replicating, ReplicationGroup,
+        PrePredicted, ReplicateOnce, Replicated, Replicating, ReplicationGroup,
         ReplicationMarker, ShouldBePredicted, TargetEntity,
     };
     pub use crate::shared::replication::entity_map::RemoteEntityMap;

--- a/lightyear/src/lib.rs
+++ b/lightyear/src/lib.rs
@@ -214,8 +214,8 @@ pub mod prelude {
     pub use crate::shared::replication::authority::HasAuthority;
     pub use crate::shared::replication::components::{
         DeltaCompression, DisableReplicateHierarchy, DisabledComponents, NetworkRelevanceMode,
-        PrePredicted, ReplicateOnce, Replicated, Replicating, ReplicationGroup,
-        ReplicationMarker, ShouldBePredicted, TargetEntity,
+        PrePredicted, ReplicateOnce, Replicated, Replicating, ReplicationGroup, ReplicationMarker,
+        ShouldBePredicted, TargetEntity,
     };
     pub use crate::shared::replication::entity_map::RemoteEntityMap;
     pub use crate::shared::replication::hierarchy::{ChildOfSync, RelationshipSync, ReplicateLike};

--- a/lightyear/src/protocol/component.rs
+++ b/lightyear/src/protocol/component.rs
@@ -235,8 +235,6 @@ impl TempWriteBuffer {
 #[derive(Debug, Clone, PartialEq)]
 pub struct ReplicationMetadata {
     pub direction: ChannelDirection,
-    pub delta_compression_id: ComponentId,
-    pub replicate_once_id: ComponentId,
     pub write: RawWriteFn,
     pub buffer_insert_fn: RawBufferInsertFn,
     pub remove: Option<RawBufferRemoveFn>,
@@ -762,7 +760,6 @@ mod interpolation {
 
 mod replication {
     use super::*;
-    use crate::prelude::{DeltaCompression, ReplicateOnceComponent};
     use crate::serialize::reader::Reader;
     use crate::serialize::ToBytes;
     use crate::shared::replication::entity_map::ReceiveEntityMap;
@@ -786,8 +783,6 @@ mod replication {
                 ComponentKind::of::<C>(),
                 ReplicationMetadata {
                     direction,
-                    delta_compression_id: world.register_component::<DeltaCompression<C>>(),
-                    replicate_once_id: world.register_component::<ReplicateOnceComponent<C>>(),
                     write: Self::write::<C>,
                     buffer_insert_fn: Self::buffer_insert::<C>,
                     remove: Some(Self::buffer_remove::<C>),
@@ -1052,9 +1047,6 @@ mod delta {
                         .get(&kind)
                         .map(|m| m.direction)
                         .unwrap_or(ChannelDirection::Bidirectional),
-                    // NOTE: we set these to 0 because they are never used for the DeltaMessage component
-                    delta_compression_id: ComponentId::new(0),
-                    replicate_once_id: ComponentId::new(0),
                     write,
                     buffer_insert_fn: Self::buffer_insert_delta::<C>,
                     // we never need to remove the DeltaMessage<C> component

--- a/lightyear/src/server/replication.rs
+++ b/lightyear/src/server/replication.rs
@@ -52,7 +52,11 @@ pub(crate) mod receive {
 pub(crate) mod send {
     use super::*;
     use crate::prelude::server::AuthorityCommandExt;
-    use crate::prelude::{is_host_server, ClientId, ComponentRegistry, DeltaCompression, DisabledComponents, NetworkRelevanceMode, ReplicateLike, ReplicateOnce, ReplicationGroup, ShouldBePredicted, TargetEntity, Tick, TickManager, TimeManager};
+    use crate::prelude::{
+        is_host_server, ClientId, ComponentRegistry, DeltaCompression, DisabledComponents,
+        NetworkRelevanceMode, ReplicateLike, ReplicateOnce, ReplicationGroup, ShouldBePredicted,
+        TargetEntity, Tick, TickManager, TimeManager,
+    };
     use crate::protocol::component::ComponentKind;
     use crate::server::error::ServerError;
     use crate::server::prediction::handle_pre_predicted;
@@ -653,8 +657,10 @@ pub(crate) mod send {
                         override_target.and_then(|o| o.get_kind(replicated_component.kind));
                     // TODO: maybe the old method was faster because we had-precached the delta-compression data
                     //  for the archetype?
-                    let delta_compression = delta_compression.is_some_and(|d| d.enabled_kind(replicated_component.kind));
-                    let replicate_once = replicate_once.is_some_and(|r| r.enabled_kind(replicated_component.kind));
+                    let delta_compression = delta_compression
+                        .is_some_and(|d| d.enabled_kind(replicated_component.kind));
+                    let replicate_once =
+                        replicate_once.is_some_and(|r| r.enabled_kind(replicated_component.kind));
 
                     replicate_component_updates(
                         tick_manager.tick(),

--- a/lightyear/src/shared/replication/archetypes.rs
+++ b/lightyear/src/shared/replication/archetypes.rs
@@ -118,8 +118,6 @@ pub(crate) struct ReplicatedArchetype {
 }
 
 pub(crate) struct ReplicatedComponent {
-    pub(crate) delta_compression: bool,
-    pub(crate) replicate_once: bool,
     pub(crate) id: ComponentId,
     pub(crate) kind: ComponentKind,
     pub(crate) storage_type: StorageType,
@@ -205,21 +203,10 @@ impl<C: Component> ReplicatedArchetypes<C> {
                     }
                     trace!("including {:?} in replicated components", info.name());
 
-                    // check per component metadata
-                    // TODO: should we store the components in a hashmap for faster lookup?
-                    let delta_compression = archetype
-                        .components()
-                        .any(|c| c == replication_metadata.delta_compression_id);
-                    let replicate_once = archetype
-                        .components()
-                        .any(|c| c == replication_metadata.replicate_once_id);
-
                     // SAFETY: component ID obtained from this archetype.
                     let storage_type =
                         unsafe { archetype.get_storage_type(component).unwrap_unchecked() };
                     replicated_archetype.components.push(ReplicatedComponent {
-                        delta_compression,
-                        replicate_once,
                         id: component,
                         kind,
                         storage_type,

--- a/lightyear/src/shared/replication/components.rs
+++ b/lightyear/src/shared/replication/components.rs
@@ -153,8 +153,6 @@ impl DeltaCompression {
     }
 }
 
-
-
 /// If this component is present, we won't replicate the component
 ///
 /// (By default, all components that are present in the [`ComponentRegistry`](crate::prelude::ComponentRegistry) will be replicated.)
@@ -251,8 +249,6 @@ impl ReplicateOnce {
         self.kinds.contains(&kind)
     }
 }
-
-
 
 #[derive(Debug, Default, Copy, Clone, PartialEq, Reflect)]
 pub enum ReplicationGroupIdBuilder {

--- a/lightyear/src/shared/replication/components.rs
+++ b/lightyear/src/shared/replication/components.rs
@@ -125,19 +125,35 @@ pub struct DisableReplicateHierarchy;
 ///
 /// Instead of sending the full component every time, we will only send the diffs between the old
 /// and new state.
-#[derive(Component, Clone, Copy, Debug, PartialEq, Reflect)]
+#[derive(Component, Clone, Debug, Default, PartialEq, Reflect)]
 #[reflect(Component)]
-pub struct DeltaCompression<C> {
-    _marker: std::marker::PhantomData<C>,
+pub struct DeltaCompression {
+    // we use a Vec instead of a HashSet to go faster, I doubt there would be many cases
+    // where we have duplicate kinds here
+    kinds: Vec<ComponentKind>,
 }
 
-impl<C> Default for DeltaCompression<C> {
-    fn default() -> Self {
-        Self {
-            _marker: Default::default(),
-        }
+impl DeltaCompression {
+    pub fn add<C: Component>(mut self) -> Self {
+        self.kinds.push(ComponentKind::of::<C>());
+        self
+    }
+
+    pub fn remove<C: Component>(mut self) -> Self {
+        self.kinds.retain(|kind| *kind != ComponentKind::of::<C>());
+        self
+    }
+
+    pub fn enabled<C: Component>(&self) -> bool {
+        self.enabled_kind(ComponentKind::of::<C>())
+    }
+
+    pub(crate) fn enabled_kind(&self, kind: ComponentKind) -> bool {
+        self.kinds.contains(&kind)
     }
 }
+
+
 
 /// If this component is present, we won't replicate the component
 ///
@@ -198,21 +214,45 @@ impl DisabledComponents {
     }
 }
 
-/// If this component is present, we will replicate only the inserts/removals of the component,
-/// not the updates (i.e. the component will get only replicated once at entity spawn)
-#[derive(Component, Clone, Copy, Debug, PartialEq, Reflect)]
+/// Component that can be used to specify which components we will only send inserts/removals
+/// but not component updates. The component will only get replicated once at entity spawn.
+#[derive(Component, Clone, Debug, Default, PartialEq, Reflect)]
 #[reflect(Component)]
-pub struct ReplicateOnceComponent<C> {
-    _marker: std::marker::PhantomData<C>,
+pub struct ReplicateOnce {
+    // we use a Vec instead of a HashSet to go faster, I doubt there would be many cases
+    // where we have duplicate kinds here
+    kinds: Vec<ComponentKind>,
 }
 
-impl<C> Default for ReplicateOnceComponent<C> {
-    fn default() -> Self {
-        Self {
-            _marker: Default::default(),
-        }
+impl ReplicateOnce {
+    pub fn add<C: Component>(mut self) -> Self {
+        self.add_mut::<C>();
+        self
+    }
+
+    pub fn add_mut<C: Component>(&mut self) {
+        self.kinds.push(ComponentKind::of::<C>());
+    }
+
+    pub fn remove<C: Component>(mut self) -> Self {
+        self.remove_mut::<C>();
+        self
+    }
+
+    pub fn remove_mut<C: Component>(&mut self) {
+        self.kinds.retain(|kind| *kind != ComponentKind::of::<C>());
+    }
+
+    pub fn enabled<C: Component>(&self) -> bool {
+        self.enabled_kind(ComponentKind::of::<C>())
+    }
+
+    pub(crate) fn enabled_kind(&self, kind: ComponentKind) -> bool {
+        self.kinds.contains(&kind)
     }
 }
+
+
 
 #[derive(Debug, Default, Copy, Clone, PartialEq, Reflect)]
 pub enum ReplicationGroupIdBuilder {


### PR DESCRIPTION
Pros:
- the code is generally simpler
- it is easier to call `ReplicateOnce.remove::<C>`() then `commands.entity(e).remove::<ReplicateOnce<C>>()`
- consistency with other replication components
- limits archetype fragmentation

Cons:
- makes code slightly less optimized because we need to look at the value of the component instead of caching at the archetype level that a component is replicate-once. This optimization was only possible because ReplicateOnce<C> is currently a marker component, which might change in the future