### PR TITLE
fix: update ActionMock import path for bevy_enhanced_input 0.24

### DIFF
--- a/examples/projectiles/src/client.rs
+++ b/examples/projectiles/src/client.rs
@@ -3,7 +3,7 @@ use crate::shared;
 use crate::shared::{Rooms, color_from_id};
 use avian2d::prelude::*;
 use bevy::prelude::*;
-use bevy_enhanced_input::action::ActionMock;
+use bevy_enhanced_input::action::mock::ActionMock;
 use bevy_enhanced_input::bindings;
 use core::time::Duration;
 use lightyear::input::bei::prelude::*;

--- a/examples/projectiles/src/renderer.rs
+++ b/examples/projectiles/src/renderer.rs
@@ -5,7 +5,7 @@ use bevy::color::palettes::basic::{GREEN, RED};
 use bevy::color::palettes::css::BLUE;
 use bevy::ecs::query::QueryFilter;
 use bevy::prelude::*;
-use bevy_enhanced_input::action::{Action, ActionMock};
+use bevy_enhanced_input::action::{Action, mock::ActionMock};
 use bevy_enhanced_input::prelude::{ActionValue, Actions};
 use lightyear::input::bei::prelude::InputMarker;
 use lightyear::interpolation::Interpolated;


### PR DESCRIPTION
## Summary

The `ActionMock` struct moved from `bevy_enhanced_input::action::ActionMock` to `bevy_enhanced_input::action::mock::ActionMock` in 0.24. The projectiles example imports were not updated in #1415, causing the example to fail to compile.