### PR TITLE
fix(rollback): More rollback fixes for deterministic replication

### DIFF
--- a/examples/deterministic_replication/src/client.rs
+++ b/examples/deterministic_replication/src/client.rs
@@ -102,12 +102,13 @@ fn handle_game_start(
     resource: Option<Res<GameStart>>,
 ) {
     if let Some(res) = resource
-        && timeline.tick() == res.0 + 20
+        && timeline.tick() >= res.0 + 20
     {
+        info!("Time to remove DisableRollback");
         query.iter().for_each(|e| {
             info!("Removed DisableRollback from entity: {:?}", e);
             commands.entity(e).remove::<DisableRollback>();
         });
+        commands.remove_resource::<GameStart>();
     }
-    commands.remove_resource::<GameStart>();
 }

--- a/examples/deterministic_replication/src/shared.rs
+++ b/examples/deterministic_replication/src/shared.rs
@@ -180,6 +180,7 @@ pub(crate) fn fixed_pre_physics(
 }
 
 pub(crate) fn fixed_last_log(
+    contact_graph: Res<ContactGraph>,
     timeline: Single<(&LocalTimeline, Has<Rollback>), Or<(With<Client>, Without<ClientOf>)>>,
     players: Query<
         (
@@ -199,6 +200,7 @@ pub(crate) fn fixed_last_log(
 ) {
     let (timeline, rollback) = timeline.into_inner();
     let tick = timeline.tick();
+    // info!(?tick, "contact graph: {:#?}", contact_graph);
 
     for (entity, position, velocity, correction, action_state, input_buffer) in players.iter() {
         let pressed = action_state.map(|a| a.get_pressed());

--- a/lightyear_prediction/src/manager.rs
+++ b/lightyear_prediction/src/manager.rs
@@ -161,8 +161,13 @@ pub struct PredictionManager {
     /// Store the spawn tick of the entity, as well as the corresponding hash
     pub prespawn_tick_to_hash: ReadyBuffer<Tick, u64>,
 
+    // TODO: does this mean that inputs must be all sent in one packet?
     /// Store the most recent confirmed input across all remote clients.
     pub last_confirmed_input: LastConfirmedInput,
+    // // TODO: this needs to be cleaned up at regular intervals!
+    // //  do a centralized TickCleanup system in lightyear_core
+    // /// The tick when we last did a rollback. This is used to prevent rolling back multiple times to the same tick.
+    // pub last_rollback_tick: Option<Tick>,
     /// We use a RwLock because we want to be able to update this value from multiple systems
     /// in parallel.
     #[reflect(ignore)]
@@ -186,7 +191,7 @@ pub struct LastConfirmedInput {
 
 impl LastConfirmedInput {
     /// Returns true if we have received any input messages from remote clients
-    pub(crate) fn received_input(&self) -> bool {
+    pub fn received_input(&self) -> bool {
         // If we received any messages, we can assume that we have a confirmed input
         self.received_any_messages
             .load(bevy_platform::sync::atomic::Ordering::Relaxed)
@@ -202,6 +207,7 @@ impl Default for PredictionManager {
             prespawn_hash_to_entities: EntityHashMap::default(),
             prespawn_tick_to_hash: ReadyBuffer::default(),
             last_confirmed_input: LastConfirmedInput::default(),
+            // last_rollback_tick: None,
             rollback: RwLock::new(RollbackState::Default),
             input_rollback: RwLock::new(RollbackState::Default),
         }


### PR DESCRIPTION
Deterministic Replication example is now working!

Some important prediction/rollback fixes:
- we switched from PredictionHistory.pop_until_tick to PredictionHistory.clear_until_tick which leaves the value in the history for the rollback tick. This is important since we can have multiple rollbacks starting from the same tick (if RollbackMode::Always, we would rollback from the LastConfirmedInput, or from the LastConfirmedState)

  Note that for state-based rollbacks we need to fully clear the history, since we will add the confirmed value to the history for the rollback tick

- in input rollback mode = Always, we were update the LastConfirmedTick to the latest received end_tick from each remote input message, and then doing rollback. This is incorrect since we need to rollback to the **previous** LastConfirmedTick. For example if we had a LastConfirmedTick of 13 and we receive an input message with end_tick 17, we need to rollback from tick 13 (because inputs 14,15,16,17 might be new)!

- We had added a check to prevent doing multiple rollbacks from the same tick. I.e. a rollback can only happen from a tick that is strictly more recent than previous rollbacks. We added this because values would be missing from the PredictionHistory so we cannot rollback to older values. However we **have** to accept doing multiple rollbacks from the same tick, otherwise we would have issue with the example given above (we rolled back once at tick 13, then if we receive a message for tick 17 we need to rollback from tick 13 again!)