### PR TITLE
Add replicate-once component registration

### DIFF
--- a/examples/deterministic_replication/src/protocol.rs
+++ b/examples/deterministic_replication/src/protocol.rs
@@ -1,6 +1,5 @@
 use avian2d::prelude::*;
 use bevy::prelude::*;
-use bevy_replicon::prelude::AppRuleExt;
 use leafwing_input_manager::prelude::*;
 use lightyear::input::config::InputConfig;
 use lightyear::prelude::input::leafwing;
@@ -117,24 +116,24 @@ impl Plugin for ProtocolPlugin {
         // add_confirmed_write ensures the replicated value goes to
         // PredictionHistory as confirmed state (instead of overwriting the
         // component), so input-triggered rollbacks snap to the correct value.
-        app.replicate_once::<Position>();
+        app.register_component_once::<Position>();
         app.add_rollback::<Position>()
             .add_confirmed_write()
             .add_custom_hash(lightyear_avian2d::types::position::hash)
             .register_linear_interpolation()
             .add_linear_correction_fn();
 
-        app.replicate_once::<Rotation>();
+        app.register_component_once::<Rotation>();
         app.add_rollback::<Rotation>()
             .add_confirmed_write()
             .add_custom_hash(lightyear_avian2d::types::rotation::hash)
             .register_linear_interpolation()
             .add_linear_correction_fn();
 
-        app.replicate_once::<LinearVelocity>();
+        app.register_component_once::<LinearVelocity>();
         app.add_rollback::<LinearVelocity>().add_confirmed_write();
 
-        app.replicate_once::<AngularVelocity>();
+        app.register_component_once::<AngularVelocity>();
         app.add_rollback::<AngularVelocity>().add_confirmed_write();
     }
 }

--- a/lightyear_replication/src/REPLICON_INTEGRATION.md
+++ b/lightyear_replication/src/REPLICON_INTEGRATION.md
@@ -128,10 +128,9 @@ Action entities (spawned by `bevy_enhanced_input`) need to be replicated via the
 
 ### Priority 4: Replication Edge Cases
 
-**Affects**: 4 replication tests
+**Affects**: 3 replication tests
 
 - **`test_component_remove_not_replicating`**: Removing `Replicated` with replicon causes a despawn on remote, not a pause. Need a different mechanism to pause/resume replication.
-- **`test_component_replicate_once`**: `CompReplicateOnce` is not registered in replicon. Needs `app.replicate::<CompReplicateOnce>()`.
 - **`test_owned_by`**: `ControlledBy` + disconnect behavior not integrated with replicon.
 - **`test_reinsert_replicate`**: Crossbeam channel disconnects during `Replicate` re-insertion. Likely a race condition in transport channel teardown/recreation.
 
@@ -145,4 +144,3 @@ Action entities (spawned by `bevy_enhanced_input`) need to be replicated via the
 
 - **Delta compression**: The old delta compression system was removed. If needed, investigate replicon's built-in delta support or re-implement on top of replicon's `RuleFns`.
 - **Multi-threaded test stability**: Tests crash with SIGABRT when run multi-threaded due to bevy's shared `ComputeTaskPool`. Currently requires `--test-threads=1`.
-- **`ReplicateOnce` support**: Need to implement one-shot replication for components that should be sent once and not tracked for changes.

--- a/lightyear_replication/src/registry/mod.rs
+++ b/lightyear_replication/src/registry/mod.rs
@@ -15,8 +15,6 @@ use core::any::TypeId;
 use lightyear_core::network::NetId;
 use lightyear_serde::SerializationError;
 use lightyear_utils::registry::{RegistryHash, RegistryHasher, TypeKind, TypeMapper};
-use serde::de::DeserializeOwned;
-use serde::ser::Serialize;
 #[allow(unused_imports)]
 use tracing::{debug, info, trace};
 
