### PR TITLE
Fix prespawn tick mismatch

### DIFF
--- a/lightyear/src/shared/replication/receive.rs
+++ b/lightyear/src/shared/replication/receive.rs
@@ -769,6 +769,11 @@ impl GroupChannel {
             }
         }
 
+        // Flush commands because the entities that were inserted might have triggered some observers
+        // In particular, the PreSpawned component triggers an observer that inserts Confirmed, and
+        // we want Confirmed to be added so that it can be updated with the correct tick!
+        world.flush();
+
         // TODO: apply authority check for the update confirmed tick?
         self.update_confirmed_tick(world, group_id, remote_tick, remote_entity_map);
     }
@@ -840,6 +845,11 @@ impl GroupChannel {
                     });
             }
         }
+
+        // Flush commands because the entities that were inserted might have triggered some observers
+        // In particular, the PreSpawned component triggers an observer that inserts Confirmed, and
+        // we want Confirmed to be added so that it can be updated with the correct tick!
+        world.flush();
 
         // TODO: should the update_confirmed_tick only be for entities in the group for which
         //  we have authority?


### PR DESCRIPTION
This PR is a solution for https://github.com/cBournhonesque/lightyear/issues/957 where the PreSpawned observer adds a Command that runs Confirmed, but the command is not flushed so Confirmed is not updated with the right tick.

We still want to add a unit test for this bug though