### PR TITLE
interpolation: initialize confirmed history when Interpolated is added

### DIFF
--- a/lightyear_interpolation/src/interpolation_history.rs
+++ b/lightyear_interpolation/src/interpolation_history.rs
@@ -119,6 +119,24 @@ pub(crate) fn insert_confirmed_history<C: Component>(
     }
 }
 
+/// When [`Interpolated`] is inserted on an entity that already has [`Confirmed<C>`], we also
+/// need to ensure [`ConfirmedHistory<C>`] exists.
+///
+/// This complements [`insert_confirmed_history`] so both marker insertion orders are supported:
+/// - `Interpolated` first, then `Confirmed<C>`
+/// - `Confirmed<C>` first, then `Interpolated`
+pub(crate) fn insert_confirmed_history_on_interpolated<C: Component>(
+    trigger: On<Add, Interpolated>,
+    mut commands: Commands,
+    query: Query<(), (With<Confirmed<C>>, Without<ConfirmedHistory<C>>)>,
+) {
+    if query.get(trigger.entity).is_ok() {
+        commands
+            .entity(trigger.entity)
+            .try_insert(ConfirmedHistory::<C>::default());
+    }
+}
+
 /// When we receive a server update for an interpolated component, we need to store it in the confirmed history,
 pub(crate) fn apply_confirmed_update<C: Component + Clone>(
     // TODO: this should be a trigger, we should trigger an event whenever Confirmed gets inserted or modified
@@ -160,5 +178,72 @@ pub(crate) fn apply_confirmed_update<C: Component + Clone>(
         //  We enforce this invariant in replication::receive
         history.push(tick, component.0);
         // TODO: here we do not want to update directly the component, that will be done during interpolation
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bevy_app::App;
+    use lightyear_core::prelude::Tick;
+
+    #[derive(Component, Clone, PartialEq, Debug)]
+    struct TestComp(f32);
+
+    #[test]
+    fn inserts_history_when_confirmed_added_after_interpolated() {
+        let mut app = App::new();
+        app.add_observer(insert_confirmed_history::<TestComp>);
+        app.add_observer(insert_confirmed_history_on_interpolated::<TestComp>);
+
+        let entity = app.world_mut().spawn(Interpolated).id();
+        app.update();
+        app.world_mut()
+            .entity_mut(entity)
+            .insert((Confirmed(TestComp(1.0)), ConfirmedTick { tick: Tick(7) }));
+        app.update();
+
+        assert!(
+            app.world()
+                .entity(entity)
+                .contains::<ConfirmedHistory<TestComp>>()
+        );
+    }
+
+    #[test]
+    fn inserts_history_when_interpolated_added_after_confirmed() {
+        let mut app = App::new();
+        app.add_observer(insert_confirmed_history::<TestComp>);
+        app.add_observer(insert_confirmed_history_on_interpolated::<TestComp>);
+
+        let entity = app
+            .world_mut()
+            .spawn((Confirmed(TestComp(2.0)), ConfirmedTick { tick: Tick(11) }))
+            .id();
+        app.update();
+        app.world_mut().entity_mut(entity).insert(Interpolated);
+        app.update();
+
+        assert!(
+            app.world()
+                .entity(entity)
+                .contains::<ConfirmedHistory<TestComp>>()
+        );
+    }
+
+    #[test]
+    fn does_not_insert_history_without_confirmed_component() {
+        let mut app = App::new();
+        app.add_observer(insert_confirmed_history::<TestComp>);
+        app.add_observer(insert_confirmed_history_on_interpolated::<TestComp>);
+
+        let entity = app.world_mut().spawn(Interpolated).id();
+        app.update();
+
+        assert!(
+            !app.world()
+                .entity(entity)
+                .contains::<ConfirmedHistory<TestComp>>()
+        );
     }
 }

--- a/lightyear_interpolation/src/plugin.rs
+++ b/lightyear_interpolation/src/plugin.rs
@@ -1,4 +1,6 @@
-use super::interpolation_history::{apply_confirmed_update, insert_confirmed_history};
+use super::interpolation_history::{
+    apply_confirmed_update, insert_confirmed_history, insert_confirmed_history_on_interpolated,
+};
 use crate::SyncComponent;
 use crate::despawn::removed_components;
 use crate::interpolate::{interpolate, update_confirmed_history};
@@ -65,8 +67,6 @@ impl ToBytes for InterpolationDelay {
 
 // TODO: if Interpolated is added on an existing entity, we need to swap all its existing interpolated components to Confirmed<C>
 
-// TODO (IMPORTANT): when a component with interpolation is inserted, we need to insert ConfirmedHistory
-
 /// Plugin that enables interpolating between replicated updates received from the remote.
 ///
 /// Each remote update will be stored in a buffer, and the component will smoothly interpolate between two consecutive remote updates.
@@ -102,6 +102,7 @@ pub(crate) fn add_prepare_interpolation_systems<C: Component + Clone>(app: &mut 
     // TODO: maybe create an overarching prediction set that contains all others?
     app.add_observer(removed_components::<C>);
     app.add_observer(insert_confirmed_history::<C>);
+    app.add_observer(insert_confirmed_history_on_interpolated::<C>);
     app.add_systems(
         Update,
         (apply_confirmed_update::<C>, update_confirmed_history::<C>)


### PR DESCRIPTION
## Summary
- initialize `ConfirmedHistory<C>` when `Interpolated` is added to an entity that already has `Confirmed<C>`
- keep the existing `Confirmed<C> -> ConfirmedHistory<C>` insertion path
- add regression tests for both insertion orders

## Problem
`ConfirmedHistory<C>` was only initialized when `Confirmed<C>` was inserted after `Interpolated` was already present.

That left a gap for the opposite insertion order:
- entity already has `Confirmed<C>`
- `Interpolated` is added later

In that case interpolation state could be missing until a later update repaired it implicitly, which is the wrong contract.

## Fix
Add a complementary observer that reacts to `On<Add, Interpolated>` and inserts `ConfirmedHistory<C>` when the entity already has `Confirmed<C>` and does not already have history.

This makes both valid insertion orders behave the same:
- `Interpolated` -> `Confirmed<C>`
- `Confirmed<C>` -> `Interpolated`

## Tests
- inserts history when confirmed is added after interpolated
- inserts history when interpolated is added after confirmed
- does not insert history when no confirmed component exists

## Notes

This fixes a TODO that was already present.
