### PR TITLE
chore(docs): explain handle_predicted_spawn more

### DIFF
--- a/examples/simple_box/src/client.rs
+++ b/examples/simple_box/src/client.rs
@@ -93,6 +93,10 @@ pub(crate) fn receive_message1(mut receiver: Single<&mut MessageReceiver<Message
 /// When the predicted copy of the client-owned entity is spawned, do stuff
 /// - assign it a different saturation
 /// - keep track of it in the Global resource
+///
+/// Note that this will be triggered multiple times: for the entity that will have
+/// [`Confirmed`] and then again for the [`Predicted`] or [`Interpolated`] copy. The
+/// `With<Predicted>` filter ensures we only add the `InputMarker` once.
 pub(crate) fn handle_predicted_spawn(
     trigger: Trigger<OnAdd, (PlayerId, Predicted)>,
     mut predicted: Query<&mut PlayerColor, With<Predicted>>,


### PR DESCRIPTION
This just adds a comment to explain what's happening in the `simple_box` example a bit more in case it helps someone else who is learning how the library works. The docs explain it clearly enough, but I missed some subtleties reading it through the first time.