### PR TITLE
Fix inserting ChildOfSync in host-server mode

### DIFF
--- a/lightyear/src/client/prediction/spawn.rs
+++ b/lightyear/src/client/prediction/spawn.rs
@@ -153,7 +153,7 @@ mod tests {
                 .world()
                 .get::<ChildOf>(confirmed_child)
                 .expect("confirmed child entity doesn't have a parent")
-                .get(),
+                .parent(),
             confirmed_parent
         );
 
@@ -179,7 +179,7 @@ mod tests {
                 .world()
                 .get::<ChildOf>(predicted_child)
                 .expect("predicted child entity doesn't have a parent")
-                .get(),
+                .parent(),
             predicted_parent
         );
     }


### PR DESCRIPTION
Before this change, inserting ChildOfSync could break the hierarchy in host-server mode if ChildOf was inserted before any replication components