### PR TITLE
fix(replication): use correct mode in handle_connection to set per-sender predicted/interpolated

### DIFF
--- a/lightyear_replication/src/send/components.rs
+++ b/lightyear_replication/src/send/components.rs
@@ -1114,7 +1114,7 @@ impl Replicate {
                         Entity,
                         &mut Commands,
                     )| {
-                        match &replicate.mode {
+                        match mode {
                             ReplicationMode::SingleSender => {
                                 todo!()
                             }


### PR DESCRIPTION
**Crash:** when a new client connected, `Replicate::handle_connection` updated per-sender `predicted` / `interpolated` state using the wrong mode (matching on `replicate.mode` even while processing `PredictionTarget` / `InterpolationTarget`). This could mark an entity as both predicted and interpolated for the same sender, producing an invalid `SpawnAction` and causing `ActionsMessage` serialization to fail with `Serialization(InvalidValue)`, followed by a writer-empty assert panic.

**Fix:** use the passed-in `mode` when updating per-sender prediction/interpolation state so each sender gets the correct flags, preventing invalid spawn actions and the resulting crash.