### PR TITLE
fix: ignore WSAECONNRESET on Windows UDP receive

### DIFF
--- a/lightyear_udp/src/lib.rs
+++ b/lightyear_udp/src/lib.rs
@@ -167,6 +167,10 @@ impl UdpPlugin {
                         link.recv.push(payload.freeze(), Instant::now());
                     }
                     Err(ref e) if e.kind() == ErrorKind::WouldBlock => return,
+                    // Windows-specific: when the remote end rejects a UDP packet, the OS
+                    // raises WSAECONNRESET (10054) on the next recv. This is harmless for
+                    // a connectionless UDP socket — just skip to the next receive attempt.
+                    Err(ref e) if e.kind() == ErrorKind::ConnectionReset => continue,
                     Err(e) => {
                         error!("Error receiving UDP packet: {}", e);
                         return;

--- a/lightyear_udp/src/server.rs
+++ b/lightyear_udp/src/server.rs
@@ -233,6 +233,10 @@ impl ServerUdpPlugin {
                             };
                         }
                         Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => break,
+                        // Windows-specific: when a UDP client disconnects, the OS sends an
+                        // ICMP "port unreachable" back, which surfaces as ConnectionReset on
+                        // the next recv. This is harmless — just skip to the next packet.
+                        Err(ref e) if e.kind() == std::io::ErrorKind::ConnectionReset => continue,
                         Err(e) => {
                             error!("Error receiving UDP packet: {}", e);
                             break;


### PR DESCRIPTION
## Summary

On Windows, when a UDP peer disconnects (e.g. client closes the app), the OS
sends back an ICMP \"port unreachable\" message. This surfaces as
`ErrorKind::ConnectionReset` on the *next* `recv_from` call on the socket.

The current code falls through to the catch-all error arm, which logs
`Error receiving UDP packet: An existing connection was forcibly closed by
the remote host. (os error 10054)` and then exits the receive loop for that
frame (`return` in the client path, `break` in the server path).

The fix adds a `ConnectionReset => continue` arm before the catch-all in
both `UdpPlugin::receive` (client, `lib.rs`) and `ServerUdpPlugin::receive`
(server, `server.rs`), so the loop simply moves on to the next packet.

**Why this is safe on all platforms:** `ErrorKind::ConnectionReset` is never
emitted by a non-blocking UDP socket on Linux or macOS in normal operation —
those platforms raise it only for connected TCP sockets. Hitting this branch
on non-Windows is therefore a no-op in practice. On Windows it correctly
suppresses the spurious ICMP-driven pseudo-error that would otherwise spam
the log and skip buffered packets.