### PR TITLE
feat: improve DeterministicPredicted

### DIFF
--- a/examples/deterministic_replication/src/client.rs
+++ b/examples/deterministic_replication/src/client.rs
@@ -17,9 +17,7 @@ pub struct ExampleClientPlugin;
 
 impl Plugin for ExampleClientPlugin {
     fn build(&self, app: &mut App) {
-        app.add_systems(FixedUpdate, handle_game_start);
         app.add_observer(handle_player_spawn);
-        app.add_observer(handle_ball_spawn);
     }
 }
 
@@ -42,7 +40,6 @@ fn handle_player_spawn(
     let mut entity_mut = commands.entity(trigger.entity);
     entity_mut.insert(player_bundle(peer_id));
     // keep track of when the entity was spawned
-    entity_mut.insert(Spawned(tick));
     if local_id.0 == peer_id {
         entity_mut.insert(InputMap::new([
             (PlayerActions::Up, KeyCode::KeyW),
@@ -51,55 +48,4 @@ fn handle_player_spawn(
             (PlayerActions::Right, KeyCode::KeyD),
         ]));
     }
-}
-
-// Same thing, we insert Spawned on the ball so that DisableRollback can get removed
-fn handle_ball_spawn(
-    trigger: On<Add, BallMarker>,
-    client: Single<&LocalTimeline, With<Client>>,
-    mut commands: Commands,
-) {
-    commands
-        .entity(trigger.entity)
-        .insert(Spawned(client.tick()));
-}
-
-#[derive(Component)]
-struct Spawned(Tick);
-
-/// Remove the DisableRollback component from all entities a little bit after the game started.
-///
-/// Set the correct color to show that we are ready.
-fn handle_game_start(
-    timeline: Single<&LocalTimeline, (With<Client>, With<IsSynced<InputTimeline>>)>,
-    mut query: Query<
-        (
-            Entity,
-            Option<&PlayerId>,
-            Option<&mut ColorComponent>,
-            &Spawned,
-            &PredictionHistory<Position>,
-        ),
-        With<DisableRollback>,
-    >,
-    mut commands: Commands,
-) {
-    let tick = timeline.tick();
-    query
-        .iter_mut()
-        .for_each(|(e, player, color, spawned, history)| {
-            if tick > spawned.0 + 20 {
-                info!(
-                    "Removed DisableRollback from entity: {:?}. History: {:?}",
-                    e, history
-                );
-                if let (Some(player), Some(mut color)) = (player, color) {
-                    color.0 = color_from_id(player.0);
-                }
-                commands
-                    .entity(e)
-                    .remove::<DisableRollback>()
-                    .remove::<Spawned>();
-            }
-        });
 }

--- a/examples/deterministic_replication/src/main.rs
+++ b/examples/deterministic_replication/src/main.rs
@@ -67,6 +67,7 @@ fn main() {
     app.run();
 }
 
+
 #[cfg(feature = "client")]
 fn add_input_delay(app: &mut App) {
     use lightyear::prelude::client::{Input, InputDelayConfig};

--- a/examples/projectiles/src/client.rs
+++ b/examples/projectiles/src/client.rs
@@ -103,8 +103,11 @@ pub(crate) fn handle_deterministic_spawn(
     {
         commands.entity(trigger.entity).insert((
             shared::player_bundle(player_id.0, GameReplicationMode::OnlyInputsReplicated),
-            DeterministicPredicted,
-            DisableRollback,
+            DeterministicPredicted {
+                // make sure that we don't despawn the player if there is a rollback
+                skip_despawn: true,
+                ..default()
+            },
         ));
         info!("Adding PlayerContext for player {:?}", player_id);
 

--- a/examples/projectiles/src/shared.rs
+++ b/examples/projectiles/src/shared.rs
@@ -814,7 +814,7 @@ mod full_entity {
                 }
                 GameReplicationMode::OnlyInputsReplicated => {
                     // do hit detection
-                    commands.spawn((spawn_bundle, DeterministicPredicted));
+                    commands.spawn((spawn_bundle, DeterministicPredicted::default()));
                 }
             }
         }
@@ -901,7 +901,7 @@ mod full_entity {
                     // we don't spawn anything, it will be replicated to us
                 }
                 GameReplicationMode::OnlyInputsReplicated => {
-                    commands.spawn((bullet_bundle, DeterministicPredicted));
+                    commands.spawn((bullet_bundle, DeterministicPredicted::default()));
                 }
             }
         }
@@ -1181,7 +1181,7 @@ pub(crate) mod direction_only {
                     //  and it spawns the bullet at the correct offset from the player ?
                 }
                 GameReplicationMode::OnlyInputsReplicated => {
-                    commands.spawn((spawn_bundle, DeterministicPredicted));
+                    commands.spawn((spawn_bundle, DeterministicPredicted::default()));
                 }
             }
         }

--- a/lightyear_replication/src/prespawn.rs
+++ b/lightyear_replication/src/prespawn.rs
@@ -238,6 +238,7 @@ pub struct PreSpawnedReceiver {
     /// If the interpolation_tick reaches that tick and there is till no match, we should despawn the entity
     pub prespawn_hash_to_entities: EntityHashMap<u64, Vec<Entity>>,
     #[doc(hidden)]
+    // TODO(perf): prespawned entities are added in order or tick, so we can use a Vec!
     /// Store the spawn tick of the entity, as well as the corresponding hash
     pub prespawn_tick_to_hash: ReadyBuffer<Tick, u64>,
 }


### PR DESCRIPTION
- Add an extra parameter to DeterministicPredicted to specify if the entity should be excluded from rollback for a few ticks after being spawned. This can be useful if the entity was spawned as part of a one-time event
- Despawn DeterministicPredicted entities if they were spawned before rollback (they should be respawned during rollback)