@@ -68,7 +66,12 @@ impl From<TypeId> for ComponentKind {
 /// You register components by calling the [`register_component`](AppComponentExt::register_component) method directly on the App.
 ///
 /// By default, a component needs to implement `Serialize` and `Deserialize`, but you can also provide your own
-/// serialization functions by using the [`register_component_custom_serde`](AppComponentExt::register_component_custom_serde) method.
+/// serialization functions by using the [`register_component_with`](AppComponentExt::register_component_with) method.
+///
+/// Components that should only send insertions and removals can use
+/// [`register_component_once`](AppComponentExt::register_component_once). For
+/// once-replicated components with custom serialization, use
+/// [`register_component_once_with`](AppComponentExt::register_component_once_with).
 ///
 /// ```rust
 /// # use bevy_app::App;
@@ -180,10 +183,7 @@ impl ComponentRegistry {
         self.kind_map.net_id(&ComponentKind::of::<C>()).is_some()
     }
 
-    pub fn register_component<C: Component + Serialize + DeserializeOwned>(
-        &mut self,
-        world: &mut World,
-    ) {
+    pub fn register_component<C: Component>(&mut self, world: &mut World) {
         let component_kind = self.kind_map.add::<C>();
         let component_id = world.register_component::<C>();
         self.component_id_to_kind
@@ -226,37 +226,4 @@ impl TransformLinearInterpolation {
         );
         res
     }
-}
-
-#[cfg(test)]
-mod tests {
-    // use super::*;
-    // use crate::serialize::writer::Writer;
-    // use crate::shared::replication::entity_map::SendEntityMap;
-    // use crate::tests::protocol::*;
-    //
-    // #[test]
-    // fn test_custom_serde() {
-    //     let mut world = World::new();
-    //     let mut registry = ComponentRegistry::default();
-    //     registry.register_component_custom_serde::<ComponentSyncModeSimple>(
-    //         &mut world,
-    //         SerializeFns {
-    //             serialize: serialize_component2,
-    //             deserialize: deserialize_component2,
-    //         },
-    //     );
-    //     let mut component = ComponentSyncModeSimple(1.0);
-    //     let mut writer = Writer::default();
-    //     registry
-    //         .serialize(&mut component, &mut writer, &mut SendEntityMap::default())
-    //         .unwrap();
-    //     let data = writer.to_bytes();
-    //
-    //     let mut reader = Reader::from(data);
-    //     let read = registry
-    //         .deserialize(&mut reader, &mut ReceiveEntityMap::default())
-    //         .unwrap();
-    //     assert_eq!(component, read);
-    // }
 }

--- a/lightyear_replication/src/registry/replication.rs
+++ b/lightyear_replication/src/registry/replication.rs
@@ -2,7 +2,7 @@ use crate::registry::ComponentRegistry;
 use bevy_app::App;
 use bevy_ecs::change_detection::Mut;
 use bevy_ecs::component::Component;
-use bevy_replicon::prelude::{AppRuleExt, RuleFns};
+use bevy_replicon::prelude::{AppRuleExt, ReplicationMode, RuleFns};
 use bevy_replicon::shared::replication::registry::receive_fns::MutWrite;
 use bevy_replicon::shared::replication::registry::rule_fns::{DeserializeFn, SerializeFn};
 use serde::{Serialize, de::DeserializeOwned};
@@ -15,10 +15,28 @@ pub trait AppComponentExt {
         &mut self,
     ) -> ComponentRegistration<'_, C>;
 
+    /// Registers the component in the Registry with `ReplicationMode::Once`.
+    ///
+    /// This component can now be sent over the network, but only insertions and
+    /// removals are replicated. Component mutations are not sent.
+    fn register_component_once<
+        C: Component<Mutability: MutWrite<C>> + Serialize + DeserializeOwned,
+    >(
+        &mut self,
+    ) -> ComponentRegistration<'_, C>;
+
     /// Registers the component in the Registry: this component can now be sent over the network.
     ///
-    /// You need to provide your own [`SerializeFns`]
+    /// You need to provide your own serialization functions.
     fn register_component_with<C: Component<Mutability: MutWrite<C>>>(
+        &mut self,
+        serialize_fn: SerializeFn<C>,
+        deserialize_fn: DeserializeFn<C>,
+    ) -> ComponentRegistration<'_, C>;
+
+    /// Registers the component in the Registry with custom serialization and
+    /// `ReplicationMode::Once`.
+    fn register_component_once_with<C: Component<Mutability: MutWrite<C>>>(
         &mut self,
         serialize_fn: SerializeFn<C>,
         deserialize_fn: DeserializeFn<C>,
@@ -38,21 +56,18 @@ impl AppComponentExt for App {
     fn register_component<C: Component<Mutability: MutWrite<C>> + Serialize + DeserializeOwned>(
         &mut self,
     ) -> ComponentRegistration<'_, C> {
-        if self
-            .world_mut()
-            .get_resource_mut::<ComponentRegistry>()
-            .is_none()
-        {
-            self.world_mut().init_resource::<ComponentRegistry>();
-        }
-        self.world_mut()
-            .resource_scope(|world, mut registry: Mut<ComponentRegistry>| {
-                if !registry.is_registered::<C>() {
-                    registry.register_component::<C>(world);
-                }
-            });
-
+        register_component_metadata::<C>(self);
         self.replicate::<C>();
+        ComponentRegistration::new(self)
+    }
+
+    fn register_component_once<
+        C: Component<Mutability: MutWrite<C>> + Serialize + DeserializeOwned,
+    >(
+        &mut self,
+    ) -> ComponentRegistration<'_, C> {
+        register_component_metadata::<C>(self);
+        self.replicate_once::<C>();
         ComponentRegistration::new(self)
     }
 
@@ -61,7 +76,21 @@ impl AppComponentExt for App {
         serialize_fn: SerializeFn<C>,
         deserialize_fn: DeserializeFn<C>,
     ) -> ComponentRegistration<'_, C> {
+        register_component_metadata::<C>(self);
         self.replicate_with(RuleFns::new(serialize_fn, deserialize_fn));
+        ComponentRegistration::new(self)
+    }
+
+    fn register_component_once_with<C: Component<Mutability: MutWrite<C>>>(
+        &mut self,
+        serialize_fn: SerializeFn<C>,
+        deserialize_fn: DeserializeFn<C>,
+    ) -> ComponentRegistration<'_, C> {
+        register_component_metadata::<C>(self);
+        self.replicate_with((
+            RuleFns::new(serialize_fn, deserialize_fn),
+            ReplicationMode::Once,
+        ));
         ComponentRegistration::new(self)
     }
 
