### PR TITLE
Disable default features for BEI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -219,7 +219,9 @@ bevy_winit = { version = "0.18", default-features = false }
 tracy-client = { version = "0.18" }
 
 # input
-bevy_enhanced_input = { version = "0.23", features = ["serialize"] }
+bevy_enhanced_input = { version = "0.23", default-features = false, features = [
+  "serialize",
+] }
 leafwing-input-manager = { version = "0.20", default-features = false, features = [
   "keyboard",
 ] }


### PR DESCRIPTION
It results in 2 less crates to build, which saves a little bit of compilation time !