### PR TITLE
fix(avian): update avian examples

### DIFF
--- a/examples/avian_3d_character/src/main.rs
+++ b/examples/avian_3d_character/src/main.rs
@@ -3,7 +3,7 @@
 #![allow(dead_code)]
 use bevy::prelude::*;
 use core::time::Duration;
-use lightyear::prelude::client::{Input, InputDelayConfig};
+
 use lightyear::prelude::{Client, InputTimeline, Timeline};
 use lightyear_examples_common::cli::{Cli, Mode};
 use lightyear_examples_common::shared::FIXED_TIMESTEP_HZ;
@@ -59,16 +59,18 @@ fn main() {
 
 #[cfg(feature = "client")]
 fn add_input_delay(app: &mut App) {
+    use lightyear::prelude::client::{Input, InputDelayConfig};
+    
     let client = app
         .world_mut()
         .query_filtered::<Entity, With<Client>>()
         .single(app.world_mut())
         .unwrap();
 
-    // set some input-delay since we are predicting all entities
-    app.world_mut()
-        .entity_mut(client)
-        .insert(InputTimeline(Timeline::from(
-            Input::default().with_input_delay(InputDelayConfig::fixed_input_delay(10)),
-        )));
+    // // set some input-delay since we are predicting all entities
+    // app.world_mut()
+    //     .entity_mut(client)
+    //     .insert(InputTimeline(Timeline::from(
+    //         Input::default().with_input_delay(InputDelayConfig::fixed_input_delay(10)),
+    //     )));
 }

--- a/examples/avian_3d_character/src/main.rs
+++ b/examples/avian_3d_character/src/main.rs
@@ -60,7 +60,7 @@ fn main() {
 #[cfg(feature = "client")]
 fn add_input_delay(app: &mut App) {
     use lightyear::prelude::client::{Input, InputDelayConfig};
-    
+
     let client = app
         .world_mut()
         .query_filtered::<Entity, With<Client>>()

--- a/examples/avian_3d_character/src/renderer.rs
+++ b/examples/avian_3d_character/src/renderer.rs
@@ -37,11 +37,6 @@ impl Plugin for ExampleRendererPlugin {
                 .before(RollbackSet::Check),
         );
 
-        app.add_systems(
-            PostUpdate,
-            position_to_transform_for_interpolated.before(TransformSystem::TransformPropagate),
-        );
-
         // Set up visual interp plugins for Position/Rotation. Position/Rotation is updated in FixedUpdate
         // by the physics plugin so we make sure that in PostUpdate we interpolate it
         app.add_plugins(FrameInterpolationPlugin::<Position>::default());
@@ -71,50 +66,6 @@ fn init(mut commands: Commands) {
     ));
 }
 
-type ParentComponents = (
-    &'static GlobalTransform,
-    Option<&'static Position>,
-    Option<&'static Rotation>,
-);
-
-type PosToTransformComponents = (
-    &'static mut Transform,
-    &'static Position,
-    &'static Rotation,
-    Option<&'static ChildOf>,
-);
-
-// Avian's sync plugin only runs for entities with RigidBody, but we want to also apply it for interpolated entities
-pub fn position_to_transform_for_interpolated(
-    mut query: Query<PosToTransformComponents, With<Interpolated>>,
-    parents: Query<ParentComponents, With<Children>>,
-) {
-    for (mut transform, pos, rot, parent) in &mut query {
-        if let Some(child_of) = parent {
-            if let Ok((parent_transform, parent_pos, parent_rot)) = parents.get(child_of.parent()) {
-                let parent_transform = parent_transform.compute_transform();
-                let parent_pos = parent_pos.map_or(parent_transform.translation, |pos| pos.f32());
-                let parent_rot = parent_rot.map_or(parent_transform.rotation, |rot| rot.f32());
-                let parent_scale = parent_transform.scale;
-                let parent_transform = Transform::from_translation(parent_pos)
-                    .with_rotation(parent_rot)
-                    .with_scale(parent_scale);
-
-                let new_transform = GlobalTransform::from(
-                    Transform::from_translation(pos.f32()).with_rotation(rot.f32()),
-                )
-                .reparented_to(&GlobalTransform::from(parent_transform));
-
-                transform.translation = new_transform.translation;
-                transform.rotation = new_transform.rotation;
-            }
-        } else {
-            transform.translation = pos.f32();
-            transform.rotation = rot.f32();
-        }
-    }
-}
-
 /// Add the VisualInterpolateStatus::<Transform> component to non-floor entities with
 /// component `Position`. Floors don't need to be visually interpolated because we
 /// don't expect them to move.
@@ -133,24 +84,22 @@ fn add_visual_interpolation_components(
     if !query.contains(trigger.target()) {
         return;
     }
-    commands
-        .entity(trigger.target())
-        .insert((
-            FrameInterpolate::<Position> {
-                // We must trigger change detection on visual interpolation
-                // to make sure that child entities (sprites, meshes, text)
-                // are also interpolated
-                trigger_change_detection: true,
-                ..default()
-            },
-            FrameInterpolate::<Rotation> {
-                // We must trigger change detection on visual interpolation
-                // to make sure that child entities (sprites, meshes, text)
-                // are also interpolated
-                trigger_change_detection: true,
-                ..default()
-            }
-        ));
+    commands.entity(trigger.target()).insert((
+        FrameInterpolate::<Position> {
+            // We must trigger change detection on visual interpolation
+            // to make sure that child entities (sprites, meshes, text)
+            // are also interpolated
+            trigger_change_detection: true,
+            ..default()
+        },
+        FrameInterpolate::<Rotation> {
+            // We must trigger change detection on visual interpolation
+            // to make sure that child entities (sprites, meshes, text)
+            // are also interpolated
+            trigger_change_detection: true,
+            ..default()
+        },
+    ));
 }
 
 /// Add components to characters that impact how they are rendered. We only
@@ -236,8 +185,6 @@ fn add_block_cosmetics(
     }
 }
 
