### PR TITLE
Fix `InputPlugin` of `lightyear_inputs_bei` to `FixedPreUpdate`

### DIFF
--- a/lightyear_inputs_bei/src/plugin.rs
+++ b/lightyear_inputs_bei/src/plugin.rs
@@ -27,7 +27,7 @@ impl<C> Default for InputPlugin<C> {
     }
 }
 
-impl<C: InputContext> Plugin for InputPlugin<C> {
+impl<C: InputContext<Schedule = FixedPreUpdate>> Plugin for InputPlugin<C> {
     fn build(&self, app: &mut App) {
         if !app.is_plugin_added::<bevy_enhanced_input::EnhancedInputPlugin>() {
             app.add_plugins(bevy_enhanced_input::EnhancedInputPlugin);


### PR DESCRIPTION
Having a `InputContext` on `PreUpdate` causes weirdness, to prevent this `InputPlugin` (of `lightyear_inputs_bei`) now only allows `InputContext` that run in `FixedPreUpdate`