### PR TITLE
fix(prediction): clamp confirmed_tick > local in check_rollback

### DIFF
--- a/lightyear_prediction/src/rollback.rs
+++ b/lightyear_prediction/src/rollback.rs
@@ -364,17 +364,24 @@ fn check_rollback(
             if !confirmed_ticks.is_changed(system_ticks.last_run(), system_ticks.this_run()) {
                 return
             };
-            let confirmed_tick = entity_mut.get::<ConfirmedTick>().unwrap().tick;
-            trace!("Checking rollback for entity {:?} that received update at tick {:?}", entity_mut.id(), confirmed_tick);
-            if confirmed_tick > tick {
-                debug!(
-                    "Confirmed entity {:?} is at a tick in the future: {:?} compared to client timeline. Current tick: {:?}",
-                    entity_mut.id(),
-                    confirmed_tick,
-                    tick
-                );
-                return;
-            }
+            let raw_confirmed_tick = entity_mut.get::<ConfirmedTick>().unwrap().tick;
+            trace!("Checking rollback for entity {:?} that received update at tick {:?}", entity_mut.id(), raw_confirmed_tick);
+            // Clamp `confirmed_tick` to local `tick` when the latest
+            // confirmed snapshot lands ahead of local (sync slip under
+            // jitter). Previously this case returned early and silently
+            // skipped the mismatch check, leaving predicted state
+            // diverged from confirmed indefinitely until something else
+            // tripped a rollback at a later tick. After clamping, the
+            // mismatch check runs normally and — if it fires —
+            // `do_rollback`'s `delta = tick - rollback_tick = 0` passes
+            // the `max_rollback_ticks` guard and the resulting
+            // re-simulation loop runs zero iterations. Effectively a
+            // snap-to-confirmed with no replay cost.
+            let confirmed_tick = if raw_confirmed_tick > tick {
+                tick
+            } else {
+                raw_confirmed_tick
+            };
 
             // TODO: maybe pre-cache the components of the archetypes that we want to iterate over?
             //  we need to archetypes that have Predicted, and we cache the history id and the confirmed id. (The confirmed could be absent)
@@ -611,12 +618,23 @@ pub(crate) fn prepare_rollback<C: SyncComponent>(
                 // since it will be replaced with the state-replicated value
                 predicted_history.clear();
                 trace!(?entity, "Rollback to the confirmed state");
-                // Confirm that we are in rollback, with the correct tick
-                debug_assert_eq!(
-                    rollback_tick,
-                    confirmed.unwrap().tick,
-                    "The rollback tick (LEFT) does not match the confirmed tick (RIGHT) for confirmed entity {entity:?}. Are all predicted entities in the same replication group?",
-                );
+                // The pre-existing `debug_assert_eq!(rollback_tick,
+                // confirmed.tick)` was a sanity check tying the rollback
+                // tick to the entity's ConfirmedTick. After the
+                // sync-slip clamp at `check_rollback` (see the comment
+                // around line 369), those values can legitimately differ
+                // when `confirmed.tick > local_tick`. The downstream
+                // logic — write `Confirmed<C>.0` into the predicted
+                // component, record the value at `rollback_tick` in
+                // history — is correct regardless of the relationship.
+                if rollback_tick != confirmed.unwrap().tick {
+                    trace!(
+                        ?entity,
+                        ?rollback_tick,
+                        confirmed_tick = ?confirmed.unwrap().tick,
+                        "rollback_tick clamped to local tick because confirmed_tick was ahead",
+                    );
+                }
                 (confirmed_component.map(|c| &c.0), false)
             }
             // we will rollback to the value stored in the PredictionHistory

--- a/lightyear_tests/src/client_server/prediction/rollback.rs
+++ b/lightyear_tests/src/client_server/prediction/rollback.rs
@@ -193,6 +193,68 @@ fn test_check_rollback() {
     );
 }
 