@@ -70,6 +99,22 @@ impl AppComponentExt for App {
     ) -> ComponentRegistration<'_, C> {
         ComponentRegistration::new(self)
     }
+}
+
+fn register_component_metadata<C: Component>(app: &mut App) {
+    if app
+        .world_mut()
+        .get_resource_mut::<ComponentRegistry>()
+        .is_none()
+    {
+        app.world_mut().init_resource::<ComponentRegistry>();
+    }
+    app.world_mut()
+        .resource_scope(|world, mut registry: Mut<ComponentRegistry>| {
+            if !registry.is_registered::<C>() {
+                registry.register_component::<C>(world);
+            }
+        });
 }
 
 pub struct ComponentRegistration<'a, C> {

--- a/lightyear_tests/src/client_server/deterministic/protocol.rs
+++ b/lightyear_tests/src/client_server/deterministic/protocol.rs
@@ -10,7 +10,6 @@
 use avian2d::prelude::*;
 use bevy::prelude::*;
 use bevy_enhanced_input::prelude::*;
-use bevy_replicon::prelude::AppRuleExt;
 use bevy_replicon::server::visibility::registry::FilterRegistry;
 use lightyear::frame_interpolation::{FrameInterpolate, FrameInterpolationPlugin};
 use lightyear::input::bei::prelude::BEIBuffer;
