### PR TITLE
fix: Add `Without<HostClient>` to recieve and buffer in replication

### DIFF
--- a/lightyear_replication/src/receive.rs
+++ b/lightyear_replication/src/receive.rs
@@ -8,6 +8,7 @@ use bevy_ecs::{
     schedule::IntoScheduleConfigs,
 };
 use bevy_platform::collections::{HashMap, HashSet};
+use lightyear_connection::host::HostClient;
 
 use crate::components::{Confirmed, InitialReplicated, Replicated};
 use crate::message::{ActionsMessage, SenderMetadata, SpawnAction, UpdatesMessage};
@@ -88,7 +89,7 @@ impl ReplicationReceivePlugin {
                 &mut MessageReceiver<UpdatesMessage>,
                 &mut ReplicationReceiver,
             ),
-            With<Connected>,
+            (With<Connected>, Without<HostClient>),
         >,
     ) {
         #[cfg(feature = "metrics")]

--- a/lightyear_replication/src/send/buffer.rs
+++ b/lightyear_replication/src/send/buffer.rs
@@ -26,6 +26,7 @@ use bevy_ecs::{
 };
 use bevy_ptr::Ptr;
 use lightyear_connection::client::Connected;
+use lightyear_connection::host::HostClient;
 use lightyear_core::tick::Tick;
 use lightyear_core::timeline::{LocalTimeline, NetworkTimeline};
 use lightyear_link::prelude::Server;
@@ -70,7 +71,7 @@ pub(crate) fn replicate(
             Option<&DeltaManager>,
             Option<&LinkOf>,
         ),
-        With<Connected>,
+        (With<Connected>, Without<HostClient>),
     >,
     delta_query: Query<&DeltaManager, With<Server>>,
     component_registry: Res<ComponentRegistry>,


### PR DESCRIPTION
To fix replication issues when using HostClient related to:  [discord conversation](https://discord.com/channels/691052431525675048/1189344685546811564/1421581519398502472)

No need to merge, just making sure it's not forgotten :)