+/// Regression test for the rollback short-circuit when the latest confirmed
+/// snapshot's tick lands ahead of the local client tick (sync slip under
+/// jitter). On `main`, `check_rollback` at `lightyear_prediction/src/rollback.rs`
+/// returns early in that case:
+///
+/// ```ignore
+/// if confirmed_tick > tick {
+///     debug!("Confirmed entity ... is at a tick in the future ...");
+///     return;
+/// }
+/// ```
+///
+/// — silently skipping the per-component mismatch check. If predicted state
+/// has diverged from confirmed at the moment of the slip, the rollback that
+/// would otherwise reconcile it never fires, and predicted stays diverged
+/// indefinitely (until something else trips a rollback at a later
+/// `confirmed_tick <= tick`).
+///
+/// This test sets up a confirmed-predicted mismatch and triggers a rollback
+/// check with `ConfirmedTick` ahead of local. Rollback must fire.
+#[test]
+fn test_rollback_fires_when_confirmed_tick_is_ahead_of_local() {
+    let (mut stepper, predicted) = setup();
+    // The setup already triggered an initial rollback check; consume it.
+    stepper.frame_step(1);
+    let rollbacks_before = stepper
+        .client_app()
+        .world()
+        .resource::<PredictionMetrics>()
+        .rollbacks;
+
+    // Diverge predicted from confirmed.
+    stepper
+        .client_app()
+        .world_mut()
+        .entity_mut(predicted)
+        .insert(Confirmed(CompFull(2.0)));
+
+    // Trigger a rollback check with ConfirmedTick set ahead of local tick.
+    // `trigger_rollback_check` writes `confirmed_tick.tick = local_tick + 5`
+    // into the predicted entity. The rollback check then runs with
+    // `confirmed_tick > tick`, which is the sync-slip condition.
+    let local_tick = stepper.client_tick(0);
+    trigger_rollback_check(&mut stepper, local_tick + 5);
+    stepper.frame_step(1);
+
+    let rollbacks_after = stepper
+        .client_app()
+        .world()
+        .resource::<PredictionMetrics>()
+        .rollbacks;
+
+    assert!(
+        rollbacks_after > rollbacks_before,
+        "rollback should have fired (predicted CompFull missing vs Confirmed CompFull(2.0) with \
+         ConfirmedTick ahead of local), but the upstream `confirmed_tick > tick` short-circuit \
+         silently skipped the check. rollbacks: {} → {}",
+        rollbacks_before,
+        rollbacks_after,
+    );
+}
+
 /// Test that:
 /// - we remove a component from the predicted entity
 /// - rolling back before the remove should re-add it


### PR DESCRIPTION
This is the 3rd PR in the series to fix the desync issues that I experienced. With these 3 fixes, I have not been able to anymore get my clients (so far) to desync by just normal movement from each other or server. Again, let me know about the verbosity of the comments and/or other issues that you see.

---

## The bug

When `ConfirmedTick` lands ahead of the local prediction tick (typical under brief sync slip or jitter spike), `check_rollback` in `lightyear_prediction/src/rollback.rs` currently returns early and **silently skips the mismatch comparison entirely**:

```rust
let confirmed_tick = entity_mut.get::<ConfirmedTick>().unwrap().tick;
trace!("Checking rollback for entity {:?} that received update at tick {:?}", entity_mut.id(), confirmed_tick);
if confirmed_tick > tick {
    debug!(
        "Confirmed entity {:?} is at a tick in the future: {:?} compared to client timeline. Current tick: {:?}",
        entity_mut.id(),
        confirmed_tick,
        tick
    );
    return;
}
```

The early `return` exits the function without ever comparing the predicted history against the confirmed value. The `Changed`/`is_changed` flag on `ConfirmedTick` is *consumed* on this frame, so the same mismatch won't be re-evaluated until a **new** update arrives that moves `ConfirmedTick` again — which may be many ticks later, or never, if the server isn't sending updates faster than the desync resolves itself.

Symptom in practice: brief visual desync (e.g. health bar reads stale, position lags behind authority) that resolves itself only when the next replicated update happens to land while local is at or ahead of the new `ConfirmedTick`. With localhost RTT and default sync config, `ConfirmedTick` slipping one tick ahead of local is routine — these are exactly the conditions upstream PR #1470 fixes deterministically, but transient slips can still occur from jitter alone.

