### PR TITLE
Improve correction and add test

### DIFF
--- a/lightyear/src/client/prediction/correction.rs
+++ b/lightyear/src/client/prediction/correction.rs
@@ -1,65 +1,34 @@
-//! This module provides the ability to smooth the rollback (from the Predicted state to the Corrected state) over a certain amount of ticks, instead
-//! of just snapping back instantly to the Corrected state
-
-// maybe multiple correction_modes:
-// - instant (default)
-// - interpolate (provided)
-// - custom
-
+//! This module provides the ability to smooth the rollback (from the Predicted state to the Corrected state) over a period
+//! of time instead of just snapping back instantly to the Corrected state. This might help hide rollback artifacts.
+//! We will call the interpolated state the Visual state.
+//!
+//! For example the current tick is 10, and you have a predicted value P10.
+//! You receive a confirmed update C5 for tick 5, which doesn't match with the value we had stored in the
+//! prediction history at tick 5. This means we need to rollback.
+//!
+//! Without correction, we would simply snap back the value at tick 5 to C5, and then re-run the simulation
+//! from tick 5 to 10 to get a new value C10 at tick 10. The simulation will visually snap back from (predicted) P10 to (corrected) C10.
+//! Instead what we can do is correct the value from P10 to C10 over a period of time.
+//!
+//! The flow is (if T is the tick for the start of the rollback, and X is the current tick)
+//! - PreUpdate: we see that there is a rollback needed. We insert Correction {
+//!   original_value = PT, start_tick, end_tick
+//! }
+//! - RunRollback, which lets us compute the correct CT value.
+//! - FixedUpdate: we run the simulation to get the new value C(T+1)
+//! - FixedPostUpdate: set the component value to the interpolation between PT and C(T+1)
+//!
+//! - PreUpdate: restore the C(T+1) value (corrected value at the current tick T+1)
+//!   - if there is a rollback, restart correction from the current corrected value
+//! - FixedUpdate: run the simulation to compute C(T+2).
+//! - FixedPostUpdate: set the component value to the interpolation between PT (predicted value at rollback start T) and C(T+2)
 use bevy::prelude::{Commands, Component, DetectChangesMut, Entity, Query, Res};
 use tracing::debug;
 
-use crate::client::components::{LerpFn, SyncComponent};
-use crate::client::easings::ease_out_quad;
+use crate::client::components::SyncComponent;
 use crate::prelude::{ComponentRegistry, Tick, TickManager};
 
