### PR TITLE
Fix RemoteTimeline syncing

### DIFF
--- a/lightyear_core/src/time.rs
+++ b/lightyear_core/src/time.rs
@@ -395,6 +395,9 @@ impl Add for TickDelta {
     type Output = TickDelta;
 
     fn add(self, rhs: Self) -> Self::Output {
+        if rhs.is_negative() {
+            return self - (-rhs);
+        }
         if self.is_negative() {
             return rhs - (-self);
         }
@@ -418,8 +421,11 @@ impl Sub for TickDelta {
     type Output = TickDelta;
 
     fn sub(self, rhs: Self) -> Self::Output {
+        if rhs.is_negative() {
+            return self + (-rhs);
+        }
         if self.is_negative() {
-            return rhs + (-self);
+            return -(rhs + (-self));
         }
 
         let total_ticks = self.tick_diff.wrapping_sub(rhs.tick_diff);
@@ -807,6 +813,16 @@ mod tests {
         assert_eq!(double_negated.tick_diff, 5);
         assert_relative_eq!(delta.overstep.value(), 0.3);
         assert!(!double_negated.neg);
+    }
+
+    #[test]
+    fn test_tickdelta_signed_addition() {
+        let delta = TickDelta::from_i16(10);
+
+        assert_eq!((delta + delta).to_i16(), 20);
+        assert_eq!((delta + (-delta)).to_i16(), 0);
+        assert_eq!(((-delta) + delta).to_i16(), 0);
+        assert_eq!(((-delta) + (-delta)).to_i16(), -20);
     }
 
     #[test]

--- a/lightyear_replication/src/hierarchy.rs
+++ b/lightyear_replication/src/hierarchy.rs
@@ -382,7 +382,7 @@ impl HierarchySendPlugin {
         while let Some(parent) = stack.pop() {
             for child in children_query.relationship_sources(parent) {
                 if let Ok(()) = child_filter.get(child) {
-                    commands.entity(child)..try_remove::<(ReplicateLike, ChildOfSync)>();
+                    commands.entity(child).try_remove::<(ReplicateLike, ChildOfSync)>();
                 }
             }
         }

--- a/lightyear_sync/src/timeline/remote.rs
+++ b/lightyear_sync/src/timeline/remote.rs
@@ -7,7 +7,7 @@ use bevy_ecs::query::{With, Without};
 use bevy_ecs::system::{Query, Res};
 use bevy_ecs::world::OnAdd;
 use bevy_reflect::Reflect;
-use bevy_time::Time;
+use bevy_time::{Time, Real};
 use core::time::Duration;
 use lightyear_connection::client::Connected;
 use lightyear_core::prelude::Rollback;
@@ -207,10 +207,9 @@ pub(crate) fn update_remote_timeline(
     }
 }
 
-// TODO: should this be based on real time?
 /// Advance our estimate of the remote timeline based on the real time
 pub(crate) fn advance_remote_timeline(
-    fixed_time: Res<Time>,
+    fixed_time: Res<Time<Real>>,
     tick_duration: Res<TickDuration>,
     mut query: Query<&mut RemoteTimeline, (With<Linked>, Without<Rollback>)>,
 ) {


### PR DESCRIPTION
Two main issues:
1. InputTimeline drives `Time<Virtual>` and speeds up or slows down to attempt to synchronize with RemoteTimeline. Advancing RemoteTimeline based on `Res<Time>` (aka `Res<Time<Virtual>>`) means when we're, say, a bit behind the server and speed up the input timeline to catch up, we also start updating our estimate of the server timeline as if the server was speeding up along with us. I noticed that with more extreme SyncConfig settings, this was sometimes causing runaway feedback loops, where a client kept accelerating and getting further and further ahead of the server, while thinking the server was still ahead of it. Even with more conservative settings and no runaway feedback loop, it's probably not helping the synchronization.
TL;DR yes imo this should be based on real time

2. I chased my tail for a while thinking that how we track `this.offset` in RemoteTimeline is somehow wrong, because it seemed like the tracking worked better when I updated `this.now` directly with corrections instead of maintaining a separate `now` and `offset`. But it turns out that `TickDelta::add` was just broken for negative RHS 😛

I do think `RemoteTimeline::update` could be simplified (while still behaving exactly the same) by getting rid of the `offset` and just adjusting `now` based on `raw_offset`, but I don't know if you had a specific reason to keep those separate that I'm not aware of. I also wonder if TickDelta math could be simplified (and made less branchy) if `tick_diff` was a signed integer instead of having a separate `neg: bool` member. What do you think?

(also fixed typo in hierarchy.rs that broke compilation)