### PR TITLE
fix(transport): fix rare bug when ack metadata causes a panic on wrapped PacketId

### DIFF
--- a/lightyear_transport/src/plugin.rs
+++ b/lightyear_transport/src/plugin.rs
@@ -1,3 +1,4 @@
+use alloc::vec;
 use crate::channel::builder::Transport;
 use crate::channel::receivers::ChannelReceive;
 use crate::channel::registry::{ChannelId, ChannelRegistry};
@@ -210,7 +211,7 @@ impl TransportPlugin {
                                         if *num_fragments == 0 {
                                             entry.remove();
                                             trace!(
-                                                "Acked all fragments in packet: channel={:?},message_ack={:?}",
+                                                "Acked all fragments in message: channel={:?},message_ack={:?}",
                                                 sender_metadata.name, message_ack
                                             );
                                             sender_metadata.message_acks.push(message_ack.message_id);
@@ -322,9 +323,11 @@ impl TransportPlugin {
                             if let Some(num_fragments) = metadata.num_fragments {
                                 transport.fragment_acks.insert(metadata.message, num_fragments);
                             }
-
+                            
                             transport.packet_to_message_map
                                 .entry(packet.packet_id)
+                                // we could have some old data from wrapped PacketIds, so we start by clearing
+                                .and_modify(|v| v.clear())
                                 .or_default()
                                 .push((*channel_kind, MessageAck {
                                     message_id: metadata.message,


### PR DESCRIPTION
- On Send, we track a map from PacketId to messages stored in that packet id.

- On receiving an ack, we clear that map

However when a packet is lost, we wouldn't clear the map and an old packetId -> message mapping would be stored.