### PR TITLE
skip spawning predicted/interpolated entities if not connected

### DIFF
--- a/lightyear_interpolation/src/spawn.rs
+++ b/lightyear_interpolation/src/spawn.rs
@@ -9,10 +9,11 @@ use bevy_ecs::{
 use lightyear_core::prelude::{LocalTimeline, NetworkTimeline};
 use lightyear_replication::prelude::{Confirmed, ReplicationReceiver, ShouldBeInterpolated};
 use tracing::trace;
+use lightyear_connection::client::Connected;
 
 /// Spawn an interpolated entity for each confirmed entity that has the `ShouldBeInterpolated` component added
 pub(crate) fn spawn_interpolated_entity(
-    connection: Single<(&ReplicationReceiver, &LocalTimeline), With<InterpolationManager>>,
+    connection: Single<(&ReplicationReceiver, &LocalTimeline), (With<InterpolationManager>, With<Connected>)>,
     mut commands: Commands,
     mut confirmed_entities: Query<(Entity, Option<&mut Confirmed>), Added<ShouldBeInterpolated>>,
 ) -> Result {

--- a/lightyear_prediction/src/spawn.rs
+++ b/lightyear_prediction/src/spawn.rs
@@ -9,6 +9,7 @@ use bevy_ecs::{
 use lightyear_core::prelude::{LocalTimeline, NetworkTimeline};
 use lightyear_replication::prelude::{Confirmed, ReplicationReceiver, ShouldBePredicted};
 use tracing::debug;
+use lightyear_connection::client::Connected;
 
 /// Spawn a predicted entity for each confirmed entity that has the `ShouldBePredicted` component added
 /// The `Confirmed` entity could already exist because we share the Confirmed component for prediction and interpolation.
@@ -19,7 +20,7 @@ pub(crate) fn spawn_predicted_entity(
     // only handle predicted that have ShouldBePredicted
     // (if the entity was handled by prespawn or prepredicted before, ShouldBePredicted gets removed)
     mut confirmed_entities: Query<(Entity, Option<&mut Confirmed>), Added<ShouldBePredicted>>,
-    link: Single<(&ReplicationReceiver, &LocalTimeline), With<PredictionManager>>,
+    link: Single<(&ReplicationReceiver, &LocalTimeline), (With<PredictionManager>, With<Connected>)>,
 ) {
     let (receiver, timeline) = link.into_inner();
     // TODO: should we check if the sender for the entity corresponds to the link?


### PR DESCRIPTION
Might help with https://github.com/cBournhonesque/lightyear/issues/1159