### PR TITLE
feature: simplify interpolation

### DIFF
--- a/demos/spaceships/src/renderer.rs
+++ b/demos/spaceships/src/renderer.rs
@@ -56,19 +56,19 @@ impl Plugin for ExampleRendererPlugin {
 
         // observers that add VisualInterpolationStatus components to entities which receive
         // a Position
-        app.add_observer(add_visual_interpolation_components);
+        app.add_observer(add_frame_interpolation_components);
     }
 }
 
-// Non-wall entities get some visual interpolation by adding the lightyear
-// VisualInterpolateStatus component
+// Non-wall entities get some frame interpolation by adding the lightyear
+// FrameInterpolate component
 //
 // We query filter With<Predicted> so that the correct client entities get visual-interpolation.
-// We don't want to visually interpolate the client's Confirmed entities, since they are not rendered.
+// We don't want to frame interpolate the client's Confirmed entities, since they are not rendered.
 //
 // We must trigger change detection so that the Transform updates from interpolation
 // will be propagated to children (sprites, meshes, text, etc.)
-fn add_visual_interpolation_components(
+fn add_frame_interpolation_components(
     // We use Position because it's added by avian later, and when it's added
     // we know that Predicted is already present on the entity
     trigger: Trigger<OnAdd, Position>,

--- a/examples/avian_3d_character/src/renderer.rs
+++ b/examples/avian_3d_character/src/renderer.rs
@@ -66,12 +66,12 @@ fn init(mut commands: Commands) {
     ));
 }
 
-/// Add the VisualInterpolateStatus::<Transform> component to non-floor entities with
-/// component `Position`. Floors don't need to be visually interpolated because we
+/// Add the FrameInterpolate::<Position> component to non-floor entities with
+/// component `Position`. Floors don't need to be frame interpolated because we
 /// don't expect them to move.
 ///
 /// We query Without<Confirmed> instead of With<Predicted> so that the server's