Trigger conditions for the visible bug:
1. Predicted entity has `ConfirmedTick > local_tick`.
2. The latest confirmed value differs from the predicted value at that tick.
3. The server is not sending another update soon (or the rate is slow enough that the desync window is visible).

## The fix

Clamp `confirmed_tick = min(confirmed_tick, local_tick)` and let the mismatch check run normally. If the predicted/confirmed values differ, the rollback fires and re-simulates **zero** ticks (`delta = tick - rollback_tick = 0`) — effectively a snap-to-confirmed with no replay cost.

```diff
-let confirmed_tick = entity_mut.get::<ConfirmedTick>().unwrap().tick;
-trace!("Checking rollback for entity {:?} that received update at tick {:?}", entity_mut.id(), confirmed_tick);
-if confirmed_tick > tick {
-    debug!(
-        "Confirmed entity {:?} is at a tick in the future: {:?} compared to client timeline. Current tick: {:?}",
-        entity_mut.id(),
-        confirmed_tick,
-        tick
-    );
-    return;
-}
+let raw_confirmed_tick = entity_mut.get::<ConfirmedTick>().unwrap().tick;
+trace!("Checking rollback for entity {:?} that received update at tick {:?}", entity_mut.id(), raw_confirmed_tick);
+let confirmed_tick = if raw_confirmed_tick > tick {
+    tick
+} else {
+    raw_confirmed_tick
+};
```

The matching `debug_assert_eq!(rollback_tick, confirmed.tick)` in `prepare_rollback` is converted to a `trace!` for the same reason — those ticks can now legitimately differ:

```diff
-debug_assert_eq!(
-    rollback_tick,
-    confirmed.unwrap().tick,
-    "The rollback tick (LEFT) does not match the confirmed tick (RIGHT) for confirmed entity {entity:?}. Are all predicted entities in the same replication group?",
-);
+if rollback_tick != confirmed.unwrap().tick {
+    trace!(
+        ?entity,
+        ?rollback_tick,
+        confirmed_tick = ?confirmed.unwrap().tick,
+        "rollback_tick clamped to local tick because confirmed_tick was ahead",
+    );
+}
```

The downstream logic — write `Confirmed<C>.0` into the predicted component and record the value at `rollback_tick` in history — is correct regardless of the relationship between the two ticks.

## Test — behavioural red, then green

Added a test in `lightyear_tests/src/client_server/prediction/rollback.rs` that exercises the production `check_rollback` path. It uses the existing `setup()` and `trigger_rollback_check()` helpers (both already in the repo), so the test depends on no new API — the red is the production behaviour, not a missing symbol:

```rust
#[test]
fn test_rollback_fires_when_confirmed_tick_is_ahead_of_local() {
    let (mut stepper, predicted) = setup();
    stepper.frame_step(1);

    let rollbacks_before = stepper
        .client_app()
        .world()
        .resource::<PredictionMetrics>()
        .rollbacks;

    // Diverge predicted vs confirmed: insert a fresh Confirmed value
    // on the predicted entity (no matching Predicted value at this tick).
    stepper
        .client_app()
        .world_mut()
        .entity_mut(predicted)
        .insert(Confirmed(CompFull(2.0)));

    // Put ConfirmedTick 5 ticks AHEAD of the client's local tick — the
    // exact condition the upstream short-circuit drops on the floor.
    let local_tick = stepper.client_tick(0);
    trigger_rollback_check(&mut stepper, local_tick + 5);
    stepper.frame_step(1);

    let rollbacks_after = stepper
        .client_app()
        .world()
        .resource::<PredictionMetrics>()
        .rollbacks;

    assert!(
        rollbacks_after > rollbacks_before,
        "rollback should have fired (predicted CompFull missing vs Confirmed \
         CompFull(2.0) with ConfirmedTick ahead of local), but the upstream \
         `confirmed_tick > tick` short-circuit silently skipped the check. \
         rollbacks: {} → {}",
        rollbacks_before,
        rollbacks_after,
    );
}
```

