### PR TITLE
Support immutable components in prediction/interpolation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -227,7 +227,7 @@ bevy_egui = { version = "0.35", default-features = false, features = [
   "render",
 ] }
 bevy_metrics_dashboard = { version = "0.7", features = ["bevy_egui"] }
-egui_extras = "0.32"
+egui_extras = "0.31"
 
 [workspace.lints.rust]
 dead_code = "allow"

--- a/examples/avian_3d_character/src/main.rs
+++ b/examples/avian_3d_character/src/main.rs
@@ -3,7 +3,7 @@
 #![allow(dead_code)]
 use bevy::prelude::*;
 use core::time::Duration;
-use lightyear::prelude::client::{Input, InputDelayConfig};
+
 use lightyear::prelude::{Client, InputTimeline, Timeline};
 use lightyear_examples_common::cli::{Cli, Mode};
 use lightyear_examples_common::shared::FIXED_TIMESTEP_HZ;
@@ -59,16 +59,18 @@ fn main() {
 
 #[cfg(feature = "client")]
 fn add_input_delay(app: &mut App) {
+    use lightyear::prelude::client::{Input, InputDelayConfig};
+
     let client = app
         .world_mut()
         .query_filtered::<Entity, With<Client>>()
         .single(app.world_mut())
         .unwrap();
 
-    // set some input-delay since we are predicting all entities
-    app.world_mut()
-        .entity_mut(client)
-        .insert(InputTimeline(Timeline::from(
-            Input::default().with_input_delay(InputDelayConfig::fixed_input_delay(10)),
-        )));
+    // // set some input-delay since we are predicting all entities
+    // app.world_mut()
+    //     .entity_mut(client)
+    //     .insert(InputTimeline(Timeline::from(
+    //         Input::default().with_input_delay(InputDelayConfig::fixed_input_delay(10)),
+    //     )));
 }

--- a/examples/avian_3d_character/src/shared.rs
+++ b/examples/avian_3d_character/src/shared.rs
@@ -91,11 +91,6 @@ impl Plugin for SharedPlugin {
             angular: -0.01,
         });
 
-        // app.add_systems(
-        //     FixedPostUpdate,
-        //     after_physics_log.after(PhysicsSet::StepSimulation),
-        // );
-
         app.add_plugins(
             PhysicsPlugins::default()
                 .build()
@@ -103,18 +98,6 @@ impl Plugin for SharedPlugin {
                 .disable::<PhysicsInterpolationPlugin>()
                 // disable Sleeping plugin as it can mess up physics rollbacks
                 .disable::<SleepingPlugin>(),
-        );
-
-        // add an extra sync for cases where:
-        // - we receive a Position, do a rollback and set C=Correct, apply sync
-        // - in RunFixedMainLoop, we set C=Original
-        // - FixedUpdate doesn't run because frame rate is too high!
-        // - then the Transform that we show is C=Correct instead of C=Original!
-        app.add_systems(
-            PostUpdate,
-            position_to_transform
-                .in_set(PhysicsSet::Sync)
-                .run_if(|config: Res<avian3d::sync::SyncConfig>| config.position_to_transform),
         );
     }
 }

