### PR TITLE
clarify packet loss for samples

### DIFF
--- a/examples/common/src/settings.rs
+++ b/examples/common/src/settings.rs
@@ -105,6 +105,7 @@ pub struct Conditioner {
     /// One way jitter in milliseconds
     pub jitter_ms: u16,
     /// Percentage of packet loss
+    /// Represented as a value between 0 and 1
     pub packet_loss: f32,
 }
 


### PR DESCRIPTION
Added a simple comment to indicate that package loss is defined between `[0,1]` as described in the `LinkConditionerConfig`