### PR TITLE
Fix Inputs

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1,3 +1,12 @@
+# BEVY
+
+I noticed that when system ordering is ambiguous, once my app is compiled, the system order is completely fixed (i.e. all the ambiguous systems get ordered in a given fixed order). Is there a way to get what that fixed system order is?
+Is it the cached topsort of the schedule?
+Does bevy_mod_debugdump show that 'fixed' system order?
+It would be immensely useful to know what the exact system order being used is, so that I can debug which ambiguity is causing a given bug.
+Should I create an issue for something like this? I would love the editor to somehow provide tools to help me debug ambiguities 
+
+
 # PrePrediction
 
 - Current situation:

--- a/examples/avian_physics/src/main.rs
+++ b/examples/avian_physics/src/main.rs
@@ -3,9 +3,7 @@
 #![allow(dead_code)]
 use crate::shared::SharedPlugin;
 use bevy::prelude::*;
-use lightyear::prelude::client::PredictionConfig;
 use lightyear_examples_common::app::{Apps, Cli};
-use lightyear_examples_common::settings::Settings;
 
 #[cfg(feature = "client")]
 mod client;
@@ -33,7 +31,9 @@ fn main() {
     });
 
     apps.add_lightyear_plugins();
-    apps.add_user_shared_plugin(SharedPlugin);
+    apps.add_user_shared_plugin(SharedPlugin {
+        predict_all: settings.predict_all,
+    });
     #[cfg(feature = "client")]
     apps.add_user_client_plugin(client::ExampleClientPlugin);
     #[cfg(feature = "server")]

--- a/examples/avian_physics/src/protocol.rs
+++ b/examples/avian_physics/src/protocol.rs
@@ -154,7 +154,9 @@ pub enum AdminActions {
 }
 
 // Protocol
