### PR TITLE
skip crossbeam links in ServerUdpIO

### DIFF
--- a/lightyear_crossbeam/src/lib.rs
+++ b/lightyear_crossbeam/src/lib.rs
@@ -39,8 +39,8 @@ const LOCALHOST: SocketAddr = SocketAddr::new(core::net::IpAddr::V4(Ipv4Addr::LO
 /// and receiver ends of the channels.
 #[derive(Component, Clone)]
 #[require(Link::new(None))]
-#[require(LocalAddr(LOCALHOST))]
-#[require(PeerAddr(LOCALHOST))]
+// #[require(LocalAddr(LOCALHOST))]
+// #[require(PeerAddr(LOCALHOST))]
 pub struct CrossbeamIo {
     sender: Sender<Bytes>,
     receiver: Receiver<Bytes>,

--- a/lightyear_crossbeam/src/lib.rs
+++ b/lightyear_crossbeam/src/lib.rs
@@ -39,8 +39,8 @@ const LOCALHOST: SocketAddr = SocketAddr::new(core::net::IpAddr::V4(Ipv4Addr::LO
 /// and receiver ends of the channels.
 #[derive(Component, Clone)]
 #[require(Link::new(None))]
-// #[require(LocalAddr(LOCALHOST))]
-// #[require(PeerAddr(LOCALHOST))]
+#[require(LocalAddr(LOCALHOST))]
+#[require(PeerAddr(LOCALHOST))]
 pub struct CrossbeamIo {
     sender: Sender<Bytes>,
     receiver: Receiver<Bytes>,

--- a/lightyear_link/src/server.rs
+++ b/lightyear_link/src/server.rs
@@ -24,6 +24,8 @@ pub struct Server {
     links: Vec<Entity>,
 }
 
+
+
 impl Server {
     fn on_add(mut world: DeferredWorld, context: HookContext) {
         let entity_ref = world.entity(context.entity);
@@ -66,6 +68,7 @@ pub struct LinkOf {
     pub server: Entity,
 }
 
+
 impl Relationship for LinkOf {
     type RelationshipTarget = Server;
     #[inline(always)]
@@ -74,7 +77,7 @@ impl Relationship for LinkOf {
     }
     #[inline]
     fn from(entity: Entity) -> Self {
-        Self { server: entity }
+        Self { server: entity}
     }
 }
 

--- a/lightyear_udp/Cargo.toml
+++ b/lightyear_udp/Cargo.toml
@@ -15,6 +15,7 @@ server = ["bevy_platform"]
 [dependencies]
 lightyear_core.workspace = true
 lightyear_link.workspace = true
+lightyear_crossbeam.workspace = true
 
 aeronet_io.workspace = true
 

--- a/lightyear_udp/Cargo.toml
+++ b/lightyear_udp/Cargo.toml
@@ -15,7 +15,6 @@ server = ["bevy_platform"]
 [dependencies]
 lightyear_core.workspace = true
 lightyear_link.workspace = true
-lightyear_crossbeam.workspace = true
 
 aeronet_io.workspace = true
 

--- a/lightyear_udp/src/server.rs
+++ b/lightyear_udp/src/server.rs
@@ -84,7 +84,7 @@ impl ServerUdpPlugin {
             let socket = std::net::UdpSocket::bind(local_addr)?;
             socket.set_nonblocking(true)?;
             udp_io.socket = Some(socket);
-            commands.entity(trigger.target()).insert((Linked, UdpLinkOfIO));
+            commands.entity(trigger.target()).insert(Linked);
         }
         Ok(())
     }
@@ -98,7 +98,7 @@ impl ServerUdpPlugin {
 
     fn send(
         mut server_query: Query<(&mut ServerUdpIo, &Server), With<Linked>>,
-        mut link_query: Query<(&mut Link, &PeerAddr), With<UdpLinkOfIO>>,
+        mut link_query: Query<(&mut Link, &PeerAddr)>,
     ) {
         // TODO: parallelize
         server_query

--- a/lightyear_udp/src/server.rs
+++ b/lightyear_udp/src/server.rs
@@ -107,7 +107,8 @@ impl ServerUdpPlugin {
                 server.collection().iter().for_each(|client_entity| {
                     let Some((mut link, remote_addr)) = link_query.get_mut(*client_entity).ok()
                     else {
-                        error!("Client entity {} not found in link query", client_entity);
+                        // Not all server links are Udp Links, so we might not want this to ever print
+                        debug!("Client entity {} not found in link query", client_entity);
                         return;
                     };
                     link.send.drain().for_each(|send_payload| {

--- a/lightyear_udp/src/server.rs
+++ b/lightyear_udp/src/server.rs
@@ -41,6 +41,7 @@ pub struct ServerUdpIo {
     connected_addresses: HashMap<SocketAddr, LinkOfStatus>,
 }
 
+/// Marker component to identify this LinkOf as being the server-side Link of a ServerUdpIO
 #[derive(Component)]
 pub struct UdpLinkOfIO;
 

--- a/lightyear_udp/src/server.rs
+++ b/lightyear_udp/src/server.rs
@@ -111,6 +111,9 @@ impl ServerUdpPlugin {
                         debug!("Client entity {} not found in link query", client_entity);
                         return;
                     };
+
+                    
+
                     link.send.drain().for_each(|send_payload| {
                         server_udp_io
                             .socket

--- a/lightyear_udp/src/server.rs
+++ b/lightyear_udp/src/server.rs
@@ -84,7 +84,7 @@ impl ServerUdpPlugin {
             let socket = std::net::UdpSocket::bind(local_addr)?;
             socket.set_nonblocking(true)?;
             udp_io.socket = Some(socket);
-            commands.entity(trigger.target()).insert((Linked, UdpLinkOfIO));
+            commands.entity(trigger.target()).insert(Linked);
         }
         Ok(())
     }
@@ -227,6 +227,7 @@ impl ServerUdpPlugin {
                                                 link,
                                                 Linked,
                                                 PeerAddr(address),
+                                                UdpLinkOfIO,
                                                 // TODO: should we add LocalAddr?
                                             ))
                                             .id();

--- a/lightyear_udp/src/server.rs
+++ b/lightyear_udp/src/server.rs
@@ -84,7 +84,7 @@ impl ServerUdpPlugin {
             let socket = std::net::UdpSocket::bind(local_addr)?;
             socket.set_nonblocking(true)?;
             udp_io.socket = Some(socket);
-            commands.entity(trigger.target()).insert(Linked);
+            commands.entity(trigger.target()).insert((Linked, UdpLinkOfIO));
         }
         Ok(())
     }
@@ -98,7 +98,7 @@ impl ServerUdpPlugin {
 
     fn send(
         mut server_query: Query<(&mut ServerUdpIo, &Server), With<Linked>>,
-        mut link_query: Query<(&mut Link, &PeerAddr)>,
+        mut link_query: Query<(&mut Link, &PeerAddr), With<UdpLinkOfIO>>,
     ) {
         // TODO: parallelize
         server_query


### PR DESCRIPTION
I believe this bug will show up for steamIO and any other future IO's

The send vec was being drained by Udp for a crossbeam link