### PR TITLE
Fix up lightyear_connection use statement

### DIFF
--- a/lightyear_messages/src/plugin.rs
+++ b/lightyear_messages/src/plugin.rs
@@ -172,7 +172,7 @@ mod tests {
     use lightyear_connection::client::Connected;
     use lightyear_core::id::{PeerId, RemoteId};
     use lightyear_core::plugin::CorePlugins;
-    use lightyear_core::prelude::{LocalTimeline, Tick};
+    use lightyear_core::prelude::Tick;
     use lightyear_link::{Link, Linked};
     use lightyear_transport::channel::ChannelKind;
     use lightyear_transport::plugin::TestChannel;

--- a/lightyear_netcode/src/server.rs
+++ b/lightyear_netcode/src/server.rs
@@ -18,7 +18,7 @@ use super::{
     token::{ChallengeToken, ConnectToken, ConnectTokenBuilder, ConnectTokenPrivate},
 };
 use crate::token::TOKEN_EXPIRE_SEC;
-use lightyear_connection::prelude::client::Connecting;
+use lightyear_connection::prelude::Connecting;
 use lightyear_connection::shared::{
     ConnectionRequestHandler, DefaultConnectionRequestHandler, DeniedReason,
 };

--- a/lightyear_transport/src/plugin.rs
+++ b/lightyear_transport/src/plugin.rs
@@ -18,7 +18,7 @@ use bevy_utils::default;
 use bytes::Bytes;
 use lightyear_connection::host::HostClient;
 #[cfg(any(feature = "client", feature = "server"))]
-use lightyear_connection::prelude::client::Disconnected;
+use lightyear_connection::prelude::Disconnected;
 use lightyear_core::prelude::LocalTimeline;
 use lightyear_core::tick::Tick;
 use lightyear_link::{Link, LinkPlugin, LinkSystems, Linked};


### PR DESCRIPTION
While mucking about with a game project, I got this:
```
tux@linuxbox:~/Projects/game$ cargo check -p game-server
    Checking lightyear_transport v0.26.4
error[E0432]: unresolved import `lightyear_connection::prelude::client`
  --> /home/tux/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/lightyear_transport-0.26.4/src/plugin.rs:21:36
   |
21 | use lightyear_connection::prelude::client::Disconnected;
   |                                    ^^^^^^ could not find `client` in `prelude`
   |
note: found an item that was configured out
  --> /home/tux/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/lightyear_connection-0.26.4/src/lib.rs:70:13
   |
69 |     #[cfg(feature = "client")]
   |           ------------------ the item is gated behind the `client` feature
70 |     pub mod client {
   |             ^^^^^^

For more information about this error, try `rustc --explain E0432`.
error: could not compile `lightyear_transport` (lib) due to 1 previous error
```

The interesting bit was that things would compile and work fine, but this `cargo check` command would error out.

I poked into it a bit, and found this section of `lightyear_connection` that is building the prelude for that module:

```
pub mod prelude {
    pub use crate::ConnectionSystems;
    pub use crate::direction::NetworkDirection;
    pub use crate::network_target::NetworkTarget;

    // we also export these types at the top level for easier access
    pub use crate::client::{
        Client, Connect, Connected, Connecting, ConnectionError, Disconnect, Disconnected,
        PeerMetadata,
    };

    #[cfg(feature = "client")]
    pub mod client {
        pub use crate::client::{
            Client, Connect, Connected, Connecting, ConnectionError, Disconnect, Disconnected,
        };
    }

    #[cfg(feature = "server")]
    pub mod server {
        pub use crate::client_of::ClientOf;
        pub use crate::server::{
            ConnectionError, Start, Started, Starting, Stop, Stopped, is_headless_server,
        };
    }
}
```

The prelude depends on the features enabled, so `lightyear_connection::prelude::client::Disconnected` only exists when the `client` feature is enabled, which it was not for my server crate.

But, it also exports all the client stuff at the top level, so while `lightyear_connection::prelude::client::Disconnected` only exists with feature `client`, the other export `lightyear_connection::prelude::Disconnected` always exists.

So, I made a small modification to `lightyear_transport` to use that one instead. Now the server doesn't have to reach down into the client-only prelude to find what it needs.


I also removed an unused `LocalTimeline` from `lightyear_messages`. It was marked unused in the IDE and seemed like an easy chance for a simple cleanup.