### PR TITLE
Handle op_delta for prediction/interpolation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -238,7 +238,7 @@ leafwing-input-manager = { version = "0.20", default-features = false, features 
 ] }
 
 # replication
-bevy_replicon = { version = "=0.39.4" }
+bevy_replicon = { path = "../bevy_replicon" }
 
 # physics
 avian2d = { version = "0.6", default-features = false }

--- a/lightyear_interpolation/src/registry.rs
+++ b/lightyear_interpolation/src/registry.rs
@@ -1,6 +1,7 @@
 use crate::SyncComponent;
 use crate::interpolation_history::ConfirmedHistory;
 use crate::plugin::{add_interpolation_systems, add_prepare_interpolation_systems};
+use alloc::format;
 use bevy_ecs::component::Mutable;
 use bevy_ecs::{component::Component, resource::Resource};
 use bevy_math::{
@@ -10,11 +11,13 @@ use bevy_math::{
 use bevy_platform::collections::HashMap;
 use bevy_platform::collections::HashSet;
 use bevy_replicon::bytes::Bytes;
-use bevy_replicon::prelude::RepliconTick;
-use bevy_replicon::prelude::{AppMarkerExt, RuleFns};
+use bevy_replicon::postcard_utils;
+use bevy_replicon::prelude::{AppMarkerExt, OpDeltaComponent, RepliconTick, RuleFns};
 use bevy_replicon::shared::replication::deferred_entity::DeferredEntity;
+use bevy_replicon::shared::replication::op_delta::{OpDeltaReceiver, OpDeltaWire};
 use bevy_replicon::shared::replication::receive_markers::MarkerConfig;
 use bevy_replicon::shared::replication::registry::ctx::{RemoveCtx, WriteCtx};
+use bevy_utils::prelude::DebugName;
 use lightyear_core::interpolation::Interpolated;
 use lightyear_core::prelude::Tick;
 use lightyear_replication::checkpoint::ReplicationCheckpointMap;
@@ -85,6 +88,42 @@ impl InterpolationRegistry {
 }
 
 fn register_interpolated_marker_fns<C: SyncComponent>(app: &mut bevy_app::App) {
+    register_interpolated_marker_fns_with::<C>(
+        app,
+        write_history::<C>,
+        remove_history::<C>,
+        InterpolatedMarkerRegistration::InsertIfMissing,
+    );
+}
+
+fn register_interpolated_marker_fns_op_delta<C: SyncComponent + OpDeltaComponent>(
+    app: &mut bevy_app::App,
+) {
+    register_interpolated_marker_fns_with::<C>(
+        app,
+        write_history_op_delta::<C>,
+        remove_history_op_delta::<C>,
+        InterpolatedMarkerRegistration::ReplaceExisting,
+    );
+}
+
+#[derive(Clone, Copy)]
+enum InterpolatedMarkerRegistration {
+    InsertIfMissing,
+    ReplaceExisting,
+}
+
+fn register_interpolated_marker_fns_with<C: SyncComponent>(
+    app: &mut bevy_app::App,
+    write: fn(
+        &mut WriteCtx,
+        &RuleFns<C>,
+        &mut DeferredEntity,
+        &mut Bytes,
+    ) -> bevy_ecs::error::Result<()>,
+    remove: fn(&mut RemoveCtx, &mut DeferredEntity),
+    registration: InterpolatedMarkerRegistration,
+) {
     if !app
         .world()
         .contains_resource::<InterpolatedMarkerFnRegistry>()
@@ -97,18 +136,27 @@ fn register_interpolated_marker_fns<C: SyncComponent>(app: &mut bevy_app::App) {
         let registry = app.world().resource::<InterpolatedMarkerFnRegistry>();
         registry.kinds.contains(&kind)
     };
-    if already_registered {
+    if already_registered
+        && matches!(
+            registration,
+            InterpolatedMarkerRegistration::InsertIfMissing
+        )
+    {
         return;
     }
-    app.register_marker_with::<Interpolated>(MarkerConfig {
-        priority: 100,
-        need_history: true,
-    });
-    app.set_marker_fns::<Interpolated, C>(write_history::<C>, remove_history::<C>);
-    app.world_mut()
-        .resource_mut::<InterpolatedMarkerFnRegistry>()
-        .kinds
-        .insert(kind);
+    if !already_registered {
+        app.register_marker_with::<Interpolated>(MarkerConfig {
+            priority: 100,
+            need_history: true,
+        });
+    }
+    app.set_marker_fns::<Interpolated, C>(write, remove);
+    if !already_registered {
+        app.world_mut()
+            .resource_mut::<InterpolatedMarkerFnRegistry>()
+            .kinds
+            .insert(kind);
+    }
 }
 
 fn resolve_message_tick(
@@ -155,6 +203,12 @@ pub trait InterpolationRegistrationExt<C> {
     fn add_custom_interpolation(self) -> Self
     where
         C: SyncComponent;
+
+    /// Like [`Self::add_custom_interpolation`], but for components replicated through
+    /// Replicon's op-delta rule.
+    fn add_custom_interpolation_op_delta(self) -> Self
+    where
+        C: SyncComponent + OpDeltaComponent;
 }
 
 impl<C> InterpolationRegistrationExt<C> for ComponentRegistration<'_, C> {
@@ -162,7 +216,6 @@ impl<C> InterpolationRegistrationExt<C> for ComponentRegistration<'_, C> {
     where
         C: SyncComponent,
     {
-        register_interpolated_marker_fns::<C>(self.app);
         if !self
             .app
             .world()
@@ -189,6 +242,7 @@ impl<C> InterpolationRegistrationExt<C> for ComponentRegistration<'_, C> {
         C: SyncComponent,
     {
         self = self.register_interpolation_fn(interpolation_fn);
+        register_interpolated_marker_fns::<C>(self.app);
         add_prepare_interpolation_systems::<C>(self.app);
         add_interpolation_systems::<C>(self.app);
 
@@ -217,6 +271,44 @@ impl<C> InterpolationRegistrationExt<C> for ComponentRegistration<'_, C> {
     {
         let kind = ComponentKind::of::<C>();
         register_interpolated_marker_fns::<C>(self.app);
+        if !self
+            .app
+            .world()
+            .contains_resource::<InterpolationRegistry>()
+        {
+            self.app
+                .world_mut()
+                .insert_resource(InterpolationRegistry::default());
+        }
+        let mut registry = self.app.world_mut().resource_mut::<InterpolationRegistry>();
+        registry
+            .interpolation_map
+            .entry(kind)
+            .and_modify(|r| r.custom_interpolation = true)
+            .or_insert_with(|| InterpolationMetadata {
+                interpolation: None,
+                custom_interpolation: true,
+            });
+        add_prepare_interpolation_systems::<C>(self.app);
+
+        let mut registry = self.app.world_mut().resource_mut::<ComponentRegistry>();
+        registry
+            .component_metadata_map
+            .get_mut(&ComponentKind::of::<C>())
+            .unwrap()
+            .replication
+            .as_mut()
+            .unwrap()
+            .set_interpolated(true);
+        self
+    }
+
+    fn add_custom_interpolation_op_delta(self) -> Self
+    where
+        C: SyncComponent + OpDeltaComponent,
+    {
+        let kind = ComponentKind::of::<C>();
+        register_interpolated_marker_fns_op_delta::<C>(self.app);
         if !self
             .app
             .world()
@@ -287,6 +379,95 @@ fn write_history<C: Component<Mutability = Mutable>>(
     Ok(())
 }
 
+fn write_history_op_delta<C: Component<Mutability = Mutable> + Clone + OpDeltaComponent>(
+    ctx: &mut WriteCtx,
+    _rule_fns: &RuleFns<C>,
+    entity: &mut DeferredEntity,
+    message: &mut Bytes,
+) -> bevy_ecs::error::Result<()> {
+    let Some(component) = op_delta_interpolation_component::<C>(entity, message)? else {
+        return Ok(());
+    };
+    push_confirmed_history(ctx, entity, component)
+}
+
+fn op_delta_interpolation_component<
+    C: Component<Mutability = Mutable> + Clone + OpDeltaComponent,
+>(
+    entity: &mut DeferredEntity,
+    message: &mut Bytes,
+) -> bevy_ecs::error::Result<Option<C>> {
+    match postcard_utils::from_buf(message)? {
+        OpDeltaWire::<C, C::Op>::Snapshot { cursor, value } => {
+            entity.insert(OpDeltaReceiver::<C>::new(cursor));
+            Ok(Some(value))
+        }
+        OpDeltaWire::<C, C::Op>::Ops { ops, .. } => {
+            let ready_ops = {
+                let mut receiver = entity.get_mut::<OpDeltaReceiver<C>>().ok_or_else(|| {
+                    format!(
+                        "received op-delta operations for `{}` before an interpolation snapshot",
+                        DebugName::type_name::<C>()
+                    )
+                })?;
+                receiver.queue_and_take_ready(ops)
+            };
+            if ready_ops.is_empty() {
+                return Ok(None);
+            }
+
+            let mut value = entity
+                .get::<ConfirmedHistory<C>>()
+                .and_then(|history| history.newest())
+                .map(|(_, value)| value.clone())
+                .or_else(|| entity.get::<C>().map(|value| value.clone()))
+                .ok_or_else(|| {
+                    format!(
+                        "received op-delta operations for `{}` without a confirmed interpolation base",
+                        DebugName::type_name::<C>()
+                    )
+                })?;
+            for op in ready_ops {
+                value.apply_op(&op)?;
+            }
+            Ok(Some(value))
+        }
+    }
+}
+
+fn push_confirmed_history<C: Component<Mutability = Mutable>>(
+    ctx: &mut WriteCtx,
+    entity: &mut DeferredEntity,
+    component: C,
+) -> bevy_ecs::error::Result<()> {
+    // SAFETY: we only access resources, which don't alias with the DeferredEntity's component access.
+    let checkpoints = {
+        let world = unsafe { entity.world_mut() };
+        let checkpoints =
+            world.resource::<ReplicationCheckpointMap>() as *const ReplicationCheckpointMap;
+        unsafe { &*checkpoints }
+    };
+    let Some(tick) = resolve_message_tick(checkpoints, ctx.message_tick) else {
+        error!(
+            message_tick = ?ctx.message_tick,
+            "missing authoritative checkpoint mapping while writing interpolation history"
+        );
+        debug_assert!(
+            false,
+            "missing authoritative checkpoint mapping while writing interpolation history"
+        );
+        return Ok(());
+    };
+    if let Some(mut history) = entity.get_mut::<ConfirmedHistory<C>>() {
+        history.push(tick, component);
+    } else {
+        let mut history = ConfirmedHistory::<C>::default();
+        history.push(tick, component);
+        entity.insert(history);
+    }
+    Ok(())
+}
+
 /// Records a component removal in `ConfirmedHistory<C>`.
 ///
 /// The live component is removed later by interpolation systems once the interpolation timeline
@@ -317,6 +498,14 @@ fn remove_history<C: Component>(ctx: &mut RemoveCtx, entity: &mut DeferredEntity
         history.push_remove(tick);
         entity.insert(history);
     }
+}
+
+fn remove_history_op_delta<C: Component + OpDeltaComponent>(
+    ctx: &mut RemoveCtx,
+    entity: &mut DeferredEntity,
+) {
+    entity.remove::<OpDeltaReceiver<C>>();
+    remove_history::<C>(ctx, entity);
 }
 
 #[cfg(test)]

--- a/lightyear_prediction/src/registry.rs
+++ b/lightyear_prediction/src/registry.rs
@@ -6,7 +6,6 @@ use crate::plugin::{
 };
 use crate::predicted_history::PredictionHistory;
 use crate::prelude::PredictionManager;
-#[cfg(feature = "metrics")]
 use alloc::format;
 use bevy_app::App;
 use bevy_ecs::component::ComponentId;
@@ -18,8 +17,10 @@ use bevy_math::{
     curve::{Ease, EaseFunction, EasingCurve},
 };
 use bevy_replicon::bytes::Bytes;
-use bevy_replicon::prelude::{AppMarkerExt, RepliconTick, RuleFns};
+use bevy_replicon::postcard_utils;
+use bevy_replicon::prelude::{AppMarkerExt, OpDeltaComponent, RepliconTick, RuleFns};
 use bevy_replicon::shared::replication::deferred_entity::DeferredEntity;
+use bevy_replicon::shared::replication::op_delta::{OpDeltaReceiver, OpDeltaWire};
 use bevy_replicon::shared::replication::receive_markers::MarkerConfig;
 use bevy_replicon::shared::replication::registry::ctx::{RemoveCtx, WriteCtx};
 use bevy_utils::prelude::DebugName;
@@ -456,6 +457,15 @@ pub trait PredictionRegistrationExt<C> {
     where
         C: SyncComponent;
 
+    /// Enable prediction for an op-delta replicated component.
+    ///
+    /// Replicon mutation payloads for these components can contain operation
+    /// deltas instead of full component snapshots, so confirmed writes must
+    /// reconstruct a component value before storing it in `PredictionHistory<C>`.
+    fn add_prediction_op_delta(self) -> Self
+    where
+        C: SyncComponent + OpDeltaComponent;
+
     /// Register `write_history` as the default replicon receive function for
     /// this component, so that replicated values are stored in
     /// `PredictionHistory<C>` as confirmed state (and optionally trigger a
@@ -609,6 +619,54 @@ impl<C> PredictionRegistrationExt<C> for ComponentRegistration<'_, C> {
         self
     }
 
+    fn add_prediction_op_delta(self) -> Self
+    where
+        C: SyncComponent + OpDeltaComponent,
+    {
+        if !self.app.world().contains_resource::<PredictionRegistry>() {
+            trace!(
+                "Skipping op-delta prediction registration for component {:?} because PredictionPlugin is not present",
+                DebugName::type_name::<C>()
+            );
+            return self;
+        }
+        self.app.register_marker_with::<Predicted>(MarkerConfig {
+            priority: 100,
+            need_history: true,
+        });
+        self.app.set_marker_fns::<Predicted, C>(
+            write_history_op_delta::<C>,
+            remove_history_op_delta::<C>,
+        );
+        self.app.register_marker_with::<PreSpawned>(MarkerConfig {
+            priority: 100,
+            need_history: true,
+        });
+        self.app.set_marker_fns::<PreSpawned, C>(
+            write_history_op_delta::<C>,
+            remove_history_op_delta::<C>,
+        );
+        let history_id = self
+            .app
+            .world_mut()
+            .register_component::<PredictionHistory<C>>();
+        let mut registry = self.app.world_mut().resource_mut::<PredictionRegistry>();
+        trace!(
+            "Adding op-delta prediction for component {:?}",
+            DebugName::type_name::<C>()
+        );
+        registry.register::<C>(history_id);
+        add_prediction_systems::<C>(self.app);
+
+        let mut registry = self.app.world_mut().resource_mut::<ComponentRegistry>();
+        let metadata = registry
+            .component_metadata_map
+            .get_mut(&ComponentKind::of::<C>())
+            .unwrap();
+        metadata.replication.as_mut().unwrap().set_predicted(true);
+        self
+    }
+
     fn enable_correction(self) -> Self
     where
         C: SyncComponent,
@@ -733,6 +791,68 @@ fn write_history<C: SyncComponent>(
     Ok(())
 }
 
+fn write_history_op_delta<C: SyncComponent + OpDeltaComponent>(
+    ctx: &mut WriteCtx,
+    _rule_fns: &RuleFns<C>,
+    entity: &mut DeferredEntity,
+    message: &mut Bytes,
+) -> Result<()> {
+    let Some(component) = op_delta_prediction_component::<C>(entity, message)? else {
+        return Ok(());
+    };
+    let (tick, should_rollback) =
+        add_confirmed_to_history(ctx.message_tick, Some(component), entity, true)?;
+    if should_rollback {
+        // SAFETY: we only access resources, which don't alias with the DeferredEntity's component access
+        unsafe { entity.world_mut() }
+            .resource_mut::<StateRollbackMetadata>()
+            .record_mismatch(tick);
+    }
+    Ok(())
+}
+
+fn op_delta_prediction_component<C: SyncComponent + OpDeltaComponent>(
+    entity: &mut DeferredEntity,
+    message: &mut Bytes,
+) -> Result<Option<C>> {
+    match postcard_utils::from_buf(message)? {
+        OpDeltaWire::<C, C::Op>::Snapshot { cursor, value } => {
+            entity.insert(OpDeltaReceiver::<C>::new(cursor));
+            Ok(Some(value))
+        }
+        OpDeltaWire::<C, C::Op>::Ops { ops, .. } => {
+            let ready_ops = {
+                let mut receiver = entity.get_mut::<OpDeltaReceiver<C>>().ok_or_else(|| {
+                    format!(
+                        "received op-delta operations for `{}` before a prediction snapshot",
+                        DebugName::type_name::<C>()
+                    )
+                })?;
+                receiver.queue_and_take_ready(ops)
+            };
+            if ready_ops.is_empty() {
+                return Ok(None);
+            }
+
+            let mut value = entity
+                .get::<PredictionHistory<C>>()
+                .and_then(|history| history.last_confirmed())
+                .and_then(|state| state.value())
+                .cloned()
+                .ok_or_else(|| {
+                    format!(
+                        "received op-delta operations for `{}` without a confirmed prediction base",
+                        DebugName::type_name::<C>()
+                    )
+                })?;
+            for op in ready_ops {
+                value.apply_op(&op)?;
+            }
+            Ok(Some(value))
+        }
+    }
+}
+
 fn add_confirmed_to_history<C: SyncComponent>(
     message_tick: RepliconTick,
     confirmed_component: Option<C>,
@@ -828,6 +948,14 @@ fn remove_history<C: SyncComponent>(ctx: &mut RemoveCtx, entity: &mut DeferredEn
             .resource_mut::<StateRollbackMetadata>()
             .record_mismatch(tick);
     }
+}
+
+fn remove_history_op_delta<C: SyncComponent + OpDeltaComponent>(
+    ctx: &mut RemoveCtx,
+    entity: &mut DeferredEntity,
+) {
+    entity.remove::<OpDeltaReceiver<C>>();
+    remove_history::<C>(ctx, entity);
 }
 
 /// Variant of [`write_history`] used by `add_confirmed_write`.

--- a/lightyear_tests/Cargo.toml
+++ b/lightyear_tests/Cargo.toml
@@ -61,6 +61,7 @@ lightyear_crossbeam.workspace = true
 lightyear_connection = { workspace = true, features = ["client", "server"] }
 lightyear_sync = { workspace = true, features = ["client", "server"] }
 lightyear_prediction = { workspace = true, features = ["deterministic"] }
+lightyear_interpolation.workspace = true
 lightyear_deterministic_replication.workspace = true
 lightyear_inputs = { workspace = true, features = ["client", "server"] }
 lightyear_inputs_leafwing.workspace = true

--- a/lightyear_tests/src/client_server/mod.rs
+++ b/lightyear_tests/src/client_server/mod.rs
@@ -8,6 +8,7 @@ mod deterministic;
 mod hierarchy;
 mod input;
 mod messages;
+mod op_delta;
 mod prediction;
 mod replication;
 // mod replication_advanced;

--- a/lightyear_tests/src/client_server/op_delta.rs
+++ b/lightyear_tests/src/client_server/op_delta.rs
@@ -1,0 +1,264 @@
+use bevy::prelude::*;
+use bevy::state::app::StatesPlugin;
+use bevy_replicon::postcard_utils;
+use bevy_replicon::prelude::*;
+use bevy_replicon::shared::replication::op_delta::{
+    OpDeltaComponent, OpDeltaReceiver, OpDeltaWire, OpIndex, SequencedOp,
+};
+use bevy_replicon::shared::replication::registry::FnsId;
+use bevy_replicon::shared::replication::registry::test_fns::TestFnsEntityExt;
+use bevy_replicon::shared::replication::rules::ReplicationRules;
+use lightyear_core::prelude::{Interpolated, Predicted, Tick};
+use lightyear_interpolation::prelude::{ConfirmedHistory, InterpolationRegistrationExt};
+use lightyear_prediction::prelude::{
+    PredictionHistory, PredictionManager, PredictionRegistrationExt, PredictionRegistry,
+    RollbackMode, RollbackPolicy, StateRollbackMetadata,
+};
+use lightyear_replication::checkpoint::ReplicationCheckpointMap;
+use lightyear_replication::prelude::ComponentRegistry;
+use lightyear_replication::registry::replication::ComponentRegistration;
+use serde::{Deserialize, Serialize};
+
+#[test]
+fn op_delta_prediction_writes_snapshot_and_ops_to_prediction_history() {
+    let mut app = setup_app();
+    let fns_id = op_delta_fns_id(&app);
+    let entity = app.world_mut().spawn((Predicted, OpDeltaCounter(999))).id();
+
+    app.world_mut().entity_mut(entity).apply_write(
+        snapshot(0, OpDeltaCounter(10)),
+        fns_id,
+        RepliconTick::new(1),
+    );
+    app.world_mut().entity_mut(entity).apply_write(
+        ops(0, 2, [(1, CounterOp::Add(5)), (2, CounterOp::Add(7))]),
+        fns_id,
+        RepliconTick::new(2),
+    );
+
+    let entity_ref = app.world().entity(entity);
+    assert_eq!(
+        entity_ref.get::<OpDeltaCounter>(),
+        Some(&OpDeltaCounter(999))
+    );
+    assert!(entity_ref.contains::<OpDeltaReceiver<OpDeltaCounter>>());
+
+    let history = entity_ref
+        .get::<PredictionHistory<OpDeltaCounter>>()
+        .expect("op-delta predicted writes should populate PredictionHistory");
+    assert_eq!(
+        confirmed_prediction_value(history, Tick(10)),
+        Some(OpDeltaCounter(10))
+    );
+    assert_eq!(
+        confirmed_prediction_value(history, Tick(11)),
+        Some(OpDeltaCounter(22))
+    );
+}
+
+#[test]
+fn op_delta_interpolation_writes_snapshot_and_ops_to_confirmed_history() {
+    let mut app = setup_app();
+    let fns_id = op_delta_fns_id(&app);
+    let entity = app.world_mut().spawn(Interpolated).id();
+
+    app.world_mut().entity_mut(entity).apply_write(
+        snapshot(0, OpDeltaCounter(10)),
+        fns_id,
+        RepliconTick::new(1),
+    );
+    app.world_mut().entity_mut(entity).apply_write(
+        ops(0, 2, [(1, CounterOp::Add(5)), (2, CounterOp::Add(7))]),
+        fns_id,
+        RepliconTick::new(2),
+    );
+
+    let entity_ref = app.world().entity(entity);
+    assert!(!entity_ref.contains::<OpDeltaCounter>());
+    assert!(entity_ref.contains::<OpDeltaReceiver<OpDeltaCounter>>());
+
+    let history = entity_ref
+        .get::<ConfirmedHistory<OpDeltaCounter>>()
+        .expect("op-delta interpolated writes should populate ConfirmedHistory");
+    assert_eq!(
+        history_value(history.start()),
+        Some((Tick(10), OpDeltaCounter(10)))
+    );
+    assert_eq!(
+        history_value(history.end()),
+        Some((Tick(11), OpDeltaCounter(22)))
+    );
+    assert_eq!(
+        history_value(history.newest()),
+        Some((Tick(11), OpDeltaCounter(22)))
+    );
+}
+
+#[test]
+fn op_delta_interpolation_replaces_writer_registered_by_interpolation_fn() {
+    let mut app = setup_app_with_registration(register_op_delta_component_interpolation_fn_first);
+    let fns_id = op_delta_fns_id(&app);
+    let entity = app.world_mut().spawn(Interpolated).id();
+
+    app.world_mut().entity_mut(entity).apply_write(
+        snapshot(0, OpDeltaCounter(10)),
+        fns_id,
+        RepliconTick::new(1),
+    );
+    app.world_mut().entity_mut(entity).apply_write(
+        ops(0, 2, [(1, CounterOp::Add(5)), (2, CounterOp::Add(7))]),
+        fns_id,
+        RepliconTick::new(2),
+    );
+
+    let entity_ref = app.world().entity(entity);
+    assert!(!entity_ref.contains::<OpDeltaCounter>());
+    assert!(entity_ref.contains::<OpDeltaReceiver<OpDeltaCounter>>());
+
+    let history = entity_ref
+        .get::<ConfirmedHistory<OpDeltaCounter>>()
+        .expect("op-delta interpolated writes should populate ConfirmedHistory");
+    assert_eq!(
+        history_value(history.start()),
+        Some((Tick(10), OpDeltaCounter(10)))
+    );
+    assert_eq!(
+        history_value(history.end()),
+        Some((Tick(11), OpDeltaCounter(22)))
+    );
+}
+
+fn setup_app() -> App {
+    setup_app_with_registration(register_op_delta_component)
+}
+
+fn setup_app_with_registration(register: impl FnOnce(&mut App)) -> App {
+    let mut app = App::new();
+    app.add_plugins((
+        MinimalPlugins,
+        StatesPlugin,
+        RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
+    ));
+    app.init_resource::<PredictionRegistry>();
+    app.init_resource::<StateRollbackMetadata>();
+    app.init_resource::<ReplicationCheckpointMap>();
+
+    app.world_mut()
+        .resource_mut::<ReplicationCheckpointMap>()
+        .record(RepliconTick::new(1), Tick(10));
+    app.world_mut()
+        .resource_mut::<ReplicationCheckpointMap>()
+        .record(RepliconTick::new(2), Tick(11));
+
+    app.world_mut()
+        .spawn(PredictionManager {
+            rollback_policy: RollbackPolicy {
+                state: RollbackMode::Disabled,
+                input: RollbackMode::Disabled,
+                ..Default::default()
+            },
+            ..Default::default()
+        })
+        .flush();
+
+    register(&mut app);
+    app.finish();
+    app
+}
+
+fn register_op_delta_component(app: &mut App) {
+    app.world_mut().init_resource::<ComponentRegistry>();
+    app.world_mut()
+        .resource_scope(|world, mut registry: Mut<ComponentRegistry>| {
+            if !registry.is_registered::<OpDeltaCounter>() {
+                registry.register_component::<OpDeltaCounter>(world);
+            }
+        });
+
+    app.replicate_op_delta::<OpDeltaCounter>();
+    ComponentRegistration::<OpDeltaCounter>::new(app)
+        .add_prediction_op_delta()
+        .add_custom_interpolation_op_delta();
+}
+
+fn register_op_delta_component_interpolation_fn_first(app: &mut App) {
+    app.world_mut().init_resource::<ComponentRegistry>();
+    app.world_mut()
+        .resource_scope(|world, mut registry: Mut<ComponentRegistry>| {
+            if !registry.is_registered::<OpDeltaCounter>() {
+                registry.register_component::<OpDeltaCounter>(world);
+            }
+        });
+
+    app.replicate_op_delta::<OpDeltaCounter>();
+    ComponentRegistration::<OpDeltaCounter>::new(app)
+        .add_prediction_op_delta()
+        .register_interpolation_fn(interpolate_counter)
+        .add_custom_interpolation_op_delta();
+}
+
+fn confirmed_prediction_value(
+    history: &PredictionHistory<OpDeltaCounter>,
+    tick: Tick,
+) -> Option<OpDeltaCounter> {
+    history
+        .get_confirmed_at(tick)
+        .and_then(|state| state.value())
+        .cloned()
+}
+
+fn history_value(value: Option<(Tick, &OpDeltaCounter)>) -> Option<(Tick, OpDeltaCounter)> {
+    value.map(|(tick, value)| (tick, value.clone()))
+}
+
+fn op_delta_fns_id(app: &App) -> FnsId {
+    app.world().resource::<ReplicationRules>()[0].components[0].fns_id
+}
+
+fn snapshot(cursor: OpIndex, value: OpDeltaCounter) -> Vec<u8> {
+    wire(OpDeltaWire::Snapshot { cursor, value })
+}
+
+fn ops<const N: usize>(
+    base_cursor: OpIndex,
+    cursor: OpIndex,
+    ops: [(OpIndex, CounterOp); N],
+) -> Vec<u8> {
+    wire(OpDeltaWire::Ops {
+        base_cursor,
+        cursor,
+        ops: ops
+            .into_iter()
+            .map(|(seq, op)| SequencedOp { seq, op })
+            .collect(),
+    })
+}
+
+fn wire(wire: OpDeltaWire<OpDeltaCounter, CounterOp>) -> Vec<u8> {
+    let mut message = Vec::new();
+    postcard_utils::to_extend_mut(&wire, &mut message).unwrap();
+    message
+}
+
+fn interpolate_counter(start: OpDeltaCounter, end: OpDeltaCounter, t: f32) -> OpDeltaCounter {
+    OpDeltaCounter(((1.0 - t) * start.0 as f32 + t * end.0 as f32).round() as i32)
+}
+
+#[derive(Component, Clone, Debug, Deserialize, PartialEq, Serialize)]
+struct OpDeltaCounter(i32);
+
+impl OpDeltaComponent for OpDeltaCounter {
+    type Op = CounterOp;
+
+    fn apply_op(&mut self, op: &Self::Op) -> bevy::ecs::error::Result<()> {
+        match *op {
+            CounterOp::Add(value) => self.0 += value,
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+enum CounterOp {
+    Add(i32),
+}


### PR DESCRIPTION
The 'write/remove' markers for prediction/interpolation need to be updated in the op_delta case