### PR TITLE
feat(replication): add ReplicationState::is_visible helper

### DIFF
--- a/lightyear_replication/src/send/components.rs
+++ b/lightyear_replication/src/send/components.rs
@@ -624,6 +624,14 @@ impl ReplicationState {
         &self.per_sender_state
     }
 
+    /// Returns `true` if the entity is visible for `sender`,
+    /// and `false` if there is no [`NetworkVisibility`], no sender entry, or visibility is not `Visible`/`Gained`.
+    pub fn is_visible(&self, sender: Entity) -> bool {
+        self.per_sender_state
+            .get(&sender)
+            .is_some_and(|s| matches!(s.visibility, VisibilityState::Visible | VisibilityState::Gained))
+    }
+
     /// Indicate that the entity is not visible for that [`ReplicationSender`] entity.
     pub fn lose_visibility(&mut self, sender: Entity) {
         let state = self


### PR DESCRIPTION
Add a helper to check per-sender visibility (Visible/Gained) via ReplicationState.