### PR TITLE
Fix steam callback system

### DIFF
--- a/lightyear_steam/src/lib.rs
+++ b/lightyear_steam/src/lib.rs
@@ -16,7 +16,7 @@ extern crate alloc;
 extern crate std;
 
 use bevy_app::PreUpdate;
-use bevy_ecs::prelude::NonSend;
+use bevy_ecs::prelude::Res;
 
 #[cfg(feature = "client")]
 pub mod client;
@@ -62,7 +62,7 @@ impl SteamAppExt for bevy_app::App {
         steam.networking_utils().init_relay_network_access();
 
         self.insert_resource(prelude::SteamworksClient(steam))
-            .add_systems(PreUpdate, |steam: NonSend<prelude::SteamworksClient>| {
+            .add_systems(PreUpdate, |steam: Res<prelude::SteamworksClient>| {
                 steam.run_callbacks();
             });
         self


### PR DESCRIPTION
The NonSend resource insertion was removed here:
https://github.com/cBournhonesque/lightyear/commit/55eeef99590e8e2c9eb0460bd6ac017963aeb282#diff-c3e1a634cd860af3b6a4913834dc86fa6f2ed66990f4b16374366f66ef6163fc

So it crashes the app when it tries to run the system. Changed it to using Res on my fork and it works as expected.