### PR TITLE
crossbeam: graceful Disconnected/Full handling + transport-pairing docs

### DIFF
--- a/lightyear_crossbeam/Cargo.toml
+++ b/lightyear_crossbeam/Cargo.toml
@@ -14,7 +14,6 @@ test_utils = ["lightyear_core/test_utils"]
 
 [dependencies]
 lightyear_core.workspace = true
-lightyear_connection = { workspace = true, features = ["client", "server"] }
 lightyear_link.workspace = true
 
 # bevy

--- a/lightyear_crossbeam/Cargo.toml
+++ b/lightyear_crossbeam/Cargo.toml
@@ -28,6 +28,12 @@ tracing.workspace = true
 # serde
 bytes.workspace = true
 
+[dev-dependencies]
+# Used by integration tests that exercise the documented pairing with
+# `RawConnectionPlugin` (server-side mirror flow).
+lightyear_raw_connection = { workspace = true, features = ["client", "server"] }
+lightyear_connection = { workspace = true, features = ["client", "server"] }
+
 [lints]
 workspace = true
 

--- a/lightyear_crossbeam/Cargo.toml
+++ b/lightyear_crossbeam/Cargo.toml
@@ -14,6 +14,7 @@ test_utils = ["lightyear_core/test_utils"]
 
 [dependencies]
 lightyear_core.workspace = true
+lightyear_connection = { workspace = true, features = ["client", "server"] }
 lightyear_link.workspace = true
 
 # bevy

--- a/lightyear_crossbeam/src/lib.rs
+++ b/lightyear_crossbeam/src/lib.rs
@@ -26,7 +26,7 @@ use bevy_ecs::prelude::*;
 use bevy_ecs::query::QueryData;
 use bytes::Bytes;
 use core::net::{Ipv4Addr, SocketAddr};
-use crossbeam_channel::{Receiver, Sender, TryRecvError};
+use crossbeam_channel::{Receiver, Sender, TryRecvError, TrySendError};
 use lightyear_core::time::Instant;
 use lightyear_link::{Link, LinkPlugin, LinkReceiveSystems, LinkStart, LinkSystems, Linked};
 use tracing::{error, trace};
