### PR TITLE
Fix Dropped Inputs and Collapsed JustPressed Events

### DIFF
--- a/lightyear_inputs/src/input_message.rs
+++ b/lightyear_inputs/src/input_message.rs
@@ -235,6 +235,24 @@ pub trait ActionStateSequence:
     /// Modify the given state to reflect the given snapshot.
     fn from_snapshot<'w>(state: StateMutItemInner<'w, Self>, snapshot: &Self::Snapshot);
 
+    /// Apply a snapshot to the state while preserving button transition semantics.
+    ///
+    /// Unlike `from_snapshot` (which raw-clones), this method:
+    /// 1. Ticks the state to advance JustPressed→Pressed, JustReleased→Released
+    /// 2. Compares current state against the snapshot
+    /// 3. Calls press()/release() for detected transitions
+    ///
+    /// This produces correct JustPressed/JustReleased on the server, where the wire
+    /// format collapses these into Pressed/Released.
+    ///
+    /// Default implementation falls back to `from_snapshot`.
+    fn from_snapshot_transitions<'w>(
+        state: StateMutItemInner<'w, Self>,
+        snapshot: &Self::Snapshot,
+    ) {
+        Self::from_snapshot(state, snapshot);
+    }
+
     /// Apply decay to the given state for the given tick duration.
     fn decay_tick(state: StateMutItem<Self>, tick_duration: Duration) {
         let mut snapshot =

--- a/lightyear_inputs/src/server.rs
+++ b/lightyear_inputs/src/server.rs
@@ -302,7 +302,7 @@ fn update_action_state<S: ActionStateSequence>(
         // We only apply the ActionState from the buffer if we have one.
         // If we don't (because the input packet is late or lost), we won't do anything.
         // This is equivalent to considering that the player will keep playing the last action they played.
-        if let Some(snapshot) = input_buffer.get(tick) {
+        if let Some(snapshot) = input_buffer.get_predict(tick) {
             S::from_snapshot(S::State::into_inner(action_state), snapshot);
             trace!(
                 ?tick,

--- a/lightyear_inputs/src/server.rs
+++ b/lightyear_inputs/src/server.rs
@@ -303,7 +303,7 @@ fn update_action_state<S: ActionStateSequence>(
         // If we don't (because the input packet is late or lost), we won't do anything.
         // This is equivalent to considering that the player will keep playing the last action they played.
         if let Some(snapshot) = input_buffer.get_predict(tick) {
-            S::from_snapshot(S::State::into_inner(action_state), snapshot);
+            S::from_snapshot_transitions(S::State::into_inner(action_state), snapshot);
             trace!(
                 ?tick,
                 ?entity,

--- a/lightyear_inputs_leafwing/src/input_message.rs
+++ b/lightyear_inputs_leafwing/src/input_message.rs
@@ -7,7 +7,7 @@ use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::entity::{EntityMapper, MapEntities};
 use core::time::Duration;
 use leafwing_input_manager::Actionlike;
-use leafwing_input_manager::action_state::ActionState;
+use leafwing_input_manager::action_state::{ActionKindData, ActionState};
 use leafwing_input_manager::input_map::InputMap;
 use lightyear_core::prelude::Tick;
 use lightyear_inputs::input_buffer::{Compressed, InputBuffer};
@@ -130,6 +130,55 @@ impl<A: LeafwingUserAction> ActionStateSequence for LeafwingSequence<A> {
 
     fn from_snapshot<'w, 's>(state: &mut ActionState<A>, snapshot: &Self::Snapshot) {
         *state = snapshot.0.clone();
+    }
+
+    /// Apply snapshot with transition-aware button state handling.
+    ///
+    /// The wire format (`ActionDiff`) collapses `JustPressed` into `Pressed`, so
+    /// raw-cloning a snapshot on the server loses `JustPressed`/`JustReleased`.
+    ///
+    /// This method instead:
+    /// 1. Ticks the state (`JustPressed→Pressed`, `JustReleased→Released`)
+    /// 2. For each action, compares current vs snapshot and calls `press()`/`release()`
+    ///    to produce correct `JustPressed`/`JustReleased` transitions
+    /// 3. Applies axis values directly
+    fn from_snapshot_transitions<'w>(state: &mut ActionState<A>, snapshot: &Self::Snapshot) {
+        // Advance button state machine so JustPressed→Pressed between consecutive
+        // fixed ticks within a single frame (tick_action_state only runs in PreUpdate).
+        state.tick(Instant::now(), Instant::now());
+
+        let new = &snapshot.0;
+        for (action, new_data) in new.all_action_data() {
+            match &new_data.kind_data {
+                ActionKindData::Button(new_button) => {
+                    let is_pressed = new_button.pressed();
+                    if is_pressed {
+                        // press() sets JustPressed unless already Pressed
+                        state.press(action);
+                    } else {
+                        // release() sets JustReleased unless already Released
+                        state.release(action);
+                    }
+                }
+                ActionKindData::Axis(axis_data) => {
+                    state.set_value(action, axis_data.value);
+                }
+                ActionKindData::DualAxis(dual_data) => {
+                    state.set_axis_pair(action, dual_data.pair);
+                }
+                ActionKindData::TripleAxis(triple_data) => {
+                    state.set_axis_triple(action, triple_data.triple);
+                }
+            }
+        }
+
+        // Release any buttons present in current state but absent from snapshot
+        let snapshot_keys: Vec<A> = new.keys();
+        for action in state.keys() {
+            if !snapshot_keys.contains(&action) && state.pressed(&action) {
+                state.release(&action);
+            }
+        }
     }
 }
 

--- a/lightyear_inputs_leafwing/src/input_message.rs
+++ b/lightyear_inputs_leafwing/src/input_message.rs
@@ -7,6 +7,7 @@ use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::entity::{EntityMapper, MapEntities};
 use core::time::Duration;
 use leafwing_input_manager::Actionlike;
+use leafwing_input_manager::InputControlKind;
 use leafwing_input_manager::action_state::{ActionKindData, ActionState};
 use leafwing_input_manager::input_map::InputMap;
 use lightyear_core::prelude::Tick;
@@ -175,6 +176,9 @@ impl<A: LeafwingUserAction> ActionStateSequence for LeafwingSequence<A> {
         // Release any buttons present in current state but absent from snapshot
         let snapshot_keys: Vec<A> = new.keys();
         for action in state.keys() {
+            if action.input_control_kind() != InputControlKind::Button {
+                continue;
+            }
             if !snapshot_keys.contains(&action) && state.pressed(&action) {
                 state.release(&action);
             }


### PR DESCRIPTION
Two commits targetting different issues:
- Predicted entities inputs were being dropped. Server was using `get` instead of `get_predict` for input snapshots. This still seems to be consistent with the comment that claims to consider "that the player will keep playing the last action they played" when no snapshot present because afaict the `get_predict` will `get_last` so same behavior as comment
- The server was not recognizing `just_pressed` but recognizing `pressed`. `ActionDiff` has no `JustPressed` variant, so every button press arrived as `Pressed` on the server, and the old `from_snapshot`  raw-cloned it as-is. Instead of raw-cloning the snapshot, `from_snapshot_transitions` compares the previous server state against the new snapshot and calls `press()`/`release()`, which produces `JustPressed`/`JustReleased` when a transition is detected.