### PR TITLE
fix: do not send component remove messages for non-visible entities

### DIFF
--- a/lightyear_replication/src/send/buffer.rs
+++ b/lightyear_replication/src/send/buffer.rs
@@ -693,7 +693,6 @@ fn replicate_component_update(
 // - check if the entity is in the sender's replication components
 
 /// Send component remove message when a component gets removed
-// TODO: use a common observer for all removed components
 // TODO: you could have a case where you remove a component C, and then afterwards
 //   modify the replication target, but we still send messages to the old components.
 //   Maybe we should just add the components to a buffer?
@@ -717,9 +716,22 @@ pub(crate) fn buffer_component_removed(
     let Some(replicate) = entity_ref.get::<Replicate>() else {
         return;
     };
+
+    // Note: this is not needed because the SystemParamBuilder already makes sure that the entity
+    //  must have both Replicate and Replicating
+    // if !entity_ref.contains::<Replicating>() {
+    //     return;
+    // }
+
     manager_query
         .par_iter_many_unique_mut(replicate.senders.as_slice())
         .for_each(|(sender_entity, mut sender, manager)| {
+            if entity_ref
+                .get::<NetworkVisibility>()
+                .is_some_and(|v| !v.is_visible(sender_entity))
+            {
+                return;
+            }
             // convert the entity to a network entity (possibly mapped)
             let entity = manager.entity_mapper.to_remote(entity);
             for component_id in trigger.trigger().components {

--- a/lightyear_replication/src/send/plugin.rs
+++ b/lightyear_replication/src/send/plugin.rs
@@ -418,7 +418,13 @@ impl Plugin for ReplicationSendPlugin {
                     });
                 });
                 builder.optional(|b| {
-                    b.data::<(&ReplicateLike, &Replicate, &ReplicationGroup)>();
+                    b.data::<(
+                        &ReplicateLike,
+                        &Replicate,
+                        &Replicating,
+                        &NetworkVisibility,
+                        &ReplicationGroup,
+                    )>();
                     // include access to &C and &ComponentReplicationOverrides<C> for all replication components with the right direction
                     component_registry
                         .component_metadata_map

--- a/lightyear_tests/src/client_server/visibility.rs
+++ b/lightyear_tests/src/client_server/visibility.rs
@@ -1,9 +1,11 @@
 //! Check various replication scenarios between 2 peers only
 
+use crate::protocol::*;
 use crate::stepper::*;
+use bevy::prelude::*;
 use lightyear_connection::network_target::NetworkTarget;
 use lightyear_messages::MessageManager;
-use lightyear_replication::prelude::{NetworkVisibility, Replicate, ReplicationGroup};
+use lightyear_replication::prelude::*;
 use test_log::test;
 #[allow(unused_imports)]
 use tracing::info;
@@ -178,18 +180,41 @@ fn test_despawn_add_network_visibility() {}
 fn test_despawn_non_visible_logspam() {
     let mut stepper: ClientServerStepper =
         ClientServerStepper::from_config(StepperConfig::single());
-    let server_entity_0 = stepper
+    let server_parent = stepper
+        .server_app
+        .world_mut()
+        .spawn((
+            Replicate::to_clients(NetworkTarget::All),
+            CompFull(1.0),
+            NetworkVisibility::default(),
+            ReplicationGroup::new_id(1),
+        ))
+        .id();
+    let server_child = stepper
         .server_app
         .world_mut()
         .spawn((
             Replicate::to_clients(NetworkTarget::All),
             NetworkVisibility::default(),
             ReplicationGroup::new_id(1),
+            ChildOf(server_parent),
         ))
         .id();
 
     stepper.frame_step(1);
-    info!("Server despawning entity that is not visible to the client");
-    stepper.server_app.world_mut().despawn(server_entity_0);
+    info!("Server despawning parent that is not visible to the client");
+    stepper.server_app.world_mut().despawn(server_parent);
     stepper.frame_step(10);
+
+    // check that we didn't send any replication messages
+    // because the entity was not visible to the client
+    assert!(
+        stepper
+            .client_of(0)
+            .get::<ReplicationSender>()
+            .unwrap()
+            .group_channels
+            .get(&ReplicationGroupId(1))
+            .is_none()
+    );
 }


### PR DESCRIPTION
We were not considering NetworkVisibility when replicating component removes!