### PR TITLE
feat: used 16.16 fixed-point types for tick math

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,6 +113,7 @@ chrono = "0.4.38"
 cfg-if = "1.0"
 dashmap = "6.1.0"
 enum_dispatch = "0.3"
+fixed = { version = "1.29", features = ["serde"] }
 governor = "0.10"
 hashbrown = { version = "0.16", default-features = false }
 indexmap = { version = "2.9.0", default-features = false }

--- a/examples/avian_physics/src/client.rs
+++ b/examples/avian_physics/src/client.rs
@@ -122,7 +122,7 @@ pub(crate) fn handle_interpolated_spawn(
 // Debug system to check on the oversteps
 fn print_overstep(time: Res<Time<Fixed>>, timeline: Single<&InputTimeline, With<Client>>) {
     let input_overstep = timeline.overstep();
-    let input_overstep_ms = input_overstep.value() * (time.timestep().as_millis() as f32);
+    let input_overstep_ms = input_overstep.to_f32() * (time.timestep().as_millis() as f32);
     let time_overstep = time.overstep();
     trace!(?input_overstep_ms, ?time_overstep, "overstep");
 }

--- a/examples/replication_groups/src/client.rs
+++ b/examples/replication_groups/src/client.rs
@@ -178,7 +178,7 @@ pub(crate) fn interpolate(
     )>,
 ) {
     let interpolation_tick = timeline.tick();
-    let interpolation_overstep = timeline.overstep().value();
+    let interpolation_overstep = timeline.overstep().to_f32();
     'outer: for (tail_entity, parent, tail_length, mut tail, tail_history) in tail_query.iter_mut()
     {
         let Ok((mut parent_position, parent_history)) = parent_query.get_mut(parent.0) else {

--- a/lightyear_core/Cargo.toml
+++ b/lightyear_core/Cargo.toml
@@ -20,6 +20,7 @@ lightyear_serde.workspace = true
 
 # utils
 chrono.workspace = true
+fixed.workspace = true
 tracing.workspace = true
 
 # bevy

--- a/lightyear_core/src/timeline.rs
+++ b/lightyear_core/src/timeline.rs
@@ -70,11 +70,11 @@ impl<C: TimelineContext, T: Component<Mutability = Mutable> + DerefMut<Target = 
     }
 
     fn tick(&self) -> Tick {
-        self.now().tick
+        self.now().tick()
     }
 
     fn overstep(&self) -> Overstep {
-        self.now().overstep
+        self.now().overstep()
     }
 
     fn set_now(&mut self, now: TickInstant) {

--- a/lightyear_frame_interpolation/src/lib.rs
+++ b/lightyear_frame_interpolation/src/lib.rs
@@ -200,7 +200,7 @@ pub(crate) fn visual_interpolation<C: Component<Mutability = Mutable> + Clone + 
     )>,
 ) {
     let kind = DebugName::type_name::<C>();
-    let tick = timeline.now.tick;
+    let tick = timeline.now.tick();
     // TODO: how should we get the overstep? the LocalTimeline is only incremented during FixedUpdate so has an overstep of 0.0
     //  the InputTimeline seems to have an overstep, but it doesn't match the Time<Fixed> overstep
     let overstep = time.overstep_fraction();

--- a/lightyear_interpolation/src/interpolate.rs
+++ b/lightyear_interpolation/src/interpolate.rs
@@ -44,7 +44,7 @@ pub(crate) fn update_confirmed_history<C: Component + Clone>(
         / tick_duration.as_secs_f32())
     .ceil() as i16;
 
-    let current_interpolate_tick = timeline.now().tick;
+    let current_interpolate_tick = timeline.now().tick();
     for (entity, mut history, present) in query.iter_mut() {
         // the ConfirmedHistory contains an ordered list (from oldest to most recent) of Confirmed component updates to interpolate between
         // The component must always be interpolating between the oldest and the second oldest values in the history.
@@ -124,7 +124,7 @@ pub(crate) fn interpolate<C: Component<Mutability = Mutable> + Clone>(
     mut query: Query<(&mut C, &ConfirmedHistory<C>)>,
 ) {
     let interpolation_tick = timeline.tick();
-    let interpolation_overstep = timeline.overstep().value();
+    let interpolation_overstep = timeline.overstep().to_f32();
     for (mut component, history) in query.iter_mut() {
         if let Some(interpolated) = history.interpolate(
             interpolation_tick,

--- a/lightyear_interpolation/src/plugin.rs
+++ b/lightyear_interpolation/src/plugin.rs
@@ -34,12 +34,12 @@ impl InterpolationDelay {
     /// Get the tick and the overstep of the interpolation time by removing the delay
     /// from the current tick
     pub fn tick_and_overstep(&self, tick: Tick) -> (Tick, f32) {
-        if self.delay.overstep.value() == 0.0 {
-            (tick - self.delay.tick_diff, 0.0)
+        if self.delay.overstep().value().is_zero() {
+            (tick - self.delay.tick_diff(), 0.0)
         } else {
             (
-                tick - self.delay.tick_diff - 1,
-                1.0 - self.delay.overstep.value(),
+                tick - self.delay.tick_diff() - 1,
+                1.0 - self.delay.overstep().to_f32(),
             )
         }
     }
@@ -153,23 +153,16 @@ impl Plugin for InterpolationPlugin {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use lightyear_core::time::Overstep;
 
     #[test]
     fn test_interpolation_delay() {
         let delay = InterpolationDelay {
-            delay: PositiveTickDelta {
-                tick_diff: 2,
-                overstep: Default::default(),
-            },
+            delay: PositiveTickDelta::lit("2"),
         };
         assert_eq!(delay.tick_and_overstep(Tick(3)), (Tick(1), 0.0));
 
         let delay = InterpolationDelay {
-            delay: PositiveTickDelta {
-                tick_diff: 2,
-                overstep: Overstep::new(0.4),
-            },
+            delay: PositiveTickDelta::lit("2.4"),
         };
         assert_eq!(delay.tick_and_overstep(Tick(3)), (Tick(0), 0.6));
     }

--- a/lightyear_sync/src/client.rs
+++ b/lightyear_sync/src/client.rs
@@ -91,9 +91,8 @@ mod tests {
     use super::*;
     use bevy_time::{TimePlugin, TimeUpdateStrategy};
     use core::time::Duration;
-    use lightyear_core::prelude::Tick;
     use lightyear_core::tick::TickDuration;
-    use lightyear_core::time::{Instant, Overstep, TickInstant};
+    use lightyear_core::time::{Instant, TickInstant};
     use test_log::test;
 
     #[test]
@@ -113,18 +112,12 @@ mod tests {
         let e = app.world_mut().spawn(RemoteTimeline::default()).id();
         assert_eq!(
             app.world().get::<RemoteTimeline>(e).unwrap().now,
-            TickInstant {
-                tick: Tick(0),
-                overstep: Overstep::new(0.0),
-            }
+            TickInstant::zero()
         );
         app.update();
         assert_eq!(
             app.world().get::<RemoteTimeline>(e).unwrap().now,
-            TickInstant {
-                tick: Tick(1),
-                overstep: Overstep::new(0.0),
-            }
+            TickInstant::lit("1.0")
         );
     }
 }

--- a/lightyear_sync/src/timeline/sync.rs
+++ b/lightyear_sync/src/timeline/sync.rs
@@ -226,10 +226,10 @@ impl<Synced: SyncedTimeline, Remote: SyncTargetTimeline, const DRIVING: bool>
         let overstep = fixed_time.overstep_fraction();
         query.iter_mut().for_each(|(local_timeline, mut synced)| {
             // Desired phase: LocalTimeline.tick + Time<Fixed> overstep.
-            synced.set_now(TickInstant {
-                tick: local_timeline.tick(),
-                overstep: Overstep::from_f32(overstep),
-            });
+            synced.set_now(TickInstant::from_tick_and_overstep(
+                local_timeline.tick(),
+                Overstep::from_f32(overstep),
+            ));
         });
     }
 

--- a/lightyear_tests/Cargo.toml
+++ b/lightyear_tests/Cargo.toml
@@ -37,7 +37,7 @@ lightyear = { workspace = true, features = [
   "crossbeam",
   "avian2d",
   "frame_interpolation",
-    "metrics",
+  "metrics",
   "netcode",
   "input_native",
   "input_bei",


### PR DESCRIPTION
Use fixed-point types from https://docs.rs/fixed/latest/fixed/ instead of i16+f32 to represent Overstep, TickInstant, TickDelta, and PositiveTickDelta.
Pros:
- overstep precision is constant for all values
- really cheap arithmetic ops
- bit more compact
- naturally wrapping
- no need for error-prone, branchy code to handle negative values and overstep carry

Cons:
- API change
- Less precise overstep (238ns resolution, which seems like plenty tbf)
- TickDelta is using an i16.16 instead of unsigned + flag so technically it has half the range it did before

This shouldn't change anything functionally and it is pretty large so there's no hurry to merge this, especially if you want to test it out and make sure it doesn't seem to break anything.
You could definitely spread these types through more of the tick-related code but I tried to limit the blast radius with the tick() and overstep() wrappers so code touching tick math types can mostly stay the same. Not sure how you feel about pulling in another dependency for this, but I thought this crate was useful and made me feel a lot more confident in the correctness of the code than I would have felt implementing float conversions and multiplications and stuff like that by hand