-/// gui will also get some visual interpolation. But we're usually just
+/// gui will also get some frame interpolation. But we're usually just
 /// concerned that the client's Predicted entities get the interpolation
 /// treatment.
 fn add_visual_interpolation_components(

--- a/examples/bevy_enhanced_inputs/src/shared.rs
+++ b/examples/bevy_enhanced_inputs/src/shared.rs
@@ -44,12 +44,7 @@ pub(crate) fn confirmed_log(
 pub(crate) fn interpolate_log(
     timeline: Single<&LocalTimeline, Or<(With<Client>, Without<ClientOf>)>>,
     players: Query<
-        (
-            Entity,
-            &PlayerPosition,
-            &InterpolateStatus<PlayerPosition>,
-            &ConfirmedHistory<PlayerPosition>,
-        ),
+        (Entity, &PlayerPosition, &ConfirmedHistory<PlayerPosition>),
         With<Interpolated>,
     >,
 ) {

--- a/examples/simple_box/src/shared.rs
+++ b/examples/simple_box/src/shared.rs
@@ -53,20 +53,20 @@ pub(crate) fn confirmed_log(
 }
 
 pub(crate) fn interpolate_log(
-    timeline: Single<&LocalTimeline, Or<(With<Client>, Without<ClientOf>)>>,
+    timeline: Single<
+        (&LocalTimeline, &InterpolationTimeline),
+        Or<(With<Client>, Without<ClientOf>)>,
+    >,
     players: Query<
-        (
-            Entity,
-            &PlayerPosition,
-            &InterpolateStatus<PlayerPosition>,
-            &ConfirmedHistory<PlayerPosition>,
-        ),
+        (Entity, &PlayerPosition, &ConfirmedHistory<PlayerPosition>),
         With<Interpolated>,
     >,
 ) {
+    let (timeline, interpolation_timeline) = timeline.into_inner();
     let tick = timeline.tick();
+    let interpolation_tick = interpolation_timeline.tick();
     for status in players.iter() {
-        trace!(?tick, ?status, "Interpolation");
+        trace!(?tick, ?interpolation_tick, ?status, "Interpolation");
     }
 }
 

--- a/lightyear_core/src/history_buffer.rs
+++ b/lightyear_core/src/history_buffer.rs
@@ -89,6 +89,11 @@ impl<R> HistoryBuffer<R> {
         self.buffer.back()
     }
 
+    /// Get the n-th most recent value in the buffer (starts from n = 0)
+    pub fn get_nth(&self, n: usize) -> Option<&(Tick, HistoryState<R>)> {
+        self.buffer.get(n)
+    }
+
     #[doc(hidden)]
     /// Get the second most recent value in the buffer, knowing that tick is the current tick.
     ///
@@ -187,6 +192,11 @@ impl<R> HistoryBuffer<R> {
     #[cfg(feature = "test_utils")]
     pub fn buffer(&self) -> &VecDeque<(Tick, HistoryState<R>)> {
         &self.buffer
+    }
+
+    /// Pop the oldest value in the history
+    pub fn pop(&mut self) -> Option<(Tick, HistoryState<R>)> {
+        self.buffer.pop_front()
     }
 }
 

--- a/lightyear_interpolation/src/despawn.rs
+++ b/lightyear_interpolation/src/despawn.rs
@@ -1,4 +1,3 @@
-use crate::interpolate::InterpolateStatus;
 use crate::interpolation_history::ConfirmedHistory;
 use bevy_ecs::component::Component;
 use bevy_ecs::{
@@ -19,7 +18,7 @@ pub(crate) fn removed_components<C: Component>(
         && let Some(interpolated) = confirmed.interpolated
         && let Ok(mut entity) = commands.get_entity(interpolated)
     {
-        entity.try_remove::<(C, ConfirmedHistory<C>, InterpolateStatus<C>)>();
+        entity.try_remove::<(C, ConfirmedHistory<C>)>();
     }
 }
 

--- a/lightyear_interpolation/src/lib.rs
+++ b/lightyear_interpolation/src/lib.rs
@@ -15,7 +15,7 @@ use tracing::{debug, error};
 use crate::manager::InterpolationManager;
 
 mod despawn;
-/// Contains the `InterpolateStatus` component and interpolation logic.
+/// Contains interpolation logic.
 pub mod interpolate;
 /// Defines `ConfirmedHistory` for storing historical states of confirmed entities.
 pub mod interpolation_history;
@@ -29,7 +29,7 @@ pub mod timeline;
 
 /// Commonly used items for client-side interpolation.
 pub mod prelude {
-    pub use crate::interpolate::InterpolateStatus;
+    pub use crate::interpolate::interpolation_fraction;
     pub use crate::interpolation_history::ConfirmedHistory;
     pub use crate::manager::InterpolationManager;
     pub use crate::plugin::{InterpolationDelay, InterpolationPlugin, InterpolationSet};

--- a/lightyear_interpolation/src/sync.rs
+++ b/lightyear_interpolation/src/sync.rs
@@ -14,7 +14,8 @@ use bevy_reflect::Reflect;
 use lightyear_replication::components::{Confirmed, Replicated};
 use lightyear_replication::prelude::ComponentRegistry;
 use lightyear_replication::registry::buffered::BufferedChanges;
-use tracing::trace;
+#[allow(unused_imports)]
+use tracing::{info, trace};
 
 /// Plugin that syncs components that were inserted on the Confirmed entity to the Interpolated entity
 pub(crate) struct SyncPlugin;
@@ -70,6 +71,7 @@ struct InterpolatedSyncEvent {
 pub(crate) struct InterpolationSyncBuffer(BufferedChanges);
 
 /// Sync components from confirmed entity to interpolated entity
+// TODO: sync removals! when C gets removed on confirmed, we should remove C + ConfirmedHistory<C> on interpolated
 fn apply_interpolated_sync(world: &mut World) {
     world.resource_scope(|world, mut events: Mut<Events<InterpolatedSyncEvent>>| {
         events.drain().for_each(|event| {

--- a/lightyear_transport/src/packet/priority_manager.rs
+++ b/lightyear_transport/src/packet/priority_manager.rs
@@ -9,6 +9,7 @@ use crate::channel::registry::{ChannelId, ChannelRegistry};
 use crate::packet::message::{FragmentData, MessageData, SendMessage, SingleData};
 use governor::{DefaultDirectRateLimiter, Quota};
 use lightyear_core::network::NetId;
+#[cfg(feature = "metrics")]
 use lightyear_serde::ToBytes;
 use nonzero_ext::*;
 #[cfg(feature = "trace")]

--- a/lightyear_transport/src/plugin.rs
+++ b/lightyear_transport/src/plugin.rs
@@ -1,4 +1,3 @@
-use alloc::vec;
 use crate::channel::builder::Transport;
 use crate::channel::receivers::ChannelReceive;
 use crate::channel::registry::{ChannelId, ChannelRegistry};
@@ -347,7 +346,6 @@ impl TransportPlugin {
                             if let Some(num_fragments) = metadata.num_fragments {
                                 transport.fragment_acks.insert(metadata.message, num_fragments);
                             }
-                            
                             transport.packet_to_message_map
                                 .entry(packet.packet_id)
                                 // we could have some old data from wrapped PacketIds, so we start by clearing


### PR DESCRIPTION
The current interpolation system is pretty complicated, and has a lot of extra clones with InterpolateStatus. It can be simplified by instead just updating the ConfirmedHistory so that we always need to interpolate between the first two values.