--- a/examples/avian_physics/src/renderer.rs
+++ b/examples/avian_physics/src/renderer.rs
@@ -98,6 +98,7 @@ pub(crate) fn draw_elements(
     walls: Query<(&Wall, &ColorComponent), (Without<BallMarker>, Without<PlayerId>)>,
 ) {
     for (position, rotation, color) in &players {
+        info!("Draw player at position {position:?}");
         gizmos.rect_2d(
             Isometry2d {
                 rotation: Rot2 {

--- a/examples/bevy_enhanced_inputs/src/shared.rs
+++ b/examples/bevy_enhanced_inputs/src/shared.rs
@@ -5,8 +5,7 @@
 use crate::protocol::*;
 use bevy::prelude::*;
 use lightyear::connection::client_of::ClientOf;
-use lightyear::interpolation::{ConfirmedHistory, InterpolateStatus, Interpolated};
-use lightyear::prelude::{Client, Confirmed, LocalTimeline, NetworkTimeline, Rollback};
+use lightyear::prelude::*;
 use lightyear_examples_common::shared::SharedSettings;
 
 pub struct SharedPlugin;

--- a/examples/client_replication/Cargo.toml
+++ b/examples/client_replication/Cargo.toml
@@ -45,7 +45,6 @@ lightyear = { "workspace" = true, features = [
 lightyear_examples_common.workspace = true
 
 serde.workspace = true
-tracing.workspace = true
 bevy.workspace = true
 
 [lints]

--- a/examples/client_replication/src/client.rs
+++ b/examples/client_replication/src/client.rs
@@ -55,7 +55,6 @@ pub(crate) fn write_inputs(
     keypress: Res<ButtonInput<KeyCode>>,
 ) {
     if let Ok(mut action_state) = query.single_mut() {
-        let mut input;
         let mut direction = Direction {
             up: false,
             down: false,
@@ -74,11 +73,11 @@ pub(crate) fn write_inputs(
         if keypress.pressed(KeyCode::KeyD) || keypress.pressed(KeyCode::ArrowRight) {
             direction.right = true;
         }
-        input = Some(Inputs::Direction(direction));
+        let mut input = Inputs::Direction(direction);
         if keypress.pressed(KeyCode::KeyK) {
-            input = Some(Inputs::Delete);
+            input = Inputs::Delete;
         }
-        action_state.value = input;
+        action_state.0 = input;
     }
 }
 
@@ -89,11 +88,9 @@ fn player_movement(
     mut position_query: Query<(&mut PlayerPosition, &ActionState<Inputs>), With<Predicted>>,
 ) {
     for (position, input) in position_query.iter_mut() {
-        if let Some(input) = &input.value {
-            // NOTE: be careful to directly pass Mut<PlayerPosition>
-            // getting a mutable reference triggers change detection, unless you use `as_deref_mut()`
-            shared_movement_behaviour(position, input);
-        }
+        // NOTE: be careful to directly pass Mut<PlayerPosition>
+        // getting a mutable reference triggers change detection, unless you use `as_deref_mut()`
+        shared_movement_behaviour(position, input);
     }
 }
 
@@ -147,7 +144,7 @@ fn delete_player(
     >,
 ) {
     for (entity, inputs) in players.iter() {
-        if inputs.value.as_ref().is_some_and(|v| v == &Inputs::Delete) {
+        if inputs.0 == Inputs::Delete {
             if let Ok(mut entity_mut) = commands.get_entity(entity) {
                 // we need to use this special function to despawn prediction entity
                 // the reason is that we actually keep the entity around for a while,

--- a/examples/client_replication/src/protocol.rs
+++ b/examples/client_replication/src/protocol.rs
@@ -54,6 +54,17 @@ pub enum Inputs {
     Delete,
 }
 
+impl Default for Inputs {
+    fn default() -> Self {
+        Inputs::Direction(Direction {
+            up: false,
+            down: false,
+            left: false,
+            right: false,
+        })
+    }
+}
+
 // Inputs must all implement MapEntities
 impl MapEntities for Inputs {
     fn map_entities<M: EntityMapper>(&mut self, entity_mapper: &mut M) {}

--- a/examples/client_replication/src/server.rs
+++ b/examples/client_replication/src/server.rs
@@ -42,11 +42,9 @@ pub(crate) fn movement(
     >,
 ) {
     for (position, inputs) in position_query.iter_mut() {
-        if let Some(input) = &inputs.value {
-            // NOTE: be careful to directly pass Mut<PlayerPosition>
-            // getting a mutable reference triggers change detection, unless you use `as_deref_mut()`
-            shared_movement_behaviour(position, input);
-        }
+        // NOTE: be careful to directly pass Mut<PlayerPosition>
+        // getting a mutable reference triggers change detection, unless you use `as_deref_mut()`
+        shared_movement_behaviour(position, inputs);
     }
 }
 
@@ -55,7 +53,7 @@ fn delete_player(
     query: Query<(Entity, &ActionState<Inputs>), With<PlayerPosition>>,
 ) {
     for (entity, inputs) in query.iter() {
-        if inputs.value.as_ref().is_some_and(|v| v == &Inputs::Delete) {
+        if inputs.0 == Inputs::Delete {
             // You can try 2 things here:
             // - either you consider that the client's action is correct, and you despawn the entity. This should get replicated
             //   to other clients.

--- a/examples/common/src/cli.rs
+++ b/examples/common/src/cli.rs
@@ -332,9 +332,7 @@ pub fn new_gui_app(add_inspector: bool) -> App {
     }
 
     if add_inspector {
-        app.add_plugins(bevy_inspector_egui::bevy_egui::EguiPlugin {
-            enable_multipass_for_primary_context: true,
-        });
+        app.add_plugins(bevy_inspector_egui::bevy_egui::EguiPlugin::default());
         app.add_plugins(bevy_inspector_egui::quick::WorldInspectorPlugin::new());
     }
     app

--- a/examples/delta_compression/src/client.rs
+++ b/examples/delta_compression/src/client.rs
@@ -59,9 +59,8 @@ pub(crate) fn buffer_input(
         if keypress.pressed(KeyCode::KeyD) || keypress.pressed(KeyCode::ArrowRight) {
             direction.right = true;
         }
-        // we always set the value. Setting it to None means that the input was missing, it's not the same
-        // as saying that the input was 'no keys pressed'
-        action_state.value = Some(Inputs::Direction(direction));
+        // we always set the value.
+        action_state.0 = Inputs::Direction(direction);
     });
 }
 
@@ -74,12 +73,10 @@ fn player_movement(
 ) {
     // let tick = timeline.tick();
     for (position, input) in position_query.iter_mut() {
-        if let Some(input) = &input.value {
-            // trace!(?tick, ?position, ?input, "client");
-            // NOTE: be careful to directly pass Mut<PlayerPosition>
-            // getting a mutable reference triggers change detection, unless you use `as_deref_mut()`
-            shared::shared_movement_behaviour(position, input);
-        }
+        // trace!(?tick, ?position, ?input, "client");
+        // NOTE: be careful to directly pass Mut<PlayerPosition>
+        // getting a mutable reference triggers change detection, unless you use `as_deref_mut()`
+        shared::shared_movement_behaviour(position, input);
     }
 }
 

--- a/examples/delta_compression/src/protocol.rs
+++ b/examples/delta_compression/src/protocol.rs
@@ -115,6 +115,17 @@ pub enum Inputs {
     Direction(Direction),
 }
 
+impl Default for Inputs {
+    fn default() -> Self {
+        Self::Direction(Direction {
+            up: false,
+            down: false,
+            left: false,
+            right: false,
+        })
+    }
+}
+
 impl MapEntities for Inputs {
     fn map_entities<M: EntityMapper>(&mut self, entity_mapper: &mut M) {}
 }

--- a/examples/delta_compression/src/server.rs
+++ b/examples/delta_compression/src/server.rs
@@ -85,9 +85,7 @@ fn movement(
 ) {
     let tick = timeline.tick();
     for (position, inputs) in position_query.iter_mut() {
-        if let Some(inputs) = &inputs.value {
-            trace!(?tick, ?position, ?inputs, "server");
-            shared::shared_movement_behaviour(position, inputs);
-        }
+        trace!(?tick, ?position, ?inputs, "server");
+        shared::shared_movement_behaviour(position, inputs);
     }
 }

--- a/examples/deterministic_replication/Cargo.toml
+++ b/examples/deterministic_replication/Cargo.toml
@@ -20,11 +20,12 @@ lightyear = { workspace = true, features = [
   "replication",
   "leafwing",
   "deterministic",
-  "avian2d",
 ] }
 lightyear_examples_common.workspace = true
 lightyear_frame_interpolation.workspace = true
 leafwing-input-manager.workspace = true
+# add avian2d directly to customize the plugin 
+lightyear_avian2d = { workspace = true, features = ["deterministic", "2d"]}
 avian2d = { workspace = true, features = [
   "2d",
   "f32",

--- a/examples/deterministic_replication/src/main.rs
+++ b/examples/deterministic_replication/src/main.rs
@@ -94,7 +94,8 @@ fn add_input_delay(app: &mut App) {
             Input::default()
                 // Enable `no_prediction()` to do deterministic_lockstep! 100% of the latency will be covered
                 // by input delay so there won't be any rollbacks
-                .with_input_delay(InputDelayConfig::no_prediction()), // Otherwise control the input delay manually
-                                                                      // .with_input_delay(InputDelayConfig::fixed_input_delay(INPUT_DELAY_TICKS)),
+                // .with_input_delay(InputDelayConfig::no_prediction()),
+                // Otherwise control the input delay manually
+                .with_input_delay(InputDelayConfig::fixed_input_delay(INPUT_DELAY_TICKS)),
         )));
 }

--- a/examples/deterministic_replication/src/protocol.rs
+++ b/examples/deterministic_replication/src/protocol.rs
@@ -99,13 +99,13 @@ impl Plugin for ProtocolPlugin {
         app.add_rollback::<Position>()
             .add_should_rollback(position_should_rollback)
             // add a hash function to perform a checksum in order to catch desyncs
-            .add_custom_hash(lightyear::avian2d::types::position::hash)
+            .add_custom_hash(lightyear_avian2d::types::position::hash)
             .add_linear_interpolation_fn()
             .add_linear_correction_fn();
 
         app.add_rollback::<Rotation>()
             .add_should_rollback(rotation_should_rollback)
-            .add_custom_hash(lightyear::avian2d::types::rotation::hash)
+            .add_custom_hash(lightyear_avian2d::types::rotation::hash)
             .add_linear_interpolation_fn()
             .add_linear_correction_fn();
 

--- a/examples/deterministic_replication/src/shared.rs
+++ b/examples/deterministic_replication/src/shared.rs
@@ -27,7 +27,7 @@ impl Plugin for SharedPlugin {
         app.add_systems(Startup, init);
 
         // physics
-        app.add_plugins(lightyear::avian2d::plugin::LightyearAvianPlugin {
+        app.add_plugins(lightyear_avian2d::plugin::LightyearAvianPlugin {
             rollback_resources: true,
             ..default()
         });

--- a/examples/distributed_authority/src/client.rs
+++ b/examples/distributed_authority/src/client.rs
@@ -77,15 +77,13 @@ pub(crate) fn buffer_input(
         if keypress.pressed(KeyCode::KeyD) || keypress.pressed(KeyCode::ArrowRight) {
             direction.right = true;
         }
-        action_state.value = Some(Inputs::Direction(direction));
+        action_state.0 = Inputs::Direction(direction);
     });
 }
 
 fn player_movement(mut position_query: Query<(&mut Position, &ActionState<Inputs>)>) {
     for (position, input) in position_query.iter_mut() {
-        if let Some(inputs) = &input.value {
-            shared::shared_movement_behaviour(position, inputs);
-        }
+        shared::shared_movement_behaviour(position, input);
     }
 }
 

--- a/examples/distributed_authority/src/protocol.rs
+++ b/examples/distributed_authority/src/protocol.rs
@@ -62,6 +62,17 @@ pub enum Inputs {
     Direction(Direction),
 }
 
+impl Default for Inputs {
+    fn default() -> Self {
+        Inputs::Direction(Direction {
+            up: false,
+            down: false,
+            left: false,
+            right: false,
+        })
+    }
+}
+
 impl MapEntities for Inputs {
     fn map_entities<M: EntityMapper>(&mut self, entity_mapper: &mut M) {}
 }

--- a/examples/distributed_authority/src/server.rs
+++ b/examples/distributed_authority/src/server.rs
@@ -88,9 +88,7 @@ fn movement(
     >,
 ) {
     for (position, inputs) in position_query.iter_mut() {
-        if let Some(inputs) = &inputs.value {
-            shared::shared_movement_behaviour(position, inputs);
-        }
+        shared::shared_movement_behaviour(position, inputs);
     }
 }
 

--- a/examples/lobby/src/client.rs
+++ b/examples/lobby/src/client.rs
@@ -3,7 +3,7 @@ use core::net::{Ipv4Addr, SocketAddr};
 use crate::protocol::*;
 use crate::HOST_SERVER_PORT;
 use bevy::prelude::*;
-use bevy_egui::{egui, EguiContexts};
+use bevy_egui::{egui, EguiContexts, EguiPrimaryContextPass};
 use lightyear::input::client::InputSet;
 use lightyear::netcode::client_plugin::NetcodeConfig;
 use lightyear::netcode::NetcodeClient;
@@ -49,7 +49,7 @@ impl Plugin for ExampleClientPlugin {
                 .run_if(in_state(AppState::Game)),
         );
         app.add_systems(
-            PostUpdate,
+            EguiPrimaryContextPass,
             (lobby::lobby_ui, lobby::receive_start_game_message),
         );
         app.add_observer(on_disconnect);
@@ -225,7 +225,7 @@ mod lobby {
         )>,
         app_state: Res<State<AppState>>,
         mut next_app_state: ResMut<NextState<AppState>>,
-    ) {
+    ) -> Result {
         let (client_entity, client, mut send_start_game, mut send_join_lobby, mut exit_lobby) =
             message_sender.into_inner();
         let window_name = match app_state.get() {
@@ -236,7 +236,7 @@ mod lobby {
         };
         egui::Window::new(window_name)
             .anchor(egui::Align2::LEFT_TOP, [30.0, 30.0])
-            .show(contexts.ctx_mut().unwrap(), |ui| {
+            .show(contexts.ctx_mut()?, |ui| {
                 match app_state.get() {
                     AppState::Lobby { joined_lobby } => {
                         if joined_lobby.is_none() {
@@ -395,6 +395,7 @@ mod lobby {
                     }
                 }
             });
+        Ok(())
     }
 
     /// Listen for the StartGame message, and start the game if it was (which means that a client clicked on the 'start game' button)

--- a/examples/lobby/src/client.rs
+++ b/examples/lobby/src/client.rs
@@ -3,7 +3,7 @@ use core::net::{Ipv4Addr, SocketAddr};
 use crate::protocol::*;
 use crate::HOST_SERVER_PORT;
 use bevy::prelude::*;
-use bevy_egui::{egui, EguiContextPass, EguiContexts};
+use bevy_egui::{egui, EguiContexts};
 use lightyear::input::client::InputSet;
 use lightyear::netcode::client_plugin::NetcodeConfig;
 use lightyear::netcode::NetcodeClient;
@@ -49,7 +49,7 @@ impl Plugin for ExampleClientPlugin {
                 .run_if(in_state(AppState::Game)),
         );
         app.add_systems(
-            EguiContextPass,
+            PostUpdate,
             (lobby::lobby_ui, lobby::receive_start_game_message),
         );
         app.add_observer(on_disconnect);
@@ -125,7 +125,7 @@ mod game {
             if keypress.pressed(KeyCode::KeyD) || keypress.pressed(KeyCode::ArrowRight) {
                 direction.right = true;
             }
-            action_state.value = Some(Inputs::Direction(direction));
+            action_state.0 = Inputs::Direction(direction);
         }
     }
 
@@ -136,11 +136,9 @@ mod game {
         mut position_query: Query<(&mut PlayerPosition, &ActionState<Inputs>), With<Predicted>>,
     ) {
         for (position, input) in position_query.iter_mut() {
-            if let Some(input) = &input.value {
-                // NOTE: be careful to directly pass Mut<PlayerPosition>
-                // getting a mutable reference triggers change detection, unless you use `as_deref_mut()`
-                shared_movement_behaviour(position, input);
-            }
+            // NOTE: be careful to directly pass Mut<PlayerPosition>
+            // getting a mutable reference triggers change detection, unless you use `as_deref_mut()`
+            shared_movement_behaviour(position, input);
         }
     }
 
@@ -238,7 +236,7 @@ mod lobby {
         };
         egui::Window::new(window_name)
             .anchor(egui::Align2::LEFT_TOP, [30.0, 30.0])
-            .show(contexts.ctx_mut(), |ui| {
+            .show(contexts.ctx_mut().unwrap(), |ui| {
                 match app_state.get() {
                     AppState::Lobby { joined_lobby } => {
                         if joined_lobby.is_none() {

--- a/examples/lobby/src/protocol.rs
+++ b/examples/lobby/src/protocol.rs
@@ -155,6 +155,17 @@ pub enum Inputs {
     Direction(Direction),
 }
 
+impl Default for Inputs {
+    fn default() -> Self {
+        Inputs::Direction(Direction {
+            up: false,
+            down: false,
+            left: false,
+            right: false,
+        })
+    }
+}
+
 impl MapEntities for Inputs {
     fn map_entities<M: EntityMapper>(&mut self, entity_mapper: &mut M) {}
 }

--- a/examples/lobby/src/server.rs
+++ b/examples/lobby/src/server.rs
@@ -146,9 +146,7 @@ mod game {
         mut position_query: Query<(&mut PlayerPosition, &ActionState<Inputs>), Without<Predicted>>,
     ) {
         for (position, inputs) in position_query.iter_mut() {
-            if let Some(inputs) = &inputs.value {
-                shared_movement_behaviour(position, inputs);
-            }
+            shared_movement_behaviour(position, inputs);
         }
     }
 }

--- a/examples/network_visibility/src/client.rs
+++ b/examples/network_visibility/src/client.rs
@@ -45,7 +45,7 @@ pub(crate) fn buffer_input(
         if keypress.pressed(KeyCode::KeyD) || keypress.pressed(KeyCode::ArrowRight) {
             direction.right = true;
         }
-        action_state.value = Some(direction);
+        action_state.0 = direction;
     }
 }
 
@@ -54,9 +54,7 @@ pub(crate) fn movement(
     mut position_query: Query<(&mut Position, &ActionState<Inputs>), With<Predicted>>,
 ) {
     for (position, input) in position_query.iter_mut() {
-        if let Some(input) = &input.value {
-            shared_movement_behaviour(position, input);
-        }
+        shared_movement_behaviour(position, input);
     }
 }
 

--- a/examples/network_visibility/src/server.rs
+++ b/examples/network_visibility/src/server.rs
@@ -143,8 +143,6 @@ pub(crate) fn movement(
     mut position_query: Query<(&mut Position, &ActionState<Inputs>), Without<InputMarker<Inputs>>>,
 ) {
     for (position, input) in position_query.iter_mut() {
-        if let Some(input) = &input.value {
-            shared_movement_behaviour(position, input);
-        }
+        shared_movement_behaviour(position, input);
     }
 }

--- a/examples/replication_groups/src/client.rs
+++ b/examples/replication_groups/src/client.rs
@@ -2,7 +2,6 @@ use crate::protocol::Direction;
 use crate::protocol::*;
 use crate::shared::{shared_movement_behaviour, shared_tail_behaviour};
 use bevy::prelude::*;
-use lightyear::interpolation::{ConfirmedHistory, InterpolateStatus};
 use lightyear::prelude::input::client::*;
 use lightyear::prelude::input::native::*;
 use lightyear::prelude::*;
@@ -46,17 +45,17 @@ pub(crate) fn buffer_input(
 ) {
     if let Ok(mut action_state) = query.single_mut() {
         if keypress.pressed(KeyCode::KeyW) || keypress.pressed(KeyCode::ArrowUp) {
-            action_state.value = Some(Inputs::Direction(Direction::Up));
+            action_state.0 = Inputs::Direction(Direction::Up);
         } else if keypress.pressed(KeyCode::KeyS) || keypress.pressed(KeyCode::ArrowDown) {
-            action_state.value = Some(Inputs::Direction(Direction::Down));
+            action_state.0 = Inputs::Direction(Direction::Down);
         } else if keypress.pressed(KeyCode::KeyA) || keypress.pressed(KeyCode::ArrowLeft) {
-            action_state.value = Some(Inputs::Direction(Direction::Left));
+            action_state.0 = Inputs::Direction(Direction::Left);
         } else if keypress.pressed(KeyCode::KeyD) || keypress.pressed(KeyCode::ArrowRight) {
-            action_state.value = Some(Inputs::Direction(Direction::Right));
+            action_state.0 = Inputs::Direction(Direction::Right);
         } else {
-            // make sure to set the ActionState to None if no keys are pressed
-            // otherwise the previous tick's ActionState will be used!
-            action_state.value = None;
+            // we always set the value, so that the server can distinguish between no inputs received
+            // and no keys pressed
+            action_state.0 = Inputs::Empty
         }
     }
 }
@@ -68,9 +67,7 @@ fn movement(
     mut position_query: Query<(&mut PlayerPosition, &ActionState<Inputs>), With<Predicted>>,
 ) {
     for (position, input) in position_query.iter_mut() {
-        if let Some(inputs) = &input.value {
-            shared_movement_behaviour(position, inputs);
-        }
+        shared_movement_behaviour(position, input);
     }
 }
 

--- a/examples/replication_groups/src/protocol.rs
+++ b/examples/replication_groups/src/protocol.rs
@@ -148,7 +148,7 @@ impl TailPoints {
 // This can be done by calling `app.add_component_map_entities::<PlayerParent>()` in your protocol,
 // and deriving the `MapEntities` trait for the component.
 #[derive(Component, Deserialize, Serialize, Clone, Debug, PartialEq, Reflect)]
-pub struct PlayerParent(pub(crate) Entity);
+pub struct PlayerParent(#[entities] pub(crate) Entity);
 
 impl MapEntities for PlayerParent {
     fn map_entities<M: EntityMapper>(&mut self, entity_mapper: &mut M) {
@@ -204,11 +204,13 @@ impl Direction {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Reflect)]
+#[derive(Serialize, Deserialize, Debug, Default, PartialEq, Clone, Reflect)]
 pub enum Inputs {
     Direction(Direction),
     Delete,
     Spawn,
+    #[default]
+    Empty,
 }
 
 impl MapEntities for Inputs {

--- a/examples/replication_groups/src/server.rs
+++ b/examples/replication_groups/src/server.rs
@@ -91,10 +91,8 @@ pub(crate) fn movement(
     >,
 ) {
     for (position, inputs) in position_query.iter_mut() {
-        if let Some(input) = &inputs.value {
-            // NOTE: be careful to directly pass Mut<PlayerPosition>
-            // getting a mutable reference triggers change detection, unless you use `as_deref_mut()`
-            shared_movement_behaviour(position, input);
-        }
+        // NOTE: be careful to directly pass Mut<PlayerPosition>
+        // getting a mutable reference triggers change detection, unless you use `as_deref_mut()`
+        shared_movement_behaviour(position, inputs);
     }
 }

--- a/examples/simple_box/src/client.rs
+++ b/examples/simple_box/src/client.rs
@@ -61,7 +61,7 @@ pub(crate) fn buffer_input(
         }
         // we always set the value. Setting it to None means that the input was missing, it's not the same
         // as saying that the input was 'no keys pressed'
-        action_state.value = Some(Inputs::Direction(direction));
+        action_state.0 = Inputs::Direction(direction);
     }
 }
 
@@ -74,12 +74,10 @@ fn player_movement(
 ) {
     // let tick = timeline.tick();
     for (position, input) in position_query.iter_mut() {
-        if let Some(input) = &input.value {
-            // trace!(?tick, ?position, ?input, "client");
-            // NOTE: be careful to directly pass Mut<PlayerPosition>
-            // getting a mutable reference triggers change detection, unless you use `as_deref_mut()`
-            shared::shared_movement_behaviour(position, input);
-        }
+        // trace!(?tick, ?position, ?input, "client");
+        // NOTE: be careful to directly pass Mut<PlayerPosition>
+        // getting a mutable reference triggers change detection, unless you use `as_deref_mut()`
+        shared::shared_movement_behaviour(position, input);
     }
 }
 

--- a/examples/simple_box/src/protocol.rs
+++ b/examples/simple_box/src/protocol.rs
@@ -77,7 +77,7 @@ pub struct Message1(pub usize);
 
 // Inputs
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Reflect)]
+#[derive(Serialize, Deserialize, Debug, Default, PartialEq, Eq, Clone, Reflect)]
 pub struct Direction {
     pub(crate) up: bool,
     pub(crate) down: bool,
@@ -94,6 +94,12 @@ impl Direction {
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Reflect)]
 pub enum Inputs {
     Direction(Direction),
+}
+
+impl Default for Inputs {
+    fn default() -> Self {
+        Self::Direction(Direction::default())
+    }
 }
 
 impl MapEntities for Inputs {

--- a/examples/simple_box/src/server.rs
+++ b/examples/simple_box/src/server.rs
@@ -84,10 +84,8 @@ fn movement(
 ) {
     let tick = timeline.tick();
     for (position, inputs) in position_query.iter_mut() {
-        if let Some(inputs) = &inputs.value {
-            trace!(?tick, ?position, ?inputs, "server");
-            shared::shared_movement_behaviour(position, inputs);
-        }
+        trace!(?tick, ?position, ?inputs, "server");
+        shared::shared_movement_behaviour(position, inputs);
     }
 }
 

--- a/examples/simple_box/src/shared.rs
+++ b/examples/simple_box/src/shared.rs
@@ -5,8 +5,7 @@
 use crate::protocol::*;
 use bevy::prelude::*;
 use lightyear::connection::client_of::ClientOf;
-use lightyear::interpolation::{ConfirmedHistory, InterpolateStatus, Interpolated};
-use lightyear::prelude::{Client, Confirmed, LocalTimeline, NetworkTimeline, Rollback};
+use lightyear::prelude::*;
 use lightyear_examples_common::shared::SharedSettings;
 
 pub struct SharedPlugin;

--- a/lightyear/src/shared.rs
+++ b/lightyear/src/shared.rs
@@ -43,6 +43,13 @@ impl Plugin for SharedPlugins {
         app.add_plugins(lightyear_interpolation::plugin::InterpolationPlugin::new(
             lightyear_interpolation::plugin::InterpolationConfig::default(),
         ));
+
+        #[cfg(feature = "avian2d")]
+        app.add_plugins(lightyear_avian2d::prelude::LightyearAvianPlugin::default());
+        #[cfg(feature = "avian3d")]
+        {
+            app.add_plugins(lightyear_avian3d::prelude::LightyearAvianPlugin::default());
+        }
     }
 
     fn is_unique(&self) -> bool {

--- a/lightyear/src/shared.rs
+++ b/lightyear/src/shared.rs
@@ -1,7 +1,5 @@
 //! Bevy [`Plugin`] used by both the server and the client
 use bevy_app::{App, Plugin};
-#[cfg(feature = "replication")]
-use bevy_ecs::hierarchy::ChildOf;
 use core::time::Duration;
 use lightyear_core::plugin::CorePlugins;
 
@@ -29,15 +27,6 @@ impl Plugin for SharedPlugins {
         #[cfg(feature = "replication")]
         app.add_plugins(lightyear_replication::prelude::ReplicationSendPlugin)
             .add_plugins(lightyear_replication::prelude::NetworkVisibilityPlugin)
-            // TODO: this is dangerous because every registered message/component/etc.
-            //  needs to be registered at the same time on client/server to guarantee that
-            //  they shared the same network_id!
-            .add_plugins(lightyear_replication::prelude::RelationshipSendPlugin::<
-                ChildOf,
-            >::default())
-            .add_plugins(lightyear_replication::prelude::RelationshipReceivePlugin::<
-                ChildOf,
-            >::default())
             .add_plugins(lightyear_replication::prelude::HierarchySendPlugin)
             .add_plugins(lightyear_replication::prelude::AuthorityPlugin)
             .add_plugins(lightyear_replication::prelude::ReplicationReceivePlugin);

--- a/lightyear_avian/src/correction_2d.rs
+++ b/lightyear_avian/src/correction_2d.rs
@@ -1,0 +1,36 @@
+//! Handle Correction for avian. We need to handle this manually because we replicate
+//! Position and Rotation, but the visual representation is a Transform.
+//!
+//! The flow is:
+//! - PreUpdate:
+//!   - rollback check. We store the previous Position/Rotation in PreviousVisual<Position>/PreviousVisual<Rotation>
+//!   - apply rollback
+//!   - end rollback
+//!     - set current/previous values to be the last 2 values from the history
+//!     - compute the visual using the previous frame's overstep
+//!     - compute the error between the new visual and the previous visual (when they both use the same overstep)
+//! - BeforeFixedUpdate:
+//!   - restore Position/Rotation to the tick value from FrameInterpolation
+//! - FixedUpdate:
+//!   - Run Physics simulation
+//!   - Sync Position/Rotation to Transform
+//!   - Update FrameInterpolation<Transform> with the new Transform value
+//! - PostUpdate:
+//!   - interpolate with FrameInterpolation<Transform>
+//!   - apply VisualCorrection<Transform> if present
+//!   - apply TransformPropagation
+//!
+//! If the user is running FrameInterpolation<Transform>, we need to either:
+//! - in end_rollback, compute the error in Position/Rotation space, then convert it to Transform space? How do we handle the Local/Global transform?
+//! - or in end_rollback, compute the error in Position/Rotation space.
+//!
+//! Id the user is running FrameInterpolation<GlobalTransform>, we can:
+//! -
+use bevy_app::prelude::*;
+pub struct Correction2DPlugin;
+
+impl Plugin for Correction2DPlugin {
+    fn build(&self, _app: &mut App) {
+        todo!()
+    }
+}

--- a/lightyear_avian/src/lib.rs
+++ b/lightyear_avian/src/lib.rs
@@ -29,6 +29,9 @@ pub use types_3d as types;
 #[cfg(any(feature = "2d", feature = "3d"))]
 pub mod plugin;
 
+#[cfg(feature = "2d")]
+mod correction_2d;
+
 /// Commonly used items for Lightyear Avian integration.
 pub mod prelude {
     #[cfg(feature = "lag_compensation")]

--- a/lightyear_avian/src/plugin.rs
+++ b/lightyear_avian/src/plugin.rs
@@ -109,6 +109,14 @@ impl Plugin for LightyearAvianPlugin {
                         position_to_transform: false,
                         ..default()
                     });
+                    app.configure_sets(
+                        FixedPostUpdate,
+                        SyncSet::PositionToTransform.in_set(PhysicsSet::Sync),
+                    );
+                    app.configure_sets(
+                        PostUpdate,
+                        SyncSet::PositionToTransform.in_set(PhysicsSet::Sync),
+                    );
                     // We manually sync Position/Rotation to Transform. We do it even
                     // for entities that are not RigidBodies (for example Interpolated entities)
                     app.add_systems(

--- a/lightyear_avian/src/plugin.rs
+++ b/lightyear_avian/src/plugin.rs
@@ -77,23 +77,24 @@ impl Plugin for LightyearAvianPlugin {
                     (
                         // update physics
                         PhysicsSet::StepSimulation,
-                        // run physics before spawning we sync so that PreSpawned entities have accurate Position/Rotation values in their history
-                        PredictionSet::Sync,
+                        // TODO: run physics before we sync so that PreSpawned entities have accurate Position/Rotation values in their history -> Do we have PredictionSet::Sync systems in
+                        // FixedPostUpdate?
+
+                        // update the history only after the physics have been updated
+                        PredictionSet::UpdateHistory,
                         PhysicsSet::Sync,
                         // the transform value has to be updated (from Position) before we can store it for FrameInterpolation
                         FrameInterpolationSet::Update,
                     )
                         .chain(),
                 );
-                // In case the user is running physics in PostUpdate: Sync Pos/Rotation to Transform before applying frame interpolation to Transform
                 app.configure_sets(
                     PostUpdate,
                     (
-                        // TODO: revisit this. The VisualCorrection is computed on the Position/Rotation, but the
-                        //  FrameInterpolation is applied to the Transform.
-                        PhysicsSet::Sync,
                         FrameInterpolationSet::Interpolate,
                         RollbackSet::VisualCorrection,
+                        // In case the user is running FrameInterpolation for Position/Rotation, we run FrameInterpolation and Correction before syncing to Transform
+                        PhysicsSet::Sync,
                         TransformSystem::TransformPropagate,
                     )
                         .chain(),
@@ -149,7 +150,7 @@ impl Plugin for LightyearAvianPlugin {
                         // update physics
                         PhysicsSet::StepSimulation,
                         // run physics before spawning we sync so that PreSpawned entities have accurate Position/Rotation values in their history
-                        PredictionSet::Sync,
+                        PredictionSet::UpdateHistory,
                         PhysicsSet::Sync,
                         // the transform value has to be updated (from Position) before we can store it for FrameInterpolation
                         FrameInterpolationSet::Update,

--- a/lightyear_avian2d/Cargo.toml
+++ b/lightyear_avian2d/Cargo.toml
@@ -44,6 +44,7 @@ tracing.workspace = true
 bevy_app.workspace = true
 bevy_ecs.workspace = true
 bevy_math.workspace = true
+bevy_time.workspace = true
 bevy_transform = { workspace = true, features = ["bevy-support", "libm"] }
 bevy_utils.workspace = true
 

--- a/lightyear_deterministic_replication/src/archetypes.rs
+++ b/lightyear_deterministic_replication/src/archetypes.rs
@@ -83,6 +83,7 @@ unsafe impl<const HISTORY: bool> SystemParam for ChecksumWorld<'_, '_, HISTORY> 
                 .prediction_map
                 .iter()
                 .filter_map(|(kind, pred)| {
+                    // TODO: for non-full components, just fetch the component value directly
                     let history_id = pred.history_id?;
                     // We need write access because we will call `pop_until_tick` on the history component
                     filtered_access.add_component_write(history_id);
@@ -94,7 +95,7 @@ unsafe impl<const HISTORY: bool> SystemParam for ChecksumWorld<'_, '_, HISTORY> 
                     );
                     registry.component_metadata_map
                         .get(kind)
-                        .and_then(|m| m.deterministic.as_ref().map(|d| (history_id, (*d, pred.pop_until_tick_and_hash))))
+                        .and_then(|m| m.deterministic.as_ref().map(|d| (history_id, (*d, pred.pop_until_tick_and_hash()))))
                 })
                 .collect()
         };

--- a/lightyear_frame_interpolation/src/lib.rs
+++ b/lightyear_frame_interpolation/src/lib.rs
@@ -64,7 +64,7 @@ use lightyear_connection::client::Client;
 use lightyear_core::prelude::LocalTimeline;
 use lightyear_core::timeline::is_in_rollback;
 use lightyear_interpolation::prelude::InterpolationRegistry;
-use lightyear_replication::prelude::ReplicationSet;
+use lightyear_replication::prelude::ReplicationBufferSet;
 use tracing::trace;
 
 /// System sets used by the `FrameInterpolationPlugin`.
@@ -124,7 +124,7 @@ impl<C: Component<Mutability = Mutable> + Clone + Debug> Plugin for FrameInterpo
             FrameInterpolationSet::Interpolate
                 .before(TransformSystem::TransformPropagate)
                 // we don't want the visual interpolation value to be the one replicated!
-                .after(ReplicationSet::Send),
+                .after(ReplicationBufferSet::Buffer),
         );
 
         // SYSTEMS
@@ -250,8 +250,8 @@ pub(crate) fn restore_from_visual_interpolation<
         if let Some(current_value) = &interpolate_status.current_value {
             trace!(
                 ?kind,
-                ?component,
-                ?current_value,
+                visual = ?component,
+                correct = ?current_value,
                 "Restoring visual interpolation"
             );
             *component.bypass_change_detection() = current_value.clone();

--- a/lightyear_inputs/src/client.rs
+++ b/lightyear_inputs/src/client.rs
@@ -561,7 +561,7 @@ fn prepare_input_message<S: ActionStateSequence>(
 
     // TODO: revisit this; maybe we should not send an empty message?
     // we send a message even when there are 0 inputs because that itself is information
-    trace!(
+    debug!(
         ?tick,
         ?num_tick,
         "sending input message for {:?}: {:?}",

--- a/lightyear_inputs/src/input_message.rs
+++ b/lightyear_inputs/src/input_message.rs
@@ -130,6 +130,7 @@ pub trait ActionStateSequence:
                 input_buffer.set_raw(prev_end + delta, InputData::SameAsPrecedent);
             }
         }
+        debug!("input buffer after update: {input_buffer:?}");
         earliest_mismatch
     }
 

--- a/lightyear_inputs_native/Cargo.toml
+++ b/lightyear_inputs_native/Cargo.toml
@@ -26,6 +26,7 @@ serde.workspace = true
 
 # bevy
 bevy_app.workspace = true
+bevy_derive.workspace = true
 bevy_ecs.workspace = true
 bevy_reflect.workspace = true
 

--- a/lightyear_inputs_native/src/action_state.rs
+++ b/lightyear_inputs_native/src/action_state.rs
@@ -1,3 +1,4 @@
+use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::{
     component::Component,
     entity::{EntityMapper, MapEntities},
@@ -10,45 +11,30 @@ use lightyear_inputs::input_buffer::InputData;
 use serde::{Deserialize, Serialize};
 
 /// The component that will store the current status of the action for the entity
-#[derive(Component, Clone, Debug, PartialEq, Serialize, Deserialize, Reflect)]
-pub struct ActionState<A> {
-    pub value: Option<A>,
-}
+///
+/// Note that your action HAS to implement `MapEntities` and `Default`.
+/// The `Default` value should be when no actions/inputs are active.
+/// It is important to distinguish between "no input" (e.g. no keys pressed) and "input not received" (e.g. network packet loss).
+#[derive(
+    Component, Clone, Debug, Default, PartialEq, Serialize, Deserialize, Reflect, Deref, DerefMut,
+)]
+pub struct ActionState<A>(pub A);
 
 impl<A: MapEntities> MapEntities for ActionState<A> {
     fn map_entities<E: EntityMapper>(&mut self, entity_mapper: &mut E) {
-        if let Some(value) = &mut self.value {
-            value.map_entities(entity_mapper);
-        }
+        self.0.map_entities(entity_mapper);
     }
 }
 
 impl<A: Clone> From<&ActionState<A>> for InputData<A> {
     fn from(value: &ActionState<A>) -> Self {
-        value
-            .value
-            .as_ref()
-            .map_or(InputData::Absent, |v| InputData::Input(v.clone()))
-    }
-}
-
-impl<A> Default for ActionState<A> {
-    fn default() -> Self {
-        Self { value: None }
+        InputData::Input(value.0.clone())
     }
 }
 
 /// Marker component to identify the ActionState that the player is actively updating
 /// (as opposed to the ActionState of other players, for instance)
-#[derive(Component, Clone, Copy, Debug, PartialEq, Reflect)]
+#[derive(Component, Clone, Copy, Debug, Default, PartialEq, Reflect)]
 pub struct InputMarker<A> {
     marker: PhantomData<A>,
-}
-
-impl<A> Default for InputMarker<A> {
-    fn default() -> Self {
-        Self {
-            marker: PhantomData,
-        }
-    }
 }

--- a/lightyear_inputs_native/src/lib.rs
+++ b/lightyear_inputs_native/src/lib.rs
@@ -20,11 +20,12 @@
 //! # use bevy_reflect::Reflect;
 //! use lightyear_inputs_native::prelude::*;
 //!
-//! #[derive(Serialize, Deserialize, Clone, PartialEq, Reflect, Debug)]
+//! #[derive(Serialize, Deserialize, Clone, PartialEq, Reflect, Debug, Default)]
 //! pub enum MyInput {
 //!     Move { x: f32, y: f32 },
 //!     Jump,
 //!     // we need a variant for "no input", to differentiate between "no input" and "missing input packet"
+//!     #[default]
 //!     None,
 //! }
 //!

--- a/lightyear_inputs_native/src/plugin.rs
+++ b/lightyear_inputs_native/src/plugin.rs
@@ -11,16 +11,9 @@ use lightyear_inputs::input_buffer::InputBuffer;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 
+#[derive(Default)]
 pub struct InputPlugin<A> {
     pub config: InputConfig<A>,
-}
-
-impl<A> Default for InputPlugin<A> {
-    fn default() -> Self {
-        Self {
-            config: Default::default(),
-        }
-    }
 }
 
 impl<
@@ -31,6 +24,7 @@ impl<
         + Send
         + Sync
         + Debug
+        + Default
         + 'static
         + MapEntities
         + Reflectable

--- a/lightyear_interpolation/src/despawn.rs
+++ b/lightyear_interpolation/src/despawn.rs
@@ -1,6 +1,6 @@
-use crate::SyncComponent;
 use crate::interpolate::InterpolateStatus;
 use crate::interpolation_history::ConfirmedHistory;
+use bevy_ecs::component::Component;
 use bevy_ecs::{
     error::Result,
     observer::Trigger,
@@ -10,7 +10,7 @@ use bevy_ecs::{
 use lightyear_replication::prelude::Confirmed;
 
 /// Remove the component from interpolated entities when it gets removed from confirmed
-pub(crate) fn removed_components<C: SyncComponent>(
+pub(crate) fn removed_components<C: Component>(
     trigger: Trigger<OnRemove, C>,
     mut commands: Commands,
     query: Query<&Confirmed>,

--- a/lightyear_interpolation/src/lib.rs
+++ b/lightyear_interpolation/src/lib.rs
@@ -10,7 +10,7 @@ use bevy_ecs::{
     world::DeferredWorld,
 };
 use lightyear_replication::prelude::Replicated;
-use tracing::error;
+use tracing::{error};
 
 use crate::manager::InterpolationManager;
 

--- a/lightyear_interpolation/src/lib.rs
+++ b/lightyear_interpolation/src/lib.rs
@@ -9,10 +9,7 @@ use bevy_ecs::{
     component::{Component, HookContext, Mutable},
     world::DeferredWorld,
 };
-pub use interpolate::InterpolateStatus;
-pub use interpolation_history::ConfirmedHistory;
 use lightyear_replication::prelude::Replicated;
-pub use plugin::{add_interpolation_systems, add_prepare_interpolation_systems};
 use tracing::error;
 
 use crate::manager::InterpolationManager;
@@ -25,12 +22,14 @@ pub mod interpolation_history;
 mod manager;
 /// Provides the `InterpolationPlugin` and related systems for Bevy integration.
 pub mod plugin;
-mod registry;
+pub mod registry;
 mod spawn;
-mod timeline;
+pub mod timeline;
 
 /// Commonly used items for client-side interpolation.
 pub mod prelude {
+    pub use crate::interpolate::InterpolateStatus;
+    pub use crate::interpolation_history::ConfirmedHistory;
     pub use crate::manager::InterpolationManager;
     pub use crate::plugin::{
         InterpolationConfig, InterpolationDelay, InterpolationPlugin, InterpolationSet,

--- a/lightyear_interpolation/src/lib.rs
+++ b/lightyear_interpolation/src/lib.rs
@@ -10,7 +10,7 @@ use bevy_ecs::{
     world::DeferredWorld,
 };
 use lightyear_replication::prelude::Replicated;
-use tracing::{error};
+use tracing::error;
 
 use crate::manager::InterpolationManager;
 

--- a/lightyear_prediction/src/correction.rs
+++ b/lightyear_prediction/src/correction.rs
@@ -144,8 +144,8 @@ pub(crate) fn add_visual_correction<C: SyncComponent + Diffable<Delta = C>>(
                 interpolation.interpolate(C::base_value(), visual_correction.error.clone(), r);
             component.bypass_change_detection().apply_diff(&error);
             trace!(
-                ?visual_correction,
-                ?error,
+                previous = ?visual_correction,
+                new = ?error,
                 ?r,
                 "Applied visual correction and decaying error for {:?}",
                 core::any::type_name::<C>()
@@ -186,5 +186,13 @@ impl CorrectionPolicy {
         let dt = delta.as_secs_f32();
         let neg_decay_constant = self.decay_ratio.ln() / self.decay_period.as_secs_f32();
         (neg_decay_constant * dt).exp()
+    }
+
+    pub fn instant_correction() -> Self {
+        Self {
+            decay_period: core::time::Duration::from_millis(1),
+            decay_ratio: 0.0000001,
+            max_correction_period: core::time::Duration::from_millis(10),
+        }
     }
 }

--- a/lightyear_prediction/src/correction.rs
+++ b/lightyear_prediction/src/correction.rs
@@ -42,7 +42,7 @@ use lightyear_core::prelude::{LocalTimeline, NetworkTimeline};
 use lightyear_frame_interpolation::FrameInterpolate;
 use lightyear_interpolation::prelude::InterpolationRegistry;
 use lightyear_replication::delta::Diffable;
-use tracing::{error, trace};
+use tracing::trace;
 
 /// The visual value of the component before the rollback started
 #[derive(Component, Debug, Reflect)]
@@ -83,22 +83,14 @@ pub(crate) fn update_frame_interpolation_post_rollback<C: SyncComponent + Diffab
         &mut C,
         &PreviousVisual<C>,
         &PredictionHistory<C>,
-        Option<&mut FrameInterpolate<C>>,
+        &mut FrameInterpolate<C>,
     )>,
     mut commands: Commands,
 ) {
     // NOTE: this is the overstep from the previous frame since we are running this before RunFixedMainLoop
     let overstep = time.overstep_fraction();
     let tick = timeline.tick();
-    for (entity, component, previous_visual, history, interpolate) in query.iter_mut() {
-        let Some(mut interpolate) = interpolate else {
-            error!(
-                ?entity,
-                "We have a VisualCorrection but not FrameInterpolate for {:?}",
-                core::any::type_name::<C>()
-            );
-            continue;
-        };
+    for (entity, component, previous_visual, history, mut interpolate) in query.iter_mut() {
         interpolate.current_value = Some(component.clone());
         interpolate.previous_value = history.nth_most_recent(1).cloned();
         let Some(previous) = &interpolate.previous_value else {

--- a/lightyear_prediction/src/rollback.rs
+++ b/lightyear_prediction/src/rollback.rs
@@ -436,7 +436,7 @@ fn reset_input_rollback_tracker(
     // set a high value to the AtomicTick so we can then compute the minimum last_confirmed_tick among all clients
     if let Some(last_confirmed_input) = last_confirmed_input {
         last_confirmed_input.tick.0.store(
-            tick.0 + 1000,
+            (tick + 1000).0,
             bevy_platform::sync::atomic::Ordering::Relaxed,
         );
         last_confirmed_input
@@ -446,7 +446,7 @@ fn reset_input_rollback_tracker(
     if let Some(prediction_manager) = prediction_manager {
         // set a high value to the AtomicTick so we can then compute the minimum earliest_mismatch_tick among all clients
         prediction_manager.earliest_mismatch_input.tick.0.store(
-            tick.0 + 1000,
+            (tick + 1000).0,
             bevy_platform::sync::atomic::Ordering::Relaxed,
         );
         prediction_manager

--- a/lightyear_prediction/src/rollback.rs
+++ b/lightyear_prediction/src/rollback.rs
@@ -81,6 +81,7 @@ impl Plugin for RollbackPlugin {
         app.configure_sets(
             PostUpdate,
             // we add the correction error AFTER the interpolation was done
+            // (which means it's also after we buffer the component for replication)
             RollbackSet::VisualCorrection
                 .after(FrameInterpolationSet::Interpolate)
                 .in_set(PredictionSet::All),
@@ -154,7 +155,6 @@ impl Plugin for RollbackPlugin {
             ParamBuilder,
             ParamBuilder,
             ParamBuilder,
-            ParamBuilder,
         )
             .build_state(app.world_mut())
             .build_system(check_rollback)
@@ -202,7 +202,6 @@ fn check_rollback(
         With<IsSynced<InputTimeline>>,
     >,
     prediction_registry: Res<PredictionRegistry>,
-    component_registry: Res<ComponentRegistry>,
     system_ticks: SystemChangeTick,
     parallel_commands: ParallelCommands,
     mut commands: Commands,

--- a/lightyear_prediction/src/rollback.rs
+++ b/lightyear_prediction/src/rollback.rs
@@ -328,7 +328,8 @@ fn check_rollback(
                 .values()
                 .filter(|m| m.sync_mode == PredictionMode::Full)
                 .take_while(|_| !prediction_manager.is_rollback()) {
-                if (prediction_metadata.check_rollback)(&prediction_registry, confirmed_tick, &confirmed_ref, &mut predicted_mut) {
+                let check_rollback = prediction_metadata.full.as_ref().unwrap().check_rollback;
+                if check_rollback(&prediction_registry, confirmed_tick, &confirmed_ref, &mut predicted_mut) {
                     trace!("Rollback because we have received a new confirmed state. (mismatch check)");
                     // During `prepare_rollback` we will reset the component to their values on `confirmed_tick`.
                     // Then when we do Rollback in PreUpdate, we will start by incrementing the tick, which will be equal to `confirmed_tick + 1`
@@ -421,7 +422,7 @@ fn check_rollback(
 /// could be overwritten by each other.
 ///
 /// This must run after the rollback check.
-fn reset_input_rollback_tracker(
+pub fn reset_input_rollback_tracker(
     client: Single<
         (
             &LocalTimeline,

--- a/lightyear_prediction/src/shared.rs
+++ b/lightyear_prediction/src/shared.rs
@@ -1,9 +1,10 @@
 use crate::PredictionMode;
 use crate::prelude::{PreSpawned, PredictionRegistrationExt};
 use bevy_app::{App, Plugin};
+use bevy_ecs::hierarchy::ChildOf;
 use lightyear_replication::components::PrePredicted;
 use lightyear_replication::control::Controlled;
-use lightyear_replication::prelude::{AppComponentExt, ChildOfSync};
+use lightyear_replication::prelude::AppComponentExt;
 
 pub struct SharedPlugin;
 
@@ -15,8 +16,8 @@ impl Plugin for SharedPlugin {
         //  insert this plugin at the same time! All the component registration must be in a single spot
         app.register_component::<Controlled>()
             .add_prediction(PredictionMode::Once);
-        app.register_component::<ChildOfSync>()
-            .add_prediction(PredictionMode::Once);
+        app.register_component::<ChildOf>()
+            .add_immutable_prediction(PredictionMode::Once);
         app.register_component::<PreSpawned>();
         app.register_component::<PrePredicted>();
     }

--- a/lightyear_replication/src/lib.rs
+++ b/lightyear_replication/src/lib.rs
@@ -54,8 +54,7 @@ pub mod prelude {
     pub use crate::control::{Controlled, ControlledBy, ControlledByRemote, Lifetime};
     pub use crate::delta::{DeltaManager, Diffable};
     pub use crate::hierarchy::{
-        ChildOfSync, DisableReplicateHierarchy, HierarchySendPlugin, RelationshipReceivePlugin,
-        RelationshipSendPlugin, RelationshipSync, ReplicateLike, ReplicateLikeChildren,
+        DisableReplicateHierarchy, HierarchySendPlugin, ReplicateLike, ReplicateLikeChildren,
     };
     pub use crate::message::*;
     pub use crate::plugin::ReplicationSet;

--- a/lightyear_replication/src/plugin.rs
+++ b/lightyear_replication/src/plugin.rs
@@ -97,31 +97,4 @@ impl Plugin for SharedPlugin {
         app.add_trigger_to_bytes::<SenderMetadata>()
             .add_direction(NetworkDirection::Bidirectional);
     }
-
-    fn finish(&self, app: &mut App) {
-        // PROTOCOL
-        // we register components here because
-        // - we need to run this in `finish` so that all plugins have been built (so ClientPlugin and ServerPlugin
-        // both exists)
-        // - the replication::SharedPlugin should only be added once, even when running in host-server mode
-        // app.register_component::<PreSpawned>(ChannelDirection::Bidirectional);
-        // app.register_component::<PrePredicted>(ChannelDirection::Bidirectional);
-
-        // TODO: add direction?
-
-        // app.register_component::<RelationshipSync<ChildOf>>(ChannelDirection::Bidirectional)
-        //     // to replicate ReplicationSync on the predicted/interpolated entities so that they spawn their own hierarchies
-        //     .add_prediction(ComponentSyncMode::Simple)
-        //     .add_interpolation(ComponentSyncMode::Simple)
-        //     .add_map_entities();
-        // app.register_component::<Controlled>(ChannelDirection::ServerToClient)
-        //     .add_prediction(ComponentSyncMode::Once)
-        //     .add_interpolation(ComponentSyncMode::Once);
-        //
-        // app.register_message::<AuthorityChange>(ChannelDirection::ServerToClient)
-        //     .add_map_entities();
-        //
-        // // check that the protocol was built correctly
-        // app.world().resource::<ComponentRegistry>().check();
-    }
 }

--- a/lightyear_replication/src/registry/registry.rs
+++ b/lightyear_replication/src/registry/registry.rs
@@ -395,9 +395,7 @@ impl ComponentRegistry {
 pub trait AppComponentExt {
     /// Registers the component in the Registry
     /// This component can now be sent over the network.
-    fn register_component<
-        C: Component<Mutability: GetWriteFns<C>> + Serialize + DeserializeOwned,
-    >(
+    fn register_component<C: Component<Mutability: GetWriteFns<C>> + Serialize + DeserializeOwned>(
         &mut self,
     ) -> ComponentRegistration<'_, C>;
 
@@ -500,7 +498,7 @@ impl<C> ComponentRegistration<'_, C> {
 
     pub fn with_replication_config(self, config: ComponentReplicationConfig) -> Self
     where
-        C: Component<Mutability: GetWriteFns<C>>
+        C: Component<Mutability: GetWriteFns<C>>,
     {
         let overrides_component_id = self
             .app

--- a/lightyear_replication/src/registry/registry.rs
+++ b/lightyear_replication/src/registry/registry.rs
@@ -396,7 +396,7 @@ pub trait AppComponentExt {
     /// Registers the component in the Registry
     /// This component can now be sent over the network.
     fn register_component<
-        C: Component<Mutability: GetWriteFns<C>> + Serialize + DeserializeOwned + PartialEq,
+        C: Component<Mutability: GetWriteFns<C>> + Serialize + DeserializeOwned,
     >(
         &mut self,
     ) -> ComponentRegistration<'_, C>;
@@ -404,7 +404,7 @@ pub trait AppComponentExt {
     /// Registers the component in the Registry: this component can now be sent over the network.
     ///
     /// You need to provide your own [`SerializeFns`]
-    fn register_component_custom_serde<C: Component<Mutability: GetWriteFns<C>> + PartialEq>(
+    fn register_component_custom_serde<C: Component<Mutability: GetWriteFns<C>>>(
         &mut self,
         serialize_fns: SerializeFns<C>,
     ) -> ComponentRegistration<'_, C>;
@@ -421,14 +421,14 @@ pub trait AppComponentExt {
 
 impl AppComponentExt for App {
     fn register_component<
-        C: Component<Mutability: GetWriteFns<C>> + PartialEq + Serialize + DeserializeOwned,
+        C: Component<Mutability: GetWriteFns<C>> + Serialize + DeserializeOwned,
     >(
         &mut self,
     ) -> ComponentRegistration<'_, C> {
         self.register_component_custom_serde(SerializeFns::<C>::default())
     }
 
-    fn register_component_custom_serde<C: Component<Mutability: GetWriteFns<C>> + PartialEq>(
+    fn register_component_custom_serde<C: Component<Mutability: GetWriteFns<C>>>(
         &mut self,
         serialize_fns: SerializeFns<C>,
     ) -> ComponentRegistration<'_, C> {
@@ -500,7 +500,7 @@ impl<C> ComponentRegistration<'_, C> {
 
     pub fn with_replication_config(self, config: ComponentReplicationConfig) -> Self
     where
-        C: Component<Mutability: GetWriteFns<C>> + PartialEq,
+        C: Component<Mutability: GetWriteFns<C>>
     {
         let overrides_component_id = self
             .app

--- a/lightyear_replication/src/registry/replication.rs
+++ b/lightyear_replication/src/registry/replication.rs
@@ -50,7 +50,7 @@ impl ReplicationMetadata {
         }
     }
 
-    pub(crate) fn default_fns<C: Component<Mutability: GetWriteFns<C>> + PartialEq>(
+    pub(crate) fn default_fns<C: Component<Mutability: GetWriteFns<C>>>(
         config: ComponentReplicationConfig,
         overrides_component_id: ComponentId,
     ) -> Self {

--- a/lightyear_sync/src/timeline/input.rs
+++ b/lightyear_sync/src/timeline/input.rs
@@ -237,6 +237,14 @@ impl InputDelayConfig {
     }
 }
 
+/// Timeline that is used to keep track of when the client should buffer inputs.
+///
+/// This timeline is synced with the server timeline, and is the main driving timeline:
+/// any speed adjustments applied to this timeline will also be applied to the Time<Virtual> timeline.
+/// (and will therefore affect how fast the FixedUpdate loop runs, and how ticks are incremented)
+///
+/// This timeline is updated in PreUpdate; it CANNOT be used to get accurate `tick` in PreUpdate;
+/// use `LocalTimeline` instead.
 #[derive(Component, Deref, DerefMut, Default, Debug, Reflect)]
 pub struct InputTimeline(pub Timeline<Input>);
 

--- a/lightyear_sync/src/timeline/input.rs
+++ b/lightyear_sync/src/timeline/input.rs
@@ -164,7 +164,7 @@ impl InputDelayConfig {
         }
     }
 
-    /// No input-delay, all the latency will be covered by prediction
+    /// No input-delay, all the latency will be covered by prediction. We have unlimited prediction
     pub fn no_input_delay() -> Self {
         Self {
             minimum_input_delay_ticks: 0,

--- a/lightyear_tests/src/client_server/input/native.rs
+++ b/lightyear_tests/src/client_server/input/native.rs
@@ -59,7 +59,7 @@ fn test_remote_client_replicated_input() {
         .world_mut()
         .get_mut::<ActionState<MyInput>>(client_entity)
         .unwrap()
-        .value = Some(MyInput(1));
+        .0 = MyInput(1);
 
     stepper.frame_step(1);
     let server_tick = stepper.server_tick();
@@ -74,9 +74,7 @@ fn test_remote_client_replicated_input() {
             .unwrap()
             .get(client_tick)
             .unwrap(),
-        &ActionState {
-            value: Some(MyInput(1))
-        }
+        &ActionState(MyInput(1))
     );
 
     // Advance to client tick to verify server applies the input
@@ -88,9 +86,7 @@ fn test_remote_client_replicated_input() {
             .world()
             .get::<ActionState<MyInput>>(server_entity)
             .unwrap(),
-        &ActionState {
-            value: Some(MyInput(1))
-        }
+        &ActionState(MyInput(1))
     );
 }
 
@@ -139,7 +135,7 @@ fn test_remote_client_predicted_input() {
         .world_mut()
         .get_mut::<ActionState<MyInput>>(client_predicted)
         .unwrap()
-        .value = Some(MyInput(2));
+        .0 = MyInput(2);
 
     stepper.frame_step(1);
     let server_tick = stepper.server_tick();
@@ -154,9 +150,7 @@ fn test_remote_client_predicted_input() {
             .unwrap()
             .get(client_tick)
             .unwrap(),
-        &ActionState {
-            value: Some(MyInput(2))
-        }
+        &ActionState(MyInput(2))
     );
 
     // Advance to client tick to verify server applies the input
@@ -168,9 +162,7 @@ fn test_remote_client_predicted_input() {
             .world()
             .get::<ActionState<MyInput>>(server_entity)
             .unwrap(),
-        &ActionState {
-            value: Some(MyInput(2))
-        }
+        &ActionState(MyInput(2))
     );
 }
 
@@ -210,7 +202,7 @@ fn test_remote_client_confirmed_input() {
         .world_mut()
         .get_mut::<ActionState<MyInput>>(client_confirmed)
         .unwrap()
-        .value = Some(MyInput(3));
+        .0 = MyInput(3);
 
     stepper.frame_step(1);
     let server_tick = stepper.server_tick();
@@ -225,9 +217,7 @@ fn test_remote_client_confirmed_input() {
             .unwrap()
             .get(client_tick)
             .unwrap(),
-        &ActionState {
-            value: Some(MyInput(3))
-        }
+        &ActionState(MyInput(3))
     );
 
     // Advance to client tick to verify server applies the input
@@ -239,9 +229,7 @@ fn test_remote_client_confirmed_input() {
             .world()
             .get::<ActionState<MyInput>>(server_entity)
             .unwrap(),
-        &ActionState {
-            value: Some(MyInput(3))
-        }
+        &ActionState(MyInput(3))
     );
 }
 
@@ -337,7 +325,7 @@ fn test_input_broadcasting_prediction() {
         .world_mut()
         .get_mut::<ActionState<MyInput>>(client0_predicted)
         .unwrap()
-        .value = Some(MyInput(10));
+        .0 = MyInput(10);
     stepper.frame_step(1);
     let client1_tick = stepper.client_tick(1);
 
@@ -346,7 +334,7 @@ fn test_input_broadcasting_prediction() {
         .world_mut()
         .get_mut::<ActionState<MyInput>>(client0_predicted)
         .unwrap()
-        .value = Some(MyInput(5));
+        .0 = MyInput(5);
 
     // Step 2 more frames because the input is delayed. And because we need client0 -> server -> client1
     // the client 1 should just have received the Input(10)
@@ -364,7 +352,7 @@ fn test_input_broadcasting_prediction() {
         .world()
         .get::<ActionState<MyInput>>(client1_predicted)
         .expect("action state should exist");
-    assert_eq!(action_state.value, Some(MyInput(10)));
+    assert_eq!(action_state.0, MyInput(10));
 
     stepper.frame_step_server_first(2);
     // check that the next input has been received
@@ -372,7 +360,7 @@ fn test_input_broadcasting_prediction() {
         .world()
         .get::<ActionState<MyInput>>(client1_predicted)
         .expect("action state should exist");
-    assert_eq!(action_state.value, Some(MyInput(5)));
+    assert_eq!(action_state.0, MyInput(5));
 
     // check that during rollbacks, we fetch the input value from the input buffer even for remote inputs
     let check_input =
@@ -380,14 +368,14 @@ fn test_input_broadcasting_prediction() {
               q: Single<&ActionState<MyInput>, Without<InputMarker<MyInput>>>| {
             info!(
                 "Checking input value {:?} during rollback. Tick: {:?}",
-                q.value,
+                q.0,
                 c.tick()
             );
             if c.tick() == client1_tick {
                 info!("checking that we fetch old value from the buffer");
                 assert_eq!(
-                    q.value,
-                    Some(MyInput(10)),
+                    q.0,
+                    MyInput(10),
                     "During rollback, we should fetch the ActionState from the buffer",
                 );
             }
@@ -396,8 +384,8 @@ fn test_input_broadcasting_prediction() {
                     "checking that the action state stays correct for ticks for which we don't have an input in the buffer. (we predict that it stays the same)"
                 );
                 assert_eq!(
-                    q.value,
-                    Some(MyInput(5)),
+                    q.0,
+                    MyInput(5),
                     "During rollback, we should fetch the ActionState from the buffer",
                 );
             }

--- a/lightyear_tests/src/client_server/prediction/rollback.rs
+++ b/lightyear_tests/src/client_server/prediction/rollback.rs
@@ -18,7 +18,7 @@ use lightyear_core::prelude::{LocalTimeline, NetworkTimeline};
 use lightyear_messages::MessageManager;
 use lightyear_prediction::manager::{LastConfirmedInput, RollbackMode};
 use lightyear_prediction::prelude::{PredictionManager, RollbackSet};
-use lightyear_prediction::rollback::DeterministicPredicted;
+use lightyear_prediction::rollback::{DeterministicPredicted, reset_input_rollback_tracker};
 use lightyear_replication::components::Confirmed;
 use lightyear_replication::prelude::{PredictionTarget, Replicate, ReplicationSet};
 use test_log::test;
@@ -735,7 +735,7 @@ fn test_input_rollback_always_mode() {
         PreUpdate,
         check_rollback_start
             .after(RollbackSet::Check)
-            .before(RollbackSet::Prepare),
+            .before(reset_input_rollback_tracker),
     );
 
     // server broadcast input message to clients
@@ -798,7 +798,7 @@ fn test_input_rollback_check_mode_earliest_mismatch() {
         .world_mut()
         .get_mut::<ActionState<NativeInput>>(client_entity_1)
         .unwrap()
-        .value = Some(NativeInput(1));
+        .0 = NativeInput(1);
     stepper.frame_step(1);
     let input_tick = stepper.client_tick(1);
 
@@ -817,7 +817,7 @@ fn test_input_rollback_check_mode_earliest_mismatch() {
         PreUpdate,
         check_rollback_start
             .after(RollbackSet::Check)
-            .before(RollbackSet::Prepare),
+            .before(reset_input_rollback_tracker),
     );
 
     // server broadcast input message to clients

--- a/lightyear_tests/src/host_server/input/native.rs
+++ b/lightyear_tests/src/host_server/input/native.rs
@@ -55,7 +55,7 @@ fn test_remote_client_replicated_input() {
         .world_mut()
         .get_mut::<ActionState<MyInput>>(client_entity)
         .unwrap()
-        .value = Some(MyInput(1));
+        .0 = MyInput(1);
 
     stepper.frame_step(1);
     let server_tick = stepper.server_tick();
@@ -70,9 +70,7 @@ fn test_remote_client_replicated_input() {
             .unwrap()
             .get(client_tick)
             .unwrap(),
-        &ActionState {
-            value: Some(MyInput(1))
-        }
+        &ActionState(MyInput(1))
     );
 
     // Advance to client tick to verify server applies the input
@@ -84,9 +82,7 @@ fn test_remote_client_replicated_input() {
             .world()
             .get::<ActionState<MyInput>>(server_entity)
             .unwrap(),
-        &ActionState {
-            value: Some(MyInput(1))
-        }
+        &ActionState(MyInput(1))
     );
 }
 
@@ -137,7 +133,7 @@ fn test_remote_client_predicted_input() {
         .world_mut()
         .get_mut::<ActionState<MyInput>>(client_predicted)
         .unwrap()
-        .value = Some(MyInput(2));
+        .0 = MyInput(2);
 
     stepper.frame_step(1);
     let server_tick = stepper.server_tick();
@@ -152,9 +148,7 @@ fn test_remote_client_predicted_input() {
             .unwrap()
             .get(client_tick)
             .unwrap(),
-        &ActionState {
-            value: Some(MyInput(2))
-        }
+        &ActionState(MyInput(2))
     );
 
     // Advance to client tick to verify server applies the input
@@ -166,9 +160,7 @@ fn test_remote_client_predicted_input() {
             .world()
             .get::<ActionState<MyInput>>(server_entity)
             .unwrap(),
-        &ActionState {
-            value: Some(MyInput(2))
-        }
+        &ActionState(MyInput(2))
     );
 }
 
@@ -220,7 +212,7 @@ fn test_host_client_inputers_replicated_to_remote_client() {
         .world_mut()
         .get_mut::<ActionState<MyInput>>(server_entity)
         .unwrap()
-        .value = Some(MyInput(1));
+        .0 = MyInput(1);
 
     stepper.frame_step(1);
     let server_tick = stepper.server_tick();
@@ -241,8 +233,6 @@ fn test_host_client_inputers_replicated_to_remote_client() {
             .unwrap()
             .get(server_tick)
             .unwrap(),
-        &ActionState {
-            value: Some(MyInput(1))
-        }
+        &ActionState(MyInput(1))
     );
 }

--- a/lightyear_tests/src/protocol.rs
+++ b/lightyear_tests/src/protocol.rs
@@ -102,7 +102,7 @@ impl Diffable for CompDelta {
 }
 
 // Native Inputs
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Copy, Reflect)]
+#[derive(Serialize, Deserialize, Debug, Default, PartialEq, Eq, Clone, Copy, Reflect)]
 pub struct NativeInput(pub i16);
 
 impl MapEntities for NativeInput {


### PR DESCRIPTION
- This also unblocks deprecating RelationshipSync, since users can now directly do
`app.register_component::<R>` on their relationship components