### PR TITLE
Fix child collider sync

### DIFF
--- a/lightyear_avian/src/plugin.rs
+++ b/lightyear_avian/src/plugin.rs
@@ -357,10 +357,6 @@ impl LightyearAvianPlugin {
             .resource::<PhysicsTransformConfig>()
             .position_to_transform
         {
-            // Make sure that PositionToTransform sync also runs for Interpolated entities
-            app.register_required_components::<Position, ApplyPosToTransform>();
-            app.register_required_components::<Rotation, ApplyPosToTransform>();
-
             // TODO(important): handle this
             // NOTE: we do NOT include this because Position/Rotation might not be added at the same time (for example on the Interpolated entity)
             //  we only want to add Transform if both are added at the same time


### PR DESCRIPTION
Fixes: #1128

I ran into a similar problem on my project and after a few investigation and trials I noticed that the problem was solved if I remove the `app.register_required_components::<Position, ApplyPosToTransform>();` and `app.register_required_components::<Rotation, ApplyPosToTransform>();` in the `sync_position_to_transform` function. I didn't notice sides effect on my project after this change but I don't have a good enough understanding of lightyear + avian codebase to ensure that this doesn't cause issues elsewhere.