### PR TITLE
fix: fix issues with deterministic replication example

### DIFF
--- a/examples/common/src/cli.rs
+++ b/examples/common/src/cli.rs
@@ -26,7 +26,9 @@ use crate::shared::{CLIENT_PORT, SERVER_ADDR, SERVER_PORT, SHARED_SETTINGS, STEA
 #[cfg(feature = "gui")]
 use bevy::window::PresentMode;
 use lightyear::link::RecvLinkConditioner;
-use lightyear::prelude::{Client, LinkConditionerConfig, LinkOf, SteamAppExt};
+#[cfg(feature = "steam")]
+use lightyear::prelude::SteamAppExt;
+use lightyear::prelude::{Client, LinkConditionerConfig, LinkOf};
 
 /// CLI options to create an [`App`]
 #[derive(Parser, Debug)]

--- a/examples/deterministic_replication/src/renderer.rs
+++ b/examples/deterministic_replication/src/renderer.rs
@@ -21,11 +21,6 @@ impl Plugin for ExampleRendererPlugin {
                 .after(RollbackSet::VisualCorrection),
         );
 
-        #[cfg(feature = "client")]
-        {
-            app.add_systems(Startup, ready_button);
-        }
-
         // add visual interpolation for Position and Rotation
         // (normally we would interpolate on Transform but here this is fine
         // since rendering is done via Gizmos that only depend on Position/Rotation)
@@ -78,36 +73,4 @@ pub(crate) fn draw_elements(
     for (wall, color) in &walls {
         gizmos.line_2d(wall.start, wall.end, color.0);
     }
-}
-
-#[cfg(feature = "client")]
-pub(crate) fn ready_button(mut commands: Commands) {
-    commands
-        .spawn((
-            Text("Ready".to_string()),
-            TextColor(Color::srgb(0.9, 0.9, 0.9)),
-            TextFont::from_font_size(20.0),
-            Button,
-            BorderColor(Color::BLACK),
-            Node {
-                width: Val::Px(150.0),
-                height: Val::Px(65.0),
-                padding: UiRect::all(Val::Px(10.0)),
-                border: UiRect::all(Val::Px(5.0)),
-                position_type: PositionType::Absolute,
-                right: Val::Percent(0.10),
-                // horizontally center child text
-                justify_content: JustifyContent::Center,
-                // vertically center child text
-                align_items: AlignItems::Center,
-                ..default()
-            },
-        ))
-        .observe(
-            |_: Trigger<Pointer<Click>>,
-             mut sender: Single<&mut TriggerSender<Ready>, (With<Client>, With<Connected>)>| {
-                info!("Client is ready!");
-                sender.trigger::<Channel1>(Ready);
-            },
-        );
 }

--- a/examples/deterministic_replication/src/shared.rs
+++ b/examples/deterministic_replication/src/shared.rs
@@ -6,6 +6,7 @@ use core::hash::{Hash, Hasher};
 use leafwing_input_manager::input_map::InputMap;
 use leafwing_input_manager::prelude::ActionState;
 use lightyear::connection::client_of::ClientOf;
+use lightyear::connection::host::HostClient;
 use lightyear::input::input_buffer::InputBuffer;
 use lightyear::prediction::predicted_history::PredictionHistory;
 use lightyear::prediction::rollback::{DeterministicPredicted, DisableRollback};
@@ -230,7 +231,7 @@ pub(crate) fn fixed_pre_physics(
 
 pub(crate) fn fixed_last_log(
     contact_graph: Res<ContactGraph>,
-    timeline: Single<(&LocalTimeline, Has<Rollback>), Or<(With<Client>, Without<ClientOf>)>>,
+    timeline: Single<(&LocalTimeline, Has<Rollback>), Or<(With<Client>, With<HostClient>)>>,
     players: Query<
         (
             Entity,

--- a/lightyear_deterministic_replication/src/checksum.rs
+++ b/lightyear_deterministic_replication/src/checksum.rs
@@ -47,6 +47,7 @@ impl ChecksumSendPlugin {
         world: ChecksumWorld<'_, '_, true>,
         client: Single<
             (
+                &LocalTimeline,
                 &LastConfirmedInput,
                 &MessageManager,
                 &mut MessageSender<ChecksumMessage>,
@@ -56,8 +57,14 @@ impl ChecksumSendPlugin {
     ) {
         let mut checksum = 0u64;
 
-        let (last_confirmed_input, message_manager, mut sender) = client.into_inner();
+        let (local_timeline, last_confirmed_input, message_manager, mut sender) =
+            client.into_inner();
+        let current_tick = local_timeline.tick();
         let tick = last_confirmed_input.tick.get();
+        // only compute the checksum when we have received remote inputs
+        if tick > current_tick {
+            return;
+        }
 
         world.iter_archetypes().for_each(|(archetype, checksum_archetype)| {
             // TODO: how can we guarantee that the order is the same on client and server? We need a stable order for entities, otherwise the checksum will differ even if the data is the same.

--- a/lightyear_inputs/src/client.rs
+++ b/lightyear_inputs/src/client.rs
@@ -43,11 +43,11 @@
 //! - handle inputs in your game logic in systems that run in the `FixedUpdate` schedule. These systems
 //!   will read the inputs using the [`InputBuffer`] component.
 
-use crate::InputChannel;
 use crate::config::{InputConfig, SharedInputConfig};
 use crate::input_buffer::InputBuffer;
 use crate::input_message::{ActionStateSequence, InputMessage, InputTarget, PerTargetData};
 use crate::plugin::InputPlugin;
+use crate::{HISTORY_DEPTH, InputChannel};
 #[cfg(feature = "metrics")]
 use alloc::format;
 use alloc::{vec, vec::Vec};
@@ -412,7 +412,7 @@ fn clean_buffers<S: ActionStateSequence>(
         return;
     };
     // assuming that we don't rollback more than 20 ticks, or send more than 20 ticks worth of inputs
-    let old_tick = local_timeline.tick() - 20;
+    let old_tick = local_timeline.tick() - HISTORY_DEPTH;
 
     // trace!(
     //     "popping all input buffers since old tick: {old_tick:?}",

--- a/lightyear_inputs/src/lib.rs
+++ b/lightyear_inputs/src/lib.rs
@@ -20,6 +20,8 @@ pub mod plugin;
 #[cfg(feature = "server")]
 pub mod server;
 
+pub(crate) const HISTORY_DEPTH: u16 = 20;
+
 /// Default channel to send inputs from client to server. This is a Sequenced Unreliable channel.
 /// A marker struct for the default channel used to send inputs from client to server.
 ///

--- a/lightyear_prediction/src/predicted_history.rs
+++ b/lightyear_prediction/src/predicted_history.rs
@@ -46,6 +46,10 @@ pub(crate) fn update_prediction_history<T: Component + Clone>(
     for (component, mut history) in query.iter_mut() {
         // change detection works even when running the schedule for rollback
         if component.is_changed() {
+            trace!(
+                "Prediction history changed for tick {tick:?} component {:?}",
+                core::any::type_name::<T>()
+            );
             history.add_update(tick, component.deref().clone());
         }
     }
@@ -61,6 +65,11 @@ pub(crate) fn handle_tick_event_prediction_history<C: Component>(
     mut query: Query<&mut PredictionHistory<C>>,
 ) {
     for mut history in query.iter_mut() {
+        trace!(
+            "Prediction history updated for {:?} with tick delta {:?}",
+            core::any::type_name::<C>(),
+            trigger.tick_delta
+        );
         history.update_ticks(trigger.tick_delta);
     }
 }
@@ -251,6 +260,11 @@ pub(crate) fn add_prediction_history<C: Component>(
     >,
 ) {
     if query.get(trigger.target()).is_ok() {
+        trace!(
+            "Add prediction history for {:?} on entity {:?}",
+            core::any::type_name::<C>(),
+            trigger.target()
+        );
         commands
             .entity(trigger.target())
             .insert(PredictionHistory::<C>::default());


### PR DESCRIPTION
Fixes https://github.com/cBournhonesque/lightyear/issues/1139

1) the example didn't work in host-client mode because the input-buffer
   maintained by the host-client was not long enough (we were using the
   `clear_buffer` method from the server InputPlugin) which was
   aggressively clearing all inputs

2) Simplify the example by removing the `Ready` buttons and directly
   spawning the players

3) Issue where the Checksum plugin was calling `pop_until_tick` on the
   PredictionHistory even when LastConfirmedTick = tick + 1000, which
   was replacing the correct history tick value