@@ -157,24 +156,24 @@ impl Plugin for DetProtocolPlugin {
         app.register_component::<DetPlayerId>();
         app.register_component::<DetPlayerActivationTick>();
 
-        app.replicate_once::<Position>();
+        app.register_component_once::<Position>();
         app.add_rollback::<Position>()
             .add_confirmed_write()
             .add_custom_hash(lightyear_avian2d::types::position::hash)
             .register_linear_interpolation()
             .add_linear_correction_fn();
 
-        app.replicate_once::<Rotation>();
+        app.register_component_once::<Rotation>();
         app.add_rollback::<Rotation>()
             .add_confirmed_write()
             .add_custom_hash(lightyear_avian2d::types::rotation::hash)
             .register_linear_interpolation()
             .add_linear_correction_fn();
 
-        app.replicate_once::<LinearVelocity>();
+        app.register_component_once::<LinearVelocity>();
         app.add_rollback::<LinearVelocity>().add_confirmed_write();
 
-        app.replicate_once::<AngularVelocity>();
+        app.register_component_once::<AngularVelocity>();
         app.add_rollback::<AngularVelocity>().add_confirmed_write();
 
         // Apply movement via a Fire observer on the action.

--- a/lightyear_tests/src/client_server/replication.rs
+++ b/lightyear_tests/src/client_server/replication.rs
@@ -1,6 +1,6 @@
 //! Check various replication scenarios between 2 peers only
 
-use crate::protocol::{CompA, CompCustomInterp, CompReplicateOnce};
+use crate::protocol::{CompA, CompCustomInterp, CompCustomReplicateOnce, CompReplicateOnce};
 use crate::stepper::*;
 use bevy::prelude::{Bundle, Entity, Name, With, World};
 use bevy_replicon::prelude::Replicated;
@@ -811,6 +811,91 @@ fn test_component_replicate_once() {
             updated_comp,
             Some(CompReplicateOnce(1.0)),
             "replicate_once component updates should not replicate for {direction:?}"
+        );
+
+        with_source_world(&mut stepper, direction, |world| {
+            world
+                .entity_mut(source_entity)
+                .remove::<CompReplicateOnce>();
+        });
+        stepper.frame_step(direction.propagation_frames());
+
+        let removed = with_target_world(&mut stepper, direction, |world| {
+            world
+                .entity(mirrored_entity)
+                .get::<CompReplicateOnce>()
+                .is_none()
+        });
+        assert!(
+            removed,
+            "replicate_once component remove should replicate for {direction:?}"
+        );
+    }
+}
+
+#[test]
+fn test_component_replicate_once_with_custom_serde() {
+    for direction in active_replication_directions() {
+        let mut stepper = ClientServerStepper::from_config(StepperConfig::single());
+
+        let source_entity = spawn_on_source(
+            &mut stepper,
+            direction,
+            (direction.replicate(), CompCustomReplicateOnce(1.0)),
+        );
+        stepper.frame_step(direction.propagation_frames());
+
+        let mirrored_entity = target_entity(&stepper, direction, source_entity)
+            .unwrap_or_else(|| panic!("entity is not present in entity map for {direction:?}"));
+        let initial_comp = with_target_world(&mut stepper, direction, |world| {
+            world
+                .entity(mirrored_entity)
+                .get::<CompCustomReplicateOnce>()
+                .cloned()
+        });
+        assert_eq!(
+            initial_comp,
+            Some(CompCustomReplicateOnce(1.0)),
+            "initial custom-serde replicate_once component should replicate for {direction:?}"
+        );
+
+        with_source_world(&mut stepper, direction, |world| {
+            world
+                .entity_mut(source_entity)
+                .get_mut::<CompCustomReplicateOnce>()
+                .unwrap()
+                .0 = 2.0;
+        });
+        stepper.frame_step(direction.propagation_frames());
+
+        let updated_comp = with_target_world(&mut stepper, direction, |world| {
+            world
+                .entity(mirrored_entity)
+                .get::<CompCustomReplicateOnce>()
+                .cloned()
+        });
+        assert_eq!(
+            updated_comp,
+            Some(CompCustomReplicateOnce(1.0)),
+            "custom-serde replicate_once component updates should not replicate for {direction:?}"
+        );
+
+        with_source_world(&mut stepper, direction, |world| {
+            world
+                .entity_mut(source_entity)
+                .remove::<CompCustomReplicateOnce>();
+        });
+        stepper.frame_step(direction.propagation_frames());
+
+        let removed = with_target_world(&mut stepper, direction, |world| {
+            world
+                .entity(mirrored_entity)
+                .get::<CompCustomReplicateOnce>()
+                .is_none()
+        });
+        assert!(
+            removed,
+            "custom-serde replicate_once component remove should replicate for {direction:?}"
         );
     }
 }

