### PR TITLE
fix(inputs): server pop wipes get_predict fallback (#1402 part 2)

### DIFF
--- a/lightyear_inputs/src/input_buffer.rs
+++ b/lightyear_inputs/src/input_buffer.rs
@@ -222,6 +222,20 @@ impl<T: Clone + PartialEq, M> InputBuffer<T, M> {
         *entry = value;
     }
 
+    /// Like [`pop`](Self::pop), but preserves the most recent entry so it
+    /// remains available as a [`get_predict`](Self::get_predict) fallback.
+    pub fn pop_keeping_last(&mut self, tick: Tick) -> Option<T> {
+        let Some((last_tick, _)) = self.get_last_with_tick() else {
+            return self.pop(tick);
+        };
+        let clamped = if tick >= last_tick {
+            last_tick - 1
+        } else {
+            tick
+        };
+        self.pop(clamped)
+    }
+
     /// Remove all the inputs that are older or equal than the given tick, then return the input
     /// for the given tick
     pub fn pop(&mut self, tick: Tick) -> Option<T> {
@@ -502,6 +516,24 @@ mod tests {
         assert_eq!(input_buffer.pop(Tick(20)), None);
         assert_eq!(input_buffer.buffer.len(), 0);
         assert_eq!(input_buffer.start_tick, Some(Tick(21)));
+    }
+
+    #[test]
+    fn test_server_pop_pattern_preserves_get_predict_fallback() {
+        let mut buf: InputBuffer<i32, i32> = InputBuffer::default();
+        buf.set(Tick(10), 42);
+
+        assert_eq!(buf.get_predict(Tick(13)), Some(&42));
+
+        // Mirror server.rs::update_action_state: advance the buffer floor
+        // past the last entry. Plain `pop` would wipe the fallback here.
+        buf.pop_keeping_last(Tick(11));
+
+        assert_eq!(
+            buf.get_predict(Tick(13)),
+            Some(&42),
+            "advancing the floor past the last entry must preserve the fallback",
+        );
     }
 
     #[test]

--- a/lightyear_inputs/src/server.rs
+++ b/lightyear_inputs/src/server.rs
@@ -588,7 +588,7 @@ fn update_action_state<S: ActionStateSequence>(
         // remove all the previous values
         // we keep the current value in the InputBuffer so that if future messages are lost, we can still
         // fallback on the last known value
-        input_buffer.pop(tick - history_depth);
+        input_buffer.pop_keeping_last(tick - history_depth);
         // info!("Buffer length: {}", input_buffer.len());
     }
 }


### PR DESCRIPTION
This is the 2nd PR out of 3 to fix the de-sync issues that I encountered. Again, please let me know if you want the comments pruned. This and #1470 resulted in my local manual testing for cases where server would stop accepting inputs from one or both of the clients. Combined with my next PR that is for rollback behavior, the clients and server never agreed on positions of the players and drifted abruptly or slowly.

---

## The bug

PR #1438 changed server-side `update_action_state` in `lightyear_inputs/src/server.rs` from `input_buffer.get(tick)` to `input_buffer.get_predict(tick)`, fixing the documented "keep playing the last action they played" behaviour when no fresh input is available. Great fix.

However, the line immediately after that:

```rust
input_buffer.pop(tick - history_depth);
```

invokes the "pop everything" branch in `InputBuffer::pop` when `tick - history_depth > buffer_end`:

```rust
if tick > start_tick + (self.buffer.len() as i16 - 1) {
    // pop everything
    self.buffer = VecDeque::new();
    self.start_tick = Some(tick + 1);
    return None;
}
```

After this wipe, `get_last()` returns `None`, so the very next frame's `get_predict` has nothing to fall back to. The benefit of #1438 is consumed within one frame in any case where a snapshot arrives even one tick late.

## The fix

Add a new method `InputBuffer::pop_keeping_last`, which behaves identically to `pop` for the common case (target within buffer range) but **preserves the most recent entry** when the target is beyond the buffer end. Switch `update_action_state` to use the new method. Leave `pop` itself unchanged so the other caller, `clean_buffers` on the client, keeps its existing semantics.

```rust
pub fn pop_keeping_last(&mut self, tick: Tick) -> Option<T> {
    let Some((last_tick, _)) = self.get_last_with_tick() else {
        return self.pop(tick);
    };
    let clamped = if tick >= last_tick {
        last_tick - 1
    } else {
        tick
    };
    self.pop(clamped)
}
```

```diff
-input_buffer.pop(tick - history_depth);
+input_buffer.pop_keeping_last(tick - history_depth);
```

## Test — behavioural red, then green

The test mirrors the two-step server pattern (`get_predict` → advance via `pop_keeping_last`) and asserts that the fallback survives the advancement. Located in `lightyear_inputs/src/input_buffer.rs::tests`:

```rust
#[test]
fn test_server_pop_pattern_preserves_get_predict_fallback() {
    let mut buf: InputBuffer<i32, i32> = InputBuffer::default();
    buf.set(Tick(10), 42);

    // Initial fallback works: tick 13 has no entry, get_predict returns
    // the most recent entry (tick 10).
    assert_eq!(buf.get_predict(Tick(13)), Some(&42));

    // Mirror server.rs::update_action_state: after reading via
    // get_predict at the current tick, advance the buffer floor to
    // `current_tick - history_depth`. With current_tick=11 and
    // history_depth=0, the target is Tick(11) — beyond the only
    // buffered entry at Tick(10).
    buf.pop_keeping_last(Tick(11));

    // Subsequent frame: still no fresh input has arrived. The
    // documented intent of update_action_state ("keep playing the
    // last action they played") requires that get_predict can still
    // return the fallback from Tick(10).
    assert_eq!(
        buf.get_predict(Tick(13)),
        Some(&42),
        "after the server advances the buffer floor, get_predict must \
         still return the most recent input as fallback (issue #1402, \
         second half). The plain `pop` upstream invokes the \"pop \
         everything\" branch in this case, wiping the fallback and \
         contradicting the documented update_action_state behaviour.",
    );
}
```

### Behavioural red

Change the single line `buf.pop_keeping_last(Tick(11))` to `buf.pop(Tick(11))` — i.e. exactly the call upstream's `update_action_state` makes today — and re-run the test on this branch. The assertion fails behaviourally (not by compile error):

```
running 1 test
test input_buffer::tests::test_server_pop_pattern_preserves_get_predict_fallback ... FAILED

---- input_buffer::tests::test_server_pop_pattern_preserves_get_predict_fallback stdout ----

thread '...' panicked at lightyear_inputs/src/input_buffer.rs:573:9:
assertion `left == right` failed: after the server advances the buffer
floor, get_predict must still return the most recent input as fallback
(issue #1402, second half). The plain `pop` upstream invokes the "pop
everything" branch in this case, wiping the fallback and contradicting
the documented update_action_state behaviour.
  left: None
 right: Some(42)

test result: FAILED. 0 passed; 1 failed
```

That `left: None / right: Some(42)` is the actual bug — `get_predict` on a wiped buffer returns `None` instead of the fallback the caller in `update_action_state` expects.

### Green (this PR applied)

```
$ cargo test --package lightyear_inputs --lib test_server_pop_pattern_preserves_get_predict_fallback

test input_buffer::tests::test_server_pop_pattern_preserves_get_predict_fallback ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 14 filtered out
```

## Why not change `pop` itself?

`InputBuffer::pop` has two call sites:
1. `update_action_state` on the server (this PR's target).
2. `clean_buffers` on the client (called every frame to keep at most `HISTORY_DEPTH = 20` ticks of history).

For (1), preserving the last entry is the intent. For (2), the wipe is arguably correct — if the buffer holds only entries older than the 20-tick window, the intent is to discard them. Preserving an old entry would be a behaviour change for `clean_buffers`.

Adding a new method is the conservative choice. The existing `test_pop_out_of_range` keeps its assertion, and `clean_buffers` keeps its semantics. We pay one extra public API symbol, which seems fine for the clarity.

## Safety / risk

**Correctness.** `pop_keeping_last` delegates to `pop` after clamping the target. The clamp is a no-op when `tick < last_tick`, so for the common case (buffer current) the behaviour is identical. The new behaviour only differs when `tick >= last_tick`, which is the bug case from #1402.

**Performance.** Identical for the common case (clamp short-circuits). For the bug case, we get the same set of buffer ops via `pop(clamped)` rather than a wipe — slightly more work per buggy frame, but those frames were already discarded buffer state, so the extra work matches the work the wipe path used to do.

**Compatibility risk for other consumers.** Zero — `pop`'s contract is unchanged. The new method is purely additive.

**Wider test suite.** `lightyear_tests` baseline on main: 88 passed, 7 failed (same flaky tests as upstream PR #1470, all pre-existing parallel-run interference). After this PR: same set, no regressions.

## Related

- PR #1438 — `get` → `get_predict`. Already merged. This PR completes the input-arrival fix that #1438 started.
- Upstream PR #1470 — `sync_objective` floor `remote + 1`. Companion sync-side fix for #1402. Once both #1470 and this PR land, the localhost-RTT input-loss bug from #1402 is fully resolved.
- Rollback short-circuit when `confirmed_tick > tick` (unrelated, separate PR pending — see `rollback-ctick-ahead` branch).