### PR TITLE
Add RequiredComponents for leafwing inputs

### DIFF
--- a/lightyear/src/client/input/leafwing.rs
+++ b/lightyear/src/client/input/leafwing.rs
@@ -128,10 +128,6 @@ impl<A: LeafwingUserAction> Plugin for LeafwingInputPlugin<A>
         );
 
         // SYSTEMS
-        // TODO: should we have an observer that adds ActionState if InputBuffer is added?
-        // we use required components for native inputs; here let's use observers
-        app.add_observer(add_action_state::<A>);
-        app.add_observer(add_input_buffer::<A>);
         if self.config.rebroadcast_inputs {
             app.add_systems(
                 RunFixedMainLoop,
@@ -153,36 +149,6 @@ impl<A: LeafwingUserAction> Plugin for LeafwingInputPlugin<A>
         );
         // if the client tick is updated because of a desync, update the ticks in the input buffers
         app.add_observer(receive_tick_events::<A>);
-    }
-}
-
-/// For each entity that has the Action component, insert an input buffer.
-fn add_input_buffer<A: LeafwingUserAction>(
-    trigger: Trigger<OnAdd, ActionState<A>>,
-    mut commands: Commands,
-    query: Query<(), Without<InputBuffer<A>>>,
-) {
-    // TODO: find a way to add input-buffer/action-diff-buffer only for controlled entity
-    //  maybe provide the "controlled" component? or just use With<InputMap>?
-    if let Ok(()) = query.get(trigger.entity()) {
-        commands
-            .entity(trigger.entity())
-            .insert((InputBuffer::<A>::default(),));
-    }
-}
-
-/// For each entity that has the Action component, insert an input buffer.
-fn add_action_state<A: LeafwingUserAction>(
-    trigger: Trigger<OnAdd, InputMap<A>>,
-    mut commands: Commands,
-    query: Query<(), Without<ActionState<A>>>,
-) {
-    // TODO: find a way to add input-buffer/action-diff-buffer only for controlled entity
-    //  maybe provide the "controlled" component? or just use With<InputMap>?
-    if let Ok(()) = query.get(trigger.entity()) {
-        commands
-            .entity(trigger.entity())
-            .insert((ActionState::<A>::default(),));
     }
 }
 

--- a/lightyear/src/server/input/leafwing.rs
+++ b/lightyear/src/server/input/leafwing.rs
@@ -38,8 +38,6 @@ impl<A: LeafwingUserAction> Plugin for LeafwingInputPlugin<A> {
         });
 
         // SYSTEMS
-        // TODO: this runs twice in host-server mode. How to avoid this?
-        app.add_observer(add_action_state_buffer::<A>);
         app.add_systems(
             PreUpdate,
             receive_input_message::<A>.in_set(InputSystemSet::ReceiveInputs),
@@ -69,18 +67,6 @@ impl<A: LeafwingUserAction> Plugin for LeafwingInputPlugin<A> {
     }
 }
 
-/// For each entity that has the Action component, insert an input buffer.
-fn add_action_state_buffer<A: LeafwingUserAction>(
-    trigger: Trigger<OnAdd, ActionState<A>>,
-    mut commands: Commands,
-    query: Query<(), Without<InputBuffer<A>>>,
-) {
-    if let Ok(()) = query.get(trigger.entity()) {
-        commands
-            .entity(trigger.entity())
-            .insert((InputBuffer::<A>::default(),));
-    }
-}
 
 // TODO? is this correct? maybe she would update the FixedUpdate state! not the Update state?
 /// Read the input messages from the server events to update the InputBuffers

--- a/lightyear/src/shared/input/leafwing.rs
+++ b/lightyear/src/shared/input/leafwing.rs
@@ -1,12 +1,13 @@
 //! Plugin to register and handle user inputs.
 
-use bevy::app::{App, Plugin};
-
 use crate::client::config::ClientConfig;
+use crate::inputs::leafwing::input_buffer::InputBuffer;
 use crate::prelude::{ChannelDirection, InputMessage, LeafwingUserAction};
 use crate::protocol::message::registry::AppMessageInternalExt;
 use crate::server::config::ServerConfig;
 use crate::shared::input::InputConfig;
+use bevy::app::{App, Plugin};
+use leafwing_input_manager::prelude::{ActionState, InputMap};
 
 pub struct LeafwingInputPlugin<A> {
     pub config: InputConfig<A>,
@@ -24,10 +25,15 @@ impl<A: LeafwingUserAction> Plugin for LeafwingInputPlugin<A> {
     fn build(&self, app: &mut App) {
         let is_client = app.world().get_resource::<ClientConfig>().is_some();
         let is_server = app.world().get_resource::<ServerConfig>().is_some();
+
         assert!(
             is_client || is_server,
             "LeafwingInputPlugin must be added after the Client/Server plugins have been added"
         );
+
+        app.register_required_components::<ActionState<A>, InputBuffer<A>>();
+        app.register_required_components::<InputBuffer<A>, ActionState<A>>();
+        app.register_required_components::<InputMap<A>, ActionState<A>>();
         if is_client {
             app.add_plugins(
                 crate::client::input::leafwing::LeafwingInputPlugin::<A>::new(self.config),

--- a/lightyear/src/shared/input/native.rs
+++ b/lightyear/src/shared/input/native.rs
@@ -1,7 +1,9 @@
 //! Plugin to register and handle user inputs.
 
 use crate::client::config::ClientConfig;
+use crate::inputs::native::input_buffer::InputBuffer;
 use crate::inputs::native::input_message::InputMessage;
+use crate::inputs::native::ActionState;
 use crate::prelude::{ChannelDirection, UserAction};
 use crate::protocol::message::registry::AppMessageInternalExt;
 use crate::server::config::ServerConfig;
@@ -34,6 +36,9 @@ impl<A: UserAction + MapEntities> Plugin for InputPlugin<A> {
         let is_client = app.world().get_resource::<ClientConfig>().is_some();
         let is_server = app.world().get_resource::<ServerConfig>().is_some();
         assert!(is_client || is_server, "Either ClientConfig or ServerConfig must be present! Make sure that your SharedPlugin is registered after the ClientPlugins/ServerPlugins");
+
+        app.register_required_components::<InputBuffer<ActionState<A>>, ActionState<A>>();
+
         if is_client {
             app.add_plugins(crate::client::input::native::InputPlugin::<A>::new(
                 self.config.clone(),


### PR DESCRIPTION
Native inputs was using required components to always add the necessary components:
- ActionState if InputMap is added
- InputBuffer if ActionState is added
- ActionState if InputBuffer is added

I just realized that bevy has an api to add required components bounds to external components, so add these to lightyear ActionState as well