### PR TITLE
feat(deterministic): Add lightyear_deterministic_replication

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ lightyear_netcode = { path = "./lightyear_netcode", version = " 0.21.1", default
 lightyear_connection = { path = "./lightyear_connection", version = " 0.21.1", default-features = false }
 lightyear_core = { path = "./lightyear_core", version = " 0.21.1", default-features = false }
 lightyear_crossbeam = { path = "./lightyear_crossbeam", version = " 0.21.1", default-features = false }
+lightyear_deterministic_replication = { path = "./lightyear_deterministic_replication", version = " 0.21.1", default-features = false }
 lightyear_frame_interpolation = { path = "./lightyear_frame_interpolation", version = " 0.21.1", default-features = false }
 lightyear_inputs = { path = "./lightyear_inputs", version = " 0.21.1", default-features = false }
 lightyear_inputs_bei = { path = "./lightyear_inputs_bei", version = " 0.21.1", default-features = false }

--- a/NOTES.md
+++ b/NOTES.md
@@ -6,28 +6,6 @@
   during rollbacks? So the current_value of VisualInterpolation is updated thanks to Correction, but the previous value
   is wrong!
 
-- Our correction interpolates from the original value to the new value; maybe we should instead do the lerp smoothing,
-  where we lerp our visual value a certain amount towards the correct value.
-  We could do it all the time, in which case we don't need to do frame interpolation? Also we can do it at 
-
-- We don't remove Correction like we should be doing if the states match..
-  on the last tick of rollback, we should check if the final value we have computed is the same as the computed value.
-  If it is, remove Correction. -> FIXED
-
-
-- Simpler Correction design: 
-  - if users add a component with correction on it (or maybe with PredictionMode::Full), we automatically insert Corrected<C> on the entity.
-    FrameInterpolation will not run on entities with Corrected<C>.
-    It will act the same as FrameInterpolation:
-    - automatically interpolates by taking the last 2 values of the PredictionHistory.
-    - TODO: handle if predictionhistory is not present
-
-- on rollback: 
-  - C is equal to the FrameInterpolation value (remove restore_visual_interp) = previous_visual
-  - we compute the 
-  
-
-
 
 ### DON'T ENABLE GUI ON SERVER - all these errors seem related
 - Is the sync system even working? C1 is 7 ticks behind the server and stays behind!

--- a/examples/deterministic_replication/Cargo.toml
+++ b/examples/deterministic_replication/Cargo.toml
@@ -19,9 +19,9 @@ lightyear = { workspace = true, features = [
   "prediction",
   "replication",
   "leafwing",
+  "deterministic",
+  "avian2d",
 ] }
-lightyear_avian2d.workspace = true
-#lightyear_avian2d = { workspace = true, features = ["2d"]}
 lightyear_examples_common.workspace = true
 lightyear_frame_interpolation.workspace = true
 leafwing-input-manager.workspace = true

--- a/examples/deterministic_replication/src/client.rs
+++ b/examples/deterministic_replication/src/client.rs
@@ -3,43 +3,21 @@ use bevy::app::PluginGroupBuilder;
 use bevy::prelude::*;
 use core::time::Duration;
 use leafwing_input_manager::prelude::*;
+use lightyear::prediction::predicted_history::PredictionHistory;
 use lightyear::prediction::rollback::{DeterministicPredicted, DisableRollback};
 use lightyear::prelude::client::*;
 use lightyear::prelude::*;
 
 use crate::protocol::*;
 use crate::shared;
-use crate::shared::{SharedPlugin, color_from_id, shared_movement_behaviour};
+use crate::shared::{SharedPlugin, color_from_id, player_bundle, shared_movement_behaviour};
 
 pub struct ExampleClientPlugin;
 
 impl Plugin for ExampleClientPlugin {
     fn build(&self, app: &mut App) {
-        app.add_systems(FixedUpdate, (player_movement, handle_game_start));
+        app.add_systems(FixedUpdate, handle_game_start);
         app.add_observer(handle_player_spawn);
-    }
-}
-
-/// In deterministic replication, the client simulates all players.
-fn player_movement(
-    timeline: Single<&LocalTimeline, With<Client>>,
-    mut velocity_query: Query<(
-        Entity,
-        &PlayerId,
-        &Position,
-        &mut LinearVelocity,
-        &ActionState<PlayerActions>,
-    )>,
-) {
-    let tick = timeline.tick();
-    for (entity, player_id, position, velocity, action_state) in velocity_query.iter_mut() {
-        if !action_state.get_pressed().is_empty() {
-            trace!(?entity, ?tick, ?position, actions = ?action_state.get_pressed(), "applying movement to predicted player");
-            // note that we also apply the input to the other predicted clients! even though
-            //  their inputs are only replicated with a delay!
-            // TODO: add input decay?
-            shared_movement_behaviour(velocity, action_state);
-        }
     }
 }
 
@@ -61,26 +39,8 @@ fn handle_player_spawn(
     info!("Received GameStart at tick: {tick:?}");
 
     let peer_id = player_query.get(trigger.target()).unwrap().0;
-    let y = (peer_id.to_bits() as f32 * 50.0) % 500.0 - 250.0;
-    let color = color_from_id(peer_id);
     let mut entity_mut = commands.entity(trigger.target());
-    entity_mut.insert((
-        Position::from(Vec2::new(-50.0, y)),
-        ColorComponent(color),
-        PhysicsBundle::player(),
-        Name::from("Player"),
-        // this indicates that the entity will only do rollbacks from input updates, and not state updates!
-        // It is currently REQUIRED to add this component to indicate which entities will be rollbacked
-        // in deterministic replication mode.
-        DeterministicPredicted,
-        // this is a bit subtle:
-        // when we add DeterministicPredicted to the entity, we enable it for rollbacks. Since we have RollbackMode::Always,
-        // we will try to rollback on every input received. We will therefore rollback to before the entity was spawned,
-        // which will immediately despawn the entity!
-        // This is because we are not creating the entity in a deterministic way. (if we did, we would be re-creating the
-        // entity during the rollbacks). As a workaround, we disable rollbacks for this entity for a few ticks.
-        DisableRollback,
-    ));
+    entity_mut.insert(player_bundle(peer_id));
     if local_id.0 == peer_id {
         entity_mut.insert(InputMap::new([
             (PlayerActions::Up, KeyCode::KeyW),

--- a/examples/deterministic_replication/src/protocol.rs
+++ b/examples/deterministic_replication/src/protocol.rs
@@ -98,11 +98,14 @@ impl Plugin for ProtocolPlugin {
         // add prediction for non-networked components
         app.add_rollback::<Position>()
             .add_should_rollback(position_should_rollback)
+            // add a hash function to perform a checksum in order to catch desyncs
+            .add_custom_hash(lightyear::avian2d::types::position::hash)
             .add_linear_interpolation_fn()
             .add_linear_correction_fn();
 
         app.add_rollback::<Rotation>()
             .add_should_rollback(rotation_should_rollback)
+            .add_custom_hash(lightyear::avian2d::types::rotation::hash)
             .add_linear_interpolation_fn()
             .add_linear_correction_fn();
 

--- a/examples/deterministic_replication/src/server.rs
+++ b/examples/deterministic_replication/src/server.rs
@@ -1,6 +1,8 @@
 use crate::protocol::*;
 use crate::shared;
-use crate::shared::{SharedPlugin, WallBundle, color_from_id, shared_movement_behaviour};
+use crate::shared::{
+    SharedPlugin, WallBundle, color_from_id, player_bundle, shared_movement_behaviour,
+};
 use avian2d::prelude::*;
 use bevy::color::palettes::css;
 use bevy::platform::collections::HashMap;
@@ -63,6 +65,7 @@ pub(crate) fn start_game(
             commands.spawn((
                 Replicate::to_clients(NetworkTarget::All),
                 PlayerId(remote_id.0),
+                player_bundle(remote_id.0),
             ));
         } else {
             panic!("Failed to get entity for server link {link:?}");

--- a/lightyear/Cargo.toml
+++ b/lightyear/Cargo.toml
@@ -75,6 +75,14 @@ server = [
   "lightyear_udp?/server",
   "lightyear_webtransport?/server",
 ]
+## Adds helper plugins to use for deterministic replication (where only inputs are replicated)
+deterministic = [
+  "dep:lightyear_deterministic_replication",
+  "lightyear_replication?/deterministic",
+  "lightyear_prediction?/deterministic",
+  "lightyear_avian2d?/deterministic",
+  "lightyear_avian3d?/deterministic",
+]
 ## Enables replicating entities between two peers
 replication = [
   "dep:lightyear_replication",
@@ -157,6 +165,7 @@ lightyear_avian2d = { workspace = true, optional = true, features = ["2d"] }
 lightyear_avian3d = { workspace = true, optional = true, features = ["3d"] }
 lightyear_connection.workspace = true
 lightyear_core.workspace = true
+lightyear_deterministic_replication = { workspace = true, optional = true }
 lightyear_frame_interpolation = { workspace = true, optional = true }
 lightyear_link.workspace = true
 lightyear_netcode = { workspace = true, optional = true }

--- a/lightyear/src/client.rs
+++ b/lightyear/src/client.rs
@@ -27,6 +27,9 @@ impl PluginGroup for ClientPlugins {
             tick_duration: self.tick_duration,
         });
 
+        #[cfg(feature = "deterministic")]
+        let builder = builder.add(lightyear_deterministic_replication::prelude::ChecksumSendPlugin);
+
         #[cfg(feature = "prediction")]
         let builder = builder.add(lightyear_prediction::plugin::PredictionPlugin);
 

--- a/lightyear/src/lib.rs
+++ b/lightyear/src/lib.rs
@@ -284,6 +284,16 @@ pub mod webtransport {
     pub use lightyear_webtransport::*;
 }
 
+#[cfg(feature = "avian2d")]
+pub mod avian2d {
+    pub use lightyear_avian2d::*;
+}
+
+#[cfg(feature = "avian3d")]
+pub mod avian3d {
+    pub use lightyear_avian3d::*;
+}
+
 #[cfg(any(feature = "input_native", feature = "leafwing", feature = "input_bei"))]
 pub mod input {
     pub use lightyear_inputs::*;

--- a/lightyear/src/server.rs
+++ b/lightyear/src/server.rs
@@ -48,6 +48,10 @@ impl PluginGroup for ServerPlugins {
             tick_duration: self.tick_duration,
         });
 
+        #[cfg(feature = "deterministic")]
+        let builder =
+            builder.add(lightyear_deterministic_replication::prelude::ChecksumReceivePlugin);
+
         let builder = builder.add(lightyear_connection::host::HostPlugin);
 
         #[cfg(feature = "replication")]

--- a/lightyear/src/shared.rs
+++ b/lightyear/src/shared.rs
@@ -54,11 +54,6 @@ impl Plugin for SharedPlugins {
         app.add_plugins(lightyear_interpolation::plugin::InterpolationPlugin::new(
             lightyear_interpolation::plugin::InterpolationConfig::default(),
         ));
-
-        #[cfg(feature = "avian2d")]
-        app.add_plugins(lightyear_avian2d::prelude::LightyearAvianPlugin::default());
-        #[cfg(feature = "avian3d")]
-        app.add_plugins(lightyear_avian3d::prelude::LightyearAvianPlugin::default());
     }
 
     fn is_unique(&self) -> bool {

--- a/lightyear_avian/src/lib.rs
+++ b/lightyear_avian/src/lib.rs
@@ -23,11 +23,11 @@ mod sync;
 #[cfg(feature = "3d")]
 pub mod types_3d;
 
-#[cfg(any(feature = "2d", feature = "3d"))]
-mod plugin;
-
 #[cfg(feature = "3d")]
 pub use types_3d as types;
+
+#[cfg(any(feature = "2d", feature = "3d"))]
+pub mod plugin;
 
 /// Commonly used items for Lightyear Avian integration.
 pub mod prelude {

--- a/lightyear_avian/src/plugin.rs
+++ b/lightyear_avian/src/plugin.rs
@@ -39,6 +39,9 @@ pub enum AvianReplicationMode {
     Transform,
 }
 
+/// Plugin that integrates Avian with Lightyear for networked physics replication.
+///
+/// NOTE: this plugin is NOT added automatically by ClientPlugins/ServerPlugins, you have to add it manually!
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
 pub struct LightyearAvianPlugin {
     /// The replication mode to use for the Avian plugin.

--- a/lightyear_avian/src/types_2d.rs
+++ b/lightyear_avian/src/types_2d.rs
@@ -3,6 +3,9 @@ use avian2d::math::Scalar;
 use avian2d::prelude::*;
 use tracing::trace;
 
+#[cfg(feature = "deterministic")]
+use core::hash::Hasher;
+
 pub mod position {
     use super::*;
 
@@ -14,6 +17,12 @@ pub mod position {
             start, other, t, res
         );
         res
+    }
+
+    #[cfg(feature = "deterministic")]
+    pub fn hash(pos: &Position, hasher: &mut seahash::SeaHasher) {
+        hasher.write_u32(pos.x.to_bits());
+        hasher.write_u32(pos.y.to_bits());
     }
 }
 
@@ -39,6 +48,12 @@ pub mod rotation {
             res.as_degrees()
         );
         res
+    }
+
+    #[cfg(feature = "deterministic")]
+    pub fn hash(rot: &Rotation, hasher: &mut seahash::SeaHasher) {
+        hasher.write_u32(rot.cos.to_bits());
+        hasher.write_u32(rot.sin.to_bits());
     }
 }
 

--- a/lightyear_avian/src/types_3d.rs
+++ b/lightyear_avian/src/types_3d.rs
@@ -3,6 +3,9 @@ use avian3d::math::Scalar;
 use avian3d::prelude::*;
 use tracing::trace;
 
+#[cfg(feature = "deterministic")]
+use core::hash::Hasher;
+
 pub mod position {
     use super::*;
 
@@ -15,14 +18,31 @@ pub mod position {
         );
         res
     }
+
+    #[cfg(feature = "deterministic")]
+    pub fn hash(pos: &Position, hasher: &mut seahash::SeaHasher) {
+        hasher.write_u32(pos.x.to_bits());
+        hasher.write_u32(pos.y.to_bits());
+        hasher.write_u32(pos.z.to_bits());
+    }
 }
 
 pub mod rotation {
     use super::*;
+
     /// We want to smoothly interpolate between the two quaternions by default,
     /// rather than using a quicker but less correct linear interpolation.
     pub fn lerp(start: &Rotation, other: &Rotation, t: f32) -> Rotation {
         start.slerp(*other, Scalar::from(t))
+    }
+
+    #[cfg(feature = "deterministic")]
+    pub fn hash(rot: &Rotation, hasher: &mut seahash::SeaHasher) {
+        let [x, y, z, w] = rot.to_array();
+        hasher.write_u32(x.to_bits());
+        hasher.write_u32(y.to_bits());
+        hasher.write_u32(z.to_bits());
+        hasher.write_u32(w.to_bits());
     }
 }
 

--- a/lightyear_avian2d/Cargo.toml
+++ b/lightyear_avian2d/Cargo.toml
@@ -14,6 +14,7 @@ publish = true
 
 [lib]
 name = "lightyear_avian2d"
+path = "../lightyear_avian/src/lib.rs"
 required-features = ["2d"]
 bench = false
 
@@ -24,6 +25,7 @@ default = ["std", "2d"]
     "avian2d/parry-f32",
 ]
 std = ["lightyear_prediction/std"]
+deterministic = ["dep:seahash"]
 lag_compensation = []
 
 [dependencies]
@@ -44,6 +46,9 @@ bevy_ecs.workspace = true
 bevy_math.workspace = true
 bevy_transform = { workspace = true, features = ["bevy-support", "libm"] }
 bevy_utils.workspace = true
+
+# utils
+seahash = { workspace = true, optional = true }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/lightyear_avian2d/src
+++ b/lightyear_avian2d/src
@@ -1,1 +1,0 @@
-../lightyear_avian/src

--- a/lightyear_avian3d/Cargo.toml
+++ b/lightyear_avian3d/Cargo.toml
@@ -14,6 +14,7 @@ publish = true
 
 [lib]
 name = "lightyear_avian3d"
+path = "../lightyear_avian/src/lib.rs"
 required-features = ["3d"]
 bench = false
 
@@ -24,6 +25,7 @@ default = ["std", "3d"]
     "avian3d/parry-f32",
 ]
 std = ["lightyear_prediction/std"]
+deterministic = ["dep:seahash"]
 lag_compensation = []
 
 [dependencies]
@@ -36,7 +38,6 @@ lightyear_replication = { workspace = true, features = ["avian3d"] }
 
 avian3d.workspace = true
 
-tracing.workspace = true
 
 # bevy
 bevy_app.workspace = true
@@ -44,6 +45,10 @@ bevy_ecs.workspace = true
 bevy_math.workspace = true
 bevy_transform = { workspace = true, features = ["bevy-support", "libm"] }
 bevy_utils.workspace = true
+
+# utils
+tracing.workspace = true
+seahash = { workspace = true, optional = true }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/lightyear_avian3d/src
+++ b/lightyear_avian3d/src
@@ -1,1 +1,0 @@
-../lightyear_avian/src

--- a/lightyear_deterministic_replication/Cargo.toml
+++ b/lightyear_deterministic_replication/Cargo.toml
@@ -9,38 +9,32 @@ description = "Primitives for deterministic replication (as opposed to state rep
 repository = "https://github.com/cBournhonesque/lightyear"
 
 [features]
+std = [
+    "lightyear_messages/std",
+]
 default = []
-prediction = []
-interpolation = []
-test_utils = ["dep:mock_instant"]
-# special feature to avoid using mock_instant when running cargo doc and cargo clippy
-not_mock = []
 
 [dependencies]
 lightyear_utils.workspace = true
-lightyear_serde.workspace = true
+lightyear_core.workspace = true
+lightyear_inputs = {workspace = true, features = ["client"] }
+lightyear_link.workspace = true
 lightyear_messages.workspace = true
+lightyear_connection.workspace = true
+lightyear_sync.workspace = true
+lightyear_prediction = { workspace = true, features = ["deterministic"] }
+lightyear_replication = { workspace = true, features = ["deterministic"]}
 
 # utils
-chrono.workspace = true
+seahash.workspace = true
 tracing.workspace = true
 
 # bevy
 bevy_app = { workspace = true, features = ["bevy_reflect"] }
-bevy_derive.workspace = true
 bevy_ecs.workspace = true
-bevy_platform.workspace = true
-bevy_reflect.workspace = true
-bevy_time.workspace = true
 
 # serde
 serde.workspace = true
-
-# test
-mock_instant = { workspace = true, optional = true }
-
-[dev-dependencies]
-approx.workspace = true
 
 [lints]
 workspace = true

--- a/lightyear_deterministic_replication/src/archetypes.rs
+++ b/lightyear_deterministic_replication/src/archetypes.rs
@@ -1,0 +1,195 @@
+use crate::Deterministic;
+use alloc::collections::BTreeMap;
+use alloc::vec::Vec;
+use bevy_ecs::archetype::{Archetype, ArchetypeId};
+use bevy_ecs::component::{ComponentId, StorageType, Tick};
+use bevy_ecs::prelude::World;
+use bevy_ecs::query::FilteredAccess;
+use bevy_ecs::system::{ReadOnlySystemParam, SystemMeta, SystemParam};
+use bevy_ecs::world::unsafe_world_cell::UnsafeWorldCell;
+use lightyear_prediction::prelude::PredictionRegistry;
+use lightyear_prediction::registry::PopUntilTickAndHashFn;
+use lightyear_prediction::rollback::DisableRollback;
+use lightyear_replication::prelude::ComponentRegistry;
+use lightyear_replication::registry::deterministic::DeterministicFns;
+use tracing::trace;
+
+/// A [`SystemParam`] that holds the list of archetypes in the world that should be hashed
+/// for checksum calculation.
+///
+/// Only entities with the [`Deterministic`] marker component are considered, and we will
+/// only iterate through their components that have a hash function registered.
+///
+/// HISTORY: if True, the archetypes will contain the [`PredictionHistory<C>`](lightyear_prediction::prelude::PredictionHistory) instead of C.
+/// THis is useful on the client-side where we want the checksum to use the history value at the LastConfirmedTick.
+pub(crate) struct ChecksumWorld<'w, 's, const HISTORY: bool> {
+    pub(crate) world: UnsafeWorldCell<'w>,
+    pub(crate) state: &'s ChecksumState,
+}
+
+impl<'w, const HISTORY: bool> ChecksumWorld<'w, '_, HISTORY> {
+    /// Return iterator over checksum archetypes.
+    pub(super) fn iter_archetypes(&self) -> impl Iterator<Item = (&Archetype, &ChecksumArchetype)> {
+        self.state.archetypes.iter().map(|checksum_archetype| {
+            // SAFETY: the id is valid because it was obtained from an existing archetype in `new_archetype`.
+            let archetype = unsafe {
+                self.world
+                    .archetypes()
+                    .get(checksum_archetype.id)
+                    .unwrap_unchecked()
+            };
+
+            (archetype, checksum_archetype)
+        })
+    }
+}
+
+unsafe impl<const HISTORY: bool> SystemParam for ChecksumWorld<'_, '_, HISTORY> {
+    type State = ChecksumState;
+    type Item<'world, 'state> = ChecksumWorld<'world, 'state, HISTORY>;
+
+    fn init_state(world: &mut World, system_meta: &mut SystemMeta) -> Self::State {
+        let mut filtered_access = FilteredAccess::default();
+
+        let marker_id = world.register_component::<Deterministic>();
+        let disable_rollback_id = world.register_component::<DisableRollback>();
+        filtered_access.add_component_read(marker_id);
+
+        let registry = world.resource::<ComponentRegistry>();
+
+        let combined_access = system_meta.component_access_set().combined_access();
+
+        let hash_fns = if !HISTORY {
+            let registry = world.resource::<ComponentRegistry>();
+            registry
+            .component_metadata_map
+            .values()
+            .filter_map(| m| m.deterministic
+                .as_ref()
+                .map(|d| {
+                    filtered_access.add_component_read(m.component_id);
+                    assert!(
+                        !combined_access.has_component_write(m.component_id),
+                        "replicated component `{}` in system `{}` shouldn't be in conflict with other system parameters",
+                        world.components().get_name(m.component_id).unwrap(),
+                        system_meta.name(),
+                    );
+                    (m.component_id, (*d, None))
+                }))
+            .collect()
+        } else {
+            let prediction_registry = world.resource::<PredictionRegistry>();
+            prediction_registry
+                .prediction_map
+                .iter()
+                .filter_map(|(kind, pred)| {
+                    let history_id = pred.history_id?;
+                    // We need write access because we will call `pop_until_tick` on the history component
+                    filtered_access.add_component_write(history_id);
+                    assert!(
+                        !combined_access.has_component_read(history_id),
+                        "replicated component `{}` in system `{}` shouldn't be in conflict with other system parameters",
+                        world.components().get_name(history_id).unwrap(),
+                        system_meta.name(),
+                    );
+                    registry.component_metadata_map
+                        .get(kind)
+                        .and_then(|m| m.deterministic.as_ref().map(|d| (history_id, (*d, pred.pop_until_tick_and_hash))))
+                })
+                .collect()
+        };
+
+        // SAFETY: used only to extend access.
+        unsafe {
+            system_meta.component_access_set_mut().add(filtered_access);
+        }
+        trace!("HashFns used for ChecksumState: {:?}", hash_fns);
+
+        ChecksumState {
+            marker_id,
+            disable_rollback_id,
+            archetypes: Default::default(),
+            hash_fns,
+        }
+    }
+
+    unsafe fn new_archetype(
+        state: &mut Self::State,
+        archetype: &Archetype,
+        system_meta: &mut SystemMeta,
+    ) {
+        if !archetype.contains(state.marker_id) {
+            return;
+        }
+        if HISTORY && archetype.contains(state.disable_rollback_id) {
+            trace!(
+                "skipping archetype {:?} because it contains DisableRollback",
+                archetype.id()
+            );
+            return;
+        }
+
+        let mut checksum_archetype = ChecksumArchetype::new(archetype.id());
+        state.hash_fns.keys().for_each(|component_id| {
+            if archetype.contains(*component_id) {
+                trace!("found component {:?} in archetype", component_id);
+                // SAFETY: archetype contains this component.
+                let storage =
+                    unsafe { archetype.get_storage_type(*component_id).unwrap_unchecked() };
+                checksum_archetype.components.push((*component_id, storage));
+
+                // SAFETY: archetype contains this component and we don't remove access from system meta.
+                unsafe {
+                    let archetype_id = archetype
+                        .get_archetype_component_id(*component_id)
+                        .unwrap_unchecked();
+                    system_meta
+                        .archetype_component_access_mut()
+                        .add_component_read(archetype_id)
+                }
+            }
+        });
+
+        // Store for future iteration.
+        state.archetypes.push(checksum_archetype);
+    }
+
+    unsafe fn get_param<'world, 'state>(
+        state: &'state mut Self::State,
+        _system_meta: &SystemMeta,
+        world: UnsafeWorldCell<'world>,
+        _change_tick: Tick,
+    ) -> Self::Item<'world, 'state> {
+        ChecksumWorld { world, state }
+    }
+}
+
+unsafe impl<const HISTORY: bool> ReadOnlySystemParam for ChecksumWorld<'_, '_, HISTORY> {}
+
+pub(crate) struct ChecksumState {
+    /// ComponentId for the `Deterministic` marker component.
+    pub(crate) marker_id: ComponentId,
+    /// ComponentId for the `DisableRollback` marker component.
+    ///
+    /// We will not compute the checksum for entities that have this component, as it could mess up the rollback logic
+    /// since we are removing elements from the history.
+    pub(crate) disable_rollback_id: ComponentId,
+    pub(crate) archetypes: Vec<ChecksumArchetype>,
+    pub(crate) hash_fns: BTreeMap<ComponentId, (DeterministicFns, Option<PopUntilTickAndHashFn>)>,
+}
+
+pub(crate) struct ChecksumArchetype {
+    /// The ID of the archetype.
+    pub(crate) id: ArchetypeId,
+    /// Components in this archetype that have a hash function registered.
+    pub(crate) components: Vec<(ComponentId, StorageType)>,
+}
+
+impl ChecksumArchetype {
+    fn new(id: ArchetypeId) -> Self {
+        Self {
+            id,
+            components: Default::default(),
+        }
+    }
+}

--- a/lightyear_deterministic_replication/src/checksum.rs
+++ b/lightyear_deterministic_replication/src/checksum.rs
@@ -1,0 +1,228 @@
+//! Utilities for computing checksums for data integrity verification.
+//!
+//! The clients will send checksums at regular intervals to the server, which will verify them against its own computed checksums.
+//!
+//! Note: we don't have a good way to guarantee that we are iterating through entities in a stable order on both client and server.
+//! Because of this, we will compute an order-independent checksum by only hashing component data and then XOR-ing the results together.
+
+use crate::archetypes::ChecksumWorld;
+use crate::plugin::DeterministicReplicationPlugin;
+use alloc::collections::BTreeMap;
+use bevy_app::{App, FixedLast, Plugin, PostUpdate};
+use bevy_ecs::prelude::*;
+use core::hash::Hasher;
+use lightyear_connection::client::{Client, Connected};
+use lightyear_connection::direction::NetworkDirection;
+use lightyear_connection::server::Started;
+use lightyear_core::id::RemoteId;
+use lightyear_core::prelude::{LocalTimeline, NetworkTimeline};
+use lightyear_core::tick::Tick;
+use lightyear_inputs::InputChannel;
+use lightyear_inputs::client::InputSet;
+use lightyear_link::server::{LinkOf, Server};
+use lightyear_messages::MessageManager;
+use lightyear_messages::plugin::MessageSet;
+use lightyear_messages::prelude::{AppMessageExt, MessageSender};
+use lightyear_messages::receive::MessageReceiver;
+use lightyear_prediction::manager::LastConfirmedInput;
+use lightyear_sync::prelude::{InputTimeline, IsSynced};
+use serde::{Deserialize, Serialize};
+use tracing::{debug, error, trace};
+
+/// History of the checksums on the server to validate client checksums against.
+#[derive(Component, Debug, Default)]
+pub struct ChecksumHistory {
+    history: BTreeMap<Tick, u64>,
+}
+
+/// Plugin that can be added to clients to compute and send checksums for all deterministic entities with hashable components.
+///
+/// The server will receive these checksums and verify them against its own computed checksums.
+/// If a checksum does not match, it indicates a desync between the client and server.
+pub struct ChecksumSendPlugin;
+
+impl ChecksumSendPlugin {
+    /// Compute a checksum for all deterministic entities with hashable components.
+    fn compute_and_send_checksum(
+        world: ChecksumWorld<'_, '_, true>,
+        client: Single<
+            (
+                &LastConfirmedInput,
+                &MessageManager,
+                &mut MessageSender<ChecksumMessage>,
+            ),
+            (With<Client>, With<IsSynced<InputTimeline>>),
+        >,
+    ) {
+        let mut checksum = 0u64;
+
+        let (last_confirmed_input, message_manager, mut sender) = client.into_inner();
+        let tick = last_confirmed_input.tick.get();
+
+        world.iter_archetypes().for_each(|(archetype, checksum_archetype)| {
+            // TODO: how can we guarantee that the order is the same on client and server? We need a stable order for entities, otherwise the checksum will differ even if the data is the same.
+            archetype.entities().iter().for_each(|entity| {
+                // // TODO: currently this only works if the entity was replicated from the server
+                // //  if the entity was created locally on the client, it won't have a mapping to a remote entity and will be ignored
+                // // convert to a remote entity
+                // if let Some(mapped_entity) = message_manager.entity_mapper.get_remote(entity.id()) {
+                //     trace!("Adding entity {:?} (mapped to remote entity {:?}) to checksum for tick {:?}", entity.id(), mapped_entity, tick);
+                //     // hasher.write_u64(mapped_entity.to_bits());
+                // }
+                checksum_archetype.components.iter().for_each(|(component_id, storage_type)| {
+                    trace!("Adding component {:?} from entity {:?} to checksum for tick {:?}",
+                        component_id, entity.id(), tick);
+                    // SAFETY: the way we constructed the archetypes guarantees that the component exists on the entity and we have unique write access
+                    let history_ptr = unsafe {
+                        lightyear_utils::ecs::get_component_unchecked_mut(world.world, entity, archetype.table_id(), *storage_type, *component_id)
+                    };
+                    let (hash_fn, pop_until_tick_and_hash_fn) = world.state.hash_fns.get(component_id).expect("Component in checksum archetype must have a hash function registered");
+
+                    let mut hasher = seahash::SeaHasher::default();
+                    pop_until_tick_and_hash_fn.unwrap()(history_ptr, tick, &mut hasher, hash_fn.inner);
+                    let hash = hasher.finish();
+                    checksum ^= hash; // XOR the hashes together to get an order-independent checksum
+                });
+            });
+        });
+        debug!(
+            "Computed checksum for LastConfirmedInput tick {:?}: {:016x}",
+            tick, checksum
+        );
+
+        sender.send::<InputChannel>(ChecksumMessage { tick, checksum });
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct ChecksumMessage {
+    pub tick: Tick,
+    pub checksum: u64,
+}
+
+impl Plugin for ChecksumSendPlugin {
+    fn build(&self, app: &mut App) {
+        if !app.is_plugin_added::<DeterministicReplicationPlugin>() {
+            app.add_plugins(DeterministicReplicationPlugin);
+        }
+
+        // we need the LastConfirmedInput to compute the checksums
+        app.register_required_components::<InputTimeline, LastConfirmedInput>();
+
+        app.add_message::<ChecksumMessage>()
+            .add_direction(NetworkDirection::ClientToServer);
+    }
+
+    fn finish(&self, app: &mut App) {
+        app.add_systems(
+            PostUpdate,
+            ChecksumSendPlugin::compute_and_send_checksum
+                // the LastConfirmedInput must be updated before we compute the checksum
+                .after(InputSet::UpdateRemoteInputTicks)
+                .before(MessageSet::Send),
+        );
+    }
+}
+
+/// Plugin that can be added to the server to receive and validate checksums sent by clients.
+///
+/// The server needs to also run the simulation to be able to compute its own checksums for comparison.
+pub struct ChecksumReceivePlugin;
+
+impl ChecksumReceivePlugin {
+    /// Compute a checksum for all deterministic entities with hashable components.
+    fn compute_and_store_checksum(
+        world: ChecksumWorld<'_, '_, false>,
+        server: Single<(&LocalTimeline, &mut ChecksumHistory), With<Started>>,
+    ) {
+        let mut checksum = 0u64;
+
+        let (timeline, mut history) = server.into_inner();
+        let tick = timeline.tick();
+
+        world.iter_archetypes().for_each(|(archetype, checksum_archetype)| {
+            // TODO: how can we ensure that we are iterating entities in a stable order on both client and server?
+            archetype.entities().iter().for_each(|entity| {
+                // TODO: we don't write entities in the checksum because if there are some non-replicated entities, the entity ids will differ between client and server.
+                //  We should maybe wait for the ability to reserve ranges of entities so that entity ids match perfectly.
+                // hasher.write_u64(entity.id().to_bits());
+                checksum_archetype.components.iter().for_each(|(component_id, storage_type)| {
+                    trace!("Adding component {:?} from entity {:?} to checksum for tick {:?}", component_id, entity.id(), tick);
+                    // SAFETY: the way we constructed the archetypes guarantees that the component exists on the entity and we have unique write access
+                    let component_ptr = unsafe {
+                        lightyear_utils::ecs::get_component_unchecked(world.world, entity, archetype.table_id(), *storage_type, *component_id)
+                    };
+                    let (hash_fn, _) = world.state.hash_fns.get(component_id).expect("Component in checksum archetype must have a hash function registered");
+                    let mut hasher = seahash::SeaHasher::default();
+                    hash_fn.hash_component(component_ptr, &mut hasher);
+                    let hash = hasher.finish();
+                    checksum ^= hash; // XOR the hashes together to get an order-independent checksum
+                });
+            });
+        });
+
+        debug!("Computed checksum for tick {:?}: {:016x}", tick, checksum);
+
+        history.history.insert(tick, checksum);
+    }
+
+    fn receive_checksum_message(
+        mut messages: Query<
+            (&mut MessageReceiver<ChecksumMessage>, &LinkOf, &RemoteId),
+            With<Connected>,
+        >,
+        server: Query<&ChecksumHistory, (With<Server>, With<Started>)>,
+    ) {
+        messages.iter_mut().for_each(|(mut receiver, link_of, remote_id)| {
+            if let Ok(history) = server.get(link_of.server) {
+                receiver.receive().for_each(|message| {
+                    let expected = history.history.get(&message.tick);
+                    if let Some(&expected) = expected {
+                        if expected != message.checksum {
+                            if message.checksum != 0 {
+                                error!("Checksum mismatch from client {:?} at tick {:?}: expected {:016x}, got {:016x}", remote_id, message.tick, expected, message.checksum);
+                            }
+                        } else {
+                            debug!("Checksum match from client {:?} at tick {:?}: {:016x}", remote_id, message.tick, message.checksum);
+                        }
+                    }
+                })
+            }
+        })
+    }
+
+    fn clean_history(
+        history: Single<(&LocalTimeline, &mut ChecksumHistory), (With<Server>, With<Started>)>,
+    ) {
+        let (timeline, mut history) = history.into_inner();
+        let tick = timeline.tick();
+        // keep only the last 30 ticks of history
+        history.history.retain(|t, _| *t >= tick - 30);
+    }
+}
+
+impl Plugin for ChecksumReceivePlugin {
+    fn build(&self, app: &mut App) {
+        if !app.is_plugin_added::<DeterministicReplicationPlugin>() {
+            app.add_plugins(DeterministicReplicationPlugin);
+        }
+
+        // the server will check the checksum validity
+        app.register_required_components::<Server, ChecksumHistory>();
+
+        app.add_message::<ChecksumMessage>()
+            .add_direction(NetworkDirection::ClientToServer);
+
+        app.add_systems(
+            PostUpdate,
+            (
+                ChecksumReceivePlugin::clean_history,
+                ChecksumReceivePlugin::receive_checksum_message,
+            ),
+        );
+    }
+
+    fn finish(&self, app: &mut App) {
+        app.add_systems(FixedLast, ChecksumReceivePlugin::compute_and_store_checksum);
+    }
+}

--- a/lightyear_deterministic_replication/src/lib.rs
+++ b/lightyear_deterministic_replication/src/lib.rs
@@ -12,8 +12,22 @@
 extern crate alloc;
 extern crate core;
 
+use bevy_ecs::component::Component;
+
+mod archetypes;
+mod checksum;
 /// Messages exchanged betwen client and server
 pub mod messages;
+mod plugin;
 
 /// Commonly used items from the `lightyear_core` crate.
-pub mod prelude {}
+pub mod prelude {
+    pub use crate::checksum::{
+        ChecksumHistory, ChecksumMessage, ChecksumReceivePlugin, ChecksumSendPlugin,
+    };
+    pub use crate::plugin::DeterministicReplicationPlugin;
+}
+
+/// Marker component that indicates that this entity is deterministic. It is not updated via state, but only via inputs.
+#[derive(Component, Default)]
+pub struct Deterministic;

--- a/lightyear_deterministic_replication/src/plugin.rs
+++ b/lightyear_deterministic_replication/src/plugin.rs
@@ -1,0 +1,11 @@
+use crate::Deterministic;
+use bevy_app::{App, Plugin};
+use lightyear_prediction::rollback::DeterministicPredicted;
+
+pub struct DeterministicReplicationPlugin;
+
+impl Plugin for DeterministicReplicationPlugin {
+    fn build(&self, app: &mut App) {
+        app.register_required_components::<DeterministicPredicted, Deterministic>();
+    }
+}

--- a/lightyear_inputs/src/lib.rs
+++ b/lightyear_inputs/src/lib.rs
@@ -29,6 +29,7 @@ pub mod server;
 pub struct InputChannel;
 
 pub mod prelude {
+    pub use crate::InputChannel;
     pub use crate::config::InputConfig;
     pub use crate::input_buffer::InputBuffer;
 

--- a/lightyear_prediction/Cargo.toml
+++ b/lightyear_prediction/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/cBournhonesque/lightyear"
 [features]
 default = ["std"]
 std = ["lightyear_replication/std"]
+deterministic = []
 server = ["dep:lightyear_messages"]
 metrics = ["dep:metrics", "std"]
 

--- a/lightyear_prediction/src/correction.rs
+++ b/lightyear_prediction/src/correction.rs
@@ -69,7 +69,7 @@ pub fn add_correction_systems<C: SyncComponent + Diffable<Delta = C>>(app: &mut 
     );
 }
 
-/// After the rollback is over, we need to update the values in the FrameInterpolate<C> component.
+/// After the rollback is over, we need to update the values in the [`FrameInterpolate<C>`] component.
 ///
 /// If we have correction enabled, then we can compute the error between the previous visual value
 /// [`PreviousVisual<C>`] and the new visual value.
@@ -188,7 +188,7 @@ impl Default for CorrectionPolicy {
 impl CorrectionPolicy {
     /// Returns the lerp constant to use for exponentially decaying the error in a framestep-insensitive way
     ///
-    /// See: https://www.youtube.com/watch?v=LSNQuFEDOyQ
+    /// See: <https://www.youtube.com/watch?v=LSNQuFEDOyQ>
     #[inline]
     pub fn lerp_ratio(&self, delta: core::time::Duration) -> f32 {
         let dt = delta.as_secs_f32();

--- a/lightyear_prediction/src/lib.rs
+++ b/lightyear_prediction/src/lib.rs
@@ -19,7 +19,7 @@ pub mod plugin;
 pub mod pre_prediction;
 pub mod predicted_history;
 pub mod prespawn;
-mod registry;
+pub mod registry;
 pub mod resource_history;
 pub mod rollback;
 pub mod spawn;
@@ -36,8 +36,11 @@ pub mod prelude {
     pub use crate::despawn::{PredictionDespawnCommandsExt, PredictionDisable};
     pub use crate::manager::{PredictionManager, RollbackMode, RollbackPolicy};
     pub use crate::plugin::{PredictionPlugin, PredictionSet};
+    pub use crate::predicted_history::PredictionHistory;
     pub use crate::prespawn::PreSpawned;
-    pub use crate::registry::{PredictionAppRegistrationExt, PredictionRegistrationExt};
+    pub use crate::registry::{
+        PredictionAppRegistrationExt, PredictionRegistrationExt, PredictionRegistry,
+    };
     pub use crate::rollback::RollbackSet;
 
     #[cfg(feature = "server")]

--- a/lightyear_prediction/src/plugin.rs
+++ b/lightyear_prediction/src/plugin.rs
@@ -45,7 +45,7 @@ pub enum PredictionSet {
     /// Sync components from the Confirmed entity to the Predicted entity, and potentially
     /// insert PredictedHistory components
     Sync,
-    /// System set encompassing the sets in [`RollbackSet`](crate::rollback::RollbackSet)
+    /// System set encompassing the sets in [`RollbackSet`]
     Rollback,
 
     // FixedPostUpdate Sets

--- a/lightyear_prediction/src/predicted_history.rs
+++ b/lightyear_prediction/src/predicted_history.rs
@@ -333,12 +333,13 @@ pub(crate) fn add_sync_systems(app: &mut App) {
 
     // Sync components that are added on the Confirmed entity
     let mut observer = Observer::new(added_on_confirmed_sync);
-    for component in prediction_registry
-        .prediction_map
-        .keys()
-        .filter_map(|k| component_registry.kind_to_component_id.get(k))
-    {
-        observer = observer.with_component(*component);
+    for component_id in prediction_registry.prediction_map.keys().filter_map(|k| {
+        component_registry
+            .component_metadata_map
+            .get(k)
+            .map(|m| m.component_id)
+    }) {
+        observer = observer.with_component(component_id);
     }
     app.world_mut().spawn(observer);
 

--- a/lightyear_replication/Cargo.toml
+++ b/lightyear_replication/Cargo.toml
@@ -15,6 +15,7 @@ client = []
 server = ["lightyear_connection/server"]
 prediction = ["lightyear_core/prediction"]
 interpolation = ["lightyear_core/interpolation"]
+deterministic = ["dep:seahash"]
 trace = []
 metrics = ["dep:metrics", "std"]
 test_utils = []
@@ -36,6 +37,7 @@ metrics = { workspace = true, optional = true }
 smallvec.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
+seahash = {workspace = true, optional = true}
 
 # serde
 serde.workspace = true

--- a/lightyear_replication/src/registry/deterministic.rs
+++ b/lightyear_replication/src/registry/deterministic.rs
@@ -1,0 +1,101 @@
+use crate::prelude::{ComponentRegistration, ComponentRegistry};
+use crate::registry::ComponentKind;
+use crate::registry::registry::ComponentMetadata;
+use bevy_ecs::change_detection::Mut;
+use bevy_ecs::component::Component;
+use bevy_ptr::Ptr;
+use core::fmt::Debug;
+use tracing::trace;
+
+#[derive(Debug, Clone, Copy)]
+pub struct DeterministicFns {
+    // function fn(&C, &mut seahash::SeaHasher) converted to unsafe fn() to avoid generic parameters in enum
+    pub inner: fn(),
+    hash_fn: fn(Ptr, &mut seahash::SeaHasher, unsafe fn()),
+}
+
+impl DeterministicFns {
+    pub fn new<C: Debug>(inner: fn(&C, &mut seahash::SeaHasher)) -> Self {
+        DeterministicFns {
+            inner: unsafe { core::mem::transmute::<fn(&C, &mut seahash::SeaHasher), fn()>(inner) },
+            hash_fn: custom_hash_fn::<C>,
+        }
+    }
+
+    pub fn hash_component(&self, ptr: Ptr, hasher: &mut seahash::SeaHasher) {
+        (self.hash_fn)(ptr, hasher, self.inner);
+    }
+}
+
+fn custom_hash_fn<C: Debug>(ptr: Ptr, hasher: &mut seahash::SeaHasher, f: unsafe fn()) {
+    let f = unsafe { core::mem::transmute::<_, fn(&C, &mut seahash::SeaHasher)>(f) };
+    // SAFETY: the caller must ensure that the pointer is valid and points to a value of type C
+    let value = unsafe { ptr.deref::<C>() };
+    trace!(
+        "Hashing component value: {:?} into {:?}",
+        value,
+        core::any::type_name::<C>()
+    );
+    f(value, hasher);
+}
+
+fn default_inner_hash_fn<C: core::hash::Hash>(value: &C, hasher: &mut seahash::SeaHasher) {
+    value.hash(hasher)
+}
+
+impl<C: Debug> ComponentRegistration<'_, C> {
+    /// Add a hash function for this component using the `core::hash::Hash` trait implementation.
+    ///
+    /// This will be used to compute a checksum for determinism checks.
+    pub fn add_default_hash(self) -> Self
+    where
+        C: core::hash::Hash + Component,
+    {
+        self.app
+            .world_mut()
+            .resource_scope(|world, mut registry: Mut<ComponentRegistry>| {
+                let component_id = world.register_component::<C>();
+
+                let kind = ComponentKind::of::<C>();
+                registry
+                    .component_metadata_map
+                    .entry(kind)
+                    .or_insert_with(|| ComponentMetadata {
+                        component_id,
+                        replication: None,
+                        serialization: None,
+                        delta: None,
+                        deterministic: None,
+                    })
+                    .deterministic = Some(DeterministicFns::new::<C>(default_inner_hash_fn::<C>));
+            });
+        self
+    }
+
+    /// Add a hash function for this component using the `core::hash::Hash` trait implementation.
+    ///
+    /// This will be used to compute a checksum for determinism checks.
+    pub fn add_custom_hash(self, f: fn(&C, &mut seahash::SeaHasher)) -> Self
+    where
+        C: Component,
+    {
+        self.app
+            .world_mut()
+            .resource_scope(|world, mut registry: Mut<ComponentRegistry>| {
+                let component_id = world.register_component::<C>();
+                let kind = ComponentKind::of::<C>();
+                registry
+                    .component_metadata_map
+                    .entry(kind)
+                    .or_insert_with(|| ComponentMetadata {
+                        component_id,
+                        replication: None,
+                        serialization: None,
+                        delta: None,
+                        deterministic: None,
+                    })
+                    .deterministic = Some(DeterministicFns::new(f));
+            });
+        self
+    }
+}

--- a/lightyear_replication/src/registry/mod.rs
+++ b/lightyear_replication/src/registry/mod.rs
@@ -10,6 +10,9 @@ mod delta;
 pub mod registry;
 pub(crate) mod replication;
 
+#[cfg(feature = "deterministic")]
+pub mod deterministic;
+
 pub type ComponentNetId = NetId;
 
 #[derive(thiserror::Error, Debug)]

--- a/lightyear_replication/src/send/archetypes.rs
+++ b/lightyear_replication/src/send/archetypes.rs
@@ -79,7 +79,11 @@ impl ReplicatedArchetypes {
                 // if the component has a type_id (i.e. is a rust type)
                 if let Some(kind) = info.type_id().map(ComponentKind) {
                     // the component is not registered for replication in the ComponentProtocol
-                    let Some(replication_metadata) = registry.replication_map.get(&kind) else {
+                    let Some(replication_metadata) = registry
+                        .component_metadata_map
+                        .get(&kind)
+                        .and_then(|m| m.replication.as_ref())
+                    else {
                         trace!(
                             "not including {:?} because it is not registered for replication",
                             info.name()

--- a/lightyear_replication/src/send/buffer.rs
+++ b/lightyear_replication/src/send/buffer.rs
@@ -316,7 +316,13 @@ pub(crate) fn replicate_entity(
         has_overrides,
     } in replicated_components
     {
-        let replication_metadata = component_registry.replication_map.get(kind).unwrap();
+        let replication_metadata = component_registry
+            .component_metadata_map
+            .get(kind)
+            .unwrap()
+            .replication
+            .as_ref()
+            .unwrap();
         let mut disable = replication_metadata.config.disable;
         let mut replicate_once = replication_metadata.config.replicate_once;
         let delta_compression = replication_metadata.config.delta_compression;
@@ -756,7 +762,13 @@ pub(crate) fn buffer_component_removed(
                 let Some(kind) = registry.component_id_to_kind.get(component_id) else {
                     continue;
                 };
-                let metadata = registry.replication_map.get(kind).unwrap();
+                let metadata = registry
+                    .component_metadata_map
+                    .get(kind)
+                    .unwrap()
+                    .replication
+                    .as_ref()
+                    .unwrap();
                 let mut disable = metadata.config.disable;
                 if let Some(overrides) = entity_ref
                     .get_by_id(metadata.overrides_component_id)

--- a/lightyear_replication/src/send/buffer_bis.rs
+++ b/lightyear_replication/src/send/buffer_bis.rs
@@ -299,12 +299,19 @@ pub fn replicate_entity_bis(
     } in replicated_components
     {
         let is_map_entities = component_registry
-            .serialize_fns_map
+            .component_metadata_map
             .get(kind)
             .unwrap()
-            .map_entities
-            .is_some();
-        let replication_metadata = component_registry.replication_map.get(kind).unwrap();
+            .serialization
+            .as_ref()
+            .is_some_and(|s| s.map_entities.is_some());
+        let replication_metadata = component_registry
+            .component_metadata_map
+            .get(kind)
+            .unwrap()
+            .replication
+            .as_ref()
+            .unwrap();
         let disable = replication_metadata.config.disable;
         let replicate_once = replication_metadata.config.replicate_once;
         let delta_compression = replication_metadata.config.delta_compression;

--- a/lightyear_replication/src/send/plugin.rs
+++ b/lightyear_replication/src/send/plugin.rs
@@ -314,17 +314,14 @@ impl Plugin for ReplicationSendPlugin {
                     b.data::<&InterpolationTarget>();
                     // include access to &C and &ComponentReplicationOverrides<C> for all replication components with the right direction
                     component_registry
-                        .replication_map
+                        .component_metadata_map
                         .iter()
-                        .for_each(|(kind, _)| {
-                            let id = component_registry.kind_to_component_id.get(kind).unwrap();
-                            b.ref_id(*id);
-                            let override_id = component_registry
-                                .replication_map
-                                .get(kind)
-                                .unwrap()
-                                .overrides_component_id;
-                            b.ref_id(override_id);
+                        .for_each(|(kind, m)| {
+                            let id = m.component_id;
+                            b.ref_id(id);
+                            if let Some(r) = &m.replication {
+                                b.ref_id(r.overrides_component_id);
+                            }
                         });
                 });
             }),
@@ -406,17 +403,13 @@ impl Plugin for ReplicationSendPlugin {
                     b.data::<(&ReplicateLike, &Replicate, &ReplicationGroup)>();
                     // include access to &C and &ComponentReplicationOverrides<C> for all replication components with the right direction
                     component_registry
-                        .replication_map
+                        .component_metadata_map
                         .iter()
-                        .for_each(|(kind, _)| {
-                            let id = component_registry.kind_to_component_id.get(kind).unwrap();
-                            b.ref_id(*id);
-                            let override_id = component_registry
-                                .replication_map
-                                .get(kind)
-                                .unwrap()
-                                .overrides_component_id;
-                            b.ref_id(override_id);
+                        .for_each(|(kind, m)| {
+                            b.ref_id(m.component_id);
+                            if let Some(r) = &m.replication {
+                                b.ref_id(r.overrides_component_id);
+                            }
                         });
                 });
             }),

--- a/lightyear_replication/src/send/sender.rs
+++ b/lightyear_replication/src/send/sender.rs
@@ -485,7 +485,6 @@ impl ReplicationSender {
                     .inspect_err(|e| {
                         error!(
                             ?entity,
-                            name = ?registry.name(kind),
                             "Could not find old component value from tick {:?} to compute delta: {e:?}",
                             ack_tick,
                         );
@@ -884,7 +883,7 @@ mod tests {
         let component_registry = ComponentRegistry::default();
         sender.handle_acks(
             &component_registry,
-            &mut delta_manager,
+            Some(&mut delta_manager),
             &mut vec![message_2],
         );
         let group = sender.group_channels.get(&group_1).unwrap();

--- a/lightyear_utils/Cargo.toml
+++ b/lightyear_utils/Cargo.toml
@@ -12,8 +12,6 @@ repository = "https://github.com/cBournhonesque/lightyear"
 default = []
 
 [dependencies]
-lightyear_serde.workspace = true
-
 # utils
 hashbrown.workspace = true
 paste.workspace = true

--- a/lightyear_utils/src/ecs.rs
+++ b/lightyear_utils/src/ecs.rs
@@ -1,0 +1,67 @@
+//! Helpers for low-level ECS operations.
+
+use bevy_ecs::archetype::ArchetypeEntity;
+use bevy_ecs::component::{ComponentId, StorageType};
+use bevy_ecs::ptr::{Ptr, PtrMut};
+use bevy_ecs::storage::TableId;
+use bevy_ecs::world::unsafe_world_cell::UnsafeWorldCell;
+
+/// Extracts a component as [`Ptr`] and its ticks from a table or sparse set, depending on its storage type.
+///
+/// # Safety
+///
+/// The component must be present in this archetype, have the specified storage type and we must have write access to it.
+pub unsafe fn get_component_unchecked_mut<'w>(
+    unsafe_world_cell: UnsafeWorldCell<'w>,
+    entity: &'w ArchetypeEntity,
+    table_id: TableId,
+    storage: StorageType,
+    component_id: ComponentId,
+) -> PtrMut<'w> {
+    let storages = unsafe { unsafe_world_cell.storages() };
+    match storage {
+        // SAFETY: we know from the accesses that we have unique write access to these components
+        StorageType::Table => unsafe {
+            let table = storages.tables.get(table_id).unwrap_unchecked();
+            table
+                .get_component(component_id, entity.table_row())
+                .unwrap_unchecked()
+                .assert_unique()
+        },
+        StorageType::SparseSet => unsafe {
+            let sparse_set = storages.sparse_sets.get(component_id).unwrap_unchecked();
+            sparse_set
+                .get(entity.id())
+                .unwrap_unchecked()
+                .assert_unique()
+        },
+    }
+}
+
+/// Extracts a component as [`Ptr`] and its ticks from a table or sparse set, depending on its storage type.
+///
+/// # Safety
+///
+/// The component must be present in this archetype, have the specified storage type and we must have read access to it.
+pub unsafe fn get_component_unchecked<'w>(
+    unsafe_world_cell: UnsafeWorldCell<'w>,
+    entity: &'w ArchetypeEntity,
+    table_id: TableId,
+    storage: StorageType,
+    component_id: ComponentId,
+) -> Ptr<'w> {
+    let storages = unsafe { unsafe_world_cell.storages() };
+    match storage {
+        // SAFETY: we know from the accesses that we have unique write access to these components
+        StorageType::Table => unsafe {
+            let table = storages.tables.get(table_id).unwrap_unchecked();
+            table
+                .get_component(component_id, entity.table_row())
+                .unwrap_unchecked()
+        },
+        StorageType::SparseSet => unsafe {
+            let sparse_set = storages.sparse_sets.get(component_id).unwrap_unchecked();
+            sparse_set.get(entity.id()).unwrap_unchecked()
+        },
+    }
+}

--- a/lightyear_utils/src/lib.rs
+++ b/lightyear_utils/src/lib.rs
@@ -15,5 +15,6 @@ pub mod captures;
 pub mod collections;
 
 pub mod easings;
+pub mod ecs;
 pub mod registry;
 pub mod wrapping_id;


### PR DESCRIPTION
which contains helper plugins for deterministic replication

- Introduces a Deterministic component (in case we do determinism without Prediction). Also useful to identify deterministic entities on the server

- Introduce Checksum plugins that compute a checksum on the client and server to check if determinism is maintained

- Split out LastConfirmedInput into its own component, in case we want to compute checksum without prediction (for example in locksetp)

- Coalesce all HashMap<ComponentKind, ...> of the ComponentRegistry into a single hashmap