### PR TITLE
feat: improve authority transfer behavior

### DIFF
--- a/examples/common/src/client.rs
+++ b/examples/common/src/client.rs
@@ -108,7 +108,10 @@ impl ExampleClient {
                             ClientConfig::builder().with_no_cert_validation()
                         }
                     };
-                    entity_mut.insert(WebSocketClientIo { config, scheme: Default::default() });
+                    entity_mut.insert(WebSocketClientIo {
+                        config,
+                        scheme: Default::default(),
+                    });
                 }
                 #[cfg(feature = "steam")]
                 ClientTransports::Steam => {

--- a/examples/distributed_authority/src/client.rs
+++ b/examples/distributed_authority/src/client.rs
@@ -1,9 +1,4 @@
 //! The client plugin.
-//! The client will be responsible for:
-//! - connecting to the server at Startup
-//! - sending inputs to the server
-//! - applying inputs to the locally predicted player (for prediction to work, inputs have to be applied to both the
-//! predicted entity and the server entity)
 use std::net::{Ipv4Addr, SocketAddr};
 use std::str::FromStr;
 
@@ -34,7 +29,7 @@ impl Plugin for ExampleClientPlugin {
     }
 }
 
-/// When a Ball entity gets replicated to use from the server, add the Replicate component
+/// When a Ball entity gets replicated to us from the server, add the Replicate component
 /// on the client so that we can replicate updates to the server if we get authority
 /// over the ball
 pub(crate) fn handle_ball(trigger: On<Add, BallMarker>, mut commands: Commands) {
@@ -44,7 +39,7 @@ pub(crate) fn handle_ball(trigger: On<Add, BallMarker>, mut commands: Commands) 
         ..default()
     });
     commands.entity(trigger.entity).insert((
-        Replicate::to_server(),
+        Replicate::to_server().without_authority(),
         Name::new("Ball"),
         // Disable PlayerColor replication from client to server
         color_override,

--- a/lightyear_connection/src/lib.rs
+++ b/lightyear_connection/src/lib.rs
@@ -64,6 +64,7 @@ pub mod prelude {
     // we also export these types at the top level for easier access
     pub use crate::client::{
         Client, Connect, Connected, Connecting, ConnectionError, Disconnect, Disconnected,
+        PeerMetadata,
     };
 
     #[cfg(feature = "client")]

--- a/lightyear_connection/src/server.rs
+++ b/lightyear_connection/src/server.rs
@@ -1,4 +1,4 @@
-use crate::client::{Client, Disconnected, Disconnecting};
+use crate::client::{Client, Disconnected, Disconnecting, PeerMetadata};
 use crate::client_of::ClientOf;
 use bevy_app::{App, Last, Plugin};
 use bevy_ecs::lifecycle::HookContext;
@@ -6,6 +6,7 @@ use bevy_ecs::prelude::*;
 use bevy_ecs::world::DeferredWorld;
 use bevy_reflect::Reflect;
 use core::fmt::Debug;
+use lightyear_core::id::PeerId;
 use lightyear_link::prelude::Server;
 use lightyear_link::{LinkStart, Unlinked};
 use tracing::trace;
@@ -53,6 +54,10 @@ pub struct Started;
 
 impl Started {
     fn on_add(mut world: DeferredWorld, context: HookContext) {
+        world
+            .resource_mut::<PeerMetadata>()
+            .mapping
+            .insert(PeerId::Server, context.entity);
         trace!("Started added: removing Starting/Stopped");
         world
             .commands()
@@ -81,6 +86,10 @@ pub struct Stopped;
 
 impl Stopped {
     fn on_add(mut world: DeferredWorld, context: HookContext) {
+        world
+            .resource_mut::<PeerMetadata>()
+            .mapping
+            .remove(&PeerId::Server);
         trace!("Stopped added: removing Started/Starting");
         world
             .commands()

--- a/lightyear_replication/src/lib.rs
+++ b/lightyear_replication/src/lib.rs
@@ -49,8 +49,8 @@ pub mod visibility;
 /// Commonly used items for replication.
 pub mod prelude {
     pub use crate::authority::{
-        AuthorityPlugin, AuthorityRequestEvent, AuthorityResponseEvent, AuthorityTransfer,
-        AuthorityTransferRequest, AuthorityTransferResponse, GiveAuthority, RequestAuthority,
+        AuthorityBroker, AuthorityGrantedEvent, AuthorityPlugin, AuthorityTransfer,
+        AuthorityTransferEvent, AuthorityTransferType, GiveAuthority, RequestAuthority,
     };
     pub use crate::components::*;
     pub use crate::control::{Controlled, ControlledBy, ControlledByRemote, Lifetime};

--- a/lightyear_replication/src/send/buffer.rs
+++ b/lightyear_replication/src/send/buffer.rs
@@ -31,11 +31,10 @@ use lightyear_messages::MessageManager;
 use lightyear_serde::entity_map::RemoteEntityMap;
 #[cfg(feature = "metrics")]
 use lightyear_utils::metrics::DormantTimerGauge;
-use tracing::warn;
 #[cfg(feature = "trace")]
 use tracing::{Level, instrument};
 #[allow(unused_imports)]
-use tracing::{debug, error, info, info_span, trace, trace_span};
+use tracing::{debug, error, info, info_span, trace, trace_span, warn};
 
 pub(crate) fn replicate(
     // query &C + various replication components
@@ -112,7 +111,7 @@ pub(crate) fn replicate(
                     continue;
                 }
                 let Ok(root_entity_ref) = entity_query.get(entity) else {
-                    warn!("Replicated Entity {:?} not found in entity_query", entity);
+                    debug!("Replicated Entity {:?} not found in entity_query", entity);
                     continue;
                 };
                 let _root_span = trace_span!("root", ?entity).entered();

--- a/lightyear_replication/src/send/sender.rs
+++ b/lightyear_replication/src/send/sender.rs
@@ -61,7 +61,7 @@ pub struct ReplicationStatus {
     /// If true, the sender has sent a Spawn message about the entity.
     /// This is useful because each sender runs the replication system at a different time (because they might have
     /// different send_intervals)
-    spawned: bool,
+    pub(crate) spawned: bool,
 }
 
 #[derive(Component, Debug)]
@@ -185,14 +185,13 @@ impl ReplicationSender {
         }
     }
 
-    pub(crate) fn add_replicated_entity(&mut self, entity: Entity, authority: bool) {
-        self.replicated_entities.insert(
-            entity,
-            ReplicationStatus {
-                authority,
+    pub(crate) fn add_replicated_entity(&mut self, entity: Entity) {
+        self.replicated_entities
+            .entry(entity)
+            .or_insert(ReplicationStatus {
+                authority: true,
                 spawned: false,
-            },
-        );
+            });
     }
 
     pub fn gain_authority(&mut self, entity: Entity) {

--- a/lightyear_tests/src/client_server/authority.rs
+++ b/lightyear_tests/src/client_server/authority.rs
@@ -1,13 +1,15 @@
 use crate::protocol::{CompA, CompMap};
 use crate::stepper::*;
-use lightyear_connection::network_target::NetworkTarget;
+use lightyear_connection::prelude::*;
 use lightyear_core::id::PeerId;
 use lightyear_messages::MessageManager;
 use lightyear_replication::prelude::*;
 use test_log::test;
+#[allow(unused_imports)]
+use tracing::info;
 
 #[test]
-fn test_give_authority() {
+fn test_give_authority_server_to_client() {
     let mut stepper = ClientServerStepper::from_config(StepperConfig::single());
 
     let sender = stepper.client_of(0).id();
@@ -16,6 +18,16 @@ fn test_give_authority() {
         .world_mut()
         .spawn((Replicate::to_clients(NetworkTarget::All),))
         .id();
+    assert_eq!(
+        stepper
+            .server()
+            .get::<AuthorityBroker>()
+            .unwrap()
+            .owners
+            .get(&server_entity)
+            .unwrap(),
+        &Some(PeerId::Server)
+    );
     stepper.frame_step(2);
     let client_entity = stepper
         .client(0)
@@ -28,15 +40,24 @@ fn test_give_authority() {
         .client_app()
         .world_mut()
         .entity_mut(client_entity)
-        .insert(Replicate::to_server().without_authority());
+        .insert(Replicate::to_server());
     stepper.server_app.world_mut().trigger(GiveAuthority {
-        sender,
         entity: server_entity,
-        remote_peer: PeerId::Netcode(0),
+        remote_peer: Some(PeerId::Netcode(0)),
     });
     stepper.frame_step(2);
 
     // check that the server lost authority and client gained authority
+    assert_eq!(
+        stepper
+            .server()
+            .get::<AuthorityBroker>()
+            .unwrap()
+            .owners
+            .get(&server_entity)
+            .unwrap(),
+        &Some(PeerId::Netcode(0))
+    );
     assert!(
         !stepper
             .client_of(0)
@@ -80,6 +101,100 @@ fn test_give_authority() {
     );
 }
 
+#[test]
+fn test_give_authority_client_to_server() {
+    let mut stepper = ClientServerStepper::from_config(StepperConfig::single());
+
+    let sender = stepper.client_of(0).id();
+    let client_entity = stepper
+        .client_app()
+        .world_mut()
+        .spawn(Replicate::to_server())
+        .id();
+    stepper.frame_step(2);
+
+    let server_entity = stepper
+        .client_of(0)
+        .get::<MessageManager>()
+        .unwrap()
+        .entity_mapper
+        .get_local(client_entity)
+        .expect("entity is not present in entity map");
+    assert_eq!(
+        stepper
+            .server()
+            .get::<AuthorityBroker>()
+            .unwrap()
+            .owners
+            .get(&server_entity)
+            .unwrap(),
+        &Some(PeerId::Netcode(0))
+    );
+    stepper
+        .server_app
+        .world_mut()
+        .entity_mut(server_entity)
+        .insert(Replicate::to_clients(NetworkTarget::All));
+    stepper.client_app().world_mut().trigger(GiveAuthority {
+        entity: client_entity,
+        remote_peer: Some(PeerId::Server),
+    });
+    stepper.frame_step(2);
+
+    // check that the server lost authority and client gained authority
+    assert_eq!(
+        stepper
+            .server()
+            .get::<AuthorityBroker>()
+            .unwrap()
+            .owners
+            .get(&server_entity)
+            .unwrap(),
+        &Some(PeerId::Server)
+    );
+    assert!(
+        stepper
+            .client_of(0)
+            .get::<ReplicationSender>()
+            .unwrap()
+            .has_authority(server_entity)
+    );
+    assert!(
+        !stepper
+            .client(0)
+            .get::<ReplicationSender>()
+            .unwrap()
+            .has_authority(client_entity)
+    );
+
+    // check that the client updates are not replicated
+    stepper
+        .client_app()
+        .world_mut()
+        .entity_mut(client_entity)
+        .insert(CompA(1.0));
+    stepper.frame_step(2);
+    assert!(
+        stepper
+            .server_app
+            .world()
+            .get::<CompA>(server_entity)
+            .is_none()
+    );
+
+    // check that server updates are replicated
+    stepper
+        .server_app
+        .world_mut()
+        .entity_mut(server_entity)
+        .insert(CompA(2.0));
+    stepper.frame_step(2);
+    assert_eq!(
+        stepper.client_app().world().get::<CompA>(client_entity),
+        Some(&CompA(2.0))
+    );
+}
+
 /// Spawn on client, transfer authority to server, despawn entity on server.
 /// The entity should get despawned correctly on client.
 /// Relevant issue: https://github.com/cBournhonesque/lightyear/issues/644
@@ -105,12 +220,11 @@ fn test_transfer_authority_despawn() {
         .server_app
         .world_mut()
         .entity_mut(server_entity)
-        .insert(Replicate::to_clients(NetworkTarget::All).without_authority());
+        .insert(Replicate::to_clients(NetworkTarget::All));
 
     stepper.client_app().world_mut().trigger(GiveAuthority {
-        sender,
         entity: client_entity,
-        remote_peer: PeerId::Server,
+        remote_peer: Some(PeerId::Server),
     });
     stepper.frame_step(2);
 
@@ -174,14 +288,13 @@ fn test_transfer_authority_map_entities() {
         .world_mut()
         .entity_mut(server_entity)
         .insert((
-            Replicate::to_clients(NetworkTarget::All).without_authority(),
+            Replicate::to_clients(NetworkTarget::All),
             CompMap(server_entity),
         ));
 
     stepper.client_app().world_mut().trigger(GiveAuthority {
-        sender,
         entity: client_entity,
-        remote_peer: PeerId::Server,
+        remote_peer: Some(PeerId::Server),
     });
     stepper.frame_step(2);
 
@@ -208,53 +321,174 @@ fn test_transfer_authority_map_entities() {
     );
 }
 
-// /// Spawn on client, transfer authority from client 1 to client 2
-// /// Update on server, the updates from the server use entity mapping on the send side.
-// /// (both for the Entity in Updates and for the content of the components in the Update)
-// #[test]
-// fn test_transfer_authority_client_to_client() {
-//      let mut stepper =  ClientServerStepper::from_config(StepperConfig::with_netcode_clients(2));
-//
-//     let client_sender_0 = stepper.client(0).id();
-//     // send an entity from client 0 to server
-//     let client_entity_0 = stepper.client_apps[0].world_mut().spawn((
-//         Replicate::manual(vec![client_sender_0]),
-//         // the authority can be freely stolen
-//         AuthorityTransfer::Steal
-//     )).id();
-//     info!("Client entity 0: {client_entity_0:?}");
-//     stepper.frame_step(1);
-//     let server_entity = stepper.client_of(0).get::<MessageManager>().unwrap().entity_mapper.get_local(client_entity_0)
-//         .expect("entity is not present in entity map");
-//
-//     stepper.server_app.world_mut().entity_mut(server_entity).insert((
-//         Replicate::to_clients(NetworkTarget::All).without_authority(),
-//         CompMap(server_entity),
-//     ));
-//     // gain authority over the entity for client 1
-//     stepper.client_of_mut(1).get_mut::<ReplicationSender>().unwrap().gain_authority(server_entity);
-//
-//     stepper.frame_step(2);
-//
-//     // check that the client 1 has the replicated entity
-//     let client_entity_1 = stepper.client(1).get::<MessageManager>().unwrap().entity_mapper.get_local(server_entity)
-//         .expect("entity is not present in entity map");
-//
-//     // transfer the authority from client 0 to client 1
-//     // TODO: have a dedicated TransferAuthority system for the server?
-//     stepper.server_app.world_mut().trigger(GiveAuthority {
-//         entity: server_entity,
-//         remote_peer: PeerId::Netcode(1)
-//     });
-//     stepper.server_app.world_mut().trigger(RequestAuthority {
-//         entity: server_entity,
-//         remote_peer: PeerId::Netcode(0)
-//     });
-//     stepper.frame_step(2);
-//
-//     // check that the client 0 lost authority and client 1 gained authority
-//     assert!(!stepper.client(0).get::<ReplicationSender>().unwrap().has_authority(client_entity_0));
-//     assert!(stepper.client(1).get::<ReplicationSender>().unwrap().has_authority(client_entity_1));
-//     assert!(stepper.client_of(0).get::<ReplicationSender>().unwrap().has_authority(server_entity));
-//     assert!(!stepper.client_of(1).get::<ReplicationSender>().unwrap().has_authority(server_entity));
-// }
+/// Spawn on client, transfer authority from client 1 to client 2
+#[test]
+fn test_transfer_authority_client_to_client() {
+    let mut stepper = ClientServerStepper::from_config(StepperConfig::with_netcode_clients(2));
+
+    let client_sender_0 = stepper.client(0).id();
+    // send an entity from client 0 to server
+    let client_entity_0 = stepper.client_apps[0]
+        .world_mut()
+        .spawn((Replicate::manual(vec![client_sender_0]),))
+        .id();
+    info!("Client entity 0: {client_entity_0:?}");
+    stepper.frame_step(1);
+    let server_entity = stepper
+        .client_of(0)
+        .get::<MessageManager>()
+        .unwrap()
+        .entity_mapper
+        .get_local(client_entity_0)
+        .expect("entity is not present in entity map");
+    assert!(
+        stepper
+            .client_of_mut(0)
+            .get_mut::<ReplicationSender>()
+            .unwrap()
+            .replicated_entities
+            .get(&server_entity)
+            .is_some()
+    );
+    assert!(
+        !stepper
+            .client_of_mut(0)
+            .get_mut::<ReplicationSender>()
+            .unwrap()
+            .has_authority(server_entity)
+    );
+    assert_eq!(
+        stepper
+            .server()
+            .get::<AuthorityBroker>()
+            .unwrap()
+            .owners
+            .get(&server_entity)
+            .unwrap(),
+        &Some(PeerId::Netcode(0))
+    );
+
+    stepper
+        .server_app
+        .world_mut()
+        .entity_mut(server_entity)
+        .insert((
+            Replicate::to_clients(NetworkTarget::All),
+            CompMap(server_entity),
+        ));
+    assert!(
+        !stepper
+            .client_of_mut(0)
+            .get_mut::<ReplicationSender>()
+            .unwrap()
+            .has_authority(server_entity)
+    );
+    assert!(
+        stepper
+            .client_of_mut(1)
+            .get_mut::<ReplicationSender>()
+            .unwrap()
+            .has_authority(server_entity)
+    );
+    assert_eq!(
+        stepper
+            .server()
+            .get::<AuthorityBroker>()
+            .unwrap()
+            .owners
+            .get(&server_entity)
+            .unwrap(),
+        &Some(PeerId::Netcode(0))
+    );
+
+    stepper.frame_step(2);
+
+    // check that the client 1 has the replicated entity
+    let client_entity_1 = stepper
+        .client(1)
+        .get::<MessageManager>()
+        .unwrap()
+        .entity_mapper
+        .get_local(server_entity)
+        .expect("entity is not present in entity map");
+    // the authority can be freely stolen
+    stepper.client_apps[1]
+        .world_mut()
+        .entity_mut(client_entity_1)
+        .insert(AuthorityTransfer::Steal);
+
+    // give the authority from client 0 to client 1
+    stepper.client_apps[0].world_mut().trigger(GiveAuthority {
+        entity: client_entity_0,
+        remote_peer: Some(PeerId::Netcode(1)),
+    });
+    stepper.frame_step(4);
+
+    // check that the client 0 lost authority and client 1 gained authority
+    assert!(
+        !stepper
+            .client(0)
+            .get::<ReplicationSender>()
+            .unwrap()
+            .has_authority(client_entity_0)
+    );
+    assert!(
+        stepper
+            .client(1)
+            .get::<ReplicationSender>()
+            .unwrap()
+            .has_authority(client_entity_1)
+    );
+    assert!(
+        stepper
+            .client_of(0)
+            .get::<ReplicationSender>()
+            .unwrap()
+            .has_authority(server_entity)
+    );
+    assert!(
+        !stepper
+            .client_of(1)
+            .get::<ReplicationSender>()
+            .unwrap()
+            .has_authority(server_entity)
+    );
+
+    // request the authority from client 0 to client 1
+    stepper.client_apps[0]
+        .world_mut()
+        .trigger(RequestAuthority {
+            entity: client_entity_0,
+        });
+    stepper.frame_step(4);
+
+    // check that the client 1 lost authority and client 0 gained authority
+    assert!(
+        stepper
+            .client(0)
+            .get::<ReplicationSender>()
+            .unwrap()
+            .has_authority(client_entity_0)
+    );
+    assert!(
+        !stepper
+            .client(1)
+            .get::<ReplicationSender>()
+            .unwrap()
+            .has_authority(client_entity_1)
+    );
+    assert!(
+        !stepper
+            .client_of(0)
+            .get::<ReplicationSender>()
+            .unwrap()
+            .has_authority(server_entity)
+    );
+    assert!(
+        stepper
+            .client_of(1)
+            .get::<ReplicationSender>()
+            .unwrap()
+            .has_authority(server_entity)
+    );
+}

--- a/lightyear_tests/src/client_server/base.rs
+++ b/lightyear_tests/src/client_server/base.rs
@@ -30,12 +30,12 @@ fn test_setup_client_server() {
     assert!(
         stepper
             .client(0)
-            .contains::<EventSender<AuthorityRequestEvent>>()
+            .contains::<EventSender<AuthorityTransferEvent>>()
     );
     assert!(
         stepper
             .client(0)
-            .contains::<EventSender<AuthorityResponseEvent>>()
+            .contains::<EventSender<AuthorityGrantedEvent>>()
     );
     assert!(stepper.client(0).contains::<ReplicationSender>());
     assert!(stepper.client(0).contains::<ReplicationReceiver>());
@@ -70,12 +70,12 @@ fn test_setup_client_server() {
     assert!(
         stepper
             .client_of(0)
-            .contains::<EventSender<AuthorityRequestEvent>>()
+            .contains::<EventSender<AuthorityTransferEvent>>()
     );
     assert!(
         stepper
             .client_of(0)
-            .contains::<EventSender<AuthorityResponseEvent>>()
+            .contains::<EventSender<AuthorityGrantedEvent>>()
     );
     assert!(stepper.client_of(0).contains::<CrossbeamIo>());
     assert!(stepper.client_of(0).contains::<Connected>());


### PR DESCRIPTION
The current authority system was a bit clunky because it required uses to specify
`Replicate::without_authority()` when spawning an entity. 
Also the authority was only known on each Link but the server had no global view of which peer has authority over an entity.

This PR fixes this by:
- adding a `AuthorityBroker` component on the `Server` which tracks the current peer that has authority over an entity
- `RequestAuthority` doesn't need to specify from which peer we get the authority, since the server can forward the message to the correct peer
- we automatically update `AuthorityBroker` and the authority metadata in ReplicationSender upon receiving an entity or inserting Replicate