### PR TITLE
Enable lz4 compression in lightyear_transport

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,6 +143,11 @@ bincode = { version = "2.0.1", default-features = false, features = [
   "alloc",
 ] }
 bytes = { version = "1.8", default-features = false, features = ["serde"] }
+lz4_flex = { version = "0.13.1", default-features = false, features = [
+  "safe-encode",
+  "safe-decode",
+  "checked-decode",
+] }
 serde = { version = "1", default-features = false, features = [
   "alloc",
   "derive",

--- a/benches/criterion/Cargo.toml
+++ b/benches/criterion/Cargo.toml
@@ -12,7 +12,12 @@ categories = ["game-development", "network-programming"]
 license.workspace = true
 
 [dependencies]
-lightyear = { workspace = true, features = ["interpolation", "metrics", "std"] }
+lightyear = { workspace = true, features = [
+  "compression_lz4",
+  "interpolation",
+  "metrics",
+  "std",
+] }
 lightyear_tests = { workspace = true }
 
 # enable all the bevy defaults:

--- a/benches/criterion/benches/bandwidth/main.rs
+++ b/benches/criterion/benches/bandwidth/main.rs
@@ -1,5 +1,9 @@
 use criterion::criterion_main;
 
 mod replication;
+mod transport_compression;
 
-criterion_main!(replication::replication_bandwidth);
+criterion_main!(
+    replication::replication_bandwidth,
+    transport_compression::transport_compression_bandwidth,
+);

--- a/benches/criterion/benches/bandwidth/replication.rs
+++ b/benches/criterion/benches/bandwidth/replication.rs
@@ -3,7 +3,7 @@
 
 use bevy::prelude::With;
 use core::time::Duration;
-use lightyear::prelude::{GLOBAL_RECORDER, MetricsRegistry, NetworkTarget, Replicate, Replicating};
+use lightyear::prelude::{GLOBAL_RECORDER, MetricsRegistry, NetworkTarget, Replicate};
 use std::ops::Deref;
 use std::time::Instant;
 
@@ -100,7 +100,7 @@ fn send_float_update_one_client(criterion: &mut Criterion<Bandwidth>) {
         for mut component in stepper
             .server_app
             .world_mut()
-            .query_filtered::<&mut CompFull, With<Replicating>>()
+            .query_filtered::<&mut CompFull, With<Replicate>>()
             .iter_mut(stepper.server_app.world_mut())
         {
             component.0 = 0.0;

--- a/benches/criterion/benches/bandwidth/transport_compression.rs
+++ b/benches/criterion/benches/bandwidth/transport_compression.rs
@@ -1,0 +1,45 @@
+use core::time::Duration;
+
+use criterion::{BenchmarkId, Criterion, criterion_group};
+use lightyear_benches::measurements::bandwidth::Bandwidth;
+use lightyear_benches::transport_compression::{
+    CompressionMode, TRANSPORT_COMPRESSION_CASES, print_transport_compression_stats_once,
+    run_transport_compression_case,
+};
+
+criterion_group!(
+    name = transport_compression_bandwidth;
+    config = Criterion::default().with_measurement(Bandwidth);
+    targets = send_receive_messages,
+);
+
+fn send_receive_messages(criterion: &mut Criterion<Bandwidth>) {
+    let mut group =
+        criterion.benchmark_group("transport/compression/bandwidth/send_receive_messages");
+    group.sample_size(10);
+    group.warm_up_time(Duration::from_millis(10));
+    group.measurement_time(Duration::from_millis(10));
+
+    for case in TRANSPORT_COMPRESSION_CASES {
+        for mode in CompressionMode::ALL {
+            print_transport_compression_stats_once(*case, mode);
+            group.bench_with_input(
+                BenchmarkId::new(case.name, mode.name()),
+                &(*case, mode),
+                |bencher, &(case, mode)| {
+                    bencher.iter_custom(|iter| {
+                        let mut total = 0.0;
+                        for _ in 0..iter {
+                            let run = run_transport_compression_case(case, mode);
+                            std::hint::black_box(run.compression_above_mtu_packets);
+                            total += std::hint::black_box(run.send_bytes);
+                        }
+                        total
+                    });
+                },
+            );
+        }
+    }
+
+    group.finish();
+}

--- a/benches/criterion/benches/timing/main.rs
+++ b/benches/criterion/benches/timing/main.rs
@@ -3,5 +3,10 @@ use criterion::criterion_main;
 mod message;
 
 mod replication;
+mod transport_compression;
 
-criterion_main!(message::message_benches, replication::replication_benches,);
+criterion_main!(
+    message::message_benches,
+    replication::replication_benches,
+    transport_compression::transport_compression_benches,
+);

--- a/benches/criterion/benches/timing/replication.rs
+++ b/benches/criterion/benches/timing/replication.rs
@@ -3,7 +3,7 @@
 
 use bevy::prelude::With;
 use core::time::Duration;
-use lightyear::prelude::{NetworkTarget, Replicate, Replicating};
+use lightyear::prelude::{NetworkTarget, Replicate};
 use lightyear_benches::profiler::FlamegraphProfiler;
 use std::time::Instant;
 
@@ -82,7 +82,7 @@ fn send_float_update_one_client(criterion: &mut Criterion) {
                         for mut component in stepper
                             .server_app
                             .world_mut()
-                            .query_filtered::<&mut CompFull, With<Replicating>>()
+                            .query_filtered::<&mut CompFull, With<Replicate>>()
                             .iter_mut(stepper.server_app.world_mut())
                         {
                             component.0 = 0.0;
@@ -161,7 +161,7 @@ fn receive_float_update(criterion: &mut Criterion) {
                         for mut component in stepper
                             .server_app
                             .world_mut()
-                            .query_filtered::<&mut CompFull, With<Replicating>>()
+                            .query_filtered::<&mut CompFull, With<Replicate>>()
                             .iter_mut(stepper.server_app.world_mut())
                         {
                             component.0 = 0.0;

--- a/benches/criterion/benches/timing/transport_compression.rs
+++ b/benches/criterion/benches/timing/transport_compression.rs
@@ -1,0 +1,42 @@
+use core::time::Duration;
+
+use criterion::{BatchSize, BenchmarkId, Criterion, criterion_group};
+use lightyear_benches::transport_compression::{
+    CompressionMode, TRANSPORT_COMPRESSION_CASES, prepare_transport_compression_case,
+    print_transport_compression_stats_once, run_prepared_transport_compression_case,
+};
+
+criterion_group!(
+    name = transport_compression_benches;
+    config = Criterion::default();
+    targets = send_receive_messages,
+);
+
+fn send_receive_messages(criterion: &mut Criterion) {
+    let mut group = criterion.benchmark_group("transport/compression/timing/send_receive_messages");
+    group.sample_size(10);
+    group.warm_up_time(Duration::from_millis(100));
+    group.measurement_time(Duration::from_millis(1000));
+
+    for case in TRANSPORT_COMPRESSION_CASES {
+        for mode in CompressionMode::ALL {
+            print_transport_compression_stats_once(*case, mode);
+            group.bench_with_input(
+                BenchmarkId::new(case.name, mode.name()),
+                &(*case, mode),
+                |bencher, &(case, mode)| {
+                    bencher.iter_batched(
+                        || prepare_transport_compression_case(case, mode),
+                        |mut prepared| {
+                            let run = run_prepared_transport_compression_case(&mut prepared);
+                            std::hint::black_box(run);
+                        },
+                        BatchSize::SmallInput,
+                    );
+                },
+            );
+        }
+    }
+
+    group.finish();
+}

--- a/benches/criterion/src/lib.rs
+++ b/benches/criterion/src/lib.rs
@@ -6,3 +6,4 @@
 #![allow(dead_code)]
 pub mod measurements;
 pub mod profiler;
+pub mod transport_compression;

--- a/benches/criterion/src/transport_compression.rs
+++ b/benches/criterion/src/transport_compression.rs
@@ -75,7 +75,7 @@ pub const TRANSPORT_COMPRESSION_CASES: &[TransportCompressionCase] = &[
 #[derive(Clone, Copy, Debug, Default)]
 pub struct TransportCompressionRun {
     pub send_bytes: f64,
-    pub compression_attempts: f64,
+    pub compression_abandoned: f64,
     pub compression_saved_bytes: f64,
     pub compression_skipped: f64,
     pub compression_expanded_packets: f64,
@@ -131,11 +131,11 @@ pub fn print_transport_compression_stats_once(
 ) {
     let stats = run_transport_compression_case(case, mode);
     eprintln!(
-        "transport_compression_stats case={} mode={} send_bytes={} attempts={} saved_bytes={} skipped={} expanded={} above_mtu={}",
+        "transport_compression_stats case={} mode={} send_bytes={} abandoned={} saved_bytes={} skipped={} expanded={} above_mtu={}",
         case.name,
         mode.name(),
         stats.send_bytes,
-        stats.compression_attempts,
+        stats.compression_abandoned,
         stats.compression_saved_bytes,
         stats.compression_skipped,
         stats.compression_expanded_packets,
@@ -162,10 +162,10 @@ impl TransportCompressionRun {
     fn from_metrics(registry: &MetricsRegistry) -> Self {
         Self {
             send_bytes: metric_value(registry, MetricKind::Gauge, "transport/send_bytes"),
-            compression_attempts: metric_value(
+            compression_abandoned: metric_value(
                 registry,
                 MetricKind::Counter,
-                "transport/compression_attempts",
+                "transport/compression_abandoned",
             ),
             compression_saved_bytes: metric_value(
                 registry,
@@ -197,7 +197,7 @@ impl core::ops::Sub for TransportCompressionRun {
     fn sub(self, rhs: Self) -> Self::Output {
         Self {
             send_bytes: self.send_bytes - rhs.send_bytes,
-            compression_attempts: self.compression_attempts - rhs.compression_attempts,
+            compression_abandoned: self.compression_abandoned - rhs.compression_abandoned,
             compression_saved_bytes: self.compression_saved_bytes - rhs.compression_saved_bytes,
             compression_skipped: self.compression_skipped - rhs.compression_skipped,
             compression_expanded_packets: self.compression_expanded_packets

--- a/benches/criterion/src/transport_compression.rs
+++ b/benches/criterion/src/transport_compression.rs
@@ -1,0 +1,257 @@
+use lightyear::metrics::metrics::Key;
+use lightyear::metrics::metrics_util::{CompositeKey, MetricKind};
+use lightyear::prelude::{
+    CompressionConfig, GLOBAL_RECORDER, MessageSender, MetricsRegistry, Transport,
+};
+use lightyear_tests::protocol::{Channel1, StringMessage};
+use lightyear_tests::stepper::{ClientServerStepper, StepperConfig};
+
+#[derive(Clone, Copy, Debug)]
+pub enum PayloadPattern {
+    Repeated,
+    Structured,
+    RandomAscii,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct TransportCompressionCase {
+    pub name: &'static str,
+    pub pattern: PayloadPattern,
+    pub message_len: usize,
+    pub messages: usize,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CompressionMode {
+    Disabled,
+    Lz4,
+}
+
+impl CompressionMode {
+    pub const ALL: [Self; 2] = [Self::Disabled, Self::Lz4];
+
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::Disabled => "disabled",
+            Self::Lz4 => "lz4",
+        }
+    }
+
+    pub const fn config(self) -> CompressionConfig {
+        match self {
+            Self::Disabled => CompressionConfig::DISABLED,
+            Self::Lz4 => CompressionConfig::LZ4,
+        }
+    }
+}
+
+pub const TRANSPORT_COMPRESSION_CASES: &[TransportCompressionCase] = &[
+    TransportCompressionCase {
+        name: "repeated_64b_128msg",
+        pattern: PayloadPattern::Repeated,
+        message_len: 64,
+        messages: 128,
+    },
+    TransportCompressionCase {
+        name: "structured_128b_128msg",
+        pattern: PayloadPattern::Structured,
+        message_len: 128,
+        messages: 128,
+    },
+    TransportCompressionCase {
+        name: "random_ascii_128b_128msg",
+        pattern: PayloadPattern::RandomAscii,
+        message_len: 128,
+        messages: 128,
+    },
+    TransportCompressionCase {
+        name: "repeated_1024b_16msg",
+        pattern: PayloadPattern::Repeated,
+        message_len: 1024,
+        messages: 16,
+    },
+];
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct TransportCompressionRun {
+    pub send_bytes: f64,
+    pub compression_attempts: f64,
+    pub compression_saved_bytes: f64,
+    pub compression_skipped: f64,
+    pub compression_expanded_packets: f64,
+    pub compression_above_mtu_packets: f64,
+}
+
+pub struct PreparedTransportCompressionRun {
+    stepper: ClientServerStepper,
+}
+
+pub fn run_transport_compression_case(
+    case: TransportCompressionCase,
+    mode: CompressionMode,
+) -> TransportCompressionRun {
+    let mut prepared = prepare_transport_compression_case(case, mode);
+    run_prepared_transport_compression_case(&mut prepared)
+}
+
+pub fn prepare_transport_compression_case(
+    case: TransportCompressionCase,
+    mode: CompressionMode,
+) -> PreparedTransportCompressionRun {
+    let mut config = StepperConfig::single();
+    config.server_registry = Some(GLOBAL_RECORDER.clone());
+    config.client_registry = Some(GLOBAL_RECORDER.clone());
+    let mut stepper = ClientServerStepper::from_config(config);
+    set_compression(&mut stepper, mode.config());
+
+    for message_index in 0..case.messages {
+        let payload = payload(case.pattern, case.message_len, message_index);
+        stepper
+            .client_of_mut(0)
+            .get_mut::<MessageSender<StringMessage>>()
+            .unwrap()
+            .send::<Channel1>(StringMessage(payload));
+    }
+
+    PreparedTransportCompressionRun { stepper }
+}
+
+pub fn run_prepared_transport_compression_case(
+    prepared: &mut PreparedTransportCompressionRun,
+) -> TransportCompressionRun {
+    let start = TransportCompressionRun::from_metrics(&GLOBAL_RECORDER);
+    prepared.stepper.frame_step_server_first(1);
+    let end = TransportCompressionRun::from_metrics(&GLOBAL_RECORDER);
+    end - start
+}
+
+pub fn print_transport_compression_stats_once(
+    case: TransportCompressionCase,
+    mode: CompressionMode,
+) {
+    let stats = run_transport_compression_case(case, mode);
+    eprintln!(
+        "transport_compression_stats case={} mode={} send_bytes={} attempts={} saved_bytes={} skipped={} expanded={} above_mtu={}",
+        case.name,
+        mode.name(),
+        stats.send_bytes,
+        stats.compression_attempts,
+        stats.compression_saved_bytes,
+        stats.compression_skipped,
+        stats.compression_expanded_packets,
+        stats.compression_above_mtu_packets,
+    );
+}
+
+fn set_compression(stepper: &mut ClientServerStepper, compression: CompressionConfig) {
+    for client_id in 0..stepper.client_entities.len() {
+        stepper
+            .client_mut(client_id)
+            .get_mut::<Transport>()
+            .unwrap()
+            .set_compression(compression);
+        stepper
+            .client_of_mut(client_id)
+            .get_mut::<Transport>()
+            .unwrap()
+            .set_compression(compression);
+    }
+}
+
+impl TransportCompressionRun {
+    fn from_metrics(registry: &MetricsRegistry) -> Self {
+        Self {
+            send_bytes: metric_value(registry, MetricKind::Gauge, "transport/send_bytes"),
+            compression_attempts: metric_value(
+                registry,
+                MetricKind::Counter,
+                "transport/compression_attempts",
+            ),
+            compression_saved_bytes: metric_value(
+                registry,
+                MetricKind::Counter,
+                "transport/compression_saved_bytes",
+            ),
+            compression_skipped: metric_value(
+                registry,
+                MetricKind::Counter,
+                "transport/compression_skipped",
+            ),
+            compression_expanded_packets: metric_value(
+                registry,
+                MetricKind::Counter,
+                "transport/compression_expanded_packets",
+            ),
+            compression_above_mtu_packets: metric_value(
+                registry,
+                MetricKind::Counter,
+                "transport/compression_above_mtu_packets",
+            ),
+        }
+    }
+}
+
+impl core::ops::Sub for TransportCompressionRun {
+    type Output = Self;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        Self {
+            send_bytes: self.send_bytes - rhs.send_bytes,
+            compression_attempts: self.compression_attempts - rhs.compression_attempts,
+            compression_saved_bytes: self.compression_saved_bytes - rhs.compression_saved_bytes,
+            compression_skipped: self.compression_skipped - rhs.compression_skipped,
+            compression_expanded_packets: self.compression_expanded_packets
+                - rhs.compression_expanded_packets,
+            compression_above_mtu_packets: self.compression_above_mtu_packets
+                - rhs.compression_above_mtu_packets,
+        }
+    }
+}
+
+fn metric_value(registry: &MetricsRegistry, kind: MetricKind, name: &'static str) -> f64 {
+    registry
+        .fetch_metric_value(&CompositeKey::new(kind, Key::from_name(name)))
+        .unwrap_or_default()
+}
+
+fn payload(pattern: PayloadPattern, len: usize, message_index: usize) -> String {
+    match pattern {
+        PayloadPattern::Repeated => "A".repeat(len),
+        PayloadPattern::Structured => structured_payload(len, message_index),
+        PayloadPattern::RandomAscii => random_ascii_payload(len, message_index),
+    }
+}
+
+fn structured_payload(len: usize, message_index: usize) -> String {
+    let seed = format!(
+        "{{entity:{:04},x:{:04},y:{:04},state:idle,tag:replicated}};",
+        message_index,
+        message_index % 128,
+        (message_index * 3) % 128
+    );
+    repeat_to_len(&seed, len)
+}
+
+fn random_ascii_payload(len: usize, message_index: usize) -> String {
+    let mut state = 0x9e37_79b9_7f4a_7c15u64 ^ message_index as u64;
+    let mut payload = String::with_capacity(len);
+    for _ in 0..len {
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        let byte = b'!' + (state % 94) as u8;
+        payload.push(byte as char);
+    }
+    payload
+}
+
+fn repeat_to_len(seed: &str, len: usize) -> String {
+    let mut payload = String::with_capacity(len);
+    while payload.len() + seed.len() <= len {
+        payload.push_str(seed);
+    }
+    if payload.len() < len {
+        payload.push_str(&seed[..len - payload.len()]);
+    }
+    payload
+}

--- a/lightyear/Cargo.toml
+++ b/lightyear/Cargo.toml
@@ -129,6 +129,8 @@ metrics = [
   "lightyear_udp?/metrics",
 ]
 debug = ["dep:lightyear_tools", "metrics"]
+compression = ["lightyear_transport/compression"]
+compression_lz4 = ["compression", "lightyear_transport/compression_lz4"]
 
 ## INPUTS
 ## Add support for handling inputs where you can define your own input structs

--- a/lightyear_transport/Cargo.toml
+++ b/lightyear_transport/Cargo.toml
@@ -13,6 +13,8 @@ default = ["std"]
 std = ["bevy_ecs/std"]
 client = ["lightyear_connection/client"]
 server = ["lightyear_connection/server"]
+compression = []
+compression_lz4 = ["compression", "dep:lz4_flex"]
 metrics = ["dep:metrics", "std", "lightyear_utils/metrics", "bevy_utils/debug"]
 trace = []
 
@@ -43,6 +45,7 @@ crossbeam-channel.workspace = true
 enum_dispatch.workspace = true
 indexmap.workspace = true
 governor.workspace = true
+lz4_flex = { workspace = true, optional = true }
 metrics = { workspace = true, optional = true }
 nonzero_ext.workspace = true
 ringbuffer.workspace = true

--- a/lightyear_transport/src/channel/builder.rs
+++ b/lightyear_transport/src/channel/builder.rs
@@ -499,10 +499,12 @@ mod tests {
             })
             .collect::<VecDeque<_>>();
         assert!(fragments.len() < 3);
+        assert_eq!(fragments[0].compression, Some(FragmentCompression::Lz4));
         assert!(
             fragments
                 .iter()
-                .all(|fragment| fragment.compression == FragmentCompression::Lz4)
+                .skip(1)
+                .all(|fragment| fragment.compression.is_none())
         );
 
         let packets = sender_transport

--- a/lightyear_transport/src/channel/builder.rs
+++ b/lightyear_transport/src/channel/builder.rs
@@ -245,7 +245,9 @@ impl Transport {
             .senders
             .get_mut(&kind)
             .ok_or(TransportError::ChannelNotFound(kind))?;
-        let message_id = sender_metadata.sender.buffer_send(bytes, priority);
+        let message_id = sender_metadata
+            .sender
+            .buffer_send(bytes, priority, self.compression);
         Ok(message_id)
     }
 
@@ -430,11 +432,105 @@ pub struct AuthorityChannel;
 #[cfg(all(test, feature = "compression_lz4"))]
 mod tests {
     use super::*;
+    use crate::channel::receivers::ChannelReceive;
+    use crate::packet::compression::decompress_payload;
     use crate::packet::error::PacketError;
+    use crate::packet::header::PacketHeader;
+    use crate::packet::message::{
+        FragmentCompression, FragmentData, MessageData, ReceiveMessage, SingleData,
+    };
+    use crate::packet::packet::{FRAGMENT_SIZE, Packet};
+    use crate::packet::packet_type::PacketType;
+    use alloc::collections::VecDeque;
     use bytes::Bytes;
     use lightyear_core::tick::Tick;
+    use lightyear_serde::reader::{ReadInteger, Reader};
+    use lightyear_serde::{SerializationError, ToBytes};
 
-    struct LimiterCompressionChannel;
+    struct CompressionChannel;
+
+    #[test]
+    fn compressed_fragmented_message_round_trips_through_sender_packet_builder_and_receiver()
+    -> Result<(), PacketError> {
+        let compression = CompressionConfig {
+            min_payload_size: 0,
+            max_decompressed_payload_size: FRAGMENT_SIZE * 4,
+            ..CompressionConfig::LZ4
+        };
+        let settings = ChannelSettings {
+            mode: ChannelMode::SequencedUnreliable,
+            ..ChannelSettings::default()
+        };
+        let mut registry = ChannelRegistry::default();
+        let (channel_kind, channel_id) = registry.add_channel::<CompressionChannel>(settings);
+
+        let mut sender_transport =
+            Transport::new(PriorityConfig::default()).with_compression(compression);
+        sender_transport.add_sender::<CompressionChannel>(
+            (&settings).into(),
+            settings.mode,
+            channel_id,
+        );
+
+        let mut receiver_transport =
+            Transport::new(PriorityConfig::default()).with_compression(compression);
+        receiver_transport.add_receiver::<CompressionChannel>((&settings).into(), channel_id);
+
+        let message = Bytes::from(vec![7u8; FRAGMENT_SIZE * 3]);
+        let message_id = sender_transport
+            .send_mut_erased(channel_kind, message.clone(), 1.0)
+            .unwrap()
+            .unwrap();
+
+        let sender = &mut sender_transport
+            .senders
+            .get_mut(&channel_kind)
+            .unwrap()
+            .sender;
+        let (single_messages, fragment_messages) = sender.send_packet();
+        assert!(single_messages.is_empty());
+        assert!(!fragment_messages.is_empty());
+
+        let fragments = fragment_messages
+            .into_iter()
+            .map(|message| match message.data {
+                MessageData::Fragment(fragment) => fragment,
+                MessageData::Single(_) => panic!("oversized message should be fragmented"),
+            })
+            .collect::<VecDeque<_>>();
+        assert!(fragments.len() < 3);
+        assert!(
+            fragments
+                .iter()
+                .all(|fragment| fragment.compression == FragmentCompression::Lz4)
+        );
+
+        let packets = sender_transport
+            .packet_manager
+            .build_packets_with_compression(
+                Duration::default(),
+                Tick(0),
+                vec![],
+                vec![(channel_id, fragments)],
+                compression,
+            )?;
+        assert!(!packets.is_empty());
+
+        for packet in packets {
+            buffer_packet_into_receivers(&mut receiver_transport, packet, compression)?;
+        }
+
+        let receiver = &mut receiver_transport
+            .receivers
+            .get_mut(&channel_id)
+            .unwrap()
+            .receiver;
+        assert_eq!(
+            receiver.read_message(),
+            Some((Tick(0), message, Some(message_id)))
+        );
+        Ok(())
+    }
 
     #[test]
     fn bandwidth_limiter_uses_compressed_packet_size_after_packing() -> Result<(), PacketError> {
@@ -447,14 +543,9 @@ mod tests {
             ..ChannelSettings::default()
         };
         let mut registry = ChannelRegistry::default();
-        let (channel_kind, channel_id) =
-            registry.add_channel::<LimiterCompressionChannel>(settings);
+        let (channel_kind, channel_id) = registry.add_channel::<CompressionChannel>(settings);
         let mut transport = Transport::new(PriorityConfig::new(600)).with_compression(compression);
-        transport.add_sender::<LimiterCompressionChannel>(
-            (&settings).into(),
-            settings.mode,
-            channel_id,
-        );
+        transport.add_sender::<CompressionChannel>((&settings).into(), settings.mode, channel_id);
 
         for _ in 0..8 {
             transport
@@ -488,6 +579,58 @@ mod tests {
                 .priority_manager
                 .consume_packet_quota(packets[0].payload.len() as u32)
         );
+        Ok(())
+    }
+
+    fn buffer_packet_into_receivers(
+        transport: &mut Transport,
+        packet: Packet,
+        compression: CompressionConfig,
+    ) -> Result<(), PacketError> {
+        let mut cursor = Reader::from(packet.payload);
+        let header = PacketHeader::from_bytes(&mut cursor)?;
+        let tick = header.tick;
+        let mut packet_type = header.get_packet_type();
+        if packet_type.is_compressed() {
+            let compressed_payload = cursor.split();
+            let decompressed_payload =
+                decompress_payload(compressed_payload.as_ref(), compression)?;
+            cursor = Reader::from(decompressed_payload);
+            packet_type = packet_type.uncompressed_variant();
+        }
+
+        if packet_type == PacketType::DataFragment {
+            let channel_id = ChannelId::from_bytes(&mut cursor)?;
+            let fragment_data = FragmentData::from_bytes(&mut cursor)?;
+            transport
+                .receivers
+                .get_mut(&channel_id)
+                .ok_or(PacketError::ChannelNotFound)?
+                .receiver
+                .buffer_recv(ReceiveMessage {
+                    data: fragment_data.into(),
+                    remote_sent_tick: tick,
+                    compression,
+                })?;
+        }
+
+        while cursor.has_remaining() {
+            let channel_id = ChannelId::from_bytes(&mut cursor)?;
+            let num_messages = cursor.read_u8().map_err(SerializationError::from)?;
+            for _ in 0..num_messages {
+                let single_data = SingleData::from_bytes(&mut cursor)?;
+                transport
+                    .receivers
+                    .get_mut(&channel_id)
+                    .ok_or(PacketError::ChannelNotFound)?
+                    .receiver
+                    .buffer_recv(ReceiveMessage {
+                        data: single_data.into(),
+                        remote_sent_tick: tick,
+                        compression,
+                    })?;
+            }
+        }
         Ok(())
     }
 }

--- a/lightyear_transport/src/channel/builder.rs
+++ b/lightyear_transport/src/channel/builder.rs
@@ -3,6 +3,7 @@ use crate::channel::receivers::ChannelReceiverEnum;
 use crate::channel::registry::{ChannelId, ChannelKind};
 use crate::channel::senders::ChannelSend;
 use crate::channel::senders::ChannelSenderEnum;
+use crate::packet::compression::CompressionConfig;
 use crate::packet::message::{MessageAck, MessageId};
 use crate::packet::packet::PacketId;
 use crate::packet::packet_builder::{PacketBuilder, RecvPayload};
@@ -63,6 +64,7 @@ pub struct Transport {
     pub priority_manager: PriorityManager,
     /// PacketBuilder shared between all channels of this transport
     pub(crate) packet_manager: PacketBuilder,
+    pub compression: CompressionConfig,
 
     // TODO: do a HashMap<MessageId, PacketId> instead?
     // - when we receive a packet, go through all messages and check which ones match the packet? there shouldn't be too many
@@ -95,6 +97,7 @@ impl Transport {
             senders: Default::default(),
             priority_manager: PriorityManager::new(priority_config),
             packet_manager: PacketBuilder::default(),
+            compression: CompressionConfig::default(),
             packet_to_message_map: Default::default(),
             fragment_acks: Default::default(),
             send_channel,
@@ -102,6 +105,15 @@ impl Transport {
             send: vec![],
             recv: vec![],
         }
+    }
+
+    pub fn with_compression(mut self, compression: CompressionConfig) -> Self {
+        self.compression = compression;
+        self
+    }
+
+    pub fn set_compression(&mut self, compression: CompressionConfig) {
+        self.compression = compression;
     }
 }
 

--- a/lightyear_transport/src/channel/builder.rs
+++ b/lightyear_transport/src/channel/builder.rs
@@ -426,3 +426,68 @@ pub struct InputChannel;
 /// Channel to send messages related to Authority transfers
 /// This is an Ordered Reliable channel
 pub struct AuthorityChannel;
+
+#[cfg(all(test, feature = "compression_lz4"))]
+mod tests {
+    use super::*;
+    use crate::packet::error::PacketError;
+    use bytes::Bytes;
+    use lightyear_core::tick::Tick;
+
+    struct LimiterCompressionChannel;
+
+    #[test]
+    fn bandwidth_limiter_uses_compressed_packet_size_after_packing() -> Result<(), PacketError> {
+        let compression = CompressionConfig {
+            min_payload_size: 0,
+            ..CompressionConfig::LZ4
+        };
+        let settings = ChannelSettings {
+            mode: ChannelMode::UnorderedUnreliableWithAcks,
+            ..ChannelSettings::default()
+        };
+        let mut registry = ChannelRegistry::default();
+        let (channel_kind, channel_id) =
+            registry.add_channel::<LimiterCompressionChannel>(settings);
+        let mut transport = Transport::new(PriorityConfig::new(600)).with_compression(compression);
+        transport.add_sender::<LimiterCompressionChannel>(
+            (&settings).into(),
+            settings.mode,
+            channel_id,
+        );
+
+        for _ in 0..8 {
+            transport
+                .send_mut_erased(channel_kind, Bytes::from(vec![5u8; 200]), 1.0)
+                .unwrap();
+        }
+
+        let sender = &mut transport.senders.get_mut(&channel_kind).unwrap().sender;
+        let (single_messages, fragment_messages) = sender.send_packet();
+        assert_eq!(single_messages.len(), 8);
+        assert!(fragment_messages.is_empty());
+        transport
+            .priority_manager
+            .buffer_messages(channel_id, single_messages, fragment_messages);
+
+        let (single_data, fragment_data) = transport.priority_manager.prioritize(&registry);
+        let packets = transport.packet_manager.build_packets_with_compression(
+            Duration::default(),
+            Tick(0),
+            single_data,
+            fragment_data,
+            compression,
+        )?;
+
+        assert_eq!(packets.len(), 1);
+        assert_eq!(packets[0].num_messages(), 8);
+        assert!(packets[0].compression.is_some());
+        assert!(packets[0].payload.len() <= 600);
+        assert!(
+            transport
+                .priority_manager
+                .consume_packet_quota(packets[0].payload.len() as u32)
+        );
+        Ok(())
+    }
+}

--- a/lightyear_transport/src/channel/receivers/error.rs
+++ b/lightyear_transport/src/channel/receivers/error.rs
@@ -21,6 +21,8 @@ pub enum ChannelReceiveError {
         expected: &'static str,
         actual: &'static str,
     },
+    #[error("fragmented message completed before receiving compression metadata")]
+    MissingFragmentCompression,
     #[error("fragment uses unsupported compression: {compression}")]
     UnsupportedFragmentCompression { compression: &'static str },
     #[error("compressed fragment payload could not be decompressed")]

--- a/lightyear_transport/src/channel/receivers/error.rs
+++ b/lightyear_transport/src/channel/receivers/error.rs
@@ -5,4 +5,30 @@ pub type Result<T> = core::result::Result<T, ChannelReceiveError>;
 pub enum ChannelReceiveError {
     #[error("A message was received without a message ID")]
     MissingMessageId,
+    #[error("fragmented message declared an invalid fragment count: {num_fragments}")]
+    InvalidFragmentCount { num_fragments: u64 },
+    #[error("fragment index {fragment_index} is outside fragment count {num_fragments}")]
+    InvalidFragmentIndex {
+        fragment_index: u64,
+        num_fragments: u64,
+    },
+    #[error("fragment count changed while reassembling message: expected {expected}, got {actual}")]
+    FragmentCountMismatch { expected: usize, actual: usize },
+    #[error(
+        "fragment compression changed while reassembling message: expected {expected}, got {actual}"
+    )]
+    FragmentCompressionMismatch {
+        expected: &'static str,
+        actual: &'static str,
+    },
+    #[error("fragment uses unsupported compression: {compression}")]
+    UnsupportedFragmentCompression { compression: &'static str },
+    #[error("compressed fragment payload could not be decompressed")]
+    FragmentDecompressionFailed,
+    #[error("decompressed fragment payload size {actual} exceeds configured limit {limit}")]
+    FragmentDecompressedPayloadTooLarge { actual: usize, limit: usize },
+    #[error("non-final fragment has size {actual}, expected {expected}")]
+    InvalidNonFinalFragmentSize { actual: usize, expected: usize },
+    #[error("final fragment has size {actual}, maximum {max}")]
+    InvalidFinalFragmentSize { actual: usize, max: usize },
 }

--- a/lightyear_transport/src/channel/receivers/fragment_receiver.rs
+++ b/lightyear_transport/src/channel/receivers/fragment_receiver.rs
@@ -1,7 +1,12 @@
 use alloc::{vec, vec::Vec};
 use bevy_platform::collections::HashMap;
 
-use crate::packet::message::{FragmentData, MessageId};
+use crate::channel::receivers::error::{ChannelReceiveError, Result};
+#[cfg(feature = "compression_lz4")]
+use crate::packet::compression::CompressionAlgorithm;
+use crate::packet::compression::{CompressionConfig, decompress_payload};
+use crate::packet::error::PacketError;
+use crate::packet::message::{FragmentCompression, FragmentData, MessageId};
 use crate::packet::packet::FRAGMENT_SIZE;
 use bytes::Bytes;
 use core::time::Duration;
@@ -42,25 +47,55 @@ impl FragmentReceiver {
         fragment: FragmentData,
         remote_sent_tick: Tick,
         current_time: Option<Duration>,
-    ) -> Option<(Tick, Bytes)> {
-        let fragment_message = self
-            .fragment_messages
-            .entry(fragment.message_id)
-            .or_insert_with(|| {
-                FragmentConstructor::new(remote_sent_tick, fragment.num_fragments.0 as usize)
+        compression: CompressionConfig,
+    ) -> Result<Option<(Tick, Bytes)>> {
+        let num_fragments = fragment.num_fragments.0;
+        let fragment_index = fragment.fragment_id.0;
+        if num_fragments == 0 {
+            return Err(ChannelReceiveError::InvalidFragmentCount { num_fragments });
+        }
+        if fragment_index >= num_fragments {
+            return Err(ChannelReceiveError::InvalidFragmentIndex {
+                fragment_index,
+                num_fragments,
             });
+        }
+
+        let message_id = fragment.message_id;
+        let fragment_compression = fragment.compression;
+        let fragment_message = self.fragment_messages.entry(message_id).or_insert_with(|| {
+            FragmentConstructor::new(
+                remote_sent_tick,
+                num_fragments as usize,
+                fragment_compression,
+            )
+        });
+        if fragment_message.num_fragments != num_fragments as usize {
+            return Err(ChannelReceiveError::FragmentCountMismatch {
+                expected: fragment_message.num_fragments,
+                actual: num_fragments as usize,
+            });
+        }
+        if fragment_message.compression != fragment_compression {
+            return Err(ChannelReceiveError::FragmentCompressionMismatch {
+                expected: fragment_message.compression.as_str(),
+                actual: fragment_compression.as_str(),
+            });
+        }
 
         // completed the fragmented message!
         if let Some(payload) = fragment_message.receive_fragment(
-            fragment.fragment_id.0 as usize,
+            fragment_index as usize,
             fragment.bytes.as_ref(),
             current_time,
-        ) {
-            self.fragment_messages.remove(&fragment.message_id);
-            return Some(payload);
+        )? {
+            self.fragment_messages.remove(&message_id);
+            let (tick, payload) = payload;
+            return decompress_fragment_payload(fragment_compression, payload, compression)
+                .map(|payload| Some((tick, payload)));
         }
 
-        None
+        Ok(None)
     }
 }
 
@@ -74,17 +109,19 @@ pub struct FragmentConstructor {
     bytes: Vec<u8>,
 
     tick: Tick,
+    compression: FragmentCompression,
     last_received: Option<Duration>,
 }
 
 impl FragmentConstructor {
-    pub fn new(tick: Tick, num_fragments: usize) -> Self {
+    pub fn new(tick: Tick, num_fragments: usize, compression: FragmentCompression) -> Self {
         Self {
             num_fragments,
             num_received_fragments: 0,
             received: vec![false; num_fragments],
             bytes: vec![0; num_fragments * FRAGMENT_SIZE],
             tick,
+            compression,
             last_received: None,
         }
     }
@@ -94,12 +131,23 @@ impl FragmentConstructor {
         fragment_index: usize,
         bytes: &[u8],
         received_time: Option<Duration>,
-    ) -> Option<(Tick, Bytes)> {
+    ) -> Result<Option<(Tick, Bytes)>> {
         self.last_received = received_time;
 
         let is_last_fragment = fragment_index == self.num_fragments - 1;
 
-        // TODO: check sizes?
+        if !is_last_fragment && bytes.len() != FRAGMENT_SIZE {
+            return Err(ChannelReceiveError::InvalidNonFinalFragmentSize {
+                actual: bytes.len(),
+                expected: FRAGMENT_SIZE,
+            });
+        }
+        if is_last_fragment && bytes.len() > FRAGMENT_SIZE {
+            return Err(ChannelReceiveError::InvalidFinalFragmentSize {
+                actual: bytes.len(),
+                max: FRAGMENT_SIZE,
+            });
+        }
 
         if !self.received[fragment_index] {
             self.received[fragment_index] = true;
@@ -118,10 +166,68 @@ impl FragmentConstructor {
         if self.num_received_fragments == self.num_fragments {
             trace!("Received all fragments!");
             let payload = core::mem::take(&mut self.bytes);
-            return Some((self.tick, payload.into()));
+            return Ok(Some((self.tick, payload.into())));
         }
 
-        None
+        Ok(None)
+    }
+}
+
+fn decompress_fragment_payload(
+    compression: FragmentCompression,
+    payload: Bytes,
+    config: CompressionConfig,
+) -> Result<Bytes> {
+    match compression {
+        FragmentCompression::None => Ok(payload),
+        FragmentCompression::Lz4 => {
+            let config = config_for_fragment_compression(compression, config)?;
+            decompress_payload(payload.as_ref(), config)
+                .map(Bytes::from)
+                .map_err(map_fragment_decompression_error)
+        }
+    }
+}
+
+fn config_for_fragment_compression(
+    compression: FragmentCompression,
+    config: CompressionConfig,
+) -> Result<CompressionConfig> {
+    match compression {
+        FragmentCompression::None => Ok(config),
+        FragmentCompression::Lz4 => {
+            #[cfg(feature = "compression_lz4")]
+            {
+                if config.algorithm == Some(CompressionAlgorithm::Lz4) {
+                    Ok(config)
+                } else {
+                    Err(ChannelReceiveError::UnsupportedFragmentCompression {
+                        compression: compression.as_str(),
+                    })
+                }
+            }
+            #[cfg(not(feature = "compression_lz4"))]
+            {
+                Err(ChannelReceiveError::UnsupportedFragmentCompression {
+                    compression: compression.as_str(),
+                })
+            }
+        }
+    }
+}
+
+fn map_fragment_decompression_error(error: PacketError) -> ChannelReceiveError {
+    match error {
+        PacketError::UnsupportedCompression => {
+            ChannelReceiveError::UnsupportedFragmentCompression {
+                compression: FragmentCompression::Lz4.as_str(),
+            }
+        }
+        PacketError::DecompressionFailed => ChannelReceiveError::FragmentDecompressionFailed,
+        PacketError::DecompressedPayloadTooLarge { actual, limit } => {
+            ChannelReceiveError::FragmentDecompressedPayloadTooLarge { actual, limit }
+        }
+        _ => ChannelReceiveError::FragmentDecompressionFailed,
     }
 }
 
@@ -132,19 +238,62 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_receiver() {
+    fn test_receiver() -> Result<()> {
         let mut receiver = FragmentReceiver::new();
         let num_bytes = (FRAGMENT_SIZE as f32 * 1.5) as usize;
         let message_bytes = Bytes::from(vec![1u8; num_bytes]);
         let fragments = FragmentSender::new().build_fragments(MessageId(0), message_bytes.clone());
 
         assert_eq!(
-            receiver.receive_fragment(fragments[0].clone(), Tick(0), None),
+            receiver.receive_fragment(
+                fragments[0].clone(),
+                Tick(0),
+                None,
+                CompressionConfig::DISABLED
+            )?,
             None
         );
         assert_eq!(
-            receiver.receive_fragment(fragments[1].clone(), Tick(1), None),
+            receiver.receive_fragment(
+                fragments[1].clone(),
+                Tick(1),
+                None,
+                CompressionConfig::DISABLED
+            )?,
             Some((Tick(0), message_bytes.clone()))
         );
+        Ok(())
+    }
+
+    #[cfg(feature = "compression_lz4")]
+    #[test]
+    fn compressed_fragments_are_decompressed_after_reassembly() -> Result<()> {
+        let compression = CompressionConfig {
+            min_payload_size: 0,
+            max_decompressed_payload_size: FRAGMENT_SIZE * 4,
+            ..CompressionConfig::LZ4
+        };
+        let mut receiver = FragmentReceiver::new();
+        let message_bytes = Bytes::from(vec![7u8; FRAGMENT_SIZE * 3]);
+        let fragments = FragmentSender::new().build_fragments_for_message(
+            MessageId(1),
+            message_bytes.clone(),
+            compression,
+        );
+
+        assert!(fragments.len() < 3);
+        assert!(
+            fragments
+                .iter()
+                .all(|fragment| fragment.compression == FragmentCompression::Lz4)
+        );
+
+        let mut result = None;
+        for (index, fragment) in fragments.into_iter().enumerate() {
+            result = receiver.receive_fragment(fragment, Tick(index as u32), None, compression)?;
+        }
+
+        assert_eq!(result, Some((Tick(0), message_bytes)));
+        Ok(())
     }
 }

--- a/lightyear_transport/src/channel/receivers/fragment_receiver.rs
+++ b/lightyear_transport/src/channel/receivers/fragment_receiver.rs
@@ -63,24 +63,20 @@ impl FragmentReceiver {
 
         let message_id = fragment.message_id;
         let fragment_compression = fragment.compression;
-        let fragment_message = self.fragment_messages.entry(message_id).or_insert_with(|| {
-            FragmentConstructor::new(
-                remote_sent_tick,
-                num_fragments as usize,
-                fragment_compression,
-            )
-        });
+        let fragment_message = self
+            .fragment_messages
+            .entry(message_id)
+            .or_insert_with(|| FragmentConstructor::new(remote_sent_tick, num_fragments as usize));
         if fragment_message.num_fragments != num_fragments as usize {
             return Err(ChannelReceiveError::FragmentCountMismatch {
                 expected: fragment_message.num_fragments,
                 actual: num_fragments as usize,
             });
         }
-        if fragment_message.compression != fragment_compression {
-            return Err(ChannelReceiveError::FragmentCompressionMismatch {
-                expected: fragment_message.compression.as_str(),
-                actual: fragment_compression.as_str(),
-            });
+        if let Some(fragment_compression) = fragment_compression {
+            fragment_message.set_compression(fragment_compression)?;
+        } else if fragment_index == 0 {
+            return Err(ChannelReceiveError::MissingFragmentCompression);
         }
 
         // completed the fragmented message!
@@ -89,6 +85,9 @@ impl FragmentReceiver {
             fragment.bytes.as_ref(),
             current_time,
         )? {
+            let fragment_compression = fragment_message
+                .compression
+                .ok_or(ChannelReceiveError::MissingFragmentCompression)?;
             self.fragment_messages.remove(&message_id);
             let (tick, payload) = payload;
             return decompress_fragment_payload(fragment_compression, payload, compression)
@@ -109,21 +108,35 @@ pub struct FragmentConstructor {
     bytes: Vec<u8>,
 
     tick: Tick,
-    compression: FragmentCompression,
+    compression: Option<FragmentCompression>,
     last_received: Option<Duration>,
 }
 
 impl FragmentConstructor {
-    pub fn new(tick: Tick, num_fragments: usize, compression: FragmentCompression) -> Self {
+    pub fn new(tick: Tick, num_fragments: usize) -> Self {
         Self {
             num_fragments,
             num_received_fragments: 0,
             received: vec![false; num_fragments],
             bytes: vec![0; num_fragments * FRAGMENT_SIZE],
             tick,
-            compression,
+            compression: None,
             last_received: None,
         }
+    }
+
+    pub fn set_compression(&mut self, compression: FragmentCompression) -> Result<()> {
+        if let Some(expected) = self.compression {
+            if expected != compression {
+                return Err(ChannelReceiveError::FragmentCompressionMismatch {
+                    expected: expected.as_str(),
+                    actual: compression.as_str(),
+                });
+            }
+        } else {
+            self.compression = Some(compression);
+        }
+        Ok(())
     }
 
     pub fn receive_fragment(
@@ -246,8 +259,8 @@ mod tests {
 
         assert_eq!(
             receiver.receive_fragment(
-                fragments[0].clone(),
-                Tick(0),
+                fragments[1].clone(),
+                Tick(1),
                 None,
                 CompressionConfig::DISABLED
             )?,
@@ -255,12 +268,12 @@ mod tests {
         );
         assert_eq!(
             receiver.receive_fragment(
-                fragments[1].clone(),
-                Tick(1),
+                fragments[0].clone(),
+                Tick(0),
                 None,
                 CompressionConfig::DISABLED
             )?,
-            Some((Tick(0), message_bytes.clone()))
+            Some((Tick(1), message_bytes.clone()))
         );
         Ok(())
     }
@@ -282,10 +295,12 @@ mod tests {
         );
 
         assert!(fragments.len() < 3);
+        assert_eq!(fragments[0].compression, Some(FragmentCompression::Lz4));
         assert!(
             fragments
                 .iter()
-                .all(|fragment| fragment.compression == FragmentCompression::Lz4)
+                .skip(1)
+                .all(|fragment| fragment.compression.is_none())
         );
 
         let mut result = None;

--- a/lightyear_transport/src/channel/receivers/ordered_reliable.rs
+++ b/lightyear_transport/src/channel/receivers/ordered_reliable.rs
@@ -63,7 +63,8 @@ impl ChannelReceive for OrderedReliableReceiver {
                         fragment,
                         message.remote_sent_tick,
                         None,
-                    ) {
+                        message.compression,
+                    )? {
                         entry.insert(res);
                     }
                 }
@@ -93,6 +94,7 @@ impl ChannelReceive for OrderedReliableReceiver {
 mod tests {
     use crate::channel::receivers::ChannelReceive;
     use crate::channel::receivers::ordered_reliable::OrderedReliableReceiver;
+    use crate::packet::compression::CompressionConfig;
     use crate::packet::error::PacketError;
     use crate::packet::message::{MessageId, ReceiveMessage, SingleData};
     use bytes::Bytes;
@@ -113,6 +115,7 @@ mod tests {
         receiver.buffer_recv(ReceiveMessage {
             data: stale.clone().into(),
             remote_sent_tick: Tick(1),
+            compression: CompressionConfig::DISABLED,
         })?;
         assert_eq!(receiver.recv_message_buffer.len(), 0);
 
@@ -123,6 +126,7 @@ mod tests {
         receiver.buffer_recv(ReceiveMessage {
             data: single2.clone().into(),
             remote_sent_tick: Tick(2),
+            compression: CompressionConfig::DISABLED,
         })?;
 
         // the message has been buffered, but we are not processing it yet
@@ -137,6 +141,7 @@ mod tests {
         receiver.buffer_recv(ReceiveMessage {
             data: single1.clone().into(),
             remote_sent_tick: Tick(3),
+            compression: CompressionConfig::DISABLED,
         })?;
         assert_eq!(receiver.recv_message_buffer.len(), 2);
 

--- a/lightyear_transport/src/channel/receivers/sequenced_reliable.rs
+++ b/lightyear_transport/src/channel/receivers/sequenced_reliable.rs
@@ -69,7 +69,8 @@ impl ChannelReceive for SequencedReliableReceiver {
                         fragment,
                         message.remote_sent_tick,
                         None,
-                    ) {
+                        message.compression,
+                    )? {
                         entry.insert(res);
                     }
                 }
@@ -93,6 +94,7 @@ mod tests {
     use bytes::Bytes;
 
     use crate::channel::receivers::ChannelReceive;
+    use crate::packet::compression::CompressionConfig;
     use crate::packet::message::SingleData;
 
     use super::*;
@@ -114,6 +116,7 @@ mod tests {
         receiver.buffer_recv(ReceiveMessage {
             data: stale.clone().into(),
             remote_sent_tick: Tick(1),
+            compression: CompressionConfig::DISABLED,
         })?;
         assert_eq!(receiver.recv_message_buffer.len(), 0);
 
@@ -124,6 +127,7 @@ mod tests {
         receiver.buffer_recv(ReceiveMessage {
             data: single2.clone().into(),
             remote_sent_tick: Tick(2),
+            compression: CompressionConfig::DISABLED,
         })?;
 
         // we process the message
@@ -142,6 +146,7 @@ mod tests {
         receiver.buffer_recv(ReceiveMessage {
             data: single1.clone().into(),
             remote_sent_tick: Tick(3),
+            compression: CompressionConfig::DISABLED,
         })?;
         assert_eq!(receiver.recv_message_buffer.len(), 0);
         assert_eq!(receiver.read_message(), None);

--- a/lightyear_transport/src/channel/receivers/sequenced_unreliable.rs
+++ b/lightyear_transport/src/channel/receivers/sequenced_unreliable.rs
@@ -77,7 +77,8 @@ impl ChannelReceive for SequencedUnreliableReceiver {
                     fragment,
                     message.remote_sent_tick,
                     Some(self.current_time),
-                ) {
+                    message.compression,
+                )? {
                     self.recv_message_buffer
                         .push_back((tick, bytes, message_id));
                 }
@@ -96,6 +97,7 @@ impl ChannelReceive for SequencedUnreliableReceiver {
 mod tests {
     use crate::channel::receivers::ChannelReceive;
     use crate::channel::receivers::sequenced_unreliable::SequencedUnreliableReceiver;
+    use crate::packet::compression::CompressionConfig;
     use crate::packet::error::PacketError;
     use crate::packet::message::{MessageId, ReceiveMessage, SingleData};
     use bytes::Bytes;
@@ -116,6 +118,7 @@ mod tests {
         receiver.buffer_recv(ReceiveMessage {
             data: stale.clone().into(),
             remote_sent_tick: Tick(1),
+            compression: CompressionConfig::DISABLED,
         })?;
         assert_eq!(receiver.recv_message_buffer.len(), 0);
 
@@ -126,6 +129,7 @@ mod tests {
         receiver.buffer_recv(ReceiveMessage {
             data: single2.clone().into(),
             remote_sent_tick: Tick(2),
+            compression: CompressionConfig::DISABLED,
         })?;
 
         // the message has been buffered, and we can read it instantly
@@ -143,6 +147,7 @@ mod tests {
         receiver.buffer_recv(ReceiveMessage {
             data: single1.clone().into(),
             remote_sent_tick: Tick(3),
+            compression: CompressionConfig::DISABLED,
         })?;
         // we don't add it to the buffer since we have read a more recent message.
         assert_eq!(receiver.recv_message_buffer.len(), 0);
@@ -153,6 +158,7 @@ mod tests {
         receiver.buffer_recv(ReceiveMessage {
             data: single3.clone().into(),
             remote_sent_tick: Tick(4),
+            compression: CompressionConfig::DISABLED,
         })?;
         // it's the most recent message so we receive it
         assert_eq!(receiver.recv_message_buffer.len(), 1);

--- a/lightyear_transport/src/channel/receivers/unordered_reliable.rs
+++ b/lightyear_transport/src/channel/receivers/unordered_reliable.rs
@@ -81,7 +81,8 @@ impl ChannelReceive for UnorderedReliableReceiver {
                         fragment,
                         message.remote_sent_tick,
                         None,
-                    ) {
+                        message.compression,
+                    )? {
                         // receive the message if we haven't received it already
                         if !self.received_message_ids.contains(&message_id) {
                             self.received_message_ids.insert(message_id);
@@ -122,6 +123,7 @@ mod tests {
     use bytes::Bytes;
 
     use crate::channel::receivers::ChannelReceive;
+    use crate::packet::compression::CompressionConfig;
     use crate::packet::message::SingleData;
 
     use super::*;
@@ -141,6 +143,7 @@ mod tests {
         receiver.buffer_recv(ReceiveMessage {
             data: stale.clone().into(),
             remote_sent_tick: Tick(1),
+            compression: CompressionConfig::DISABLED,
         })?;
         assert_eq!(receiver.recv_message_buffer.len(), 0);
 
@@ -151,6 +154,7 @@ mod tests {
         receiver.buffer_recv(ReceiveMessage {
             data: single2.clone().into(),
             remote_sent_tick: Tick(3),
+            compression: CompressionConfig::DISABLED,
         })?;
 
         // we process the message
@@ -169,6 +173,7 @@ mod tests {
         receiver.buffer_recv(ReceiveMessage {
             data: single1.clone().into(),
             remote_sent_tick: Tick(5),
+            compression: CompressionConfig::DISABLED,
         })?;
 
         // we process the message

--- a/lightyear_transport/src/channel/receivers/unordered_unreliable.rs
+++ b/lightyear_transport/src/channel/receivers/unordered_unreliable.rs
@@ -50,7 +50,8 @@ impl ChannelReceive for UnorderedUnreliableReceiver {
                     fragment,
                     message.remote_sent_tick,
                     Some(self.current_time),
-                ) {
+                    message.compression,
+                )? {
                     self.recv_message_buffer.push_back(data);
                 }
             }
@@ -71,6 +72,7 @@ mod tests {
 
     use crate::channel::receivers::ChannelReceive;
     use crate::channel::receivers::error::ChannelReceiveError;
+    use crate::packet::compression::CompressionConfig;
     use crate::packet::message::{MessageId, SingleData};
 
     use super::*;
@@ -87,6 +89,7 @@ mod tests {
         receiver.buffer_recv(ReceiveMessage {
             data: single2.clone().into(),
             remote_sent_tick: Tick(1),
+            compression: CompressionConfig::DISABLED,
         })?;
 
         // it still gets read
@@ -101,6 +104,7 @@ mod tests {
         receiver.buffer_recv(ReceiveMessage {
             data: single2.clone().into(),
             remote_sent_tick: Tick(2),
+            compression: CompressionConfig::DISABLED,
         })?;
 
         // we process the message
@@ -115,6 +119,7 @@ mod tests {
         receiver.buffer_recv(ReceiveMessage {
             data: single1.clone().into(),
             remote_sent_tick: Tick(3),
+            compression: CompressionConfig::DISABLED,
         })?;
 
         // we process the message

--- a/lightyear_transport/src/channel/senders/fragment_sender.rs
+++ b/lightyear_transport/src/channel/senders/fragment_sender.rs
@@ -1,7 +1,11 @@
-use crate::packet::message::{FragmentData, FragmentIndex, MessageId};
+use crate::packet::compression::{
+    CompressionConfig, PayloadCompressionCandidate, try_build_compressed_payload,
+};
+use crate::packet::message::{FragmentCompression, FragmentData, FragmentIndex, MessageId};
 use crate::packet::packet::FRAGMENT_SIZE;
 use alloc::vec::Vec;
 use bytes::Bytes;
+use tracing::trace;
 
 /// `FragmentReceiver` is used to reconstruct fragmented messages
 #[derive(Debug)]
@@ -21,12 +25,59 @@ impl FragmentSender {
         fragment_message_id: MessageId,
         fragment_bytes: Bytes,
     ) -> Vec<FragmentData> {
-        if fragment_bytes.len() <= FRAGMENT_SIZE {
+        if fragment_bytes.len() <= self.fragment_size {
             unreachable!(
                 "Message size must be at least {} to need to be fragmented",
-                FRAGMENT_SIZE
+                self.fragment_size
             );
         }
+        self.build_fragments_with_compression(
+            fragment_message_id,
+            fragment_bytes,
+            FragmentCompression::None,
+        )
+    }
+
+    pub(crate) fn build_fragments_for_message(
+        &self,
+        fragment_message_id: MessageId,
+        message: Bytes,
+        compression: CompressionConfig,
+    ) -> Vec<FragmentData> {
+        if message.len() <= self.fragment_size {
+            unreachable!(
+                "Message size must be at least {} to need to be fragmented",
+                self.fragment_size
+            );
+        }
+
+        if let Ok(PayloadCompressionCandidate::Compressed {
+            payload,
+            original_len,
+            compressed_len,
+        }) = try_build_compressed_payload(message.as_ref(), compression)
+            && let Some(fragment_compression) = fragment_compression(compression)
+        {
+            trace!(
+                original_len,
+                compressed_len, "compressed fragmented message payload"
+            );
+            return self.build_fragments_with_compression(
+                fragment_message_id,
+                Bytes::from(payload),
+                fragment_compression,
+            );
+        }
+
+        self.build_fragments(fragment_message_id, message)
+    }
+
+    fn build_fragments_with_compression(
+        &self,
+        fragment_message_id: MessageId,
+        fragment_bytes: Bytes,
+        compression: FragmentCompression,
+    ) -> Vec<FragmentData> {
         let chunks = fragment_bytes.chunks(self.fragment_size);
         let num_fragments = chunks.len();
         chunks
@@ -36,9 +87,20 @@ impl FragmentSender {
                 message_id: fragment_message_id,
                 fragment_id: FragmentIndex(fragment_index as u64),
                 num_fragments: FragmentIndex(num_fragments as u64),
+                compression,
                 bytes: fragment_bytes.slice_ref(chunk),
             })
             .collect::<_>()
+    }
+}
+
+fn fragment_compression(compression: CompressionConfig) -> Option<FragmentCompression> {
+    match compression.algorithm {
+        #[cfg(feature = "compression_lz4")]
+        Some(crate::packet::compression::CompressionAlgorithm::Lz4) => {
+            Some(FragmentCompression::Lz4)
+        }
+        None => None,
     }
 }
 
@@ -69,6 +131,7 @@ mod tests {
                 message_id,
                 fragment_id: FragmentIndex(0),
                 num_fragments: FragmentIndex(expected_num_fragments as u64),
+                compression: FragmentCompression::None,
                 bytes: bytes.slice(0..FRAGMENT_SIZE),
             }
         );
@@ -78,6 +141,7 @@ mod tests {
                 message_id,
                 fragment_id: FragmentIndex(1),
                 num_fragments: FragmentIndex(expected_num_fragments as u64),
+                compression: FragmentCompression::None,
                 bytes: bytes.slice(FRAGMENT_SIZE..2 * FRAGMENT_SIZE),
             }
         );
@@ -88,6 +152,7 @@ mod tests {
                 // tick: None,
                 fragment_id: FragmentIndex(2),
                 num_fragments: FragmentIndex(expected_num_fragments as u64),
+                compression: FragmentCompression::None,
                 bytes: bytes.slice(2 * FRAGMENT_SIZE..),
             }
         );

--- a/lightyear_transport/src/channel/senders/fragment_sender.rs
+++ b/lightyear_transport/src/channel/senders/fragment_sender.rs
@@ -87,7 +87,7 @@ impl FragmentSender {
                 message_id: fragment_message_id,
                 fragment_id: FragmentIndex(fragment_index as u64),
                 num_fragments: FragmentIndex(num_fragments as u64),
-                compression,
+                compression: (fragment_index == 0).then_some(compression),
                 bytes: fragment_bytes.slice_ref(chunk),
             })
             .collect::<_>()
@@ -131,7 +131,7 @@ mod tests {
                 message_id,
                 fragment_id: FragmentIndex(0),
                 num_fragments: FragmentIndex(expected_num_fragments as u64),
-                compression: FragmentCompression::None,
+                compression: Some(FragmentCompression::None),
                 bytes: bytes.slice(0..FRAGMENT_SIZE),
             }
         );
@@ -141,7 +141,7 @@ mod tests {
                 message_id,
                 fragment_id: FragmentIndex(1),
                 num_fragments: FragmentIndex(expected_num_fragments as u64),
-                compression: FragmentCompression::None,
+                compression: None,
                 bytes: bytes.slice(FRAGMENT_SIZE..2 * FRAGMENT_SIZE),
             }
         );
@@ -152,7 +152,7 @@ mod tests {
                 // tick: None,
                 fragment_id: FragmentIndex(2),
                 num_fragments: FragmentIndex(expected_num_fragments as u64),
-                compression: FragmentCompression::None,
+                compression: None,
                 bytes: bytes.slice(2 * FRAGMENT_SIZE..),
             }
         );

--- a/lightyear_transport/src/channel/senders/mod.rs
+++ b/lightyear_transport/src/channel/senders/mod.rs
@@ -2,6 +2,7 @@ use crate::channel::senders::reliable::ReliableSender;
 use crate::channel::senders::sequenced_unreliable::SequencedUnreliableSender;
 use crate::channel::senders::unordered_unreliable::UnorderedUnreliableSender;
 use crate::channel::senders::unordered_unreliable_with_acks::UnorderedUnreliableWithAcksSender;
+use crate::packet::compression::CompressionConfig;
 use crate::packet::message::{MessageAck, MessageId, SendMessage};
 use crate::prelude::{ChannelMode, ChannelSettings};
 use alloc::collections::VecDeque;
@@ -31,7 +32,12 @@ pub trait ChannelSend {
     /// The priority of the message needs to be specified
     ///
     /// Returns the MessageId of the message that was queued, if there is one
-    fn buffer_send(&mut self, message: Bytes, priority: f32) -> Option<MessageId>;
+    fn buffer_send(
+        &mut self,
+        message: Bytes,
+        priority: f32,
+        compression: CompressionConfig,
+    ) -> Option<MessageId>;
 
     /// Reads from the buffer of messages to send to prepare a list of Packets
     /// that can be sent over the network for this channel

--- a/lightyear_transport/src/channel/senders/reliable.rs
+++ b/lightyear_transport/src/channel/senders/reliable.rs
@@ -6,6 +6,7 @@ use bevy_time::{Real, Time, Timer, TimerMode};
 use crate::channel::builder::ReliableSettings;
 use crate::channel::senders::ChannelSend;
 use crate::channel::senders::fragment_sender::FragmentSender;
+use crate::packet::compression::CompressionConfig;
 use crate::packet::message::{FragmentData, MessageAck, MessageId, SendMessage, SingleData};
 use bytes::Bytes;
 use core::time::Duration;
@@ -110,10 +111,17 @@ impl ChannelSend for ReliableSender {
 
     /// Add a new message to the buffer of messages to be sent.
     /// This is a client-facing function, to be called when you want to send a message
-    fn buffer_send(&mut self, message: Bytes, priority: f32) -> Option<MessageId> {
+    fn buffer_send(
+        &mut self,
+        message: Bytes,
+        priority: f32,
+        compression: CompressionConfig,
+    ) -> Option<MessageId> {
         let message_id = self.next_send_message_id;
         let unacked_message = if message.len() > self.fragment_sender.fragment_size {
-            let fragments = self.fragment_sender.build_fragments(message_id, message);
+            let fragments =
+                self.fragment_sender
+                    .build_fragments_for_message(message_id, message, compression);
             UnackedMessage::Fragmented(
                 fragments
                     .into_iter()
@@ -314,7 +322,9 @@ mod tests {
 
         // Buffer a new message
         let message1 = Bytes::from("hello");
-        sender.buffer_send(message1.clone(), 1.0).unwrap();
+        sender
+            .buffer_send(message1.clone(), 1.0, CompressionConfig::DISABLED)
+            .unwrap();
         assert_eq!(sender.unacked_messages.len(), 1);
         assert_eq!(sender.next_send_message_id, MessageId(1));
         // Collect the messages to be sent

--- a/lightyear_transport/src/channel/senders/sequenced_unreliable.rs
+++ b/lightyear_transport/src/channel/senders/sequenced_unreliable.rs
@@ -1,5 +1,6 @@
 use crate::channel::senders::ChannelSend;
 use crate::channel::senders::fragment_sender::FragmentSender;
+use crate::packet::compression::CompressionConfig;
 use crate::packet::message::{MessageAck, MessageData, MessageId, SendMessage, SingleData};
 use alloc::collections::VecDeque;
 use bevy_time::{Real, Time, Timer, TimerMode};
@@ -50,10 +51,18 @@ impl ChannelSend for SequencedUnreliableSender {
 
     /// Add a new message to the buffer of messages to be sent.
     /// This is a client-facing function, to be called when you want to send a message
-    fn buffer_send(&mut self, message: Bytes, priority: f32) -> Option<MessageId> {
+    fn buffer_send(
+        &mut self,
+        message: Bytes,
+        priority: f32,
+        compression: CompressionConfig,
+    ) -> Option<MessageId> {
         let message_id = self.next_send_message_id;
         if message.len() > self.fragment_sender.fragment_size {
-            for fragment in self.fragment_sender.build_fragments(message_id, message) {
+            for fragment in
+                self.fragment_sender
+                    .build_fragments_for_message(message_id, message, compression)
+            {
                 self.fragmented_messages_to_send.push_back(SendMessage {
                     data: MessageData::Fragment(fragment),
                     priority,
@@ -97,7 +106,9 @@ mod tests {
         let mut sender = SequencedUnreliableSender::new(Duration::from_secs(1));
         assert!(sender.timer.as_ref().is_some_and(|t| !t.is_finished()));
 
-        sender.buffer_send(Bytes::from("hello"), 1.0).unwrap();
+        sender
+            .buffer_send(Bytes::from("hello"), 1.0, CompressionConfig::DISABLED)
+            .unwrap();
 
         // we do not send because we didn't reach the timer
         let (single, _) = sender.send_packet();

--- a/lightyear_transport/src/channel/senders/unordered_unreliable.rs
+++ b/lightyear_transport/src/channel/senders/unordered_unreliable.rs
@@ -4,6 +4,7 @@ use core::time::Duration;
 
 use crate::channel::senders::ChannelSend;
 use crate::channel::senders::fragment_sender::FragmentSender;
+use crate::packet::compression::CompressionConfig;
 use crate::packet::message::{MessageAck, MessageData, MessageId, SendMessage, SingleData};
 use bytes::Bytes;
 use lightyear_link::LinkStats;
@@ -51,12 +52,18 @@ impl ChannelSend for UnorderedUnreliableSender {
 
     /// Add a new message to the buffer of messages to be sent.
     /// This is a client-facing function, to be called when you want to send a message
-    fn buffer_send(&mut self, message: Bytes, priority: f32) -> Option<MessageId> {
+    fn buffer_send(
+        &mut self,
+        message: Bytes,
+        priority: f32,
+        compression: CompressionConfig,
+    ) -> Option<MessageId> {
         if message.len() > self.fragment_sender.fragment_size {
-            for fragment in self
-                .fragment_sender
-                .build_fragments(self.next_send_fragmented_message_id, message)
-            {
+            for fragment in self.fragment_sender.build_fragments_for_message(
+                self.next_send_fragmented_message_id,
+                message,
+                compression,
+            ) {
                 self.fragmented_messages_to_send.push_back(SendMessage {
                     data: MessageData::Fragment(fragment),
                     priority,

--- a/lightyear_transport/src/channel/senders/unordered_unreliable_with_acks.rs
+++ b/lightyear_transport/src/channel/senders/unordered_unreliable_with_acks.rs
@@ -5,6 +5,7 @@ use core::time::Duration;
 use crate::channel::senders::ChannelSend;
 use crate::channel::senders::fragment_ack_receiver::FragmentAckReceiver;
 use crate::channel::senders::fragment_sender::FragmentSender;
+use crate::packet::compression::CompressionConfig;
 use crate::packet::message::{MessageAck, MessageData, MessageId, SendMessage, SingleData};
 use bytes::Bytes;
 use lightyear_link::LinkStats;
@@ -60,10 +61,17 @@ impl ChannelSend for UnorderedUnreliableWithAcksSender {
 
     /// Add a new message to the buffer of messages to be sent.
     /// This is a client-facing function, to be called when you want to send a message
-    fn buffer_send(&mut self, message: Bytes, priority: f32) -> Option<MessageId> {
+    fn buffer_send(
+        &mut self,
+        message: Bytes,
+        priority: f32,
+        compression: CompressionConfig,
+    ) -> Option<MessageId> {
         let message_id = self.next_send_message_id;
         if message.len() > self.fragment_sender.fragment_size {
-            let fragments = self.fragment_sender.build_fragments(message_id, message);
+            let fragments =
+                self.fragment_sender
+                    .build_fragments_for_message(message_id, message, compression);
             self.fragment_ack_receiver
                 .add_new_fragment_to_wait_for(message_id, fragments.len());
             for fragment in fragments {

--- a/lightyear_transport/src/lib.rs
+++ b/lightyear_transport/src/lib.rs
@@ -25,5 +25,6 @@ pub mod prelude {
     pub use crate::channel::builder::{ChannelMode, ChannelSettings, ReliableSettings, Transport};
     pub use crate::channel::registry::AppChannelExt;
     pub use crate::channel::registry::ChannelRegistry;
+    pub use crate::packet::compression::{CompressionAlgorithm, CompressionConfig};
     pub use crate::packet::priority_manager::{PriorityConfig, PriorityManager};
 }

--- a/lightyear_transport/src/packet/compression.rs
+++ b/lightyear_transport/src/packet/compression.rs
@@ -264,6 +264,8 @@ mod tests {
         Packet {
             payload,
             messages: Vec::<MessageMetadata>::new(),
+            #[cfg(feature = "metrics")]
+            message_stats: Vec::new(),
             packet_id: PacketId(0),
             prewritten_size: 0,
             compression: None,

--- a/lightyear_transport/src/packet/compression.rs
+++ b/lightyear_transport/src/packet/compression.rs
@@ -102,6 +102,27 @@ pub(crate) enum CompressionCandidate {
     },
 }
 
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum PayloadCompressionCandidate {
+    Disabled,
+    TooSmall {
+        payload_len: usize,
+    },
+    TooLargeForDecompressionLimit {
+        payload_len: usize,
+        limit: usize,
+    },
+    NotSmaller {
+        original_len: usize,
+        compressed_len: usize,
+    },
+    Compressed {
+        payload: Vec<u8>,
+        original_len: usize,
+        compressed_len: usize,
+    },
+}
+
 /// Try to compress the packet payload body in place.
 ///
 /// The packet is only modified if the compressed final packet is strictly smaller than the original
@@ -148,9 +169,9 @@ pub(crate) fn try_build_compressed_packet_payload(
     packet_payload: &[u8],
     config: CompressionConfig,
 ) -> Result<CompressionCandidate, PacketError> {
-    let Some(algorithm) = config.algorithm else {
+    if config.algorithm.is_none() {
         return Ok(CompressionCandidate::Disabled);
-    };
+    }
 
     if packet_payload.len() <= HEADER_BYTES {
         return Ok(CompressionCandidate::TooSmall { payload_len: 0 });
@@ -161,36 +182,81 @@ pub(crate) fn try_build_compressed_packet_payload(
         return Ok(CompressionCandidate::AlreadyCompressed);
     };
 
-    let payload_len = packet_payload.len() - HEADER_BYTES;
+    match try_build_compressed_payload(&packet_payload[HEADER_BYTES..], config)? {
+        PayloadCompressionCandidate::Disabled => Ok(CompressionCandidate::Disabled),
+        PayloadCompressionCandidate::TooSmall { payload_len } => {
+            Ok(CompressionCandidate::TooSmall { payload_len })
+        }
+        PayloadCompressionCandidate::TooLargeForDecompressionLimit { payload_len, limit } => {
+            Ok(CompressionCandidate::TooLargeForDecompressionLimit { payload_len, limit })
+        }
+        PayloadCompressionCandidate::NotSmaller {
+            original_len,
+            compressed_len,
+        } => Ok(CompressionCandidate::NotSmaller {
+            original_len: HEADER_BYTES + original_len,
+            compressed_len: HEADER_BYTES + compressed_len,
+        }),
+        PayloadCompressionCandidate::Compressed {
+            payload: compressed_payload,
+            original_len,
+            compressed_len,
+        } => {
+            let compressed_packet_len = HEADER_BYTES + compressed_len;
+            let original_packet_len = HEADER_BYTES + original_len;
+            if compressed_packet_len > MAX_PACKET_SIZE {
+                return Ok(CompressionCandidate::NotSmaller {
+                    original_len: original_packet_len,
+                    compressed_len: compressed_packet_len,
+                });
+            }
+
+            let mut payload = Vec::with_capacity(compressed_packet_len);
+            payload.extend_from_slice(&packet_payload[..HEADER_BYTES]);
+            payload[PacketHeader::PACKET_TYPE_OFFSET] = compressed_packet_type.into();
+            payload.extend_from_slice(&compressed_payload);
+
+            Ok(CompressionCandidate::Compressed {
+                payload,
+                original_len: original_packet_len,
+                compressed_len: compressed_packet_len,
+            })
+        }
+    }
+}
+
+pub(crate) fn try_build_compressed_payload(
+    payload: &[u8],
+    config: CompressionConfig,
+) -> Result<PayloadCompressionCandidate, PacketError> {
+    let Some(algorithm) = config.algorithm else {
+        return Ok(PayloadCompressionCandidate::Disabled);
+    };
+
+    let payload_len = payload.len();
     if payload_len < config.min_payload_size {
-        return Ok(CompressionCandidate::TooSmall { payload_len });
+        return Ok(PayloadCompressionCandidate::TooSmall { payload_len });
     }
     if payload_len > config.max_decompressed_payload_size {
-        return Ok(CompressionCandidate::TooLargeForDecompressionLimit {
+        return Ok(PayloadCompressionCandidate::TooLargeForDecompressionLimit {
             payload_len,
             limit: config.max_decompressed_payload_size,
         });
     }
 
-    let compressed_payload = compress_payload(&packet_payload[HEADER_BYTES..], algorithm);
-    let compressed_len = HEADER_BYTES + compressed_payload.len();
-    let original_len = packet_payload.len();
+    let compressed_payload = compress_payload(payload, algorithm);
+    let compressed_len = compressed_payload.len();
 
-    if compressed_len >= original_len || compressed_len > MAX_PACKET_SIZE {
-        return Ok(CompressionCandidate::NotSmaller {
-            original_len,
+    if compressed_len >= payload_len {
+        return Ok(PayloadCompressionCandidate::NotSmaller {
+            original_len: payload_len,
             compressed_len,
         });
     }
 
-    let mut payload = Vec::with_capacity(compressed_len);
-    payload.extend_from_slice(&packet_payload[..HEADER_BYTES]);
-    payload[PacketHeader::PACKET_TYPE_OFFSET] = compressed_packet_type.into();
-    payload.extend_from_slice(&compressed_payload);
-
-    Ok(CompressionCandidate::Compressed {
-        payload,
-        original_len,
+    Ok(PayloadCompressionCandidate::Compressed {
+        payload: compressed_payload,
+        original_len: payload_len,
         compressed_len,
     })
 }

--- a/lightyear_transport/src/packet/compression.rs
+++ b/lightyear_transport/src/packet/compression.rs
@@ -10,10 +10,11 @@ use alloc::vec::Vec;
 
 use crate::packet::error::PacketError;
 use crate::packet::header::PacketHeader;
-use crate::packet::packet::{HEADER_BYTES, MAX_PACKET_SIZE, Packet};
+use crate::packet::packet::{HEADER_BYTES, MAX_PACKET_SIZE, Packet, PacketCompressionInfo};
 use crate::packet::packet_type::PacketType;
 
 const DEFAULT_MIN_PAYLOAD_SIZE: usize = 128;
+const DEFAULT_MAX_DECOMPRESSED_PAYLOAD_SIZE: usize = 64 * 1024;
 
 /// Compression algorithm used for transport packet payloads.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -37,14 +38,14 @@ impl CompressionConfig {
     pub const DISABLED: Self = Self {
         algorithm: None,
         min_payload_size: DEFAULT_MIN_PAYLOAD_SIZE,
-        max_decompressed_payload_size: MAX_PACKET_SIZE,
+        max_decompressed_payload_size: DEFAULT_MAX_DECOMPRESSED_PAYLOAD_SIZE,
     };
 
     #[cfg(feature = "compression_lz4")]
     pub const LZ4: Self = Self {
         algorithm: Some(CompressionAlgorithm::Lz4),
         min_payload_size: DEFAULT_MIN_PAYLOAD_SIZE,
-        max_decompressed_payload_size: MAX_PACKET_SIZE,
+        max_decompressed_payload_size: DEFAULT_MAX_DECOMPRESSED_PAYLOAD_SIZE,
     };
 
     pub const fn is_enabled(&self) -> bool {
@@ -65,11 +66,37 @@ pub(crate) enum CompressionOutcome {
     TooSmall {
         payload_len: usize,
     },
+    TooLargeForDecompressionLimit {
+        payload_len: usize,
+        limit: usize,
+    },
     NotSmaller {
         original_len: usize,
         compressed_len: usize,
     },
     Compressed {
+        original_len: usize,
+        compressed_len: usize,
+    },
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum CompressionCandidate {
+    Disabled,
+    AlreadyCompressed,
+    TooSmall {
+        payload_len: usize,
+    },
+    TooLargeForDecompressionLimit {
+        payload_len: usize,
+        limit: usize,
+    },
+    NotSmaller {
+        original_len: usize,
+        compressed_len: usize,
+    },
+    Compressed {
+        payload: Vec<u8>,
         original_len: usize,
         compressed_len: usize,
     },
@@ -83,40 +110,86 @@ pub(crate) fn try_compress_packet(
     packet: &mut Packet,
     config: CompressionConfig,
 ) -> Result<CompressionOutcome, PacketError> {
+    match try_build_compressed_packet_payload(&packet.payload, config)? {
+        CompressionCandidate::Disabled => Ok(CompressionOutcome::Disabled),
+        CompressionCandidate::AlreadyCompressed => Ok(CompressionOutcome::AlreadyCompressed),
+        CompressionCandidate::TooSmall { payload_len } => {
+            Ok(CompressionOutcome::TooSmall { payload_len })
+        }
+        CompressionCandidate::TooLargeForDecompressionLimit { payload_len, limit } => {
+            Ok(CompressionOutcome::TooLargeForDecompressionLimit { payload_len, limit })
+        }
+        CompressionCandidate::NotSmaller {
+            original_len,
+            compressed_len,
+        } => Ok(CompressionOutcome::NotSmaller {
+            original_len,
+            compressed_len,
+        }),
+        CompressionCandidate::Compressed {
+            payload,
+            original_len,
+            compressed_len,
+        } => {
+            packet.payload = payload;
+            packet.compression = Some(PacketCompressionInfo {
+                original_len,
+                compressed_len,
+            });
+            Ok(CompressionOutcome::Compressed {
+                original_len,
+                compressed_len,
+            })
+        }
+    }
+}
+
+pub(crate) fn try_build_compressed_packet_payload(
+    packet_payload: &[u8],
+    config: CompressionConfig,
+) -> Result<CompressionCandidate, PacketError> {
     let Some(algorithm) = config.algorithm else {
-        return Ok(CompressionOutcome::Disabled);
+        return Ok(CompressionCandidate::Disabled);
     };
 
-    if packet.payload.len() <= HEADER_BYTES {
-        return Ok(CompressionOutcome::TooSmall { payload_len: 0 });
+    if packet_payload.len() <= HEADER_BYTES {
+        return Ok(CompressionCandidate::TooSmall { payload_len: 0 });
     }
 
-    let packet_type = PacketType::try_from(packet.payload[PacketHeader::PACKET_TYPE_OFFSET])?;
+    let packet_type = PacketType::try_from(packet_payload[PacketHeader::PACKET_TYPE_OFFSET])?;
     let Some(compressed_packet_type) = packet_type.compressed_variant() else {
-        return Ok(CompressionOutcome::AlreadyCompressed);
+        return Ok(CompressionCandidate::AlreadyCompressed);
     };
 
-    let payload_len = packet.payload.len() - HEADER_BYTES;
+    let payload_len = packet_payload.len() - HEADER_BYTES;
     if payload_len < config.min_payload_size {
-        return Ok(CompressionOutcome::TooSmall { payload_len });
+        return Ok(CompressionCandidate::TooSmall { payload_len });
+    }
+    if payload_len > config.max_decompressed_payload_size {
+        return Ok(CompressionCandidate::TooLargeForDecompressionLimit {
+            payload_len,
+            limit: config.max_decompressed_payload_size,
+        });
     }
 
-    let compressed_payload = compress_payload(&packet.payload[HEADER_BYTES..], algorithm);
+    let compressed_payload = compress_payload(&packet_payload[HEADER_BYTES..], algorithm);
     let compressed_len = HEADER_BYTES + compressed_payload.len();
-    let original_len = packet.payload.len();
+    let original_len = packet_payload.len();
 
     if compressed_len >= original_len || compressed_len > MAX_PACKET_SIZE {
-        return Ok(CompressionOutcome::NotSmaller {
+        return Ok(CompressionCandidate::NotSmaller {
             original_len,
             compressed_len,
         });
     }
 
-    packet.payload[PacketHeader::PACKET_TYPE_OFFSET] = compressed_packet_type.into();
-    packet.payload.truncate(HEADER_BYTES);
-    packet.payload.extend_from_slice(&compressed_payload);
+    let mut payload = Vec::with_capacity(compressed_len);
+    payload.extend_from_slice(&packet_payload[..HEADER_BYTES]);
+    payload[PacketHeader::PACKET_TYPE_OFFSET] = compressed_packet_type.into();
+    payload.extend_from_slice(&compressed_payload);
 
-    Ok(CompressionOutcome::Compressed {
+    Ok(CompressionCandidate::Compressed {
+        payload,
         original_len,
         compressed_len,
     })
@@ -193,6 +266,7 @@ mod tests {
             messages: Vec::<MessageMetadata>::new(),
             packet_id: PacketId(0),
             prewritten_size: 0,
+            compression: None,
         }
     }
 

--- a/lightyear_transport/src/packet/compression.rs
+++ b/lightyear_transport/src/packet/compression.rs
@@ -264,8 +264,6 @@ mod tests {
         Packet {
             payload,
             messages: Vec::<MessageMetadata>::new(),
-            #[cfg(feature = "metrics")]
-            message_stats: Vec::new(),
             packet_id: PacketId(0),
             prewritten_size: 0,
             compression: None,

--- a/lightyear_transport/src/packet/compression.rs
+++ b/lightyear_transport/src/packet/compression.rs
@@ -1,0 +1,277 @@
+//! Packet payload compression helpers.
+//!
+//! Compression is applied after packet headers have been written. The header stays
+//! uncompressed so receivers can parse packet ids, acks, ticks, and the packet type
+//! before deciding whether the payload body needs decompression.
+
+#[cfg(feature = "compression_lz4")]
+use alloc::vec;
+use alloc::vec::Vec;
+
+use crate::packet::error::PacketError;
+use crate::packet::header::PacketHeader;
+use crate::packet::packet::{HEADER_BYTES, MAX_PACKET_SIZE, Packet};
+use crate::packet::packet_type::PacketType;
+
+const DEFAULT_MIN_PAYLOAD_SIZE: usize = 128;
+
+/// Compression algorithm used for transport packet payloads.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CompressionAlgorithm {
+    #[cfg(feature = "compression_lz4")]
+    Lz4,
+}
+
+/// Configuration for post-pack packet payload compression.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CompressionConfig {
+    /// `None` disables compression.
+    pub algorithm: Option<CompressionAlgorithm>,
+    /// Do not attempt compression for payload bodies smaller than this value.
+    pub min_payload_size: usize,
+    /// Maximum decompressed packet payload body accepted on receive.
+    pub max_decompressed_payload_size: usize,
+}
+
+impl CompressionConfig {
+    pub const DISABLED: Self = Self {
+        algorithm: None,
+        min_payload_size: DEFAULT_MIN_PAYLOAD_SIZE,
+        max_decompressed_payload_size: MAX_PACKET_SIZE,
+    };
+
+    #[cfg(feature = "compression_lz4")]
+    pub const LZ4: Self = Self {
+        algorithm: Some(CompressionAlgorithm::Lz4),
+        min_payload_size: DEFAULT_MIN_PAYLOAD_SIZE,
+        max_decompressed_payload_size: MAX_PACKET_SIZE,
+    };
+
+    pub const fn is_enabled(&self) -> bool {
+        self.algorithm.is_some()
+    }
+}
+
+impl Default for CompressionConfig {
+    fn default() -> Self {
+        Self::DISABLED
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum CompressionOutcome {
+    Disabled,
+    AlreadyCompressed,
+    TooSmall {
+        payload_len: usize,
+    },
+    NotSmaller {
+        original_len: usize,
+        compressed_len: usize,
+    },
+    Compressed {
+        original_len: usize,
+        compressed_len: usize,
+    },
+}
+
+/// Try to compress the packet payload body in place.
+///
+/// The packet is only modified if the compressed final packet is strictly smaller than the original
+/// packet and still fits in the packet MTU.
+pub(crate) fn try_compress_packet(
+    packet: &mut Packet,
+    config: CompressionConfig,
+) -> Result<CompressionOutcome, PacketError> {
+    let Some(algorithm) = config.algorithm else {
+        return Ok(CompressionOutcome::Disabled);
+    };
+
+    if packet.payload.len() <= HEADER_BYTES {
+        return Ok(CompressionOutcome::TooSmall { payload_len: 0 });
+    }
+
+    let packet_type = PacketType::try_from(packet.payload[PacketHeader::PACKET_TYPE_OFFSET])?;
+    let Some(compressed_packet_type) = packet_type.compressed_variant() else {
+        return Ok(CompressionOutcome::AlreadyCompressed);
+    };
+
+    let payload_len = packet.payload.len() - HEADER_BYTES;
+    if payload_len < config.min_payload_size {
+        return Ok(CompressionOutcome::TooSmall { payload_len });
+    }
+
+    let compressed_payload = compress_payload(&packet.payload[HEADER_BYTES..], algorithm);
+    let compressed_len = HEADER_BYTES + compressed_payload.len();
+    let original_len = packet.payload.len();
+
+    if compressed_len >= original_len || compressed_len > MAX_PACKET_SIZE {
+        return Ok(CompressionOutcome::NotSmaller {
+            original_len,
+            compressed_len,
+        });
+    }
+
+    packet.payload[PacketHeader::PACKET_TYPE_OFFSET] = compressed_packet_type.into();
+    packet.payload.truncate(HEADER_BYTES);
+    packet.payload.extend_from_slice(&compressed_payload);
+
+    Ok(CompressionOutcome::Compressed {
+        original_len,
+        compressed_len,
+    })
+}
+
+pub(crate) fn decompress_payload(
+    compressed_payload: &[u8],
+    config: CompressionConfig,
+) -> Result<Vec<u8>, PacketError> {
+    let Some(algorithm) = config.algorithm else {
+        return Err(PacketError::UnsupportedCompression);
+    };
+
+    match algorithm {
+        #[cfg(feature = "compression_lz4")]
+        CompressionAlgorithm::Lz4 => decompress_lz4(compressed_payload, config),
+    }
+}
+
+fn compress_payload(payload: &[u8], algorithm: CompressionAlgorithm) -> Vec<u8> {
+    match algorithm {
+        #[cfg(feature = "compression_lz4")]
+        CompressionAlgorithm::Lz4 => lz4_flex::block::compress_prepend_size(payload),
+    }
+}
+
+#[cfg(feature = "compression_lz4")]
+fn decompress_lz4(
+    compressed_payload: &[u8],
+    config: CompressionConfig,
+) -> Result<Vec<u8>, PacketError> {
+    let (uncompressed_size, compressed_payload) =
+        lz4_flex::block::uncompressed_size(compressed_payload)
+            .map_err(|_| PacketError::DecompressionFailed)?;
+
+    if uncompressed_size > config.max_decompressed_payload_size {
+        return Err(PacketError::DecompressedPayloadTooLarge {
+            actual: uncompressed_size,
+            limit: config.max_decompressed_payload_size,
+        });
+    }
+
+    let mut decompressed = vec![0; uncompressed_size];
+    let decoded_size = lz4_flex::block::decompress_into(compressed_payload, &mut decompressed)
+        .map_err(|_| PacketError::DecompressionFailed)?;
+    if decoded_size != uncompressed_size {
+        return Err(PacketError::DecompressionFailed);
+    }
+
+    Ok(decompressed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::packet::header::PacketHeaderManager;
+    use crate::packet::packet::{MessageMetadata, PacketId};
+    use lightyear_core::tick::Tick;
+    use lightyear_serde::ToBytes;
+
+    fn packet_with_body(packet_type: PacketType, body: &[u8]) -> Packet {
+        let mut header_manager = PacketHeaderManager::new(1.5);
+        let header = header_manager.prepare_send_packet_header(
+            packet_type,
+            core::time::Duration::default(),
+            Tick(0),
+        );
+        let mut payload = Vec::new();
+        header.to_bytes(&mut payload).unwrap();
+        payload.extend_from_slice(body);
+
+        Packet {
+            payload,
+            messages: Vec::<MessageMetadata>::new(),
+            packet_id: PacketId(0),
+            prewritten_size: 0,
+        }
+    }
+
+    #[test]
+    fn disabled_compression_leaves_packet_unchanged() {
+        let mut packet = packet_with_body(PacketType::Data, &[1, 2, 3, 4]);
+        let original = packet.payload.clone();
+
+        let outcome = try_compress_packet(&mut packet, CompressionConfig::DISABLED).unwrap();
+
+        assert_eq!(outcome, CompressionOutcome::Disabled);
+        assert_eq!(packet.payload, original);
+    }
+
+    #[cfg(feature = "compression_lz4")]
+    #[test]
+    fn lz4_compression_changes_packet_type_and_preserves_payload_body() {
+        let original_body = vec![7u8; 512];
+        let mut packet = packet_with_body(PacketType::Data, &original_body);
+        let original_len = packet.payload.len();
+        let config = CompressionConfig {
+            min_payload_size: 0,
+            ..CompressionConfig::LZ4
+        };
+
+        let outcome = try_compress_packet(&mut packet, config).unwrap();
+
+        assert!(matches!(outcome, CompressionOutcome::Compressed { .. }));
+        assert!(packet.payload.len() < original_len);
+        assert_eq!(
+            PacketType::try_from(packet.payload[PacketHeader::PACKET_TYPE_OFFSET]).unwrap(),
+            PacketType::DataCompressed
+        );
+        let decompressed = decompress_payload(&packet.payload[HEADER_BYTES..], config).unwrap();
+        assert_eq!(decompressed, original_body);
+    }
+
+    #[cfg(feature = "compression_lz4")]
+    #[test]
+    fn lz4_compression_falls_back_when_not_smaller() {
+        let original_body = *b"small payload that should expand";
+        let mut packet = packet_with_body(PacketType::Data, &original_body);
+        let original = packet.payload.clone();
+        let config = CompressionConfig {
+            min_payload_size: 0,
+            ..CompressionConfig::LZ4
+        };
+
+        let outcome = try_compress_packet(&mut packet, config).unwrap();
+
+        assert!(matches!(outcome, CompressionOutcome::NotSmaller { .. }));
+        assert_eq!(packet.payload, original);
+    }
+
+    #[cfg(feature = "compression_lz4")]
+    #[test]
+    fn lz4_decompression_respects_configured_size_cap() {
+        let compressed = lz4_flex::block::compress_prepend_size(&[3u8; 32]);
+        let config = CompressionConfig {
+            max_decompressed_payload_size: 8,
+            ..CompressionConfig::LZ4
+        };
+
+        let err = decompress_payload(&compressed, config).unwrap_err();
+
+        assert!(matches!(
+            err,
+            PacketError::DecompressedPayloadTooLarge {
+                actual: 32,
+                limit: 8
+            }
+        ));
+    }
+
+    #[cfg(feature = "compression_lz4")]
+    #[test]
+    fn lz4_decompression_rejects_malformed_payload() {
+        let err = decompress_payload(&[1, 2, 3], CompressionConfig::LZ4).unwrap_err();
+
+        assert!(matches!(err, PacketError::DecompressionFailed));
+    }
+}

--- a/lightyear_transport/src/packet/error.rs
+++ b/lightyear_transport/src/packet/error.rs
@@ -18,4 +18,6 @@ pub enum PacketError {
     DecompressionFailed,
     #[error("decompressed packet payload size {actual} exceeds configured limit {limit}")]
     DecompressedPayloadTooLarge { actual: usize, limit: usize },
+    #[error("packet size {actual} exceeds MTU {mtu}")]
+    PacketTooLarge { actual: usize, mtu: usize },
 }

--- a/lightyear_transport/src/packet/error.rs
+++ b/lightyear_transport/src/packet/error.rs
@@ -12,4 +12,10 @@ pub enum PacketError {
     ChannelNotFound,
     #[error("receiver channel error: {0}")]
     ChannelReceiveError(#[from] ChannelReceiveError),
+    #[error("compression is not supported by this build or transport configuration")]
+    UnsupportedCompression,
+    #[error("compressed packet payload could not be decompressed")]
+    DecompressionFailed,
+    #[error("decompressed packet payload size {actual} exceeds configured limit {limit}")]
+    DecompressedPayloadTooLarge { actual: usize, limit: usize },
 }

--- a/lightyear_transport/src/packet/header.rs
+++ b/lightyear_transport/src/packet/header.rs
@@ -70,6 +70,11 @@ impl ToBytes for PacketHeader {
 }
 
 impl PacketHeader {
+    /// Number of bytes written by [`PacketHeader::to_bytes`].
+    pub(crate) const BYTES: usize = 17;
+    /// Offset of the packet type byte inside the serialized header.
+    pub(crate) const PACKET_TYPE_OFFSET: usize = 0;
+
     /// Get the value of the i-th bit in the bitfield (starting from the right-most bit, which is
     /// one PacketId below `last_ack_packet_id`
     ///

--- a/lightyear_transport/src/packet/message.rs
+++ b/lightyear_transport/src/packet/message.rs
@@ -155,7 +155,8 @@ pub(crate) struct FragmentData {
     pub message_id: MessageId,
     pub fragment_id: FragmentIndex,
     pub num_fragments: FragmentIndex,
-    pub compression: FragmentCompression,
+    /// Compression mode for the reassembled message. Serialized only on fragment 0.
+    pub compression: Option<FragmentCompression>,
     /// Bytes data associated with the message that is too big
     pub bytes: Bytes,
 }
@@ -199,7 +200,11 @@ impl ToBytes for FragmentData {
         self.message_id.bytes_len()
             + self.fragment_id.bytes_len()
             + self.num_fragments.bytes_len()
-            + self.compression.bytes_len()
+            + if self.is_initial_fragment() {
+                FragmentCompression::None.bytes_len()
+            } else {
+                0
+            }
             + self.bytes.bytes_len()
     }
 
@@ -207,7 +212,9 @@ impl ToBytes for FragmentData {
         self.message_id.to_bytes(buffer)?;
         self.fragment_id.to_bytes(buffer)?;
         self.num_fragments.to_bytes(buffer)?;
-        self.compression.to_bytes(buffer)?;
+        if self.is_initial_fragment() {
+            self.compression.unwrap_or_default().to_bytes(buffer)?;
+        }
         self.bytes.to_bytes(buffer)?;
         Ok(())
     }
@@ -220,7 +227,11 @@ impl ToBytes for FragmentData {
         let message_id = MessageId::from_bytes(buffer)?;
         let fragment_id = FragmentIndex::from_bytes(buffer)?;
         let num_fragments = FragmentIndex::from_bytes(buffer)?;
-        let compression = FragmentCompression::from_bytes(buffer)?;
+        let compression = if fragment_id.0 == 0 {
+            Some(FragmentCompression::from_bytes(buffer)?)
+        } else {
+            None
+        };
         let bytes = Bytes::from_bytes(buffer)?;
         Ok(Self {
             message_id,
@@ -258,6 +269,10 @@ impl ToBytes for FragmentCompression {
 }
 
 impl FragmentData {
+    pub(crate) fn is_initial_fragment(&self) -> bool {
+        self.fragment_id.0 == 0
+    }
+
     pub(crate) fn is_last_fragment(&self) -> bool {
         self.fragment_id.0 == self.num_fragments.0 - 1
     }
@@ -301,7 +316,7 @@ mod tests {
             message_id: MessageId(0),
             fragment_id: FragmentIndex(2),
             num_fragments: FragmentIndex(3),
-            compression: FragmentCompression::None,
+            compression: None,
             bytes: bytes.clone(),
         };
         let mut writer = vec![];
@@ -312,5 +327,22 @@ mod tests {
         let mut reader = writer.into();
         let decoded = FragmentData::from_bytes(&mut reader).unwrap();
         assert_eq!(decoded, data);
+
+        let initial_data = FragmentData {
+            message_id: MessageId(0),
+            fragment_id: FragmentIndex(0),
+            num_fragments: FragmentIndex(3),
+            compression: Some(FragmentCompression::Lz4),
+            bytes,
+        };
+        let mut writer = vec![];
+        initial_data.to_bytes(&mut writer).unwrap();
+
+        assert_eq!(writer.len(), initial_data.bytes_len());
+        assert_eq!(initial_data.bytes_len(), data.bytes_len() + 1);
+
+        let mut reader = writer.into();
+        let decoded = FragmentData::from_bytes(&mut reader).unwrap();
+        assert_eq!(decoded, initial_data);
     }
 }

--- a/lightyear_transport/src/packet/message.rs
+++ b/lightyear_transport/src/packet/message.rs
@@ -10,6 +10,8 @@ use lightyear_serde::writer::WriteInteger;
 use lightyear_serde::{SerializationError, ToBytes};
 use lightyear_utils::wrapping_id;
 
+use crate::packet::compression::CompressionConfig;
+
 // Internal id that we assign to each message sent over the network
 wrapping_id!(MessageId);
 
@@ -52,6 +54,7 @@ pub struct ReceiveMessage {
     pub(crate) data: MessageData,
     // keep track on the receiver side of the sender tick when the message was actually sent
     pub(crate) remote_sent_tick: Tick,
+    pub(crate) compression: CompressionConfig,
 }
 
 #[derive(Debug, PartialEq)]
@@ -152,8 +155,25 @@ pub(crate) struct FragmentData {
     pub message_id: MessageId,
     pub fragment_id: FragmentIndex,
     pub num_fragments: FragmentIndex,
+    pub compression: FragmentCompression,
     /// Bytes data associated with the message that is too big
     pub bytes: Bytes,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub(crate) enum FragmentCompression {
+    #[default]
+    None,
+    Lz4,
+}
+
+impl FragmentCompression {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::None => "none",
+            Self::Lz4 => "lz4",
+        }
+    }
 }
 
 impl ToBytes for FragmentIndex {
@@ -179,6 +199,7 @@ impl ToBytes for FragmentData {
         self.message_id.bytes_len()
             + self.fragment_id.bytes_len()
             + self.num_fragments.bytes_len()
+            + self.compression.bytes_len()
             + self.bytes.bytes_len()
     }
 
@@ -186,6 +207,7 @@ impl ToBytes for FragmentData {
         self.message_id.to_bytes(buffer)?;
         self.fragment_id.to_bytes(buffer)?;
         self.num_fragments.to_bytes(buffer)?;
+        self.compression.to_bytes(buffer)?;
         self.bytes.to_bytes(buffer)?;
         Ok(())
     }
@@ -198,13 +220,40 @@ impl ToBytes for FragmentData {
         let message_id = MessageId::from_bytes(buffer)?;
         let fragment_id = FragmentIndex::from_bytes(buffer)?;
         let num_fragments = FragmentIndex::from_bytes(buffer)?;
+        let compression = FragmentCompression::from_bytes(buffer)?;
         let bytes = Bytes::from_bytes(buffer)?;
         Ok(Self {
             message_id,
             fragment_id,
             num_fragments,
+            compression,
             bytes,
         })
+    }
+}
+
+impl ToBytes for FragmentCompression {
+    fn bytes_len(&self) -> usize {
+        1
+    }
+
+    fn to_bytes(&self, buffer: &mut impl WriteInteger) -> Result<(), SerializationError> {
+        match self {
+            Self::None => 0u8.to_bytes(buffer)?,
+            Self::Lz4 => 1u8.to_bytes(buffer)?,
+        }
+        Ok(())
+    }
+
+    fn from_bytes(buffer: &mut Reader) -> Result<Self, SerializationError>
+    where
+        Self: Sized,
+    {
+        match u8::from_bytes(buffer)? {
+            0 => Ok(Self::None),
+            1 => Ok(Self::Lz4),
+            _ => Err(SerializationError::InvalidValue),
+        }
     }
 }
 
@@ -252,6 +301,7 @@ mod tests {
             message_id: MessageId(0),
             fragment_id: FragmentIndex(2),
             num_fragments: FragmentIndex(3),
+            compression: FragmentCompression::None,
             bytes: bytes.clone(),
         };
         let mut writer = vec![];

--- a/lightyear_transport/src/packet/mod.rs
+++ b/lightyear_transport/src/packet/mod.rs
@@ -20,6 +20,7 @@ Packets that are over the maximum packet size will be fragmented into multiple `
 /// Manages the [`PacketHeader`](header::PacketHeader) which includes important packet information
 pub(crate) mod header;
 
+pub mod compression;
 pub mod message;
 
 // "module has the same name as its containing module" style nit.

--- a/lightyear_transport/src/packet/packet.rs
+++ b/lightyear_transport/src/packet/packet.rs
@@ -36,24 +36,22 @@ const MAX_FRAGMENT_METADATA_BYTES: usize = MAX_FRAGMENT_CHANNEL_ID_BYTES
 pub(crate) const FRAGMENT_SIZE: usize =
     MAX_PACKET_SIZE - HEADER_BYTES - MAX_FRAGMENT_METADATA_BYTES;
 
-/// Metadata about the message included in the packet.
-/// Useful to maintain mappings from channel to message_ids, and packet to message_ids.
+/// Metadata about messages included in a packet.
+///
+/// With the `metrics` feature enabled, this contains every message written into the packet so
+/// channel metrics can be emitted after the final packet passes the bandwidth limiter.
+///
+/// Without `metrics`, this only contains messages with an id, because the send path only needs
+/// packet-local metadata for ack/retry bookkeeping.
 #[derive(Debug, PartialEq)]
 pub(crate) struct MessageMetadata {
     pub(crate) channel: ChannelId,
-    pub(crate) message: MessageId,
+    pub(crate) message: Option<MessageId>,
     // if the message is fragmented, we store the total number of fragments
     pub(crate) fragment_index: Option<FragmentIndex>,
     pub(crate) num_fragments: Option<u64>,
     // Size of the message in bytes (for fragments, it's only the size of the fragment)
     #[cfg(feature = "metrics")]
-    pub(crate) num_bytes: usize,
-}
-
-#[cfg(feature = "metrics")]
-#[derive(Debug, PartialEq)]
-pub(crate) struct PacketMessageStats {
-    pub(crate) channel: ChannelId,
     pub(crate) num_bytes: usize,
 }
 
@@ -67,10 +65,11 @@ pub(crate) struct PacketCompressionInfo {
 #[derive(Debug)]
 pub(crate) struct Packet {
     pub(crate) payload: Payload,
-    /// MessageIds contained in the packet so we can map from channel id to message ids
+    /// Packet-local message metadata.
+    ///
+    /// See [`MessageMetadata`] for the feature-dependent rule that decides whether id-less
+    /// messages are recorded.
     pub(crate) messages: Vec<MessageMetadata>,
-    #[cfg(feature = "metrics")]
-    pub(crate) message_stats: Vec<PacketMessageStats>,
     pub(crate) packet_id: PacketId,
     // How many bytes we know we are going to have to write in the packet, but haven't written yet
     pub(crate) prewritten_size: usize,
@@ -100,10 +99,27 @@ impl Packet {
         self.messages.len()
     }
 
-    #[cfg(feature = "metrics")]
-    pub(crate) fn record_message_stats(&mut self, channel: ChannelId, num_bytes: usize) {
-        self.message_stats
-            .push(PacketMessageStats { channel, num_bytes });
+    pub(crate) fn record_message_metadata(
+        &mut self,
+        channel: ChannelId,
+        message: Option<MessageId>,
+        fragment_index: Option<FragmentIndex>,
+        num_fragments: Option<u64>,
+        #[cfg(feature = "metrics")] num_bytes: usize,
+    ) {
+        // In metrics builds, every message needs metadata so channel/send_* can be emitted only
+        // after the final packet passes bandwidth quota. In non-metrics builds, id-less entries
+        // are skipped to keep packet metadata limited to ack/retry bookkeeping.
+        if cfg!(feature = "metrics") || message.is_some() {
+            self.messages.push(MessageMetadata {
+                channel,
+                message,
+                fragment_index,
+                num_fragments,
+                #[cfg(feature = "metrics")]
+                num_bytes,
+            });
+        }
     }
 
     #[allow(unused)]

--- a/lightyear_transport/src/packet/packet.rs
+++ b/lightyear_transport/src/packet/packet.rs
@@ -1,5 +1,6 @@
 /// Defines the [`Packet`] struct
 use crate::channel::registry::ChannelId;
+use crate::packet::header::PacketHeader;
 use crate::packet::message::{FragmentIndex, MessageId};
 use crate::packet::packet_builder::Payload;
 use alloc::vec::Vec;
@@ -9,13 +10,13 @@ use lightyear_utils::wrapping_id;
 // Internal id that we assign to each packet sent over the network
 wrapping_id!(PacketId);
 
-const MAX_PACKET_SIZE: usize = 1200;
+pub(crate) const MAX_PACKET_SIZE: usize = 1200;
 /// Number of bytes written by [`PacketHeader::to_bytes`].
 ///
 /// Keep this in sync with `PacketHeader` because [`FRAGMENT_SIZE`] depends on it.
 /// If this value is too small, fragment packets can overflow the 1200-byte MTU even when
 /// the fragment payload itself appears to fit.
-const HEADER_BYTES: usize = 17;
+pub(crate) const HEADER_BYTES: usize = PacketHeader::BYTES;
 
 const MAX_FRAGMENT_CHANNEL_ID_BYTES: usize = varint_len(u16::MAX as u64);
 const MAX_FRAGMENT_ID_BYTES: usize = 8;
@@ -105,8 +106,8 @@ mod tests {
     use crate::channel::builder::{ChannelMode, ChannelSettings};
     use crate::channel::registry::{AppChannelExt, ChannelRegistry};
     use crate::packet::error::PacketError;
-    use lightyear_serde::ToBytes;
-    use lightyear_serde::reader::ReadVarInt;
+    use lightyear_serde::reader::ReadInteger;
+    use lightyear_serde::{SerializationError, ToBytes};
 
     impl Packet {
         /// For tests, parse the packet so that we can inspect the contents
@@ -129,7 +130,7 @@ mod tests {
             // TODO: avoid infinite loop here!
             while cursor.has_remaining() {
                 let channel_id = ChannelId::from_bytes(&mut cursor)?;
-                let num_messages = cursor.read_varint()?;
+                let num_messages = cursor.read_u8().map_err(SerializationError::from)?;
                 for _ in 0..num_messages {
                     let single_data = SingleData::from_bytes(&mut cursor)?;
                     res.entry(channel_id).or_default().push(single_data.bytes);

--- a/lightyear_transport/src/packet/packet.rs
+++ b/lightyear_transport/src/packet/packet.rs
@@ -50,6 +50,13 @@ pub(crate) struct MessageMetadata {
     pub(crate) num_bytes: usize,
 }
 
+#[cfg(feature = "metrics")]
+#[derive(Debug, PartialEq)]
+pub(crate) struct PacketMessageStats {
+    pub(crate) channel: ChannelId,
+    pub(crate) num_bytes: usize,
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) struct PacketCompressionInfo {
     pub(crate) original_len: usize,
@@ -62,6 +69,8 @@ pub(crate) struct Packet {
     pub(crate) payload: Payload,
     /// MessageIds contained in the packet so we can map from channel id to message ids
     pub(crate) messages: Vec<MessageMetadata>,
+    #[cfg(feature = "metrics")]
+    pub(crate) message_stats: Vec<PacketMessageStats>,
     pub(crate) packet_id: PacketId,
     // How many bytes we know we are going to have to write in the packet, but haven't written yet
     pub(crate) prewritten_size: usize,
@@ -89,6 +98,12 @@ impl Packet {
 
     pub(crate) fn num_messages(&self) -> usize {
         self.messages.len()
+    }
+
+    #[cfg(feature = "metrics")]
+    pub(crate) fn record_message_stats(&mut self, channel: ChannelId, num_bytes: usize) {
+        self.message_stats
+            .push(PacketMessageStats { channel, num_bytes });
     }
 
     #[allow(unused)]

--- a/lightyear_transport/src/packet/packet.rs
+++ b/lightyear_transport/src/packet/packet.rs
@@ -21,20 +21,20 @@ pub(crate) const HEADER_BYTES: usize = PacketHeader::BYTES;
 const MAX_FRAGMENT_CHANNEL_ID_BYTES: usize = varint_len(u16::MAX as u64);
 const MAX_FRAGMENT_ID_BYTES: usize = 8;
 const MAX_FRAGMENT_COUNT_BYTES: usize = 8;
-const FRAGMENT_COMPRESSION_BYTES: usize = 1;
+const INITIAL_FRAGMENT_COMPRESSION_BYTES: usize = 1;
 const MAX_FRAGMENT_LENGTH_BYTES: usize = varint_len(MAX_PACKET_SIZE as u64);
 const MAX_FRAGMENT_METADATA_BYTES: usize = MAX_FRAGMENT_CHANNEL_ID_BYTES
     + 4 // MessageId
     + MAX_FRAGMENT_ID_BYTES
     + MAX_FRAGMENT_COUNT_BYTES
-    + FRAGMENT_COMPRESSION_BYTES
+    + INITIAL_FRAGMENT_COMPRESSION_BYTES
     + MAX_FRAGMENT_LENGTH_BYTES;
 
 /// The maximum number of payload bytes in a transport fragment.
 ///
 /// This reserves enough room for the packet header plus the largest supported encoded fragment
-/// metadata. The receiver assumes every non-final fragment has this fixed size when
-/// reconstructing the original message.
+/// metadata, including the compression marker on fragment 0. The receiver assumes every non-final
+/// fragment has this fixed size when reconstructing the original message.
 pub(crate) const FRAGMENT_SIZE: usize =
     MAX_PACKET_SIZE - HEADER_BYTES - MAX_FRAGMENT_METADATA_BYTES;
 

--- a/lightyear_transport/src/packet/packet.rs
+++ b/lightyear_transport/src/packet/packet.rs
@@ -21,11 +21,13 @@ pub(crate) const HEADER_BYTES: usize = PacketHeader::BYTES;
 const MAX_FRAGMENT_CHANNEL_ID_BYTES: usize = varint_len(u16::MAX as u64);
 const MAX_FRAGMENT_ID_BYTES: usize = 8;
 const MAX_FRAGMENT_COUNT_BYTES: usize = 8;
+const FRAGMENT_COMPRESSION_BYTES: usize = 1;
 const MAX_FRAGMENT_LENGTH_BYTES: usize = varint_len(MAX_PACKET_SIZE as u64);
 const MAX_FRAGMENT_METADATA_BYTES: usize = MAX_FRAGMENT_CHANNEL_ID_BYTES
     + 4 // MessageId
     + MAX_FRAGMENT_ID_BYTES
     + MAX_FRAGMENT_COUNT_BYTES
+    + FRAGMENT_COMPRESSION_BYTES
     + MAX_FRAGMENT_LENGTH_BYTES;
 
 /// The maximum number of payload bytes in a transport fragment.

--- a/lightyear_transport/src/packet/packet.rs
+++ b/lightyear_transport/src/packet/packet.rs
@@ -50,6 +50,12 @@ pub(crate) struct MessageMetadata {
     pub(crate) num_bytes: usize,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct PacketCompressionInfo {
+    pub(crate) original_len: usize,
+    pub(crate) compressed_len: usize,
+}
+
 /// Data structure that will help us write the packet
 #[derive(Debug)]
 pub(crate) struct Packet {
@@ -59,6 +65,7 @@ pub(crate) struct Packet {
     pub(crate) packet_id: PacketId,
     // How many bytes we know we are going to have to write in the packet, but haven't written yet
     pub(crate) prewritten_size: usize,
+    pub(crate) compression: Option<PacketCompressionInfo>,
 }
 
 impl Packet {

--- a/lightyear_transport/src/packet/packet_builder.rs
+++ b/lightyear_transport/src/packet/packet_builder.rs
@@ -440,8 +440,14 @@ mod tests {
     use crate::channel::builder::{ChannelMode, ChannelSettings};
     use crate::channel::registry::{AppChannelExt, ChannelKind, ChannelRegistry};
     use crate::channel::senders::fragment_sender::FragmentSender;
+    #[cfg(feature = "compression_lz4")]
+    use crate::packet::compression::{CompressionConfig, decompress_payload, try_compress_packet};
     use crate::packet::error::PacketError;
+    #[cfg(feature = "compression_lz4")]
+    use crate::packet::header::PacketHeader;
     use crate::packet::message::{FragmentIndex, MessageId};
+    #[cfg(feature = "compression_lz4")]
+    use crate::packet::packet::HEADER_BYTES;
     use bytes::Bytes;
 
     use super::*;
@@ -469,6 +475,19 @@ mod tests {
         app.world_mut()
             .remove_resource::<ChannelRegistry>()
             .unwrap()
+    }
+
+    #[cfg(feature = "compression_lz4")]
+    fn decompress_packet_for_test(mut packet: Packet) -> Result<Packet, PacketError> {
+        let packet_type = PacketType::try_from(packet.payload[PacketHeader::PACKET_TYPE_OFFSET])?;
+        let decompressed_payload =
+            decompress_payload(&packet.payload[HEADER_BYTES..], CompressionConfig::LZ4)?;
+
+        packet.payload[PacketHeader::PACKET_TYPE_OFFSET] =
+            packet_type.uncompressed_variant().into();
+        packet.payload.truncate(HEADER_BYTES);
+        packet.payload.extend_from_slice(&decompressed_payload);
+        Ok(packet)
     }
 
     /// A bunch of small messages that all fit in the same packet
@@ -793,6 +812,73 @@ mod tests {
                 MAX_PACKET_SIZE
             );
         }
+        Ok(())
+    }
+
+    #[cfg(feature = "compression_lz4")]
+    #[test]
+    fn compressed_single_packet_decompresses_to_original_messages() -> Result<(), PacketError> {
+        let channel_registry = get_channel_registry();
+        let mut manager = PacketBuilder::new(1.5);
+        let channel_kind = ChannelKind::of::<Channel1>();
+        let channel_id = channel_registry.get_net_from_kind(&channel_kind).unwrap();
+
+        let bytes = Bytes::from(vec![4u8; 512]);
+        let single_data = vec![(
+            *channel_id,
+            VecDeque::from(vec![SingleData::new(None, bytes.clone())]),
+        )];
+        let mut packets =
+            manager.build_packets(Duration::default(), Tick(0), single_data, vec![])?;
+        assert_eq!(packets.len(), 1);
+
+        let mut packet = packets.pop().unwrap();
+        try_compress_packet(
+            &mut packet,
+            CompressionConfig {
+                min_payload_size: 0,
+                ..CompressionConfig::LZ4
+            },
+        )?;
+
+        let contents = decompress_packet_for_test(packet)?.parse_packet_payload()?;
+        assert_eq!(contents.get(channel_id).unwrap(), &vec![bytes]);
+        Ok(())
+    }
+
+    #[cfg(feature = "compression_lz4")]
+    #[test]
+    fn compressed_fragment_packet_decompresses_to_original_fragment() -> Result<(), PacketError> {
+        let channel_registry = get_channel_registry();
+        let mut manager = PacketBuilder::new(1.5);
+        let channel_kind = ChannelKind::of::<Channel1>();
+        let channel_id = channel_registry.get_net_from_kind(&channel_kind).unwrap();
+
+        let fragment = FragmentData {
+            message_id: MessageId(7),
+            fragment_id: FragmentIndex(0),
+            num_fragments: FragmentIndex(1),
+            bytes: Bytes::from(vec![2u8; 512]),
+        };
+        let mut packets = manager.build_packets(
+            Duration::default(),
+            Tick(0),
+            vec![],
+            vec![(*channel_id, VecDeque::from(vec![fragment.clone()]))],
+        )?;
+        assert_eq!(packets.len(), 1);
+
+        let mut packet = packets.pop().unwrap();
+        try_compress_packet(
+            &mut packet,
+            CompressionConfig {
+                min_payload_size: 0,
+                ..CompressionConfig::LZ4
+            },
+        )?;
+
+        let contents = decompress_packet_for_test(packet)?.parse_packet_payload()?;
+        assert_eq!(contents.get(channel_id).unwrap(), &vec![fragment.bytes]);
         Ok(())
     }
 

--- a/lightyear_transport/src/packet/packet_builder.rs
+++ b/lightyear_transport/src/packet/packet_builder.rs
@@ -757,6 +757,8 @@ mod tests {
     use crate::packet::error::PacketError;
     #[cfg(feature = "compression_lz4")]
     use crate::packet::header::PacketHeader;
+    #[cfg(feature = "compression_lz4")]
+    use crate::packet::message::FragmentCompression;
     use crate::packet::message::{FragmentIndex, MessageId};
     #[cfg(feature = "compression_lz4")]
     use crate::packet::packet::HEADER_BYTES;
@@ -1381,6 +1383,7 @@ mod tests {
             message_id: MessageId(7),
             fragment_id: FragmentIndex(0),
             num_fragments: FragmentIndex(1),
+            compression: FragmentCompression::None,
             bytes: Bytes::from(vec![2u8; 512]),
         };
         let mut packets = manager.build_packets(

--- a/lightyear_transport/src/packet/packet_builder.rs
+++ b/lightyear_transport/src/packet/packet_builder.rs
@@ -1383,7 +1383,7 @@ mod tests {
             message_id: MessageId(7),
             fragment_id: FragmentIndex(0),
             num_fragments: FragmentIndex(1),
-            compression: FragmentCompression::None,
+            compression: Some(FragmentCompression::None),
             bytes: Bytes::from(vec![2u8; 512]),
         };
         let mut packets = manager.build_packets(

--- a/lightyear_transport/src/packet/packet_builder.rs
+++ b/lightyear_transport/src/packet/packet_builder.rs
@@ -95,6 +95,8 @@ impl PacketBuilder {
         self.current_packet = Some(Packet {
             payload: cursor,
             messages: vec![],
+            #[cfg(feature = "metrics")]
+            message_stats: vec![],
             packet_id: header.packet_id,
             prewritten_size: 0,
             compression: None,
@@ -128,6 +130,11 @@ impl PacketBuilder {
                 fragment_index: Some(fragment_data.fragment_id),
                 num_fragments: Some(fragment_data.num_fragments.0),
                 #[cfg(feature = "metrics")]
+                num_bytes: fragment_data.bytes.len(),
+            }],
+            #[cfg(feature = "metrics")]
+            message_stats: vec![crate::packet::packet::PacketMessageStats {
+                channel: ChannelId::from(channel_id),
                 num_bytes: fragment_data.bytes.len(),
             }],
             packet_id: header.packet_id,
@@ -398,6 +405,8 @@ impl PacketBuilder {
             for _ in 0..*num_messages {
                 // TODO: deal with error
                 let message = messages.pop_front().unwrap();
+                #[cfg(feature = "metrics")]
+                let message_bytes = message.bytes_len();
                 message.to_bytes(&mut packet.payload)?;
                 packet.prewritten_size = packet
                     .prewritten_size
@@ -411,9 +420,11 @@ impl PacketBuilder {
                         fragment_index: None,
                         num_fragments: None,
                         #[cfg(feature = "metrics")]
-                        num_bytes: message.bytes_len(),
+                        num_bytes: message_bytes,
                     });
                 }
+                #[cfg(feature = "metrics")]
+                packet.record_message_stats(channel_id, message_bytes);
             }
             *num_messages = 0;
         }
@@ -463,7 +474,13 @@ impl PacketBuilder {
                 });
             }
 
-            Self::append_single_messages(&mut packet, *channel_id, single_messages, fit_count)?;
+            Self::append_single_messages(
+                &mut packet,
+                *channel_id,
+                single_messages,
+                fit_count,
+                true,
+            )?;
             for _ in 0..fit_count {
                 single_messages.pop_front();
             }
@@ -585,11 +602,13 @@ impl PacketBuilder {
         let mut candidate = Packet {
             payload: packet.payload.clone(),
             messages: Vec::new(),
+            #[cfg(feature = "metrics")]
+            message_stats: Vec::new(),
             packet_id: packet.packet_id,
             prewritten_size: 0,
             compression: None,
         };
-        Self::append_single_messages(&mut candidate, channel_id, messages, count)?;
+        Self::append_single_messages(&mut candidate, channel_id, messages, count, false)?;
         Ok(candidate)
     }
 
@@ -598,11 +617,14 @@ impl PacketBuilder {
         channel_id: ChannelId,
         messages: &VecDeque<SingleData>,
         count: usize,
+        _record_stats: bool,
     ) -> Result<(), SerializationError> {
         debug_assert!(count <= MAX_MESSAGES_PER_CHANNEL_BATCH);
         channel_id.to_bytes(&mut packet.payload)?;
         packet.payload.write_u8(count as u8)?;
         for message in messages.iter().take(count) {
+            #[cfg(feature = "metrics")]
+            let message_bytes = message.bytes_len();
             message.to_bytes(&mut packet.payload)?;
             if let Some(id) = message.id {
                 packet.messages.push(MessageMetadata {
@@ -611,8 +633,12 @@ impl PacketBuilder {
                     fragment_index: None,
                     num_fragments: None,
                     #[cfg(feature = "metrics")]
-                    num_bytes: message.bytes_len(),
+                    num_bytes: message_bytes,
                 });
+            }
+            #[cfg(feature = "metrics")]
+            if _record_stats {
+                packet.record_message_stats(channel_id, message_bytes);
             }
         }
         Ok(())
@@ -750,6 +776,8 @@ mod tests {
     use crate::packet::message::{FragmentIndex, MessageId};
     #[cfg(feature = "compression_lz4")]
     use crate::packet::packet::HEADER_BYTES;
+    #[cfg(feature = "metrics")]
+    use crate::packet::packet::PacketMessageStats;
     use bytes::Bytes;
 
     use super::*;
@@ -834,6 +862,28 @@ mod tests {
         assert_eq!(packets.len(), 1);
         let packet = packets.pop().unwrap();
         assert_eq!(packet.messages, vec![]);
+        #[cfg(feature = "metrics")]
+        assert_eq!(
+            packet.message_stats,
+            vec![
+                PacketMessageStats {
+                    channel: *channel_id1,
+                    num_bytes: small_message.bytes_len(),
+                },
+                PacketMessageStats {
+                    channel: *channel_id2,
+                    num_bytes: small_message.bytes_len(),
+                },
+                PacketMessageStats {
+                    channel: *channel_id2,
+                    num_bytes: small_message.bytes_len(),
+                },
+                PacketMessageStats {
+                    channel: *channel_id3,
+                    num_bytes: small_message.bytes_len(),
+                },
+            ]
+        );
         let contents = packet.parse_packet_payload()?;
         assert_eq!(
             contents.get(channel_id1).unwrap(),
@@ -927,6 +977,28 @@ mod tests {
         Ok(())
     }
 
+    #[cfg(feature = "metrics")]
+    #[test]
+    fn compression_candidate_packets_do_not_record_message_stats() {
+        let channel_registry = get_channel_registry();
+        let channel_kind = ChannelKind::of::<Channel1>();
+        let channel_id = channel_registry.get_net_from_kind(&channel_kind).unwrap();
+        let messages = VecDeque::from(vec![
+            SingleData::new(None, Bytes::from(vec![7u8; 32])),
+            SingleData::new(None, Bytes::from(vec![8u8; 32])),
+        ]);
+
+        let mut manager = PacketBuilder::new(1.5);
+        manager
+            .build_new_single_packet(Duration::default(), Tick(0))
+            .unwrap();
+        let packet = manager.current_packet.take().unwrap();
+        let candidate = PacketBuilder::candidate_packet(&packet, *channel_id, &messages, 2)
+            .expect("candidate packet should serialize");
+
+        assert!(candidate.message_stats.is_empty());
+    }
+
     #[cfg(feature = "compression_lz4")]
     #[test]
     fn compression_aware_packing_can_pack_beyond_uncompressed_mtu() -> Result<(), PacketError> {
@@ -964,6 +1036,13 @@ mod tests {
 
         assert_eq!(packets.len(), 1);
         assert!(packets[0].payload.len() <= MAX_PACKET_SIZE);
+        #[cfg(feature = "metrics")]
+        {
+            assert_eq!(packets[0].message_stats.len(), 128);
+            assert!(packets[0].message_stats.iter().all(|stats| {
+                stats.channel == *channel_id && stats.num_bytes == small_message.bytes_len()
+            }));
+        }
         assert_eq!(
             PacketType::try_from(packets[0].payload[PacketHeader::PACKET_TYPE_OFFSET])?,
             PacketType::DataCompressed

--- a/lightyear_transport/src/packet/packet_builder.rs
+++ b/lightyear_transport/src/packet/packet_builder.rs
@@ -7,7 +7,7 @@ use crate::packet::compression::{
 use crate::packet::error::PacketError;
 use crate::packet::header::PacketHeaderManager;
 use crate::packet::message::{FragmentData, SingleData};
-use crate::packet::packet::{FRAGMENT_SIZE, HEADER_BYTES, MessageMetadata, Packet};
+use crate::packet::packet::{FRAGMENT_SIZE, HEADER_BYTES, Packet};
 use crate::packet::packet_type::PacketType;
 use alloc::collections::VecDeque;
 use alloc::{vec, vec::Vec};
@@ -95,8 +95,6 @@ impl PacketBuilder {
         self.current_packet = Some(Packet {
             payload: cursor,
             messages: vec![],
-            #[cfg(feature = "metrics")]
-            message_stats: vec![],
             packet_id: header.packet_id,
             prewritten_size: 0,
             compression: None,
@@ -121,26 +119,23 @@ impl PacketBuilder {
         header.to_bytes(&mut cursor)?;
         channel_id.to_bytes(&mut cursor)?;
         fragment_data.to_bytes(&mut cursor)?;
-        self.current_packet = Some(Packet {
+        let mut packet = Packet {
             payload: cursor,
             // TODO(perf): reuse this vec allocation instead of newly allocating!
-            messages: vec![MessageMetadata {
-                channel: ChannelId::from(channel_id),
-                message: fragment_data.message_id,
-                fragment_index: Some(fragment_data.fragment_id),
-                num_fragments: Some(fragment_data.num_fragments.0),
-                #[cfg(feature = "metrics")]
-                num_bytes: fragment_data.bytes.len(),
-            }],
-            #[cfg(feature = "metrics")]
-            message_stats: vec![crate::packet::packet::PacketMessageStats {
-                channel: ChannelId::from(channel_id),
-                num_bytes: fragment_data.bytes.len(),
-            }],
+            messages: vec![],
             packet_id: header.packet_id,
             prewritten_size: 0,
             compression: None,
-        });
+        };
+        packet.record_message_metadata(
+            ChannelId::from(channel_id),
+            Some(fragment_data.message_id),
+            Some(fragment_data.fragment_id),
+            Some(fragment_data.num_fragments.0),
+            #[cfg(feature = "metrics")]
+            fragment_data.bytes.len(),
+        );
+        self.current_packet = Some(packet);
         Ok(())
 
         //
@@ -412,19 +407,14 @@ impl PacketBuilder {
                     .prewritten_size
                     .checked_sub(message.bytes_len())
                     .ok_or(SerializationError::SubtractionOverflow)?;
-                // only send a MessageAck when the message has an id (otherwise we don't expect an ack)
-                if let Some(id) = message.id {
-                    packet.messages.push(MessageMetadata {
-                        channel: channel_id,
-                        message: id,
-                        fragment_index: None,
-                        num_fragments: None,
-                        #[cfg(feature = "metrics")]
-                        num_bytes: message_bytes,
-                    });
-                }
-                #[cfg(feature = "metrics")]
-                packet.record_message_stats(channel_id, message_bytes);
+                packet.record_message_metadata(
+                    channel_id,
+                    message.id,
+                    None,
+                    None,
+                    #[cfg(feature = "metrics")]
+                    message_bytes,
+                );
             }
             *num_messages = 0;
         }
@@ -602,8 +592,6 @@ impl PacketBuilder {
         let mut candidate = Packet {
             payload: packet.payload.clone(),
             messages: Vec::new(),
-            #[cfg(feature = "metrics")]
-            message_stats: Vec::new(),
             packet_id: packet.packet_id,
             prewritten_size: 0,
             compression: None,
@@ -617,7 +605,7 @@ impl PacketBuilder {
         channel_id: ChannelId,
         messages: &VecDeque<SingleData>,
         count: usize,
-        _record_stats: bool,
+        record_metadata: bool,
     ) -> Result<(), SerializationError> {
         debug_assert!(count <= MAX_MESSAGES_PER_CHANNEL_BATCH);
         channel_id.to_bytes(&mut packet.payload)?;
@@ -626,19 +614,15 @@ impl PacketBuilder {
             #[cfg(feature = "metrics")]
             let message_bytes = message.bytes_len();
             message.to_bytes(&mut packet.payload)?;
-            if let Some(id) = message.id {
-                packet.messages.push(MessageMetadata {
-                    channel: channel_id,
-                    message: id,
-                    fragment_index: None,
-                    num_fragments: None,
+            if record_metadata {
+                packet.record_message_metadata(
+                    channel_id,
+                    message.id,
+                    None,
+                    None,
                     #[cfg(feature = "metrics")]
-                    num_bytes: message_bytes,
-                });
-            }
-            #[cfg(feature = "metrics")]
-            if _record_stats {
-                packet.record_message_stats(channel_id, message_bytes);
+                    message_bytes,
+                );
             }
         }
         Ok(())
@@ -776,8 +760,7 @@ mod tests {
     use crate::packet::message::{FragmentIndex, MessageId};
     #[cfg(feature = "compression_lz4")]
     use crate::packet::packet::HEADER_BYTES;
-    #[cfg(feature = "metrics")]
-    use crate::packet::packet::PacketMessageStats;
+    use crate::packet::packet::MessageMetadata;
     use bytes::Bytes;
 
     use super::*;
@@ -861,25 +844,38 @@ mod tests {
             manager.build_packets(Duration::default(), Tick(0), single_data, fragment_data)?;
         assert_eq!(packets.len(), 1);
         let packet = packets.pop().unwrap();
+        #[cfg(not(feature = "metrics"))]
         assert_eq!(packet.messages, vec![]);
         #[cfg(feature = "metrics")]
         assert_eq!(
-            packet.message_stats,
+            packet.messages,
             vec![
-                PacketMessageStats {
+                MessageMetadata {
                     channel: *channel_id1,
+                    message: None,
+                    fragment_index: None,
+                    num_fragments: None,
                     num_bytes: small_message.bytes_len(),
                 },
-                PacketMessageStats {
+                MessageMetadata {
                     channel: *channel_id2,
+                    message: None,
+                    fragment_index: None,
+                    num_fragments: None,
                     num_bytes: small_message.bytes_len(),
                 },
-                PacketMessageStats {
+                MessageMetadata {
                     channel: *channel_id2,
+                    message: None,
+                    fragment_index: None,
+                    num_fragments: None,
                     num_bytes: small_message.bytes_len(),
                 },
-                PacketMessageStats {
+                MessageMetadata {
                     channel: *channel_id3,
+                    message: None,
+                    fragment_index: None,
+                    num_fragments: None,
                     num_bytes: small_message.bytes_len(),
                 },
             ]
@@ -977,14 +973,13 @@ mod tests {
         Ok(())
     }
 
-    #[cfg(feature = "metrics")]
     #[test]
-    fn compression_candidate_packets_do_not_record_message_stats() {
+    fn compression_candidate_packets_do_not_record_message_metadata() {
         let channel_registry = get_channel_registry();
         let channel_kind = ChannelKind::of::<Channel1>();
         let channel_id = channel_registry.get_net_from_kind(&channel_kind).unwrap();
         let messages = VecDeque::from(vec![
-            SingleData::new(None, Bytes::from(vec![7u8; 32])),
+            SingleData::new(Some(MessageId(99)), Bytes::from(vec![7u8; 32])),
             SingleData::new(None, Bytes::from(vec![8u8; 32])),
         ]);
 
@@ -996,7 +991,7 @@ mod tests {
         let candidate = PacketBuilder::candidate_packet(&packet, *channel_id, &messages, 2)
             .expect("candidate packet should serialize");
 
-        assert!(candidate.message_stats.is_empty());
+        assert!(candidate.messages.is_empty());
     }
 
     #[cfg(feature = "compression_lz4")]
@@ -1038,9 +1033,13 @@ mod tests {
         assert!(packets[0].payload.len() <= MAX_PACKET_SIZE);
         #[cfg(feature = "metrics")]
         {
-            assert_eq!(packets[0].message_stats.len(), 128);
-            assert!(packets[0].message_stats.iter().all(|stats| {
-                stats.channel == *channel_id && stats.num_bytes == small_message.bytes_len()
+            assert_eq!(packets[0].messages.len(), 128);
+            assert!(packets[0].messages.iter().all(|metadata| {
+                metadata.channel == *channel_id
+                    && metadata.message.is_none()
+                    && metadata.fragment_index.is_none()
+                    && metadata.num_fragments.is_none()
+                    && metadata.num_bytes == small_message.bytes_len()
             }));
         }
         assert_eq!(
@@ -1168,7 +1167,7 @@ mod tests {
             packet.messages,
             vec![MessageMetadata {
                 channel: *channel_id2,
-                message: MessageId(3),
+                message: Some(MessageId(3)),
                 fragment_index: Some(FragmentIndex(0)),
                 num_fragments: Some(fragments.len() as u64),
                 #[cfg(feature = "metrics")]
@@ -1183,16 +1182,58 @@ mod tests {
 
         // 2nd packet
         let packet = packets_queue.pop_front().unwrap();
+        #[cfg(not(feature = "metrics"))]
         assert_eq!(
             packet.messages,
             vec![MessageMetadata {
                 channel: *channel_id2,
-                message: MessageId(3),
+                message: Some(MessageId(3)),
                 fragment_index: Some(FragmentIndex(1)),
                 num_fragments: Some(fragments.len() as u64),
                 #[cfg(feature = "metrics")]
                 num_bytes: fragments[1].bytes.len(),
             }]
+        );
+        #[cfg(feature = "metrics")]
+        assert_eq!(
+            packet.messages,
+            vec![
+                MessageMetadata {
+                    channel: *channel_id2,
+                    message: Some(MessageId(3)),
+                    fragment_index: Some(FragmentIndex(1)),
+                    num_fragments: Some(fragments.len() as u64),
+                    num_bytes: fragments[1].bytes.len(),
+                },
+                MessageMetadata {
+                    channel: *channel_id1,
+                    message: None,
+                    fragment_index: None,
+                    num_fragments: None,
+                    num_bytes: small_message.bytes_len(),
+                },
+                MessageMetadata {
+                    channel: *channel_id2,
+                    message: None,
+                    fragment_index: None,
+                    num_fragments: None,
+                    num_bytes: small_message.bytes_len(),
+                },
+                MessageMetadata {
+                    channel: *channel_id2,
+                    message: None,
+                    fragment_index: None,
+                    num_fragments: None,
+                    num_bytes: small_message.bytes_len(),
+                },
+                MessageMetadata {
+                    channel: *channel_id3,
+                    message: None,
+                    fragment_index: None,
+                    num_fragments: None,
+                    num_bytes: small_message.bytes_len(),
+                },
+            ]
         );
         let contents = packet.parse_packet_payload()?;
         assert_eq!(

--- a/lightyear_transport/src/packet/packet_builder.rs
+++ b/lightyear_transport/src/packet/packet_builder.rs
@@ -1,8 +1,13 @@
 //! Module to take a buffer of messages to send and build packets
 use crate::channel::registry::ChannelId;
+use crate::packet::compression::{
+    CompressionCandidate, CompressionConfig, try_build_compressed_packet_payload,
+    try_compress_packet,
+};
+use crate::packet::error::PacketError;
 use crate::packet::header::PacketHeaderManager;
 use crate::packet::message::{FragmentData, SingleData};
-use crate::packet::packet::{FRAGMENT_SIZE, MessageMetadata, Packet};
+use crate::packet::packet::{FRAGMENT_SIZE, HEADER_BYTES, MessageMetadata, Packet};
 use crate::packet::packet_type::PacketType;
 use alloc::collections::VecDeque;
 use alloc::{vec, vec::Vec};
@@ -19,6 +24,8 @@ pub const MAX_PACKET_SIZE: usize = 1200;
 pub const MAX_UNFRAGMENTED_PAYLOAD_SIZE: usize = FRAGMENT_SIZE;
 
 pub type Payload = Vec<u8>;
+
+const MAX_MESSAGES_PER_CHANNEL_BATCH: usize = u8::MAX as usize;
 
 /// We use `Bytes` on the receive side because we want to be able to refer to sub-slices of the original
 /// packet without allocating.
@@ -90,6 +97,7 @@ impl PacketBuilder {
             messages: vec![],
             packet_id: header.packet_id,
             prewritten_size: 0,
+            compression: None,
         });
         Ok(())
     }
@@ -124,6 +132,7 @@ impl PacketBuilder {
             }],
             packet_id: header.packet_id,
             prewritten_size: 0,
+            compression: None,
         });
         Ok(())
 
@@ -150,9 +159,11 @@ impl PacketBuilder {
     }
 
     pub fn finish_packet(&mut self) -> Packet {
-        let mut packet = self.current_packet.take().unwrap();
+        Self::finalize_packet(self.current_packet.take().unwrap())
+    }
+
+    fn finalize_packet(mut packet: Packet) -> Packet {
         packet.payload.shrink_to_fit();
-        // TODO: should we use bytes so this clone is cheap?
         packet
     }
 
@@ -167,9 +178,60 @@ impl PacketBuilder {
         &mut self,
         real: Duration,
         current_tick: Tick,
-        mut single_data: Vec<(ChannelId, VecDeque<SingleData>)>,
+        single_data: Vec<(ChannelId, VecDeque<SingleData>)>,
         fragment_data: Vec<(ChannelId, VecDeque<FragmentData>)>,
     ) -> Result<Vec<Packet>, SerializationError> {
+        self.build_packets_uncompressed(real, current_tick, single_data, fragment_data)
+    }
+
+    #[cfg_attr(feature = "trace", instrument(level = Level::INFO, skip_all))]
+    pub fn build_packets_with_compression(
+        &mut self,
+        real: Duration,
+        current_tick: Tick,
+        single_data: Vec<(ChannelId, VecDeque<SingleData>)>,
+        fragment_data: Vec<(ChannelId, VecDeque<FragmentData>)>,
+        compression: CompressionConfig,
+    ) -> Result<Vec<Packet>, PacketError> {
+        if !compression.is_enabled() {
+            return Ok(self.build_packets_uncompressed(
+                real,
+                current_tick,
+                single_data,
+                fragment_data,
+            )?);
+        }
+        self.build_packets_internal(real, current_tick, single_data, fragment_data, compression)
+    }
+
+    fn build_packets_uncompressed(
+        &mut self,
+        real: Duration,
+        current_tick: Tick,
+        single_data: Vec<(ChannelId, VecDeque<SingleData>)>,
+        fragment_data: Vec<(ChannelId, VecDeque<FragmentData>)>,
+    ) -> Result<Vec<Packet>, SerializationError> {
+        self.build_packets_internal(
+            real,
+            current_tick,
+            single_data,
+            fragment_data,
+            CompressionConfig::DISABLED,
+        )
+        .map_err(|error| match error {
+            PacketError::Serialization(error) => error,
+            other => panic!("unexpected packet builder error without compression: {other:?}"),
+        })
+    }
+
+    fn build_packets_internal(
+        &mut self,
+        real: Duration,
+        current_tick: Tick,
+        mut single_data: Vec<(ChannelId, VecDeque<SingleData>)>,
+        fragment_data: Vec<(ChannelId, VecDeque<FragmentData>)>,
+        compression: CompressionConfig,
+    ) -> Result<Vec<Packet>, PacketError> {
         let mut packets: Vec<Packet> = vec![];
 
         // indices in the main vec
@@ -243,6 +305,18 @@ impl PacketBuilder {
         debug_assert!(self.current_packet.is_none());
 
         // all fragment messages have been written, now write small messages
+        if compression.is_enabled() {
+            self.build_single_packets_compression_aware(
+                real,
+                current_tick,
+                &mut single_data,
+                single_data_idx,
+                &mut packets,
+                compression,
+            )?;
+            return Ok(packets);
+        }
+
         'out: while single_data_idx < single_data.len() {
             let (channel_id, single_messages) = &mut single_data[single_data_idx];
             // start a new packet if we aren't already writing one
@@ -344,6 +418,234 @@ impl PacketBuilder {
             *num_messages = 0;
         }
         Ok(())
+    }
+
+    fn build_single_packets_compression_aware(
+        &mut self,
+        real: Duration,
+        current_tick: Tick,
+        single_data: &mut [(ChannelId, VecDeque<SingleData>)],
+        mut single_data_idx: usize,
+        packets: &mut Vec<Packet>,
+        compression: CompressionConfig,
+    ) -> Result<(), PacketError> {
+        while single_data_idx < single_data.len() {
+            if single_data[single_data_idx].1.is_empty() {
+                single_data_idx += 1;
+                continue;
+            }
+
+            if self.current_packet.is_none() {
+                self.build_new_single_packet(real, current_tick)?;
+            }
+
+            let mut packet = self.current_packet.take().unwrap();
+            let (channel_id, single_messages) = &mut single_data[single_data_idx];
+            let max_count = single_messages.len().min(MAX_MESSAGES_PER_CHANNEL_BATCH);
+            let fit_count = Self::find_compression_aware_message_count(
+                &packet,
+                *channel_id,
+                single_messages,
+                max_count,
+                compression,
+            )?;
+
+            if fit_count == 0 {
+                if Self::packet_has_body(&packet) {
+                    packets.push(Self::finish_compression_aware_packet(packet, compression)?);
+                    continue;
+                }
+                let candidate_len =
+                    Self::candidate_packet_len(&packet, *channel_id, single_messages, 1)?;
+                return Err(PacketError::PacketTooLarge {
+                    actual: candidate_len,
+                    mtu: MAX_PACKET_SIZE,
+                });
+            }
+
+            Self::append_single_messages(&mut packet, *channel_id, single_messages, fit_count)?;
+            for _ in 0..fit_count {
+                single_messages.pop_front();
+            }
+
+            let channel_drained = single_messages.is_empty();
+            let hit_channel_batch_limit =
+                fit_count == MAX_MESSAGES_PER_CHANNEL_BATCH && !channel_drained;
+            let packet_full = fit_count < max_count || hit_channel_batch_limit;
+
+            if channel_drained {
+                single_data_idx += 1;
+            }
+
+            if packet_full {
+                packets.push(Self::finish_compression_aware_packet(packet, compression)?);
+            } else {
+                self.current_packet = Some(packet);
+            }
+        }
+
+        if let Some(packet) = self.current_packet.take()
+            && Self::packet_has_body(&packet)
+        {
+            packets.push(Self::finish_compression_aware_packet(packet, compression)?);
+        }
+        Ok(())
+    }
+
+    fn find_compression_aware_message_count(
+        packet: &Packet,
+        channel_id: ChannelId,
+        messages: &VecDeque<SingleData>,
+        max_count: usize,
+        compression: CompressionConfig,
+    ) -> Result<usize, PacketError> {
+        if max_count == 0 {
+            return Ok(0);
+        }
+
+        if !Self::candidate_packet_fits(packet, channel_id, messages, 1, compression)? {
+            return Ok(0);
+        }
+
+        let mut best = 1;
+        let mut next = 2;
+
+        while next <= max_count {
+            if Self::candidate_packet_fits(packet, channel_id, messages, next, compression)? {
+                best = next;
+                if next == max_count {
+                    return Ok(best);
+                }
+                next = next.saturating_mul(2).min(max_count);
+            } else {
+                break;
+            }
+        }
+
+        let mut low = best + 1;
+        let mut high = next.min(max_count);
+        while low <= high {
+            let mid = low + (high - low) / 2;
+            if Self::candidate_packet_fits(packet, channel_id, messages, mid, compression)? {
+                best = mid;
+                low = mid + 1;
+            } else if mid == 0 {
+                break;
+            } else {
+                high = mid - 1;
+            }
+        }
+
+        Ok(best)
+    }
+
+    fn candidate_packet_fits(
+        packet: &Packet,
+        channel_id: ChannelId,
+        messages: &VecDeque<SingleData>,
+        count: usize,
+        compression: CompressionConfig,
+    ) -> Result<bool, PacketError> {
+        let candidate = Self::candidate_packet(packet, channel_id, messages, count)?;
+        if candidate.payload.len() <= MAX_PACKET_SIZE {
+            return Ok(true);
+        }
+        let compression_candidate =
+            try_build_compressed_packet_payload(&candidate.payload, compression)?;
+        #[cfg(feature = "metrics")]
+        if matches!(
+            compression_candidate,
+            CompressionCandidate::Compressed { .. } | CompressionCandidate::NotSmaller { .. }
+        ) {
+            metrics::counter!("transport/compression_abandoned").increment(1);
+        }
+        Ok(matches!(
+            compression_candidate,
+            CompressionCandidate::Compressed { .. }
+        ))
+    }
+
+    fn candidate_packet_len(
+        packet: &Packet,
+        channel_id: ChannelId,
+        messages: &VecDeque<SingleData>,
+        count: usize,
+    ) -> Result<usize, SerializationError> {
+        Ok(Self::candidate_packet(packet, channel_id, messages, count)?
+            .payload
+            .len())
+    }
+
+    fn candidate_packet(
+        packet: &Packet,
+        channel_id: ChannelId,
+        messages: &VecDeque<SingleData>,
+        count: usize,
+    ) -> Result<Packet, SerializationError> {
+        let mut candidate = Packet {
+            payload: packet.payload.clone(),
+            messages: Vec::new(),
+            packet_id: packet.packet_id,
+            prewritten_size: 0,
+            compression: None,
+        };
+        Self::append_single_messages(&mut candidate, channel_id, messages, count)?;
+        Ok(candidate)
+    }
+
+    fn append_single_messages(
+        packet: &mut Packet,
+        channel_id: ChannelId,
+        messages: &VecDeque<SingleData>,
+        count: usize,
+    ) -> Result<(), SerializationError> {
+        debug_assert!(count <= MAX_MESSAGES_PER_CHANNEL_BATCH);
+        channel_id.to_bytes(&mut packet.payload)?;
+        packet.payload.write_u8(count as u8)?;
+        for message in messages.iter().take(count) {
+            message.to_bytes(&mut packet.payload)?;
+            if let Some(id) = message.id {
+                packet.messages.push(MessageMetadata {
+                    channel: channel_id,
+                    message: id,
+                    fragment_index: None,
+                    num_fragments: None,
+                    #[cfg(feature = "metrics")]
+                    num_bytes: message.bytes_len(),
+                });
+            }
+        }
+        Ok(())
+    }
+
+    fn finish_compression_aware_packet(
+        mut packet: Packet,
+        compression: CompressionConfig,
+    ) -> Result<Packet, PacketError> {
+        if packet.payload.len() > MAX_PACKET_SIZE {
+            match try_compress_packet(&mut packet, compression)? {
+                crate::packet::compression::CompressionOutcome::Compressed { .. } => {}
+                crate::packet::compression::CompressionOutcome::NotSmaller { .. } => {
+                    #[cfg(feature = "metrics")]
+                    metrics::counter!("transport/compression_abandoned").increment(1);
+                    return Err(PacketError::PacketTooLarge {
+                        actual: packet.payload.len(),
+                        mtu: MAX_PACKET_SIZE,
+                    });
+                }
+                _ => {
+                    return Err(PacketError::PacketTooLarge {
+                        actual: packet.payload.len(),
+                        mtu: MAX_PACKET_SIZE,
+                    });
+                }
+            }
+        }
+        Ok(Self::finalize_packet(packet))
+    }
+
+    fn packet_has_body(packet: &Packet) -> bool {
+        packet.payload.len() > HEADER_BYTES
     }
 
     // /// Uses multiple exponential searches to fill a packet. Has a good worst case runtime and doesn't
@@ -490,6 +792,19 @@ mod tests {
         Ok(packet)
     }
 
+    #[cfg(feature = "compression_lz4")]
+    fn random_payload(len: usize, message_index: usize) -> Vec<u8> {
+        let mut state = 0x9e37_79b9_7f4a_7c15u64 ^ message_index as u64;
+        let mut payload = Vec::with_capacity(len);
+        for _ in 0..len {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            payload.push((state & 0xff) as u8);
+        }
+        payload
+    }
+
     /// A bunch of small messages that all fit in the same packet
     #[test]
     fn test_pack_small_messages() -> Result<(), PacketError> {
@@ -609,6 +924,94 @@ mod tests {
         let packets =
             manager.build_packets(Duration::default(), Tick(0), single_data, fragment_data)?;
         assert_eq!(packets.len(), 7);
+        Ok(())
+    }
+
+    #[cfg(feature = "compression_lz4")]
+    #[test]
+    fn compression_aware_packing_can_pack_beyond_uncompressed_mtu() -> Result<(), PacketError> {
+        let channel_registry = get_channel_registry();
+        let channel_kind = ChannelKind::of::<Channel1>();
+        let channel_id = channel_registry.get_net_from_kind(&channel_kind).unwrap();
+        let small_bytes = Bytes::from(vec![7u8; 64]);
+        let small_message = SingleData::new(None, small_bytes.clone());
+
+        let uncompressed_packets = PacketBuilder::new(1.5).build_packets(
+            Duration::default(),
+            Tick(0),
+            vec![(
+                *channel_id,
+                VecDeque::from(vec![small_message.clone(); 128]),
+            )],
+            vec![],
+        )?;
+        assert!(uncompressed_packets.len() > 1);
+
+        let mut manager = PacketBuilder::new(1.5);
+        let mut packets = manager.build_packets_with_compression(
+            Duration::default(),
+            Tick(0),
+            vec![(
+                *channel_id,
+                VecDeque::from(vec![small_message.clone(); 128]),
+            )],
+            vec![],
+            CompressionConfig {
+                min_payload_size: 0,
+                ..CompressionConfig::LZ4
+            },
+        )?;
+
+        assert_eq!(packets.len(), 1);
+        assert!(packets[0].payload.len() <= MAX_PACKET_SIZE);
+        assert_eq!(
+            PacketType::try_from(packets[0].payload[PacketHeader::PACKET_TYPE_OFFSET])?,
+            PacketType::DataCompressed
+        );
+        let packet = decompress_packet_for_test(packets.pop().unwrap())?;
+        let contents = packet.parse_packet_payload()?;
+        assert_eq!(contents.get(channel_id).unwrap().len(), 128);
+        assert_eq!(contents.get(channel_id).unwrap()[0], small_bytes);
+        Ok(())
+    }
+
+    #[cfg(feature = "compression_lz4")]
+    #[test]
+    fn compression_aware_packing_preserves_mtu_for_incompressible_data() -> Result<(), PacketError>
+    {
+        let channel_registry = get_channel_registry();
+        let channel_kind = ChannelKind::of::<Channel1>();
+        let channel_id = channel_registry.get_net_from_kind(&channel_kind).unwrap();
+        let messages = (0..128)
+            .map(|message_index| SingleData::new(None, random_payload(128, message_index).into()))
+            .collect();
+
+        let mut manager = PacketBuilder::new(1.5);
+        let packets = manager.build_packets_with_compression(
+            Duration::default(),
+            Tick(0),
+            vec![(*channel_id, messages)],
+            vec![],
+            CompressionConfig {
+                min_payload_size: 0,
+                ..CompressionConfig::LZ4
+            },
+        )?;
+
+        let mut total_messages = 0;
+        for packet in packets {
+            assert!(packet.payload.len() <= MAX_PACKET_SIZE);
+            let packet_type =
+                PacketType::try_from(packet.payload[PacketHeader::PACKET_TYPE_OFFSET])?;
+            let packet = if packet_type.is_compressed() {
+                decompress_packet_for_test(packet)?
+            } else {
+                packet
+            };
+            let contents = packet.parse_packet_payload()?;
+            total_messages += contents.get(channel_id).map_or(0, Vec::len);
+        }
+        assert_eq!(total_messages, 128);
         Ok(())
     }
 

--- a/lightyear_transport/src/packet/packet_type.rs
+++ b/lightyear_transport/src/packet/packet_type.rs
@@ -15,6 +15,8 @@ pub enum PacketType {
     /// - channel_id = 0 = indication of end of packet
     Data = 0,
     DataFragment = 1,
+    DataCompressed = 2,
+    DataFragmentCompressed = 3,
 }
 
 impl From<PacketType> for u8 {
@@ -30,7 +32,73 @@ impl TryFrom<u8> for PacketType {
         match value {
             0 => Ok(PacketType::Data),
             1 => Ok(PacketType::DataFragment),
+            2 => Ok(PacketType::DataCompressed),
+            3 => Ok(PacketType::DataFragmentCompressed),
             _ => Err(lightyear_serde::SerializationError::InvalidPacketType),
         }
+    }
+}
+
+impl PacketType {
+    pub(crate) fn is_compressed(self) -> bool {
+        matches!(
+            self,
+            PacketType::DataCompressed | PacketType::DataFragmentCompressed
+        )
+    }
+
+    pub(crate) fn compressed_variant(self) -> Option<Self> {
+        match self {
+            PacketType::Data => Some(PacketType::DataCompressed),
+            PacketType::DataFragment => Some(PacketType::DataFragmentCompressed),
+            PacketType::DataCompressed | PacketType::DataFragmentCompressed => None,
+        }
+    }
+
+    pub(crate) fn uncompressed_variant(self) -> Self {
+        match self {
+            PacketType::Data | PacketType::DataCompressed => PacketType::Data,
+            PacketType::DataFragment | PacketType::DataFragmentCompressed => {
+                PacketType::DataFragment
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PacketType;
+
+    #[test]
+    fn packet_type_roundtrip_includes_compressed_variants() {
+        for packet_type in [
+            PacketType::Data,
+            PacketType::DataFragment,
+            PacketType::DataCompressed,
+            PacketType::DataFragmentCompressed,
+        ] {
+            let raw: u8 = packet_type.into();
+            assert_eq!(PacketType::try_from(raw).unwrap(), packet_type);
+        }
+    }
+
+    #[test]
+    fn packet_type_compressed_helpers_map_to_original_variants() {
+        assert_eq!(
+            PacketType::Data.compressed_variant(),
+            Some(PacketType::DataCompressed)
+        );
+        assert_eq!(
+            PacketType::DataFragment.compressed_variant(),
+            Some(PacketType::DataFragmentCompressed)
+        );
+        assert_eq!(
+            PacketType::DataCompressed.uncompressed_variant(),
+            PacketType::Data
+        );
+        assert_eq!(
+            PacketType::DataFragmentCompressed.uncompressed_variant(),
+            PacketType::DataFragment
+        );
     }
 }

--- a/lightyear_transport/src/packet/packet_type.rs
+++ b/lightyear_transport/src/packet/packet_type.rs
@@ -16,6 +16,11 @@ pub enum PacketType {
     Data = 0,
     DataFragment = 1,
     DataCompressed = 2,
+    /// A packet containing a fragment, where packet-level compression is enabled
+    /// for the non-fragment data.
+    ///
+    /// Compression for the fragment payload itself is tracked separately in the
+    /// fragment metadata serialized on the first fragment.
     DataFragmentCompressed = 3,
 }
 

--- a/lightyear_transport/src/packet/priority_manager.rs
+++ b/lightyear_transport/src/packet/priority_manager.rs
@@ -1,10 +1,7 @@
-use crate::channel::ChannelKind;
-use crate::channel::builder::SenderMetadata;
 use crate::channel::registry::{ChannelId, ChannelRegistry};
 use crate::packet::message::{FragmentData, MessageData, SendMessage, SingleData};
 use alloc::collections::VecDeque;
 use alloc::{vec, vec::Vec};
-use bevy_platform::collections::HashMap;
 use core::num::NonZeroU32;
 use governor::{DefaultDirectRateLimiter, Quota};
 use lightyear_core::network::NetId;
@@ -15,8 +12,6 @@ use nonzero_ext::*;
 use tracing::{Level, instrument};
 #[allow(unused_imports)]
 use tracing::{debug, error, info, trace};
-
-const BYPASS_QUOTA_PRIORITY: f32 = 100000.0;
 
 #[derive(Debug)]
 pub struct BufferedMessage {
@@ -99,19 +94,17 @@ impl PriorityManager {
         self.data_to_send.push((net_id, (single, fragment)));
     }
 
-    // TODO: maybe accumulate the used_bytes in the priority_manager instead of returning here?
-    /// Filter the messages by priority and bandwidth quota
-    /// Returns the list of messages that we can send, along with the amount of bytes we used
-    /// in the rate limiter.
+    /// Sort queued messages by priority and return the data to packetize.
+    ///
+    /// Bandwidth quota is intentionally consumed after packet building, because packet building
+    /// can compress selected messages and the limiter should use final packet bytes.
     #[cfg_attr(feature = "trace", instrument(level = Level::INFO, skip_all))]
-    pub(crate) fn priority_filter(
+    pub(crate) fn prioritize(
         &mut self,
         channel_registry: &ChannelRegistry,
-        senders: &mut HashMap<ChannelKind, SenderMetadata>,
     ) -> (
         Vec<(ChannelId, VecDeque<SingleData>)>,
         Vec<(ChannelId, VecDeque<FragmentData>)>,
-        u32,
     ) {
         // if the bandwidth quota is disabled, just pass all messages through
         // As an optimization: no need to send the tick of the message, it is the same as the header tick
@@ -138,18 +131,6 @@ impl PriorityManager {
                                 metrics::gauge!("channel/send_bytes", "channel" => channel_name)
                                     .increment(single.bytes_len() as f64);
                             }
-                            // we don't actually use the `messages_sent` field when the priority filter is disabled
-                            // but we still include it so that we can easily check in tests how many messages were sent
-                            #[cfg(feature = "test_utils")]
-                            if let Some(message_id) = single.id {
-                                let channel_kind =
-                                    channel_registry.get_kind_from_net_id(net_id).unwrap();
-                                senders
-                                    .get_mut(channel_kind)
-                                    .unwrap()
-                                    .messages_sent
-                                    .push(message_id);
-                            }
                             single
                         })
                         .collect(),
@@ -172,7 +153,7 @@ impl PriorityManager {
                         .collect(),
                 ));
             }
-            return (single_data, fragment_data, 0);
+            return (single_data, fragment_data);
         }
 
         // compute the priority of each new message
@@ -211,43 +192,12 @@ impl PriorityManager {
             all_messages
         );
 
-        // select the top messages with the rate limiter
-        let mut single_data: HashMap<ChannelId, VecDeque<SingleData>> = HashMap::default();
-        let mut fragment_data: HashMap<ChannelId, VecDeque<FragmentData>> = HashMap::default();
-        let mut bytes_used = 0;
+        // Return messages in priority order. Keep each message as its own channel batch so the
+        // packet builder sees priority ordering instead of a grouping hash-map order.
+        let mut single_data: Vec<(ChannelId, VecDeque<SingleData>)> = vec![];
+        let mut fragment_data: Vec<(ChannelId, VecDeque<FragmentData>)> = vec![];
         while let Some(buffered_message) = all_messages.pop() {
-            // we don't use the exact size of the message, but the size of the bytes
-            // we will adjust for this later
-            let message_bytes = buffered_message.data.bytes_len() as u32;
-            let nonzero_message_bytes = NonZeroU32::try_from(message_bytes).unwrap();
-            let Ok(result) = self.limiter.check_n(nonzero_message_bytes) else {
-                error!("the bandwidth does not have enough capacity for a message of this size!");
-                break;
-            };
-
-            // above BYPASS_QUOTA_PRIORITY, we still send the message
-            if buffered_message.priority < BYPASS_QUOTA_PRIORITY {
-                let Ok(()) = result else {
-                    debug!("Bandwidth quota reached, no more messages can be sent this tick");
-                    break;
-                };
-            }
-            trace!(channel=?buffered_message.channel_net_id, "Sending message with priority {:?}", buffered_message.priority);
-
-            // keep track of the bytes we added to the rate limiter
-            bytes_used += message_bytes;
-
-            // notify the replication sender that the message was actually sent
-            if let Some(message_id) = buffered_message.data.message_id() {
-                let channel_kind = channel_registry
-                    .get_kind_from_net_id(buffered_message.channel_net_id)
-                    .unwrap();
-                senders
-                    .get_mut(channel_kind)
-                    .unwrap()
-                    .messages_sent
-                    .push(message_id);
-            }
+            trace!(channel=?buffered_message.channel_net_id, "Selected message with priority {:?}", buffered_message.priority);
 
             #[cfg(feature = "metrics")]
             {
@@ -261,40 +211,47 @@ impl PriorityManager {
             // the message is allowed, add it to the list of messages to send
             match buffered_message.data {
                 MessageData::Single(single) => {
-                    single_data
-                        .entry(buffered_message.channel_net_id)
-                        .or_default()
-                        .push_back(single);
+                    single_data.push((buffered_message.channel_net_id, VecDeque::from([single])));
                 }
                 MessageData::Fragment(fragment) => {
                     fragment_data
-                        .entry(buffered_message.channel_net_id)
-                        .or_default()
-                        .push_back(fragment);
+                        .push((buffered_message.channel_net_id, VecDeque::from([fragment])));
                 }
             }
         }
 
-        // all the other messages that don't make the cut, we just drop
-        // - unreliable messages: they are unreliable so it's ok
-        // - reliable messages: they will be retried later, maybe with higher priority?
-        // - unreliable entity updates: the replication sender keeps track for each entity of when we were able to send an update
-        //   - PROBLEM: we could have the entity action not get sent (bandwidth), and then the priority still drops because the entity update
-        //     was sent right after...
-        // - reliable entity actions:
-        let num_messages_sent = single_data.values().map(|data| data.len()).sum::<usize>()
-            + fragment_data.values().map(|data| data.len()).sum::<usize>();
-        debug!(
-            bytes_sent = ?bytes_used,
-            ?num_messages_sent,
-            num_messages_discarded = ?all_messages.len(),
-            "priority filter done.");
+        let num_messages_sent = single_data
+            .iter()
+            .map(|(_, data)| data.len())
+            .sum::<usize>()
+            + fragment_data
+                .iter()
+                .map(|(_, data)| data.len())
+                .sum::<usize>();
+        debug!(?num_messages_sent, "priority ordering complete.");
 
         self.data_to_send.clear();
-        (
-            single_data.into_iter().collect(),
-            fragment_data.into_iter().collect(),
-            bytes_used,
-        )
+        (single_data, fragment_data)
+    }
+
+    /// Consume bandwidth quota for a final packet payload.
+    ///
+    /// Returns false when this packet cannot currently fit. The caller should stop sending for
+    /// this tick, because subsequent packets are not higher priority than this one.
+    pub(crate) fn consume_packet_quota(&mut self, packet_bytes: u32) -> bool {
+        if !self.config.enabled {
+            return true;
+        }
+
+        let nonzero_packet_bytes = NonZeroU32::try_from(packet_bytes).unwrap();
+        let Ok(result) = self.limiter.check_n(nonzero_packet_bytes) else {
+            error!("the bandwidth quota cannot fit a packet of size {packet_bytes}");
+            return false;
+        };
+        if result.is_err() {
+            debug!("Bandwidth quota reached, no more packets can be sent this tick");
+            return false;
+        }
+        true
     }
 }

--- a/lightyear_transport/src/packet/priority_manager.rs
+++ b/lightyear_transport/src/packet/priority_manager.rs
@@ -5,8 +5,6 @@ use alloc::{vec, vec::Vec};
 use core::num::NonZeroU32;
 use governor::{DefaultDirectRateLimiter, Quota};
 use lightyear_core::network::NetId;
-#[cfg(feature = "metrics")]
-use lightyear_serde::ToBytes;
 use nonzero_ext::*;
 #[cfg(feature = "trace")]
 use tracing::{Level, instrument};
@@ -112,12 +110,6 @@ impl PriorityManager {
             let mut single_data = vec![];
             let mut fragment_data = vec![];
             for (net_id, (single, fragment)) in self.data_to_send.drain(..) {
-                #[cfg(feature = "metrics")]
-                let channel_name = channel_registry.get_name_from_net_id(net_id);
-                #[cfg(feature = "metrics")]
-                metrics::gauge!("channel/send_messages", "channel" => channel_name)
-                    .increment((single.len() + fragment.len()) as f64);
-
                 single_data.push((
                     net_id,
                     single
@@ -126,11 +118,6 @@ impl PriorityManager {
                             let MessageData::Single(single) = message.data else {
                                 unreachable!()
                             };
-                            #[cfg(feature = "metrics")]
-                            {
-                                metrics::gauge!("channel/send_bytes", "channel" => channel_name)
-                                    .increment(single.bytes_len() as f64);
-                            }
                             single
                         })
                         .collect(),
@@ -143,11 +130,6 @@ impl PriorityManager {
                             let MessageData::Fragment(fragment) = message.data else {
                                 unreachable!()
                             };
-                            #[cfg(feature = "metrics")]
-                            {
-                                metrics::gauge!("channel/send_bytes", "channel" => channel_name)
-                                    .increment(fragment.bytes_len() as f64);
-                            }
                             fragment
                         })
                         .collect(),
@@ -198,15 +180,6 @@ impl PriorityManager {
         let mut fragment_data: Vec<(ChannelId, VecDeque<FragmentData>)> = vec![];
         while let Some(buffered_message) = all_messages.pop() {
             trace!(channel=?buffered_message.channel_net_id, "Selected message with priority {:?}", buffered_message.priority);
-
-            #[cfg(feature = "metrics")]
-            {
-                let channel_name =
-                    channel_registry.get_name_from_net_id(buffered_message.channel_net_id);
-                metrics::gauge!("channel/send_messages", "channel" => channel_name).increment(1);
-                metrics::gauge!("channel/send_bytes", "channel" => channel_name)
-                    .increment(buffered_message.data.bytes_len() as f64);
-            }
 
             // the message is allowed, add it to the list of messages to send
             match buffered_message.data {

--- a/lightyear_transport/src/plugin.rs
+++ b/lightyear_transport/src/plugin.rs
@@ -401,6 +401,14 @@ impl TransportPlugin {
                 {
                     break;
                 }
+                #[cfg(feature = "metrics")]
+                for stats in packet.message_stats.iter() {
+                    let channel_name = channel_registry.get_name_from_net_id(stats.channel);
+                    metrics::gauge!("channel/send_messages", "channel" => channel_name)
+                        .increment(1);
+                    metrics::gauge!("channel/send_bytes", "channel" => channel_name)
+                        .increment(stats.num_bytes as f64);
+                }
                 if let Some(compression_info) = packet.compression {
                     #[cfg(feature = "metrics")]
                     {

--- a/lightyear_transport/src/plugin.rs
+++ b/lightyear_transport/src/plugin.rs
@@ -402,12 +402,12 @@ impl TransportPlugin {
                     break;
                 }
                 #[cfg(feature = "metrics")]
-                for stats in packet.message_stats.iter() {
-                    let channel_name = channel_registry.get_name_from_net_id(stats.channel);
+                for metadata in packet.messages.iter() {
+                    let channel_name = channel_registry.get_name_from_net_id(metadata.channel);
                     metrics::gauge!("channel/send_messages", "channel" => channel_name)
                         .increment(1);
                     metrics::gauge!("channel/send_bytes", "channel" => channel_name)
-                        .increment(stats.num_bytes as f64);
+                        .increment(metadata.num_bytes as f64);
                 }
                 if let Some(compression_info) = packet.compression {
                     #[cfg(feature = "metrics")]
@@ -447,10 +447,11 @@ impl TransportPlugin {
                         let sender_metadata = transport.senders
                             .get_mut(channel_kind)
                             .ok_or(PacketError::ChannelNotFound)?;
+                        let Some(message_id) = metadata.message else {
+                            return Ok(());
+                        };
 
-                        // note: cannot compute send metrics here because this is just for messages
-                        //   that have a message id
-                        sender_metadata.messages_sent.push(metadata.message);
+                        sender_metadata.messages_sent.push(message_id);
                         if sender_metadata.mode.is_watching_acks() {
                             trace!(
                                 "Registering message ack (ChannelId:{:?} {:?}) for packet {:?}",
@@ -460,13 +461,13 @@ impl TransportPlugin {
                             );
 
                             if let Some(num_fragments) = metadata.num_fragments {
-                                transport.fragment_acks.insert(metadata.message, num_fragments);
+                                transport.fragment_acks.insert(message_id, num_fragments);
                             }
                             transport.packet_to_message_map
                                 .entry(packet.packet_id)
                                 .or_default()
                                 .push((*channel_kind, MessageAck {
-                                    message_id: metadata.message,
+                                    message_id,
                                     fragment_id: metadata.fragment_index,
                                 }));
                             trace!(?transport.packet_to_message_map, "packet to message");

--- a/lightyear_transport/src/plugin.rs
+++ b/lightyear_transport/src/plugin.rs
@@ -387,13 +387,14 @@ impl TransportPlugin {
             // TODO: swap to try_for_each when available
             let Ok(packets) =
                 transport.packet_manager
-                    .build_packets(real_time.elapsed(), tick, single_data, fragment_data) else {
+                    .build_packets_with_compression(real_time.elapsed(), tick, single_data, fragment_data, transport.compression) else {
                 error!("Failed to build packets");
                 return
             };
 
             let mut total_bytes_sent = 0;
             for mut packet in packets {
+                let compression_info = packet.compression;
                 match try_compress_packet(&mut packet, transport.compression) {
                     Ok(CompressionOutcome::Compressed {
                         original_len,
@@ -401,7 +402,6 @@ impl TransportPlugin {
                     }) => {
                         #[cfg(feature = "metrics")]
                         {
-                            metrics::counter!("transport/compression_attempts").increment(1);
                             metrics::counter!("transport/compression_saved_bytes")
                                 .increment((original_len - compressed_len) as u64);
                         }
@@ -412,11 +412,24 @@ impl TransportPlugin {
                         );
                     }
                     Ok(CompressionOutcome::Disabled) => {}
-                    Ok(CompressionOutcome::AlreadyCompressed)
-                    | Ok(CompressionOutcome::TooSmall { .. }) => {
+                    Ok(CompressionOutcome::AlreadyCompressed) => {
+                        if let Some(compression_info) = compression_info {
+                            #[cfg(feature = "metrics")]
+                            {
+                                metrics::counter!("transport/compression_saved_bytes")
+                                    .increment((compression_info.original_len - compression_info.compressed_len) as u64);
+                            }
+                            trace!(
+                                original_len = compression_info.original_len,
+                                compressed_len = compression_info.compressed_len,
+                                "transport packet was already compressed by packet builder"
+                            );
+                        }
+                    }
+                    Ok(CompressionOutcome::TooSmall { .. })
+                    | Ok(CompressionOutcome::TooLargeForDecompressionLimit { .. }) => {
                         #[cfg(feature = "metrics")]
                         if transport.compression.is_enabled() {
-                            metrics::counter!("transport/compression_attempts").increment(1);
                             metrics::counter!("transport/compression_skipped").increment(1);
                         }
                     }
@@ -426,7 +439,7 @@ impl TransportPlugin {
                     }) => {
                         #[cfg(feature = "metrics")]
                         if transport.compression.is_enabled() {
-                            metrics::counter!("transport/compression_attempts").increment(1);
+                            metrics::counter!("transport/compression_abandoned").increment(1);
                             metrics::counter!("transport/compression_skipped").increment(1);
                             if compressed_len > original_len {
                                 metrics::counter!("transport/compression_expanded_packets")

--- a/lightyear_transport/src/plugin.rs
+++ b/lightyear_transport/src/plugin.rs
@@ -220,6 +220,7 @@ impl TransportPlugin {
                                 .buffer_recv(ReceiveMessage {
                                     data: fragment_data.into(),
                                     remote_sent_tick: tick,
+                                    compression: transport.compression,
                                 })?;
                         }
                         // read single message data
@@ -269,6 +270,7 @@ impl TransportPlugin {
                                     .buffer_recv(ReceiveMessage {
                                         data: single_data.into(),
                                         remote_sent_tick: tick,
+                                        compression: transport.compression,
                                     })?;
                             }
                         }
@@ -361,7 +363,9 @@ impl TransportPlugin {
             transport.recv_channel.try_iter().try_for_each(|(channel_kind, bytes, priority)| {
                 let sender_metadata = transport.senders.get_mut(&channel_kind).ok_or(TransportError::ChannelNotFound(channel_kind))?;
                 // TODO: do we need the message_id?
-                sender_metadata.sender.buffer_send(bytes, priority);
+                sender_metadata
+                    .sender
+                    .buffer_send(bytes, priority, transport.compression);
                 Ok::<(), TransportError>(())
             }).inspect_err(|e| error!("error sending message: {e:?}")).ok();
 

--- a/lightyear_transport/src/plugin.rs
+++ b/lightyear_transport/src/plugin.rs
@@ -3,12 +3,10 @@ use crate::channel::receivers::ChannelReceive;
 use crate::channel::registry::{ChannelId, ChannelRegistry};
 use crate::channel::senders::ChannelSend;
 use crate::error::TransportError;
-use crate::packet::compression::{CompressionOutcome, decompress_payload, try_compress_packet};
+use crate::packet::compression::decompress_payload;
 use crate::packet::error::PacketError;
 use crate::packet::header::PacketHeader;
 use crate::packet::message::{FragmentData, MessageAck, ReceiveMessage, SingleData};
-#[cfg(feature = "metrics")]
-use crate::packet::packet::MAX_PACKET_SIZE;
 use crate::packet::packet_type::PacketType;
 #[cfg(feature = "test_utils")]
 use crate::prelude::{AppChannelExt, ChannelMode, ChannelSettings};
@@ -378,10 +376,9 @@ impl TransportPlugin {
                 }
             });
 
-            // get the list of messages that we can send according to the bandwidth limiter
-            let (single_data, fragment_data, num_bytes_added_to_limiter) = transport
-                .priority_manager
-                .priority_filter(&channel_registry, &mut transport.senders);
+            // get the list of messages to pack, ordered by priority
+            let (single_data, fragment_data) =
+                transport.priority_manager.prioritize(&channel_registry);
 
             // build actual packets from these messages
             // TODO: swap to try_for_each when available
@@ -394,78 +391,30 @@ impl TransportPlugin {
 
             let mut total_bytes_sent = 0;
             for mut packet in packets {
-                let compression_info = packet.compression;
-                match try_compress_packet(&mut packet, transport.compression) {
-                    Ok(CompressionOutcome::Compressed {
-                        original_len,
-                        compressed_len,
-                    }) => {
-                        #[cfg(feature = "metrics")]
-                        {
-                            metrics::counter!("transport/compression_saved_bytes")
-                                .increment((original_len - compressed_len) as u64);
-                        }
-                        trace!(
-                            original_len,
-                            compressed_len,
-                            "compressed transport packet payload"
-                        );
-                    }
-                    Ok(CompressionOutcome::Disabled) => {}
-                    Ok(CompressionOutcome::AlreadyCompressed) => {
-                        if let Some(compression_info) = compression_info {
-                            #[cfg(feature = "metrics")]
-                            {
-                                metrics::counter!("transport/compression_saved_bytes")
-                                    .increment((compression_info.original_len - compression_info.compressed_len) as u64);
-                            }
-                            trace!(
-                                original_len = compression_info.original_len,
-                                compressed_len = compression_info.compressed_len,
-                                "transport packet was already compressed by packet builder"
-                            );
-                        }
-                    }
-                    Ok(CompressionOutcome::TooSmall { .. })
-                    | Ok(CompressionOutcome::TooLargeForDecompressionLimit { .. }) => {
-                        #[cfg(feature = "metrics")]
-                        if transport.compression.is_enabled() {
-                            metrics::counter!("transport/compression_skipped").increment(1);
-                        }
-                    }
-                    Ok(CompressionOutcome::NotSmaller {
-                        original_len,
-                        compressed_len,
-                    }) => {
-                        #[cfg(feature = "metrics")]
-                        if transport.compression.is_enabled() {
-                            metrics::counter!("transport/compression_abandoned").increment(1);
-                            metrics::counter!("transport/compression_skipped").increment(1);
-                            if compressed_len > original_len {
-                                metrics::counter!("transport/compression_expanded_packets")
-                                    .increment(1);
-                            }
-                            if compressed_len > MAX_PACKET_SIZE {
-                                metrics::counter!("transport/compression_above_mtu_packets")
-                                    .increment(1);
-                            }
-                        }
-                        trace!(
-                            original_len,
-                            compressed_len,
-                            "skipped transport packet compression because output was not smaller"
-                        );
-                    }
-                    Err(error) => {
-                        #[cfg(feature = "metrics")]
-                        metrics::counter!("transport/compression_errors").increment(1);
-                        error!("Failed to compress packet payload: {error:?}");
-                    }
-                }
                 trace!(packet_id = ?packet.packet_id, num_messages = ?packet.num_messages(), "sending packet");
                 let packet_id = packet.packet_id;
                 let num_messages = packet.num_messages();
                 let packet_len = packet.payload.len();
+                if !transport
+                    .priority_manager
+                    .consume_packet_quota(packet_len as u32)
+                {
+                    break;
+                }
+                if let Some(compression_info) = packet.compression {
+                    #[cfg(feature = "metrics")]
+                    {
+                        metrics::counter!("transport/compression_saved_bytes").increment(
+                            (compression_info.original_len - compression_info.compressed_len)
+                                as u64,
+                        );
+                    }
+                    trace!(
+                        original_len = compression_info.original_len,
+                        compressed_len = compression_info.compressed_len,
+                        "transport packet was compressed by packet builder"
+                    );
+                }
                 trace!(
                     target: "lightyear_debug::transport",
                     kind = "packet_send",
@@ -493,6 +442,7 @@ impl TransportPlugin {
 
                         // note: cannot compute send metrics here because this is just for messages
                         //   that have a message id
+                        sender_metadata.messages_sent.push(metadata.message);
                         if sender_metadata.mode.is_watching_acks() {
                             trace!(
                                 "Registering message ack (ChannelId:{:?} {:?}) for packet {:?}",
@@ -534,17 +484,6 @@ impl TransportPlugin {
 
             #[cfg(feature = "metrics")]
             metrics::gauge!("transport/send_bytes").increment(total_bytes_sent as f64);
-
-            // adjust the real amount of bytes that we sent through the limiter (to account for the actual packet size)
-            if transport.priority_manager.config.enabled
-                && let Ok(remaining_bytes_to_add) =
-                    (total_bytes_sent - num_bytes_added_to_limiter).try_into()
-                {
-                    let _ = transport
-                        .priority_manager
-                        .limiter
-                        .check_n(remaining_bytes_to_add);
-            }
         });
     }
 

--- a/lightyear_transport/src/plugin.rs
+++ b/lightyear_transport/src/plugin.rs
@@ -399,6 +399,13 @@ impl TransportPlugin {
                     .priority_manager
                     .consume_packet_quota(packet_len as u32)
                 {
+                    // Packets are built from messages ordered by priority. The limiter is checked
+                    // here, after packet building/compression, so quota is charged on final packet
+                    // bytes. Once this packet does not fit, later packets are not higher priority.
+                    //
+                    // Unsent unreliable messages are dropped for this tick. Reliable messages will
+                    // be retried by their channel sender because their ack bookkeeping is only
+                    // updated after a packet is accepted below.
                     break;
                 }
                 #[cfg(feature = "metrics")]

--- a/lightyear_transport/src/plugin.rs
+++ b/lightyear_transport/src/plugin.rs
@@ -3,9 +3,13 @@ use crate::channel::receivers::ChannelReceive;
 use crate::channel::registry::{ChannelId, ChannelRegistry};
 use crate::channel::senders::ChannelSend;
 use crate::error::TransportError;
+use crate::packet::compression::{CompressionOutcome, decompress_payload, try_compress_packet};
 use crate::packet::error::PacketError;
 use crate::packet::header::PacketHeader;
 use crate::packet::message::{FragmentData, MessageAck, ReceiveMessage, SingleData};
+#[cfg(feature = "metrics")]
+use crate::packet::packet::MAX_PACKET_SIZE;
+use crate::packet::packet_type::PacketType;
 #[cfg(feature = "test_utils")]
 use crate::prelude::{AppChannelExt, ChannelMode, ChannelSettings};
 use bevy_app::prelude::*;
@@ -175,14 +179,19 @@ impl TransportPlugin {
                             .header_manager
                             .process_recv_packet_header(&header);
 
-
+                        let mut packet_type = header.get_packet_type();
+                        if packet_type.is_compressed() {
+                            let compressed_payload = cursor.split();
+                            let decompressed_payload =
+                                decompress_payload(compressed_payload.as_ref(), transport.compression)?;
+                            cursor = Reader::from(decompressed_payload);
+                            packet_type = packet_type.uncompressed_variant();
+                        }
 
                         // Parse the payload into messages, put them in the internal buffers for each channel
                         // we read directly from the packet and don't create intermediary datastructures to avoid allocations
                         // TODO: maybe do this in a helper function?
-                        if header.get_packet_type()
-                            == crate::packet::packet_type::PacketType::DataFragment
-                        {
+                        if packet_type == PacketType::DataFragment {
                             // read the fragment data
                             let channel_id = ChannelId::from_bytes(&mut cursor)?;
                             let fragment_data = FragmentData::from_bytes(&mut cursor)?;
@@ -385,6 +394,61 @@ impl TransportPlugin {
 
             let mut total_bytes_sent = 0;
             for mut packet in packets {
+                match try_compress_packet(&mut packet, transport.compression) {
+                    Ok(CompressionOutcome::Compressed {
+                        original_len,
+                        compressed_len,
+                    }) => {
+                        #[cfg(feature = "metrics")]
+                        {
+                            metrics::counter!("transport/compression_attempts").increment(1);
+                            metrics::counter!("transport/compression_saved_bytes")
+                                .increment((original_len - compressed_len) as u64);
+                        }
+                        trace!(
+                            original_len,
+                            compressed_len,
+                            "compressed transport packet payload"
+                        );
+                    }
+                    Ok(CompressionOutcome::Disabled) => {}
+                    Ok(CompressionOutcome::AlreadyCompressed)
+                    | Ok(CompressionOutcome::TooSmall { .. }) => {
+                        #[cfg(feature = "metrics")]
+                        if transport.compression.is_enabled() {
+                            metrics::counter!("transport/compression_attempts").increment(1);
+                            metrics::counter!("transport/compression_skipped").increment(1);
+                        }
+                    }
+                    Ok(CompressionOutcome::NotSmaller {
+                        original_len,
+                        compressed_len,
+                    }) => {
+                        #[cfg(feature = "metrics")]
+                        if transport.compression.is_enabled() {
+                            metrics::counter!("transport/compression_attempts").increment(1);
+                            metrics::counter!("transport/compression_skipped").increment(1);
+                            if compressed_len > original_len {
+                                metrics::counter!("transport/compression_expanded_packets")
+                                    .increment(1);
+                            }
+                            if compressed_len > MAX_PACKET_SIZE {
+                                metrics::counter!("transport/compression_above_mtu_packets")
+                                    .increment(1);
+                            }
+                        }
+                        trace!(
+                            original_len,
+                            compressed_len,
+                            "skipped transport packet compression because output was not smaller"
+                        );
+                    }
+                    Err(error) => {
+                        #[cfg(feature = "metrics")]
+                        metrics::counter!("transport/compression_errors").increment(1);
+                        error!("Failed to compress packet payload: {error:?}");
+                    }
+                }
                 trace!(packet_id = ?packet.packet_id, num_messages = ?packet.num_messages(), "sending packet");
                 let packet_id = packet.packet_id;
                 let num_messages = packet.num_messages();


### PR DESCRIPTION
Enable compression to reduce the size of the payload.
The packets will now be HEADER (including a byte to indicate if the packet is compressed) + COMPRESSED_PAYLOAD.

This was implemented in 3 steps:
- step 1: enable simply compressing the entire message bytes after the packet bytes have been written. Only use the compressed bytes if they are smaller than the uncompressed version.

This is simple but potentially inefficient: we first create the uncompressed packet up to size 1200 and then try to compress that. But we could potentially fit way more compressed messages into a packet.

- step 2: exponentially take 1, 2, 4, 8 .. messages from the rate-limiter in order of priority and try to build the packet with compression. We keep the highest number of messages that fit into the MTU limit. This lets us compress more messages together.

- step 3: compress fragment messages (that exceed MTU). Fragment messages were treated separately; we try to compress them before splitting them up into parts.