### PR TITLE
fix: use strongly typed clone in buffer_insert_delta

### DIFF
--- a/lightyear_replication/src/registry/delta.rs
+++ b/lightyear_replication/src/registry/delta.rs
@@ -270,7 +270,7 @@ fn buffer_insert_delta<
                     );
                     let confirmed_component_id = entity_mut.component_id::<Confirmed<C>>();
                     if predicted && !entity_mut.entity.contains::<C>() {
-                        let cloned = clone.unwrap()(&new_value.0);
+                        let cloned = new_value.0.clone();
                         // SAFETY: we made sure that component_id corresponds to C
                         unsafe {
                             entity_mut.buffered.insert::<C>(cloned, component_id);


### PR DESCRIPTION
It suddenly occurred to me that we are in generic context inside `buffer_insert_delta` with `new_value.0` having type `C` so there is no need to use type erased clone. The `delta-compression` example is working after this change.

closes #1460