### PR TITLE
Spoofed InputTarget:Entity lets a modified client hijack any entity and Unbounded end_tick lets a client exhaust server memory

### DIFF
--- a/lightyear_inputs/src/server.rs
+++ b/lightyear_inputs/src/server.rs
@@ -17,6 +17,7 @@ use bevy_ecs::{
     entity::{Entity, MapEntities},
     error::Result,
     query::With,
+    relationship::RelationshipTarget,
     resource::Resource,
     schedule::{IntoScheduleConfigs, SystemSet},
     system::{Commands, Query, Res, Single},
@@ -30,13 +31,95 @@ use lightyear_connection::prelude::NetworkTarget;
 use lightyear_connection::server::Started;
 use lightyear_core::id::RemoteId;
 use lightyear_core::prelude::LocalTimeline;
-use lightyear_core::tick::TickDuration;
+use lightyear_core::tick::{Tick, TickDuration};
 use lightyear_link::prelude::{LinkOf, Server};
 use lightyear_messages::plugin::MessageSystems;
 use lightyear_messages::prelude::MessageReceiver;
 use lightyear_messages::server::ServerMultiMessageSender;
+use lightyear_replication::control::ControlledByRemote;
 use lightyear_replication::prelude::{PreSpawned, RoomId, Rooms};
 use tracing::{debug, error, trace};
+
+/// Maximum number of ticks ahead of the server's current tick that an
+/// incoming `InputMessage::end_tick` is allowed to be. Messages with
+/// `end_tick > server_tick + MAX_INPUT_LOOKAHEAD_TICKS` are dropped
+/// before they're written into the [`InputBuffer`].
+///
+/// Without this bound, [`InputBuffer::set_raw`] extends the internal
+/// `VecDeque` to fit *any* tick value (filling intermediate entries
+/// with `SameAsPrecedent`). A modified client sending
+/// `end_tick = current + 30_000` would cause a 30 000-entry allocation
+/// per message; repeated across messages / connections, the server is
+/// memory-exhausted.
+///
+/// Legitimate clients run at most a few ticks ahead of the server
+/// (typical `InputDelayConfig` values are 0–3 ticks). 64 ticks
+/// (~1 s at 64 Hz) is generous compared to that range while still
+/// bounding attacker memory cost per message.
+const MAX_INPUT_LOOKAHEAD_TICKS: i32 = 64;
+
+/// Maximum number of ticks BEHIND the server's current tick that an
+/// incoming `InputMessage::end_tick` is allowed to be.
+///
+/// Past-direction messages are normally handled harmlessly by
+/// [`InputBuffer::set_raw`]'s start-tick guard. The reason we still
+/// bound them: `Tick - Tick` returns `i32` via signed wrapping
+/// arithmetic over `u32` tick values. A far-future tick at the i32
+/// boundary (`end_tick = server_tick + 2^31`) wraps to `i32::MIN`,
+/// which a naive `delta <= LOOKAHEAD` check would accept. Rejecting
+/// "very far past" deltas catches that wrap-around attack while still
+/// accepting reasonable late inputs (up to ~4 s of network lag at 64
+/// Hz). The wrap-around scenario is now astronomically improbable
+/// (2^31 ticks at 64 Hz ≈ 1.06 years of continuous server runtime)
+/// but the symmetric bound is cheap belt-and-suspenders.
+const MAX_INPUT_PAST_TICKS: i32 = 256;
+
+/// Authorizes an `InputTarget::Entity` from a remote peer.
+///
+/// Returns `true` iff `target_entity` is listed in the peer's
+/// [`ControlledByRemote`] (auto-populated when `ControlledBy { owner: peer }`
+/// is added to a controlled entity). `None` means the peer controls
+/// nothing yet — reject.
+///
+/// **Host-client bypass.** Caller checks `RemoteId::is_local()` before
+/// invoking this helper; host clients drive inputs through in-process
+/// state and have no `ControlledByRemote`.
+///
+/// **`InputTarget::PreSpawned` bypass.** PreSpawned targets are identified
+/// by a hash (spawn tick + sorted component net-IDs + optional user salt),
+/// not entity id, so they bypass this check at the call site. A client
+/// that knows the salt could forge a colliding hash — a pre-existing risk
+/// out of scope here; a follow-up could bind `PreSpawned` to an owner.
+///
+/// **Distinct from `HasAuthority` / `AuthorityPeer`.** This helper uses
+/// `ControlledBy` (semantic input ownership, rarely changes), NOT the
+/// dynamic simulation-authority components that transfer via
+/// `GiveAuthority`. `examples/distributed_authority` uses both
+/// independently. If your use case needs input authority to follow
+/// `GiveAuthority` (e.g. a vehicle multiple players take turns driving),
+/// update `ControlledBy` alongside the authority transfer.
+pub(crate) fn is_input_target_authorized(
+    target_entity: Entity,
+    controlled_by_remote: Option<&ControlledByRemote>,
+) -> bool {
+    match controlled_by_remote {
+        None => false,
+        Some(controlled) => controlled.collection().contains(&target_entity),
+    }
+}
+
+/// Returns `true` iff `end_tick - server_tick` falls within
+/// `[-MAX_INPUT_PAST_TICKS, MAX_INPUT_LOOKAHEAD_TICKS]`. See those
+/// constants for the threat model behind each bound.
+///
+/// The symmetric past bound is what makes this safe under wrap-around: a
+/// naive `delta <= MAX_LOOKAHEAD` check accepts `i32::MIN` because it's
+/// trivially ≤ any positive bound. Rejecting on both ends eliminates the
+/// ambiguity regardless of which interpretation an attacker intended.
+pub(crate) fn is_input_within_lookahead(end_tick: Tick, server_tick: Tick) -> bool {
+    let delta = end_tick - server_tick;
+    (-MAX_INPUT_PAST_TICKS..=MAX_INPUT_LOOKAHEAD_TICKS).contains(&delta)
+}
 
 /// Server-side plugin that receives input messages from clients and applies
 /// them to [`InputBuffer`](crate::input_buffer::InputBuffer) components.
@@ -166,6 +249,11 @@ fn receive_input_message<S: ActionStateSequence>(
             &mut MessageReceiver<InputMessage<S>>,
             &RemoteId,
             Option<&InputRebroadcaster<S::Action>>,
+            // List of entities this peer is authorized to control.
+            // Inputs targeting entities outside this list are dropped
+            // so a modified client cannot forge
+            // `InputTarget::Entity(other)` to hijack another player.
+            Option<&ControlledByRemote>,
         ),
         // We also receive inputs from the HostClient, in case we want the HostClient's inputs to be
         // rebroadcast to other clients (so that they can do prediction of the HostClient's entity)
@@ -182,14 +270,12 @@ fn receive_input_message<S: ActionStateSequence>(
     mut commands: Commands,
 ) -> Result {
     // TODO: use par_iter_mut
-    receivers.iter_mut().try_for_each(|(client_entity, link_of, mut receiver, client_id, rebroadcaster)| {
+    receivers.iter_mut().try_for_each(|(client_entity, link_of, mut receiver, client_id, rebroadcaster, controlled_by_remote)| {
         // TODO: this drains the messages... but the user might want to re-broadcast them?
         //  should we just read instead?
         let server_entity = link_of.server;
         let tick = timeline.tick();
-        receiver.receive().try_for_each(|message| {
-            #[cfg(feature = "prediction")]
-            let mut message = message;
+        receiver.receive().try_for_each(|mut message| {
             // ignore input messages from the local client (if running in host-server mode)
             // if we're not doing rebroadcasting
             if client_id.is_local() && !config.rebroadcast_inputs {
@@ -219,12 +305,47 @@ fn receive_input_message<S: ActionStateSequence>(
                 "server received input message"
             );
 
-            // TODO: or should we try to store in a buffer the interpolation delay for the exact tick
-            //  that the message was intended for?
+            if !is_input_within_lookahead(message.end_tick, tick) {
+                trace!(
+                    ?tick,
+                    ?client_id,
+                    end_tick = ?message.end_tick,
+                    "Dropping input message: end_tick outside [server-{}, server+{}] window",
+                    MAX_INPUT_PAST_TICKS,
+                    MAX_INPUT_LOOKAHEAD_TICKS,
+                );
+                return Ok(())
+            }
+
+            // Connection-level metadata: apply before the target filter
+            // so it still updates when every target is dropped.
             #[cfg(feature = "interpolation")]
             if let Some(interpolation_delay) = message.interpolation_delay {
-                // update the interpolation delay estimate for the client
                 commands.entity(client_entity).insert(interpolation_delay);
+            }
+
+            // Filter pre-rebroadcast so the server doesn't relay forged
+            // entries to other clients.
+            if !client_id.is_local() {
+                let before = message.inputs.len();
+                message.inputs.retain(|data| match data.target {
+                    InputTarget::Entity(entity) => {
+                        is_input_target_authorized(entity, controlled_by_remote)
+                    }
+                    InputTarget::PreSpawned(_) => true,
+                });
+                let dropped = before - message.inputs.len();
+                if dropped > 0 {
+                    trace!(
+                        ?tick,
+                        ?client_id,
+                        dropped,
+                        "Filtered unauthorized input targets (spoofed-target defense)",
+                    );
+                    if message.inputs.is_empty() {
+                        return Ok(())
+                    }
+                }
             }
 
             #[cfg(feature = "prediction")]
@@ -291,6 +412,10 @@ fn receive_input_message<S: ActionStateSequence>(
             for data in message.inputs {
                 let Some(entity) = (match data.target {
                     InputTarget::Entity(entity) => {
+                        // Authorization was already enforced by the
+                        // `message.inputs.retain` filter above (or
+                        // bypassed for `is_local()`); unauthorized
+                        // targets cannot reach this point.
                         Some(entity)
                     },
                     InputTarget::PreSpawned(hash) => {
@@ -590,5 +715,108 @@ fn update_action_state<S: ActionStateSequence>(
         // fallback on the last known value
         input_buffer.pop(tick - history_depth);
         // info!("Buffer length: {}", input_buffer.len());
+    }
+}
+
+#[cfg(test)]
+mod patch_tests {
+    use super::*;
+    use bevy_ecs::world::World;
+    use lightyear_replication::prelude::{ControlledBy, Lifetime};
+
+    /// No `ControlledByRemote` means the peer hasn't been granted
+    /// control yet — drop the input.
+    #[test]
+    fn authorization_rejects_when_controlled_by_remote_is_none() {
+        let mut world = World::new();
+        let entity = world.spawn_empty().id();
+        assert!(!is_input_target_authorized(entity, None));
+    }
+
+    /// The relationship-target machinery populates `ControlledByRemote`
+    /// when `ControlledBy { owner }` is added.
+    #[test]
+    fn authorization_accepts_legitimate_target_and_rejects_foreign() {
+        let mut world = World::new();
+        let peer = world.spawn_empty().id();
+        let controlled = world
+            .spawn(ControlledBy {
+                owner: peer,
+                lifetime: Lifetime::default(),
+            })
+            .id();
+        let foreign = world.spawn_empty().id();
+
+        let cbr = world
+            .entity(peer)
+            .get::<ControlledByRemote>()
+            .expect("ControlledByRemote auto-populated on the peer entity")
+            .clone();
+
+        assert!(is_input_target_authorized(controlled, Some(&cbr)));
+        assert!(!is_input_target_authorized(foreign, Some(&cbr)));
+    }
+
+    /// Forward bound is inclusive.
+    #[test]
+    fn lookahead_accepts_within_forward_bound() {
+        let server = Tick(1000);
+        assert!(is_input_within_lookahead(server, server));
+        assert!(is_input_within_lookahead(Tick(server.0 + 1), server));
+        assert!(is_input_within_lookahead(
+            Tick(server.0 + MAX_INPUT_LOOKAHEAD_TICKS as u32),
+            server,
+        ));
+        assert!(!is_input_within_lookahead(
+            Tick(server.0 + (MAX_INPUT_LOOKAHEAD_TICKS as u32) + 1),
+            server,
+        ));
+    }
+
+    /// Past bound is inclusive — legitimate late inputs accepted up to
+    /// `MAX_INPUT_PAST_TICKS` behind.
+    #[test]
+    fn lookahead_accepts_within_past_bound() {
+        let server = Tick(1000);
+        assert!(is_input_within_lookahead(Tick(server.0 - 1), server));
+        assert!(is_input_within_lookahead(
+            Tick(server.0 - MAX_INPUT_PAST_TICKS as u32),
+            server
+        ));
+        assert!(!is_input_within_lookahead(
+            Tick(server.0 - (MAX_INPUT_PAST_TICKS as u32) - 1),
+            server,
+        ));
+    }
+
+    /// `server + 2^31` wraps to `i32::MIN`; the symmetric past bound
+    /// rejects it. Also covers the plain `+30_000` DOS value (caught by
+    /// the forward bound, not the wrap defense).
+    #[test]
+    fn lookahead_rejects_wraparound_far_future() {
+        let server = Tick(1000);
+        let attack_wrap = Tick(server.0.wrapping_add(1u32 << 31));
+        assert!(
+            !is_input_within_lookahead(attack_wrap, server),
+            "wrap-around at exactly i32::MIN must be rejected",
+        );
+        let attack_wrap_plus_one = Tick(server.0.wrapping_add((1u32 << 31) + 1));
+        assert!(
+            !is_input_within_lookahead(attack_wrap_plus_one, server),
+            "wrap-around past i32::MIN must be rejected",
+        );
+        let attack_30000 = Tick(server.0.wrapping_add(30_000));
+        assert!(!is_input_within_lookahead(attack_30000, server));
+    }
+
+    /// The defense is arithmetic, not position-dependent: high
+    /// `server_tick` yields the same i32 delta for the same offset.
+    #[test]
+    fn lookahead_rejects_wraparound_at_high_server_tick() {
+        let server = Tick(u32::MAX / 2);
+        let attack = Tick(server.0.wrapping_add(1u32 << 31));
+        assert!(!is_input_within_lookahead(attack, server));
+        assert!(is_input_within_lookahead(Tick(server.0 + 64), server));
+        assert!(!is_input_within_lookahead(Tick(server.0 + 65), server));
     }
 }

--- a/lightyear_tests/src/client_server/input/bei.rs
+++ b/lightyear_tests/src/client_server/input/bei.rs
@@ -17,7 +17,7 @@ use lightyear_link::Link;
 use lightyear_link::prelude::LinkConditionerConfig;
 use lightyear_messages::MessageManager;
 use lightyear_prediction::diagnostics::PredictionMetrics;
-use lightyear_replication::prelude::{PreSpawned, PredictionTarget, Replicate};
+use lightyear_replication::prelude::{ControlledBy, PreSpawned, PredictionTarget, Replicate};
 use lightyear_sync::prelude::client::{InputDelayConfig, InputTimelineConfig};
 use test_log::test;
 use tracing::info;
@@ -645,6 +645,7 @@ fn test_input_broadcasting_prediction() {
     ));
 
     // SETUP - Create an entity controlled by client 0, predicted by all clients
+    let client_of_0 = stepper.client_of(0).id();
     let server_entity = stepper
         .server_app
         .world_mut()
@@ -652,6 +653,10 @@ fn test_input_broadcasting_prediction() {
             Replicate::to_clients(NetworkTarget::All),
             PredictionTarget::to_clients(NetworkTarget::All),
             BEIContext,
+            ControlledBy {
+                owner: client_of_0,
+                lifetime: Default::default(),
+            },
         ))
         .id();
 
@@ -664,6 +669,10 @@ fn test_input_broadcasting_prediction() {
             Action::<BEIAction1>::default(),
             PreSpawned::new(TEST_HASH),
             Replicate::to_clients(NetworkTarget::All),
+            ControlledBy {
+                owner: client_of_0,
+                lifetime: Default::default(),
+            },
         ))
         .id();
 

--- a/lightyear_tests/src/client_server/input/leafwing.rs
+++ b/lightyear_tests/src/client_server/input/leafwing.rs
@@ -232,7 +232,10 @@ fn test_from_snapshot_transitions_produces_just_pressed() {
 /// so the server must reconstruct the transition from the state change.
 #[test]
 fn test_server_just_pressed() {
+    use lightyear_replication::prelude::ControlledBy;
+
     let mut stepper = ClientServerStepper::from_config(StepperConfig::single());
+    let client_of_0 = stepper.client_of(0).id();
 
     let server_entity = stepper
         .server_app
@@ -240,6 +243,10 @@ fn test_server_just_pressed() {
         .spawn((
             ActionState::<LeafwingInput1>::default(),
             Replicate::to_clients(NetworkTarget::All),
+            ControlledBy {
+                owner: client_of_0,
+                lifetime: Default::default(),
+            },
         ))
         .id();
     stepper.frame_step(2);
@@ -293,9 +300,10 @@ fn test_server_just_pressed() {
 /// inputs until the buffer catches up to the current tick.
 #[test]
 fn test_rebroadcast_initializes_action_state_from_buffer() {
-    use lightyear_replication::prelude::PredictionTarget;
+    use lightyear_replication::prelude::{ControlledBy, PredictionTarget};
 
     let mut stepper = ClientServerStepper::from_config(StepperConfig::with_netcode_clients(2));
+    let client_of_0 = stepper.client_of(0).id();
 
     let server_entity = stepper
         .server_app
@@ -304,6 +312,10 @@ fn test_rebroadcast_initializes_action_state_from_buffer() {
             ActionState::<LeafwingInput1>::default(),
             Replicate::to_clients(NetworkTarget::All),
             PredictionTarget::to_clients(NetworkTarget::All),
+            ControlledBy {
+                owner: client_of_0,
+                lifetime: Default::default(),
+            },
         ))
         .id();
     stepper.frame_step_server_first(1);
@@ -365,9 +377,10 @@ fn test_rebroadcast_initializes_action_state_from_buffer() {
 /// Client 1 should see the pressed state in its InputBuffer for the remote player.
 #[test]
 fn test_leafwing_input_rebroadcast() {
-    use lightyear_replication::prelude::PredictionTarget;
+    use lightyear_replication::prelude::{ControlledBy, PredictionTarget};
 
     let mut stepper = ClientServerStepper::from_config(StepperConfig::with_netcode_clients(2));
+    let client_of_0 = stepper.client_of(0).id();
 
     // Create an entity replicated to both clients with prediction
     let server_entity = stepper
@@ -377,6 +390,10 @@ fn test_leafwing_input_rebroadcast() {
             ActionState::<LeafwingInput1>::default(),
             Replicate::to_clients(NetworkTarget::All),
             PredictionTarget::to_clients(NetworkTarget::All),
+            ControlledBy {
+                owner: client_of_0,
+                lifetime: Default::default(),
+            },
         ))
         .id();
     stepper.frame_step_server_first(1);
@@ -440,4 +457,311 @@ fn test_leafwing_input_rebroadcast() {
             "Client 1's InputBuffer should have a last_remote_tick from the rebroadcast"
         );
     }
+}
+
+/// Spoofed-target attack: client 0 emits an `InputMessage` whose
+/// `InputTarget::Entity(...)` is client 1's controlled entity. The
+/// defense in `is_input_target_authorized` should drop it.
+///
+/// Two assertions in one run:
+/// - **Defense:** victim's server-side `Jump` MUST NOT be pressed.
+/// - **Non-overblocking:** attacker's own server-side `Jump` MUST be
+///   pressed (a defense that drops all cross-client inputs would fail
+///   here).
+#[test]
+fn test_input_message_with_spoofed_target_is_rejected() {
+    use lightyear_replication::prelude::ControlledBy;
+
+    let mut stepper = ClientServerStepper::from_config(StepperConfig::with_netcode_clients(2));
+
+    let client_of_0 = stepper.client_of(0).id();
+    let client_of_1 = stepper.client_of(1).id();
+
+    let victim_server_entity = stepper
+        .server_app
+        .world_mut()
+        .spawn((
+            ActionState::<LeafwingInput1>::default(),
+            Replicate::to_clients(NetworkTarget::All),
+            ControlledBy {
+                owner: client_of_1,
+                lifetime: Default::default(),
+            },
+        ))
+        .id();
+
+    let attacker_server_entity = stepper
+        .server_app
+        .world_mut()
+        .spawn((
+            ActionState::<LeafwingInput1>::default(),
+            Replicate::to_clients(NetworkTarget::All),
+            ControlledBy {
+                owner: client_of_0,
+                lifetime: Default::default(),
+            },
+        ))
+        .id();
+
+    // Warm-up: `ControlledByRemote` must auto-populate on the peer
+    // connection entity before the receive-path filter accepts inputs.
+    stepper.frame_step(10);
+
+    let victim_local_on_client_0 = stepper
+        .client(0)
+        .get::<MessageManager>()
+        .unwrap()
+        .entity_mapper
+        .get_local(victim_server_entity)
+        .expect("victim entity should be replicated to client 0");
+    let attacker_local_on_client_0 = stepper
+        .client(0)
+        .get::<MessageManager>()
+        .unwrap()
+        .entity_mapper
+        .get_local(attacker_server_entity)
+        .expect("attacker entity should be replicated to client 0");
+
+    // KeyJ on victim's replica = the attack; KeyA on attacker's own = the
+    // legitimate positive control. `InputMap` requires `InputBuffer`, no
+    // explicit buffer insertion needed.
+    stepper.client_apps[0]
+        .world_mut()
+        .entity_mut(victim_local_on_client_0)
+        .insert(InputMap::<LeafwingInput1>::new([(
+            LeafwingInput1::Jump,
+            KeyCode::KeyJ,
+        )]));
+    stepper.client_apps[0]
+        .world_mut()
+        .entity_mut(attacker_local_on_client_0)
+        .insert(InputMap::<LeafwingInput1>::new([(
+            LeafwingInput1::Jump,
+            KeyCode::KeyA,
+        )]));
+
+    // leafwing needs a frame to register the InputMap before key presses
+    // produce action-state transitions.
+    stepper.frame_step(1);
+
+    stepper.client_apps[0]
+        .world_mut()
+        .resource_mut::<ButtonInput<KeyCode>>()
+        .press(KeyCode::KeyJ);
+    stepper.client_apps[0]
+        .world_mut()
+        .resource_mut::<ButtonInput<KeyCode>>()
+        .press(KeyCode::KeyA);
+
+    stepper.frame_step(20);
+
+    let victim_server_state = stepper
+        .server_app
+        .world()
+        .entity(victim_server_entity)
+        .get::<ActionState<LeafwingInput1>>()
+        .expect("victim has ActionState");
+    assert!(
+        !victim_server_state.pressed(&LeafwingInput1::Jump),
+        "Server applied client 0's forged input to client 1's entity \
+         (`ActionState::pressed` shows Jump pressed). The input-message \
+         receive path does not authorize the target entity against \
+         the sender's ControlledByRemote — see \
+         `is_input_target_authorized` in lightyear_inputs::server.",
+    );
+
+    let attacker_server_state = stepper
+        .server_app
+        .world()
+        .entity(attacker_server_entity)
+        .get::<ActionState<LeafwingInput1>>()
+        .expect("attacker has ActionState");
+    assert!(
+        attacker_server_state.pressed(&LeafwingInput1::Jump),
+        "Client 0's legitimate Jump input for its OWN entity did not \
+         reach the server (`ActionState::pressed` shows Jump released). \
+         The authorization defense is dropping authorized inputs too \
+         — broken in the opposite direction from the spoofed-target \
+         case.",
+    );
+}
+
+/// Exercises the empty-after-filter early-return branch in
+/// `receive_input_message`: client 0 controls nothing, forges an input
+/// targeting client 1's entity, retain drops it, `inputs.is_empty()`
+/// fires before the rebroadcast / per-target-apply blocks.
+#[test]
+fn test_input_message_with_only_spoofed_targets_filters_to_empty() {
+    use lightyear_replication::prelude::ControlledBy;
+
+    let mut stepper = ClientServerStepper::from_config(StepperConfig::with_netcode_clients(2));
+    let client_of_1 = stepper.client_of(1).id();
+
+    let victim_server_entity = stepper
+        .server_app
+        .world_mut()
+        .spawn((
+            ActionState::<LeafwingInput1>::default(),
+            Replicate::to_clients(NetworkTarget::All),
+            ControlledBy {
+                owner: client_of_1,
+                lifetime: Default::default(),
+            },
+        ))
+        .id();
+
+    stepper.frame_step(3);
+
+    let victim_local_on_client_0 = stepper
+        .client(0)
+        .get::<MessageManager>()
+        .unwrap()
+        .entity_mapper
+        .get_local(victim_server_entity)
+        .expect("victim entity should be replicated to client 0");
+
+    stepper.client_apps[0]
+        .world_mut()
+        .entity_mut(victim_local_on_client_0)
+        .insert(InputMap::<LeafwingInput1>::new([(
+            LeafwingInput1::Jump,
+            KeyCode::KeyJ,
+        )]));
+    stepper.frame_step(1);
+    stepper.client_apps[0]
+        .world_mut()
+        .resource_mut::<ButtonInput<KeyCode>>()
+        .press(KeyCode::KeyJ);
+
+    stepper.frame_step(10);
+
+    let victim_server_state = stepper
+        .server_app
+        .world()
+        .entity(victim_server_entity)
+        .get::<ActionState<LeafwingInput1>>()
+        .expect("victim has ActionState");
+    assert!(
+        !victim_server_state.pressed(&LeafwingInput1::Jump),
+        "spoofed-target input was applied despite client 0 controlling \
+         nothing — the empty-after-filter early-return path is broken \
+         or the upstream auth filter is missing.",
+    );
+}
+
+/// End_tick DOS: a forged `InputMessage` with `end_tick = server_tick +
+/// 30_000` causes `InputBuffer::set_raw` to allocate ~30k entries.
+/// Goes end-to-end via the public `MessageSender::send::<InputChannel>`
+/// API (no internal-API hooks) and asserts the server's buffer stays
+/// bounded. See `is_input_within_lookahead` for the defense.
+#[test]
+fn test_input_message_with_huge_end_tick_does_not_allocate_unbounded_buffer() {
+    use lightyear::input::leafwing::input_message::{LeafwingSequence, LeafwingSnapshot};
+    use lightyear_inputs::input_buffer::InputBuffer;
+    use lightyear_inputs::input_message::{
+        ActionStateSequence, InputMessage, InputTarget, PerTargetData,
+    };
+    use lightyear_inputs::prelude::InputChannel;
+    use lightyear_messages::prelude::MessageSender;
+    use lightyear_replication::prelude::ControlledBy;
+
+    let mut stepper = ClientServerStepper::from_config(StepperConfig::with_netcode_clients(1));
+    let client_of_0 = stepper.client_of(0).id();
+
+    let target_server_entity = stepper
+        .server_app
+        .world_mut()
+        .spawn((
+            ActionState::<LeafwingInput1>::default(),
+            Replicate::to_clients(NetworkTarget::All),
+            ControlledBy {
+                owner: client_of_0,
+                lifetime: Default::default(),
+            },
+        ))
+        .id();
+
+    // Warm-up: `ControlledByRemote` must auto-populate before the
+    // receive-path filter accepts inputs.
+    stepper.frame_step(5);
+
+    let target_local = stepper
+        .client(0)
+        .get::<MessageManager>()
+        .unwrap()
+        .entity_mapper
+        .get_local(target_server_entity)
+        .expect("target entity should be replicated to client 0");
+
+    // Establish a baseline server-side InputBuffer at the current tick
+    // range. Without this the attack just initializes the buffer at the
+    // huge tick (no gap to fill, no growth).
+    stepper.client_apps[0]
+        .world_mut()
+        .entity_mut(target_local)
+        .insert(InputMap::<LeafwingInput1>::new([(
+            LeafwingInput1::Jump,
+            KeyCode::KeyA,
+        )]));
+    stepper.frame_step(1);
+    stepper.client_apps[0]
+        .world_mut()
+        .resource_mut::<ButtonInput<KeyCode>>()
+        .press(KeyCode::KeyA);
+    stepper.frame_step(5);
+
+    let server_tick_before = stepper.server_tick();
+    let attack_end_tick = server_tick_before + 30_000;
+
+    // The sequence content doesn't matter — only `end_tick` controls
+    // how far `set_raw` extends the server's buffer.
+    let mut sequence_buf =
+        InputBuffer::<LeafwingSnapshot<LeafwingInput1>, LeafwingInput1>::default();
+    let mut snapshot_state = ActionState::<LeafwingInput1>::default();
+    snapshot_state.press(&LeafwingInput1::Jump);
+    sequence_buf.set(attack_end_tick, LeafwingSnapshot(snapshot_state));
+    let sequence = LeafwingSequence::<LeafwingInput1>::build_from_input_buffer(
+        &sequence_buf,
+        1,
+        attack_end_tick,
+    )
+    .expect("sequence built from non-empty buffer");
+
+    let mut forged: InputMessage<LeafwingSequence<LeafwingInput1>> =
+        InputMessage::new(attack_end_tick);
+    forged.inputs.push(PerTargetData {
+        target: InputTarget::Entity(target_local),
+        states: sequence,
+    });
+
+    // Send via the public MessageSender API — models exactly what a
+    // modified client binary could do.
+    {
+        let client_app = &mut stepper.client_apps[0];
+        let mut client_entity_mut = client_app
+            .world_mut()
+            .entity_mut(stepper.client_entities[0]);
+        let mut sender = client_entity_mut
+            .get_mut::<MessageSender<InputMessage<LeafwingSequence<LeafwingInput1>>>>()
+            .expect("client has a MessageSender for InputMessage<LeafwingSequence>");
+        sender.send::<InputChannel>(forged);
+    }
+
+    // Frames for serialize → wire → deserialize → receive.
+    stepper.frame_step(3);
+
+    let buffer = stepper
+        .server_app
+        .world()
+        .entity(target_server_entity)
+        .get::<InputBuffer<LeafwingSnapshot<LeafwingInput1>, LeafwingInput1>>()
+        .expect("server should have an InputBuffer for the target after receiving inputs");
+    let buffer_len = buffer.len();
+    assert!(
+        buffer_len < 1_000,
+        "DOS: server allocated {buffer_len} entries in the InputBuffer for a \
+         single forged InputMessage with end_tick = server_tick + 30000. The \
+         receive path does not bound the message's end_tick — see \
+         `is_input_within_lookahead` in lightyear_inputs::server.",
+    );
 }

--- a/lightyear_tests/src/client_server/input/native.rs
+++ b/lightyear_tests/src/client_server/input/native.rs
@@ -10,7 +10,7 @@ use lightyear_link::Link;
 use lightyear_link::prelude::LinkConditionerConfig;
 use lightyear_messages::MessageManager;
 use lightyear_prediction::prelude::PredictionManager;
-use lightyear_replication::prelude::{PredictionTarget, Replicate};
+use lightyear_replication::prelude::{ControlledBy, PredictionTarget, Replicate};
 use lightyear_replication::prelude::{RoomAllocator, Rooms};
 use lightyear_sync::prelude::InputTimeline;
 use lightyear_sync::prelude::client::IsSynced;
@@ -31,10 +31,17 @@ fn test_remote_client_replicated_input() {
 
     // SETUP
     // entity controlled by the remote client
+    let client_of_0 = stepper.client_of(0).id();
     let server_entity = stepper
         .server_app
         .world_mut()
-        .spawn(Replicate::to_clients(NetworkTarget::All))
+        .spawn((
+            Replicate::to_clients(NetworkTarget::All),
+            ControlledBy {
+                owner: client_of_0,
+                lifetime: Default::default(),
+            },
+        ))
         .id();
 
     stepper.frame_step(2);
@@ -95,12 +102,17 @@ fn test_remote_client_predicted_input() {
     let mut stepper = ClientServerStepper::from_config(StepperConfig::single());
 
     // SETUP
+    let client_of_0 = stepper.client_of(0).id();
     let server_entity = stepper
         .server_app
         .world_mut()
         .spawn((
             Replicate::to_clients(NetworkTarget::All),
             PredictionTarget::to_clients(NetworkTarget::All),
+            ControlledBy {
+                owner: client_of_0,
+                lifetime: Default::default(),
+            },
         ))
         .id();
 
@@ -185,6 +197,7 @@ fn test_input_broadcasting_prediction() {
     ));
 
     // SETUP - Create an entity controlled by client 0, predicted by all clients
+    let client_of_0 = stepper.client_of(0).id();
     let server_entity = stepper
         .server_app
         .world_mut()
@@ -192,6 +205,10 @@ fn test_input_broadcasting_prediction() {
             Replicate::to_clients(NetworkTarget::All),
             PredictionTarget::to_clients(NetworkTarget::All),
             ActionState::<MyInput>::default(),
+            ControlledBy {
+                owner: client_of_0,
+                lifetime: Default::default(),
+            },
         ))
         .id();
     stepper.frame_step_server_first(1);
@@ -343,6 +360,7 @@ fn test_input_custom_rebroadcast() {
     ));
 
     // SETUP - Create an entity controlled by client 0, predicted by all clients
+    let client_of_0 = stepper.client_of(0).id();
     let server_entity = stepper
         .server_app
         .world_mut()
@@ -350,6 +368,10 @@ fn test_input_custom_rebroadcast() {
             Replicate::to_clients(NetworkTarget::All),
             PredictionTarget::to_clients(NetworkTarget::All),
             ActionState::<MyInput>::default(),
+            ControlledBy {
+                owner: client_of_0,
+                lifetime: Default::default(),
+            },
         ))
         .id();
     stepper.frame_step_server_first(1);

--- a/lightyear_tests/src/client_server/prediction/rollback.rs
+++ b/lightyear_tests/src/client_server/prediction/rollback.rs
@@ -718,19 +718,29 @@ fn setup_stepper_for_input_rollback(
     prediction_manager.rollback_policy.input = mode;
     prediction_manager.rollback_policy.state = RollbackMode::Disabled;
 
+    let client_of_1 = stepper.client_of(1).id();
+    let client_of_2 = stepper.client_of(2).id();
     let server_entity_1 = stepper
         .server_app
         .world_mut()
-        .spawn(Replicate::to_clients(NetworkTarget::AllExceptSingle(
-            PeerId::Netcode(2),
-        )))
+        .spawn((
+            Replicate::to_clients(NetworkTarget::AllExceptSingle(PeerId::Netcode(2))),
+            ControlledBy {
+                owner: client_of_1,
+                lifetime: Default::default(),
+            },
+        ))
         .id();
     let server_entity_2 = stepper
         .server_app
         .world_mut()
-        .spawn(Replicate::to_clients(NetworkTarget::AllExceptSingle(
-            PeerId::Netcode(1),
-        )))
+        .spawn((
+            Replicate::to_clients(NetworkTarget::AllExceptSingle(PeerId::Netcode(1))),
+            ControlledBy {
+                owner: client_of_2,
+                lifetime: Default::default(),
+            },
+        ))
         .id();
     stepper.frame_step_server_first(1);
 

--- a/lightyear_tests/src/host_server/input/native.rs
+++ b/lightyear_tests/src/host_server/input/native.rs
@@ -4,7 +4,7 @@ use lightyear::input::native::prelude::{InputMarker, NativeBuffer};
 use lightyear::prelude::input::native::ActionState;
 use lightyear_connection::network_target::NetworkTarget;
 use lightyear_messages::MessageManager;
-use lightyear_replication::prelude::{PredictionTarget, Replicate};
+use lightyear_replication::prelude::{ControlledBy, PredictionTarget, Replicate};
 use lightyear_sync::prelude::InputTimeline;
 use lightyear_sync::prelude::client::IsSynced;
 use test_log::test;
@@ -26,10 +26,17 @@ fn test_remote_client_replicated_input() {
 
     // SETUP
     // entity controlled by the remote client
+    let client_of_0 = stepper.client_of(0).id();
     let server_entity = stepper
         .server_app
         .world_mut()
-        .spawn(Replicate::to_clients(NetworkTarget::All))
+        .spawn((
+            Replicate::to_clients(NetworkTarget::All),
+            ControlledBy {
+                owner: client_of_0,
+                lifetime: Default::default(),
+            },
+        ))
         .id();
 
     stepper.frame_step(2);
@@ -92,12 +99,17 @@ fn test_remote_client_predicted_input() {
     let mut stepper = ClientServerStepper::from_config(StepperConfig::host_server());
 
     // SETUP
+    let client_of_0 = stepper.client_of(0).id();
     let server_entity = stepper
         .server_app
         .world_mut()
         .spawn((
             Replicate::to_clients(NetworkTarget::All),
             PredictionTarget::to_clients(NetworkTarget::All),
+            ControlledBy {
+                owner: client_of_0,
+                lifetime: Default::default(),
+            },
         ))
         .id();
 


### PR DESCRIPTION
Here are two input validation bugs that I found during my tinkering and prompting Claude. Note, there is downstream impact related to `ControlledBy` now being enforced. If you want the doc and examples updated as well, let me know. Or if you prefer more compact comments on the code.

---

## The bug — two related input-pipeline security gaps

### 1. Spoofed `InputTarget::Entity` lets a modified client hijack any entity

`lightyear_inputs/src/server.rs::receive_input_message` reads `InputTarget::Entity(entity)` from the wire and writes the inputs to that entity's `InputBuffer` with **no authorization check**. Note that #1361's new client-side `ControlledBy` filter in `prepare_input_message` does NOT close this gap on its own: `ControlledBy` is server-side state and is never replicated to clients, so the client filter only kicks in when a user manually inserts `ControlledBy` on the local replica — and a tampered client trivially skips the check anyway. The receive path itself must enforce the boundary.

```rust
// lightyear_inputs/src/server.rs (upstream main, paraphrased)
for data in message.inputs {
    let Some(entity) = (match data.target {
        InputTarget::Entity(entity) => Some(entity),
        InputTarget::PreSpawned(hash) => ...,
    }) else { continue };
    if let Ok(buffer) = query.get_mut(entity) {
        // ...writes data into entity's InputBuffer with no check that
        //   `entity` belongs to the sending client.
    }
}
```



The legitimate client-side `prepare_input_message` filters by `With<InputMap<A>>`, so a well-behaved client only emits inputs for entities it controls. A modified client bypasses this filter:

1. The client observes another player's entity via normal replication. Its `SendEntityMap` is populated bidirectionally — `local_to_remote` maps the client's local id to the server-local id, marked "already mapped" so the receive-side mapper accepts the id as-is.
2. The modified client puts an `InputMap` on the foreign entity's local replica (or builds the message manually) and sends `InputTarget::Entity(victim_local_id)`.
3. `SendEntityMap` remaps it to `victim_server_id` with the "already mapped" flag.
4. Server's `receive_input_message` accepts it, writes to victim's `InputBuffer`.
5. Server's `update_action_state` applies it to victim's `ActionState.fixed_update_state` next tick.

Any server-side gameplay system running in `FixedUpdate` (most game logic) now sees the attacker's input on the victim's entity.

### 2. Unbounded `end_tick` lets a client exhaust server memory

`InputBuffer::set_raw` (called transitively from `receive_input_message`) extends its `VecDeque` to fit any `tick` value passed to it, filling intermediate entries with `SameAsPrecedent`:

```rust
// lightyear_inputs/src/input_buffer.rs
if tick > end_tick {
    for _ in 0..(tick - end_tick - 1) {
        self.buffer.push_back(Compressed::SameAsPrecedent);
    }
    self.buffer.push_back(value);
}
```

A modified client sending `end_tick = server_tick + 30_000` triggers a 30 000-entry allocation per message; repeated across messages and connections, the server is memory-exhausted.

## The fix

Two `pub(crate)` helpers in `lightyear_inputs/src/server.rs`, both wired into `receive_input_message` BEFORE the rebroadcast and per-target-apply paths.

### `is_input_target_authorized`

The natural authorization map is `ControlledByRemote` — the relationship-target component on a peer's connection entity, auto-populated when `ControlledBy { owner: peer }` is added to a controlled entity. The helper checks list membership:

```rust
pub(crate) fn is_input_target_authorized(
    target_entity: Entity,
    controlled_by_remote: Option<&ControlledByRemote>,
) -> bool {
    match controlled_by_remote {
        None => false,
        Some(controlled) => controlled.collection().contains(&target_entity),
    }
}
```

Returns `false` when the peer has no `ControlledByRemote` at all (no controlled entities yet) or when the target isn't in the list.

### `is_input_within_lookahead`

```rust
pub(crate) fn is_input_within_lookahead(end_tick: Tick, server_tick: Tick) -> bool {
    let delta = end_tick - server_tick;  // i32, via wrapping_diff
    delta <= MAX_INPUT_LOOKAHEAD_TICKS && delta >= -MAX_INPUT_PAST_TICKS
}
```

Post-#1361, `Tick` is `u32` and `Tick - Tick` returns `i32`. The forward bound (`MAX_INPUT_LOOKAHEAD_TICKS = 64`) is what blocks the unbounded-allocation DOS — a forged `end_tick = server_tick + 30_000` no longer fits, and the receive path drops the message before `InputBuffer::set_raw` can extend the buffer. The **symmetric past bound** (`-MAX_INPUT_PAST_TICKS = -256`) is cheap belt-and-suspenders: in the `i32` regime, the wrap-around vector at `+2^31` requires the server to run ~1.06 years of continuous ticks at 64 Hz to reach the boundary, so it's practically unreachable, but the past bound is still useful for rejecting absurdly stale messages (256 ticks at 64 Hz ≈ 4 s of network lag — legitimate clients should not be that far behind).

### Wired into `receive_input_message`

```rust
// 1. existing early-return for is_local() + !rebroadcast
// 2. NEW: drop message if end_tick outside the lookahead window
if !is_input_within_lookahead(message.end_tick, tick) {
    trace!(...);
    return Ok(())
}
// 3. interpolation-delay update (moved here so it runs even if filter empties)
#[cfg(feature = "interpolation")]
if let Some(delay) = message.interpolation_delay { ... }
// 4. NEW: filter inputs by authorization (bypass for is_local() host-server)
if !client_id.is_local() {
    message.inputs.retain(|data| match data.target {
        InputTarget::Entity(entity) =>
            is_input_target_authorized(entity, controlled_by_remote),
        InputTarget::PreSpawned(_) => true,  // hash-based, separate concern
    });
    if message.inputs.is_empty() { return Ok(()) }
}
// 5. rebroadcast (existing — now safely operates on filtered message)
// 6. per-target apply (existing — auth check removed, filter handled it)
```

`InputTarget::PreSpawned(hash)` bypasses the authorization check at the call site. The hash is computed from spawn tick + sorted component net-IDs + optional user salt; a client that knows the convention CAN potentially forge a colliding hash for a constant user-salted PreSpawned. This is a pre-existing risk that pre-dates this patch and is out of scope here; a follow-up could extend `PreSpawned` with an `owner: Entity` or similar binding.

### Why filter pre-rebroadcast, not at the per-target apply step

If the auth check ran only inside the per-target apply loop, the `#[cfg(feature = "prediction")]` rebroadcast block above it would forward forged inputs to all OTHER clients before the server dropped them locally. The server would effectively become a spam relay for forged input messages. Moving the check into a `retain` filter before the rebroadcast closes that hole — both the rebroadcast and the per-target apply operate on the already-filtered message.

### Why `is_local()` bypass

Host-server mode runs a client in-process with the server. Local clients drive their inputs through the server's in-process state path and may not have a `ControlledByRemote` relationship populated the same way (since the existing early-return for `is_local() && !rebroadcast_inputs` already short-circuits the common host-server path). Skipping the authorization filter for `is_local()` is consistent with that existing exemption and matches the trust model — a host client IS the server.

### Why `ControlledBy` rather than `HasAuthority` / `AuthorityPeer`

The filter uses `ControlledByRemote` (the relationship-target of `ControlledBy`), not the replication-authority components (`HasAuthority` / `AuthorityPeer`). These are two distinct concepts in lightyear:

- **`ControlledBy { owner }`** — semantic ownership. "This entity is owned by peer X for input/lifetime purposes." Set at spawn and rarely changes.
- **`HasAuthority` / `AuthorityPeer`** — dynamic simulation authority. "This peer currently simulates this entity's state and is allowed to send replication updates for it." Can transfer at runtime via `GiveAuthority` / `RequestAuthority`.

`examples/distributed_authority` uses both, in the way they're designed for: player entities are spawned with `ControlledBy { owner: client }` (inputs flow from `client`); ball entities use `GiveAuthority` to transfer simulation authority between peers (motion driven by a `With<HasAuthority>` filter, NOT by input messages). The two concepts intentionally decouple.

For input authorization, `ControlledBy` is the right map: a peer's inputs apply to their owned entities, regardless of who's currently simulating which entity.

**Caveat for advanced use.** If you have a use case where input authority itself needs to follow authority transfer (e.g. a vehicle multiple players take turns driving via inputs), you'll need to update `ControlledBy` alongside the `GiveAuthority` call. Most games don't need this — `distributed_authority` does not — but the docstring on `is_input_target_authorized` flags it so users hitting this pattern know what to update.

## Test — TDD-first: behavioural red on bare main, then green

The integration tests were written FIRST against bare `upstream/main` (no fix) to confirm both vulnerabilities are reachable on the current tip, then the fix was applied to flip them green.

### Unit tests (`lightyear_inputs::server::patch_tests`)

Six tests covering both helpers:

```
patch_tests::authorization_rejects_when_controlled_by_remote_is_none
patch_tests::authorization_accepts_legitimate_target_and_rejects_foreign
patch_tests::lookahead_accepts_within_forward_bound
patch_tests::lookahead_accepts_within_past_bound
patch_tests::lookahead_rejects_wraparound_far_future
patch_tests::lookahead_rejects_wraparound_at_high_server_tick
```

The wrap-around tests cover the `i32::MAX`-side boundary at both a low server tick and an upper-half-of-`u32` server tick to verify the symmetric bound catches the `i32` overflow at any server-tick position. While `i32` wrap-around is practically unreachable in real-world server uptime (~1 year at 64 Hz), the unit tests defend the invariant in case future changes alter the tick type or arithmetic.

### Integration tests (`lightyear_tests/src/client_server/input/leafwing.rs`)

```
test_input_message_with_spoofed_target_is_rejected
test_input_message_with_only_spoofed_targets_filters_to_empty
test_input_message_with_huge_end_tick_does_not_allocate_unbounded_buffer
```

**Test 1 — spoofed-target attack.** Sets up 2 clients, two server entities (one per client) with `ControlledBy`. On client 0, it inserts `InputMap<LeafwingInput1>` on BOTH local replicas: `KeyJ → Jump` on the victim's, `KeyA → Jump` on the attacker's own. Holding both keys means the legitimate `prepare_input_message` query emits messages for both — one with `target = victim_server_entity` (the attack) and one with `target = attacker_server_entity` (legitimate). Two assertions:

- **Negative (defense):** victim's server-side `ActionState::pressed(&Jump)` is `false`.
- **Positive (non-overblocking):** attacker's server-side `ActionState::pressed(&Jump)` is `true`.

The negative assertion catches the spoofed-target attack landing. The positive assertion catches an over-broad defense that drops all cross-client inputs.

**Test 2 — empty-after-filter early-return.** Sets up just the victim entity, no entity for client 0. Client 0 forges an input message targeting the victim. After server-side `retain`, `message.inputs` is empty and the early-return branch fires. Covers a code path the first test never reaches (always leaves at least one authorized entry).

**Test 3 — end_tick DOS.** End-to-end via public `MessageSender::send::<InputChannel>` (no test-only API additions). Builds an `InputMessage<LeafwingSequence<LeafwingInput1>>` on the client side with `end_tick = server_tick + 30_000`, sends it from a client that legitimately owns the target entity. After the server's receive runs, asserts that the target's `InputBuffer::len()` is under 1000 (without the fix, it grows to ~30 000). Models exactly what a modified client binary could do — there are no internal-API hooks.

### Behavioural red (bare upstream/main, no fix)

All three integration tests fail with explicit security-failure messages:

```
test test_input_message_with_spoofed_target_is_rejected ... FAILED
  → "Server applied client 0's forged input to client 1's entity
     (`ActionState::pressed` shows Jump pressed)..."

test test_input_message_with_only_spoofed_targets_filters_to_empty ... FAILED
  → "spoofed-target input was applied despite client 0 controlling nothing..."

test test_input_message_with_huge_end_tick_does_not_allocate_unbounded_buffer ... FAILED
  → "DOS: server allocated 29998 entries in the InputBuffer for a single
     forged InputMessage with end_tick = server_tick + 30000..."
```

### Green (with the fix)

```
$ cargo test --package lightyear_tests --lib -- test_input_message_with

running 3 tests
test test_input_message_with_huge_end_tick_does_not_allocate_unbounded_buffer ... ok
test test_input_message_with_only_spoofed_targets_filters_to_empty ... ok
test test_input_message_with_spoofed_target_is_rejected ... ok

test result: ok. 3 passed; 0 failed

$ cargo test --package lightyear_inputs --lib --features server -- patch_tests

running 6 tests
test server::patch_tests::authorization_rejects_when_controlled_by_remote_is_none ... ok
test server::patch_tests::authorization_accepts_legitimate_target_and_rejects_foreign ... ok
test server::patch_tests::lookahead_accepts_within_forward_bound ... ok
test server::patch_tests::lookahead_accepts_within_past_bound ... ok
test server::patch_tests::lookahead_rejects_wraparound_far_future ... ok
test server::patch_tests::lookahead_rejects_wraparound_at_high_server_tick ... ok

test result: ok. 6 passed; 0 failed
```

### Full suite — no regressions

`cargo test -p lightyear_tests --lib -- --test-threads=1` (serial run, avoids unrelated parallel-test flakiness): **124 passed, 1 failed**. The single failure is `test_server_just_pressed`, a pre-existing upstream input-flow bug that also fails on bare `upstream/main`; not addressed by this patch.

## Safety / risk

**Correctness.** The authorization filter operates on `ControlledByRemote` membership, which is already lightyear's source of truth for which peer controls which entity. The semantics match the existing `prepare_input_message` send-side filter (`With<InputMap<A>>`) — a legitimate client only emits inputs for entities it has `InputMap` on, and those entities are the ones marked `ControlledBy { owner: client }` on the server. The receive-side filter just enforces what the send-side already does for honest clients.

**Past-tick rejection.** Past-direction messages were previously handled harmlessly by `InputBuffer::set_raw`'s start-tick guard. The new `MAX_INPUT_PAST_TICKS = 256` bound is a security tightening — past messages > 256 ticks behind are now dropped at receive instead of being silently discarded by `set_raw`. 256 ticks at 64 Hz is ~4 seconds of network lag; legitimate clients should not be that far behind. If a use case needs a higher bound, the constant can be raised — happy to make it configurable via `ServerInputConfig` if reviewers prefer.

**Host-server mode.** The `is_local()` bypass mirrors the existing early-return at the top of `receive_input_message`. Host clients pass through both gates unchanged.

**Authority transfer.** Documented in the helper docstring: callers must reinsert `ControlledBy` when transferring authority. No code change to the existing authority API.

**Performance.** One additional component fetch per peer per tick (the `Option<&ControlledByRemote>` query addition). One `retain` pass per received `InputMessage`. Both are negligible.

**Compatibility risk for other consumers.** Zero — both helpers are `pub(crate)`. `receive_input_message` is a private system; this PR changes its internal behaviour but doesn't alter any public API surface.

## Behavior change for downstream users

This is the deliberate, security-positive consequence of the patch:

> **An input-bearing server entity now MUST have `ControlledBy { owner: <client peer entity> }` for the server to accept inputs targeting it.**

That requirement was previously implicit (matched what `examples/distributed_authority` and other real games already do) but unenforced. Most existing code already conforms — anything that uses `ControlledBy` to express ownership at spawn is unaffected. The change bites tests and toy setups that drove inputs through entities without `ControlledBy`.

**Test patches included in this PR** for upstream tests that were previously relying on the missing enforcement:

- `lightyear_tests/src/client_server/input/leafwing.rs`
  — `test_leafwing_input_rebroadcast`, `test_rebroadcast_initializes_action_state_from_buffer`
- `lightyear_tests/src/client_server/input/bei.rs`
  — `test_input_broadcasting_prediction`
- `lightyear_tests/src/client_server/input/native.rs`
  — `test_remote_client_replicated_input`, `test_remote_client_predicted_input`,
    `test_input_broadcasting_prediction`, `test_input_custom_rebroadcast`
- `lightyear_tests/src/host_server/input/native.rs`
  — `test_remote_client_replicated_input`, `test_remote_client_predicted_input`
- `lightyear_tests/src/client_server/prediction/rollback.rs`
  — `setup_stepper_for_input_rollback` (covers `test_input_rollback_always_mode`,
    `test_last_confirmed_input_multiple_clients`,
    `test_input_rollback_check_mode_earliest_mismatch`,
    `test_no_rollback_without_input_mismatches`)

Each patch is a small addition: `let client_of_N = stepper.client_of(N).id();` before the spawn, plus `ControlledBy { owner: client_of_N, lifetime: Default::default() }` in the spawn bundle. No semantic change to the tests' intent.

**Docs the maintainer may want to update** (intentionally not in this PR — flagging for direction):
- `book/src/concepts/advanced_replication/inputs.md` — should mention that input-bearing entities need `ControlledBy { owner: client }` for server acceptance under the new auth filter.
- The doc-comment on `receive_input_message` (or `ServerInputPlugin`) could reference `is_input_target_authorized` so users tracing input flow find the gate.
- `examples/*` — spot-checked, the input-using examples already set `ControlledBy`. No changes needed.

## Related

This is one of several PRs sharing root-cause analysis from a downstream project that hit the input-pipeline-trust class of bugs:

- #1470 *(sync floor)*: keeps the client tick ahead of the server's read tick.
- #1471 *(server pop wipe)*: keeps a fallback input live for the `get_predict` path.
- **This PR**: closes the trust-boundary holes — clients can't forge inputs for entities they don't control, and can't exhaust server memory via crafted `end_tick`.