### PR TITLE
fix(bug): fix important bug on input broadcast

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1,3 +1,13 @@
+# Why do my predictions don't work at all
+
+- when i receive an update from the server for the predicted entity, i should also have received that inputs for that entity since we send
+  the inputs more frequently. But it seems like it's not the case?
+- Maybe we should rollback immediately when I notice that the inputs are not correct on the predicted entity?
+  No need to wait to wait for an actual replication update! i.e. we should predict the ActionState! We just don't revert to the Confirmed tick, instead we revert to the history we had for that tick.
+
+- BIG BUG: after Correction, it looks like we are not setting the inputs correctly! We look at the current input instead of looking at the current input w.r.t to the buffer!
+
+
 # CHANGES FOR REPLICATION
 
 - SinceLastAck:

--- a/examples/avian_physics/src/main.rs
+++ b/examples/avian_physics/src/main.rs
@@ -8,7 +8,6 @@ use crate::server::ExampleServerPlugin;
 use crate::shared::SharedPlugin;
 use bevy::prelude::*;
 use core::time::Duration;
-use lightyear::prelude::client::*;
 use lightyear::prelude::*;
 use lightyear_examples_common::cli::{Cli, Mode};
 use lightyear_examples_common::shared::FIXED_TIMESTEP_HZ;
@@ -77,9 +76,9 @@ fn add_input_delay(app: &mut App) {
         .unwrap();
 
     // set some input-delay since we are predicting all entities
-    app.world_mut()
-        .entity_mut(client)
-        .insert(InputTimeline(Timeline::from(
-            Input::default().with_input_delay(InputDelayConfig::fixed_input_delay(10)),
-        )));
+    // app.world_mut()
+    //     .entity_mut(client)
+    //     .insert(InputTimeline(Timeline::from(
+    //         Input::default().with_input_delay(InputDelayConfig::fixed_input_delay(10)),
+    //     )));
 }

--- a/examples/common/src/cli.rs
+++ b/examples/common/src/cli.rs
@@ -9,17 +9,17 @@ use core::time::Duration;
 use bevy::log::{Level, LogPlugin};
 use bevy::prelude::*;
 
+use bevy::DefaultPlugins;
 use bevy::diagnostic::DiagnosticsPlugin;
 use bevy::state::app::StatesPlugin;
-use bevy::DefaultPlugins;
 use clap::{Parser, Subcommand};
 
 #[cfg(feature = "client")]
-use crate::client::{connect, ClientTransports, ExampleClient};
+use crate::client::{ClientTransports, ExampleClient, connect};
 #[cfg(all(feature = "gui", feature = "client"))]
 use crate::client_renderer::ExampleClientRendererPlugin;
 #[cfg(feature = "server")]
-use crate::server::{start, ExampleServer, ServerTransports, WebTransportCertificateSettings};
+use crate::server::{ExampleServer, ServerTransports, WebTransportCertificateSettings, start};
 #[cfg(all(feature = "gui", feature = "server"))]
 use crate::server_renderer::ExampleServerRendererPlugin;
 use crate::shared::{CLIENT_PORT, SERVER_ADDR, SERVER_PORT, SHARED_SETTINGS};

--- a/lightyear_prediction/src/correction.rs
+++ b/lightyear_prediction/src/correction.rs
@@ -141,6 +141,8 @@ pub(crate) fn restore_corrected_state<C: SyncComponent>(
     for (mut component, mut correction) in query.iter_mut() {
         if let Some(correction) = core::mem::take(&mut correction.current_correction) {
             trace!(
+                ?component,
+                ?correction,
                 "Restoring corrected component before FixedUpdate: {:?}",
                 kind
             );

--- a/lightyear_sync/src/timeline/input.rs
+++ b/lightyear_sync/src/timeline/input.rs
@@ -75,6 +75,8 @@ impl Input {
         }
     }
 
+    // TODO: we want to limit this when only the config updates, not the timeline itself!
+    //  disabling this for now
     /// Update the input delay based on the current RTT and tick duration
     /// when the InputDelayConfig is updated
     pub(crate) fn recompute_input_delay_on_config_update(
@@ -82,7 +84,6 @@ impl Input {
         mut query: Query<(&Link, &mut InputTimeline), Changed<InputTimeline>>,
     ) {
         query.iter_mut().for_each(|(link, mut timeline)| {
-            // TODO: we want to limit this when only the config updates, not the timeline itself!
             let rtt = link.stats.rtt;
             timeline.input_delay_ticks = timeline
                 .input_delay_config

--- a/lightyear_tests/src/client_server/prediction/correction.rs
+++ b/lightyear_tests/src/client_server/prediction/correction.rs
@@ -280,7 +280,7 @@ fn test_two_consecutive_frame_updates() {
     let frame_duration = Duration::from_millis(10);
     // very long tick duration to guarantee that we have 2 consecutive frames without a tick
     // choose a value where Syncing stops at the end of tick
-    let tick_duration = Duration::from_millis(21);
+    let tick_duration = Duration::from_millis(23);
     let (mut stepper, confirmed, predicted, _, _) = setup(tick_duration, frame_duration);
 
     // we insert the component at a different frame to not trigger an early rollback
@@ -295,8 +295,11 @@ fn test_two_consecutive_frame_updates() {
     // trigger a rollback (the predicted value doesn't exist in the prediction history)
     let original_tick = stepper.client_tick(0);
     let rollback_tick = original_tick - 5;
+    info!(?original_tick, ?rollback_tick, "trigger rollback");
     trigger_rollback_check(&mut stepper, rollback_tick);
     stepper.frame_step(1);
+    assert_eq!(stepper.client_tick(0), original_tick);
+    info!("end rollback and advanced by 1 frame. Normally no FixedUpdate has run");
     // check that a correction Component is added, however no Correction is applied yet because FixedUpdate didn't run
     assert_eq!(
         stepper


### PR DESCRIPTION
Fixed 2 important bugs:
- we were doing RestoreVisualCorrection on PreUpdate, because "we needed the corrected value for the rollback check". I don't think that's correct! The rollback check compares the confirmed value with the history value, so we don't need a correct Predicted value! Also the Correction is only used in FixedUpdate, so we can just do it in FixedPreUpdate!

- we were not updating the ActionState correctly when receiving remote client inputs! We were updating the InputBuffer, and then the `get_input` system was supposed to fetch the correct input for us, but it wasn't the case..

These 2 bug fixes improve a bit the feel of predicting other clients.
TODOs:
- check if there's some FrameInterpolation missing for remote clients in the examples; or maybe it doesn't interact well with Correction?
- do a rollback whenever we receive a remote input that doesn't match with the inputs we had for the RemoteClient! That way we would rollback much faster, instead of rollbacking only when we receive a state update, which could be pretty rarely