### PR TITLE
Feat: Bump avian version - Check comments

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -219,8 +219,8 @@ leafwing-input-manager = { version = "0.19", default-features = false, features 
 ] }
 
 # physics
-avian2d = { version = "0.4", default-features = false }
-avian3d = { version = "0.4", default-features = false }
+avian2d = { version = "0.4.1", default-features = false }
+avian3d = { version = "0.4.1", default-features = false }
 
 # gui debug ui
 bevy-inspector-egui = { version = "0.35", default-features = false, features = [


### PR DESCRIPTION
This should fix the little collider being reteleported to transform default whenever a rigidbody is inserted. Note- All tests compile and examples dont seem to go bazonga with rollbacks so this is okey dokey.
First I ran 
    cargo test -p lightyear_test
A few tests failed than I noticed the comments and ran
    cargo test -p lightyear_tests --all-features -- --test-threads=1

No fails, @cBournhonesque, is that okey dokey?