### PR TITLE
Fix Tick: Ord transitivity violation corrupting BTreeMap<Tick, _>

### DIFF
--- a/lightyear_avian/src/lag_compensation/history.rs
+++ b/lightyear_avian/src/lag_compensation/history.rs
@@ -139,20 +139,18 @@ fn update_collision_layers(
     >,
     mut commands: Commands,
 ) {
-    parent_query
-        .iter()
-        .for_each(|(parent, layers, children)| {
-            for child in children.iter() {
-                if child_query.get(child).is_ok() {
-                    commands.entity(child).insert(*layers);
-                    trace!(
-                        ?child,
-                        ?parent,
-                        "Adding layers {layers:?} on lag compensation child collider"
-                    );
-                }
+    parent_query.iter().for_each(|(parent, layers, children)| {
+        for child in children.iter() {
+            if child_query.get(child).is_ok() {
+                commands.entity(child).insert(*layers);
+                trace!(
+                    ?child,
+                    ?parent,
+                    "Adding layers {layers:?} on lag compensation child collider"
+                );
             }
-        });
+        }
+    });
 }
 
 /// For each lag-compensated collider, store every tick a copy of the

--- a/lightyear_core/src/history_buffer.rs
+++ b/lightyear_core/src/history_buffer.rs
@@ -100,7 +100,7 @@ impl<R> HistoryBuffer<R> {
     /// Used to efficiently get the previous value when doing correction.
     pub fn second_most_recent(&self, tick: Tick) -> Option<&R> {
         let (most_recent_tick, most_recent) = self.most_recent()?;
-        if *most_recent_tick < tick {
+        if most_recent_tick.is_older_than(tick) {
             return most_recent.into();
         }
         let len = self.buffer.len();
@@ -115,7 +115,7 @@ impl<R> HistoryBuffer<R> {
         // find first idx `partition` such that self.buffer[partition].0 > tick
         let partition = self
             .buffer
-            .partition_point(|(buffer_tick, _)| *buffer_tick <= tick);
+            .partition_point(|(buffer_tick, _)| buffer_tick.wrapping_cmp(&tick).is_le());
         if partition == 0 {
             return None;
         }
@@ -132,7 +132,7 @@ impl<R> HistoryBuffer<R> {
         // self.buffer[partition] is the first element where the buffer_tick > tick
         let partition = self
             .buffer
-            .partition_point(|(buffer_tick, _)| buffer_tick <= &tick);
+            .partition_point(|(buffer_tick, _)| buffer_tick.wrapping_cmp(&tick).is_le());
         // all elements are strictly more recent than the tick
         if partition == 0 {
             return;
@@ -251,7 +251,7 @@ impl<R: Clone> HistoryBuffer<R> {
         // self.buffer[partition] is the first element where the buffer_tick > tick
         let partition = self
             .buffer
-            .partition_point(|(buffer_tick, _)| buffer_tick <= &tick);
+            .partition_point(|(buffer_tick, _)| buffer_tick.wrapping_cmp(&tick).is_le());
         // all elements are strictly more recent than the tick
         if partition == 0 {
             return None;
@@ -289,7 +289,7 @@ impl<R: Clone> HistoryBuffer<R> {
         // self.buffer[partition] is the first element where the buffer_tick > tick
         let partition = self
             .buffer
-            .partition_point(|(buffer_tick, _)| buffer_tick <= &tick);
+            .partition_point(|(buffer_tick, _)| buffer_tick.wrapping_cmp(&tick).is_le());
         // all elements are strictly more recent than the tick
         if partition == 0 {
             self.clear();

--- a/lightyear_core/src/tick.rs
+++ b/lightyear_core/src/tick.rs
@@ -9,6 +9,45 @@ use bevy_reflect::Reflect;
 // Internal id that tracks the Tick value for the server and the client
 wrapping_id!(Tick);
 
+impl Ord for Tick {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+        self.0.cmp(&other.0)
+    }
+}
+
+impl PartialOrd for Tick {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Tick {
+    /// Wrap-aware "is this tick more recent than `other`" check.
+    /// Correct only when `|self - other| < 32768`. Use this instead of `>`
+    /// when you want sequence semantics, not numeric ordering.
+    #[inline]
+    pub fn is_newer_than(self, other: Self) -> bool {
+        lightyear_utils::wrapping_id::wrapping_diff(other.0, self.0) > 0
+    }
+
+    /// Wrap-aware "is this tick older than `other`".
+    #[inline]
+    pub fn is_older_than(self, other: Self) -> bool {
+        lightyear_utils::wrapping_id::wrapping_diff(other.0, self.0) < 0
+    }
+
+    /// Wrap-aware Ordering for use in comparators (e.g., partition_point closures).
+    #[inline]
+    pub fn wrapping_cmp(&self, other: &Self) -> core::cmp::Ordering {
+        use core::cmp::Ordering;
+        match lightyear_utils::wrapping_id::wrapping_diff(other.0, self.0) {
+            0 => Ordering::Equal,
+            x if x > 0 => Ordering::Greater,
+            _ => Ordering::Less,
+        }
+    }
+}
+
 /// Resource that contains the global TickDuration
 #[derive(Resource, Debug, Clone, Copy, PartialEq, Eq, Reflect, Deref, DerefMut)]
 pub struct TickDuration(pub Duration);
@@ -65,8 +104,73 @@ impl AtomicTick {
 mod tests {
     use super::*;
     use alloc::vec;
+    use alloc::vec::Vec;
     use std::thread;
     use test_log::test;
+
+    #[test]
+    fn tick_ord_transitivity() {
+        let t1 = Tick(0u16);
+        let t2 = Tick(32_768u16);
+        let t3 = Tick(33_000u16);
+
+        assert!(t1 < t2);
+        assert!(t2 < t3);
+        assert!(
+            t1 < t3,
+            "transitivity violated: t1 < t2 && t2 < t3 but !(t1 < t3)"
+        );
+        assert!(t3 > t1);
+    }
+
+    #[test]
+    fn tick_ord_btreemap_consistency() {
+        use std::collections::BTreeMap;
+
+        let mut m: BTreeMap<Tick, u32> = BTreeMap::new();
+        for t in [0u16, 16_000, 32_768, 33_000, 49_000] {
+            m.insert(Tick(t), t as u32);
+        }
+
+        for t in [0u16, 16_000, 32_768, 33_000, 49_000] {
+            assert!(
+                m.get(&Tick(t)).is_some(),
+                "BTreeMap.get failed for tick {}",
+                t
+            );
+        }
+
+        let visited: Vec<u16> = m.keys().map(|k| k.0).collect();
+        assert_eq!(
+            visited.len(),
+            5,
+            "BTreeMap iteration count wrong: {visited:?}"
+        );
+    }
+
+    #[test]
+    fn tick_ord_is_total() {
+        // BTreeMap-style total ordering: numeric u16 ordering.
+        assert!(Tick(0) < Tick(32_768));
+        assert!(Tick(32_768) < Tick(33_000));
+        assert!(Tick(0) < Tick(33_000));
+        // Reflexivity / antisymmetry.
+        assert!(Tick(100) <= Tick(100));
+        assert!(Tick(100) >= Tick(100));
+        assert!(Tick(50) < Tick(100));
+        assert!(Tick(100) > Tick(50));
+    }
+
+    #[test]
+    fn tick_wrap_aware_methods() {
+        // Within the half-range where wrap-aware sequence comparison is defined.
+        assert!(Tick(32_000).is_newer_than(Tick(0)));
+        assert!(!Tick(0).is_newer_than(Tick(32_000)));
+        // Across wrap boundary
+        assert!(Tick(5).is_newer_than(Tick(65_530)));
+        assert!(Tick(65_530).is_older_than(Tick(5)));
+        assert!(!Tick(5).is_older_than(Tick(65_530)));
+    }
 
     // TODO: test with loom?
     #[test]

--- a/lightyear_inputs/src/client.rs
+++ b/lightyear_inputs/src/client.rs
@@ -732,7 +732,7 @@ fn update_buffer_from_remote_player_message<S: ActionStateSequence>(
         //  (for example in lockstep mode, we should have all player inputs for tick T before simulating tick T,
         //  so we will receive those inputs in advance)
         if let RollbackMode::Check = prediction_manager.rollback_policy.input
-            && mismatch <= tick
+            && !mismatch.is_newer_than(tick)
         {
             debug!(
                 ?entity,

--- a/lightyear_inputs/src/input_buffer.rs
+++ b/lightyear_inputs/src/input_buffer.rs
@@ -118,12 +118,12 @@ impl<T: Clone + PartialEq, M> InputBuffer<T, M> {
             return;
         };
         let start_tick = self.start_tick.unwrap();
-        if tick < start_tick {
+        if tick.is_older_than(start_tick) {
             self.start_tick = None;
             self.buffer.clear();
             return;
         }
-        if tick >= end_tick {
+        if !tick.is_older_than(end_tick) {
             return;
         }
         let new_end = usize::try_from(tick - start_tick + 1).unwrap();
@@ -140,7 +140,7 @@ impl<T: Clone + PartialEq, M> InputBuffer<T, M> {
         }
         let mut current_start = self.start_tick.unwrap();
         // Extend to the left if needed
-        if start_tick < current_start {
+        if start_tick.is_older_than(current_start) {
             let prepend_count = (current_start - start_tick) as usize;
             for _ in 0..prepend_count {
                 self.buffer.push_front(Compressed::Absent);
@@ -151,7 +151,7 @@ impl<T: Clone + PartialEq, M> InputBuffer<T, M> {
 
         // Extend to the right if needed
         let current_end = current_start + (self.buffer.len() as i16 - 1);
-        if end_tick > current_end {
+        if end_tick.is_newer_than(current_end) {
             let append_count = (end_tick - current_end) as usize;
             for _ in 0..append_count {
                 self.buffer.push_back(Compressed::Absent);
@@ -192,7 +192,7 @@ impl<T: Clone + PartialEq, M> InputBuffer<T, M> {
         };
 
         // cannot set lower values than start_tick
-        if tick < start_tick {
+        if tick.is_older_than(start_tick) {
             return;
         }
 
@@ -201,7 +201,7 @@ impl<T: Clone + PartialEq, M> InputBuffer<T, M> {
         // NOTE: we fill the value for the given tick, and we fill the ticks between start_tick and tick
         // with InputData::SameAsPrecedent (i.e. if there are any gaps, we consider that the user repeated
         // their last action)
-        if tick > end_tick {
+        if tick.is_newer_than(end_tick) {
             // TODO: Think about how to fill the buffer between ticks
             //  - we want: if an input is missing, we consider that the user did the same action (RocketLeague or Overwatch GDC)
 
@@ -226,10 +226,10 @@ impl<T: Clone + PartialEq, M> InputBuffer<T, M> {
     /// for the given tick
     pub fn pop(&mut self, tick: Tick) -> Option<T> {
         let start_tick = self.start_tick?;
-        if tick < start_tick {
+        if tick.is_older_than(start_tick) {
             return None;
         }
-        if tick > start_tick + (self.buffer.len() as i16 - 1) {
+        if tick.is_newer_than(start_tick + (self.buffer.len() as i16 - 1)) {
             // pop everything
             self.buffer = VecDeque::new();
             self.start_tick = Some(tick + 1);
@@ -269,7 +269,9 @@ impl<T: Clone + PartialEq, M> InputBuffer<T, M> {
         if self.buffer.is_empty() {
             return &Compressed::Absent;
         }
-        if tick < start_tick || tick > start_tick + (self.buffer.len() as i16 - 1) {
+        if tick.is_older_than(start_tick)
+            || tick.is_newer_than(start_tick + (self.buffer.len() as i16 - 1))
+        {
             return &Compressed::Absent;
         }
         self.buffer.get((tick - start_tick) as usize).unwrap()
@@ -282,7 +284,9 @@ impl<T: Clone + PartialEq, M> InputBuffer<T, M> {
         if self.buffer.is_empty() {
             return None;
         }
-        if tick < start_tick || tick > start_tick + (self.buffer.len() as i16 - 1) {
+        if tick.is_older_than(start_tick)
+            || tick.is_newer_than(start_tick + (self.buffer.len() as i16 - 1))
+        {
             return None;
         }
         let data = self.buffer.get((tick - start_tick) as usize).unwrap();
@@ -304,10 +308,10 @@ impl<T: Clone + PartialEq, M> InputBuffer<T, M> {
         if self.buffer.is_empty() {
             return None;
         }
-        if tick < start_tick {
+        if tick.is_older_than(start_tick) {
             return None;
         }
-        if tick > start_tick + (self.buffer.len() as i16 - 1) {
+        if tick.is_newer_than(start_tick + (self.buffer.len() as i16 - 1)) {
             return self.get_last();
         }
         let data = self.buffer.get((tick - start_tick) as usize).unwrap();

--- a/lightyear_inputs/src/input_message.rs
+++ b/lightyear_inputs/src/input_message.rs
@@ -171,7 +171,7 @@ pub trait ActionStateSequence:
 
             // if the tick is within the buffer, just fetch from it
             // TODO: ideally we just clone the last element from the buffer
-            if previous_end_tick.is_some_and(|end_tick| end_tick >= tick) {
+            if previous_end_tick.is_some_and(|end_tick| !end_tick.is_older_than(tick)) {
                 previous_predicted_input = input_buffer.get(tick).cloned();
             } else {
                 // else manually decay
@@ -192,13 +192,13 @@ pub trait ActionStateSequence:
                     _ => {}
                 }
                 // only try to detect mismatches after the last_remote_tick
-                if last_remote_tick.is_none_or(|t| tick > t) {
+                if last_remote_tick.is_none_or(|t| tick.is_newer_than(t)) {
                     if match (&previous_predicted_input, &latest_received_input) {
                         (Some(prev), Some(latest)) => prev == latest,
                         (None, None) => true,
                         _ => false,
                     } {
-                        if previous_end_tick.is_none_or(|end_tick| tick > end_tick) {
+                        if previous_end_tick.is_none_or(|end_tick| tick.is_newer_than(end_tick)) {
                             input_buffer
                                 .set_raw(tick, Compressed::from(latest_received_input.clone()));
                         }

--- a/lightyear_interpolation/src/interpolate.rs
+++ b/lightyear_interpolation/src/interpolate.rs
@@ -68,7 +68,7 @@ pub(crate) fn update_confirmed_history<C: Component + Clone>(
                 // - if H1...H2..X, H2 is a good starting point for the interpolation
                 commands.entity(entity).insert(end_value.clone());
             }
-            if current_interpolate_tick >= history_tick {
+            if !current_interpolate_tick.is_older_than(history_tick) {
                 history.pop();
             }
         }

--- a/lightyear_interpolation/src/interpolation_history.rs
+++ b/lightyear_interpolation/src/interpolation_history.rs
@@ -84,7 +84,7 @@ impl<C: Component + Clone> ConfirmedHistory<C> {
         if let Some((start_tick, start)) = self.start()
             && let Some((end_tick, end)) = self.end()
         {
-            if interpolation_tick < start_tick {
+            if interpolation_tick.is_older_than(start_tick) {
                 return None;
             }
             let fraction = ((interpolation_tick - start_tick) as f32 + interpolation_overstep)

--- a/lightyear_prediction/src/rollback.rs
+++ b/lightyear_prediction/src/rollback.rs
@@ -366,7 +366,7 @@ fn check_rollback(
             };
             let confirmed_tick = entity_mut.get::<ConfirmedTick>().unwrap().tick;
             trace!("Checking rollback for entity {:?} that received update at tick {:?}", entity_mut.id(), confirmed_tick);
-            if confirmed_tick > tick {
+            if confirmed_tick.is_newer_than(tick) {
                 debug!(
                     "Confirmed entity {:?} is at a tick in the future: {:?} compared to client timeline. Current tick: {:?}",
                     entity_mut.id(),
@@ -465,7 +465,7 @@ fn check_rollback(
             .deterministic_despawn
             .drain(..)
             .for_each(|(t, e)| {
-                if t > rollback_tick
+                if t.is_newer_than(rollback_tick)
                     && let Ok(mut c) = commands.get_entity(e)
                 {
                     c.despawn();
@@ -478,7 +478,7 @@ fn check_rollback(
         // - for all remaining entities (where rollback_tick < tick) we insert DisableRollback
         let split_idx = prediction_manager
             .deterministic_skip_despawn
-            .partition_point(|(t, _)| *t <= rollback_tick);
+            .partition_point(|(t, _)| t.wrapping_cmp(&rollback_tick).is_le());
         let should_disable_rollback = prediction_manager
             .deterministic_skip_despawn
             .split_off(split_idx);

--- a/lightyear_replication/src/prespawn.rs
+++ b/lightyear_replication/src/prespawn.rs
@@ -138,7 +138,7 @@ impl PreSpawnedPlugin {
         // remove all the prespawned entities that have not been matched with a server entity
         let split_idx = manager
             .prespawn_tick_to_hash
-            .partition_point(|(t, _)| *t < past_tick);
+            .partition_point(|(t, _)| t.wrapping_cmp(&past_tick).is_lt());
         for (_, hash) in manager.prespawn_tick_to_hash.drain(..split_idx) {
             manager
                 .prespawn_hash_to_entities
@@ -288,7 +288,7 @@ impl PreSpawnedReceiver {
         // split_idx = first index where prespawn_tick >= tick
         let split_idx = self
             .prespawn_tick_to_hash
-            .partition_point(|(t, _)| *t < tick);
+            .partition_point(|(t, _)| t.wrapping_cmp(&tick).is_lt());
         // self.prespawn_tick_to_hash still contains elements with prespawn_tick < tick, which we might
         // still want to match
         for (_, hash) in self.prespawn_tick_to_hash.drain(split_idx..) {

--- a/lightyear_replication/src/receive.rs
+++ b/lightyear_replication/src/receive.rs
@@ -313,7 +313,10 @@ impl ReplicationReceiver {
 
         // NOTE: this is valid even after tick wrapping because we keep clamping the latest_tick values for each channel
         // if we have already applied a more recent update for this group, no need to keep this one (or should we keep it for history?)
-        if channel.latest_tick.is_some_and(|t| remote_tick <= t) {
+        if channel
+            .latest_tick
+            .is_some_and(|t| !remote_tick.is_newer_than(t))
+        {
             trace!(
                 "discard because the update's tick {remote_tick:?} is older than the latest tick {:?}",
                 channel.latest_tick
@@ -358,7 +361,7 @@ impl ReplicationReceiver {
         // skip cleanup if we did one recently
         if self
             .last_cleanup_tick
-            .is_some_and(|last| tick < last + (i16::MAX / 3))
+            .is_some_and(|last| tick.is_older_than(last + (i16::MAX / 3)))
         {
             return;
         }
@@ -616,7 +619,9 @@ impl UpdatesBuffer {
     /// Insert a new message in the right position to make sure that the buffer
     /// is still sorted in descending order
     fn insert(&mut self, message: UpdatesMessage, remote_tick: Tick) {
-        let index = self.0.partition_point(|(tick, _)| remote_tick < *tick);
+        let index = self
+            .0
+            .partition_point(|(tick, _)| remote_tick.wrapping_cmp(tick).is_lt());
         self.0.insert(index, (remote_tick, message));
     }
 
@@ -646,7 +651,7 @@ impl UpdatesBuffer {
                 // and locally we haven't applied any actions yet, we can't apply it!
                 return true;
             };
-            last_action_tick > latest_tick
+            last_action_tick.is_newer_than(latest_tick)
         });
         if idx == self.len() { None } else { Some(idx) }
     }

--- a/lightyear_replication/src/receive.rs
+++ b/lightyear_replication/src/receive.rs
@@ -983,21 +983,21 @@ impl GroupChannel {
 
             // inserts
             // TODO: remove updates that are duplicate for the same component
-            actions
-                .insert
-                .into_iter()
-                .for_each(|bytes| {
-                    if let Err(e) = component_registry.buffer(
-                        bytes,
-                        &mut buffered_entity,
-                        remote_tick,
-                        &mut remote_entity_map.remote_to_local,
-                        predicted,
-                        interpolated,
-                    ) {
-                        error!("could not insert a component to entity {:?}: {:?}", local_entity, e);
-                    }
-                });
+            actions.insert.into_iter().for_each(|bytes| {
+                if let Err(e) = component_registry.buffer(
+                    bytes,
+                    &mut buffered_entity,
+                    remote_tick,
+                    &mut remote_entity_map.remote_to_local,
+                    predicted,
+                    interpolated,
+                ) {
+                    error!(
+                        "could not insert a component to entity {:?}: {:?}",
+                        local_entity, e
+                    );
+                }
+            });
 
             // removals
             actions.remove.into_iter().for_each(|component_net_id| {

--- a/lightyear_replication/src/send/sender.rs
+++ b/lightyear_replication/src/send/sender.rs
@@ -295,7 +295,7 @@ impl ReplicationSender {
         // skip cleanup if we did one recently
         if self
             .last_cleanup_tick
-            .is_some_and(|last| tick < last + (i16::MAX / 3))
+            .is_some_and(|last| tick.is_older_than(last + (i16::MAX / 3)))
         {
             return;
         }

--- a/lightyear_replication/src/visibility/room.rs
+++ b/lightyear_replication/src/visibility/room.rs
@@ -38,7 +38,9 @@ commands.trigger(RoomEvent { target: RoomTarget::AddSender(client), room });
 
 */
 
-use crate::prelude::{InterpolationTarget, PerSenderReplicationState, PredictionTarget, ReplicationState};
+use crate::prelude::{
+    InterpolationTarget, PerSenderReplicationState, PredictionTarget, ReplicationState,
+};
 use crate::send::plugin::ReplicationBufferSystems;
 use crate::visibility::error::NetworkVisibilityError;
 use crate::visibility::immediate::{NetworkVisibility, NetworkVisibilityPlugin, VisibilityState};
@@ -219,9 +221,7 @@ impl RoomPlugin {
                                 // predicted/interpolated = false. Restore these flags from
                                 // the entity's PredictionTarget/InterpolationTarget so the
                                 // client spawns the entity with prediction/interpolation.
-                                if let Some(per_sender) =
-                                    vis.per_sender_state.get_mut(&sender)
-                                {
+                                if let Some(per_sender) = vis.per_sender_state.get_mut(&sender) {
                                     #[cfg(feature = "prediction")]
                                     if has_prediction {
                                         per_sender.predicted = true;

--- a/lightyear_sync/src/ping/store.rs
+++ b/lightyear_sync/src/ping/store.rs
@@ -6,6 +6,25 @@ use lightyear_utils::wrapping_id;
 
 wrapping_id!(PingId);
 
+// Preserve the previous wrap-aware sequence ordering for any PingId ordering users.
+impl Ord for PingId {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+        use core::cmp::Ordering;
+        match lightyear_utils::wrapping_id::wrapping_diff(self.0, other.0) {
+            0 => Ordering::Equal,
+            x if x > 0 => Ordering::Less,
+            x if x < 0 => Ordering::Greater,
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl PartialOrd for PingId {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
 const PING_BUFFER_SIZE: usize = 128;
 
 /// Data structure to store the latest pings sent to remote

--- a/lightyear_sync/src/timeline/remote.rs
+++ b/lightyear_sync/src/timeline/remote.rs
@@ -118,7 +118,7 @@ impl RemoteTimeline {
         if self
             .context
             .last_received_tick
-            .is_none_or(|previous_tick| remote_tick >= previous_tick)
+            .is_none_or(|previous_tick| !remote_tick.is_older_than(previous_tick))
         {
             // only update if the remote tick is newer than the last received tick
             self.context.received_packet = true;

--- a/lightyear_transport/src/packet/message.rs
+++ b/lightyear_transport/src/packet/message.rs
@@ -13,6 +13,26 @@ use lightyear_utils::wrapping_id;
 // Internal id that we assign to each message sent over the network
 wrapping_id!(MessageId);
 
+// Sequence ordering for in-order delivery. Transport channel BTreeMap<MessageId, _>
+// users rely on this wrap-aware comparison.
+impl Ord for MessageId {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+        use core::cmp::Ordering;
+        match lightyear_utils::wrapping_id::wrapping_diff(self.0, other.0) {
+            0 => Ordering::Equal,
+            x if x > 0 => Ordering::Less,
+            x if x < 0 => Ordering::Greater,
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl PartialOrd for MessageId {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
 /// The index of a fragment in a fragmented message.
 ///
 /// It will be serialized as a varint, so it will take only 1 byte if there

--- a/lightyear_transport/src/packet/packet.rs
+++ b/lightyear_transport/src/packet/packet.rs
@@ -9,6 +9,26 @@ use lightyear_utils::wrapping_id;
 // Internal id that we assign to each packet sent over the network
 wrapping_id!(PacketId);
 
+// Sequence ordering for in-order delivery. Transport channel BTreeMap<PacketId, _>
+// users rely on this wrap-aware comparison.
+impl Ord for PacketId {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+        use core::cmp::Ordering;
+        match lightyear_utils::wrapping_id::wrapping_diff(self.0, other.0) {
+            0 => Ordering::Equal,
+            x if x > 0 => Ordering::Less,
+            x if x < 0 => Ordering::Greater,
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl PartialOrd for PacketId {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
 const MAX_PACKET_SIZE: usize = 1200;
 /// Number of bytes to write the header
 const HEADER_BYTES: usize = 11;

--- a/lightyear_utils/src/wrapping_id.rs
+++ b/lightyear_utils/src/wrapping_id.rs
@@ -25,7 +25,6 @@ macro_rules! wrapping_id {
         mod [<$struct_name:lower _module>] {
             use serde::{Deserialize, Serialize};
             use core::ops::{Add, AddAssign, Deref, Sub};
-            use core::cmp::Ordering;
             use bevy_reflect::Reflect;
             use lightyear_serde::{SerializationError, reader::{Reader, ReadInteger}, writer::WriteInteger, ToBytes};
             use lightyear_utils::wrapping_id::{wrapping_diff, WrappedId};
@@ -63,23 +62,6 @@ macro_rules! wrapping_id {
                 type Target = u16;
                 fn deref(&self) -> &Self::Target {
                     &self.0
-                }
-            }
-
-            impl Ord for $struct_name {
-                fn cmp(&self, other: &Self) -> Ordering {
-                    match wrapping_diff(self.0, other.0) {
-                        0 => Ordering::Equal,
-                        x if x > 0 => Ordering::Less,
-                        x if x < 0 => Ordering::Greater,
-                        _ => unreachable!(),
-                    }
-                }
-            }
-
-            impl PartialOrd for $struct_name {
-                fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-                    Some(self.cmp(other))
                 }
             }
 


### PR DESCRIPTION
## Summary

`Tick`'s `Ord` impl uses signed wrap-aware semantics, which violates the transitivity contract: `a < b && b < c` does not always imply `a < c`. This silently corrupts any `BTreeMap<Tick, _>` whose entries span more than 32 768 ticks (~13.65 min at 40 Hz).

`lightyear_replication/src/delta.rs` has two such maps — `DeltaComponentHistory.buffer: BTreeMap<Tick, C>` and `DeltaManager.data: BTreeMap<Tick, PerTickData>` — both populated continuously during a session, both vulnerable.

## Reproducer (verifiable on pristine `main`)

Drop these into `lightyear_core::tick::tests` and run `cargo test -p lightyear_core`:

```rust
#[test]
fn upstream_tick_ord_transitivity() {
    let t1 = Tick(0);
    let t2 = Tick(32_768);
    let t3 = Tick(33_000);
    assert!(t1 < t2);  // wrapping_diff = -32_768 -> Greater -> fails
    assert!(t2 < t3);
    assert!(t1 < t3);  // wrapping_diff = -32_536 -> Greater -> fails
}

#[test]
fn upstream_tick_ord_btreemap_consistency() {
    use std::collections::BTreeMap;
    let mut m: BTreeMap<Tick, u32> = BTreeMap::new();
    for t in [0u16, 16_000, 32_768, 33_000, 49_000] {
        m.insert(Tick(t), t as u32);
    }
    for t in [0u16, 16_000, 32_768, 33_000, 49_000] {
        assert!(m.get(&Tick(t)).is_some(), "BTreeMap.get failed for tick {t}");
    }
}
```

Verified on `main@013c51fa`:
```
test tick::tests::upstream_tick_ord_transitivity ... FAILED
  assertion failed: t1 < t2
test tick::tests::upstream_tick_ord_btreemap_consistency ... FAILED
  BTreeMap.get failed for tick 16000
```

## Fix

**Type-system foundation (commit 1):** Remove `Ord` / `PartialOrd` from the `wrapping_id!` macro. Give `Tick` a *total* numeric (`u16`) `Ord` that satisfies transitivity. Add explicit wrap-aware methods at the `Tick` site:

- `Tick::is_newer_than(self, other) -> bool`
- `Tick::is_older_than(self, other) -> bool`
- `Tick::wrapping_cmp(&self, other) -> core::cmp::Ordering`

`MessageId`, `PacketId`, and `PingId` retain wrap-aware `Ord` at their definition sites — transport channels' in-order delivery depends on it. Those types carry a latent BTreeMap-corruption risk under very high message rates, but this PR limits scope to `Tick` (the type that actually appears as a `BTreeMap` key in delta paths today).

**Site migration (commit 2):** Every site that previously relied on `Tick: Ord` for sequence semantics now uses the explicit method. Sites unchanged: those already using `Sub` returning `i16` (e.g. `tick - other > delta`), equality checks, and numeric tick deltas.

**Pre-existing fmt drift (commit 3):** Three files (`lag_compensation/history.rs`, `receive.rs`, `visibility/room.rs`) failed `cargo fmt --check` on `main` before this PR; the Lint job has been red since 2026-04-26 because of them. Folded the mechanical fixes here so this PR can go green on Lint. Drop this commit during squash-merge if a separate fmt PR is preferred.

## Tests

Four new tests in `lightyear_core::tick`:
- `tick_ord_transitivity` — `t1 < t2 < t3` across the i16 boundary
- `tick_ord_btreemap_consistency` — round-trip insert / lookup across the wrap
- `tick_ord_is_total` — total-order spot checks
- `tick_wrap_aware_methods` — `is_newer_than` / `is_older_than` semantics

```
$ cargo test -p lightyear_core tick_
running 6 tests
... 6 passed; 0 failed
```

`cargo build --workspace`: clean. `cargo test -p lightyear_inputs` (14/14) and `cargo test -p lightyear_replication` (19/19): all pass.

## Notes

- This was discovered while investigating an unrelated production issue. The downstream gameplay symptom turned out to have a different root cause, but the latent correctness bug here is real, reproducible on pristine `main`, and worth fixing on its own merits.
- A follow-up could give `MessageId` / `PacketId` / `PingId` the same split-treatment if any of them ever land in a `BTreeMap` keyed structure.