-pub(crate) struct ProtocolPlugin;
+pub(crate) struct ProtocolPlugin {
+    pub(crate) predict_all: bool,
+}
 
 impl Plugin for ProtocolPlugin {
     fn build(&self, app: &mut App) {
@@ -163,7 +165,7 @@ impl Plugin for ProtocolPlugin {
         // inputs
         app.add_plugins(LeafwingInputPlugin::<PlayerActions> {
             config: InputConfig::<PlayerActions> {
-                rebroadcast_inputs: true,
+                rebroadcast_inputs: self.predict_all,
                 ..default()
             },
         });

--- a/examples/avian_physics/src/shared.rs
+++ b/examples/avian_physics/src/shared.rs
@@ -19,11 +19,15 @@ pub(crate) const MAX_VELOCITY: f32 = 200.0;
 const WALL_SIZE: f32 = 350.0;
 
 #[derive(Clone)]
-pub struct SharedPlugin;
+pub struct SharedPlugin {
+    pub predict_all: bool,
+}
 
 impl Plugin for SharedPlugin {
     fn build(&self, app: &mut App) {
-        app.add_plugins(ProtocolPlugin);
+        app.add_plugins(ProtocolPlugin {
+            predict_all: self.predict_all,
+        });
         // bundles
         app.add_systems(Startup, init);
 

--- a/examples/spaceships/Cargo.toml
+++ b/examples/spaceships/Cargo.toml
@@ -34,11 +34,9 @@ avian2d = { workspace = true, features = [
 ] }
 lightyear = { workspace = true, features = ["leafwing", "avian2d"] }
 serde.workspace = true
-anyhow.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 bevy.workspace = true
-rand.workspace = true
 bevygap_client_plugin = { workspace = true, optional = true, features = [
   "matchmaker-tls",
 ] }

--- a/examples/spaceships/src/client.rs
+++ b/examples/spaceships/src/client.rs
@@ -102,11 +102,6 @@ fn handle_new_player(
             ]));
         } else {
             info!("Remote player replicated to us: {entity:?} {player:?}");
-            // inserting an input buffer for other clients so that we can predict them properly
-            // (the server will send other player's inputs to us; we will receive them on time thanks to input delay)
-            commands
-                .entity(entity)
-                .insert(InputBuffer::<PlayerActions>::default());
         }
         let client_id = connection.id();
         info!(?entity, ?client_id, "adding physics to predicted player");

--- a/lightyear/src/client/input/leafwing.rs
+++ b/lightyear/src/client/input/leafwing.rs
@@ -128,6 +128,7 @@ impl<A: LeafwingUserAction> Plugin for LeafwingInputPlugin<A>
         );
 
         // SYSTEMS
+        // TODO: should we have an observer that adds ActionState if InputBuffer is added?
         // we use required components for native inputs; here let's use observers
         app.add_observer(add_action_state::<A>);
         app.add_observer(add_input_buffer::<A>);
@@ -371,14 +372,14 @@ fn receive_remote_player_input_messages<A: LeafwingUserAction>(
                 InputTarget::PrePredictedEntity(entity) => Some(entity),
             };
             if let Some(entity) = entity {
-                debug!(
+                trace!(
                     "received input message for entity: {:?}. Applying to diff buffer.",
                     entity
                 );
                 if let Ok(confirmed) = confirmed_query.get(entity) {
                     if let Some(predicted) = confirmed.predicted {
                         if let Ok(input_buffer) = predicted_query.get_mut(predicted) {
-                            debug!(?entity, ?target_data.diffs, end_tick = ?message.end_tick, "update action diff buffer for remote player PREDICTED using input message");
+                            trace!(?entity, ?target_data.diffs, end_tick = ?message.end_tick, "update action diff buffer for remote player PREDICTED using input message");
                             if let Some(mut input_buffer) = input_buffer {
                                 input_buffer.update_from_diffs(
                                     message.end_tick,
@@ -403,6 +404,7 @@ fn receive_remote_player_input_messages<A: LeafwingUserAction>(
                                         .set(input_buffer.len() as f64);
                                 }
                             } else {
+                                debug!(?entity, "Inserting input buffer for remote player!");
                                 // add the ActionState or InputBuffer if they are missing
                                 let mut input_buffer = InputBuffer::<A>::default();
                                 input_buffer.update_from_diffs(

--- a/lightyear/src/client/input/native.rs
+++ b/lightyear/src/client/input/native.rs
@@ -118,6 +118,9 @@ impl<A: UserAction> Plugin for InputPlugin<A> {
         app.init_resource::<MessageBuffer<A>>();
 
         // SYSTEMS
+        // we don't need this for native inputs because it's handled by required components
+        // app.add_observer(add_action_state::<A>);
+        // app.add_observer(add_input_buffer::<A>);
         if self.config.rebroadcast_inputs {
             app.add_systems(
                 RunFixedMainLoop,

--- a/lightyear/src/client/interpolation/visual_interpolation.rs
+++ b/lightyear/src/client/interpolation/visual_interpolation.rs
@@ -213,7 +213,7 @@ mod tests {
     use crate::tests::protocol::*;
     use crate::tests::stepper::BevyStepper;
     use approx::assert_relative_eq;
-    
+
     use bevy::utils::Duration;
 
     #[derive(Resource, Debug)]

--- a/lightyear/src/client/networking.rs
+++ b/lightyear/src/client/networking.rs
@@ -388,6 +388,14 @@ fn on_connect_host_server(
     mut server_manager: ResMut<crate::server::connection::ConnectionManager>,
     mut connect_event_writer: EventWriter<ConnectEvent>,
 ) {
+    // make sure the `is_synced` run conditions return true
+    // TODO: for some reason, enabling this breaks a LOT of things. I think we use the `is_synced` condition
+    //  too liberally in the code-base, normally it should just mean that SyncPlugin is done, but in a lot cases
+    //  we use it to mean: 'client is connected'. Investigate why this breaks things.
+    //  For example in host-server mode in AvianPhysics example, the ReplicationTarget component is not added
+    //   on the entity!
+    // connection_manager.sync_manager.synced = true;
+
     // TODO: put this elsewhere! Maybe the SyncPlugin should have a startup function that runs if in host-server?
     // set the input delay value (since SyncPlugin does not run)
     connection_manager.sync_manager.current_input_delay = config

--- a/lightyear/src/client/prediction/correction.rs
+++ b/lightyear/src/client/prediction/correction.rs
@@ -290,7 +290,10 @@ mod tests {
             .get::<Correction<ComponentCorrection>>(predicted)
             .unwrap();
         let current_visual = Some(ComponentCorrection(2.0 + ease_out_quad(0.4) * (11.0 - 2.0)));
-        assert_relative_eq!(correction.current_visual.as_ref().unwrap().0, current_visual.as_ref().unwrap().0);
+        assert_relative_eq!(
+            correction.current_visual.as_ref().unwrap().0,
+            current_visual.as_ref().unwrap().0
+        );
         assert_eq!(correction.current_correction.as_ref().unwrap().0, 11.0);
 
         // trigger a new rollback while the correction is under way
@@ -314,8 +317,13 @@ mod tests {
             original_tick + (original_tick - rollback_tick)
         );
         // interpolate 20% of the way
-        let current_visual = Some(ComponentCorrection(previous_visual + ease_out_quad(0.2) * (17.0 - previous_visual)));
-        assert_relative_eq!(correction.current_visual.as_ref().unwrap().0, current_visual.as_ref().unwrap().0);
+        let current_visual = Some(ComponentCorrection(
+            previous_visual + ease_out_quad(0.2) * (17.0 - previous_visual),
+        ));
+        assert_relative_eq!(
+            correction.current_visual.as_ref().unwrap().0,
+            current_visual.as_ref().unwrap().0
+        );
         assert_eq!(correction.current_correction.as_ref().unwrap().0, 17.0);
         stepper.frame_step();
         stepper.frame_step();
@@ -326,8 +334,13 @@ mod tests {
             .get::<Correction<ComponentCorrection>>(predicted)
             .unwrap();
         // interpolate 80% of the way
-        let current_visual = Some(ComponentCorrection(previous_visual + ease_out_quad(0.8) * (20.0 - previous_visual)));
-        assert_relative_eq!(correction.current_visual.as_ref().unwrap().0, current_visual.as_ref().unwrap().0);
+        let current_visual = Some(ComponentCorrection(
+            previous_visual + ease_out_quad(0.8) * (20.0 - previous_visual),
+        ));
+        assert_relative_eq!(
+            correction.current_visual.as_ref().unwrap().0,
+            current_visual.as_ref().unwrap().0
+        );
         assert_eq!(correction.current_correction.as_ref().unwrap().0, 20.0);
     }
 
@@ -340,7 +353,8 @@ mod tests {
     fn test_no_correction_if_no_misprediction() {
         let frame_duration = Duration::from_millis(10);
         let tick_duration = Duration::from_millis(10);
-        let (mut stepper, confirmed_a, predicted_a, confirmed_b, predicted_b) = setup(frame_duration, tick_duration);
+        let (mut stepper, confirmed_a, predicted_a, confirmed_b, predicted_b) =
+            setup(frame_duration, tick_duration);
 
         // we insert the component at a different frame to not trigger an early rollback
         stepper
@@ -434,7 +448,13 @@ mod tests {
             }
         );
         // check that the component is still visually the original prediction at the end of the frame
-        assert_eq!(stepper.client_app.world().get::<ComponentCorrection>(predicted), Some(&ComponentCorrection(2.0)));
+        assert_eq!(
+            stepper
+                .client_app
+                .world()
+                .get::<ComponentCorrection>(predicted),
+            Some(&ComponentCorrection(2.0))
+        );
         stepper.frame_step();
         // check that this time we ran FixedUpdate, but that we use the Corrected value as the final value to correct towards
         // not the original prediction! If that were the case, we would correct towards ComponentCorrection(3.0)
@@ -443,9 +463,9 @@ mod tests {
                 .client_app
                 .world()
                 .get::<Correction<ComponentCorrection>>(predicted)
-                .unwrap().current_correction,
+                .unwrap()
+                .current_correction,
             Some(ComponentCorrection(9.0)),
         );
     }
-
 }

--- a/lightyear/src/connection/client.rs
+++ b/lightyear/src/connection/client.rs
@@ -156,9 +156,9 @@ impl NetConfig {
             } => {
                 let client = super::steam::client::Client::new(
                     steamworks_client.unwrap_or_else(|| {
-                        Arc::new(RwLock::new(SteamworksClient::new_with_app_id(
-                            config.app_id,
-                        )))
+                        Arc::new(RwLock::new(
+                            SteamworksClient::new_with_app_id(config.app_id).unwrap(),
+                        ))
                     }),
                     config,
                     conditioner,

--- a/lightyear/src/connection/server.rs
+++ b/lightyear/src/connection/server.rs
@@ -158,9 +158,9 @@ impl NetConfig {
                 // TODO: handle errors
                 let server = super::steam::server::Server::new(
                     steamworks_client.unwrap_or_else(|| {
-                        Arc::new(RwLock::new(SteamworksClient::new_with_app_id(
-                            config.app_id,
-                        )))
+                        Arc::new(RwLock::new(
+                            SteamworksClient::new_with_app_id(config.app_id).unwrap(),
+                        ))
                     }),
                     config,
                     conditioner,

--- a/lightyear/src/connection/steam/steamworks_client.rs
+++ b/lightyear/src/connection/steam/steamworks_client.rs
@@ -1,5 +1,5 @@
 use bevy::utils::synccell::SyncCell;
-use steamworks::{ClientManager, SingleClient};
+use steamworks::{ClientManager, SingleClient, SIResult};
 
 /// This wraps the Steamworks client. It must only be created once per
 /// application run. For convenience, Lightyear can automatically create the
@@ -21,28 +21,28 @@ impl std::fmt::Debug for SteamworksClient {
 impl SteamworksClient {
     /// Creates and initializes the Steamworks client with the specified AppId.
     /// This must only be called once per application run.
-    pub fn new_with_app_id(app_id: u32) -> Self {
-        let (client, single) = steamworks::Client::<ClientManager>::init_app(app_id).unwrap();
+    pub fn new_with_app_id(app_id: u32) -> SIResult<Self> {
+        let (client, single) = steamworks::Client::<ClientManager>::init_app(app_id)?;
 
-        Self {
+        Ok(Self {
             app_id,
             client,
             single: SyncCell::new(single),
-        }
+        })
     }
 
     /// Creates and initializes the Steamworks client. If the game isn’t being run through steam
     /// this can be provided by placing a steam_appid.txt with the ID inside in the current
     /// working directory.
     /// This must only be called once per application run.
-    pub fn new() -> Self {
-        let (client, single) = steamworks::Client::<ClientManager>::init().unwrap();
+    pub fn new() -> SIResult<Self> {
+        let (client, single) = steamworks::Client::<ClientManager>::init()?;
 
-        Self {
+        Ok(Self {
             app_id: client.utils().app_id().0,
             client,
             single: SyncCell::new(single),
-        }
+        })
     }
 
     /// Gets the thread-safe Steamworks client. Most Steamworks API calls live

--- a/lightyear/src/inputs/native/mod.rs
+++ b/lightyear/src/inputs/native/mod.rs
@@ -79,7 +79,7 @@ impl<A: Serialize + DeserializeOwned + Clone + PartialEq + Send + Sync + Debug +
 {
 }
 
-pub trait UserActionState: UserAction + Component + Default {
+pub trait UserActionState: UserAction + Component + Default + Debug {
     type UserAction: UserAction;
 }
 

--- a/lightyear/src/server/input/leafwing.rs
+++ b/lightyear/src/server/input/leafwing.rs
@@ -50,6 +50,8 @@ impl<A: LeafwingUserAction> Plugin for LeafwingInputPlugin<A> {
             app.add_systems(
                 PostUpdate,
                 (
+                    // TODO: is this necessary? why don't we just use the client's SendInputMessage?
+                    //  now messages work seamlessly in host-server mode, so it should work!
                     send_host_server_input_message::<A>.run_if(is_host_server),
                     rebroadcast_inputs::<A>,
                 )
@@ -155,8 +157,8 @@ fn receive_input_message<A: LeafwingUserAction>(
 /// In host-server mode, we usually don't need to send any input messages because any update
 /// to the ActionState is immediately visible to the server.
 /// However we might want other clients to see the inputs of the host client, in which case we will create
-/// a InputMessage and send it to the server. The user can then have a `replicate_inputs` system that takes this
-/// message and propagates it to other clients
+/// a InputMessage and send it to the server.
+/// Then the 'rebroadcast_inputs' system will be able to rebroadcast the host-server's inputs to other clients.
 fn send_host_server_input_message<A: LeafwingUserAction>(
     connection: Res<ClientConnectionManager>,
     netclient: Res<ClientConnection>,

--- a/lightyear/src/server/input/mod.rs
+++ b/lightyear/src/server/input/mod.rs
@@ -7,7 +7,7 @@ pub mod leafwing;
 
 use crate::inputs::native::input_buffer::InputBuffer;
 use crate::inputs::native::UserActionState;
-use crate::prelude::{server::is_started, TickManager};
+use crate::prelude::{is_host_server, server::is_started, TickManager};
 use crate::shared::sets::{InternalMainSet, ServerMarker};
 use bevy::prelude::*;
 
@@ -48,11 +48,12 @@ impl<A: UserActionState> Plugin for BaseInputPlugin<A> {
                 InternalMainSet::<ServerMarker>::ReceiveEvents,
                 InputSystemSet::ReceiveInputs.run_if(is_started),
             )
-                .chain()
+                .chain(),
         );
         app.configure_sets(
             FixedPreUpdate,
-            InputSystemSet::UpdateActionState.run_if(is_started),
+            InputSystemSet::UpdateActionState.run_if(is_started)
+                .after(crate::client::input::InputSystemSet::BufferClientInputs),
         );
         // TODO: maybe put this in a Fixed schedule to avoid sending multiple host-server identical
         //  messages per frame if we didn't run FixedUpdate at all?
@@ -102,6 +103,8 @@ fn update_action_state<A: UserActionState>(
                 .set(input_buffer.len() as f64);
             }
         }
+        // TODO: in host-server mode, if we rebroadcast inputs, we might want to keep a bit of a history
+        //  in the buffer so that we have redundancy when we broadcast to other clients
         // remove all the previous values
         // we keep the current value in the InputBuffer so that if future messages are lost, we can still
         // fallback on the last known value

--- a/lightyear/src/server/input/native.rs
+++ b/lightyear/src/server/input/native.rs
@@ -5,11 +5,7 @@ use crate::connection::client::{ClientConnection, NetClient};
 use crate::inputs::native::input_buffer::InputBuffer;
 use crate::inputs::native::input_message::{InputMessage, InputTarget};
 use crate::inputs::native::{ActionState, InputMarker};
-use crate::prelude::{
-    is_host_server, ChannelKind, ChannelRegistry, ClientConnectionManager, InputChannel,
-    MessageRegistry, NetworkTarget, ServerReceiveMessage, ServerSendMessage, TickManager,
-    UserAction,
-};
+use crate::prelude::{is_host_server, ChannelKind, ChannelRegistry, ClientConnectionManager, InputChannel, LeafwingUserAction, MessageRegistry, NetworkTarget, ServerReceiveMessage, ServerSendMessage, TickManager, UserAction};
 use crate::server::connection::ConnectionManager;
 use crate::server::input::InputSystemSet;
 use crate::shared::input::InputConfig;
@@ -40,6 +36,8 @@ impl<A: UserAction> Plugin for InputPlugin<A> {
             marker: std::marker::PhantomData,
         });
         // SYSTEMS
+        // we don't need this for native inputs because InputBuffer is required by ActionState
+        // app.add_observer(add_action_state_buffer::<A>);
         app.add_systems(
             PreUpdate,
             (receive_input_message::<A>,).in_set(InputSystemSet::ReceiveInputs),


### PR DESCRIPTION
- Spaceships example was inserting InputBuffer on the remote players, which was preventing the logic that inserts InputBuffer + ActionState to run
- In HostServer:
  - We won't run the BufferInputs from client, but use the one from server instead (which does input-buffer cleanup as a bonus). Don't forget to add the correct ordering!
  - don't set `is_synced=True` because this causes issues for some reason