### PR TITLE
Fixes for bevy-main wrt latest bevy

### DIFF
--- a/benches/criterion/src/local_stepper.rs
+++ b/benches/criterion/src/local_stepper.rs
@@ -6,10 +6,7 @@ use std::net::SocketAddr;
 use std::str::FromStr;
 
 use bevy::platform_support::collections::HashMap;
-use bevy::prelude::{
-    default, App, Commands, Mut, Plugin, Real, Resource
-    , Time,
-};
+use bevy::prelude::{default, App, Commands, Mut, Plugin, Real, Resource, Time};
 use bevy::state::app::StatesPlugin;
 use bevy::time::TimeUpdateStrategy;
 use bevy::MinimalPlugins;

--- a/benches/criterion/src/replication.rs
+++ b/benches/criterion/src/replication.rs
@@ -4,9 +4,7 @@
 use bevy::prelude::{default, With};
 use core::time::Duration;
 use lightyear::prelude::server::Replicate;
-use lightyear::prelude::{
-    Replicating, ReplicationGroup,
-};
+use lightyear::prelude::{Replicating, ReplicationGroup};
 use lightyear_benches::local_stepper::{LocalBevyStepper, Step as LocalStep};
 use lightyear_benches::profiler::FlamegraphProfiler;
 use lightyear_benches::protocol::*;

