### PR TITLE
Fix incorrect resource removal during rollback

### DIFF
--- a/lightyear_prediction/src/rollback.rs
+++ b/lightyear_prediction/src/rollback.rs
@@ -629,10 +629,10 @@ pub(crate) fn prepare_rollback<C: SyncComponent>(
                     "Rollback to the value stored in the PredictionHistory"
                 );
                 (
-                    original_predicted_value.as_ref().and_then(|v| match v {
-                        HistoryState::Updated(v) => Some(v),
+                    match original_predicted_value.as_ref() {
+                        Some(HistoryState::Updated(v)) => Some(v),
                         _ => None,
-                    }),
+                    },
                     true,
                 )
             }
@@ -704,13 +704,22 @@ pub(crate) fn prepare_rollback_resource<R: Resource + Clone>(
 
     // 1. restore the resource to the historical value
     match history_value {
-        None | Some(HistoryState::Removed) => {
+        None => {
+            // No captured value at or before `rollback_tick`. We have no
+            // evidence about what the resource's value was.
+            //
+            // The best strategy is to leave the resource alone. Deleting it
+            // would conflate "no recorded data" with "explicit absence". Bevy
+            // may panic if it runs systems that require access to the resource
+            // next tick.
+        }
+        Some(HistoryState::Removed) => {
             if resource.is_some() {
                 debug!(
                     ?kind,
-                    "Resource didn't exist at time of rollback, removing it"
+                    "Resource was removed at time of rollback, removing it"
                 );
-                // the resource didn't exist at the time, remove it!
+                // the resource was removed at the time, remove it!
                 commands.remove_resource::<R>();
             }
         }


### PR DESCRIPTION
`prepare_rollback_resource` treated `clear_except_tick` returning `None` as "the value was absent at this tick" and removed the resource. But `clear_except_tick` also returns `None` when the history buffer is non-empty but every entry is after the requested tick.  This is a typical scenario when a client joins a server and performs its first rollback.

Removing the resource may cause bevy to panic when trying to run a system that requires access to the resource in the next tick. This is an issue with `LightyearAvianPlugin::rollback_resources` which marks some avian resources has rollbackable.

The fix is to leave the resource alone if there is no value at or before the given rollback tick.

Fixes #1467