### PR TITLE
Fix host-server mode for avian_physics and spaceships example

### DIFF
--- a/examples/avian_physics/src/main.rs
+++ b/examples/avian_physics/src/main.rs
@@ -3,9 +3,7 @@
 #![allow(dead_code)]
 use crate::shared::SharedPlugin;
 use bevy::prelude::*;
-use lightyear::prelude::client::PredictionConfig;
 use lightyear_examples_common::app::{Apps, Cli};
-use lightyear_examples_common::settings::Settings;
 
 #[cfg(feature = "client")]
 mod client;
@@ -33,7 +31,9 @@ fn main() {
     });
 
     apps.add_lightyear_plugins();
-    apps.add_user_shared_plugin(SharedPlugin);
+    apps.add_user_shared_plugin(SharedPlugin {
+        predict_all: settings.predict_all
+    });
     #[cfg(feature = "client")]
     apps.add_user_client_plugin(client::ExampleClientPlugin);
     #[cfg(feature = "server")]

--- a/examples/avian_physics/src/main.rs
+++ b/examples/avian_physics/src/main.rs
@@ -32,7 +32,7 @@ fn main() {
 
     apps.add_lightyear_plugins();
     apps.add_user_shared_plugin(SharedPlugin {
-        predict_all: settings.predict_all
+        predict_all: settings.predict_all,
     });
     #[cfg(feature = "client")]
     apps.add_user_client_plugin(client::ExampleClientPlugin);

--- a/examples/avian_physics/src/protocol.rs
+++ b/examples/avian_physics/src/protocol.rs
@@ -154,7 +154,9 @@ pub enum AdminActions {
 }
 
 // Protocol
-pub(crate) struct ProtocolPlugin;
+pub(crate) struct ProtocolPlugin  {
+    pub(crate) predict_all: bool,
+}
 
 impl Plugin for ProtocolPlugin {
     fn build(&self, app: &mut App) {
@@ -163,7 +165,7 @@ impl Plugin for ProtocolPlugin {
         // inputs
         app.add_plugins(LeafwingInputPlugin::<PlayerActions> {
             config: InputConfig::<PlayerActions> {
-                rebroadcast_inputs: true,
+                rebroadcast_inputs: self.predict_all,
                 ..default()
             },
         });

--- a/examples/avian_physics/src/protocol.rs
+++ b/examples/avian_physics/src/protocol.rs
@@ -154,7 +154,7 @@ pub enum AdminActions {
 }
 
 // Protocol
-pub(crate) struct ProtocolPlugin  {
+pub(crate) struct ProtocolPlugin {
     pub(crate) predict_all: bool,
 }
 

--- a/examples/avian_physics/src/server.rs
+++ b/examples/avian_physics/src/server.rs
@@ -100,6 +100,7 @@ pub(crate) fn replicate_players(
         // for all player entities we have received, add a Replicate component so that we can start replicating it
         // to other clients
         if let Some(mut e) = commands.get_entity(entity) {
+            info!("Adding replicate");
             // we want to replicate back to the original client, since they are using a pre-predicted entity
             let mut sync_target = SyncTarget::default();
 

--- a/examples/avian_physics/src/server.rs
+++ b/examples/avian_physics/src/server.rs
@@ -100,7 +100,6 @@ pub(crate) fn replicate_players(
         // for all player entities we have received, add a Replicate component so that we can start replicating it
         // to other clients
         if let Some(mut e) = commands.get_entity(entity) {
-            info!("Adding replicate");
             // we want to replicate back to the original client, since they are using a pre-predicted entity
             let mut sync_target = SyncTarget::default();
 
@@ -120,6 +119,7 @@ pub(crate) fn replicate_players(
                 group: REPLICATION_GROUP,
                 ..default()
             };
+            info!("Adding replicate");
             e.insert((
                 replicate,
                 // if we receive a pre-predicted entity, only send the prepredicted component back

--- a/examples/avian_physics/src/server.rs
+++ b/examples/avian_physics/src/server.rs
@@ -119,7 +119,6 @@ pub(crate) fn replicate_players(
                 group: REPLICATION_GROUP,
                 ..default()
             };
-            info!("Adding replicate");
             e.insert((
                 replicate,
                 // if we receive a pre-predicted entity, only send the prepredicted component back

--- a/examples/avian_physics/src/shared.rs
+++ b/examples/avian_physics/src/shared.rs
@@ -20,13 +20,13 @@ const WALL_SIZE: f32 = 350.0;
 
 #[derive(Clone)]
 pub struct SharedPlugin {
-    pub predict_all: bool
+    pub predict_all: bool,
 }
 
 impl Plugin for SharedPlugin {
     fn build(&self, app: &mut App) {
         app.add_plugins(ProtocolPlugin {
-            predict_all: self.predict_all
+            predict_all: self.predict_all,
         });
         // bundles
         app.add_systems(Startup, init);

--- a/examples/avian_physics/src/shared.rs
+++ b/examples/avian_physics/src/shared.rs
@@ -19,11 +19,15 @@ pub(crate) const MAX_VELOCITY: f32 = 200.0;
 const WALL_SIZE: f32 = 350.0;
 
 #[derive(Clone)]
-pub struct SharedPlugin;
+pub struct SharedPlugin {
+    pub predict_all: bool
+}
 
 impl Plugin for SharedPlugin {
     fn build(&self, app: &mut App) {
-        app.add_plugins(ProtocolPlugin);
+        app.add_plugins(ProtocolPlugin {
+            predict_all: self.predict_all
+        });
         // bundles
         app.add_systems(Startup, init);
 

--- a/examples/spaceships/Cargo.toml
+++ b/examples/spaceships/Cargo.toml
@@ -34,11 +34,9 @@ avian2d = { workspace = true, features = [
 ] }
 lightyear = { workspace = true, features = ["leafwing", "avian2d"] }
 serde.workspace = true
-anyhow.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 bevy.workspace = true
-rand.workspace = true
 bevygap_client_plugin = { workspace = true, optional = true, features = [
   "matchmaker-tls",
 ] }

--- a/lightyear/src/client/input/mod.rs
+++ b/lightyear/src/client/input/mod.rs
@@ -155,11 +155,16 @@ impl<A: UserActionState, F: Component> Plugin for BaseInputPlugin<A, F> {
             FixedPreUpdate,
             (
                 (
-                    // update_action_state_remote_players::<A>,
+                    // We run this even in host-server mode because there might be input-delay.
+                    // Also we want to buffer inputs in the InputBuffer so that we can broadcast
+                    // the host-server client's inputs to other clients
                     buffer_action_state::<A, F>,
                     // If InputDelay is enabled, we get the ActionState for the current tick
                     // from the InputBuffer (which was added to the InputBuffer input_delay ticks ago)
-                    get_non_rollback_action_state::<A>.run_if(is_input_delay),
+                    //
+                    // In host-server mode, we run the server's UpdateActionState which basically does this,
+                    // but also removes old inputs from the buffer!
+                    get_non_rollback_action_state::<A>.run_if(is_input_delay.and(should_run.clone())),
                 )
                     .chain()
                     .run_if(not(is_in_rollback)),

--- a/lightyear/src/client/input/mod.rs
+++ b/lightyear/src/client/input/mod.rs
@@ -164,7 +164,8 @@ impl<A: UserActionState, F: Component> Plugin for BaseInputPlugin<A, F> {
                     //
                     // In host-server mode, we run the server's UpdateActionState which basically does this,
                     // but also removes old inputs from the buffer!
-                    get_non_rollback_action_state::<A>.run_if(is_input_delay.and(should_run.clone())),
+                    get_non_rollback_action_state::<A>
+                        .run_if(is_input_delay.and(should_run.clone())),
                 )
                     .chain()
                     .run_if(not(is_in_rollback)),

--- a/lightyear/src/client/interpolation/visual_interpolation.rs
+++ b/lightyear/src/client/interpolation/visual_interpolation.rs
@@ -213,7 +213,7 @@ mod tests {
     use crate::tests::protocol::*;
     use crate::tests::stepper::BevyStepper;
     use approx::assert_relative_eq;
-    
+
     use bevy::utils::Duration;
 
     #[derive(Resource, Debug)]

--- a/lightyear/src/client/networking.rs
+++ b/lightyear/src/client/networking.rs
@@ -388,9 +388,15 @@ fn on_connect_host_server(
     mut server_manager: ResMut<crate::server::connection::ConnectionManager>,
     mut connect_event_writer: EventWriter<ConnectEvent>,
 ) {
-    // TODO: put this elsewhere! Maybe the SyncPlugin should have a startup function that runs if in host-server?
     // make sure the `is_synced` run conditions return true
-    connection_manager.sync_manager.synced = true;
+    // TODO: for some reason, enabling this breaks a LOT of things. I think we use the `is_synced` condition
+    //  too liberally in the code-base, normally it should just mean that SyncPlugin is done, but in a lot cases
+    //  we use it to mean: 'client is connected'. Investigate why this breaks things.
+    //  For example in host-server mode in AvianPhysics example, the ReplicationTarget component is not added
+    //   on the entity!
+    // connection_manager.sync_manager.synced = true;
+
+    // TODO: put this elsewhere! Maybe the SyncPlugin should have a startup function that runs if in host-server?
     // set the input delay value (since SyncPlugin does not run)
     connection_manager.sync_manager.current_input_delay = config
         .prediction

--- a/lightyear/src/client/networking.rs
+++ b/lightyear/src/client/networking.rs
@@ -389,6 +389,8 @@ fn on_connect_host_server(
     mut connect_event_writer: EventWriter<ConnectEvent>,
 ) {
     // TODO: put this elsewhere! Maybe the SyncPlugin should have a startup function that runs if in host-server?
+    // make sure the `is_synced` run conditions return true
+    connection_manager.sync_manager.synced = true;
     // set the input delay value (since SyncPlugin does not run)
     connection_manager.sync_manager.current_input_delay = config
         .prediction

--- a/lightyear/src/client/prediction/correction.rs
+++ b/lightyear/src/client/prediction/correction.rs
@@ -290,7 +290,10 @@ mod tests {
             .get::<Correction<ComponentCorrection>>(predicted)
             .unwrap();
         let current_visual = Some(ComponentCorrection(2.0 + ease_out_quad(0.4) * (11.0 - 2.0)));
-        assert_relative_eq!(correction.current_visual.as_ref().unwrap().0, current_visual.as_ref().unwrap().0);
+        assert_relative_eq!(
+            correction.current_visual.as_ref().unwrap().0,
+            current_visual.as_ref().unwrap().0
+        );
         assert_eq!(correction.current_correction.as_ref().unwrap().0, 11.0);
 
         // trigger a new rollback while the correction is under way
@@ -314,8 +317,13 @@ mod tests {
             original_tick + (original_tick - rollback_tick)
         );
         // interpolate 20% of the way
-        let current_visual = Some(ComponentCorrection(previous_visual + ease_out_quad(0.2) * (17.0 - previous_visual)));
-        assert_relative_eq!(correction.current_visual.as_ref().unwrap().0, current_visual.as_ref().unwrap().0);
+        let current_visual = Some(ComponentCorrection(
+            previous_visual + ease_out_quad(0.2) * (17.0 - previous_visual),
+        ));
+        assert_relative_eq!(
+            correction.current_visual.as_ref().unwrap().0,
+            current_visual.as_ref().unwrap().0
+        );
         assert_eq!(correction.current_correction.as_ref().unwrap().0, 17.0);
         stepper.frame_step();
         stepper.frame_step();
@@ -326,8 +334,13 @@ mod tests {
             .get::<Correction<ComponentCorrection>>(predicted)
             .unwrap();
         // interpolate 80% of the way
-        let current_visual = Some(ComponentCorrection(previous_visual + ease_out_quad(0.8) * (20.0 - previous_visual)));
-        assert_relative_eq!(correction.current_visual.as_ref().unwrap().0, current_visual.as_ref().unwrap().0);
+        let current_visual = Some(ComponentCorrection(
+            previous_visual + ease_out_quad(0.8) * (20.0 - previous_visual),
+        ));
+        assert_relative_eq!(
+            correction.current_visual.as_ref().unwrap().0,
+            current_visual.as_ref().unwrap().0
+        );
         assert_eq!(correction.current_correction.as_ref().unwrap().0, 20.0);
     }
 
@@ -340,7 +353,8 @@ mod tests {
     fn test_no_correction_if_no_misprediction() {
         let frame_duration = Duration::from_millis(10);
         let tick_duration = Duration::from_millis(10);
-        let (mut stepper, confirmed_a, predicted_a, confirmed_b, predicted_b) = setup(frame_duration, tick_duration);
+        let (mut stepper, confirmed_a, predicted_a, confirmed_b, predicted_b) =
+            setup(frame_duration, tick_duration);
 
         // we insert the component at a different frame to not trigger an early rollback
         stepper
@@ -434,7 +448,13 @@ mod tests {
             }
         );
         // check that the component is still visually the original prediction at the end of the frame
-        assert_eq!(stepper.client_app.world().get::<ComponentCorrection>(predicted), Some(&ComponentCorrection(2.0)));
+        assert_eq!(
+            stepper
+                .client_app
+                .world()
+                .get::<ComponentCorrection>(predicted),
+            Some(&ComponentCorrection(2.0))
+        );
         stepper.frame_step();
         // check that this time we ran FixedUpdate, but that we use the Corrected value as the final value to correct towards
         // not the original prediction! If that were the case, we would correct towards ComponentCorrection(3.0)
@@ -443,9 +463,9 @@ mod tests {
                 .client_app
                 .world()
                 .get::<Correction<ComponentCorrection>>(predicted)
-                .unwrap().current_correction,
+                .unwrap()
+                .current_correction,
             Some(ComponentCorrection(9.0)),
         );
     }
-
 }

--- a/lightyear/src/server/input/leafwing.rs
+++ b/lightyear/src/server/input/leafwing.rs
@@ -155,8 +155,8 @@ fn receive_input_message<A: LeafwingUserAction>(
 /// In host-server mode, we usually don't need to send any input messages because any update
 /// to the ActionState is immediately visible to the server.
 /// However we might want other clients to see the inputs of the host client, in which case we will create
-/// a InputMessage and send it to the server. The user can then have a `replicate_inputs` system that takes this
-/// message and propagates it to other clients
+/// a InputMessage and send it to the server.
+/// Then the 'rebroadcast_inputs' system will be able to rebroadcast the host-server's inputs to other clients.
 fn send_host_server_input_message<A: LeafwingUserAction>(
     connection: Res<ClientConnectionManager>,
     netclient: Res<ClientConnection>,

--- a/lightyear/src/server/input/mod.rs
+++ b/lightyear/src/server/input/mod.rs
@@ -58,11 +58,9 @@ impl<A: UserActionState> Plugin for BaseInputPlugin<A> {
         //  messages per frame if we didn't run FixedUpdate at all?
         app.configure_sets(
             PostUpdate,
-            (
-                InputSystemSet::RebroadcastInputs
-                .run_if(is_started)
-                .before(InternalMainSet::<ServerMarker>::SendEvents),
-            )
+            InputSystemSet::RebroadcastInputs
+            .run_if(is_started)
+            .before(InternalMainSet::<ServerMarker>::SendEvents)
         );
 
         // SYSTEMS
@@ -104,20 +102,6 @@ fn update_action_state<A: UserActionState>(
                 .set(input_buffer.len() as f64);
             }
         }
-        / remove all the previous values
-        // we keep the current value in the InputBuffer so that if future messages are lost, we can still
-        // fallback on the last known value
-        input_buffer.pop(tick - 1);
-    }
-}
-
-
-fn clean_buffers<A: UserActionState>(
-    tick_manager: Res<TickManager>,
-    mut action_state_query: Query<(Entity, &mut InputBuffer<A>)>,
-) {
-    let tick = tick_manager.tick();
-    for (entity, mut input_buffer) in action_state_query.iter_mut() {
         // remove all the previous values
         // we keep the current value in the InputBuffer so that if future messages are lost, we can still
         // fallback on the last known value

--- a/lightyear/src/server/input/mod.rs
+++ b/lightyear/src/server/input/mod.rs
@@ -48,7 +48,7 @@ impl<A: UserActionState> Plugin for BaseInputPlugin<A> {
                 InternalMainSet::<ServerMarker>::ReceiveEvents,
                 InputSystemSet::ReceiveInputs.run_if(is_started),
             )
-                .chain()
+                .chain(),
         );
         app.configure_sets(
             FixedPreUpdate,
@@ -59,8 +59,8 @@ impl<A: UserActionState> Plugin for BaseInputPlugin<A> {
         app.configure_sets(
             PostUpdate,
             InputSystemSet::RebroadcastInputs
-            .run_if(is_started)
-            .before(InternalMainSet::<ServerMarker>::SendEvents)
+                .run_if(is_started)
+                .before(InternalMainSet::<ServerMarker>::SendEvents),
         );
 
         // SYSTEMS


### PR DESCRIPTION
For some reason in some cases the inputs wouldn't work properly in host-server mode.
I think it's some system ordering issue, because we would run both the client system and the server system that fetches the input from the InputBuffer and set the ActionState to it.

The examples still seem to have some issues:
- avian_physics is not smooth despite having VisualInterpolation turned on
- the host-server inputs cause some rollbacks on the remote client, even though it looks like there is enough input-delay so that the remote-client can always perfectly predict the host-server's actions