### PR TITLE
Alternative replication system

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -179,11 +179,18 @@ mock_instant = "0.6"
 approx = "0.5.1"
 
 # Bevy
-# (we add back features needed for gui clients if desired)
-bevy = { version = "0.16", default-features = false }
+# (the full app is used for examples)
+bevy = { version = "0.16", default-features = false, features = [
+  "bevy_state",
+  "bevy_log",
+  "serialize",
+  "bevy_asset",
+  "bevy_state",
+  "bevy_color",
+  "multi_threaded",
+  "sysinfo_plugin",
+] }
 bevy_app = { version = "0.16", default-features = false }
-bevy_asset = { version = "0.16", default-features = false }
-bevy_color = { version = "0.16", default-features = false }
 bevy_derive = { version = "0.16", default-features = false }
 bevy_diagnostic = { version = "0.16", default-features = false }
 bevy_ecs = { version = "0.16", default-features = false }
@@ -193,10 +200,10 @@ bevy_math = { version = "0.16", default-features = false }
 bevy_platform = { version = "0.16", default-features = false }
 bevy_ptr = { version = "0.16", default-features = false }
 bevy_reflect = { version = "0.16", default-features = false }
-bevy_state = { version = "0.16", default-features = false }
 bevy_time = { version = "0.16", default-features = false }
 bevy_transform = { version = "0.16", default-features = false }
 bevy_utils = { version = "0.16", default-features = false }
+tracy-client = { version = "=0.18.0" }
 
 # input
 bevy_enhanced_input = { git = "https://github.com/cBournhonesque/bevy_enhanced_input.git", branch = "cb/networking" }

--- a/benches/criterion/Cargo.toml
+++ b/benches/criterion/Cargo.toml
@@ -19,16 +19,21 @@ lightyear_tests = { workspace = true }
 
 # enable all the bevy defaults:
 bevy = { workspace = true, default-features = true }
+tracy-client = { version = "=0.18.0" }
 
 # crates specific to benchmarks, so not in top-level Cargo workspace
 pprof = { version = "0.14.0", features = ["flamegraph", "frame-pointer"] }
 criterion = { version = "0.6", features = ["html_reports"] }
 divan = "0.1.14"
 
+[lib]
+bench = false
+
 [[bin]]
 name = "replication_profiling"
 path = "src/replication_profiling.rs"
 doc = false
+bench = false
 
 [[bench]]
 name = "replication"

--- a/examples/client_replication/src/client.rs
+++ b/examples/client_replication/src/client.rs
@@ -192,7 +192,7 @@ fn window_relative_mouse_position(window: &Window) -> Option<Vec2> {
 
     Some(Vec2::new(
         cursor_pos.x - (window.width() / 2.0),
-        (cursor_pos.y - (window.height() / 2.0)) * -1.0,
+        -(cursor_pos.y - (window.height() / 2.0)),
     ))
 }
 

