### PR TITLE
fix: don't import websocket server prelude in wasm

### DIFF
--- a/lightyear/src/lib.rs
+++ b/lightyear/src/lib.rs
@@ -421,7 +421,7 @@ pub mod prelude {
         pub use lightyear_netcode::prelude::server::*;
         #[cfg(feature = "steam")]
         pub use lightyear_steam::prelude::server::*;
-        #[cfg(feature = "websocket")]
+        #[cfg(all(feature = "websocket", not(target_family = "wasm")))]
         pub use lightyear_websocket::prelude::server::*;
         #[cfg(all(feature = "webtransport", not(target_family = "wasm")))]
         pub use lightyear_webtransport::prelude::server::*;


### PR DESCRIPTION
Existing wasm builds are broken with "could not find `server` in `prelude`" even when they don't use the `server` feature of lightyear. 

This fixes the issue, but it seems off that builds try to import websocket server prelude even without `server` feature.