### PR TITLE
fix(lockstep): fixes for lockstep

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1,5 +1,7 @@
 # Current bugs:
 
+- with input-delay, we receive remote inputs at a different tick than when the client sent them!
+
 - Something causes a full redraw of gizmos on rollbacks! What?
 
 - Maybe my problem is that I don't recompute the VisualInterpolation previous value

--- a/examples/deterministic_replication/src/main.rs
+++ b/examples/deterministic_replication/src/main.rs
@@ -6,6 +6,7 @@ use crate::client::ExampleClientPlugin;
 #[cfg(feature = "server")]
 use crate::server::ExampleServerPlugin;
 use crate::shared::SharedPlugin;
+use avian2d::position::Position;
 use bevy::prelude::*;
 use core::time::Duration;
 use lightyear::prelude::*;
@@ -91,6 +92,9 @@ fn add_input_delay(app: &mut App) {
         })
         .insert(InputTimeline(Timeline::from(
             Input::default()
-                .with_input_delay(InputDelayConfig::fixed_input_delay(INPUT_DELAY_TICKS)),
+                // Enable `no_prediction()` to do deterministic_lockstep! 100% of the latency will be covered
+                // by input delay so there won't be any rollbacks
+                .with_input_delay(InputDelayConfig::no_prediction()), // Otherwise control the input delay manually
+                                                                      // .with_input_delay(InputDelayConfig::fixed_input_delay(INPUT_DELAY_TICKS)),
         )));
 }

--- a/examples/deterministic_replication/src/shared.rs
+++ b/examples/deterministic_replication/src/shared.rs
@@ -239,7 +239,6 @@ pub(crate) fn fixed_last_log(
             Option<&VisualCorrection<Position>>,
             Option<&ActionState<PlayerActions>>,
             Option<&InputBuffer<ActionState<PlayerActions>>>,
-            Option<&PredictionHistory<Position>>,
         ),
         (Without<BallMarker>, Without<Confirmed>, With<PlayerId>),
     >,
@@ -252,9 +251,7 @@ pub(crate) fn fixed_last_log(
     let tick = timeline.tick();
     // info!(?tick, "contact graph: {:#?}", contact_graph);
 
-    for (entity, position, velocity, correction, action_state, input_buffer, history) in
-        players.iter()
-    {
+    for (entity, position, velocity, correction, action_state, input_buffer) in players.iter() {
         let pressed = action_state.map(|a| a.get_pressed());
         let last_buffer_tick = input_buffer.and_then(|b| b.get_last_with_tick().map(|(t, _)| t));
         info!(
@@ -266,7 +263,6 @@ pub(crate) fn fixed_last_log(
             ?correction,
             ?pressed,
             ?last_buffer_tick,
-            ?history,
             "Player after physics update"
         );
     }

--- a/lightyear_deterministic_replication/src/checksum.rs
+++ b/lightyear_deterministic_replication/src/checksum.rs
@@ -69,6 +69,8 @@ impl ChecksumSendPlugin {
                 //     trace!("Adding entity {:?} (mapped to remote entity {:?}) to checksum for tick {:?}", entity.id(), mapped_entity, tick);
                 //     // hasher.write_u64(mapped_entity.to_bits());
                 // }
+                // TODO: in deterministic lockstep mode, we need to fetch directly from the component! There is no
+                //  prediction-history and the LastConfirmedTick is always the current tick.
                 checksum_archetype.components.iter().for_each(|(component_id, storage_type)| {
                     trace!("Adding component {:?} from entity {:?} to checksum for tick {:?}",
                         component_id, entity.id(), tick);

--- a/lightyear_inputs/src/input_message.rs
+++ b/lightyear_inputs/src/input_message.rs
@@ -113,7 +113,9 @@ pub trait ActionStateSequence:
                         }
                     }
                     // set the new value for the mismatch tick
-                    debug!("Mismatch detected at tick {tick:?} for input {input:?}");
+                    debug!(
+                        "Mismatch detected at tick {tick:?} for new_input {input:?}. Previous predicted input: {previous_predicted_input:?}"
+                    );
                     input_buffer.set_raw(tick, input);
                     earliest_mismatch = Some(tick);
                 }

--- a/lightyear_link/src/lib.rs
+++ b/lightyear_link/src/lib.rs
@@ -179,7 +179,7 @@ impl Link {
 }
 
 /// Stores statistics about a `Link`, such as bytes/packets sent and received, RTT, and jitter.
-#[derive(Default)]
+#[derive(Default, Debug, Clone, Copy)]
 pub struct LinkStats {
     pub rtt: Duration,
     pub jitter: Duration,

--- a/lightyear_prediction/src/resource_history.rs
+++ b/lightyear_prediction/src/resource_history.rs
@@ -11,7 +11,7 @@ use lightyear_core::history_buffer::{HistoryBuffer, HistoryState};
 use lightyear_core::prelude::{LocalTimeline, NetworkTimeline};
 use lightyear_core::timeline::SyncEvent;
 use lightyear_sync::prelude::InputTimeline;
-use tracing::info;
+use tracing::trace;
 
 pub(crate) type ResourceHistory<R> = HistoryBuffer<R>;
 
@@ -40,7 +40,7 @@ pub(crate) fn update_resource_history<R: Resource + Clone>(
 
     if let Some(resource) = resource {
         if resource.is_changed() {
-            info!(?tick, "Adding resource to history");
+            trace!(?tick, "Adding resource to history");
             history.add_update(tick, resource.clone());
         }
     // resource does not exist, it might have been just removed
@@ -49,7 +49,7 @@ pub(crate) fn update_resource_history<R: Resource + Clone>(
             Some((_, HistoryState::Removed)) => (),
             // if there is no latest item or the latest item isn't a removal then the resource just got removed.
             _ => {
-                info!(?tick, "Adding resource removal to history");
+                trace!(?tick, "Adding resource removal to history");
                 history.add_remove(tick)
             }
         }

--- a/lightyear_sync/src/timeline/sync.rs
+++ b/lightyear_sync/src/timeline/sync.rs
@@ -115,6 +115,12 @@ pub struct SyncConfig {
     pub speedup_factor: f32,
 }
 
+impl SyncConfig {
+    pub(crate) fn jitter_margin(&self, jitter: Duration) -> Duration {
+        jitter * self.jitter_multiple as u32 + self.jitter_margin
+    }
+}
+
 impl Default for SyncConfig {
     fn default() -> Self {
         SyncConfig {


### PR DESCRIPTION
- We were incorrectly updating the ActionState from the InputMessage for lockstep
- Add more leeway when computing input_delay; and add extra margin for lockstep
- Make sure that LastConfirmedInput is simply the current tick for lockstep, so that checksums match
- Update deterministic replication to run in lockstep mode, and make sure that it runs with 0 rollbacks and 0 checksum mismatches