### PR TITLE
feat: Add Raw connection layer where the IO acts as a connection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [
   "lightyear_messages",
   "lightyear_netcode",
   "lightyear_prediction",
+  "lightyear_raw_connection",
   "lightyear_replication",
   "lightyear_serde",
   "lightyear_steam",
@@ -90,6 +91,7 @@ lightyear = { path = "lightyear", version = "0.25.3", default-features = false }
 lightyear_transport = { path = "lightyear_transport", version = "0.25.3", default-features = false }
 lightyear_prediction = { path = "./lightyear_prediction", version = "0.25.3", default-features = false }
 lightyear_link = { path = "./lightyear_link", version = "0.25.3", default-features = false }
+lightyear_raw_connection = { path = "./lightyear_raw_connection", version = "0.25.3", default-features = false }
 lightyear_replication = { path = "./lightyear_replication", version = "0.25.3", default-features = false }
 lightyear_serde = { path = "./lightyear_serde", version = "0.25.3", default-features = false }
 lightyear_steam = { path = "./lightyear_steam", version = "0.25.3", default-features = false }

--- a/examples/avian_physics/src/server.rs
+++ b/examples/avian_physics/src/server.rs
@@ -7,6 +7,7 @@ use bevy::platform::collections::HashMap;
 use bevy::prelude::*;
 use core::time::Duration;
 use leafwing_input_manager::prelude::*;
+use lightyear::prelude::client::*;
 use lightyear::prelude::server::*;
 use lightyear::prelude::*;
 use lightyear_examples_common::shared::SEND_INTERVAL;

--- a/examples/avian_physics/src/shared.rs
+++ b/examples/avian_physics/src/shared.rs
@@ -9,6 +9,7 @@ use lightyear::connection::client_of::ClientOf;
 use lightyear::input::input_buffer::InputBuffer;
 use lightyear::input::leafwing::prelude::LeafwingBuffer;
 use lightyear::prediction::correction::VisualCorrection;
+use lightyear::prelude::client::*;
 use lightyear::prelude::*;
 
 pub(crate) const MAX_VELOCITY: f32 = 200.0;

--- a/examples/common/src/cli.rs
+++ b/examples/common/src/cli.rs
@@ -24,6 +24,8 @@ use crate::server::{ExampleServer, ServerTransports, WebTransportCertificateSett
 use crate::server_renderer::ExampleServerRendererPlugin;
 use crate::shared::{CLIENT_PORT, SERVER_ADDR, SERVER_PORT, SHARED_SETTINGS, STEAM_APP_ID};
 use lightyear::link::RecvLinkConditioner;
+#[cfg(feature = "client")]
+use lightyear::prelude::client::*;
 use lightyear::prelude::*;
 #[cfg(feature = "gui")]
 use {

--- a/examples/common/src/client_renderer.rs
+++ b/examples/common/src/client_renderer.rs
@@ -3,6 +3,7 @@ use bevy::prelude::*;
 #[cfg(feature = "bevygap_client")]
 use bevygap_client_plugin::prelude::*;
 use lightyear::connection::client::ClientState;
+use lightyear::prelude::client::*;
 use lightyear::prelude::*;
 
 pub struct ExampleClientRendererPlugin {

--- a/examples/deterministic_replication/src/renderer.rs
+++ b/examples/deterministic_replication/src/renderer.rs
@@ -4,7 +4,8 @@ use avian2d::prelude::{Position, Rotation};
 use bevy::prelude::*;
 use lightyear::prediction::Predicted;
 use lightyear::prediction::rollback::DeterministicPredicted;
-use lightyear::prelude::{Client, Connected, EventSender, InterpolationSystems, RollbackSystems};
+use lightyear::prelude::client::*;
+use lightyear::prelude::{EventSender, InterpolationSystems, RollbackSystems};
 use lightyear_frame_interpolation::{FrameInterpolate, FrameInterpolationPlugin};
 
 #[derive(Clone)]

--- a/examples/simple_setup/src/server.rs
+++ b/examples/simple_setup/src/server.rs
@@ -8,6 +8,7 @@
 //! Lightyear will handle the replication of entities automatically if you add a `Replicate` component to them.
 use crate::shared::*;
 use bevy::prelude::*;
+use lightyear::prelude::client::*;
 use lightyear::prelude::server::*;
 use lightyear::prelude::*;
 
@@ -40,7 +41,7 @@ fn handle_new_client(trigger: On<Add, Connected>, mut commands: Commands) {
 fn startup(mut commands: Commands) -> Result {
     let server = commands
         .spawn((
-            NetcodeServer::new(NetcodeConfig::default()),
+            NetcodeServer::new(server::NetcodeConfig::default()),
             LocalAddr(SERVER_ADDR),
             ServerUdpIo::default(),
         ))

--- a/lightyear/Cargo.toml
+++ b/lightyear/Cargo.toml
@@ -54,6 +54,7 @@ client = [
   "lightyear_inputs_native?/client",
   "lightyear_messages/client",
   "lightyear_netcode?/client",
+  "lightyear_raw_connection?/client",
   "lightyear_replication?/client",
   "lightyear_steam?/client",
   "lightyear_sync/client",
@@ -71,6 +72,7 @@ server = [
   "lightyear_messages/server",
   "lightyear_netcode?/server",
   "lightyear_prediction?/server",
+  "lightyear_raw_connection?/server",
   "lightyear_replication?/server",
   "lightyear_steam?/server",
   "lightyear_sync/server",
@@ -108,6 +110,8 @@ interpolation = [
   "lightyear_inputs?/interpolation",
   "lightyear_replication/interpolation",
 ]
+
+## UTILS
 trace = [
   "lightyear_netcode?/trace",
   "lightyear_replication?/trace",
@@ -127,11 +131,8 @@ metrics = [
   "lightyear_udp?/metrics",
   "dep:lightyear_ui",
 ]
-## Enables netcode to provide persistent IDs to clients
-##
-## Note: currently, this must always be enabled when not using Steam
-netcode = ["dep:lightyear_netcode"]
 
+## INPUTS
 ## Add support for handling inputs where you can define your own input structs
 input_native = ["dep:lightyear_inputs", "dep:lightyear_inputs_native"]
 ## Add support for handling inputs using the leafwing-input-manager crate
@@ -174,6 +175,10 @@ websocket_self_signed = ["lightyear_websocket/self-signed"]
 # CONNECTION LAYERS
 ## Enables Steam as a connection layer
 steam = ["dep:lightyear_steam", "std"]
+## Enables netcode to provide persistent IDs to clients
+netcode = ["dep:lightyear_netcode"]
+## Enables using the IO directly as a connection layer
+raw_connection = ["dep:lightyear_raw_connection"]
 
 [dependencies]
 # local crates
@@ -199,6 +204,7 @@ lightyear_inputs_bei = { workspace = true, optional = true }
 lightyear_inputs_leafwing = { workspace = true, optional = true }
 lightyear_inputs_native = { workspace = true, optional = true }
 lightyear_crossbeam = { workspace = true, optional = true }
+lightyear_raw_connection = { workspace = true, optional = true }
 lightyear_webtransport = { workspace = true, optional = true }
 lightyear_websocket = { workspace = true, optional = true }
 lightyear_steam = { workspace = true, optional = true }

--- a/lightyear/src/client.rs
+++ b/lightyear/src/client.rs
@@ -54,6 +54,8 @@ impl PluginGroup for ClientPlugins {
         // CONNECTION
         #[cfg(feature = "netcode")]
         let builder = builder.add(lightyear_netcode::client_plugin::NetcodeClientPlugin);
+        #[cfg(feature = "raw_connection")]
+        let builder = builder.add(lightyear_raw_connection::client::RawConnectionPlugin);
 
         #[cfg(target_family = "wasm")]
         let builder = builder.add(crate::web::WebPlugin);

--- a/lightyear/src/lib.rs
+++ b/lightyear/src/lib.rs
@@ -391,10 +391,13 @@ pub mod prelude {
     pub mod client {
         pub use crate::client::ClientPlugins;
 
+        pub use lightyear_connection::prelude::client::*;
         pub use lightyear_sync::prelude::client::*;
 
         #[cfg(feature = "netcode")]
         pub use lightyear_netcode::prelude::client::*;
+        #[cfg(feature = "raw_connection")]
+        pub use lightyear_raw_connection::prelude::client::*;
         #[cfg(feature = "steam")]
         pub use lightyear_steam::prelude::client::*;
         #[cfg(feature = "websocket")]
@@ -419,6 +422,8 @@ pub mod prelude {
 
         #[cfg(feature = "netcode")]
         pub use lightyear_netcode::prelude::server::*;
+        #[cfg(feature = "raw_connection")]
+        pub use lightyear_raw_connection::prelude::server::*;
         #[cfg(feature = "steam")]
         pub use lightyear_steam::prelude::server::*;
         #[cfg(feature = "websocket")]

--- a/lightyear/src/server.rs
+++ b/lightyear/src/server.rs
@@ -77,6 +77,8 @@ impl PluginGroup for ServerPlugins {
         // CONNECTION
         #[cfg(feature = "netcode")]
         let builder = builder.add(lightyear_netcode::server_plugin::NetcodeServerPlugin);
+        #[cfg(feature = "raw_connection")]
+        let builder = builder.add(lightyear_raw_connection::server::RawConnectionPlugin);
         builder
     }
 }

--- a/lightyear_avian/src/correction_2d.rs
+++ b/lightyear_avian/src/correction_2d.rs
@@ -73,17 +73,17 @@ pub(crate) fn update_frame_interpolation_post_rollback(
         skip,
     ) in query.iter_mut()
     {
-
-
         if skip.is_some() {
             let current_transform = to_transform(position, rotation);
 
             interpolate.current_value = Some(current_transform);
             interpolate.previous_value = Some(current_transform);
 
-            commands
-                .entity(entity)
-                .remove::<(PreviousVisual<Position>, PreviousVisual<Rotation>, SkipFrameInterpolation)>();
+            commands.entity(entity).remove::<(
+                PreviousVisual<Position>,
+                PreviousVisual<Rotation>,
+                SkipFrameInterpolation,
+            )>();
             continue;
         }
         // - the previous visual value is PreviousVisual

--- a/lightyear_avian/src/correction_3d.rs
+++ b/lightyear_avian/src/correction_3d.rs
@@ -81,9 +81,11 @@ pub(crate) fn update_frame_interpolation_post_rollback(
             interpolate.current_value = Some(current_transform);
             interpolate.previous_value = Some(current_transform);
 
-            commands
-                .entity(entity)
-                .remove::<(PreviousVisual<Position>, PreviousVisual<Rotation>, SkipFrameInterpolation)>();
+            commands.entity(entity).remove::<(
+                PreviousVisual<Position>,
+                PreviousVisual<Rotation>,
+                SkipFrameInterpolation,
+            )>();
             continue;
         }
 

--- a/lightyear_avian/src/plugin.rs
+++ b/lightyear_avian/src/plugin.rs
@@ -2,13 +2,20 @@
 Helpers to network avian components.
 
 Some subtle footguns with avian replication:
-- for Predicted entities, your `Position` is replicated as `Confirmed<Position>`. This triggers an immediate rollback on the client which inserts the correct `Position`.
-- for `Interpolated` entities, it is possible that only one of `Position` or `Rotation` gets added (and not both at the same time). This can happen if Rotation doesn't get updated frequently for your
-entity, since we insert the real component only after receiving two remote updates. This can cause issues because the `sync_pos_to_transform` system from avian only does the sync from
-`Position/Rotation` -> `Transform` when BOTH are present on the same time. So you might be stuck with a `Transform::default()` for a short-while, until both Position/Rotation are present on the entity. For that reason it's best to add rendering components on `Interpolated` entities only when BOTH Position and Rotation are present.
-- Inserting `RigidBody` on an entity automatically inserts Position/Rotation/Transform on it. For that reason you do NOT want to add `RigidBody` on interpolated
-entities because it's going to display the entity at `Transform::default()` until the first interpolation updates are received. (And also because you don't want any avian systems to run for
-`Interpolated` entities)
+- for Predicted entities, your `Position` is replicated as `Confirmed<Position>`. This triggers an immediate
+  rollback on the client which inserts the correct `Position`.
+- for `Interpolated` entities, it is possible that only one of `Position` or `Rotation` gets added
+  (and not both at the same time). This can happen if Rotation doesn't get updated frequently for your
+  entity, since we insert the real component only after receiving two remote updates. This can cause
+  issues because the `sync_pos_to_transform` system from avian only does the sync from
+  `Position/Rotation` -> `Transform` when BOTH are present on the same time. So you might be stuck with
+  a `Transform::default()` for a short-while, until both Position/Rotation are present on the
+  entity. For that reason it's best to add rendering components on `Interpolated` entities only when
+  BOTH Position and Rotation are present.
+- Inserting `RigidBody` on an entity automatically inserts Position/Rotation/Transform on it. For that reason
+  you do NOT want to add `RigidBody` on interpolated entities because it's going to display the entity at
+  `Transform::default()` until the first interpolation updates are received. (And also because you don't
+  want any avian systems to run for `Interpolated` entities)
 - Do not forget to disable some of the avian plugins!
 ```rust,ignore
 PhysicsPlugins::default()

--- a/lightyear_connection/src/lib.rs
+++ b/lightyear_connection/src/lib.rs
@@ -61,12 +61,17 @@ pub mod prelude {
     pub use crate::direction::NetworkDirection;
     pub use crate::network_target::NetworkTarget;
 
+    // we also export these types at the top level for easier access
     pub use crate::client::{
         Client, Connect, Connected, Connecting, ConnectionError, Disconnect, Disconnected,
     };
 
     #[cfg(feature = "client")]
-    pub mod client {}
+    pub mod client {
+        pub use crate::client::{
+            Client, Connect, Connected, Connecting, ConnectionError, Disconnect, Disconnected,
+        };
+    }
 
     #[cfg(feature = "server")]
     pub mod server {

--- a/lightyear_link/src/id.rs
+++ b/lightyear_link/src/id.rs
@@ -1,7 +1,0 @@
-use core::net::SocketAddr;
-
-#[derive(Debug, PartialEq, Clone)]
-pub enum LinkId {
-    Channel,
-    Udp(SocketAddr),
-}

--- a/lightyear_link/src/lib.rs
+++ b/lightyear_link/src/lib.rs
@@ -17,7 +17,6 @@ extern crate alloc;
 extern crate std;
 
 mod conditioner;
-mod id;
 pub mod server;
 
 use alloc::{collections::vec_deque::Drain, string::String};

--- a/lightyear_link/src/server.rs
+++ b/lightyear_link/src/server.rs
@@ -48,6 +48,7 @@ impl Server {
                     reason: unlinked.reason.clone(),
                 });
                 if let Ok(mut c) = commands.get_entity(*link_of) {
+                    trace!("d");
                     // cannot simply insert Unlinked because then we wouldn't close aeronet sessions...
                     c.try_despawn();
                 }
@@ -57,7 +58,7 @@ impl Server {
 }
 
 // We add our own relationship hooks instead of deriving relationship
-//  because we don't want to despawn Server if there are no more LinkOfs.
+// because we don't want to despawn Server if there are no more LinkOfs.
 #[derive(Component, Clone, Copy, PartialEq, Eq, Debug, Reflect)]
 #[component(on_insert = LinkOf::on_insert_hook)]
 #[component(on_replace = LinkOf::on_replace)]

--- a/lightyear_messages/src/plugin.rs
+++ b/lightyear_messages/src/plugin.rs
@@ -53,7 +53,7 @@ impl Plugin for MessagePlugin {
         app.add_observer(Self::handle_disconnection);
 
         #[cfg(feature = "client")]
-        app.register_required_components::<lightyear_connection::prelude::Client, MessageManager>();
+        app.register_required_components::<lightyear_connection::client::Client, MessageManager>();
 
         #[cfg(feature = "server")]
         app.register_required_components::<lightyear_connection::prelude::server::ClientOf, MessageManager>();

--- a/lightyear_netcode/src/server.rs
+++ b/lightyear_netcode/src/server.rs
@@ -18,7 +18,7 @@ use super::{
     token::{ChallengeToken, ConnectToken, ConnectTokenBuilder, ConnectTokenPrivate},
 };
 use crate::token::TOKEN_EXPIRE_SEC;
-use lightyear_connection::prelude::Connecting;
+use lightyear_connection::prelude::client::Connecting;
 use lightyear_connection::shared::{
     ConnectionRequestHandler, DefaultConnectionRequestHandler, DeniedReason,
 };

--- a/lightyear_raw_connection/Cargo.toml
+++ b/lightyear_raw_connection/Cargo.toml
@@ -1,0 +1,41 @@
+[package]
+name = "lightyear_raw_connection"
+version = "0.25.3"
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+description = "Connection layer that directly uses the underlying IO"
+repository = "https://github.com/cBournhonesque/lightyear"
+
+[features]
+default = []
+client = ["lightyear_connection/client"]
+server = ["lightyear_connection/server"]
+
+[dependencies]
+# local crates
+lightyear_core.workspace = true
+lightyear_connection.workspace = true
+lightyear_link.workspace = true
+lightyear_serde.workspace = true
+
+# bevy
+bevy_app.workspace = true
+bevy_ecs.workspace = true
+bevy_platform.workspace = true
+bevy_reflect.workspace = true
+
+# utils
+aeronet_io.workspace = true
+bytes.workspace = true
+serde.workspace = true
+smallvec.workspace = true
+thiserror.workspace = true
+tracing.workspace = true
+
+[lints]
+workspace = true
+
+[package.metadata.docs.rs]
+all-features = true

--- a/lightyear_raw_connection/src/client.rs
+++ b/lightyear_raw_connection/src/client.rs
@@ -1,0 +1,61 @@
+use aeronet_io::connection::LocalAddr;
+use alloc::string::ToString;
+use bevy_app::{App, Plugin};
+use bevy_ecs::prelude::*;
+use lightyear_connection::prelude::client::*;
+use lightyear_core::id::{LocalId, PeerId, RemoteId};
+use lightyear_link::{Link, Linked, Unlink};
+#[allow(unused_imports)]
+use tracing::{info, trace};
+
+pub struct RawConnectionPlugin;
+
+/// Marker type to represent a client where the IO layer (UDP/Websocket/WebTransport/etc.) which also acts as a Connection layer
+///
+/// In this case, Linked/Connected are equivalent; same for Unlinked/Disconnected.
+///
+/// The PeerId associated with the connection is the entity itself.
+#[derive(Component, Debug, Clone, Copy, PartialEq, Eq)]
+#[require(Link, lightyear_connection::client::Client)]
+#[require(Disconnected)]
+pub struct RawClient;
+
+impl RawConnectionPlugin {
+    /// For RawClients, Linked implies Connected
+    fn on_linked(
+        trigger: On<Add, Linked>,
+        query: Query<&LocalAddr, With<RawClient>>,
+        mut commands: Commands,
+    ) {
+        if let Ok(local_addr) = query.get(trigger.entity) {
+            trace!("RawClient Linked! Adding Connected");
+            commands.entity(trigger.entity).insert((
+                Connected,
+                LocalId(PeerId::Raw(local_addr.0)),
+                RemoteId(PeerId::Server),
+            ));
+        }
+    }
+
+    /// For RawClients, Disconnect implies Unlinked
+    fn on_disconnect(
+        trigger: On<Disconnect>,
+        mut commands: Commands,
+        mut query: Query<(), (Without<Disconnected>, With<RawClient>)>,
+    ) {
+        if query.get_mut(trigger.entity).is_ok() {
+            trace!("RawClient Disconnect! Triggering Unlink");
+            commands.trigger(Unlink {
+                entity: trigger.entity,
+                reason: "Client requested".to_string(),
+            });
+        }
+    }
+}
+
+impl Plugin for RawConnectionPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_observer(Self::on_linked);
+        app.add_observer(Self::on_disconnect);
+    }
+}

--- a/lightyear_raw_connection/src/lib.rs
+++ b/lightyear_raw_connection/src/lib.rs
@@ -1,0 +1,32 @@
+/*! # Lightyear Raw Connection
+Lightyear separates between the IO layer (Link) which handles transmitting bytes to a remote peer,
+and the Connection layer  which symbolizes a more long-term connection on top of a Link.
+
+In particular every Connection entity must be associated with a LocalId and RemoteId that identifies
+the peers independently of the underlying Link.
+
+This crates provide a connection implementation where the establishing the Link is equivalent to establishing the Connection.
+The LocalId and RemoteId come from the Link's SocketAddr.
+*/
+#![no_std]
+
+extern crate alloc;
+extern crate core;
+
+#[cfg(feature = "client")]
+pub mod client;
+
+#[cfg(feature = "server")]
+pub mod server;
+
+pub mod prelude {
+    #[cfg(feature = "client")]
+    pub mod client {
+        pub use crate::client::RawClient;
+    }
+
+    #[cfg(feature = "server")]
+    pub mod server {
+        pub use crate::server::RawServer;
+    }
+}

--- a/lightyear_raw_connection/src/server.rs
+++ b/lightyear_raw_connection/src/server.rs
@@ -1,0 +1,104 @@
+use aeronet_io::connection::PeerAddr;
+use alloc::string::ToString;
+use bevy_app::{App, Plugin};
+use bevy_ecs::entity::UniqueEntitySlice;
+use bevy_ecs::prelude::*;
+use core::fmt::Debug;
+use lightyear_connection::prelude::client::*;
+use lightyear_connection::prelude::server::*;
+use lightyear_link::prelude::*;
+
+use lightyear_connection::client::Disconnecting;
+use lightyear_connection::host::HostClient;
+use lightyear_connection::server::Stopping;
+use lightyear_core::id::{LocalId, PeerId, RemoteId};
+#[allow(unused_imports)]
+use tracing::{error, trace};
+
+pub struct RawConnectionPlugin;
+
+/// Marker type to represent a server where the IO layer (UDP/Websocket/WebTransport/etc.) which also acts as a Connection layer
+///
+/// In this case, Linked/Started are equivalent; same for Unlinked/Stopped.
+///
+/// The PeerId associated with the connection is the entity itself.
+#[derive(Component, Debug, Clone, Copy, PartialEq, Eq)]
+#[require(Server)]
+pub struct RawServer;
+
+impl RawConnectionPlugin {
+    /// For RawServers, Linked implies Started
+    fn on_server_linked(
+        trigger: On<Add, Linked>,
+        query: Query<(), With<RawServer>>,
+        mut commands: Commands,
+    ) {
+        if query.get(trigger.entity).is_ok() {
+            trace!("RawClient Server Linked! Adding Started");
+            commands.entity(trigger.entity).insert(Started);
+        }
+    }
+
+    /// For RawServers, when a LinkOf gets Linked, it also becomes Connected
+    fn on_link_of_linked(
+        trigger: On<Add, Linked>,
+        link_of: Query<(&LinkOf, &PeerAddr)>,
+        server: Query<(), With<RawServer>>,
+        mut commands: Commands,
+    ) {
+        if let Ok((link_of, peer_addr)) = link_of.get(trigger.entity)
+            && server.get(link_of.server).is_ok()
+        {
+            trace!("RawClient LinkOf Linked! Adding Connected");
+            commands.entity(trigger.entity).insert((
+                Connected,
+                LocalId(PeerId::Server),
+                RemoteId(PeerId::Raw(peer_addr.0)),
+                ClientOf,
+            ));
+        }
+    }
+
+    /// For RawServers, Stop implies Unlinked. We also unlink all LinkOfs.
+    fn on_stop(
+        trigger: On<Stop>,
+        mut commands: Commands,
+        mut query: Query<&Server, (Without<Stopped>, With<RawServer>)>,
+        link_query: Query<(Entity, &RemoteId), (With<ClientOf>, Without<HostClient>)>,
+    ) -> Result {
+        if let Ok(server) = query.get_mut(trigger.entity) {
+            trace!("RawClient Stop! Disconnecting all LinkOfs and triggering Unlink");
+            commands.trigger(Unlink {
+                entity: trigger.entity,
+                reason: "Server stopped".to_string(),
+            });
+            commands.entity(trigger.entity).insert(Stopping);
+            // SAFETY: we know that the list of client entities are unique because it is a Relationship
+            let unique_slice =
+                unsafe { UniqueEntitySlice::from_slice_unchecked(server.collection()) };
+            link_query.iter_many_unique(unique_slice).try_for_each(
+                |(entity, remote_peer_id)| {
+                    let PeerId::Raw(_) = remote_peer_id.0 else {
+                        error!("Client {:?} is not a Netcode client", remote_peer_id);
+                        return Err(
+                            lightyear_connection::server::ConnectionError::InvalidConnectionType,
+                        );
+                    };
+                    // insert Disconnecting, so that the `Diconnected` component is added on the LinkOf
+                    // before the entity gets despawned
+                    commands.entity(entity).insert(Disconnecting);
+                    Ok(())
+                },
+            )?;
+        }
+        Ok(())
+    }
+}
+
+impl Plugin for RawConnectionPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_observer(Self::on_server_linked);
+        app.add_observer(Self::on_link_of_linked);
+        app.add_observer(Self::on_stop);
+    }
+}

--- a/lightyear_replication/src/visibility/room.rs
+++ b/lightyear_replication/src/visibility/room.rs
@@ -46,7 +46,7 @@ use bevy_ecs::entity::{EntityHashMap, EntityHashSet, EntityIndexMap};
 use bevy_ecs::prelude::*;
 use bevy_platform::collections::hash_map::Entry;
 use bevy_reflect::Reflect;
-use lightyear_connection::prelude::Disconnected;
+use lightyear_connection::prelude::client::Disconnected;
 #[allow(unused_imports)]
 use tracing::{info, trace};
 

--- a/lightyear_tests/Cargo.toml
+++ b/lightyear_tests/Cargo.toml
@@ -43,6 +43,7 @@ lightyear = { workspace = true, features = [
     "leafwing",
     "interpolation",
     "prediction",
+    "raw_connection",
     "replication",
     "steam",
 ] }
@@ -52,6 +53,10 @@ lightyear_transport = { workspace = true, features = ["client", "server"] }
 lightyear_core.workspace = true
 lightyear_netcode = { workspace = true, features = ["client", "server"] }
 lightyear_messages = { workspace = true, features = ["client", "server"] }
+lightyear_raw_connection = { workspace = true, features = [
+    "client",
+    "server",
+] }
 lightyear_replication = { workspace = true, features = [
     "client",
     "server",

--- a/lightyear_tests/src/client_server/base.rs
+++ b/lightyear_tests/src/client_server/base.rs
@@ -84,6 +84,23 @@ fn test_setup_client_server() {
     assert!(stepper.client_of(0).contains::<RemoteId>());
 }
 
+/// Check that the client/server setup is correct when the connection type is Raw instead of Netcode
+#[test]
+fn test_setup_raw_client_server() {
+    let stepper = ClientServerStepper::single_raw();
+    assert!(stepper.client(0).contains::<Transport>());
+    assert!(stepper.client(0).contains::<Connected>());
+    assert!(stepper.client(0).contains::<PeerAddr>());
+    assert!(stepper.client(0).contains::<LocalId>());
+    assert!(stepper.client(0).contains::<RemoteId>());
+
+    assert!(stepper.client_of(0).contains::<Transport>());
+    assert!(stepper.client_of(0).contains::<Connected>());
+    assert!(stepper.client_of(0).contains::<PeerAddr>());
+    assert!(stepper.client_of(0).contains::<LocalId>());
+    assert!(stepper.client_of(0).contains::<RemoteId>());
+}
+
 #[test]
 fn test_sender_metadata() {
     let stepper = ClientServerStepper::single();

--- a/lightyear_tests/src/client_server/prediction/prespawn.rs
+++ b/lightyear_tests/src/client_server/prediction/prespawn.rs
@@ -315,7 +315,7 @@ fn panic_on_rollback() {
 /// on the PreSpawned entity should match the client history when it was spawned.
 #[test]
 fn test_prespawn_local_despawn_match() {
-    let mut stepper = ClientServerStepper::default_no_init();
+    let mut stepper = ClientServerStepper::default_no_init(false);
     let tick_duration = stepper.tick_duration;
     stepper.new_client();
     // add a conditioner to make sure that the client is ahead of the server, and make sure there is a resync

--- a/lightyear_tests/src/multi_server/steam.rs
+++ b/lightyear_tests/src/multi_server/steam.rs
@@ -3,6 +3,7 @@
 
 use crate::stepper::{ClientServerStepper, SERVER_PORT, STEAM_APP_ID};
 use core::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
+use lightyear::prelude::client::*;
 use lightyear::prelude::server::{ListenTarget, SteamServerIo};
 use lightyear::prelude::*;
 use lightyear::prelude::{SessionConfig, SteamAppExt};
@@ -31,7 +32,7 @@ fn add_steam_server_io(stepper: &mut ClientServerStepper) {
 // only run this manually since it requires Steam to be started
 #[ignore]
 fn test_steam_server_with_netcode_server() {
-    let mut stepper = ClientServerStepper::default_no_init();
+    let mut stepper = ClientServerStepper::default_no_init(false);
     // start the server first and make sure the SteamServer is Started
     info!("Starting server app");
     add_steam_server_io(&mut stepper);

--- a/lightyear_transport/src/plugin.rs
+++ b/lightyear_transport/src/plugin.rs
@@ -18,7 +18,7 @@ use bevy_utils::default;
 use bytes::Bytes;
 use lightyear_connection::host::HostClient;
 #[cfg(any(feature = "client", feature = "server"))]
-use lightyear_connection::prelude::Disconnected;
+use lightyear_connection::prelude::client::Disconnected;
 use lightyear_core::prelude::{LocalTimeline, NetworkTimeline};
 use lightyear_core::tick::Tick;
 use lightyear_link::{Link, LinkPlugin, LinkSystems, Linked};


### PR DESCRIPTION
Adds `lightyear_raw_connection`, another Connection layer similar to `lightyear_netcode` and `lightyear_steam`.
Clients marked a `RawClient` will just use their underlying IO (for example WebTransport) as the connection layer.