### PR TITLE
Init ComponentRegistry resource if necessary during protocol check

### DIFF
--- a/examples/auth/src/main.rs
+++ b/examples/auth/src/main.rs
@@ -45,11 +45,6 @@ fn main() {
     let auth_backend_address = auth_backend_address();
 
     let mut app = cli.build_app(Duration::from_secs_f64(1.0 / FIXED_TIMESTEP_HZ), true);
-    // This example does not register any replicated protocol components, but the shared example
-    // harness still enables prediction/replication features on the client. Seed the registry so
-    // PredictionPlugin::finish has the expected resource even when the example itself has no
-    // protocol setup.
-    app.init_resource::<ComponentRegistry>();
 
     match cli.mode {
         None => {}

--- a/lightyear/src/protocol.rs
+++ b/lightyear/src/protocol.rs
@@ -96,6 +96,13 @@ impl Plugin for ProtocolCheckPlugin {
     }
 
     fn finish(&self, app: &mut App) {
+        // Replication can be enabled without any user-defined components. In that case,
+        // make sure the registry exists on both sides so the protocol check compares
+        // empty registries rather than `Some(...)` vs `None`.
+        if !app.world().contains_resource::<ComponentRegistry>() {
+            app.world_mut().init_resource::<ComponentRegistry>();
+        }
+
         app.add_observer(Self::send_verify_protocol);
         app.add_observer(Self::receive_verify_protocol);
     }
@@ -112,4 +119,21 @@ impl Plugin for ProtocolCheckPlugin {
     //     app.add_trigger::<ProtocolCheck>()
     //         .add_direction(NetworkDirection::ServerToClient);
     // }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ProtocolCheckPlugin;
+    use bevy_app::App;
+    use lightyear_replication::registry::ComponentRegistry;
+
+    #[test]
+    fn protocol_check_initializes_empty_component_registry() {
+        let mut app = App::new();
+
+        app.add_plugins(ProtocolCheckPlugin);
+        app.finish();
+
+        assert!(app.world().contains_resource::<ComponentRegistry>());
+    }
 }


### PR DESCRIPTION
I got this error while testing my client crate:

>2026-06-08T00:18:58.246249Z INFO lightyear_netcode::client_plugin: Client Netcode(1) connected Encountered an error in observer `lightyear::protocol::ProtocolCheckPlugin::receive_verify_protocol`: the component protocol doesn't match

Turns out, the client doesn't initialize `ComponentRegistry` by default. You must add at least one component to the protocol to get a ComponentRegistry added.

The `auth` example says as much:
https://github.com/cBournhonesque/lightyear/blob/main/examples/auth/src/main.rs#L52

I think the server is using `SendPlugin`, which does the initialization when `build()` is called:
https://github.com/cBournhonesque/lightyear/blob/main/lightyear_replication/src/send.rs#L1074

But the client is waiting for a call to `register_component_metadata` to initialize the registry:
https://github.com/cBournhonesque/lightyear/blob/main/lightyear_replication/src/registry/replication.rs#L110

If the client never registers a component, the `ComponentRegistry` never gets created.

This isn't a problem, until the `ProtocolCheckPlugin` compares the state of the client and server protocols.
https://github.com/cBournhonesque/lightyear/blob/main/lightyear/src/protocol.rs#L59

The server has an empty registry `Some($HASH_CODE_HERE)` , but the client has a `None`. This causes an error and the client to disconnect; thinking it is not using a compatible protocol.

This PR modifies `ProtocolCheckPlugin` to create an empty registry if no registry has been created. Because the existing paths (and the new path) have creation guards (if not-exist then create), this doesn't affect anything in most cases. However, in some cases like the `auth` example or my own project, where components haven't been added to the protocol yet, it lets things "just work".

One could argue it's a little weird to:
- have the ProtocolCheckPlugin initializing the ComponentRegistry
- not have a Component in the protocol (what exactly are you replicating anyway?)

So this PR is more a Developer Quality of Life fix.

Existing work-arounds are:
- add a ComponentRegistry yourself (ala the `auth` example)
- OR add a DummyComponent (ala `app.register_component::<DummyComponent>();`)

The new test case can be run with:
`cargo test -p lightyear protocol_check_initializes_empty_component_registry --lib`