-
-
 fn disable_projectile_rollback(
     mut commands: Commands,
     q_projectile: Query<
@@ -247,7 +194,7 @@ fn disable_projectile_rollback(
             With<ProjectileMarker>,
             // Or<(With<ProjectileMarker>, With<CharacterMarker>)>,
             // disabling character rollbacks while we debug projectiles with this janky setup
-            
+
             // We stop checking for state rollbacks after the first frame where the projectile is predicted
             Without<DeterministicPredicted>,
         ),

--- a/examples/avian_3d_character/src/shared.rs
+++ b/examples/avian_3d_character/src/shared.rs
@@ -91,11 +91,6 @@ impl Plugin for SharedPlugin {
             angular: -0.01,
         });
 
-        // app.add_systems(
-        //     FixedPostUpdate,
-        //     after_physics_log.after(PhysicsSet::StepSimulation),
-        // );
-
         app.add_plugins(
             PhysicsPlugins::default()
                 .build()
@@ -103,18 +98,6 @@ impl Plugin for SharedPlugin {
                 .disable::<PhysicsInterpolationPlugin>()
                 // disable Sleeping plugin as it can mess up physics rollbacks
                 .disable::<SleepingPlugin>(),
-        );
-
-        // add an extra sync for cases where:
-        // - we receive a Position, do a rollback and set C=Correct, apply sync
-        // - in RunFixedMainLoop, we set C=Original
-        // - FixedUpdate doesn't run because frame rate is too high!
-        // - then the Transform that we show is C=Correct instead of C=Original!
-        app.add_systems(
-            PostUpdate,
-            position_to_transform
-                .in_set(PhysicsSet::Sync)
-                .run_if(|config: Res<avian3d::sync::SyncConfig>| config.position_to_transform),
         );
     }
 }

