### PR TITLE
Feature: enable customizing input rebroadcasting target

### DIFF
--- a/lightyear_inputs/src/client.rs
+++ b/lightyear_inputs/src/client.rs
@@ -87,7 +87,7 @@ use lightyear_sync::prelude::InputTimeline;
 use lightyear_sync::prelude::client::IsSynced;
 use lightyear_transport::channel::ChannelKind;
 use lightyear_transport::prelude::ChannelRegistry;
-use tracing::{debug, error, trace};
+use tracing::{debug, error, trace, warn};
 
 #[derive(SystemSet, Debug, Hash, PartialEq, Eq, Clone, Copy)]
 pub enum InputSet {
@@ -633,7 +633,7 @@ fn receive_remote_player_input_messages<S: ActionStateSequence>(
                 InputTarget::ActionEntity(entity) | InputTarget::PrePredictedEntity(entity) => Some(entity),
             };
             let Some(entity) = entity else {
-                error!("Could not find entity in entity_map for remote player input message {:?}", target_data.target);
+                warn!("Could not find entity in entity_map for remote player input message {:?}", target_data.target);
                 continue;
             };
             debug!(

--- a/lightyear_inputs/src/lib.rs
+++ b/lightyear_inputs/src/lib.rs
@@ -41,6 +41,6 @@ pub mod prelude {
     }
     #[cfg(feature = "server")]
     pub mod server {
-        pub use crate::server::{InputSet, ServerInputPlugin};
+        pub use crate::server::{InputRebroadcaster, InputSet, ServerInputPlugin};
     }
 }

--- a/lightyear_sync/src/lib.rs
+++ b/lightyear_sync/src/lib.rs
@@ -36,7 +36,7 @@ pub mod prelude {
     pub use crate::ping::PingChannel;
     pub use crate::ping::manager::{PingConfig, PingManager};
     pub use crate::ping::message::{Ping, Pong};
-    pub use crate::plugin::{TimelineSyncPlugin, SyncSet};
+    pub use crate::plugin::{SyncSet, TimelineSyncPlugin};
     pub use crate::timeline::sync::{IsSynced, SyncConfig};
     pub use crate::timeline::{DrivingTimeline, input::InputTimeline};
 

--- a/lightyear_tests/src/stepper.rs
+++ b/lightyear_tests/src/stepper.rs
@@ -75,7 +75,7 @@ impl ClientServerStepper {
             InputPlugin,
             LogPlugin::default(),
         ));
-        server_app.add_plugins(server::ServerPlugins { tick_duration });
+        server_app.add_plugins((server::ServerPlugins { tick_duration }, RoomPlugin));
         // ProtocolPlugin needs to be added AFTER InputPlugin
         server_app.add_plugins(ProtocolPlugin);
         let server_entity = server_app


### PR DESCRIPTION
You can add a `InputRebroadcaster` component on a ClientOf entity to customize the list of clients that we will rebroadcast the inputs to