### PR TITLE
Remove confusing duplicate replication interval settings

### DIFF
--- a/examples/common/src/app.rs
+++ b/examples/common/src/app.rs
@@ -232,20 +232,6 @@ impl Apps {
         }
     }
 
-    /// Set the `server_replication_send_interval` on client and server apps.
-    /// Use to overwrite the default [`SharedConfig`] value in the settings file.
-    pub fn with_server_replication_send_interval(mut self, replication_interval: Duration) -> Self {
-        self.update_lightyear_client_config(|cc: &mut ClientConfig| {
-            cc.shared.server_replication_send_interval = replication_interval
-        });
-        self.update_lightyear_server_config(|sc: &mut ServerConfig| {
-            // the server replication currently needs to be overwritten in both places...
-            sc.shared.server_replication_send_interval = replication_interval;
-            sc.replication.send_interval = replication_interval;
-        });
-        self
-    }
-
     /// Add the lightyear [`ClientPlugins`] and [`ServerPlugins`] plugin groups to the app.
     ///
     /// This can be called after any modifications to the [`ClientConfig`] and [`ServerConfig`]
@@ -523,10 +509,6 @@ pub fn client_app(settings: Settings, net_config: client::NetConfig) -> (App, Cl
     let client_config = ClientConfig {
         shared: shared_config(),
         net: net_config,
-        replication: ReplicationConfig {
-            send_interval: REPLICATION_INTERVAL,
-            ..default()
-        },
         ..default()
     };
     (app, client_config)
@@ -557,10 +539,6 @@ pub fn server_app(
     let server_config = ServerConfig {
         shared: shared_config(),
         net: net_configs,
-        replication: ReplicationConfig {
-            send_interval: REPLICATION_INTERVAL,
-            ..default()
-        },
         ..default()
     };
     (app, server_config)
@@ -583,10 +561,6 @@ pub fn combined_app(
     let server_config = ServerConfig {
         shared: shared_config(),
         net: net_configs,
-        replication: ReplicationConfig {
-            send_interval: REPLICATION_INTERVAL,
-            ..default()
-        },
         ..default()
     };
 

--- a/examples/spaceships/src/main.rs
+++ b/examples/spaceships/src/main.rs
@@ -1,15 +1,10 @@
 #![allow(unused_imports)]
 #![allow(unused_variables)]
 #![allow(dead_code)]
-use std::time::Duration;
 
 use crate::settings::get_settings;
 use bevy::prelude::*;
-use lightyear::client::config::ClientConfig;
-use lightyear::prelude::client::PredictionConfig;
-use lightyear::server::config::ServerConfig;
 use lightyear_examples_common::app::{Apps, Cli};
-use lightyear_examples_common::settings::Settings;
 
 #[cfg(feature = "client")]
 mod client;
@@ -32,10 +27,7 @@ fn main() {
     lightyear_examples_common::settings::modify_digest_on_wasm(&mut settings.common.client);
     // build the bevy app (this adds common plugin such as the DefaultPlugins)
     // and returns the `ClientConfig` and `ServerConfig` so that we can modify them if needed
-    let mut apps = Apps::new(settings.common, cli, env!("CARGO_PKG_NAME").to_string())
-        .with_server_replication_send_interval(Duration::from_millis(
-            settings.server_replication_send_interval,
-        ));
+    let mut apps = Apps::new(settings.common, cli, env!("CARGO_PKG_NAME").to_string());
     // use input delay and a correction function to smooth over rollback errors
     apps.update_lightyear_client_config(|config| {
         config

--- a/lightyear/src/client/interpolation/plugin.rs
+++ b/lightyear/src/client/interpolation/plugin.rs
@@ -72,8 +72,8 @@ pub struct InterpolationConfig {
 impl Default for InterpolationConfig {
     fn default() -> Self {
         Self {
-            min_delay: Duration::from_millis(0),
-            send_interval_ratio: 2.0,
+            min_delay: Duration::from_millis(5),
+            send_interval_ratio: 1.3,
         }
     }
 }

--- a/lightyear/src/client/replication.rs
+++ b/lightyear/src/client/replication.rs
@@ -169,8 +169,8 @@ pub(crate) mod send {
             let send_interval = app
                 .world()
                 .resource::<ClientConfig>()
-                .replication
-                .send_interval;
+                .shared
+                .client_replication_send_interval;
 
             app
                 // REFLECTION

--- a/lightyear/src/server/plugin.rs
+++ b/lightyear/src/server/plugin.rs
@@ -36,19 +36,16 @@ use super::config::ServerConfig;
 ///   disabled if you don't need client to server replication.
 /// - [`ServerReplicationSendPlugin`]: Handles the replication of entities and resources from the server to the client. This can be
 ///   disabled if you don't need server to client replication.
+#[derive(Default)]
 pub struct ServerPlugins {
     pub config: ServerConfig,
 }
 
 impl ServerPlugins {
     pub fn new(config: ServerConfig) -> Self {
-        if config.shared.server_replication_send_interval != config.replication.send_interval {
-            error!(
-                "The config.shared.server_replication_send_interval {:?} is different from the config.replication.send_interval {:?}. This can cause issues. They should be set to the same value",
-                config.shared.server_replication_send_interval, config.replication.send_interval
-            );
+        Self {
+            config
         }
-        Self { config }
     }
 }
 

--- a/lightyear/src/server/replication.rs
+++ b/lightyear/src/server/replication.rs
@@ -85,8 +85,8 @@ pub(crate) mod send {
             let send_interval = app
                 .world()
                 .resource::<ServerConfig>()
-                .replication
-                .send_interval;
+                .shared
+                .server_replication_send_interval;
 
             app
                 // REFLECTION

--- a/lightyear/src/shared/config.rs
+++ b/lightyear/src/shared/config.rs
@@ -7,9 +7,16 @@ use crate::shared::tick_manager::TickConfig;
 /// Configuration that has to be the same between the server and the client.
 #[derive(Clone, Copy, Debug, Reflect)]
 pub struct SharedConfig {
-    /// how often does the server send replication updates to the client?
-    /// A duration of 0 means that we send replication updates every frame
+    /// How often does the server send replication updates to the client?
+    /// A duration of 0 means that we send replication updates every frame.
+    ///
+    /// This setting is present here and not in the server's ReplicationConfig
+    /// because the client needs to have access to this value to compute
+    /// how much interpolation delay to use.
     pub server_replication_send_interval: Duration,
+    /// How often does the client send replication updates to the server?
+    /// A duration of 0 means that we send replication updates every frame.
+    pub client_replication_send_interval: Duration,
     /// configuration for the [`FixedUpdate`](bevy::prelude::FixedUpdate) schedule
     pub tick: TickConfig,
 }
@@ -18,6 +25,7 @@ impl Default for SharedConfig {
     fn default() -> Self {
         Self {
             server_replication_send_interval: Duration::from_millis(0),
+            client_replication_send_interval: Duration::from_millis(0),
             tick: TickConfig::new(Duration::from_millis(16)),
         }
     }

--- a/lightyear/src/shared/replication/plugin.rs
+++ b/lightyear/src/shared/replication/plugin.rs
@@ -16,10 +16,6 @@ use bevy::utils::Duration;
 pub struct ReplicationConfig {
     /// How do send component updates?
     pub send_updates_mode: SendUpdatesMode,
-    /// How often we send replication updates.
-    ///
-    /// Set to `Duration::default()` to send updates every frame.
-    pub send_interval: Duration,
 }
 
 #[derive(Clone, Copy, Debug, Reflect)]
@@ -46,7 +42,6 @@ impl Default for ReplicationConfig {
     fn default() -> Self {
         Self {
             send_updates_mode: SendUpdatesMode::SinceLastAck,
-            send_interval: Duration::default(),
         }
     }
 }

--- a/lightyear/src/shared/replication/send.rs
+++ b/lightyear/src/shared/replication/send.rs
@@ -585,9 +585,8 @@ impl ReplicationSender {
         let priority_multiplier = 1.0;
         self.group_channels.values_mut().for_each(|channel| {
             trace!(
-                "in accumulate priority: accumulated={:?} base={:?} multiplier={:?}, send_interval={:?}, time_manager_delta={:?}",
+                "in accumulate priority: accumulated={:?} base={:?} multiplier={:?}, time_manager_delta={:?}",
                 channel.accumulated_priority, channel.base_priority, priority_multiplier,
-                self.replication_config.send_interval.as_nanos(),
                 time_manager.delta().as_nanos()
             );
             channel.accumulated_priority += channel.base_priority * priority_multiplier;


### PR DESCRIPTION
- remove duplicate replication_interval settings and put all settings in SharedConfig
- set a minimum InterpolationDelay of 5ms by default