### PR TITLE
chore: add test for AvianMode::Transform

### DIFF
--- a/lightyear_tests/src/protocol.rs
+++ b/lightyear_tests/src/protocol.rs
@@ -232,6 +232,7 @@ impl Plugin for ProtocolPlugin {
                 .disable::<IslandSleepingPlugin>()
                 .disable::<PhysicsInterpolationPlugin>(),
         );
+        // app.register_component::<Collider>();
 
         match self.avian_mode {
             AvianReplicationMode::Position => {


### PR DESCRIPTION
We make sure to distinguish between:
- the child entity is another RigidBody
- the child entity is a ColliderOf