### PR TITLE
Add gain authority regression unit test for issue #1347

### DIFF
--- a/lightyear_replication/src/send.rs
+++ b/lightyear_replication/src/send.rs
@@ -834,6 +834,15 @@ mod tests {
         assert_eq!(app.world().resource::<ServerTick>().get(), 2);
         assert_eq!(app.world().resource::<SendCount>().0, 2);
     }
+
+    #[test]
+    fn gain_authority_without_existing_entry() {
+        let mut state = ReplicationState::default();
+        let sender = Entity::from_raw_u32(0).unwrap();
+
+        state.gain_authority(sender);
+        assert!(state.has_authority(sender));
+    }
 }
 
 pub struct SendPlugin;


### PR DESCRIPTION
Addresses the second part of this issue with a unit test for the gain authority method: https://github.com/cBournhonesque/lightyear/issues/1347

With [`.or_insert_with(PerSenderReplicationState::with_authority);` in `#gain_authority`](https://github.com/cBournhonesque/lightyear/pull/1361/changes#diff-5b9818d41607b05f281fe8b75c078301de678e2caed7cdc201da992a690b4278R156) commented out: `assertion failed: state.has_authority(sender)`

With [that change](https://github.com/cBournhonesque/lightyear/pull/1361/changes#diff-5b9818d41607b05f281fe8b75c078301de678e2caed7cdc201da992a690b4278R156):
`test send::tests::gain_authority_without_existing_entry ... ok`