--- a/examples/simple_box/src/server.rs
+++ b/examples/simple_box/src/server.rs
@@ -43,18 +43,19 @@ pub(crate) fn handle_connections(
 ) {
     for connection in connections.read() {
         let client_id = connection.client_id;
-        let entity = commands.spawn((
-            PlayerBundle::new(client_id, Vec2::ZERO),
-            ReplicateToClient::default(),
-            SyncTarget {
-                prediction: NetworkTarget::Single(client_id),
-                interpolation: NetworkTarget::AllExceptSingle(client_id),
-            },
-            ControlledBy {
-                target: NetworkTarget::Single(client_id),
-                ..default()
-            },
-        ))
+        let entity = commands
+            .spawn((
+                PlayerBundle::new(client_id, Vec2::ZERO),
+                ReplicateToClient::default(),
+                SyncTarget {
+                    prediction: NetworkTarget::Single(client_id),
+                    interpolation: NetworkTarget::AllExceptSingle(client_id),
+                },
+                ControlledBy {
+                    target: NetworkTarget::Single(client_id),
+                    ..default()
+                },
+            ))
             .id();
         info!("Create entity {:?} for client {:?}", entity, client_id);
     }

--- a/lightyear/src/client/input/mod.rs
+++ b/lightyear/src/client/input/mod.rs
@@ -235,22 +235,22 @@ fn get_non_rollback_action_state<A: UserActionState>(
     mut action_state_query: Query<(Entity, &mut A, &InputBuffer<A>)>,
 ) {
     let tick = tick_manager.tick();
-    // for (entity, mut action_state, input_buffer) in action_state_query.iter_mut() {
-    //     // We only apply the ActionState from the buffer if we have one.
-    //     // If we don't (which could happen for remote inputs), we won't do anything.
-    //     // This is equivalent to considering that the remote player will keep playing the last action they played.
-    //     if let Some(action) = input_buffer.get(tick) {
-    //         *action_state = action.clone();
-    //         trace!(
-    //             ?entity,
-    //             ?tick,
-    //             "fetched action state {:?} from input buffer: {:?}",
-    //             action_state,
-    //             // action_state.get_pressed(),
-    //             input_buffer
-    //         );
-    //     }
-    // }
+    for (entity, mut action_state, input_buffer) in action_state_query.iter_mut() {
+        // We only apply the ActionState from the buffer if we have one.
+        // If we don't (which could happen for remote inputs), we won't do anything.
+        // This is equivalent to considering that the remote player will keep playing the last action they played.
+        if let Some(action) = input_buffer.get(tick) {
+            *action_state = action.clone();
+            trace!(
+                ?entity,
+                ?tick,
+                "fetched action state {:?} from input buffer: {:?}",
+                action_state,
+                // action_state.get_pressed(),
+                input_buffer
+            );
+        }
+    }
 }
 
 /// During rollback, fetch the action-state from the InputBuffer for the corresponding tick and use that
@@ -278,16 +278,16 @@ fn get_rollback_action_state<A: UserActionState>(
     let tick = rollback
         .get_rollback_tick()
         .expect("we should be in rollback");
-    // for (entity, mut action_state, input_buffer) in player_action_state_query.iter_mut() {
-    //     *action_state = input_buffer.get(tick).cloned().unwrap_or_default();
-    //     trace!(
-    //         ?entity,
-    //         ?tick,
-    //         ?action_state,
-    //         "updated action state for rollback using input_buffer: {}",
-    //         input_buffer
-    //     );
-    // }
+    for (entity, mut action_state, input_buffer) in player_action_state_query.iter_mut() {
+        *action_state = input_buffer.get(tick).cloned().unwrap_or_default();
+        trace!(
+            ?entity,
+            ?tick,
+            ?action_state,
+            "updated action state for rollback using input_buffer: {}",
+            input_buffer
+        );
+    }
 }
 
 /// At the start of the frame, restore the ActionState to the latest-action state in buffer
@@ -304,22 +304,22 @@ fn get_delayed_action_state<A: UserActionState, F: Component>(
 ) {
     let input_delay_ticks = connection_manager.input_delay_ticks() as i16;
     let delayed_tick = tick_manager.tick() + input_delay_ticks;
-    // for (entity, mut action_state, input_buffer) in action_state_query.iter_mut() {
-    //     // TODO: lots of clone + is complicated. Shouldn't we just have a DelayedActionState component + resource?
-    //     //  the problem is that the Leafwing Plugin works on ActionState directly...
-    //     if let Some(delayed_action_state) = input_buffer.get(delayed_tick) {
-    //         *action_state = delayed_action_state.clone();
-    //         trace!(
-    //             ?entity,
-    //             ?delayed_tick,
-    //             "fetched delayed action state {:?} from input buffer: {:?}",
-    //             action_state,
-    //             // action_state.get_pressed(),
-    //             input_buffer
-    //         );
-    //     }
-    //     // TODO: if we don't find an ActionState in the buffer, should we reset the delayed one to default?
-    // }
+    for (entity, mut action_state, input_buffer) in action_state_query.iter_mut() {
+        // TODO: lots of clone + is complicated. Shouldn't we just have a DelayedActionState component + resource?
+        //  the problem is that the Leafwing Plugin works on ActionState directly...
+        if let Some(delayed_action_state) = input_buffer.get(delayed_tick) {
+            *action_state = delayed_action_state.clone();
+            trace!(
+                ?entity,
+                ?delayed_tick,
+                "fetched delayed action state {:?} from input buffer: {:?}",
+                action_state,
+                // action_state.get_pressed(),
+                input_buffer
+            );
+        }
+        // TODO: if we don't find an ActionState in the buffer, should we reset the delayed one to default?
+    }
 }
 
 /// System that removes old entries from the InputBuffer

--- a/lightyear/src/client/input/mod.rs
+++ b/lightyear/src/client/input/mod.rs
@@ -235,22 +235,22 @@ fn get_non_rollback_action_state<A: UserActionState>(
     mut action_state_query: Query<(Entity, &mut A, &InputBuffer<A>)>,
 ) {
     let tick = tick_manager.tick();
-    for (entity, mut action_state, input_buffer) in action_state_query.iter_mut() {
-        // We only apply the ActionState from the buffer if we have one.
-        // If we don't (which could happen for remote inputs), we won't do anything.
-        // This is equivalent to considering that the remote player will keep playing the last action they played.
-        if let Some(action) = input_buffer.get(tick) {
-            *action_state = action.clone();
-            trace!(
-                ?entity,
-                ?tick,
-                "fetched action state {:?} from input buffer: {:?}",
-                action_state,
-                // action_state.get_pressed(),
-                input_buffer
-            );
-        }
-    }
+    // for (entity, mut action_state, input_buffer) in action_state_query.iter_mut() {
+    //     // We only apply the ActionState from the buffer if we have one.
+    //     // If we don't (which could happen for remote inputs), we won't do anything.
+    //     // This is equivalent to considering that the remote player will keep playing the last action they played.
+    //     if let Some(action) = input_buffer.get(tick) {
+    //         *action_state = action.clone();
+    //         trace!(
+    //             ?entity,
+    //             ?tick,
+    //             "fetched action state {:?} from input buffer: {:?}",
+    //             action_state,
+    //             // action_state.get_pressed(),
+    //             input_buffer
+    //         );
+    //     }
+    // }
 }
 
 /// During rollback, fetch the action-state from the InputBuffer for the corresponding tick and use that
@@ -278,16 +278,16 @@ fn get_rollback_action_state<A: UserActionState>(
     let tick = rollback
         .get_rollback_tick()
         .expect("we should be in rollback");
-    for (entity, mut action_state, input_buffer) in player_action_state_query.iter_mut() {
-        *action_state = input_buffer.get(tick).cloned().unwrap_or_default();
-        trace!(
-            ?entity,
-            ?tick,
-            ?action_state,
-            "updated action state for rollback using input_buffer: {}",
-            input_buffer
-        );
-    }
+    // for (entity, mut action_state, input_buffer) in player_action_state_query.iter_mut() {
+    //     *action_state = input_buffer.get(tick).cloned().unwrap_or_default();
+    //     trace!(
+    //         ?entity,
+    //         ?tick,
+    //         ?action_state,
+    //         "updated action state for rollback using input_buffer: {}",
+    //         input_buffer
+    //     );
+    // }
 }
 
 /// At the start of the frame, restore the ActionState to the latest-action state in buffer
@@ -304,22 +304,22 @@ fn get_delayed_action_state<A: UserActionState, F: Component>(
 ) {
     let input_delay_ticks = connection_manager.input_delay_ticks() as i16;
     let delayed_tick = tick_manager.tick() + input_delay_ticks;
-    for (entity, mut action_state, input_buffer) in action_state_query.iter_mut() {
-        // TODO: lots of clone + is complicated. Shouldn't we just have a DelayedActionState component + resource?
-        //  the problem is that the Leafwing Plugin works on ActionState directly...
-        if let Some(delayed_action_state) = input_buffer.get(delayed_tick) {
-            *action_state = delayed_action_state.clone();
-            trace!(
-                ?entity,
-                ?delayed_tick,
-                "fetched delayed action state {:?} from input buffer: {:?}",
-                action_state,
-                // action_state.get_pressed(),
-                input_buffer
-            );
-        }
-        // TODO: if we don't find an ActionState in the buffer, should we reset the delayed one to default?
-    }
+    // for (entity, mut action_state, input_buffer) in action_state_query.iter_mut() {
+    //     // TODO: lots of clone + is complicated. Shouldn't we just have a DelayedActionState component + resource?
+    //     //  the problem is that the Leafwing Plugin works on ActionState directly...
+    //     if let Some(delayed_action_state) = input_buffer.get(delayed_tick) {
+    //         *action_state = delayed_action_state.clone();
+    //         trace!(
+    //             ?entity,
+    //             ?delayed_tick,
+    //             "fetched delayed action state {:?} from input buffer: {:?}",
+    //             action_state,
+    //             // action_state.get_pressed(),
+    //             input_buffer
+    //         );
+    //     }
+    //     // TODO: if we don't find an ActionState in the buffer, should we reset the delayed one to default?
+    // }
 }
 
 /// System that removes old entries from the InputBuffer

--- a/lightyear/src/client/input/native.rs
+++ b/lightyear/src/client/input/native.rs
@@ -56,7 +56,7 @@
 use bevy::prelude::*;
 use bevy::reflect::Reflect;
 use core::time::Duration;
-use tracing::{error, trace};
+use tracing::{error, trace, debug};
 
 use crate::channel::builder::InputChannel;
 use crate::client::components::Confirmed;

--- a/lightyear/src/client/input/native.rs
+++ b/lightyear/src/client/input/native.rs
@@ -56,7 +56,7 @@
 use bevy::prelude::*;
 use bevy::reflect::Reflect;
 use core::time::Duration;
-use tracing::{error, trace, debug};
+use tracing::{debug, error, trace};
 
 use crate::channel::builder::InputChannel;
 use crate::client::components::Confirmed;

--- a/lightyear/src/client/input/native.rs
+++ b/lightyear/src/client/input/native.rs
@@ -578,7 +578,8 @@ mod tests {
             .server_app
             .world_mut()
             .query_filtered::<Entity, With<PrePredicted>>()
-            .single(stepper.server_app.world());
+            .single(stepper.server_app.world())
+            .unwrap();
         // replicate back the pre-predicted entity
         stepper
             .server_app

--- a/lightyear/src/client/interpolation/despawn.rs
+++ b/lightyear/src/client/interpolation/despawn.rs
@@ -12,7 +12,7 @@ pub(crate) fn removed_components<C: SyncComponent>(
 ) {
     if let Ok(confirmed) = query.get(trigger.target()) {
         if let Some(interpolated) = confirmed.interpolated {
-            if let Some(mut entity) = commands.get_entity(interpolated) {
+            if let Ok(mut entity) = commands.get_entity(interpolated) {
                 entity.remove::<(C, ConfirmedHistory<C>, InterpolateStatus<C>)>();
             }
         }
@@ -29,7 +29,7 @@ pub(crate) fn despawn_interpolated(
     mut commands: Commands,
 ) {
     if let Some(interpolated) = query.get(trigger.target()).unwrap().interpolated {
-        if let Some(mut entity_mut) = commands.get_entity(interpolated) {
+        if let Ok(mut entity_mut) = commands.get_entity(interpolated) {
             entity_mut.despawn();
         }
     }

--- a/lightyear/src/client/interpolation/visual_interpolation.rs
+++ b/lightyear/src/client/interpolation/visual_interpolation.rs
@@ -34,6 +34,7 @@
 
 use bevy::prelude::*;
 use bevy::transform::TransformSystem::TransformPropagate;
+use tracing::trace;
 
 use crate::client::components::SyncComponent;
 use crate::prelude::client::{is_in_rollback, Correction, InterpolationSet, PredictionSet};

--- a/lightyear/src/client/networking.rs
+++ b/lightyear/src/client/networking.rs
@@ -1,10 +1,10 @@
 //! Defines the plugin related to the client networking (sending and receiving packets).
-use std::ops::DerefMut;
-use std::time::Duration;
 use async_channel::TryRecvError;
 use bevy::ecs::system::{RunSystemOnce, SystemChangeTick};
 use bevy::prelude::ResMut;
 use bevy::prelude::*;
+use std::ops::DerefMut;
+use std::time::Duration;
 use tracing::{debug, error, trace};
 
 use crate::client::config::ClientConfig;

--- a/lightyear/src/client/networking.rs
+++ b/lightyear/src/client/networking.rs
@@ -1,12 +1,11 @@
 //! Defines the plugin related to the client networking (sending and receiving packets).
 use std::ops::DerefMut;
-
+use std::time::Duration;
 use async_channel::TryRecvError;
 use bevy::ecs::system::{RunSystemOnce, SystemChangeTick};
 use bevy::prelude::ResMut;
 use bevy::prelude::*;
-use bevy::utils::Duration;
-use tracing::{error, trace};
+use tracing::{debug, error, trace};
 
 use crate::client::config::ClientConfig;
 use crate::client::connection::ConnectionManager;
@@ -420,7 +419,7 @@ fn on_disconnecting(
 ) {
     // despawn any entities that were spawned from replication
     received_entities.iter().for_each(|e| {
-        if let Some(mut commands) = commands.get_entity(e) {
+        if let Ok(mut commands) = commands.get_entity(e) {
             commands.despawn();
         }
     });

--- a/lightyear/src/client/networking.rs
+++ b/lightyear/src/client/networking.rs
@@ -372,7 +372,7 @@ fn on_connect(
         "Running OnConnect schedule with client id: {:?}",
         netcode.id()
     );
-    connect_event_writer.send(ConnectEvent::new(netcode.id()));
+    connect_event_writer.write(ConnectEvent::new(netcode.id()));
     // also trigger the event
     commands.trigger(ConnectEvent::new(netcode.id()));
 }
@@ -401,7 +401,7 @@ fn on_connect_host_server(
         .unwrap()
         .set_local_client();
     metadata.client_entity = Some(client_entity);
-    connect_event_writer.send(ConnectEvent::new(netcode.id()));
+    connect_event_writer.write(ConnectEvent::new(netcode.id()));
     // also trigger the event
     commands.trigger(ConnectEvent::new(netcode.id()));
 }
@@ -432,7 +432,7 @@ fn on_disconnecting(
     // no need to update the io state, because we will recreate a new `ClientConnection`
     // for the next connection attempt
     let reason = std::mem::take(&mut netclient.disconnect_reason);
-    disconnect_event_writer.send(DisconnectEvent { reason });
+    disconnect_event_writer.write(DisconnectEvent { reason });
     // TODO: how can we also provide a reason here? or do we even need to?
     // we need to also trigger the event because we sometimes react to it via observers
     commands.trigger(DisconnectEvent { reason: None });

--- a/lightyear/src/client/prediction/archetypes.rs
+++ b/lightyear/src/client/prediction/archetypes.rs
@@ -22,7 +22,6 @@ pub(crate) struct PredictedArchetypes {
     pub(crate) archetypes: HashMap<ArchetypeId, Vec<PredictedComponent>>,
 }
 
-
 /// A component that is predicted
 pub(crate) struct PredictedComponent {
     pub(crate) id: ComponentId,
@@ -40,17 +39,19 @@ impl FromWorld for PredictedArchetypes {
 }
 
 impl PredictedArchetypes {
-
     /// Update the list of predicted archetypes by going through all newly-added archetypes
-    pub(crate) fn update(&mut self, archetypes: &Archetypes, components: &Components, registry: &ComponentRegistry) {
+    pub(crate) fn update(
+        &mut self,
+        archetypes: &Archetypes,
+        components: &Components,
+        registry: &ComponentRegistry,
+    ) {
         let old_generation = core::mem::replace(&mut self.generation, archetypes.generation());
 
         // iterate through the newly added archetypes
         for archetype in archetypes[old_generation..]
             .iter()
-            .filter(|archetype| {
-                archetype.contains(self.predicted_component_id)
-            })
+            .filter(|archetype| archetype.contains(self.predicted_component_id))
         {
             let mut predicted_archetype = Vec::new();
             // add all components from the registry that are predicted

--- a/lightyear/src/client/prediction/correction.rs
+++ b/lightyear/src/client/prediction/correction.rs
@@ -253,7 +253,10 @@ mod tests {
             .get::<Correction<ComponentCorrection>>(predicted)
             .unwrap();
         let current_visual = Some(ComponentCorrection(2.0 + ease_out_quad(0.4) * (11.0 - 2.0)));
-        assert_relative_eq!(correction.current_visual.as_ref().unwrap().0, current_visual.as_ref().unwrap().0);
+        assert_relative_eq!(
+            correction.current_visual.as_ref().unwrap().0,
+            current_visual.as_ref().unwrap().0
+        );
         assert_eq!(correction.current_correction.as_ref().unwrap().0, 11.0);
 
         // trigger a new rollback while the correction is under way
@@ -277,8 +280,13 @@ mod tests {
             original_tick + (original_tick - rollback_tick)
         );
         // interpolate 20% of the way
-        let current_visual = Some(ComponentCorrection(previous_visual + ease_out_quad(0.2) * (17.0 - previous_visual)));
-        assert_relative_eq!(correction.current_visual.as_ref().unwrap().0, current_visual.as_ref().unwrap().0);
+        let current_visual = Some(ComponentCorrection(
+            previous_visual + ease_out_quad(0.2) * (17.0 - previous_visual),
+        ));
+        assert_relative_eq!(
+            correction.current_visual.as_ref().unwrap().0,
+            current_visual.as_ref().unwrap().0
+        );
         assert_eq!(correction.current_correction.as_ref().unwrap().0, 17.0);
         stepper.frame_step();
         stepper.frame_step();
@@ -289,8 +297,13 @@ mod tests {
             .get::<Correction<ComponentCorrection>>(predicted)
             .unwrap();
         // interpolate 80% of the way
-        let current_visual = Some(ComponentCorrection(previous_visual + ease_out_quad(0.8) * (20.0 - previous_visual)));
-        assert_relative_eq!(correction.current_visual.as_ref().unwrap().0, current_visual.as_ref().unwrap().0);
+        let current_visual = Some(ComponentCorrection(
+            previous_visual + ease_out_quad(0.8) * (20.0 - previous_visual),
+        ));
+        assert_relative_eq!(
+            correction.current_visual.as_ref().unwrap().0,
+            current_visual.as_ref().unwrap().0
+        );
         assert_eq!(correction.current_correction.as_ref().unwrap().0, 20.0);
     }
 

--- a/lightyear/src/client/prediction/despawn.rs
+++ b/lightyear/src/client/prediction/despawn.rs
@@ -78,7 +78,7 @@ pub(crate) fn despawn_confirmed(
     mut commands: Commands,
 ) {
     if let Some(predicted) = query.get(trigger.target()).unwrap().predicted {
-        if let Some(mut entity_mut) = commands.get_entity(predicted) {
+        if let Ok(mut entity_mut) = commands.get_entity(predicted) {
             entity_mut.despawn();
         }
     }

--- a/lightyear/src/client/prediction/mod.rs
+++ b/lightyear/src/client/prediction/mod.rs
@@ -5,6 +5,7 @@ use bevy::ecs::world::DeferredWorld;
 use bevy::prelude::{Component, Entity, Reflect, ReflectComponent};
 use std::fmt::Debug;
 
+pub(crate) mod archetypes;
 pub mod correction;
 pub mod despawn;
 pub mod diagnostics;
@@ -16,7 +17,6 @@ pub(crate) mod resource;
 pub mod resource_history;
 pub mod rollback;
 pub mod spawn;
-pub(crate) mod archetypes;
 
 /// Marks an entity that is being predicted by the client
 #[derive(Debug, Reflect)]

--- a/lightyear/src/client/prediction/plugin.rs
+++ b/lightyear/src/client/prediction/plugin.rs
@@ -379,14 +379,15 @@ impl Plugin for PredictionPlugin {
             .register_type::<PredictionDisable>()
             .register_type::<PredictionConfig>();
 
-
         // RESOURCES
         app.init_resource::<PredictionManager>();
         app.insert_resource(Rollback::new(RollbackState::Default));
 
         // Custom entity disabling
         let prediction_disable_id = app.world_mut().register_component::<PredictionDisable>();
-        app.world_mut().resource_mut::<DefaultQueryFilters>().register_disabling_component(prediction_disable_id);
+        app.world_mut()
+            .resource_mut::<DefaultQueryFilters>()
+            .register_disabling_component(prediction_disable_id);
 
         // PreUpdate systems:
         // 1. Receive confirmed entities, add Confirmed and Predicted components

--- a/lightyear/src/client/prediction/pre_prediction.rs
+++ b/lightyear/src/client/prediction/pre_prediction.rs
@@ -158,6 +158,7 @@ mod tests {
     use crate::tests::host_server_stepper::HostServerStepper;
     use crate::tests::protocol::{ComponentClientToServer, ComponentSyncModeFull};
     use crate::tests::stepper::{BevyStepper, TEST_CLIENT_ID};
+    use bevy::ecs::relationship::Relationship;
 
     /// Simple preprediction case
     /// Also check that the PredictionHistory is correctly added to the PrePredicted entity
@@ -187,7 +188,7 @@ mod tests {
             .client_app
             .world_mut()
             .query_filtered::<Entity, With<Confirmed>>()
-            .get_single(stepper.client_app.world())
+            .single(stepper.client_app.world())
             .unwrap();
 
         // need to step multiple times because the server entity doesn't handle messages from future ticks
@@ -311,13 +312,13 @@ mod tests {
             .server_app
             .world_mut()
             .query_filtered::<Entity, With<ComponentClientToServer>>()
-            .get_single(stepper.server_app.world())
+            .single(stepper.server_app.world())
             .expect("parent entity was not replicated");
         let server_child = stepper
             .server_app
             .world_mut()
             .query_filtered::<Entity, With<ComponentSyncModeFull>>()
-            .get_single(stepper.server_app.world())
+            .single(stepper.server_app.world())
             .expect("child entity was not replicated");
         assert_eq!(
             stepper
@@ -380,7 +381,7 @@ mod tests {
             .server_app
             .world_mut()
             .query_filtered::<Entity, With<Predicted>>()
-            .get_single(stepper.server_app.world())
+            .single(stepper.server_app.world())
             .unwrap();
 
         // need to step multiple times because the server entity doesn't handle messages from future ticks

--- a/lightyear/src/client/prediction/pre_prediction.rs
+++ b/lightyear/src/client/prediction/pre_prediction.rs
@@ -2,6 +2,7 @@
 //! then the ownership gets transferred to the server.
 
 use bevy::prelude::*;
+use tracing::{debug};
 
 use crate::client::components::Confirmed;
 use crate::client::prediction::resource::PredictionManager;

--- a/lightyear/src/client/prediction/pre_prediction.rs
+++ b/lightyear/src/client/prediction/pre_prediction.rs
@@ -2,7 +2,7 @@
 //! then the ownership gets transferred to the server.
 
 use bevy::prelude::*;
-use tracing::{debug};
+use tracing::debug;
 
 use crate::client::components::Confirmed;
 use crate::client::prediction::resource::PredictionManager;

--- a/lightyear/src/client/prediction/predicted_history.rs
+++ b/lightyear/src/client/prediction/predicted_history.rs
@@ -84,7 +84,7 @@ pub(crate) fn apply_component_removal_confirmed<C: Component>(
     // Components that are removed from the Confirmed entity also get removed from the Predicted entity
     if let Ok(confirmed) = confirmed_query.get(trigger.target()) {
         if let Some(p) = confirmed.predicted {
-            if let Some(mut commands) = commands.get_entity(p) {
+            if let Ok(mut commands) = commands.get_entity(p) {
                 commands.remove::<C>();
             }
         }

--- a/lightyear/src/client/prediction/predicted_history.rs
+++ b/lightyear/src/client/prediction/predicted_history.rs
@@ -624,7 +624,7 @@ mod tests {
                 With<ComponentSyncModeSimple>,
                 With<Predicted>
             )>()
-            .get_single(stepper.client_app.world())
+            .single(stepper.client_app.world())
             .is_ok());
     }
 

--- a/lightyear/src/client/prediction/prespawn.rs
+++ b/lightyear/src/client/prediction/prespawn.rs
@@ -646,7 +646,8 @@ mod tests {
             .client_app
             .world_mut()
             .query_filtered::<(Entity, &Confirmed), With<Replicated>>()
-            .single(stepper.client_app.world());
+            .single(stepper.client_app.world())
+            .unwrap();
         let client_predicted = confirmed.predicted.unwrap();
 
         // run prespawned entity on server.

--- a/lightyear/src/client/prediction/prespawn.rs
+++ b/lightyear/src/client/prediction/prespawn.rs
@@ -241,7 +241,7 @@ impl PreSpawnedPlayerObjectPlugin {
                 .iter()
                 .flatten()
                 .for_each(|entity| {
-                    if let Some(mut entity_commands) = commands.get_entity(*entity) {
+                    if let Ok(mut entity_commands) = commands.get_entity(*entity) {
                         trace!(
                             ?tick,
                             ?entity,

--- a/lightyear/src/client/prediction/prespawn.rs
+++ b/lightyear/src/client/prediction/prespawn.rs
@@ -3,7 +3,7 @@
 use bevy::ecs::component::{Components, HookContext, Mutable, StorageType};
 use bevy::prelude::*;
 use serde::{Deserialize, Serialize};
-use tracing::{debug, trace, error, warn};
+use tracing::{debug, error, trace, warn};
 
 use crate::client::components::Confirmed;
 use crate::client::connection::ConnectionManager;

--- a/lightyear/src/client/prediction/prespawn.rs
+++ b/lightyear/src/client/prediction/prespawn.rs
@@ -3,7 +3,7 @@
 use bevy::ecs::component::{Components, HookContext, Mutable, StorageType};
 use bevy::prelude::*;
 use serde::{Deserialize, Serialize};
-use tracing::{debug, trace};
+use tracing::{debug, trace, error, warn};
 
 use crate::client::components::Confirmed;
 use crate::client::connection::ConnectionManager;
@@ -146,7 +146,7 @@ impl PreSpawnedPlayerObjectPlugin {
             // 1.a if the client_entity exists, remove the PreSpawnedPlayerObject component from the client entity
             //  and add a Predicted component to it
             let predicted_entity =
-                if let Some(mut entity_commands) = commands.get_entity(client_entity) {
+                if let Ok(mut entity_commands) = commands.get_entity(client_entity) {
                     #[cfg(feature = "metrics")]
                     {
                         metrics::counter!("prespawn::match::found").increment(1);

--- a/lightyear/src/client/prediction/resource_history.rs
+++ b/lightyear/src/client/prediction/resource_history.rs
@@ -57,6 +57,7 @@ mod tests {
     use crate::prelude::Tick;
     use crate::tests::stepper::BevyStepper;
     use bevy::ecs::system::RunSystemOnce;
+    use tracing::info;
 
     #[derive(Resource, Clone, PartialEq, Debug)]
     struct TestResource(f32);

--- a/lightyear/src/client/prediction/rollback.rs
+++ b/lightyear/src/client/prediction/rollback.rs
@@ -11,7 +11,7 @@ use bevy::prelude::*;
 use bevy::reflect::Reflect;
 use bevy::time::{Fixed, Time};
 use parking_lot::RwLock;
-use tracing::{debug, error, trace, trace_span};
+use tracing::{debug, error, trace, trace_span, warn};
 
 use super::predicted_history::PredictionHistory;
 use super::resource_history::ResourceHistory;
@@ -481,7 +481,7 @@ pub(crate) fn prepare_rollback_prespawn<C: SyncComponent>(
             ?entity,
             "deleting pre-spawned entity because it was created after the rollback tick"
         );
-        if let Some(mut entity_commands) = commands.get_entity(*entity) {
+        if let Ok(mut entity_commands) = commands.get_entity(*entity) {
             entity_commands.despawn();
         }
     });

--- a/lightyear/src/client/prediction/rollback.rs
+++ b/lightyear/src/client/prediction/rollback.rs
@@ -810,7 +810,9 @@ mod unit_tests {
     use super::*;
     use crate::client::prediction::rollback::test_utils::received_confirmed_update;
     use crate::prelude::server::SyncTarget;
-    use crate::prelude::{NetworkTarget, SharedConfig, TickConfig};
+    use crate::prelude::{
+        AppComponentExt, ChannelDirection, NetworkTarget, SharedConfig, TickConfig,
+    };
     use crate::tests::protocol::{ComponentRollback, ComponentSyncModeFull};
     use crate::tests::stepper::BevyStepper;
     use bevy::ecs::entity::MapEntities;
@@ -1548,7 +1550,7 @@ mod unit_tests {
         let _ = stepper
             .client_app
             .world_mut()
-            .run_system_once(check_rollback::<ComponentSyncModeFull>);
+            .run_system_once(check_rollback);
         assert_eq!(
             stepper
                 .client_app

--- a/lightyear/src/client/prediction/spawn.rs
+++ b/lightyear/src/client/prediction/spawn.rs
@@ -84,6 +84,7 @@ mod tests {
     use crate::prelude::{client, server, ClientId, NetworkTarget};
     use crate::tests::stepper::{BevyStepper, TEST_CLIENT_ID};
     use bevy::ecs::hierarchy::ChildOf;
+    use bevy::ecs::relationship::Relationship;
     use bevy::prelude::default;
 
     /// https://github.com/cBournhonesque/lightyear/issues/627

--- a/lightyear/src/client/replication.rs
+++ b/lightyear/src/client/replication.rs
@@ -18,6 +18,7 @@ pub(crate) mod receive {
     use crate::shared::replication::components::{ReplicationGroupId, ShouldBeInterpolated};
     use crate::shared::sets::InternalMainSet;
     use bevy::ecs::entity::Entities;
+    use tracing::{debug, trace};
 
     #[derive(Default)]
     pub struct ClientReplicationReceivePlugin {
@@ -161,6 +162,8 @@ pub(crate) mod send {
     use bevy::ecs::system::{ParamBuilder, QueryParamBuilder, SystemChangeTick};
     use bevy::ecs::world::FilteredEntityRef;
     use bevy::ptr::Ptr;
+
+    use tracing::{debug, trace, error};
 
     #[derive(Default)]
     pub struct ClientReplicationSendPlugin {

--- a/lightyear/src/client/replication.rs
+++ b/lightyear/src/client/replication.rs
@@ -828,7 +828,9 @@ pub(crate) mod send {
             let client_child = stepper
                 .client_app
                 .world_mut()
-                .spawn(ChildOf(client_entity))
+                .spawn(ChildOf {
+                    parent: client_entity,
+                })
                 .id();
             stepper.frame_step();
             stepper.frame_step();
@@ -908,7 +910,9 @@ pub(crate) mod send {
             let client_child = stepper
                 .client_app
                 .world_mut()
-                .spawn(ChildOf(client_entity))
+                .spawn(ChildOf {
+                    parent: client_entity,
+                })
                 .id();
             for _ in 0..10 {
                 stepper.frame_step();
@@ -1041,7 +1045,9 @@ pub(crate) mod send {
             let client_child = stepper
                 .client_app
                 .world_mut()
-                .spawn(ChildOf(client_entity))
+                .spawn(ChildOf {
+                    parent: client_entity,
+                })
                 .id();
             for _ in 0..10 {
                 stepper.frame_step();
@@ -1096,7 +1102,9 @@ pub(crate) mod send {
             let client_child = stepper
                 .client_app
                 .world_mut()
-                .spawn(ChildOf(client_entity))
+                .spawn(ChildOf {
+                    parent: client_entity,
+                })
                 .id();
             for _ in 0..10 {
                 stepper.frame_step();
@@ -1447,7 +1455,12 @@ pub(crate) mod send {
             let client_child = stepper
                 .client_app
                 .world_mut()
-                .spawn((ChildOf(client_entity), ComponentSyncModeFull(1.0)))
+                .spawn((
+                    ChildOf {
+                        parent: client_entity,
+                    },
+                    ComponentSyncModeFull(1.0),
+                ))
                 .id();
             for _ in 0..10 {
                 stepper.frame_step();

--- a/lightyear/src/client/replication.rs
+++ b/lightyear/src/client/replication.rs
@@ -163,7 +163,7 @@ pub(crate) mod send {
     use bevy::ecs::world::FilteredEntityRef;
     use bevy::ptr::Ptr;
 
-    use tracing::{debug, trace, error};
+    use tracing::{debug, error, trace};
 
     #[derive(Default)]
     pub struct ClientReplicationSendPlugin {

--- a/lightyear/src/inputs/native/input_message.rs
+++ b/lightyear/src/inputs/native/input_message.rs
@@ -43,8 +43,8 @@ impl<A: UserAction + MapEntities> MapEntities for InputMessage<A> {
     // NOTE: we only map the inputs for the pre-predicted entities
     fn map_entities<M: EntityMapper>(&mut self, entity_mapper: &mut M) {
         self.inputs.iter_mut().for_each(|data| {
-            if let InputTarget::PrePredictedEntity(ref mut e) = data.target {
-                *e = entity_mapper.map_entity(*e);
+            if let InputTarget::PrePredictedEntity(e) = &mut data.target {
+                *e = entity_mapper.get_mapped(*e);
             }
             data.states.iter_mut().for_each(|state| {
                 if let InputData::Input(ref mut action_state) = state {

--- a/lightyear/src/inputs/native/mod.rs
+++ b/lightyear/src/inputs/native/mod.rs
@@ -21,6 +21,7 @@ There are several steps to use the `InputPlugin`:
 
 use crate::inputs::native::input_buffer::{InputBuffer, InputData};
 use crate::prelude::Deserialize;
+use bevy::ecs::component::{ComponentMutability, Mutable};
 use bevy::prelude::{Component, Reflect};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
@@ -32,7 +33,7 @@ pub mod input_buffer;
 pub(crate) mod input_message;
 
 /// The component that will store the current status of the action for the entity
-#[derive(Component, Clone, Debug, PartialEq, Serialize, Deserialize, Reflect)]
+#[derive(Component, Clone, Debug, Serialize, Deserialize, Reflect)]
 #[require(InputBuffer<ActionState<A>>)]
 pub struct ActionState<A: Send + Sync> {
     pub value: Option<A>,
@@ -79,8 +80,14 @@ impl<A: Serialize + DeserializeOwned + Clone + PartialEq + Send + Sync + Debug +
 {
 }
 
-pub trait UserActionState: UserAction + Component + Default {
+pub trait UserActionState: UserAction + Component<Mutability = Mutable> + Default {
     type UserAction: UserAction;
+}
+
+impl<A: UserAction> PartialEq for ActionState<A> {
+    fn eq(&self, other: &Self) -> bool {
+        todo!()
+    }
 }
 
 impl<A: UserAction> UserActionState for ActionState<A> {

--- a/lightyear/src/inputs/native/mod.rs
+++ b/lightyear/src/inputs/native/mod.rs
@@ -21,7 +21,7 @@ There are several steps to use the `InputPlugin`:
 
 use crate::inputs::native::input_buffer::{InputBuffer, InputData};
 use crate::prelude::Deserialize;
-use bevy::ecs::component::{ComponentMutability, Mutable};
+use bevy::ecs::component::Mutable;
 use bevy::prelude::{Component, Reflect};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
@@ -33,7 +33,7 @@ pub mod input_buffer;
 pub(crate) mod input_message;
 
 /// The component that will store the current status of the action for the entity
-#[derive(Component, Clone, Debug, Serialize, Deserialize, Reflect)]
+#[derive(Component, Clone, Debug, PartialEq, Serialize, Deserialize, Reflect)]
 #[require(InputBuffer<ActionState<A>>)]
 pub struct ActionState<A: Send + Sync> {
     pub value: Option<A>,
@@ -82,14 +82,4 @@ impl<A: Serialize + DeserializeOwned + Clone + PartialEq + Send + Sync + Debug +
 
 pub trait UserActionState: UserAction + Component<Mutability = Mutable> + Default {
     type UserAction: UserAction;
-}
-
-impl<A: UserAction> PartialEq for ActionState<A> {
-    fn eq(&self, other: &Self) -> bool {
-        todo!()
-    }
-}
-
-impl<A: UserAction> UserActionState for ActionState<A> {
-    type UserAction = A;
 }

--- a/lightyear/src/inputs/native/mod.rs
+++ b/lightyear/src/inputs/native/mod.rs
@@ -83,3 +83,7 @@ impl<A: Serialize + DeserializeOwned + Clone + PartialEq + Send + Sync + Debug +
 pub trait UserActionState: UserAction + Component<Mutability = Mutable> + Default {
     type UserAction: UserAction;
 }
+
+impl<A: UserAction> UserActionState for ActionState<A> {
+    type UserAction = A;
+}

--- a/lightyear/src/protocol/component/replication.rs
+++ b/lightyear/src/protocol/component/replication.rs
@@ -478,7 +478,11 @@ mod tests {
 
         // make sure that the ComponentSyncModeSimple was only inserted twice, not three times
         assert_eq!(
-            world.query::<&ComponentSyncModeFull>().single(&world).0,
+            world
+                .query::<&ComponentSyncModeFull>()
+                .single(&world)
+                .unwrap()
+                .0,
             2.0
         );
     }

--- a/lightyear/src/protocol/component/replication.rs
+++ b/lightyear/src/protocol/component/replication.rs
@@ -14,7 +14,7 @@ use bevy::ptr::OwningPtr;
 use bytes::Bytes;
 use std::alloc::Layout;
 use std::ptr::NonNull;
-use tracing::debug;
+use tracing::{debug, trace};
 
 /// Temporary buffer to store component data that we want to insert
 /// using `entity_world_mut.insert_by_ids`

--- a/lightyear/src/protocol/message/registry.rs
+++ b/lightyear/src/protocol/message/registry.rs
@@ -15,6 +15,7 @@ use bevy::platform_support::collections::HashMap;
 use bevy::prelude::*;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
+use tracing::debug;
 
 pub struct MessageRegistration<'a, M> {
     pub(crate) app: &'a mut App,

--- a/lightyear/src/server/clients.rs
+++ b/lightyear/src/server/clients.rs
@@ -374,7 +374,8 @@ mod tests {
             .server_app
             .world_mut()
             .query_filtered::<Entity, With<Replicated>>()
-            .single(stepper.server_app.world());
+            .single(stepper.server_app.world())
+            .unwrap();
         // add ControlledBy on the entity
         stepper
             .server_app

--- a/lightyear/src/server/clients.rs
+++ b/lightyear/src/server/clients.rs
@@ -125,14 +125,14 @@ mod systems {
                         "Despawning entity {entity:?} controlled by disconnected client {:?}",
                         client_id
                     );
-                    if let Some(mut command) = commands.get_entity(*entity) {
+                    if let Ok(mut command) = commands.get_entity(*entity) {
                         command.despawn();
                     }
                 }
             }
         }
         // despawn the client entity itself
-        if let Some(mut command) = commands.get_entity(client_entity) {
+        if let Ok(mut command) = commands.get_entity(client_entity) {
             command.despawn();
         };
     }

--- a/lightyear/src/server/events.rs
+++ b/lightyear/src/server/events.rs
@@ -49,7 +49,7 @@ fn emit_connect_events(
         if connection_manager.events.has_connections() {
             for connect_event in connection_manager.events.iter_connections() {
                 debug!("Client connected event: {}", connect_event.client_id);
-                connect_events.send(connect_event);
+                connect_events.write(connect_event);
                 // TODO: trigger all events in batch? https://github.com/bevyengine/bevy/pull/13953
                 // NOTE: we don't trigger the event immediately because we're inside world.resource_scope
                 //  so a bunch of Resources have been removed from the World
@@ -61,7 +61,7 @@ fn emit_connect_events(
         if connection_manager.events.has_disconnections() {
             for disconnect_event in connection_manager.events.iter_disconnections() {
                 debug!("Client disconnected event: {}", disconnect_event.client_id);
-                disconnect_events.send(disconnect_event);
+                disconnect_events.write(disconnect_event);
                 // TODO: trigger all events in batch? https://github.com/bevyengine/bevy/pull/13953
                 // NOTE: we don't trigger the event immediately because we're inside world.resource_scope
                 //  so a bunch of Resources have been removed from the World

--- a/lightyear/src/server/events.rs
+++ b/lightyear/src/server/events.rs
@@ -13,6 +13,8 @@ use crate::shared::events::plugin::EventsPlugin;
 use crate::shared::events::systems::push_component_events;
 use crate::shared::sets::{InternalMainSet, ServerMarker};
 
+use tracing::debug;
+
 /// Plugin that adds bevy [`Events`] related to networking and replication
 #[derive(Default)]
 pub struct ServerEventsPlugin;

--- a/lightyear/src/server/input/mod.rs
+++ b/lightyear/src/server/input/mod.rs
@@ -10,6 +10,7 @@ use crate::inputs::native::UserActionState;
 use crate::prelude::{server::is_started, TickManager};
 use crate::shared::sets::{InternalMainSet, ServerMarker};
 use bevy::prelude::*;
+use tracing::trace;
 
 pub struct BaseInputPlugin<A> {
     rebroadcast_inputs: bool,
@@ -78,6 +79,7 @@ fn update_action_state<A: UserActionState>(
     mut action_state_query: Query<(Entity, &mut A, &mut InputBuffer<A>)>,
 ) {
     let tick = tick_manager.tick();
+
     for (entity, mut action_state, mut input_buffer) in action_state_query.iter_mut() {
         // We only apply the ActionState from the buffer if we have one.
         // If we don't (because the input packet is late or lost), we won't do anything.

--- a/lightyear/src/server/input/native.rs
+++ b/lightyear/src/server/input/native.rs
@@ -16,7 +16,7 @@ use crate::server::connection::ConnectionManager;
 use crate::server::input::InputSystemSet;
 use crate::shared::input::InputConfig;
 use bevy::prelude::*;
-use tracing::{trace, debug};
+use tracing::{debug, trace};
 
 pub struct InputPlugin<A> {
     /// If True, the server will rebroadcast a client's inputs to all other clients.

--- a/lightyear/src/server/input/native.rs
+++ b/lightyear/src/server/input/native.rs
@@ -191,7 +191,7 @@ pub(crate) fn rebroadcast_inputs<A: UserAction>(
     // rebroadcast the input to other clients
     // we are calling drain() here so make sure that this system runs after the `ReceiveInputs` set,
     // so that the server had the time to process the inputs
-    send_inputs.send_batch(receive_inputs.drain().map(|ev| {
+    send_inputs.write_batch(receive_inputs.drain().map(|ev| {
         ServerSendMessage::new_with_target::<InputChannel>(
             ev.message,
             NetworkTarget::AllExceptSingle(ev.from),

--- a/lightyear/src/server/input/native.rs
+++ b/lightyear/src/server/input/native.rs
@@ -16,6 +16,7 @@ use crate::server::connection::ConnectionManager;
 use crate::server::input::InputSystemSet;
 use crate::shared::input::InputConfig;
 use bevy::prelude::*;
+use tracing::{trace, debug};
 
 pub struct InputPlugin<A> {
     /// If True, the server will rebroadcast a client's inputs to all other clients.

--- a/lightyear/src/server/networking.rs
+++ b/lightyear/src/server/networking.rs
@@ -20,7 +20,7 @@ use crate::transport::error::Error as TransportError;
 use async_channel::TryRecvError;
 use bevy::ecs::system::{RunSystemOnce, SystemChangeTick};
 use bevy::prelude::*;
-use tracing::{debug, error, trace};
+use tracing::{debug, error, trace, info, warn, info_span};
 
 /// Plugin handling the server networking systems: sending/receiving packets to clients
 #[derive(Default)]

--- a/lightyear/src/server/networking.rs
+++ b/lightyear/src/server/networking.rs
@@ -20,7 +20,7 @@ use crate::transport::error::Error as TransportError;
 use async_channel::TryRecvError;
 use bevy::ecs::system::{RunSystemOnce, SystemChangeTick};
 use bevy::prelude::*;
-use tracing::{debug, error, trace, info, warn, info_span};
+use tracing::{debug, error, info, info_span, trace, warn};
 
 /// Plugin handling the server networking systems: sending/receiving packets to clients
 #[derive(Default)]

--- a/lightyear/src/server/networking.rs
+++ b/lightyear/src/server/networking.rs
@@ -521,7 +521,7 @@ mod tests {
             .server_app
             .world_mut()
             .query_filtered::<Entity, With<ControlledEntities>>()
-            .get_single(stepper.server_app.world())
+            .single(stepper.server_app.world())
             .unwrap();
 
         stepper.frame_step();

--- a/lightyear/src/server/prediction.rs
+++ b/lightyear/src/server/prediction.rs
@@ -3,7 +3,7 @@
 use crate::prelude::server::{AuthorityCommandExt, AuthorityPeer};
 use crate::prelude::{PrePredicted, Replicated, ServerConnectionManager};
 use bevy::prelude::*;
-use tracing::{debug};
+use tracing::debug;
 
 /// When we receive an entity that a clients wants PrePredicted,
 /// we immediately transfer authority back to the server. The server will replicate the PrePredicted

--- a/lightyear/src/server/prediction.rs
+++ b/lightyear/src/server/prediction.rs
@@ -3,6 +3,7 @@
 use crate::prelude::server::{AuthorityCommandExt, AuthorityPeer};
 use crate::prelude::{PrePredicted, Replicated, ServerConnectionManager};
 use bevy::prelude::*;
+use tracing::{debug};
 
 /// When we receive an entity that a clients wants PrePredicted,
 /// we immediately transfer authority back to the server. The server will replicate the PrePredicted

--- a/lightyear/src/server/replication.rs
+++ b/lightyear/src/server/replication.rs
@@ -1259,7 +1259,9 @@ pub(crate) mod send {
             let server_child = stepper
                 .server_app
                 .world_mut()
-                .spawn(ChildOf(server_entity))
+                .spawn(ChildOf {
+                    parent: server_entity,
+                })
                 .id();
             stepper.frame_step();
             stepper.frame_step();
@@ -1373,7 +1375,9 @@ pub(crate) mod send {
             let server_child = stepper
                 .server_app
                 .world_mut()
-                .spawn(ChildOf(server_entity))
+                .spawn(ChildOf {
+                    parent: server_entity,
+                })
                 .id();
 
             stepper.frame_step();
@@ -1430,7 +1434,9 @@ pub(crate) mod send {
             let server_child = stepper
                 .server_app
                 .world_mut()
-                .spawn(ChildOf(server_entity))
+                .spawn(ChildOf {
+                    parent: server_entity,
+                })
                 .id();
             stepper.frame_step();
             stepper.frame_step();
@@ -1599,7 +1605,9 @@ pub(crate) mod send {
             let server_child = stepper
                 .server_app
                 .world_mut()
-                .spawn(ChildOf(server_entity))
+                .spawn(ChildOf {
+                    parent: server_entity,
+                })
                 .id();
             stepper.frame_step();
             stepper.frame_step();
@@ -1648,10 +1656,13 @@ pub(crate) mod send {
                 .world_mut()
                 .spawn(ReplicateToClient::default())
                 .id();
+
             let server_child = stepper
                 .server_app
                 .world_mut()
-                .spawn(ChildOf(server_entity))
+                .spawn(ChildOf {
+                    parent: server_entity,
+                })
                 .id();
             stepper.frame_step();
             stepper.frame_step();
@@ -3281,7 +3292,12 @@ pub(crate) mod send {
             let server_child = stepper
                 .server_app
                 .world_mut()
-                .spawn((ChildOf(server_entity), ComponentSyncModeOnce(1.0)))
+                .spawn((
+                    ChildOf {
+                        parent: server_entity,
+                    },
+                    ComponentSyncModeOnce(1.0),
+                ))
                 .id();
             stepper.frame_step();
             stepper.frame_step();
@@ -3813,7 +3829,7 @@ pub(crate) mod commands {
                 .client_app
                 .world_mut()
                 .query_filtered::<Entity, With<ComponentSyncModeFull>>()
-                .get_single(stepper.client_app.world())
+                .single(stepper.client_app.world())
                 .unwrap();
 
             // if we remove the Replicate bundle directly, and then despawn the entity
@@ -3831,7 +3847,7 @@ pub(crate) mod commands {
                 .client_app
                 .world_mut()
                 .query::<&ComponentSyncModeFull>()
-                .get_single(stepper.client_app.world())
+                .single(stepper.client_app.world())
                 .is_err());
 
             // spawn a new entity
@@ -3846,7 +3862,7 @@ pub(crate) mod commands {
                 .client_app
                 .world_mut()
                 .query::<&ComponentSyncModeFull>()
-                .get_single(stepper.client_app.world())
+                .single(stepper.client_app.world())
                 .is_ok());
 
             // apply the command to remove replicate
@@ -3858,7 +3874,7 @@ pub(crate) mod commands {
                 .client_app
                 .world_mut()
                 .query::<&ComponentSyncModeFull>()
-                .get_single(stepper.client_app.world())
+                .single(stepper.client_app.world())
                 .is_ok());
         }
     }

--- a/lightyear/src/server/replication.rs
+++ b/lightyear/src/server/replication.rs
@@ -78,7 +78,7 @@ pub(crate) mod send {
     use bevy::ecs::world::FilteredEntityRef;
     use bevy::ptr::Ptr;
 
-    use tracing::{trace, debug, error};
+    use tracing::{debug, error, trace};
 
     #[derive(Default)]
     pub struct ServerReplicationSendPlugin {

--- a/lightyear/src/server/replication.rs
+++ b/lightyear/src/server/replication.rs
@@ -78,6 +78,8 @@ pub(crate) mod send {
     use bevy::ecs::world::FilteredEntityRef;
     use bevy::ptr::Ptr;
 
+    use tracing::{trace, debug, error};
+
     #[derive(Default)]
     pub struct ServerReplicationSendPlugin {
         pub tick_interval: Duration,

--- a/lightyear/src/shared/events/systems.rs
+++ b/lightyear/src/shared/events/systems.rs
@@ -43,13 +43,13 @@ pub(crate) fn push_entity_events<R: ReplicationReceive>(
     mut entity_spawn_events: EventWriter<EntitySpawnEvent<R::EventContext>>,
     mut entity_despawn_events: EventWriter<EntityDespawnEvent<R::EventContext>>,
 ) {
-    entity_spawn_events.send_batch(
+    entity_spawn_events.write_batch(
         connection_manager
             .events()
             .into_iter_entity_spawn()
             .map(|(entity, ctx)| EntitySpawnEvent::new(entity, ctx)),
     );
-    entity_despawn_events.send_batch(
+    entity_despawn_events.write_batch(
         connection_manager
             .events()
             .into_iter_entity_despawn()

--- a/lightyear/src/shared/events/systems.rs
+++ b/lightyear/src/shared/events/systems.rs
@@ -17,19 +17,19 @@ pub(crate) fn push_component_events<C: Component, R: ReplicationReceive>(
     mut component_remove_events: EventWriter<ComponentRemoveEvent<C, R::EventContext>>,
     mut component_update_events: EventWriter<ComponentUpdateEvent<C, R::EventContext>>,
 ) {
-    component_insert_events.send_batch(
+    component_insert_events.write_batch(
         connection_manager
             .events()
             .iter_component_insert::<C>()
             .map(|(entity, ctx)| ComponentInsertEvent::new(entity, ctx)),
     );
-    component_remove_events.send_batch(
+    component_remove_events.write_batch(
         connection_manager
             .events()
             .iter_component_remove::<C>()
             .map(|(entity, ctx)| ComponentRemoveEvent::new(entity, ctx)),
     );
-    component_update_events.send_batch(
+    component_update_events.write_batch(
         connection_manager
             .events()
             .iter_component_update::<C>()

--- a/lightyear/src/shared/replication/archetypes.rs
+++ b/lightyear/src/shared/replication/archetypes.rs
@@ -16,7 +16,7 @@ use bevy::{
     },
     prelude::*,
 };
-use tracing::{trace};
+use tracing::trace;
 
 /// Cached information about all replicated archetypes.
 ///

--- a/lightyear/src/shared/replication/archetypes.rs
+++ b/lightyear/src/shared/replication/archetypes.rs
@@ -16,6 +16,7 @@ use bevy::{
     },
     prelude::*,
 };
+use tracing::{trace};
 
 /// Cached information about all replicated archetypes.
 ///

--- a/lightyear/src/shared/replication/components.rs
+++ b/lightyear/src/shared/replication/components.rs
@@ -1,7 +1,7 @@
 //! Components used for replication
 
 use bevy::ecs::reflect::ReflectComponent;
-use bevy::prelude::{require, Component, Entity, Reflect};
+use bevy::prelude::{Component, Entity, Reflect};
 use bevy::time::{Timer, TimerMode};
 use byteorder::{NetworkEndian, ReadBytesExt, WriteBytesExt};
 use serde::{Deserialize, Serialize};

--- a/lightyear/src/shared/replication/hierarchy.rs
+++ b/lightyear/src/shared/replication/hierarchy.rs
@@ -13,6 +13,7 @@ use bevy::reflect::GetTypeRegistration;
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
 use std::fmt::{Debug, Formatter};
+use tracing::trace;
 
 pub type ChildOfSync = RelationshipSync<ChildOf>;
 

--- a/lightyear/src/shared/replication/hierarchy.rs
+++ b/lightyear/src/shared/replication/hierarchy.rs
@@ -817,13 +817,13 @@ mod tests {
             .client_app
             .world_mut()
             .query_filtered::<Entity, With<ComponentSyncModeFull>>()
-            .get_single(stepper.client_app.world())
+            .single(stepper.client_app.world())
             .unwrap();
         let (client_parent, client_parent_sync, client_parent_component) = stepper
             .client_app
             .world_mut()
             .query_filtered::<(Entity, &ChildOfSync, &ChildOf), With<ComponentSyncModeSimple>>()
-            .get_single(stepper.client_app.world())
+            .single(stepper.client_app.world())
             .unwrap();
 
         assert_eq!(client_parent_sync.entity, Some(client_grandparent));
@@ -906,19 +906,19 @@ mod tests {
             .client_app
             .world_mut()
             .query_filtered::<Entity, With<ComponentSyncModeFull>>()
-            .get_single(stepper.client_app.world())
+            .single(stepper.client_app.world())
             .unwrap();
         let client_parent = stepper
             .client_app
             .world_mut()
             .query_filtered::<Entity, With<ComponentSyncModeSimple>>()
-            .get_single(stepper.client_app.world())
+            .single(stepper.client_app.world())
             .unwrap();
         let client_child = stepper
             .client_app
             .world_mut()
             .query_filtered::<Entity, With<ComponentSyncModeOnce>>()
-            .get_single(stepper.client_app.world())
+            .single(stepper.client_app.world())
             .unwrap();
 
         // 2. check that the hierarchies have been replicated
@@ -985,13 +985,13 @@ mod tests {
             .server_app
             .world_mut()
             .query_filtered::<Entity, With<ComponentSyncModeFull>>()
-            .get_single(stepper.server_app.world())
+            .single(stepper.server_app.world())
             .expect("parent entity was not replicated");
         let server_child = stepper
             .server_app
             .world_mut()
             .query_filtered::<Entity, With<ComponentClientToServer>>()
-            .get_single(stepper.server_app.world())
+            .single(stepper.server_app.world())
             .expect("child entity was not replicated");
         assert_eq!(
             stepper

--- a/lightyear/src/shared/replication/receive.rs
+++ b/lightyear/src/shared/replication/receive.rs
@@ -1487,7 +1487,7 @@ mod tests {
             .client_app
             .world_mut()
             .query_filtered::<(), (With<ComponentSyncModeOnce>, With<ComponentSyncModeSimple>)>()
-            .get_single(stepper.client_app.world())
+            .single(stepper.client_app.world())
             .is_ok());
     }
 
@@ -1546,7 +1546,7 @@ mod tests {
                 Without<ComponentSyncModeSimple>,
                 Without<ComponentSyncModeOnce>
             )>()
-            .get_single(stepper.client_app.world())
+            .single(stepper.client_app.world())
             .is_ok());
     }
 }


### PR DESCRIPTION
I was trying to consume bevy-main branch in my own project, so I figured it's useful to share the fixes I've made to that branch.

that said, i couldn't quite figure out what's going on with PreSpawnedPlayerObject, so the tests that use it fail to compile (was this struct removed?). Apart from that, there should be no more compilation errors.

I also ran cargo fmt and fixed a few deprecated functions (like: send_batch -> write_batch, send -> write)