### PR TITLE
Update avian2d/avian3d from 0.5 to 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -225,8 +225,8 @@ leafwing-input-manager = { version = "0.20", default-features = false, features 
 ] }
 
 # physics
-avian2d = { version = "0.5", default-features = false }
-avian3d = { version = "0.5", default-features = false }
+avian2d = { version = "0.6", default-features = false }
+avian3d = { version = "0.6", default-features = false }
 
 # gui debug ui
 bevy-inspector-egui = { version = "0.36", default-features = false, features = [

--- a/lightyear_avian/src/lag_compensation/history.rs
+++ b/lightyear_avian/src/lag_compensation/history.rs
@@ -132,25 +132,24 @@ fn spawn_broad_phase_aabb_envelope(
 
 /// Update the collision layers of the child AabbEnvelopeHolder to match the parent
 fn update_collision_layers(
-    mut child_query: Query<&mut CollisionLayers, With<AabbEnvelopeHolder>>,
-    mut parent_query: Query<
-        (Entity, &mut CollisionLayers, &Children),
+    child_query: Query<Entity, With<AabbEnvelopeHolder>>,
+    parent_query: Query<
+        (Entity, &CollisionLayers, &Children),
         (Without<AabbEnvelopeHolder>, Changed<CollisionLayers>),
     >,
+    mut commands: Commands,
 ) {
     parent_query
-        .iter_mut()
+        .iter()
         .for_each(|(parent, layers, children)| {
-            if layers.is_changed() || !layers.is_added() {
-                for child in children.iter() {
-                    if let Ok(mut child_layers) = child_query.get_mut(child) {
-                        *child_layers = *layers;
-                        trace!(
-                            ?child,
-                            ?parent,
-                            "Adding layers {layers:?} on lag compensation child collider"
-                        );
-                    }
+            for child in children.iter() {
+                if child_query.get(child).is_ok() {
+                    commands.entity(child).insert(*layers);
+                    trace!(
+                        ?child,
+                        ?parent,
+                        "Adding layers {layers:?} on lag compensation child collider"
+                    );
                 }
             }
         });


### PR DESCRIPTION
Update avian to 0.6. Adapts `update_collision_layers` for immutable `CollisionLayers`.