### PR TITLE
Add option to exclude an entity from rollback

### DIFF
--- a/lightyear/src/client/prediction/rollback.rs
+++ b/lightyear/src/client/prediction/rollback.rs
@@ -4,10 +4,7 @@ use std::ops::{Deref, DerefMut};
 use bevy::app::FixedMain;
 use bevy::ecs::entity::EntityHashSet;
 use bevy::ecs::reflect::ReflectResource;
-use bevy::prelude::{
-    Commands, Component, DespawnRecursiveExt, DetectChanges, Entity, Query, Ref, Res, ResMut,
-    Resource, With, Without, World,
-};
+use bevy::prelude::{Commands, Component, DespawnRecursiveExt, DetectChanges, Entity, Has, Query, Ref, Res, ResMut, Resource, With, Without, World};
 use bevy::reflect::Reflect;
 use bevy::time::{Fixed, Time};
 use parking_lot::RwLock;
@@ -24,6 +21,14 @@ use crate::prelude::{ComponentRegistry, HistoryState, PreSpawnedPlayerObject, Ti
 use super::predicted_history::PredictionHistory;
 use super::resource_history::ResourceHistory;
 use super::Predicted;
+
+
+#[derive(Component)]
+/// Marker component used to indicate that an entity:
+/// - won't trigger rollbacks
+/// - will never have mispredictions. During rollbacks we will revert the entity to the
+///   past value from the PredictionHistory instead of the confirmed value
+pub struct DisableRollback;
 
 /// Resource that indicates whether we are in a rollback state or not
 #[derive(Default, Resource, Reflect)]
@@ -108,7 +113,7 @@ pub(crate) fn check_rollback<C: SyncComponent>(
     tick_manager: Res<TickManager>,
     connection: Res<ConnectionManager>,
     // We also snap the value of the component to the server state if we are in rollback
-    mut predicted_query: Query<&mut PredictionHistory<C>, (With<Predicted>, Without<Confirmed>)>,
+    mut predicted_query: Query<&mut PredictionHistory<C>, (With<Predicted>, Without<Confirmed>, Without<DisableRollback>)>,
     // We use Option<> because the predicted component could have been removed while it still exists in Confirmed
     confirmed_query: Query<(Entity, Option<&C>, Ref<Confirmed>)>,
     rollback: Res<Rollback>,
@@ -280,6 +285,7 @@ pub(crate) fn prepare_rollback<C: SyncComponent>(
             Option<&mut C>,
             &mut PredictionHistory<C>,
             Option<&mut Correction<C>>,
+            Has<DisableRollback>,
         ),
         (
             With<Predicted>,
@@ -314,7 +320,7 @@ pub(crate) fn prepare_rollback<C: SyncComponent>(
         };
 
         // 1. Get the predicted entity, and its history
-        let Ok((predicted_component, mut predicted_history, mut correction)) =
+        let Ok((predicted_component, mut predicted_history, mut correction, disable_rollback)) =
             predicted_query.get_mut(predicted_entity)
         else {
             debug!(
@@ -328,13 +334,23 @@ pub(crate) fn prepare_rollback<C: SyncComponent>(
         // 2. we need to clear the history so we can write a new one
         let original_predicted_value = predicted_history.pop_until_tick_and_clear(rollback_tick);
 
+        // if rollback is disabled, we will restore the component to its past value from the prediction history
+        let correct_value = if disable_rollback {
+            original_predicted_value.as_ref().and_then(|v| match v {
+                HistoryState::Updated(v) => Some(v),
+                _ => None,
+            })
+        } else {
+            confirmed_component
+        };
+
         // SAFETY: we know the predicted entity exists
         let mut entity_mut = commands.entity(predicted_entity);
 
         // 3. we update the state to the Corrected state
         // NOTE: visually, we will use the CorrectionFn to interpolate between the current Predicted state and the Corrected state
         //  even though for other purposes (physics, etc.) we switch directly to the Corrected state
-        match confirmed_component {
+        match correct_value {
             // confirm does not exist, remove on predicted
             None => {
                 predicted_history.add_remove(rollback_tick);
@@ -342,11 +358,16 @@ pub(crate) fn prepare_rollback<C: SyncComponent>(
             }
             // confirm exist, update or insert on predicted
             Some(confirmed_component) => {
+                
                 let mut rollbacked_predicted_component = confirmed_component.clone();
-                let _ = manager.map_entities(
-                    &mut rollbacked_predicted_component,
-                    component_registry.as_ref(),
-                );
+                // when rollback is disabled, the correct value is taken from the prediction history
+                // so no need to map entities
+                if !disable_rollback {
+                    let _ = manager.map_entities(
+                        &mut rollbacked_predicted_component,
+                        component_registry.as_ref(),
+                    );
+                }
                 // TODO: do i need to add this to the history?
                 predicted_history.add_update(rollback_tick, rollbacked_predicted_component.clone());
                 match predicted_component {
@@ -406,7 +427,8 @@ pub(crate) fn prepare_rollback<C: SyncComponent>(
         };
     }
 }
-
+ 
+// TODO: handle disable rollback, by combining all prepare_rollback systems into one
 /// For prespawned predicted entities, we do not have a Confirmed component,
 /// we just rollback the entity to the previous state
 /// - entities that did not exist at the rollback tick are despawned (and should be respawned during rollback)
@@ -949,6 +971,8 @@ mod unit_tests {
             .resource::<Rollback>()
             .is_rollback());
     }
+    
+
 }
 
 /// More general integration tests for rollback
@@ -958,7 +982,9 @@ mod integration_tests {
 
     use super::test_utils::*;
 
+    use crate::client::prediction::predicted_history::PredictionHistory;
     use crate::client::prediction::resource::PredictionManager;
+    use crate::client::prediction::rollback::{check_rollback, DisableRollback};
     use crate::prelude::server::SyncTarget;
     use crate::prelude::{
         client::*, AppComponentExt, ChannelDirection, NetworkTarget, SharedConfig, TickConfig,
@@ -966,6 +992,7 @@ mod integration_tests {
     use crate::tests::protocol::*;
     use crate::tests::stepper::BevyStepper;
     use bevy::ecs::entity::MapEntities;
+    use bevy::ecs::system::RunSystemOnce;
     use bevy::prelude::*;
     use serde::{Deserialize, Serialize};
 
@@ -1466,5 +1493,120 @@ mod integration_tests {
             .get_mut::<ComponentSyncModeFull>(predicted)
             .unwrap()
             .0 = 4.0;
+    }
+
+    /// If we have disable_rollback:
+    /// 1) we don't check rollback for that entity
+    /// 2) if a rollback happens, we reset to the predicted history value instead of the confirmed value
+    #[test]
+    fn test_disable_rollback() {
+        let mut stepper = BevyStepper::default();
+
+        // add predicted/confirmed entities
+        let tick = stepper.client_tick();
+        let confirmed_a = stepper
+            .client_app
+            .world_mut()
+            .spawn((Confirmed {
+                tick,
+                ..Default::default()
+            }, ComponentSyncModeFull(1.0)))
+            .id();
+        let predicted_a = stepper
+            .client_app
+            .world_mut()
+            .spawn((Predicted {
+                confirmed_entity: Some(confirmed_a),
+            }, DisableRollback))
+            .id();
+        stepper
+            .client_app
+            .world_mut()
+            .entity_mut(confirmed_a)
+            .get_mut::<Confirmed>()
+            .unwrap()
+            .predicted = Some(predicted_a);
+        let confirmed_b = stepper
+            .client_app
+            .world_mut()
+            .spawn((Confirmed {
+                tick,
+                ..Default::default()
+            }, ComponentSyncModeFull(1.0)))
+            .id();
+        let predicted_b = stepper
+            .client_app
+            .world_mut()
+            .spawn(Predicted {
+                confirmed_entity: Some(confirmed_b),
+            })
+            .id();
+        stepper
+            .client_app
+            .world_mut()
+            .entity_mut(confirmed_b)
+            .get_mut::<Confirmed>()
+            .unwrap()
+            .predicted = Some(predicted_b);
+        stepper.frame_step();
+
+        stepper.client_app.world_mut().entity_mut(predicted_a).insert(ComponentSyncModeFull(1000.0));
+        stepper.client_app.world_mut().entity_mut(predicted_b).insert(ComponentSyncModeFull(1000.0));
+
+        // 1. check rollback doesn't trigger on disable-rollback entities
+        let tick = stepper.client_tick();
+        stepper
+            .client_app
+            .world_mut()
+            .entity_mut(confirmed_a)
+            .get_mut::<ComponentSyncModeFull>()
+            .unwrap()
+            .0 = 2.0;
+        // simulate that we received a server message for the confirmed entity on tick `tick`
+        received_confirmed_update(&mut stepper, confirmed_a, tick);
+        let _ = stepper
+            .client_app
+            .world_mut()
+            .run_system_once(check_rollback::<ComponentSyncModeFull>);
+        assert_eq!(
+            stepper
+                .client_app
+                .world()
+                .resource::<Rollback>()
+                .get_rollback_tick(),
+            None
+        );
+
+        // 2. If a rollback happens, then we reset DisableRollback entities to their historical value
+        stepper.frame_step();
+        let tick = stepper.client_tick();
+        stepper
+            .client_app
+            .world_mut()
+            .entity_mut(confirmed_b)
+            .get_mut::<ComponentSyncModeFull>()
+            .unwrap()
+            .0 = 2.0;
+        let mut history = PredictionHistory::<ComponentSyncModeFull>::default();
+        history.add_update(tick, ComponentSyncModeFull(10.0));
+        stepper
+            .client_app
+            .world_mut()
+            .entity_mut(predicted_a)
+            .insert(history);
+        // simulate that we received a server message for the confirmed entity on tick `tick`
+        received_confirmed_update(&mut stepper, confirmed_b, tick);
+        received_confirmed_update(&mut stepper, confirmed_a, tick);
+        stepper.frame_step();
+
+        // the DisableRollback entity was rolledback to the past PredictionHistory value
+        assert_eq!(stepper
+            .client_app
+            .world()
+            .get::<ComponentSyncModeFull>(predicted_a).unwrap().0, 10.0);
+        assert_eq!(stepper
+            .client_app
+            .world()
+            .get::<ComponentSyncModeFull>(predicted_b).unwrap().0, 2.0);
     }
 }


### PR DESCRIPTION
Adds a DisableRollback component which:
- excludes an entity from rollback checks
- during rollback, reverts the entity to its PredictionHistory state instead of to the Confirmed state