### PR TITLE
fix: register Transform as required for Collider for avian 0.6 compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -225,8 +225,8 @@ leafwing-input-manager = { version = "0.20", default-features = false, features 
 ] }
 
 # physics
-avian2d = { version = "0.5", default-features = false }
-avian3d = { version = "0.5", default-features = false }
+avian2d = { version = "0.6", default-features = false }
+avian3d = { version = "0.6", default-features = false }
 
 # gui debug ui
 bevy-inspector-egui = { version = "0.36", default-features = false, features = [

--- a/lightyear_avian/src/lag_compensation/history.rs
+++ b/lightyear_avian/src/lag_compensation/history.rs
@@ -132,25 +132,24 @@ fn spawn_broad_phase_aabb_envelope(
 
 /// Update the collision layers of the child AabbEnvelopeHolder to match the parent
 fn update_collision_layers(
-    mut child_query: Query<&mut CollisionLayers, With<AabbEnvelopeHolder>>,
-    mut parent_query: Query<
-        (Entity, &mut CollisionLayers, &Children),
+    child_query: Query<Entity, With<AabbEnvelopeHolder>>,
+    parent_query: Query<
+        (Entity, &CollisionLayers, &Children),
         (Without<AabbEnvelopeHolder>, Changed<CollisionLayers>),
     >,
+    mut commands: Commands,
 ) {
     parent_query
-        .iter_mut()
+        .iter()
         .for_each(|(parent, layers, children)| {
-            if layers.is_changed() || !layers.is_added() {
-                for child in children.iter() {
-                    if let Ok(mut child_layers) = child_query.get_mut(child) {
-                        *child_layers = *layers;
-                        trace!(
-                            ?child,
-                            ?parent,
-                            "Adding layers {layers:?} on lag compensation child collider"
-                        );
-                    }
+            for child in children.iter() {
+                if child_query.get(child).is_ok() {
+                    commands.entity(child).insert(*layers);
+                    trace!(
+                        ?child,
+                        ?parent,
+                        "Adding layers {layers:?} on lag compensation child collider"
+                    );
                 }
             }
         });

--- a/lightyear_avian/src/plugin.rs
+++ b/lightyear_avian/src/plugin.rs
@@ -292,6 +292,16 @@ impl Plugin for LightyearAvianPlugin {
             }
         }
 
+        // Avian's ColliderOf::on_insert requires GlobalTransform to set up
+        // the RigidBodyColliders relationship. Since PhysicsTransformPlugin is disabled,
+        // we register Transform as required for Collider so GlobalTransform is present.
+        #[cfg(all(feature = "3d", not(feature = "2d")))]
+        app.try_register_required_components::<avian3d::prelude::Collider, Transform>()
+            .ok();
+        #[cfg(all(feature = "2d", not(feature = "3d")))]
+        app.try_register_required_components::<avian2d::prelude::Collider, Transform>()
+            .ok();
+
         if self.rollback_resources {
             app.init_resource::<ContactGraph>();
             app.init_resource::<ConstraintGraph>();
@@ -361,11 +371,10 @@ impl LightyearAvianPlugin {
             app.register_required_components::<Position, ApplyPosToTransform>();
             app.register_required_components::<Rotation, ApplyPosToTransform>();
 
-            // TODO(important): handle this
-            // NOTE: we do NOT include this because Position/Rotation might not be added at the same time (for example on the Interpolated entity)
-            //  we only want to add Transform if both are added at the same time
-            // app.try_register_required_components::<Position, Transform>().ok();
-            // app.try_register_required_components::<Rotation, Transform>().ok();
+            // NOTE: we do NOT register Transform as required for Position/Rotation because
+            //  they might not be added at the same time (e.g. on Interpolated entities).
+            //  The `add_transform` system below handles adding Transform when both are present.
+            //  For physics entities, Transform is registered as required for Collider above.
         }
         let schedule = schedule.intern();
 


### PR DESCRIPTION
Builds on #1433 (avian 0.5 → 0.6 upgrade).

## Summary

Avian 0.6's `ColliderOf::on_insert` hook requires `GlobalTransform` to establish the
`ColliderOf → RigidBodyColliders` relationship. When `PhysicsTransformPlugin` is disabled
(as lightyear requires), `GlobalTransform` was missing, causing `ColliderOf::on_insert` to
return early. This left `RigidBodyColliders` empty, so `update_solver_body_aabbs` skipped
the entity and its AABB stayed frozen at the spawn position. The broad phase never detected
collisions and objects fell through each other.

This worked in avian 0.5 because the old sweep-and-prune broad phase rebuilt from scratch
every frame and didn't depend on `RigidBodyColliders`.

The fix registers `Transform` as a required component for `Collider` (not `Position`/`Rotation`,
which would cause issues with Interpolated entities). This ensures `GlobalTransform` is present
when avian's hooks run.

## Related issues

- Fixes #1253 (collision issue with avian)
- Partially addresses #1128 (child collider sync — fixes the `ColliderOf` relationship setup,
  but the `ApplyPosToTransform` interference is a separate issue)