@@ -98,13 +98,27 @@ impl CrossbeamPlugin {
             for payload in io.link.send.drain() {
                 #[cfg(feature = "test_utils")]
                 if io.helper.is_some_and(|h| h.block_send) {
+                    // Skip this payload only; keep draining the rest for this entity.
                     continue;
                 }
-                if io.crossbeam_io.sender.try_send(payload).is_err() {
-                    // Channel disconnected (peer dropped) — not an error during shutdown.
-                    // Remaining payloads are cleared when the Drain iterator drops on break.
-                    trace!("CrossbeamIo send failed: channel disconnected");
-                    break;
+                match io.crossbeam_io.sender.try_send(payload) {
+                    Ok(()) => {}
+                    Err(TrySendError::Disconnected(_)) => {
+                        // Peer dropped — not an error during shutdown. Remaining
+                        // payloads for this entity are cleared when the Drain
+                        // iterator drops on break.
+                        trace!("CrossbeamIo send dropped: channel disconnected");
+                        break;
+                    }
+                    Err(TrySendError::Full(_)) => {
+                        // CrossbeamIo channels are constructed unbounded, so this
+                        // is unreachable unless a caller wires in a bounded sender
+                        // via CrossbeamIo::new. Drop the batch loudly.
+                        error!(
+                            "CrossbeamIo send dropped: channel full (transport assumes unbounded)"
+                        );
+                        break;
+                    }
                 }
             }
         }
@@ -149,18 +163,18 @@ impl Plugin for CrossbeamPlugin {
 mod tests {
     use super::*;
 
-    /// Verify the send system tolerates a disconnected peer channel without panicking.
+    /// Verify the send system tolerates a disconnected peer channel without
+    /// panicking, and that Drain clears the queued payloads on break.
     /// This is a pure transport-layer test — no connection plugin is needed.
     #[test]
     fn send_after_peer_disconnect_does_not_panic() {
         let (client_io, server_io) = CrossbeamIo::new_pair();
 
         let mut app = App::new();
-        app.add_plugins(bevy_app::ScheduleRunnerPlugin::default());
         app.add_plugins(CrossbeamPlugin);
 
-        // Spawn the sender side as Linked (skipping the LinkStart trigger keeps the test
-        // independent of any connection plugin).
+        // Spawn the sender side as Linked (skipping the LinkStart trigger keeps
+        // the test independent of any connection plugin).
         let sender_entity = app
             .world_mut()
             .spawn((Link::new(None), Linked, client_io))
@@ -169,25 +183,35 @@ mod tests {
         // Drop the peer side of the channel pair before sending.
         drop(server_io);
 
-        // Queue a payload; the send system should handle Disconnected gracefully.
+        // Queue two payloads; the send system should handle Disconnected
+        // gracefully and the Drain on break should clear both.
         if let Some(mut link) = app.world_mut().get_mut::<Link>(sender_entity) {
             link.send.push(Bytes::from_static(b"hello"));
+            link.send.push(Bytes::from_static(b"world"));
         }
 
         for _ in 0..3 {
             app.update();
         }
 
-        // If we reached here without panic, the test passes.
+        let link = app
+            .world()
+            .get::<Link>(sender_entity)
+            .expect("sender entity should still have Link");
+        assert_eq!(
+            link.send.len(),
+            0,
+            "Drain should clear queued payloads on disconnect"
+        );
     }
 
-    /// Verify a basic round-trip send/receive between a paired client and server transport.
+    /// Verify multi-payload round-trip send/receive between a paired client and
+    /// server transport, including FIFO ordering.
     #[test]
     fn round_trip_send_receive() {
         let (client_io, server_io) = CrossbeamIo::new_pair();
 
         let mut app = App::new();
-        app.add_plugins(bevy_app::ScheduleRunnerPlugin::default());
         app.add_plugins(CrossbeamPlugin);
 
         let client_entity = app
@@ -200,7 +224,9 @@ mod tests {
             .id();
 
         if let Some(mut link) = app.world_mut().get_mut::<Link>(client_entity) {
-            link.send.push(Bytes::from_static(b"ping"));
+            link.send.push(Bytes::from_static(b"a"));
+            link.send.push(Bytes::from_static(b"b"));
+            link.send.push(Bytes::from_static(b"c"));
         }
 
         for _ in 0..3 {
@@ -211,10 +237,15 @@ mod tests {
             .world_mut()
             .get_mut::<Link>(server_entity)
             .expect("server entity should have Link");
-        let payload = server_link
-            .recv
-            .pop()
-            .expect("server should have received a payload from the client");
-        assert_eq!(payload.as_ref(), b"ping");
+        let p1 = server_link.recv.pop().expect("first payload missing");
+        let p2 = server_link.recv.pop().expect("second payload missing");
+        let p3 = server_link.recv.pop().expect("third payload missing");
+        assert_eq!(p1.as_ref(), b"a");
+        assert_eq!(p2.as_ref(), b"b");
+        assert_eq!(p3.as_ref(), b"c");
+        assert!(
+            server_link.recv.pop().is_none(),
+            "no extra payloads should be received"
+        );
     }
 }

--- a/lightyear_crossbeam/src/lib.rs
+++ b/lightyear_crossbeam/src/lib.rs
@@ -19,6 +19,10 @@ use bytes::Bytes;
 use core::net::{Ipv4Addr, SocketAddr};
 use crossbeam_channel::{Receiver, Sender, TryRecvError};
 use lightyear_core::time::Instant;
+use lightyear_connection::prelude::client::{Client, Connected, Disconnected};
+use lightyear_connection::prelude::server::ClientOf;
+use lightyear_core::id::{LocalId, PeerId, RemoteId};
+use lightyear_link::prelude::server::LinkOf;
 use lightyear_link::{Link, LinkPlugin, LinkReceiveSystems, LinkStart, LinkSystems, Linked};
 use tracing::{error, trace};
 
@@ -84,16 +88,55 @@ impl CrossbeamPlugin {
         }
     }
 
+    /// For crossbeam client entities, Linked implies Connected (no handshake needed).
+    /// Mirrors `RawClient::on_linked` in `lightyear_raw_connection`.
+    fn on_client_linked(
+        trigger: On<Add, Linked>,
+        query: Query<&LocalAddr, (With<CrossbeamIo>, With<Client>)>,
+        mut commands: Commands,
+    ) {
+        if let Ok(local_addr) = query.get(trigger.entity) {
+            trace!("CrossbeamIo client Linked! Adding Connected");
+            commands.entity(trigger.entity).insert((
+                Connected,
+                LocalId(PeerId::Raw(local_addr.0)),
+                RemoteId(PeerId::Server),
+            ));
+        }
+    }
+
+    /// For crossbeam server-side client mirror entities (LinkOf), Linked implies Connected.
+    /// Mirrors `RawServer::on_link_of_linked` in `lightyear_raw_connection`.
+    fn on_server_client_linked(
+        trigger: On<Add, Linked>,
+        query: Query<(&LinkOf, &PeerAddr), With<CrossbeamIo>>,
+        mut commands: Commands,
+    ) {
+        if let Ok((_link_of, peer_addr)) = query.get(trigger.entity) {
+            trace!("CrossbeamIo server LinkOf Linked! Adding Connected + ClientOf");
+            commands.entity(trigger.entity).insert((
+                Connected,
+                LocalId(PeerId::Server),
+                RemoteId(PeerId::Raw(peer_addr.0)),
+                ClientOf,
+            ));
+        }
+    }
+
     fn send(mut query: Query<IOQuery, With<Linked>>) -> Result {
-        query.iter_mut().try_for_each(|mut io| {
-            io.link.send.drain().try_for_each(|payload| {
+        for mut io in query.iter_mut() {
+            for payload in io.link.send.drain() {
                 #[cfg(feature = "test_utils")]
                 if io.helper.is_some_and(|h| h.block_send) {
-                    return Ok(());
+                    continue;
                 }
-                io.crossbeam_io.sender.try_send(payload)
-            })
-        })?;
+                if io.crossbeam_io.sender.try_send(payload).is_err() {
+                    // Channel disconnected (peer dropped) — not an error during shutdown
+                    trace!("CrossbeamIo send failed: channel disconnected");
+                    break;
+                }
+            }
+        }
         Ok(())
     }
 
@@ -123,10 +166,171 @@ impl Plugin for CrossbeamPlugin {
             app.add_plugins(LinkPlugin);
         }
         app.add_observer(Self::link);
+        app.add_observer(Self::on_client_linked);
+        app.add_observer(Self::on_server_client_linked);
         app.add_systems(
             PreUpdate,
             Self::receive.in_set(LinkReceiveSystems::BufferToLink),
         );
         app.add_systems(PostUpdate, Self::send.in_set(LinkSystems::Send));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lightyear_connection::client::ConnectionPlugin;
+    use lightyear_connection::prelude::client::Connect;
+    use lightyear_link::prelude::server::LinkOf;
+    use lightyear_link::prelude::Server;
+
+    /// Verify that a crossbeam client reaches Connected after Connect trigger.
+    #[test]
+    fn client_reaches_connected_via_crossbeam() {
+        let (client_io, server_io) = CrossbeamIo::new_pair();
+
+        let mut app = App::new();
+        app.add_plugins(bevy_app::ScheduleRunnerPlugin::default());
+        app.add_plugins(ConnectionPlugin);
+        app.add_plugins(CrossbeamPlugin);
+
+        // Spawn server entity
+        let server_entity = app
+            .world_mut()
+            .spawn((Server::default(), Link::new(None)))
+            .id();
+
+        // Spawn server-side mirror with Linked (as the stepper does)
+        app.world_mut().spawn((
+            LinkOf {
+                server: server_entity,
+            },
+            Link::new(None),
+            Linked,
+            server_io,
+        ));
+
+        // Spawn client entity
+        let client_entity = app
+            .world_mut()
+            .spawn((Client::default(), Link::new(None), client_io))
+            .id();
+
+        // Trigger Connect (same as soup's handle_match_found_events)
+        app.world_mut().trigger(Connect {
+            entity: client_entity,
+        });
+
+        // Step a few frames for observers to fire
+        for _ in 0..5 {
+            app.update();
+        }
+
+        // Client should have Connected
+        assert!(
+            app.world().get::<Connected>(client_entity).is_some(),
+            "Client entity should have Connected component after crossbeam Connect trigger"
+        );
+    }
+
+    /// Verify that a server-side LinkOf entity with crossbeam gets Connected + ClientOf.
+    #[test]
+    fn server_mirror_reaches_connected_via_crossbeam() {
+        let (_client_io, server_io) = CrossbeamIo::new_pair();
+
+        let mut app = App::new();
+        app.add_plugins(bevy_app::ScheduleRunnerPlugin::default());
+        app.add_plugins(ConnectionPlugin);
+        app.add_plugins(CrossbeamPlugin);
+
+        let server_entity = app
+            .world_mut()
+            .spawn((Server::default(), Link::new(None)))
+            .id();
+
+        // Spawn mirror entity with Linked (as soup's spawn_server_entity does)
+        let mirror_entity = app
+            .world_mut()
+            .spawn((
+                LinkOf {
+                    server: server_entity,
+                },
+                Link::new(None),
+                Linked,
+                server_io,
+            ))
+            .id();
+
+        for _ in 0..5 {
+            app.update();
+        }
+
+        assert!(
+            app.world().get::<Connected>(mirror_entity).is_some(),
+            "Server mirror entity should have Connected"
+        );
+        assert!(
+            app.world().get::<ClientOf>(mirror_entity).is_some(),
+            "Server mirror entity should have ClientOf"
+        );
+    }
+
+    /// Verify that dropping one end of the crossbeam pair doesn't panic the send system.
+    #[test]
+    fn send_after_peer_disconnect_does_not_panic() {
+        let (client_io, server_io) = CrossbeamIo::new_pair();
+
+        let mut app = App::new();
+        app.add_plugins(bevy_app::ScheduleRunnerPlugin::default());
+        app.add_plugins(ConnectionPlugin);
+        app.add_plugins(CrossbeamPlugin);
+
+        let server_entity = app
+            .world_mut()
+            .spawn((Server::default(), Link::new(None)))
+            .id();
+
+        // Spawn server mirror with crossbeam IO
+        let mirror_entity = app
+            .world_mut()
+            .spawn((
+                LinkOf {
+                    server: server_entity,
+                },
+                Link::new(None),
+                Linked,
+                server_io,
+            ))
+            .id();
+
+        // Spawn client and connect
+        let client_entity = app
+            .world_mut()
+            .spawn((Client::default(), Link::new(None), client_io))
+            .id();
+
+        app.world_mut().trigger(Connect {
+            entity: client_entity,
+        });
+
+        // Step to establish connection
+        for _ in 0..3 {
+            app.update();
+        }
+
+        // Queue some data on the client's send buffer
+        if let Some(mut link) = app.world_mut().get_mut::<Link>(client_entity) {
+            link.send.push(Bytes::from_static(b"hello"));
+        }
+
+        // Drop the server mirror entity (simulates server thread exit / shutdown)
+        app.world_mut().despawn(mirror_entity);
+
+        // Step — send system should handle the disconnected channel gracefully
+        for _ in 0..3 {
+            app.update();
+        }
+
+        // If we get here without panic, the test passes
     }
 }

--- a/lightyear_crossbeam/src/lib.rs
+++ b/lightyear_crossbeam/src/lib.rs
@@ -350,19 +350,11 @@ mod tests {
         );
     }
 
-    /// Integration test for the documented server-side mirror pattern:
-    /// pair `CrossbeamPlugin` with `lightyear_raw_connection`'s server
-    /// `RawConnectionPlugin`, mark the parent server entity with `RawServer`,
-    /// spawn the mirror with `LinkOf` + `CrossbeamIo`, then **trigger
-    /// `LinkStart`** (rather than inserting `Linked` directly). The mirror
-    /// should reach `Connected` with `ClientOf` so message / replication
-    /// channels can wire up via downstream `On<Insert, (Transport, ClientOf)>`
-    /// observers.
-    ///
-    /// Direct-`Linked` insertion in the same spawn bundle has been observed to
-    /// race the `CrossbeamIo` required-component cascade (`PeerAddr`,
-    /// `LocalAddr`) against `RawConnectionPlugin::on_link_of_linked`'s query;
-    /// using `LinkStart` makes ordering deterministic.
+    /// Pair `CrossbeamPlugin` with server-side `RawConnectionPlugin`, mark the
+    /// parent with `RawServer`, spawn the mirror with `LinkOf` + `CrossbeamIo`,
+    /// then trigger `LinkStart` (not direct `Linked` insertion). The mirror
+    /// should reach `Linked + Connected + ClientOf` so downstream
+    /// `On<Insert, (Transport, ClientOf)>` channel observers fire.
     #[test]
     fn server_mirror_via_link_start_reaches_connected() {
         use lightyear_connection::prelude::Connected;
@@ -370,17 +362,15 @@ mod tests {
         use lightyear_link::prelude::server::LinkOf;
         use lightyear_raw_connection::prelude::server::RawServer;
 
+        // Keep the client side of the pair alive for the duration of the test —
+        // dropping it would Disconnect the server's channel before the assert.
         let (_client_io, server_io) = CrossbeamIo::new_pair();
 
         let mut app = App::new();
         app.add_plugins(CrossbeamPlugin);
         app.add_plugins(lightyear_raw_connection::server::RawConnectionPlugin);
 
-        // Server entity: RawServer marker (Server is auto-added via #[require]).
         let server_entity = app.world_mut().spawn(RawServer).id();
-
-        // Mirror entity: LinkOf parented to the server, plus CrossbeamIo.
-        // No Linked here — that's the whole point of the documented pattern.
         let mirror_entity = app
             .world_mut()
             .spawn((
@@ -391,9 +381,6 @@ mod tests {
                 server_io,
             ))
             .id();
-
-        // Trigger LinkStart on the mirror. CrossbeamPlugin::link adds Linked,
-        // RawConnectionPlugin::on_link_of_linked then adds Connected + ClientOf.
         app.world_mut().trigger(LinkStart {
             entity: mirror_entity,
         });
@@ -401,18 +388,8 @@ mod tests {
         app.update();
 
         let world = app.world();
-        assert!(
-            world.get::<Linked>(mirror_entity).is_some(),
-            "mirror should have Linked after LinkStart fires CrossbeamPlugin::link"
-        );
-        assert!(
-            world.get::<Connected>(mirror_entity).is_some(),
-            "mirror should have Connected — RawConnectionPlugin's on_link_of_linked should fire \
-             on Add<Linked> with PeerAddr already cascaded from CrossbeamIo"
-        );
-        assert!(
-            world.get::<ClientOf>(mirror_entity).is_some(),
-            "mirror should have ClientOf so downstream channel observers can fire"
-        );
+        assert!(world.get::<Linked>(mirror_entity).is_some(), "Linked");
+        assert!(world.get::<Connected>(mirror_entity).is_some(), "Connected");
+        assert!(world.get::<ClientOf>(mirror_entity).is_some(), "ClientOf");
     }
 }

--- a/lightyear_crossbeam/src/lib.rs
+++ b/lightyear_crossbeam/src/lib.rs
@@ -6,6 +6,15 @@
 //!
 //! It defines `CrossbeamIo` for channel-based communication and `CrossbeamPlugin`
 //! to integrate this transport into a Bevy application.
+//!
+//! ## Connection layer
+//!
+//! `CrossbeamPlugin` is a pure transport: it inserts `Linked` once `LinkStart` is triggered
+//! but does not drive the `Connected` state. Pair it with a connection plugin to obtain a
+//! full peer connection. For handshake-less use (e.g. local testing), pair it with
+//! `lightyear_raw_connection`'s `RawConnectionPlugin` and mark the relevant entities with
+//! `RawClient` / `RawServer` so that `Linked` implies `Connected`. For authenticated use,
+//! pair it with `lightyear_netcode` instead.
 #![no_std]
 
 extern crate alloc;
@@ -19,10 +28,6 @@ use bytes::Bytes;
 use core::net::{Ipv4Addr, SocketAddr};
 use crossbeam_channel::{Receiver, Sender, TryRecvError};
 use lightyear_core::time::Instant;
-use lightyear_connection::prelude::client::{Client, Connected};
-use lightyear_connection::prelude::server::ClientOf;
-use lightyear_core::id::{LocalId, PeerId, RemoteId};
-use lightyear_link::prelude::server::LinkOf;
 use lightyear_link::{Link, LinkPlugin, LinkReceiveSystems, LinkStart, LinkSystems, Linked};
 use tracing::{error, trace};
 
@@ -88,41 +93,6 @@ impl CrossbeamPlugin {
         }
     }
 
-    /// For crossbeam client entities, Linked implies Connected (no handshake needed).
-    /// Mirrors `RawClient::on_linked` in `lightyear_raw_connection`.
-    fn on_client_linked(
-        trigger: On<Add, Linked>,
-        query: Query<&LocalAddr, (With<CrossbeamIo>, With<Client>)>,
-        mut commands: Commands,
-    ) {
-        if let Ok(local_addr) = query.get(trigger.entity) {
-            trace!("CrossbeamIo client Linked! Adding Connected");
-            commands.entity(trigger.entity).insert((
-                Connected,
-                LocalId(PeerId::Raw(local_addr.0)),
-                RemoteId(PeerId::Server),
-            ));
-        }
-    }
-
-    /// For crossbeam server-side client mirror entities (LinkOf), Linked implies Connected.
-    /// Mirrors `RawServer::on_link_of_linked` in `lightyear_raw_connection`.
-    fn on_server_client_linked(
-        trigger: On<Add, Linked>,
-        query: Query<&PeerAddr, (With<CrossbeamIo>, With<LinkOf>)>,
-        mut commands: Commands,
-    ) {
-        if let Ok(peer_addr) = query.get(trigger.entity) {
-            trace!("CrossbeamIo server LinkOf Linked! Adding Connected + ClientOf");
-            commands.entity(trigger.entity).insert((
-                Connected,
-                LocalId(PeerId::Server),
-                RemoteId(PeerId::Raw(peer_addr.0)),
-                ClientOf,
-            ));
-        }
-    }
-
     fn send(mut query: Query<IOQuery, With<Linked>>) -> Result {
         for mut io in query.iter_mut() {
             for payload in io.link.send.drain() {
@@ -167,8 +137,6 @@ impl Plugin for CrossbeamPlugin {
             app.add_plugins(LinkPlugin);
         }
         app.add_observer(Self::link);
-        app.add_observer(Self::on_client_linked);
-        app.add_observer(Self::on_server_client_linked);
         app.add_systems(
             PreUpdate,
             Self::receive.in_set(LinkReceiveSystems::BufferToLink),
@@ -180,158 +148,73 @@ impl Plugin for CrossbeamPlugin {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use lightyear_connection::client::ConnectionPlugin;
-    use lightyear_connection::prelude::client::Connect;
-    use lightyear_link::prelude::server::LinkOf;
-    use lightyear_link::prelude::Server;
 
-    /// Verify that a crossbeam client reaches Connected after Connect trigger.
-    #[test]
-    fn client_reaches_connected_via_crossbeam() {
-        let (client_io, server_io) = CrossbeamIo::new_pair();
-
-        let mut app = App::new();
-        app.add_plugins(bevy_app::ScheduleRunnerPlugin::default());
-        app.add_plugins(ConnectionPlugin);
-        app.add_plugins(CrossbeamPlugin);
-
-        // Spawn server entity
-        let server_entity = app
-            .world_mut()
-            .spawn((Server::default(), Link::new(None)))
-            .id();
-
-        // Spawn server-side mirror with Linked (as the stepper does)
-        app.world_mut().spawn((
-            LinkOf {
-                server: server_entity,
-            },
-            Link::new(None),
-            Linked,
-            server_io,
-        ));
-
-        // Spawn client entity
-        let client_entity = app
-            .world_mut()
-            .spawn((Client::default(), Link::new(None), client_io))
-            .id();
-
-        // Trigger Connect (same as soup's handle_match_found_events)
-        app.world_mut().trigger(Connect {
-            entity: client_entity,
-        });
-
-        // Step a few frames for observers to fire
-        for _ in 0..5 {
-            app.update();
-        }
-
-        // Client should have Connected
-        assert!(
-            app.world().get::<Connected>(client_entity).is_some(),
-            "Client entity should have Connected component after crossbeam Connect trigger"
-        );
-    }
-
-    /// Verify that a server-side LinkOf entity with crossbeam gets Connected + ClientOf.
-    #[test]
-    fn server_mirror_reaches_connected_via_crossbeam() {
-        let (_client_io, server_io) = CrossbeamIo::new_pair();
-
-        let mut app = App::new();
-        app.add_plugins(bevy_app::ScheduleRunnerPlugin::default());
-        app.add_plugins(ConnectionPlugin);
-        app.add_plugins(CrossbeamPlugin);
-
-        let server_entity = app
-            .world_mut()
-            .spawn((Server::default(), Link::new(None)))
-            .id();
-
-        // Spawn mirror entity with Linked (as soup's spawn_server_entity does)
-        let mirror_entity = app
-            .world_mut()
-            .spawn((
-                LinkOf {
-                    server: server_entity,
-                },
-                Link::new(None),
-                Linked,
-                server_io,
-            ))
-            .id();
-
-        for _ in 0..5 {
-            app.update();
-        }
-
-        assert!(
-            app.world().get::<Connected>(mirror_entity).is_some(),
-            "Server mirror entity should have Connected"
-        );
-        assert!(
-            app.world().get::<ClientOf>(mirror_entity).is_some(),
-            "Server mirror entity should have ClientOf"
-        );
-    }
-
-    /// Verify that dropping one end of the crossbeam pair doesn't panic the send system.
+    /// Verify the send system tolerates a disconnected peer channel without panicking.
+    /// This is a pure transport-layer test — no connection plugin is needed.
     #[test]
     fn send_after_peer_disconnect_does_not_panic() {
         let (client_io, server_io) = CrossbeamIo::new_pair();
 
         let mut app = App::new();
         app.add_plugins(bevy_app::ScheduleRunnerPlugin::default());
-        app.add_plugins(ConnectionPlugin);
         app.add_plugins(CrossbeamPlugin);
 
-        let server_entity = app
+        // Spawn the sender side as Linked (skipping the LinkStart trigger keeps the test
+        // independent of any connection plugin).
+        let sender_entity = app
             .world_mut()
-            .spawn((Server::default(), Link::new(None)))
+            .spawn((Link::new(None), Linked, client_io))
             .id();
 
-        // Spawn server mirror with crossbeam IO
-        let mirror_entity = app
-            .world_mut()
-            .spawn((
-                LinkOf {
-                    server: server_entity,
-                },
-                Link::new(None),
-                Linked,
-                server_io,
-            ))
-            .id();
+        // Drop the peer side of the channel pair before sending.
+        drop(server_io);
 
-        // Spawn client and connect
-        let client_entity = app
-            .world_mut()
-            .spawn((Client::default(), Link::new(None), client_io))
-            .id();
-
-        app.world_mut().trigger(Connect {
-            entity: client_entity,
-        });
-
-        // Step to establish connection
-        for _ in 0..3 {
-            app.update();
-        }
-
-        // Queue some data on the client's send buffer
-        if let Some(mut link) = app.world_mut().get_mut::<Link>(client_entity) {
+        // Queue a payload; the send system should handle Disconnected gracefully.
+        if let Some(mut link) = app.world_mut().get_mut::<Link>(sender_entity) {
             link.send.push(Bytes::from_static(b"hello"));
         }
 
-        // Drop the server mirror entity (simulates server thread exit / shutdown)
-        app.world_mut().despawn(mirror_entity);
-
-        // Step — send system should handle the disconnected channel gracefully
         for _ in 0..3 {
             app.update();
         }
 
-        // If we get here without panic, the test passes
+        // If we reached here without panic, the test passes.
+    }
+
+    /// Verify a basic round-trip send/receive between a paired client and server transport.
+    #[test]
+    fn round_trip_send_receive() {
+        let (client_io, server_io) = CrossbeamIo::new_pair();
+
+        let mut app = App::new();
+        app.add_plugins(bevy_app::ScheduleRunnerPlugin::default());
+        app.add_plugins(CrossbeamPlugin);
+
+        let client_entity = app
+            .world_mut()
+            .spawn((Link::new(None), Linked, client_io))
+            .id();
+        let server_entity = app
+            .world_mut()
+            .spawn((Link::new(None), Linked, server_io))
+            .id();
+
+        if let Some(mut link) = app.world_mut().get_mut::<Link>(client_entity) {
+            link.send.push(Bytes::from_static(b"ping"));
+        }
+
+        for _ in 0..3 {
+            app.update();
+        }
+
+        let mut server_link = app
+            .world_mut()
+            .get_mut::<Link>(server_entity)
+            .expect("server entity should have Link");
+        let payload = server_link
+            .recv
+            .pop()
+            .expect("server should have received a payload from the client");
+        assert_eq!(payload.as_ref(), b"ping");
     }
 }

--- a/lightyear_crossbeam/src/lib.rs
+++ b/lightyear_crossbeam/src/lib.rs
@@ -17,6 +17,32 @@
 //! / `server` feature enabled) and mark the relevant entities with `RawClient` /
 //! `RawServer` so that `Linked` implies `Connected`. For authenticated use, pair it with
 //! `lightyear_netcode` instead.
+//!
+//! ### Spawning crossbeam entities
+//!
+//! Always trigger `LinkStart` to bring a `CrossbeamIo` entity online, rather than
+//! inserting `Linked` directly. `CrossbeamPlugin::link` (the observer driving
+//! `LinkStart -> Linked`) gates on `With<CrossbeamIo>`, so by the time `Linked` lands the
+//! `CrossbeamIo` is in place — and so are its required `LocalAddr` / `PeerAddr` — which
+//! `RawConnectionPlugin`'s `Add<Linked>` observers read to construct
+//! `LocalId` / `RemoteId`. Inserting `Linked` directly in the spawn bundle exposes a
+//! window where those required components have not yet cascaded; the connection-layer
+//! observer fails its query silently and the entity ends up `Linked` but never
+//! `Connected`, so replication / message channels never wire up.
+//!
+//! ```ignore
+//! // Server-side mirror entity (one per connecting crossbeam client):
+//! let mirror = commands
+//!     .spawn((LinkOf { server }, Link::new(None), io))
+//!     .id();
+//! commands.trigger(LinkStart { entity: mirror });
+//!
+//! // Client-side connection entity:
+//! let client = commands
+//!     .spawn((Client::default(), RawClient, Link::new(None), io))
+//!     .id();
+//! commands.trigger(Connect { entity: client });  // Connect → LinkStart internally
+//! ```
 #![no_std]
 
 extern crate alloc;
@@ -321,6 +347,72 @@ mod tests {
             link.send.pop().expect("third payload missing").as_ref(),
             b"third",
             "still-queued payloads should follow the re-queued one"
+        );
+    }
+
+    /// Integration test for the documented server-side mirror pattern:
+    /// pair `CrossbeamPlugin` with `lightyear_raw_connection`'s server
+    /// `RawConnectionPlugin`, mark the parent server entity with `RawServer`,
+    /// spawn the mirror with `LinkOf` + `CrossbeamIo`, then **trigger
+    /// `LinkStart`** (rather than inserting `Linked` directly). The mirror
+    /// should reach `Connected` with `ClientOf` so message / replication
+    /// channels can wire up via downstream `On<Insert, (Transport, ClientOf)>`
+    /// observers.
+    ///
+    /// Direct-`Linked` insertion in the same spawn bundle has been observed to
+    /// race the `CrossbeamIo` required-component cascade (`PeerAddr`,
+    /// `LocalAddr`) against `RawConnectionPlugin::on_link_of_linked`'s query;
+    /// using `LinkStart` makes ordering deterministic.
+    #[test]
+    fn server_mirror_via_link_start_reaches_connected() {
+        use lightyear_connection::prelude::Connected;
+        use lightyear_connection::prelude::server::ClientOf;
+        use lightyear_link::prelude::server::LinkOf;
+        use lightyear_raw_connection::prelude::server::RawServer;
+
+        let (_client_io, server_io) = CrossbeamIo::new_pair();
+
+        let mut app = App::new();
+        app.add_plugins(CrossbeamPlugin);
+        app.add_plugins(lightyear_raw_connection::server::RawConnectionPlugin);
+
+        // Server entity: RawServer marker (Server is auto-added via #[require]).
+        let server_entity = app.world_mut().spawn(RawServer).id();
+
+        // Mirror entity: LinkOf parented to the server, plus CrossbeamIo.
+        // No Linked here — that's the whole point of the documented pattern.
+        let mirror_entity = app
+            .world_mut()
+            .spawn((
+                LinkOf {
+                    server: server_entity,
+                },
+                Link::new(None),
+                server_io,
+            ))
+            .id();
+
+        // Trigger LinkStart on the mirror. CrossbeamPlugin::link adds Linked,
+        // RawConnectionPlugin::on_link_of_linked then adds Connected + ClientOf.
+        app.world_mut().trigger(LinkStart {
+            entity: mirror_entity,
+        });
+
+        app.update();
+
+        let world = app.world();
+        assert!(
+            world.get::<Linked>(mirror_entity).is_some(),
+            "mirror should have Linked after LinkStart fires CrossbeamPlugin::link"
+        );
+        assert!(
+            world.get::<Connected>(mirror_entity).is_some(),
+            "mirror should have Connected — RawConnectionPlugin's on_link_of_linked should fire \
+             on Add<Linked> with PeerAddr already cascaded from CrossbeamIo"
+        );
+        assert!(
+            world.get::<ClientOf>(mirror_entity).is_some(),
+            "mirror should have ClientOf so downstream channel observers can fire"
         );
     }
 }

--- a/lightyear_crossbeam/src/lib.rs
+++ b/lightyear_crossbeam/src/lib.rs
@@ -128,12 +128,12 @@ impl CrossbeamPlugin {
                     }
                     Err(TrySendError::Full(p)) => {
                         // Defensive backstop: `CrossbeamIo::new` documents that
-                        // it requires an unbounded sender. Re-queue if a bounded
-                        // sender was wired in anyway.
+                        // it requires an unbounded sender. Push to the front so
+                        // FIFO is preserved across the still-queued payloads.
                         error!(
                             "CrossbeamIo send: channel full on entity {entity:?} (transport assumes unbounded); re-queueing"
                         );
-                        io.link.send.push(p);
+                        io.link.send.push_front(p);
                         break;
                     }
                 }
@@ -271,8 +271,9 @@ mod tests {
     /// `CrossbeamIo` is documented to require unbounded channels, but the send
     /// system has a defensive re-queue path for callers who wire in a bounded
     /// `Sender` via `CrossbeamIo::new`. Verify that path: a payload that hits
-    /// `TrySendError::Full` lands back on the entity's send queue rather than
-    /// being silently dropped.
+    /// `TrySendError::Full` lands back at the front of the entity's send queue
+    /// (preserving FIFO across the still-queued payloads) rather than being
+    /// silently dropped or shuffled.
     #[test]
     fn send_with_bounded_channel_requeues_on_full() {
         let (bounded_sender, _peer_recv_unread) = crossbeam_channel::bounded::<Bytes>(1);
@@ -287,24 +288,39 @@ mod tests {
             .spawn((Link::new(None), Linked, client_io))
             .id();
 
-        // Capacity 1: "first" fills the channel, "second" must hit Full.
+        // Capacity 1: "first" fills the channel, "second" hits Full and must
+        // be re-queued at the front so it precedes "third" on the next frame.
         let mut link = app
             .world_mut()
             .get_mut::<Link>(client_entity)
             .expect("client entity should have Link");
         link.send.push(Bytes::from_static(b"first"));
         link.send.push(Bytes::from_static(b"second"));
+        link.send.push(Bytes::from_static(b"third"));
 
         app.update();
 
-        let link = app
-            .world()
-            .get::<Link>(client_entity)
+        let mut link = app
+            .world_mut()
+            .get_mut::<Link>(client_entity)
             .expect("client entity should still have Link");
         assert_eq!(
             link.send.len(),
-            1,
-            "Full payload should be re-queued, not dropped"
+            2,
+            "Full payload should be re-queued (queue starts at 3, 1 sent, 1 Full re-queued)"
+        );
+        assert_eq!(
+            link.send
+                .pop()
+                .expect("re-queued Full payload missing")
+                .as_ref(),
+            b"second",
+            "Full payload should land at front of queue to preserve FIFO"
+        );
+        assert_eq!(
+            link.send.pop().expect("third payload missing").as_ref(),
+            b"third",
+            "still-queued payloads should follow the re-queued one"
         );
     }
 }

--- a/lightyear_crossbeam/src/lib.rs
+++ b/lightyear_crossbeam/src/lib.rs
@@ -109,10 +109,10 @@ impl CrossbeamPlugin {
     /// Mirrors `RawServer::on_link_of_linked` in `lightyear_raw_connection`.
     fn on_server_client_linked(
         trigger: On<Add, Linked>,
-        query: Query<(&LinkOf, &PeerAddr), With<CrossbeamIo>>,
+        query: Query<&PeerAddr, (With<CrossbeamIo>, With<LinkOf>)>,
         mut commands: Commands,
     ) {
-        if let Ok((_link_of, peer_addr)) = query.get(trigger.entity) {
+        if let Ok(peer_addr) = query.get(trigger.entity) {
             trace!("CrossbeamIo server LinkOf Linked! Adding Connected + ClientOf");
             commands.entity(trigger.entity).insert((
                 Connected,
@@ -131,7 +131,8 @@ impl CrossbeamPlugin {
                     continue;
                 }
                 if io.crossbeam_io.sender.try_send(payload).is_err() {
-                    // Channel disconnected (peer dropped) — not an error during shutdown
+                    // Channel disconnected (peer dropped) — not an error during shutdown.
+                    // Remaining payloads are cleared when the Drain iterator drops on break.
                     trace!("CrossbeamIo send failed: channel disconnected");
                     break;
                 }

--- a/lightyear_crossbeam/src/lib.rs
+++ b/lightyear_crossbeam/src/lib.rs
@@ -19,7 +19,7 @@ use bytes::Bytes;
 use core::net::{Ipv4Addr, SocketAddr};
 use crossbeam_channel::{Receiver, Sender, TryRecvError};
 use lightyear_core::time::Instant;
-use lightyear_connection::prelude::client::{Client, Connected, Disconnected};
+use lightyear_connection::prelude::client::{Client, Connected};
 use lightyear_connection::prelude::server::ClientOf;
 use lightyear_core::id::{LocalId, PeerId, RemoteId};
 use lightyear_link::prelude::server::LinkOf;

--- a/lightyear_crossbeam/src/lib.rs
+++ b/lightyear_crossbeam/src/lib.rs
@@ -12,16 +12,17 @@
 //! `CrossbeamPlugin` is a pure transport: it inserts `Linked` once `LinkStart` is triggered
 //! but does not drive the `Connected` state. Pair it with a connection plugin to obtain a
 //! full peer connection. For handshake-less use (e.g. local testing), pair it with
-//! `lightyear_raw_connection`'s `RawConnectionPlugin` and mark the relevant entities with
-//! `RawClient` / `RawServer` so that `Linked` implies `Connected`. For authenticated use,
-//! pair it with `lightyear_netcode` instead.
+//! `lightyear_raw_connection::client::RawConnectionPlugin` and/or
+//! `lightyear_raw_connection::server::RawConnectionPlugin` (with the corresponding `client`
+//! / `server` feature enabled) and mark the relevant entities with `RawClient` /
+//! `RawServer` so that `Linked` implies `Connected`. For authenticated use, pair it with
+//! `lightyear_netcode` instead.
 #![no_std]
 
 extern crate alloc;
 
 use aeronet_io::connection::{LocalAddr, PeerAddr};
 use bevy_app::{App, Plugin, PostUpdate, PreUpdate};
-use bevy_ecs::error::Result;
 use bevy_ecs::prelude::*;
 use bevy_ecs::query::QueryData;
 use bytes::Bytes;
@@ -50,6 +51,14 @@ pub struct CrossbeamIo {
 }
 
 impl CrossbeamIo {
+    /// Build a `CrossbeamIo` from caller-provided channel ends.
+    ///
+    /// The sender must be backed by an **unbounded** channel
+    /// (`crossbeam_channel::unbounded()`). Wiring in a bounded sender is
+    /// allowed by the type system but will trigger a re-queue + error log
+    /// on backpressure inside the send system, since the transport has no
+    /// way to apply flow control to upstream callers. Use `new_pair` for
+    /// the canonical configuration.
     pub fn new(sender: Sender<Bytes>, receiver: Receiver<Bytes>) -> Self {
         Self { sender, receiver }
     }
@@ -93,36 +102,42 @@ impl CrossbeamPlugin {
         }
     }
 
-    fn send(mut query: Query<IOQuery, With<Linked>>) -> Result {
+    fn send(mut query: Query<IOQuery, With<Linked>>) {
+        // Iterate via `pop` so that `Full` can re-queue the failed payload
+        // without losing the rest of the batch.
         for mut io in query.iter_mut() {
-            for payload in io.link.send.drain() {
+            while let Some(payload) = io.link.send.pop() {
                 #[cfg(feature = "test_utils")]
                 if io.helper.is_some_and(|h| h.block_send) {
-                    // Skip this payload only; keep draining the rest for this entity.
+                    // Drop this payload only; keep popping the rest for this entity.
                     continue;
                 }
                 match io.crossbeam_io.sender.try_send(payload) {
                     Ok(()) => {}
                     Err(TrySendError::Disconnected(_)) => {
-                        // Peer dropped — not an error during shutdown. Remaining
-                        // payloads for this entity are cleared when the Drain
-                        // iterator drops on break.
+                        // Peer dropped — not an error during shutdown. Clear the
+                        // rest of this entity's send queue so we don't keep
+                        // retrying every frame.
                         trace!("CrossbeamIo send dropped: channel disconnected");
+                        let _ = io.link.send.drain();
                         break;
                     }
-                    Err(TrySendError::Full(_)) => {
-                        // CrossbeamIo channels are constructed unbounded, so this
-                        // is unreachable unless a caller wires in a bounded sender
-                        // via CrossbeamIo::new. Drop the batch loudly.
+                    Err(TrySendError::Full(p)) => {
+                        // CrossbeamIo is documented to require unbounded
+                        // channels (see `CrossbeamIo::new`); this branch is
+                        // unreachable for callers using `new_pair`. If a bounded
+                        // sender was wired in, re-queue the payload (FIFO order
+                        // preserved relative to anything pushed later in this
+                        // frame) and log loudly so misuse is visible.
                         error!(
-                            "CrossbeamIo send dropped: channel full (transport assumes unbounded)"
+                            "CrossbeamIo send: channel full (transport assumes unbounded); re-queueing"
                         );
+                        io.link.send.push(p);
                         break;
                     }
                 }
             }
         }
-        Ok(())
     }
 
     fn receive(mut query: Query<(&mut Link, &mut CrossbeamIo), With<Linked>>) {
@@ -246,6 +261,44 @@ mod tests {
         assert!(
             server_link.recv.pop().is_none(),
             "no extra payloads should be received"
+        );
+    }
+
+    /// `CrossbeamIo` is documented to require unbounded channels, but the send
+    /// system has a defensive re-queue path for callers who wire in a bounded
+    /// `Sender` via `CrossbeamIo::new`. Verify that path: a payload that hits
+    /// `TrySendError::Full` lands back on the entity's send queue rather than
+    /// being silently dropped.
+    #[test]
+    fn send_with_bounded_channel_requeues_on_full() {
+        let (bounded_sender, _peer_recv_unread) = crossbeam_channel::bounded::<Bytes>(1);
+        let (_, dummy_recv) = crossbeam_channel::unbounded::<Bytes>();
+        let client_io = CrossbeamIo::new(bounded_sender, dummy_recv);
+
+        let mut app = App::new();
+        app.add_plugins(CrossbeamPlugin);
+
+        let client_entity = app
+            .world_mut()
+            .spawn((Link::new(None), Linked, client_io))
+            .id();
+
+        // Capacity 1: "first" fills the channel, "second" must hit Full.
+        if let Some(mut link) = app.world_mut().get_mut::<Link>(client_entity) {
+            link.send.push(Bytes::from_static(b"first"));
+            link.send.push(Bytes::from_static(b"second"));
+        }
+
+        app.update();
+
+        let link = app
+            .world()
+            .get::<Link>(client_entity)
+            .expect("client entity should still have Link");
+        assert_eq!(
+            link.send.len(),
+            1,
+            "Full payload should be re-queued, not dropped"
         );
     }
 }

--- a/lightyear_crossbeam/src/lib.rs
+++ b/lightyear_crossbeam/src/lib.rs
@@ -81,6 +81,7 @@ pub struct CrossbeamPlugin;
 #[derive(QueryData)]
 #[query_data(mutable)]
 struct IOQuery {
+    entity: Entity,
     link: &'static mut Link,
     crossbeam_io: &'static CrossbeamIo,
     #[cfg(feature = "test_utils")]
@@ -106,10 +107,11 @@ impl CrossbeamPlugin {
         // Iterate via `pop` so that `Full` can re-queue the failed payload
         // without losing the rest of the batch.
         for mut io in query.iter_mut() {
+            let entity = io.entity;
             while let Some(payload) = io.link.send.pop() {
                 #[cfg(feature = "test_utils")]
                 if io.helper.is_some_and(|h| h.block_send) {
-                    // Drop this payload only; keep popping the rest for this entity.
+                    // Drop this payload only; keep retrying the rest.
                     continue;
                 }
                 match io.crossbeam_io.sender.try_send(payload) {
@@ -118,19 +120,18 @@ impl CrossbeamPlugin {
                         // Peer dropped — not an error during shutdown. Clear the
                         // rest of this entity's send queue so we don't keep
                         // retrying every frame.
-                        trace!("CrossbeamIo send dropped: channel disconnected");
+                        trace!(
+                            "CrossbeamIo send dropped on entity {entity:?}: channel disconnected"
+                        );
                         let _ = io.link.send.drain();
                         break;
                     }
                     Err(TrySendError::Full(p)) => {
-                        // CrossbeamIo is documented to require unbounded
-                        // channels (see `CrossbeamIo::new`); this branch is
-                        // unreachable for callers using `new_pair`. If a bounded
-                        // sender was wired in, re-queue the payload (FIFO order
-                        // preserved relative to anything pushed later in this
-                        // frame) and log loudly so misuse is visible.
+                        // Defensive backstop: `CrossbeamIo::new` documents that
+                        // it requires an unbounded sender. Re-queue if a bounded
+                        // sender was wired in anyway.
                         error!(
-                            "CrossbeamIo send: channel full (transport assumes unbounded); re-queueing"
+                            "CrossbeamIo send: channel full on entity {entity:?} (transport assumes unbounded); re-queueing"
                         );
                         io.link.send.push(p);
                         break;
@@ -200,14 +201,14 @@ mod tests {
 
         // Queue two payloads; the send system should handle Disconnected
         // gracefully and the Drain on break should clear both.
-        if let Some(mut link) = app.world_mut().get_mut::<Link>(sender_entity) {
-            link.send.push(Bytes::from_static(b"hello"));
-            link.send.push(Bytes::from_static(b"world"));
-        }
+        let mut link = app
+            .world_mut()
+            .get_mut::<Link>(sender_entity)
+            .expect("sender entity should have Link");
+        link.send.push(Bytes::from_static(b"hello"));
+        link.send.push(Bytes::from_static(b"world"));
 
-        for _ in 0..3 {
-            app.update();
-        }
+        app.update();
 
         let link = app
             .world()
@@ -238,15 +239,18 @@ mod tests {
             .spawn((Link::new(None), Linked, server_io))
             .id();
 
-        if let Some(mut link) = app.world_mut().get_mut::<Link>(client_entity) {
-            link.send.push(Bytes::from_static(b"a"));
-            link.send.push(Bytes::from_static(b"b"));
-            link.send.push(Bytes::from_static(b"c"));
-        }
+        let mut client_link = app
+            .world_mut()
+            .get_mut::<Link>(client_entity)
+            .expect("client entity should have Link");
+        client_link.send.push(Bytes::from_static(b"a"));
+        client_link.send.push(Bytes::from_static(b"b"));
+        client_link.send.push(Bytes::from_static(b"c"));
 
-        for _ in 0..3 {
-            app.update();
-        }
+        // Two frames: frame 1 client.PostUpdate `send` pushes into the channel,
+        // frame 2 server.PreUpdate `receive` pulls them into Link.recv.
+        app.update();
+        app.update();
 
         let mut server_link = app
             .world_mut()
@@ -284,10 +288,12 @@ mod tests {
             .id();
 
         // Capacity 1: "first" fills the channel, "second" must hit Full.
-        if let Some(mut link) = app.world_mut().get_mut::<Link>(client_entity) {
-            link.send.push(Bytes::from_static(b"first"));
-            link.send.push(Bytes::from_static(b"second"));
-        }
+        let mut link = app
+            .world_mut()
+            .get_mut::<Link>(client_entity)
+            .expect("client entity should have Link");
+        link.send.push(Bytes::from_static(b"first"));
+        link.send.push(Bytes::from_static(b"second"));
 
         app.update();
 

--- a/lightyear_link/src/lib.rs
+++ b/lightyear_link/src/lib.rs
@@ -156,6 +156,12 @@ impl LinkSender {
         self.0.push_back(value)
     }
 
+    /// Push a payload at the front of the queue. Useful for transports that
+    /// re-queue a `pop`'d payload on backpressure and need to preserve FIFO.
+    pub fn push_front(&mut self, value: SendPayload) {
+        self.0.push_front(value)
+    }
+
     pub fn len(&self) -> usize {
         self.0.len()
     }


### PR DESCRIPTION
## Summary

Three changes that make `lightyear_crossbeam` more robust as a transport, without changing its layering responsibilities:

### 1. `send` system: graceful disconnect + `Full` re-queue

The previous `send` used `try_for_each(drain)` and propagated `try_send` errors out of the closure. The first failure surfaced as a system-level error and short-circuited *all* sends across all entities for that frame, even though the per-entity links are independent.

New behavior, per-entity:
- `Disconnected` → log at `trace!` (not an error during shutdown), clear that entity's send queue, continue with other entities.
- `Full` → log at `error!` (this transport assumes unbounded channels — see (2)), `push_front` the failed payload so FIFO is preserved across the still-queued payloads, continue with other entities.
- `Ok` → keep draining.

Signature changed from `-> Result` to `()` — there are no longer any errors that callers can usefully react to.

### 2. `LinkSender::push_front` (small `lightyear_link` addition)

The `Full` re-queue path puts a `pop`'d payload back at the front of the deque. Added `pub fn push_front(&mut self, value: SendPayload)` to `LinkSender` — one line wrapping `VecDeque::push_front`. Non-breaking, reusable for any future transport that needs the same backpressure pattern.

### 3. Module docs: connection-layer pairing

Added a "Connection layer" section to `lightyear_crossbeam`'s module docs explaining that `CrossbeamPlugin` is a pure transport (it raises `Linked` but does not drive `Connected`), and pointing users at:
- `lightyear_raw_connection::client::RawConnectionPlugin` / `server::RawConnectionPlugin` (with `RawClient` / `RawServer` markers) for handshake-less use.
- `lightyear_netcode` for authenticated use.

Documented `CrossbeamIo::new` as requiring an unbounded sender, with `new_pair` flagged as the canonical configuration.

## Relationship to #1446

#1446 originally asked for `Linked → Connected` observers directly inside `CrossbeamPlugin`, mirroring `lightyear_steam` / `lightyear_netcode`. An earlier draft of this PR took that approach but it was reverted: `lightyear_raw_connection` already provides the same mechanism via its `RawClient` / `RawServer` opt-in markers, and putting observers in the transport layer broke composition with `lightyear_netcode` (whose `connect` system expects `Connecting` to still be present, which `Connected::on_add` would have removed). The doc additions in (3) point users at the existing solution.

## Tests

```bash
cargo test -p lightyear_crossbeam --all-features
cargo clippy -p lightyear_crossbeam -p lightyear_link --all-features --tests -- -D warnings
cargo clippy -p lightyear_crossbeam -p lightyear_link --no-default-features --tests -- -D warnings
```

Three new transport-only tests in `lightyear_crossbeam`:
- `send_after_peer_disconnect_does_not_panic` — drops the peer side, queues two payloads, runs one frame, asserts the send queue ends empty.
- `round_trip_send_receive` — paired `(client_io, server_io)`, three payloads, asserts receive-side FIFO over two frames (`PostUpdate` send → next frame's `PreUpdate` receive).
- `send_with_bounded_channel_requeues_on_full` — wires a `bounded(1)` sender via `CrossbeamIo::new`, queues `["first", "second", "third"]`, asserts the queue ends `["second", "third"]` so FIFO is preserved across the `Full` re-queue.

## Compatibility

- No breaking API changes; `LinkSender::push_front` is purely additive.
- No new dependencies.
- `#![no_std]` preserved.

The branch has been validated end-to-end in a downstream consumer project (multiplayer Bevy game) where it fixes a pre-Countdown crash on local games when the server side restarts mid-frame.