### PR TITLE
Fix some client feature visibility issues in lightyear_replication

### DIFF
--- a/lightyear_replication/src/lib.rs
+++ b/lightyear_replication/src/lib.rs
@@ -90,7 +90,6 @@ extern crate alloc;
 extern crate std;
 
 use bevy_app::PluginGroupBuilder;
-#[cfg(feature = "client")]
 use bevy_app::prelude::Plugin;
 use bevy_app::prelude::PluginGroup;
 use bevy_ecs::prelude::SystemSet;

--- a/lightyear_replication/src/send.rs
+++ b/lightyear_replication/src/send.rs
@@ -960,8 +960,6 @@ fn emulate_replicate_on_host_client_added(
                 }
                 true
             }
-            #[cfg(not(feature = "client"))]
-            ReplicationMode::SingleClient => false,
             #[cfg(feature = "server")]
             ReplicationMode::SingleServer(target) => {
                 host_peer_id.is_some_and(|peer_id| target.targets(&peer_id))


### PR DESCRIPTION
## Fix 1: Allow Bevy's `Plugin` trait to be visible without the `client` feature
```
   Compiling lightyear_replication v0.26.4 (/home/tux/Projects/lightyear/lightyear_replication)
error[E0405]: cannot find trait `Plugin` in this scope
   --> /home/tux/Projects/lightyear/lightyear_replication/src/lib.rs:220:6
    |
220 | impl Plugin for LightyearRepliconServerBackend {
    |      ^^^^^^ not found in this scope
    |
note: found an item that was configured out
   --> /home/tux/Projects/lightyear/lightyear_replication/src/lib.rs:94:24
    |
 93 | #[cfg(feature = "client")]
    |       ------------------ the item is gated behind the `client` feature
 94 | use bevy_app::prelude::Plugin;
    |                        ^^^^^^
```

I encountered this when trying to compile my server crate. As the error message says on the tin, `LightyearRepliconServerBackend` (a struct only visible with the `server` feature) is implementing Bevy's `Plugin` trait (a trait only visible with the `client` feature).

Because both `LightyearRepliconServerBackend` and `LightyearRepliconClientBackend` need that trait, I've just removed the `#[cfg(feature = "client")]` line. That way when the `server` feature is enabled, it doesn't require the `client` feature as well.


## Fix 2: Remove a match arm that cannot exist (does not exist without the client feature)
```
error[E0599]: no variant or associated item named `SingleClient` found for enum `send::ReplicationMode` in the current scope
   --> /home/tux/Projects/lightyear/lightyear_replication/src/send.rs:964:30
    |
 60 | pub enum ReplicationMode {
    | ------------------------ variant or associated item `SingleClient` not found for this enum
...
964 |             ReplicationMode::SingleClient => false,
    |                              ^^^^^^^^^^^^ variant or associated item not found in `send::ReplicationMode`
```

The `SingleClient` replication mode is now behind the `client` feature:
```
    #[cfg(feature = "client")]
    /// Replicates to the server (finds the single `Client` entity).
    SingleClient,
```

Thus a match arm referencing SingleClient when the `client` feature is not present, cannot exist:
```
            #[cfg(not(feature = "client"))]
            ReplicationMode::SingleClient => false,
```

So I just removed it.