--- a/examples/avian_physics/src/renderer.rs
+++ b/examples/avian_physics/src/renderer.rs
@@ -98,6 +98,7 @@ pub(crate) fn draw_elements(
     walls: Query<(&Wall, &ColorComponent), (Without<BallMarker>, Without<PlayerId>)>,
 ) {
     for (position, rotation, color) in &players {
+        info!("Draw player at position {position:?}");
         gizmos.rect_2d(
             Isometry2d {
                 rotation: Rot2 {

--- a/examples/deterministic_replication/Cargo.toml
+++ b/examples/deterministic_replication/Cargo.toml
@@ -20,11 +20,12 @@ lightyear = { workspace = true, features = [
   "replication",
   "leafwing",
   "deterministic",
-  "avian2d",
 ] }
 lightyear_examples_common.workspace = true
 lightyear_frame_interpolation.workspace = true
 leafwing-input-manager.workspace = true
+# add avian2d directly to customize the plugin 
+lightyear_avian2d = { workspace = true, features = ["deterministic", "2d"]}
 avian2d = { workspace = true, features = [
   "2d",
   "f32",

--- a/examples/deterministic_replication/src/main.rs
+++ b/examples/deterministic_replication/src/main.rs
@@ -94,7 +94,8 @@ fn add_input_delay(app: &mut App) {
             Input::default()
                 // Enable `no_prediction()` to do deterministic_lockstep! 100% of the latency will be covered
                 // by input delay so there won't be any rollbacks
-                .with_input_delay(InputDelayConfig::no_prediction()), // Otherwise control the input delay manually
-                                                                      // .with_input_delay(InputDelayConfig::fixed_input_delay(INPUT_DELAY_TICKS)),
+                // .with_input_delay(InputDelayConfig::no_prediction()),
+                // Otherwise control the input delay manually
+                .with_input_delay(InputDelayConfig::fixed_input_delay(INPUT_DELAY_TICKS)),
         )));
 }

--- a/examples/deterministic_replication/src/protocol.rs
+++ b/examples/deterministic_replication/src/protocol.rs
@@ -99,13 +99,13 @@ impl Plugin for ProtocolPlugin {
         app.add_rollback::<Position>()
             .add_should_rollback(position_should_rollback)
             // add a hash function to perform a checksum in order to catch desyncs
-            .add_custom_hash(lightyear::avian2d::types::position::hash)
+            .add_custom_hash(lightyear_avian2d::types::position::hash)
             .add_linear_interpolation_fn()
             .add_linear_correction_fn();
 
         app.add_rollback::<Rotation>()
             .add_should_rollback(rotation_should_rollback)
-            .add_custom_hash(lightyear::avian2d::types::rotation::hash)
+            .add_custom_hash(lightyear_avian2d::types::rotation::hash)
             .add_linear_interpolation_fn()
             .add_linear_correction_fn();
 

--- a/examples/deterministic_replication/src/shared.rs
+++ b/examples/deterministic_replication/src/shared.rs
@@ -27,7 +27,7 @@ impl Plugin for SharedPlugin {
         app.add_systems(Startup, init);
 
         // physics
-        app.add_plugins(lightyear::avian2d::plugin::LightyearAvianPlugin {
+        app.add_plugins(lightyear_avian2d::plugin::LightyearAvianPlugin {
             rollback_resources: true,
             ..default()
         });

--- a/lightyear/src/shared.rs
+++ b/lightyear/src/shared.rs
@@ -43,6 +43,13 @@ impl Plugin for SharedPlugins {
         app.add_plugins(lightyear_interpolation::plugin::InterpolationPlugin::new(
             lightyear_interpolation::plugin::InterpolationConfig::default(),
         ));
+
+        #[cfg(feature = "avian2d")]
+        app.add_plugins(lightyear_avian2d::prelude::LightyearAvianPlugin::default());
+        #[cfg(feature = "avian3d")]
+        {
+            app.add_plugins(lightyear_avian3d::prelude::LightyearAvianPlugin::default());
+        }
     }
 
     fn is_unique(&self) -> bool {

--- a/lightyear_avian/src/correction_2d.rs
+++ b/lightyear_avian/src/correction_2d.rs
@@ -1,6 +1,6 @@
-//! Handle Correction for avian. We need to handle this manually because we replicate 
+//! Handle Correction for avian. We need to handle this manually because we replicate
 //! Position and Rotation, but the visual representation is a Transform.
-//! 
+//!
 //! The flow is:
 //! - PreUpdate:
 //!   - rollback check. We store the previous Position/Rotation in PreviousVisual<Position>/PreviousVisual<Rotation>
@@ -19,84 +19,18 @@
 //!   - interpolate with FrameInterpolation<Transform>
 //!   - apply VisualCorrection<Transform> if present
 //!   - apply TransformPropagation
-//! 
+//!
 //! If the user is running FrameInterpolation<Transform>, we need to either:
 //! - in end_rollback, compute the error in Position/Rotation space, then convert it to Transform space? How do we handle the Local/Global transform?
 //! - or in end_rollback, compute the error in Position/Rotation space.
-//! 
+//!
 //! Id the user is running FrameInterpolation<GlobalTransform>, we can:
-//! - 
-
-use bevy_app::{App, Plugin};
-use bevy_ecs::change_detection::Res;
-use bevy_ecs::entity::Entity;
-use bevy_ecs::prelude::{Commands, Query, Single, With};
-use tracing::trace;
-use lightyear_core::prelude::LocalTimeline;
-use lightyear_frame_interpolation::FrameInterpolate;
-use lightyear_interpolation::prelude::InterpolationRegistry;
-use lightyear_prediction::correction::VisualCorrection;
-use lightyear_prediction::manager::PredictionManager;
-use lightyear_prediction::predicted_history::PredictionHistory;
-use lightyear_prediction::SyncComponent;
-use lightyear_replication::delta::Diffable;
-
+//! -
+use bevy_app::prelude::*;
 pub struct Correction2DPlugin;
 
-
 impl Plugin for Correction2DPlugin {
-    fn build(&self, app: &mut App) {
+    fn build(&self, _app: &mut App) {
         todo!()
-    }
-}
-
-
-/// After the rollback is over, we need to update the values in the [`FrameInterpolate<C>`] component.
-///
-/// If we have correction enabled, then we can compute the error between the previous visual value
-/// [`PreviousVisual<C>`] and the new visual value.
-pub(crate) fn update_frame_interpolation_post_rollback(
-    time: Res<Time<Fixed>>,
-    // only run if there is a VisualCorrection<C> to do.
-    timeline: Single<&LocalTimeline, With<PredictionManager>>,
-    registry: Res<InterpolationRegistry>,
-    mut query: Query<(
-        Entity,
-        &mut Position,
-        &mut Rotation,
-        &PreviousVisual<Position>,
-        &PreviousVisual<Rotation>,
-        &PredictionHistory<Position>,
-        &PredictionHistory<Rotation>,
-        &mut FrameInterpolate<Transform>,
-    )>,
-    mut commands: Commands,
-) {
-    // NOTE: this is the overstep from the previous frame since we are running this before RunFixedMainLoop
-    let overstep = time.overstep_fraction();
-    let tick = timeline.tick();
-    for (entity, position, rotation, previous_visual_position, previous_visual_rotation, position_history, rotation_history, interpolate) in query.iter_mut() {
-        k
-        interpolate.current_value = Some(component.clone());
-        interpolate.previous_value = history.nth_most_recent(1).cloned();
-        let Some(previous) = &interpolate.previous_value else {
-            continue;
-        };
-        let current_visual = registry.interpolate(previous.clone(), component.clone(), overstep);
-        // error = previous_visual - current_visual
-        let error = current_visual.diff(&previous_visual.0);
-        trace!(
-            ?tick,
-            ?entity,
-            ?current_visual,
-            ?previous_visual,
-            ?error,
-            "Updating VisualCorrection post rollback for {:?}",
-            core::any::type_name::<C>()
-        );
-        commands
-            .entity(entity)
-            .insert(VisualCorrection::<C> { error })
-            .remove::<PreviousVisual<C>>();
     }
 }

--- a/lightyear_avian/src/correction_2d.rs
+++ b/lightyear_avian/src/correction_2d.rs
@@ -1,0 +1,102 @@
+//! Handle Correction for avian. We need to handle this manually because we replicate 
+//! Position and Rotation, but the visual representation is a Transform.
+//! 
+//! The flow is:
+//! - PreUpdate:
+//!   - rollback check. We store the previous Position/Rotation in PreviousVisual<Position>/PreviousVisual<Rotation>
+//!   - apply rollback
+//!   - end rollback
+//!     - set current/previous values to be the last 2 values from the history
+//!     - compute the visual using the previous frame's overstep
+//!     - compute the error between the new visual and the previous visual (when they both use the same overstep)
+//! - BeforeFixedUpdate:
+//!   - restore Position/Rotation to the tick value from FrameInterpolation
+//! - FixedUpdate:
+//!   - Run Physics simulation
+//!   - Sync Position/Rotation to Transform
+//!   - Update FrameInterpolation<Transform> with the new Transform value
+//! - PostUpdate:
+//!   - interpolate with FrameInterpolation<Transform>
+//!   - apply VisualCorrection<Transform> if present
+//!   - apply TransformPropagation
+//! 
+//! If the user is running FrameInterpolation<Transform>, we need to either:
+//! - in end_rollback, compute the error in Position/Rotation space, then convert it to Transform space? How do we handle the Local/Global transform?
+//! - or in end_rollback, compute the error in Position/Rotation space.
+//! 
+//! Id the user is running FrameInterpolation<GlobalTransform>, we can:
+//! - 
+
+use bevy_app::{App, Plugin};
+use bevy_ecs::change_detection::Res;
+use bevy_ecs::entity::Entity;
+use bevy_ecs::prelude::{Commands, Query, Single, With};
+use tracing::trace;
+use lightyear_core::prelude::LocalTimeline;
+use lightyear_frame_interpolation::FrameInterpolate;
+use lightyear_interpolation::prelude::InterpolationRegistry;
+use lightyear_prediction::correction::VisualCorrection;
+use lightyear_prediction::manager::PredictionManager;
+use lightyear_prediction::predicted_history::PredictionHistory;
+use lightyear_prediction::SyncComponent;
+use lightyear_replication::delta::Diffable;
+
+pub struct Correction2DPlugin;
+
+
+impl Plugin for Correction2DPlugin {
+    fn build(&self, app: &mut App) {
+        todo!()
+    }
+}
+
+
+/// After the rollback is over, we need to update the values in the [`FrameInterpolate<C>`] component.
+///
+/// If we have correction enabled, then we can compute the error between the previous visual value
+/// [`PreviousVisual<C>`] and the new visual value.
+pub(crate) fn update_frame_interpolation_post_rollback(
+    time: Res<Time<Fixed>>,
+    // only run if there is a VisualCorrection<C> to do.
+    timeline: Single<&LocalTimeline, With<PredictionManager>>,
+    registry: Res<InterpolationRegistry>,
+    mut query: Query<(
+        Entity,
+        &mut Position,
+        &mut Rotation,
+        &PreviousVisual<Position>,
+        &PreviousVisual<Rotation>,
+        &PredictionHistory<Position>,
+        &PredictionHistory<Rotation>,
+        &mut FrameInterpolate<Transform>,
+    )>,
+    mut commands: Commands,
+) {
+    // NOTE: this is the overstep from the previous frame since we are running this before RunFixedMainLoop
+    let overstep = time.overstep_fraction();
+    let tick = timeline.tick();
+    for (entity, position, rotation, previous_visual_position, previous_visual_rotation, position_history, rotation_history, interpolate) in query.iter_mut() {
+        k
+        interpolate.current_value = Some(component.clone());
+        interpolate.previous_value = history.nth_most_recent(1).cloned();
+        let Some(previous) = &interpolate.previous_value else {
+            continue;
+        };
+        let current_visual = registry.interpolate(previous.clone(), component.clone(), overstep);
+        // error = previous_visual - current_visual
+        let error = current_visual.diff(&previous_visual.0);
+        trace!(
+            ?tick,
+            ?entity,
+            ?current_visual,
+            ?previous_visual,
+            ?error,
+            "Updating VisualCorrection post rollback for {:?}",
+            core::any::type_name::<C>()
+        );
+        commands
+            .entity(entity)
+            .insert(VisualCorrection::<C> { error })
+            .remove::<PreviousVisual<C>>();
+    }
+}

--- a/lightyear_avian/src/lib.rs
+++ b/lightyear_avian/src/lib.rs
@@ -29,6 +29,9 @@ pub use types_3d as types;
 #[cfg(any(feature = "2d", feature = "3d"))]
 pub mod plugin;
 
+#[cfg(feature = "2d")]
+mod correction_2d;
+
 /// Commonly used items for Lightyear Avian integration.
 pub mod prelude {
     #[cfg(feature = "lag_compensation")]

--- a/lightyear_avian/src/plugin.rs
+++ b/lightyear_avian/src/plugin.rs
@@ -77,8 +77,11 @@ impl Plugin for LightyearAvianPlugin {
                     (
                         // update physics
                         PhysicsSet::StepSimulation,
-                        // run physics before spawning we sync so that PreSpawned entities have accurate Position/Rotation values in their history
-                        PredictionSet::Sync,
+                        // TODO: run physics before we sync so that PreSpawned entities have accurate Position/Rotation values in their history -> Do we have PredictionSet::Sync systems in
+                        // FixedPostUpdate?
+
+                        // update the history only after the physics have been updated
+                        PredictionSet::UpdateHistory,
                         PhysicsSet::Sync,
                         // the transform value has to be updated (from Position) before we can store it for FrameInterpolation
                         FrameInterpolationSet::Update,
@@ -147,7 +150,7 @@ impl Plugin for LightyearAvianPlugin {
                         // update physics
                         PhysicsSet::StepSimulation,
                         // run physics before spawning we sync so that PreSpawned entities have accurate Position/Rotation values in their history
-                        PredictionSet::Sync,
+                        PredictionSet::UpdateHistory,
                         PhysicsSet::Sync,
                         // the transform value has to be updated (from Position) before we can store it for FrameInterpolation
                         FrameInterpolationSet::Update,

--- a/lightyear_avian/src/plugin.rs
+++ b/lightyear_avian/src/plugin.rs
@@ -85,15 +85,13 @@ impl Plugin for LightyearAvianPlugin {
                     )
                         .chain(),
                 );
-                // In case the user is running physics in PostUpdate: Sync Pos/Rotation to Transform before applying frame interpolation to Transform
                 app.configure_sets(
                     PostUpdate,
                     (
-                        // TODO: revisit this. The VisualCorrection is computed on the Position/Rotation, but the
-                        //  FrameInterpolation is applied to the Transform.
-                        PhysicsSet::Sync,
                         FrameInterpolationSet::Interpolate,
                         RollbackSet::VisualCorrection,
+                        // In case the user is running FrameInterpolation for Position/Rotation, we run FrameInterpolation and Correction before syncing to Transform
+                        PhysicsSet::Sync,
                         TransformSystem::TransformPropagate,
                     )
                         .chain(),

--- a/lightyear_avian2d/Cargo.toml
+++ b/lightyear_avian2d/Cargo.toml
@@ -44,6 +44,7 @@ tracing.workspace = true
 bevy_app.workspace = true
 bevy_ecs.workspace = true
 bevy_math.workspace = true
+bevy_time.workspace = true
 bevy_transform = { workspace = true, features = ["bevy-support", "libm"] }
 bevy_utils.workspace = true
 

--- a/lightyear_frame_interpolation/src/lib.rs
+++ b/lightyear_frame_interpolation/src/lib.rs
@@ -64,7 +64,7 @@ use lightyear_connection::client::Client;
 use lightyear_core::prelude::LocalTimeline;
 use lightyear_core::timeline::is_in_rollback;
 use lightyear_interpolation::prelude::InterpolationRegistry;
-use lightyear_replication::prelude::ReplicationSet;
+use lightyear_replication::prelude::ReplicationBufferSet;
 use tracing::trace;
 
 /// System sets used by the `FrameInterpolationPlugin`.
@@ -124,7 +124,7 @@ impl<C: Component<Mutability = Mutable> + Clone + Debug> Plugin for FrameInterpo
             FrameInterpolationSet::Interpolate
                 .before(TransformSystem::TransformPropagate)
                 // we don't want the visual interpolation value to be the one replicated!
-                .after(ReplicationSet::Send),
+                .after(ReplicationBufferSet::Buffer),
         );
 
         // SYSTEMS
@@ -250,8 +250,8 @@ pub(crate) fn restore_from_visual_interpolation<
         if let Some(current_value) = &interpolate_status.current_value {
             trace!(
                 ?kind,
-                ?component,
-                ?current_value,
+                visual = ?component,
+                correct = ?current_value,
                 "Restoring visual interpolation"
             );
             *component.bypass_change_detection() = current_value.clone();

--- a/lightyear_interpolation/src/lib.rs
+++ b/lightyear_interpolation/src/lib.rs
@@ -10,7 +10,7 @@ use bevy_ecs::{
     world::DeferredWorld,
 };
 use lightyear_replication::prelude::Replicated;
-use tracing::error;
+use tracing::{error};
 
 use crate::manager::InterpolationManager;
 

--- a/lightyear_prediction/src/correction.rs
+++ b/lightyear_prediction/src/correction.rs
@@ -42,7 +42,7 @@ use lightyear_core::prelude::{LocalTimeline, NetworkTimeline};
 use lightyear_frame_interpolation::FrameInterpolate;
 use lightyear_interpolation::prelude::InterpolationRegistry;
 use lightyear_replication::delta::Diffable;
-use tracing::{trace};
+use tracing::trace;
 
 /// The visual value of the component before the rollback started
 #[derive(Component, Debug, Reflect)]

--- a/lightyear_prediction/src/rollback.rs
+++ b/lightyear_prediction/src/rollback.rs
@@ -81,6 +81,7 @@ impl Plugin for RollbackPlugin {
         app.configure_sets(
             PostUpdate,
             // we add the correction error AFTER the interpolation was done
+            // (which means it's also after we buffer the component for replication)
             RollbackSet::VisualCorrection
                 .after(FrameInterpolationSet::Interpolate)
                 .in_set(PredictionSet::All),
@@ -154,7 +155,6 @@ impl Plugin for RollbackPlugin {
             ParamBuilder,
             ParamBuilder,
             ParamBuilder,
-            ParamBuilder,
         )
             .build_state(app.world_mut())
             .build_system(check_rollback)
@@ -202,7 +202,6 @@ fn check_rollback(
         With<IsSynced<InputTimeline>>,
     >,
     prediction_registry: Res<PredictionRegistry>,
-    component_registry: Res<ComponentRegistry>,
     system_ticks: SystemChangeTick,
     parallel_commands: ParallelCommands,
     mut commands: Commands,

--- a/lightyear_sync/src/timeline/input.rs
+++ b/lightyear_sync/src/timeline/input.rs
@@ -237,6 +237,14 @@ impl InputDelayConfig {
     }
 }
 
+/// Timeline that is used to keep track of when the client should buffer inputs.
+///
+/// This timeline is synced with the server timeline, and is the main driving timeline:
+/// any speed adjustments applied to this timeline will also be applied to the Time<Virtual> timeline.
+/// (and will therefore affect how fast the FixedUpdate loop runs, and how ticks are incremented)
+///
+/// This timeline is updated in PreUpdate; it CANNOT be used to get accurate `tick` in PreUpdate;
+/// use `LocalTimeline` instead.
 #[derive(Component, Deref, DerefMut, Default, Debug, Reflect)]
 pub struct InputTimeline(pub Timeline<Input>);
 


### PR DESCRIPTION
fix tricky bugs to bring back the avian2d example to be smooth

- we cannot use InputTimeline.tick() as the InputTimeline is only
  updated in PreUpdate

- the lightyear_avian plugins were not being used anymore in the
  examples, and they were missing an ordering for
  PredictionSet::UpdateHistory