### PR TITLE
fix: more input improvements

### DIFF
--- a/lightyear_inputs/src/client.rs
+++ b/lightyear_inputs/src/client.rs
@@ -608,7 +608,7 @@ fn receive_remote_player_input_messages<S: ActionStateSequence>(
                 // do not parse the remote message our current Buffer end_tick is later than the message end_tick
                 // this can happen if we receive multiple messages out of order.
                 if input_buffer.last_remote_tick.is_some_and(|t| t >= message.end_tick) {
-                    trace!("Ignoring input message because our current last_remote_tick {:?} is more recent than the remote_end_tick", input_buffer.last_remote_tick);
+                    trace!("Ignoring input message because our current last_remote_tick {:?} is more recent than the remote_end_tick {:?}", input_buffer.last_remote_tick, message.end_tick);
                     continue
                 }
                 update_buffer_from_remote_player_message::<S>(

--- a/lightyear_inputs/src/config.rs
+++ b/lightyear_inputs/src/config.rs
@@ -46,7 +46,7 @@ impl<A> Default for InputConfig<A> {
         InputConfig {
             #[cfg(feature = "interpolation")]
             lag_compensation: false,
-            packet_redundancy: 3,
+            packet_redundancy: 5,
             send_interval: Duration::default(),
             ignore_rollbacks: false,
             rebroadcast_inputs: false,

--- a/lightyear_inputs/src/server.rs
+++ b/lightyear_inputs/src/server.rs
@@ -172,9 +172,11 @@ fn receive_input_message<S: ActionStateSequence>(
                 error!("Received input message from HostClient for action {:?} even though rebroadcasting is disabled. Ignoring the message.", DebugName::type_name::<S::Action>());
                 return Ok(())
             }
-            if message.is_empty() {
-                return Ok(())
-            }
+            // NOTE: This can cause issues because the clients expect a steady stream of messages.
+            //  For example the LastConfirmedTick could be really old which would cause a massive rollback
+            // if message.is_empty() {
+            //     return Ok(())
+            // }
             trace!(?client_id, action = ?DebugName::type_name::<S::Action>(), ?message.end_tick, ?message.inputs, "received input message");
 
             // TODO: or should we try to store in a buffer the interpolation delay for the exact tick

--- a/lightyear_inputs_native/Cargo.toml
+++ b/lightyear_inputs_native/Cargo.toml
@@ -30,6 +30,9 @@ bevy_derive.workspace = true
 bevy_ecs.workspace = true
 bevy_reflect.workspace = true
 
+[dev-dependencies]
+test-log.workspace = true
+
 [lints]
 workspace = true
 

--- a/lightyear_messages/src/registry.rs
+++ b/lightyear_messages/src/registry.rs
@@ -118,7 +118,7 @@ pub(crate) struct SendTriggerMetadata {
 /// struct MyMessage;
 ///
 /// fn add_messages(app: &mut App) {
-///   app.add_message::<MyMessage>()
+///   app.register_message::<MyMessage>()
 ///     .add_direction(NetworkDirection::ServerToClient);
 /// }
 /// ```
@@ -149,7 +149,7 @@ pub(crate) struct SendTriggerMetadata {
 /// }
 ///
 /// fn add_messages(app: &mut App) {
-///   app.add_message::<MyMessage>()
+///   app.register_message::<MyMessage>()
 ///       .add_map_entities();
 /// }
 /// ```

--- a/lightyear_prediction/src/correction.rs
+++ b/lightyear_prediction/src/correction.rs
@@ -197,9 +197,9 @@ pub struct CorrectionPolicy {
 impl Default for CorrectionPolicy {
     fn default() -> Self {
         Self {
-            decay_period: core::time::Duration::from_millis(100),
+            decay_period: core::time::Duration::from_millis(200),
             decay_ratio: 0.5,
-            max_correction_period: core::time::Duration::from_secs(500),
+            max_correction_period: core::time::Duration::from_secs(600),
         }
     }
 }


### PR DESCRIPTION
- Server always rebroadcast inputs even if they are empty, as that updates the `last_remote_tick` on the client and is valuable information
- In `update_buffer`:
  - check for mismatch even if the input is SameAsPrecedent
  - clear the input buffer after any mismatch
  - fetch the existing value from the InputBuffer instead of taking it from the `last_remote_tick`, which might be old