### PR TITLE
Enable replay protection only after Connection

### DIFF
--- a/lightyear_netcode/src/client.rs
+++ b/lightyear_netcode/src/client.rs
@@ -492,7 +492,7 @@ impl<Ctx> Client<Ctx> {
             self.token.protocol_id,
             now,
             self.token.server_to_client_key,
-            Some(&mut self.replay_protection),
+            (self.state == ClientState::Connected).then_some(&mut self.replay_protection),
             Self::ALLOWED_PACKETS,
         ) {
             Ok(packet) => packet,


### PR DESCRIPTION
If we are trying to reconnect frequently, the client could
- receive older packets that were sent by the server
- those packets would get registered in the ReplayProtectionBuffer
- then newer packets sent by the Server (with a sequence_id that is reset to the default value) would get ignored because of the ReplayProtectionBuffer

Instead we activate the replay protection buffer only after the client is connected.

(The main goal of the replay buffer is to prevent an attacker from sending existing received packets again)