### PR TITLE
Applying rust fmt + vscode friendly

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,9 @@
+{
+    "recommendations": [
+        "rust-lang.rust-analyzer",
+        "tamasfe.even-better-toml",
+        "usernamehw.errorlens",
+        "pixl-garden.bongocat",
+        "wilfriedago.vscode-symbols-icon-theme"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,12 @@
+{
+    // Allow `rust-analyzer` and `cargo` to run simultaneously.
+    // This uses extra storage space, so consider commenting it out.
+    "rust-analyzer.linkedProjects": [
+        "./Cargo.toml",
+    ],
+    "rust-analyzer.check.command": "clippy",
+    "[rust]": {
+        "editor.defaultFormatter": "rust-lang.rust-analyzer",
+        "editor.formatOnSave": true
+    }
+}

--- a/benches/bitcode_packing/src/main.rs
+++ b/benches/bitcode_packing/src/main.rs
@@ -1,9 +1,7 @@
 //! Benchmark for how to use bitcode to pack messages into packets of MTU bytes
 #![allow(unused_variables)]
-use divan::counter::ItemsCount;
-use divan::Bencher;
-use rand::distributions::Standard;
-use rand::prelude::*;
+use divan::{counter::ItemsCount, Bencher};
+use rand::{distributions::Standard, prelude::*};
 
 trait Packer {
     /// packet the messages into packets (preferably of size <=MAX_SIZE)

--- a/benches/criterion/src/local_stepper.rs
+++ b/benches/criterion/src/local_stepper.rs
@@ -1,28 +1,26 @@
 //! Helpers to setup a bevy app where I can just step the world easily.
 //! Uses crossbeam channels to mock the network
-use bevy::core::TaskPoolThreadAssignmentPolicy;
-use bevy::ecs::system::RunSystemOnce;
-use bevy::log::{error, Level, LogPlugin};
-use bevy::utils::Duration;
-use std::net::SocketAddr;
-use std::str::FromStr;
+use std::{net::SocketAddr, str::FromStr};
 
-use bevy::prelude::{
-    default, App, Commands, Mut, Plugin, PluginGroup, Real, Resource, TaskPoolOptions,
-    TaskPoolPlugin, Time,
+use bevy::{
+    core::TaskPoolThreadAssignmentPolicy,
+    ecs::system::RunSystemOnce,
+    log::{error, Level, LogPlugin},
+    prelude::{
+        default, App, Commands, Mut, Plugin, PluginGroup, Real, Resource, TaskPoolOptions,
+        TaskPoolPlugin, Time,
+    },
+    state::app::StatesPlugin,
+    tasks::available_parallelism,
+    time::TimeUpdateStrategy,
+    utils::{Duration, HashMap},
+    MinimalPlugins,
 };
-use bevy::state::app::StatesPlugin;
-use bevy::tasks::available_parallelism;
-use bevy::time::TimeUpdateStrategy;
-use bevy::utils::HashMap;
-use bevy::MinimalPlugins;
-
-use lightyear::connection::netcode::generate_key;
-use lightyear::prelude::client::*;
-use lightyear::prelude::server::*;
-use lightyear::prelude::*;
-use lightyear::prelude::{client, server};
-use lightyear::transport::LOCAL_SOCKET;
+use lightyear::{
+    connection::netcode::generate_key,
+    prelude::{client, client::*, server, server::*, *},
+    transport::LOCAL_SOCKET,
+};
 
 use crate::protocol::*;
 

--- a/benches/criterion/src/message.rs
+++ b/benches/criterion/src/message.rs
@@ -1,22 +1,26 @@
 //! Benchmark to measure the performance of replicating Entity spawns
 #![allow(unused_imports)]
 
-use bevy::log::tracing_subscriber::fmt::format::FmtSpan;
-use bevy::log::{info, tracing_subscriber};
-use bevy::prelude::{default, error, Events};
-use bevy::utils::tracing;
-use bevy::utils::tracing::Level;
-use bevy::utils::Duration;
-use lightyear::client::sync::SyncConfig;
-use lightyear::prelude::client::{InterpolationConfig, PredictionConfig};
-use lightyear::prelude::{client, server, MessageRegistry, Tick, TickManager};
-use lightyear::prelude::{ClientId, SharedConfig, TickConfig};
-use lightyear::server::input::native::InputBuffers;
-use lightyear::shared::replication::network_target::NetworkTarget;
-use lightyear_benches::local_stepper::{LocalBevyStepper, Step as LocalStep};
-use lightyear_benches::protocol::*;
-
+use bevy::{
+    log::{info, tracing_subscriber, tracing_subscriber::fmt::format::FmtSpan},
+    prelude::{default, error, Events},
+    utils::{tracing, tracing::Level, Duration},
+};
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+use lightyear::{
+    client::sync::SyncConfig,
+    prelude::{
+        client,
+        client::{InterpolationConfig, PredictionConfig},
+        server, ClientId, MessageRegistry, SharedConfig, Tick, TickConfig, TickManager,
+    },
+    server::input::native::InputBuffers,
+    shared::replication::network_target::NetworkTarget,
+};
+use lightyear_benches::{
+    local_stepper::{LocalBevyStepper, Step as LocalStep},
+    protocol::*,
+};
 
 criterion_group!(message_benches, send_receive_simple_messages_to_one_client);
 criterion_main!(message_benches);

--- a/benches/criterion/src/protocol.rs
+++ b/benches/criterion/src/protocol.rs
@@ -1,12 +1,15 @@
-use bevy::app::{App, Plugin};
-use bevy::prelude::Component;
-use bevy::utils::default;
-use lightyear::client::components::ComponentSyncMode;
-use lightyear::client::prediction::plugin::add_prediction_systems;
-use serde::{Deserialize, Serialize};
 use std::ops::{Add, Mul};
 
-use lightyear::prelude::*;
+use bevy::{
+    app::{App, Plugin},
+    prelude::Component,
+    utils::default,
+};
+use lightyear::{
+    client::{components::ComponentSyncMode, prediction::plugin::add_prediction_systems},
+    prelude::*,
+};
+use serde::{Deserialize, Serialize};
 
 // Messages
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]

--- a/benches/criterion/src/replication.rs
+++ b/benches/criterion/src/replication.rs
@@ -1,32 +1,34 @@
 //! Benchmark to measure the performance of replicating Entity spawns
 #![allow(unused_imports)]
 
-use bevy::log::tracing_subscriber::fmt::format::FmtSpan;
-use bevy::log::{info, tracing_subscriber};
-use bevy::prelude::{default, error, Events, With};
-use bevy::utils::tracing;
-use bevy::utils::tracing::Level;
-use bevy::utils::Duration;
-use divan::{AllocProfiler, Bencher};
-use lightyear::client::sync::SyncConfig;
-use lightyear::prelude::client::{
-    ClientConnection, InterpolationConfig, NetClient, PredictionConfig,
-};
-use lightyear::prelude::server::Replicate;
-use lightyear::prelude::{
-    client, server, MessageRegistry, Replicating, ReplicationGroup, Tick, TickManager,
-};
-use lightyear::prelude::{ClientId, SharedConfig, TickConfig};
-use lightyear::server::input::native::InputBuffers;
-use lightyear::shared::replication::network_target::NetworkTarget;
-use lightyear_benches::local_stepper::{LocalBevyStepper, Step as LocalStep};
-use lightyear_benches::profiler::FlamegraphProfiler;
-use lightyear_benches::protocol::*;
 use std::time::Instant;
 
+use bevy::{
+    log::{info, tracing_subscriber, tracing_subscriber::fmt::format::FmtSpan},
+    prelude::{default, error, Events, With},
+    utils::{tracing, tracing::Level, Duration},
+};
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
-use lightyear::channel::builder::EntityActionsChannel;
-use lightyear::server::connection::ConnectionManager;
+use divan::{AllocProfiler, Bencher};
+use lightyear::{
+    channel::builder::EntityActionsChannel,
+    client::sync::SyncConfig,
+    prelude::{
+        client,
+        client::{ClientConnection, InterpolationConfig, NetClient, PredictionConfig},
+        server,
+        server::Replicate,
+        ClientId, MessageRegistry, Replicating, ReplicationGroup, SharedConfig, Tick, TickConfig,
+        TickManager,
+    },
+    server::{connection::ConnectionManager, input::native::InputBuffers},
+    shared::replication::network_target::NetworkTarget,
+};
+use lightyear_benches::{
+    local_stepper::{LocalBevyStepper, Step as LocalStep},
+    profiler::FlamegraphProfiler,
+    protocol::*,
+};
 
 criterion_group!(
     name = replication_benches;

--- a/benches/criterion/src/replication_profiling.rs
+++ b/benches/criterion/src/replication_profiling.rs
@@ -1,9 +1,11 @@
-use bevy::prelude::*;
-use lightyear::prelude::server::Replicate;
-use lightyear::prelude::ReplicationGroup;
-use lightyear_benches::local_stepper::{LocalBevyStepper, Step};
-use lightyear_benches::protocol::Component1;
 use std::fs::File;
+
+use bevy::prelude::*;
+use lightyear::prelude::{server::Replicate, ReplicationGroup};
+use lightyear_benches::{
+    local_stepper::{LocalBevyStepper, Step},
+    protocol::Component1,
+};
 
 const N: usize = 100;
 

--- a/examples/auth/src/client.rs
+++ b/examples/auth/src/client.rs
@@ -4,24 +4,22 @@
 //! - sending inputs to the server
 //! - applying inputs to the locally predicted player (for prediction to work, inputs have to be applied to both the
 //! predicted entity and the server entity)
-use async_compat::Compat;
-use std::io::Read;
-use std::net::SocketAddr;
-use std::str::FromStr;
+use std::{io::Read, net::SocketAddr, str::FromStr};
 
-use bevy::prelude::*;
-use bevy::tasks::futures_lite::future;
-use bevy::tasks::{block_on, IoTaskPool, Task};
-use bevy::time::common_conditions::on_timer;
-use bevy::utils::Duration;
-use lightyear::connection::netcode::CONNECT_TOKEN_BYTES;
+use async_compat::Compat;
+use bevy::{
+    prelude::*,
+    tasks::{block_on, futures_lite::future, IoTaskPool, Task},
+    time::common_conditions::on_timer,
+    utils::Duration,
+};
+use lightyear::{
+    connection::netcode::CONNECT_TOKEN_BYTES,
+    prelude::{client::*, *},
+};
 use tokio::io::AsyncReadExt;
 
-use lightyear::prelude::client::*;
-use lightyear::prelude::*;
-
-use crate::protocol::*;
-use crate::shared;
+use crate::{protocol::*, shared};
 
 pub struct ExampleClientPlugin {
     pub auth_backend_address: SocketAddr,

--- a/examples/auth/src/main.rs
+++ b/examples/auth/src/main.rs
@@ -11,11 +11,15 @@
 #![allow(unused_variables)]
 #![allow(dead_code)]
 
-use crate::shared::SharedPlugin;
-use lightyear_examples_common::app::{Apps, Cli};
-use lightyear_examples_common::settings::Settings;
-use serde::{Deserialize, Serialize};
 use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
+
+use lightyear_examples_common::{
+    app::{Apps, Cli},
+    settings::Settings,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::shared::SharedPlugin;
 
 #[cfg(feature = "client")]
 mod client;

--- a/examples/auth/src/protocol.rs
+++ b/examples/auth/src/protocol.rs
@@ -6,15 +6,14 @@
 //! - how the component should be synchronized between the `Confirmed` entity and the `Predicted`/`Interpolated` entity
 use std::ops::Mul;
 
-use bevy::ecs::entity::MapEntities;
-use bevy::prelude::{
-    default, Bundle, Color, Component, Deref, DerefMut, Entity, EntityMapper, Vec2,
+use bevy::{
+    ecs::entity::MapEntities,
+    prelude::{
+        default, App, Bundle, Color, Component, Deref, DerefMut, Entity, EntityMapper, Plugin, Vec2,
+    },
 };
-use bevy::prelude::{App, Plugin};
+use lightyear::{client::components::ComponentSyncMode, prelude::*};
 use serde::{Deserialize, Serialize};
-
-use lightyear::client::components::ComponentSyncMode;
-use lightyear::prelude::*;
 
 // Protocol
 pub(crate) struct ProtocolPlugin;

--- a/examples/auth/src/renderer.rs
+++ b/examples/auth/src/renderer.rs
@@ -1,5 +1,4 @@
-use bevy::prelude::*;
-use bevy::render::RenderPlugin;
+use bevy::{prelude::*, render::RenderPlugin};
 
 use crate::protocol::*;
 

--- a/examples/auth/src/server.rs
+++ b/examples/auth/src/server.rs
@@ -6,22 +6,22 @@
 //! - read inputs from the clients and move the player entities accordingly
 //!
 //! Lightyear will handle the replication of entities automatically if you add a `Replicate` component to them.
+use std::{
+    net::SocketAddr,
+    sync::{Arc, RwLock},
+};
+
 use anyhow::Context;
 use async_compat::Compat;
-use std::net::SocketAddr;
-use std::sync::{Arc, RwLock};
-
-use bevy::prelude::*;
-use bevy::tasks::IoTaskPool;
-use bevy::utils::{Duration, HashSet};
+use bevy::{
+    prelude::*,
+    tasks::IoTaskPool,
+    utils::{Duration, HashSet},
+};
+use lightyear::prelude::{server::*, ClientId::Netcode, *};
 use tokio::io::AsyncWriteExt;
 
-use lightyear::prelude::server::*;
-use lightyear::prelude::ClientId::Netcode;
-use lightyear::prelude::*;
-
-use crate::protocol::*;
-use crate::shared;
+use crate::{protocol::*, shared};
 
 pub struct ExampleServerPlugin {
     pub protocol_id: u64,

--- a/examples/auth/src/settings.rs
+++ b/examples/auth/src/settings.rs
@@ -1,10 +1,10 @@
+use std::{net::Ipv4Addr, string::ToString};
+
 use lightyear::prelude::{CompressionConfig, Deserialize, Serialize};
 use lightyear_examples_common::settings::{
     ClientSettings, ClientTransports, Conditioner, ServerSettings, ServerTransports, Settings,
     SharedSettings, WebTransportCertificateSettings,
 };
-use std::net::Ipv4Addr;
-use std::string::ToString;
 
 #[derive(Clone, Debug)]
 pub struct MySettings {

--- a/examples/avian_3d_character/src/client.rs
+++ b/examples/avian_3d_character/src/client.rs
@@ -1,17 +1,14 @@
 use avian3d::prelude::*;
-use bevy::app::PluginGroupBuilder;
-use bevy::prelude::*;
-use bevy::utils::Duration;
+use bevy::{app::PluginGroupBuilder, prelude::*, utils::Duration};
 use leafwing_input_manager::prelude::*;
-use lightyear::inputs::leafwing::input_buffer::InputBuffer;
-use lightyear::prelude::client::*;
-use lightyear::prelude::*;
-use lightyear::shared::replication::components::Controlled;
-use lightyear::shared::tick_manager;
+use lightyear::{
+    inputs::leafwing::input_buffer::InputBuffer,
+    prelude::{client::*, *},
+    shared::{replication::components::Controlled, tick_manager},
+};
 use lightyear_examples_common::shared::FIXED_TIMESTEP_HZ;
 
-use crate::protocol::*;
-use crate::shared::*;
+use crate::{protocol::*, shared::*};
 
 pub struct ExampleClientPlugin;
 

--- a/examples/avian_3d_character/src/main.rs
+++ b/examples/avian_3d_character/src/main.rs
@@ -1,12 +1,15 @@
 #![allow(unused_imports)]
 #![allow(unused_variables)]
 #![allow(dead_code)]
-use crate::shared::SharedPlugin;
 use bevy::prelude::*;
 use lightyear::prelude::client::PredictionConfig;
-use lightyear_examples_common::app::{Apps, Cli, Mode};
-use lightyear_examples_common::settings::Settings;
+use lightyear_examples_common::{
+    app::{Apps, Cli, Mode},
+    settings::Settings,
+};
 use serde::{Deserialize, Serialize};
+
+use crate::shared::SharedPlugin;
 
 #[cfg(feature = "client")]
 mod client;

--- a/examples/avian_3d_character/src/protocol.rs
+++ b/examples/avian_3d_character/src/protocol.rs
@@ -1,20 +1,27 @@
 use avian3d::prelude::*;
-use bevy::prelude::*;
-use bevy::utils::Duration;
+use bevy::{prelude::*, utils::Duration};
 use leafwing_input_manager::prelude::*;
+use lightyear::{
+    client::{
+        components::{ComponentSyncMode, LerpFn},
+        interpolation::LinearInterpolator,
+    },
+    prelude::{
+        client::{self},
+        server::{Replicate, SyncTarget},
+        *,
+    },
+    shared::input::InputConfig,
+    utils::{
+        avian3d::{position, rotation},
+        bevy::TransformLinearInterpolation,
+    },
+};
 use lightyear_examples_common::shared::FIXED_TIMESTEP_HZ;
 use serde::{Deserialize, Serialize};
+use tracing_subscriber::util::SubscriberInitExt;
 
 use crate::shared::color_from_id;
-use lightyear::client::components::{ComponentSyncMode, LerpFn};
-use lightyear::client::interpolation::LinearInterpolator;
-use lightyear::prelude::client::{self};
-use lightyear::prelude::server::{Replicate, SyncTarget};
-use lightyear::prelude::*;
-use lightyear::shared::input::InputConfig;
-use lightyear::utils::avian3d::{position, rotation};
-use lightyear::utils::bevy::TransformLinearInterpolation;
-use tracing_subscriber::util::SubscriberInitExt;
 
 // For prediction, we want everything entity that is predicted to be part of
 // the same replication group This will make sure that they will be replicated

--- a/examples/avian_3d_character/src/renderer.rs
+++ b/examples/avian_3d_character/src/renderer.rs
@@ -1,17 +1,17 @@
+use avian3d::prelude::*;
+use bevy::prelude::*;
+use lightyear::{
+    client::prediction::diagnostics::PredictionDiagnosticsPlugin,
+    prelude::{client::*, server::ReplicationTarget, *},
+    transport::io::IoDiagnosticsPlugin,
+};
+
 use crate::{
     protocol::{BlockMarker, CharacterMarker, ColorComponent, FloorMarker},
     shared::{
         BLOCK_HEIGHT, BLOCK_WIDTH, CHARACTER_CAPSULE_HEIGHT, CHARACTER_CAPSULE_RADIUS,
         FLOOR_HEIGHT, FLOOR_WIDTH,
     },
-};
-use avian3d::prelude::*;
-use bevy::prelude::*;
-use lightyear::prelude::server::ReplicationTarget;
-use lightyear::{
-    client::prediction::diagnostics::PredictionDiagnosticsPlugin,
-    prelude::{client::*, *},
-    transport::io::IoDiagnosticsPlugin,
 };
 
 pub struct ExampleRendererPlugin;

--- a/examples/avian_3d_character/src/server.rs
+++ b/examples/avian_3d_character/src/server.rs
@@ -1,34 +1,36 @@
 use std::f32::consts::TAU;
 
 use avian3d::prelude::*;
-use bevy::color::palettes::css;
-use bevy::math::VectorSpace;
-use bevy::prelude::*;
-use bevy::time::common_conditions::on_timer;
-use bevy::utils::Duration;
-use bevy::utils::HashMap;
+use bevy::{
+    color::palettes::css,
+    math::VectorSpace,
+    prelude::*,
+    time::common_conditions::on_timer,
+    utils::{Duration, HashMap},
+};
 use client::Rollback;
-use leafwing_input_manager::action_diff::ActionDiff;
-use leafwing_input_manager::prelude::*;
-use lightyear::client::connection;
-use lightyear::prelude::client::{Confirmed, Predicted};
-use lightyear::prelude::server::*;
-use lightyear::prelude::*;
-use lightyear::server::input::InputSystemSet;
-use lightyear::shared::tick_manager;
+use leafwing_input_manager::{action_diff::ActionDiff, prelude::*};
+use lightyear::{
+    client::connection,
+    prelude::{
+        client::{Confirmed, Predicted},
+        server::*,
+        *,
+    },
+    server::input::InputSystemSet,
+    shared::tick_manager,
+};
 use lightyear_examples_common::shared::FIXED_TIMESTEP_HZ;
 
-use crate::protocol::*;
-use crate::shared;
-use crate::shared::apply_character_action;
-use crate::shared::BlockPhysicsBundle;
-use crate::shared::CharacterPhysicsBundle;
-use crate::shared::CharacterQuery;
-use crate::shared::FloorPhysicsBundle;
-use crate::shared::CHARACTER_CAPSULE_HEIGHT;
-use crate::shared::CHARACTER_CAPSULE_RADIUS;
-use crate::shared::FLOOR_HEIGHT;
-use crate::shared::FLOOR_WIDTH;
+use crate::{
+    protocol::*,
+    shared,
+    shared::{
+        apply_character_action, BlockPhysicsBundle, CharacterPhysicsBundle, CharacterQuery,
+        FloorPhysicsBundle, CHARACTER_CAPSULE_HEIGHT, CHARACTER_CAPSULE_RADIUS, FLOOR_HEIGHT,
+        FLOOR_WIDTH,
+    },
+};
 
 // Plugin for server-specific logic
 pub struct ExampleServerPlugin;

--- a/examples/avian_3d_character/src/settings.rs
+++ b/examples/avian_3d_character/src/settings.rs
@@ -1,10 +1,10 @@
+use std::{net::Ipv4Addr, string::ToString};
+
 use lightyear::prelude::CompressionConfig;
 use lightyear_examples_common::settings::{
     ClientSettings, ClientTransports, Conditioner, ServerSettings, ServerTransports, Settings,
     SharedSettings, WebTransportCertificateSettings,
 };
-use std::net::Ipv4Addr;
-use std::string::ToString;
 
 #[derive(Clone, Debug)]
 pub struct MySettings {

--- a/examples/avian_3d_character/src/shared.rs
+++ b/examples/avian_3d_character/src/shared.rs
@@ -1,21 +1,21 @@
-use bevy::ecs::query::QueryData;
-use bevy::math::VectorSpace;
-use bevy::prelude::*;
-use bevy::utils::Duration;
-use lightyear::inputs::leafwing::input_buffer::InputBuffer;
-use server::ControlledEntities;
 use std::hash::{Hash, Hasher};
 
 use avian3d::prelude::*;
-use bevy::prelude::TransformSystem::TransformPropagate;
+use bevy::{
+    ecs::query::QueryData,
+    math::VectorSpace,
+    prelude::{TransformSystem::TransformPropagate, *},
+    utils::Duration,
+};
 use leafwing_input_manager::prelude::ActionState;
-use lightyear::shared::replication::components::Controlled;
-use tracing::Level;
-
-use lightyear::prelude::client::*;
-use lightyear::prelude::TickManager;
-use lightyear::prelude::*;
+use lightyear::{
+    inputs::leafwing::input_buffer::InputBuffer,
+    prelude::{client::*, TickManager, *},
+    shared::replication::components::Controlled,
+};
 use lightyear_examples_common::shared::FIXED_TIMESTEP_HZ;
+use server::ControlledEntities;
+use tracing::Level;
 
 use crate::protocol::*;
 

--- a/examples/avian_physics/src/client.rs
+++ b/examples/avian_physics/src/client.rs
@@ -1,14 +1,13 @@
 use avian2d::prelude::*;
-use bevy::app::PluginGroupBuilder;
-use bevy::prelude::*;
-use bevy::utils::Duration;
+use bevy::{app::PluginGroupBuilder, prelude::*, utils::Duration};
 use leafwing_input_manager::prelude::*;
-use lightyear::prelude::client::*;
-use lightyear::prelude::*;
+use lightyear::prelude::{client::*, *};
 
-use crate::protocol::*;
-use crate::shared;
-use crate::shared::{color_from_id, shared_movement_behaviour};
+use crate::{
+    protocol::*,
+    shared,
+    shared::{color_from_id, shared_movement_behaviour},
+};
 
 pub struct ExampleClientPlugin;
 

--- a/examples/avian_physics/src/main.rs
+++ b/examples/avian_physics/src/main.rs
@@ -1,11 +1,14 @@
 #![allow(unused_imports)]
 #![allow(unused_variables)]
 #![allow(dead_code)]
-use crate::shared::SharedPlugin;
 use bevy::prelude::*;
 use lightyear::prelude::client::PredictionConfig;
-use lightyear_examples_common::app::{Apps, Cli};
-use lightyear_examples_common::settings::Settings;
+use lightyear_examples_common::{
+    app::{Apps, Cli},
+    settings::Settings,
+};
+
+use crate::shared::SharedPlugin;
 
 #[cfg(feature = "client")]
 mod client;

--- a/examples/avian_physics/src/protocol.rs
+++ b/examples/avian_physics/src/protocol.rs
@@ -1,16 +1,21 @@
 use avian2d::prelude::*;
 use bevy::prelude::*;
 use leafwing_input_manager::prelude::*;
+use lightyear::{
+    client::{
+        components::{ComponentSyncMode, LerpFn},
+        interpolation::LinearInterpolator,
+    },
+    prelude::{
+        client,
+        server::{Replicate, SyncTarget},
+        *,
+    },
+    utils::{avian2d::*, bevy::TransformLinearInterpolation},
+};
 use serde::{Deserialize, Serialize};
 
 use crate::shared::color_from_id;
-use lightyear::client::components::{ComponentSyncMode, LerpFn};
-use lightyear::client::interpolation::LinearInterpolator;
-use lightyear::prelude::client;
-use lightyear::prelude::server::{Replicate, SyncTarget};
-use lightyear::prelude::*;
-use lightyear::utils::avian2d::*;
-use lightyear::utils::bevy::TransformLinearInterpolation;
 
 pub const BALL_SIZE: f32 = 15.0;
 pub const PLAYER_SIZE: f32 = 40.0;

--- a/examples/avian_physics/src/renderer.rs
+++ b/examples/avian_physics/src/renderer.rs
@@ -1,14 +1,16 @@
-use crate::protocol::*;
-use crate::shared::Wall;
-use avian2d::position::{Position, Rotation};
-use avian2d::prelude::LinearVelocity;
-use bevy::color::palettes::css;
-use bevy::prelude::*;
-use bevy::render::RenderPlugin;
-use lightyear::client::components::Confirmed;
-use lightyear::client::interpolation::VisualInterpolateStatus;
-use lightyear::client::prediction::Predicted;
-use lightyear::prelude::client::{InterpolationSet, PredictionSet, VisualInterpolationPlugin};
+use avian2d::{
+    position::{Position, Rotation},
+    prelude::LinearVelocity,
+};
+use bevy::{color::palettes::css, prelude::*, render::RenderPlugin};
+use lightyear::{
+    client::{
+        components::Confirmed, interpolation::VisualInterpolateStatus, prediction::Predicted,
+    },
+    prelude::client::{InterpolationSet, PredictionSet, VisualInterpolationPlugin},
+};
+
+use crate::{protocol::*, shared::Wall};
 
 #[derive(Clone)]
 pub struct ExampleRendererPlugin {

--- a/examples/avian_physics/src/server.rs
+++ b/examples/avian_physics/src/server.rs
@@ -1,17 +1,25 @@
-use crate::protocol::*;
-use crate::shared;
-use crate::shared::{color_from_id, shared_movement_behaviour};
 use avian2d::prelude::*;
-use bevy::color::palettes::css;
-use bevy::prelude::*;
-use bevy::utils::Duration;
-use bevy::utils::HashMap;
+use bevy::{
+    color::palettes::css,
+    prelude::*,
+    utils::{Duration, HashMap},
+};
 use leafwing_input_manager::prelude::*;
-use lightyear::prelude::client::{Confirmed, Predicted};
-use lightyear::prelude::server::*;
-use lightyear::prelude::*;
-use lightyear::server::input::InputSystemSet;
-use lightyear::shared::replication::components::InitialReplicated;
+use lightyear::{
+    prelude::{
+        client::{Confirmed, Predicted},
+        server::*,
+        *,
+    },
+    server::input::InputSystemSet,
+    shared::replication::components::InitialReplicated,
+};
+
+use crate::{
+    protocol::*,
+    shared,
+    shared::{color_from_id, shared_movement_behaviour},
+};
 
 // Plugin for server-specific logic
 pub struct ExampleServerPlugin {

--- a/examples/avian_physics/src/settings.rs
+++ b/examples/avian_physics/src/settings.rs
@@ -1,10 +1,10 @@
+use std::{net::Ipv4Addr, string::ToString};
+
 use lightyear::prelude::CompressionConfig;
 use lightyear_examples_common::settings::{
     ClientSettings, ClientTransports, Conditioner, ServerSettings, ServerTransports, Settings,
     SharedSettings, WebTransportCertificateSettings,
 };
-use std::net::Ipv4Addr;
-use std::string::ToString;
 
 #[derive(Clone, Debug)]
 pub struct MySettings {

--- a/examples/avian_physics/src/shared.rs
+++ b/examples/avian_physics/src/shared.rs
@@ -1,18 +1,14 @@
 use avian2d::prelude::*;
-use bevy::color::palettes::css;
-use bevy::diagnostic::LogDiagnosticsPlugin;
-use bevy::prelude::*;
-use bevy::utils::Duration;
+use bevy::{color::palettes::css, diagnostic::LogDiagnosticsPlugin, prelude::*, utils::Duration};
 use leafwing_input_manager::prelude::ActionState;
-use tracing::Level;
-
-use lightyear::client::prediction::diagnostics::PredictionDiagnosticsPlugin;
-use lightyear::prelude::client::*;
-use lightyear::prelude::TickManager;
-use lightyear::prelude::*;
-use lightyear::shared::ping::diagnostics::PingDiagnosticsPlugin;
-use lightyear::transport::io::IoDiagnosticsPlugin;
+use lightyear::{
+    client::prediction::diagnostics::PredictionDiagnosticsPlugin,
+    prelude::{client::*, TickManager, *},
+    shared::ping::diagnostics::PingDiagnosticsPlugin,
+    transport::io::IoDiagnosticsPlugin,
+};
 use lightyear_examples_common::shared::FIXED_TIMESTEP_HZ;
+use tracing::Level;
 
 use crate::protocol::*;
 pub(crate) const MAX_VELOCITY: f32 = 200.0;

--- a/examples/client_replication/src/client.rs
+++ b/examples/client_replication/src/client.rs
@@ -1,13 +1,14 @@
-use bevy::prelude::*;
-use bevy::utils::Duration;
-use lightyear::client::input::InputSystemSet;
-use lightyear::inputs::native::{ActionState, InputMarker};
-use lightyear::prelude::client::*;
-use lightyear::prelude::*;
+use bevy::{prelude::*, utils::Duration};
+use lightyear::{
+    client::input::InputSystemSet,
+    inputs::native::{ActionState, InputMarker},
+    prelude::{client::*, *},
+};
 
-use crate::protocol::Direction;
-use crate::protocol::*;
-use crate::shared::{color_from_id, shared_movement_behaviour};
+use crate::{
+    protocol::{Direction, *},
+    shared::{color_from_id, shared_movement_behaviour},
+};
 
 pub struct ExampleClientPlugin;
 

--- a/examples/client_replication/src/main.rs
+++ b/examples/client_replication/src/main.rs
@@ -1,10 +1,13 @@
 #![allow(unused_imports)]
 #![allow(unused_variables)]
 #![allow(dead_code)]
-use crate::shared::SharedPlugin;
 use bevy::prelude::*;
-use lightyear_examples_common::app::{Apps, Cli};
-use lightyear_examples_common::settings::Settings;
+use lightyear_examples_common::{
+    app::{Apps, Cli},
+    settings::Settings,
+};
+
+use crate::shared::SharedPlugin;
 
 #[cfg(feature = "client")]
 mod client;

--- a/examples/client_replication/src/protocol.rs
+++ b/examples/client_replication/src/protocol.rs
@@ -1,13 +1,15 @@
 use std::ops::{Add, Mul};
 
-use bevy::app::{App, Plugin};
-use bevy::ecs::entity::MapEntities;
-use bevy::prelude::{default, Bundle, Color, Component, Deref, DerefMut, EntityMapper, Vec2};
+use bevy::{
+    app::{App, Plugin},
+    ecs::entity::MapEntities,
+    prelude::{default, Bundle, Color, Component, Deref, DerefMut, EntityMapper, Vec2},
+};
+use lightyear::{
+    client::components::ComponentSyncMode,
+    prelude::{client::Replicate, *},
+};
 use serde::{Deserialize, Serialize};
-
-use lightyear::client::components::ComponentSyncMode;
-use lightyear::prelude::client::Replicate;
-use lightyear::prelude::*;
 
 use crate::shared::color_from_id;
 

--- a/examples/client_replication/src/renderer.rs
+++ b/examples/client_replication/src/renderer.rs
@@ -1,7 +1,7 @@
-use crate::protocol::*;
-use bevy::prelude::*;
-use bevy::render::RenderPlugin;
+use bevy::{prelude::*, render::RenderPlugin};
 use lightyear::client::components::Confirmed;
+
+use crate::protocol::*;
 
 #[derive(Clone)]
 pub struct ExampleRendererPlugin;

--- a/examples/client_replication/src/server.rs
+++ b/examples/client_replication/src/server.rs
@@ -1,16 +1,16 @@
-use bevy::prelude::*;
-use bevy::utils::Duration;
+use bevy::{prelude::*, utils::Duration};
+use lightyear::{
+    client::{components::Confirmed, interpolation::Interpolated, prediction::Predicted},
+    inputs::native::ActionState,
+    prelude::{server::*, *},
+    shared::replication::components::InitialReplicated,
+};
 
-use crate::protocol::*;
-use crate::shared;
-use crate::shared::{color_from_id, shared_movement_behaviour};
-use lightyear::client::components::Confirmed;
-use lightyear::client::interpolation::Interpolated;
-use lightyear::client::prediction::Predicted;
-use lightyear::inputs::native::ActionState;
-use lightyear::prelude::server::*;
-use lightyear::prelude::*;
-use lightyear::shared::replication::components::InitialReplicated;
+use crate::{
+    protocol::*,
+    shared,
+    shared::{color_from_id, shared_movement_behaviour},
+};
 
 // Plugin for server-specific logic
 pub struct ExampleServerPlugin;

--- a/examples/client_replication/src/settings.rs
+++ b/examples/client_replication/src/settings.rs
@@ -1,10 +1,10 @@
+use std::{net::Ipv4Addr, string::ToString};
+
 use lightyear::prelude::CompressionConfig;
 use lightyear_examples_common::settings::{
     ClientSettings, ClientTransports, Conditioner, ServerSettings, ServerTransports, Settings,
     SharedSettings, WebTransportCertificateSettings,
 };
-use std::net::Ipv4Addr;
-use std::string::ToString;
 
 pub(crate) fn get_settings() -> Settings {
     Settings {

--- a/examples/client_replication/src/shared.rs
+++ b/examples/client_replication/src/shared.rs
@@ -1,8 +1,5 @@
-use bevy::prelude::*;
-use bevy::utils::Duration;
-
-use lightyear::prelude::client::Confirmed;
-use lightyear::prelude::*;
+use bevy::{prelude::*, utils::Duration};
+use lightyear::prelude::{client::Confirmed, *};
 
 use crate::protocol::*;
 

--- a/examples/common/src/app.rs
+++ b/examples/common/src/app.rs
@@ -3,34 +3,34 @@
 #![allow(unused_variables)]
 #![allow(dead_code)]
 
-use std::net::SocketAddr;
-use std::str::FromStr;
-use std::time::Duration;
+use std::{net::SocketAddr, str::FromStr, time::Duration};
 
-use bevy::asset::ron;
-use bevy::log::{Level, LogPlugin};
-use bevy::prelude::*;
-
-use bevy::diagnostic::{DiagnosticsPlugin, LogDiagnosticsPlugin};
-use bevy::state::app::StatesPlugin;
-use bevy::DefaultPlugins;
+#[cfg(feature = "gui")]
+use bevy::window::PresentMode;
+use bevy::{
+    asset::ron,
+    diagnostic::{DiagnosticsPlugin, LogDiagnosticsPlugin},
+    log::{Level, LogPlugin},
+    prelude::*,
+    state::app::StatesPlugin,
+    DefaultPlugins,
+};
 use clap::{Parser, Subcommand, ValueEnum};
-use lightyear::prelude::client::ClientConfig;
-use lightyear::prelude::*;
-use lightyear::prelude::{client, server};
-use lightyear::server::config::ServerConfig;
-use lightyear::transport::LOCAL_SOCKET;
+use lightyear::{
+    prelude::{client, client::ClientConfig, server, *},
+    server::config::ServerConfig,
+    transport::LOCAL_SOCKET,
+};
 use serde::{Deserialize, Serialize};
-
-use crate::settings::*;
-use crate::shared::{shared_config, REPLICATION_INTERVAL};
 
 #[cfg(all(feature = "gui", feature = "client"))]
 use crate::client_renderer::ExampleClientRendererPlugin;
 #[cfg(all(feature = "gui", feature = "server"))]
 use crate::server_renderer::ExampleServerRendererPlugin;
-#[cfg(feature = "gui")]
-use bevy::window::PresentMode;
+use crate::{
+    settings::*,
+    shared::{shared_config, REPLICATION_INTERVAL},
+};
 
 /// CLI options to create an [`App`]
 #[derive(Parser, Debug)]

--- a/examples/common/src/client_renderer.rs
+++ b/examples/common/src/client_renderer.rs
@@ -1,9 +1,10 @@
-use bevy::picking::prelude::{Click, Pointer};
-use bevy::prelude::*;
+use bevy::{
+    picking::prelude::{Click, Pointer},
+    prelude::*,
+};
 #[cfg(feature = "bevygap_client")]
 use bevygap_client_plugin::prelude::*;
-use lightyear::prelude::client::*;
-use lightyear::prelude::MainSet;
+use lightyear::prelude::{client::*, MainSet};
 
 pub struct ExampleClientRendererPlugin {
     /// The name of the example, which must also match the edgegap application name.

--- a/examples/common/src/settings.rs
+++ b/examples/common/src/settings.rs
@@ -3,22 +3,17 @@
 #![allow(unused_variables)]
 use std::net::{Ipv4Addr, SocketAddr};
 
-use bevy::asset::ron;
-use bevy::prelude::*;
-use bevy::utils::Duration;
-
 #[cfg(not(target_family = "wasm"))]
 use async_compat::Compat;
 #[cfg(not(target_family = "wasm"))]
 use bevy::tasks::IoTaskPool;
-
-use lightyear::connection::netcode::PRIVATE_KEY_BYTES;
-use lightyear::prelude::client::Authentication;
+use bevy::{asset::ron, prelude::*, utils::Duration};
 #[cfg(feature = "steam")]
 use lightyear::prelude::client::{SocketConfig, SteamConfig};
-use lightyear::prelude::{CompressionConfig, LinkConditionerConfig};
-
-use lightyear::prelude::{client, server};
+use lightyear::{
+    connection::netcode::PRIVATE_KEY_BYTES,
+    prelude::{client, client::Authentication, server, CompressionConfig, LinkConditionerConfig},
+};
 
 /// Read certificate digest from alternate sources, for WASM builds.
 #[cfg(target_family = "wasm")]

--- a/examples/common/src/shared.rs
+++ b/examples/common/src/shared.rs
@@ -1,5 +1,6 @@
-use lightyear::prelude::{SharedConfig, TickConfig};
 use std::time::Duration;
+
+use lightyear::prelude::{SharedConfig, TickConfig};
 
 pub const FIXED_TIMESTEP_HZ: f64 = 64.0;
 pub const REPLICATION_INTERVAL: Duration = Duration::from_millis(100);

--- a/examples/delta_compression/src/client.rs
+++ b/examples/delta_compression/src/client.rs
@@ -4,22 +4,25 @@
 //! - sending inputs to the server
 //! - applying inputs to the locally predicted player (for prediction to work, inputs have to be applied to both the
 //! predicted entity and the server entity)
-use std::net::{Ipv4Addr, SocketAddr};
-use std::str::FromStr;
+use std::{
+    net::{Ipv4Addr, SocketAddr},
+    str::FromStr,
+};
 
-use bevy::app::PluginGroupBuilder;
-use bevy::prelude::*;
-use bevy::time::common_conditions::on_timer;
-use bevy::utils::Duration;
-
-use lightyear::client::input::InputSystemSet;
-use lightyear::inputs::native::{ActionState, InputMarker};
+use bevy::{
+    app::PluginGroupBuilder, prelude::*, time::common_conditions::on_timer, utils::Duration,
+};
 pub use lightyear::prelude::client::*;
-use lightyear::prelude::*;
+use lightyear::{
+    client::input::InputSystemSet,
+    inputs::native::{ActionState, InputMarker},
+    prelude::*,
+};
 
-use crate::protocol::Direction;
-use crate::protocol::*;
-use crate::shared;
+use crate::{
+    protocol::{Direction, *},
+    shared,
+};
 
 pub struct ExampleClientPlugin;
 

--- a/examples/delta_compression/src/main.rs
+++ b/examples/delta_compression/src/main.rs
@@ -11,8 +11,10 @@
 #![allow(unused_variables)]
 #![allow(dead_code)]
 use bevy::prelude::*;
-use lightyear_examples_common::app::{Apps, Cli};
-use lightyear_examples_common::settings::Settings;
+use lightyear_examples_common::{
+    app::{Apps, Cli},
+    settings::Settings,
+};
 use protocol::ProtocolPlugin;
 
 #[cfg(feature = "client")]

--- a/examples/delta_compression/src/protocol.rs
+++ b/examples/delta_compression/src/protocol.rs
@@ -6,14 +6,16 @@
 //! - how the component should be synchronized between the `Confirmed` entity and the `Predicted`/`Interpolated` entity
 use std::ops::{Add, Mul};
 
-use bevy::ecs::entity::MapEntities;
-use bevy::prelude::{
-    default, Bundle, Color, Component, Deref, DerefMut, Entity, EntityMapper, Transform, Vec2,
+use bevy::{
+    ecs::entity::MapEntities,
+    prelude::{
+        default, App, Bundle, Color, Component, Deref, DerefMut, Entity, EntityMapper, Plugin,
+        Transform, Vec2,
+    },
 };
-use bevy::prelude::{App, Plugin};
-use lightyear::client::components::ComponentSyncMode;
-use lightyear::prelude::*;
-use lightyear::shared::replication::delta::Diffable;
+use lightyear::{
+    client::components::ComponentSyncMode, prelude::*, shared::replication::delta::Diffable,
+};
 use serde::{Deserialize, Serialize};
 use tracing::{info, trace};
 

--- a/examples/delta_compression/src/renderer.rs
+++ b/examples/delta_compression/src/renderer.rs
@@ -1,5 +1,4 @@
-use bevy::prelude::*;
-use bevy::render::RenderPlugin;
+use bevy::{prelude::*, render::RenderPlugin};
 
 use crate::protocol::*;
 

--- a/examples/delta_compression/src/server.rs
+++ b/examples/delta_compression/src/server.rs
@@ -6,15 +6,15 @@
 //! - read inputs from the clients and move the player entities accordingly
 //!
 //! Lightyear will handle the replication of entities automatically if you add a `Replicate` component to them.
-use crate::protocol::*;
-use crate::shared;
-use bevy::app::PluginGroupBuilder;
-use bevy::prelude::*;
-use bevy::utils::HashMap;
-use lightyear::inputs::native::ActionState;
-use lightyear::prelude::server::*;
-use lightyear::prelude::*;
 use std::sync::Arc;
+
+use bevy::{app::PluginGroupBuilder, prelude::*, utils::HashMap};
+use lightyear::{
+    inputs::native::ActionState,
+    prelude::{server::*, *},
+};
+
+use crate::{protocol::*, shared};
 
 pub struct ExampleServerPlugin;
 

--- a/examples/delta_compression/src/settings.rs
+++ b/examples/delta_compression/src/settings.rs
@@ -1,10 +1,10 @@
+use std::{net::Ipv4Addr, string::ToString};
+
 use lightyear::prelude::CompressionConfig;
 use lightyear_examples_common::settings::{
     ClientSettings, ClientTransports, Conditioner, ServerSettings, ServerTransports, Settings,
     SharedSettings, WebTransportCertificateSettings,
 };
-use std::net::Ipv4Addr;
-use std::string::ToString;
 
 pub(crate) fn get_settings() -> Settings {
     Settings {

--- a/examples/distributed_authority/src/client.rs
+++ b/examples/distributed_authority/src/client.rs
@@ -4,22 +4,26 @@
 //! - sending inputs to the server
 //! - applying inputs to the locally predicted player (for prediction to work, inputs have to be applied to both the
 //! predicted entity and the server entity)
-use std::net::{Ipv4Addr, SocketAddr};
-use std::str::FromStr;
+use std::{
+    net::{Ipv4Addr, SocketAddr},
+    str::FromStr,
+};
 
-use crate::protocol::Direction;
-use crate::protocol::*;
-use crate::shared;
-use bevy::app::PluginGroupBuilder;
-use bevy::prelude::*;
-use bevy::time::common_conditions::on_timer;
-use bevy::utils::Duration;
-use lightyear::client::input::InputSystemSet;
-use lightyear::inputs::native::{ActionState, InputMarker};
+use bevy::{
+    app::PluginGroupBuilder, prelude::*, time::common_conditions::on_timer, utils::Duration,
+};
 pub use lightyear::prelude::client::*;
-use lightyear::prelude::server::AuthorityPeer;
-use lightyear::prelude::*;
+use lightyear::{
+    client::input::InputSystemSet,
+    inputs::native::{ActionState, InputMarker},
+    prelude::{server::AuthorityPeer, *},
+};
 use lightyear_examples_common::client_renderer::ClientIdText;
+
+use crate::{
+    protocol::{Direction, *},
+    shared,
+};
 
 pub struct ExampleClientPlugin;
 

--- a/examples/distributed_authority/src/main.rs
+++ b/examples/distributed_authority/src/main.rs
@@ -10,10 +10,13 @@
 #![allow(unused_imports)]
 #![allow(unused_variables)]
 #![allow(dead_code)]
-use crate::shared::SharedPlugin;
 use bevy::prelude::*;
-use lightyear_examples_common::app::{Apps, Cli};
-use lightyear_examples_common::settings::Settings;
+use lightyear_examples_common::{
+    app::{Apps, Cli},
+    settings::Settings,
+};
+
+use crate::shared::SharedPlugin;
 
 #[cfg(feature = "client")]
 mod client;

--- a/examples/distributed_authority/src/protocol.rs
+++ b/examples/distributed_authority/src/protocol.rs
@@ -4,18 +4,21 @@
 //! You can use the `#[protocol]` attribute to specify additional behaviour:
 //! - how entities contained in the message should be mapped from the remote world to the local world
 //! - how the component should be synchronized between the `Confirmed` entity and the `Predicted`/`Interpolated` entity
-use bevy::color::palettes;
-use bevy::ecs::entity::MapEntities;
-use bevy::prelude::{
-    default, Bundle, Color, Component, Deref, DerefMut, Entity, EntityMapper, Reflect, Vec2,
-};
-use bevy::prelude::{App, Plugin};
-use serde::{Deserialize, Serialize};
 use std::ops::{Add, Mul};
 
-use lightyear::client::components::ComponentSyncMode;
-use lightyear::prelude::server::AuthorityPeer;
-use lightyear::prelude::*;
+use bevy::{
+    color::palettes,
+    ecs::entity::MapEntities,
+    prelude::{
+        default, App, Bundle, Color, Component, Deref, DerefMut, Entity, EntityMapper, Plugin,
+        Reflect, Vec2,
+    },
+};
+use lightyear::{
+    client::components::ComponentSyncMode,
+    prelude::{server::AuthorityPeer, *},
+};
+use serde::{Deserialize, Serialize};
 
 // Player
 #[derive(Bundle)]

--- a/examples/distributed_authority/src/renderer.rs
+++ b/examples/distributed_authority/src/renderer.rs
@@ -1,7 +1,7 @@
-use crate::protocol::*;
-use bevy::prelude::*;
-use bevy::render::RenderPlugin;
+use bevy::{prelude::*, render::RenderPlugin};
 use lightyear::client::components::Confirmed;
+
+use crate::protocol::*;
 
 #[derive(Clone)]
 pub struct ExampleRendererPlugin;

--- a/examples/distributed_authority/src/server.rs
+++ b/examples/distributed_authority/src/server.rs
@@ -6,16 +6,15 @@
 //! - read inputs from the clients and move the player entities accordingly
 //!
 //! Lightyear will handle the replication of entities automatically if you add a `Replicate` component to them.
-use crate::protocol::*;
-use crate::shared;
-use bevy::app::PluginGroupBuilder;
-use bevy::prelude::*;
-use bevy::utils::HashMap;
-use lightyear::inputs::native::ActionState;
-use lightyear::prelude::server::*;
-use lightyear::prelude::*;
-use std::sync::Arc;
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
+
+use bevy::{app::PluginGroupBuilder, prelude::*, utils::HashMap};
+use lightyear::{
+    inputs::native::ActionState,
+    prelude::{server::*, *},
+};
+
+use crate::{protocol::*, shared};
 
 pub struct ExampleServerPlugin;
 

--- a/examples/distributed_authority/src/settings.rs
+++ b/examples/distributed_authority/src/settings.rs
@@ -1,10 +1,10 @@
+use std::{net::Ipv4Addr, string::ToString};
+
 use lightyear::prelude::CompressionConfig;
 use lightyear_examples_common::settings::{
     ClientSettings, ClientTransports, Conditioner, ServerSettings, ServerTransports, Settings,
     SharedSettings, WebTransportCertificateSettings,
 };
-use std::net::Ipv4Addr;
-use std::string::ToString;
 
 pub(crate) fn get_settings() -> Settings {
     Settings {

--- a/examples/distributed_authority/src/shared.rs
+++ b/examples/distributed_authority/src/shared.rs
@@ -5,9 +5,7 @@
 //! mispredictions/rollbacks.
 
 use bevy::prelude::*;
-
-use lightyear::prelude::client::Interpolated;
-use lightyear::prelude::*;
+use lightyear::prelude::{client::Interpolated, *};
 
 use crate::protocol::*;
 

--- a/examples/fps/src/client.rs
+++ b/examples/fps/src/client.rs
@@ -1,17 +1,19 @@
-use bevy::prelude::*;
-use bevy::utils::Duration;
-use leafwing_input_manager::action_state::ActionData;
-use leafwing_input_manager::buttonlike::ButtonState::Pressed;
-use leafwing_input_manager::plugin::InputManagerSystem;
-use leafwing_input_manager::prelude::*;
-use lightyear::client::input::InputSystemSet;
-use lightyear::inputs::native::input_buffer::InputBuffer;
-use lightyear::prelude::client::*;
-use lightyear::prelude::*;
+use bevy::{prelude::*, utils::Duration};
+use leafwing_input_manager::{
+    action_state::ActionData, buttonlike::ButtonState::Pressed, plugin::InputManagerSystem,
+    prelude::*,
+};
+use lightyear::{
+    client::input::InputSystemSet,
+    inputs::native::input_buffer::InputBuffer,
+    prelude::{client::*, *},
+};
 
-use crate::protocol::*;
-use crate::shared;
-use crate::shared::{color_from_id, shared_player_movement};
+use crate::{
+    protocol::*,
+    shared,
+    shared::{color_from_id, shared_player_movement},
+};
 
 pub struct ExampleClientPlugin;
 

--- a/examples/fps/src/main.rs
+++ b/examples/fps/src/main.rs
@@ -1,11 +1,14 @@
 #![allow(unused_imports)]
 #![allow(unused_variables)]
 #![allow(dead_code)]
-use crate::shared::SharedPlugin;
 use bevy::prelude::*;
 use lightyear::prelude::client::PredictionConfig;
-use lightyear_examples_common::app::{Apps, Cli};
-use lightyear_examples_common::settings::Settings;
+use lightyear_examples_common::{
+    app::{Apps, Cli},
+    settings::Settings,
+};
+
+use crate::shared::SharedPlugin;
 
 #[cfg(feature = "client")]
 mod client;

--- a/examples/fps/src/protocol.rs
+++ b/examples/fps/src/protocol.rs
@@ -1,15 +1,13 @@
 use avian2d::prelude::RigidBody;
 use bevy::prelude::*;
 use leafwing_input_manager::prelude::*;
+use lightyear::{
+    client::components::{ComponentSyncMode, LerpFn},
+    prelude::{client::Replicate, server::SyncTarget, *},
+    shared::{input::InputConfig, replication::components::ReplicationGroupIdBuilder},
+    utils::bevy::*,
+};
 use serde::{Deserialize, Serialize};
-
-use lightyear::client::components::{ComponentSyncMode, LerpFn};
-use lightyear::prelude::client::Replicate;
-use lightyear::prelude::server::SyncTarget;
-use lightyear::prelude::*;
-use lightyear::shared::input::InputConfig;
-use lightyear::shared::replication::components::ReplicationGroupIdBuilder;
-use lightyear::utils::bevy::*;
 
 use crate::shared::color_from_id;
 

--- a/examples/fps/src/renderer.rs
+++ b/examples/fps/src/renderer.rs
@@ -1,15 +1,20 @@
-use crate::protocol::*;
-use crate::shared::BOT_RADIUS;
 use avian2d::prelude::*;
-use bevy::color::palettes::basic::GREEN;
-use bevy::color::palettes::css::BLUE;
-use bevy::ecs::query::QueryFilter;
-use bevy::prelude::*;
-use lightyear::client::interpolation::VisualInterpolationPlugin;
-use lightyear::prelude::client::{Interpolated, Predicted, VisualInterpolateStatus};
-use lightyear::prelude::server::ReplicationTarget;
-use lightyear::prelude::{NetworkIdentity, PreSpawnedPlayerObject, Replicated};
+use bevy::{
+    color::palettes::{basic::GREEN, css::BLUE},
+    ecs::query::QueryFilter,
+    prelude::*,
+};
+use lightyear::{
+    client::interpolation::VisualInterpolationPlugin,
+    prelude::{
+        client::{Interpolated, Predicted, VisualInterpolateStatus},
+        server::ReplicationTarget,
+        NetworkIdentity, PreSpawnedPlayerObject, Replicated,
+    },
+};
 use lightyear_avian::prelude::AabbEnvelopeHolder;
+
+use crate::{protocol::*, shared::BOT_RADIUS};
 
 #[derive(Clone)]
 pub struct ExampleRendererPlugin;

--- a/examples/fps/src/server.rs
+++ b/examples/fps/src/server.rs
@@ -1,20 +1,25 @@
-use avian2d::prelude::*;
-use bevy::prelude::*;
-use bevy::time::Stopwatch;
-use bevy::utils::Duration;
-use leafwing_input_manager::prelude::*;
 use std::ops::DerefMut;
 
-use crate::protocol::*;
-use crate::shared;
-use crate::shared::{color_from_id, shared_player_movement, BOT_RADIUS};
-use lightyear::client::prediction::Predicted;
-use lightyear::prelude::client::{Confirmed, InterpolationDelay};
-use lightyear::prelude::server::*;
-use lightyear::prelude::*;
-use lightyear::shared::replication::components::InitialReplicated;
+use avian2d::prelude::*;
+use bevy::{prelude::*, time::Stopwatch, utils::Duration};
+use leafwing_input_manager::prelude::*;
+use lightyear::{
+    client::prediction::Predicted,
+    prelude::{
+        client::{Confirmed, InterpolationDelay},
+        server::*,
+        *,
+    },
+    shared::replication::components::InitialReplicated,
+};
 use lightyear_avian::prelude::{
     LagCompensationHistory, LagCompensationPlugin, LagCompensationSet, LagCompensationSpatialQuery,
+};
+
+use crate::{
+    protocol::*,
+    shared,
+    shared::{color_from_id, shared_player_movement, BOT_RADIUS},
 };
 
 // Plugin for server-specific logic

--- a/examples/fps/src/settings.rs
+++ b/examples/fps/src/settings.rs
@@ -1,10 +1,10 @@
+use std::{net::Ipv4Addr, string::ToString};
+
 use lightyear::prelude::CompressionConfig;
 use lightyear_examples_common::settings::{
     ClientSettings, ClientTransports, Conditioner, ServerSettings, ServerTransports, Settings,
     SharedSettings, WebTransportCertificateSettings,
 };
-use std::net::Ipv4Addr;
-use std::string::ToString;
 
 #[derive(Clone, Debug)]
 pub struct MySettings {

--- a/examples/fps/src/shared.rs
+++ b/examples/fps/src/shared.rs
@@ -1,20 +1,18 @@
-use avian2d::collision::ColliderHierarchyPlugin;
-use avian2d::prelude::*;
-use avian2d::PhysicsPlugins;
-use bevy::diagnostic::LogDiagnosticsPlugin;
-use bevy::prelude::*;
-use bevy::time::Stopwatch;
-use bevy::utils::Duration;
-use leafwing_input_manager::prelude::ActionState;
-use server::ControlledBy;
 use std::ops::DerefMut;
 
-use lightyear::client::prediction::plugin::is_in_rollback;
-use lightyear::prelude::client::*;
-use lightyear::prelude::server::{Replicate, ReplicationTarget, SyncTarget};
-use lightyear::prelude::TickManager;
-use lightyear::prelude::*;
-use lightyear::transport::io::IoDiagnosticsPlugin;
+use avian2d::{collision::ColliderHierarchyPlugin, prelude::*, PhysicsPlugins};
+use bevy::{diagnostic::LogDiagnosticsPlugin, prelude::*, time::Stopwatch, utils::Duration};
+use leafwing_input_manager::prelude::ActionState;
+use lightyear::{
+    client::prediction::plugin::is_in_rollback,
+    prelude::{
+        client::*,
+        server::{Replicate, ReplicationTarget, SyncTarget},
+        TickManager, *,
+    },
+    transport::io::IoDiagnosticsPlugin,
+};
+use server::ControlledBy;
 
 use crate::protocol::*;
 

--- a/examples/interest_management/src/client.rs
+++ b/examples/interest_management/src/client.rs
@@ -1,11 +1,9 @@
 use bevy::prelude::*;
 use leafwing_input_manager::prelude::*;
-
 pub use lightyear::prelude::client::*;
 use lightyear::prelude::*;
 
-use crate::protocol::*;
-use crate::shared::shared_movement_behaviour;
+use crate::{protocol::*, shared::shared_movement_behaviour};
 
 pub struct ExampleClientPlugin;
 

--- a/examples/interest_management/src/main.rs
+++ b/examples/interest_management/src/main.rs
@@ -2,8 +2,7 @@
 #![allow(unused_variables)]
 #![allow(dead_code)]
 use bevy::prelude::*;
-use lightyear_examples_common::app::Apps;
-use lightyear_examples_common::settings::Settings;
+use lightyear_examples_common::{app::Apps, settings::Settings};
 
 #[cfg(feature = "client")]
 mod client;

--- a/examples/interest_management/src/protocol.rs
+++ b/examples/interest_management/src/protocol.rs
@@ -1,19 +1,19 @@
 use std::ops::{Add, Mul};
 
-use bevy::ecs::entity::MapEntities;
-use bevy::math::Vec2;
-use bevy::prelude::*;
-use leafwing_input_manager::action_state::ActionState;
-use leafwing_input_manager::input_map::InputMap;
-use leafwing_input_manager::prelude::Actionlike;
-use leafwing_input_manager::InputManagerBundle;
+use bevy::{ecs::entity::MapEntities, math::Vec2, prelude::*};
+use leafwing_input_manager::{
+    action_state::ActionState, input_map::InputMap, prelude::Actionlike, InputManagerBundle,
+};
+use lightyear::{
+    client::components::ComponentSyncMode,
+    prelude::{
+        server::{ControlledBy, Replicate, SyncTarget},
+        *,
+    },
+    shared::replication::components::NetworkRelevanceMode,
+};
 use serde::{Deserialize, Serialize};
 use tracing::info;
-
-use lightyear::client::components::ComponentSyncMode;
-use lightyear::prelude::server::{ControlledBy, Replicate, SyncTarget};
-use lightyear::prelude::*;
-use lightyear::shared::replication::components::NetworkRelevanceMode;
 use UserAction;
 
 use crate::shared::color_from_id;

--- a/examples/interest_management/src/renderer.rs
+++ b/examples/interest_management/src/renderer.rs
@@ -1,8 +1,7 @@
-use crate::protocol::*;
-use bevy::color::palettes::basic::GREEN;
-use bevy::prelude::*;
-use bevy::render::RenderPlugin;
+use bevy::{color::palettes::basic::GREEN, prelude::*, render::RenderPlugin};
 use lightyear::client::components::Confirmed;
+
+use crate::protocol::*;
 
 #[derive(Clone)]
 pub struct ExampleRendererPlugin;

--- a/examples/interest_management/src/server.rs
+++ b/examples/interest_management/src/server.rs
@@ -1,14 +1,15 @@
-use bevy::prelude::*;
-use bevy::utils::Duration;
-use bevy::utils::HashMap;
+use bevy::{
+    prelude::*,
+    utils::{Duration, HashMap},
+};
 use leafwing_input_manager::prelude::{ActionState, InputMap};
+use lightyear::prelude::{server::*, *};
 
-use lightyear::prelude::server::*;
-use lightyear::prelude::*;
-
-use crate::protocol::*;
-use crate::shared;
-use crate::shared::{color_from_id, shared_movement_behaviour};
+use crate::{
+    protocol::*,
+    shared,
+    shared::{color_from_id, shared_movement_behaviour},
+};
 
 const GRID_SIZE: f32 = 200.0;
 const NUM_CIRCLES: i32 = 10;

--- a/examples/interest_management/src/settings.rs
+++ b/examples/interest_management/src/settings.rs
@@ -1,10 +1,10 @@
+use std::{net::Ipv4Addr, string::ToString};
+
 use lightyear::prelude::CompressionConfig;
 use lightyear_examples_common::settings::{
     ClientSettings, ClientTransports, Conditioner, ServerSettings, ServerTransports, Settings,
     SharedSettings, WebTransportCertificateSettings,
 };
-use std::net::Ipv4Addr;
-use std::string::ToString;
 
 pub(crate) fn get_settings() -> Settings {
     Settings {

--- a/examples/interest_management/src/shared.rs
+++ b/examples/interest_management/src/shared.rs
@@ -1,11 +1,8 @@
-use bevy::color::palettes::css::GREEN;
-use bevy::prelude::*;
-use bevy::utils::Duration;
-use leafwing_input_manager::action_state::ActionState;
 use std::ops::Deref;
 
-use lightyear::client::components::Confirmed;
-use lightyear::prelude::*;
+use bevy::{color::palettes::css::GREEN, prelude::*, utils::Duration};
+use leafwing_input_manager::action_state::ActionState;
+use lightyear::{client::components::Confirmed, prelude::*};
 
 use crate::protocol::*;
 

--- a/examples/lobby/src/client.rs
+++ b/examples/lobby/src/client.rs
@@ -8,13 +8,14 @@ use std::net::SocketAddr;
 
 use bevy::prelude::*;
 use bevy_egui::{egui, EguiContexts};
-use lightyear::client::input::InputSystemSet;
 pub use lightyear::prelude::client::*;
-use lightyear::prelude::server::ServerCommandsExt;
-use lightyear::prelude::*;
+use lightyear::{
+    client::input::InputSystemSet,
+    prelude::{server::ServerCommandsExt, *},
+};
+use lightyear_examples_common::settings::{get_client_net_config, Settings};
 
 use crate::protocol::*;
-use lightyear_examples_common::settings::{get_client_net_config, Settings};
 
 pub struct ExampleClientPlugin {
     pub(crate) settings: Settings,
@@ -108,11 +109,10 @@ fn on_disconnect(
 }
 
 mod game {
-    use crate::protocol::Direction;
-    use crate::shared::shared_movement_behaviour;
     use lightyear::inputs::native::{ActionState, InputMarker};
 
     use super::*;
+    use crate::{protocol::Direction, shared::shared_movement_behaviour};
 
     /// System that reads from peripherals and adds inputs to the buffer
     /// This system must be run in the
@@ -201,17 +201,16 @@ mod lobby {
     use std::net::SocketAddr;
 
     use bevy::utils::HashMap;
-    use bevy_egui::egui::Separator;
-    use bevy_egui::{egui, EguiContexts};
+    use bevy_egui::{egui, egui::Separator, EguiContexts};
     use egui_extras::{Column, TableBuilder};
+    use lightyear::server::config::ServerConfig;
     use tracing::{error, info};
 
-    use lightyear::server::config::ServerConfig;
-
-    use crate::client::{lobby, AppState};
-    use crate::HOST_SERVER_PORT;
-
     use super::*;
+    use crate::{
+        client::{lobby, AppState},
+        HOST_SERVER_PORT,
+    };
 
     #[derive(Resource, Default, Debug)]
     pub(crate) struct LobbyTable {

--- a/examples/lobby/src/main.rs
+++ b/examples/lobby/src/main.rs
@@ -10,12 +10,14 @@
 #![allow(unused_imports)]
 #![allow(unused_variables)]
 #![allow(dead_code)]
-use crate::settings::get_settings;
-use crate::shared::SharedPlugin;
 use bevy::prelude::*;
 use lightyear::prelude::{Deserialize, Serialize};
-use lightyear_examples_common::app::{Apps, Cli, Mode};
-use lightyear_examples_common::settings::ServerTransports;
+use lightyear_examples_common::{
+    app::{Apps, Cli, Mode},
+    settings::ServerTransports,
+};
+
+use crate::{settings::get_settings, shared::SharedPlugin};
 
 #[cfg(feature = "client")]
 mod client;

--- a/examples/lobby/src/protocol.rs
+++ b/examples/lobby/src/protocol.rs
@@ -6,16 +6,16 @@
 //! - how the component should be synchronized between the `Confirmed` entity and the `Predicted`/`Interpolated` entity
 use std::ops::{Add, Mul};
 
-use bevy::app::{App, Plugin};
-use bevy::ecs::entity::MapEntities;
-use bevy::prelude::{
-    default, Bundle, Color, Component, Deref, DerefMut, Entity, EntityMapper, Vec2,
+use bevy::{
+    app::{App, Plugin},
+    ecs::entity::MapEntities,
+    prelude::{
+        default, Bundle, Color, Component, Deref, DerefMut, Entity, EntityMapper, Reflect,
+        Resource, Vec2,
+    },
 };
-use bevy::prelude::{Reflect, Resource};
+use lightyear::{client::components::ComponentSyncMode, prelude::*};
 use serde::{Deserialize, Serialize};
-
-use lightyear::client::components::ComponentSyncMode;
-use lightyear::prelude::*;
 
 // Player
 #[derive(Bundle)]

--- a/examples/lobby/src/renderer.rs
+++ b/examples/lobby/src/renderer.rs
@@ -1,9 +1,8 @@
-use crate::protocol::*;
-use bevy::prelude::*;
-use bevy::render::RenderPlugin;
+use bevy::{prelude::*, render::RenderPlugin};
 use bevy_egui::EguiPlugin;
-use lightyear::client::interpolation::Interpolated;
-use lightyear::client::prediction::Predicted;
+use lightyear::client::{interpolation::Interpolated, prediction::Predicted};
+
+use crate::protocol::*;
 
 #[derive(Clone)]
 pub struct ExampleRendererPlugin;

--- a/examples/lobby/src/server.rs
+++ b/examples/lobby/src/server.rs
@@ -6,16 +6,13 @@
 //! - read inputs from the clients and move the player entities accordingly
 //!
 //! Lightyear will handle the replication of entities automatically if you add a `Replicate` component to them.
-use bevy::prelude::*;
-use bevy::utils::Duration;
-use bevy::utils::HashMap;
+use bevy::{
+    prelude::*,
+    utils::{Duration, HashMap},
+};
+use lightyear::prelude::{server::*, *};
 
-use lightyear::prelude::server::*;
-use lightyear::prelude::*;
-
-use crate::protocol::*;
-use crate::shared;
-use crate::shared::shared_movement_behaviour;
+use crate::{protocol::*, shared, shared::shared_movement_behaviour};
 
 pub struct ExampleServerPlugin {
     pub(crate) is_dedicated_server: bool,
@@ -93,8 +90,9 @@ fn spawn_player_entity(
 }
 
 mod game {
-    use super::*;
     use lightyear::inputs::native::ActionState;
+
+    use super::*;
 
     /// When a player connects, create a new player entity.
     /// This is only for the HostServer mode (for the dedicated server mode, the clients are already connected to the server
@@ -139,8 +137,7 @@ mod game {
 }
 
 mod lobby {
-    use lightyear::server::connection::ConnectionManager;
-    use lightyear::server::relevance::room::RoomManager;
+    use lightyear::server::{connection::ConnectionManager, relevance::room::RoomManager};
 
     use super::*;
 

--- a/examples/lobby/src/settings.rs
+++ b/examples/lobby/src/settings.rs
@@ -1,10 +1,10 @@
+use std::{net::Ipv4Addr, string::ToString};
+
 use lightyear::prelude::CompressionConfig;
 use lightyear_examples_common::settings::{
     ClientSettings, ClientTransports, Conditioner, ServerSettings, ServerTransports, Settings,
     SharedSettings, WebTransportCertificateSettings,
 };
-use std::net::Ipv4Addr;
-use std::string::ToString;
 
 pub(crate) fn get_settings() -> Settings {
     Settings {

--- a/examples/priority/src/client.rs
+++ b/examples/priority/src/client.rs
@@ -1,6 +1,5 @@
 use bevy::prelude::*;
 use leafwing_input_manager::prelude::*;
-
 pub use lightyear::prelude::client::*;
 use lightyear::prelude::*;
 

--- a/examples/priority/src/main.rs
+++ b/examples/priority/src/main.rs
@@ -1,11 +1,14 @@
 #![allow(unused_imports)]
 #![allow(unused_variables)]
 #![allow(dead_code)]
-use crate::settings::get_settings;
 use bevy::prelude::*;
 use lightyear::prelude::server::PacketConfig;
-use lightyear_examples_common::app::{Apps, Cli};
-use lightyear_examples_common::settings::Settings;
+use lightyear_examples_common::{
+    app::{Apps, Cli},
+    settings::Settings,
+};
+
+use crate::settings::get_settings;
 
 #[cfg(feature = "client")]
 mod client;

--- a/examples/priority/src/protocol.rs
+++ b/examples/priority/src/protocol.rs
@@ -1,16 +1,15 @@
 use std::ops::{Add, Mul};
 
 use bevy::prelude::*;
-use leafwing_input_manager::action_state::ActionState;
-use leafwing_input_manager::input_map::InputMap;
-use leafwing_input_manager::prelude::Actionlike;
-use leafwing_input_manager::InputManagerBundle;
+use leafwing_input_manager::{
+    action_state::ActionState, input_map::InputMap, prelude::Actionlike, InputManagerBundle,
+};
+use lightyear::{
+    client::components::ComponentSyncMode,
+    prelude::{server::*, *},
+};
 use serde::{Deserialize, Serialize};
 use tracing::info;
-
-use lightyear::client::components::ComponentSyncMode;
-use lightyear::prelude::server::*;
-use lightyear::prelude::*;
 
 // Player
 #[derive(Bundle)]

--- a/examples/priority/src/renderer.rs
+++ b/examples/priority/src/renderer.rs
@@ -1,8 +1,11 @@
-use crate::protocol::*;
-use bevy::color::palettes::basic::{BLUE, GREEN, RED};
-use bevy::prelude::*;
-use bevy::render::RenderPlugin;
+use bevy::{
+    color::palettes::basic::{BLUE, GREEN, RED},
+    prelude::*,
+    render::RenderPlugin,
+};
 use lightyear::client::components::Confirmed;
+
+use crate::protocol::*;
 
 #[derive(Clone)]
 pub struct ExampleRendererPlugin;

--- a/examples/priority/src/server.rs
+++ b/examples/priority/src/server.rs
@@ -1,7 +1,6 @@
-use bevy::prelude::*;
-use bevy::utils::HashMap;
 use std::ops::Deref;
 
+use bevy::{prelude::*, utils::HashMap};
 pub use lightyear::prelude::server::*;
 use lightyear::prelude::*;
 

--- a/examples/priority/src/settings.rs
+++ b/examples/priority/src/settings.rs
@@ -1,10 +1,10 @@
+use std::{net::Ipv4Addr, string::ToString};
+
 use lightyear::prelude::CompressionConfig;
 use lightyear_examples_common::settings::{
     ClientSettings, ClientTransports, Conditioner, ServerSettings, ServerTransports, Settings,
     SharedSettings, WebTransportCertificateSettings,
 };
-use std::net::Ipv4Addr;
-use std::string::ToString;
 
 pub(crate) fn get_settings() -> Settings {
     Settings {

--- a/examples/priority/src/shared.rs
+++ b/examples/priority/src/shared.rs
@@ -1,12 +1,15 @@
-use bevy::color::palettes::css::{BLUE, GREEN, RED};
-use bevy::prelude::*;
-use bevy::utils::Duration;
-use leafwing_input_manager::action_state::ActionState;
 use std::ops::Deref;
 
-use lightyear::prelude::client::Confirmed;
-use lightyear::prelude::*;
-use lightyear::transport::io::IoDiagnosticsPlugin;
+use bevy::{
+    color::palettes::css::{BLUE, GREEN, RED},
+    prelude::*,
+    utils::Duration,
+};
+use leafwing_input_manager::action_state::ActionState;
+use lightyear::{
+    prelude::{client::Confirmed, *},
+    transport::io::IoDiagnosticsPlugin,
+};
 
 use crate::protocol::*;
 

--- a/examples/replication_groups/src/client.rs
+++ b/examples/replication_groups/src/client.rs
@@ -1,12 +1,14 @@
-use crate::protocol::Direction;
-use crate::protocol::*;
-use crate::shared::{shared_movement_behaviour, shared_tail_behaviour};
-use bevy::prelude::*;
-use bevy::utils::Duration;
-use lightyear::client::input::InputSystemSet;
-use lightyear::inputs::native::{ActionState, InputMarker};
-use lightyear::prelude::client::*;
-use lightyear::prelude::*;
+use bevy::{prelude::*, utils::Duration};
+use lightyear::{
+    client::input::InputSystemSet,
+    inputs::native::{ActionState, InputMarker},
+    prelude::{client::*, *},
+};
+
+use crate::{
+    protocol::{Direction, *},
+    shared::{shared_movement_behaviour, shared_tail_behaviour},
+};
 
 pub struct ExampleClientPlugin;
 

--- a/examples/replication_groups/src/main.rs
+++ b/examples/replication_groups/src/main.rs
@@ -1,10 +1,13 @@
 #![allow(unused_imports)]
 #![allow(unused_variables)]
 #![allow(dead_code)]
-use crate::settings::get_settings;
 use bevy::prelude::*;
-use lightyear_examples_common::app::{Apps, Cli};
-use lightyear_examples_common::settings::Settings;
+use lightyear_examples_common::{
+    app::{Apps, Cli},
+    settings::Settings,
+};
+
+use crate::settings::get_settings;
 
 #[cfg(feature = "client")]
 mod client;

--- a/examples/replication_groups/src/protocol.rs
+++ b/examples/replication_groups/src/protocol.rs
@@ -1,19 +1,22 @@
-use std::collections::VecDeque;
-use std::ops::{Add, Mul};
+use std::{
+    collections::VecDeque,
+    ops::{Add, Mul},
+};
 
-use bevy::app::{App, Plugin};
-use bevy::ecs::entity::MapEntities;
-use bevy::prelude::{
-    default, Bundle, Color, Component, Deref, DerefMut, Entity, EntityMapper, Reflect, Vec2,
+use bevy::{
+    app::{App, Plugin},
+    ecs::entity::MapEntities,
+    prelude::{
+        default, Bundle, Color, Component, Deref, DerefMut, Entity, EntityMapper, Reflect, Vec2,
+    },
+};
+use lightyear::{
+    client::components::ComponentSyncMode,
+    prelude::{client::LerpFn, server::*, *},
+    shared::replication::components::ReplicationGroup,
 };
 use serde::{Deserialize, Serialize};
 use tracing::{debug, info, trace};
-
-use lightyear::client::components::ComponentSyncMode;
-use lightyear::prelude::client::LerpFn;
-use lightyear::prelude::server::*;
-use lightyear::prelude::*;
-use lightyear::shared::replication::components::ReplicationGroup;
 
 // Player
 #[derive(Bundle)]

--- a/examples/replication_groups/src/renderer.rs
+++ b/examples/replication_groups/src/renderer.rs
@@ -1,7 +1,7 @@
-use crate::protocol::*;
-use bevy::prelude::*;
-use bevy::render::RenderPlugin;
+use bevy::{prelude::*, render::RenderPlugin};
 use lightyear::client::components::Confirmed;
+
+use crate::protocol::*;
 
 #[derive(Clone)]
 pub struct ExampleRendererPlugin;

--- a/examples/replication_groups/src/server.rs
+++ b/examples/replication_groups/src/server.rs
@@ -1,11 +1,14 @@
 use bevy::prelude::*;
-use lightyear::client::components::Confirmed;
-use lightyear::client::prediction::Predicted;
-use lightyear::inputs::native::ActionState;
-use lightyear::prelude::server::*;
+use lightyear::{
+    client::{components::Confirmed, prediction::Predicted},
+    inputs::native::ActionState,
+    prelude::server::*,
+};
 
-use crate::protocol::*;
-use crate::shared::{shared_movement_behaviour, shared_tail_behaviour};
+use crate::{
+    protocol::*,
+    shared::{shared_movement_behaviour, shared_tail_behaviour},
+};
 
 // Plugin for server-specific logic
 pub struct ExampleServerPlugin;

--- a/examples/replication_groups/src/settings.rs
+++ b/examples/replication_groups/src/settings.rs
@@ -1,10 +1,10 @@
+use std::{net::Ipv4Addr, string::ToString};
+
 use lightyear::prelude::CompressionConfig;
 use lightyear_examples_common::settings::{
     ClientSettings, ClientTransports, Conditioner, ServerSettings, ServerTransports, Settings,
     SharedSettings, WebTransportCertificateSettings,
 };
-use std::net::Ipv4Addr;
-use std::string::ToString;
 
 pub(crate) fn get_settings() -> Settings {
     Settings {

--- a/examples/replication_groups/src/shared.rs
+++ b/examples/replication_groups/src/shared.rs
@@ -1,13 +1,15 @@
-use bevy::prelude::*;
-use bevy::utils::Duration;
+use bevy::{prelude::*, utils::Duration};
+use lightyear::{
+    client::prediction::Predicted,
+    prelude::{
+        client::{Confirmed, Interpolated},
+        server::ReplicationTarget,
+        *,
+    },
+};
 use tracing::Level;
 
-use crate::protocol::Direction;
-use crate::protocol::*;
-use lightyear::client::prediction::Predicted;
-use lightyear::prelude::client::{Confirmed, Interpolated};
-use lightyear::prelude::server::ReplicationTarget;
-use lightyear::prelude::*;
+use crate::protocol::{Direction, *};
 
 #[derive(Clone)]
 pub struct SharedPlugin;

--- a/examples/simple_box/src/client.rs
+++ b/examples/simple_box/src/client.rs
@@ -4,22 +4,25 @@
 //! - sending inputs to the server
 //! - applying inputs to the locally predicted player (for prediction to work, inputs have to be applied to both the
 //! predicted entity and the server entity)
-use std::net::{Ipv4Addr, SocketAddr};
-use std::str::FromStr;
+use std::{
+    net::{Ipv4Addr, SocketAddr},
+    str::FromStr,
+};
 
-use bevy::app::PluginGroupBuilder;
-use bevy::prelude::*;
-use bevy::time::common_conditions::on_timer;
-use bevy::utils::Duration;
-
-use lightyear::client::input::InputSystemSet;
-use lightyear::inputs::native::{ActionState, InputMarker};
+use bevy::{
+    app::PluginGroupBuilder, prelude::*, time::common_conditions::on_timer, utils::Duration,
+};
 pub use lightyear::prelude::client::*;
-use lightyear::prelude::*;
+use lightyear::{
+    client::input::InputSystemSet,
+    inputs::native::{ActionState, InputMarker},
+    prelude::*,
+};
 
-use crate::protocol::Direction;
-use crate::protocol::*;
-use crate::shared;
+use crate::{
+    protocol::{Direction, *},
+    shared,
+};
 
 pub struct ExampleClientPlugin;
 

--- a/examples/simple_box/src/main.rs
+++ b/examples/simple_box/src/main.rs
@@ -10,11 +10,14 @@
 #![allow(unused_imports)]
 #![allow(unused_variables)]
 #![allow(dead_code)]
-use crate::settings::get_settings;
 use bevy::prelude::*;
-use lightyear_examples_common::app::{Apps, Cli};
-use lightyear_examples_common::settings::Settings;
+use lightyear_examples_common::{
+    app::{Apps, Cli},
+    settings::Settings,
+};
 use protocol::ProtocolPlugin;
+
+use crate::settings::get_settings;
 
 #[cfg(feature = "client")]
 mod client;

--- a/examples/simple_box/src/protocol.rs
+++ b/examples/simple_box/src/protocol.rs
@@ -6,15 +6,14 @@
 //! - how the component should be synchronized between the `Confirmed` entity and the `Predicted`/`Interpolated` entity
 use std::ops::{Add, Mul};
 
-use bevy::ecs::entity::MapEntities;
-use bevy::prelude::{
-    default, Bundle, Color, Component, Deref, DerefMut, Entity, EntityMapper, Vec2,
+use bevy::{
+    ecs::entity::MapEntities,
+    prelude::{
+        default, App, Bundle, Color, Component, Deref, DerefMut, Entity, EntityMapper, Plugin, Vec2,
+    },
 };
-use bevy::prelude::{App, Plugin};
+use lightyear::{client::components::ComponentSyncMode, prelude::*};
 use serde::{Deserialize, Serialize};
-
-use lightyear::client::components::ComponentSyncMode;
-use lightyear::prelude::*;
 
 // Player
 #[derive(Bundle)]

--- a/examples/simple_box/src/renderer.rs
+++ b/examples/simple_box/src/renderer.rs
@@ -1,5 +1,4 @@
-use bevy::prelude::*;
-use bevy::render::RenderPlugin;
+use bevy::{prelude::*, render::RenderPlugin};
 
 use crate::protocol::*;
 

--- a/examples/simple_box/src/server.rs
+++ b/examples/simple_box/src/server.rs
@@ -6,17 +6,16 @@
 //! - read inputs from the clients and move the player entities accordingly
 //!
 //! Lightyear will handle the replication of entities automatically if you add a `Replicate` component to them.
-use crate::protocol::*;
-use crate::shared;
-use bevy::app::PluginGroupBuilder;
-use bevy::prelude::*;
-use bevy::utils::HashMap;
-use lightyear::client::components::Confirmed;
-use lightyear::client::prediction::Predicted;
-use lightyear::inputs::native::ActionState;
-use lightyear::prelude::server::*;
-use lightyear::prelude::*;
 use std::sync::Arc;
+
+use bevy::{app::PluginGroupBuilder, prelude::*, utils::HashMap};
+use lightyear::{
+    client::{components::Confirmed, prediction::Predicted},
+    inputs::native::ActionState,
+    prelude::{server::*, *},
+};
+
+use crate::{protocol::*, shared};
 
 pub struct ExampleServerPlugin;
 

--- a/examples/simple_box/src/settings.rs
+++ b/examples/simple_box/src/settings.rs
@@ -1,10 +1,10 @@
+use std::{net::Ipv4Addr, string::ToString};
+
 use lightyear::prelude::CompressionConfig;
 use lightyear_examples_common::settings::{
     ClientSettings, ClientTransports, Conditioner, ServerSettings, ServerTransports, Settings,
     SharedSettings, WebTransportCertificateSettings,
 };
-use std::net::Ipv4Addr;
-use std::string::ToString;
 
 pub(crate) fn get_settings() -> Settings {
     Settings {

--- a/examples/simple_setup/src/client.rs
+++ b/examples/simple_setup/src/client.rs
@@ -1,9 +1,11 @@
 //! The client plugin.
-use crate::shared::{shared_config, SharedPlugin, SERVER_ADDR};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
 use bevy::prelude::*;
 pub use lightyear::prelude::client::*;
 use lightyear::prelude::*;
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+use crate::shared::{shared_config, SharedPlugin, SERVER_ADDR};
 
 pub struct ExampleClientPlugin;
 

--- a/examples/simple_setup/src/server.rs
+++ b/examples/simple_setup/src/server.rs
@@ -6,9 +6,11 @@
 //! - read inputs from the clients and move the player entities accordingly
 //!
 //! Lightyear will handle the replication of entities automatically if you add a `Replicate` component to them.
-use bevy::log::{Level, LogPlugin};
-use bevy::prelude::*;
-use bevy::state::app::StatesPlugin;
+use bevy::{
+    log::{Level, LogPlugin},
+    prelude::*,
+    state::app::StatesPlugin,
+};
 use lightyear::prelude::server::*;
 
 use crate::shared::{shared_config, SharedPlugin, SERVER_ADDR};

--- a/examples/simple_setup/src/shared.rs
+++ b/examples/simple_setup/src/shared.rs
@@ -1,9 +1,8 @@
 //! This module contains the shared code between the client and the server.
 
-use bevy::prelude::*;
-use bevy::utils::Duration;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
+use bevy::{prelude::*, utils::Duration};
 use lightyear::prelude::*;
 
 pub const FIXED_TIMESTEP_HZ: f64 = 64.0;

--- a/examples/spaceships/src/client.rs
+++ b/examples/spaceships/src/client.rs
@@ -1,17 +1,14 @@
 use avian2d::prelude::*;
-use bevy::app::PluginGroupBuilder;
-use bevy::prelude::*;
-use bevy::utils::Duration;
+use bevy::{app::PluginGroupBuilder, prelude::*, utils::Duration};
 use leafwing_input_manager::prelude::*;
-use lightyear::inputs::leafwing::input_buffer::InputBuffer;
-use lightyear::prelude::client::*;
-use lightyear::prelude::*;
-use lightyear::shared::replication::components::Controlled;
-use lightyear::shared::tick_manager;
+use lightyear::{
+    inputs::leafwing::input_buffer::InputBuffer,
+    prelude::{client::*, *},
+    shared::{replication::components::Controlled, tick_manager},
+};
 use lightyear_examples_common::shared::FIXED_TIMESTEP_HZ;
 
-use crate::protocol::*;
-use crate::shared::*;
+use crate::{protocol::*, shared::*};
 
 pub struct ExampleClientPlugin;
 

--- a/examples/spaceships/src/entity_label.rs
+++ b/examples/spaceships/src/entity_label.rs
@@ -1,10 +1,9 @@
 use avian2d::prelude::{Position, Rotation};
-use bevy::prelude::TransformSystem::TransformPropagate;
 /// Utility plugin to display a text label next to an entity.
 ///
 /// Label will track parent position, ignoring rotation.
 use bevy::prelude::*;
-use bevy::text::TextReader;
+use bevy::{prelude::TransformSystem::TransformPropagate, text::TextReader};
 use lightyear::{
     client::{
         interpolation::{plugin::InterpolationSet, VisualInterpolateStatus},

--- a/examples/spaceships/src/main.rs
+++ b/examples/spaceships/src/main.rs
@@ -2,9 +2,10 @@
 #![allow(unused_variables)]
 #![allow(dead_code)]
 
-use crate::settings::get_settings;
 use bevy::prelude::*;
 use lightyear_examples_common::app::{Apps, Cli};
+
+use crate::settings::get_settings;
 
 #[cfg(feature = "client")]
 mod client;

--- a/examples/spaceships/src/protocol.rs
+++ b/examples/spaceships/src/protocol.rs
@@ -1,20 +1,24 @@
 use avian2d::prelude::*;
-use bevy::prelude::*;
-use bevy::utils::Duration;
+use bevy::{prelude::*, utils::Duration};
 use leafwing_input_manager::prelude::*;
+use lightyear::{
+    client::{
+        components::{ComponentSyncMode, LerpFn},
+        interpolation::LinearInterpolator,
+    },
+    prelude::{
+        client::{self},
+        server::{Replicate, SyncTarget},
+        *,
+    },
+    shared::input::InputConfig,
+    utils::{avian2d::*, bevy::TransformLinearInterpolation},
+};
 use lightyear_examples_common::shared::FIXED_TIMESTEP_HZ;
 use serde::{Deserialize, Serialize};
+use tracing_subscriber::util::SubscriberInitExt;
 
 use crate::shared::color_from_id;
-use lightyear::client::components::{ComponentSyncMode, LerpFn};
-use lightyear::client::interpolation::LinearInterpolator;
-use lightyear::prelude::client::{self};
-use lightyear::prelude::server::{Replicate, SyncTarget};
-use lightyear::prelude::*;
-use lightyear::shared::input::InputConfig;
-use lightyear::utils::avian2d::*;
-use lightyear::utils::bevy::TransformLinearInterpolation;
-use tracing_subscriber::util::SubscriberInitExt;
 
 pub const BULLET_SIZE: f32 = 1.5;
 pub const SHIP_WIDTH: f32 = 19.0;

--- a/examples/spaceships/src/renderer.rs
+++ b/examples/spaceships/src/renderer.rs
@@ -1,33 +1,37 @@
-use crate::entity_label::*;
-/// Renders entities using gizmos to draw outlines
-use crate::protocol::*;
-use crate::shared::*;
-use avian2d::parry::shape::SharedShape;
-use avian2d::prelude::*;
-use bevy::color::palettes::css;
-use bevy::core_pipeline::bloom::Bloom;
-use bevy::core_pipeline::tonemapping::Tonemapping;
-use bevy::prelude::*;
-use bevy::time::common_conditions::on_timer;
+use std::{
+    f32::consts::{PI, TAU},
+    time::Duration,
+};
+
+use avian2d::{parry::shape::SharedShape, prelude::*};
+use bevy::{
+    color::palettes::css,
+    core_pipeline::{bloom::Bloom, tonemapping::Tonemapping},
+    prelude::*,
+    time::common_conditions::on_timer,
+};
 use leafwing_input_manager::action_state::ActionState;
-use lightyear::client::prediction::prespawn::PreSpawnedPlayerObject;
-use lightyear::inputs::leafwing::input_buffer::InputBuffer;
-use lightyear::prelude::client::*;
-use lightyear::prelude::Replicating;
-use lightyear::shared::tick_manager;
-use lightyear::shared::tick_manager::Tick;
-use lightyear::shared::tick_manager::TickManager;
-use lightyear::transport::io::IoDiagnosticsPlugin;
 use lightyear::{
     client::{
         interpolation::plugin::InterpolationSet,
-        prediction::{diagnostics::PredictionDiagnosticsPlugin, plugin::PredictionSet},
+        prediction::{
+            diagnostics::PredictionDiagnosticsPlugin, plugin::PredictionSet,
+            prespawn::PreSpawnedPlayerObject,
+        },
     },
-    shared::run_conditions::is_server,
+    inputs::leafwing::input_buffer::InputBuffer,
+    prelude::{client::*, Replicating},
+    shared::{
+        run_conditions::is_server,
+        tick_manager,
+        tick_manager::{Tick, TickManager},
+    },
+    transport::io::IoDiagnosticsPlugin,
 };
-use std::f32::consts::PI;
-use std::f32::consts::TAU;
-use std::time::Duration;
+
+/// Renders entities using gizmos to draw outlines
+use crate::protocol::*;
+use crate::{entity_label::*, shared::*};
 
 pub struct SpaceshipsRendererPlugin;
 

--- a/examples/spaceships/src/server.rs
+++ b/examples/spaceships/src/server.rs
@@ -1,27 +1,34 @@
 use std::f32::consts::TAU;
 
 use avian2d::prelude::*;
-use bevy::color::palettes::css;
-use bevy::prelude::*;
-use bevy::time::common_conditions::on_timer;
-use bevy::utils::Duration;
-use bevy::utils::HashMap;
+use bevy::{
+    color::palettes::css,
+    prelude::*,
+    time::common_conditions::on_timer,
+    utils::{Duration, HashMap},
+};
 use client::Rollback;
-use leafwing_input_manager::action_diff::ActionDiff;
-use leafwing_input_manager::prelude::*;
-use lightyear::client::connection;
-use lightyear::prelude::client::{Confirmed, Predicted};
-use lightyear::prelude::server::*;
-use lightyear::prelude::*;
-use lightyear::server::input::InputSystemSet;
-use lightyear::shared::tick_manager;
+use leafwing_input_manager::{action_diff::ActionDiff, prelude::*};
+use lightyear::{
+    client::connection,
+    prelude::{
+        client::{Confirmed, Predicted},
+        server::*,
+        *,
+    },
+    server::input::InputSystemSet,
+    shared::tick_manager,
+};
 use lightyear_examples_common::shared::FIXED_TIMESTEP_HZ;
 
-use crate::protocol::*;
-use crate::shared;
-use crate::shared::ApplyInputsQuery;
-use crate::shared::ApplyInputsQueryItem;
-use crate::shared::{apply_action_state_to_player_movement, color_from_id};
+use crate::{
+    protocol::*,
+    shared,
+    shared::{
+        apply_action_state_to_player_movement, color_from_id, ApplyInputsQuery,
+        ApplyInputsQueryItem,
+    },
+};
 
 // Plugin for server-specific logic
 pub struct ExampleServerPlugin {

--- a/examples/spaceships/src/settings.rs
+++ b/examples/spaceships/src/settings.rs
@@ -1,10 +1,10 @@
+use std::{net::Ipv4Addr, string::ToString};
+
 use lightyear::prelude::CompressionConfig;
 use lightyear_examples_common::settings::{
     ClientSettings, ClientTransports, Conditioner, ServerSettings, ServerTransports, Settings,
     SharedSettings, WebTransportCertificateSettings,
 };
-use std::net::Ipv4Addr;
-use std::string::ToString;
 
 #[derive(Clone, Debug)]
 pub struct MySettings {

--- a/examples/spaceships/src/shared.rs
+++ b/examples/spaceships/src/shared.rs
@@ -1,23 +1,21 @@
-use bevy::diagnostic::LogDiagnosticsPlugin;
-use bevy::ecs::query::QueryData;
-use bevy::prelude::*;
-use bevy::utils::Duration;
-use lightyear::inputs::leafwing::input_buffer::InputBuffer;
-use server::ControlledEntities;
 use std::hash::{Hash, Hasher};
 
 use avian2d::prelude::*;
+use bevy::{diagnostic::LogDiagnosticsPlugin, ecs::query::QueryData, prelude::*, utils::Duration};
 use leafwing_input_manager::prelude::ActionState;
-use lightyear::shared::replication::components::Controlled;
-use tracing::Level;
-
-use lightyear::prelude::client::*;
-use lightyear::prelude::server::{DespawnReplicationCommandExt, ReplicationTarget};
-use lightyear::prelude::TickManager;
-use lightyear::prelude::*;
-use lightyear::shared::ping::diagnostics::PingDiagnosticsPlugin;
-use lightyear::transport::io::IoDiagnosticsPlugin;
+use lightyear::{
+    inputs::leafwing::input_buffer::InputBuffer,
+    prelude::{
+        client::*,
+        server::{DespawnReplicationCommandExt, ReplicationTarget},
+        TickManager, *,
+    },
+    shared::{ping::diagnostics::PingDiagnosticsPlugin, replication::components::Controlled},
+    transport::io::IoDiagnosticsPlugin,
+};
 use lightyear_examples_common::shared::FIXED_TIMESTEP_HZ;
+use server::ControlledEntities;
+use tracing::Level;
 
 use crate::protocol::*;
 #[cfg(feature = "gui")]

--- a/lightyear/.vscode/settings.json
+++ b/lightyear/.vscode/settings.json
@@ -1,6 +1,0 @@
-{
-    "rust-analyzer.linkedProjects": [
-        "./Cargo.toml",
-        "./Cargo.toml"
-    ]
-}

--- a/lightyear/src/channel/builder.rs
+++ b/lightyear/src/channel/builder.rs
@@ -1,22 +1,26 @@
 //! This module contains the [`Channel`] trait
 use bevy::utils::Duration;
-
 use lightyear_macros::ChannelInternal;
 
-use crate::channel::receivers::ordered_reliable::OrderedReliableReceiver;
-use crate::channel::receivers::sequenced_reliable::SequencedReliableReceiver;
-use crate::channel::receivers::sequenced_unreliable::SequencedUnreliableReceiver;
-use crate::channel::receivers::unordered_reliable::UnorderedReliableReceiver;
-use crate::channel::receivers::unordered_unreliable::UnorderedUnreliableReceiver;
-use crate::channel::receivers::ChannelReceiver;
-use crate::channel::senders::reliable::ReliableSender;
-use crate::channel::senders::sequenced_unreliable::SequencedUnreliableSender;
-use crate::channel::senders::unordered_unreliable::UnorderedUnreliableSender;
-use crate::channel::senders::unordered_unreliable_with_acks::UnorderedUnreliableWithAcksSender;
-use crate::channel::senders::ChannelSender;
 #[cfg(feature = "trace")]
 use crate::channel::stats::send::ChannelSendStats;
-use crate::prelude::ChannelKind;
+use crate::{
+    channel::{
+        receivers::{
+            ordered_reliable::OrderedReliableReceiver,
+            sequenced_reliable::SequencedReliableReceiver,
+            sequenced_unreliable::SequencedUnreliableReceiver,
+            unordered_reliable::UnorderedReliableReceiver,
+            unordered_unreliable::UnorderedUnreliableReceiver, ChannelReceiver,
+        },
+        senders::{
+            reliable::ReliableSender, sequenced_unreliable::SequencedUnreliableSender,
+            unordered_unreliable::UnorderedUnreliableSender,
+            unordered_unreliable_with_acks::UnorderedUnreliableWithAcksSender, ChannelSender,
+        },
+    },
+    prelude::ChannelKind,
+};
 
 /// A ChannelContainer is a struct that implements the [`Channel`] trait
 #[derive(Debug)]

--- a/lightyear/src/channel/receivers/fragment_receiver.rs
+++ b/lightyear/src/channel/receivers/fragment_receiver.rs
@@ -3,10 +3,14 @@ use std::collections::HashMap;
 use bytes::Bytes;
 use tracing::trace;
 
-use crate::packet::message::{FragmentData, MessageId};
-use crate::packet::packet::FRAGMENT_SIZE;
-use crate::prelude::Tick;
-use crate::shared::time_manager::WrappedTime;
+use crate::{
+    packet::{
+        message::{FragmentData, MessageId},
+        packet::FRAGMENT_SIZE,
+    },
+    prelude::Tick,
+    shared::time_manager::WrappedTime,
+};
 
 /// `FragmentReceiver` is used to reconstruct fragmented messages
 #[derive(Debug)]
@@ -127,9 +131,8 @@ impl FragmentConstructor {
 
 #[cfg(test)]
 mod tests {
-    use crate::channel::senders::fragment_sender::FragmentSender;
-
     use super::*;
+    use crate::channel::senders::fragment_sender::FragmentSender;
 
     #[test]
     fn test_receiver() {

--- a/lightyear/src/channel/receivers/mod.rs
+++ b/lightyear/src/channel/receivers/mod.rs
@@ -1,12 +1,13 @@
 //! This module contains the various types of receivers available to receive messages over a channel
 use bytes::Bytes;
 use enum_dispatch::enum_dispatch;
-
-use crate::packet::message::ReceiveMessage;
-use crate::prelude::Tick;
-use crate::shared::tick_manager::TickManager;
-use crate::shared::time_manager::TimeManager;
 use error::Result;
+
+use crate::{
+    packet::message::ReceiveMessage,
+    prelude::Tick,
+    shared::{tick_manager::TickManager, time_manager::TimeManager},
+};
 
 /// Utilities to receive a Message from multiple fragment packets
 pub(crate) mod fragment_receiver;

--- a/lightyear/src/channel/receivers/ordered_reliable.rs
+++ b/lightyear/src/channel/receivers/ordered_reliable.rs
@@ -3,12 +3,12 @@ use std::collections::{btree_map, BTreeMap};
 use bytes::Bytes;
 
 use super::error::{ChannelReceiveError, Result};
-use crate::channel::receivers::fragment_receiver::FragmentReceiver;
-use crate::channel::receivers::ChannelReceive;
-use crate::packet::message::{MessageData, MessageId, ReceiveMessage};
-use crate::prelude::Tick;
-pub use crate::shared::tick_manager::TickManager;
-pub use crate::shared::time_manager::TimeManager;
+pub use crate::shared::{tick_manager::TickManager, time_manager::TimeManager};
+use crate::{
+    channel::receivers::{fragment_receiver::FragmentReceiver, ChannelReceive},
+    packet::message::{MessageData, MessageId, ReceiveMessage},
+    prelude::Tick,
+};
 
 /// Ordered Reliable receiver: make sure that all messages are received,
 /// and return them in order
@@ -89,10 +89,11 @@ impl ChannelReceive for OrderedReliableReceiver {
 mod tests {
     use bytes::Bytes;
 
-    use crate::channel::receivers::ordered_reliable::OrderedReliableReceiver;
-    use crate::channel::receivers::ChannelReceive;
-    use crate::packet::message::{MessageId, ReceiveMessage, SingleData};
-    use crate::prelude::{PacketError, Tick};
+    use crate::{
+        channel::receivers::{ordered_reliable::OrderedReliableReceiver, ChannelReceive},
+        packet::message::{MessageId, ReceiveMessage, SingleData},
+        prelude::{PacketError, Tick},
+    };
 
     #[test]
     fn test_ordered_reliable_receiver_internals() -> Result<(), PacketError> {

--- a/lightyear/src/channel/receivers/sequenced_reliable.rs
+++ b/lightyear/src/channel/receivers/sequenced_reliable.rs
@@ -3,13 +3,12 @@ use std::collections::{btree_map, BTreeMap};
 use bytes::Bytes;
 
 use super::error::{ChannelReceiveError, Result};
-
-use crate::channel::receivers::fragment_receiver::FragmentReceiver;
-use crate::channel::receivers::ChannelReceive;
-use crate::packet::message::{MessageData, MessageId, ReceiveMessage};
-use crate::prelude::Tick;
-use crate::shared::tick_manager::TickManager;
-use crate::shared::time_manager::TimeManager;
+use crate::{
+    channel::receivers::{fragment_receiver::FragmentReceiver, ChannelReceive},
+    packet::message::{MessageData, MessageId, ReceiveMessage},
+    prelude::Tick,
+    shared::{tick_manager::TickManager, time_manager::TimeManager},
+};
 
 /// Sequenced Reliable receiver: make sure that all messages are received,
 /// do not return them in order, but ignore the messages that are older than the most recent one received
@@ -88,10 +87,8 @@ impl ChannelReceive for SequencedReliableReceiver {
 mod tests {
     use bytes::Bytes;
 
-    use crate::channel::receivers::ChannelReceive;
-    use crate::packet::message::SingleData;
-
     use super::*;
+    use crate::{channel::receivers::ChannelReceive, packet::message::SingleData};
 
     // TODO: check that the fragment receiver correctly removes items from the buffer, so they dont accumulate!
 

--- a/lightyear/src/channel/receivers/sequenced_unreliable.rs
+++ b/lightyear/src/channel/receivers/sequenced_unreliable.rs
@@ -3,13 +3,15 @@ use std::collections::VecDeque;
 use bytes::Bytes;
 
 use super::error::{ChannelReceiveError, Result};
-
-use crate::channel::receivers::fragment_receiver::FragmentReceiver;
-use crate::channel::receivers::ChannelReceive;
-use crate::packet::message::{MessageData, MessageId, ReceiveMessage};
-use crate::prelude::Tick;
-use crate::shared::tick_manager::TickManager;
-use crate::shared::time_manager::{TimeManager, WrappedTime};
+use crate::{
+    channel::receivers::{fragment_receiver::FragmentReceiver, ChannelReceive},
+    packet::message::{MessageData, MessageId, ReceiveMessage},
+    prelude::Tick,
+    shared::{
+        tick_manager::TickManager,
+        time_manager::{TimeManager, WrappedTime},
+    },
+};
 
 const DISCARD_AFTER: chrono::Duration = chrono::Duration::milliseconds(3000);
 
@@ -88,10 +90,11 @@ impl ChannelReceive for SequencedUnreliableReceiver {
 mod tests {
     use bytes::Bytes;
 
-    use crate::channel::receivers::sequenced_unreliable::SequencedUnreliableReceiver;
-    use crate::channel::receivers::ChannelReceive;
-    use crate::packet::message::{MessageId, ReceiveMessage, SingleData};
-    use crate::prelude::{PacketError, Tick};
+    use crate::{
+        channel::receivers::{sequenced_unreliable::SequencedUnreliableReceiver, ChannelReceive},
+        packet::message::{MessageId, ReceiveMessage, SingleData},
+        prelude::{PacketError, Tick},
+    };
 
     #[test]
     fn test_sequenced_unreliable_receiver_internals() -> Result<(), PacketError> {

--- a/lightyear/src/channel/receivers/unordered_reliable.rs
+++ b/lightyear/src/channel/receivers/unordered_reliable.rs
@@ -3,13 +3,12 @@ use std::collections::{btree_map, BTreeMap, HashSet};
 use bytes::Bytes;
 
 use super::error::ChannelReceiveError;
-
-use crate::channel::receivers::fragment_receiver::FragmentReceiver;
-use crate::channel::receivers::ChannelReceive;
-use crate::packet::message::{MessageData, MessageId, ReceiveMessage};
-use crate::prelude::Tick;
-use crate::shared::tick_manager::TickManager;
-use crate::shared::time_manager::TimeManager;
+use crate::{
+    channel::receivers::{fragment_receiver::FragmentReceiver, ChannelReceive},
+    packet::message::{MessageData, MessageId, ReceiveMessage},
+    prelude::Tick,
+    shared::{tick_manager::TickManager, time_manager::TimeManager},
+};
 
 /// Unordered Reliable receiver: make sure that all messages are received,
 /// and return them in any order
@@ -108,10 +107,8 @@ impl ChannelReceive for UnorderedReliableReceiver {
 mod tests {
     use bytes::Bytes;
 
-    use crate::channel::receivers::ChannelReceive;
-    use crate::packet::message::SingleData;
-
     use super::*;
+    use crate::{channel::receivers::ChannelReceive, packet::message::SingleData};
 
     #[test]
     fn test_unordered_reliable_receiver_internals() -> Result<(), ChannelReceiveError> {

--- a/lightyear/src/channel/receivers/unordered_unreliable.rs
+++ b/lightyear/src/channel/receivers/unordered_unreliable.rs
@@ -1,13 +1,18 @@
-use bytes::Bytes;
 use std::collections::VecDeque;
 
-use crate::channel::receivers::error::ChannelReceiveError;
-use crate::channel::receivers::fragment_receiver::FragmentReceiver;
-use crate::channel::receivers::ChannelReceive;
-use crate::packet::message::{MessageData, ReceiveMessage};
-use crate::prelude::Tick;
-use crate::shared::tick_manager::TickManager;
-use crate::shared::time_manager::{TimeManager, WrappedTime};
+use bytes::Bytes;
+
+use crate::{
+    channel::receivers::{
+        error::ChannelReceiveError, fragment_receiver::FragmentReceiver, ChannelReceive,
+    },
+    packet::message::{MessageData, ReceiveMessage},
+    prelude::Tick,
+    shared::{
+        tick_manager::TickManager,
+        time_manager::{TimeManager, WrappedTime},
+    },
+};
 
 const DISCARD_AFTER: chrono::Duration = chrono::Duration::milliseconds(3000);
 
@@ -63,11 +68,11 @@ impl ChannelReceive for UnorderedUnreliableReceiver {
 mod tests {
     use bytes::Bytes;
 
-    use crate::channel::receivers::error::ChannelReceiveError;
-    use crate::channel::receivers::ChannelReceive;
-    use crate::packet::message::{MessageId, SingleData};
-
     use super::*;
+    use crate::{
+        channel::receivers::{error::ChannelReceiveError, ChannelReceive},
+        packet::message::{MessageId, SingleData},
+    };
 
     #[test]
     fn test_unordered_unreliable_receiver_internals() -> Result<(), ChannelReceiveError> {

--- a/lightyear/src/channel/senders/fragment_ack_receiver.rs
+++ b/lightyear/src/channel/senders/fragment_ack_receiver.rs
@@ -1,8 +1,10 @@
 use bevy::utils::HashMap;
 use tracing::{error, trace};
 
-use crate::packet::message::{FragmentIndex, MessageId};
-use crate::shared::time_manager::WrappedTime;
+use crate::{
+    packet::message::{FragmentIndex, MessageId},
+    shared::time_manager::WrappedTime,
+};
 
 /// `FragmentReceiver` is used to reconstruct fragmented messages
 #[derive(Debug, PartialEq)]

--- a/lightyear/src/channel/senders/fragment_sender.rs
+++ b/lightyear/src/channel/senders/fragment_sender.rs
@@ -1,9 +1,13 @@
 use bytes::Bytes;
 
-use crate::packet::message::{FragmentData, FragmentIndex, MessageId};
-use crate::packet::packet::FRAGMENT_SIZE;
-use crate::serialize::SerializationError;
-use crate::shared::tick_manager::Tick;
+use crate::{
+    packet::{
+        message::{FragmentData, FragmentIndex, MessageId},
+        packet::FRAGMENT_SIZE,
+    },
+    serialize::SerializationError,
+    shared::tick_manager::Tick,
+};
 
 /// `FragmentReceiver` is used to reconstruct fragmented messages
 #[derive(Debug)]
@@ -50,9 +54,8 @@ impl FragmentSender {
 mod tests {
     use bytes::Bytes;
 
-    use crate::packet::packet::FRAGMENT_SIZE;
-
     use super::*;
+    use crate::packet::packet::FRAGMENT_SIZE;
 
     #[test]
     fn test_build_fragments() {

--- a/lightyear/src/channel/senders/mod.rs
+++ b/lightyear/src/channel/senders/mod.rs
@@ -4,11 +4,11 @@ use bytes::Bytes;
 use crossbeam_channel::Receiver;
 use enum_dispatch::enum_dispatch;
 
-use crate::packet::message::{MessageAck, MessageId, SendMessage};
-use crate::serialize::SerializationError;
-use crate::shared::ping::manager::PingManager;
-use crate::shared::tick_manager::TickManager;
-use crate::shared::time_manager::TimeManager;
+use crate::{
+    packet::message::{MessageAck, MessageId, SendMessage},
+    serialize::SerializationError,
+    shared::{ping::manager::PingManager, tick_manager::TickManager, time_manager::TimeManager},
+};
 
 pub(crate) mod fragment_ack_receiver;
 pub(crate) mod fragment_sender;

--- a/lightyear/src/channel/senders/reliable.rs
+++ b/lightyear/src/channel/senders/reliable.rs
@@ -1,20 +1,26 @@
-use bevy::prelude::{Timer, TimerMode};
-use std::collections::VecDeque;
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, HashSet, VecDeque};
 
-use bevy::utils::Duration;
+use bevy::{
+    prelude::{Timer, TimerMode},
+    utils::Duration,
+};
 use bytes::Bytes;
 use crossbeam_channel::{Receiver, Sender};
 use tracing::trace;
 
-use crate::channel::builder::ReliableSettings;
-use crate::channel::senders::fragment_sender::FragmentSender;
-use crate::channel::senders::ChannelSend;
-use crate::packet::message::{FragmentData, MessageAck, MessageId, SendMessage, SingleData};
-use crate::serialize::SerializationError;
-use crate::shared::ping::manager::PingManager;
-use crate::shared::tick_manager::TickManager;
-use crate::shared::time_manager::{TimeManager, WrappedTime};
+use crate::{
+    channel::{
+        builder::ReliableSettings,
+        senders::{fragment_sender::FragmentSender, ChannelSend},
+    },
+    packet::message::{FragmentData, MessageAck, MessageId, SendMessage, SingleData},
+    serialize::SerializationError,
+    shared::{
+        ping::manager::PingManager,
+        tick_manager::TickManager,
+        time_manager::{TimeManager, WrappedTime},
+    },
+};
 
 #[derive(Debug)]
 pub struct FragmentAck {
@@ -340,10 +346,8 @@ mod tests {
     use bevy::utils::Duration;
     use bytes::Bytes;
 
-    use crate::channel::builder::ReliableSettings;
-    use crate::packet::message::SingleData;
-
     use super::*;
+    use crate::{channel::builder::ReliableSettings, packet::message::SingleData};
 
     #[test]
     fn test_reliable_sender_internals() {

--- a/lightyear/src/channel/senders/sequenced_unreliable.rs
+++ b/lightyear/src/channel/senders/sequenced_unreliable.rs
@@ -1,17 +1,18 @@
-use bevy::time::{Timer, TimerMode};
-use bevy::utils::Duration;
 use std::collections::VecDeque;
 
+use bevy::{
+    time::{Timer, TimerMode},
+    utils::Duration,
+};
 use bytes::Bytes;
 use crossbeam_channel::{Receiver, Sender};
 
-use crate::channel::senders::fragment_sender::FragmentSender;
-use crate::channel::senders::ChannelSend;
-use crate::packet::message::{MessageAck, MessageData, MessageId, SendMessage, SingleData};
-use crate::serialize::SerializationError;
-use crate::shared::ping::manager::PingManager;
-use crate::shared::tick_manager::TickManager;
-use crate::shared::time_manager::TimeManager;
+use crate::{
+    channel::senders::{fragment_sender::FragmentSender, ChannelSend},
+    packet::message::{MessageAck, MessageData, MessageId, SendMessage, SingleData},
+    serialize::SerializationError,
+    shared::{ping::manager::PingManager, tick_manager::TickManager, time_manager::TimeManager},
+};
 
 /// A sender that simply sends the messages without checking if they were received
 /// Same as UnorderedUnreliableSender, but includes ordering information (MessageId)

--- a/lightyear/src/channel/senders/unordered_unreliable.rs
+++ b/lightyear/src/channel/senders/unordered_unreliable.rs
@@ -1,18 +1,15 @@
-use bevy::prelude::Timer;
-use bevy::time::TimerMode;
-use bevy::utils::Duration;
 use std::collections::VecDeque;
 
+use bevy::{prelude::Timer, time::TimerMode, utils::Duration};
 use bytes::Bytes;
 use crossbeam_channel::{Receiver, Sender};
 
-use crate::channel::senders::fragment_sender::FragmentSender;
-use crate::channel::senders::ChannelSend;
-use crate::packet::message::{MessageAck, MessageData, MessageId, SendMessage, SingleData};
-use crate::serialize::SerializationError;
-use crate::shared::ping::manager::PingManager;
-use crate::shared::tick_manager::TickManager;
-use crate::shared::time_manager::TimeManager;
+use crate::{
+    channel::senders::{fragment_sender::FragmentSender, ChannelSend},
+    packet::message::{MessageAck, MessageData, MessageId, SendMessage, SingleData},
+    serialize::SerializationError,
+    shared::{ping::manager::PingManager, tick_manager::TickManager, time_manager::TimeManager},
+};
 
 /// A sender that simply sends the messages without checking if they were received
 /// Does not include any ordering information

--- a/lightyear/src/channel/senders/unordered_unreliable_with_acks.rs
+++ b/lightyear/src/channel/senders/unordered_unreliable_with_acks.rs
@@ -1,18 +1,24 @@
-use bevy::prelude::{Timer, TimerMode};
-use bevy::utils::Duration;
 use std::collections::VecDeque;
 
+use bevy::{
+    prelude::{Timer, TimerMode},
+    utils::Duration,
+};
 use bytes::Bytes;
 use crossbeam_channel::{Receiver, Sender};
 
-use crate::channel::senders::fragment_ack_receiver::FragmentAckReceiver;
-use crate::channel::senders::fragment_sender::FragmentSender;
-use crate::channel::senders::ChannelSend;
-use crate::packet::message::{MessageAck, MessageData, MessageId, SendMessage, SingleData};
-use crate::serialize::SerializationError;
-use crate::shared::ping::manager::PingManager;
-use crate::shared::tick_manager::TickManager;
-use crate::shared::time_manager::{TimeManager, WrappedTime};
+use crate::{
+    channel::senders::{
+        fragment_ack_receiver::FragmentAckReceiver, fragment_sender::FragmentSender, ChannelSend,
+    },
+    packet::message::{MessageAck, MessageData, MessageId, SendMessage, SingleData},
+    serialize::SerializationError,
+    shared::{
+        ping::manager::PingManager,
+        tick_manager::TickManager,
+        time_manager::{TimeManager, WrappedTime},
+    },
+};
 
 const DISCARD_AFTER: chrono::Duration = chrono::Duration::milliseconds(3000);
 
@@ -167,9 +173,8 @@ impl ChannelSend for UnorderedUnreliableWithAcksSender {
 
 #[cfg(test)]
 mod tests {
-    use crate::packet::packet::FRAGMENT_SIZE;
-
     use super::*;
+    use crate::packet::packet::FRAGMENT_SIZE;
 
     #[test]
     fn test_receive_ack() {

--- a/lightyear/src/client/components.rs
+++ b/lightyear/src/client/components.rs
@@ -3,8 +3,10 @@ Defines components that are used for the client-side prediction and interpolatio
 */
 use std::fmt::Debug;
 
-use bevy::prelude::{Component, Entity, ReflectComponent};
-use bevy::reflect::Reflect;
+use bevy::{
+    prelude::{Component, Entity, ReflectComponent},
+    reflect::Reflect,
+};
 
 use crate::prelude::{Message, Tick};
 

--- a/lightyear/src/client/config.rs
+++ b/lightyear/src/client/config.rs
@@ -1,16 +1,18 @@
 //! Defines client-specific configuration options
-use bevy::prelude::Resource;
-use bevy::reflect::Reflect;
+use bevy::{prelude::Resource, reflect::Reflect};
 use governor::Quota;
 use nonzero_ext::nonzero;
 
-use crate::client::interpolation::plugin::InterpolationConfig;
-use crate::client::prediction::plugin::PredictionConfig;
-use crate::client::sync::SyncConfig;
-use crate::connection::client::NetConfig;
-use crate::shared::config::SharedConfig;
-use crate::shared::ping::manager::PingConfig;
-use crate::shared::replication::plugin::ReplicationConfig;
+use crate::{
+    client::{
+        interpolation::plugin::InterpolationConfig, prediction::plugin::PredictionConfig,
+        sync::SyncConfig,
+    },
+    connection::client::NetConfig,
+    shared::{
+        config::SharedConfig, ping::manager::PingConfig, replication::plugin::ReplicationConfig,
+    },
+};
 
 #[derive(Clone, Reflect)]
 /// Config related to the netcode protocol (abstraction of a connection over raw UDP-like transport)

--- a/lightyear/src/client/connection.rs
+++ b/lightyear/src/client/connection.rs
@@ -1,49 +1,51 @@
 //! Specify how a Client sends/receives messages with a Server
-use bevy::ecs::component::Tick as BevyTick;
-use bevy::ecs::entity::MapEntities;
-use bevy::prelude::{Resource, World};
-use bevy::utils::Duration;
 #[cfg(feature = "leafwing")]
 use bevy::utils::HashMap;
+use bevy::{
+    ecs::{component::Tick as BevyTick, entity::MapEntities},
+    prelude::{Resource, World},
+    utils::Duration,
+};
 use bytes::Bytes;
 use tracing::{debug, trace, trace_span};
 
-use crate::channel::builder::{
-    EntityActionsChannel, EntityUpdatesChannel, PingChannel, PongChannel,
-};
-
-use crate::channel::receivers::ChannelReceive;
-use crate::channel::senders::ChannelSend;
-use crate::client::config::ClientConfig;
-use crate::client::error::ClientError;
-use crate::client::sync::SyncConfig;
-use crate::connection::netcode::MAX_PACKET_SIZE;
-use crate::packet::message_manager::MessageManager;
-use crate::packet::packet_builder::{Payload, RecvPayload};
-use crate::packet::priority_manager::PriorityConfig;
-use crate::prelude::client::PredictionConfig;
-use crate::prelude::{ChannelKind, ClientId, Message, MessageRegistry, ReplicationConfig};
-use crate::protocol::channel::ChannelRegistry;
-use crate::protocol::component::ComponentRegistry;
-use crate::protocol::registry::NetId;
-use crate::serialize::reader::Reader;
-use crate::serialize::writer::Writer;
-use crate::serialize::{SerializationError, ToBytes};
-use crate::server::error::ServerError;
-use crate::shared::events::connection::ConnectionEvents;
-use crate::shared::ping::manager::{PingConfig, PingManager};
-use crate::shared::ping::message::{Ping, Pong};
-use crate::shared::replication::delta::DeltaManager;
-use crate::shared::replication::receive::ReplicationReceiver;
-use crate::shared::replication::send::ReplicationSender;
-use crate::shared::replication::{EntityActionsMessage, EntityUpdatesMessage, ReplicationSend};
-use crate::shared::replication::{ReplicationPeer, ReplicationReceive};
-use crate::shared::sets::ClientMarker;
-use crate::shared::tick_manager::Tick;
-use crate::shared::tick_manager::TickManager;
-use crate::shared::time_manager::TimeManager;
-
 use super::sync::SyncManager;
+use crate::{
+    channel::{
+        builder::{EntityActionsChannel, EntityUpdatesChannel, PingChannel, PongChannel},
+        receivers::ChannelReceive,
+        senders::ChannelSend,
+    },
+    client::{config::ClientConfig, error::ClientError, sync::SyncConfig},
+    connection::netcode::MAX_PACKET_SIZE,
+    packet::{
+        message_manager::MessageManager,
+        packet_builder::{Payload, RecvPayload},
+        priority_manager::PriorityConfig,
+    },
+    prelude::{
+        client::PredictionConfig, ChannelKind, ClientId, Message, MessageRegistry,
+        ReplicationConfig,
+    },
+    protocol::{channel::ChannelRegistry, component::ComponentRegistry, registry::NetId},
+    serialize::{reader::Reader, writer::Writer, SerializationError, ToBytes},
+    server::error::ServerError,
+    shared::{
+        events::connection::ConnectionEvents,
+        ping::{
+            manager::{PingConfig, PingManager},
+            message::{Ping, Pong},
+        },
+        replication::{
+            delta::DeltaManager, receive::ReplicationReceiver, send::ReplicationSender,
+            EntityActionsMessage, EntityUpdatesMessage, ReplicationPeer, ReplicationReceive,
+            ReplicationSend,
+        },
+        sets::ClientMarker,
+        tick_manager::{Tick, TickManager},
+        time_manager::TimeManager,
+    },
+};
 
 /// Wrapper that handles the connection with the server
 ///
@@ -506,9 +508,10 @@ impl ReplicationSend for ConnectionManager {
 
 #[cfg(test)]
 mod tests {
-    use crate::prelude::{client, server, ClientConnectionManager, RemoteEntityMap};
-    use crate::tests::protocol::EntityMessage;
-    use crate::tests::stepper::BevyStepper;
+    use crate::{
+        prelude::{client, server, ClientConnectionManager, RemoteEntityMap},
+        tests::{protocol::EntityMessage, stepper::BevyStepper},
+    };
 
     /// Check that we can map entities from the local world to the remote world
     /// using the ConnectionManager

--- a/lightyear/src/client/diagnostics.rs
+++ b/lightyear/src/client/diagnostics.rs
@@ -1,15 +1,18 @@
-use crate::client::connection::ConnectionManager;
-use crate::client::prediction::diagnostics::PredictionDiagnosticsPlugin;
-use bevy::app::{App, Plugin, PostUpdate};
-use bevy::diagnostic::Diagnostics;
-use bevy::prelude::{not, Condition, IntoSystemConfigs, Real, Res, ResMut, Time};
-use bevy::time::common_conditions::on_timer;
-use bevy::utils::Duration;
+use bevy::{
+    app::{App, Plugin, PostUpdate},
+    diagnostic::Diagnostics,
+    prelude::{not, Condition, IntoSystemConfigs, Real, Res, ResMut, Time},
+    time::common_conditions::on_timer,
+    utils::Duration,
+};
 
-use crate::connection::client::{ClientConnection, NetClient};
-use crate::prelude::{client::is_disconnected, is_host_server};
-use crate::shared::ping::diagnostics::PingDiagnosticsPlugin;
-use crate::transport::io::IoDiagnosticsPlugin;
+use crate::{
+    client::{connection::ConnectionManager, prediction::diagnostics::PredictionDiagnosticsPlugin},
+    connection::client::{ClientConnection, NetClient},
+    prelude::{client::is_disconnected, is_host_server},
+    shared::ping::diagnostics::PingDiagnosticsPlugin,
+    transport::io::IoDiagnosticsPlugin,
+};
 
 // TODO: ideally make this a plugin group? but nested plugin groups are not supported
 #[derive(Debug)]

--- a/lightyear/src/client/events.rs
+++ b/lightyear/src/client/events.rs
@@ -13,14 +13,20 @@
 //! }
 //! ```
 
-use crate::client::connection::ConnectionManager;
-use crate::connection::client::ConnectionError;
-use crate::prelude::ClientId;
-use crate::shared::events::plugin::EventsPlugin;
-use crate::shared::events::systems::push_component_events;
-use crate::shared::sets::{ClientMarker, InternalMainSet};
-use bevy::app::{App, Plugin, PreUpdate};
-use bevy::prelude::{Component, Event, IntoSystemConfigs};
+use bevy::{
+    app::{App, Plugin, PreUpdate},
+    prelude::{Component, Event, IntoSystemConfigs},
+};
+
+use crate::{
+    client::connection::ConnectionManager,
+    connection::client::ConnectionError,
+    prelude::ClientId,
+    shared::{
+        events::{plugin::EventsPlugin, systems::push_component_events},
+        sets::{ClientMarker, InternalMainSet},
+    },
+};
 
 /// Plugin that handles generating bevy [`Events`](Event) related to networking and replication
 #[derive(Default)]

--- a/lightyear/src/client/input/leafwing.rs
+++ b/lightyear/src/client/input/leafwing.rs
@@ -33,28 +33,25 @@
 use std::fmt::Debug;
 
 use bevy::prelude::*;
-use leafwing_input_manager::plugin::InputManagerSystem;
-use leafwing_input_manager::prelude::*;
+use leafwing_input_manager::{plugin::InputManagerSystem, prelude::*};
 use tracing::{error, trace};
 
-use crate::channel::builder::InputChannel;
-use crate::client::components::Confirmed;
-use crate::client::config::ClientConfig;
-use crate::client::connection::ConnectionManager;
-use crate::client::input::{BaseInputPlugin, InputSystemSet};
-use crate::client::prediction::plugin::is_in_rollback;
-use crate::client::prediction::resource::PredictionManager;
-use crate::client::prediction::Predicted;
-use crate::inputs::leafwing::input_buffer::InputBuffer;
-use crate::inputs::leafwing::input_message::InputTarget;
-use crate::inputs::leafwing::LeafwingUserAction;
-use crate::prelude::{
-    is_host_server, ChannelKind, ChannelRegistry, ClientReceiveMessage, InputMessage,
-    MessageRegistry, TickManager, TimeManager,
+use crate::{
+    channel::builder::InputChannel,
+    client::{
+        components::Confirmed,
+        config::ClientConfig,
+        connection::ConnectionManager,
+        input::{BaseInputPlugin, InputSystemSet},
+        prediction::{plugin::is_in_rollback, resource::PredictionManager, Predicted},
+    },
+    inputs::leafwing::{input_buffer::InputBuffer, input_message::InputTarget, LeafwingUserAction},
+    prelude::{
+        is_host_server, ChannelKind, ChannelRegistry, ClientReceiveMessage, InputMessage,
+        MessageRegistry, TickManager, TimeManager,
+    },
+    shared::{input::InputConfig, replication::components::PrePredicted, tick_manager::TickEvent},
 };
-use crate::shared::input::InputConfig;
-use crate::shared::replication::components::PrePredicted;
-use crate::shared::tick_manager::TickEvent;
 
 // TODO: is this actually necessary? The sync happens in PostUpdate,
 //  so maybe it's ok if the InputMessages contain the pre-sync tick! (since those inputs happened
@@ -455,16 +452,20 @@ fn receive_tick_events<A: LeafwingUserAction>(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use leafwing_input_manager::action_state::ActionState;
-    use leafwing_input_manager::input_map::InputMap;
     use std::time::Duration;
 
-    use crate::prelude::client::{InterpolationDelay, PredictionConfig};
-    use crate::prelude::server::Replicate;
-    use crate::prelude::{client, SharedConfig, TickConfig};
-    use crate::tests::protocol::*;
-    use crate::tests::stepper::BevyStepper;
+    use leafwing_input_manager::{action_state::ActionState, input_map::InputMap};
+
+    use super::*;
+    use crate::{
+        prelude::{
+            client,
+            client::{InterpolationDelay, PredictionConfig},
+            server::Replicate,
+            SharedConfig, TickConfig,
+        },
+        tests::{protocol::*, stepper::BevyStepper},
+    };
 
     fn build_stepper_with_input_delay(delay_ticks: u16) -> BevyStepper {
         let frame_duration = Duration::from_millis(10);

--- a/lightyear/src/client/input/mod.rs
+++ b/lightyear/src/client/input/mod.rs
@@ -51,22 +51,28 @@ pub enum InputSystemSet {
     CleanUp,
 }
 
-use bevy::prelude::*;
 use std::marker::PhantomData;
+
+use bevy::prelude::*;
 use tracing::trace;
 
-use crate::client::config::ClientConfig;
-use crate::client::connection::ConnectionManager;
-use crate::client::prediction::plugin::is_in_rollback;
-use crate::client::prediction::rollback::Rollback;
-use crate::client::run_conditions::is_synced;
-use crate::client::sync::SyncSet;
-use crate::inputs::native::input_buffer::InputBuffer;
-use crate::inputs::native::input_message::InputMessage;
-use crate::inputs::native::{UserAction, UserActionState};
-use crate::prelude::{is_host_server, TickManager};
-use crate::shared::input::InputConfig;
-use crate::shared::sets::{ClientMarker, InternalMainSet};
+use crate::{
+    client::{
+        config::ClientConfig,
+        connection::ConnectionManager,
+        prediction::{plugin::is_in_rollback, rollback::Rollback},
+        run_conditions::is_synced,
+        sync::SyncSet,
+    },
+    inputs::native::{
+        input_buffer::InputBuffer, input_message::InputMessage, UserAction, UserActionState,
+    },
+    prelude::{is_host_server, TickManager},
+    shared::{
+        input::InputConfig,
+        sets::{ClientMarker, InternalMainSet},
+    },
+};
 
 pub(crate) struct BaseInputPlugin<A, F> {
     config: InputConfig<A>,

--- a/lightyear/src/client/input/native.rs
+++ b/lightyear/src/client/input/native.rs
@@ -56,23 +56,26 @@
 use bevy::prelude::*;
 use tracing::{error, trace};
 
-use crate::channel::builder::InputChannel;
-use crate::client::components::Confirmed;
-use crate::client::config::ClientConfig;
-use crate::client::connection::ConnectionManager;
-use crate::client::input::{BaseInputPlugin, InputSystemSet};
-use crate::client::prediction::plugin::is_in_rollback;
-use crate::client::prediction::resource::PredictionManager;
-use crate::client::prediction::Predicted;
-use crate::inputs::native::input_buffer::InputBuffer;
-use crate::inputs::native::input_message::{InputMessage, InputTarget};
-use crate::inputs::native::{ActionState, InputMarker, UserAction};
-use crate::prelude::{
-    ChannelKind, ChannelRegistry, ClientReceiveMessage, MessageRegistry, PrePredicted, TickManager,
-    TimeManager,
+use crate::{
+    channel::builder::InputChannel,
+    client::{
+        components::Confirmed,
+        config::ClientConfig,
+        connection::ConnectionManager,
+        input::{BaseInputPlugin, InputSystemSet},
+        prediction::{plugin::is_in_rollback, resource::PredictionManager, Predicted},
+    },
+    inputs::native::{
+        input_buffer::InputBuffer,
+        input_message::{InputMessage, InputTarget},
+        ActionState, InputMarker, UserAction,
+    },
+    prelude::{
+        ChannelKind, ChannelRegistry, ClientReceiveMessage, MessageRegistry, PrePredicted,
+        TickManager, TimeManager,
+    },
+    shared::{input::InputConfig, tick_manager::TickEvent},
 };
-use crate::shared::input::InputConfig;
-use crate::shared::tick_manager::TickEvent;
 
 pub struct InputPlugin<A> {
     config: InputConfig<A>,
@@ -454,10 +457,14 @@ fn receive_tick_events<A: UserAction>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::prelude::server::{Replicate, SyncTarget};
-    use crate::prelude::{client, NetworkTarget};
-    use crate::tests::host_server_stepper::HostServerStepper;
-    use crate::tests::protocol::MyInput;
+    use crate::{
+        prelude::{
+            client,
+            server::{Replicate, SyncTarget},
+            NetworkTarget,
+        },
+        tests::{host_server_stepper::HostServerStepper, protocol::MyInput},
+    };
 
     // Test with no input delay:
     // 1. remote client replicated entity sending inputs to server

--- a/lightyear/src/client/interpolation/despawn.rs
+++ b/lightyear/src/client/interpolation/despawn.rs
@@ -1,8 +1,9 @@
 use bevy::prelude::{Commands, DespawnRecursiveExt, OnRemove, Query, Trigger};
 
-use crate::client::components::{Confirmed, SyncComponent};
-use crate::client::interpolation::interpolate::InterpolateStatus;
-use crate::client::interpolation::interpolation_history::ConfirmedHistory;
+use crate::client::{
+    components::{Confirmed, SyncComponent},
+    interpolation::{interpolate::InterpolateStatus, interpolation_history::ConfirmedHistory},
+};
 
 /// Remove the component from interpolated entities when it gets removed from confirmed
 pub(crate) fn removed_components<C: SyncComponent>(

--- a/lightyear/src/client/interpolation/interpolate.rs
+++ b/lightyear/src/client/interpolation/interpolate.rs
@@ -1,12 +1,14 @@
 use bevy::prelude::{Commands, Component, Entity, Query, Res, Without};
 use tracing::{debug, trace};
 
-use crate::client::components::SyncComponent;
-use crate::client::config::ClientConfig;
-use crate::client::connection::ConnectionManager;
-use crate::client::interpolation::interpolation_history::ConfirmedHistory;
-use crate::prelude::{ComponentRegistry, TickManager};
-use crate::shared::tick_manager::Tick;
+use crate::{
+    client::{
+        components::SyncComponent, config::ClientConfig, connection::ConnectionManager,
+        interpolation::interpolation_history::ConfirmedHistory,
+    },
+    prelude::{ComponentRegistry, TickManager},
+    shared::tick_manager::Tick,
+};
 
 // if we haven't received updates since UPDATE_INTERPOLATION_START_TICK_FACTOR * send_interval
 // then we update the start_tick so that the interpolation looks good when we receive a new update

--- a/lightyear/src/client/interpolation/interpolation_history.rs
+++ b/lightyear/src/client/interpolation/interpolation_history.rs
@@ -5,15 +5,18 @@ use bevy::prelude::{
 };
 use tracing::{debug, trace};
 
-use crate::client::components::Confirmed;
-use crate::client::components::{ComponentSyncMode, SyncComponent};
-use crate::client::connection::ConnectionManager;
-use crate::client::interpolation::interpolate::InterpolateStatus;
-use crate::client::interpolation::resource::InterpolationManager;
-use crate::client::interpolation::Interpolated;
-use crate::prelude::{ComponentRegistry, HasAuthority, TickManager};
-use crate::shared::tick_manager::Tick;
-use crate::utils::ready_buffer::ReadyBuffer;
+use crate::{
+    client::{
+        components::{ComponentSyncMode, Confirmed, SyncComponent},
+        connection::ConnectionManager,
+        interpolation::{
+            interpolate::InterpolateStatus, resource::InterpolationManager, Interpolated,
+        },
+    },
+    prelude::{ComponentRegistry, HasAuthority, TickManager},
+    shared::tick_manager::Tick,
+    utils::ready_buffer::ReadyBuffer,
+};
 
 /// To know if we need to do rollback, we need to compare the interpolated entity's history with the server's state updates
 #[derive(Component, Debug)]

--- a/lightyear/src/client/interpolation/mod.rs
+++ b/lightyear/src/client/interpolation/mod.rs
@@ -1,16 +1,16 @@
 //! Handles interpolation of entities between server updates
-use bevy::ecs::component::StorageType;
-use bevy::ecs::world::DeferredWorld;
-use bevy::prelude::{Component, Entity, Reflect, ReflectComponent};
 use std::ops::{Add, Mul};
 
+use bevy::{
+    ecs::{component::StorageType, world::DeferredWorld},
+    prelude::{Component, Entity, Reflect, ReflectComponent},
+};
 pub use interpolate::InterpolateStatus;
 pub use interpolation_history::ConfirmedHistory;
 pub use plugin::{add_interpolation_systems, add_prepare_interpolation_systems};
 pub use visual_interpolation::{VisualInterpolateStatus, VisualInterpolationPlugin};
 
-use crate::client::components::LerpFn;
-use crate::client::interpolation::resource::InterpolationManager;
+use crate::client::{components::LerpFn, interpolation::resource::InterpolationManager};
 
 mod despawn;
 pub mod interpolate;

--- a/lightyear/src/client/interpolation/plugin.rs
+++ b/lightyear/src/client/interpolation/plugin.rs
@@ -1,21 +1,24 @@
-use bevy::prelude::*;
-use bevy::utils::Duration;
+use bevy::{prelude::*, utils::Duration};
 
 use super::interpolation_history::{
     add_component_history, apply_confirmed_update_mode_full, apply_confirmed_update_mode_simple,
 };
-use crate::client::components::{ComponentSyncMode, SyncComponent};
-use crate::client::interpolation::despawn::{despawn_interpolated, removed_components};
-use crate::client::interpolation::interpolate::{
-    insert_interpolated_component, interpolate, update_interpolate_status,
+use crate::{
+    client::{
+        components::{ComponentSyncMode, SyncComponent},
+        interpolation::{
+            despawn::{despawn_interpolated, removed_components},
+            interpolate::{insert_interpolated_component, interpolate, update_interpolate_status},
+            resource::InterpolationManager,
+            spawn::spawn_interpolated_entity,
+            Interpolated,
+        },
+        run_conditions::is_synced,
+        sync::SyncSet,
+    },
+    prelude::{is_host_server, Deserialize, Serialize, Tick},
+    shared::time_manager::WrappedTime,
 };
-use crate::client::interpolation::resource::InterpolationManager;
-use crate::client::interpolation::spawn::spawn_interpolated_entity;
-use crate::client::interpolation::Interpolated;
-use crate::client::run_conditions::is_synced;
-use crate::client::sync::SyncSet;
-use crate::prelude::{is_host_server, Deserialize, Serialize, Tick};
-use crate::shared::time_manager::WrappedTime;
 
 /// Interpolation delay of the client at the time the message is sent
 ///

--- a/lightyear/src/client/interpolation/resource.rs
+++ b/lightyear/src/client/interpolation/resource.rs
@@ -1,10 +1,12 @@
 //! Defines bevy resources needed for Interpolation
-use crate::prelude::ComponentRegistry;
-use crate::protocol::component::ComponentError;
-use bevy::prelude::Resource;
 use std::cell::UnsafeCell;
 
-use crate::shared::replication::entity_map::InterpolatedEntityMap;
+use bevy::prelude::Resource;
+
+use crate::{
+    prelude::ComponentRegistry, protocol::component::ComponentError,
+    shared::replication::entity_map::InterpolatedEntityMap,
+};
 
 #[derive(Resource, Default)]
 pub struct InterpolationManager {

--- a/lightyear/src/client/interpolation/spawn.rs
+++ b/lightyear/src/client/interpolation/spawn.rs
@@ -1,12 +1,14 @@
 use bevy::prelude::{Added, Commands, Entity, Query, Res};
 use tracing::trace;
 
-use crate::client::components::Confirmed;
-use crate::client::config::ClientConfig;
-use crate::client::connection::ConnectionManager;
-use crate::client::interpolation::Interpolated;
-use crate::prelude::TickManager;
-use crate::shared::replication::components::ShouldBeInterpolated;
+use crate::{
+    client::{
+        components::Confirmed, config::ClientConfig, connection::ConnectionManager,
+        interpolation::Interpolated,
+    },
+    prelude::TickManager,
+    shared::replication::components::ShouldBeInterpolated,
+};
 
 /// Spawn an interpolated entity for each confirmed entity that has the `ShouldBeInterpolated` component added
 pub(crate) fn spawn_interpolated_entity(

--- a/lightyear/src/client/interpolation/visual_interpolation.rs
+++ b/lightyear/src/client/interpolation/visual_interpolation.rs
@@ -32,12 +32,15 @@
 // - then in PostUpdate (visual interpolation) we interpolate between the previous tick and the current tick using the overstep
 // - in PreUpdate, we restore the component value to the previous tick values
 
-use bevy::prelude::*;
-use bevy::transform::TransformSystem::TransformPropagate;
+use bevy::{prelude::*, transform::TransformSystem::TransformPropagate};
 
-use crate::client::components::SyncComponent;
-use crate::prelude::client::{Correction, InterpolationSet, PredictionSet};
-use crate::prelude::{ComponentRegistry, MainSet, TickManager, TimeManager};
+use crate::{
+    client::components::SyncComponent,
+    prelude::{
+        client::{Correction, InterpolationSet, PredictionSet},
+        ComponentRegistry, MainSet, TickManager, TimeManager,
+    },
+};
 
 pub struct VisualInterpolationPlugin<C: SyncComponent> {
     _marker: std::marker::PhantomData<C>,
@@ -195,16 +198,15 @@ pub(crate) fn restore_from_visual_interpolation<C: SyncComponent>(
 
 #[cfg(test)]
 mod tests {
-    use crate::client::config::ClientConfig;
     use approx::assert_relative_eq;
-    use bevy::prelude::*;
-    use bevy::utils::Duration;
-
-    use crate::prelude::{SharedConfig, TickConfig};
-    use crate::tests::protocol::*;
-    use crate::tests::stepper::BevyStepper;
+    use bevy::{prelude::*, utils::Duration};
 
     use super::*;
+    use crate::{
+        client::config::ClientConfig,
+        prelude::{SharedConfig, TickConfig},
+        tests::{protocol::*, stepper::BevyStepper},
+    };
 
     #[derive(Resource, Debug)]
     pub struct Toggle(bool);

--- a/lightyear/src/client/io/config.rs
+++ b/lightyear/src/client/io/config.rs
@@ -1,27 +1,34 @@
-use crate::client::io::transport::{ClientTransportBuilder, ClientTransportBuilderEnum};
-use crate::client::io::{Io, IoContext};
-use crate::prelude::CompressionConfig;
-use crate::transport::config::SharedIoConfig;
-use crate::transport::dummy::DummyIo;
-use crate::transport::error::Result;
-use crate::transport::io::{BaseIo, IoStats};
-use crate::transport::local::LocalChannelBuilder;
+use std::net::SocketAddr;
+
+use bevy::prelude::TypePath;
+use crossbeam_channel::{Receiver, Sender};
+
 #[cfg(feature = "zstd")]
 use crate::transport::middleware::compression::zstd::compression::ZstdCompressor;
 #[cfg(feature = "zstd")]
 use crate::transport::middleware::compression::zstd::decompression::ZstdDecompressor;
-use crate::transport::middleware::conditioner::LinkConditioner;
-use crate::transport::middleware::PacketReceiverWrapper;
 #[cfg(not(target_family = "wasm"))]
 use crate::transport::udp::UdpSocketBuilder;
 #[cfg(feature = "websocket")]
 use crate::transport::websocket::client::WebSocketClientSocketBuilder;
 #[cfg(feature = "webtransport")]
 use crate::transport::webtransport::client::WebTransportClientSocketBuilder;
-use crate::transport::{BoxedReceiver, Transport};
-use bevy::prelude::TypePath;
-use crossbeam_channel::{Receiver, Sender};
-use std::net::SocketAddr;
+use crate::{
+    client::io::{
+        transport::{ClientTransportBuilder, ClientTransportBuilderEnum},
+        Io, IoContext,
+    },
+    prelude::CompressionConfig,
+    transport::{
+        config::SharedIoConfig,
+        dummy::DummyIo,
+        error::Result,
+        io::{BaseIo, IoStats},
+        local::LocalChannelBuilder,
+        middleware::{conditioner::LinkConditioner, PacketReceiverWrapper},
+        BoxedReceiver, Transport,
+    },
+};
 
 /// Use this to configure the [`Transport`] that will be used to establish a connection with the
 /// server.

--- a/lightyear/src/client/io/mod.rs
+++ b/lightyear/src/client/io/mod.rs
@@ -3,10 +3,13 @@
 pub(crate) mod config;
 pub(crate) mod transport;
 
-use crate::transport::error::{Error, Result};
-use crate::transport::io::{BaseIo, IoState};
 use async_channel::{Receiver, Sender};
 use bevy::prelude::{Deref, DerefMut};
+
+use crate::transport::{
+    error::{Error, Result},
+    io::{BaseIo, IoState},
+};
 
 pub struct IoContext {
     pub(crate) event_sender: Option<ClientNetworkEventSender>,

--- a/lightyear/src/client/io/transport.rs
+++ b/lightyear/src/client/io/transport.rs
@@ -1,8 +1,5 @@
-use crate::client::io::{ClientIoEventReceiver, ClientNetworkEventSender};
-use crate::transport::dummy::DummyIo;
-use crate::transport::error::Error as TransportError;
-use crate::transport::io::IoState;
-use crate::transport::local::{LocalChannel, LocalChannelBuilder};
+use enum_dispatch::enum_dispatch;
+
 #[cfg(not(target_family = "wasm"))]
 use crate::transport::udp::{UdpSocket, UdpSocketBuilder};
 #[cfg(feature = "websocket")]
@@ -11,7 +8,15 @@ use crate::transport::websocket::client::{WebSocketClientSocket, WebSocketClient
 use crate::transport::webtransport::client::{
     WebTransportClientSocket, WebTransportClientSocketBuilder,
 };
-use enum_dispatch::enum_dispatch;
+use crate::{
+    client::io::{ClientIoEventReceiver, ClientNetworkEventSender},
+    transport::{
+        dummy::DummyIo,
+        error::Error as TransportError,
+        io::IoState,
+        local::{LocalChannel, LocalChannelBuilder},
+    },
+};
 
 /// Transport combines a PacketSender and a PacketReceiver
 ///

--- a/lightyear/src/client/message.rs
+++ b/lightyear/src/client/message.rs
@@ -1,22 +1,27 @@
 //! Defines the [`ClientMessage`] enum used to send messages from the client to the server
 
-use crate::client::connection::ConnectionManager;
-use crate::client::error::ClientError;
-use crate::prelude::client::{ClientConnection, NetClient};
-use crate::prelude::{
-    client::is_connected, is_host_server, Channel, ChannelKind, ClientId, MainSet, Message,
-    MessageRegistry, MessageSend,
+use bevy::{
+    ecs::system::{FilteredResourcesMutParamBuilder, ParamBuilder},
+    prelude::*,
 };
-use crate::serialize::reader::Reader;
-use crate::serialize::{SerializationError, ToBytes};
-use crate::shared::message::private::InternalMessageSend;
-use crate::shared::replication::network_target::NetworkTarget;
-use crate::shared::sets::{ClientMarker, InternalMainSet};
-use bevy::ecs::system::{FilteredResourcesMutParamBuilder, ParamBuilder};
-use bevy::prelude::*;
 use byteorder::WriteBytesExt;
 use bytes::Bytes;
 use tracing::error;
+
+use crate::{
+    client::{connection::ConnectionManager, error::ClientError},
+    prelude::{
+        client::{is_connected, ClientConnection, NetClient},
+        is_host_server, Channel, ChannelKind, ClientId, MainSet, Message, MessageRegistry,
+        MessageSend,
+    },
+    serialize::{reader::Reader, SerializationError, ToBytes},
+    shared::{
+        message::private::InternalMessageSend,
+        replication::network_target::NetworkTarget,
+        sets::{ClientMarker, InternalMainSet},
+    },
+};
 
 /// Bevy [`Event`] emitted on the client when a (non-replication) message is received
 #[allow(type_alias_bounds)]
@@ -340,14 +345,18 @@ fn read_triggers(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::prelude::client::ClientTriggerExt;
-    use crate::prelude::{ClientSendMessage, ServerReceiveMessage};
-    use crate::serialize::writer::Writer;
-    use crate::tests::host_server_stepper::HostServerStepper;
-    use crate::tests::protocol::{Channel1, IntegerEvent, StringMessage};
-    use crate::tests::stepper::BevyStepper;
     use bevy::prelude::{EventReader, Resource, Update};
+
+    use super::*;
+    use crate::{
+        prelude::{client::ClientTriggerExt, ClientSendMessage, ServerReceiveMessage},
+        serialize::writer::Writer,
+        tests::{
+            host_server_stepper::HostServerStepper,
+            protocol::{Channel1, IntegerEvent, StringMessage},
+            stepper::BevyStepper,
+        },
+    };
 
     #[test]
     fn client_message_serde() {

--- a/lightyear/src/client/networking.rs
+++ b/lightyear/src/client/networking.rs
@@ -2,30 +2,39 @@
 use std::ops::DerefMut;
 
 use async_channel::TryRecvError;
-use bevy::ecs::system::{RunSystemOnce, SystemChangeTick};
-use bevy::prelude::ResMut;
-use bevy::prelude::*;
-use bevy::utils::Duration;
+use bevy::{
+    ecs::system::{RunSystemOnce, SystemChangeTick},
+    prelude::{ResMut, *},
+    utils::Duration,
+};
 use tracing::{error, trace};
 
-use crate::client::config::ClientConfig;
-use crate::client::connection::ConnectionManager;
-use crate::client::events::{ConnectEvent, DisconnectEvent};
-use crate::client::io::ClientIoEvent;
-use crate::client::replication::send::ReplicateToServer;
-use crate::client::run_conditions::is_disconnected;
-use crate::client::sync::SyncSet;
-use crate::connection::client::{ClientConnection, ConnectionError, ConnectionState, NetClient};
-use crate::connection::server::IoConfig;
-use crate::prelude::client::NetConfig;
-use crate::prelude::{
-    is_host_server, server, ChannelRegistry, MainSet, MessageRegistry, TickManager, TimeManager,
+use crate::{
+    client::{
+        config::ClientConfig,
+        connection::ConnectionManager,
+        events::{ConnectEvent, DisconnectEvent},
+        io::ClientIoEvent,
+        replication::send::ReplicateToServer,
+        run_conditions::is_disconnected,
+        sync::SyncSet,
+    },
+    connection::{
+        client::{ClientConnection, ConnectionError, ConnectionState, NetClient},
+        server::IoConfig,
+    },
+    prelude::{
+        client::NetConfig, is_host_server, server, ChannelRegistry, MainSet, MessageRegistry,
+        TickManager, TimeManager,
+    },
+    protocol::component::ComponentRegistry,
+    server::clients::ControlledEntities,
+    shared::{
+        replication::components::Replicated,
+        sets::{ClientMarker, InternalMainSet},
+    },
+    transport::io::IoState,
 };
-use crate::protocol::component::ComponentRegistry;
-use crate::server::clients::ControlledEntities;
-use crate::shared::replication::components::Replicated;
-use crate::shared::sets::{ClientMarker, InternalMainSet};
-use crate::transport::io::IoState;
 
 #[derive(Default)]
 pub(crate) struct ClientNetworkingPlugin;

--- a/lightyear/src/client/plugin.rs
+++ b/lightyear/src/client/plugin.rs
@@ -8,21 +8,21 @@
 //! while keeping the rest of the features intact.
 //!
 //! Most plugins are truly necessary for the server functionality to work properly, but some could be disabled.
-use bevy::app::PluginGroupBuilder;
-use bevy::prelude::*;
-
-use crate::client::diagnostics::ClientDiagnosticsPlugin;
-use crate::client::events::ClientEventsPlugin;
-use crate::client::interpolation::plugin::InterpolationPlugin;
-use crate::client::message::ClientMessagePlugin;
-use crate::client::networking::ClientNetworkingPlugin;
-use crate::client::prediction::plugin::PredictionPlugin;
-use crate::client::replication::{
-    receive::ClientReplicationReceivePlugin, send::ClientReplicationSendPlugin,
-};
-use crate::shared::plugin::SharedPlugin;
+use bevy::{app::PluginGroupBuilder, prelude::*};
 
 use super::config::ClientConfig;
+use crate::{
+    client::{
+        diagnostics::ClientDiagnosticsPlugin,
+        events::ClientEventsPlugin,
+        interpolation::plugin::InterpolationPlugin,
+        message::ClientMessagePlugin,
+        networking::ClientNetworkingPlugin,
+        prediction::plugin::PredictionPlugin,
+        replication::{receive::ClientReplicationReceivePlugin, send::ClientReplicationSendPlugin},
+    },
+    shared::plugin::SharedPlugin,
+};
 
 /// A plugin group containing all the client plugins.
 ///

--- a/lightyear/src/client/prediction/correction.rs
+++ b/lightyear/src/client/prediction/correction.rs
@@ -25,8 +25,10 @@
 use bevy::prelude::{Commands, Component, DetectChangesMut, Entity, Query, Res};
 use tracing::debug;
 
-use crate::client::components::SyncComponent;
-use crate::prelude::{ComponentRegistry, Tick, TickManager};
+use crate::{
+    client::components::SyncComponent,
+    prelude::{ComponentRegistry, Tick, TickManager},
+};
 
 #[derive(Component, Debug, PartialEq)]
 pub struct Correction<C: Component> {
@@ -112,20 +114,24 @@ pub(crate) fn restore_corrected_state<C: SyncComponent>(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::client::components::Confirmed;
-    use crate::client::config::ClientConfig;
-    use crate::client::prediction::predicted_history::PredictionHistory;
-    use crate::client::prediction::rollback::test_utils::received_confirmed_update;
-    use crate::client::prediction::Predicted;
-    use crate::prelude::client::PredictionConfig;
-    use crate::prelude::{SharedConfig, TickConfig};
-    use crate::tests::protocol::ComponentCorrection;
-    use crate::tests::stepper::BevyStepper;
-    use approx::assert_relative_eq;
-    use bevy::app::FixedUpdate;
-    use bevy::prelude::default;
     use std::time::Duration;
+
+    use approx::assert_relative_eq;
+    use bevy::{app::FixedUpdate, prelude::default};
+
+    use super::*;
+    use crate::{
+        client::{
+            components::Confirmed,
+            config::ClientConfig,
+            prediction::{
+                predicted_history::PredictionHistory,
+                rollback::test_utils::received_confirmed_update, Predicted,
+            },
+        },
+        prelude::{client::PredictionConfig, SharedConfig, TickConfig},
+        tests::{protocol::ComponentCorrection, stepper::BevyStepper},
+    };
 
     fn increment_component_system(mut query: Query<(Entity, &mut ComponentCorrection)>) {
         for (entity, mut component) in query.iter_mut() {

--- a/lightyear/src/client/prediction/despawn.rs
+++ b/lightyear/src/client/prediction/despawn.rs
@@ -1,14 +1,19 @@
-use bevy::ecs::system::EntityCommands;
-use bevy::ecs::world::Command;
-use bevy::prelude::*;
+use bevy::{
+    ecs::{system::EntityCommands, world::Command},
+    prelude::*,
+};
 use tracing::{debug, error, trace};
 
-use crate::client::components::{ComponentSyncMode, Confirmed, SyncComponent};
-use crate::client::prediction::Predicted;
-use crate::prelude::{
-    AppIdentityExt, ComponentRegistry, PreSpawnedPlayerObject, ShouldBePredicted, TickManager,
+use crate::{
+    client::{
+        components::{ComponentSyncMode, Confirmed, SyncComponent},
+        prediction::Predicted,
+    },
+    prelude::{
+        AppIdentityExt, ComponentRegistry, PreSpawnedPlayerObject, ShouldBePredicted, TickManager,
+    },
+    shared::tick_manager::Tick,
 };
-use crate::shared::tick_manager::Tick;
 
 // - TODO: despawning another client entity as a consequence from prediction, but we want to roll that back:
 //   - maybe we don't do it, and we wait until we are sure (confirmed despawn) before actually despawning the entity
@@ -164,14 +169,22 @@ pub(crate) fn remove_despawn_marker(
 
 #[cfg(test)]
 mod tests {
-    use crate::client::prediction::despawn::PredictionDespawnMarker;
-    use crate::client::prediction::resource::PredictionManager;
-    use crate::prelude::client::{Confirmed, PredictionDespawnCommandsExt};
-    use crate::prelude::server::SyncTarget;
-    use crate::prelude::{client, server, NetworkTarget};
-    use crate::tests::protocol::{ComponentSyncModeFull, ComponentSyncModeSimple};
-    use crate::tests::stepper::BevyStepper;
     use bevy::prelude::{default, Component};
+
+    use crate::{
+        client::prediction::{despawn::PredictionDespawnMarker, resource::PredictionManager},
+        prelude::{
+            client,
+            client::{Confirmed, PredictionDespawnCommandsExt},
+            server,
+            server::SyncTarget,
+            NetworkTarget,
+        },
+        tests::{
+            protocol::{ComponentSyncModeFull, ComponentSyncModeSimple},
+            stepper::BevyStepper,
+        },
+    };
 
     #[derive(Component, Debug, PartialEq)]
     struct TestComponent(usize);

--- a/lightyear/src/client/prediction/diagnostics.rs
+++ b/lightyear/src/client/prediction/diagnostics.rs
@@ -1,10 +1,13 @@
 //! Collect diagnostics for the prediction systems.
 
+use bevy::{
+    diagnostic::{Diagnostic, DiagnosticPath, Diagnostics, RegisterDiagnostic},
+    prelude::*,
+    time::common_conditions::on_timer,
+    utils::Duration,
+};
+
 use crate::prelude::{client::is_disconnected, is_host_server};
-use bevy::diagnostic::{Diagnostic, DiagnosticPath, Diagnostics, RegisterDiagnostic};
-use bevy::prelude::*;
-use bevy::time::common_conditions::on_timer;
-use bevy::utils::Duration;
 
 /// Plugin in charge of collecting diagnostics for the prediction systems.
 pub struct PredictionDiagnosticsPlugin {

--- a/lightyear/src/client/prediction/mod.rs
+++ b/lightyear/src/client/prediction/mod.rs
@@ -1,9 +1,12 @@
 //! Handles client-side prediction
-use crate::client::prediction::resource::PredictionManager;
-use bevy::ecs::component::StorageType;
-use bevy::ecs::world::DeferredWorld;
-use bevy::prelude::{Component, Entity, Reflect, ReflectComponent};
 use std::fmt::Debug;
+
+use bevy::{
+    ecs::{component::StorageType, world::DeferredWorld},
+    prelude::{Component, Entity, Reflect, ReflectComponent},
+};
+
+use crate::client::prediction::resource::PredictionManager;
 
 pub mod correction;
 pub mod despawn;

--- a/lightyear/src/client/prediction/plugin.rs
+++ b/lightyear/src/client/prediction/plugin.rs
@@ -1,36 +1,42 @@
-use crate::client::components::{ComponentSyncMode, Confirmed, SyncComponent};
-use crate::client::prediction::correction::{get_corrected_state, restore_corrected_state};
-use crate::client::prediction::despawn::{
-    despawn_confirmed, remove_component_for_despawn_predicted, remove_despawn_marker,
-    restore_components_if_despawn_rolled_back, PredictionDespawnMarker,
-};
-use crate::client::prediction::predicted_history::{
-    add_prediction_history, add_sync_systems, apply_component_removal_confirmed,
-    apply_component_removal_predicted, handle_tick_event_prediction_history,
-    update_prediction_history,
-};
-use crate::client::prediction::prespawn::PreSpawnedPlayerObjectPlugin;
-use crate::client::prediction::resource::PredictionManager;
-use crate::client::prediction::Predicted;
-use crate::prelude::{is_host_server, PreSpawnedPlayerObject};
-use crate::shared::sets::{ClientMarker, InternalMainSet};
-use bevy::prelude::*;
-use bevy::reflect::Reflect;
-use bevy::utils::Duration;
 use std::fmt::Debug;
 
-use super::pre_prediction::PrePredictionPlugin;
-use super::predicted_history::apply_confirmed_update;
-use super::resource_history::{
-    handle_tick_event_resource_history, update_resource_history, ResourceHistory,
-};
-use super::rollback::{
-    check_rollback, increment_rollback_tick, prepare_rollback, prepare_rollback_non_networked,
-    prepare_rollback_prespawn, prepare_rollback_resource, run_rollback, Rollback, RollbackState,
-};
-use super::spawn::spawn_predicted_entity;
+use bevy::{prelude::*, reflect::Reflect, utils::Duration};
 
-use crate::prelude::client::is_connected;
+use super::{
+    pre_prediction::PrePredictionPlugin,
+    predicted_history::apply_confirmed_update,
+    resource_history::{
+        handle_tick_event_resource_history, update_resource_history, ResourceHistory,
+    },
+    rollback::{
+        check_rollback, increment_rollback_tick, prepare_rollback, prepare_rollback_non_networked,
+        prepare_rollback_prespawn, prepare_rollback_resource, run_rollback, Rollback,
+        RollbackState,
+    },
+    spawn::spawn_predicted_entity,
+};
+use crate::{
+    client::{
+        components::{ComponentSyncMode, Confirmed, SyncComponent},
+        prediction::{
+            correction::{get_corrected_state, restore_corrected_state},
+            despawn::{
+                despawn_confirmed, remove_component_for_despawn_predicted, remove_despawn_marker,
+                restore_components_if_despawn_rolled_back, PredictionDespawnMarker,
+            },
+            predicted_history::{
+                add_prediction_history, add_sync_systems, apply_component_removal_confirmed,
+                apply_component_removal_predicted, handle_tick_event_prediction_history,
+                update_prediction_history,
+            },
+            prespawn::PreSpawnedPlayerObjectPlugin,
+            resource::PredictionManager,
+            Predicted,
+        },
+    },
+    prelude::{client::is_connected, is_host_server, PreSpawnedPlayerObject},
+    shared::sets::{ClientMarker, InternalMainSet},
+};
 
 /// Configuration to specify how the prediction plugin should behave
 #[derive(Debug, Clone, Copy, Reflect)]

--- a/lightyear/src/client/prediction/pre_prediction.rs
+++ b/lightyear/src/client/prediction/pre_prediction.rs
@@ -3,18 +3,22 @@
 
 use bevy::prelude::*;
 
-use crate::client::components::Confirmed;
-use crate::client::prediction::resource::PredictionManager;
-use crate::client::prediction::Predicted;
-use crate::client::replication::send::ReplicateToServer;
-use crate::prelude::client::is_synced;
-use crate::prelude::{
-    is_host_server, HasAuthority, NetworkIdentityState, ReplicateHierarchy, Replicating,
-    ReplicationGroup, ShouldBePredicted, TickManager,
+use crate::{
+    client::{
+        components::Confirmed,
+        prediction::{resource::PredictionManager, Predicted},
+        replication::send::ReplicateToServer,
+    },
+    prelude::{
+        client::is_synced, is_host_server, HasAuthority, NetworkIdentityState, ReplicateHierarchy,
+        Replicating, ReplicationGroup, ShouldBePredicted, TickManager,
+    },
+    server::replication::send::ReplicationTarget,
+    shared::{
+        replication::components::PrePredicted,
+        sets::{ClientMarker, InternalReplicationSet},
+    },
 };
-use crate::server::replication::send::ReplicationTarget;
-use crate::shared::replication::components::PrePredicted;
-use crate::shared::sets::{ClientMarker, InternalReplicationSet};
 
 #[derive(Default)]
 pub(crate) struct PrePredictionPlugin;
@@ -149,13 +153,15 @@ impl PrePredictionPlugin {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::client::prediction::predicted_history::PredictionHistory;
-    use crate::prelude::server;
-    use crate::prelude::server::AuthorityPeer;
-    use crate::prelude::{client, ClientId};
-    use crate::tests::host_server_stepper::HostServerStepper;
-    use crate::tests::protocol::{ComponentClientToServer, ComponentSyncModeFull};
-    use crate::tests::stepper::{BevyStepper, TEST_CLIENT_ID};
+    use crate::{
+        client::prediction::predicted_history::PredictionHistory,
+        prelude::{client, server, server::AuthorityPeer, ClientId},
+        tests::{
+            host_server_stepper::HostServerStepper,
+            protocol::{ComponentClientToServer, ComponentSyncModeFull},
+            stepper::{BevyStepper, TEST_CLIENT_ID},
+        },
+    };
 
     /// Simple preprediction case
     /// Also check that the PredictionHistory is correctly added to the PrePredicted entity

--- a/lightyear/src/client/prediction/predicted_history.rs
+++ b/lightyear/src/client/prediction/predicted_history.rs
@@ -1,19 +1,20 @@
 //! Managed the history buffer, which is a buffer of the past predicted component states,
 //! so that whenever we receive an update from the server we can compare the predicted entity's history with the server update.
-use bevy::app::App;
-use bevy::ecs::component::ComponentId;
-use bevy::prelude::*;
 use std::ops::Deref;
 
-use crate::client::components::{ComponentSyncMode, Confirmed, SyncComponent};
-use crate::client::prediction::resource::PredictionManager;
-use crate::client::prediction::rollback::Rollback;
-use crate::client::prediction::Predicted;
-use crate::prelude::client::{Correction, PredictionSet};
-use crate::prelude::{
-    ComponentRegistry, HistoryBuffer, PrePredicted, PreSpawnedPlayerObject, TickManager,
+use bevy::{app::App, ecs::component::ComponentId, prelude::*};
+
+use crate::{
+    client::{
+        components::{ComponentSyncMode, Confirmed, SyncComponent},
+        prediction::{resource::PredictionManager, rollback::Rollback, Predicted},
+    },
+    prelude::{
+        client::{Correction, PredictionSet},
+        ComponentRegistry, HistoryBuffer, PrePredicted, PreSpawnedPlayerObject, TickManager,
+    },
+    shared::tick_manager::TickEvent,
 };
-use crate::shared::tick_manager::TickEvent;
 
 pub(crate) type PredictionHistory<C> = HistoryBuffer<C>;
 
@@ -303,12 +304,13 @@ pub(crate) fn add_sync_systems(app: &mut App) {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::prelude::client::RollbackState;
-    use crate::prelude::{HistoryState, ShouldBePredicted, Tick};
-    use crate::tests::protocol::*;
-    use crate::tests::stepper::BevyStepper;
     use bevy::ecs::system::RunSystemOnce;
+
+    use super::*;
+    use crate::{
+        prelude::{client::RollbackState, HistoryState, ShouldBePredicted, Tick},
+        tests::{protocol::*, stepper::BevyStepper},
+    };
 
     /// Test that components are synced from Confirmed to Predicted and that PredictionHistory is
     /// added correctly

--- a/lightyear/src/client/prediction/prespawn.rs
+++ b/lightyear/src/client/prediction/prespawn.rs
@@ -1,19 +1,23 @@
 //! Handles spawning entities that are predicted
 
-use bevy::ecs::component::{Components, StorageType};
-use bevy::prelude::*;
+use bevy::{
+    ecs::component::{Components, StorageType},
+    prelude::*,
+};
 use serde::{Deserialize, Serialize};
 use tracing::{debug, trace};
 
-use crate::client::components::Confirmed;
-use crate::client::connection::ConnectionManager;
-use crate::client::prediction::resource::PredictionManager;
-use crate::client::prediction::rollback::Rollback;
-use crate::client::prediction::Predicted;
-use crate::prelude::client::PredictionSet;
-use crate::prelude::{ComponentRegistry, Replicated, ShouldBePredicted, TickManager};
-
-use crate::shared::replication::prespawn::compute_default_hash;
+use crate::{
+    client::{
+        components::Confirmed,
+        connection::ConnectionManager,
+        prediction::{resource::PredictionManager, rollback::Rollback, Predicted},
+    },
+    prelude::{
+        client::PredictionSet, ComponentRegistry, Replicated, ShouldBePredicted, TickManager,
+    },
+    shared::replication::prespawn::compute_default_hash,
+};
 
 #[derive(Default)]
 pub(crate) struct PreSpawnedPlayerObjectPlugin;
@@ -366,17 +370,23 @@ impl Component for PreSpawnedPlayerObject {
 
 #[cfg(test)]
 mod tests {
-    use crate::client::prediction::predicted_history::PredictionHistory;
-    use crate::client::prediction::resource::PredictionManager;
-    use crate::prelude::client::{is_in_rollback, PredictionDespawnCommandsExt, PredictionSet};
-    use crate::prelude::client::{Confirmed, Predicted};
-    use crate::prelude::server::{Replicate, SyncTarget};
-    use crate::prelude::*;
-    use crate::tests::protocol::*;
-    use crate::tests::stepper::BevyStepper;
-    use crate::utils::ready_buffer::ItemWithReadyKey;
-    use bevy::app::PreUpdate;
-    use bevy::prelude::{default, Entity, IntoSystemConfigs, With};
+    use bevy::{
+        app::PreUpdate,
+        prelude::{default, Entity, IntoSystemConfigs, With},
+    };
+
+    use crate::{
+        client::prediction::{predicted_history::PredictionHistory, resource::PredictionManager},
+        prelude::{
+            client::{
+                is_in_rollback, Confirmed, Predicted, PredictionDespawnCommandsExt, PredictionSet,
+            },
+            server::{Replicate, SyncTarget},
+            *,
+        },
+        tests::{protocol::*, stepper::BevyStepper},
+        utils::ready_buffer::ItemWithReadyKey,
+    };
 
     #[test]
     fn test_compute_hash() {

--- a/lightyear/src/client/prediction/resource.rs
+++ b/lightyear/src/client/prediction/resource.rs
@@ -1,14 +1,19 @@
 //! Defines bevy resources needed for Prediction
 
-use bevy::ecs::entity::EntityHash;
-use bevy::prelude::{Entity, Resource};
 use std::cell::UnsafeCell;
 
-use crate::prelude::{ComponentRegistry, Tick};
-use crate::protocol::component::ComponentError;
-use crate::shared::replication::entity_map::PredictedEntityMap;
-use crate::utils::ready_buffer::ReadyBuffer;
-use bevy::utils::hashbrown;
+use bevy::{
+    ecs::entity::EntityHash,
+    prelude::{Entity, Resource},
+    utils::hashbrown,
+};
+
+use crate::{
+    prelude::{ComponentRegistry, Tick},
+    protocol::component::ComponentError,
+    shared::replication::entity_map::PredictedEntityMap,
+    utils::ready_buffer::ReadyBuffer,
+};
 
 type EntityHashMap<K, V> = hashbrown::HashMap<K, V, EntityHash>;
 

--- a/lightyear/src/client/prediction/resource_history.rs
+++ b/lightyear/src/client/prediction/resource_history.rs
@@ -1,9 +1,11 @@
 //! There's a lot of overlap with `client::prediction_history` because resources are components in ECS so rollback is going to look similar.
-use crate::prelude::{HistoryBuffer, HistoryState, TickManager};
 use bevy::prelude::*;
 
 use super::rollback::Rollback;
-use crate::shared::tick_manager::TickEvent;
+use crate::{
+    prelude::{HistoryBuffer, HistoryState, TickManager},
+    shared::tick_manager::TickEvent,
+};
 
 pub(crate) type ResourceHistory<R> = HistoryBuffer<R>;
 
@@ -51,12 +53,13 @@ pub(crate) fn update_resource_history<R: Resource + Clone>(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::prelude::client::RollbackState;
-    use crate::prelude::AppComponentExt;
-    use crate::prelude::Tick;
-    use crate::tests::stepper::BevyStepper;
     use bevy::ecs::system::RunSystemOnce;
+
+    use super::*;
+    use crate::{
+        prelude::{client::RollbackState, AppComponentExt, Tick},
+        tests::stepper::BevyStepper,
+    };
 
     #[derive(Resource, Clone, PartialEq, Debug)]
     struct TestResource(f32);

--- a/lightyear/src/client/prediction/rollback.rs
+++ b/lightyear/src/client/prediction/rollback.rs
@@ -1,29 +1,33 @@
-use std::fmt::Debug;
-use std::ops::{Deref, DerefMut};
-
-use bevy::app::FixedMain;
-use bevy::ecs::entity::EntityHashSet;
-use bevy::ecs::reflect::ReflectResource;
-use bevy::prelude::{
-    Commands, Component, DespawnRecursiveExt, DetectChanges, Entity, Has, Query, Ref, Res, ResMut,
-    Resource, With, Without, World,
+use std::{
+    fmt::Debug,
+    ops::{Deref, DerefMut},
 };
-use bevy::reflect::Reflect;
-use bevy::time::{Fixed, Time};
+
+use bevy::{
+    app::FixedMain,
+    ecs::{entity::EntityHashSet, reflect::ReflectResource},
+    prelude::{
+        Commands, Component, DespawnRecursiveExt, DetectChanges, Entity, Has, Query, Ref, Res,
+        ResMut, Resource, With, Without, World,
+    },
+    reflect::Reflect,
+    time::{Fixed, Time},
+};
 use parking_lot::RwLock;
 use tracing::{debug, error, trace, trace_span};
 
-use crate::client::components::{Confirmed, SyncComponent};
-use crate::client::config::ClientConfig;
-use crate::client::connection::ConnectionManager;
-use crate::client::prediction::correction::Correction;
-use crate::client::prediction::diagnostics::PredictionMetrics;
-use crate::client::prediction::resource::PredictionManager;
-use crate::prelude::{ComponentRegistry, HistoryState, PreSpawnedPlayerObject, Tick, TickManager};
-
-use super::predicted_history::PredictionHistory;
-use super::resource_history::ResourceHistory;
-use super::Predicted;
+use super::{predicted_history::PredictionHistory, resource_history::ResourceHistory, Predicted};
+use crate::{
+    client::{
+        components::{Confirmed, SyncComponent},
+        config::ClientConfig,
+        connection::ConnectionManager,
+        prediction::{
+            correction::Correction, diagnostics::PredictionMetrics, resource::PredictionManager,
+        },
+    },
+    prelude::{ComponentRegistry, HistoryState, PreSpawnedPlayerObject, Tick, TickManager},
+};
 
 #[derive(Component)]
 /// Marker component used to indicate that an entity:
@@ -780,12 +784,15 @@ pub(crate) fn increment_rollback_tick(rollback: Res<Rollback>) {
 
 #[cfg(test)]
 pub(crate) mod test_utils {
-    use crate::client::components::Confirmed;
-    use crate::client::connection::ConnectionManager;
-    use crate::prelude::Tick;
-    use crate::tests::stepper::BevyStepper;
-    use bevy::prelude::Entity;
     use std::time::Duration;
+
+    use bevy::prelude::Entity;
+
+    use crate::{
+        client::{components::Confirmed, connection::ConnectionManager},
+        prelude::Tick,
+        tests::stepper::BevyStepper,
+    };
 
     /// Helper function to simulate that we received a server message
     pub(crate) fn received_confirmed_update(
@@ -814,22 +821,26 @@ pub(crate) mod test_utils {
 mod tests {
     use std::time::Duration;
 
-    use super::test_utils::*;
-
-    use crate::client::prediction::diagnostics::PredictionMetrics;
-    use crate::client::prediction::predicted_history::PredictionHistory;
-    use crate::client::prediction::resource::PredictionManager;
-    use crate::client::prediction::rollback::{check_rollback, DisableRollback};
-    use crate::prelude::server::SyncTarget;
-    use crate::prelude::{
-        client::*, AppComponentExt, ChannelDirection, NetworkTarget, SharedConfig, TickConfig,
+    use bevy::{
+        ecs::{entity::MapEntities, system::RunSystemOnce},
+        prelude::*,
     };
-    use crate::tests::protocol::*;
-    use crate::tests::stepper::BevyStepper;
-    use bevy::ecs::entity::MapEntities;
-    use bevy::ecs::system::RunSystemOnce;
-    use bevy::prelude::*;
     use serde::{Deserialize, Serialize};
+
+    use super::test_utils::*;
+    use crate::{
+        client::prediction::{
+            diagnostics::PredictionMetrics,
+            predicted_history::PredictionHistory,
+            resource::PredictionManager,
+            rollback::{check_rollback, DisableRollback},
+        },
+        prelude::{
+            client::*, server::SyncTarget, AppComponentExt, ChannelDirection, NetworkTarget,
+            SharedConfig, TickConfig,
+        },
+        tests::{protocol::*, stepper::BevyStepper},
+    };
 
     fn setup(increment_component: bool) -> (BevyStepper, Entity, Entity) {
         fn increment_component_system(

--- a/lightyear/src/client/prediction/spawn.rs
+++ b/lightyear/src/client/prediction/spawn.rs
@@ -2,10 +2,10 @@
 use bevy::prelude::{Added, Commands, Entity, Query, Res};
 use tracing::debug;
 
-use crate::client::components::Confirmed;
-use crate::client::connection::ConnectionManager;
-use crate::client::prediction::Predicted;
-use crate::prelude::{ShouldBePredicted, TickManager};
+use crate::{
+    client::{components::Confirmed, connection::ConnectionManager, prediction::Predicted},
+    prelude::{ShouldBePredicted, TickManager},
+};
 
 /// Spawn a predicted entity for each confirmed entity that has the `ShouldBePredicted` component added
 /// The `Confirmed` entity could already exist because we share the Confirmed component for prediction and interpolation.
@@ -79,12 +79,16 @@ pub(crate) fn spawn_predicted_entity(
 //
 #[cfg(test)]
 mod tests {
-    use crate::client::components::Confirmed;
-    use crate::prelude::server::SyncTarget;
-    use crate::prelude::{client, server, ClientId, NetworkTarget};
-    use crate::tests::stepper::{BevyStepper, TEST_CLIENT_ID};
-    use bevy::hierarchy::{BuildChildren, Parent};
-    use bevy::prelude::default;
+    use bevy::{
+        hierarchy::{BuildChildren, Parent},
+        prelude::default,
+    };
+
+    use crate::{
+        client::components::Confirmed,
+        prelude::{client, server, server::SyncTarget, ClientId, NetworkTarget},
+        tests::stepper::{BevyStepper, TEST_CLIENT_ID},
+    };
 
     /// https://github.com/cBournhonesque/lightyear/issues/627
     /// Test that when we spawn a parent + child with hierarchy (ParentSync),

--- a/lightyear/src/client/run_conditions.rs
+++ b/lightyear/src/client/run_conditions.rs
@@ -1,7 +1,10 @@
 //! Common client-related run conditions
-use crate::client::connection::ConnectionManager;
-use crate::connection::client::{ClientConnection, ConnectionState, NetClient};
 use bevy::prelude::Res;
+
+use crate::{
+    client::connection::ConnectionManager,
+    connection::client::{ClientConnection, ConnectionState, NetClient},
+};
 
 /// Returns true if the client is connected
 ///

--- a/lightyear/src/client/sync.rs
+++ b/lightyear/src/client/sync.rs
@@ -1,18 +1,23 @@
 /*! Handles syncing the time between the client and the server
 */
-use bevy::prelude::{Reflect, SystemSet};
-use bevy::utils::Duration;
+use bevy::{
+    prelude::{Reflect, SystemSet},
+    utils::Duration,
+};
 use chrono::Duration as ChronoDuration;
 use tracing::{debug, trace};
 
-use crate::client::interpolation::plugin::InterpolationConfig;
-use crate::packet::packet::PacketId;
-use crate::prelude::client::{InterpolationDelay, PredictionConfig};
-use crate::shared::ping::manager::PingManager;
-use crate::shared::tick_manager::TickManager;
-use crate::shared::tick_manager::{Tick, TickEvent};
-use crate::shared::time_manager::{TimeManager, WrappedTime};
-use crate::utils::ready_buffer::ReadyBuffer;
+use crate::{
+    client::interpolation::plugin::InterpolationConfig,
+    packet::packet::PacketId,
+    prelude::client::{InterpolationDelay, PredictionConfig},
+    shared::{
+        ping::manager::PingManager,
+        tick_manager::{Tick, TickEvent, TickManager},
+        time_manager::{TimeManager, WrappedTime},
+    },
+    utils::ready_buffer::ReadyBuffer,
+};
 
 /// SystemSet that holds systems that update the client's tick/time to match the server's tick/time
 #[derive(SystemSet, Debug, Hash, PartialEq, Eq, Clone, Copy)]
@@ -589,12 +594,11 @@ impl SyncManager {
 mod tests {
     use bevy::utils::Duration;
 
-    use crate::prelude::server::Replicate;
-    use crate::prelude::*;
-    use crate::tests::protocol::*;
-    use crate::tests::stepper::BevyStepper;
-
     use super::*;
+    use crate::{
+        prelude::{server::Replicate, *},
+        tests::{protocol::*, stepper::BevyStepper},
+    };
 
     /// Check that after a big tick discrepancy between server/client, the client tick gets updated
     /// to match the server tick

--- a/lightyear/src/connection/client.rs
+++ b/lightyear/src/connection/client.rs
@@ -1,27 +1,23 @@
-use std::net::SocketAddr;
-use std::str::FromStr;
 #[cfg(all(feature = "steam", not(target_family = "wasm")))]
 use std::sync::Arc;
+use std::{net::SocketAddr, str::FromStr};
 
 use bevy::prelude::{Reflect, Resource};
 use enum_dispatch::enum_dispatch;
 #[cfg(all(feature = "steam", not(target_family = "wasm")))]
 use parking_lot::RwLock;
 
-use crate::client::config::NetcodeConfig;
-use crate::client::io::Io;
-use crate::connection::id::ClientId;
-use crate::connection::netcode::ConnectToken;
-
 #[cfg(all(feature = "steam", not(target_family = "wasm")))]
 use crate::connection::steam::{client::SteamConfig, steamworks_client::SteamworksClient};
-use crate::packet::packet_builder::RecvPayload;
-
-use crate::prelude::client::ClientTransport;
 #[cfg(all(feature = "steam", not(target_family = "wasm")))]
 use crate::prelude::LinkConditionerConfig;
-use crate::prelude::{generate_key, Key};
-use crate::transport::config::SharedIoConfig;
+use crate::{
+    client::{config::NetcodeConfig, io::Io},
+    connection::{id::ClientId, netcode::ConnectToken},
+    packet::packet_builder::RecvPayload,
+    prelude::{client::ClientTransport, generate_key, Key},
+    transport::config::SharedIoConfig,
+};
 
 #[derive(Debug)]
 pub enum ConnectionState {

--- a/lightyear/src/connection/id.rs
+++ b/lightyear/src/connection/id.rs
@@ -1,10 +1,11 @@
 //! Module to handle the various possible ClientIds
-use crate::serialize::reader::Reader;
-use crate::serialize::{SerializationError, ToBytes};
+use std::fmt::Formatter;
+
 use bevy::reflect::Reflect;
 use byteorder::{NetworkEndian, ReadBytesExt, WriteBytesExt};
 use serde::{Deserialize, Serialize};
-use std::fmt::Formatter;
+
+use crate::serialize::{reader::Reader, SerializationError, ToBytes};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Reflect)]
 pub enum ClientId {

--- a/lightyear/src/connection/local/client.rs
+++ b/lightyear/src/connection/local/client.rs
@@ -1,9 +1,12 @@
-use crate::client::io::Io;
-use crate::connection::client::{ConnectionError, ConnectionState, NetClient};
-use crate::packet::packet_builder::RecvPayload;
-use crate::prelude::ClientId;
-use crate::transport::LOCAL_SOCKET;
 use std::net::SocketAddr;
+
+use crate::{
+    client::io::Io,
+    connection::client::{ConnectionError, ConnectionState, NetClient},
+    packet::packet_builder::RecvPayload,
+    prelude::ClientId,
+    transport::LOCAL_SOCKET,
+};
 
 #[derive(Default)]
 pub struct Client {

--- a/lightyear/src/connection/netcode/client.rs
+++ b/lightyear/src/connection/netcode/client.rs
@@ -3,14 +3,6 @@ use std::{collections::VecDeque, net::SocketAddr};
 use bevy::prelude::Resource;
 use tracing::{debug, error, info, trace};
 
-use crate::client::io::Io;
-use crate::connection::client::{ConnectionError, ConnectionState, IoConfig, NetClient};
-use crate::connection::id;
-use crate::packet::packet_builder::RecvPayload;
-use crate::transport::io::IoState;
-use crate::transport::{PacketReceiver, PacketSender, LOCAL_SOCKET};
-use crate::utils::pool::Pool;
-
 use super::{
     bytes::Bytes,
     error::{Error, Result},
@@ -20,6 +12,16 @@ use super::{
     replay::ReplayProtection,
     token::{ChallengeToken, ConnectToken},
     utils, ClientId, MAX_PACKET_SIZE, MAX_PKT_BUF_SIZE, PACKET_SEND_RATE_SEC,
+};
+use crate::{
+    client::io::Io,
+    connection::{
+        client::{ConnectionError, ConnectionState, IoConfig, NetClient},
+        id,
+    },
+    packet::packet_builder::RecvPayload,
+    transport::{io::IoState, PacketReceiver, PacketSender, LOCAL_SOCKET},
+    utils::pool::Pool,
 };
 
 type Callback<Ctx> = Box<dyn FnMut(ClientState, ClientState, &mut Ctx) + Send + Sync + 'static>;
@@ -652,8 +654,9 @@ impl<Ctx> NetcodeClient<Ctx> {
 }
 
 pub(crate) mod connection {
-    use super::*;
     use core::result::Result;
+
+    use super::*;
 
     /// Client that can establish a connection to the Server
     #[derive(Resource)]
@@ -735,13 +738,18 @@ pub(crate) mod connection {
 
 #[cfg(test)]
 mod tests {
-    use crate::client::networking::ClientCommandsExt;
-    use crate::connection::server::ServerConnections;
-    use crate::prelude::client;
-    use crate::prelude::server::{NetServer, ServerCommandsExt};
-    use crate::tests::stepper::BevyStepper;
     use bevy::prelude::State;
     use tracing::trace;
+
+    use crate::{
+        client::networking::ClientCommandsExt,
+        connection::server::ServerConnections,
+        prelude::{
+            client,
+            server::{NetServer, ServerCommandsExt},
+        },
+        tests::stepper::BevyStepper,
+    };
 
     // TODO: investigate why this test is not working!
     /// Check that if the client disconnects during the handshake, the server

--- a/lightyear/src/connection/netcode/packet.rs
+++ b/lightyear/src/connection/netcode/packet.rs
@@ -7,9 +7,6 @@ use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use chacha20poly1305::XNonce;
 use tracing::debug;
 
-use crate::connection::netcode::ClientId;
-use crate::connection::server::DeniedReason;
-
 use super::{
     bytes::Bytes,
     crypto::{self, Key},
@@ -18,6 +15,7 @@ use super::{
     token::{ChallengeToken, ConnectTokenPrivate},
     MAC_BYTES, MAX_PKT_BUF_SIZE, NETCODE_VERSION,
 };
+use crate::connection::{netcode::ClientId, server::DeniedReason};
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -559,11 +557,10 @@ pub fn sequence_len(sequence: u64) -> u8 {
 mod tests {
     use chacha20poly1305::{aead::OsRng, AeadCore, XChaCha20Poly1305};
 
+    use super::*;
     use crate::connection::netcode::{
         crypto::generate_key, token::AddressList, MAX_PACKET_SIZE, USER_DATA_BYTES,
     };
-
-    use super::*;
 
     #[test]
     fn sequence_number_bytes_required() {

--- a/lightyear/src/connection/netcode/server.rs
+++ b/lightyear/src/connection/netcode/server.rs
@@ -1,24 +1,14 @@
-use std::collections::{HashMap, VecDeque};
-use std::net::SocketAddr;
-use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::{
+    collections::{HashMap, VecDeque},
+    net::SocketAddr,
+    sync::Arc,
+    time::{SystemTime, UNIX_EPOCH},
+};
 
 use bevy::prelude::Resource;
 use tracing::{debug, error, trace, warn};
-
 #[cfg(feature = "trace")]
 use tracing::{instrument, Level};
-
-use crate::connection::id;
-use crate::connection::netcode::token::TOKEN_EXPIRE_SEC;
-use crate::connection::server::{
-    ConnectionError, ConnectionRequestHandler, DefaultConnectionRequestHandler, DeniedReason,
-    IoConfig, NetServer,
-};
-use crate::packet::packet_builder::RecvPayload;
-use crate::server::config::NetcodeConfig;
-use crate::server::io::{Io, ServerIoEvent, ServerNetworkEventSender};
-use crate::transport::{PacketReceiver, PacketSender};
 
 use super::{
     bytes::Bytes,
@@ -31,6 +21,22 @@ use super::{
     replay::ReplayProtection,
     token::{ChallengeToken, ConnectToken, ConnectTokenBuilder, ConnectTokenPrivate},
     MAC_BYTES, MAX_PACKET_SIZE, MAX_PKT_BUF_SIZE, PACKET_SEND_RATE_SEC,
+};
+use crate::{
+    connection::{
+        id,
+        netcode::token::TOKEN_EXPIRE_SEC,
+        server::{
+            ConnectionError, ConnectionRequestHandler, DefaultConnectionRequestHandler,
+            DeniedReason, IoConfig, NetServer,
+        },
+    },
+    packet::packet_builder::RecvPayload,
+    server::{
+        config::NetcodeConfig,
+        io::{Io, ServerIoEvent, ServerNetworkEventSender},
+    },
+    transport::{PacketReceiver, PacketSender},
 };
 
 pub const MAX_CLIENTS: usize = 256;
@@ -1044,9 +1050,10 @@ impl<Ctx> NetcodeServer<Ctx> {
 }
 
 pub(crate) mod connection {
+    use core::result::Result;
+
     use super::*;
     use crate::connection::server::ConnectionError;
-    use core::result::Result;
 
     #[derive(Default)]
     pub(crate) struct NetcodeServerContext {

--- a/lightyear/src/connection/server.rs
+++ b/lightyear/src/connection/server.rs
@@ -1,23 +1,22 @@
-use bevy::prelude::Resource;
-use bevy::utils::HashMap;
+use std::{fmt::Debug, net::SocketAddr, sync::Arc};
+
+use bevy::{prelude::Resource, utils::HashMap};
 use enum_dispatch::enum_dispatch;
 #[cfg(all(feature = "steam", not(target_family = "wasm")))]
 use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
-use std::fmt::Debug;
-use std::net::SocketAddr;
-use std::sync::Arc;
 
-use crate::connection::id::ClientId;
 #[cfg(all(feature = "steam", not(target_family = "wasm")))]
 use crate::connection::steam::{server::SteamConfig, steamworks_client::SteamworksClient};
-use crate::packet::packet_builder::RecvPayload;
-use crate::prelude::server::ServerTransport;
 #[cfg(all(feature = "steam", not(target_family = "wasm")))]
 use crate::prelude::LinkConditionerConfig;
-use crate::server::config::NetcodeConfig;
-use crate::server::io::Io;
-use crate::transport::config::SharedIoConfig;
+use crate::{
+    connection::id::ClientId,
+    packet::packet_builder::RecvPayload,
+    prelude::server::ServerTransport,
+    server::{config::NetcodeConfig, io::Io},
+    transport::config::SharedIoConfig,
+};
 
 /// Reasons for denying a connection request
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
@@ -261,10 +260,12 @@ pub enum ConnectionError {
 
 #[cfg(test)]
 mod tests {
-    use crate::connection::server::{NetServer, ServerConnections};
-    use crate::prelude::ClientId;
-    use crate::tests::stepper::{BevyStepper, TEST_CLIENT_ID};
-    use crate::transport::LOCAL_SOCKET;
+    use crate::{
+        connection::server::{NetServer, ServerConnections},
+        prelude::ClientId,
+        tests::stepper::{BevyStepper, TEST_CLIENT_ID},
+        transport::LOCAL_SOCKET,
+    };
 
     // Check that the server can successfully disconnect a client
     // and that there aren't any excessive logs afterwards

--- a/lightyear/src/connection/steam/client.rs
+++ b/lightyear/src/connection/steam/client.rs
@@ -1,21 +1,30 @@
-use crate::connection::client::{ConnectionError, ConnectionState, NetClient};
-use crate::connection::id::ClientId;
-use crate::packet::packet_builder::RecvPayload;
-use crate::prelude::client::Io;
-use crate::prelude::LinkConditionerConfig;
-use crate::transport::LOCAL_SOCKET;
-use parking_lot::RwLock;
-use std::collections::VecDeque;
-use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
-use std::sync::Arc;
-use steamworks::networking_sockets::{InvalidHandle, NetConnection};
-use steamworks::networking_types::{
-    NetConnectionEnd, NetConnectionInfo, NetworkingConnectionState, NetworkingIdentity, SendFlags,
+use std::{
+    collections::VecDeque,
+    net::{Ipv4Addr, SocketAddr, SocketAddrV4},
+    sync::Arc,
 };
-use steamworks::{ClientManager, SteamError, SteamId};
+
+use parking_lot::RwLock;
+use steamworks::{
+    networking_sockets::{InvalidHandle, NetConnection},
+    networking_types::{
+        NetConnectionEnd, NetConnectionInfo, NetworkingConnectionState, NetworkingIdentity,
+        SendFlags,
+    },
+    ClientManager, SteamError, SteamId,
+};
 use tracing::info;
 
 use super::steamworks_client::SteamworksClient;
+use crate::{
+    connection::{
+        client::{ConnectionError, ConnectionState, NetClient},
+        id::ClientId,
+    },
+    packet::packet_builder::RecvPayload,
+    prelude::{client::Io, LinkConditionerConfig},
+    transport::LOCAL_SOCKET,
+};
 
 const MAX_MESSAGE_BATCH_SIZE: usize = 512;
 

--- a/lightyear/src/connection/steam/mod.rs
+++ b/lightyear/src/connection/steam/mod.rs
@@ -1,5 +1,6 @@
-use crate::prelude::LinkConditionerConfig;
 use steamworks::networking_types::{NetworkingConfigEntry, NetworkingConfigValue};
+
+use crate::prelude::LinkConditionerConfig;
 
 pub(crate) mod client;
 pub(crate) mod server;

--- a/lightyear/src/connection/steam/server.rs
+++ b/lightyear/src/connection/steam/server.rs
@@ -1,22 +1,31 @@
-use crate::connection::id::ClientId;
-use crate::connection::netcode::MAX_PACKET_SIZE;
-use crate::connection::server::{
-    ConnectionError, ConnectionRequestHandler, DefaultConnectionRequestHandler, NetServer,
+use std::{
+    collections::VecDeque,
+    net::{Ipv4Addr, SocketAddr},
+    sync::Arc,
 };
-use crate::packet::packet_builder::RecvPayload;
-use crate::prelude::LinkConditionerConfig;
-use crate::server::io::Io;
+
 use bevy::utils::HashMap;
 use parking_lot::RwLock;
-use std::collections::VecDeque;
-use std::net::{Ipv4Addr, SocketAddr};
-use std::sync::Arc;
-use steamworks::networking_sockets::{ListenSocket, NetConnection};
-use steamworks::networking_types::{ListenSocketEvent, NetConnectionEnd, SendFlags};
-use steamworks::{ClientManager, ServerMode, SteamError};
+use steamworks::{
+    networking_sockets::{ListenSocket, NetConnection},
+    networking_types::{ListenSocketEvent, NetConnectionEnd, SendFlags},
+    ClientManager, ServerMode, SteamError,
+};
 use tracing::{error, info};
 
 use super::steamworks_client::SteamworksClient;
+use crate::{
+    connection::{
+        id::ClientId,
+        netcode::MAX_PACKET_SIZE,
+        server::{
+            ConnectionError, ConnectionRequestHandler, DefaultConnectionRequestHandler, NetServer,
+        },
+    },
+    packet::packet_builder::RecvPayload,
+    prelude::LinkConditionerConfig,
+    server::io::Io,
+};
 
 #[derive(Debug, Clone)]
 pub struct SteamConfig {

--- a/lightyear/src/inputs/leafwing/action_diff.rs
+++ b/lightyear/src/inputs/leafwing/action_diff.rs
@@ -1,7 +1,10 @@
-use crate::prelude::{Deserialize, LeafwingUserAction, Serialize};
-use bevy::math::{Vec2, Vec3};
-use bevy::prelude::Reflect;
+use bevy::{
+    math::{Vec2, Vec3},
+    prelude::Reflect,
+};
 use leafwing_input_manager::action_state::{ActionKindData, ActionState};
+
+use crate::prelude::{Deserialize, LeafwingUserAction, Serialize};
 
 // TODO: can reuse the ActionDiff from leafwing_input_manager?
 /// Stores presses and releases of buttons without timing information
@@ -171,15 +174,16 @@ impl<A: LeafwingUserAction> ActionDiff<A> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{
-        inputs::leafwing::action_diff::ActionDiff,
-        prelude::{Deserialize, Serialize},
-    };
     use bevy::{
         math::{Vec2, Vec3},
         prelude::Reflect,
     };
     use leafwing_input_manager::{action_state::ActionState, Actionlike};
+
+    use crate::{
+        inputs::leafwing::action_diff::ActionDiff,
+        prelude::{Deserialize, Serialize},
+    };
 
     #[derive(
         Serialize, Deserialize, Copy, Clone, Eq, PartialEq, Debug, Hash, Reflect, Actionlike,

--- a/lightyear/src/inputs/leafwing/input_buffer.rs
+++ b/lightyear/src/inputs/leafwing/input_buffer.rs
@@ -8,13 +8,11 @@
 //!   Therefore, we will store the computed ActionState at tick t + delay, but then we load the ActionState at tick t
 //!   from the buffer
 use bevy::utils::Instant;
-
-use crate::inputs::leafwing::action_diff::ActionDiff;
-use crate::shared::tick_manager::Tick;
 use leafwing_input_manager::prelude::ActionState;
 use tracing::trace;
 
 use super::LeafwingUserAction;
+use crate::{inputs::leafwing::action_diff::ActionDiff, shared::tick_manager::Tick};
 
 /// The InputBuffer contains a history of the ActionState for each tick between
 /// `start_tick` and `end_tick`. All ticks between `start_tick` and `end_tick` must be included in the buffer.
@@ -57,11 +55,12 @@ impl<T: LeafwingUserAction> InputBuffer<T> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::inputs::native::input_buffer::InputData;
     use bevy::prelude::Reflect;
     use leafwing_input_manager::Actionlike;
     use serde::{Deserialize, Serialize};
+
+    use super::*;
+    use crate::inputs::native::input_buffer::InputData;
 
     #[derive(
         Serialize, Deserialize, Copy, Clone, Eq, PartialEq, Debug, Hash, Reflect, Actionlike,

--- a/lightyear/src/inputs/leafwing/input_message.rs
+++ b/lightyear/src/inputs/leafwing/input_message.rs
@@ -1,12 +1,16 @@
-use crate::client::interpolation::plugin::InterpolationDelay;
-use crate::inputs::leafwing::action_diff::ActionDiff;
-use crate::inputs::leafwing::input_buffer::InputBuffer;
-use crate::prelude::{Deserialize, LeafwingUserAction, Serialize, Tick};
-use bevy::ecs::entity::MapEntities;
-use bevy::prelude::{Entity, EntityMapper, Reflect};
-use leafwing_input_manager::action_state::ActionState;
-use leafwing_input_manager::Actionlike;
 use std::fmt::{Formatter, Write};
+
+use bevy::{
+    ecs::entity::MapEntities,
+    prelude::{Entity, EntityMapper, Reflect},
+};
+use leafwing_input_manager::{action_state::ActionState, Actionlike};
+
+use crate::{
+    client::interpolation::plugin::InterpolationDelay,
+    inputs::leafwing::{action_diff::ActionDiff, input_buffer::InputBuffer},
+    prelude::{Deserialize, LeafwingUserAction, Serialize, Tick},
+};
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, Debug, Reflect)]
 pub(crate) struct PerTargetData<A: Actionlike> {
@@ -156,8 +160,9 @@ impl<A: LeafwingUserAction> InputMessage<A> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use leafwing_input_manager::Actionlike;
+
+    use super::*;
 
     #[derive(
         Serialize, Deserialize, Copy, Clone, Eq, PartialEq, Debug, Hash, Reflect, Actionlike,

--- a/lightyear/src/inputs/leafwing/mod.rs
+++ b/lightyear/src/inputs/leafwing/mod.rs
@@ -1,9 +1,8 @@
 //! Handles buffering and networking of inputs from client to server, using `leafwing_input_manager`
 
-use crate::inputs::native::UserActionState;
-use crate::prelude::UserAction;
-use leafwing_input_manager::prelude::ActionState;
-use leafwing_input_manager::Actionlike;
+use leafwing_input_manager::{prelude::ActionState, Actionlike};
+
+use crate::{inputs::native::UserActionState, prelude::UserAction};
 
 pub(crate) mod action_diff;
 pub mod input_buffer;

--- a/lightyear/src/inputs/native/input_buffer.rs
+++ b/lightyear/src/inputs/native/input_buffer.rs
@@ -1,10 +1,14 @@
-use super::{ActionState, UserAction};
-use crate::shared::tick_manager::Tick;
+use std::{
+    collections::VecDeque,
+    fmt::{Debug, Formatter},
+};
+
 use bevy::prelude::Component;
 use serde::{Deserialize, Serialize};
-use std::collections::VecDeque;
-use std::fmt::{Debug, Formatter};
 use tracing::trace;
+
+use super::{ActionState, UserAction};
+use crate::shared::tick_manager::Tick;
 
 #[derive(Component, Debug)]
 pub struct InputBuffer<T> {

--- a/lightyear/src/inputs/native/input_message.rs
+++ b/lightyear/src/inputs/native/input_message.rs
@@ -1,11 +1,20 @@
-use crate::inputs::native::input_buffer::{InputBuffer, InputData};
-use crate::inputs::native::ActionState;
-use crate::prelude::client::InterpolationDelay;
-use crate::prelude::{Deserialize, Serialize, Tick, UserAction};
-use bevy::ecs::entity::MapEntities;
-use bevy::prelude::{Entity, EntityMapper, Reflect};
-use std::cmp::max;
-use std::fmt::{Formatter, Write};
+use std::{
+    cmp::max,
+    fmt::{Formatter, Write},
+};
+
+use bevy::{
+    ecs::entity::MapEntities,
+    prelude::{Entity, EntityMapper, Reflect},
+};
+
+use crate::{
+    inputs::native::{
+        input_buffer::{InputBuffer, InputData},
+        ActionState,
+    },
+    prelude::{client::InterpolationDelay, Deserialize, Serialize, Tick, UserAction},
+};
 
 // TODO: use Mode to specify how to serialize a message (serde vs bitcode)! + can specify custom serialize function as well (similar to interpolation mode)
 #[derive(Serialize, Deserialize, Clone, PartialEq, Debug, Reflect)]
@@ -142,11 +151,16 @@ impl<T: UserAction> InputMessage<T> {
 
 #[cfg(test)]
 mod tests {
-    use crate::inputs::native::input_buffer::{InputBuffer, InputData};
-    use crate::inputs::native::input_message::{InputMessage, InputTarget, PerTargetData};
-    use crate::inputs::native::ActionState;
-    use crate::prelude::Tick;
     use bevy::prelude::Entity;
+
+    use crate::{
+        inputs::native::{
+            input_buffer::{InputBuffer, InputData},
+            input_message::{InputMessage, InputTarget, PerTargetData},
+            ActionState,
+        },
+        prelude::Tick,
+    };
 
     #[test]
     fn test_create_message() {

--- a/lightyear/src/inputs/native/mod.rs
+++ b/lightyear/src/inputs/native/mod.rs
@@ -19,13 +19,15 @@ There are several steps to use the `InputPlugin`:
 
 */
 
-use crate::inputs::native::input_buffer::{InputBuffer, InputData};
-use crate::prelude::Deserialize;
+use std::{fmt::Debug, marker::PhantomData};
+
 use bevy::prelude::{Component, Reflect};
-use serde::de::DeserializeOwned;
-use serde::Serialize;
-use std::fmt::Debug;
-use std::marker::PhantomData;
+use serde::{de::DeserializeOwned, Serialize};
+
+use crate::{
+    inputs::native::input_buffer::{InputBuffer, InputData},
+    prelude::Deserialize,
+};
 
 /// Defines an [`InputBuffer`](input_buffer::InputBuffer) buffer to store the inputs of a player for each tick
 pub mod input_buffer;

--- a/lightyear/src/lib.rs
+++ b/lightyear/src/lib.rs
@@ -184,163 +184,183 @@ pub mod prelude {
     pub use lightyear_macros::Channel;
     pub use serde::{Deserialize, Serialize};
 
-    pub use crate::channel::builder::{
-        Channel, ChannelBuilder, ChannelContainer, ChannelDirection, ChannelMode, ChannelSettings,
-        InputChannel, ReliableSettings,
-    };
-    pub use crate::client::prediction::prespawn::PreSpawnedPlayerObject;
-    pub use crate::connection::id::ClientId;
-    pub use crate::connection::netcode::{generate_key, ConnectToken, Key};
     #[cfg(feature = "leafwing")]
     pub use crate::inputs::leafwing::{input_message::InputMessage, LeafwingUserAction};
-    pub use crate::inputs::native::UserAction;
-    pub use crate::packet::error::PacketError;
-    pub use crate::packet::message::Message;
-    pub use crate::protocol::channel::{AppChannelExt, ChannelKind, ChannelRegistry};
-    pub use crate::protocol::component::{AppComponentExt, ComponentRegistry, Linear};
-    pub use crate::protocol::message::{
-        registry::{AppMessageExt, MessageRegistry},
-        resource::AppResourceExt,
-    };
-    pub use crate::protocol::serialize::AppSerializeExt;
-    pub use crate::shared::config::SharedConfig;
-    pub use crate::shared::identity::{AppIdentityExt, NetworkIdentity, NetworkIdentityState};
     #[cfg(feature = "leafwing")]
     pub use crate::shared::input::leafwing::LeafwingInputPlugin;
-    pub use crate::shared::input::native::InputPlugin;
-    pub use crate::shared::input::InputConfig;
-    pub use crate::shared::message::MessageSend;
-    pub use crate::shared::ping::manager::PingConfig;
-    pub use crate::shared::plugin::SharedPlugin;
-    pub use crate::shared::replication::authority::HasAuthority;
-    pub use crate::shared::replication::components::{
-        DeltaCompression, DisabledComponents, NetworkRelevanceMode, OverrideTargetComponent,
-        PrePredicted, ReplicateHierarchy, ReplicateOnceComponent, Replicated, Replicating,
-        ReplicationGroup, ShouldBePredicted, TargetEntity,
+    pub use crate::{
+        channel::builder::{
+            Channel, ChannelBuilder, ChannelContainer, ChannelDirection, ChannelMode,
+            ChannelSettings, InputChannel, ReliableSettings,
+        },
+        client::prediction::prespawn::PreSpawnedPlayerObject,
+        connection::{
+            id::ClientId,
+            netcode::{generate_key, ConnectToken, Key},
+        },
+        inputs::native::UserAction,
+        packet::{error::PacketError, message::Message},
+        protocol::{
+            channel::{AppChannelExt, ChannelKind, ChannelRegistry},
+            component::{AppComponentExt, ComponentRegistry, Linear},
+            message::{
+                registry::{AppMessageExt, MessageRegistry},
+                resource::AppResourceExt,
+            },
+            serialize::AppSerializeExt,
+        },
+        shared::{
+            config::SharedConfig,
+            identity::{AppIdentityExt, NetworkIdentity, NetworkIdentityState},
+            input::{native::InputPlugin, InputConfig},
+            message::MessageSend,
+            ping::manager::PingConfig,
+            plugin::SharedPlugin,
+            replication::{
+                authority::HasAuthority,
+                components::{
+                    DeltaCompression, DisabledComponents, NetworkRelevanceMode,
+                    OverrideTargetComponent, PrePredicted, ReplicateHierarchy,
+                    ReplicateOnceComponent, Replicated, Replicating, ReplicationGroup,
+                    ShouldBePredicted, TargetEntity,
+                },
+                entity_map::RemoteEntityMap,
+                hierarchy::ParentSync,
+                network_target::NetworkTarget,
+                plugin::{ReplicationConfig, SendUpdatesMode},
+                resources::{
+                    ReplicateResourceExt, ReplicateResourceMetadata, StopReplicateResourceExt,
+                },
+            },
+            run_conditions::*,
+            sets::{FixedUpdateSet, MainSet},
+            tick_manager::{Tick, TickConfig, TickManager},
+            time_manager::TimeManager,
+        },
+        transport::middleware::{
+            compression::CompressionConfig, conditioner::LinkConditionerConfig,
+        },
+        utils::history_buffer::{HistoryBuffer, HistoryState},
     };
-    pub use crate::shared::replication::entity_map::RemoteEntityMap;
-    pub use crate::shared::replication::hierarchy::ParentSync;
-    pub use crate::shared::replication::network_target::NetworkTarget;
-    pub use crate::shared::replication::plugin::ReplicationConfig;
-    pub use crate::shared::replication::plugin::SendUpdatesMode;
-    pub use crate::shared::replication::resources::{
-        ReplicateResourceExt, ReplicateResourceMetadata, StopReplicateResourceExt,
-    };
-    pub use crate::shared::run_conditions::*;
-    pub use crate::shared::sets::{FixedUpdateSet, MainSet};
-    pub use crate::shared::tick_manager::TickManager;
-    pub use crate::shared::tick_manager::{Tick, TickConfig};
-    pub use crate::shared::time_manager::TimeManager;
-    pub use crate::transport::middleware::compression::CompressionConfig;
-    pub use crate::transport::middleware::conditioner::LinkConditionerConfig;
-    pub use crate::utils::history_buffer::{HistoryBuffer, HistoryState};
 
     mod rename {
-        pub use crate::client::events::ComponentInsertEvent as ClientComponentInsertEvent;
-        pub use crate::client::events::ComponentRemoveEvent as ClientComponentRemoveEvent;
-        pub use crate::client::events::ComponentUpdateEvent as ClientComponentUpdateEvent;
-        pub use crate::client::events::ConnectEvent as ClientConnectEvent;
-        pub use crate::client::events::DisconnectEvent as ClientDisconnectEvent;
-        pub use crate::client::events::EntityDespawnEvent as ClientEntityDespawnEvent;
-        pub use crate::client::events::EntitySpawnEvent as ClientEntitySpawnEvent;
-        pub use crate::client::message::ReceiveMessage as ClientReceiveMessage;
-        pub use crate::client::message::ReceiveMessage as FromServer;
-        pub use crate::client::message::SendMessage as ClientSendMessage;
-        pub use crate::client::message::SendMessage as ToServer;
-        pub use crate::client::replication::send::Replicate as ClientReplicate;
-
-        pub use crate::client::connection::ConnectionManager as ClientConnectionManager;
-
-        pub use crate::server::events::ComponentInsertEvent as ServerComponentInsertEvent;
-        pub use crate::server::events::ComponentRemoveEvent as ServerComponentRemoveEvent;
-        pub use crate::server::events::ComponentUpdateEvent as ServerComponentUpdateEvent;
-        pub use crate::server::events::ConnectEvent as ServerConnectEvent;
-        pub use crate::server::events::DisconnectEvent as ServerDisconnectEvent;
-        pub use crate::server::events::EntityDespawnEvent as ServerEntityDespawnEvent;
-        pub use crate::server::events::EntitySpawnEvent as ServerEntitySpawnEvent;
-        pub use crate::server::message::ReceiveMessage as ServerReceiveMessage;
-        pub use crate::server::message::ReceiveMessage as FromClients;
-        pub use crate::server::message::SendMessage as ServerSendMessage;
-        pub use crate::server::message::SendMessage as ToClients;
-
-        pub use crate::server::connection::ConnectionManager as ServerConnectionManager;
-
-        pub use crate::server::replication::send::Replicate as ServerReplicate;
+        pub use crate::{
+            client::{
+                connection::ConnectionManager as ClientConnectionManager,
+                events::{
+                    ComponentInsertEvent as ClientComponentInsertEvent,
+                    ComponentRemoveEvent as ClientComponentRemoveEvent,
+                    ComponentUpdateEvent as ClientComponentUpdateEvent,
+                    ConnectEvent as ClientConnectEvent, DisconnectEvent as ClientDisconnectEvent,
+                    EntityDespawnEvent as ClientEntityDespawnEvent,
+                    EntitySpawnEvent as ClientEntitySpawnEvent,
+                },
+                message::{
+                    ReceiveMessage as ClientReceiveMessage, ReceiveMessage as FromServer,
+                    SendMessage as ClientSendMessage, SendMessage as ToServer,
+                },
+                replication::send::Replicate as ClientReplicate,
+            },
+            server::{
+                connection::ConnectionManager as ServerConnectionManager,
+                events::{
+                    ComponentInsertEvent as ServerComponentInsertEvent,
+                    ComponentRemoveEvent as ServerComponentRemoveEvent,
+                    ComponentUpdateEvent as ServerComponentUpdateEvent,
+                    ConnectEvent as ServerConnectEvent, DisconnectEvent as ServerDisconnectEvent,
+                    EntityDespawnEvent as ServerEntityDespawnEvent,
+                    EntitySpawnEvent as ServerEntitySpawnEvent,
+                },
+                message::{
+                    ReceiveMessage as ServerReceiveMessage, ReceiveMessage as FromClients,
+                    SendMessage as ServerSendMessage, SendMessage as ToClients,
+                },
+                replication::send::Replicate as ServerReplicate,
+            },
+        };
     }
     pub use rename::*;
 
     pub mod client {
-        pub use crate::client::components::{
-            ComponentSyncMode, Confirmed, LerpFn, SyncComponent, SyncMetadata,
-        };
-        pub use crate::client::config::{ClientConfig, NetcodeConfig, PacketConfig};
-        pub use crate::client::connection::ConnectionManager;
-        pub use crate::client::error::ClientError;
-        pub use crate::client::events::{
-            ComponentInsertEvent, ComponentRemoveEvent, ComponentUpdateEvent, ConnectEvent,
-            DisconnectEvent, EntityDespawnEvent, EntitySpawnEvent, InputEvent,
-        };
-        pub use crate::client::interpolation::interpolation_history::ConfirmedHistory;
-        pub use crate::client::interpolation::plugin::{
-            InterpolationConfig, InterpolationDelay, InterpolationSet,
-        };
-        pub use crate::client::interpolation::{
-            InterpolateStatus, Interpolated, VisualInterpolateStatus, VisualInterpolationPlugin,
-        };
-        pub use crate::client::io::config::ClientTransport;
-        pub use crate::client::io::Io;
-        pub use crate::client::message::ReceiveMessage;
-        pub use crate::client::networking::{ClientCommandsExt, ConnectedState, NetworkingState};
-        pub use crate::client::plugin::ClientPlugins;
-        pub use crate::client::prediction::correction::Correction;
-        pub use crate::client::prediction::despawn::PredictionDespawnCommandsExt;
-        pub use crate::client::prediction::plugin::is_in_rollback;
-        pub use crate::client::prediction::plugin::{PredictionConfig, PredictionSet};
-        pub use crate::client::prediction::rollback::{Rollback, RollbackState};
-        pub use crate::client::prediction::Predicted;
-        pub use crate::client::replication::commands::DespawnReplicationCommandExt;
-        pub use crate::client::replication::send::{Replicate, ReplicateToServer};
-        pub use crate::client::run_conditions::{is_connected, is_disconnected, is_synced};
-        pub use crate::client::sync::SyncConfig;
-        pub use crate::connection::client::{
-            Authentication, ClientConnection, IoConfig, NetClient, NetConfig,
-        };
         #[cfg(all(feature = "steam", not(target_family = "wasm")))]
         pub use crate::connection::steam::client::{SocketConfig, SteamConfig};
-        pub use crate::protocol::message::client::ClientTriggerExt;
+        pub use crate::{
+            client::{
+                components::{ComponentSyncMode, Confirmed, LerpFn, SyncComponent, SyncMetadata},
+                config::{ClientConfig, NetcodeConfig, PacketConfig},
+                connection::ConnectionManager,
+                error::ClientError,
+                events::{
+                    ComponentInsertEvent, ComponentRemoveEvent, ComponentUpdateEvent, ConnectEvent,
+                    DisconnectEvent, EntityDespawnEvent, EntitySpawnEvent, InputEvent,
+                },
+                interpolation::{
+                    interpolation_history::ConfirmedHistory,
+                    plugin::{InterpolationConfig, InterpolationDelay, InterpolationSet},
+                    InterpolateStatus, Interpolated, VisualInterpolateStatus,
+                    VisualInterpolationPlugin,
+                },
+                io::{config::ClientTransport, Io},
+                message::ReceiveMessage,
+                networking::{ClientCommandsExt, ConnectedState, NetworkingState},
+                plugin::ClientPlugins,
+                prediction::{
+                    correction::Correction,
+                    despawn::PredictionDespawnCommandsExt,
+                    plugin::{is_in_rollback, PredictionConfig, PredictionSet},
+                    rollback::{Rollback, RollbackState},
+                    Predicted,
+                },
+                replication::{
+                    commands::DespawnReplicationCommandExt,
+                    send::{Replicate, ReplicateToServer},
+                },
+                run_conditions::{is_connected, is_disconnected, is_synced},
+                sync::SyncConfig,
+            },
+            connection::client::{
+                Authentication, ClientConnection, IoConfig, NetClient, NetConfig,
+            },
+            protocol::message::client::ClientTriggerExt,
+        };
     }
     pub mod server {
         #[cfg(all(feature = "webtransport", not(target_family = "wasm")))]
         pub use wtransport::tls::Identity;
 
-        pub use crate::connection::server::{IoConfig, NetConfig, NetServer, ServerConnection};
         #[cfg(all(feature = "steam", not(target_family = "wasm")))]
         pub use crate::connection::steam::server::{SocketConfig, SteamConfig};
-        pub use crate::protocol::message::server::ServerTriggerExt;
-        pub use crate::server::clients::ControlledEntities;
-        pub use crate::server::config::{NetcodeConfig, PacketConfig, ServerConfig};
-        pub use crate::server::connection::ConnectionManager;
-        pub use crate::server::error::ServerError;
-        pub use crate::server::events::{
-            ComponentInsertEvent, ComponentRemoveEvent, ComponentUpdateEvent, ConnectEvent,
-            DisconnectEvent, EntityDespawnEvent, EntitySpawnEvent, InputEvent,
-        };
-        pub use crate::server::io::config::ServerTransport;
-        pub use crate::server::io::Io;
-        pub use crate::server::networking::{NetworkingState, ServerCommandsExt};
-        pub use crate::server::plugin::ServerPlugins;
-        pub use crate::server::relevance::immediate::RelevanceManager;
-        pub use crate::server::relevance::room::{RoomId, RoomManager};
-        pub use crate::server::replication::commands::AuthorityCommandExt;
-        pub use crate::server::replication::commands::DespawnReplicationCommandExt;
-        pub use crate::server::replication::{
-            send::{
-                ControlledBy, Lifetime, Replicate, ReplicationTarget, ServerFilter, SyncTarget,
+        pub use crate::{
+            connection::server::{IoConfig, NetConfig, NetServer, ServerConnection},
+            protocol::message::server::ServerTriggerExt,
+            server::{
+                clients::ControlledEntities,
+                config::{NetcodeConfig, PacketConfig, ServerConfig},
+                connection::ConnectionManager,
+                error::ServerError,
+                events::{
+                    ComponentInsertEvent, ComponentRemoveEvent, ComponentUpdateEvent, ConnectEvent,
+                    DisconnectEvent, EntityDespawnEvent, EntitySpawnEvent, InputEvent,
+                },
+                io::{config::ServerTransport, Io},
+                networking::{NetworkingState, ServerCommandsExt},
+                plugin::ServerPlugins,
+                relevance::{
+                    immediate::RelevanceManager,
+                    room::{RoomId, RoomManager},
+                },
+                replication::{
+                    commands::{AuthorityCommandExt, DespawnReplicationCommandExt},
+                    send::{
+                        ControlledBy, Lifetime, Replicate, ReplicationTarget, ServerFilter,
+                        SyncTarget,
+                    },
+                    ReplicationSet, ServerReplicationSet,
+                },
+                run_conditions::{is_started, is_stopped},
             },
-            ReplicationSet, ServerReplicationSet,
+            shared::replication::authority::AuthorityPeer,
         };
-        pub use crate::server::run_conditions::{is_started, is_stopped};
-        pub use crate::shared::replication::authority::AuthorityPeer;
     }
 
     #[cfg(all(feature = "steam", not(target_family = "wasm")))]

--- a/lightyear/src/packet/error.rs
+++ b/lightyear/src/packet/error.rs
@@ -1,7 +1,6 @@
 //! Errors for building packets
 
-use crate::channel::receivers::error::ChannelReceiveError;
-use crate::serialize::SerializationError;
+use crate::{channel::receivers::error::ChannelReceiveError, serialize::SerializationError};
 
 pub type Result<T> = core::result::Result<T, PacketError>;
 #[derive(thiserror::Error, Debug)]

--- a/lightyear/src/packet/header.rs
+++ b/lightyear/src/packet/header.rs
@@ -1,18 +1,16 @@
 use bevy::utils::HashMap;
-use byteorder::NetworkEndian;
-use byteorder::ReadBytesExt;
+use byteorder::{NetworkEndian, ReadBytesExt};
 use ringbuffer::{ConstGenericRingBuffer, RingBuffer};
 use tracing::trace;
 
-use crate::packet::packet::PacketId;
-use crate::packet::packet_type::PacketType;
-use crate::packet::stats_manager::packet::PacketStatsManager;
-use crate::prelude::TimeManager;
-use crate::serialize::reader::Reader;
-use crate::serialize::{SerializationError, ToBytes};
-use crate::shared::ping::manager::PingManager;
-use crate::shared::tick_manager::Tick;
-use crate::shared::time_manager::WrappedTime;
+use crate::{
+    packet::{
+        packet::PacketId, packet_type::PacketType, stats_manager::packet::PacketStatsManager,
+    },
+    prelude::TimeManager,
+    serialize::{reader::Reader, SerializationError, ToBytes},
+    shared::{ping::manager::PingManager, tick_manager::Tick, time_manager::WrappedTime},
+};
 
 /// Header included at the start of all packets
 #[derive(Debug, Clone, PartialEq)]
@@ -349,9 +347,8 @@ impl ReceiveBuffer {
 // TODO: add test for notification of packet delivered
 #[cfg(test)]
 mod tests {
-    use crate::serialize::ToBytes;
-
     use super::*;
+    use crate::serialize::ToBytes;
 
     #[test]
     fn test_recv_buffer() {

--- a/lightyear/src/packet/message.rs
+++ b/lightyear/src/packet/message.rs
@@ -4,12 +4,16 @@ use std::fmt::Debug;
 use byteorder::{NetworkEndian, ReadBytesExt, WriteBytesExt};
 use bytes::Bytes;
 
-use crate::protocol::EventContext;
-use crate::serialize::reader::Reader;
-use crate::serialize::varint::{varint_len, VarIntReadExt, VarIntWriteExt};
-use crate::serialize::{SerializationError, ToBytes};
-use crate::shared::tick_manager::Tick;
-use crate::utils::wrapping_id::wrapping_id;
+use crate::{
+    protocol::EventContext,
+    serialize::{
+        reader::Reader,
+        varint::{varint_len, VarIntReadExt, VarIntWriteExt},
+        SerializationError, ToBytes,
+    },
+    shared::tick_manager::Tick,
+    utils::wrapping_id::wrapping_id,
+};
 
 // Internal id that we assign to each message sent over the network
 wrapping_id!(MessageId);

--- a/lightyear/src/packet/message_manager.rs
+++ b/lightyear/src/packet/message_manager.rs
@@ -1,36 +1,38 @@
+use std::collections::{HashMap, VecDeque};
+
 use byteorder::ReadBytesExt;
 use bytes::Bytes;
 use crossbeam_channel::{Receiver, Sender};
-use std::collections::{HashMap, VecDeque};
 use tracing::trace;
 #[cfg(feature = "trace")]
 use tracing::{instrument, Level};
 
-use crate::channel::builder::ChannelContainer;
-use crate::channel::receivers::ChannelReceive;
-use crate::channel::senders::ChannelSend;
 #[cfg(feature = "trace")]
 use crate::channel::stats::send::ChannelSendStats;
-use crate::packet::error::PacketError;
-use crate::packet::header::PacketHeader;
-use crate::packet::message::{
-    FragmentData, MessageAck, MessageId, ReceiveMessage, SendMessage, SingleData,
-};
-use crate::packet::packet::PacketId;
-use crate::packet::packet_builder::{PacketBuilder, Payload, RecvPayload};
-use crate::packet::packet_type::PacketType;
-use crate::packet::priority_manager::{PriorityConfig, PriorityManager};
-use crate::protocol::channel::{ChannelId, ChannelKind, ChannelRegistry};
-use crate::protocol::registry::NetId;
-use crate::serialize::reader::Reader;
-use crate::serialize::writer::Writer;
-use crate::serialize::{SerializationError, ToBytes};
-use crate::shared::ping::manager::PingManager;
-use crate::shared::tick_manager::Tick;
-use crate::shared::tick_manager::TickManager;
-use crate::shared::time_manager::TimeManager;
 #[cfg(test)]
 use crate::utils::captures::Captures;
+use crate::{
+    channel::{builder::ChannelContainer, receivers::ChannelReceive, senders::ChannelSend},
+    packet::{
+        error::PacketError,
+        header::PacketHeader,
+        message::{FragmentData, MessageAck, MessageId, ReceiveMessage, SendMessage, SingleData},
+        packet::PacketId,
+        packet_builder::{PacketBuilder, Payload, RecvPayload},
+        packet_type::PacketType,
+        priority_manager::{PriorityConfig, PriorityManager},
+    },
+    protocol::{
+        channel::{ChannelId, ChannelKind, ChannelRegistry},
+        registry::NetId,
+    },
+    serialize::{reader::Reader, writer::Writer, SerializationError, ToBytes},
+    shared::{
+        ping::manager::PingManager,
+        tick_manager::{Tick, TickManager},
+        time_manager::TimeManager,
+    },
+};
 
 // TODO: hard to split message manager into send/receive because the acks need both the send side and receive side
 //  maybe have a separate actor for acks?
@@ -439,14 +441,12 @@ mod tests {
 
     use bevy::prelude::default;
 
-    use crate::packet::message::MessageId;
-    use crate::packet::packet::FRAGMENT_SIZE;
-    use crate::packet::priority_manager::PriorityConfig;
-    use crate::prelude::*;
-
-    use crate::tests::protocol::*;
-
     use super::*;
+    use crate::{
+        packet::{message::MessageId, packet::FRAGMENT_SIZE, priority_manager::PriorityConfig},
+        prelude::*,
+        tests::protocol::*,
+    };
 
     fn setup() -> (MessageManager, MessageManager) {
         let mut channel_registry = ChannelRegistry::default();

--- a/lightyear/src/packet/packet.rs
+++ b/lightyear/src/packet/packet.rs
@@ -1,10 +1,11 @@
 /// Defines the [`Packet`] struct
 use crate::connection::netcode::MAX_PACKET_SIZE;
-use crate::packet::message::MessageAck;
-use crate::packet::packet_builder::Payload;
-use crate::protocol::channel::ChannelId;
-use crate::serialize::ToBytes;
-use crate::utils::wrapping_id::wrapping_id;
+use crate::{
+    packet::{message::MessageAck, packet_builder::Payload},
+    protocol::channel::ChannelId,
+    serialize::ToBytes,
+    utils::wrapping_id::wrapping_id,
+};
 
 cfg_if::cfg_if!(
     if #[cfg(test)] {
@@ -102,7 +103,6 @@ impl Packet {
 #[cfg(test)]
 mod tests {
     use bevy::prelude::{default, Reflect};
-
     use lightyear_macros::ChannelInternal;
 
     use crate::prelude::{ChannelMode, ChannelRegistry, ChannelSettings};

--- a/lightyear/src/packet/packet_builder.rs
+++ b/lightyear/src/packet/packet_builder.rs
@@ -1,20 +1,24 @@
 //! Module to take a buffer of messages to send and build packets
-use crate::connection::netcode::MAX_PACKET_SIZE;
-use crate::packet::header::PacketHeaderManager;
-use crate::packet::message::{FragmentData, MessageAck, SingleData};
-use crate::packet::packet::{Packet, FRAGMENT_SIZE};
-use crate::packet::packet_type::PacketType;
-use crate::prelude::Tick;
-use crate::protocol::channel::ChannelId;
-use crate::protocol::registry::NetId;
-use crate::serialize::varint::varint_len;
-use crate::serialize::{SerializationError, ToBytes};
+use std::collections::VecDeque;
+
 use byteorder::WriteBytesExt;
 use bytes::Bytes;
-use std::collections::VecDeque;
 use tracing::trace;
 #[cfg(feature = "trace")]
 use tracing::{instrument, Level};
+
+use crate::{
+    connection::netcode::MAX_PACKET_SIZE,
+    packet::{
+        header::PacketHeaderManager,
+        message::{FragmentData, MessageAck, SingleData},
+        packet::{Packet, FRAGMENT_SIZE},
+        packet_type::PacketType,
+    },
+    prelude::Tick,
+    protocol::{channel::ChannelId, registry::NetId},
+    serialize::{varint::varint_len, SerializationError, ToBytes},
+};
 
 pub type Payload = Vec<u8>;
 
@@ -422,14 +426,12 @@ mod tests {
 
     use bevy::prelude::{default, TypePath};
     use bytes::Bytes;
-
     use lightyear_macros::ChannelInternal;
 
-    use crate::channel::senders::fragment_sender::FragmentSender;
-    use crate::packet::message::MessageId;
-    use crate::prelude::*;
-
     use super::*;
+    use crate::{
+        channel::senders::fragment_sender::FragmentSender, packet::message::MessageId, prelude::*,
+    };
 
     #[derive(ChannelInternal, TypePath)]
     struct Channel1;

--- a/lightyear/src/packet/priority_manager.rs
+++ b/lightyear/src/packet/priority_manager.rs
@@ -1,7 +1,6 @@
-use bevy::utils::HashMap;
-use std::collections::VecDeque;
-use std::num::NonZeroU32;
+use std::{collections::VecDeque, num::NonZeroU32};
 
+use bevy::utils::HashMap;
 use crossbeam_channel::{Receiver, Sender};
 use governor::{DefaultDirectRateLimiter, Quota};
 use nonzero_ext::*;
@@ -9,10 +8,11 @@ use tracing::{debug, error, trace};
 #[cfg(feature = "trace")]
 use tracing::{instrument, Level};
 
-use crate::packet::message::{FragmentData, MessageData, MessageId, SendMessage, SingleData};
-use crate::prelude::{ChannelRegistry, Tick};
-use crate::protocol::channel::ChannelId;
-use crate::protocol::registry::NetId;
+use crate::{
+    packet::message::{FragmentData, MessageData, MessageId, SendMessage, SingleData},
+    prelude::{ChannelRegistry, Tick},
+    protocol::{channel::ChannelId, registry::NetId},
+};
 
 const BYPASS_QUOTA_PRIORITY: f32 = 100000.0;
 

--- a/lightyear/src/packet/stats_manager.rs
+++ b/lightyear/src/packet/stats_manager.rs
@@ -1,11 +1,14 @@
 /// Statistics for packets
 pub(crate) mod packet {
-    use bevy::utils::Duration;
     use std::ops::{AddAssign, SubAssign};
+
+    use bevy::utils::Duration;
     use tracing::trace;
 
-    use crate::shared::time_manager::{TimeManager, WrappedTime};
-    use crate::utils::ready_buffer::ReadyBuffer;
+    use crate::{
+        shared::time_manager::{TimeManager, WrappedTime},
+        utils::ready_buffer::ReadyBuffer,
+    };
     type PacketStatsBuffer = ReadyBuffer<WrappedTime, PacketStats>;
 
     #[derive(Default, Copy, Clone, Debug, PartialEq)]

--- a/lightyear/src/protocol/channel.rs
+++ b/lightyear/src/protocol/channel.rs
@@ -1,17 +1,19 @@
-use bevy::app::App;
-use bevy::prelude::{Resource, TypePath};
-use bevy::utils::Duration;
-use std::any::TypeId;
-use std::collections::HashMap;
+use std::{any::TypeId, collections::HashMap};
 
-use crate::channel::builder::{
-    AuthorityChannel, Channel, ChannelBuilder, ChannelSettings, PongChannel,
+use bevy::{
+    app::App,
+    prelude::{Resource, TypePath},
+    utils::Duration,
 };
-use crate::channel::builder::{
-    ChannelContainer, EntityActionsChannel, EntityUpdatesChannel, InputChannel, PingChannel,
+
+use crate::{
+    channel::builder::{
+        AuthorityChannel, Channel, ChannelBuilder, ChannelContainer, ChannelSettings,
+        EntityActionsChannel, EntityUpdatesChannel, InputChannel, PingChannel, PongChannel,
+    },
+    prelude::{ChannelMode, ReliableSettings},
+    protocol::registry::{NetId, TypeKind, TypeMapper},
 };
-use crate::prelude::{ChannelMode, ReliableSettings};
-use crate::protocol::registry::{NetId, TypeKind, TypeMapper};
 
 // TODO: derive Reflect once we reach bevy 0.14
 /// ChannelKind - internal wrapper around the type of the channel
@@ -198,9 +200,8 @@ mod tests {
     use bevy::prelude::{default, TypePath};
     use lightyear_macros::ChannelInternal;
 
-    use crate::channel::builder::{ChannelMode, ChannelSettings};
-
     use super::*;
+    use crate::channel::builder::{ChannelMode, ChannelSettings};
 
     #[derive(ChannelInternal, TypePath)]
     pub struct MyChannel;

--- a/lightyear/src/protocol/delta.rs
+++ b/lightyear/src/protocol/delta.rs
@@ -1,10 +1,15 @@
-use crate::prelude::Tick;
-use crate::protocol::component::ComponentKind;
-use crate::shared::replication::delta::{DeltaMessage, DeltaType, Diffable};
-use bevy::prelude::Component;
-use bevy::ptr::{Ptr, PtrMut};
-use std::any::TypeId;
-use std::ptr::NonNull;
+use std::{any::TypeId, ptr::NonNull};
+
+use bevy::{
+    prelude::Component,
+    ptr::{Ptr, PtrMut},
+};
+
+use crate::{
+    prelude::Tick,
+    protocol::component::ComponentKind,
+    shared::replication::delta::{DeltaMessage, DeltaType, Diffable},
+};
 
 type ErasedCloneFn = unsafe fn(data: Ptr) -> NonNull<u8>;
 type ErasedDiffFn = unsafe fn(start_tick: Tick, start: Ptr, present: Ptr) -> NonNull<u8>;

--- a/lightyear/src/protocol/message/client.rs
+++ b/lightyear/src/protocol/message/client.rs
@@ -1,21 +1,24 @@
-use super::MessageKind;
-use crate::packet::message_manager::MessageManager;
-use crate::prelude::{
-    Channel, ClientId, ClientReceiveMessage, ClientSendMessage, Message, ServerReceiveMessage,
+use bevy::{
+    app::App,
+    ecs::{change_detection::MutUntyped, component::ComponentId},
+    prelude::{Commands, Entity, Event, Events, FilteredResourcesMut, TypePath, World},
+    utils::HashMap,
 };
-use crate::protocol::message::registry::MessageRegistry;
-use crate::protocol::message::trigger::TriggerMessage;
-use crate::protocol::message::MessageError;
-use crate::protocol::registry::NetId;
-use crate::protocol::serialize::ErasedSerializeFns;
-use crate::serialize::reader::Reader;
-use crate::serialize::ToBytes;
-use crate::shared::replication::entity_map::{ReceiveEntityMap, SendEntityMap};
-use bevy::app::App;
-use bevy::ecs::change_detection::MutUntyped;
-use bevy::ecs::component::ComponentId;
-use bevy::prelude::{Commands, Entity, Event, Events, FilteredResourcesMut, TypePath, World};
-use bevy::utils::HashMap;
+
+use super::MessageKind;
+use crate::{
+    packet::message_manager::MessageManager,
+    prelude::{
+        Channel, ClientId, ClientReceiveMessage, ClientSendMessage, Message, ServerReceiveMessage,
+    },
+    protocol::{
+        message::{registry::MessageRegistry, trigger::TriggerMessage, MessageError},
+        registry::NetId,
+        serialize::ErasedSerializeFns,
+    },
+    serialize::{reader::Reader, ToBytes},
+    shared::replication::entity_map::{ReceiveEntityMap, SendEntityMap},
+};
 
 /// Metadata needed to receive/send messages
 ///

--- a/lightyear/src/protocol/message/mod.rs
+++ b/lightyear/src/protocol/message/mod.rs
@@ -1,5 +1,6 @@
-use crate::protocol::registry::TypeKind;
 use std::any::TypeId;
+
+use crate::protocol::registry::TypeKind;
 
 pub(crate) mod client;
 

--- a/lightyear/src/protocol/message/registry.rs
+++ b/lightyear/src/protocol/message/registry.rs
@@ -1,20 +1,20 @@
+use bevy::{ecs::entity::MapEntities, prelude::*, utils::HashMap};
+use serde::{de::DeserializeOwned, Serialize};
+
 use super::{client, server};
-use crate::client::config::ClientConfig;
-use crate::prelude::{ChannelDirection, Message};
-use crate::protocol::message::{MessageError, MessageKind};
-use crate::protocol::registry::{NetId, TypeMapper};
-use crate::protocol::serialize::ErasedSerializeFns;
-use crate::protocol::SerializeFns;
-use crate::serialize::reader::Reader;
-use crate::serialize::writer::Writer;
-use crate::serialize::ToBytes;
-use crate::server::config::ServerConfig;
-use crate::shared::replication::entity_map::{ReceiveEntityMap, SendEntityMap};
-use bevy::ecs::entity::MapEntities;
-use bevy::prelude::*;
-use bevy::utils::HashMap;
-use serde::de::DeserializeOwned;
-use serde::Serialize;
+use crate::{
+    client::config::ClientConfig,
+    prelude::{ChannelDirection, Message},
+    protocol::{
+        message::{MessageError, MessageKind},
+        registry::{NetId, TypeMapper},
+        serialize::ErasedSerializeFns,
+        SerializeFns,
+    },
+    serialize::{reader::Reader, writer::Writer, ToBytes},
+    server::config::ServerConfig,
+    shared::replication::entity_map::{ReceiveEntityMap, SendEntityMap},
+};
 
 pub struct MessageRegistration<'a, M> {
     pub(crate) app: &'a mut App,
@@ -301,17 +301,17 @@ impl MessageRegistry {
 
 #[cfg(test)]
 mod tests {
-    use crate::prelude::MessageRegistry;
-    use crate::protocol::message::MessageKind;
-    use crate::protocol::serialize::ErasedSerializeFns;
-    use crate::protocol::SerializeFns;
-    use crate::serialize::reader::Reader;
-    use crate::serialize::writer::Writer;
-    use crate::shared::replication::entity_map::{ReceiveEntityMap, SendEntityMap};
-    use crate::tests::protocol::{
-        deserialize_resource2, serialize_resource2, ComponentMapEntities, Resource1, Resource2,
-    };
     use bevy::prelude::Entity;
+
+    use crate::{
+        prelude::MessageRegistry,
+        protocol::{message::MessageKind, serialize::ErasedSerializeFns, SerializeFns},
+        serialize::{reader::Reader, writer::Writer},
+        shared::replication::entity_map::{ReceiveEntityMap, SendEntityMap},
+        tests::protocol::{
+            deserialize_resource2, serialize_resource2, ComponentMapEntities, Resource1, Resource2,
+        },
+    };
 
     #[test]
     fn test_serde() {

--- a/lightyear/src/protocol/message/resource.rs
+++ b/lightyear/src/protocol/message/resource.rs
@@ -1,13 +1,13 @@
-use crate::client::config::ClientConfig;
-use crate::prelude::{ChannelDirection, Message};
-use crate::protocol::message::registry::AppMessageExt;
-use crate::protocol::SerializeFns;
-use crate::server::config::ServerConfig;
-use crate::shared::replication::resources::DespawnResource;
-use bevy::app::App;
-use bevy::prelude::Resource;
-use serde::de::DeserializeOwned;
-use serde::Serialize;
+use bevy::{app::App, prelude::Resource};
+use serde::{de::DeserializeOwned, Serialize};
+
+use crate::{
+    client::config::ClientConfig,
+    prelude::{ChannelDirection, Message},
+    protocol::{message::registry::AppMessageExt, SerializeFns},
+    server::config::ServerConfig,
+    shared::replication::resources::DespawnResource,
+};
 
 fn register_resource_send<R: Resource + Message>(app: &mut App, direction: ChannelDirection) {
     let is_client = app.world().get_resource::<ClientConfig>().is_some();

--- a/lightyear/src/protocol/message/server.rs
+++ b/lightyear/src/protocol/message/server.rs
@@ -1,21 +1,24 @@
-use super::MessageKind;
-use crate::prelude::{
-    Channel, ClientId, ClientReceiveMessage, Message, NetworkTarget, ServerConnectionManager,
-    ServerReceiveMessage, ServerSendMessage,
+use bevy::{
+    app::App,
+    ecs::{change_detection::MutUntyped, component::ComponentId},
+    prelude::{Commands, Entity, Event, Events, FilteredResourcesMut, TypePath, World},
+    utils::HashMap,
 };
-use crate::protocol::message::registry::MessageRegistry;
-use crate::protocol::message::trigger::TriggerMessage;
-use crate::protocol::message::MessageError;
-use crate::protocol::registry::NetId;
-use crate::protocol::serialize::ErasedSerializeFns;
-use crate::serialize::reader::Reader;
-use crate::serialize::ToBytes;
-use crate::shared::replication::entity_map::{ReceiveEntityMap, SendEntityMap};
-use bevy::app::App;
-use bevy::ecs::change_detection::MutUntyped;
-use bevy::ecs::component::ComponentId;
-use bevy::prelude::{Commands, Entity, Event, Events, FilteredResourcesMut, TypePath, World};
-use bevy::utils::HashMap;
+
+use super::MessageKind;
+use crate::{
+    prelude::{
+        Channel, ClientId, ClientReceiveMessage, Message, NetworkTarget, ServerConnectionManager,
+        ServerReceiveMessage, ServerSendMessage,
+    },
+    protocol::{
+        message::{registry::MessageRegistry, trigger::TriggerMessage, MessageError},
+        registry::NetId,
+        serialize::ErasedSerializeFns,
+    },
+    serialize::{reader::Reader, ToBytes},
+    shared::replication::entity_map::{ReceiveEntityMap, SendEntityMap},
+};
 
 /// Metadata needed to receive/send messages
 ///

--- a/lightyear/src/protocol/message/trigger.rs
+++ b/lightyear/src/protocol/message/trigger.rs
@@ -1,13 +1,15 @@
-use crate::client::config::ClientConfig;
-use crate::prelude::server::ServerConfig;
-use crate::prelude::{ChannelDirection, Deserialize, Message, MessageRegistry};
-use crate::protocol::message::registry::AppMessageInternalExt;
-use crate::protocol::SerializeFns;
-use bevy::app::App;
-use bevy::ecs::entity::MapEntities;
-use bevy::prelude::{Entity, EntityMapper, Event};
-use serde::de::DeserializeOwned;
-use serde::Serialize;
+use bevy::{
+    app::App,
+    ecs::entity::MapEntities,
+    prelude::{Entity, EntityMapper, Event},
+};
+use serde::{de::DeserializeOwned, Serialize};
+
+use crate::{
+    client::config::ClientConfig,
+    prelude::{server::ServerConfig, ChannelDirection, Deserialize, Message, MessageRegistry},
+    protocol::{message::registry::AppMessageInternalExt, SerializeFns},
+};
 
 pub trait AppTriggerExt {
     /// Registers an [`Event`] that can be triggered over the network

--- a/lightyear/src/protocol/registry.rs
+++ b/lightyear/src/protocol/registry.rs
@@ -1,10 +1,13 @@
-use crate::serialize::reader::Reader;
-use crate::serialize::varint::{varint_len, VarIntReadExt, VarIntWriteExt};
-use crate::serialize::{SerializationError, ToBytes};
+use std::{any::TypeId, hash::Hash};
+
 use bevy::utils::HashMap;
 use byteorder::WriteBytesExt;
-use std::any::TypeId;
-use std::hash::Hash;
+
+use crate::serialize::{
+    reader::Reader,
+    varint::{varint_len, VarIntReadExt, VarIntWriteExt},
+    SerializationError, ToBytes,
+};
 
 /// ID used to serialize IDs over the network efficiently
 pub(crate) type NetId = u16;

--- a/lightyear/src/protocol/serialize.rs
+++ b/lightyear/src/protocol/serialize.rs
@@ -1,12 +1,17 @@
-use crate::prelude::{ComponentRegistry, Message, MessageRegistry};
-use crate::serialize::{reader::Reader, writer::Writer, SerializationError};
-use crate::shared::replication::entity_map::{EntityMap, ReceiveEntityMap, SendEntityMap};
-use bevy::app::App;
-use bevy::ecs::entity::MapEntities;
-use bevy::ptr::{Ptr, PtrMut};
-use serde::de::DeserializeOwned;
-use serde::Serialize;
 use std::any::TypeId;
+
+use bevy::{
+    app::App,
+    ecs::entity::MapEntities,
+    ptr::{Ptr, PtrMut},
+};
+use serde::{de::DeserializeOwned, Serialize};
+
+use crate::{
+    prelude::{ComponentRegistry, Message, MessageRegistry},
+    serialize::{reader::Reader, writer::Writer, SerializationError},
+    shared::replication::entity_map::{EntityMap, ReceiveEntityMap, SendEntityMap},
+};
 
 /// Stores function pointers related to serialization and deserialization
 #[derive(Clone, Debug, PartialEq)]
@@ -244,13 +249,16 @@ impl AppSerializeExt for App {
 
 #[cfg(test)]
 mod tests {
-    use crate::protocol::serialize::{erased_serialize_fn, ErasedSerializeFns};
-    use crate::serialize::reader::Reader;
-    use crate::serialize::writer::Writer;
-    use crate::shared::replication::authority::AuthorityChange;
-    use crate::shared::replication::entity_map::{ReceiveEntityMap, SendEntityMap};
-    use bevy::prelude::Entity;
-    use bevy::ptr::Ptr;
+    use bevy::{prelude::Entity, ptr::Ptr};
+
+    use crate::{
+        protocol::serialize::{erased_serialize_fn, ErasedSerializeFns},
+        serialize::{reader::Reader, writer::Writer},
+        shared::replication::{
+            authority::AuthorityChange,
+            entity_map::{ReceiveEntityMap, SendEntityMap},
+        },
+    };
 
     /// Test serializing/deserializing using the ErasedSerializeFns
     #[test]

--- a/lightyear/src/serialize/mod.rs
+++ b/lightyear/src/serialize/mod.rs
@@ -1,11 +1,15 @@
 //! Serialization and deserialization of types
 
-use crate::serialize::reader::Reader;
-use crate::serialize::varint::{varint_len, VarIntReadExt, VarIntWriteExt};
+use std::hash::{BuildHasher, Hash};
+
 use bevy::utils::hashbrown::HashMap;
 use byteorder::{ReadBytesExt, WriteBytesExt};
 use bytes::Bytes;
-use std::hash::{BuildHasher, Hash};
+
+use crate::serialize::{
+    reader::Reader,
+    varint::{varint_len, VarIntReadExt, VarIntWriteExt},
+};
 
 pub mod reader;
 pub(crate) mod varint;

--- a/lightyear/src/serialize/reader.rs
+++ b/lightyear/src/serialize/reader.rs
@@ -1,5 +1,6 @@
-use bytes::{Buf, Bytes};
 use std::io::{Cursor, Read, Seek, SeekFrom};
+
+use bytes::{Buf, Bytes};
 
 #[derive(Clone)]
 pub struct Reader(Cursor<Bytes>);

--- a/lightyear/src/serialize/varint.rs
+++ b/lightyear/src/serialize/varint.rs
@@ -1,6 +1,8 @@
-use crate::serialize::SerializationError;
-use byteorder::{NetworkEndian, ReadBytesExt, WriteBytesExt};
 use std::io::Seek;
+
+use byteorder::{NetworkEndian, ReadBytesExt, WriteBytesExt};
+
+use crate::serialize::SerializationError;
 
 /// Returns how many bytes it would take to encode `v` as a variable-length
 /// integer.
@@ -91,8 +93,9 @@ impl<T: ReadBytesExt + Seek> VarIntReadExt for T {}
 
 #[cfg(test)]
 mod tests {
-    use crate::serialize::varint::{VarIntReadExt, VarIntWriteExt};
     use std::io::Cursor;
+
+    use crate::serialize::varint::{VarIntReadExt, VarIntWriteExt};
 
     #[test]
     fn test_varint_len_1() {

--- a/lightyear/src/serialize/writer.rs
+++ b/lightyear/src/serialize/writer.rs
@@ -5,8 +5,9 @@
 //!
 //! The idea is that we have one allocation under the [`BytesMut`], when we finish writing a message,
 //! we can split the message of as a separate [`Bytes`], but
-use bytes::{BufMut, Bytes, BytesMut};
 use std::io::Write;
+
+use bytes::{BufMut, Bytes, BytesMut};
 
 #[derive(Debug)]
 pub struct Writer(bytes::buf::Writer<BytesMut>);

--- a/lightyear/src/server/clients.rs
+++ b/lightyear/src/server/clients.rs
@@ -1,11 +1,12 @@
 //! The server spawns an entity per connected client to store metadata about them.
 //!
 //! This module contains components and systems to manage the metadata on client entities.
-use crate::server::clients::systems::handle_controlled_by_remove;
-use crate::server::replication::send::Lifetime;
-use crate::shared::sets::{InternalReplicationSet, ServerMarker};
-use bevy::ecs::entity::EntityHashMap;
-use bevy::prelude::*;
+use bevy::{ecs::entity::EntityHashMap, prelude::*};
+
+use crate::{
+    server::{clients::systems::handle_controlled_by_remove, replication::send::Lifetime},
+    shared::sets::{InternalReplicationSet, ServerMarker},
+};
 
 /// List of entities under the control of a client
 #[derive(Component, Default, Debug, Deref, DerefMut, PartialEq)]
@@ -26,12 +27,15 @@ impl ControlledEntities {
 pub(crate) struct ClientsMetadataPlugin;
 
 mod systems {
-    use super::*;
-    use crate::prelude::server::ControlledBy;
-    use crate::server::clients::ControlledEntities;
-    use crate::server::connection::ConnectionManager;
-    use crate::server::events::DisconnectEvent;
     use tracing::{debug, trace};
+
+    use super::*;
+    use crate::{
+        prelude::server::ControlledBy,
+        server::{
+            clients::ControlledEntities, connection::ConnectionManager, events::DisconnectEvent,
+        },
+    };
 
     // TODO: remove entity in ControlledEntities lists after the component gets updated
     //  (e.g. control goes from client 1 to client 2)
@@ -171,16 +175,27 @@ impl Plugin for ClientsMetadataPlugin {
 
 #[cfg(test)]
 mod tests {
-    use crate::client::networking::ClientCommandsExt;
-    use crate::prelude::server::{ConnectionManager, ControlledBy, Replicate};
-    use crate::prelude::{client, ClientId, NetworkTarget, Replicated};
-    use crate::server::clients::ControlledEntities;
-    use crate::server::replication::send::Lifetime;
-    use crate::server::replication::send::ReplicationTarget;
-    use crate::tests::multi_stepper::{MultiBevyStepper, TEST_CLIENT_ID_1, TEST_CLIENT_ID_2};
-    use crate::tests::stepper::{BevyStepper, TEST_CLIENT_ID};
-    use bevy::ecs::entity::EntityHashMap;
-    use bevy::prelude::{default, Entity, With};
+    use bevy::{
+        ecs::entity::EntityHashMap,
+        prelude::{default, Entity, With},
+    };
+
+    use crate::{
+        client::networking::ClientCommandsExt,
+        prelude::{
+            client,
+            server::{ConnectionManager, ControlledBy, Replicate},
+            ClientId, NetworkTarget, Replicated,
+        },
+        server::{
+            clients::ControlledEntities,
+            replication::send::{Lifetime, ReplicationTarget},
+        },
+        tests::{
+            multi_stepper::{MultiBevyStepper, TEST_CLIENT_ID_1, TEST_CLIENT_ID_2},
+            stepper::{BevyStepper, TEST_CLIENT_ID},
+        },
+    };
 
     /// Check that the Client Entities are updated after ControlledBy is added
     #[test]

--- a/lightyear/src/server/config.rs
+++ b/lightyear/src/server/config.rs
@@ -1,16 +1,18 @@
 //! Defines server-specific configuration options
+use std::sync::Arc;
+
 use bevy::prelude::Resource;
 use governor::Quota;
 use nonzero_ext::nonzero;
-use std::sync::Arc;
 
-use crate::connection::netcode::{Key, PRIVATE_KEY_BYTES};
-use crate::connection::server::{
-    ConnectionRequestHandler, DefaultConnectionRequestHandler, NetConfig,
+use crate::{
+    connection::{
+        netcode::{Key, PRIVATE_KEY_BYTES},
+        server::{ConnectionRequestHandler, DefaultConnectionRequestHandler, NetConfig},
+    },
+    prelude::ReplicationConfig,
+    shared::{config::SharedConfig, ping::manager::PingConfig},
 };
-use crate::prelude::ReplicationConfig;
-use crate::shared::config::SharedConfig;
-use crate::shared::ping::manager::PingConfig;
 
 #[derive(Debug, Clone)]
 pub struct NetcodeConfig {
@@ -117,15 +119,17 @@ pub struct ServerConfig {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::client::networking::NetworkingState;
-    use crate::connection::server::DeniedReason;
-    use crate::prelude::ClientId;
+    use std::{fmt::Debug, sync::Arc};
 
-    use crate::tests::stepper::{BevyStepper, TEST_CLIENT_ID};
     use bevy::prelude::State;
-    use std::fmt::Debug;
-    use std::sync::Arc;
+
+    use super::*;
+    use crate::{
+        client::networking::NetworkingState,
+        connection::server::DeniedReason,
+        prelude::ClientId,
+        tests::stepper::{BevyStepper, TEST_CLIENT_ID},
+    };
 
     #[derive(Debug, Clone)]
     struct CustomConnectionRequestHandler;

--- a/lightyear/src/server/events.rs
+++ b/lightyear/src/server/events.rs
@@ -1,18 +1,26 @@
 //! Wrapper around [`ConnectionEvents`] that adds server-specific functionality
 
-use bevy::ecs::entity::EntityHash;
-use bevy::prelude::*;
-use bevy::utils::{hashbrown, HashMap};
-
-use crate::connection::id::ClientId;
-use crate::server::connection::ConnectionManager;
-use crate::shared::events::connection::{
-    ConnectionEvents, IterComponentInsertEvent, IterComponentRemoveEvent, IterComponentUpdateEvent,
-    IterEntityDespawnEvent, IterEntitySpawnEvent,
+use bevy::{
+    ecs::entity::EntityHash,
+    prelude::*,
+    utils::{hashbrown, HashMap},
 };
-use crate::shared::events::plugin::EventsPlugin;
-use crate::shared::events::systems::push_component_events;
-use crate::shared::sets::{InternalMainSet, ServerMarker};
+
+use crate::{
+    connection::id::ClientId,
+    server::connection::ConnectionManager,
+    shared::{
+        events::{
+            connection::{
+                ConnectionEvents, IterComponentInsertEvent, IterComponentRemoveEvent,
+                IterComponentUpdateEvent, IterEntityDespawnEvent, IterEntitySpawnEvent,
+            },
+            plugin::EventsPlugin,
+            systems::push_component_events,
+        },
+        sets::{InternalMainSet, ServerMarker},
+    },
+};
 
 type EntityHashMap<K, V> = hashbrown::HashMap<K, V, EntityHash>;
 
@@ -279,11 +287,12 @@ pub type ComponentRemoveEvent<C> =
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::prelude::Tick;
-    use crate::protocol::channel::ChannelKind;
-    use crate::protocol::component::ComponentKind;
-    use crate::tests::protocol::{
-        Channel1, Channel2, ComponentSyncModeFull, ComponentSyncModeOnce, StringMessage,
+    use crate::{
+        prelude::Tick,
+        protocol::{channel::ChannelKind, component::ComponentKind},
+        tests::protocol::{
+            Channel1, Channel2, ComponentSyncModeFull, ComponentSyncModeOnce, StringMessage,
+        },
     };
 
     #[test]

--- a/lightyear/src/server/input/leafwing.rs
+++ b/lightyear/src/server/input/leafwing.rs
@@ -1,20 +1,19 @@
 //! Handles client-generated inputs
 
-use crate::client::config::ClientConfig;
-use crate::connection::client::ClientConnection;
-use crate::inputs::leafwing::input_buffer::InputBuffer;
-use crate::inputs::leafwing::input_message::InputTarget;
-use crate::inputs::leafwing::LeafwingUserAction;
-use crate::prelude::client::NetClient;
-use crate::prelude::{
-    is_host_server, ChannelKind, ChannelRegistry, ClientConnectionManager, InputChannel,
-    InputConfig, InputMessage, MessageRegistry, NetworkTarget, ServerReceiveMessage,
-    ServerSendMessage, TickManager,
-};
-use crate::server::connection::ConnectionManager;
-use crate::server::input::InputSystemSet;
 use bevy::prelude::*;
 use leafwing_input_manager::prelude::*;
+
+use crate::{
+    client::config::ClientConfig,
+    connection::client::ClientConnection,
+    inputs::leafwing::{input_buffer::InputBuffer, input_message::InputTarget, LeafwingUserAction},
+    prelude::{
+        client::NetClient, is_host_server, ChannelKind, ChannelRegistry, ClientConnectionManager,
+        InputChannel, InputConfig, InputMessage, MessageRegistry, NetworkTarget,
+        ServerReceiveMessage, ServerSendMessage, TickManager,
+    },
+    server::{connection::ConnectionManager, input::InputSystemSet},
+};
 
 pub struct LeafwingInputPlugin<A> {
     pub(crate) rebroadcast_inputs: bool,
@@ -230,14 +229,14 @@ pub(crate) fn rebroadcast_inputs<A: LeafwingUserAction>(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::inputs::leafwing::input_buffer::InputBuffer;
     use leafwing_input_manager::prelude::ActionState;
 
-    use crate::prelude::client;
-    use crate::prelude::server::*;
-    use crate::tests::protocol::*;
-    use crate::tests::stepper::BevyStepper;
+    use super::*;
+    use crate::{
+        inputs::leafwing::input_buffer::InputBuffer,
+        prelude::{client, server::*},
+        tests::{protocol::*, stepper::BevyStepper},
+    };
 
     #[test]
     fn test_leafwing_inputs() {

--- a/lightyear/src/server/input/mod.rs
+++ b/lightyear/src/server/input/mod.rs
@@ -5,11 +5,13 @@ pub mod native;
 #[cfg(feature = "leafwing")]
 pub mod leafwing;
 
-use crate::inputs::native::input_buffer::InputBuffer;
-use crate::inputs::native::UserActionState;
-use crate::prelude::{server::is_started, TickManager};
-use crate::shared::sets::{InternalMainSet, ServerMarker};
 use bevy::prelude::*;
+
+use crate::{
+    inputs::native::{input_buffer::InputBuffer, UserActionState},
+    prelude::{server::is_started, TickManager},
+    shared::sets::{InternalMainSet, ServerMarker},
+};
 
 pub struct BaseInputPlugin<A> {
     rebroadcast_inputs: bool,

--- a/lightyear/src/server/input/native.rs
+++ b/lightyear/src/server/input/native.rs
@@ -1,19 +1,23 @@
 //! Handles client-generated inputs
 
-use crate::client::config::ClientConfig;
-use crate::connection::client::{ClientConnection, NetClient};
-use crate::inputs::native::input_buffer::InputBuffer;
-use crate::inputs::native::input_message::{InputMessage, InputTarget};
-use crate::inputs::native::{ActionState, InputMarker};
-use crate::prelude::{
-    is_host_server, ChannelKind, ChannelRegistry, ClientConnectionManager, InputChannel,
-    MessageRegistry, NetworkTarget, ServerReceiveMessage, ServerSendMessage, TickManager,
-    UserAction,
-};
-use crate::server::connection::ConnectionManager;
-use crate::server::input::InputSystemSet;
-use crate::shared::input::InputConfig;
 use bevy::prelude::*;
+
+use crate::{
+    client::config::ClientConfig,
+    connection::client::{ClientConnection, NetClient},
+    inputs::native::{
+        input_buffer::InputBuffer,
+        input_message::{InputMessage, InputTarget},
+        ActionState, InputMarker,
+    },
+    prelude::{
+        is_host_server, ChannelKind, ChannelRegistry, ClientConnectionManager, InputChannel,
+        MessageRegistry, NetworkTarget, ServerReceiveMessage, ServerSendMessage, TickManager,
+        UserAction,
+    },
+    server::{connection::ConnectionManager, input::InputSystemSet},
+    shared::input::InputConfig,
+};
 
 pub struct InputPlugin<A> {
     /// If True, the server will rebroadcast a client's inputs to all other clients.

--- a/lightyear/src/server/io/config.rs
+++ b/lightyear/src/server/io/config.rs
@@ -1,27 +1,31 @@
+use std::net::IpAddr;
+
+use bevy::prelude::TypePath;
+#[cfg(all(feature = "webtransport", not(target_family = "wasm")))]
+use wtransport::Identity;
+
 use super::*;
-use crate::prelude::CompressionConfig;
-use crate::server::io::transport::{ServerTransportBuilder, ServerTransportBuilderEnum};
-use crate::transport::channels::Channels;
-use crate::transport::config::SharedIoConfig;
-use crate::transport::dummy::DummyIo;
-use crate::transport::io::IoStats;
 #[cfg(feature = "zstd")]
 use crate::transport::middleware::compression::zstd::compression::ZstdCompressor;
 #[cfg(feature = "zstd")]
 use crate::transport::middleware::compression::zstd::decompression::ZstdDecompressor;
-use crate::transport::middleware::conditioner::LinkConditioner;
-use crate::transport::middleware::PacketReceiverWrapper;
-use crate::transport::udp::UdpSocketBuilder;
 #[cfg(all(feature = "websocket", not(target_family = "wasm")))]
 use crate::transport::websocket::server::WebSocketServerSocketBuilder;
 #[cfg(all(feature = "webtransport", not(target_family = "wasm")))]
 use crate::transport::webtransport::server::WebTransportServerSocketBuilder;
-use crate::transport::BoxedReceiver;
-use crate::transport::Transport;
-use bevy::prelude::TypePath;
-use std::net::IpAddr;
-#[cfg(all(feature = "webtransport", not(target_family = "wasm")))]
-use wtransport::Identity;
+use crate::{
+    prelude::CompressionConfig,
+    server::io::transport::{ServerTransportBuilder, ServerTransportBuilderEnum},
+    transport::{
+        channels::Channels,
+        config::SharedIoConfig,
+        dummy::DummyIo,
+        io::IoStats,
+        middleware::{conditioner::LinkConditioner, PacketReceiverWrapper},
+        udp::UdpSocketBuilder,
+        BoxedReceiver, Transport,
+    },
+};
 
 #[derive(Debug, TypePath)]
 pub enum ServerTransport {

--- a/lightyear/src/server/io/mod.rs
+++ b/lightyear/src/server/io/mod.rs
@@ -3,11 +3,15 @@
 pub(crate) mod config;
 pub(crate) mod transport;
 
-use crate::transport::error::{Error, Result};
-use crate::transport::io::{BaseIo, IoState};
+use std::net::SocketAddr;
+
 use bevy::prelude::{Deref, DerefMut};
 use crossbeam_channel::Sender;
-use std::net::SocketAddr;
+
+use crate::transport::{
+    error::{Error, Result},
+    io::{BaseIo, IoState},
+};
 
 pub struct IoContext {
     pub(crate) event_sender: Option<ServerNetworkEventSender>,

--- a/lightyear/src/server/io/transport.rs
+++ b/lightyear/src/server/io/transport.rs
@@ -1,16 +1,21 @@
-use crate::server::io::{ServerIoEventReceiver, ServerNetworkEventSender};
-use crate::transport::channels::Channels;
-use crate::transport::dummy::DummyIo;
-use crate::transport::error::Result;
-use crate::transport::io::IoState;
-use crate::transport::udp::{UdpSocket, UdpSocketBuilder};
+use enum_dispatch::enum_dispatch;
+
 #[cfg(all(feature = "websocket", not(target_family = "wasm")))]
 use crate::transport::websocket::server::{WebSocketServerSocket, WebSocketServerSocketBuilder};
 #[cfg(all(feature = "webtransport", not(target_family = "wasm")))]
 use crate::transport::webtransport::server::{
     WebTransportServerSocket, WebTransportServerSocketBuilder,
 };
-use enum_dispatch::enum_dispatch;
+use crate::{
+    server::io::{ServerIoEventReceiver, ServerNetworkEventSender},
+    transport::{
+        channels::Channels,
+        dummy::DummyIo,
+        error::Result,
+        io::IoState,
+        udp::{UdpSocket, UdpSocketBuilder},
+    },
+};
 
 #[enum_dispatch]
 pub(crate) trait ServerTransportBuilder: Send + Sync {

--- a/lightyear/src/server/message.rs
+++ b/lightyear/src/server/message.rs
@@ -1,18 +1,24 @@
-use crate::prelude::server::{is_stopped, RoomId, RoomManager, ServerError};
-use crate::prelude::{
-    is_host_server, Channel, ChannelKind, ClientId, MainSet, Message, MessageRegistry, MessageSend,
+use bevy::{
+    ecs::system::{FilteredResourcesMutParamBuilder, ParamBuilder},
+    prelude::*,
 };
-use crate::serialize::reader::Reader;
-use crate::server::connection::ConnectionManager;
-use crate::server::relevance::error::RelevanceError;
-use crate::shared::message::private::InternalMessageSend;
-use crate::shared::replication::entity_map::SendEntityMap;
-use crate::shared::replication::network_target::NetworkTarget;
-use crate::shared::sets::{InternalMainSet, ServerMarker};
-use bevy::ecs::system::{FilteredResourcesMutParamBuilder, ParamBuilder};
-use bevy::prelude::*;
 use bytes::Bytes;
 use tracing::error;
+
+use crate::{
+    prelude::{
+        is_host_server,
+        server::{is_stopped, RoomId, RoomManager, ServerError},
+        Channel, ChannelKind, ClientId, MainSet, Message, MessageRegistry, MessageSend,
+    },
+    serialize::reader::Reader,
+    server::{connection::ConnectionManager, relevance::error::RelevanceError},
+    shared::{
+        message::private::InternalMessageSend,
+        replication::{entity_map::SendEntityMap, network_target::NetworkTarget},
+        sets::{InternalMainSet, ServerMarker},
+    },
+};
 
 /// Bevy [`Event`] emitted on the server on the frame where a (non-replication) message is received
 #[allow(type_alias_bounds)]
@@ -359,13 +365,21 @@ impl InternalMessageSend for ConnectionManager {
 
 #[cfg(test)]
 mod tests {
-    use crate::prelude::server::ServerTriggerExt;
-    use crate::prelude::{ClientReceiveMessage, NetworkTarget, ServerSendMessage};
-    use crate::shared::message::MessageSend;
-    use crate::tests::host_server_stepper::HostServerStepper;
-    use crate::tests::protocol::{Channel1, IntegerEvent, StringMessage};
-    use bevy::app::Update;
-    use bevy::prelude::{EventReader, Events, ResMut, Resource, Trigger};
+    use bevy::{
+        app::Update,
+        prelude::{EventReader, Events, ResMut, Resource, Trigger},
+    };
+
+    use crate::{
+        prelude::{
+            server::ServerTriggerExt, ClientReceiveMessage, NetworkTarget, ServerSendMessage,
+        },
+        shared::message::MessageSend,
+        tests::{
+            host_server_stepper::HostServerStepper,
+            protocol::{Channel1, IntegerEvent, StringMessage},
+        },
+    };
 
     #[derive(Resource, Default)]
     struct Counter(usize);

--- a/lightyear/src/server/networking.rs
+++ b/lightyear/src/server/networking.rs
@@ -1,26 +1,29 @@
 //! Defines the server bevy systems and run conditions
-use crate::connection::netcode::Error as NetcodeError;
-use crate::connection::server::{
-    ConnectionError, IoConfig, NetServer, ServerConnection, ServerConnections,
-};
-use crate::prelude::server::is_stopped;
-use crate::prelude::{
-    is_host_server, ChannelRegistry, ClientId, MainSet, MessageRegistry, TickManager, TimeManager,
-};
-use crate::protocol::component::ComponentRegistry;
-use crate::serialize::reader::Reader;
-use crate::server::clients::ControlledEntities;
-use crate::server::config::ServerConfig;
-use crate::server::connection::ConnectionManager;
-use crate::server::error::ServerError;
-use crate::server::io::ServerIoEvent;
-use crate::server::run_conditions::is_started_ref;
-use crate::shared::sets::{InternalMainSet, ServerMarker};
-use crate::transport::error::Error as TransportError;
 use async_channel::TryRecvError;
-use bevy::ecs::system::{RunSystemOnce, SystemChangeTick};
-use bevy::prelude::*;
+use bevy::{
+    ecs::system::{RunSystemOnce, SystemChangeTick},
+    prelude::*,
+};
 use tracing::{debug, error, trace};
+
+use crate::{
+    connection::{
+        netcode::Error as NetcodeError,
+        server::{ConnectionError, IoConfig, NetServer, ServerConnection, ServerConnections},
+    },
+    prelude::{
+        is_host_server, server::is_stopped, ChannelRegistry, ClientId, MainSet, MessageRegistry,
+        TickManager, TimeManager,
+    },
+    protocol::component::ComponentRegistry,
+    serialize::reader::Reader,
+    server::{
+        clients::ControlledEntities, config::ServerConfig, connection::ConnectionManager,
+        error::ServerError, io::ServerIoEvent, run_conditions::is_started_ref,
+    },
+    shared::sets::{InternalMainSet, ServerMarker},
+    transport::error::Error as TransportError,
+};
 
 /// Plugin handling the server networking systems: sending/receiving packets to clients
 #[derive(Default)]
@@ -490,10 +493,16 @@ impl ServerCommandsExt for World {
 
 #[cfg(test)]
 mod tests {
-    use crate::prelude::server::{ControlledBy, ControlledEntities, ServerCommandsExt};
-    use crate::prelude::{client, server, ClientId, NetworkTarget, ServerConnectionManager};
-    use crate::tests::stepper::{BevyStepper, TEST_CLIENT_ID};
     use bevy::prelude::{default, Entity, With};
+
+    use crate::{
+        prelude::{
+            client, server,
+            server::{ControlledBy, ControlledEntities, ServerCommandsExt},
+            ClientId, NetworkTarget, ServerConnectionManager,
+        },
+        tests::stepper::{BevyStepper, TEST_CLIENT_ID},
+    };
 
     /// Test that when the server stops:
     /// - Controlled entities are removed

--- a/lightyear/src/server/plugin.rs
+++ b/lightyear/src/server/plugin.rs
@@ -8,21 +8,20 @@
 //! while keeping the rest of the features intact.
 //!
 //! Most plugins are truly necessary for the server functionality to work properly, but some could be disabled.
-use crate::server::clients::ClientsMetadataPlugin;
-use bevy::app::PluginGroupBuilder;
-use bevy::prelude::*;
-
-use crate::server::events::ServerEventsPlugin;
-use crate::server::message::ServerMessagePlugin;
-use crate::server::networking::ServerNetworkingPlugin;
-use crate::server::relevance::immediate::NetworkRelevancePlugin;
-use crate::server::relevance::room::RoomPlugin;
-use crate::server::replication::{
-    receive::ServerReplicationReceivePlugin, send::ServerReplicationSendPlugin,
-};
-use crate::shared::plugin::SharedPlugin;
+use bevy::{app::PluginGroupBuilder, prelude::*};
 
 use super::config::ServerConfig;
+use crate::{
+    server::{
+        clients::ClientsMetadataPlugin,
+        events::ServerEventsPlugin,
+        message::ServerMessagePlugin,
+        networking::ServerNetworkingPlugin,
+        relevance::{immediate::NetworkRelevancePlugin, room::RoomPlugin},
+        replication::{receive::ServerReplicationReceivePlugin, send::ServerReplicationSendPlugin},
+    },
+    shared::plugin::SharedPlugin,
+};
 
 /// A plugin group containing all the server plugins.
 ///

--- a/lightyear/src/server/prediction.rs
+++ b/lightyear/src/server/prediction.rs
@@ -1,8 +1,11 @@
 //! Handles logic related to prespawning entities
 
-use crate::prelude::server::{AuthorityCommandExt, AuthorityPeer};
-use crate::prelude::{PrePredicted, Replicated, ServerConnectionManager};
 use bevy::prelude::*;
+
+use crate::prelude::{
+    server::{AuthorityCommandExt, AuthorityPeer},
+    PrePredicted, Replicated, ServerConnectionManager,
+};
 
 /// When we receive an entity that a clients wants PrePredicted,
 /// we immediately transfer authority back to the server. The server will replicate the PrePredicted

--- a/lightyear/src/server/relevance/immediate.rs
+++ b/lightyear/src/server/relevance/immediate.rs
@@ -23,12 +23,13 @@ fn my_system(
 }
 ```
 */
-use crate::prelude::{server::is_started, ClientId};
-use crate::shared::sets::{InternalReplicationSet, ServerMarker};
-use bevy::ecs::entity::EntityHashSet;
-use bevy::prelude::*;
-use bevy::utils::HashMap;
+use bevy::{ecs::entity::EntityHashSet, prelude::*, utils::HashMap};
 use tracing::trace;
+
+use crate::{
+    prelude::{server::is_started, ClientId},
+    shared::sets::{InternalReplicationSet, ServerMarker},
+};
 
 /// Event related to [`Entities`](Entity) which are relevant to a client
 #[derive(Debug, PartialEq, Clone, Copy, Reflect)]
@@ -120,11 +121,10 @@ impl RelevanceManager {
 }
 
 pub(super) mod systems {
-    use super::*;
-
-    use crate::prelude::NetworkRelevanceMode;
-
     use bevy::prelude::DetectChanges;
+
+    use super::*;
+    use crate::prelude::NetworkRelevanceMode;
 
     // NOTE: this might not be needed because we drain the event cache every Send update
     // /// Clear the internal room buffers when a client disconnects
@@ -295,12 +295,14 @@ impl Plugin for NetworkRelevancePlugin {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::prelude::server::Replicate;
-    use crate::prelude::{client, ClientConnectionManager, NetworkRelevanceMode};
-    use crate::shared::replication::components::ReplicationGroupId;
-    use crate::tests::stepper::{BevyStepper, TEST_CLIENT_ID};
     use bevy::ecs::system::RunSystemOnce;
+
+    use super::*;
+    use crate::{
+        prelude::{client, server::Replicate, ClientConnectionManager, NetworkRelevanceMode},
+        shared::replication::components::ReplicationGroupId,
+        tests::stepper::{BevyStepper, TEST_CLIENT_ID},
+    };
 
     /// Multiple entities gain relevance for a given client
     /// Check that interest management works correctly

--- a/lightyear/src/server/relevance/room.rs
+++ b/lightyear/src/server/relevance/room.rs
@@ -37,21 +37,21 @@ it just caches the room metadata to keep track of the relevance of entities.
 
 */
 
-use bevy::app::App;
-use bevy::ecs::entity::EntityHash;
-use bevy::prelude::*;
-use bevy::reflect::Reflect;
-use bevy::utils::{Entry, HashMap, HashSet};
-
+use bevy::{
+    app::App,
+    ecs::entity::EntityHash,
+    prelude::*,
+    reflect::Reflect,
+    utils::{hashbrown, Entry, HashMap, HashSet},
+};
 use serde::{Deserialize, Serialize};
 
-use crate::connection::id::ClientId;
-use crate::prelude::server::is_started;
-
-use crate::server::relevance::immediate::{NetworkRelevanceSet, RelevanceEvents, RelevanceManager};
-use crate::shared::sets::{InternalReplicationSet, ServerMarker};
-
-use bevy::utils::hashbrown;
+use crate::{
+    connection::id::ClientId,
+    prelude::server::is_started,
+    server::relevance::immediate::{NetworkRelevanceSet, RelevanceEvents, RelevanceManager},
+    shared::sets::{InternalReplicationSet, ServerMarker},
+};
 
 type EntityHashMap<K, V> = hashbrown::HashMap<K, V, EntityHash>;
 type EntityHashSet<K> = hashbrown::HashSet<K, EntityHash>;
@@ -326,10 +326,10 @@ impl RoomManager {
 }
 
 pub(super) mod systems {
-    use super::*;
-    use crate::prelude::ReplicationGroup;
-    use crate::server::events::DisconnectEvent;
     use bevy::prelude::Trigger;
+
+    use super::*;
+    use crate::{prelude::ReplicationGroup, server::events::DisconnectEvent};
 
     /// Clear the internal room buffers when a client disconnects
     pub fn handle_client_disconnect(
@@ -362,24 +362,21 @@ pub(super) mod systems {
 
 #[cfg(test)]
 mod tests {
-    use bevy::ecs::system::RunSystemOnce;
-    use bevy::prelude::Events;
-    use bevy::utils::HashMap;
+    use bevy::{ecs::system::RunSystemOnce, prelude::Events, utils::HashMap};
 
-    use crate::prelude::client::*;
-    use crate::prelude::server::Replicate;
-    use crate::prelude::*;
-    use crate::server::relevance::immediate::systems::{
-        add_cached_network_relevance, update_relevance_from_events,
+    use super::{systems::buffer_room_relevance_events, *};
+    use crate::{
+        prelude::{client::*, server::Replicate, *},
+        server::relevance::immediate::{
+            systems::{add_cached_network_relevance, update_relevance_from_events},
+            CachedNetworkRelevance, ClientRelevance,
+        },
+        shared::replication::components::NetworkRelevanceMode,
+        tests::{
+            multi_stepper::{MultiBevyStepper, TEST_CLIENT_ID_1, TEST_CLIENT_ID_2},
+            stepper::BevyStepper,
+        },
     };
-    use crate::server::relevance::immediate::{CachedNetworkRelevance, ClientRelevance};
-    use crate::shared::replication::components::NetworkRelevanceMode;
-    use crate::tests::multi_stepper::{MultiBevyStepper, TEST_CLIENT_ID_1, TEST_CLIENT_ID_2};
-    use crate::tests::stepper::BevyStepper;
-
-    use super::systems::buffer_room_relevance_events;
-
-    use super::*;
 
     #[test]
     // client is in a room

--- a/lightyear/src/server/run_conditions.rs
+++ b/lightyear/src/server/run_conditions.rs
@@ -1,6 +1,7 @@
 //! Common server-related run conditions
-use crate::prelude::server::NetworkingState;
 use bevy::prelude::{Ref, Res, State};
+
+use crate::prelude::server::NetworkingState;
 
 /// Returns true if the server is started.
 ///

--- a/lightyear/src/shared/config.rs
+++ b/lightyear/src/shared/config.rs
@@ -1,6 +1,5 @@
 //! Configuration that has to be the same between the server and the client.
-use bevy::reflect::Reflect;
-use bevy::utils::Duration;
+use bevy::{reflect::Reflect, utils::Duration};
 
 use crate::shared::tick_manager::TickConfig;
 

--- a/lightyear/src/shared/events/connection.rs
+++ b/lightyear/src/shared/events/connection.rs
@@ -2,13 +2,16 @@
  */
 use std::iter;
 
-use bevy::prelude::{Component, Entity, Resource};
-use bevy::utils::HashMap;
+use bevy::{
+    prelude::{Component, Entity, Resource},
+    utils::HashMap,
+};
 use tracing::trace;
 
-use crate::prelude::Tick;
-use crate::protocol::component::ComponentKind;
-use crate::protocol::EventContext;
+use crate::{
+    prelude::Tick,
+    protocol::{component::ComponentKind, EventContext},
+};
 
 // TODO: don't make fields pub but instead make accessors
 #[derive(Debug, Resource)]

--- a/lightyear/src/shared/events/message.rs
+++ b/lightyear/src/shared/events/message.rs
@@ -1,6 +1,8 @@
-use crate::prelude::{Channel, ChannelKind, ClientId, Message, NetworkTarget};
-use bevy::prelude::Event;
 use std::marker::PhantomData;
+
+use bevy::prelude::Event;
+
+use crate::prelude::{Channel, ChannelKind, ClientId, Message, NetworkTarget};
 
 // Note: we cannot simply use `ReceiveMessage<M>` because we would have no way of differentiating
 // between the client or the server receiving a message in host-server mode

--- a/lightyear/src/shared/events/plugin.rs
+++ b/lightyear/src/shared/events/plugin.rs
@@ -1,12 +1,18 @@
 //! Create the bevy [`Plugin`]
 
-use bevy::app::{App, PreUpdate};
-use bevy::prelude::{IntoSystemConfigs, Plugin};
+use bevy::{
+    app::{App, PreUpdate},
+    prelude::{IntoSystemConfigs, Plugin},
+};
 
-use crate::shared::events::components::{EntityDespawnEvent, EntitySpawnEvent};
-use crate::shared::events::systems::{clear_events, push_entity_events};
-use crate::shared::replication::ReplicationReceive;
-use crate::shared::sets::InternalMainSet;
+use crate::shared::{
+    events::{
+        components::{EntityDespawnEvent, EntitySpawnEvent},
+        systems::{clear_events, push_entity_events},
+    },
+    replication::ReplicationReceive,
+    sets::InternalMainSet,
+};
 
 pub struct EventsPlugin<R> {
     marker: std::marker::PhantomData<R>,

--- a/lightyear/src/shared/events/systems.rs
+++ b/lightyear/src/shared/events/systems.rs
@@ -1,14 +1,18 @@
 use bevy::prelude::{Component, EventWriter, ResMut};
 
-use crate::shared::events::components::{
-    ComponentInsertEvent, ComponentRemoveEvent, ComponentUpdateEvent, EntityDespawnEvent,
-    EntitySpawnEvent,
+use crate::shared::{
+    events::{
+        components::{
+            ComponentInsertEvent, ComponentRemoveEvent, ComponentUpdateEvent, EntityDespawnEvent,
+            EntitySpawnEvent,
+        },
+        connection::{
+            ClearEvents, IterComponentInsertEvent, IterComponentRemoveEvent,
+            IterComponentUpdateEvent, IterEntityDespawnEvent, IterEntitySpawnEvent,
+        },
+    },
+    replication::ReplicationReceive,
 };
-use crate::shared::events::connection::{
-    ClearEvents, IterComponentInsertEvent, IterComponentRemoveEvent, IterComponentUpdateEvent,
-    IterEntityDespawnEvent, IterEntitySpawnEvent,
-};
-use crate::shared::replication::ReplicationReceive;
 
 /// System that gathers the replication events received by the local host and sends them to bevy Events
 pub(crate) fn push_component_events<C: Component, R: ReplicationReceive>(

--- a/lightyear/src/shared/identity.rs
+++ b/lightyear/src/shared/identity.rs
@@ -1,6 +1,9 @@
+use bevy::{
+    ecs::system::SystemParam,
+    prelude::{ComputedStates, Res, State, World},
+};
+
 use crate::prelude::{client, server};
-use bevy::ecs::system::SystemParam;
-use bevy::prelude::{ComputedStates, Res, State, World};
 
 /// State that will contain the current role of the peer. This state is only active if the peer is connected
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]

--- a/lightyear/src/shared/input/leafwing.rs
+++ b/lightyear/src/shared/input/leafwing.rs
@@ -2,11 +2,13 @@
 
 use bevy::app::{App, Plugin};
 
-use crate::client::config::ClientConfig;
-use crate::prelude::{ChannelDirection, InputMessage, LeafwingUserAction};
-use crate::protocol::message::registry::AppMessageInternalExt;
-use crate::server::config::ServerConfig;
-use crate::shared::input::InputConfig;
+use crate::{
+    client::config::ClientConfig,
+    prelude::{ChannelDirection, InputMessage, LeafwingUserAction},
+    protocol::message::registry::AppMessageInternalExt,
+    server::config::ServerConfig,
+    shared::input::InputConfig,
+};
 
 pub struct LeafwingInputPlugin<A> {
     pub config: InputConfig<A>,

--- a/lightyear/src/shared/input/mod.rs
+++ b/lightyear/src/shared/input/mod.rs
@@ -1,6 +1,6 @@
+use std::{marker::PhantomData, time::Duration};
+
 use bevy::prelude::{Reflect, Resource};
-use std::marker::PhantomData;
-use std::time::Duration;
 
 pub mod native;
 

--- a/lightyear/src/shared/input/native.rs
+++ b/lightyear/src/shared/input/native.rs
@@ -1,13 +1,18 @@
 //! Plugin to register and handle user inputs.
 
-use crate::client::config::ClientConfig;
-use crate::inputs::native::input_message::InputMessage;
-use crate::prelude::{ChannelDirection, UserAction};
-use crate::protocol::message::registry::AppMessageInternalExt;
-use crate::server::config::ServerConfig;
-use crate::shared::input::InputConfig;
-use bevy::app::{App, Plugin};
-use bevy::ecs::entity::MapEntities;
+use bevy::{
+    app::{App, Plugin},
+    ecs::entity::MapEntities,
+};
+
+use crate::{
+    client::config::ClientConfig,
+    inputs::native::input_message::InputMessage,
+    prelude::{ChannelDirection, UserAction},
+    protocol::message::registry::AppMessageInternalExt,
+    server::config::ServerConfig,
+    shared::input::InputConfig,
+};
 
 pub struct InputPlugin<A: UserAction> {
     pub config: InputConfig<A>,

--- a/lightyear/src/shared/message.rs
+++ b/lightyear/src/shared/message.rs
@@ -1,7 +1,11 @@
-use crate::prelude::{Channel, ChannelKind, Message};
-use crate::shared::replication::network_target::NetworkTarget;
-use bevy::prelude::Resource;
 use std::error::Error;
+
+use bevy::prelude::Resource;
+
+use crate::{
+    prelude::{Channel, ChannelKind, Message},
+    shared::replication::network_target::NetworkTarget,
+};
 
 /// Shared trait between client and server to send messages to a target
 pub trait MessageSend: private::InternalMessageSend {

--- a/lightyear/src/shared/ping/diagnostics.rs
+++ b/lightyear/src/shared/ping/diagnostics.rs
@@ -1,9 +1,12 @@
 //! Compute Diagnostics based on ping statistics (jitter, RTT)
 
+use bevy::{
+    app::{App, Plugin},
+    diagnostic::{Diagnostic, DiagnosticPath, Diagnostics, RegisterDiagnostic},
+    utils::Duration,
+};
+
 use crate::shared::ping::manager::PingManager;
-use bevy::app::{App, Plugin};
-use bevy::diagnostic::{Diagnostic, DiagnosticPath, Diagnostics, RegisterDiagnostic};
-use bevy::utils::Duration;
 
 /// Plugin to compute some network diagnostics related to pings
 pub struct PingDiagnosticsPlugin {

--- a/lightyear/src/shared/ping/manager.rs
+++ b/lightyear/src/shared/ping/manager.rs
@@ -1,13 +1,17 @@
 //! Manages sending/receiving pings and computing network statistics
-use bevy::reflect::Reflect;
-use bevy::time::Stopwatch;
-use bevy::utils::Duration;
+use bevy::{reflect::Reflect, time::Stopwatch, utils::Duration};
 use tracing::{error, trace};
 
-use crate::shared::ping::message::{Ping, Pong};
-use crate::shared::ping::store::{PingId, PingStore};
-use crate::shared::time_manager::{TimeManager, WrappedTime};
-use crate::utils::ready_buffer::ReadyBuffer;
+use crate::{
+    shared::{
+        ping::{
+            message::{Ping, Pong},
+            store::{PingId, PingStore},
+        },
+        time_manager::{TimeManager, WrappedTime},
+    },
+    utils::ready_buffer::ReadyBuffer,
+};
 
 /// Config for the ping manager, which sends regular pings to the remote machine in order
 /// to compute network statistics (RTT, jitter)

--- a/lightyear/src/shared/ping/message.rs
+++ b/lightyear/src/shared/ping/message.rs
@@ -1,9 +1,10 @@
 //! Defines the actual ping/pong messages
-use crate::serialize::reader::Reader;
-use crate::serialize::{SerializationError, ToBytes};
-use crate::shared::ping::store::PingId;
-use crate::shared::time_manager::WrappedTime;
 use byteorder::WriteBytesExt;
+
+use crate::{
+    serialize::{reader::Reader, SerializationError, ToBytes},
+    shared::{ping::store::PingId, time_manager::WrappedTime},
+};
 
 // TODO: do we need the ping ids? we could just re-use the message id ?
 /// Ping message; the remote should respond immediately with a pong

--- a/lightyear/src/shared/ping/store.rs
+++ b/lightyear/src/shared/ping/store.rs
@@ -1,7 +1,8 @@
 //! Store the latest pings sent to remote
-use crate::shared::time_manager::WrappedTime;
-use crate::utils::sequence_buffer::SequenceBuffer;
-use crate::utils::wrapping_id::wrapping_id;
+use crate::{
+    shared::time_manager::WrappedTime,
+    utils::{sequence_buffer::SequenceBuffer, wrapping_id::wrapping_id},
+};
 
 wrapping_id!(PingId);
 

--- a/lightyear/src/shared/plugin.rs
+++ b/lightyear/src/shared/plugin.rs
@@ -1,20 +1,28 @@
 //! Bevy [`Plugin`] used by both the server and the client
-use crate::prelude::client::ComponentSyncMode;
-use crate::prelude::{
-    client, server, AppComponentExt, AppMessageExt, ChannelDirection, ChannelRegistry,
-    ComponentRegistry, LinkConditionerConfig, MessageRegistry, NetworkIdentityState, ParentSync,
-    PingConfig, PrePredicted, PreSpawnedPlayerObject, ShouldBePredicted, TickConfig,
+use bevy::{prelude::*, utils::Duration};
+
+use crate::{
+    prelude::{
+        client, client::ComponentSyncMode, server, AppComponentExt, AppMessageExt,
+        ChannelDirection, ChannelRegistry, ComponentRegistry, LinkConditionerConfig,
+        MessageRegistry, NetworkIdentityState, ParentSync, PingConfig, PrePredicted,
+        PreSpawnedPlayerObject, ShouldBePredicted, TickConfig,
+    },
+    shared::{
+        config::SharedConfig,
+        plugin::utils::AppStateExt,
+        replication::{
+            authority::AuthorityChange,
+            components::{Controlled, ShouldBeInterpolated},
+        },
+        tick_manager::TickManagerPlugin,
+        time_manager::TimePlugin,
+    },
+    transport::{
+        io::{IoState, IoStats},
+        middleware::compression::CompressionConfig,
+    },
 };
-use crate::shared::config::SharedConfig;
-use crate::shared::plugin::utils::AppStateExt;
-use crate::shared::replication::authority::AuthorityChange;
-use crate::shared::replication::components::{Controlled, ShouldBeInterpolated};
-use crate::shared::tick_manager::TickManagerPlugin;
-use crate::shared::time_manager::TimePlugin;
-use crate::transport::io::{IoState, IoStats};
-use crate::transport::middleware::compression::CompressionConfig;
-use bevy::prelude::*;
-use bevy::utils::Duration;
 
 #[derive(Default, Debug)]
 pub struct SharedPlugin {
@@ -115,9 +123,11 @@ fn spawn_metrics_visualizer(mut commands: Commands) {
 }
 
 pub(super) mod utils {
-    use bevy::app::App;
-    use bevy::prelude::{NextState, State, StateTransition, StateTransitionEvent};
-    use bevy::state::state::{setup_state_transitions_in_world, FreelyMutableState};
+    use bevy::{
+        app::App,
+        prelude::{NextState, State, StateTransition, StateTransitionEvent},
+        state::state::{setup_state_transitions_in_world, FreelyMutableState},
+    };
 
     pub(super) trait AppStateExt {
         // Helper function that runs `init_state::<S>` without entering the state

--- a/lightyear/src/shared/replication/archetypes.rs
+++ b/lightyear/src/shared/replication/archetypes.rs
@@ -1,21 +1,22 @@
 //! Keep track of the archetypes that should be replicated
 use std::mem;
 
-use crate::client::replication::send::ReplicateToServer;
-use crate::prelude::{ChannelDirection, ComponentRegistry, Replicating};
-use crate::protocol::component::ComponentKind;
-use crate::server::replication::send::ReplicationTarget;
-use crate::shared::replication::authority::HasAuthority;
-use bevy::ecs::archetype::ArchetypeEntity;
-use bevy::ecs::component::{ComponentTicks, StorageType};
-use bevy::ecs::storage::{SparseSets, Table};
-use bevy::ptr::Ptr;
 use bevy::{
     ecs::{
-        archetype::{ArchetypeGeneration, ArchetypeId},
-        component::ComponentId,
+        archetype::{ArchetypeEntity, ArchetypeGeneration, ArchetypeId},
+        component::{ComponentId, ComponentTicks, StorageType},
+        storage::{SparseSets, Table},
     },
     prelude::*,
+    ptr::Ptr,
+};
+
+use crate::{
+    client::replication::send::ReplicateToServer,
+    prelude::{ChannelDirection, ComponentRegistry, Replicating},
+    protocol::component::ComponentKind,
+    server::replication::send::ReplicationTarget,
+    shared::replication::authority::HasAuthority,
 };
 
 /// Cached information about all replicated archetypes.

--- a/lightyear/src/shared/replication/authority.rs
+++ b/lightyear/src/shared/replication/authority.rs
@@ -6,9 +6,9 @@
 //! In this case C1 has authority even though the server is still replicating some states.
 //!
 
+use bevy::{ecs::entity::MapEntities, prelude::*};
+
 use crate::prelude::{ClientId, Deserialize, Serialize};
-use bevy::ecs::entity::MapEntities;
-use bevy::prelude::*;
 
 /// Authority is used to define who is in charge of simulating an entity.
 ///
@@ -51,18 +51,25 @@ impl MapEntities for AuthorityChange {
 
 #[cfg(test)]
 mod tests {
-    use crate::client::prediction::predicted_history::PredictionHistory;
-    use crate::prelude::client::{Confirmed, ConfirmedHistory};
-    use crate::prelude::server::{Replicate, SyncTarget};
-    use crate::prelude::{client, server, ClientId, NetworkTarget, Replicated};
-    use crate::server::replication::commands::AuthorityCommandExt;
-    use crate::shared::replication::authority::{AuthorityPeer, HasAuthority};
-    use crate::tests::multi_stepper::{MultiBevyStepper, TEST_CLIENT_ID_1, TEST_CLIENT_ID_2};
-    use crate::tests::protocol::{
-        ComponentMapEntities, ComponentSyncModeFull, ComponentSyncModeSimple,
-    };
-    use crate::tests::stepper::{BevyStepper, TEST_CLIENT_ID};
     use bevy::prelude::{default, Entity};
+
+    use crate::{
+        client::prediction::predicted_history::PredictionHistory,
+        prelude::{
+            client,
+            client::{Confirmed, ConfirmedHistory},
+            server,
+            server::{Replicate, SyncTarget},
+            ClientId, NetworkTarget, Replicated,
+        },
+        server::replication::commands::AuthorityCommandExt,
+        shared::replication::authority::{AuthorityPeer, HasAuthority},
+        tests::{
+            multi_stepper::{MultiBevyStepper, TEST_CLIENT_ID_1, TEST_CLIENT_ID_2},
+            protocol::{ComponentMapEntities, ComponentSyncModeFull, ComponentSyncModeSimple},
+            stepper::{BevyStepper, TEST_CLIENT_ID},
+        },
+    };
 
     #[test]
     fn test_transfer_authority_server_to_client() {

--- a/lightyear/src/shared/replication/components.rs
+++ b/lightyear/src/shared/replication/components.rs
@@ -1,15 +1,18 @@
 //! Components used for replication
-use bevy::ecs::reflect::ReflectComponent;
-use bevy::prelude::{Component, Entity, Reflect};
-use bevy::time::{Timer, TimerMode};
+use bevy::{
+    ecs::reflect::ReflectComponent,
+    prelude::{Component, Entity, Reflect},
+    time::{Timer, TimerMode},
+};
 use byteorder::{NetworkEndian, ReadBytesExt, WriteBytesExt};
 use serde::{Deserialize, Serialize};
 
-use crate::connection::id::ClientId;
-use crate::protocol::component::ComponentKind;
-use crate::serialize::reader::Reader;
-use crate::serialize::{SerializationError, ToBytes};
-use crate::shared::replication::network_target::NetworkTarget;
+use crate::{
+    connection::id::ClientId,
+    protocol::component::ComponentKind,
+    serialize::{reader::Reader, SerializationError, ToBytes},
+    shared::replication::network_target::NetworkTarget,
+};
 
 /// Marker component that indicates that the entity was initially spawned via replication
 /// (it was being replicated from a remote world)

--- a/lightyear/src/shared/replication/delta.rs
+++ b/lightyear/src/shared/replication/delta.rs
@@ -1,16 +1,20 @@
 //! Logic related to delta compression (sending only the changes between two states, instead of the new state)
 
-use crate::prelude::{ComponentRegistry, Message, Tick};
-use crate::protocol::component::ComponentKind;
-use crate::shared::replication::components::ReplicationGroupId;
-use bevy::ecs::entity::EntityHash;
-use bevy::prelude::{Component, Entity};
-use bevy::ptr::Ptr;
-use bevy::utils::{hashbrown, HashMap};
+use std::{collections::BTreeMap, ptr::NonNull};
 
+use bevy::{
+    ecs::entity::EntityHash,
+    prelude::{Component, Entity},
+    ptr::Ptr,
+    utils::{hashbrown, HashMap},
+};
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
-use std::ptr::NonNull;
+
+use crate::{
+    prelude::{ComponentRegistry, Message, Tick},
+    protocol::component::ComponentKind,
+    shared::replication::components::ReplicationGroupId,
+};
 
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq)]
 pub enum DeltaType {
@@ -219,9 +223,10 @@ impl DeltaComponentStore {
 
 #[cfg(test)]
 mod tests {
+    use bevy::prelude::World;
+
     use super::*;
     use crate::tests::protocol::ComponentDeltaCompression;
-    use bevy::prelude::World;
 
     #[test]
     fn test_add_get_data() {

--- a/lightyear/src/shared/replication/entity_map.rs
+++ b/lightyear/src/shared/replication/entity_map.rs
@@ -1,7 +1,9 @@
 //! Map between local and remote entities
-use bevy::ecs::entity::{EntityHashMap, EntityMapper};
-use bevy::prelude::{Deref, DerefMut, Entity, EntityWorldMut, World};
-use bevy::reflect::Reflect;
+use bevy::{
+    ecs::entity::{EntityHashMap, EntityMapper},
+    prelude::{Deref, DerefMut, Entity, EntityWorldMut, World},
+    reflect::Reflect,
+};
 use tracing::{debug, error, trace};
 
 const MARKED: u64 = 1 << 62;
@@ -191,12 +193,16 @@ impl RemoteEntityMap {
 
 #[cfg(test)]
 mod tests {
-    use crate::client::components::Confirmed;
-    use crate::prelude::server::{Replicate, SyncTarget};
-    use crate::prelude::*;
-    use crate::tests::protocol::*;
-    use crate::tests::stepper::BevyStepper;
     use bevy::prelude::{default, Entity};
+
+    use crate::{
+        client::components::Confirmed,
+        prelude::{
+            server::{Replicate, SyncTarget},
+            *,
+        },
+        tests::{protocol::*, stepper::BevyStepper},
+    };
 
     /// Test marking entities as mapped or not
     #[test]

--- a/lightyear/src/shared/replication/hierarchy.rs
+++ b/lightyear/src/shared/replication/hierarchy.rs
@@ -1,20 +1,24 @@
 //! This module is responsible for making sure that parent-children hierarchies are replicated correctly.
-use crate::client::replication::send::ReplicateToServer;
-use bevy::ecs::entity::MapEntities;
-use bevy::prelude::*;
+use bevy::{ecs::entity::MapEntities, prelude::*};
 use serde::{Deserialize, Serialize};
 
-use crate::prelude::client::{InterpolationSet, PredictionSet};
-use crate::prelude::server::ControlledBy;
-use crate::prelude::{
-    NetworkRelevanceMode, PrePredicted, Replicated, Replicating, ReplicationGroup,
+use crate::{
+    client::replication::send::ReplicateToServer,
+    prelude::{
+        client::{InterpolationSet, PredictionSet},
+        server::ControlledBy,
+        NetworkRelevanceMode, PrePredicted, Replicated, Replicating, ReplicationGroup,
+    },
+    server::replication::send::{ReplicationTarget, SyncTarget},
+    shared::{
+        replication::{
+            authority::{AuthorityPeer, HasAuthority},
+            components::ReplicateHierarchy,
+            ReplicationPeer, ReplicationSend,
+        },
+        sets::{InternalMainSet, InternalReplicationSet},
+    },
 };
-use crate::server::replication::send::ReplicationTarget;
-use crate::server::replication::send::SyncTarget;
-use crate::shared::replication::authority::{AuthorityPeer, HasAuthority};
-use crate::shared::replication::components::ReplicateHierarchy;
-use crate::shared::replication::{ReplicationPeer, ReplicationSend};
-use crate::shared::sets::{InternalMainSet, InternalReplicationSet};
 
 /// This component can be added to an entity to replicate the entity's hierarchy to the remote world.
 /// The `ParentSync` component will be updated automatically when the `Parent` component changes,
@@ -334,17 +338,24 @@ impl<R: ReplicationPeer> Plugin for HierarchyReceivePlugin<R> {
 mod tests {
     use std::ops::Deref;
 
-    use bevy::hierarchy::{BuildChildren, Children, Parent};
-    use bevy::prelude::{default, Entity, With};
+    use bevy::{
+        hierarchy::{BuildChildren, Children, Parent},
+        prelude::{default, Entity, With},
+    };
 
-    use crate::prelude::server::{Replicate, ReplicationTarget};
-    use crate::prelude::ReplicationGroup;
-    use crate::prelude::{client, server, ClientId, NetworkTarget};
-    use crate::shared::replication::components::ReplicateHierarchy;
-    use crate::shared::replication::hierarchy::ParentSync;
-    use crate::tests::multi_stepper::{MultiBevyStepper, TEST_CLIENT_ID_1, TEST_CLIENT_ID_2};
-    use crate::tests::protocol::*;
-    use crate::tests::stepper::BevyStepper;
+    use crate::{
+        prelude::{
+            client, server,
+            server::{Replicate, ReplicationTarget},
+            ClientId, NetworkTarget, ReplicationGroup,
+        },
+        shared::replication::{components::ReplicateHierarchy, hierarchy::ParentSync},
+        tests::{
+            multi_stepper::{MultiBevyStepper, TEST_CLIENT_ID_1, TEST_CLIENT_ID_2},
+            protocol::*,
+            stepper::BevyStepper,
+        },
+    };
 
     fn setup_hierarchy() -> (BevyStepper, Entity, Entity, Entity) {
         let mut stepper = BevyStepper::default();

--- a/lightyear/src/shared/replication/mod.rs
+++ b/lightyear/src/shared/replication/mod.rs
@@ -1,27 +1,33 @@
 //! Module to handle replicating entities and components from server to client
-use bevy::ecs::entity::EntityHash;
-use std::fmt::Debug;
-use std::hash::Hash;
+use std::{fmt::Debug, hash::Hash};
 
-use bevy::prelude::{Entity, Resource};
-use bevy::utils::hashbrown::HashMap;
+use bevy::{
+    ecs::entity::EntityHash,
+    prelude::{Entity, Resource},
+    utils::hashbrown::HashMap,
+};
 use byteorder::{NetworkEndian, ReadBytesExt, WriteBytesExt};
 use bytes::Bytes;
 
-use crate::connection::id::ClientId;
-use crate::packet::message::MessageId;
-use crate::prelude::Tick;
-use crate::protocol::component::ComponentNetId;
-use crate::protocol::EventContext;
-use crate::serialize::reader::Reader;
-use crate::serialize::varint::{varint_len, VarIntReadExt, VarIntWriteExt};
-use crate::serialize::writer::Writer;
-use crate::serialize::{SerializationError, ToBytes};
-use crate::shared::events::connection::{
-    ClearEvents, IterComponentInsertEvent, IterComponentRemoveEvent, IterComponentUpdateEvent,
-    IterEntityDespawnEvent, IterEntitySpawnEvent,
+use crate::{
+    connection::id::ClientId,
+    packet::message::MessageId,
+    prelude::Tick,
+    protocol::{component::ComponentNetId, EventContext},
+    serialize::{
+        reader::Reader,
+        varint::{varint_len, VarIntReadExt, VarIntWriteExt},
+        writer::Writer,
+        SerializationError, ToBytes,
+    },
+    shared::{
+        events::connection::{
+            ClearEvents, IterComponentInsertEvent, IterComponentRemoveEvent,
+            IterComponentUpdateEvent, IterEntityDespawnEvent, IterEntitySpawnEvent,
+        },
+        replication::components::ReplicationGroupId,
+    },
 };
-use crate::shared::replication::components::ReplicationGroupId;
 
 pub mod components;
 

--- a/lightyear/src/shared/replication/network_target.rs
+++ b/lightyear/src/shared/replication/network_target.rs
@@ -1,10 +1,11 @@
-use crate::prelude::ClientId;
-use crate::serialize::reader::Reader;
-use crate::serialize::{SerializationError, ToBytes};
-use bevy::prelude::Reflect;
-use bevy::utils::HashSet;
+use bevy::{prelude::Reflect, utils::HashSet};
 use byteorder::{ReadBytesExt, WriteBytesExt};
 use serde::{Deserialize, Serialize};
+
+use crate::{
+    prelude::ClientId,
+    serialize::{reader::Reader, SerializationError, ToBytes},
+};
 
 #[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq, Reflect)]
 /// NetworkTarget indicated which clients should receive some message

--- a/lightyear/src/shared/replication/plugin.rs
+++ b/lightyear/src/shared/replication/plugin.rs
@@ -1,16 +1,16 @@
 //! This module contains the `ReplicationReceivePlugin` and `ReplicationSendPlugin` plugins, which control
 //! the replication of entities and resources.
 //!
-use crate::shared::replication::hierarchy::{HierarchyReceivePlugin, HierarchySendPlugin};
-use crate::shared::replication::resources::{
-    receive::ResourceReceivePlugin, send::ResourceSendPlugin,
+use bevy::{prelude::*, time::common_conditions::on_timer, utils::Duration};
+
+use crate::shared::{
+    replication::{
+        hierarchy::{HierarchyReceivePlugin, HierarchySendPlugin},
+        resources::{receive::ResourceReceivePlugin, send::ResourceSendPlugin},
+        systems, ReplicationReceive, ReplicationSend,
+    },
+    sets::{InternalMainSet, InternalReplicationSet, MainSet},
 };
-use crate::shared::replication::systems;
-use crate::shared::replication::{ReplicationReceive, ReplicationSend};
-use crate::shared::sets::{InternalMainSet, InternalReplicationSet, MainSet};
-use bevy::prelude::*;
-use bevy::time::common_conditions::on_timer;
-use bevy::utils::Duration;
 
 #[derive(Clone, Copy, Debug, Reflect)]
 pub struct ReplicationConfig {
@@ -241,20 +241,25 @@ pub(crate) mod send {
 }
 
 pub(crate) mod shared {
-    use crate::client::replication::send::ReplicateToServer;
-    use crate::prelude::{
-        NetworkRelevanceMode, PrePredicted, RemoteEntityMap, ReplicateHierarchy, Replicated,
-        ReplicationConfig, ReplicationGroup, ShouldBePredicted, TargetEntity,
-    };
-    use crate::server::replication::send::ReplicationTarget;
-    use crate::shared::replication::authority::{AuthorityPeer, HasAuthority};
-    use crate::shared::replication::components::{
-        Controlled, Replicating, ReplicationGroupId, ReplicationGroupIdBuilder,
-        ShouldBeInterpolated,
-    };
-    use crate::shared::replication::entity_map::{InterpolatedEntityMap, PredictedEntityMap};
-    use crate::shared::replication::network_target::NetworkTarget;
     use bevy::prelude::{App, Plugin};
+
+    use crate::{
+        client::replication::send::ReplicateToServer,
+        prelude::{
+            NetworkRelevanceMode, PrePredicted, RemoteEntityMap, ReplicateHierarchy, Replicated,
+            ReplicationConfig, ReplicationGroup, ShouldBePredicted, TargetEntity,
+        },
+        server::replication::send::ReplicationTarget,
+        shared::replication::{
+            authority::{AuthorityPeer, HasAuthority},
+            components::{
+                Controlled, Replicating, ReplicationGroupId, ReplicationGroupIdBuilder,
+                ShouldBeInterpolated,
+            },
+            entity_map::{InterpolatedEntityMap, PredictedEntityMap},
+            network_target::NetworkTarget,
+        },
+    };
 
     pub(crate) struct SharedPlugin;
 

--- a/lightyear/src/shared/replication/prespawn.rs
+++ b/lightyear/src/shared/replication/prespawn.rs
@@ -1,15 +1,21 @@
 //! Shared logic to handle prespawning entities
 
-use crate::prelude::{
-    ComponentRegistry, ParentSync, PrePredicted, PreSpawnedPlayerObject, ShouldBePredicted, Tick,
+use std::{
+    any::TypeId,
+    hash::{Hash, Hasher},
 };
-use crate::protocol::component::ComponentKind;
-use crate::shared::replication::components::{Controlled, ShouldBeInterpolated};
-use bevy::ecs::archetype::Archetype;
-use bevy::ecs::component::Components;
-use std::any::TypeId;
-use std::hash::{Hash, Hasher};
+
+use bevy::ecs::{archetype::Archetype, component::Components};
 use tracing::trace;
+
+use crate::{
+    prelude::{
+        ComponentRegistry, ParentSync, PrePredicted, PreSpawnedPlayerObject, ShouldBePredicted,
+        Tick,
+    },
+    protocol::component::ComponentKind,
+    shared::replication::components::{Controlled, ShouldBeInterpolated},
+};
 
 /// Compute the default PreSpawnedPlayerObject hash used to match server entities with prespawned client entities
 pub(crate) fn compute_default_hash(

--- a/lightyear/src/shared/replication/receive.rs
+++ b/lightyear/src/shared/replication/receive.rs
@@ -1,24 +1,31 @@
 //! General struct handling replication
 use std::collections::BTreeMap;
 
-use super::entity_map::RemoteEntityMap;
-use super::{EntityActionsMessage, EntityUpdatesMessage, SpawnAction};
-use crate::packet::message::MessageId;
-use crate::prelude::client::Confirmed;
-use crate::prelude::{ClientId, Tick};
-use crate::protocol::component::ComponentRegistry;
-use crate::serialize::reader::Reader;
-use crate::shared::events::connection::ConnectionEvents;
-use crate::shared::replication::authority::{AuthorityPeer, HasAuthority};
-use crate::shared::replication::components::{InitialReplicated, Replicated, ReplicationGroupId};
-#[cfg(test)]
-use crate::utils::captures::Captures;
-use bevy::ecs::entity::EntityHash;
-use bevy::prelude::{DespawnRecursiveExt, Entity, EntityWorldMut, World};
-use bevy::utils::{hashbrown, HashSet};
+use bevy::{
+    ecs::entity::EntityHash,
+    prelude::{DespawnRecursiveExt, Entity, EntityWorldMut, World},
+    utils::{hashbrown, HashSet},
+};
 use tracing::{debug, error, info, trace, warn};
 #[cfg(feature = "trace")]
 use tracing::{instrument, Level};
+
+use super::{entity_map::RemoteEntityMap, EntityActionsMessage, EntityUpdatesMessage, SpawnAction};
+#[cfg(test)]
+use crate::utils::captures::Captures;
+use crate::{
+    packet::message::MessageId,
+    prelude::{client::Confirmed, ClientId, Tick},
+    protocol::component::ComponentRegistry,
+    serialize::reader::Reader,
+    shared::{
+        events::connection::ConnectionEvents,
+        replication::{
+            authority::{AuthorityPeer, HasAuthority},
+            components::{InitialReplicated, Replicated, ReplicationGroupId},
+        },
+    },
+};
 
 type EntityHashMap<K, V> = hashbrown::HashMap<K, V, EntityHash>;
 
@@ -889,12 +896,17 @@ impl GroupChannel {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::prelude::ServerReplicate;
-    use crate::shared::replication::EntityActions;
-    use crate::tests::protocol::{ComponentSyncModeOnce, ComponentSyncModeSimple};
-    use crate::tests::stepper::BevyStepper;
     use bevy::prelude::{OnAdd, Query, Trigger, With};
+
+    use super::*;
+    use crate::{
+        prelude::ServerReplicate,
+        shared::replication::EntityActions,
+        tests::{
+            protocol::{ComponentSyncModeOnce, ComponentSyncModeSimple},
+            stepper::BevyStepper,
+        },
+    };
 
     /// Test that the UpdatesIterator works correctly, when we want to iterate through
     /// the buffered updates we have received

--- a/lightyear/src/shared/replication/resources.rs
+++ b/lightyear/src/shared/replication/resources.rs
@@ -2,18 +2,23 @@
 
 use std::marker::PhantomData;
 
-use bevy::app::App;
-use bevy::prelude::{
-    Commands, DetectChanges, IntoSystemConfigs, IntoSystemSetConfigs, Plugin, PostUpdate,
-    PreUpdate, Res, ResMut, Resource,
+use bevy::{
+    app::App,
+    prelude::{
+        Commands, DetectChanges, IntoSystemConfigs, IntoSystemSetConfigs, Plugin, PostUpdate,
+        PreUpdate, Res, ResMut, Resource,
+    },
 };
 pub use command::{ReplicateResourceExt, StopReplicateResourceExt};
 use serde::{Deserialize, Serialize};
 
-use crate::prelude::{ChannelKind, Message};
-use crate::shared::replication::network_target::NetworkTarget;
-use crate::shared::replication::ReplicationSend;
-use crate::shared::sets::{InternalMainSet, InternalReplicationSet};
+use crate::{
+    prelude::{ChannelKind, Message},
+    shared::{
+        replication::{network_target::NetworkTarget, ReplicationSend},
+        sets::{InternalMainSet, InternalReplicationSet},
+    },
+};
 
 mod command {
     use super::*;
@@ -76,12 +81,14 @@ impl<R> Default for DespawnResource<R> {
 }
 
 pub(crate) mod send {
-    use super::*;
-
-    use crate::connection::client::{ClientConnection, NetClient};
-    use crate::shared::message::MessageSend;
     use bevy::prelude::resource_removed;
     use tracing::trace;
+
+    use super::*;
+    use crate::{
+        connection::client::{ClientConnection, NetClient},
+        shared::message::MessageSend,
+    };
 
     pub(crate) struct ResourceSendPlugin<R> {
         _marker: PhantomData<R>,
@@ -180,14 +187,13 @@ pub(crate) mod send {
 }
 
 pub(crate) mod receive {
-    use crate::shared::events::message::ReceiveMessage;
-    use crate::shared::message::MessageSend;
-
-    use crate::shared::replication::ReplicationPeer;
     use bevy::prelude::{DetectChangesMut, EventReader, Events};
     use tracing::trace;
 
     use super::*;
+    use crate::shared::{
+        events::message::ReceiveMessage, message::MessageSend, replication::ReplicationPeer,
+    };
 
     pub(crate) struct ResourceReceivePlugin<R> {
         _marker: PhantomData<R>,
@@ -303,13 +309,17 @@ pub(crate) mod receive {
 
 #[cfg(test)]
 mod tests {
-    use super::StopReplicateResourceExt;
-    use crate::shared::replication::network_target::NetworkTarget;
-    use crate::shared::replication::resources::ReplicateResourceExt;
-    use crate::tests::host_server_stepper::HostServerStepper;
-    use crate::tests::protocol::{Channel1, Resource1, Resource2};
-    use crate::tests::stepper::BevyStepper;
     use bevy::prelude::*;
+
+    use super::StopReplicateResourceExt;
+    use crate::{
+        shared::replication::{network_target::NetworkTarget, resources::ReplicateResourceExt},
+        tests::{
+            host_server_stepper::HostServerStepper,
+            protocol::{Channel1, Resource1, Resource2},
+            stepper::BevyStepper,
+        },
+    };
 
     #[test]
     fn test_resource_replication_via_commands() {

--- a/lightyear/src/shared/replication/send.rs
+++ b/lightyear/src/shared/replication/send.rs
@@ -1,35 +1,36 @@
 //! General struct handling replication
 use std::iter::Extend;
 
-use crate::channel::builder::{EntityActionsChannel, EntityUpdatesChannel};
-use bevy::ecs::component::Tick as BevyTick;
-use bevy::ecs::entity::EntityHash;
-use bevy::prelude::Entity;
-use bevy::ptr::Ptr;
-use bevy::utils::{hashbrown, HashMap};
+use bevy::{
+    ecs::{component::Tick as BevyTick, entity::EntityHash},
+    prelude::Entity,
+    ptr::Ptr,
+    utils::{hashbrown, HashMap},
+};
 use bytes::Bytes;
 use crossbeam_channel::Receiver;
 use tracing::{debug, error, trace};
 #[cfg(feature = "trace")]
 use tracing::{instrument, Level};
-
-use super::{EntityActions, SendEntityActionsMessage, SendEntityUpdatesMessage, SpawnAction};
-use crate::packet::message::MessageId;
-use crate::packet::message_manager::MessageManager;
-use crate::prelude::{
-    ChannelKind, ComponentRegistry, PacketError, RemoteEntityMap, Tick, TimeManager,
-};
-use crate::protocol::component::{ComponentKind, ComponentNetId};
-use crate::serialize::writer::Writer;
-use crate::serialize::{SerializationError, ToBytes};
-use crate::shared::replication::components::ReplicationGroupId;
-use crate::shared::replication::delta::DeltaManager;
-use crate::shared::replication::error::ReplicationError;
-use crate::shared::replication::plugin::{ReplicationConfig, SendUpdatesMode};
 #[cfg(test)]
 use {
     super::{EntityActionsMessage, EntityUpdatesMessage},
     crate::utils::captures::Captures,
+};
+
+use super::{EntityActions, SendEntityActionsMessage, SendEntityUpdatesMessage, SpawnAction};
+use crate::{
+    channel::builder::{EntityActionsChannel, EntityUpdatesChannel},
+    packet::{message::MessageId, message_manager::MessageManager},
+    prelude::{ChannelKind, ComponentRegistry, PacketError, RemoteEntityMap, Tick, TimeManager},
+    protocol::component::{ComponentKind, ComponentNetId},
+    serialize::{writer::Writer, SerializationError, ToBytes},
+    shared::replication::{
+        components::ReplicationGroupId,
+        delta::DeltaManager,
+        error::ReplicationError,
+        plugin::{ReplicationConfig, SendUpdatesMode},
+    },
 };
 
 type EntityHashMap<K, V> = hashbrown::HashMap<K, V, EntityHash>;
@@ -857,15 +858,17 @@ impl Default for GroupChannel {
 
 #[cfg(test)]
 mod tests {
-    use crate::prelude::server::Replicate;
-    use crate::prelude::ClientId;
-    use crate::server::connection::ConnectionManager;
-
-    use crate::tests::protocol::ComponentSyncModeFull;
-    use crate::tests::stepper::{BevyStepper, TEST_CLIENT_ID};
     use bevy::prelude::*;
 
     use super::*;
+    use crate::{
+        prelude::{server::Replicate, ClientId},
+        server::connection::ConnectionManager,
+        tests::{
+            protocol::ComponentSyncModeFull,
+            stepper::{BevyStepper, TEST_CLIENT_ID},
+        },
+    };
 
     #[test]
     fn test_delta_compression() {

--- a/lightyear/src/shared/replication/systems.rs
+++ b/lightyear/src/shared/replication/systems.rs
@@ -2,8 +2,10 @@
 
 use bevy::prelude::{Res, ResMut};
 
-use crate::prelude::TickManager;
-use crate::shared::replication::{ReplicationReceive, ReplicationSend};
+use crate::{
+    prelude::TickManager,
+    shared::replication::{ReplicationReceive, ReplicationSend},
+};
 
 /// Systems that runs internal clean-up on the ReplicationSender
 /// (handle tick wrapping, etc.)

--- a/lightyear/src/shared/replication/utils.rs
+++ b/lightyear/src/shared/replication/utils.rs
@@ -1,12 +1,17 @@
-use bevy::ecs::component::{ComponentId, StorageType, Tick, TickCells};
-use bevy::ecs::entity::EntityLocation;
-use bevy::ecs::world::unsafe_world_cell::UnsafeWorldCell;
-use bevy::prelude::*;
-#[allow(unused_imports)]
-use bevy::ptr::{Ptr, UnsafeCellDeref};
 use std::any::TypeId;
 #[cfg(feature = "track_change_detection")]
 use std::{cell::UnsafeCell, panic::Location};
+
+#[allow(unused_imports)]
+use bevy::ptr::{Ptr, UnsafeCellDeref};
+use bevy::{
+    ecs::{
+        component::{ComponentId, StorageType, Tick, TickCells},
+        entity::EntityLocation,
+        world::unsafe_world_cell::UnsafeWorldCell,
+    },
+    prelude::*,
+};
 
 #[cfg(feature = "track_change_detection")]
 pub(crate) type MaybeUnsafeCellLocation<'a> = &'a UnsafeCell<&'static Location<'static>>;

--- a/lightyear/src/shared/run_conditions.rs
+++ b/lightyear/src/shared/run_conditions.rs
@@ -1,6 +1,7 @@
 //! Common run conditions
-use crate::shared::identity::NetworkIdentityState;
 use bevy::prelude::{Res, State};
+
+use crate::shared::identity::NetworkIdentityState;
 
 /// Returns true if the peer is a client (host-server counts as a server)
 pub fn is_client(identity: Option<Res<State<NetworkIdentityState>>>) -> bool {

--- a/lightyear/src/shared/tick_manager.rs
+++ b/lightyear/src/shared/tick_manager.rs
@@ -1,12 +1,12 @@
 //! Module to handle the [`Tick`], a sequence number incremented at each [`bevy::prelude::FixedUpdate`] schedule run
-use bevy::prelude::*;
-use bevy::utils::Duration;
+use bevy::{prelude::*, utils::Duration};
 use tracing::trace;
 
-use crate::client::prediction::plugin::is_in_rollback;
-use crate::client::prediction::rollback::Rollback;
-use crate::prelude::FixedUpdateSet;
-use crate::utils::wrapping_id::wrapping_id;
+use crate::{
+    client::prediction::{plugin::is_in_rollback, rollback::Rollback},
+    prelude::FixedUpdateSet,
+    utils::wrapping_id::wrapping_id,
+};
 
 // Internal id that tracks the Tick value for the server and the client
 wrapping_id!(Tick);

--- a/lightyear/src/shared/time_manager.rs
+++ b/lightyear/src/shared/time_manager.rs
@@ -9,16 +9,18 @@ It will interact with bevy's [`Time`] resource, and potentially change the relat
 The network serialization uses a u32 which can only represent times up to 46 days.
 This module contains some helper functions to compute the difference between two times.
 */
-use std::fmt::Formatter;
-use std::ops::{Add, AddAssign, Mul, Sub, SubAssign};
+use std::{
+    fmt::Formatter,
+    ops::{Add, AddAssign, Mul, Sub, SubAssign},
+};
 
-use bevy::app::{App, RunFixedMainLoop, RunFixedMainLoopSystem};
-use bevy::prelude::{IntoSystemConfigs, Plugin, Res, ResMut, Resource, Time};
-use bevy::time::Fixed;
-use bevy::utils::Duration;
-use bevy::utils::Instant;
+use bevy::{
+    app::{App, RunFixedMainLoop, RunFixedMainLoopSystem},
+    prelude::{IntoSystemConfigs, Plugin, Res, ResMut, Resource, Time},
+    time::Fixed,
+    utils::{Duration, Instant},
+};
 use chrono::Duration as ChronoDuration;
-
 pub use wrapped_time::WrappedTime;
 
 use crate::prelude::Tick;
@@ -143,8 +145,6 @@ impl TimeManager {
 }
 
 mod wrapped_time {
-    use crate::serialize::reader::Reader;
-    use crate::serialize::{SerializationError, ToBytes};
     use byteorder::{NetworkEndian, ReadBytesExt, WriteBytesExt};
     use serde::{
         de::{Error, Visitor},
@@ -152,6 +152,7 @@ mod wrapped_time {
     };
 
     use super::*;
+    use crate::serialize::{reader::Reader, SerializationError, ToBytes};
 
     /// Time since start of server, in milliseconds
     /// Serializes in a compact manner (we only serialize up to the milliseconds)

--- a/lightyear/src/tests/host_server_stepper.rs
+++ b/lightyear/src/tests/host_server_stepper.rs
@@ -1,20 +1,27 @@
 //! Stepper to run tests in host-server mode (client and server are in the same app)
 
-use crate::client::networking::ClientCommandsExt;
-use crate::connection::netcode::generate_key;
-use crate::prelude::client::{Authentication, ClientConfig, ClientTransport, NetConfig};
-use crate::prelude::server::{NetcodeConfig, ServerCommandsExt, ServerConfig, ServerTransport};
-use crate::prelude::*;
-use crate::shared::time_manager::WrappedTime;
-use crate::tests::protocol::*;
-use crate::transport::LOCAL_SOCKET;
-use bevy::ecs::system::RunSystemOnce;
-use bevy::input::InputPlugin;
-use bevy::prelude::{default, App, Commands, Mut, Real, Time, World};
-use bevy::state::app::StatesPlugin;
-use bevy::time::TimeUpdateStrategy;
-use bevy::utils::Duration;
-use bevy::MinimalPlugins;
+use bevy::{
+    ecs::system::RunSystemOnce,
+    input::InputPlugin,
+    prelude::{default, App, Commands, Mut, Real, Time, World},
+    state::app::StatesPlugin,
+    time::TimeUpdateStrategy,
+    utils::Duration,
+    MinimalPlugins,
+};
+
+use crate::{
+    client::networking::ClientCommandsExt,
+    connection::netcode::generate_key,
+    prelude::{
+        client::{Authentication, ClientConfig, ClientTransport, NetConfig},
+        server::{NetcodeConfig, ServerCommandsExt, ServerConfig, ServerTransport},
+        *,
+    },
+    shared::time_manager::WrappedTime,
+    tests::protocol::*,
+    transport::LOCAL_SOCKET,
+};
 
 pub const LOCAL_CLIENT_ID: u64 = 111;
 pub const EXTERNAL_CLIENT_ID: u64 = 112;

--- a/lightyear/src/tests/integration/multi_transport.rs
+++ b/lightyear/src/tests/integration/multi_transport.rs
@@ -1,10 +1,14 @@
 //! Tests related to the server using multiple transports at the same time to connect to clients
-use crate::client::sync::SyncConfig;
-use crate::prelude::client::{InterpolationConfig, PredictionConfig};
-use crate::prelude::{SharedConfig, TickConfig};
-use crate::tests::multi_stepper::MultiBevyStepper;
-use bevy::prelude::*;
-use bevy::utils::Duration;
+use bevy::{prelude::*, utils::Duration};
+
+use crate::{
+    client::sync::SyncConfig,
+    prelude::{
+        client::{InterpolationConfig, PredictionConfig},
+        SharedConfig, TickConfig,
+    },
+    tests::multi_stepper::MultiBevyStepper,
+};
 
 #[test]
 fn test_multi_transport() {

--- a/lightyear/src/tests/integration/tick_wrapping.rs
+++ b/lightyear/src/tests/integration/tick_wrapping.rs
@@ -1,10 +1,10 @@
-use crate::prelude::server::Replicate;
-use crate::prelude::*;
-use crate::shared::time_manager::WrappedTime;
-use crate::tests::protocol::*;
-use crate::tests::stepper::BevyStepper;
-use bevy::prelude::*;
-use bevy::utils::Duration;
+use bevy::{prelude::*, utils::Duration};
+
+use crate::{
+    prelude::{server::Replicate, *},
+    shared::time_manager::WrappedTime,
+    tests::{protocol::*, stepper::BevyStepper},
+};
 
 /// This test checks that replication still works if the client connect when the server
 /// is on a new tick generation

--- a/lightyear/src/tests/multi_stepper.rs
+++ b/lightyear/src/tests/multi_stepper.rs
@@ -1,20 +1,26 @@
 //! Tests related to the server using multiple transports at the same time to connect to clients
-use crate::client::networking::ClientCommandsExt;
-use bevy::prelude::{default, App, PluginGroup, Real, Time};
-use bevy::state::app::StatesPlugin;
-use bevy::time::TimeUpdateStrategy;
-use bevy::utils::Duration;
-use bevy::MinimalPlugins;
-
-use crate::connection::netcode::generate_key;
-use crate::prelude::client::{
-    Authentication, ClientConfig, ClientTransport, InterpolationConfig, NetClient, NetConfig,
-    PredictionConfig, SyncConfig,
+use bevy::{
+    prelude::{default, App, PluginGroup, Real, Time},
+    state::app::StatesPlugin,
+    time::TimeUpdateStrategy,
+    utils::Duration,
+    MinimalPlugins,
 };
-use crate::prelude::server::{NetcodeConfig, ServerCommandsExt, ServerConfig, ServerTransport};
-use crate::prelude::*;
-use crate::tests::protocol::*;
-use crate::transport::LOCAL_SOCKET;
+
+use crate::{
+    client::networking::ClientCommandsExt,
+    connection::netcode::generate_key,
+    prelude::{
+        client::{
+            Authentication, ClientConfig, ClientTransport, InterpolationConfig, NetClient,
+            NetConfig, PredictionConfig, SyncConfig,
+        },
+        server::{NetcodeConfig, ServerCommandsExt, ServerConfig, ServerTransport},
+        *,
+    },
+    tests::protocol::*,
+    transport::LOCAL_SOCKET,
+};
 
 pub(crate) const TEST_CLIENT_ID_1: u64 = 1;
 pub(crate) const TEST_CLIENT_ID_2: u64 = 2;

--- a/lightyear/src/tests/protocol.rs
+++ b/lightyear/src/tests/protocol.rs
@@ -1,25 +1,26 @@
 use std::ops::{Add, Mul};
 
-use bevy::app::{App, Plugin};
-use bevy::ecs::entity::{MapEntities, VisitEntities, VisitEntitiesMut};
-use bevy::prelude::{default, Component, Entity, EntityMapper, Event, Reflect, Resource};
-use bevy::utils::HashSet;
+use bevy::{
+    app::{App, Plugin},
+    ecs::entity::{MapEntities, VisitEntities, VisitEntitiesMut},
+    prelude::{default, Component, Entity, EntityMapper, Event, Reflect, Resource},
+    utils::HashSet,
+};
 use byteorder::{NetworkEndian, ReadBytesExt, WriteBytesExt};
 use cfg_if::cfg_if;
 use lightyear_macros::ChannelInternal;
 use serde::{Deserialize, Serialize};
 
-use crate::client::components::ComponentSyncMode;
-use crate::prelude::*;
-use crate::protocol::message::registry::AppMessageExt;
-use crate::protocol::message::resource::AppResourceExt;
-use crate::protocol::message::trigger::AppTriggerExt;
-use crate::protocol::serialize::SerializeFns;
-use crate::serialize::reader::Reader;
-use crate::serialize::writer::Writer;
-use crate::serialize::SerializationError;
-use crate::shared::input::InputConfig;
-use crate::shared::replication::delta::Diffable;
+use crate::{
+    client::components::ComponentSyncMode,
+    prelude::*,
+    protocol::{
+        message::{registry::AppMessageExt, resource::AppResourceExt, trigger::AppTriggerExt},
+        serialize::SerializeFns,
+    },
+    serialize::{reader::Reader, writer::Writer, SerializationError},
+    shared::{input::InputConfig, replication::delta::Diffable},
+};
 
 // Event
 #[derive(Event, Serialize, Deserialize, Debug, PartialEq, Clone, Reflect)]

--- a/lightyear/src/tests/stepper.rs
+++ b/lightyear/src/tests/stepper.rs
@@ -1,19 +1,24 @@
-use crate::client::networking::ClientCommandsExt;
-use crate::connection::netcode::generate_key;
-use crate::prelude::client::{
-    Authentication, ClientConfig, ClientTransport, NetConfig, NetworkingState,
+use bevy::{
+    input::InputPlugin,
+    prelude::{default, App, Mut, PluginGroup, Real, State, Time, World},
+    state::app::StatesPlugin,
+    time::TimeUpdateStrategy,
+    utils::Duration,
+    MinimalPlugins,
 };
-use crate::prelude::server::{NetcodeConfig, ServerCommandsExt, ServerConfig, ServerTransport};
-use crate::prelude::*;
-use crate::shared::time_manager::WrappedTime;
-use crate::tests::protocol::*;
-use crate::transport::LOCAL_SOCKET;
-use bevy::input::InputPlugin;
-use bevy::prelude::{default, App, Mut, PluginGroup, Real, State, Time, World};
-use bevy::state::app::StatesPlugin;
-use bevy::time::TimeUpdateStrategy;
-use bevy::utils::Duration;
-use bevy::MinimalPlugins;
+
+use crate::{
+    client::networking::ClientCommandsExt,
+    connection::netcode::generate_key,
+    prelude::{
+        client::{Authentication, ClientConfig, ClientTransport, NetConfig, NetworkingState},
+        server::{NetcodeConfig, ServerCommandsExt, ServerConfig, ServerTransport},
+        *,
+    },
+    shared::time_manager::WrappedTime,
+    tests::protocol::*,
+    transport::LOCAL_SOCKET,
+};
 
 pub const TEST_CLIENT_ID: u64 = 111;
 

--- a/lightyear/src/transport/channels.rs
+++ b/lightyear/src/transport/channels.rs
@@ -7,14 +7,17 @@ use crossbeam_channel::{Receiver, Select, Sender};
 use self_cell::self_cell;
 use tracing::debug;
 
-use crate::server::io::transport::{ServerTransportBuilder, ServerTransportEnum};
-use crate::server::io::{ServerIoEventReceiver, ServerNetworkEventSender};
-use crate::transport::io::IoState;
-use crate::transport::{
-    BoxedReceiver, BoxedSender, PacketReceiver, PacketSender, Transport, LOCAL_SOCKET,
-};
-
 use super::error::{Error, Result};
+use crate::{
+    server::io::{
+        transport::{ServerTransportBuilder, ServerTransportEnum},
+        ServerIoEventReceiver, ServerNetworkEventSender,
+    },
+    transport::{
+        io::IoState, BoxedReceiver, BoxedSender, PacketReceiver, PacketSender, Transport,
+        LOCAL_SOCKET,
+    },
+};
 
 pub struct Channels {
     sender: ChannelsSender,

--- a/lightyear/src/transport/config.rs
+++ b/lightyear/src/transport/config.rs
@@ -1,6 +1,8 @@
-use crate::transport::middleware::compression::CompressionConfig;
-use crate::transport::middleware::conditioner::LinkConditionerConfig;
 use bevy::prelude::Reflect;
+
+use crate::transport::middleware::{
+    compression::CompressionConfig, conditioner::LinkConditionerConfig,
+};
 
 #[derive(Clone, Debug, Default, Reflect)]
 #[reflect(from_reflect = false)]

--- a/lightyear/src/transport/dummy.rs
+++ b/lightyear/src/transport/dummy.rs
@@ -1,15 +1,21 @@
 //! Dummy io for connections that provide their own way of sending and receiving raw bytes (for example steamworks).
-use crate::client::io::transport::{ClientTransportBuilder, ClientTransportEnum};
-use crate::client::io::{ClientIoEventReceiver, ClientNetworkEventSender};
-use crate::server::io::transport::{ServerTransportBuilder, ServerTransportEnum};
-use crate::server::io::{ServerIoEventReceiver, ServerNetworkEventSender};
-use crate::transport::io::IoState;
-use crate::transport::{
-    BoxedReceiver, BoxedSender, PacketReceiver, PacketSender, Transport, LOCAL_SOCKET,
-};
 use std::net::SocketAddr;
 
 use super::error::Result;
+use crate::{
+    client::io::{
+        transport::{ClientTransportBuilder, ClientTransportEnum},
+        ClientIoEventReceiver, ClientNetworkEventSender,
+    },
+    server::io::{
+        transport::{ServerTransportBuilder, ServerTransportEnum},
+        ServerIoEventReceiver, ServerNetworkEventSender,
+    },
+    transport::{
+        io::IoState, BoxedReceiver, BoxedSender, PacketReceiver, PacketSender, Transport,
+        LOCAL_SOCKET,
+    },
+};
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DummyIo;

--- a/lightyear/src/transport/io.rs
+++ b/lightyear/src/transport/io.rs
@@ -1,17 +1,19 @@
 //! Wrapper around a transport, that can perform additional transformations such as
 //! bandwidth monitoring or compression
-use std::fmt::{Debug, Formatter};
-use std::net::SocketAddr;
+use std::{
+    fmt::{Debug, Formatter},
+    net::SocketAddr,
+};
 
-use bevy::diagnostic::{Diagnostic, DiagnosticPath, Diagnostics, RegisterDiagnostic};
-use bevy::prelude::*;
+use bevy::{
+    diagnostic::{Diagnostic, DiagnosticPath, Diagnostics, RegisterDiagnostic},
+    prelude::*,
+};
 #[cfg(feature = "metrics")]
 use metrics;
 
+use super::{error::Result, BoxedReceiver, BoxedSender};
 use crate::transport::{PacketReceiver, PacketSender};
-
-use super::error::Result;
-use super::{BoxedReceiver, BoxedSender};
 
 /// Connected io layer that can send/receive bytes
 #[derive(Resource)]

--- a/lightyear/src/transport/local.rs
+++ b/lightyear/src/transport/local.rs
@@ -4,14 +4,17 @@ use std::net::SocketAddr;
 
 use crossbeam_channel::{Receiver, Sender};
 
-use crate::client::io::transport::{ClientTransportBuilder, ClientTransportEnum};
-use crate::client::io::{ClientIoEventReceiver, ClientNetworkEventSender};
-use crate::transport::io::IoState;
-use crate::transport::{
-    BoxedReceiver, BoxedSender, PacketReceiver, PacketSender, Transport, LOCAL_SOCKET,
-};
-
 use super::error::{Error, Result};
+use crate::{
+    client::io::{
+        transport::{ClientTransportBuilder, ClientTransportEnum},
+        ClientIoEventReceiver, ClientNetworkEventSender,
+    },
+    transport::{
+        io::IoState, BoxedReceiver, BoxedSender, PacketReceiver, PacketSender, Transport,
+        LOCAL_SOCKET,
+    },
+};
 
 // TODO: this is client only; separate client/server transport traits
 pub(crate) struct LocalChannelBuilder {

--- a/lightyear/src/transport/middleware/compression/lz4.rs
+++ b/lightyear/src/transport/middleware/compression/lz4.rs
@@ -1,18 +1,21 @@
 //! Zstd compression
 
-use crate::connection::netcode::MAX_PKT_BUF_SIZE;
-use crate::transport::error::{Error, Result};
 use std::net::SocketAddr;
 
 pub(crate) use compression::Compressor;
 pub(crate) use decompression::Decompressor;
 
+use crate::{
+    connection::netcode::MAX_PKT_BUF_SIZE,
+    transport::error::{Error, Result},
+};
+
 pub(crate) mod compression {
-    use super::*;
-    use crate::transport::middleware::PacketSenderWrapper;
-    use crate::transport::PacketSender;
     use lz4_flex::block::compress_into;
     use tracing::error;
+
+    use super::*;
+    use crate::transport::{middleware::PacketSenderWrapper, PacketSender};
 
     pub(crate) struct Compressor {
         result: Vec<u8>,
@@ -63,10 +66,10 @@ pub(crate) mod compression {
 }
 
 pub(crate) mod decompression {
-    use super::*;
-    use crate::transport::middleware::PacketReceiverWrapper;
-    use crate::transport::PacketReceiver;
     use lz4_flex::block::decompress_into;
+
+    use super::*;
+    use crate::transport::{middleware::PacketReceiverWrapper, PacketReceiver};
 
     pub(crate) struct Decompressor {
         result: Vec<u8>,
@@ -116,10 +119,12 @@ pub(crate) mod decompression {
 
 #[cfg(test)]
 mod tests {
-    use crate::client::io::config::ClientTransport;
-    use crate::transport::config::SharedIoConfig;
-    use crate::transport::middleware::compression::CompressionConfig;
-    use crate::transport::LOCAL_SOCKET;
+    use crate::{
+        client::io::config::ClientTransport,
+        transport::{
+            config::SharedIoConfig, middleware::compression::CompressionConfig, LOCAL_SOCKET,
+        },
+    };
 
     #[test]
     fn test_compression() {

--- a/lightyear/src/transport/middleware/compression/zstd.rs
+++ b/lightyear/src/transport/middleware/compression/zstd.rs
@@ -1,14 +1,17 @@
 //! Zstd compression
 
-use crate::connection::netcode::MAX_PKT_BUF_SIZE;
-use crate::transport::error::{Error, Result};
 use std::net::SocketAddr;
 
+use crate::{
+    connection::netcode::MAX_PKT_BUF_SIZE,
+    transport::error::{Error, Result},
+};
+
 pub(crate) mod compression {
-    use super::*;
-    use crate::transport::middleware::PacketSenderWrapper;
-    use crate::transport::PacketSender;
     use zstd::bulk::Compressor;
+
+    use super::*;
+    use crate::transport::{middleware::PacketSenderWrapper, PacketSender};
 
     pub(crate) struct ZstdCompressor {
         result: Vec<u8>,
@@ -54,10 +57,10 @@ pub(crate) mod compression {
 }
 
 pub(crate) mod decompression {
-    use super::*;
-    use crate::transport::middleware::PacketReceiverWrapper;
-    use crate::transport::PacketReceiver;
     use zstd::bulk::Decompressor;
+
+    use super::*;
+    use crate::transport::{middleware::PacketReceiverWrapper, PacketReceiver};
 
     pub(crate) struct ZstdDecompressor {
         result: Vec<u8>,
@@ -108,9 +111,10 @@ pub(crate) mod decompression {
 
 #[cfg(test)]
 mod tests {
-    use crate::prelude::{SharedIoConfig, TransportConfig};
-    use crate::transport::middleware::compression::CompressionConfig;
-    use crate::transport::LOCAL_SOCKET;
+    use crate::{
+        prelude::{SharedIoConfig, TransportConfig},
+        transport::{middleware::compression::CompressionConfig, LOCAL_SOCKET},
+    };
 
     #[test]
     fn test_compression() {

--- a/lightyear/src/transport/middleware/conditioner.rs
+++ b/lightyear/src/transport/middleware/conditioner.rs
@@ -1,16 +1,14 @@
 //! Contains the `LinkConditioner` struct which can be used to simulate network conditions
-use bevy::reflect::Reflect;
 use std::net::SocketAddr;
 
-use bevy::utils::Duration;
+use bevy::{reflect::Reflect, utils::Duration};
 use cfg_if::cfg_if;
-use rand;
-use rand::{thread_rng, Rng};
+use rand::{self, thread_rng, Rng};
 
-use crate::transport::error::Result;
-use crate::transport::middleware::PacketReceiverWrapper;
-use crate::transport::PacketReceiver;
-use crate::utils::ready_buffer::ReadyBuffer;
+use crate::{
+    transport::{error::Result, middleware::PacketReceiverWrapper, PacketReceiver},
+    utils::ready_buffer::ReadyBuffer,
+};
 
 cfg_if! {
     if #[cfg(test)] {

--- a/lightyear/src/transport/mod.rs
+++ b/lightyear/src/transport/mod.rs
@@ -4,16 +4,10 @@
 use std::net::SocketAddr;
 
 use enum_dispatch::enum_dispatch;
-
 use error::Result;
 
 // required import for enum dispatch to work
 use crate::client::io::transport::ClientTransportEnum;
-use crate::server::io::transport::ServerTransportEnum;
-use crate::transport::channels::Channels;
-use crate::transport::dummy::DummyIo;
-use crate::transport::local::LocalChannel;
-use crate::transport::udp::UdpSocket;
 #[cfg(feature = "websocket")]
 use crate::transport::websocket::client::{WebSocketClientSocket, WebSocketClientSocketBuilder};
 #[cfg(all(feature = "websocket", not(target_family = "wasm")))]
@@ -25,6 +19,10 @@ use crate::transport::webtransport::client::{
 #[cfg(all(feature = "webtransport", not(target_family = "wasm")))]
 use crate::transport::webtransport::server::{
     WebTransportServerSocket, WebTransportServerSocketBuilder,
+};
+use crate::{
+    server::io::transport::ServerTransportEnum,
+    transport::{channels::Channels, dummy::DummyIo, local::LocalChannel, udp::UdpSocket},
 };
 
 /// io is a wrapper around the underlying transport layer

--- a/lightyear/src/transport/udp.rs
+++ b/lightyear/src/transport/udp.rs
@@ -1,15 +1,23 @@
 //! The transport is a UDP socket
-use std::net::SocketAddr;
-use std::sync::{Arc, Mutex};
-
-use crate::client::io::transport::{ClientTransportBuilder, ClientTransportEnum};
-use crate::client::io::{ClientIoEventReceiver, ClientNetworkEventSender};
-use crate::server::io::transport::{ServerTransportBuilder, ServerTransportEnum};
-use crate::server::io::{ServerIoEventReceiver, ServerNetworkEventSender};
-use crate::transport::io::IoState;
-use crate::transport::{BoxedReceiver, BoxedSender, PacketReceiver, PacketSender, Transport, MTU};
+use std::{
+    net::SocketAddr,
+    sync::{Arc, Mutex},
+};
 
 use super::error::Result;
+use crate::{
+    client::io::{
+        transport::{ClientTransportBuilder, ClientTransportEnum},
+        ClientIoEventReceiver, ClientNetworkEventSender,
+    },
+    server::io::{
+        transport::{ServerTransportBuilder, ServerTransportEnum},
+        ServerIoEventReceiver, ServerNetworkEventSender,
+    },
+    transport::{
+        io::IoState, BoxedReceiver, BoxedSender, PacketReceiver, PacketSender, Transport, MTU,
+    },
+};
 
 pub struct UdpSocketBuilder {
     pub(crate) local_addr: SocketAddr,
@@ -131,17 +139,22 @@ impl PacketReceiver for UdpSocketBuffer {
 #[cfg(not(target_family = "wasm"))]
 #[cfg(test)]
 mod tests {
-    use std::net::SocketAddr;
-    use std::str::FromStr;
+    use std::{net::SocketAddr, str::FromStr};
 
-    use crate::client::io::transport::ClientTransportBuilder;
-    use crate::server::io::transport::ServerTransportBuilder;
     use bevy::utils::Duration;
 
-    use crate::transport::middleware::conditioner::{LinkConditioner, LinkConditionerConfig};
-    use crate::transport::middleware::PacketReceiverWrapper;
-    use crate::transport::udp::UdpSocketBuilder;
-    use crate::transport::{PacketReceiver, PacketSender, Transport};
+    use crate::{
+        client::io::transport::ClientTransportBuilder,
+        server::io::transport::ServerTransportBuilder,
+        transport::{
+            middleware::{
+                conditioner::{LinkConditioner, LinkConditionerConfig},
+                PacketReceiverWrapper,
+            },
+            udp::UdpSocketBuilder,
+            PacketReceiver, PacketSender, Transport,
+        },
+    };
 
     #[test]
     fn test_udp_socket() {

--- a/lightyear/src/transport/websocket/client_native.rs
+++ b/lightyear/src/transport/websocket/client_native.rs
@@ -1,16 +1,21 @@
-use std::ops::Deref;
 use std::{
     future::Future,
     io::BufReader,
     net::{SocketAddr, SocketAddrV4},
+    ops::Deref,
     sync::Arc,
 };
 
 use async_compat::Compat;
-use bevy::tasks::{futures_lite, IoTaskPool};
-use bevy::utils::hashbrown::HashMap;
-use futures_util::stream::FusedStream;
-use futures_util::{future, pin_mut, stream::TryStreamExt, SinkExt, StreamExt, TryFutureExt};
+use bevy::{
+    tasks::{futures_lite, IoTaskPool},
+    utils::hashbrown::HashMap,
+};
+use futures_util::{
+    future, pin_mut,
+    stream::{FusedStream, TryStreamExt},
+    SinkExt, StreamExt, TryFutureExt,
+};
 use tokio::{
     net::{TcpListener, TcpStream},
     sync::{
@@ -27,12 +32,16 @@ use tokio_tungstenite::{
 use tracing::{debug, info, trace};
 use tracing_log::log::error;
 
-use crate::client::io::transport::{ClientTransportBuilder, ClientTransportEnum};
-use crate::client::io::{ClientIoEvent, ClientIoEventReceiver, ClientNetworkEventSender};
-use crate::transport::error::{Error, Result};
-use crate::transport::io::IoState;
-use crate::transport::{
-    BoxedReceiver, BoxedSender, PacketReceiver, PacketSender, Transport, LOCAL_SOCKET, MTU,
+use crate::{
+    client::io::{
+        transport::{ClientTransportBuilder, ClientTransportEnum},
+        ClientIoEvent, ClientIoEventReceiver, ClientNetworkEventSender,
+    },
+    transport::{
+        error::{Error, Result},
+        io::IoState,
+        BoxedReceiver, BoxedSender, PacketReceiver, PacketSender, Transport, LOCAL_SOCKET, MTU,
+    },
 };
 
 pub(crate) struct WebSocketClientSocketBuilder {

--- a/lightyear/src/transport/websocket/client_wasm.rs
+++ b/lightyear/src/transport/websocket/client_wasm.rs
@@ -17,12 +17,16 @@ use web_sys::{
     BinaryType, CloseEvent, ErrorEvent, MessageEvent, WebSocket,
 };
 
-use crate::client::io::transport::{ClientTransportBuilder, ClientTransportEnum};
-use crate::client::io::{ClientIoEventReceiver, ClientNetworkEventSender};
-use crate::transport::error::{Error, Result};
-use crate::transport::io::IoState;
-use crate::transport::{
-    BoxedReceiver, BoxedSender, PacketReceiver, PacketSender, Transport, LOCAL_SOCKET, MTU,
+use crate::{
+    client::io::{
+        transport::{ClientTransportBuilder, ClientTransportEnum},
+        ClientIoEventReceiver, ClientNetworkEventSender,
+    },
+    transport::{
+        error::{Error, Result},
+        io::IoState,
+        BoxedReceiver, BoxedSender, PacketReceiver, PacketSender, Transport, LOCAL_SOCKET, MTU,
+    },
 };
 
 pub(crate) struct WebSocketClientSocketBuilder {

--- a/lightyear/src/transport/websocket/server.rs
+++ b/lightyear/src/transport/websocket/server.rs
@@ -4,27 +4,37 @@ use std::{
 };
 
 use async_compat::Compat;
-use bevy::tasks::{futures_lite, IoTaskPool};
-use bevy::utils::HashMap;
+use bevy::{
+    tasks::{futures_lite, IoTaskPool},
+    utils::HashMap,
+};
 use futures_util::{
     future, pin_mut,
     stream::{SplitSink, TryStreamExt},
     SinkExt, StreamExt, TryFutureExt,
 };
-use tokio::sync::mpsc;
 use tokio::{
     net::{TcpListener, TcpStream},
-    sync::mpsc::{error::TryRecvError, unbounded_channel, UnboundedReceiver, UnboundedSender},
+    sync::{
+        mpsc,
+        mpsc::{error::TryRecvError, unbounded_channel, UnboundedReceiver, UnboundedSender},
+    },
 };
 use tokio_tungstenite::{tungstenite::Message, WebSocketStream};
 use tracing::{debug, info, trace};
 use tracing_log::log::error;
 
-use crate::server::io::transport::{ServerTransportBuilder, ServerTransportEnum};
-use crate::server::io::{ServerIoEvent, ServerIoEventReceiver, ServerNetworkEventSender};
-use crate::transport::error::{Error, Result};
-use crate::transport::io::IoState;
-use crate::transport::{BoxedReceiver, BoxedSender, PacketReceiver, PacketSender, Transport, MTU};
+use crate::{
+    server::io::{
+        transport::{ServerTransportBuilder, ServerTransportEnum},
+        ServerIoEvent, ServerIoEventReceiver, ServerNetworkEventSender,
+    },
+    transport::{
+        error::{Error, Result},
+        io::IoState,
+        BoxedReceiver, BoxedSender, PacketReceiver, PacketSender, Transport, MTU,
+    },
+};
 
 pub(crate) struct WebSocketServerSocketBuilder {
     pub(crate) server_addr: SocketAddr,

--- a/lightyear/src/transport/webtransport/client_native.rs
+++ b/lightyear/src/transport/webtransport/client_native.rs
@@ -1,24 +1,23 @@
 #![cfg(not(target_family = "wasm"))]
 //! WebTransport client implementation.
-use std::net::SocketAddr;
-use std::sync::Arc;
+use std::{net::SocketAddr, sync::Arc};
 
 use async_compat::Compat;
 use bevy::tasks::IoTaskPool;
-use tokio::sync::mpsc;
-use tokio::sync::mpsc::error::TryRecvError;
+use tokio::sync::{mpsc, mpsc::error::TryRecvError};
 use tracing::{debug, error, info, trace};
-use wtransport;
-use wtransport::datagram::Datagram;
-use wtransport::error::ConnectingError;
-use wtransport::ClientConfig;
+use wtransport::{self, datagram::Datagram, error::ConnectingError, ClientConfig};
 
-use crate::client::io::transport::{ClientTransportBuilder, ClientTransportEnum};
-use crate::client::io::{ClientIoEvent, ClientIoEventReceiver, ClientNetworkEventSender};
-use crate::transport::error::{Error, Result};
-use crate::transport::io::IoState;
-use crate::transport::{
-    BoxedReceiver, BoxedSender, PacketReceiver, PacketSender, Transport, MIN_MTU, MTU,
+use crate::{
+    client::io::{
+        transport::{ClientTransportBuilder, ClientTransportEnum},
+        ClientIoEvent, ClientIoEventReceiver, ClientNetworkEventSender,
+    },
+    transport::{
+        error::{Error, Result},
+        io::IoState,
+        BoxedReceiver, BoxedSender, PacketReceiver, PacketSender, Transport, MIN_MTU, MTU,
+    },
 };
 
 pub(crate) struct WebTransportClientSocketBuilder {

--- a/lightyear/src/transport/webtransport/client_wasm.rs
+++ b/lightyear/src/transport/webtransport/client_wasm.rs
@@ -1,22 +1,27 @@
 #![cfg(target_family = "wasm")]
 //! WebTransport client implementation.
-use std::net::SocketAddr;
-use std::rc::Rc;
-use std::sync::Arc;
+use std::{net::SocketAddr, rc::Rc, sync::Arc};
 
 use bevy::tasks::{IoTaskPool, TaskPool};
-use tokio::sync::mpsc;
-use tokio::sync::mpsc::error::TryRecvError;
+use tokio::sync::{mpsc, mpsc::error::TryRecvError};
 use tracing::{debug, error, info, trace};
 use xwt_core::prelude::*;
 
-use crate::client::io::transport::{ClientTransportBuilder, ClientTransportEnum};
-use crate::client::io::{ClientIoEvent, ClientIoEventReceiver, ClientNetworkEventSender};
-use crate::server::io::transport::{ServerTransportBuilder, ServerTransportEnum};
-use crate::server::io::{ServerIoEventReceiver, ServerNetworkEventSender};
-use crate::transport::error::{Error, Result};
-use crate::transport::io::IoState;
-use crate::transport::{BoxedReceiver, BoxedSender, PacketReceiver, PacketSender, Transport, MTU};
+use crate::{
+    client::io::{
+        transport::{ClientTransportBuilder, ClientTransportEnum},
+        ClientIoEvent, ClientIoEventReceiver, ClientNetworkEventSender,
+    },
+    server::io::{
+        transport::{ServerTransportBuilder, ServerTransportEnum},
+        ServerIoEventReceiver, ServerNetworkEventSender,
+    },
+    transport::{
+        error::{Error, Result},
+        io::IoState,
+        BoxedReceiver, BoxedSender, PacketReceiver, PacketSender, Transport, MTU,
+    },
+};
 
 // Adapted from https://github.com/briansmith/ring/blob/befdc87ac7cbca615ab5d68724f4355434d3a620/src/test.rs#L364-L393
 pub fn from_hex(hex_str: &str) -> std::result::Result<Vec<u8>, String> {

--- a/lightyear/src/transport/webtransport/mod.rs
+++ b/lightyear/src/transport/webtransport/mod.rs
@@ -12,14 +12,17 @@ cfg_if::cfg_if! {
 
 #[cfg(test)]
 mod tests {
-    use crate::client::io::transport::ClientTransportBuilder;
-    use crate::server::io::transport::ServerTransportBuilder;
-    use bevy::tasks::{IoTaskPool, TaskPoolBuilder};
-    use bevy::utils::Duration;
+    use bevy::{
+        tasks::{IoTaskPool, TaskPoolBuilder},
+        utils::Duration,
+    };
     use wtransport::Identity;
 
-    use super::client::*;
-    use super::server::*;
+    use super::{client::*, server::*};
+    use crate::{
+        client::io::transport::ClientTransportBuilder,
+        server::io::transport::ServerTransportBuilder,
+    };
 
     #[cfg(not(target_family = "wasm"))]
     #[tokio::test]

--- a/lightyear/src/transport/webtransport/server.rs
+++ b/lightyear/src/transport/webtransport/server.rs
@@ -1,25 +1,27 @@
 //! WebTransport client implementation.
-use std::net::SocketAddr;
-use std::sync::{Arc, Mutex};
+use std::{
+    net::SocketAddr,
+    sync::{Arc, Mutex},
+};
 
 use async_compat::Compat;
-use bevy::tasks::IoTaskPool;
-use bevy::utils::HashMap;
-use tokio::sync::mpsc;
-use tokio::sync::mpsc::error::TryRecvError;
-use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
+use bevy::{tasks::IoTaskPool, utils::HashMap};
+use tokio::sync::{
+    mpsc,
+    mpsc::{error::TryRecvError, UnboundedReceiver, UnboundedSender},
+};
 use tracing::{debug, error, info, trace};
-use wtransport;
-use wtransport::datagram::Datagram;
-use wtransport::Connection;
-use wtransport::{Identity, ServerConfig};
+use wtransport::{self, datagram::Datagram, Connection, Identity, ServerConfig};
 
-use crate::server::io::transport::{ServerTransportBuilder, ServerTransportEnum};
-use crate::server::io::{ServerIoEvent, ServerIoEventReceiver, ServerNetworkEventSender};
-use crate::transport::error::Result;
-use crate::transport::io::IoState;
-use crate::transport::{
-    BoxedReceiver, BoxedSender, PacketReceiver, PacketSender, Transport, MIN_MTU, MTU,
+use crate::{
+    server::io::{
+        transport::{ServerTransportBuilder, ServerTransportEnum},
+        ServerIoEvent, ServerIoEventReceiver, ServerNetworkEventSender,
+    },
+    transport::{
+        error::Result, io::IoState, BoxedReceiver, BoxedSender, PacketReceiver, PacketSender,
+        Transport, MIN_MTU, MTU,
+    },
 };
 
 pub(crate) struct WebTransportServerSocketBuilder {

--- a/lightyear/src/utils/avian2d.rs
+++ b/lightyear/src/utils/avian2d.rs
@@ -1,13 +1,18 @@
 //! Implement lightyear traits for some common bevy types
-use crate::prelude::client::{InterpolationSet, PredictionSet};
-use crate::shared::replication::delta::Diffable;
-use avian2d::math::Scalar;
-use avian2d::prelude::*;
-use bevy::app::{RunFixedMainLoop, RunFixedMainLoopSystem};
-use bevy::prelude::TransformSystem::TransformPropagate;
-use bevy::prelude::{App, FixedPostUpdate, Plugin};
-use bevy::prelude::{IntoSystemSetConfigs, PostUpdate};
+use avian2d::{math::Scalar, prelude::*};
+use bevy::{
+    app::{RunFixedMainLoop, RunFixedMainLoopSystem},
+    prelude::{
+        App, FixedPostUpdate, IntoSystemSetConfigs, Plugin, PostUpdate,
+        TransformSystem::TransformPropagate,
+    },
+};
 use tracing::trace;
+
+use crate::{
+    prelude::client::{InterpolationSet, PredictionSet},
+    shared::replication::delta::Diffable,
+};
 
 pub(crate) struct Avian2dPlugin;
 

--- a/lightyear/src/utils/avian3d.rs
+++ b/lightyear/src/utils/avian3d.rs
@@ -1,12 +1,18 @@
 //! Implement lightyear traits for some common bevy types
-use crate::prelude::client::{InterpolationSet, PredictionSet};
-use crate::shared::replication::delta::Diffable;
-use avian3d::math::Scalar;
-use avian3d::prelude::*;
-use bevy::app::{App, FixedPostUpdate, Plugin};
-use bevy::prelude::TransformSystem::TransformPropagate;
-use bevy::prelude::{IntoSystemSetConfigs, PostUpdate, RunFixedMainLoop, RunFixedMainLoopSystem};
+use avian3d::{math::Scalar, prelude::*};
+use bevy::{
+    app::{App, FixedPostUpdate, Plugin},
+    prelude::{
+        IntoSystemSetConfigs, PostUpdate, RunFixedMainLoop, RunFixedMainLoopSystem,
+        TransformSystem::TransformPropagate,
+    },
+};
 use tracing::trace;
+
+use crate::{
+    prelude::client::{InterpolationSet, PredictionSet},
+    shared::replication::delta::Diffable,
+};
 
 pub(crate) struct Avian3dPlugin;
 impl Plugin for Avian3dPlugin {

--- a/lightyear/src/utils/history_buffer.rs
+++ b/lightyear/src/utils/history_buffer.rs
@@ -1,10 +1,9 @@
-use crate::prelude::Tick;
-use bevy::prelude::{Component, Reflect, Resource};
-use bevy::prelude::{ReflectComponent, ReflectResource};
-use std::collections::VecDeque;
-use std::fmt::Debug;
-use std::iter::FilterMap;
+use std::{collections::VecDeque, fmt::Debug, iter::FilterMap};
+
+use bevy::prelude::{Component, Reflect, ReflectComponent, ReflectResource, Resource};
 use tracing::debug;
+
+use crate::prelude::Tick;
 
 /// Stores a past value in the history buffer
 #[derive(Debug, PartialEq, Clone, Default, Reflect)]

--- a/lightyear/src/utils/pool.rs
+++ b/lightyear/src/utils/pool.rs
@@ -66,9 +66,11 @@
 //!
 //! [`std::sync::Arc`]: https://doc.rust-lang.org/stable/std/sync/struct.Arc.html
 
-use std::iter::FromIterator;
-use std::mem::{forget, ManuallyDrop};
-use std::ops::{Deref, DerefMut};
+use std::{
+    iter::FromIterator,
+    mem::{forget, ManuallyDrop},
+    ops::{Deref, DerefMut},
+};
 
 use parking_lot::Mutex;
 

--- a/lightyear/src/utils/ready_buffer.rs
+++ b/lightyear/src/utils/ready_buffer.rs
@@ -191,12 +191,10 @@ impl<K: Ord, T> Ord for ItemWithReadyKey<K, T> {
 #[cfg(test)]
 mod tests {
     use bevy::utils::Duration;
-    use mock_instant::global::Instant;
-    use mock_instant::global::MockClock;
-
-    use crate::shared::tick_manager::Tick;
+    use mock_instant::global::{Instant, MockClock};
 
     use super::*;
+    use crate::shared::tick_manager::Tick;
 
     #[test]
     fn test_peek_max_item() {

--- a/lightyear/src/utils/sequence_buffer.rs
+++ b/lightyear/src/utils/sequence_buffer.rs
@@ -60,9 +60,8 @@ impl<K: WrappedId, T, const N: usize> SequenceBuffer<K, T, N> {
 
 #[cfg(test)]
 mod tests {
-    use crate::packet::message::MessageId;
-
     use super::*;
+    use crate::packet::message::MessageId;
 
     #[test]
     fn test_sequence_buffer() {

--- a/lightyear_avian/src/lag_compensation/history.rs
+++ b/lightyear_avian/src/lag_compensation/history.rs
@@ -1,12 +1,11 @@
-/// This plugin maintains a history buffer of the Position, Rotation and ColliderAabb of server entities
-/// so that they can be used for lag compensation.
-use bevy::prelude::*;
-use lightyear::prelude::{HistoryBuffer, TickManager};
-
 #[cfg(all(feature = "2d", not(feature = "3d")))]
 use avian2d::{math::Vector, prelude::*};
 #[cfg(all(feature = "3d", not(feature = "2d")))]
 use avian3d::{math::Vector, prelude::*};
+/// This plugin maintains a history buffer of the Position, Rotation and ColliderAabb of server entities
+/// so that they can be used for lag compensation.
+use bevy::prelude::*;
+use lightyear::prelude::{HistoryBuffer, TickManager};
 
 /// Add this plugin to enable lag compensation on the server
 #[derive(Resource)]

--- a/lightyear_avian/src/lag_compensation/query.rs
+++ b/lightyear_avian/src/lag_compensation/query.rs
@@ -84,7 +84,7 @@ impl LagCompensationSpatialQuery<'_, '_> {
                     return false;
                 };
                 let parent = parent_component.get();
-                info!("Broadphase hit with {child:?}");
+                debug!("Broadphase hit with {child:?}");
                 let (collider, history) = self
                     .parent_query
                     .get(parent)
@@ -123,7 +123,7 @@ impl LagCompensationSpatialQuery<'_, '_> {
                     if !predicate(parent) {
                         return false;
                     }
-                    info!(
+                    debug!(
                         ?tick,
                         ?interpolation_tick,
                         ?interpolation_overstep,

--- a/lightyear_avian/src/lag_compensation/query.rs
+++ b/lightyear_avian/src/lag_compensation/query.rs
@@ -1,12 +1,8 @@
 //! Provides a system parameter for performing spatial queries while doing lag compensation.
 use std::cell::RefCell;
 
-use bevy::ecs::system::SystemParam;
-use bevy::prelude::*;
-
-use super::history::{AabbEnvelopeHolder, LagCompensationConfig, LagCompensationHistory};
-use lightyear::prelude::client::InterpolationDelay;
-use lightyear::prelude::TickManager;
+use bevy::{ecs::system::SystemParam, prelude::*};
+use lightyear::prelude::{client::InterpolationDelay, TickManager};
 #[cfg(all(feature = "2d", not(feature = "3d")))]
 use {
     avian2d::{math::*, prelude::*},
@@ -17,6 +13,8 @@ use {
     avian3d::{math::*, prelude::*},
     bevy::math::Dir3 as Dir,
 };
+
+use super::history::{AabbEnvelopeHolder, LagCompensationConfig, LagCompensationHistory};
 
 /// A system parameter for performing [spatial queries](spatial_query) while doing
 /// lag compensation.

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -4,11 +4,10 @@
 #![allow(dead_code)]
 #![allow(unused)]
 
+use channel::channel_impl;
 use proc_macro2::{Ident, Span};
 use quote::{format_ident, quote};
 use syn::{parse_macro_input, ItemEnum};
-
-use channel::channel_impl;
 
 mod channel;
 mod shared;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,2 @@
+imports_granularity = "Crate"
+group_imports = "StdExternalCrate"


### PR DESCRIPTION
Just applying rust fmt and making so vscode user have an easier time with lightyear. Rust analyzer is also giving me a series of clippy warnings, if I get the go ahead. I can find solutions on avoid them (except too many args and complex args ones I believe we should disallow those).
