### PR TITLE
feat: separate InputTimelineConfig from InputTimeline

### DIFF
--- a/demos/spaceships/src/main.rs
+++ b/demos/spaceships/src/main.rs
@@ -73,9 +73,7 @@ fn add_input_delay(app: &mut App) {
         .unwrap();
 
     // set some input-delay since we are predicting all entities
-    app.world_mut()
-        .entity_mut(client)
-        .insert(InputTimeline(Timeline::from(
-            Input::default().with_input_delay(InputDelayConfig::fixed_input_delay(10)),
-        )));
+    app.world_mut().entity_mut(client).insert(
+        InputTimelineConfig::default().with_input_delay(InputDelayConfig::fixed_input_delay(10)),
+    );
 }

--- a/examples/avian_3d_character/src/main.rs
+++ b/examples/avian_3d_character/src/main.rs
@@ -58,7 +58,7 @@ fn main() {
 
 #[cfg(feature = "client")]
 fn add_input_delay(app: &mut App) {
-    use lightyear::prelude::client::{Input, InputDelayConfig};
+    use lightyear::prelude::client::{InputDelayConfig, InputTimelineConfig};
 
     let client = app
         .world_mut()
@@ -67,9 +67,7 @@ fn add_input_delay(app: &mut App) {
         .unwrap();
 
     // set some input-delay since we are predicting all entities
-    app.world_mut()
-        .entity_mut(client)
-        .insert(InputTimeline(Timeline::from(
-            Input::default().with_input_delay(InputDelayConfig::fixed_input_delay(0)),
-        )));
+    app.world_mut().entity_mut(client).insert(
+        InputTimelineConfig::default().with_input_delay(InputDelayConfig::fixed_input_delay(0)),
+    );
 }

--- a/examples/bevy_enhanced_inputs/src/main.rs
+++ b/examples/bevy_enhanced_inputs/src/main.rs
@@ -70,7 +70,7 @@ fn main() {
 
 #[cfg(feature = "client")]
 fn add_input_delay(app: &mut App) {
-    use lightyear::prelude::client::{Input, InputDelayConfig};
+    use lightyear::prelude::client::{InputDelayConfig, InputTimelineConfig};
     use lightyear::prelude::{Client, InputTimeline, Timeline};
     let client = app
         .world_mut()
@@ -88,9 +88,7 @@ fn add_input_delay(app: &mut App) {
         ));
 
     // set some input-delay since we are predicting all entities
-    app.world_mut()
-        .entity_mut(client)
-        .insert(InputTimeline(Timeline::from(
-            Input::default().with_input_delay(InputDelayConfig::fixed_input_delay(10)),
-        )));
+    app.world_mut().entity_mut(client).insert(
+        InputTimelineConfig::default().with_input_delay(InputDelayConfig::fixed_input_delay(10)),
+    );
 }

--- a/examples/deterministic_replication/src/main.rs
+++ b/examples/deterministic_replication/src/main.rs
@@ -63,7 +63,7 @@ fn main() {
 
 #[cfg(feature = "client")]
 fn add_input_delay(app: &mut App) {
-    use lightyear::prelude::client::{Input, InputDelayConfig};
+    use lightyear::prelude::client::{InputDelayConfig, InputTimelineConfig};
     let client = app
         .world_mut()
         .query_filtered::<Entity, With<Client>>()
@@ -84,12 +84,12 @@ fn add_input_delay(app: &mut App) {
             },
             ..default()
         })
-        .insert(InputTimeline(Timeline::from(
-            Input::default()
+        .insert(
+            InputTimelineConfig::default()
                 // Enable `no_prediction()` to do deterministic_lockstep! 100% of the latency will be covered
                 // by input delay so there won't be any rollbacks
                 // .with_input_delay(InputDelayConfig::no_prediction()),
                 // Otherwise control the input delay manually
                 .with_input_delay(InputDelayConfig::fixed_input_delay(INPUT_DELAY_TICKS)),
-        )));
+        );
 }

--- a/examples/projectiles/src/main.rs
+++ b/examples/projectiles/src/main.rs
@@ -65,7 +65,7 @@ fn main() {
 
 #[cfg(feature = "client")]
 fn update_client(app: &mut App) {
-    use lightyear::prelude::client::{Input, InputDelayConfig};
+    use lightyear::prelude::client::{InputDelayConfig, InputTimelineConfig};
     use lightyear::prelude::{Client, InputTimeline, Timeline};
     let client = app
         .world_mut()

--- a/lightyear_prediction/src/manager.rs
+++ b/lightyear_prediction/src/manager.rs
@@ -14,7 +14,7 @@ use core::ops::{Deref, DerefMut};
 use lightyear_core::prelude::Tick;
 use lightyear_replication::prespawn::PreSpawnedReceiver;
 use lightyear_replication::registry::buffered::BufferedChanges;
-use lightyear_sync::prelude::InputTimeline;
+use lightyear_sync::prelude::InputTimelineConfig;
 use parking_lot::RwLock;
 
 #[derive(Resource)]
@@ -92,7 +92,7 @@ pub(crate) struct PredictionSyncBuffer(BufferedChanges);
 
 #[derive(Component, Debug, Reflect)]
 #[component(on_insert = PredictionManager::on_insert)]
-#[require(InputTimeline)]
+#[require(InputTimelineConfig)]
 #[require(PredictionSyncBuffer)]
 #[require(PreSpawnedReceiver)]
 // TODO: ideally we would only insert LastConfirmedInput if the PredictionManager is updated to use RollbackMode::AlwaysInput

--- a/lightyear_prediction/src/predicted_history.rs
+++ b/lightyear_prediction/src/predicted_history.rs
@@ -11,7 +11,7 @@ use lightyear_core::history_buffer::HistoryBuffer;
 use lightyear_core::prelude::{LocalTimeline, NetworkTimeline};
 use lightyear_core::timeline::SyncEvent;
 use lightyear_replication::prelude::{Confirmed, PreSpawned};
-use lightyear_sync::prelude::Input;
+use lightyear_sync::prelude::InputTimelineConfig;
 #[allow(unused_imports)]
 use tracing::{info, trace};
 
@@ -46,7 +46,7 @@ pub(crate) fn update_prediction_history<T: Component + Clone>(
 /// The history buffer ticks are only relevant relative to the current client tick.
 /// (i.e. X ticks in the past compared to the current tick)
 pub(crate) fn handle_tick_event_prediction_history<C: Component>(
-    trigger: On<SyncEvent<Input>>,
+    trigger: On<SyncEvent<InputTimelineConfig>>,
     mut query: Query<&mut PredictionHistory<C>>,
 ) {
     for mut history in query.iter_mut() {

--- a/lightyear_prediction/src/resource_history.rs
+++ b/lightyear_prediction/src/resource_history.rs
@@ -5,7 +5,7 @@ use bevy_utils::prelude::DebugName;
 use lightyear_core::history_buffer::{HistoryBuffer, HistoryState};
 use lightyear_core::prelude::{LocalTimeline, NetworkTimeline};
 use lightyear_core::timeline::SyncEvent;
-use lightyear_sync::prelude::client::Input;
+use lightyear_sync::prelude::client::InputTimelineConfig;
 #[allow(unused_imports)]
 use tracing::{info, trace};
 
@@ -17,7 +17,7 @@ pub(crate) type ResourceHistory<R> = HistoryBuffer<R>;
 /// The history buffer ticks are only relevant relative to the current client tick.
 /// (i.e. X ticks in the past compared to the current tick)
 pub(crate) fn handle_tick_event_resource_history<R: Resource>(
-    trigger: On<SyncEvent<Input>>,
+    trigger: On<SyncEvent<InputTimelineConfig>>,
     res: Option<ResMut<ResourceHistory<R>>>,
 ) {
     if let Some(mut history) = res {

--- a/lightyear_replication/src/prespawn.rs
+++ b/lightyear_replication/src/prespawn.rs
@@ -26,7 +26,7 @@ use lightyear_link::prelude::Server;
 #[allow(unused_imports)]
 use tracing::{debug, error, info, trace, warn};
 #[cfg(feature = "client")]
-use {lightyear_core::prelude::SyncEvent, lightyear_sync::prelude::client::Input};
+use {lightyear_core::prelude::SyncEvent, lightyear_sync::prelude::client::InputTimelineConfig};
 
 type EntityHashMap<K, V> = bevy_platform::collections::HashMap<K, V, EntityHash>;
 
@@ -309,7 +309,7 @@ impl PreSpawnedReceiver {
 
     #[cfg(feature = "client")]
     pub(crate) fn handle_tick_sync(
-        trigger: On<SyncEvent<Input>>,
+        trigger: On<SyncEvent<InputTimelineConfig>>,
         mut manager: Single<&mut Self, With<Connected>>,
     ) {
         manager

--- a/lightyear_replication/src/receive.rs
+++ b/lightyear_replication/src/receive.rs
@@ -40,7 +40,7 @@ use lightyear_utils::metrics::{DormantTimerGauge, TimerGauge};
 #[cfg(feature = "trace")]
 use tracing::{Level, instrument};
 #[cfg(feature = "client")]
-use {lightyear_core::prelude::SyncEvent, lightyear_sync::prelude::client::Input};
+use {lightyear_core::prelude::SyncEvent, lightyear_sync::prelude::client::InputTimelineConfig};
 
 type EntityHashMap<K, V> = HashMap<K, V, EntityHash>;
 
@@ -191,7 +191,7 @@ impl ReplicationReceivePlugin {
 
     #[cfg(feature = "client")]
     pub(crate) fn on_sync_event(
-        trigger: On<SyncEvent<Input>>,
+        trigger: On<SyncEvent<InputTimelineConfig>>,
         mut receiver: Query<&mut ReplicationReceiver>,
     ) {
         receiver.iter_mut().for_each(|mut receiver| {

--- a/lightyear_replication/src/registry/delta.rs
+++ b/lightyear_replication/src/registry/delta.rs
@@ -198,6 +198,7 @@ fn buffer_insert_delta<
     let entity = entity_mut.entity.id();
     let delta = deserialize.deserialize(entity_map, reader)?;
     trace!(
+        ?tick,
         ?predicted,
         ?interpolated,
         ?kind,

--- a/lightyear_sync/src/client.rs
+++ b/lightyear_sync/src/client.rs
@@ -3,10 +3,10 @@
 use crate::plugin::TimelineSyncPlugin;
 use crate::prelude::InputTimeline;
 use crate::prelude::client::RemoteTimeline;
-use crate::timeline::input::Input;
+use crate::timeline::input::InputTimelineConfig;
 use crate::timeline::remote;
 use crate::timeline::sync::SyncedTimelinePlugin;
-use bevy_app::{App, First, Last, Plugin, PreUpdate};
+use bevy_app::prelude::*;
 use bevy_ecs::prelude::*;
 use lightyear_connection::client::Client;
 use lightyear_core::prelude::{LocalTimeline, NetworkTimeline, NetworkTimelinePlugin};
@@ -24,7 +24,7 @@ pub struct ClientPlugin;
 
 impl ClientPlugin {
     pub fn update_local_timeline(
-        trigger: On<SyncEvent<Input>>,
+        trigger: On<SyncEvent<InputTimelineConfig>>,
         mut query: Query<&mut LocalTimeline>,
     ) {
         if let Ok(mut timeline) = query.get_mut(trigger.entity) {
@@ -66,12 +66,11 @@ impl Plugin for ClientPlugin {
             app.add_plugins(TimelineSyncPlugin);
         }
 
-        app.register_required_components::<Client, InputTimeline>();
+        app.register_required_components::<Client, InputTimelineConfig>();
         app.register_required_components::<Client, RemoteTimeline>();
 
-        // TODO: add a system that recomputes input_delay_ticks whenever the InputDelayConfig changes
-        app.add_observer(Input::recompute_input_delay);
-        app.add_systems(First, Input::recompute_input_delay_on_config_update);
+        app.add_observer(InputTimelineConfig::recompute_input_delay_on_sync);
+        app.add_observer(InputTimelineConfig::recompute_input_delay_on_config_update);
 
         // TODO: should the DrivingTimeline be configurable?
         // the client will use the Input timeline as the driving timeline

--- a/lightyear_sync/src/lib.rs
+++ b/lightyear_sync/src/lib.rs
@@ -40,12 +40,12 @@ pub mod prelude {
     pub use crate::timeline::sync::{IsSynced, SyncConfig};
     pub use crate::timeline::{
         DrivingTimeline,
-        input::{Input, InputTimeline},
+        input::{InputTimeline, InputTimelineConfig},
     };
 
     #[cfg(feature = "client")]
     pub mod client {
-        pub use crate::timeline::input::{Input, InputDelayConfig, InputTimeline};
+        pub use crate::timeline::input::{InputDelayConfig, InputTimeline, InputTimelineConfig};
         pub use crate::timeline::remote::{RemoteEstimate, RemoteTimeline};
         pub use crate::timeline::sync::IsSynced;
     }

--- a/lightyear_sync/src/timeline/input.rs
+++ b/lightyear_sync/src/timeline/input.rs
@@ -1,5 +1,7 @@
 use crate::ping::manager::PingManager;
-use crate::timeline::sync::{SyncAdjustment, SyncConfig, SyncTargetTimeline, SyncedTimeline};
+use crate::timeline::sync::{
+    SyncAdjustment, SyncConfig, SyncContext, SyncTargetTimeline, SyncedTimeline,
+};
 
 use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::prelude::*;
@@ -8,27 +10,23 @@ use bevy_utils::default;
 use core::time::Duration;
 use lightyear_core::tick::{Tick, TickDuration};
 use lightyear_core::time::{TickDelta, TickInstant};
-use lightyear_core::timeline::{NetworkTimeline, SyncEvent, Timeline, TimelineContext};
+use lightyear_core::timeline::{NetworkTimeline, SyncEvent, Timeline, TimelineConfig};
 use lightyear_link::{Link, LinkStats};
 use tracing::trace;
 
 /// Timeline that is used to make sure that Inputs from this peer will arrive on time
 /// on the remote peer
-#[derive(Debug, Reflect)]
-pub struct Input {
-    pub config: SyncConfig,
-    pub input_delay_config: InputDelayConfig,
-
-    /// Current input_delay_ticks that are being applied
-    pub(crate) input_delay_ticks: u16,
-    relative_speed: f32,
-    is_synced: bool,
+#[derive(Debug, Component, Reflect)]
+#[require(InputTimeline)]
+pub struct InputTimelineConfig {
+    pub(crate) sync: SyncConfig,
+    pub(crate) input_delay_config: InputDelayConfig,
 }
 
-impl Input {
+impl InputTimelineConfig {
     pub fn new(sync_config: SyncConfig, input_delay: InputDelayConfig) -> Self {
         Self {
-            config: sync_config,
+            sync: sync_config,
             input_delay_config: input_delay,
             ..default()
         }
@@ -40,15 +38,8 @@ impl Input {
     }
 
     pub fn with_sync_config(mut self, sync_config: SyncConfig) -> Self {
-        self.config = sync_config;
+        self.sync = sync_config;
         self
-    }
-
-    // TODO: currently this is fixed, but the input delay should be updated everytime we have a
-    //  SyncEvent. We want to make it configurable based on prediction settings.
-    /// Return the input delay in number of ticks
-    pub fn input_delay(&self) -> u16 {
-        self.input_delay_ticks
     }
 
     /// Returns the true if the timeline is configured for deterministic lockstep mode,
@@ -60,15 +51,15 @@ impl Input {
 
     /// Update the input delay based on the current RTT and tick duration
     /// when there is a SyncEvent
-    pub(crate) fn recompute_input_delay(
-        trigger: On<SyncEvent<Input>>,
+    pub(crate) fn recompute_input_delay_on_sync(
+        trigger: On<SyncEvent<InputTimelineConfig>>,
         tick_duration: Res<TickDuration>,
-        mut query: Query<(&Link, &mut InputTimeline)>,
+        mut query: Query<(&Link, &mut InputTimeline, &InputTimelineConfig)>,
     ) {
-        if let Ok((link, mut timeline)) = query.get_mut(trigger.entity) {
-            timeline.input_delay_ticks = timeline.input_delay_config.input_delay_ticks(
+        if let Ok((link, mut timeline, config)) = query.get_mut(trigger.entity) {
+            timeline.input_delay_ticks = config.input_delay_config.input_delay_ticks(
                 link.stats,
-                &timeline.config,
+                &config.sync,
                 tick_duration.0,
             );
             trace!(
@@ -83,30 +74,55 @@ impl Input {
     /// Update the input delay based on the current RTT and tick duration
     /// when the InputDelayConfig is updated
     pub(crate) fn recompute_input_delay_on_config_update(
+        trigger: On<Insert, InputTimelineConfig>,
         tick_duration: Res<TickDuration>,
-        mut query: Query<(&Link, &mut InputTimeline), Changed<InputTimeline>>,
+        mut query: Query<(&Link, &mut InputTimeline, &InputTimelineConfig)>,
     ) {
-        query.iter_mut().for_each(|(link, mut timeline)| {
-            timeline.input_delay_ticks = timeline.input_delay_config.input_delay_ticks(
+        if let Ok((link, mut timeline, config)) = query.get_mut(trigger.entity) {
+            timeline.input_delay_ticks = config.input_delay_config.input_delay_ticks(
                 link.stats,
-                &timeline.config,
+                &config.sync,
                 tick_duration.0,
             );
             trace!(
                 "Recomputing input delay on config update! Input delay ticks: {}. Config: {:?}",
-                timeline.input_delay_ticks, timeline.input_delay_config
+                timeline.input_delay_ticks, config.input_delay_config
             );
-        });
+        }
     }
 }
 
-impl Default for Input {
+impl Default for InputTimelineConfig {
     fn default() -> Self {
         Self {
-            config: SyncConfig::default(),
+            sync: SyncConfig::default(),
+            input_delay_config: InputDelayConfig::no_input_delay(),
+        }
+    }
+}
+
+#[derive(Debug, Reflect)]
+pub struct InputContext {
+    sync: SyncContext,
+    /// Current input_delay_ticks that are being applied
+    input_delay_ticks: u16,
+    relative_speed: f32,
+    is_synced: bool,
+}
+
+impl InputContext {
+    /// Return the input delay in number of ticks
+    pub fn input_delay(&self) -> u16 {
+        self.input_delay_ticks
+    }
+}
+
+impl Default for InputContext {
+    fn default() -> Self {
+        Self {
+            sync: SyncContext::default(),
             input_delay_ticks: 0,
             relative_speed: 1.0,
-            input_delay_config: InputDelayConfig::no_input_delay(),
             is_synced: false,
         }
     }
@@ -241,9 +257,12 @@ impl InputDelayConfig {
 /// This timeline is updated in PostUpdate; it CANNOT be used to get accurate `tick` in PreUpdate or Update;
 /// use `LocalTimeline` instead.
 #[derive(Component, Deref, DerefMut, Default, Debug, Reflect)]
-pub struct InputTimeline(pub Timeline<Input>);
+pub struct InputTimeline(pub Timeline<InputTimelineConfig>);
 
-impl TimelineContext for Input {}
+impl TimelineConfig for InputTimelineConfig {
+    type Context = InputContext;
+    type Timeline = InputTimeline;
+}
 
 impl SyncedTimeline for InputTimeline {
     /// We want the Predicted timeline to be:
@@ -255,13 +274,14 @@ impl SyncedTimeline for InputTimeline {
     fn sync_objective<T: SyncTargetTimeline>(
         &self,
         remote: &T,
+        config: &Self::Config,
         ping_manager: &PingManager,
         tick_duration: Duration,
     ) -> TickInstant {
         let remote = remote.current_estimate();
         let network_delay = TickDelta::from_duration(ping_manager.rtt() / 2, tick_duration);
         let jitter_margin = TickDelta::from_duration(
-            self.context.config.jitter_margin(ping_manager.jitter()),
+            config.sync.jitter_margin(ping_manager.jitter()),
             tick_duration,
         );
         let input_delay: TickDelta = Tick(self.context.input_delay_ticks).into();
@@ -297,29 +317,30 @@ impl SyncedTimeline for InputTimeline {
     fn sync<T: SyncTargetTimeline>(
         &mut self,
         main: &T,
+        config: &Self::Config,
         ping_manager: &PingManager,
         tick_duration: Duration,
     ) -> Option<i16> {
         // skip syncing if we haven't received enough information
-        if ping_manager.pongs_recv < self.config.handshake_pings as u32 {
+        if ping_manager.pongs_recv < config.sync.handshake_pings as u32 {
             return None;
         }
         let now = self.now();
-        let objective = self.sync_objective(main, ping_manager, tick_duration);
+        let objective = self.sync_objective(main, config, ping_manager, tick_duration);
         let error = now - objective;
         let error_ticks = error.to_f32();
         let adjustment = if !self.is_synced {
             SyncAdjustment::Resync
         } else {
-            self.config.speed_adjustment(error_ticks)
+            self.sync.speed_adjustment(&config.sync, error_ticks)
         };
         trace!(
             ?now,
             ?objective,
             ?adjustment,
             ?error_ticks,
-            error_margin = ?self.config.error_margin,
-            max_error_margin = ?self.config.max_error_margin,
+            error_margin = ?config.sync.error_margin,
+            max_error_margin = ?config.sync.max_error_margin,
             "InputTimeline sync"
         );
         self.is_synced = true;

--- a/lightyear_sync/src/timeline/remote.rs
+++ b/lightyear_sync/src/timeline/remote.rs
@@ -9,10 +9,14 @@ use lightyear_connection::client::Connected;
 use lightyear_core::prelude::Rollback;
 use lightyear_core::tick::{Tick, TickDuration};
 use lightyear_core::time::{TickDelta, TickInstant};
-use lightyear_core::timeline::{NetworkTimeline, Timeline, TimelineContext};
+use lightyear_core::timeline::{NetworkTimeline, Timeline, TimelineConfig};
 use lightyear_link::Linked;
 use lightyear_transport::plugin::PacketReceived;
 use tracing::trace;
+
+#[derive(Component, Default, Debug, Reflect)]
+#[require(RemoteTimeline)]
+pub struct RemoteTimelineConfig;
 
 /// The local peer's estimate of the remote peer's timeline
 ///
@@ -60,9 +64,12 @@ impl Default for RemoteEstimate {
 
 // We need to wrap the inner Timeline to avoid the orphan rule
 #[derive(Component, Default, Debug, Deref, DerefMut, Reflect)]
-pub struct RemoteTimeline(Timeline<RemoteEstimate>);
+pub struct RemoteTimeline(Timeline<RemoteTimelineConfig>);
 
-impl TimelineContext for RemoteEstimate {}
+impl TimelineConfig for RemoteTimelineConfig {
+    type Context = RemoteEstimate;
+    type Timeline = RemoteTimeline;
+}
 
 impl RemoteTimeline {
     /// Returns the most recent tick received from the remote peer.

--- a/lightyear_tests/src/client_server/delta.rs
+++ b/lightyear_tests/src/client_server/delta.rs
@@ -102,7 +102,7 @@ fn test_component_update() {
             .get::<DeltaComponentHistory<CompDelta>>(client_entity)
             .unwrap()
             .buffer
-            .get(&client_tick_insert)
+            .get(&server_tick_insert)
             .unwrap(),
         &CompDelta(1)
     );
@@ -131,7 +131,7 @@ fn test_component_update() {
             .get::<DeltaComponentHistory<CompDelta>>(client_entity)
             .unwrap()
             .buffer
-            .get(&client_tick_update_1)
+            .get(&server_tick_update_1)
             .unwrap(),
         &CompDelta(2)
     );
@@ -189,7 +189,7 @@ fn test_component_update() {
             .get::<DeltaComponentHistory<CompDelta>>(client_entity)
             .unwrap()
             .buffer
-            .get(&client_tick_insert)
+            .get(&server_tick_insert)
             .is_none()
     );
     assert!(
@@ -199,7 +199,7 @@ fn test_component_update() {
             .get::<DeltaComponentHistory<CompDelta>>(client_entity)
             .unwrap()
             .buffer
-            .get(&client_tick_update_1)
+            .get(&server_tick_update_1)
             .is_some()
     );
     assert!(
@@ -209,7 +209,7 @@ fn test_component_update() {
             .get::<DeltaComponentHistory<CompDelta>>(client_entity)
             .unwrap()
             .buffer
-            .get(&client_tick_update_2)
+            .get(&server_tick_update_2)
             .is_some()
     );
 }

--- a/lightyear_tests/src/client_server/input/bei.rs
+++ b/lightyear_tests/src/client_server/input/bei.rs
@@ -12,14 +12,13 @@ use lightyear::input::input_message::ActionStateQueryData;
 use lightyear::input::input_message::ActionStateSequence;
 use lightyear_connection::client::Client;
 use lightyear_connection::network_target::NetworkTarget;
-use lightyear_core::prelude::{LocalTimeline, NetworkTimeline, Tick, Timeline};
+use lightyear_core::prelude::*;
 use lightyear_link::Link;
 use lightyear_link::prelude::LinkConditionerConfig;
 use lightyear_messages::MessageManager;
 use lightyear_prediction::diagnostics::PredictionMetrics;
 use lightyear_replication::prelude::{PredictionTarget, Replicate};
-use lightyear_sync::prelude::InputTimeline;
-use lightyear_sync::prelude::client::{Input, InputDelayConfig};
+use lightyear_sync::prelude::client::{InputDelayConfig, InputTimelineConfig};
 use test_log::test;
 use tracing::info;
 
@@ -98,10 +97,13 @@ fn test_actions_on_client_entity() {
 /// Check that ActionStates are stored correctly in the InputBuffer
 #[test]
 fn test_buffer_inputs_with_delay() {
-    let mut stepper = ClientServerStepper::from_config(StepperConfig::single());
-    stepper.client_mut(0).insert(InputTimeline(Timeline::from(
-        Input::default().with_input_delay(InputDelayConfig::fixed_input_delay(1)),
-    )));
+    let mut config = StepperConfig::single();
+    config.init = false;
+    let mut stepper = ClientServerStepper::from_config(config);
+    stepper.client_mut(0).insert(
+        InputTimelineConfig::default().with_input_delay(InputDelayConfig::fixed_input_delay(1)),
+    );
+    stepper.init();
     let server_entity = stepper
         .server_app
         .world_mut()

--- a/lightyear_tests/src/client_server/prediction/prespawn.rs
+++ b/lightyear_tests/src/client_server/prediction/prespawn.rs
@@ -17,7 +17,7 @@ use lightyear_replication::prelude::{
     PreSpawned, PredictionTarget, Replicate, Replicated, ReplicationGroup,
 };
 use lightyear_replication::prespawn::PreSpawnedReceiver;
-use lightyear_sync::prelude::InputTimeline;
+use lightyear_sync::prelude::*;
 use test_log::test;
 use tracing::info;
 
@@ -40,7 +40,9 @@ fn test_compute_hash() {
 
     let current_tick = stepper.client_tick(0);
     let prediction_manager = stepper.client(0).get::<PreSpawnedReceiver>().unwrap();
-    let expected_hash: u64 = 5335464222343754353;
+    let expected_hash: u64 = 6945170416458392155;
+    tracing::info!(?prediction_manager
+            .prespawn_hash_to_entities, "hi");
     assert_eq!(
         prediction_manager
             .prespawn_hash_to_entities
@@ -320,14 +322,11 @@ fn test_prespawn_local_despawn_match() {
     let mut stepper = ClientServerStepper::from_config(config);
     let tick_duration = stepper.tick_duration;
     // add a conditioner to make sure that the client is ahead of the server, and make sure there is a resync
+    let mut sync_config = SyncConfig::default();
+    sync_config.max_error_margin = 0.5;
     stepper
         .client_mut(0)
-        .get_mut::<InputTimeline>()
-        .unwrap()
-        .0
-        .context
-        .config
-        .max_error_margin = 0.5;
+        .insert(InputTimelineConfig::default().with_sync_config(sync_config));
     stepper
         .client_mut(0)
         .get_mut::<Link>()

--- a/lightyear_tests/src/host_server/input/leafwing.rs
+++ b/lightyear_tests/src/host_server/input/leafwing.rs
@@ -8,7 +8,7 @@ use lightyear::input::leafwing::prelude::LeafwingBuffer;
 use lightyear_connection::network_target::NetworkTarget;
 use lightyear_messages::MessageManager;
 use lightyear_replication::prelude::Replicate;
-use lightyear_sync::prelude::InputTimeline;
+use lightyear_sync::prelude::InputTimelineConfig;
 use lightyear_sync::prelude::client::InputDelayConfig;
 use test_log::test;
 use tracing::info;
@@ -19,11 +19,9 @@ use tracing::info;
 fn test_buffer_inputs_with_delay() {
     let mut stepper = ClientServerStepper::from_config(StepperConfig::host_server());
 
-    stepper
-        .host_client_mut()
-        .get_mut::<InputTimeline>()
-        .unwrap()
-        .input_delay_config = InputDelayConfig::fixed_input_delay(1);
+    stepper.host_client_mut().insert(
+        InputTimelineConfig::default().with_input_delay(InputDelayConfig::fixed_input_delay(1)),
+    );
 
     let server_entity = stepper
         .server_app


### PR DESCRIPTION
The `Timeline` object currently also contains the `Config`, which leads to a weird situation where the user creates the object by specifying a couple of config-related fields, and the remaining fields are provided by the Timeline internals.

This makes reacting to changes to the Config hard to do, because `Changed<Timeline>` always returns true.

Instead we separate the `TimelineConfig` from the `TimelineContext`: the internals that are needed for the timeline. That way we can use observers that react on `On<Insert, TimelineConfig>` to detect when we need to do some timeline resync