### PR TITLE
Update latest_tick correctly in receive_update

### DIFF
--- a/lightyear/src/client/prediction/correction.rs
+++ b/lightyear/src/client/prediction/correction.rs
@@ -23,7 +23,7 @@
 //! - FixedUpdate: run the simulation to compute C(T+2).
 //! - FixedPostUpdate: set the component value to the interpolation between PT (predicted value at rollback start T) and C(T+2)
 use bevy::prelude::{Commands, Component, DetectChangesMut, Entity, Query, Res};
-use tracing::{debug, warn};
+use tracing::debug;
 
 use crate::client::components::SyncComponent;
 use crate::prelude::{ComponentRegistry, Tick, TickManager};

--- a/lightyear/src/client/prediction/plugin.rs
+++ b/lightyear/src/client/prediction/plugin.rs
@@ -30,7 +30,7 @@ use super::rollback::{
 };
 use super::spawn::spawn_predicted_entity;
 
-use crate::prelude::client::{is_connected, InterpolationSet};
+use crate::prelude::client::is_connected;
 
 /// Configuration to specify how the prediction plugin should behave
 #[derive(Debug, Clone, Copy, Reflect)]

--- a/lightyear/src/client/prediction/rollback.rs
+++ b/lightyear/src/client/prediction/rollback.rs
@@ -11,7 +11,7 @@ use bevy::prelude::{
 use bevy::reflect::Reflect;
 use bevy::time::{Fixed, Time};
 use parking_lot::RwLock;
-use tracing::{debug, error, trace, trace_span, warn};
+use tracing::{debug, error, trace, trace_span};
 
 use crate::client::components::{Confirmed, SyncComponent};
 use crate::client::config::ClientConfig;


### PR DESCRIPTION
In replication_receive, we keep track of a `latest_tick` for each ReplicationChannel, which is according to the comment the latest tick at which we have receive an Action or an Update for the ReplicationGroup.

The comment was actually wrong because the `latest_tick` was only updated for Actions, not Updates.

This was causing erroneous rollbacks in the following situations:
- on the client, we receive an Action for tick T for an entity with ShouldBePredicted
- in the same frame, we receive an Update for tick T' for that same entity
- in PredictionSet::Spawn, we spawn Confirmed with `confirmed.tick = channel.latest_tick = T`, even though the entity contains component values for tick T'
- In rollback we get a mismatch because the ticks were incorrect

This fix ensures that the latest_tick is correctly updated even for `Update` messages.