### PR TITLE
fix: lightyear_metrics optional dep for std feature

### DIFF
--- a/lightyear/Cargo.toml
+++ b/lightyear/Cargo.toml
@@ -34,7 +34,7 @@ std = [
   "lightyear_inputs_native?/std",
   "lightyear_interpolation?/std",
   "lightyear_link/std",
-  "lightyear_metrics/std",
+  "lightyear_metrics?/std",
   "lightyear_messages/std",
   "lightyear_netcode?/std",
   "lightyear_prediction?/std",


### PR DESCRIPTION
Noticed that my headless server was pulling in a bunch of graphics dependencies, and narrowed it down to `lightyear_metrics` being included despite not being used. This fix fixes the `std` feature for `lightyear` so that it will only include `lightyear_metrics` if it has already been activated.