--- a/examples/common/src/server.rs
+++ b/examples/common/src/server.rs
@@ -182,14 +182,14 @@ impl From<&WebTransportCertificateSettings> for Identity {
                 let mut sans = sans.clone();
                 // Are we running on edgegap?
                 if let Ok(public_ip) = std::env::var("ARBITRIUM_PUBLIC_IP") {
-                    println!("🔐 SAN += ARBITRIUM_PUBLIC_IP: {}", public_ip);
+                    println!("🔐 SAN += ARBITRIUM_PUBLIC_IP: {public_ip}");
                     sans.push(public_ip);
                     sans.push("*.pr.edgegap.net".to_string());
                 }
                 // generic env to add domains and ips to SAN list:
                 // SELF_SIGNED_SANS="example.org,example.com,127.1.1.1"
                 if let Ok(san) = std::env::var("SELF_SIGNED_SANS") {
-                    println!("🔐 SAN += SELF_SIGNED_SANS: {}", san);
+                    println!("🔐 SAN += SELF_SIGNED_SANS: {san}");
                     sans.extend(san.split(',').map(|s| s.to_string()));
                 }
                 println!("🔐 Generating self-signed certificate with SANs: {sans:?}");
@@ -203,8 +203,7 @@ impl From<&WebTransportCertificateSettings> for Identity {
                 key: private_key_pem_path,
             } => {
                 println!(
-                    "Reading certificate PEM files:\n * cert: {}\n * key: {}",
-                    cert_pem_path, private_key_pem_path
+                    "Reading certificate PEM files:\n * cert: {cert_pem_path}\n * key: {private_key_pem_path}",
                 );
                 // this is async because we need to load the certificate from io
                 // we need async_compat because wtransport expects a tokio reactor
@@ -243,10 +242,7 @@ pub fn parse_private_key_from_env() -> Option<[u8; PRIVATE_KEY_BYTES]> {
         .collect();
 
     if private_key.len() != PRIVATE_KEY_BYTES {
-        panic!(
-            "Private key must contain exactly {} numbers",
-            PRIVATE_KEY_BYTES
-        );
+        panic!("Private key must contain exactly {PRIVATE_KEY_BYTES} numbers",);
     }
 
     let mut bytes = [0u8; PRIVATE_KEY_BYTES];

--- a/examples/simple_box/Cargo.toml
+++ b/examples/simple_box/Cargo.toml
@@ -57,6 +57,7 @@ lightyear_examples_common.workspace = true
 serde.workspace = true
 bevy.workspace = true
 
+
 [package.metadata.bevy_cli.web]
 rustflags = ["--cfg", "getrandom_backend=\"wasm_js\""]
 default-features = false

--- a/lightyear_inputs/src/input_buffer.rs
+++ b/lightyear_inputs/src/input_buffer.rs
@@ -42,13 +42,13 @@ impl<T: Debug> core::fmt::Display for InputBuffer<T> {
                 let str = match item {
                     InputData::Absent => "Absent".to_string(),
                     InputData::SameAsPrecedent => "SameAsPrecedent".to_string(),
-                    InputData::Input(data) => format!("{:?}", data),
+                    InputData::Input(data) => format!("{data:?}"),
                 };
                 format!("{:?}: {}\n", tick + i as i16, str)
             })
             .collect::<Vec<String>>()
             .join("");
-        write!(f, "InputBuffer<{:?}>:\n {}", ty, buffer_str)
+        write!(f, "InputBuffer<{ty:?}>:\n {buffer_str}")
     }
 }
 

--- a/lightyear_inputs/src/input_message.rs
+++ b/lightyear_inputs/src/input_message.rs
@@ -117,7 +117,7 @@ impl<S: ActionStateSequence + core::fmt::Display> core::fmt::Display for InputMe
         let ty = core::any::type_name::<S::Action>();
 
         if self.inputs.is_empty() {
-            return write!(f, "EmptyInputMessage<{:?}>", ty);
+            return write!(f, "EmptyInputMessage<{ty:?}>");
         }
         let buffer_str = self
             .inputs
@@ -131,8 +131,8 @@ impl<S: ActionStateSequence + core::fmt::Display> core::fmt::Display for InputMe
             .join("\n");
         write!(
             f,
-            "InputMessage<{:?}> (End Tick: {:?}):\n{}",
-            ty, self.end_tick, buffer_str
+            "InputMessage<{ty:?}> (End Tick: {:?}):\n{buffer_str}",
+            self.end_tick
         )
     }
 }

--- a/lightyear_inputs_leafwing/Cargo.toml
+++ b/lightyear_inputs_leafwing/Cargo.toml
@@ -31,6 +31,7 @@ bevy_app.workspace = true
 bevy_ecs.workspace = true
 bevy_input.workspace = true
 bevy_math.workspace = true
+bevy_platform.workspace = true
 bevy_reflect.workspace = true
 
 [lints]

--- a/lightyear_inputs_leafwing/src/input_message.rs
+++ b/lightyear_inputs_leafwing/src/input_message.rs
@@ -1,4 +1,4 @@
-use std::time::Instant;
+use bevy_platform::time::Instant;
 
 use crate::action_diff::ActionDiff;
 use crate::action_state::LeafwingUserAction;

--- a/lightyear_netcode/src/packet.rs
+++ b/lightyear_netcode/src/packet.rs
@@ -1,6 +1,12 @@
 use alloc::{borrow::ToOwned, boxed::Box, string::String, vec};
 use bytes::BytesMut;
 use core::mem::size_of;
