### PR TITLE
fix: always do a full resync on the first resync attempt

### DIFF
--- a/examples/common/src/cli.rs
+++ b/examples/common/src/cli.rs
@@ -298,8 +298,7 @@ pub fn window_plugin() -> WindowPlugin {
 pub fn log_plugin() -> LogPlugin {
     LogPlugin {
         level: Level::INFO,
-        filter: "wgpu=error,bevy_render=info,bevy_ecs=warn,bevy_time=warn,naga=warn".to_string(),
-        // filter: "wgpu=error,bevy_render=info,bevy_ecs=warn,bevy_time=warn,naga=warn,bevy_enhanced_input::action::fns=error".to_string(),
+        filter: "wgpu=error,bevy_render=info,bevy_ecs=warn,bevy_time=warn,naga=warn,bevy_enhanced_input::action::fns=error".to_string(),
         ..default()
     }
 }

--- a/lightyear_inputs_bei/src/setup.rs
+++ b/lightyear_inputs_bei/src/setup.rs
@@ -4,29 +4,25 @@ use bevy_ecs::relationship::Relationship;
 use bevy_utils::prelude::DebugName;
 #[cfg(feature = "client")]
 use {
-    bevy_enhanced_input::context::ExternallyMocked,
-    lightyear_connection::client::Client,
+    bevy_enhanced_input::context::ExternallyMocked, lightyear_connection::client::Client,
     lightyear_replication::prelude::Replicate,
 };
 
 use bevy_enhanced_input::prelude::*;
-#[cfg(any(feature = "client", feature = "server"))]
-use {
-    lightyear_link::prelude::Server,
-    lightyear_connection::host::HostClient,
-};
+#[cfg(all(feature = "client", feature = "server"))]
+use lightyear_connection::host::HostServer;
 use lightyear_replication::prelude::*;
 use lightyear_serde::SerializationError;
 use lightyear_serde::registry::SerializeFns;
 use lightyear_serde::writer::Writer;
 #[allow(unused_imports)]
 use tracing::{debug, info};
-#[cfg(all(feature = "client", feature = "server"))]
-use lightyear_connection::host::HostServer;
+#[cfg(any(feature = "client", feature = "server"))]
+use {lightyear_connection::host::HostClient, lightyear_link::prelude::Server};
 #[cfg(feature = "server")]
 use {
-    lightyear_inputs::server::ServerInputConfig,
-    lightyear_messages::MessageManager, lightyear_replication::prelude::ReplicateLike,
+    lightyear_inputs::server::ServerInputConfig, lightyear_messages::MessageManager,
+    lightyear_replication::prelude::ReplicateLike,
 };
 // TODO: ideally we would have an entity-mapped that is PreSpawn aware. If you include an entity
 //   that is PreSpawned, then in the entity-mapper we use a Query<Entity, With<PreSpawned>> to check the hash


### PR DESCRIPTION
If the client/server were within 10 ticks of each other on the first sync attempt, then there would be no immediate sync and instead the client would speed up to catchup, but this would take time.
Now we always make sure that the initial sync takes place