### PR TITLE
bug(inputs): fix inputs

### DIFF
--- a/examples/client_replication/src/client.rs
+++ b/examples/client_replication/src/client.rs
@@ -55,7 +55,7 @@ pub(crate) fn write_inputs(
     keypress: Res<ButtonInput<KeyCode>>,
 ) {
     if let Ok(mut action_state) = query.single_mut() {
-        let mut input = None;
+        let mut input;
         let mut direction = Direction {
             up: false,
             down: false,
@@ -74,9 +74,7 @@ pub(crate) fn write_inputs(
         if keypress.pressed(KeyCode::KeyD) || keypress.pressed(KeyCode::ArrowRight) {
             direction.right = true;
         }
-        if !direction.is_none() {
-            input = Some(Inputs::Direction(direction));
-        }
+        input = Some(Inputs::Direction(direction));
         if keypress.pressed(KeyCode::KeyK) {
             input = Some(Inputs::Delete);
         }

--- a/examples/delta_compression/src/client.rs
+++ b/examples/delta_compression/src/client.rs
@@ -44,7 +44,6 @@ pub(crate) fn buffer_input(
     keypress: Res<ButtonInput<KeyCode>>,
 ) {
     query.iter_mut().for_each(|mut action_state| {
-        let mut input = None;
         let mut direction = Direction {
             up: false,
             down: false,
@@ -63,12 +62,7 @@ pub(crate) fn buffer_input(
         if keypress.pressed(KeyCode::KeyD) || keypress.pressed(KeyCode::ArrowRight) {
             direction.right = true;
         }
-        if !direction.is_none() {
-            input = Some(Inputs::Direction(direction));
-        }
-        // Use the set() method for ActionState
-        action_state.set(input);
-        // action_state.value = input;
+        action_state.value = Some(Inputs::Direction(direction));
     });
 }
 

--- a/examples/distributed_authority/src/client.rs
+++ b/examples/distributed_authority/src/client.rs
@@ -59,7 +59,6 @@ pub(crate) fn buffer_input(
     keypress: Res<ButtonInput<KeyCode>>,
 ) {
     query.iter_mut().for_each(|mut action_state| {
-        let mut input = None;
         let mut direction = Direction {
             up: false,
             down: false,
@@ -78,10 +77,7 @@ pub(crate) fn buffer_input(
         if keypress.pressed(KeyCode::KeyD) || keypress.pressed(KeyCode::ArrowRight) {
             direction.right = true;
         }
-        if !direction.is_none() {
-            input = Some(Inputs::Direction(direction));
-        }
-        action_state.value = input;
+        action_state.value = Some(Inputs::Direction(direction));
     });
 }
 

--- a/examples/lobby/src/client.rs
+++ b/examples/lobby/src/client.rs
@@ -107,7 +107,6 @@ mod game {
         keypress: Res<ButtonInput<KeyCode>>,
     ) {
         if let Ok(mut action_state) = query.single_mut() {
-            let mut input = None;
             let mut direction = Direction {
                 up: false,
                 down: false,
@@ -126,10 +125,7 @@ mod game {
             if keypress.pressed(KeyCode::KeyD) || keypress.pressed(KeyCode::ArrowRight) {
                 direction.right = true;
             }
-            if !direction.is_none() {
-                input = Some(Inputs::Direction(direction));
-            }
-            action_state.value = input;
+            action_state.value = Some(Inputs::Direction(direction));
         }
     }
 

--- a/examples/network_visibility/src/client.rs
+++ b/examples/network_visibility/src/client.rs
@@ -32,7 +32,6 @@ pub(crate) fn buffer_input(
     keypress: Res<ButtonInput<KeyCode>>,
 ) {
     if let Ok(mut action_state) = query.single_mut() {
-        let mut input = None;
         let mut direction = Inputs::default();
         if keypress.pressed(KeyCode::KeyW) || keypress.pressed(KeyCode::ArrowUp) {
             direction.up = true;
@@ -46,10 +45,7 @@ pub(crate) fn buffer_input(
         if keypress.pressed(KeyCode::KeyD) || keypress.pressed(KeyCode::ArrowRight) {
             direction.right = true;
         }
-        if !direction.is_none() {
-            input = Some(direction);
-        }
-        action_state.value = input;
+        action_state.value = Some(direction);
     }
 }
 

--- a/examples/simple_box/src/client.rs
+++ b/examples/simple_box/src/client.rs
@@ -41,7 +41,6 @@ pub(crate) fn buffer_input(
     keypress: Res<ButtonInput<KeyCode>>,
 ) {
     if let Ok(mut action_state) = query.single_mut() {
-        let mut input = None;
         let mut direction = Direction {
             up: false,
             down: false,
@@ -60,10 +59,9 @@ pub(crate) fn buffer_input(
         if keypress.pressed(KeyCode::KeyD) || keypress.pressed(KeyCode::ArrowRight) {
             direction.right = true;
         }
-        if !direction.is_none() {
-            input = Some(Inputs::Direction(direction));
-        }
-        action_state.value = input;
+        // we always set the value. Setting it to None means that the input was missing, it's not the same
+        // as saying that the input was 'no keys pressed'
+        action_state.value = Some(Inputs::Direction(direction));
     }
 }
 
@@ -77,7 +75,7 @@ fn player_movement(
     // let tick = timeline.tick();
     for (position, input) in position_query.iter_mut() {
         if let Some(input) = &input.value {
-            // info!(?tick, ?position, ?input, "client");
+            // trace!(?tick, ?position, ?input, "client");
             // NOTE: be careful to directly pass Mut<PlayerPosition>
             // getting a mutable reference triggers change detection, unless you use `as_deref_mut()`
             shared::shared_movement_behaviour(position, input);

--- a/examples/simple_box/src/server.rs
+++ b/examples/simple_box/src/server.rs
@@ -85,7 +85,7 @@ fn movement(
     let tick = timeline.tick();
     for (position, inputs) in position_query.iter_mut() {
         if let Some(inputs) = &inputs.value {
-            // info!(?tick, ?position, ?inputs, "server");
+            trace!(?tick, ?position, ?inputs, "server");
             shared::shared_movement_behaviour(position, inputs);
         }
     }

--- a/examples/simple_box/src/shared.rs
+++ b/examples/simple_box/src/shared.rs
@@ -49,7 +49,7 @@ pub(crate) fn confirmed_log(
 ) {
     let tick = timeline.tick();
     for status in players.iter() {
-        info!(?tick, ?status, "Confirmed Updated");
+        trace!(?tick, ?status, "Confirmed Updated");
     }
 }
 

--- a/lightyear_sync/src/timeline/input.rs
+++ b/lightyear_sync/src/timeline/input.rs
@@ -73,11 +73,11 @@ impl Input {
         mut query: Query<(&Link, &mut InputTimeline), Changed<InputTimeline>>,
     ) {
         query.iter_mut().for_each(|(link, mut timeline)| {
+            // TODO: we want to limit this when only the config updates, not the timeline itself!
             let rtt = link.stats.rtt;
             timeline.input_delay_ticks = timeline
                 .input_delay_config
                 .input_delay_ticks(rtt, tick_duration.0);
-
             trace!(
                 "Recomputing input delay on config update! Input delay ticks: {}. Config: {:?}",
                 timeline.input_delay_ticks, timeline.input_delay_config


### PR DESCRIPTION
Several input bugs:
- issues if the input_messages's start_tick was lower than the input_buffer's start_tick
- issues when popping values and some intermediate values that were popped were InputData::Absent

- problem if the first state of the InputBuffer becomes SameAsPrecedent