+#[cfg(not(feature = "std"))]
+use no_std_io2::{
+    io,
+    io::{Read, Write},
+};
+#[cfg(feature = "std")]
 use std::io::{self, Read, Write};
 
 use super::{

--- a/lightyear_replication/src/components.rs
+++ b/lightyear_replication/src/components.rs
@@ -96,6 +96,23 @@ impl<C> ComponentReplicationOverrides<C> {
         self.all_senders.as_ref()
     }
 
+    /// Returns true if the component is disabled for all senders
+    pub(crate) fn is_disabled_for_all(&self, mut registry_disable: bool) -> bool {
+        let disable = &mut registry_disable;
+        if let Some(all) = &self.all_senders {
+            if all.disable {
+                *disable = true;
+            }
+            if all.enable {
+                *disable = false;
+            }
+        }
+        // if all_senders is disabled, we only return true if no per_sender overrides are enabled
+        *disable && !self.per_sender.values().any(|o| o.enable)
+
+        // TODO: there is the edge case where all the senders have enabled the component!
+    }
+
     /// Add an override for all senders
     pub fn global_override(&mut self, overrides: ComponentReplicationOverride) {
         self.all_senders = Some(overrides);

--- a/lightyear_replication/src/plugin.rs
+++ b/lightyear_replication/src/plugin.rs
@@ -5,6 +5,7 @@
 use crate::buffer::{Replicate, ReplicationMode};
 use crate::components::*;
 use crate::control::{Controlled, ControlledBy, ControlledByRemote};
+use crate::delta::DeltaManager;
 use crate::hierarchy::{DisableReplicateHierarchy, ReplicateLike, ReplicateLikeChildren};
 use crate::message::{ActionsChannel, MetadataChannel, SenderMetadata, UpdatesChannel};
 use crate::prelude::{ActionsMessage, AppComponentExt, UpdatesMessage};
@@ -53,6 +54,12 @@ impl Plugin for SharedPlugin {
             .register_type::<ReplicationGroupId>();
 
         app.register_component::<Controlled>();
+
+        #[cfg(feature = "server")]
+        {
+            use lightyear_link::prelude::Server;
+            app.register_required_components::<Server, DeltaManager>();
+        }
 
         #[cfg(feature = "interpolation")]
         {

--- a/lightyear_tests/src/client_server/replication.rs
+++ b/lightyear_tests/src/client_server/replication.rs
@@ -12,6 +12,7 @@ use lightyear_replication::prelude::{
 };
 use lightyear_sync::prelude::InputTimeline;
 use test_log::test;
+use tracing::info;
 
 #[test]
 fn test_spawn() {
@@ -634,6 +635,7 @@ fn test_component_replicate_once_overrides() {
 fn test_component_disabled_overrides() {
     let mut stepper = ClientServerStepper::single();
 
+    info!("start");
     let client_entity = stepper
         .client_app()
         .world_mut()
@@ -656,6 +658,7 @@ fn test_component_disabled_overrides() {
             .is_none()
     );
 
+    info!("enabled global");
     let mut overrides = ComponentReplicationOverrides::<CompDisabled>::default();
     overrides.global_override(ComponentReplicationOverride {
         enable: true,
@@ -684,6 +687,7 @@ fn test_component_disabled_overrides() {
         &CompDisabled(2.0)
     );
 
+    info!("disabled for sender");
     stepper.client_apps[0]
         .world_mut()
         .entity_mut(client_entity)

--- a/lightyear_webtransport/src/client.rs
+++ b/lightyear_webtransport/src/client.rs
@@ -50,7 +50,7 @@ impl WebTransportClientPlugin {
             let digest = client.certificate_digest.clone();
             commands.queue(move |world: &mut World| -> Result {
                 let config = Self::client_config(digest)?;
-                let server_url = format!("https://{}", server_addr);
+                let server_url = format!("https://{server_addr}");
                 let target = {
                     #[cfg(target_family = "wasm")]
                     {


### PR DESCRIPTION
The current Replication system does this:
- iterates in parallel through each ReplicationSender
- each ReplicationSender maintains a list of the entities it needs to replicate
- each ReplicationSender serializes components separately
PROS:
- we go through the senders query in parallel only once
CONS:
- we serialize the components once per sender
- not compatible with delta-compression right now; unless we do a separate system to store the component values for delta-compression
- we need each sender to keep a list of entities that they need to serialize (or we could just iterate through all entities and filter)


I am experimenting with a new ReplicationSystem that does this:
- iterates in order through each entity, and then in parallel through each ReplicationSender
- if the component is not map-entities, we serialize it only once, and then clone the Bytes to be used by all the senders
- delta-compression is enabled, and we store the component value
PROS:
- we serialize a component only once, and the serialized bytes are shared for all senders
- we might not need to store a list of replicated entities per sender?
CONS:
- we run through the parallel-query of all senders many times (once per entity and component)

Ultimately we would need great benchmarks to be able to decide between the two