### Behavioural red (without the `check_rollback` clamp)

Reverting the `lightyear_prediction/src/rollback.rs` change while keeping the test, the assertion fails with the production short-circuit in place — no compile error, a runtime behaviour mismatch:

```
running 1 test
test client_server::prediction::rollback::test_rollback_fires_when_confirmed_tick_is_ahead_of_local ... FAILED

---- ...test_rollback_fires_when_confirmed_tick_is_ahead_of_local stdout ----

thread '...' panicked at lightyear_tests/.../rollback.rs:248:5:
rollback should have fired (predicted CompFull missing vs Confirmed
CompFull(2.0) with ConfirmedTick ahead of local), but the upstream
`confirmed_tick > tick` short-circuit silently skipped the check.
rollbacks: 1 → 1

test result: FAILED. 0 passed; 1 failed
```

That `rollbacks: 1 → 1` is the actual bug: the rollback counter did not advance, because `check_rollback` returned early and never compared predicted vs confirmed.

### Green (this PR applied)

```
$ cargo test --package lightyear_tests --lib test_rollback_fires_when_confirmed_tick_is_ahead_of_local

test client_server::prediction::rollback::test_rollback_fires_when_confirmed_tick_is_ahead_of_local ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 96 filtered out; finished in 0.10s
```

3 isolated re-runs of the new test all passed; 3 isolated re-runs of the adjacent `test_input_rollback_check_mode_earliest_mismatch` also passed against this PR.

## Safety / risk

**Correctness.** The clamp only takes effect when `confirmed_tick > tick`. In every other case (the overwhelming majority) the code paths through `check_rollback` and `prepare_rollback` are unchanged.

**Zero-tick rollback is well-defined.** `do_rollback` calls `rollback.set_rollback_tick(rollback_tick + 1)` and then the simulator re-runs `tick - rollback_tick` times. With `rollback_tick == tick`, the simulator runs zero iterations; the only effect is the `Confirmed` value being written into `Predicted` and into history at that tick. This is precisely the desired snap-to-truth semantic.

**No effect on rollback-budget guards.** `do_rollback`'s `max_rollback_ticks` short-circuit checks `delta > max_rollback_ticks`; `delta = 0` always passes. The apply-confirmed step runs regardless of `delta`.

**`debug_assert_eq!` relaxation is conservative.** It was a sanity predicate, not a load-bearing invariant. Replacing with a `trace!` keeps the visibility (you can grep the log if you suspect the clamp is firing more than expected) without crashing debug builds.

**Compatibility risk for other consumers.** Zero — `check_rollback` is a private system; this PR changes its internal behaviour but doesn't alter any public API surface.

**Wider test suite.** `lightyear_tests --lib` has pre-existing parallel-run flakiness: two back-to-back runs on clean upstream `main` produced different failing sets (5 vs 7 failures, with overlapping but non-identical members). All of those tests pass individually. PR 3's new test passes individually and the `client_server::prediction::rollback` module passes as a group. The one variation in the failure set between clean-main and this-PR runs (`test_input_rollback_check_mode_earliest_mismatch` appearing in one run only) was verified to pass deterministically in isolation against this PR (5/5).

## Related

This is one of three PRs sharing root-cause analysis from a downstream project (multiplayer combat prototype) that hit reliable visual desync when the client briefly drifted ahead of the server by 1 tick:

- Upstream **#1470** *(sync floor)*: raises `sync_objective` floor to `remote + 1` so the sync target never *intentionally* sits on the boundary that triggers this rollback skip.
- Upstream **#1471** *(server pop wipe)*: keeps a fallback input live in the server-side input buffer so a single mid-flight ack doesn't wipe usable inputs.
- **This PR**: even with #1470 and #1471 in place, momentary jitter can still nudge `ConfirmedTick` ahead of local; this PR makes that case recover via a zero-tick rollback instead of silently no-oping.

Each PR can land independently; together they remove the desync class entirely.