### PR TITLE
Do not rollback on initial Confirmed spawn

### DIFF
--- a/lightyear/src/client/prediction/plugin.rs
+++ b/lightyear/src/client/prediction/plugin.rs
@@ -431,7 +431,10 @@ impl Plugin for PredictionPlugin {
             FixedPostUpdate,
             PredictionSet::All.run_if(should_prediction_run.clone()),
         );
-        app.add_systems(FixedPostUpdate, remove_despawn_marker.in_set(PredictionSet::EntityDespawn));
+        app.add_systems(
+            FixedPostUpdate,
+            remove_despawn_marker.in_set(PredictionSet::EntityDespawn),
+        );
 
         // NOTE: this needs to run in FixedPostUpdate because the order we want is (if we replicate Position):
         // - Physics update

--- a/lightyear/src/client/prediction/prespawn.rs
+++ b/lightyear/src/client/prediction/prespawn.rs
@@ -439,7 +439,6 @@ mod tests {
         );
     }
 
-
     /// Prespawning multiple entities with the same hash
     /// https://github.com/cBournhonesque/lightyear/issues/906
     ///

--- a/lightyear/src/client/prediction/rollback.rs
+++ b/lightyear/src/client/prediction/rollback.rs
@@ -141,20 +141,11 @@ pub(crate) fn check_rollback<C: SyncComponent>(
 
     let current_tick = tick_manager.tick();
     for (confirmed_entity, confirmed_component, confirmed) in confirmed_query.iter() {
-        // NOTE: it is not enough to check if we received any ComponentRemoveEvent<C>, ComponentUpdateEvent<C> and ComponentInsertEvent<C>
-        //  because we could have entity A and B in the same ReplicationGroup.
-        //  We receive a message with entity B updates, but no entity A updates, **which means that entity A is still in the same state as before**
-        //  on the confirmed tick! This means that we received an update for entity A, and we still need to check for rollback.
-
-        // TODO: using `!confirmed.is_changed` is a potential bug! we only want a rollback check to trigger when the confirmed tick is updated!
-        //  but not when the confirmed entity is first spawned, no? when the entity is first spawn, currently
-        //  we still do a rollback check immediately
-        //  instead use `!confirmed.is_changed() || confirmed.is_added() { continue; }`?
-        //  but figure out how to adapt tests
-
         // 0. only check rollback when any entity in the replication group has been updated
         // (i.e. the confirmed tick has been updated)
-        if !confirmed.is_changed() {
+        // NOTE: there is no need to check for rollbacks when Confirmed is added, because at spawn time
+        //  we know that all components match!
+        if !confirmed.is_changed() || confirmed.is_added() {
             continue;
         }
 

--- a/lightyear/src/shared/replication/receive.rs
+++ b/lightyear/src/shared/replication/receive.rs
@@ -1306,13 +1306,18 @@ mod tests {
             ]
         );
 
-
         let mut world = World::new();
         let mut component_registry = ComponentRegistry::default();
         let mut events = ConnectionEvents::default();
 
         // apply messages: only read the first action and update
-        manager.apply_world(&mut world, None, &mut component_registry, Tick(10), &mut events);
+        manager.apply_world(
+            &mut world,
+            None,
+            &mut component_registry,
+            Tick(10),
+            &mut events,
+        );
         assert!(manager
             .group_channels
             .get(&group_id)
@@ -1326,19 +1331,25 @@ mod tests {
                 .unwrap()
                 .buffered_updates
                 .0,
-            vec![
-                (
-                    Tick(5),
-                    EntityUpdatesMessage {
-                        group_id: ReplicationGroupId(0),
-                        last_action_tick: Some(Tick(3)),
-                        updates: Default::default(),
-                    }
-                ),
-            ]
+            vec![(
+                Tick(5),
+                EntityUpdatesMessage {
+                    group_id: ReplicationGroupId(0),
+                    last_action_tick: Some(Tick(3)),
+                    updates: Default::default(),
+                }
+            ),]
         );
         // latest_tick has been updated properly even for Update
-        assert_eq!(manager.group_channels.get(&group_id).unwrap().latest_tick.unwrap(), Tick(1));
+        assert_eq!(
+            manager
+                .group_channels
+                .get(&group_id)
+                .unwrap()
+                .latest_tick
+                .unwrap(),
+            Tick(1)
+        );
 
         // recv actions-3: should be buffered, we are still waiting for actions-2
         manager.recv_actions(
@@ -1350,8 +1361,22 @@ mod tests {
             Tick(3),
         );
         // apply messages: we get nothing because we are still waiting for actions-2
-        manager.apply_world(&mut world, None, &mut component_registry, Tick(10), &mut events);
-        assert_eq!(manager.group_channels.get(&group_id).unwrap().latest_tick.unwrap(), Tick(1));
+        manager.apply_world(
+            &mut world,
+            None,
+            &mut component_registry,
+            Tick(10),
+            &mut events,
+        );
+        assert_eq!(
+            manager
+                .group_channels
+                .get(&group_id)
+                .unwrap()
+                .latest_tick
+                .unwrap(),
+            Tick(1)
+        );
 
         // recv actions-2: we should now be able to read actions-2, actions-3, updates-4
         manager.recv_actions(
@@ -1363,8 +1388,22 @@ mod tests {
             Tick(2),
         );
 
-        manager.apply_world(&mut world, None, &mut component_registry, Tick(10), &mut events);
-        assert_eq!(manager.group_channels.get(&group_id).unwrap().latest_tick.unwrap(), Tick(5));
+        manager.apply_world(
+            &mut world,
+            None,
+            &mut component_registry,
+            Tick(10),
+            &mut events,
+        );
+        assert_eq!(
+            manager
+                .group_channels
+                .get(&group_id)
+                .unwrap()
+                .latest_tick
+                .unwrap(),
+            Tick(5)
+        );
     }
 
     /// Test applying to the world an EntityActionsMessage that uses SpawnReuse


### PR DESCRIPTION
When the Confirmed entity is spawned, it's guaranteed that all its components are correct, so there is no need to do a rollback