--- a/lightyear_tests/src/protocol.rs
+++ b/lightyear_tests/src/protocol.rs
@@ -2,9 +2,12 @@
 use alloc::string::String;
 use avian2d::prelude::*;
 use bevy::ecs::entity::MapEntities;
+use bevy::ecs::error::Result;
 use bevy::prelude::*;
 use bevy_enhanced_input::prelude::InputAction;
-use bevy_replicon::prelude::AppRuleExt;
+use bevy_replicon::bytes::Bytes;
+use bevy_replicon::postcard_utils;
+use bevy_replicon::shared::replication::registry::ctx::{SerializeCtx, WriteCtx};
 use leafwing_input_manager::Actionlike;
 use lightyear::avian2d::plugin::AvianReplicationMode;
 use lightyear::frame_interpolation::FrameInterpolationPlugin;
@@ -51,6 +54,26 @@ pub struct CompDisabled(pub f32);
 
 #[derive(Component, Serialize, Deserialize, Clone, Debug, PartialEq, Reflect)]
 pub struct CompReplicateOnce(pub f32);
+
+#[derive(Component, Clone, Debug, PartialEq, Reflect)]
+pub struct CompCustomReplicateOnce(pub f32);
+
+fn serialize_custom_replicate_once(
+    _ctx: &SerializeCtx,
+    component: &CompCustomReplicateOnce,
+    message: &mut Vec<u8>,
+) -> Result<()> {
+    postcard_utils::to_extend_mut(&component.0, message)?;
+    Ok(())
+}
+
+fn deserialize_custom_replicate_once(
+    _ctx: &mut WriteCtx,
+    message: &mut Bytes,
+) -> Result<CompCustomReplicateOnce> {
+    let value = postcard_utils::from_buf(message)?;
+    Ok(CompCustomReplicateOnce(value))
+}
 
 #[derive(Component, Serialize, Deserialize, Clone, Debug, PartialEq, Reflect, MapEntities)]
 pub struct CompMap(#[entities] pub Entity);
@@ -178,7 +201,11 @@ impl Plugin for ProtocolPlugin {
         // components
         app.register_component::<CompA>();
         app.register_component::<CompS>();
-        app.replicate_once::<CompReplicateOnce>();
+        app.register_component_once::<CompReplicateOnce>();
+        app.register_component_once_with::<CompCustomReplicateOnce>(
+            serialize_custom_replicate_once,
+            deserialize_custom_replicate_once,
+        );
         app.register_component::<CompFull>()
             .add_prediction()
             .add_linear_interpolation();


### PR DESCRIPTION
## Summary

Adds Lightyear component-registration wrappers for Replicon's `ReplicationMode::Once`.

This restores the Lightyear-facing API for components that should replicate insertion/removal lifecycle events without sending ordinary mutations, while keeping the implementation aligned with the Replicon integration described in `lightyear_replication/src/REPLICON_INTEGRATION.md`.

## Changes

- Add `AppComponentExt::register_component_once::<C>()`
- Add `AppComponentExt::register_component_once_with::<C>(...)` for custom Replicon serde
- Share Lightyear component metadata registration across default, once, custom, and custom-once registration paths
- Update deterministic replication protocol setup to use the Lightyear wrapper instead of calling Replicon directly
- Remove stale Replicon integration TODO notes that said replicate-once was not wired
- Add coverage for replicate-once insertion, mutation suppression, removal, and custom-serde registration

## Notes

`ReplicationMode::Once` is implemented through Replicon's rule API rather than resurrecting the old Lightyear `ComponentReplicationConfig` path. This keeps the public Lightyear API small while following the direction of the Replicon migration.

The custom-serde test component intentionally does not derive `Serialize` or `Deserialize`, so the test verifies that quantized/custom component representations can still be registered through the new wrapper.

## Testing

- `cargo fmt --all`
- `cargo check -p lightyear_replication`
- `cargo check -p deterministic_replication`
- `cargo test -p lightyear_tests test_component_replicate_once -- --nocapture`
- `git diff --check`
