### PR TITLE
fix(interpolation): converge on latest confirmed value under packet loss

### DIFF
--- a/lightyear_interpolation/src/interpolate.rs
+++ b/lightyear_interpolation/src/interpolate.rs
@@ -24,21 +24,27 @@ pub fn interpolation_fraction(start: Tick, end: Tick, current: Tick, overstep: f
     ((current - start) as f32 + overstep) / (end - start) as f32
 }
 
-/// Update the ConfirmedHistory so that interpolation can simply interpolate between the last 2 updates.
+/// Maintain the ConfirmedHistory so that `interpolate()` always sees the right anchors.
+///
+/// Goal: keep the history at `[behind, newest]` while updates flow, where `behind` is the
+/// most recent keyframe at or before the current interpolation tick. Under packet loss this
+/// means `interpolate()` blends between the freshest pair of confirmed values that bracket
+/// the current tick (or clamps at `newest` when we momentarily run out of forward anchors),
+/// instead of falling back to a single-keyframe rebase that snaps on every gap.
+///
+/// We only collapse to a single keyframe when the entity has been idle long enough that the
+/// next update is genuinely a fresh start, in which case we rebase the lone keyframe to the
+/// current tick so a future update interpolates from "now" rather than from a stale tick.
 pub(crate) fn update_confirmed_history<C: Component + Clone>(
     // TODO: handle multiple interpolation timelines
     // TODO: exclude host-server
     interpolation: Single<&InterpolationTimeline, With<IsSynced<InterpolationTimeline>>>,
     tick_duration: Res<TickDuration>,
-    // we don't insert the component immediately, instead we wait for:
-    // - either 2 updates, so that we can interpolate between them
-    // - or enough time has passed since the initial update
     mut query: Query<(Entity, &mut ConfirmedHistory<C>, Has<C>)>,
     mut commands: Commands,
 ) {
     let timeline = interpolation.into_inner();
 
-    // how many ticks between each interpolation
     let send_interval_delta_tick = (SEND_INTERVAL_TICK_FACTOR
         * timeline.remote_send_interval.as_secs_f32()
         / tick_duration.as_secs_f32())
@@ -46,76 +52,41 @@ pub(crate) fn update_confirmed_history<C: Component + Clone>(
 
     let current_interpolate_tick = timeline.now().tick();
     for (entity, mut history, present) in query.iter_mut() {
-        // the ConfirmedHistory contains an ordered list (from oldest to most recent) of Confirmed component updates to interpolate between
-        // The component must always be interpolating between the oldest and the second oldest values in the history.
-        // History: H1...X...H2.....H3
-
-        // We enforce this like so:
-        // - If we have 2 older history values than the current tick, we pop the last value
-        //   History: H1....H2..X..H3  -> pop H1
-        if let Some((history_tick, end_value)) = history.end() {
-            // we have 2 updates, we can start interpolating!
-            if !present {
-                trace!(
-                    ?entity,
-                    ?history_tick,
-                    ?current_interpolate_tick,
-                    "insert interpolated comp value because we have 2 values to interpolate between. Kind = {:?}",
-                    DebugName::type_name::<C>()
-                );
-                // we can insert the end_value because:
-                // - if H1..X...H2, we will do interpolation right after
-                // - if H1...H2..X, H2 is a good starting point for the interpolation
-                commands.entity(entity).insert(end_value.clone());
-            }
-            if current_interpolate_tick >= history_tick {
-                history.pop();
-            }
+        // Drop keyframes older than the most recent one at or before the current tick: we
+        // only need one anchor "behind" the current tick to interpolate from.
+        while history.len() >= 2
+            && history
+                .get_nth(1)
+                .is_some_and(|(t, _)| t <= current_interpolate_tick)
+        {
+            history.pop();
         }
 
-        // If it's been too long since we last received an update; we pop the value from the history and
-        // re-insert it as the current interpolation tick.
-        // Otherwise we would be interpolating from a very old value, which would look strange.
-        //   History: H1.....................................X..H2...H3 -> H1.X...H2..H3
-        // We will then wait to have 2 new values before we can interpolate.
+        // Seed the component on the first sync so the entity has something to render before
+        // `interpolate()` runs. Choose `newest` so a brand-new entity snaps to the freshest
+        // confirmed value rather than a stale tail.
+        if !present && let Some((_, value)) = history.newest() {
+            commands.entity(entity).insert(value.clone());
+        }
+
+        // Idle rebase: if only one keyframe remains and the current tick has drifted past it
+        // by more than the expected send interval, treat the entity as idle and rebase the
+        // keyframe to "now". Without this, the next incoming update would create a stale-tick
+        // pair and produce a long catch-up blend that looks like a snap.
         if history.len() == 1
-            && let Some((history_tick, val)) = history.start()
-            && (current_interpolate_tick - history_tick) >= send_interval_delta_tick
+            && let Some((newest_tick, _)) = history.newest()
+            && (current_interpolate_tick - newest_tick) >= send_interval_delta_tick
         {
-            // Always re-insert val: interpolate() returns None at len == 1, so
-            // this rebase is the only path that converges the component on the
-            // latest confirmed value while the entity is idle.
             trace!(
                 ?entity,
-                ?history_tick,
+                ?newest_tick,
                 ?current_interpolate_tick,
-                ?present,
-                "insert interpolated comp value because we enough time has passed. Kind = {:?}",
+                "rebase idle keyframe to current tick. Kind = {:?}",
                 DebugName::type_name::<C>()
             );
-            commands.entity(entity).insert(val.clone());
-
-            trace!(
-                ?current_interpolate_tick,
-                ?history_tick,
-                ?send_interval_delta_tick,
-                "Reset the start_tick because it's been too long since we received an update"
-            );
-            let (_, val) = history.pop().unwrap();
-            // TODO: the correct behaviour would be to know the exact tick at which the component started getting updated
-            //  so that we know exactly which tick to interpolate from!
-            // we reset the value to a more recent tick so that the interpolation is done between two close values.
-            history.push(current_interpolate_tick, val);
+            let (_, value) = history.pop().unwrap();
+            history.push(current_interpolate_tick, value);
         }
-
-        // It is possible that the interpolation_tick is early compared to the two updates
-        // (for example we received an update H, then no update for a while so we removed it from the history, and then
-        //  we receive two updates ahead of the interpolation_tick)
-        // X...H1...H2
-        // In which case the interpolation should not run.
-
-        // TODO: if we don't have 2 values to interpolate between, we should extrapolate
-        //   History: H1....X...  -> extrapolate X
     }
 }
 

--- a/lightyear_interpolation/src/interpolate.rs
+++ b/lightyear_interpolation/src/interpolate.rs
@@ -51,6 +51,7 @@ pub(crate) fn update_confirmed_history<C: Component + Clone>(
 ) {
     let timeline = interpolation.into_inner();
 
+    // how many ticks between each interpolation
     let send_interval_delta_tick = (SEND_INTERVAL_TICK_FACTOR
         * timeline.remote_send_interval.as_secs_f32()
         / tick_duration.as_secs_f32())
@@ -90,6 +91,9 @@ pub(crate) fn update_confirmed_history<C: Component + Clone>(
                 DebugName::type_name::<C>()
             );
             while history.pop().is_some() {}
+            // TODO: the correct behaviour would be to know the exact tick at which the
+            //  component started getting updated so that we know exactly which tick to
+            //  interpolate from! Using `current_interpolate_tick` here is a proxy.
             history.push(current_interpolate_tick, value.clone());
             commands.entity(entity).insert(value);
         }

--- a/lightyear_interpolation/src/interpolate.rs
+++ b/lightyear_interpolation/src/interpolate.rs
@@ -26,15 +26,21 @@ pub fn interpolation_fraction(start: Tick, end: Tick, current: Tick, overstep: f
 
 /// Maintain the ConfirmedHistory so that `interpolate()` always sees the right anchors.
 ///
-/// Goal: keep the history at `[behind, newest]` while updates flow, where `behind` is the
-/// most recent keyframe at or before the current interpolation tick. Under packet loss this
-/// means `interpolate()` blends between the freshest pair of confirmed values that bracket
-/// the current tick (or clamps at `newest` when we momentarily run out of forward anchors),
-/// instead of falling back to a single-keyframe rebase that snaps on every gap.
+/// Goal: keep the history walking forward through the freshest confirmed pair as the
+/// interpolation tick advances, without prematurely collapsing the buffer to a single
+/// keyframe. Under packet loss this means `interpolate()` blends between [behind, newest]
+/// (clamping at `newest` when an update is late) instead of freezing on every gap.
 ///
-/// We only collapse to a single keyframe when the entity has been idle long enough that the
-/// next update is genuinely a fresh start, in which case we rebase the lone keyframe to the
-/// current tick so a future update interpolates from "now" rather than from a stale tick.
+/// Smart drain: pop the oldest only when there are 3+ keyframes AND the second-oldest has
+/// already been passed by the current tick. This walks the blend anchor through bursty
+/// arrivals (e.g. H1 -> H2 -> H3 -> H4 as the tick advances) instead of immediately
+/// collapsing to the freshest pair, which would otherwise extrapolate backward.
+///
+/// Idle rebase: the smart drain never reduces below 2 entries on its own, so when the
+/// newest keyframe is older than the expected send interval we collapse the buffer to a
+/// single anchor at the current tick and write the component directly. This bounds the
+/// interpolator (which would otherwise stay clamped at the stale newest forever) and
+/// ensures the next incoming update produces a fresh blend from "now".
 pub(crate) fn update_confirmed_history<C: Component + Clone>(
     // TODO: handle multiple interpolation timelines
     // TODO: exclude host-server
@@ -52,9 +58,7 @@ pub(crate) fn update_confirmed_history<C: Component + Clone>(
 
     let current_interpolate_tick = timeline.now().tick();
     for (entity, mut history, present) in query.iter_mut() {
-        // Drop keyframes older than the most recent one at or before the current tick: we
-        // only need one anchor "behind" the current tick to interpolate from.
-        while history.len() >= 2
+        while history.len() >= 3
             && history
                 .get_nth(1)
                 .is_some_and(|(t, _)| t <= current_interpolate_tick)
@@ -62,30 +66,32 @@ pub(crate) fn update_confirmed_history<C: Component + Clone>(
             history.pop();
         }
 
-        // Seed the component on the first sync so the entity has something to render before
-        // `interpolate()` runs. Choose `newest` so a brand-new entity snaps to the freshest
-        // confirmed value rather than a stale tail.
-        if !present && let Some((_, value)) = history.newest() {
+        // Seed on first sync with the second-oldest (or oldest if that's all we have) so
+        // interpolate()'s first run has a sensible starting value while the blend warms up.
+        if !present
+            && let Some((_, value)) = history.end().or(history.start())
+        {
             commands.entity(entity).insert(value.clone());
         }
 
-        // Idle rebase: if only one keyframe remains and the current tick has drifted past it
-        // by more than the expected send interval, treat the entity as idle and rebase the
-        // keyframe to "now". Without this, the next incoming update would create a stale-tick
-        // pair and produce a long catch-up blend that looks like a snap.
-        if history.len() == 1
-            && let Some((newest_tick, _)) = history.newest()
-            && (current_interpolate_tick - newest_tick) >= send_interval_delta_tick
-        {
+        let idle_value = match history.newest() {
+            Some((newest_tick, value))
+                if (current_interpolate_tick - newest_tick) >= send_interval_delta_tick =>
+            {
+                Some(value.clone())
+            }
+            _ => None,
+        };
+        if let Some(value) = idle_value {
             trace!(
                 ?entity,
-                ?newest_tick,
                 ?current_interpolate_tick,
                 "rebase idle keyframe to current tick. Kind = {:?}",
                 DebugName::type_name::<C>()
             );
-            let (_, value) = history.pop().unwrap();
-            history.push(current_interpolate_tick, value);
+            while history.pop().is_some() {}
+            history.push(current_interpolate_tick, value.clone());
+            commands.entity(entity).insert(value);
         }
     }
 }

--- a/lightyear_interpolation/src/interpolate.rs
+++ b/lightyear_interpolation/src/interpolate.rs
@@ -82,16 +82,18 @@ pub(crate) fn update_confirmed_history<C: Component + Clone>(
             && let Some((history_tick, val)) = history.start()
             && (current_interpolate_tick - history_tick) >= send_interval_delta_tick
         {
-            if !present {
-                trace!(
-                    ?entity,
-                    ?history_tick,
-                    ?current_interpolate_tick,
-                    "insert interpolated comp value because we enough time has passed. Kind = {:?}",
-                    DebugName::type_name::<C>()
-                );
-                commands.entity(entity).insert(val.clone());
-            }
+            // Always re-insert val: interpolate() returns None at len == 1, so
+            // this rebase is the only path that converges the component on the
+            // latest confirmed value while the entity is idle.
+            trace!(
+                ?entity,
+                ?history_tick,
+                ?current_interpolate_tick,
+                ?present,
+                "insert interpolated comp value because we enough time has passed. Kind = {:?}",
+                DebugName::type_name::<C>()
+            );
+            commands.entity(entity).insert(val.clone());
 
             trace!(
                 ?current_interpolate_tick,

--- a/lightyear_interpolation/src/interpolate.rs
+++ b/lightyear_interpolation/src/interpolate.rs
@@ -69,9 +69,7 @@ pub(crate) fn update_confirmed_history<C: Component + Clone>(
 
         // Seed on first sync with the second-oldest (or oldest if that's all we have) so
         // interpolate()'s first run has a sensible starting value while the blend warms up.
-        if !present
-            && let Some((_, value)) = history.end().or(history.start())
-        {
+        if !present && let Some((_, value)) = history.end().or(history.start()) {
             commands.entity(entity).insert(value.clone());
         }
 

--- a/lightyear_interpolation/src/interpolation_history.rs
+++ b/lightyear_interpolation/src/interpolation_history.rs
@@ -81,26 +81,27 @@ impl<C: Component + Clone> ConfirmedHistory<C> {
         interpolation_overstep: f32,
         interpolation_registry: &InterpolationRegistry,
     ) -> Option<C> {
-        if let Some((start_tick, start)) = self.start()
-            && let Some((end_tick, end)) = self.end()
-        {
-            if interpolation_tick < start_tick {
-                return None;
-            }
-            let fraction = ((interpolation_tick - start_tick) as f32 + interpolation_overstep)
-                / (end_tick - start_tick) as f32;
-            trace!(
-                ?start_tick,
-                ?end_tick,
-                ?interpolation_tick,
-                ?interpolation_overstep,
-                ?fraction,
-                "Interpolate {:?}",
-                DebugName::type_name::<C>()
-            );
-            return Some(interpolation_registry.interpolate(start.clone(), end.clone(), fraction));
+        let (start_tick, start) = self.start()?;
+        if interpolation_tick < start_tick {
+            return None;
         }
-        None
+        let Some((end_tick, end)) = self.end() else {
+            // Only one keyframe left: snap to it so the component converges on
+            // the latest confirmed value when updates stop arriving.
+            return Some(start.clone());
+        };
+        let fraction = ((interpolation_tick - start_tick) as f32 + interpolation_overstep)
+            / (end_tick - start_tick) as f32;
+        trace!(
+            ?start_tick,
+            ?end_tick,
+            ?interpolation_tick,
+            ?interpolation_overstep,
+            ?fraction,
+            "Interpolate {:?}",
+            DebugName::type_name::<C>()
+        );
+        Some(interpolation_registry.interpolate(start.clone(), end.clone(), fraction))
     }
 }
 
@@ -160,5 +161,72 @@ pub(crate) fn apply_confirmed_update<C: Component + Clone>(
         //  We enforce this invariant in replication::receive
         history.push(tick, component.0);
         // TODO: here we do not want to update directly the component, that will be done during interpolation
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bevy_ecs::component::Component;
+
+    #[derive(Component, Clone, Debug, PartialEq)]
+    struct TestComp(f32);
+
+    fn lerp(start: TestComp, end: TestComp, t: f32) -> TestComp {
+        TestComp(start.0 + (end.0 - start.0) * t)
+    }
+
+    fn registry() -> InterpolationRegistry {
+        let mut registry = InterpolationRegistry::default();
+        registry.set_interpolation::<TestComp>(lerp);
+        registry
+    }
+
+    #[test]
+    fn test_interpolate_blends_between_two_keyframes() {
+        let registry = registry();
+        let mut history = ConfirmedHistory::<TestComp>::default();
+        history.push(Tick(10), TestComp(0.0));
+        history.push(Tick(20), TestComp(10.0));
+
+        assert_eq!(
+            history.interpolate(Tick(15), 0.0, &registry),
+            Some(TestComp(5.0))
+        );
+    }
+
+    // Regression: when only one keyframe remains, snap to it instead of returning None.
+    #[test]
+    fn test_interpolate_snaps_to_single_keyframe() {
+        let registry = registry();
+        let mut history = ConfirmedHistory::<TestComp>::default();
+        history.push(Tick(10), TestComp(42.0));
+
+        assert_eq!(
+            history.interpolate(Tick(10), 0.0, &registry),
+            Some(TestComp(42.0))
+        );
+        assert_eq!(
+            history.interpolate(Tick(50), 0.5, &registry),
+            Some(TestComp(42.0))
+        );
+    }
+
+    #[test]
+    fn test_interpolate_returns_none_when_tick_is_before_start() {
+        let registry = registry();
+        let mut history = ConfirmedHistory::<TestComp>::default();
+        history.push(Tick(10), TestComp(0.0));
+        history.push(Tick(20), TestComp(10.0));
+
+        assert_eq!(history.interpolate(Tick(5), 0.0, &registry), None);
+    }
+
+    #[test]
+    fn test_interpolate_returns_none_when_history_is_empty() {
+        let registry = registry();
+        let history = ConfirmedHistory::<TestComp>::default();
+
+        assert_eq!(history.interpolate(Tick(0), 0.0, &registry), None);
     }
 }

--- a/lightyear_interpolation/src/interpolation_history.rs
+++ b/lightyear_interpolation/src/interpolation_history.rs
@@ -81,27 +81,26 @@ impl<C: Component + Clone> ConfirmedHistory<C> {
         interpolation_overstep: f32,
         interpolation_registry: &InterpolationRegistry,
     ) -> Option<C> {
-        let (start_tick, start) = self.start()?;
-        if interpolation_tick < start_tick {
-            return None;
+        if let Some((start_tick, start)) = self.start()
+            && let Some((end_tick, end)) = self.end()
+        {
+            if interpolation_tick < start_tick {
+                return None;
+            }
+            let fraction = ((interpolation_tick - start_tick) as f32 + interpolation_overstep)
+                / (end_tick - start_tick) as f32;
+            trace!(
+                ?start_tick,
+                ?end_tick,
+                ?interpolation_tick,
+                ?interpolation_overstep,
+                ?fraction,
+                "Interpolate {:?}",
+                DebugName::type_name::<C>()
+            );
+            return Some(interpolation_registry.interpolate(start.clone(), end.clone(), fraction));
         }
-        let Some((end_tick, end)) = self.end() else {
-            // Only one keyframe left: snap to it so the component converges on
-            // the latest confirmed value when updates stop arriving.
-            return Some(start.clone());
-        };
-        let fraction = ((interpolation_tick - start_tick) as f32 + interpolation_overstep)
-            / (end_tick - start_tick) as f32;
-        trace!(
-            ?start_tick,
-            ?end_tick,
-            ?interpolation_tick,
-            ?interpolation_overstep,
-            ?fraction,
-            "Interpolate {:?}",
-            DebugName::type_name::<C>()
-        );
-        Some(interpolation_registry.interpolate(start.clone(), end.clone(), fraction))
+        None
     }
 }
 
@@ -195,21 +194,16 @@ mod tests {
         );
     }
 
-    // Regression: when only one keyframe remains, snap to it instead of returning None.
+    // interpolate() requires two anchors. The idle-convergence case is handled
+    // by update_confirmed_history's rebase branch writing the value directly.
     #[test]
-    fn test_interpolate_snaps_to_single_keyframe() {
+    fn test_interpolate_returns_none_with_single_keyframe() {
         let registry = registry();
         let mut history = ConfirmedHistory::<TestComp>::default();
         history.push(Tick(10), TestComp(42.0));
 
-        assert_eq!(
-            history.interpolate(Tick(10), 0.0, &registry),
-            Some(TestComp(42.0))
-        );
-        assert_eq!(
-            history.interpolate(Tick(50), 0.5, &registry),
-            Some(TestComp(42.0))
-        );
+        assert_eq!(history.interpolate(Tick(10), 0.0, &registry), None);
+        assert_eq!(history.interpolate(Tick(50), 0.5, &registry), None);
     }
 
     #[test]

--- a/lightyear_interpolation/src/interpolation_history.rs
+++ b/lightyear_interpolation/src/interpolation_history.rs
@@ -50,6 +50,14 @@ impl<C> ConfirmedHistory<C> {
         self.get_nth(1)
     }
 
+    /// The most recent value in the history
+    pub fn newest(&self) -> Option<(Tick, &C)> {
+        match self.history.most_recent() {
+            None | Some((_, HistoryState::Removed)) => None,
+            Some((t, HistoryState::Updated(v))) => Some((*t, v)),
+        }
+    }
+
     /// Get the n-th oldest tick in the buffer (starts from n = 0)
     pub(crate) fn get_nth(&self, n: usize) -> Option<(Tick, &C)> {
         match self.history.get_nth(n) {
@@ -81,26 +89,27 @@ impl<C: Component + Clone> ConfirmedHistory<C> {
         interpolation_overstep: f32,
         interpolation_registry: &InterpolationRegistry,
     ) -> Option<C> {
-        if let Some((start_tick, start)) = self.start()
-            && let Some((end_tick, end)) = self.end()
-        {
-            if interpolation_tick < start_tick {
-                return None;
-            }
-            let fraction = ((interpolation_tick - start_tick) as f32 + interpolation_overstep)
-                / (end_tick - start_tick) as f32;
-            trace!(
-                ?start_tick,
-                ?end_tick,
-                ?interpolation_tick,
-                ?interpolation_overstep,
-                ?fraction,
-                "Interpolate {:?}",
-                DebugName::type_name::<C>()
-            );
-            return Some(interpolation_registry.interpolate(start.clone(), end.clone(), fraction));
+        let (start_tick, start) = self.start()?;
+        if interpolation_tick < start_tick {
+            return None;
         }
-        None
+        let Some((end_tick, end)) = self.end() else {
+            // Single keyframe: snap so the component converges on the latest confirmed value.
+            return Some(start.clone());
+        };
+        let fraction = (((interpolation_tick - start_tick) as f32 + interpolation_overstep)
+            / (end_tick - start_tick) as f32)
+            .clamp(0.0, 1.0);
+        trace!(
+            ?start_tick,
+            ?end_tick,
+            ?interpolation_tick,
+            ?interpolation_overstep,
+            ?fraction,
+            "Interpolate {:?}",
+            DebugName::type_name::<C>()
+        );
+        Some(interpolation_registry.interpolate(start.clone(), end.clone(), fraction))
     }
 }
 
@@ -194,16 +203,37 @@ mod tests {
         );
     }
 
-    // interpolate() requires two anchors. The idle-convergence case is handled
-    // by update_confirmed_history's rebase branch writing the value directly.
     #[test]
-    fn test_interpolate_returns_none_with_single_keyframe() {
+    fn test_interpolate_snaps_with_single_keyframe() {
         let registry = registry();
         let mut history = ConfirmedHistory::<TestComp>::default();
         history.push(Tick(10), TestComp(42.0));
 
-        assert_eq!(history.interpolate(Tick(10), 0.0, &registry), None);
-        assert_eq!(history.interpolate(Tick(50), 0.5, &registry), None);
+        assert_eq!(
+            history.interpolate(Tick(10), 0.0, &registry),
+            Some(TestComp(42.0))
+        );
+        assert_eq!(
+            history.interpolate(Tick(50), 0.5, &registry),
+            Some(TestComp(42.0))
+        );
+    }
+
+    #[test]
+    fn test_interpolate_clamps_when_past_end_tick() {
+        let registry = registry();
+        let mut history = ConfirmedHistory::<TestComp>::default();
+        history.push(Tick(10), TestComp(0.0));
+        history.push(Tick(20), TestComp(10.0));
+
+        assert_eq!(
+            history.interpolate(Tick(30), 0.0, &registry),
+            Some(TestComp(10.0))
+        );
+        assert_eq!(
+            history.interpolate(Tick(20), 0.5, &registry),
+            Some(TestComp(10.0))
+        );
     }
 
     #[test]

--- a/lightyear_interpolation/src/interpolation_history.rs
+++ b/lightyear_interpolation/src/interpolation_history.rs
@@ -90,12 +90,19 @@ impl<C: Component + Clone> ConfirmedHistory<C> {
         interpolation_registry: &InterpolationRegistry,
     ) -> Option<C> {
         let (start_tick, start) = self.start()?;
+        // It is possible that the interpolation_tick is early compared to the updates
+        // in the history: e.g. we received an update H, then no update for a while so
+        // we rebased it forward, and then two new updates arrive ahead of the
+        // interpolation tick (X...H1...H2). In that case interpolation should not run.
         if interpolation_tick < start_tick {
             return None;
         }
         let (end_tick, end) = self.end()?;
-        // Clamp prevents extrapolation past the newest anchor on a late update,
-        // bounding the jerk when the entity reverses direction during a gap.
+        // Clamp (rather than extrapolate past end_tick): bounds jerk to
+        // |newest - behind| on direction reversals. Extrapolation would look smoother
+        // in pure continuous motion but amplify the mismatch when the server path
+        // diverges from the extrapolated one. Revisit if we add velocity-aware
+        // interpolation with reconciliation.
         let fraction = (((interpolation_tick - start_tick) as f32 + interpolation_overstep)
             / (end_tick - start_tick) as f32)
             .clamp(0.0, 1.0);

--- a/lightyear_interpolation/src/interpolation_history.rs
+++ b/lightyear_interpolation/src/interpolation_history.rs
@@ -93,10 +93,9 @@ impl<C: Component + Clone> ConfirmedHistory<C> {
         if interpolation_tick < start_tick {
             return None;
         }
-        let Some((end_tick, end)) = self.end() else {
-            // Single keyframe: snap so the component converges on the latest confirmed value.
-            return Some(start.clone());
-        };
+        let (end_tick, end) = self.end()?;
+        // Clamp prevents extrapolation past the newest anchor on a late update,
+        // bounding the jerk when the entity reverses direction during a gap.
         let fraction = (((interpolation_tick - start_tick) as f32 + interpolation_overstep)
             / (end_tick - start_tick) as f32)
             .clamp(0.0, 1.0);
@@ -203,20 +202,17 @@ mod tests {
         );
     }
 
+    // The idle-rebase path in update_confirmed_history writes the component
+    // directly when the buffer collapses to a single keyframe, so interpolate()
+    // returns None and the previously-written value stands.
     #[test]
-    fn test_interpolate_snaps_with_single_keyframe() {
+    fn test_interpolate_returns_none_with_single_keyframe() {
         let registry = registry();
         let mut history = ConfirmedHistory::<TestComp>::default();
         history.push(Tick(10), TestComp(42.0));
 
-        assert_eq!(
-            history.interpolate(Tick(10), 0.0, &registry),
-            Some(TestComp(42.0))
-        );
-        assert_eq!(
-            history.interpolate(Tick(50), 0.5, &registry),
-            Some(TestComp(42.0))
-        );
+        assert_eq!(history.interpolate(Tick(10), 0.0, &registry), None);
+        assert_eq!(history.interpolate(Tick(50), 0.5, &registry), None);
     }
 
     #[test]

--- a/lightyear_interpolation/src/interpolation_history.rs
+++ b/lightyear_interpolation/src/interpolation_history.rs
@@ -81,26 +81,27 @@ impl<C: Component + Clone> ConfirmedHistory<C> {
         interpolation_overstep: f32,
         interpolation_registry: &InterpolationRegistry,
     ) -> Option<C> {
-        if let Some((start_tick, start)) = self.start()
-            && let Some((end_tick, end)) = self.end()
-        {
-            if interpolation_tick < start_tick {
-                return None;
-            }
-            let fraction = ((interpolation_tick - start_tick) as f32 + interpolation_overstep)
-                / (end_tick - start_tick) as f32;
-            trace!(
-                ?start_tick,
-                ?end_tick,
-                ?interpolation_tick,
-                ?interpolation_overstep,
-                ?fraction,
-                "Interpolate {:?}",
-                DebugName::type_name::<C>()
-            );
-            return Some(interpolation_registry.interpolate(start.clone(), end.clone(), fraction));
+        let (start_tick, start) = self.start()?;
+        if interpolation_tick < start_tick {
+            return None;
         }
-        None
+        let Some((end_tick, end)) = self.end() else {
+            // Only one keyframe left: snap to it so the component converges on
+            // the latest confirmed value when updates stop arriving.
+            return Some(start.clone());
+        };
+        let fraction = ((interpolation_tick - start_tick) as f32 + interpolation_overstep)
+            / (end_tick - start_tick) as f32;
+        trace!(
+            ?start_tick,
+            ?end_tick,
+            ?interpolation_tick,
+            ?interpolation_overstep,
+            ?fraction,
+            "Interpolate {:?}",
+            DebugName::type_name::<C>()
+        );
+        Some(interpolation_registry.interpolate(start.clone(), end.clone(), fraction))
     }
 }
 
@@ -190,6 +191,16 @@ mod tests {
     #[derive(Component, Clone, PartialEq, Debug)]
     struct TestComp(f32);
 
+    fn lerp(start: TestComp, end: TestComp, t: f32) -> TestComp {
+        TestComp(start.0 + (end.0 - start.0) * t)
+    }
+
+    fn registry() -> InterpolationRegistry {
+        let mut registry = InterpolationRegistry::default();
+        registry.set_interpolation::<TestComp>(lerp);
+        registry
+    }
+
     #[test]
     fn inserts_history_when_confirmed_added_after_interpolated() {
         let mut app = App::new();
@@ -245,5 +256,53 @@ mod tests {
                 .entity(entity)
                 .contains::<ConfirmedHistory<TestComp>>()
         );
+    }
+
+    #[test]
+    fn test_interpolate_blends_between_two_keyframes() {
+        let registry = registry();
+        let mut history = ConfirmedHistory::<TestComp>::default();
+        history.push(Tick(10), TestComp(0.0));
+        history.push(Tick(20), TestComp(10.0));
+
+        assert_eq!(
+            history.interpolate(Tick(15), 0.0, &registry),
+            Some(TestComp(5.0))
+        );
+    }
+
+    // Regression: when only one keyframe remains, snap to it instead of returning None.
+    #[test]
+    fn test_interpolate_snaps_to_single_keyframe() {
+        let registry = registry();
+        let mut history = ConfirmedHistory::<TestComp>::default();
+        history.push(Tick(10), TestComp(42.0));
+
+        assert_eq!(
+            history.interpolate(Tick(10), 0.0, &registry),
+            Some(TestComp(42.0))
+        );
+        assert_eq!(
+            history.interpolate(Tick(50), 0.5, &registry),
+            Some(TestComp(42.0))
+        );
+    }
+
+    #[test]
+    fn test_interpolate_returns_none_when_tick_is_before_start() {
+        let registry = registry();
+        let mut history = ConfirmedHistory::<TestComp>::default();
+        history.push(Tick(10), TestComp(0.0));
+        history.push(Tick(20), TestComp(10.0));
+
+        assert_eq!(history.interpolate(Tick(5), 0.0, &registry), None);
+    }
+
+    #[test]
+    fn test_interpolate_returns_none_when_history_is_empty() {
+        let registry = registry();
+        let history = ConfirmedHistory::<TestComp>::default();
+
+        assert_eq!(history.interpolate(Tick(0), 0.0, &registry), None);
     }
 }

--- a/lightyear_interpolation/src/interpolation_history.rs
+++ b/lightyear_interpolation/src/interpolation_history.rs
@@ -81,27 +81,26 @@ impl<C: Component + Clone> ConfirmedHistory<C> {
         interpolation_overstep: f32,
         interpolation_registry: &InterpolationRegistry,
     ) -> Option<C> {
-        let (start_tick, start) = self.start()?;
-        if interpolation_tick < start_tick {
-            return None;
+        if let Some((start_tick, start)) = self.start()
+            && let Some((end_tick, end)) = self.end()
+        {
+            if interpolation_tick < start_tick {
+                return None;
+            }
+            let fraction = ((interpolation_tick - start_tick) as f32 + interpolation_overstep)
+                / (end_tick - start_tick) as f32;
+            trace!(
+                ?start_tick,
+                ?end_tick,
+                ?interpolation_tick,
+                ?interpolation_overstep,
+                ?fraction,
+                "Interpolate {:?}",
+                DebugName::type_name::<C>()
+            );
+            return Some(interpolation_registry.interpolate(start.clone(), end.clone(), fraction));
         }
-        let Some((end_tick, end)) = self.end() else {
-            // Only one keyframe left: snap to it so the component converges on
-            // the latest confirmed value when updates stop arriving.
-            return Some(start.clone());
-        };
-        let fraction = ((interpolation_tick - start_tick) as f32 + interpolation_overstep)
-            / (end_tick - start_tick) as f32;
-        trace!(
-            ?start_tick,
-            ?end_tick,
-            ?interpolation_tick,
-            ?interpolation_overstep,
-            ?fraction,
-            "Interpolate {:?}",
-            DebugName::type_name::<C>()
-        );
-        Some(interpolation_registry.interpolate(start.clone(), end.clone(), fraction))
+        None
     }
 }
 
@@ -271,21 +270,16 @@ mod tests {
         );
     }
 
-    // Regression: when only one keyframe remains, snap to it instead of returning None.
+    // interpolate() requires two anchors. The idle-convergence case is handled
+    // by update_confirmed_history's rebase branch writing the value directly.
     #[test]
-    fn test_interpolate_snaps_to_single_keyframe() {
+    fn test_interpolate_returns_none_with_single_keyframe() {
         let registry = registry();
         let mut history = ConfirmedHistory::<TestComp>::default();
         history.push(Tick(10), TestComp(42.0));
 
-        assert_eq!(
-            history.interpolate(Tick(10), 0.0, &registry),
-            Some(TestComp(42.0))
-        );
-        assert_eq!(
-            history.interpolate(Tick(50), 0.5, &registry),
-            Some(TestComp(42.0))
-        );
+        assert_eq!(history.interpolate(Tick(10), 0.0, &registry), None);
+        assert_eq!(history.interpolate(Tick(50), 0.5, &registry), None);
     }
 
     #[test]

--- a/lightyear_interpolation/src/interpolation_history.rs
+++ b/lightyear_interpolation/src/interpolation_history.rs
@@ -50,6 +50,14 @@ impl<C> ConfirmedHistory<C> {
         self.get_nth(1)
     }
 
+    /// The most recent value in the history
+    pub fn newest(&self) -> Option<(Tick, &C)> {
+        match self.history.most_recent() {
+            None | Some((_, HistoryState::Removed)) => None,
+            Some((t, HistoryState::Updated(v))) => Some((*t, v)),
+        }
+    }
+
     /// Get the n-th oldest tick in the buffer (starts from n = 0)
     pub(crate) fn get_nth(&self, n: usize) -> Option<(Tick, &C)> {
         match self.history.get_nth(n) {
@@ -81,26 +89,27 @@ impl<C: Component + Clone> ConfirmedHistory<C> {
         interpolation_overstep: f32,
         interpolation_registry: &InterpolationRegistry,
     ) -> Option<C> {
-        if let Some((start_tick, start)) = self.start()
-            && let Some((end_tick, end)) = self.end()
-        {
-            if interpolation_tick < start_tick {
-                return None;
-            }
-            let fraction = ((interpolation_tick - start_tick) as f32 + interpolation_overstep)
-                / (end_tick - start_tick) as f32;
-            trace!(
-                ?start_tick,
-                ?end_tick,
-                ?interpolation_tick,
-                ?interpolation_overstep,
-                ?fraction,
-                "Interpolate {:?}",
-                DebugName::type_name::<C>()
-            );
-            return Some(interpolation_registry.interpolate(start.clone(), end.clone(), fraction));
+        let (start_tick, start) = self.start()?;
+        if interpolation_tick < start_tick {
+            return None;
         }
-        None
+        let Some((end_tick, end)) = self.end() else {
+            // Single keyframe: snap so the component converges on the latest confirmed value.
+            return Some(start.clone());
+        };
+        let fraction = (((interpolation_tick - start_tick) as f32 + interpolation_overstep)
+            / (end_tick - start_tick) as f32)
+            .clamp(0.0, 1.0);
+        trace!(
+            ?start_tick,
+            ?end_tick,
+            ?interpolation_tick,
+            ?interpolation_overstep,
+            ?fraction,
+            "Interpolate {:?}",
+            DebugName::type_name::<C>()
+        );
+        Some(interpolation_registry.interpolate(start.clone(), end.clone(), fraction))
     }
 }
 
@@ -270,16 +279,37 @@ mod tests {
         );
     }
 
-    // interpolate() requires two anchors. The idle-convergence case is handled
-    // by update_confirmed_history's rebase branch writing the value directly.
     #[test]
-    fn test_interpolate_returns_none_with_single_keyframe() {
+    fn test_interpolate_snaps_with_single_keyframe() {
         let registry = registry();
         let mut history = ConfirmedHistory::<TestComp>::default();
         history.push(Tick(10), TestComp(42.0));
 
-        assert_eq!(history.interpolate(Tick(10), 0.0, &registry), None);
-        assert_eq!(history.interpolate(Tick(50), 0.5, &registry), None);
+        assert_eq!(
+            history.interpolate(Tick(10), 0.0, &registry),
+            Some(TestComp(42.0))
+        );
+        assert_eq!(
+            history.interpolate(Tick(50), 0.5, &registry),
+            Some(TestComp(42.0))
+        );
+    }
+
+    #[test]
+    fn test_interpolate_clamps_when_past_end_tick() {
+        let registry = registry();
+        let mut history = ConfirmedHistory::<TestComp>::default();
+        history.push(Tick(10), TestComp(0.0));
+        history.push(Tick(20), TestComp(10.0));
+
+        assert_eq!(
+            history.interpolate(Tick(30), 0.0, &registry),
+            Some(TestComp(10.0))
+        );
+        assert_eq!(
+            history.interpolate(Tick(20), 0.5, &registry),
+            Some(TestComp(10.0))
+        );
     }
 
     #[test]

--- a/lightyear_interpolation/src/interpolation_history.rs
+++ b/lightyear_interpolation/src/interpolation_history.rs
@@ -93,10 +93,9 @@ impl<C: Component + Clone> ConfirmedHistory<C> {
         if interpolation_tick < start_tick {
             return None;
         }
-        let Some((end_tick, end)) = self.end() else {
-            // Single keyframe: snap so the component converges on the latest confirmed value.
-            return Some(start.clone());
-        };
+        let (end_tick, end) = self.end()?;
+        // Clamp prevents extrapolation past the newest anchor on a late update,
+        // bounding the jerk when the entity reverses direction during a gap.
         let fraction = (((interpolation_tick - start_tick) as f32 + interpolation_overstep)
             / (end_tick - start_tick) as f32)
             .clamp(0.0, 1.0);
@@ -279,20 +278,17 @@ mod tests {
         );
     }
 
+    // The idle-rebase path in update_confirmed_history writes the component
+    // directly when the buffer collapses to a single keyframe, so interpolate()
+    // returns None and the previously-written value stands.
     #[test]
-    fn test_interpolate_snaps_with_single_keyframe() {
+    fn test_interpolate_returns_none_with_single_keyframe() {
         let registry = registry();
         let mut history = ConfirmedHistory::<TestComp>::default();
         history.push(Tick(10), TestComp(42.0));
 
-        assert_eq!(
-            history.interpolate(Tick(10), 0.0, &registry),
-            Some(TestComp(42.0))
-        );
-        assert_eq!(
-            history.interpolate(Tick(50), 0.5, &registry),
-            Some(TestComp(42.0))
-        );
+        assert_eq!(history.interpolate(Tick(10), 0.0, &registry), None);
+        assert_eq!(history.interpolate(Tick(50), 0.5, &registry), None);
     }
 
     #[test]

--- a/lightyear_interpolation/src/plugin.rs
+++ b/lightyear_interpolation/src/plugin.rs
@@ -165,6 +165,8 @@ mod tests {
         let delay = InterpolationDelay {
             delay: PositiveTickDelta::lit("2.4"),
         };
-        assert_eq!(delay.tick_and_overstep(Tick(3)), (Tick(0), 0.6));
+        let (tick, overstep) = delay.tick_and_overstep(Tick(3));
+        assert_eq!(tick, Tick(0));
+        assert!((overstep - 0.6).abs() < 0.0001);
     }
 }


### PR DESCRIPTION
This is an attempt to resolve the issue described here https://github.com/cBournhonesque/lightyear/issues/1450

I went through a few iterations with the assistance of a coding agent, the latest commit still displays jitter when simulating a poor connection (400ms+), but solves the issue of drift between what clients see and what the server has as state. I suspect there is room for improvement, but I don't have enough context to clearly identify it.

Agent generated context below.

## Summary

Fixes persistent drift and jitter on remote `Interpolated` entities when updates stop arriving or are lost. Interpolation now converges cleanly on the latest confirmed value during true idle, clamps on the freshest bracketing pair during short loss gaps, and no longer snaps mid-blend when the buffer transiently drains.

## Problem

`ConfirmedHistory<C>::interpolate` required two keyframes and returned `None` otherwise. `update_confirmed_history`'s rebase branch was the only path that could advance a single-keyframe buffer to the current tick, and it gated its component write on `!present`. Result: after the server stopped sending updates, the interpolated component stayed pinned to its last blended value — slightly behind `newest` — and never converged. Reproduced in a minimal standalone app; persistent ~0.0006 unit drift on localhost, larger under link conditioning.

## Iteration history

I tried four algorithmic variants; each fixed the previous one's failure mode and surfaced a new one. The branch is kept as separate commits for reviewability; happy to squash if preferred.

**1. `32d4b8c5` — Snap on single keyframe.** Made `interpolate()` snap to `start()` when `len == 1` so the idle-convergence case was covered without relying on the rebase's write. Fixed the drift but introduced visible jitter on remote entities during active motion at >200ms RTT: any transient drain to `len == 1` mid-blend produced an instantaneous snap to the newest anchor.

**2. `de25275b` — Time-gated rebase writes every tick.** Reverted `interpolate()` to the `len >= 2` contract; moved the write into the idle rebase path (no longer `!present`-gated), firing every tick the `len == 1 && current - newest >= send_interval_delta_tick` gate held. Smooth under true idle, but the 4-tick gate isn't idle-specific — it also fires on loss gaps during active motion. Each packet-loss event produced one stale write followed by a catch-up blend on the next arrival. Subtle at 2% loss, rough at 10%.

**3. `5258e8d0` — Structural: maintain bracketing pair.** Rewrote `update_confirmed_history` to keep `[behind, newest]` while updates flow, clamped `fraction` in `interpolate()` to `[0, 1]` to prevent extrapolation past `newest`, and re-added snap-on-`len == 1`. Eliminated the idle jerk but regressed mid-motion: the drain used `while len >= 2 && get_nth(1) <= current: pop`, which collapsed to `len == 1` on every gap, giving more visible jumps per gap than the time-gated version.

**4. `adfb183a` — Smart drain + clamp.** Tightened the drain to `while len >= 3 && get_nth(1) <= current: pop` so the buffer never drops below 2 during active replication. The idle rebase now fires from `len >= 2` (the drain doesn't reduce below 2 on its own), collapsing to a single retagged anchor at the current tick and writing the component directly. Removed snap-on-`len == 1` from `interpolate()` since the rebase is the only path that can produce `len == 1`. Clamp retained: bounded jerk on direction reversals is preferable to extrapolation overshoot when the server path diverges from a linear extrapolation.

**5. `8edf6945` — Restore context comments.** Pure docs. Restored three comments/TODOs that were still load-bearing: the "exact start tick" TODO on the idle rebase (the proxy-vs-real-tick problem remains open), the `X...H1...H2` explanation for the `interpolation_tick < start_tick` guard in `interpolate()`, and a design-decision note at the clamp site describing why clamp was chosen over extrapolation.

## Final design

`interpolate()` is now a pure geometric operation:
- `len == 0` → `None`
- `len == 1` → `None` (idle rebase path is responsible for the component write)
- `len >= 2` → clamped blend between `start()` and `end()`

`update_confirmed_history` maintains `[behind, newest]` during active replication (smart drain) and collapses to a single rebased anchor at the current tick when `current - newest >= send_interval_delta_tick` (idle rebase). The rebase writes the component directly.

Extrapolation past `end_tick` is intentionally not implemented. Clamp bounds the jerk on direction reversals to `|newest - behind|`; extrapolation would look smoother for continuous motion but amplify mismatch when the server path diverges. The TODO at the previous extrapolation site is converted into an inline design-decision comment tied to velocity-aware interpolation with reconciliation as a future direction.

## Test plan

- [x] Unit tests in `lightyear_interpolation` (`ConfirmedHistory::interpolate`) updated and passing.
- [x] Standalone minimal repro (originally used to isolate the drift bug): drift eliminated.
- [x] In-game testing with a downstream Bevy project using `LinkConditioner` presets:
  - `good` (40ms, 6ms jitter, 0.2% loss) — smooth.
  - `average` (100ms, 15ms jitter, 2% loss) — smooth with occasional jitter at ~25s cadence (matches the probability of 2 consecutive drops).
  - `poor` (200ms, 30ms jitter, 10% loss) — visibly lossy; 2-drop events occur ~every 2s and can't be hidden by interpolation alone. Raising `InterpolationConfig::send_interval_ratio` from `1.7` to `3.0` materially improves this by buffering an extra keyframe.
