### PR TITLE
feat(rollback): Add RollbackMode::Check for inputs

### DIFF
--- a/lightyear_inputs/src/input_buffer.rs
+++ b/lightyear_inputs/src/input_buffer.rs
@@ -215,7 +215,8 @@ impl<T: Clone + PartialEq> InputBuffer<T> {
         }
     }
 
-    pub(crate) fn get_raw(&self, tick: Tick) -> &InputData<T> {
+    /// Get the raw `InputData` for the given tick, without resolving `SameAsPrecedent`
+    pub fn get_raw(&self, tick: Tick) -> &InputData<T> {
         let Some(start_tick) = self.start_tick else {
             return &InputData::Absent;
         };

--- a/lightyear_inputs/src/input_message.rs
+++ b/lightyear_inputs/src/input_message.rs
@@ -1,6 +1,6 @@
 // lightyear_inputs/src/input_message.rs
 #![allow(clippy::module_inception)]
-use crate::input_buffer::InputBuffer;
+use crate::input_buffer::{InputBuffer, InputData};
 use alloc::{format, string::String, vec, vec::Vec};
 use bevy_ecs::{
     component::{Component, Mutable},
@@ -14,6 +14,7 @@ use lightyear_core::prelude::Tick;
 use lightyear_interpolation::plugin::InterpolationDelay;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
+use tracing::trace;
 
 /// Enum indicating the target entity for the input.
 #[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Debug, Reflect)]
@@ -37,6 +38,9 @@ pub struct PerTargetData<S> {
     pub states: S,
 }
 
+/// An ActionStateSequence represents a sequence of states that can be serialized and sent over the network.
+///
+/// The sequence can be decoded back into a `Iterator<Item = InputData<Self::Snapshot>>`
 pub trait ActionStateSequence:
     Serialize + DeserializeOwned + Clone + Debug + Send + Sync + 'static
 {
@@ -60,8 +64,70 @@ pub trait ActionStateSequence:
     fn is_empty(&self) -> bool;
     fn len(&self) -> usize;
 
-    /// Update the given input buffer with the data from this state sequence
-    fn update_buffer(self, input_buffer: &mut InputBuffer<Self::Snapshot>, end_tick: Tick);
+    /// Returns the sequence of snapshots from the ActionStateSequence.
+    ///
+    /// (we use this function instead of making ActionStateSequence implement `IntoIterator` because that would
+    /// leak private types that are used in the IntoIter type)
+    fn get_snapshots_from_message(self) -> impl Iterator<Item = InputData<Self::Snapshot>>;
+
+    /// Update the given input buffer with the data from this state sequence.
+    ///
+    /// Returns the earliest tick where there is a mismatch between the existing buffer and the new data,
+    /// or None if there was no mismatch
+    fn update_buffer(
+        self,
+        input_buffer: &mut InputBuffer<Self::Snapshot>,
+        end_tick: Tick,
+    ) -> Option<Tick> {
+        let previous_end_tick = input_buffer.end_tick();
+
+        let previous_predicted_input = input_buffer.get_last().cloned();
+        let mut earliest_mismatch: Option<Tick> = None;
+        let start_tick = end_tick + 1 - self.len() as u16;
+
+        // the first value is guaranteed to not be SameAsPrecedent
+        for (delta, input) in self.get_snapshots_from_message().enumerate() {
+            let tick = start_tick + Tick(delta as u16);
+
+            // after the mismatch, we just fill with the data from the message
+            if earliest_mismatch.is_some() {
+                input_buffer.set_raw(tick, input);
+            } else {
+                // only try to detect mismatches after the previous_end_tick
+                if previous_end_tick.is_none_or(|t| tick > t) {
+                    if match (&previous_predicted_input, &input) {
+                        // it is not possible to get a mismatch from SameAsPrecedent without first getting a mismatch from Input or Absent
+                        (_, InputData::SameAsPrecedent) => true,
+                        (Some(prev), InputData::Input(latest)) => latest == prev,
+                        (None, InputData::Absent) => true,
+                        _ => false,
+                    } {
+                        continue;
+                    }
+                    // mismatch! fill the ticks between previous_end_tick and this tick
+                    if let Some(prev_end) = previous_end_tick {
+                        for delta in 1..(tick - prev_end) {
+                            input_buffer.set_raw(prev_end + delta, InputData::SameAsPrecedent);
+                        }
+                    }
+                    // set the new value for the mismatch tick
+                    trace!("Mismatch detected at tick {tick:?} for input {input:?}");
+                    input_buffer.set_raw(tick, input);
+                    earliest_mismatch = Some(tick);
+                }
+            }
+        }
+
+        // if there was 0 mismatch, fill the gap between previous_end_tick and end_tick
+        if earliest_mismatch.is_none()
+            && let Some(prev_end) = previous_end_tick
+        {
+            for delta in 1..(end_tick - prev_end + 1) {
+                input_buffer.set_raw(prev_end + delta, InputData::SameAsPrecedent);
+            }
+        }
+        earliest_mismatch
+    }
 
     /// Build the state sequence (which will be sent over the network) from the input buffer
     fn build_from_input_buffer(

--- a/lightyear_inputs_bei/Cargo.toml
+++ b/lightyear_inputs_bei/Cargo.toml
@@ -38,6 +38,7 @@ bevy_reflect.workspace = true
 
 [dev-dependencies]
 bevy.workspace = true
+test-log.workspace = true
 
 [lints]
 workspace = true

--- a/lightyear_inputs_leafwing/Cargo.toml
+++ b/lightyear_inputs_leafwing/Cargo.toml
@@ -34,6 +34,9 @@ bevy_math.workspace = true
 bevy_platform.workspace = true
 bevy_reflect.workspace = true
 
+[dev-dependencies]
+test-log.workspace = true
+
 [lints]
 workspace = true
 

--- a/lightyear_prediction/src/rollback.rs
+++ b/lightyear_prediction/src/rollback.rs
@@ -364,8 +364,11 @@ fn check_rollback(
         }
         // Rollback from any mismatched input
         RollbackMode::Check => {
-            if let Some(rollback_tick) = prediction_manager.get_input_rollback_start_tick() {
-                trace!("Rollback because we have received a new remote input. (mismatch check)");
+            if prediction_manager.earliest_mismatch_input.has_mismatches() {
+                trace!(
+                    "Rollback because we have received a remote input that doesn't match our input buffer history"
+                );
+                let rollback_tick = prediction_manager.earliest_mismatch_input.tick.get();
                 do_rollback(
                     rollback_tick,
                     &prediction_manager,

--- a/lightyear_prediction/src/rollback.rs
+++ b/lightyear_prediction/src/rollback.rs
@@ -90,6 +90,7 @@ impl Plugin for RollbackPlugin {
         app.add_systems(
             PreUpdate,
             (
+                reset_input_rollback_tracker.after(RollbackSet::Check),
                 remove_prediction_disable.in_set(RollbackSet::RemoveDisable),
                 run_rollback.in_set(RollbackSet::Rollback),
                 end_rollback.in_set(RollbackSet::EndRollback),
@@ -365,10 +366,11 @@ fn check_rollback(
         // Rollback from any mismatched input
         RollbackMode::Check => {
             if prediction_manager.earliest_mismatch_input.has_mismatches() {
+                let rollback_tick = prediction_manager.earliest_mismatch_input.tick.get();
                 trace!(
+                    ?rollback_tick,
                     "Rollback because we have received a remote input that doesn't match our input buffer history"
                 );
-                let rollback_tick = prediction_manager.earliest_mismatch_input.tick.get();
                 do_rollback(
                     rollback_tick,
                     &prediction_manager,
@@ -406,6 +408,38 @@ fn check_rollback(
             }
         });
     }
+}
+
+/// Reset the trackers associated with RollbackMode::Input checks.
+///
+/// We do this here and not in `lightyear_input` because if we have multiple input types, the ticks
+/// could be overwritten by each other.
+///
+/// This must run after the rollback check.
+fn reset_input_rollback_tracker(
+    client: Single<(&LocalTimeline, &PredictionManager), With<IsSynced<InputTimeline>>>,
+) {
+    let (local_timeline, prediction_manager) = client.into_inner();
+    let tick = local_timeline.tick();
+
+    // set a high value to the AtomicTick so we can then compute the minimum last_confirmed_tick among all clients
+    prediction_manager.last_confirmed_input.tick.0.store(
+        tick.0 + 1000,
+        bevy_platform::sync::atomic::Ordering::Relaxed,
+    );
+    prediction_manager
+        .last_confirmed_input
+        .received_any_messages
+        .store(false, bevy_platform::sync::atomic::Ordering::Relaxed);
+    // set a high value to the AtomicTick so we can then compute the minimum earliest_mismatch_tick among all clients
+    prediction_manager.earliest_mismatch_input.tick.0.store(
+        tick.0 + 1000,
+        bevy_platform::sync::atomic::Ordering::Relaxed,
+    );
+    prediction_manager
+        .earliest_mismatch_input
+        .has_mismatches
+        .store(false, bevy_platform::sync::atomic::Ordering::Relaxed);
 }
 
 // TODO: maybe restore only the ones for which the Confirmed entity is not disabled?
@@ -699,7 +733,6 @@ pub(crate) fn run_rollback(world: &mut World) {
     let rollback_start_tick = prediction_manager
         .get_rollback_start_tick()
         .expect("we should be in rollback");
-    // prediction_manager.last_rollback_tick = Some(rollback_start_tick);
 
     // NOTE: we reverted all components to the end of `current_roll
     let num_rollback_ticks = current_tick - rollback_start_tick;

--- a/lightyear_tests/src/client_server/input/bei.rs
+++ b/lightyear_tests/src/client_server/input/bei.rs
@@ -1,4 +1,4 @@
-use crate::client_server::prediction::trigger_rollback;
+use crate::client_server::prediction::trigger_state_rollback;
 use crate::protocol::{BEIAction1, BEIContext};
 use crate::stepper::{ClientServerStepper, TICK_DURATION};
 use bevy::app::{App, FixedPostUpdate};
@@ -179,7 +179,7 @@ fn test_client_rollback() {
     // trigger a rollback
     // at client_tick, the elapsed_time should be 0.2.
     // We rollback to client_tick - 1, because the first FixedPreUpdate will bring us to `client_tick`
-    trigger_rollback(&mut stepper, client_tick - 1);
+    trigger_state_rollback(&mut stepper, client_tick - 1);
 
     let assert_action_duration =
         move |client: Single<&LocalTimeline, With<Client>>, query: Query<&Actions<BEIContext>>| {

--- a/lightyear_tests/src/client_server/prediction/history.rs
+++ b/lightyear_tests/src/client_server/prediction/history.rs
@@ -471,7 +471,7 @@ fn test_update_history() {
 
     // 5. Updating Comp::Full on predicted entity during rollback
     let rollback_tick = Tick(10);
-    trigger_rollback(&mut stepper, rollback_tick);
+    trigger_state_rollback(&mut stepper, rollback_tick);
     stepper
         .client_app()
         .world_mut()
@@ -494,7 +494,7 @@ fn test_update_history() {
     // 6. Updating Comp::Full on predicted entity for a tick that is in the middle of the history
     // Previous test cases had the rollback tick be earlier than the entire history; we also need to test
     // when the rollback tick is in the middle of the history
-    trigger_rollback(&mut stepper, rollback_tick + 3);
+    trigger_state_rollback(&mut stepper, rollback_tick + 3);
     stepper
         .client_app()
         .world_mut()
@@ -520,7 +520,7 @@ fn test_update_history() {
         .world_mut()
         .entity_mut(confirmed)
         .remove::<CompFull>();
-    trigger_rollback(&mut stepper, rollback_tick);
+    trigger_state_rollback(&mut stepper, rollback_tick);
     stepper.frame_step(1);
     assert_eq!(
         stepper

--- a/lightyear_tests/src/client_server/prediction/mod.rs
+++ b/lightyear_tests/src/client_server/prediction/mod.rs
@@ -44,7 +44,7 @@ pub(crate) fn trigger_rollback_check(stepper: &mut ClientServerStepper, tick: Ti
         .send(RollbackInfo { tick });
 }
 
-pub(crate) fn trigger_rollback(stepper: &mut ClientServerStepper, tick: Tick) {
+pub(crate) fn trigger_state_rollback(stepper: &mut ClientServerStepper, tick: Tick) {
     stepper.client_mut(0).insert(Rollback::FromState);
     stepper
         .client_mut(0)


### PR DESCRIPTION
Previously we had RollbackMode::Always, which meant that whenever we
receive new input messages, we would rollback to the previous last
confirmed ticks for the inputs.

It is possible to reduce the number of rollbacks by checking if any of
the newly received inputs contain mismatches with our existing
InputBuffer. If they don't, no need to rollback!

This PR refactors the ActionStateSequence trait by adding a common
`update_buffer` method to update the input buffer from the action
sequence. The method now returns a `mismatch_tick` which is the earliest
tick where we have a mismatch. It is used to select the starting tick at
which we will rollback.