### PR TITLE
fix(bug): fix bug on fps example with missing PlayerMarker component

### DIFF
--- a/examples/fps/src/protocol.rs
+++ b/examples/fps/src/protocol.rs
@@ -23,6 +23,9 @@ pub struct InterpolatedBot;
 #[derive(Component, Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Reflect)]
 pub struct PlayerId(pub PeerId);
 
+#[derive(Component, Serialize, Deserialize, Clone, Debug, PartialEq, Reflect)]
+pub struct PlayerMarker;
+
 /// Number of bullet hits
 #[derive(Component, Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Reflect)]
 pub struct Score(pub usize);
@@ -76,6 +79,9 @@ impl Plugin for ProtocolPlugin {
             .add_prediction(PredictionMode::Once)
             .add_interpolation(InterpolationMode::Once);
         app.register_component::<PlayerId>()
+            .add_prediction(PredictionMode::Once)
+            .add_interpolation(InterpolationMode::Once);
+        app.register_component::<PlayerMarker>()
             .add_prediction(PredictionMode::Once)
             .add_interpolation(InterpolationMode::Once);
 

--- a/examples/fps/src/server.rs
+++ b/examples/fps/src/server.rs
@@ -84,6 +84,7 @@ pub(crate) fn spawn_player(
         Transform::from_xyz(0.0, y, 0.0),
         ColorComponent(color),
         ActionState::<PlayerActions>::default(),
+        PlayerMarker,
         Name::new("Player"),
     ));
 }
