### PR TITLE
Make SteamworksClient construction fallible

### DIFF
--- a/lightyear/src/connection/client.rs
+++ b/lightyear/src/connection/client.rs
@@ -156,9 +156,9 @@ impl NetConfig {
             } => {
                 let client = super::steam::client::Client::new(
                     steamworks_client.unwrap_or_else(|| {
-                        Arc::new(RwLock::new(SteamworksClient::new_with_app_id(
-                            config.app_id,
-                        )))
+                        Arc::new(RwLock::new(
+                            SteamworksClient::new_with_app_id(config.app_id).unwrap(),
+                        ))
                     }),
                     config,
                     conditioner,

--- a/lightyear/src/connection/server.rs
+++ b/lightyear/src/connection/server.rs
@@ -158,9 +158,9 @@ impl NetConfig {
                 // TODO: handle errors
                 let server = super::steam::server::Server::new(
                     steamworks_client.unwrap_or_else(|| {
-                        Arc::new(RwLock::new(SteamworksClient::new_with_app_id(
-                            config.app_id,
-                        )))
+                        Arc::new(RwLock::new(
+                            SteamworksClient::new_with_app_id(config.app_id).unwrap(),
+                        ))
                     }),
                     config,
                     conditioner,

--- a/lightyear/src/connection/steam/steamworks_client.rs
+++ b/lightyear/src/connection/steam/steamworks_client.rs
@@ -1,5 +1,5 @@
 use bevy::utils::synccell::SyncCell;
-use steamworks::{ClientManager, SingleClient};
+use steamworks::{ClientManager, SingleClient, SIResult};
 
 /// This wraps the Steamworks client. It must only be created once per
 /// application run. For convenience, Lightyear can automatically create the
@@ -21,28 +21,28 @@ impl std::fmt::Debug for SteamworksClient {
 impl SteamworksClient {
     /// Creates and initializes the Steamworks client with the specified AppId.
     /// This must only be called once per application run.
-    pub fn new_with_app_id(app_id: u32) -> Self {
-        let (client, single) = steamworks::Client::<ClientManager>::init_app(app_id).unwrap();
+    pub fn new_with_app_id(app_id: u32) -> SIResult<Self> {
+        let (client, single) = steamworks::Client::<ClientManager>::init_app(app_id)?;
 
-        Self {
+        Ok(Self {
             app_id,
             client,
             single: SyncCell::new(single),
-        }
+        })
     }
 
     /// Creates and initializes the Steamworks client. If the game isn’t being run through steam
     /// this can be provided by placing a steam_appid.txt with the ID inside in the current
     /// working directory.
     /// This must only be called once per application run.
-    pub fn new() -> Self {
-        let (client, single) = steamworks::Client::<ClientManager>::init().unwrap();
+    pub fn new() -> SIResult<Self> {
+        let (client, single) = steamworks::Client::<ClientManager>::init()?;
 
-        Self {
+        Ok(Self {
             app_id: client.utils().app_id().0,
             client,
             single: SyncCell::new(single),
-        }
+        })
     }
 
     /// Gets the thread-safe Steamworks client. Most Steamworks API calls live


### PR DESCRIPTION
When Steam is not running the creation of the steamworks::Client will fail, and as-is that causes an unwrap in the constructor of SteamworksClient. The way to work around it would be to create the SteamworksClient manually, but this is not possible since the fields are private. Therefore I'm suggesting to make the construction fallible so you can choose to construct it yourself, and just not turn on the steam server if the construction fails.

I've left the existing behaviour of the built-in fallback SteamworksClient unwrapping on initialization error, but maybe this should be addressed too.