### PR TITLE
fix: fix input rebroadcasting issues

### DIFF
--- a/examples/avian_3d_character/src/server.rs
+++ b/examples/avian_3d_character/src/server.rs
@@ -180,11 +180,6 @@ pub(crate) fn handle_connected(
     // Track the number of characters to pick colors and starting positions.
     let num_characters = character_query.iter().count();
 
-    // Default prediction/interpolation: predict owner, interpolate others
-    let prediction_target = PredictionTarget::to_clients(NetworkTarget::Single(client_id));
-    let interpolation_target =
-        InterpolationTarget::to_clients(NetworkTarget::AllExceptSingle(client_id));
-
     // Pick color and position for player.
     let available_colors = [
         css::LIMEGREEN,

--- a/examples/bevy_enhanced_inputs/src/client.rs
+++ b/examples/bevy_enhanced_inputs/src/client.rs
@@ -40,23 +40,25 @@ fn player_movement(
 /// - keep track of it in the Global resource
 pub(crate) fn handle_predicted_spawn(
     trigger: On<Add, (PlayerId, Predicted)>,
-    mut predicted: Query<&mut PlayerColor, With<Predicted>>,
+    mut predicted: Query<(&mut PlayerColor, Has<Controlled>), With<Predicted>>,
     mut commands: Commands,
 ) {
     let entity = trigger.entity;
-    if let Ok(mut color) = predicted.get_mut(entity) {
+    if let Ok((mut color, controlled)) = predicted.get_mut(entity) {
         let hsva = Hsva {
             saturation: 0.4,
             ..Hsva::from(color.0)
         };
         color.0 = Color::from(hsva);
         warn!("Add InputMarker to entity: {:?}", entity);
-        // add Action entities to the predicted Context
-        commands.spawn((
-            ActionOf::<Player>::new(entity),
-            Action::<Movement>::new(),
-            Bindings::spawn(Cardinal::wasd_keys()),
-        ));
+        if controlled {
+            // add Action entities to the predicted Context
+            commands.spawn((
+                ActionOf::<Player>::new(entity),
+                Action::<Movement>::new(),
+                Bindings::spawn(Cardinal::wasd_keys()),
+            ));
+        }
     }
 }
 

--- a/examples/bevy_enhanced_inputs/src/server.rs
+++ b/examples/bevy_enhanced_inputs/src/server.rs
@@ -69,8 +69,11 @@ pub(crate) fn handle_connected(
             PlayerColor(color),
             // we replicate the Player entity to all clients that are connected to this server
             Replicate::to_clients(NetworkTarget::All),
-            PredictionTarget::to_clients(NetworkTarget::Single(client_id)),
-            InterpolationTarget::to_clients(NetworkTarget::AllExceptSingle(client_id)),
+            // NOTE: here we predict the movements of all players!
+            PredictionTarget::to_clients(NetworkTarget::All),
+            // NOTE: Uncomment this if you want to use interpolation for non-controlled entities
+            // PredictionTarget::to_clients(NetworkTarget::Single(client_id)),
+            // InterpolationTarget::to_clients(NetworkTarget::AllExceptSingle(client_id)),
             ControlledBy {
                 owner: trigger.entity,
                 lifetime: Default::default(),

--- a/lightyear_inputs/src/client.rs
+++ b/lightyear_inputs/src/client.rs
@@ -556,8 +556,9 @@ fn prepare_input_message<S: ActionStateSequence>(
     debug!(
         ?tick,
         ?num_tick,
+        ?is_host_client,
         "sending input message for {:?}: {}",
-        DebugName::type_name::<S::Action>(),
+        DebugName::type_name::<S::Action>().shortname(),
         message
     );
     message_buffer.0.push(message);

--- a/lightyear_inputs/src/input_message.rs
+++ b/lightyear_inputs/src/input_message.rs
@@ -259,6 +259,9 @@ pub struct InputMessage<S> {
     pub end_tick: Tick,
     // Map from target entity to the input data for that entity
     pub inputs: Vec<PerTargetData<S>>,
+    /// If true, indicates that this message is already a rebroadcast. The input comes from a different client,
+    /// so we should not rebarodcast it again.
+    pub rebroadcast: bool,
 }
 
 impl<S: ActionStateSequence + MapEntities> MapEntities for InputMessage<S> {
@@ -274,7 +277,8 @@ impl<S: ActionStateSequence + MapEntities> MapEntities for InputMessage<S> {
 
 impl<S: ActionStateSequence + Debug> core::fmt::Display for InputMessage<S> {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
-        let ty = DebugName::type_name::<S::Action>();
+        let debug_name = DebugName::type_name::<S::Action>();
+        let ty = debug_name.shortname();
 
         if self.inputs.is_empty() {
             return write!(f, "EmptyInputMessage<{ty:?}>");
@@ -303,6 +307,7 @@ impl<S: ActionStateSequence> InputMessage<S> {
             #[cfg(feature = "interpolation")]
             interpolation_delay: None,
             end_tick,
+            rebroadcast: false,
             inputs: vec![],
         }
     }

--- a/lightyear_inputs_bei/Cargo.toml
+++ b/lightyear_inputs_bei/Cargo.toml
@@ -21,6 +21,7 @@ lightyear_replication.workspace = true
 lightyear_serde.workspace = true
 lightyear_link.workspace = true
 lightyear_connection.workspace = true
+lightyear_messages.workspace = true
 
 # inputs
 bevy_enhanced_input.workspace = true

--- a/lightyear_serde/src/entity_map.rs
+++ b/lightyear_serde/src/entity_map.rs
@@ -78,7 +78,7 @@ impl EntityMapper for ReceiveEntityMap {
         } else {
             // if we don't find the entity, return Entity::PLACEHOLDER as an error
             self.0.get(&entity).copied().unwrap_or_else(|| {
-                warn!("Failed to map entity {entity:?}");
+                debug!("Receive: Failed to map entity {entity:?}");
                 Entity::PLACEHOLDER
             })
         }

--- a/lightyear_tests/src/host_server/input/bei.rs
+++ b/lightyear_tests/src/host_server/input/bei.rs
@@ -1,0 +1,107 @@
+use crate::protocol::{BEIAction1, BEIContext};
+use crate::stepper::*;
+use bevy::prelude::*;
+use bevy_enhanced_input::action::{Action, ActionMock, ActionState, MockSpan};
+use bevy_enhanced_input::prelude::{ActionOf, ActionValue, Actions};
+use lightyear::input::bei::input_message::BEIBuffer;
+use lightyear::prelude::input::bei::InputMarker;
+use lightyear_connection::network_target::NetworkTarget;
+use lightyear_messages::MessageManager;
+use lightyear_replication::prelude::{PredictionTarget, Replicate, ReplicateLike};
+
+/// Check that the host-server still rebroadcasts inputs from non-host clients to each other.
+#[test]
+fn test_rebroadcast() {
+    let mut stepper = ClientServerStepper::from_config(StepperConfig::from_link_types(
+        vec![ClientType::Host, ClientType::Netcode, ClientType::Netcode],
+        ServerType::Netcode,
+    ));
+
+    // Entity controlled by client 1, with inputs rebroadcast to all clients
+    let server_entity = stepper
+        .server_app
+        .world_mut()
+        .spawn((
+            Replicate::to_clients(NetworkTarget::All),
+            PredictionTarget::to_clients(NetworkTarget::All),
+            BEIContext,
+        ))
+        .id();
+    stepper.frame_step_server_first(1);
+
+    // Get the predicted entities on both clients
+    let client0_entity = stepper
+        .client(0)
+        .get::<MessageManager>()
+        .unwrap()
+        .entity_mapper
+        .get_local(server_entity)
+        .expect("entity not replicated to client 1");
+    let client1_entity = stepper
+        .client(1)
+        .get::<MessageManager>()
+        .unwrap()
+        .entity_mapper
+        .get_local(server_entity)
+        .expect("entity not replicated to client 2");
+
+    // Spawn action on client 0
+    let action0 = stepper.client_apps[0]
+        .world_mut()
+        .spawn((
+            ActionOf::<BEIContext>::new(client1_entity),
+            Action::<BEIAction1>::default(),
+            ActionMock::new(
+                ActionState::Fired,
+                ActionValue::Bool(true),
+                MockSpan::Manual,
+            ),
+        ))
+        .id();
+    stepper.frame_step(4);
+
+    // Check that client 1 received the rebroadcasted action
+    let action1 = stepper.client_apps[1]
+        .world()
+        .get::<Actions<BEIContext>>(client1_entity)
+        .unwrap()
+        .collection()[0];
+    assert!(
+        stepper.client_apps[1]
+            .world()
+            .entity(action1)
+            .get::<BEIBuffer<BEIContext>>()
+            .is_some()
+    );
+
+    // Check that the host-server did not add an InputMarker on the action entity
+    let action_host = stepper
+        .server_app
+        .world()
+        .get::<Actions<BEIContext>>(server_entity)
+        .unwrap()
+        .collection()[0];
+    assert!(
+        stepper
+            .server_app
+            .world()
+            .get::<InputMarker<BEIContext>>(action_host)
+            .is_none()
+    );
+    assert!(
+        stepper
+            .server_app
+            .world()
+            .get::<Replicate>(action_host)
+            .is_none()
+    );
+    assert!(
+        stepper
+            .server_app
+            .world()
+            .get::<ReplicateLike>(action_host)
+            .is_some()
+    );
+
+    // Check that
+}

--- a/lightyear_tests/src/host_server/input/mod.rs
+++ b/lightyear_tests/src/host_server/input/mod.rs
@@ -1,2 +1,3 @@
+mod bei;
 mod leafwing;
 mod native;


### PR DESCRIPTION
Fixes 3 important issues related to input rebroadcasting:
- for BEi, we handled rebroadcasting inputs for entities controlled by the host-client. However in a host-client scenario, inputs from non-host clients were not rebroadcasted properly!
- all inputs were being rebroadcasted multiple times! An input sent from client 1 would be rebroadcasted to other clients, which would then rebroadcast it again upon receipt. This meant that we would keep re-sending input messages even if not needed! This change should greatly decrease the bandwidth used by inputs
- the host-client was not handling input messages for other clients correctly, because its entity map was empty. (it's empty because the host-client does not receive Replication Messages since it shares the same World as the server). We explicitly add BEI Action entities in the entity map