### PR TITLE
Feat: rust based wtransport certificate generation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ members = [
   "benches/*",
   "demos/*",
   "examples/*",
+  "certificates",
 ]
 default-members = ["lightyear"]
 exclude = []

--- a/certificates/Cargo.toml
+++ b/certificates/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "certificates"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+wtransport = "0.6"

--- a/certificates/src/main.rs
+++ b/certificates/src/main.rs
@@ -1,0 +1,29 @@
+use std::io::{self, Write};
+
+use wtransport::Identity;
+use wtransport::tls::Sha256DigestFmt;
+
+fn main() -> Result<(), io::Error> {
+    let sans = vec![
+        "localhost".to_string(),
+        "127.0.0.1".to_string(),
+        "::1".to_string(),
+    ];
+    let identity = Identity::self_signed(sans).unwrap();
+    let cert = identity.certificate_chain();
+    let digest = identity.certificate_chain().as_slice()[0].hash();
+    println!("🔐 Certificate digest: {digest}");
+    let digest = digest.fmt(Sha256DigestFmt::DottedHex).replace(":", "");
+
+    std::fs::write("digest.txt", digest).expect("could not write digest.");
+
+    let mut file = std::fs::File::create("cert.pem")?;
+    for cert in cert.as_slice().iter() {
+        file.write_all(cert.to_pem().as_bytes())?;
+    }
+
+    let mut file = std::fs::File::create("key.pem")?;
+    let secret = &identity.private_key().to_secret_pem();
+    file.write_all(secret.as_bytes())?;
+    Ok(())
+}


### PR DESCRIPTION
On macOS (sequoia 15.6.1), the `generate.sh` script was generating incorrect certificates (or at least refused when running server examples), I noticed that using the self signed version of the common server was working, so I'm sharing my approach.

- [x] Rust based wtransport certificate generation
- [x] avoid tokio dependency (compared to https://gist.github.com/ThierryBerger/c905fcec169a1e706865e87947f0ce84)
- [ ] update instructions to generate certificates
- [ ] remove old `generate.sh` script

## More details

Error:

<details><summary>Details</summary>
<p>

```
thread 'main' (17352970) panicked at /Users/thierryberger/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/wtransport-0.6.1/src/tls.rs:635:14:
Certificate and private key should be already validated: General("failed to parse private key as RSA, ECDSA, or EdDSA")
```

</p>
</details> 

Incorrect files if anyone want to look into that:

<details><summary>cert.pem</summary>
<p>

```
-----BEGIN CERTIFICATE-----
MIICCzCCAbICCQC1/YV0rN8OWTAKBggqhkjOPQQDAjAUMRIwEAYDVQQDDAlsb2Nh
bGhvc3QwHhcNMjYwMTEwMjAwMDU1WhcNMjYwMTI0MjAwMDU1WjAUMRIwEAYDVQQD
DAlsb2NhbGhvc3QwggFLMIIBAwYHKoZIzj0CATCB9wIBATAsBgcqhkjOPQEBAiEA
/////wAAAAEAAAAAAAAAAAAAAAD///////////////8wWwQg/////wAAAAEAAAAA
AAAAAAAAAAD///////////////wEIFrGNdiqOpPns+u9VXaYhrxlHQawzFOw9jvO
PD4n0mBLAxUAxJ02CIbnBJNqZnjhE50mt4GffpAEQQRrF9Hy4SxCR/i85uVjpEDy
dwN9gS3rM6D0oTlF2JjClk/jQuL+Gn+bjufrSnwPnhYrzjNXazFezsu2QGg3v1H1
AiEA/////wAAAAD//////////7zm+q2nF56E87nKwvxjJVECAQEDQgAEJth6U1Sf
2O84L3+ZCTNLsNe+GvN4NOl/GdF/rZEabnFQ/tV6PvJjIPdWZ0CcskzvU+54CAPN
5q6sKUNs5COE4DAKBggqhkjOPQQDAgNHADBEAiBeOAz9xYR/U7o0qruPrQoJeCuB
PsDD8KsrGTVzVgClyQIgfVP3+yOnn17Ry1dpqdfdz91gI74E8RRMq1o6LRFVS5w=
-----END CERTIFICATE-----
```

</p>
</details> 

<details><summary>Digest</summary>
<p>

```
F0CDDDE7D8F4488AF241A12627F89710E764138C374523063E25D66ABDD5A885
```

</p>
</details> 

<details><summary>key.pem</summary>
<p>

```
-----BEGIN PRIVATE KEY-----
MIIBeQIBADCCAQMGByqGSM49AgEwgfcCAQEwLAYHKoZIzj0BAQIhAP////8AAAAB
AAAAAAAAAAAAAAAA////////////////MFsEIP////8AAAABAAAAAAAAAAAAAAAA
///////////////8BCBaxjXYqjqT57PrvVV2mIa8ZR0GsMxTsPY7zjw+J9JgSwMV
AMSdNgiG5wSTamZ44ROdJreBn36QBEEEaxfR8uEsQkf4vOblY6RA8ncDfYEt6zOg
9KE5RdiYwpZP40Li/hp/m47n60p8D54WK84zV2sxXs7LtkBoN79R9QIhAP////8A
AAAA//////////+85vqtpxeehPO5ysL8YyVRAgEBBG0wawIBAQQg0iTzo8+GHsos
4B9dfUzMUcSMbIo4csfHVl3e8yzg+S6hRANCAAQm2HpTVJ/Y7zgvf5kJM0uw174a
83g06X8Z0X+tkRpucVD+1Xo+8mMg91ZnQJyyTO9T7ngIA83mrqwpQ2zkI4Tg
-----END PRIVATE KEY-----
```

</p>
</details> 

## Open questions

- We may want to reuse code from common examples server (`WebTransportCertificateSettings`)
- We may want to upstream a better api to wtransport to write files, `store_pemfile` and `store_secret_pemfile` leaks async implementation 🤔. Or lean into tokio implementation