### PR TITLE
Fix link typo to ServerPlugins in setup.md

### DIFF
--- a/book/src/tutorial/setup.md
+++ b/book/src/tutorial/setup.md
@@ -2,7 +2,7 @@
 
 `lightyear` is split up into multiple crates that each provide a facet of networking.
 The main crate `lightyear` provides an easy way of importing all the other crates and settings up the necessary plugins.
-In particular it provides 2 plugin groups that set up the various systems needed for multiplayer app: [`ClientPlugins`](https://docs.rs/lightyear/latest/lightyear/prelude/client/struct.ClientPlugins.html) and [`ServerPlugins`](https://docs.rs/lightyear/latest/lightyear/prelude/client/struct.ServerPlugins.html).
+In particular it provides 2 plugin groups that set up the various systems needed for multiplayer app: [`ClientPlugins`](https://docs.rs/lightyear/latest/lightyear/prelude/client/struct.ClientPlugins.html) and [`ServerPlugins`](https://docs.rs/lightyear/latest/lightyear/prelude/server/struct.ServerPlugins.html).
 
 There are many different sub-plugins that handle most of the complexities of networking, such as:
 


### PR DESCRIPTION
https://docs.rs/lightyear/latest/lightyear/prelude/client/struct.ServerPlugins.html
leads to "The requested resource does not exist" page.
The "client" in the link is probably a typo and changing it to "server" makes the URL valid and actually point to ServerPlugins struct documentation.