### PR TITLE
Derive `Default`, `Clone`, `Copy` for `Interpolated`

### DIFF
--- a/lightyear_core/src/interpolation.rs
+++ b/lightyear_core/src/interpolation.rs
@@ -12,6 +12,6 @@ use bevy_reflect::Reflect;
 /// - Store the component history of the confirmed entity.
 /// - Apply interpolated values to the components of this entity based on the `InterpolationTimeline`.
 // NOTE: we create Interpolated here because it is used by multiple crates (interpolation, replication)
-#[derive(Debug, Reflect, Component)]
+#[derive(Debug, Default, Reflect, Component, Clone, Copy)]
 #[reflect(Component)]
 pub struct Interpolated;


### PR DESCRIPTION
Micro PR, because I just wanted to do a simple

```rust
app.register_required_components::<Player, Interpolated>();
```

So the player entity is always interpolated. But it requires `Interpolated` to be `Default` ! Figured it could also derive `Clone` and `Copy`