### PR TITLE
Update `rust-version` to 1.88

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ version = "0.22.5"
 authors = ["Charles Bournhonesque <charlesbour@gmail.com>"]
 publish = false
 edition = "2024"
-rust-version = "1.86"
+rust-version = "1.88"
 license = "MIT OR Apache-2.0"
 
 # Enable max optimizations for dependencies, but not for our code:


### PR DESCRIPTION
This should close https://github.com/cBournhonesque/lightyear/issues/1142 (see for more info)

Increase the minimum required rust-version to 1.88; which is the version this issue (https://github.com/rust-lang/rust/issues/53667) suggests.