### PR TITLE
fix: export server wasm types

### DIFF
--- a/lightyear/src/lib.rs
+++ b/lightyear/src/lib.rs
@@ -232,8 +232,9 @@ fn component_inserted(query: Query<Entity, (With<Replicated>, Added<MyComponent>
 #[cfg(feature = "client")]
 mod client;
 
-#[cfg(all(feature = "server", not(target_family = "wasm")))]
+#[cfg(feature = "server")]
 mod server;
+
 mod shared;
 
 #[cfg(feature = "replication")]
@@ -404,7 +405,7 @@ pub mod prelude {
         }
     }
 
-    #[cfg(all(feature = "server", not(target_family = "wasm")))]
+    #[cfg(feature = "server")]
     pub mod server {
         pub use crate::server::ServerPlugins;
         pub use lightyear_connection::prelude::server::*;
@@ -419,7 +420,7 @@ pub mod prelude {
         pub use lightyear_steam::prelude::server::*;
         #[cfg(feature = "websocket")]
         pub use lightyear_websocket::prelude::server::*;
-        #[cfg(feature = "webtransport")]
+        #[cfg(all(feature = "webtransport", not(target_family = "wasm")))]
         pub use lightyear_webtransport::prelude::server::*;
 
         #[cfg(any(feature = "input_native", feature = "leafwing", feature = "input_bei"))]

--- a/lightyear/src/server.rs
+++ b/lightyear/src/server.rs
@@ -68,13 +68,13 @@ impl PluginGroup for ServerPlugins {
         let builder = builder.add(lightyear_prediction::server::ServerPlugin);
 
         // IO
-        #[cfg(feature = "udp")]
+        #[cfg(all(feature = "udp", not(target_family = "wasm")))]
         let builder = builder.add(lightyear_udp::server::ServerUdpPlugin);
-        #[cfg(feature = "webtransport")]
+        #[cfg(all(feature = "webtransport", not(target_family = "wasm")))]
         let builder = builder.add(lightyear_webtransport::server::WebTransportServerPlugin);
-        #[cfg(feature = "websocket")]
+        #[cfg(all(feature = "websocket", not(target_family = "wasm")))]
         let builder = builder.add(lightyear_websocket::server::WebSocketServerPlugin);
-        #[cfg(feature = "steam")]
+        #[cfg(all(feature = "steam", not(target_family = "wasm")))]
         let builder = builder.add(lightyear_steam::server::SteamServerPlugin);
 
         // CONNECTION


### PR DESCRIPTION
`lightyear::prelude::server::*` is hidden behind a wasm target cfg.

Some types I need that are missing for host-client “single player”:

- lightyear::prelude::server::NetcodeConfig
- lightyear::prelude::server::ClientOf
- lightyear::prelude::server::ServerPlugins

This change will export more types from the server prelude to allow "server" compilation in wasm32, without including any server native only IO.