-// TODO: instead of requiring the component to implement the correction, we could have a separate
-//  'type registry' that stores the correction function for each component type.
-//  or we register in the protocol (that is user defined), the correction function for each component type
-//  P::CorrectionFn<C> -> CorrectionFn<C>
-//  or something like P::Interpolate<C: ComponentKind> -> InterpolationFn<C>
-
-// pub trait CorrectionFn<C> {
-//     /// How do we perform the correction between the original Predicted state and the Corrected state?
-//     /// (t is the interpolation factor between the tick of the original Predicted state and the tick of the Corrected state)
-//     fn correct(predicted: C, corrected: C, t: f32) -> C;
-//
-//     // fn get_correction_final_tick(&self, prediction_tick: Tick) -> Tick;
-// }
-
-/// We snapback instantly to the Corrected state
-pub struct InstantCorrector;
-impl<C: Clone> LerpFn<C> for InstantCorrector {
-    fn lerp(predicted: &C, corrected: &C, t: f32) -> C {
-        // the correction is instant, so we just return the Corrected state
-        corrected.clone()
-    }
-
-    // fn get_correction_final_tick(&self, prediction_tick: Tick) -> Tick {
-    //     // the correction is instant, so the final tick is the same as the prediction tick
-    //     prediction_tick
-    // }
-}
-
-/// We use the components interpolation behaviour to interpolate from the Predicted state to the
-/// Corrected state
-pub struct InterpolatedCorrector;
-// {
-//     The number of ticks that we will perform the correction over
-// correction_ticks: Tick,
-// }
-
-// impl<C: InterpolatedComponent<C>> CorrectionFn<C> for InterpolatedCorrector {
-//     fn correct(predicted: C, corrected: C, t: f32) -> C {
-//         C::lerp(predicted, corrected, t)
-//     }
-//     //
-//     // fn get_correction_final_tick(&self, prediction_tick: Tick) -> Tick {
-//     //     prediction_tick + self.correction_ticks
-//     // }
-// }
-
-#[derive(Component, Debug)]
+#[derive(Component, Debug, PartialEq)]
 pub struct Correction<C: Component> {
     /// This is what the original predicted value was before any correction was applied
     pub original_prediction: C,
@@ -67,38 +36,37 @@ pub struct Correction<C: Component> {
     pub original_tick: Tick,
     /// This is the tick at which we will have finished the correction
     pub final_correction_tick: Tick,
-
     /// This is the current visual value. We compute this so that if we rollback again in the middle of an
     /// existing correction, we start again from the current visual value.
     pub current_visual: Option<C>,
-
     /// This is the current objective (corrected) value. We need this to swap between the visual correction
     /// (interpolated between the original prediction and the final correction)
-    /// and the final correction value
+    /// and the final correction value (the correct value that we are simulating)
     pub current_correction: Option<C>,
 }
 
-/// Visually update the component to the a value that is interpolated between the original prediction
-/// and the Corrected state
-pub(crate) fn get_visually_corrected_state<C: SyncComponent>(
+/// Perform the correction: we interpolate between the original (incorrect) prediction and the final confirmed value
+/// over a period of time. The intermediary state is called the Corrected state.
+pub(crate) fn get_corrected_state<C: SyncComponent>(
     component_registry: Res<ComponentRegistry>,
     tick_manager: Res<TickManager>,
     mut commands: Commands,
     mut query: Query<(Entity, &mut C, &mut Correction<C>)>,
 ) {
     let kind = std::any::type_name::<C>();
+    let current_tick = tick_manager.tick();
     for (entity, mut component, mut correction) in query.iter_mut() {
-        let current_tick = tick_manager.tick();
         let mut t = (current_tick - correction.original_tick) as f32
             / (correction.final_correction_tick - correction.original_tick) as f32;
         t = t.clamp(0.0, 1.0);
-        let t = ease_out_quad(t);
+
+        // TODO: make the easing configurable
+        //  let t = ease_out_quad(t);
         if t == 1.0 || &correction.original_prediction == component.as_ref() {
             debug!(
                 ?t,
                 "Correction is over. Removing Correction for: {:?}", kind
             );
-            // correction is over
             commands.entity(entity).remove::<Correction<C>>();
         } else {
             debug!(?t, ?entity, start = ?correction.original_tick, end = ?correction.final_correction_tick, "Applying visual correction for {:?}", kind);
@@ -116,7 +84,7 @@ pub(crate) fn get_visually_corrected_state<C: SyncComponent>(
     }
 }
 
-/// At the start of the next frame, restore
+/// Before we check for rollbacks and run FixedUpdate, restore the correct component value
 pub(crate) fn restore_corrected_state<C: SyncComponent>(
     mut query: Query<(&mut C, &mut Correction<C>)>,
 ) {
@@ -134,7 +102,137 @@ pub(crate) fn restore_corrected_state<C: SyncComponent>(
     }
 }
 
-// - on rollback, we store the original Predicted position and the current tick
-// - we compute the final_correction_tick = current_tick + correction_ticks
-// - during rollback, the Predicted entity will take the Corrected position.
-// - in PostUpdate, during the correction_ticks, we will interpolated between the old
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::client::components::Confirmed;
+    use crate::client::config::ClientConfig;
+    use crate::client::prediction::rollback::test_utils::received_confirmed_update;
+    use crate::client::prediction::Predicted;
+    use crate::prelude::client::PredictionConfig;
+    use crate::prelude::{SharedConfig, TickConfig};
+    use crate::tests::protocol::ComponentCorrection;
+    use crate::tests::stepper::BevyStepper;
+    use approx::assert_relative_eq;
+    use bevy::app::FixedUpdate;
+    use bevy::prelude::default;
+    use std::time::Duration;
+
+    fn increment_component_system(
+        mut query: Query<(Entity, &mut ComponentCorrection)>,
+    ) {
+        for (entity, mut component) in query.iter_mut() {
+            component.0 += 1.0;
+        }
+    }
+
+    /// Test:
+    /// - normal correction
+    /// - rollback that happens while correction was under way
+    #[test]
+    fn test_correction() {
+        let frame_duration = Duration::from_millis(10);
+        let tick_duration = Duration::from_millis(10);
+        let shared_config = SharedConfig {
+            tick: TickConfig::new(tick_duration),
+            ..Default::default()
+        };
+        let client_config = ClientConfig {
+            prediction: PredictionConfig {
+                correction_ticks_factor: 1.0,
+                ..default()
+            },
+            ..default()
+        };
+        let mut stepper = BevyStepper::new(
+            shared_config,
+            client_config,
+            frame_duration
+        );
+        stepper.client_app.add_systems(FixedUpdate, increment_component_system);
+        stepper.build();
+        stepper.init();
+
+
+        // add predicted/confirmed entities
+        let tick = stepper.client_tick();
+        let confirmed = stepper
+            .client_app
+            .world_mut()
+            .spawn((
+                       Confirmed {
+                           tick,
+                           ..Default::default()
+                       }, ComponentCorrection(2.0)
+            ))
+           .id();
+        let predicted = stepper
+            .client_app
+            .world_mut()
+            .spawn(Predicted {
+                confirmed_entity: Some(confirmed),
+            })
+            .id();
+        stepper
+            .client_app
+            .world_mut()
+            .entity_mut(confirmed)
+            .get_mut::<Confirmed>()
+            .unwrap()
+            .predicted = Some(predicted);
+        stepper.frame_step();
+
+        // we insert the component at a different frame to not trigger an early rollback
+        stepper.client_app.world_mut().entity_mut(predicted).insert(ComponentCorrection(1.0));
+        stepper.frame_step();
+
+        // trigger a rollback (the predicted value doesn't exist in the prediction history)
+        let original_tick = stepper.client_tick();
+        let rollback_tick = original_tick-5;
+        received_confirmed_update(&mut stepper, confirmed, rollback_tick);
+
+        stepper.frame_step();
+        // check that a correction is applied
+        assert_eq!(
+            stepper.client_app.world().get::<Correction<ComponentCorrection>>(predicted).unwrap(),
+            &Correction::<ComponentCorrection> {
+                original_prediction: ComponentCorrection(2.0),
+                original_tick,
+                final_correction_tick: original_tick + (original_tick - rollback_tick),
+                // interpolate 20% of the way
+                current_visual: Some(ComponentCorrection(3.6)),
+                current_correction: Some(ComponentCorrection(10.0)),
+            }
+        );
+
+        // check that the correction value has been incremented and that the visual value has been updated correctly
+        stepper.frame_step();
+        let correction = stepper.client_app.world().get::<Correction<ComponentCorrection>>(predicted).unwrap();
+        assert_relative_eq!(correction.current_visual.as_ref().unwrap().0, 5.6);
+        assert_eq!(correction.current_correction.as_ref().unwrap().0, 11.0);
+
+        // trigger a new rollback while the correction is under way
+        let original_tick = stepper.client_tick();
+        let rollback_tick = original_tick-5;
+        received_confirmed_update(&mut stepper, confirmed, rollback_tick);
+        stepper.frame_step();
+
+        // check that the correction has been updated
+        let correction = stepper.client_app.world().get::<Correction<ComponentCorrection>>(predicted).unwrap();
+        // the new correction starts from the previous visual value
+        assert_relative_eq!(correction.original_prediction.0, 5.6);
+        assert_eq!(correction.original_tick, original_tick);
+        assert_eq!(correction.final_correction_tick, original_tick + (original_tick - rollback_tick));
+        // interpolate 20% of the way
+        assert_relative_eq!(correction.current_visual.as_ref().unwrap().0, 7.88);
+        assert_eq!(correction.current_correction.as_ref().unwrap().0, 17.0);
+        stepper.frame_step();
+        stepper.frame_step();
+        stepper.frame_step();
+        let correction = stepper.client_app.world().get::<Correction<ComponentCorrection>>(predicted).unwrap();
+        // interpolate 80% of the way
+        assert_relative_eq!(correction.current_visual.as_ref().unwrap().0, 17.12);
+        assert_eq!(correction.current_correction.as_ref().unwrap().0, 20.0);
+    }
+}

--- a/lightyear/src/client/prediction/plugin.rs
+++ b/lightyear/src/client/prediction/plugin.rs
@@ -1,6 +1,6 @@
 use crate::client::components::{ComponentSyncMode, Confirmed, SyncComponent};
 use crate::client::prediction::correction::{
-    get_visually_corrected_state, restore_corrected_state,
+    get_corrected_state, restore_corrected_state,
 };
 use crate::client::prediction::despawn::{
     despawn_confirmed, remove_component_for_despawn_predicted, remove_despawn_marker,
@@ -18,7 +18,6 @@ use crate::prelude::{is_host_server, PreSpawnedPlayerObject};
 use crate::shared::sets::{ClientMarker, InternalMainSet};
 use bevy::prelude::*;
 use bevy::reflect::Reflect;
-use bevy::transform::TransformSystem;
 use bevy::utils::Duration;
 use std::fmt::Debug;
 
@@ -33,7 +32,7 @@ use super::rollback::{
 };
 use super::spawn::spawn_predicted_entity;
 
-use crate::prelude::client::is_connected;
+use crate::prelude::client::{is_connected, InterpolationSet};
 
 /// Configuration to specify how the prediction plugin should behave
 #[derive(Debug, Clone, Copy, Reflect)]
@@ -205,7 +204,7 @@ pub enum PredictionSet {
     /// Update the client's predicted history; runs after each physics step in the FixedUpdate Schedule
     UpdateHistory,
 
-    // PostUpdate Sets
+    // FixedLast Sets
     /// Visually interpolate the predicted components to the corrected state
     VisualCorrection,
 
@@ -219,7 +218,7 @@ pub fn is_in_rollback(rollback: Option<Res<Rollback>>) -> bool {
 }
 
 /// Enable rollbacking a component even if the component is not networked
-pub fn add_non_networked_rollback_systems<C: Component + PartialEq + Clone>(app: &mut App) {
+pub fn add_non_networked_rollback_systems<C: Component + PartialEq + Clone + Debug>(app: &mut App) {
     app.add_observer(apply_component_removal_predicted::<C>);
     app.add_observer(add_prediction_history::<C>);
     app.add_systems(
@@ -311,8 +310,8 @@ pub fn add_prediction_systems<C: SyncComponent>(app: &mut App, prediction_mode: 
                 ),
             );
             app.add_systems(
-                PostUpdate,
-                get_visually_corrected_state::<C>.in_set(PredictionSet::VisualCorrection),
+                FixedLast,
+                get_corrected_state::<C>.in_set(PredictionSet::VisualCorrection),
             );
         }
         ComponentSyncMode::Simple => {
@@ -444,15 +443,18 @@ impl Plugin for PredictionPlugin {
             ),
         );
 
-        // PostUpdate systems
-        // 1. Visually interpolate the prediction to the corrected state
+        // FixedLast systems
+        // 1. Interpolate between the confirmed state and the incorrect predicted state
         app.configure_sets(
-            PostUpdate,
+            FixedLast,
             PredictionSet::VisualCorrection
+                // we want visual interpolation to use the corrected state
+                .before(InterpolationSet::UpdateVisualInterpolationState)
+                // no need to update the visual state during rollbacks
+                .run_if(not(is_in_rollback))
                 .in_set(PredictionSet::All)
-                .before(TransformSystem::TransformPropagate),
         )
-        .configure_sets(PostUpdate, PredictionSet::All.run_if(should_prediction_run));
+        .configure_sets(FixedLast, PredictionSet::All.run_if(should_prediction_run));
 
         // PLUGINS
         app.add_plugins((PrePredictionPlugin, PreSpawnedPlayerObjectPlugin));

--- a/lightyear/src/client/prediction/plugin.rs
+++ b/lightyear/src/client/prediction/plugin.rs
@@ -218,7 +218,7 @@ pub fn is_in_rollback(rollback: Option<Res<Rollback>>) -> bool {
 }
 
 /// Enable rollbacking a component even if the component is not networked
-pub fn add_non_networked_rollback_systems<C: Component + PartialEq + Clone + Debug>(app: &mut App) {
+pub fn add_non_networked_rollback_systems<C: Component + PartialEq + Clone>(app: &mut App) {
     app.add_observer(apply_component_removal_predicted::<C>);
     app.add_observer(add_prediction_history::<C>);
     app.add_systems(

--- a/lightyear/src/client/prediction/predicted_history.rs
+++ b/lightyear/src/client/prediction/predicted_history.rs
@@ -378,7 +378,7 @@ mod tests {
             .client_app
             .world_mut()
             .entity_mut(predicted)
-            .insert(ComponentSyncModeFull2(2.0));
+            .insert(ComponentCorrection(2.0));
         stepper.frame_step();
         let tick = stepper.client_tick();
         assert_eq!(
@@ -386,10 +386,10 @@ mod tests {
                 .client_app
                 .world_mut()
                 .entity_mut(predicted)
-                .get_mut::<PredictionHistory<ComponentSyncModeFull2>>()
+                .get_mut::<PredictionHistory<ComponentCorrection>>()
                 .expect("Expected prediction history to be added")
                 .pop_until_tick(tick),
-            Some(HistoryState::Updated(ComponentSyncModeFull2(2.0))),
+            Some(HistoryState::Updated(ComponentCorrection(2.0))),
             "Expected component value to be added to prediction history"
         );
         assert_eq!(
@@ -397,9 +397,9 @@ mod tests {
                 .client_app
                 .world()
                 .entity(predicted)
-                .get::<ComponentSyncModeFull2>()
+                .get::<ComponentCorrection>()
                 .expect("Expected component to be added to predicted entity"),
-            &ComponentSyncModeFull2(2.0),
+            &ComponentCorrection(2.0),
             "Expected component to be added to predicted entity"
         );
 

--- a/lightyear/src/client/prediction/prespawn.rs
+++ b/lightyear/src/client/prediction/prespawn.rs
@@ -80,6 +80,7 @@ impl PreSpawnedPlayerObjectPlugin {
                 .or_default()
                 .push(entity);
 
+
             if prediction_manager
                 .prespawn_hash_to_entities
                 .get(&hash)
@@ -244,6 +245,7 @@ impl PreSpawnedPlayerObjectPlugin {
                 .iter()
                 .flatten()
                 .for_each(|entity| {
+                    dbg!(entity);
                     if let Some(entity_commands) = commands.get_entity(*entity) {
                         trace!(
                             ?tick,
@@ -656,11 +658,9 @@ mod tests {
             .is_none());
 
         // if enough frames pass without match, the entity gets cleaned
-        stepper.frame_step();
-        stepper.frame_step();
-        stepper.frame_step();
-        stepper.frame_step();
-        stepper.frame_step();
+        for _ in 0..10 {
+            stepper.frame_step();
+        }
         assert!(stepper
             .client_app
             .world()

--- a/lightyear/src/client/prediction/rollback.rs
+++ b/lightyear/src/client/prediction/rollback.rs
@@ -350,7 +350,7 @@ pub(crate) fn prepare_rollback<C: SyncComponent>(
                 match predicted_component {
                     None => {
                         debug!("Re-adding deleted Full component to predicted");
-                        entity_mut.insert(rollbacked_predicted_component.clone());
+                        entity_mut.insert(rollbacked_predicted_component);
                     }
                     Some(mut predicted_component) => {
                         // // no need to do a correction if the values are the same
@@ -362,12 +362,11 @@ pub(crate) fn prepare_rollback<C: SyncComponent>(
                         let correction_ticks = ((current_tick - rollback_tick) as f32
                             * config.prediction.correction_ticks_factor)
                             .round() as i16;
-
                         // no need to add the Correction if the correction is instant
                         if correction_ticks != 0 && component_registry.has_correction::<C>() {
                             let final_correction_tick = current_tick + correction_ticks;
                             if let Some(correction) = correction.as_mut() {
-                                debug!("updating existing correction");
+                                trace!("updating existing correction");
                                 // if there is a correction, start the correction again from the previous
                                 // visual state to avoid glitches
                                 correction.original_prediction =
@@ -375,11 +374,9 @@ pub(crate) fn prepare_rollback<C: SyncComponent>(
                                         .unwrap_or_else(|| predicted_component.clone());
                                 correction.original_tick = current_tick;
                                 correction.final_correction_tick = final_correction_tick;
-                                // TODO: can set this to None, shouldnt make any diff
-                                correction.current_correction =
-                                    Some(rollbacked_predicted_component.clone());
+                                correction.current_correction = None;
                             } else {
-                                debug!("inserting new correction");
+                                trace!("inserting new correction");
                                 entity_mut.insert(Correction {
                                     original_prediction: predicted_component.clone(),
                                     original_tick: current_tick,
@@ -391,7 +388,7 @@ pub(crate) fn prepare_rollback<C: SyncComponent>(
                         }
 
                         // update the component to the corrected value
-                        *predicted_component = rollbacked_predicted_component.clone();
+                        *predicted_component = rollbacked_predicted_component;
                     }
                 };
             }
@@ -751,7 +748,7 @@ pub(crate) fn increment_rollback_tick(rollback: Res<Rollback>) {
 }
 
 #[cfg(test)]
-pub(super) mod test_utils {
+pub(crate) mod test_utils {
     use crate::client::components::Confirmed;
     use crate::client::connection::ConnectionManager;
     use crate::prelude::Tick;
@@ -760,7 +757,7 @@ pub(super) mod test_utils {
     use std::time::Duration;
 
     /// Helper function to simulate that we received a server message
-    pub(super) fn received_confirmed_update(
+    pub(crate) fn received_confirmed_update(
         stepper: &mut BevyStepper,
         confirmed: Entity,
         tick: Tick,

--- a/lightyear/src/protocol/component.rs
+++ b/lightyear/src/protocol/component.rs
@@ -1306,7 +1306,7 @@ pub trait AppComponentExt {
     ) -> ComponentRegistration<'_, C>;
 
     /// Enable rollbacks for a component even if the component is not networked
-    fn add_rollback<C: Component + PartialEq + Clone>(&mut self);
+    fn add_rollback<C: Component + PartialEq + Clone + Debug>(&mut self);
 
     /// Enable rollbacks for a resource.
     fn add_resource_rollback<R: Resource + Clone>(&mut self);
@@ -1495,7 +1495,7 @@ impl AppComponentExt for App {
 
     // TODO: move this away from protocol? since it doesn't even use the registry at all
     //  maybe put this in the PredictionPlugin?
-    fn add_rollback<C: Component + PartialEq + Clone>(&mut self) {
+    fn add_rollback<C: Component + PartialEq + Clone + Debug>(&mut self) {
         let is_client = self.world().get_resource::<ClientConfig>().is_some();
         if is_client {
             add_non_networked_rollback_systems::<C>(self);

--- a/lightyear/src/protocol/component.rs
+++ b/lightyear/src/protocol/component.rs
@@ -1306,7 +1306,7 @@ pub trait AppComponentExt {
     ) -> ComponentRegistration<'_, C>;
 
     /// Enable rollbacks for a component even if the component is not networked
-    fn add_rollback<C: Component + PartialEq + Clone + Debug>(&mut self);
+    fn add_rollback<C: Component + PartialEq + Clone>(&mut self);
 
     /// Enable rollbacks for a resource.
     fn add_resource_rollback<R: Resource + Clone>(&mut self);
@@ -1495,7 +1495,7 @@ impl AppComponentExt for App {
 
     // TODO: move this away from protocol? since it doesn't even use the registry at all
     //  maybe put this in the PredictionPlugin?
-    fn add_rollback<C: Component + PartialEq + Clone + Debug>(&mut self) {
+    fn add_rollback<C: Component + PartialEq + Clone>(&mut self) {
         let is_client = self.world().get_resource::<ClientConfig>().is_some();
         if is_client {
             add_non_networked_rollback_systems::<C>(self);

--- a/lightyear/src/tests/protocol.rs
+++ b/lightyear/src/tests/protocol.rs
@@ -87,16 +87,16 @@ impl MapEntities for ComponentMapEntities {
 }
 
 #[derive(Component, Serialize, Deserialize, Clone, Debug, PartialEq, Reflect)]
-pub struct ComponentSyncModeFull2(pub f32);
+pub struct ComponentCorrection(pub f32);
 
-impl Mul<f32> for &ComponentSyncModeFull2 {
-    type Output = ComponentSyncModeFull2;
+impl Mul<f32> for &ComponentCorrection {
+    type Output = ComponentCorrection;
     fn mul(self, rhs: f32) -> Self::Output {
-        ComponentSyncModeFull2(self.0 * rhs)
+        ComponentCorrection(self.0 * rhs)
     }
 }
 
-impl Add<Self> for ComponentSyncModeFull2 {
+impl Add<Self> for ComponentCorrection {
     type Output = Self;
 
     fn add(self, rhs: Self) -> Self::Output {
@@ -240,8 +240,9 @@ impl Plugin for ProtocolPlugin {
             .add_prediction(ComponentSyncMode::Simple)
             .add_map_entities();
 
-        app.register_component::<ComponentSyncModeFull2>(ChannelDirection::ServerToClient)
+        app.register_component::<ComponentCorrection>(ChannelDirection::ServerToClient)
             .add_prediction(ComponentSyncMode::Full)
+            .add_linear_correction_fn()
             .add_interpolation(ComponentSyncMode::Full)
             .add_linear_interpolation_fn();
 


### PR DESCRIPTION
Correction was not behaving correctly with VisualInterpolation.

- Correction was running in `PostUpdate` without ordering with VisualInterpolation, which was causing issues
- Correction was running in `PostUpdate` but wasn't taking into account the frame overstep so the values were incorrect

This PR changes `Correction` to run in `FixedLast` before `VisualInterpolation::Update`; this way correction is only responsible for computing the correct visual value at tick T, and visual interpolation can still interpolate correctly (from FixedUpdate to PostUpdate)

Also added a unit test for correction