### PR TITLE
fix: fix distributed authority example

### DIFF
--- a/examples/distributed_authority/src/server.rs
+++ b/examples/distributed_authority/src/server.rs
@@ -41,8 +41,6 @@ fn setup(mut commands: Commands) {
         PlayerColor(Color::WHITE),
         Replicate::to_clients(NetworkTarget::All),
         InterpolationTarget::to_clients(NetworkTarget::All),
-        // Add ReplicationSender to send updates back to clients
-        ReplicationSender::new(SEND_INTERVAL, SendUpdatesMode::SinceLastAck, false),
     ));
 }
 
@@ -93,83 +91,63 @@ fn movement(
     }
 }
 
-/// Assign authority over the ball to any player that comes close to it
+/// Assign authority over the ball to any player that comes close to it.
+///
+/// The server has the power to give the authority to any peer.
+/// This is controlled via the field `has_full_control` on the [`AuthorityBroker`] component.
 pub(crate) fn transfer_authority(
     // timer so that we only transfer authority every X seconds
     mut timer: Local<Timer>,
     time: Res<Time>,
-    // Use ServerConnectionManager (though not needed for sending messages anymore)
-    // mut connection: ResMut<ServerConnectionManager>,
     mut commands: Commands,
     ball_q: Query<(Entity, &Position), With<BallMarker>>,
     player_q: Query<(&PlayerId, &Position)>,
-    peer_metadata: Res<PeerMetadata>,
 ) {
     if !timer.tick(time.delta()).is_finished() {
         return;
     }
     *timer = Timer::new(Duration::from_secs_f32(0.3), TimerMode::Once);
     for (ball_entity, ball_pos) in ball_q.iter() {
-        // TODO: sort by player_id?
+        let mut closest = None;
+        let mut closest_distance = f32::MAX;
         for (player_id, player_pos) in player_q.iter() {
-            let sender = *peer_metadata.mapping.get(&player_id.0).unwrap();
-            if player_pos.0.distance(ball_pos.0) < 100.0 {
-                trace!("Give authority to Player {:?}", player_id);
-                // Use PeerId::Client for authority transfer
-                commands.trigger(GiveAuthority {
-                    sender,
-                    entity: ball_entity,
-                    remote_peer: player_id.0,
-                });
-
-                // Removed message sending for AuthorityPeer
-                // connection.send_message_to_target::<Channel1, _>(...)
-                return;
+            let dist = player_pos.0.distance(ball_pos.0);
+            if dist < 100.0 && dist < closest_distance {
+                closest_distance = dist;
+                closest = Some(player_id.0);
             }
         }
-
+        let new_authority = Some(closest.unwrap_or(PeerId::Server));
+        debug!("Give authority to peer {:?}", new_authority);
         // if no player is close to the ball, transfer authority back to the server
-        commands.trigger(RequestAuthority {
-            sender,
+        commands.trigger(GiveAuthority {
             entity: ball_entity,
-            remote_peer: player_id.0,
+            peer: new_authority,
         });
-        commands
-            .entity(ball_entity)
-            .transfer_authority(PeerId::Server); // Use PeerId::Server
-
-        // Removed message sending for AuthorityPeer
-        // connection.send_message_to_target::<Channel1, _>(...)
     }
 }
 
 /// Everytime the ball changes authority, repaint the ball according to the new owner
 pub(crate) fn update_ball_color(
-    // Query Authority component instead of AuthorityPeer
-    mut balls: Query<(&mut PlayerColor, &Authority), (With<BallMarker>, Changed<Authority>)>,
+    broker: Query<&AuthorityBroker, (With<Server>, Changed<AuthorityBroker>)>,
+    mut balls: Query<&mut PlayerColor, With<BallMarker>>,
     player_q: Query<(&PlayerId, &PlayerColor), Without<BallMarker>>, // PlayerId now contains PeerId
 ) {
-    for (mut ball_color, authority) in balls.iter_mut() {
-        info!("Ball authority changed to {:?}", authority.peer_id);
-        match authority.peer_id {
-            // Check authority.peer_id
-            PeerId::Server => {
-                // Use PeerId::Server
-                ball_color.0 = Color::WHITE;
-            }
-            PeerId::Client(client_id) => {
-                // Use PeerId::Client
-                let player_color_opt = player_q
-                    .iter()
-                    .find(|(player_id, _)| player_id.0 == client_id)
-                    .map(|(_, color)| color.0);
-                if let Some(player_color) = player_color_opt {
-                    ball_color.0 = player_color;
-                } else {
-                    warn!("Could not find player color for client {}", client_id);
-                    ball_color.0 = Color::BLACK; // Fallback color
+    if let Ok(broker) = broker.single() {
+        for (entity, current_authority) in broker.owners.iter() {
+            if let Ok(mut color) = balls.get_mut(*entity) {
+                match current_authority {
+                    None => {
+                        color.0 = Color::BLACK;
+                    }
+                    Some(PeerId::Server) => {
+                        color.0 = Color::WHITE;
+                    }
+                    Some(p) => {
+                        color.0 = color_from_id(*p);
+                    }
                 }
-            } // AuthorityPeer::None is not directly represented, absence of Authority component implies no authority
+            }
         }
     }
 }

--- a/examples/distributed_authority/src/shared.rs
+++ b/examples/distributed_authority/src/shared.rs
@@ -25,7 +25,7 @@ impl Plugin for SharedPlugin {
 
 // Generate pseudo-random color from id
 pub(crate) fn color_from_id(client_id: PeerId) -> Color {
-    let h = (((client_id.to_bits().wrapping_mul(30)) % 360) as f32) / 360.0;
+    let h = (((client_id.to_bits().wrapping_mul(80)) % 360) as f32) / 360.0;
     let s = 1.0;
     let l = 0.5;
     Color::hsl(h, s, l)
@@ -34,33 +34,26 @@ pub(crate) fn color_from_id(client_id: PeerId) -> Color {
 // This system defines how we update the player's positions when we receive an input
 pub(crate) fn shared_movement_behaviour(mut position: Mut<Position>, input: &Inputs) {
     const MOVE_SPEED: f32 = 10.0;
-    match input {
-        Inputs::Direction(direction) => {
-            if direction.up {
-                position.y += MOVE_SPEED;
-            }
-            if direction.down {
-                position.y -= MOVE_SPEED;
-            }
-            if direction.left {
-                position.x -= MOVE_SPEED;
-            }
-            if direction.right {
-                position.x += MOVE_SPEED;
-            }
-        }
-        _ => {}
+    let Inputs::Direction(direction) = input;
+    if direction.up {
+        position.y += MOVE_SPEED;
+    }
+    if direction.down {
+        position.y -= MOVE_SPEED;
+    }
+    if direction.left {
+        position.x -= MOVE_SPEED;
+    }
+    if direction.right {
+        position.x += MOVE_SPEED;
     }
 }
 
 /// We move the ball only when we have authority over it.
+///
 /// The peer that has authority could be the Server, a Client or no one
 pub(crate) fn ball_movement(
-    mut balls: Query<
-        (&mut Position, &mut Speed),
-        // Query should check for HasAuthority, which is added by lightyear based on Replicate config
-        (With<BallMarker>, With<HasAuthority>, Without<Interpolated>),
-    >,
+    mut balls: Query<(&mut Position, &mut Speed), (With<BallMarker>, With<HasAuthority>)>,
 ) {
     for (mut position, mut speed) in balls.iter_mut() {
         if position.y > 300.0 {

--- a/lightyear_replication/src/lib.rs
+++ b/lightyear_replication/src/lib.rs
@@ -49,8 +49,8 @@ pub mod visibility;
 /// Commonly used items for replication.
 pub mod prelude {
     pub use crate::authority::{
-        AuthorityBroker, AuthorityGrantedEvent, AuthorityPlugin, AuthorityTransfer,
-        AuthorityTransferEvent, AuthorityTransferType, GiveAuthority, RequestAuthority,
+        AuthorityBroker, AuthorityPlugin, AuthorityTransfer, GiveAuthority, HasAuthority,
+        RequestAuthority,
     };
     pub use crate::components::*;
     pub use crate::control::{Controlled, ControlledBy, ControlledByRemote, Lifetime};

--- a/lightyear_replication/src/receive.rs
+++ b/lightyear_replication/src/receive.rs
@@ -28,12 +28,10 @@ use crate::send::sender::ReplicationStatus;
 use crate::{plugin, prespawn};
 use lightyear_connection::client::{Connected, Disconnected, PeerMetadata};
 use lightyear_connection::host::HostClient;
-use lightyear_connection::server::Started;
 use lightyear_core::id::{PeerId, RemoteId};
 use lightyear_core::interpolation::Interpolated;
 use lightyear_core::prelude::{LocalTimeline, Predicted};
 use lightyear_core::timeline::NetworkTimeline;
-use lightyear_link::prelude::Server;
 use lightyear_messages::MessageManager;
 use lightyear_messages::plugin::MessageSystems;
 use lightyear_messages::prelude::{MessageReceiver, RemoteEvent};
@@ -134,7 +132,7 @@ impl ReplicationReceivePlugin {
                 With<LocalTimeline>,
             ),
         >,
-        authority: &mut QueryState<Entity, (With<Server>, With<Started>, With<AuthorityBroker>)>,
+        authority: &mut QueryState<Entity, With<AuthorityBroker>>,
         // buffer to avoid allocations
         mut receiver_entities: Local<Vec<(Entity, PeerId)>>,
     ) {

--- a/lightyear_replication/src/send/buffer.rs
+++ b/lightyear_replication/src/send/buffer.rs
@@ -107,7 +107,7 @@ pub(crate) fn replicate(
             for i in 0..sender.replicated_entities.len() {
                 let (&entity, status) = sender.replicated_entities.get_index(i).unwrap();
                 if !status.authority {
-                    trace!("Skipping entity {entity:?} because we don't have authority");
+                    info!("Skipping entity {entity:?} because we don't have authority");
                     continue;
                 }
                 let Ok(root_entity_ref) = entity_query.get(entity) else {

--- a/lightyear_tests/src/client_server/authority.rs
+++ b/lightyear_tests/src/client_server/authority.rs
@@ -43,7 +43,7 @@ fn test_give_authority_server_to_client() {
         .insert(Replicate::to_server());
     stepper.server_app.world_mut().trigger(GiveAuthority {
         entity: server_entity,
-        remote_peer: Some(PeerId::Netcode(0)),
+        peer: Some(PeerId::Netcode(0)),
     });
     stepper.frame_step(2);
 
@@ -137,7 +137,7 @@ fn test_give_authority_client_to_server() {
         .insert(Replicate::to_clients(NetworkTarget::All));
     stepper.client_app().world_mut().trigger(GiveAuthority {
         entity: client_entity,
-        remote_peer: Some(PeerId::Server),
+        peer: Some(PeerId::Server),
     });
     stepper.frame_step(2);
 
@@ -224,7 +224,7 @@ fn test_transfer_authority_despawn() {
 
     stepper.client_app().world_mut().trigger(GiveAuthority {
         entity: client_entity,
-        remote_peer: Some(PeerId::Server),
+        peer: Some(PeerId::Server),
     });
     stepper.frame_step(2);
 
@@ -294,7 +294,7 @@ fn test_transfer_authority_map_entities() {
 
     stepper.client_app().world_mut().trigger(GiveAuthority {
         entity: client_entity,
-        remote_peer: Some(PeerId::Server),
+        peer: Some(PeerId::Server),
     });
     stepper.frame_step(2);
 
@@ -420,7 +420,7 @@ fn test_transfer_authority_client_to_client() {
     // give the authority from client 0 to client 1
     stepper.client_apps[0].world_mut().trigger(GiveAuthority {
         entity: client_entity_0,
-        remote_peer: Some(PeerId::Netcode(1)),
+        peer: Some(PeerId::Netcode(1)),
     });
     stepper.frame_step(4);
 


### PR DESCRIPTION
Remaining issues:
- we have `Skipping entity 115v0 because we don't have authority` on the client even through entity 115 is the player, and doesn't have Replicate?
- when client has authority over the ball, updates from the ball are not replicated