@@ -133,7 +134,7 @@ pub(crate) fn compute_hit_lag_compensation(
     // (the server creates one entity for each client to store client-specific
     // metadata)
     client_query: Query<&InterpolationDelay, With<ClientOf>>,
-    mut player_query: Query<(&mut Score, &PlayerId)>,
+    mut player_query: Query<(&mut Score, &PlayerId), With<PlayerMarker>>,
 ) {
     let tick = timeline.tick();
     bullets
@@ -181,7 +182,7 @@ pub(crate) fn compute_hit_prediction(
     // the InterpolationDelay component is stored directly on the client entity
     // (the server creates one entity for each client to store client-specific
     // metadata)
-    mut player_query: Query<(&mut Score, &PlayerId)>,
+    mut player_query: Query<(&mut Score, &PlayerId), With<PlayerMarker>>,
 ) {
     let tick = timeline.tick();
     bullets.iter().for_each(|(entity, id, position, velocity)| {

--- a/lightyear_avian/src/lag_compensation/query.rs
+++ b/lightyear_avian/src/lag_compensation/query.rs
@@ -116,6 +116,7 @@ impl LagCompensationSpatialQuery<'_, '_> {
                     );
                     return false;
                 };
+                // TODO: handle this in host-server mode!
                 let (_, (target_position, target_rotation, _)) =
                     history.into_iter().nth(source_idx + 1).unwrap();
                 // we assume that the collider itself doesn't change so we don't need to interpolate it

--- a/lightyear_prediction/src/plugin.rs
+++ b/lightyear_prediction/src/plugin.rs
@@ -275,6 +275,9 @@ impl Plugin for PredictionPlugin {
             .on_add(predicted_on_add_hook)
             .on_remove(predicted_on_remove_hook);
 
+        // OBSERVERS
+        app.add_observer(PredictionManager::handle_tick_sync);
+
         // RESOURCES
         app.init_resource::<PredictionRegistry>();
 

--- a/lightyear_prediction/src/rollback.rs
+++ b/lightyear_prediction/src/rollback.rs
@@ -245,16 +245,18 @@ pub(crate) fn prepare_rollback<C: SyncComponent>(
     for (confirmed_entity, confirmed_component, confirmed) in confirmed_query.iter() {
         let rollback_tick = confirmed.tick;
 
+        // ignore the confirmed entities that only have interpolation
+        // TODO: separate ConfirmedPredicted and ConfirmedInterpolated!
+        let Some(predicted_entity) = confirmed.predicted else {
+            continue;
+        };
+
         // 0. Confirm that we are in rollback, with the correct tick
         debug_assert_eq!(
             manager.get_rollback_start_tick(),
             Some(rollback_tick),
             "The rollback tick (LEFT) does not match the confirmed tick (RIGHT) for confirmed entity {confirmed_entity:?}. Are all predicted entities in the same replication group?",
         );
-
-        let Some(predicted_entity) = confirmed.predicted else {
-            continue;
-        };
 
         // 1. Get the predicted entity, and its history
         let Ok((predicted_component, mut predicted_history, mut correction, disable_rollback)) =

--- a/lightyear_prediction/src/rollback.rs
+++ b/lightyear_prediction/src/rollback.rs
@@ -212,7 +212,7 @@ pub(crate) fn remove_prediction_disable(
     query: Query<Entity, (With<Predicted>, With<PredictionDisable>)>,
 ) {
     query.iter().for_each(|e| {
-        commands.entity(e).remove::<PredictionDisable>();
+        commands.entity(e).try_remove::<PredictionDisable>();
     });
 }
 
@@ -296,7 +296,7 @@ pub(crate) fn prepare_rollback<C: SyncComponent>(
             // confirm does not exist, remove on predicted
             None => {
                 predicted_history.add_remove(rollback_tick);
-                entity_mut.remove::<C>();
+                entity_mut.try_remove::<C>();
             }
             // confirm exist, update or insert on predicted
             Some(confirmed_component) => {
@@ -447,7 +447,7 @@ pub(crate) fn prepare_rollback_prespawn<C: SyncComponent>(
                         "Component for prespawned entity didn't exist at time of rollback, removing it"
                     );
                     // the component didn't exist at the time, remove it!
-                    commands.entity(prespawned_entity).remove::<C>();
+                    commands.entity(prespawned_entity).try_remove::<C>();
                 }
             }
             Some(HistoryState::Updated(c)) => {
@@ -518,7 +518,7 @@ pub(crate) fn prepare_rollback_non_networked<
                         "Non-networked component for predicted entity didn't exist at time of rollback, removing it"
                     );
                     // the component didn't exist at the time, remove it!
-                    commands.entity(entity).remove::<C>();
+                    commands.entity(entity).try_remove::<C>();
                 }
             }
             Some(HistoryState::Updated(c)) => {

--- a/lightyear_replication/src/components.rs
+++ b/lightyear_replication/src/components.rs
@@ -38,7 +38,7 @@ use serde::{Deserialize, Serialize};
 use tracing::debug;
 use tracing::error;
 #[cfg(feature = "server")]
-use tracing::{info, trace};
+use tracing::trace;
 // TODO: how to define which subset of components a sender iterates through?
 //  if a sender is only interested in a few components it might be expensive
 //  maybe we can have a 'direction' in ComponentReplicationConfig and Client/ClientOf peers can precompute
@@ -377,6 +377,7 @@ impl PredictionTarget {
         trigger: Trigger<OnAdd, PredictionTarget>,
         mut commands: Commands,
     ) {
+        // note: we don't need to handle this for ReplicateLike entities because they take the ReplicationGroup from the root entity
         commands.entity(trigger.target()).insert(PREDICTION_GROUP);
     }
 }
@@ -603,7 +604,7 @@ impl<T: Sync + Send + 'static> ReplicationTarget<T> {
                     #[cfg(feature = "server")]
                     ReplicationMode::SingleServer(target) => {
                         if link_of.is_some() && target.targets(remote_peer_id) {
-                            info!("Replicating existing entity {entity:?} to newly connected sender {sender_entity:?}");
+                            debug!("Replicating existing entity {entity:?} to newly connected sender {sender_entity:?}");
                             sender.add_replicated_entity(entity, true);
                             replicate.senders.insert(sender_entity);
                         }

--- a/lightyear_replication/src/receive.rs
+++ b/lightyear_replication/src/receive.rs
@@ -367,7 +367,7 @@ impl ReplicationReceiver {
         // apply all actions first
         // TODO: it's extremely strange, but it seems like the value of TempWriteBuffer can linger from previous
         //  frames. Let's clear it manually for now
-        self.buffer = BufferedChanges::default();
+        // self.buffer = BufferedChanges::default();
         self.group_channels
             .iter_mut()
             .for_each(|(group_id, channel)| {
@@ -810,6 +810,7 @@ impl GroupChannel {
                 continue;
             }
 
+            trace!(?entity, "Temp write buffer: {temp_write_buffer:?}");
             let mut buffered_entity = BufferedEntity {
                 entity: local_entity_mut,
                 buffered: temp_write_buffer,
@@ -868,6 +869,8 @@ impl GroupChannel {
                         error!("could not write the component to the entity: {:?}", e)
                     });
             }
+
+            buffered_entity.apply();
         }
 
         // Flush commands because the entities that were inserted might have triggered some observers

--- a/lightyear_replication/src/registry/buffered.rs
+++ b/lightyear_replication/src/registry/buffered.rs
@@ -7,7 +7,7 @@ use bevy_ptr::OwningPtr;
 use bevy_reflect::TypePath;
 use core::alloc::Layout;
 use core::ptr::NonNull;
-use tracing::info;
+use tracing::trace;
 
 /// An [`EntityWorldMut`] that buffers all insertions and removals so that they are all applied at once.
 pub struct BufferedEntity<'w, 'b> {
@@ -36,7 +36,7 @@ impl BufferedChanges {
     pub fn apply(&mut self, entity: &mut EntityWorldMut) {
         let entity_id = entity.id();
         if !self.removals.is_empty() {
-            info!("Removing on {entity_id}");
+            trace!("Removing on {entity_id}");
             entity.remove_by_ids(&self.removals);
         }
         self.removals.clear();

--- a/lightyear_replication/src/registry/replication.rs
+++ b/lightyear_replication/src/registry/replication.rs
@@ -11,7 +11,7 @@ use lightyear_serde::ToBytes;
 use lightyear_serde::entity_map::ReceiveEntityMap;
 use lightyear_serde::reader::Reader;
 use lightyear_serde::registry::{ContextDeserializeFns, ErasedSerializeFns};
-use tracing::debug;
+use tracing::{debug, trace};
 
 #[derive(Debug, Clone)]
 pub struct ReplicationMetadata {
@@ -91,6 +91,11 @@ impl ComponentRegistry {
             .kind_map
             .kind(net_id)
             .ok_or(ComponentError::NotRegistered)?;
+        trace!(
+            "Buffering components for entity {:?} with net_id {:?}",
+            entity_mut.entity.id(),
+            net_id
+        );
         let replication_metadata = self
             .replication_map
             .get(kind)
@@ -200,7 +205,7 @@ fn default_buffer<C: Component<Mutability = Mutable> + PartialEq>(
     let component_id = entity_mut.component_id::<C>();
     let component = deserialize.deserialize(entity_map, reader)?;
     let entity = entity_mut.entity.id();
-    debug!(
+    trace!(
         "Insert component {} to entity {entity:?}",
         core::any::type_name::<C>()
     );

--- a/lightyear_replication/src/send.rs
+++ b/lightyear_replication/src/send.rs
@@ -661,7 +661,7 @@ impl ReplicationSender {
             }) => {
                 match self.group_channels.get_mut(&group_id) { Some(channel) => {
                     // update the ack tick for the channel
-                    debug!(?group_id, ?bevy_tick, ?tick, "Update channel ack_tick");
+                    trace!(?group_id, ?bevy_tick, ?tick, "Update channel ack_tick");
                     channel.ack_bevy_tick = Some(bevy_tick);
                     // `delta_ack_ticks` won't grow indefinitely thanks to the cleanup systems
                     for (entity, component_kind) in delta {

--- a/lightyear_tests/src/client_server/prediction/prespawn.rs
+++ b/lightyear_tests/src/client_server/prediction/prespawn.rs
@@ -176,7 +176,6 @@ fn test_multiple_prespawn() {
 
 /// Client and server run the same system to prespawn an entity
 /// Server's should take over authority over the entity
-///
 #[test]
 fn test_prespawn_success() {
     let mut stepper = ClientServerStepper::single();

--- a/lightyear_utils/src/ready_buffer.rs
+++ b/lightyear_utils/src/ready_buffer.rs
@@ -124,6 +124,10 @@ impl<K: Ord + Clone, T> ReadyBuffer<K, T> {
         val
     }
 
+    pub fn drain(&mut self) -> impl Iterator<Item = (K, T)> {
+        self.heap.drain().map(|item| (item.key, item.item))
+    }
+
     /// Pop all items that are more recent or equal than the provided key, then return all the values that were popped
     pub fn drain_after(&mut self, key: &K) -> Vec<(K, T)> {
         if self.heap.is_empty() {


### PR DESCRIPTION
A few high-profile bug fixes:
- add a PlayerMarker on the fps example because otherwise bullets were spawning other bullets
- we were checking the confirmed tick on Confirmed entities that don't have Predicted entities (only Interpolated), which was causing panics
- There was an issue where we were receiving the PreSpawned multiple times (because of ReplicationMode=SinceLastAck); The second time we were inserting the component, it would cause a PreSpawned miss
- We were missing a TempWriteBuffer::apply() which was causing big issues when we had multiple entities in the same replication group