### PR TITLE
Use `last_confirmed_state` instead of ServerMutateTicks.last_tick

### DIFF
--- a/lightyear_prediction/src/checkpoint_ticks.rs
+++ b/lightyear_prediction/src/checkpoint_ticks.rs
@@ -1,7 +1,7 @@
 use bevy_replicon::prelude::RepliconTick;
 use lightyear_core::tick::Tick;
 use lightyear_replication::checkpoint::ReplicationCheckpointMap;
-use lightyear_replication::prelude::{ConfirmHistory, ServerMutateTicks};
+use lightyear_replication::prelude::ConfirmHistory;
 
 pub(crate) fn resolve_message_tick(
     checkpoints: &ReplicationCheckpointMap,
@@ -15,13 +15,6 @@ pub(crate) fn resolve_confirm_history_tick(
     history: &ConfirmHistory,
 ) -> Option<Tick> {
     resolve_message_tick(checkpoints, history.last_tick())
-}
-
-pub(crate) fn resolve_server_mutate_tick(
-    checkpoints: &ReplicationCheckpointMap,
-    ticks: &ServerMutateTicks,
-) -> Option<Tick> {
-    resolve_message_tick(checkpoints, ticks.last_tick())
 }
 
 #[cfg(test)]

--- a/lightyear_prediction/src/manager.rs
+++ b/lightyear_prediction/src/manager.rs
@@ -118,15 +118,23 @@ impl LastConfirmedInput {
 
 /// Stores metadata related to state-based prediction.
 ///
-/// Key invariant: `ServerMutateTicks.last_tick = T` guarantees that for all entities,
+/// Key invariant: `last_confirmed_tick = T` guarantees that for all entities,
 /// we have complete information at tick T:
 /// - Entities that received an update at T: their confirmed value is in the message
 /// - Entities that didn't receive an update: their value at T = their last confirmed value
 ///   (because if a message was lost/in-flight, the server would resend on the next tick)
 #[derive(Resource, Clone, Copy, Debug, Default, Reflect)]
 pub struct StateRollbackMetadata {
-    /// The last tick where we processed `ServerMutateTicks`.
-    /// Used to detect when `ServerMutateTicks.last_tick` advances.
+    /// The latest authoritative tick for which all mutate messages were received.
+    last_confirmed_tick: Option<Tick>,
+
+    /// The last confirmed tick where we checked unchanged entities.
+    ///
+    /// This is separate from `last_confirmed_tick`: a confirmed tick can stay
+    /// unchanged across many frames, and `check_rollback` only needs to scan
+    /// unchanged entities once per completed tick. If the confirmed tick is in
+    /// the client's future, it is not marked processed yet so the check can be
+    /// retried once local prediction history reaches that tick.
     last_processed_tick: Option<Tick>,
 
     /// The earliest tick where we detected a mismatch this frame.
@@ -189,6 +197,25 @@ impl StateRollbackMetadata {
         self.forced_rollback_tick
     }
 
+    /// Latest authoritative tick for which all mutate messages were received.
+    pub fn last_confirmed_tick(&self) -> Option<Tick> {
+        self.last_confirmed_tick
+    }
+
+    /// Record a newly completed mutate tick.
+    pub fn record_last_confirmed_tick(&mut self, tick: Tick) {
+        match self.last_confirmed_tick {
+            None => self.last_confirmed_tick = Some(tick),
+            Some(existing) if tick > existing => self.last_confirmed_tick = Some(tick),
+            _ => {}
+        }
+    }
+
+    /// Reset all connection-scoped rollback metadata.
+    pub(crate) fn reset_connection_state(&mut self) {
+        *self = Self::default();
+    }
+
     /// Reset the per-frame state tracking.
     /// Note: `should_rollback` and `earliest_mismatch_tick` are NOT reset here
     /// because they need to persist until consumed by `check_rollback`.
@@ -231,18 +258,28 @@ impl StateRollbackMetadata {
         Some(mismatch_tick)
     }
 
-    /// Returns the last processed tick (for checking if ServerMutateTicks advanced)
+    /// Returns the last confirmed tick that was processed for unchanged entities.
+    ///
+    /// Used to skip the unchanged-entity rollback check when `last_confirmed_tick`
+    /// has not advanced since the last successful check.
     pub fn last_processed_tick(&self) -> Option<Tick> {
         self.last_processed_tick
     }
 
-    /// Update the last processed tick after we've handled ServerMutateTicks advancement
+    /// Update the last processed tick after we've handled confirmed mutate tick advancement.
+    ///
+    /// Call this only after the unchanged-entity rollback check has actually run
+    /// for the tick, not while the confirmed tick is still in the client's future.
     pub fn set_last_processed_tick(&mut self, tick: Tick) {
         self.last_processed_tick = Some(tick);
     }
 
-    /// Check if ServerMutateTicks has advanced since we last processed it
-    pub fn has_server_mutate_ticks_advanced(&self, current_tick: Tick) -> bool {
+    /// Check if the completed mutate tick has advanced since we last processed it.
+    ///
+    /// If this returns false, `check_rollback` can skip the unchanged-entity
+    /// rollback scan because the current `last_confirmed_tick` was already
+    /// handled on an earlier frame.
+    pub fn has_confirmed_tick_advanced(&self, current_tick: Tick) -> bool {
         match self.last_processed_tick {
             None => true, // First time, always process
             Some(last) => current_tick > last,
@@ -273,6 +310,62 @@ mod tests {
         assert_eq!(metadata.take_ready_mismatch_tick(Tick(13)), Some(Tick(12)));
         assert!(!metadata.should_rollback);
         assert_eq!(metadata.earliest_mismatch_tick, None);
+    }
+
+    #[test]
+    fn record_last_confirmed_tick_keeps_latest_tick() {
+        let mut metadata = StateRollbackMetadata::default();
+
+        metadata.record_last_confirmed_tick(Tick(12));
+        metadata.record_last_confirmed_tick(Tick(10));
+        metadata.record_last_confirmed_tick(Tick(14));
+
+        assert_eq!(metadata.last_confirmed_tick(), Some(Tick(14)));
+    }
+
+    #[test]
+    fn confirmed_tick_advancement_uses_last_processed_tick() {
+        let mut metadata = StateRollbackMetadata::default();
+        assert!(metadata.has_confirmed_tick_advanced(Tick(10)));
+
+        metadata.set_last_processed_tick(Tick(10));
+        assert!(!metadata.has_confirmed_tick_advanced(Tick(10)));
+        assert!(!metadata.has_confirmed_tick_advanced(Tick(9)));
+        assert!(metadata.has_confirmed_tick_advanced(Tick(11)));
+    }
+
+    #[test]
+    fn server_mutate_last_tick_can_be_newer_than_latest_complete_tick() {
+        use bevy_replicon::client::server_mutate_ticks::ServerMutateTicks;
+        use bevy_replicon::prelude::RepliconTick;
+
+        let complete_tick = RepliconTick::new(9);
+        let incomplete_tick = RepliconTick::new(10);
+
+        let mut server_mutate_ticks = ServerMutateTicks::default();
+        assert!(server_mutate_ticks.confirm(complete_tick, 1));
+        assert!(!server_mutate_ticks.confirm(incomplete_tick, 2));
+
+        assert_eq!(server_mutate_ticks.last_tick(), incomplete_tick);
+        assert!(server_mutate_ticks.contains(complete_tick));
+        assert!(!server_mutate_ticks.contains(incomplete_tick));
+
+        let mut metadata = StateRollbackMetadata::default();
+        metadata.record_last_confirmed_tick(Tick(900));
+        assert_eq!(metadata.last_confirmed_tick(), Some(Tick(900)));
+    }
+
+    #[test]
+    fn explicit_state_mismatches_keep_earliest_ready_tick() {
+        let mut metadata = StateRollbackMetadata::default();
+
+        metadata.record_mismatch(Tick(12));
+        metadata.record_mismatch(Tick(14));
+        metadata.record_mismatch(Tick(10));
+
+        assert_eq!(metadata.not_ready_mismatch_tick(Tick(10)), Some(Tick(10)));
+        assert_eq!(metadata.take_ready_mismatch_tick(Tick(10)), None);
+        assert_eq!(metadata.take_ready_mismatch_tick(Tick(11)), Some(Tick(10)));
     }
 }
 

--- a/lightyear_prediction/src/predicted_history.rs
+++ b/lightyear_prediction/src/predicted_history.rs
@@ -247,7 +247,8 @@ impl<C> PredictionHistory<C> {
 
     /// Add a confirmed value at the given tick
     ///
-    /// This is used in situations where we know the value is unchanged (e.g., ServerMutateTicks confirms no mutation).
+    /// This is used in situations where we know the value is unchanged (e.g., a completed
+    /// mutate tick confirms no mutation).
     /// Returns true if a new confirmed value was added, false otherwise.
     pub fn add_confirmed_unchanged(&mut self, tick: Tick) -> bool
     where

--- a/lightyear_prediction/src/registry.rs
+++ b/lightyear_prediction/src/registry.rs
@@ -265,8 +265,8 @@ impl PredictionRegistry {
 
     /// Check for rollback on entities that didn't receive an explicit update.
     ///
-    /// This is called when `ServerMutateTicks.last_tick` advances and an entity didn't
-    /// receive a mutation. Since `ServerMutateTicks.last_tick = T` guarantees we have
+    /// This is called when the completed mutate tick advances and an entity didn't
+    /// receive a mutation. Since completed mutate tick T guarantees we have
     /// complete information for all entities at tick T, we know this entity's value at T
     /// equals its last confirmed value.
     ///
@@ -275,7 +275,7 @@ impl PredictionRegistry {
     /// 2. Marks the last confirmed value as confirmed at `confirmed_tick` in the history
     ///
     /// # Arguments
-    /// * `confirmed_tick` - Should be `ServerMutateTicks.last_tick()`
+    /// * `confirmed_tick` - Latest authoritative tick with complete mutate messages.
     fn check_rollback_empty_mutate<C: SyncComponent>(
         &self,
         confirmed_tick: Tick,

--- a/lightyear_prediction/src/rollback.rs
+++ b/lightyear_prediction/src/rollback.rs
@@ -1,15 +1,15 @@
 /*!
 Rollback idea:
 
- Key insight: `ServerMutateTicks.last_tick = T` guarantees that for entities not updated at tick T,
+ Key insight: the latest completed mutate tick T guarantees that for entities not updated at tick T,
 their value is equal to the last confirmed value.
 
 Proof:
-Let's say we have ServerMutateTicks.last_tick = T, and we only received a message for entity A. (there is another entity B).
+Let's say the latest completed mutate tick is T, and we only received a message for entity A. (there is another entity B).
 Does that mean that we fully know the state of entity B? How do we determine the confirmed value for B? We know that the value of B did not change on tick T-1.
 - either we received an update for B on tick T-1, then we know that at tick T the value of B is the same
-- either we have ServerMutateTicks.T-1 is confirmed, then we know that B at tick T-1 is the same as the previous confirmed value
-- either we don't have ServerMutateTicks.T-1 confirmed. We could have:
+- either we know mutate tick T-1 is complete, then we know that B at tick T-1 is the same as the previous confirmed value
+- either we don't know mutate tick T-1 is complete. We could have:
   - the server did not send any message with an update to B, so B is the same as the previous confirmed value
   - the server sent a message with an update for B, but the message is lost or in-flight. But in that case the server would not have received an ack for that message, so on tick T it would have sent an update for B again! So that is not possible.
     That means that we know for sure that B did not change compared to its last confirmed value.
@@ -17,25 +17,25 @@ Does that mean that we fully know the state of entity B? How do we determine the
 Then the question becomes, how does that affect how we rollback?
 We need:
 - when we receive an update, we can do a rollback check and add a new confirmed value in the history
-- for entities that were not updated, we do a rollback check at ServerMutateTicks.last_tick = T only if the `ServerMutateTick.last_tick` got updated (otherwise we already did the check). When `ServerMutateTick.last_tick` gets updated, then we can set a new confirmed value for all entities that were not updated. This means that the last confirmed value is AT LEAST
+- for entities that were not updated, we do a rollback check at the latest completed mutate tick T only if that completed tick advanced (otherwise we already did the check). When the completed tick advances, then we can set a new confirmed value for all entities that were not updated. This means that the last confirmed value is AT LEAST
 - To rollback we have 2 choices:
-  - rollback from the earliest confirmed tick across all predicted entities (predicted entities are a subset of all entities so it's possible that this is more recent than ServerMutateTicks.last_tick)
-  - rollback from ServerMutateTicks.last_tick
+  - rollback from the earliest confirmed tick across all predicted entities (predicted entities are a subset of all entities so it's possible that this is more recent than the latest completed mutate tick)
+  - rollback from the latest completed mutate tick
     For simplicity we will do the second choice
 - When we rollback:
-  - if we do a rollback check, we rollback from the earliest mismatch tick. Subtle: if we receive an update for tick T that mismatches but ServerMutateTicks.last_tick < T (meaning we haven't received all the updates for other ticks), then we can just
+  - if we do a rollback check, we rollback from the earliest mismatch tick. Subtle: if we receive an update for tick T that mismatches but the latest completed mutate tick < T (meaning we haven't received all the updates for other ticks), then we can just
     rollback from tick T. The reason is that we can either:
     - rollback from tick T (earliest mismatch)
     - or rollback from earliest confirmed tick X (even among entities that haven't received an update). In which case we would resimulate between ticks X to T but we don't have more recent confirmed values than X, so there's no point in doing that! Instead we rollback from T, but we have our best predicted guess for tick T (even for the entity that didn't receive an update)
-  - if we don't do a rollback check, we rollback from ServerMutateTicks.last_tick
-- One thing to be careful of is that we could have ServerMutateTicks.last_tick = T, but have received confirmed updates for ticks > T. In which case we don't want to overwrite them when we rollback, and instead use these confirmed values!
+  - if we don't do a rollback check, we rollback from the latest completed mutate tick
+- One thing to be careful of is that we could have completed mutate tick T, but have received confirmed updates for ticks > T. In which case we don't want to overwrite them when we rollback, and instead use these confirmed values!
 
  */
 
 use super::predicted_history::PredictionHistory;
 use super::resource_history::ResourceHistory;
 use super::{Predicted, SyncComponent};
-use crate::checkpoint_ticks::{resolve_confirm_history_tick, resolve_server_mutate_tick};
+use crate::checkpoint_ticks::{resolve_confirm_history_tick, resolve_message_tick};
 use crate::correction::PreviousVisual;
 use crate::despawn::PredictionDisable;
 use crate::diagnostics::PredictionMetrics;
@@ -53,18 +53,20 @@ use bevy_ecs::schedule::ScheduleLabel;
 use bevy_ecs::system::{ParamBuilder, QueryParamBuilder};
 use bevy_ecs::world::{DeferredWorld, FilteredEntityMut};
 use bevy_reflect::Reflect;
+use bevy_replicon::client::server_mutate_ticks::MutateTickReceived;
 use bevy_replicon::prelude::{ClientMessages, ClientSystems};
 use bevy_replicon::shared::backend::channels::ServerChannel;
 use bevy_time::{Fixed, Time};
 use bevy_utils::prelude::DebugName;
 use core::fmt::Debug;
+use lightyear_connection::client::{Client, Connected};
 use lightyear_connection::host::HostClient;
 use lightyear_core::history_buffer::HistoryState;
 use lightyear_core::prelude::LocalTimeline;
 use lightyear_core::tick::Tick;
 use lightyear_core::timeline::{Rollback, is_in_rollback};
 use lightyear_frame_interpolation::FrameInterpolationSystems;
-use lightyear_replication::prelude::{ConfirmHistory, ServerMutateTicks};
+use lightyear_replication::prelude::ConfirmHistory;
 use lightyear_replication::prespawn::{PreSpawned, PreSpawnedReceiver};
 use lightyear_replication::registry::ComponentRegistry;
 use lightyear_sync::prelude::{InputTimeline, IsSynced};
@@ -143,9 +145,13 @@ impl Plugin for RollbackPlugin {
         app.add_systems(
             PreUpdate,
             (
+                reset_state_rollback_metadata_if_disconnected.before(update_last_confirmed_tick),
                 check_received_replication_messages
                     .after(ClientSystems::ReceivePackets)
                     .before(ClientSystems::Receive),
+                update_last_confirmed_tick
+                    .after(ClientSystems::Receive)
+                    .before(RollbackSystems::Check),
                 reset_input_rollback_tracker.after(RollbackSystems::Check),
                 remove_prediction_disable.in_set(RollbackSystems::RemoveDisable),
                 run_rollback.in_set(RollbackSystems::Rollback),
@@ -212,7 +218,6 @@ impl Plugin for RollbackPlugin {
                     }
                 });
             }),
-            ParamBuilder,
             ParamBuilder,
             ParamBuilder,
             ParamBuilder,
@@ -353,11 +358,108 @@ fn check_received_replication_messages(
     }
 }
 
+/// Cache the latest authoritative tick for which Replicon completed all mutate messages.
+fn update_last_confirmed_tick(
+    mut received_mutate_ticks: MessageReader<MutateTickReceived>,
+    checkpoints: Res<lightyear_replication::checkpoint::ReplicationCheckpointMap>,
+    mut metadata: ResMut<StateRollbackMetadata>,
+) {
+    for event in received_mutate_ticks.read() {
+        let Some(authoritative_tick) = resolve_message_tick(&checkpoints, event.tick) else {
+            error!(
+                replicon_tick = ?event.tick,
+                "missing authoritative checkpoint mapping for completed mutate tick"
+            );
+            debug_assert!(
+                false,
+                "missing authoritative checkpoint mapping for completed mutate tick"
+            );
+            continue;
+        };
+        metadata.record_last_confirmed_tick(authoritative_tick);
+    }
+}
+
+fn reset_state_rollback_metadata_if_disconnected(
+    query: Query<
+        (),
+        (
+            With<PredictionManager>,
+            With<Client>,
+            With<Connected>,
+            Without<HostClient>,
+        ),
+    >,
+    mut metadata: ResMut<StateRollbackMetadata>,
+) {
+    if query.single().is_err() {
+        metadata.reset_connection_state();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bevy_replicon::prelude::RepliconTick;
+    use lightyear_replication::checkpoint::ReplicationCheckpointMap;
+
+    #[test]
+    fn update_last_confirmed_tick_tracks_latest_completed_mutate_message() {
+        let older_replicon_tick = RepliconTick::new(9);
+        let newer_replicon_tick = RepliconTick::new(10);
+
+        let mut app = App::new();
+        app.add_message::<MutateTickReceived>();
+        app.init_resource::<ReplicationCheckpointMap>();
+        app.init_resource::<StateRollbackMetadata>();
+        app.add_systems(Update, update_last_confirmed_tick);
+
+        {
+            let mut checkpoints = app.world_mut().resource_mut::<ReplicationCheckpointMap>();
+            checkpoints.record(older_replicon_tick, Tick(90));
+            checkpoints.record(newer_replicon_tick, Tick(100));
+        }
+
+        app.world_mut().write_message(MutateTickReceived {
+            tick: newer_replicon_tick,
+        });
+        app.world_mut().write_message(MutateTickReceived {
+            tick: older_replicon_tick,
+        });
+        app.update();
+
+        assert_eq!(
+            app.world()
+                .resource::<StateRollbackMetadata>()
+                .last_confirmed_tick(),
+            Some(Tick(100))
+        );
+    }
+
+    #[test]
+    fn update_last_confirmed_tick_without_messages_leaves_tick_unset() {
+        let mut app = App::new();
+        app.add_message::<MutateTickReceived>();
+        app.init_resource::<ReplicationCheckpointMap>();
+        app.init_resource::<StateRollbackMetadata>();
+        app.add_systems(Update, update_last_confirmed_tick);
+
+        app.update();
+
+        assert_eq!(
+            app.world()
+                .resource::<StateRollbackMetadata>()
+                .last_confirmed_tick(),
+            None
+        );
+    }
+}
+
 /// Check if we need to do a rollback.
 /// We do this separately from `prepare_rollback` because even if we stop the `check_rollback` function
 /// early as soon as we find a mismatch, but we need to rollback all components to the original state.
 ///
-/// Key invariant: `ServerMutateTicks.last_tick = T` guarantees that for all entities,
+/// Key invariant: `StateRollbackMetadata.last_confirmed_tick = T` guarantees that for all entities,
 /// we have complete information at tick T:
 /// - Entities that received an update at T: their confirmed value is in the message
 /// - Entities that didn't receive an update: their value at T = their last confirmed value
@@ -367,7 +469,6 @@ fn check_rollback(
     mut predicted_entities: Query<(&ConfirmHistory, FilteredEntityMut)>,
     timeline: Res<LocalTimeline>,
     mut state_metadata: ResMut<StateRollbackMetadata>,
-    server_mutate_ticks: Res<ServerMutateTicks>,
     checkpoints: Res<lightyear_replication::checkpoint::ReplicationCheckpointMap>,
     receiver_query: Single<
         (
@@ -394,17 +495,7 @@ fn check_rollback(
     let received_state = state_metadata.received_messages_this_frame;
 
     // The tick where ALL messages have been received (guaranteed complete information)
-    let Some(server_confirmed_tick) =
-        resolve_server_mutate_tick(&checkpoints, &server_mutate_ticks)
-    else {
-        error!(
-            replicon_tick = ?server_mutate_ticks.last_tick(),
-            "missing authoritative checkpoint mapping for ServerMutateTicks"
-        );
-        debug_assert!(
-            false,
-            "missing authoritative checkpoint mapping for ServerMutateTicks"
-        );
+    let Some(server_confirmed_tick) = state_metadata.last_confirmed_tick() else {
         return;
     };
 
@@ -558,20 +649,21 @@ fn check_rollback(
                     );
                 }
 
-                // Check if ServerMutateTicks has advanced since we last processed it
+                // Check if the completed mutate tick has advanced since we last processed it.
                 let server_ticks_advanced =
-                    state_metadata.has_server_mutate_ticks_advanced(server_confirmed_tick);
+                    state_metadata.has_confirmed_tick_advanced(server_confirmed_tick);
 
-                // Second check: if ServerMutateTicks has advanced, check unchanged entities
-                // Only check if we haven't already triggered a rollback and ServerMutateTicks advanced
+                // Second check: if the completed mutate tick advanced, check unchanged entities.
+                // Only check if we haven't already triggered a rollback.
                 if !prediction_manager.is_rollback() && server_ticks_advanced {
                     if server_confirmed_tick > tick {
                         debug!(
-                            "ServerMutateTicks tick is in the future: {:?} compared to client timeline. Current tick: {:?}",
+                            "Confirmed mutate tick is in the future: {:?} compared to client timeline. Current tick: {:?}",
                             server_confirmed_tick, tick
                         );
                     } else {
-                        // Check unchanged entities: those where ConfirmHistory.last_tick < ServerMutateTicks.last_tick
+                        // Check unchanged entities: those where ConfirmHistory.last_tick < the
+                        // latest completed mutate tick.
                         // For these entities, we know their value at server_confirmed_tick = their last confirmed value
                         trace!(
                             ?tick,
@@ -600,7 +692,7 @@ fn check_rollback(
                             }
 
                             trace!(
-                                "Checking rollback for entity {:?} (unchanged): ConfirmHistory={:?}, ServerMutateTicks={:?}",
+                                "Checking rollback for entity {:?} (unchanged): ConfirmHistory={:?}, completed_mutate_tick={:?}",
                                 entity_mut.id(),
                                 confirm_history_tick,
                                 server_confirmed_tick
@@ -639,10 +731,9 @@ fn check_rollback(
                                 }
                             }
                         });
+                        // Update the last processed tick only after we were able to process it.
+                        state_metadata.set_last_processed_tick(server_confirmed_tick);
                     }
-
-                    // Update the last processed tick
-                    state_metadata.set_last_processed_tick(server_confirmed_tick);
                 }
             }
             RollbackMode::Disabled => {}
@@ -869,7 +960,7 @@ pub(crate) fn remove_prediction_disable(
 pub(crate) fn prepare_rollback<C: SyncComponent>(
     timeline: Res<LocalTimeline>,
     prediction_registry: Res<PredictionRegistry>,
-    server_mutate_ticks: Res<ServerMutateTicks>,
+    state_metadata: Res<StateRollbackMetadata>,
     checkpoints: Res<lightyear_replication::checkpoint::ReplicationCheckpointMap>,
     mut commands: Commands,
     // We also snap the value of the component to the server state if we are in rollback
@@ -893,17 +984,7 @@ pub(crate) fn prepare_rollback<C: SyncComponent>(
     let rollback_tick = manager.get_rollback_start_tick().unwrap();
 
     // The tick where ALL messages have been received (guaranteed complete information)
-    let Some(server_confirmed_tick) =
-        resolve_server_mutate_tick(&checkpoints, &server_mutate_ticks)
-    else {
-        error!(
-            replicon_tick = ?server_mutate_ticks.last_tick(),
-            "missing authoritative checkpoint mapping for ServerMutateTicks during rollback preparation"
-        );
-        debug_assert!(
-            false,
-            "missing authoritative checkpoint mapping for ServerMutateTicks during rollback preparation"
-        );
+    let Some(server_confirmed_tick) = state_metadata.last_confirmed_tick() else {
         return;
     };
 
@@ -916,7 +997,7 @@ pub(crate) fn prepare_rollback<C: SyncComponent>(
     ) in predicted_query.iter_mut()
     {
         // For entities that didn't receive an explicit update but we know their value didn't change
-        // (because ServerMutateTicks confirms they weren't mutated), mark the latest completed
+        // (because a completed mutate tick confirms they weren't mutated), mark the latest completed
         // server checkpoint as confirmed using their last explicit confirmed value.
         if matches!(rollback, Rollback::FromState)
             && !matches!(manager.rollback_policy.state, RollbackMode::Disabled)
@@ -949,7 +1030,7 @@ pub(crate) fn prepare_rollback<C: SyncComponent>(
             // a rollback), but we haven't received the full update yet, so we will still rollback
             // from that earliest mismatch tick.
             let restore_value = predicted_history.get(rollback_tick).cloned();
-            // If state rollback is disabled, ServerMutateTicks do not certify deterministic
+            // If state rollback is disabled, completed mutate ticks do not certify deterministic
             // component values; they only say no replicated state update arrived. Keep enough
             // predicted history to support later input rollbacks to the same window.
             let clear_until_tick =

--- a/lightyear_tests/src/client_server/prediction/rollback.rs
+++ b/lightyear_tests/src/client_server/prediction/rollback.rs
@@ -14,10 +14,10 @@ use lightyear::prediction::predicted_history::PredictionHistory;
 use lightyear::prelude::input::native::ActionState;
 use lightyear_connection::prelude::NetworkTarget;
 use lightyear_core::id::PeerId;
-use lightyear_core::prelude::LocalTimeline;
+use lightyear_core::prelude::{LocalTimeline, Tick};
 use lightyear_messages::MessageManager;
 use lightyear_prediction::despawn::{PredictionDespawnCommandsExt, PredictionDisable};
-use lightyear_prediction::manager::{LastConfirmedInput, RollbackMode};
+use lightyear_prediction::manager::{LastConfirmedInput, RollbackMode, StateRollbackMetadata};
 use lightyear_prediction::prelude::*;
 use lightyear_prediction::rollback::{DeterministicPredicted, reset_input_rollback_tracker};
 use lightyear_replication::prelude::*;
@@ -36,6 +36,28 @@ fn setup() -> (ClientServerStepper, Entity) {
     // run one frame to initialize prediction history for the entity
     stepper.frame_step(1);
     (stepper, predicted)
+}
+
+#[derive(Resource, Default)]
+struct ObservedRollbackStart(Option<Tick>);
+
+fn record_rollback_start(
+    manager: Single<&PredictionManager>,
+    mut observed: ResMut<ObservedRollbackStart>,
+) {
+    if observed.0.is_none() {
+        observed.0 = manager.get_rollback_start_tick();
+    }
+}
+
+fn observe_rollback_start(app: &mut App) {
+    app.insert_resource(ObservedRollbackStart::default());
+    app.add_systems(
+        PreUpdate,
+        record_rollback_start
+            .after(RollbackSystems::Check)
+            .before(RollbackSystems::Prepare),
+    );
 }
 
 // =============================================================================
@@ -385,6 +407,263 @@ fn test_rollback_preserves_later_confirmed_values_on_other_entities() {
             .0,
         203.0,
         "Later confirmed value on another entity should be preserved and replayed across the remaining rollback ticks and the current frame tick"
+    );
+}
+
+/// A completed mutate tick is a global confirmation point. If one entity receives an
+/// explicit update at that tick and another entity does not, the unchanged entity should
+/// still be checked against its last confirmed value at the completed tick.
+#[test]
+fn test_completed_mutate_tick_checks_unchanged_entities() {
+    fn increment_component(mut query: Query<&mut CompFull, With<Predicted>>) {
+        for mut comp in query.iter_mut() {
+            comp.0 += 1.0;
+        }
+    }
+
+    let (mut stepper, updated) = setup();
+    let unchanged = stepper
+        .client_app()
+        .world_mut()
+        .spawn((Predicted, CompFull(10.0)))
+        .id();
+
+    stepper.frame_step(1);
+    stepper
+        .client_app()
+        .add_systems(FixedUpdate, increment_component);
+    observe_rollback_start(stepper.client_app());
+
+    // Build a few ticks of prediction history after initializing the second entity.
+    stepper.frame_step(4);
+    let completed_tick = stepper.client_tick(0) - 2;
+    let previous_confirmed_tick = completed_tick - 1;
+
+    let updated_replicon_tick = RepliconTick::new(700);
+    let previous_replicon_tick = RepliconTick::new(699);
+    let incomplete_replicon_tick = RepliconTick::new(701);
+
+    let world = stepper.client_app().world_mut();
+    world
+        .resource_mut::<lightyear_replication::checkpoint::ReplicationCheckpointMap>()
+        .record(updated_replicon_tick, completed_tick);
+    world
+        .resource_mut::<lightyear_replication::checkpoint::ReplicationCheckpointMap>()
+        .record(previous_replicon_tick, previous_confirmed_tick);
+    world
+        .resource_mut::<StateRollbackMetadata>()
+        .record_last_confirmed_tick(completed_tick);
+    {
+        let mut server_mutate_ticks = world.resource_mut::<ServerMutateTicks>();
+        assert!(server_mutate_ticks.confirm(updated_replicon_tick, 1));
+        assert!(!server_mutate_ticks.confirm(incomplete_replicon_tick, 2));
+        assert_eq!(server_mutate_ticks.last_tick(), incomplete_replicon_tick);
+    }
+
+    world
+        .entity_mut(updated)
+        .get_mut::<PredictionHistory<CompFull>>()
+        .unwrap()
+        .add_confirmed(completed_tick, Some(CompFull(1.0)));
+    world
+        .entity_mut(updated)
+        .insert(ConfirmHistory::new(updated_replicon_tick));
+
+    world
+        .entity_mut(unchanged)
+        .get_mut::<PredictionHistory<CompFull>>()
+        .unwrap()
+        .add_confirmed(previous_confirmed_tick, Some(CompFull(20.0)));
+    world
+        .entity_mut(unchanged)
+        .insert(ConfirmHistory::new(previous_replicon_tick));
+
+    stepper.frame_step(1);
+
+    assert_eq!(
+        stepper
+            .client_app()
+            .world()
+            .resource::<ObservedRollbackStart>()
+            .0,
+        Some(completed_tick),
+        "Unchanged entity mismatch should roll back from the completed mutate tick"
+    );
+}
+
+#[test]
+fn test_future_completed_mutate_tick_is_not_marked_processed() {
+    let (mut stepper, _) = setup();
+
+    stepper.frame_step(3);
+    let future_tick = stepper.client_tick(0) + 1_000;
+    stepper
+        .client_app()
+        .world_mut()
+        .resource_mut::<StateRollbackMetadata>()
+        .record_last_confirmed_tick(future_tick);
+
+    stepper.frame_step(1);
+
+    assert_ne!(
+        stepper
+            .client_app()
+            .world()
+            .resource::<StateRollbackMetadata>()
+            .last_processed_tick(),
+        Some(future_tick),
+        "A future completed mutate tick must not be marked processed before it can be checked"
+    );
+}
+
+#[test]
+fn test_explicit_mismatch_newer_than_completed_tick_rolls_back_from_mismatch_tick() {
+    let (mut stepper, _) = setup();
+    observe_rollback_start(stepper.client_app());
+
+    stepper.frame_step(5);
+    let completed_tick = stepper.client_tick(0) - 4;
+    let mismatch_tick = stepper.client_tick(0) - 2;
+    stepper
+        .client_app()
+        .world_mut()
+        .resource_mut::<StateRollbackMetadata>()
+        .record_last_confirmed_tick(completed_tick);
+
+    trigger_rollback_check(&mut stepper, mismatch_tick);
+    stepper.frame_step(1);
+
+    assert_eq!(
+        stepper
+            .client_app()
+            .world()
+            .resource::<ObservedRollbackStart>()
+            .0,
+        Some(mismatch_tick),
+        "Current policy consumes the earliest ready explicit mismatch even when the completed mutate tick is older"
+    );
+}
+
+/// When a completed mutate tick triggers rollback through an unchanged entity, later explicit
+/// confirmed values on other entities must be preserved for replay.
+#[test]
+fn test_completed_mutate_tick_rollback_preserves_later_confirmed_values() {
+    fn increment_component(mut query: Query<&mut CompFull, With<Predicted>>) {
+        for mut comp in query.iter_mut() {
+            comp.0 += 1.0;
+        }
+    }
+
+    let (mut stepper, predicted_a) = setup();
+    let predicted_b = stepper
+        .client_app()
+        .world_mut()
+        .spawn((Predicted, CompFull(10.0)))
+        .id();
+    let predicted_c = stepper
+        .client_app()
+        .world_mut()
+        .spawn((Predicted, CompFull(20.0)))
+        .id();
+
+    // Initialize prediction history for the second entity.
+    stepper.frame_step(1);
+    stepper
+        .client_app()
+        .add_systems(FixedUpdate, increment_component);
+    observe_rollback_start(stepper.client_app());
+
+    stepper.frame_step(4);
+    let current_tick = stepper.client_tick(0);
+    let rollback_tick = current_tick - 3;
+    let previous_confirmed_tick = rollback_tick - 1;
+    let later_confirmed_tick = current_tick - 1;
+
+    let previous_replicon_tick = RepliconTick::new(800);
+    let later_replicon_tick = RepliconTick::new(801);
+    let same_replicon_tick = RepliconTick::new(802);
+
+    let world = stepper.client_app().world_mut();
+    world
+        .resource_mut::<lightyear_replication::checkpoint::ReplicationCheckpointMap>()
+        .record(previous_replicon_tick, previous_confirmed_tick);
+    world
+        .resource_mut::<lightyear_replication::checkpoint::ReplicationCheckpointMap>()
+        .record(later_replicon_tick, later_confirmed_tick);
+    world
+        .resource_mut::<lightyear_replication::checkpoint::ReplicationCheckpointMap>()
+        .record(same_replicon_tick, rollback_tick);
+    world
+        .resource_mut::<StateRollbackMetadata>()
+        .record_last_confirmed_tick(rollback_tick);
+
+    world
+        .entity_mut(predicted_a)
+        .get_mut::<PredictionHistory<CompFull>>()
+        .unwrap()
+        .add_confirmed(previous_confirmed_tick, Some(CompFull(100.0)));
+    world
+        .entity_mut(predicted_a)
+        .insert(ConfirmHistory::new(previous_replicon_tick));
+
+    world
+        .entity_mut(predicted_b)
+        .get_mut::<PredictionHistory<CompFull>>()
+        .unwrap()
+        .add_confirmed(later_confirmed_tick, Some(CompFull(200.0)));
+    world
+        .entity_mut(predicted_b)
+        .insert(ConfirmHistory::new(later_replicon_tick));
+
+    world
+        .entity_mut(predicted_c)
+        .get_mut::<PredictionHistory<CompFull>>()
+        .unwrap()
+        .add_confirmed(rollback_tick, Some(CompFull(300.0)));
+    world
+        .entity_mut(predicted_c)
+        .insert(ConfirmHistory::new(same_replicon_tick));
+
+    stepper.frame_step(1);
+
+    assert_eq!(
+        stepper
+            .client_app()
+            .world()
+            .resource::<ObservedRollbackStart>()
+            .0,
+        Some(rollback_tick),
+        "Unchanged entity mismatch should roll back from the completed mutate tick"
+    );
+    assert_eq!(
+        stepper
+            .client_app()
+            .world()
+            .get::<CompFull>(predicted_a)
+            .unwrap()
+            .0,
+        104.0,
+        "Unchanged entity should replay from the completed mutate tick"
+    );
+    assert_eq!(
+        stepper
+            .client_app()
+            .world()
+            .get::<CompFull>(predicted_b)
+            .unwrap()
+            .0,
+        203.0,
+        "Later confirmed value on another entity should be preserved across rollback"
+    );
+    assert_eq!(
+        stepper
+            .client_app()
+            .world()
+            .get::<CompFull>(predicted_c)
+            .unwrap()
+            .0,
+        304.0,
+        "Entity already confirmed at the completed mutate tick should replay from that confirmed value"
     );
 }
 


### PR DESCRIPTION
I realized that `ServerMutateTicks.last_tick` was not the last confirmed tick. Instead we have to compute it manually!

This means that the previous prediction logic was incorrect; adding some more tests.