### PR TITLE
feat: handle diff-enabled components

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -238,7 +238,7 @@ leafwing-input-manager = { version = "0.20", default-features = false, features 
 ] }
 
 # replication
-bevy_replicon = { version = "=0.39.4" }
+bevy_replicon = { version = "=0.40.3" }
 
 # physics
 avian2d = { version = "0.6", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -238,7 +238,7 @@ leafwing-input-manager = { version = "0.20", default-features = false, features 
 ] }
 
 # replication
-bevy_replicon = { version = "=0.40.3" }
+bevy_replicon = { path = "../bevy_replicon" }
 
 # physics
 avian2d = { version = "0.6", default-features = false }

--- a/lightyear_core/src/history_buffer.rs
+++ b/lightyear_core/src/history_buffer.rs
@@ -43,7 +43,7 @@ impl<R> From<HistoryState<R>> for Option<R> {
 /// The values must always remain ordered from oldest (front) to most recent (back)
 #[derive(Resource, Component, Debug, Reflect)]
 #[reflect(Component, Resource)]
-pub struct HistoryBuffer<R> {
+pub struct HistoryBuffer<R, M = ()> {
     // Queue containing the history of the resource.
     // The front contains old elements, the back contains the more recent elements.
     // We will only store the history for the ticks where the resource got updated
@@ -54,10 +54,10 @@ pub struct HistoryBuffer<R> {
     //
     // Another option would be to store the tick difference between two updates, and only the first (most recent update)
     // gets updated in case of a TickEvent.
-    pub(crate) buffer: VecDeque<(Tick, HistoryState<R>)>,
+    pub(crate) buffer: VecDeque<((Tick, HistoryState<R>), M)>,
 }
 
-impl<R> Default for HistoryBuffer<R> {
+impl<R, M> Default for HistoryBuffer<R, M> {
     fn default() -> Self {
         Self {
             buffer: VecDeque::new(),
@@ -66,32 +66,39 @@ impl<R> Default for HistoryBuffer<R> {
 }
 
 // This is mostly present for testing, we only compare the buffer ticks, not the values
-impl<R> PartialEq for HistoryBuffer<R> {
+impl<R, M> PartialEq for HistoryBuffer<R, M> {
     fn eq(&self, other: &Self) -> bool {
-        let self_history: Vec<_> = self.buffer.iter().map(|(tick, _)| *tick).collect();
-        let other_history: Vec<_> = other.buffer.iter().map(|(tick, _)| *tick).collect();
+        let self_history: Vec<_> = self.buffer.iter().map(|((tick, _), _)| *tick).collect();
+        let other_history: Vec<_> = other.buffer.iter().map(|((tick, _), _)| *tick).collect();
         self_history.eq(&other_history)
     }
 }
 
-impl<R> HistoryBuffer<R> {
+impl<R, M> HistoryBuffer<R, M> {
     pub fn len(&self) -> usize {
         self.buffer.len()
     }
 
     /// Oldest value in the buffer
     pub fn oldest(&self) -> Option<&(Tick, HistoryState<R>)> {
-        self.buffer.front()
+        self.buffer.front().map(|(entry, _)| entry)
     }
 
     /// Most recent value in the buffer
     pub fn most_recent(&self) -> Option<&(Tick, HistoryState<R>)> {
-        self.buffer.back()
+        self.buffer.back().map(|(entry, _)| entry)
     }
 
-    /// Get the n-th most recent value in the buffer (starts from n = 0)
+    /// Get the n-th value in the buffer, ordered from oldest to newest.
     pub fn get_nth(&self, n: usize) -> Option<&(Tick, HistoryState<R>)> {
-        self.buffer.get(n)
+        self.buffer.get(n).map(|(entry, _)| entry)
+    }
+
+    #[doc(hidden)]
+    pub fn most_recent_with_metadata(&self) -> Option<(Tick, &HistoryState<R>, &M)> {
+        self.buffer
+            .back()
+            .map(|((tick, state), metadata)| (*tick, state, metadata))
     }
 
     #[doc(hidden)]
@@ -107,7 +114,7 @@ impl<R> HistoryBuffer<R> {
         if len < 2 {
             return None;
         }
-        self.buffer.get(len - 2).and_then(|(_, x)| x.into())
+        self.buffer.get(len - 2).and_then(|((_, x), _)| x.into())
     }
 
     /// Get the value at the specified tick.
@@ -115,11 +122,24 @@ impl<R> HistoryBuffer<R> {
         // find first idx `partition` such that self.buffer[partition].0 > tick
         let partition = self
             .buffer
-            .partition_point(|(buffer_tick, _)| *buffer_tick <= tick);
+            .partition_point(|((buffer_tick, _), _)| *buffer_tick <= tick);
         if partition == 0 {
             return None;
         }
-        self.buffer.get(partition - 1).and_then(|(_, x)| x.into())
+        self.buffer
+            .get(partition - 1)
+            .and_then(|((_, x), _)| x.into())
+    }
+
+    pub fn get_with_metadata(&self, metadata: &M) -> Option<&R>
+    where
+        M: PartialEq,
+    {
+        self.buffer
+            .iter()
+            .rev()
+            .find(|(_, stored_metadata)| stored_metadata == metadata)
+            .and_then(|((_, state), _)| state.into())
     }
 
     /// Reset the history for this resource
@@ -127,12 +147,20 @@ impl<R> HistoryBuffer<R> {
         self.buffer.clear();
     }
 
+    pub fn retain<F>(&mut self, mut f: F)
+    where
+        F: FnMut(Tick, &HistoryState<R>, &M) -> bool,
+    {
+        self.buffer
+            .retain(|((tick, state), metadata)| f(*tick, state, metadata));
+    }
+
     /// Clear all the values in the history buffer that are older or equal than the specified tick
     pub fn clear_until_tick(&mut self, tick: Tick) {
         // self.buffer[partition] is the first element where the buffer_tick > tick
         let partition = self
             .buffer
-            .partition_point(|(buffer_tick, _)| buffer_tick <= &tick);
+            .partition_point(|((buffer_tick, _), _)| buffer_tick <= &tick);
         // all elements are strictly more recent than the tick
         if partition == 0 {
             return;
@@ -141,45 +169,36 @@ impl<R> HistoryBuffer<R> {
         self.buffer.drain(0..partition);
     }
 
-    /// Add to the buffer that we received an update for the resource at the given tick
-    /// The tick must be more recent than the most recent update in the buffer
-    pub fn add_update(&mut self, tick: Tick, value: R) {
-        self.add(tick, Some(value));
-    }
-    /// Add to the buffer that the value got removed at the given tick
-    pub fn add_remove(&mut self, tick: Tick) {
-        self.add(tick, None);
-    }
+    /// Add a value to the history buffer, preserving tick order.
+    pub fn add_with_metadata(&mut self, tick: Tick, value: Option<R>, metadata: M) {
+        let state = (
+            (
+                tick,
+                match value {
+                    Some(value) => HistoryState::Updated(value),
+                    None => HistoryState::Removed,
+                },
+            ),
+            metadata,
+        );
 
-    /// Add a value to the history buffer
-    /// The tick must be strictly more recent than the most recent update in the buffer
-    pub fn add(&mut self, tick: Tick, value: Option<R>) {
-        if let Some(last_tick) = self.peek().map(|(tick, _)| tick) {
-            // assert!(
-            //     tick >= *last_tick,
-            //     "Tick must be more recent than the last update in the buffer"
-            // );
-            if *last_tick == tick {
-                debug!(
-                    "Adding update to history buffer for tick: {:?} but it already had a value for that tick!",
-                    tick
-                );
-                // in this case, let's pop back the update to replace it with the new value
-                self.buffer.pop_back();
-            }
+        let pos = self
+            .buffer
+            .partition_point(|((buffer_tick, _), _)| *buffer_tick < tick);
+        if pos < self.buffer.len() && self.buffer[pos].0.0 == tick {
+            debug!(
+                "Adding update to history buffer for tick: {:?} but it already had a value for that tick!",
+                tick
+            );
+            self.buffer[pos] = state;
+        } else {
+            self.buffer.insert(pos, state);
         }
-        self.buffer.push_back((
-            tick,
-            match value {
-                Some(value) => HistoryState::Updated(value),
-                None => HistoryState::Removed,
-            },
-        ));
     }
 
     /// Peek at the most recent value in the history buffer
     pub fn peek(&self) -> Option<&(Tick, HistoryState<R>)> {
-        self.buffer.back()
+        self.buffer.back().map(|(entry, _)| entry)
     }
 
     /// Update the tick of the most recent value in the history buffer.
@@ -187,7 +206,7 @@ impl<R> HistoryBuffer<R> {
     /// This is useful when a caller learns that the latest value is still valid at a newer tick
     /// and wants to advance that anchor without cloning the value again.
     pub fn set_most_recent_tick(&mut self, tick: Tick) {
-        if let Some((most_recent_tick, _)) = self.buffer.back_mut() {
+        if let Some(((most_recent_tick, _), _)) = self.buffer.back_mut() {
             debug_assert!(tick >= *most_recent_tick);
             *most_recent_tick = tick;
         }
@@ -195,59 +214,78 @@ impl<R> HistoryBuffer<R> {
 
     /// In case of a TickEvent where the client tick is changed, we need to update the ticks in the buffer
     pub fn update_ticks(&mut self, delta: i32) {
-        self.buffer.iter_mut().for_each(|(tick, _)| {
+        self.buffer.iter_mut().for_each(|((tick, _), _)| {
             *tick = *tick + delta;
         });
     }
 
     #[cfg(feature = "test_utils")]
-    pub fn buffer(&self) -> &VecDeque<(Tick, HistoryState<R>)> {
-        &self.buffer
+    pub fn buffer(&self) -> impl Iterator<Item = &(Tick, HistoryState<R>)> {
+        self.buffer.iter().map(|(entry, _)| entry)
     }
 
     /// Pop the oldest value in the history
     pub fn pop(&mut self) -> Option<(Tick, HistoryState<R>)> {
-        self.buffer.pop_front()
+        self.buffer.pop_front().map(|(entry, _)| entry)
+    }
+}
+
+impl<R, M: Default> HistoryBuffer<R, M> {
+    /// Add to the buffer that we received an update for the resource at the given tick.
+    pub fn add_update(&mut self, tick: Tick, value: R) {
+        self.add(tick, Some(value));
+    }
+
+    /// Add to the buffer that the value got removed at the given tick
+    pub fn add_remove(&mut self, tick: Tick) {
+        self.add(tick, None);
+    }
+
+    /// Add a value to the history buffer.
+    pub fn add(&mut self, tick: Tick, value: Option<R>) {
+        self.add_with_metadata(tick, value, M::default());
     }
 }
 
 /// The iterator contains the elements that are actually present in the history
 /// from the oldest to the most recent
-impl<'a, R> IntoIterator for &'a HistoryBuffer<R> {
+impl<'a, R, M> IntoIterator for &'a HistoryBuffer<R, M> {
     type Item = (Tick, &'a R);
     type IntoIter = FilterMap<
-        <&'a VecDeque<(Tick, HistoryState<R>)> as IntoIterator>::IntoIter,
-        fn(&(Tick, HistoryState<R>)) -> Option<(Tick, &R)>,
+        <&'a VecDeque<((Tick, HistoryState<R>), M)> as IntoIterator>::IntoIter,
+        fn(&((Tick, HistoryState<R>), M)) -> Option<(Tick, &R)>,
     >;
 
     fn into_iter(self) -> Self::IntoIter {
-        self.buffer.iter().filter_map(|(tick, state)| match state {
-            HistoryState::Updated(value) => Some((*tick, value)),
-            HistoryState::Removed => None,
-        })
+        self.buffer
+            .iter()
+            .filter_map(|((tick, state), _)| match state {
+                HistoryState::Updated(value) => Some((*tick, value)),
+                HistoryState::Removed => None,
+            })
     }
 }
 
 /// The iterator contains the elements that are actually present in the history
 /// from the oldest to the most recent
-impl<R> IntoIterator for HistoryBuffer<R> {
+impl<R, M> IntoIterator for HistoryBuffer<R, M> {
     type Item = (Tick, R);
     type IntoIter = FilterMap<
-        <VecDeque<(Tick, HistoryState<R>)> as IntoIterator>::IntoIter,
-        fn((Tick, HistoryState<R>)) -> Option<(Tick, R)>,
+        <VecDeque<((Tick, HistoryState<R>), M)> as IntoIterator>::IntoIter,
+        fn(((Tick, HistoryState<R>), M)) -> Option<(Tick, R)>,
     >;
 
     fn into_iter(self) -> Self::IntoIter {
         self.buffer
             .into_iter()
-            .filter_map(|(tick, state)| match state {
+            .filter_map(|((tick, state), _)| match state {
                 HistoryState::Updated(value) => Some((tick, value)),
                 HistoryState::Removed => None,
             })
     }
 }
 
-impl<R: Clone> HistoryBuffer<R> {
+impl<R: Clone, M: Clone> HistoryBuffer<R, M> {
     /// Clear the history of values strictly older than the specified tick,
     /// and return the value at the specified tick.
     ///
@@ -262,7 +300,7 @@ impl<R: Clone> HistoryBuffer<R> {
         // self.buffer[partition] is the first element where the buffer_tick > tick
         let partition = self
             .buffer
-            .partition_point(|(buffer_tick, _)| buffer_tick <= &tick);
+            .partition_point(|((buffer_tick, _), _)| buffer_tick <= &tick);
         // all elements are strictly more recent than the tick
         if partition == 0 {
             return None;
@@ -270,18 +308,14 @@ impl<R: Clone> HistoryBuffer<R> {
         // remove all elements strictly older than the tick. We need to keep the element at index `partition-1`
         // because that is the value at tick `tick`
         self.buffer.drain(0..(partition - 1));
-        let res = self.buffer.pop_front().map(|(_, state)| state);
+        let popped = self.buffer.pop_front();
+        let res = popped.as_ref().map(|((_, state), _)| state.clone());
 
         // if there is a value, re-add the value at tick `tick` to the buffer, to make sure that we have a value for ticks
         // (tick + 1)..(self.buffer[partition].0)
-        match res.as_ref() {
-            None => {}
-            Some(HistoryState::Removed) => {
-                // TODO: is this necessary? we treat None and Removed the same way anyway
-                self.buffer.push_front((tick, HistoryState::Removed))
-            }
-            Some(r) => self.buffer.push_front((tick, r.clone())),
-        };
+        if let Some(((_, state), metadata)) = popped {
+            self.buffer.push_front(((tick, state), metadata));
+        }
         res
     }
 
@@ -300,7 +334,7 @@ impl<R: Clone> HistoryBuffer<R> {
         // self.buffer[partition] is the first element where the buffer_tick > tick
         let partition = self
             .buffer
-            .partition_point(|(buffer_tick, _)| buffer_tick <= &tick);
+            .partition_point(|((buffer_tick, _), _)| buffer_tick <= &tick);
         // all elements are strictly more recent than the tick
         if partition == 0 {
             self.clear();
@@ -309,19 +343,15 @@ impl<R: Clone> HistoryBuffer<R> {
         // remove all elements strictly older than the tick. We need to keep the element at index `partition-1`
         // because that is the value at tick `tick`
         self.buffer.drain(0..(partition - 1));
-        let res = self.buffer.pop_front().map(|(_, state)| state);
+        let popped = self.buffer.pop_front();
+        let res = popped.as_ref().map(|((_, state), _)| state.clone());
         self.clear();
 
         // if there is a value, re-add the value at tick `tick` to the buffer, to make sure that we have a value for ticks
         // (tick + 1)..(self.buffer[partition].0)
-        match res.as_ref() {
-            None => {}
-            Some(HistoryState::Removed) => {
-                // TODO: is this necessary? we treat None and Removed the same way anyway
-                self.buffer.push_front((tick, HistoryState::Removed))
-            }
-            Some(r) => self.buffer.push_front((tick, r.clone())),
-        };
+        if let Some(((_, state), metadata)) = popped {
+            self.buffer.push_front(((tick, state), metadata));
+        }
         res
     }
 }
@@ -354,7 +384,7 @@ mod tests {
         assert_eq!(history.buffer.len(), 1);
         assert_eq!(
             history.buffer,
-            VecDeque::from(vec![(Tick(2), HistoryState::Updated(TestValue(2.0)))])
+            VecDeque::from(vec![((Tick(2), HistoryState::Updated(TestValue(2.0))), ())])
         );
 
         // check when we try to access a value in-between ticks
@@ -369,8 +399,8 @@ mod tests {
         assert_eq!(
             history.buffer,
             VecDeque::from(vec![
-                (Tick(3), HistoryState::Updated(TestValue(2.0))),
-                (Tick(4), HistoryState::Updated(TestValue(4.0)))
+                ((Tick(3), HistoryState::Updated(TestValue(2.0))), ()),
+                ((Tick(4), HistoryState::Updated(TestValue(4.0))), ())
             ])
         );
 
@@ -386,8 +416,8 @@ mod tests {
         assert_eq!(
             history.buffer,
             VecDeque::from(vec![
-                (Tick(4), HistoryState::Updated(TestValue(4.0))),
-                (Tick(5), HistoryState::Removed)
+                ((Tick(4), HistoryState::Updated(TestValue(4.0))), ()),
+                ((Tick(5), HistoryState::Removed), ())
             ])
         );
 

--- a/lightyear_interpolation/Cargo.toml
+++ b/lightyear_interpolation/Cargo.toml
@@ -43,6 +43,7 @@ bevy_time.workspace = true
 bevy_utils.workspace = true
 
 [dev-dependencies]
+bevy_state.workspace = true
 lightyear_replication = { workspace = true, features = [
   "interpolation",
   "test_utils",

--- a/lightyear_interpolation/Cargo.toml
+++ b/lightyear_interpolation/Cargo.toml
@@ -42,6 +42,12 @@ bevy_reflect.workspace = true
 bevy_time.workspace = true
 bevy_utils.workspace = true
 
+[dev-dependencies]
+lightyear_replication = { workspace = true, features = [
+  "interpolation",
+  "test_utils",
+] }
+
 [lints]
 workspace = true
 

--- a/lightyear_interpolation/src/interpolate.rs
+++ b/lightyear_interpolation/src/interpolate.rs
@@ -4,6 +4,7 @@ use crate::timeline::InterpolationTimeline;
 use bevy_ecs::component::Mutable;
 use bevy_ecs::prelude::Has;
 use bevy_ecs::prelude::*;
+use bevy_replicon::prelude::{Diffable as RepliconDiffable, PatchIndex};
 use bevy_utils::prelude::DebugName;
 use lightyear_core::prelude::NetworkTimeline;
 use lightyear_core::tick::Tick;
@@ -15,6 +16,8 @@ use lightyear_sync::prelude::client::IsSynced;
 #[allow(unused_imports)]
 use tracing::{info, trace};
 
+const DIFF_CURSOR_RETENTION: usize = 25;
+
 /// Compute the interpolation fraction
 pub fn interpolation_fraction(start: Tick, end: Tick, current: Tick, overstep: f32) -> f32 {
     ((current - start) as f32 + overstep) / (end - start) as f32
@@ -24,16 +27,19 @@ pub fn interpolation_fraction(start: Tick, end: Tick, current: Tick, overstep: f
 ///
 /// The goal is to keep the freshest bracketing pair while updates are flowing,
 /// then advance unchanged values using empty mutate ticks when explicit component updates stop.
-pub(crate) fn update_confirmed_history<C: Component + Clone>(
+pub(crate) fn update_confirmed_history<C, M>(
     // TODO: handle multiple interpolation timelines
     // TODO: exclude host-server
     interpolation_registry: Res<InterpolationRegistry>,
     interpolation: Single<&InterpolationTimeline>,
     checkpoints: Res<ReplicationCheckpointMap>,
     server_mutate_ticks: Res<ServerMutateTicks>,
-    mut query: Query<(Entity, &mut ConfirmedHistory<C>, Has<C>)>,
+    mut query: Query<(Entity, &mut ConfirmedHistory<C, M>, Has<C>)>,
     mut commands: Commands,
-) {
+) where
+    C: Component + Clone,
+    M: Clone + Send + Sync + 'static,
+{
     let timeline = interpolation.into_inner();
     let server_complete_tick =
         resolve_server_last_confirmed_tick(&checkpoints, &server_mutate_ticks);
@@ -86,13 +92,76 @@ pub(crate) fn update_confirmed_history<C: Component + Clone>(
     }
 }
 
+/// Diff-enabled interpolation needs to retain recent patch-cursor bases in
+/// `ConfirmedHistory`, even after those anchors are no longer needed for visual sampling.
+pub(crate) fn update_confirmed_history_diff<C>(
+    interpolation_registry: Res<InterpolationRegistry>,
+    interpolation: Single<&InterpolationTimeline>,
+    checkpoints: Res<ReplicationCheckpointMap>,
+    server_mutate_ticks: Res<ServerMutateTicks>,
+    mut query: Query<(Entity, &mut ConfirmedHistory<C, Option<PatchIndex>>, Has<C>)>,
+    mut commands: Commands,
+) where
+    C: Component + Clone + RepliconDiffable,
+{
+    let timeline = interpolation.into_inner();
+    let server_complete_tick =
+        resolve_server_last_confirmed_tick(&checkpoints, &server_mutate_ticks);
+    let current_interpolate_tick = timeline.now().tick();
+    let retained_entry_floor = DIFF_CURSOR_RETENTION.saturating_add(2);
+
+    for (entity, mut history, present) in query.iter_mut() {
+        if let Some(server_complete_tick) = server_complete_tick
+            && let Some(previous_newest_tick) = history.push_unchanged(server_complete_tick)
+        {
+            trace!(
+                target: "lightyear_debug::interpolation",
+                kind = "confirmed_history_unchanged_advance",
+                schedule = "Update",
+                sample_point = "Update",
+                entity = ?entity,
+                component = ?DebugName::type_name::<C>(),
+                previous_newest_tick = previous_newest_tick.0,
+                server_complete_tick = server_complete_tick.0,
+                history_len = history.len(),
+                "advanced unchanged interpolation history"
+            );
+        }
+
+        while history.len() > retained_entry_floor
+            && history
+                .get_nth_tick(1)
+                .is_some_and(|tick| tick <= current_interpolate_tick)
+        {
+            history.pop();
+        }
+
+        match history.sample(
+            current_interpolate_tick,
+            timeline.overstep().to_f32(),
+            interpolation_registry.as_ref(),
+        ) {
+            ConfirmedHistorySample::Pending | ConfirmedHistorySample::Removed if present => {
+                commands.entity(entity).try_remove::<C>();
+            }
+            ConfirmedHistorySample::Present(value) if !present => {
+                commands.entity(entity).try_insert(value);
+            }
+            _ => {}
+        }
+    }
+}
+
 /// Apply interpolation for the component
-pub(crate) fn interpolate<C: Component<Mutability = Mutable> + Clone>(
+pub(crate) fn interpolate<C, M>(
     interpolation_registry: Res<InterpolationRegistry>,
     timeline: Single<&InterpolationTimeline, With<IsSynced<InterpolationTimeline>>>,
-    mut query: Query<(Entity, &mut C, &ConfirmedHistory<C>)>,
+    mut query: Query<(Entity, &mut C, &ConfirmedHistory<C, M>)>,
     mut commands: Commands,
-) {
+) where
+    C: Component<Mutability = Mutable> + Clone,
+    M: Send + Sync + 'static,
+{
     let interpolation_tick = timeline.tick();
     let interpolation_overstep = timeline.overstep().to_f32();
     for (entity, mut component, history) in query.iter_mut() {
@@ -181,8 +250,8 @@ mod tests {
         app.add_systems(
             Update,
             (
-                update_confirmed_history::<TestComp>,
-                interpolate::<TestComp>,
+                update_confirmed_history::<TestComp, ()>,
+                interpolate::<TestComp, ()>,
             )
                 .chain(),
         );
@@ -219,7 +288,7 @@ mod tests {
     #[test]
     fn update_confirmed_history_coalesces_repeated_empty_mutate_ticks() {
         let mut app = setup_app(Tick(30), 40);
-        app.add_systems(Update, update_confirmed_history::<TestComp>);
+        app.add_systems(Update, update_confirmed_history::<TestComp, ()>);
         confirm_server_tick(&mut app, 1, Tick(30));
 
         let entity = app.world_mut().spawn(TestComp(9.5)).id();
@@ -249,7 +318,7 @@ mod tests {
     #[test]
     fn update_confirmed_history_does_not_move_history_backwards() {
         let mut app = setup_app(Tick(30), 40);
-        app.add_systems(Update, update_confirmed_history::<TestComp>);
+        app.add_systems(Update, update_confirmed_history::<TestComp, ()>);
         confirm_server_tick(&mut app, 1, Tick(100));
 
         let entity = app.world_mut().spawn(TestComp(9.5)).id();
@@ -273,7 +342,7 @@ mod tests {
     #[test]
     fn update_confirmed_history_advances_from_server_mutate_ticks_without_entity_confirm_history() {
         let mut app = setup_app(Tick(30), 40);
-        app.add_systems(Update, update_confirmed_history::<TestComp>);
+        app.add_systems(Update, update_confirmed_history::<TestComp, ()>);
         confirm_server_tick(&mut app, 1, Tick(20));
         confirm_server_tick(&mut app, 2, Tick(30));
 
@@ -301,8 +370,8 @@ mod tests {
         app.add_systems(
             Update,
             (
-                update_confirmed_history::<TestComp>,
-                interpolate::<TestComp>,
+                update_confirmed_history::<TestComp, ()>,
+                interpolate::<TestComp, ()>,
             )
                 .chain(),
         );
@@ -339,7 +408,7 @@ mod tests {
     #[test]
     fn update_confirmed_history_waits_to_insert_component_until_start_tick() {
         let mut app = setup_app(Tick(9), 40);
-        app.add_systems(Update, update_confirmed_history::<TestComp>);
+        app.add_systems(Update, update_confirmed_history::<TestComp, ()>);
 
         let entity = app.world_mut().spawn_empty().id();
         let mut history = ConfirmedHistory::<TestComp>::default();
@@ -355,7 +424,7 @@ mod tests {
     #[test]
     fn update_confirmed_history_removes_component_until_start_tick() {
         let mut app = setup_app(Tick(9), 40);
-        app.add_systems(Update, update_confirmed_history::<TestComp>);
+        app.add_systems(Update, update_confirmed_history::<TestComp, ()>);
 
         let entity = app.world_mut().spawn(TestComp(99.0)).id();
         let mut history = ConfirmedHistory::<TestComp>::default();
@@ -374,8 +443,8 @@ mod tests {
         app.add_systems(
             Update,
             (
-                update_confirmed_history::<TestComp>,
-                interpolate::<TestComp>,
+                update_confirmed_history::<TestComp, ()>,
+                interpolate::<TestComp, ()>,
             )
                 .chain(),
         );
@@ -400,8 +469,8 @@ mod tests {
         app.add_systems(
             Update,
             (
-                update_confirmed_history::<TestComp>,
-                interpolate::<TestComp>,
+                update_confirmed_history::<TestComp, ()>,
+                interpolate::<TestComp, ()>,
             )
                 .chain(),
         );
@@ -426,7 +495,7 @@ mod tests {
     #[test]
     fn component_reinsert_after_removal_waits_until_insert_tick() {
         let mut app = setup_app(Tick(15), 40);
-        app.add_systems(Update, update_confirmed_history::<TestComp>);
+        app.add_systems(Update, update_confirmed_history::<TestComp, ()>);
 
         let entity = app.world_mut().spawn_empty().id();
         let mut history = ConfirmedHistory::<TestComp>::default();
@@ -445,7 +514,7 @@ mod tests {
     #[test]
     fn update_confirmed_history_seeds_component_at_current_interpolation_sample() {
         let mut app = setup_app(Tick(15), 40);
-        app.add_systems(Update, update_confirmed_history::<TestComp>);
+        app.add_systems(Update, update_confirmed_history::<TestComp, ()>);
         let mut registry = InterpolationRegistry::default();
         registry.set_interpolation::<TestComp>(lerp);
         app.world_mut().insert_resource(registry);

--- a/lightyear_interpolation/src/interpolate.rs
+++ b/lightyear_interpolation/src/interpolate.rs
@@ -7,7 +7,9 @@ use bevy_ecs::prelude::*;
 use bevy_utils::prelude::DebugName;
 use lightyear_core::prelude::NetworkTimeline;
 use lightyear_core::tick::Tick;
-use lightyear_replication::checkpoint::{ReplicationCheckpointMap, resolve_server_mutate_tick};
+use lightyear_replication::checkpoint::{
+    ReplicationCheckpointMap, resolve_server_last_confirmed_tick,
+};
 use lightyear_replication::prelude::ServerMutateTicks;
 use lightyear_sync::prelude::client::IsSynced;
 #[allow(unused_imports)]
@@ -33,7 +35,8 @@ pub(crate) fn update_confirmed_history<C: Component + Clone>(
     mut commands: Commands,
 ) {
     let timeline = interpolation.into_inner();
-    let server_complete_tick = resolve_server_mutate_tick(&checkpoints, &server_mutate_ticks);
+    let server_complete_tick =
+        resolve_server_last_confirmed_tick(&checkpoints, &server_mutate_ticks);
     let current_interpolate_tick = timeline.now().tick();
     for (entity, mut history, present) in query.iter_mut() {
         // ServerMutateTicks is the global completeness signal for mutate messages. If it confirms

--- a/lightyear_interpolation/src/interpolation_history.rs
+++ b/lightyear_interpolation/src/interpolation_history.rs
@@ -2,6 +2,8 @@ use crate::prelude::InterpolationRegistry;
 use bevy_ecs::prelude::*;
 use bevy_reflect::Reflect;
 use bevy_replicon::client::confirm_history::ConfirmHistory;
+use bevy_replicon::prelude::{Diffable as RepliconDiffable, PatchIndex};
+use bevy_replicon::shared::replication::diff::DiffReceiver;
 use bevy_utils::prelude::DebugName;
 use lightyear_core::history_buffer::{HistoryBuffer, HistoryState};
 use lightyear_core::interpolation::Interpolated;
@@ -12,8 +14,8 @@ use tracing::{info, trace};
 
 /// Stores a buffer of past component values received from the remote
 #[derive(Component, Debug, Reflect)]
-pub struct ConfirmedHistory<C> {
-    history: HistoryBuffer<C>,
+pub struct ConfirmedHistory<C, M = ()> {
+    history: HistoryBuffer<C, M>,
     /// True when the newest anchor was synthesized from an empty mutate tick.
     ///
     /// Empty mutate ticks confirm that a component did not change. While this stays true, newer
@@ -28,22 +30,22 @@ pub(crate) enum ConfirmedHistorySample<C> {
     Present(C),
 }
 
-impl<C> Default for ConfirmedHistory<C> {
+impl<C, M> Default for ConfirmedHistory<C, M> {
     fn default() -> Self {
         Self {
-            history: HistoryBuffer::<C>::default(),
+            history: HistoryBuffer::<C, M>::default(),
             newest_is_unchanged: false,
         }
     }
 }
 
-impl<C> PartialEq for ConfirmedHistory<C> {
+impl<C, M> PartialEq for ConfirmedHistory<C, M> {
     fn eq(&self, other: &Self) -> bool {
         self.history.eq(&other.history) && self.newest_is_unchanged == other.newest_is_unchanged
     }
 }
 
-impl<C> ConfirmedHistory<C> {
+impl<C, M> ConfirmedHistory<C, M> {
     pub(crate) fn len(&self) -> usize {
         self.history.len()
     }
@@ -57,14 +59,36 @@ impl<C> ConfirmedHistory<C> {
         self.history.get_nth(n).map(|(t, state)| (*t, state))
     }
 
-    /// The oldest value in the history, which is used as the start value for the interpolation
+    /// The oldest value in the history.
     pub fn start(&self) -> Option<(Tick, &C)> {
         self.get_nth(0)
     }
 
-    /// The second oldest value in the history, which is used as the end value for the interpolation
+    /// The second oldest value in the history.
     pub fn end(&self) -> Option<(Tick, &C)> {
         self.get_nth(1)
+    }
+
+    /// Returns the newest value at or before `interpolation_tick`, plus the next newer value.
+    ///
+    /// Diff-enabled histories can retain older patch-cursor bases after they are no longer useful
+    /// for visual interpolation. Callers that need to interpolate manually should use these bounds
+    /// instead of [`Self::start`] and [`Self::end`].
+    pub fn interpolation_bounds(
+        &self,
+        interpolation_tick: Tick,
+    ) -> Option<((Tick, &C), Option<(Tick, &C)>)> {
+        let previous_index = (0..self.len())
+            .take_while(|i| {
+                self.get_nth_tick(*i)
+                    .is_some_and(|tick| tick <= interpolation_tick)
+            })
+            .last()?;
+
+        Some((
+            self.get_nth(previous_index)?,
+            self.get_nth(previous_index + 1),
+        ))
     }
 
     /// The most recent value in the history.
@@ -86,15 +110,22 @@ impl<C> ConfirmedHistory<C> {
     /// Push a new value in the history.
     /// It MUST be more recent than all previous values, which is guaranteed from
     /// how lightyear_replication::receive works
-    pub fn push(&mut self, tick: Tick, value: C) {
-        self.history.add_update(tick, value);
+    pub fn push_with_metadata(&mut self, tick: Tick, value: C, metadata: M) {
+        self.history.add_with_metadata(tick, Some(value), metadata);
         self.newest_is_unchanged = false;
     }
 
     /// Push a removal in the history.
-    pub(crate) fn push_remove(&mut self, tick: Tick) {
-        self.history.add_remove(tick);
+    pub(crate) fn push_remove_with_metadata(&mut self, tick: Tick, metadata: M) {
+        self.history.add_with_metadata(tick, None, metadata);
         self.newest_is_unchanged = false;
+    }
+
+    pub fn value_with_metadata(&self, metadata: &M) -> Option<&C>
+    where
+        M: PartialEq,
+    {
+        self.history.get_with_metadata(metadata)
     }
 
     /// Pop the oldest value in the history
@@ -110,13 +141,50 @@ impl<C> ConfirmedHistory<C> {
     }
 }
 
-impl<C: Clone> ConfirmedHistory<C> {
+impl<C> ConfirmedHistory<C, Option<PatchIndex>> {
+    pub(crate) fn prune_metadata_before_cursor(&mut self, min_cursor: PatchIndex) {
+        self.history
+            .retain(|_, _, metadata| retain_diff_metadata_anchor(metadata, min_cursor));
+        if self.history.len() == 0 {
+            self.newest_is_unchanged = false;
+        }
+    }
+}
+
+impl<C, M: Default> ConfirmedHistory<C, M> {
+    /// Push a new value in the history.
+    /// It MUST be more recent than all previous values, which is guaranteed from
+    /// how lightyear_replication::receive works
+    pub fn push(&mut self, tick: Tick, value: C) {
+        self.push_with_metadata(tick, value, M::default());
+    }
+
+    /// Push a removal in the history.
+    pub(crate) fn push_remove(&mut self, tick: Tick) {
+        self.push_remove_with_metadata(tick, M::default());
+    }
+}
+
+fn retain_diff_metadata_anchor(metadata: &Option<PatchIndex>, min_cursor: PatchIndex) -> bool {
+    match metadata {
+        Some(cursor) => *cursor >= min_cursor,
+        None => min_cursor == 0,
+    }
+}
+
+impl<C: Clone, M: Clone> ConfirmedHistory<C, M> {
     /// Mark the newest value as unchanged at `tick`.
     ///
     /// If the newest anchor was already synthesized from an empty mutate tick, only its tick is
     /// advanced. Otherwise a single unchanged anchor is appended by cloning the newest value.
     pub(crate) fn push_unchanged(&mut self, tick: Tick) -> Option<Tick> {
-        let (newest_tick, newest_value) = self.newest()?;
+        let (newest_tick, newest_value, newest_metadata) =
+            match self.history.most_recent_with_metadata() {
+                Some((newest_tick, HistoryState::Updated(newest_value), newest_metadata)) => {
+                    (newest_tick, newest_value.clone(), newest_metadata.clone())
+                }
+                None | Some((_, HistoryState::Removed, _)) => return None,
+            };
         if tick <= newest_tick {
             return None;
         }
@@ -124,14 +192,15 @@ impl<C: Clone> ConfirmedHistory<C> {
         if self.newest_is_unchanged {
             self.history.set_most_recent_tick(tick);
         } else {
-            self.history.add_update(tick, newest_value.clone());
+            self.history
+                .add_with_metadata(tick, Some(newest_value), newest_metadata);
             self.newest_is_unchanged = true;
         }
         Some(newest_tick)
     }
 }
 
-impl<C: Component + Clone> ConfirmedHistory<C> {
+impl<C: Component + Clone, M> ConfirmedHistory<C, M> {
     pub(crate) fn sample(
         &self,
         interpolation_tick: Tick,
@@ -204,15 +273,10 @@ impl<C: Component + Clone> ConfirmedHistory<C> {
         interpolation_overstep: f32,
         interpolation_registry: &InterpolationRegistry,
     ) -> Option<C> {
-        let (start_tick, start) = self.start()?;
-        // It is possible that the interpolation tick lags behind the buffered
-        // anchors, for example if two fresh updates arrive after a long gap:
-        // X...H1...H2. In that case interpolation should not run yet.
-        if interpolation_tick < start_tick {
-            return None;
-        }
-
-        let (end_tick, end) = self.end()?;
+        let ((start_tick, start), end) = self.interpolation_bounds(interpolation_tick)?;
+        let Some((end_tick, end)) = end else {
+            return (self.len() > 1).then(|| start.clone());
+        };
         // Clamp rather than extrapolate beyond the newest confirmed value. This
         // makes late packets converge to the freshest server state instead of
         // overshooting when motion changes direction.
@@ -244,20 +308,23 @@ impl<C: Component + Clone> ConfirmedHistory<C> {
     }
 }
 
-/// When `Interpolated` is added after component `C` was already replicated onto the entity,
-/// seed `ConfirmedHistory<C>` from the current value so interpolation has an anchor immediately.
+/// When `Interpolated` and component `C` are both present on an entity, seed
+/// `ConfirmedHistory<C>` from the current value so interpolation has an anchor immediately.
 ///
 /// This is the branch-local equivalent of `main`'s `#1421` fix, adapted to the current
 /// Replicon marker-fn receive path. Component updates for interpolated entities are normally
 /// captured by `registry::write_history::<C>`, but that only runs on future network updates.
-/// If `Interpolated` arrives after `C`, we need to synthesize the initial history entry from the
-/// existing component value and the entity's latest confirmed Replicon tick.
-pub(crate) fn insert_confirmed_history_on_interpolated<C: Component + Clone>(
-    trigger: On<Add, Interpolated>,
+/// If the marker and component are not written in the same pass, we need to synthesize the initial
+/// history entry from the existing component value and the entity's latest confirmed Replicon tick.
+pub(crate) fn insert_confirmed_history_on_interpolated<C, M>(
+    trigger: On<Add, (C, Interpolated)>,
     mut commands: Commands,
     checkpoints: Res<ReplicationCheckpointMap>,
-    query: Query<(&C, &ConfirmHistory), Without<ConfirmedHistory<C>>>,
-) {
+    query: Query<(&C, &ConfirmHistory), (With<Interpolated>, Without<ConfirmedHistory<C, M>>)>,
+) where
+    C: Component + Clone,
+    M: Default + Send + Sync + 'static,
+{
     let Ok((component, confirm_history)) = query.get(trigger.entity) else {
         return;
     };
@@ -270,8 +337,45 @@ pub(crate) fn insert_confirmed_history_on_interpolated<C: Component + Clone>(
         return;
     };
 
-    let mut history = ConfirmedHistory::<C>::default();
+    let mut history = ConfirmedHistory::<C, M>::default();
     history.push(tick, component.clone());
+    commands
+        .entity(trigger.entity)
+        .try_insert(history)
+        .try_remove::<C>();
+}
+
+pub(crate) fn insert_confirmed_history_on_interpolated_diff<C>(
+    trigger: On<Add, (C, Interpolated)>,
+    mut commands: Commands,
+    checkpoints: Res<ReplicationCheckpointMap>,
+    query: Query<
+        (&C, &ConfirmHistory, Option<&DiffReceiver<C>>),
+        (
+            With<Interpolated>,
+            Without<ConfirmedHistory<C, Option<PatchIndex>>>,
+        ),
+    >,
+) where
+    C: Component + Clone + RepliconDiffable,
+{
+    let Ok((component, confirm_history, receiver)) = query.get(trigger.entity) else {
+        return;
+    };
+
+    let Some(tick) = checkpoints.get(confirm_history.last_tick()) else {
+        debug_assert!(
+            false,
+            "missing authoritative checkpoint mapping while backfilling diff ConfirmedHistory"
+        );
+        return;
+    };
+
+    let cursor = receiver.map(DiffReceiver::last_applied).unwrap_or(None);
+    let component = component.clone();
+
+    let mut history = ConfirmedHistory::<C, Option<PatchIndex>>::default();
+    history.push_with_metadata(tick, component, cursor);
     commands
         .entity(trigger.entity)
         .try_insert(history)
@@ -283,10 +387,23 @@ mod tests {
     use crate::registry::InterpolationRegistry;
     use bevy_app::App;
     use bevy_ecs::component::Component;
-    use bevy_replicon::prelude::RepliconTick;
+    use bevy_replicon::prelude::{Diffable, RepliconTick};
+    use serde::{Deserialize, Serialize};
 
     #[derive(Component, Clone, Debug, PartialEq)]
     struct TestComp(f32);
+
+    #[derive(Component, Clone, Debug, PartialEq, Serialize, Deserialize)]
+    struct TestDiffComp(u32);
+
+    impl Diffable for TestDiffComp {
+        type Patch = u32;
+
+        fn apply_patch(&mut self, patch: &Self::Patch) -> bevy_ecs::error::Result<()> {
+            self.0 = *patch;
+            Ok(())
+        }
+    }
 
     fn lerp(start: TestComp, end: TestComp, t: f32) -> TestComp {
         TestComp(start.0 + (end.0 - start.0) * t)
@@ -326,10 +443,42 @@ mod tests {
     }
 
     #[test]
+    fn interpolation_bounds_skip_retained_diff_bases() {
+        let mut history = ConfirmedHistory::<TestComp, Option<PatchIndex>>::default();
+        for i in 0..=12 {
+            history.push_with_metadata(Tick(i), TestComp(i as f32), Some(u64::from(i)));
+        }
+
+        let ((start_tick, start), end) = history.interpolation_bounds(Tick(10)).unwrap();
+
+        assert_eq!(start_tick, Tick(10));
+        assert_eq!(*start, TestComp(10.0));
+        assert_eq!(
+            end.map(|(tick, value)| (tick, value.clone())),
+            Some((Tick(11), TestComp(11.0)))
+        );
+    }
+
+    #[test]
+    fn interpolate_uses_bounds_when_history_retains_old_bases() {
+        let mut history = ConfirmedHistory::<TestComp, Option<PatchIndex>>::default();
+        for i in 0..=12 {
+            history.push_with_metadata(Tick(i), TestComp(i as f32), Some(u64::from(i)));
+        }
+
+        let registry = registry();
+
+        assert_eq!(
+            history.interpolate(Tick(10), 0.5, &registry),
+            Some(TestComp(10.5))
+        );
+    }
+
+    #[test]
     fn inserts_history_when_interpolated_added_after_component_is_already_replicated() {
         let mut app = App::new();
         app.insert_resource(ReplicationCheckpointMap::default());
-        app.add_observer(insert_confirmed_history_on_interpolated::<TestComp>);
+        app.add_observer(insert_confirmed_history_on_interpolated::<TestComp, ()>);
 
         let replicon_tick = RepliconTick::new(11);
         app.world_mut()
@@ -355,6 +504,82 @@ mod tests {
         );
         assert!(
             !app.world().entity(entity).contains::<TestComp>(),
+            "live interpolated component should be removed until the interpolation timeline reaches the history start tick"
+        );
+    }
+
+    #[test]
+    fn inserts_history_when_component_added_after_interpolated_marker() {
+        let mut app = App::new();
+        app.insert_resource(ReplicationCheckpointMap::default());
+        app.add_observer(insert_confirmed_history_on_interpolated::<TestComp, ()>);
+
+        let replicon_tick = RepliconTick::new(11);
+        app.world_mut()
+            .resource_mut::<ReplicationCheckpointMap>()
+            .record(replicon_tick, Tick(42));
+
+        let entity = app
+            .world_mut()
+            .spawn((Interpolated, ConfirmHistory::new(replicon_tick)))
+            .id();
+        app.update();
+        app.world_mut().entity_mut(entity).insert(TestComp(2.0));
+        app.update();
+
+        let history = app
+            .world()
+            .entity(entity)
+            .get::<ConfirmedHistory<TestComp>>()
+            .unwrap();
+        assert_eq!(
+            history.start().map(|(tick, value)| (tick, value.clone())),
+            Some((Tick(42), TestComp(2.0)))
+        );
+        assert!(
+            !app.world().entity(entity).contains::<TestComp>(),
+            "live interpolated component should be removed until the interpolation timeline reaches the history start tick"
+        );
+    }
+
+    #[test]
+    fn inserts_diff_history_with_receiver_cursor_when_component_added_after_marker() {
+        let mut app = App::new();
+        app.insert_resource(ReplicationCheckpointMap::default());
+        app.add_observer(insert_confirmed_history_on_interpolated_diff::<TestDiffComp>);
+
+        let replicon_tick = RepliconTick::new(11);
+        app.world_mut()
+            .resource_mut::<ReplicationCheckpointMap>()
+            .record(replicon_tick, Tick(42));
+
+        let entity = app
+            .world_mut()
+            .spawn((
+                Interpolated,
+                ConfirmHistory::new(replicon_tick),
+                DiffReceiver::<TestDiffComp>::new(Some(7)),
+            ))
+            .id();
+        app.update();
+        app.world_mut().entity_mut(entity).insert(TestDiffComp(2));
+        app.update();
+
+        let history = app
+            .world()
+            .entity(entity)
+            .get::<ConfirmedHistory<TestDiffComp, Option<PatchIndex>>>()
+            .unwrap();
+        assert_eq!(
+            history.start().map(|(tick, value)| (tick, value.clone())),
+            Some((Tick(42), TestDiffComp(2)))
+        );
+        assert_eq!(
+            history.value_with_metadata(&Some(7)).cloned(),
+            Some(TestDiffComp(2))
+        );
+        assert!(
+            !app.world().entity(entity).contains::<TestDiffComp>(),
             "live interpolated component should be removed until the interpolation timeline reaches the history start tick"
         );
     }

--- a/lightyear_interpolation/src/plugin.rs
+++ b/lightyear_interpolation/src/plugin.rs
@@ -1,7 +1,9 @@
 use crate::SyncComponent;
 use crate::despawn::configure_delayed_interpolated_despawn;
-use crate::interpolate::{interpolate, update_confirmed_history};
-use crate::interpolation_history::insert_confirmed_history_on_interpolated;
+use crate::interpolate::{interpolate, update_confirmed_history, update_confirmed_history_diff};
+use crate::interpolation_history::{
+    insert_confirmed_history_on_interpolated, insert_confirmed_history_on_interpolated_diff,
+};
 use crate::registry::InterpolationRegistry;
 use crate::timeline::TimelinePlugin;
 use bevy_app::{App, Plugin, PreUpdate, Update};
@@ -10,6 +12,7 @@ use bevy_ecs::{
     schedule::{IntoScheduleConfigs, SystemSet},
 };
 use bevy_reflect::Reflect;
+use bevy_replicon::prelude::Diffable as RepliconDiffable;
 use bevy_replicon::shared::replication::track_mutate_messages::TrackAppExt;
 use lightyear_connection::host::HostClient;
 use lightyear_core::prelude::Tick;
@@ -98,11 +101,32 @@ pub enum InterpolationSystems {
 
 /// Add per-component systems related to interpolation
 pub(crate) fn add_prepare_interpolation_systems<C: Component + Clone>(app: &mut App) {
+    add_prepare_interpolation_systems_with_metadata::<C, ()>(app);
+}
+
+pub(crate) fn add_prepare_interpolation_systems_with_metadata<C, M>(app: &mut App)
+where
+    C: Component + Clone,
+    M: Default + Clone + Send + Sync + 'static,
+{
     // TODO: maybe create an overarching prediction set that contains all others?
-    app.add_observer(insert_confirmed_history_on_interpolated::<C>);
+    app.add_observer(insert_confirmed_history_on_interpolated::<C, M>);
     app.add_systems(
         Update,
-        update_confirmed_history::<C>
+        update_confirmed_history::<C, M>
+            .chain()
+            .in_set(InterpolationSystems::Prepare),
+    );
+}
+
+pub(crate) fn add_prepare_interpolation_systems_with_diff_metadata<C>(app: &mut App)
+where
+    C: Component + Clone + RepliconDiffable,
+{
+    app.add_observer(insert_confirmed_history_on_interpolated_diff::<C>);
+    app.add_systems(
+        Update,
+        update_confirmed_history_diff::<C>
             .chain()
             .in_set(InterpolationSystems::Prepare),
     );
@@ -111,9 +135,17 @@ pub(crate) fn add_prepare_interpolation_systems<C: Component + Clone>(app: &mut 
 // We add the interpolate system in different function because we might not want to add them
 // in case there is custom interpolation logic.
 pub fn add_interpolation_systems<C: SyncComponent>(app: &mut App) {
+    add_interpolation_systems_with_metadata::<C, ()>(app);
+}
+
+pub fn add_interpolation_systems_with_metadata<C, M>(app: &mut App)
+where
+    C: SyncComponent,
+    M: Send + Sync + 'static,
+{
     app.add_systems(
         Update,
-        interpolate::<C>.in_set(InterpolationSystems::Interpolate),
+        interpolate::<C, M>.in_set(InterpolationSystems::Interpolate),
     );
 }
 

--- a/lightyear_interpolation/src/registry.rs
+++ b/lightyear_interpolation/src/registry.rs
@@ -1,7 +1,11 @@
 use crate::SyncComponent;
 use crate::interpolation_history::ConfirmedHistory;
-use crate::plugin::{add_interpolation_systems, add_prepare_interpolation_systems};
-use bevy_ecs::component::Mutable;
+use crate::plugin::{
+    add_interpolation_systems, add_prepare_interpolation_systems,
+    add_prepare_interpolation_systems_with_diff_metadata,
+    add_prepare_interpolation_systems_with_metadata,
+};
+use alloc::format;
 use bevy_ecs::{component::Component, resource::Resource};
 use bevy_math::{
     Curve,
@@ -10,17 +14,23 @@ use bevy_math::{
 use bevy_platform::collections::HashMap;
 use bevy_platform::collections::HashSet;
 use bevy_replicon::bytes::Bytes;
-use bevy_replicon::prelude::RepliconTick;
-use bevy_replicon::prelude::{AppMarkerExt, RuleFns};
+use bevy_replicon::postcard_utils;
+use bevy_replicon::prelude::{
+    AppMarkerExt, Diffable as RepliconDiffable, PatchIndex, RepliconTick, RuleFns,
+};
 use bevy_replicon::shared::replication::deferred_entity::DeferredEntity;
+use bevy_replicon::shared::replication::diff::{DiffReceiver, DiffWire};
 use bevy_replicon::shared::replication::receive_markers::MarkerConfig;
 use bevy_replicon::shared::replication::registry::ctx::{RemoveCtx, WriteCtx};
+use bevy_replicon::shared::replication::registry::receive_fns::{RemoveFn, WriteFn};
 use lightyear_core::interpolation::Interpolated;
 use lightyear_core::prelude::Tick;
 use lightyear_replication::checkpoint::ReplicationCheckpointMap;
 use lightyear_replication::registry::replication::ComponentRegistration;
 use lightyear_replication::registry::{ComponentKind, ComponentRegistry, LerpFn};
 use tracing::error;
+
+const DIFF_CURSOR_RETENTION: PatchIndex = 10;
 
 fn lerp<C: Ease + Clone>(start: C, other: C, t: f32) -> C {
     let curve = EasingCurve::new(start, other, EaseFunction::Linear);
@@ -85,6 +95,14 @@ impl InterpolationRegistry {
 }
 
 fn register_interpolated_marker_fns<C: SyncComponent>(app: &mut bevy_app::App) {
+    register_interpolated_marker_fns_with::<C>(app, write_history::<C>, remove_history::<C, ()>);
+}
+
+fn register_interpolated_marker_fns_with<C: SyncComponent>(
+    app: &mut bevy_app::App,
+    write: WriteFn<C>,
+    remove: RemoveFn,
+) {
     if !app
         .world()
         .contains_resource::<InterpolatedMarkerFnRegistry>()
@@ -104,7 +122,7 @@ fn register_interpolated_marker_fns<C: SyncComponent>(app: &mut bevy_app::App) {
         priority: 100,
         need_history: true,
     });
-    app.set_marker_fns::<Interpolated, C>(write_history::<C>, remove_history::<C>);
+    app.set_marker_fns::<Interpolated, C>(write, remove);
     app.world_mut()
         .resource_mut::<InterpolatedMarkerFnRegistry>()
         .kinds
@@ -155,6 +173,11 @@ pub trait InterpolationRegistrationExt<C> {
     fn add_custom_interpolation(self) -> Self
     where
         C: SyncComponent;
+
+    /// Like [`Self::add_custom_interpolation`], but for components replicated with Replicon's patch-based diff mode.
+    fn add_custom_interpolation_diff(self) -> Self
+    where
+        C: SyncComponent + RepliconDiffable;
 }
 
 impl<C> InterpolationRegistrationExt<C> for ComponentRegistration<'_, C> {
@@ -215,50 +238,190 @@ impl<C> InterpolationRegistrationExt<C> for ComponentRegistration<'_, C> {
     where
         C: SyncComponent,
     {
-        let kind = ComponentKind::of::<C>();
-        register_interpolated_marker_fns::<C>(self.app);
-        if !self
-            .app
-            .world()
-            .contains_resource::<InterpolationRegistry>()
-        {
-            self.app
-                .world_mut()
-                .insert_resource(InterpolationRegistry::default());
-        }
-        let mut registry = self.app.world_mut().resource_mut::<InterpolationRegistry>();
-        registry
-            .interpolation_map
-            .entry(kind)
-            .and_modify(|r| r.custom_interpolation = true)
-            .or_insert_with(|| InterpolationMetadata {
-                interpolation: None,
-                custom_interpolation: true,
-            });
-        add_prepare_interpolation_systems::<C>(self.app);
-
-        let mut registry = self.app.world_mut().resource_mut::<ComponentRegistry>();
-        registry
-            .component_metadata_map
-            .get_mut(&ComponentKind::of::<C>())
-            .unwrap()
-            .replication
-            .as_mut()
-            .unwrap()
-            .set_interpolated(true);
-        self
+        let registration = add_custom_interpolation_with_receive_fns::<C, ()>(
+            self,
+            write_history::<C>,
+            remove_history::<C, ()>,
+        );
+        add_prepare_interpolation_systems_with_metadata::<C, ()>(registration.app);
+        registration
     }
+
+    fn add_custom_interpolation_diff(self) -> Self
+    where
+        C: SyncComponent + RepliconDiffable,
+    {
+        let registration = add_custom_interpolation_with_receive_fns::<C, Option<PatchIndex>>(
+            self,
+            write_history_diff::<C>,
+            remove_history_diff::<C>,
+        );
+        add_prepare_interpolation_systems_with_diff_metadata::<C>(registration.app);
+        registration
+    }
+}
+
+fn add_custom_interpolation_with_receive_fns<'a, C, M>(
+    registration: ComponentRegistration<'a, C>,
+    write: WriteFn<C>,
+    remove: RemoveFn,
+) -> ComponentRegistration<'a, C>
+where
+    C: SyncComponent,
+    M: Default + Clone + Send + Sync + 'static,
+{
+    let kind = ComponentKind::of::<C>();
+    register_interpolated_marker_fns_with::<C>(registration.app, write, remove);
+    if !registration
+        .app
+        .world()
+        .contains_resource::<InterpolationRegistry>()
+    {
+        registration
+            .app
+            .world_mut()
+            .insert_resource(InterpolationRegistry::default());
+    }
+    let mut registry = registration
+        .app
+        .world_mut()
+        .resource_mut::<InterpolationRegistry>();
+    registry
+        .interpolation_map
+        .entry(kind)
+        .and_modify(|r| r.custom_interpolation = true)
+        .or_insert_with(|| InterpolationMetadata {
+            interpolation: None,
+            custom_interpolation: true,
+        });
+    let mut registry = registration
+        .app
+        .world_mut()
+        .resource_mut::<ComponentRegistry>();
+    registry
+        .component_metadata_map
+        .get_mut(&ComponentKind::of::<C>())
+        .unwrap()
+        .replication
+        .as_mut()
+        .unwrap()
+        .set_interpolated(true);
+    registration
 }
 
 // TODO: ideally we would update the LastConfirmedTick at this point?
 /// Instead of writing into a component directly, it writes data into [`ConfirmedHistory<C>`].
-fn write_history<C: Component<Mutability = Mutable>>(
+fn write_history<C: SyncComponent>(
     ctx: &mut WriteCtx,
     rule_fns: &RuleFns<C>,
     entity: &mut DeferredEntity,
     message: &mut Bytes,
 ) -> bevy_ecs::error::Result<()> {
-    let component: C = rule_fns.deserialize(ctx, message)?;
+    let Some(component) = interpolation_history_component(ctx, rule_fns, entity, message)? else {
+        return Ok(());
+    };
+    push_confirmed_history(ctx, entity, component, ())
+}
+
+fn interpolation_history_component<C: SyncComponent>(
+    ctx: &mut WriteCtx,
+    rule_fns: &RuleFns<C>,
+    entity: &mut DeferredEntity,
+    message: &mut Bytes,
+) -> bevy_ecs::error::Result<Option<C>> {
+    rule_fns.deserialize(ctx, message).map(Some)
+}
+
+fn write_history_diff<C: SyncComponent + RepliconDiffable>(
+    ctx: &mut WriteCtx,
+    _rule_fns: &RuleFns<C>,
+    entity: &mut DeferredEntity,
+    message: &mut Bytes,
+) -> bevy_ecs::error::Result<()> {
+    let Some((cursor, component)) =
+        interpolation_history_component_diff::<C>(ctx, entity, message)?
+    else {
+        return Ok(());
+    };
+    push_confirmed_history(ctx, entity, component, cursor)
+}
+
+fn interpolation_history_component_diff<C: SyncComponent + RepliconDiffable>(
+    ctx: &mut WriteCtx,
+    entity: &mut DeferredEntity,
+    message: &mut Bytes,
+) -> bevy_ecs::error::Result<Option<(Option<PatchIndex>, C)>> {
+    let wire: DiffWire<C, C::Patch> = postcard_utils::from_buf(message)?;
+    let (cursor, value) = match wire {
+        DiffWire::Snapshot { cursor, mut value } => {
+            C::map_entities(&mut value, ctx);
+            entity.insert(DiffReceiver::<C>::new(cursor));
+            (cursor, value)
+        }
+        DiffWire::Patches {
+            first_patch_index,
+            patches,
+        } => {
+            if patches.is_empty() {
+                return Ok(None);
+            }
+            let base_cursor = first_patch_index.checked_sub(1);
+            let cursor = Some(first_patch_index + patches.len() as PatchIndex - 1);
+            let live_receiver_cursor = entity
+                .get::<DiffReceiver<C>>()
+                .map(|receiver| receiver.last_applied());
+            let live_is_base = live_receiver_cursor == Some(base_cursor);
+            let has_history = entity
+                .get::<ConfirmedHistory<C, Option<PatchIndex>>>()
+                .is_some();
+            let has_live_component = entity.get::<C>().is_some();
+            let mut value = entity
+                .get::<ConfirmedHistory<C, Option<PatchIndex>>>()
+                .and_then(|history| history.value_with_metadata(&base_cursor).cloned())
+                .or_else(|| {
+                    live_is_base
+                        .then(|| entity.get::<C>().map(|value| value.clone()))
+                        .flatten()
+                })
+                .ok_or_else(|| {
+                    format!(
+                        "received diff patches for `{}` without a confirmed base: base_cursor={:?}, cursor={:?}, batch_count={}, live_receiver_cursor={:?}, has_history={}, has_live_component={}",
+                        core::any::type_name::<C>(),
+                        base_cursor,
+                        cursor,
+                        patches.len(),
+                        live_receiver_cursor,
+                        has_history,
+                        has_live_component,
+                    )
+                })?;
+            for batch in patches {
+                for patch in batch.iter() {
+                    value.apply_patch(patch)?;
+                }
+            }
+            if let Some(mut history) = entity.get_mut::<ConfirmedHistory<C, Option<PatchIndex>>>() {
+                history.prune_metadata_before_cursor(
+                    first_patch_index.saturating_sub(DIFF_CURSOR_RETENTION),
+                );
+            }
+            (cursor, value)
+        }
+    };
+
+    Ok(Some((cursor, value)))
+}
+
+fn push_confirmed_history<C, M>(
+    ctx: &mut WriteCtx,
+    entity: &mut DeferredEntity,
+    component: C,
+    metadata: M,
+) -> bevy_ecs::error::Result<()>
+where
+    C: SyncComponent,
+    M: Default + Clone + Send + Sync + 'static,
+{
     // SAFETY: we only access resources, which don't alias with the DeferredEntity's component access.
     let checkpoints = {
         let world = unsafe { entity.world_mut() };
@@ -277,11 +440,11 @@ fn write_history<C: Component<Mutability = Mutable>>(
         );
         return Ok(());
     };
-    if let Some(mut history) = entity.get_mut::<ConfirmedHistory<C>>() {
-        history.push(tick, component);
+    if let Some(mut history) = entity.get_mut::<ConfirmedHistory<C, M>>() {
+        history.push_with_metadata(tick, component, metadata);
     } else {
-        let mut history = ConfirmedHistory::<C>::default();
-        history.push(tick, component);
+        let mut history = ConfirmedHistory::<C, M>::default();
+        history.push_with_metadata(tick, component, metadata);
         entity.insert(history);
     }
     Ok(())
@@ -291,7 +454,11 @@ fn write_history<C: Component<Mutability = Mutable>>(
 ///
 /// The live component is removed later by interpolation systems once the interpolation timeline
 /// reaches the server tick that produced this removal.
-fn remove_history<C: Component>(ctx: &mut RemoveCtx, entity: &mut DeferredEntity) {
+fn remove_history<C, M>(ctx: &mut RemoveCtx, entity: &mut DeferredEntity)
+where
+    C: Component,
+    M: Default + Send + Sync + 'static,
+{
     // SAFETY: we only access resources, which don't alias with the DeferredEntity's component access.
     let checkpoints = {
         let world = unsafe { entity.world_mut() };
@@ -310,18 +477,51 @@ fn remove_history<C: Component>(ctx: &mut RemoveCtx, entity: &mut DeferredEntity
         );
         return;
     };
-    if let Some(mut history) = entity.get_mut::<ConfirmedHistory<C>>() {
-        history.push_remove(tick);
+    if let Some(mut history) = entity.get_mut::<ConfirmedHistory<C, M>>() {
+        history.push_remove_with_metadata(tick, M::default());
     } else {
-        let mut history = ConfirmedHistory::<C>::default();
-        history.push_remove(tick);
+        let mut history = ConfirmedHistory::<C, M>::default();
+        history.push_remove_with_metadata(tick, M::default());
         entity.insert(history);
     }
+}
+
+fn remove_history_diff<C: Component + RepliconDiffable>(
+    ctx: &mut RemoveCtx,
+    entity: &mut DeferredEntity,
+) {
+    entity.remove::<DiffReceiver<C>>();
+    remove_history::<C, Option<PatchIndex>>(ctx, entity);
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::vec;
+    use alloc::vec::Vec;
+    use bevy_app::App;
+    use bevy_ecs::prelude::{Component, Entity, Mut};
+    use bevy_replicon::postcard_utils;
+    use bevy_replicon::prelude::{RepliconPlugins, RuleFns};
+    use bevy_replicon::shared::replication::diff::DiffWire;
+    use bevy_replicon::shared::replication::receive_markers::MarkerConfig;
+    use bevy_replicon::shared::replication::registry::{
+        FnsId, ReplicationRegistry, test_fns::TestFnsEntityExt,
+    };
+    use bevy_state::app::StatesPlugin;
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Component, Clone, Debug, Deserialize, PartialEq, Serialize)]
+    struct DiffTestValue(u32);
+
+    impl RepliconDiffable for DiffTestValue {
+        type Patch = u32;
+
+        fn apply_patch(&mut self, patch: &Self::Patch) -> bevy_ecs::error::Result<()> {
+            self.0 = *patch;
+            Ok(())
+        }
+    }
 
     #[test]
     fn resolve_message_tick_uses_authoritative_tick_for_large_replicon_gap() {
@@ -348,5 +548,170 @@ mod tests {
             resolve_message_tick(&checkpoints, RepliconTick::new(101)),
             Some(Tick(20))
         );
+    }
+
+    #[test]
+    fn interpolation_diff_records_older_subset_after_cumulative_patch() {
+        let (mut app, fns_id) = setup_diff_interpolation_app();
+        record_checkpoints(&mut app);
+
+        let entity = app.world_mut().spawn(Interpolated).id();
+
+        apply_diff_write(
+            &mut app,
+            entity,
+            fns_id,
+            RepliconTick::new(10),
+            DiffWire::Snapshot {
+                cursor: None,
+                value: DiffTestValue(0),
+            },
+        );
+        apply_diff_write(
+            &mut app,
+            entity,
+            fns_id,
+            RepliconTick::new(12),
+            DiffWire::Patches {
+                first_patch_index: 0,
+                patches: vec![vec![1], vec![2]],
+            },
+        );
+        apply_diff_write(
+            &mut app,
+            entity,
+            fns_id,
+            RepliconTick::new(11),
+            DiffWire::Patches {
+                first_patch_index: 0,
+                patches: vec![vec![1]],
+            },
+        );
+
+        let history = app
+            .world()
+            .entity(entity)
+            .get::<ConfirmedHistory<DiffTestValue, Option<PatchIndex>>>()
+            .unwrap();
+        assert_eq!(
+            history
+                .get_nth(0)
+                .map(|(tick, value)| (tick, value.clone())),
+            Some((Tick(0), DiffTestValue(0)))
+        );
+        assert_eq!(
+            history
+                .get_nth(1)
+                .map(|(tick, value)| (tick, value.clone())),
+            Some((Tick(1), DiffTestValue(1)))
+        );
+        assert_eq!(
+            history
+                .get_nth(2)
+                .map(|(tick, value)| (tick, value.clone())),
+            Some((Tick(2), DiffTestValue(2)))
+        );
+        assert_eq!(
+            history.value_with_metadata(&Some(0)).cloned(),
+            Some(DiffTestValue(1))
+        );
+    }
+
+    #[test]
+    fn interpolation_diff_prunes_bases_older_than_cursor_window() {
+        let (mut app, fns_id) = setup_diff_interpolation_app();
+        {
+            let mut checkpoints = app.world_mut().resource_mut::<ReplicationCheckpointMap>();
+            for tick in 10..=37 {
+                checkpoints.record(RepliconTick::new(tick), Tick(tick - 10));
+            }
+        }
+
+        let entity = app.world_mut().spawn(Interpolated).id();
+        apply_diff_write(
+            &mut app,
+            entity,
+            fns_id,
+            RepliconTick::new(10),
+            DiffWire::Snapshot {
+                cursor: None,
+                value: DiffTestValue(0),
+            },
+        );
+        for patch_index in 0..=26 {
+            apply_diff_write(
+                &mut app,
+                entity,
+                fns_id,
+                RepliconTick::new(11 + patch_index),
+                DiffWire::Patches {
+                    first_patch_index: patch_index as PatchIndex,
+                    patches: vec![vec![patch_index + 1]],
+                },
+            );
+        }
+
+        let history = app
+            .world()
+            .entity(entity)
+            .get::<ConfirmedHistory<DiffTestValue, Option<PatchIndex>>>()
+            .unwrap();
+        assert!(
+            history.value_with_metadata(&None).is_none(),
+            "pre-patch base should be pruned once the received patch window starts at 26"
+        );
+        assert!(
+            history.value_with_metadata(&Some(0)).is_none(),
+            "cursor 0 is older than 26 - 10"
+        );
+        assert_eq!(
+            history.value_with_metadata(&Some(16)).cloned(),
+            Some(DiffTestValue(17))
+        );
+        assert_eq!(
+            history.value_with_metadata(&Some(26)).cloned(),
+            Some(DiffTestValue(27))
+        );
+    }
+
+    fn setup_diff_interpolation_app() -> (App, FnsId) {
+        let mut app = App::new();
+        app.add_plugins((StatesPlugin, RepliconPlugins));
+        app.insert_resource(ReplicationCheckpointMap::default());
+        app.register_marker_with::<Interpolated>(MarkerConfig {
+            priority: 100,
+            need_history: true,
+        });
+        app.set_marker_fns::<Interpolated, DiffTestValue>(
+            write_history_diff::<DiffTestValue>,
+            remove_history_diff::<DiffTestValue>,
+        );
+        let (_, fns_id) =
+            app.world_mut()
+                .resource_scope(|world, mut registry: Mut<ReplicationRegistry>| {
+                    registry.register_rule_fns(world, RuleFns::<DiffTestValue>::new_diff())
+                });
+        (app, fns_id)
+    }
+
+    fn record_checkpoints(app: &mut App) {
+        let mut checkpoints = app.world_mut().resource_mut::<ReplicationCheckpointMap>();
+        checkpoints.record(RepliconTick::new(10), Tick(0));
+        checkpoints.record(RepliconTick::new(11), Tick(1));
+        checkpoints.record(RepliconTick::new(12), Tick(2));
+    }
+
+    fn apply_diff_write(
+        app: &mut App,
+        entity: Entity,
+        fns_id: FnsId,
+        message_tick: RepliconTick,
+        wire: DiffWire<DiffTestValue, u32>,
+    ) {
+        let mut message = Vec::new();
+        postcard_utils::to_extend_mut(&wire, &mut message).unwrap();
+        app.world_mut()
+            .entity_mut(entity)
+            .apply_write(message, fns_id, message_tick);
     }
 }

--- a/lightyear_prediction/Cargo.toml
+++ b/lightyear_prediction/Cargo.toml
@@ -52,6 +52,9 @@ bevy_reflect.workspace = true
 bevy_time.workspace = true
 bevy_utils.workspace = true
 
+[dev-dependencies]
+bevy_state.workspace = true
+
 [lints]
 workspace = true
 

--- a/lightyear_prediction/src/checkpoint_ticks.rs
+++ b/lightyear_prediction/src/checkpoint_ticks.rs
@@ -1,7 +1,7 @@
 use bevy_replicon::prelude::RepliconTick;
 use lightyear_core::tick::Tick;
 use lightyear_replication::checkpoint::ReplicationCheckpointMap;
-use lightyear_replication::prelude::ConfirmHistory;
+use lightyear_replication::prelude::{ConfirmHistory, ServerMutateTicks};
 
 pub(crate) fn resolve_message_tick(
     checkpoints: &ReplicationCheckpointMap,
@@ -15,6 +15,13 @@ pub(crate) fn resolve_confirm_history_tick(
     history: &ConfirmHistory,
 ) -> Option<Tick> {
     resolve_message_tick(checkpoints, history.last_tick())
+}
+
+pub(crate) fn resolve_server_last_confirmed_tick(
+    checkpoints: &ReplicationCheckpointMap,
+    ticks: &ServerMutateTicks,
+) -> Option<Tick> {
+    lightyear_replication::checkpoint::resolve_server_last_confirmed_tick(checkpoints, ticks)
 }
 
 #[cfg(test)]

--- a/lightyear_prediction/src/manager.rs
+++ b/lightyear_prediction/src/manager.rs
@@ -117,24 +117,16 @@ impl LastConfirmedInput {
 }
 
 /// Stores metadata related to state-based prediction.
-///
-/// Key invariant: `last_confirmed_tick = T` guarantees that for all entities,
-/// we have complete information at tick T:
-/// - Entities that received an update at T: their confirmed value is in the message
-/// - Entities that didn't receive an update: their value at T = their last confirmed value
-///   (because if a message was lost/in-flight, the server would resend on the next tick)
 #[derive(Resource, Clone, Copy, Debug, Default, Reflect)]
 pub struct StateRollbackMetadata {
-    /// The latest authoritative tick for which all mutate messages were received.
-    last_confirmed_tick: Option<Tick>,
-
     /// The last confirmed tick where we checked unchanged entities.
     ///
-    /// This is separate from `last_confirmed_tick`: a confirmed tick can stay
-    /// unchanged across many frames, and `check_rollback` only needs to scan
-    /// unchanged entities once per completed tick. If the confirmed tick is in
-    /// the client's future, it is not marked processed yet so the check can be
-    /// retried once local prediction history reaches that tick.
+    /// The completed mutation tick itself comes from Replicon's
+    /// `ServerMutateTicks::last_confirmed_tick`. This field only tracks whether
+    /// Lightyear already scanned unchanged predicted entities for that tick.
+    /// If the confirmed tick is in the client's future, it is not marked
+    /// processed yet so the check can be retried once local prediction history
+    /// reaches that tick.
     last_processed_tick: Option<Tick>,
 
     /// The earliest tick where we detected a mismatch this frame.
@@ -195,20 +187,6 @@ impl StateRollbackMetadata {
     /// skip), otherwise `prepare_rollback` won't find the restore value.
     pub fn forced_rollback_tick(&self) -> Option<Tick> {
         self.forced_rollback_tick
-    }
-
-    /// Latest authoritative tick for which all mutate messages were received.
-    pub fn last_confirmed_tick(&self) -> Option<Tick> {
-        self.last_confirmed_tick
-    }
-
-    /// Record a newly completed mutate tick.
-    pub fn record_last_confirmed_tick(&mut self, tick: Tick) {
-        match self.last_confirmed_tick {
-            None => self.last_confirmed_tick = Some(tick),
-            Some(existing) if tick > existing => self.last_confirmed_tick = Some(tick),
-            _ => {}
-        }
     }
 
     /// Reset all connection-scoped rollback metadata.
@@ -313,17 +291,6 @@ mod tests {
     }
 
     #[test]
-    fn record_last_confirmed_tick_keeps_latest_tick() {
-        let mut metadata = StateRollbackMetadata::default();
-
-        metadata.record_last_confirmed_tick(Tick(12));
-        metadata.record_last_confirmed_tick(Tick(10));
-        metadata.record_last_confirmed_tick(Tick(14));
-
-        assert_eq!(metadata.last_confirmed_tick(), Some(Tick(14)));
-    }
-
-    #[test]
     fn confirmed_tick_advancement_uses_last_processed_tick() {
         let mut metadata = StateRollbackMetadata::default();
         assert!(metadata.has_confirmed_tick_advanced(Tick(10)));
@@ -332,27 +299,6 @@ mod tests {
         assert!(!metadata.has_confirmed_tick_advanced(Tick(10)));
         assert!(!metadata.has_confirmed_tick_advanced(Tick(9)));
         assert!(metadata.has_confirmed_tick_advanced(Tick(11)));
-    }
-
-    #[test]
-    fn server_mutate_last_tick_can_be_newer_than_latest_complete_tick() {
-        use bevy_replicon::client::server_mutate_ticks::ServerMutateTicks;
-        use bevy_replicon::prelude::RepliconTick;
-
-        let complete_tick = RepliconTick::new(9);
-        let incomplete_tick = RepliconTick::new(10);
-
-        let mut server_mutate_ticks = ServerMutateTicks::default();
-        assert!(server_mutate_ticks.confirm(complete_tick, 1));
-        assert!(!server_mutate_ticks.confirm(incomplete_tick, 2));
-
-        assert_eq!(server_mutate_ticks.last_tick(), incomplete_tick);
-        assert!(server_mutate_ticks.contains(complete_tick));
-        assert!(!server_mutate_ticks.contains(incomplete_tick));
-
-        let mut metadata = StateRollbackMetadata::default();
-        metadata.record_last_confirmed_tick(Tick(900));
-        assert_eq!(metadata.last_confirmed_tick(), Some(Tick(900)));
     }
 
     #[test]

--- a/lightyear_prediction/src/plugin.rs
+++ b/lightyear_prediction/src/plugin.rs
@@ -3,14 +3,15 @@ use super::resource_history::{
     update_resource_history_on_prediction_manager_added,
 };
 use super::rollback::{
-    RollbackPlugin, RollbackSystems, prepare_rollback, prepare_rollback_resource,
+    RollbackPlugin, RollbackSystems, prepare_rollback, prepare_rollback_diff,
+    prepare_rollback_resource,
 };
 use crate::SyncComponent;
 use crate::despawn::PredictionDisable;
 use crate::diagnostics::PredictionDiagnosticsPlugin;
 use crate::manager::PredictionManager;
 use crate::predicted_history::{
-    add_prediction_history, apply_component_removal_predicted,
+    add_prediction_history, add_prediction_history_diff, apply_component_removal_predicted,
     handle_tick_event_prediction_history, snap_to_confirmed_during_rollback,
     update_prediction_history,
 };
@@ -22,6 +23,7 @@ use bevy_app::FixedPreUpdate;
 use bevy_app::prelude::*;
 use bevy_ecs::entity_disabling::DefaultQueryFilters;
 use bevy_ecs::prelude::*;
+use bevy_replicon::prelude::{Diffable as RepliconDiffable, PatchIndex};
 use bevy_replicon::shared::replication::track_mutate_messages::TrackAppExt;
 #[cfg(feature = "metrics")]
 use bevy_utils::prelude::DebugName;
@@ -75,20 +77,28 @@ pub(crate) fn should_run(query: Query<(), PredictionFilter>) -> bool {
 
 /// Enable rollbacking a component even if the component is not networked
 pub fn add_non_networked_rollback_systems<C: SyncComponent>(app: &mut App) {
-    app.add_observer(apply_component_removal_predicted::<C>);
-    app.add_observer(add_prediction_history::<C>);
+    add_non_networked_rollback_systems_with_metadata::<C, ()>(app);
+}
+
+pub fn add_non_networked_rollback_systems_with_metadata<C, M>(app: &mut App)
+where
+    C: SyncComponent,
+    M: Default + Clone + Send + Sync + 'static,
+{
+    app.add_observer(apply_component_removal_predicted::<C, M>);
+    app.add_observer(add_prediction_history::<C, M>);
     // Without this observer, the component's `PredictionHistory<C>` buffer
     // would not get its tick values shifted on timeline-sync, so any
     // history entries accumulated pre-sync would point to stale
     // (pre-sync) ticks after the client clock jumps forward.
-    app.add_observer(handle_tick_event_prediction_history::<C>);
+    app.add_observer(handle_tick_event_prediction_history::<C, M>);
     app.add_systems(
         PreUpdate,
-        prepare_rollback::<C>.in_set(RollbackSystems::Prepare),
+        prepare_rollback::<C, M>.in_set(RollbackSystems::Prepare),
     );
     app.add_systems(
         FixedPostUpdate,
-        update_prediction_history::<C>.in_set(PredictionSystems::UpdateHistory),
+        update_prediction_history::<C, M>.in_set(PredictionSystems::UpdateHistory),
     );
 }
 
@@ -120,6 +130,14 @@ pub fn add_resource_rollback_systems<R: Resource + Clone>(app: &mut App) {
 }
 
 pub(crate) fn add_prediction_systems<C: SyncComponent>(app: &mut App) {
+    add_prediction_systems_with_metadata::<C, ()>(app);
+}
+
+pub(crate) fn add_prediction_systems_with_metadata<C, M>(app: &mut App)
+where
+    C: SyncComponent,
+    M: Default + Clone + Send + Sync + 'static,
+{
     #[cfg(feature = "metrics")]
     {
         metrics::describe_counter!(
@@ -159,9 +177,9 @@ pub(crate) fn add_prediction_systems<C: SyncComponent>(app: &mut App) {
     // app.register_type::<HistoryState<C>>();
     // app.register_type::<PredictionHistory<C>>();
 
-    app.add_observer(apply_component_removal_predicted::<C>);
-    app.add_observer(handle_tick_event_prediction_history::<C>);
-    app.add_observer(add_prediction_history::<C>);
+    app.add_observer(apply_component_removal_predicted::<C, M>);
+    app.add_observer(handle_tick_event_prediction_history::<C, M>);
+    app.add_observer(add_prediction_history::<C, M>);
 
     app.add_systems(
         PreUpdate,
@@ -169,20 +187,79 @@ pub(crate) fn add_prediction_systems<C: SyncComponent>(app: &mut App) {
             // for SyncMode::Full, we need to check if we need to rollback.
             // TODO: for mode=simple/once, we still need to re-add the component if the entity ends up not being despawned!
             // check_rollback::<C>.in_set(PredictionSet::CheckRollback),
-            prepare_rollback::<C>.in_set(RollbackSystems::Prepare),
+            prepare_rollback::<C, M>.in_set(RollbackSystems::Prepare),
         ),
     );
     app.add_systems(
         FixedPreUpdate,
         // During rollback re-simulation, snap to confirmed values if we have them
-        snap_to_confirmed_during_rollback::<C>.in_set(PredictionSystems::SnapToConfirmed),
+        snap_to_confirmed_during_rollback::<C, M>.in_set(PredictionSystems::SnapToConfirmed),
     );
     app.add_systems(
         FixedPostUpdate,
         (
             // we need to run this during fixed update to know accurately the history for each tick
-            update_prediction_history::<C>.in_set(PredictionSystems::UpdateHistory),
+            update_prediction_history::<C, M>.in_set(PredictionSystems::UpdateHistory),
         ),
+    );
+}
+
+pub(crate) fn add_prediction_systems_with_diff_metadata<C>(app: &mut App)
+where
+    C: SyncComponent + RepliconDiffable,
+{
+    #[cfg(feature = "metrics")]
+    {
+        metrics::describe_counter!(
+            format!(
+                "prediction::rollbacks::causes::{}::missing_on_confirmed",
+                DebugName::type_name::<C>()
+            ),
+            metrics::Unit::Count,
+            "Component present in the prediction history but missing on the confirmed entity"
+        );
+        metrics::describe_counter!(
+            format!(
+                "prediction::rollbacks::causes::{}::value_mismatch",
+                DebugName::type_name::<C>()
+            ),
+            metrics::Unit::Count,
+            "Component present in the prediction history but with a different value than on the confirmed entity"
+        );
+        metrics::describe_counter!(
+            format!(
+                "prediction::rollbacks::causes::{}::missing_on_predicted",
+                DebugName::type_name::<C>()
+            ),
+            metrics::Unit::Count,
+            "Component present in the confirmed entity but missing in the prediction history"
+        );
+        metrics::describe_counter!(
+            format!(
+                "prediction::rollbacks::causes::{}::removed_on_predicted",
+                DebugName::type_name::<C>()
+            ),
+            metrics::Unit::Count,
+            "Component present in the confirmed entity but removed in the prediction history"
+        );
+    }
+
+    app.add_observer(apply_component_removal_predicted::<C, Option<PatchIndex>>);
+    app.add_observer(handle_tick_event_prediction_history::<C, Option<PatchIndex>>);
+    app.add_observer(add_prediction_history_diff::<C>);
+
+    app.add_systems(
+        PreUpdate,
+        prepare_rollback_diff::<C>.in_set(RollbackSystems::Prepare),
+    );
+    app.add_systems(
+        FixedPreUpdate,
+        snap_to_confirmed_during_rollback::<C, Option<PatchIndex>>
+            .in_set(PredictionSystems::SnapToConfirmed),
+    );
+    app.add_systems(
+        FixedPostUpdate,
+        update_prediction_history::<C, Option<PatchIndex>>.in_set(PredictionSystems::UpdateHistory),
     );
 }
 

--- a/lightyear_prediction/src/predicted_history.rs
+++ b/lightyear_prediction/src/predicted_history.rs
@@ -7,10 +7,12 @@
 
 use crate::rollback::DeterministicPredicted;
 use crate::{Predicted, SyncComponent};
-use alloc::collections::VecDeque;
+use alloc::{collections::VecDeque, vec::Vec};
 use bevy_ecs::component::Mutable;
 use bevy_ecs::prelude::*;
 use bevy_reflect::Reflect;
+use bevy_replicon::prelude::{Diffable as RepliconDiffable, PatchIndex};
+use bevy_replicon::shared::replication::diff::DiffReceiver;
 use bevy_utils::prelude::DebugName;
 use core::fmt::{self, Debug, Display};
 use core::ops::Deref;
@@ -122,13 +124,13 @@ impl<R> From<PredictionState<R>> for Option<R> {
 /// 2. During re-simulation, snap to confirmed values when we reach their tick
 /// 3. Avoid re-predicting values we already know are correct from the server
 #[derive(Component, Debug, Reflect)]
-pub struct PredictionHistory<C> {
+pub struct PredictionHistory<C, M = ()> {
     /// Queue containing the history. Front = oldest, back = most recent.
     /// Only stores ticks where the value changed.
-    buffer: VecDeque<(Tick, PredictionState<C>)>,
+    buffer: VecDeque<((Tick, PredictionState<C>), M)>,
 }
 
-impl<C> Default for PredictionHistory<C> {
+impl<C, M> Default for PredictionHistory<C, M> {
     fn default() -> Self {
         Self {
             buffer: VecDeque::new(),
@@ -136,10 +138,10 @@ impl<C> Default for PredictionHistory<C> {
     }
 }
 
-impl<C: Debug> Display for PredictionHistory<C> {
+impl<C: Debug, M> Display for PredictionHistory<C, M> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "PredictionHistory[")?;
-        for (i, (tick, state)) in self.buffer.iter().enumerate() {
+        for (i, ((tick, state), _)) in self.buffer.iter().enumerate() {
             if i > 0 {
                 write!(f, ", ")?;
             }
@@ -155,7 +157,7 @@ impl<C: Debug> Display for PredictionHistory<C> {
     }
 }
 
-impl<C> PredictionHistory<C> {
+impl<C, M> PredictionHistory<C, M> {
     pub fn len(&self) -> usize {
         self.buffer.len()
     }
@@ -166,58 +168,58 @@ impl<C> PredictionHistory<C> {
 
     /// Oldest value in the buffer
     pub fn oldest(&self) -> Option<&(Tick, PredictionState<C>)> {
-        self.buffer.front()
+        self.buffer.front().map(|(entry, _)| entry)
     }
 
     /// Most recent value in the buffer
     pub fn most_recent(&self) -> Option<&(Tick, PredictionState<C>)> {
-        self.buffer.back()
+        self.buffer.back().map(|(entry, _)| entry)
     }
 
     /// For unit tests
     #[doc(hidden)]
-    pub fn buffer(&self) -> &VecDeque<(Tick, PredictionState<C>)> {
-        &self.buffer
+    pub fn buffer(&self) -> impl Iterator<Item = &(Tick, PredictionState<C>)> {
+        self.buffer.iter().map(|(entry, _)| entry)
     }
 
     /// Get the value at the specified tick (returns the most recent value <= tick)
     pub fn get(&self, tick: Tick) -> Option<&C> {
         let partition = self
             .buffer
-            .partition_point(|(buffer_tick, _)| *buffer_tick <= tick);
+            .partition_point(|((buffer_tick, _), _)| *buffer_tick <= tick);
         if partition == 0 {
             return None;
         }
         self.buffer
             .get(partition - 1)
-            .and_then(|(_, state)| state.value())
+            .and_then(|((_, state), _)| state.value())
     }
 
     /// Get the full state at the specified tick
     pub fn get_state(&self, tick: Tick) -> Option<&PredictionState<C>> {
         let partition = self
             .buffer
-            .partition_point(|(buffer_tick, _)| *buffer_tick <= tick);
+            .partition_point(|((buffer_tick, _), _)| *buffer_tick <= tick);
         if partition == 0 {
             return None;
         }
-        self.buffer.get(partition - 1).map(|(_, state)| state)
+        self.buffer.get(partition - 1).map(|((_, state), _)| state)
     }
 
     /// Get the confirmed value exactly at the given tick, if one exists.
     pub fn get_confirmed_at(&self, tick: Tick) -> Option<&PredictionState<C>> {
         self.buffer
             .iter()
-            .find(|(t, state)| *t == tick && state.is_confirmed())
-            .map(|(_, state)| state)
+            .find(|((t, state), _)| *t == tick && state.is_confirmed())
+            .map(|((_, state), _)| state)
     }
 
     /// Get the first confirmed value at or after the given tick.
     pub fn get_confirmed_at_or_after(&self, tick: Tick) -> Option<(Tick, &PredictionState<C>)> {
         self.buffer
             .iter()
-            .find(|(t, state)| *t >= tick && state.is_confirmed())
-            .map(|(t, state)| (*t, state))
+            .find(|((t, state), _)| *t >= tick && state.is_confirmed())
+            .map(|((t, state), _)| (*t, state))
     }
 
     /// Get the last confirmed value in the history (most recent confirmed value).
@@ -225,8 +227,8 @@ impl<C> PredictionHistory<C> {
         self.buffer
             .iter()
             .rev()
-            .find(|(_, state)| state.is_confirmed())
-            .map(|(_, state)| state)
+            .find(|((_, state), _)| state.is_confirmed())
+            .map(|((_, state), _)| state)
     }
 
     /// Clear the entire history
@@ -235,17 +237,52 @@ impl<C> PredictionHistory<C> {
     }
 
     /// Add a predicted value (computed locally)
-    pub fn add_predicted(&mut self, tick: Tick, value: Option<C>) {
-        self.add_state(
+    pub fn add_predicted_with_metadata(&mut self, tick: Tick, value: Option<C>, metadata: M) {
+        self.add_state_with_metadata(
             tick,
             match value {
                 Some(value) => PredictionState::Predicted(value),
                 None => PredictionState::Removed,
             },
+            metadata,
         );
     }
 
-    /// Add a confirmed value at the given tick
+    /// Add a confirmed value (received from the server)
+    pub fn add_confirmed_with_metadata(&mut self, tick: Tick, value: Option<C>, metadata: M) {
+        let state = match value {
+            Some(value) => PredictionState::Confirmed(value),
+            None => PredictionState::ConfirmedRemoved,
+        };
+        self.insert_at_tick_with_metadata(tick, state, metadata);
+    }
+
+    pub fn last_confirmed_value_with_metadata(&self, metadata: &M) -> Option<(Tick, &C, &M)>
+    where
+        M: PartialEq,
+    {
+        self.buffer
+            .iter()
+            .rev()
+            .find(|((_, state), stored_metadata)| {
+                state.is_confirmed() && stored_metadata == metadata
+            })
+            .and_then(|((tick, state), stored_metadata)| {
+                state.value().map(|value| (*tick, value, stored_metadata))
+            })
+    }
+
+    pub fn metadata_at(&self, tick: Tick) -> Option<&M> {
+        let partition = self
+            .buffer
+            .partition_point(|((buffer_tick, _), _)| *buffer_tick <= tick);
+        if partition == 0 {
+            return None;
+        }
+        self.buffer.get(partition - 1).map(|(_, metadata)| metadata)
+    }
+
+    /// Add a confirmed value at the given tick using the previous confirmed metadata.
     ///
     /// This is used in situations where we know the value is unchanged (e.g., a completed
     /// mutate tick confirms no mutation).
@@ -253,12 +290,19 @@ impl<C> PredictionHistory<C> {
     pub fn add_confirmed_unchanged(&mut self, tick: Tick) -> bool
     where
         C: Clone,
+        M: Clone,
     {
-        let Some((existing_tick, existing_state)) = self
-            .buffer
-            .iter()
-            .rev()
-            .find(|(buffer_tick, state)| *buffer_tick <= tick && state.is_confirmed())
+        let Some((existing_tick, existing_state, metadata)) =
+            self.buffer
+                .iter()
+                .rev()
+                .find_map(|((buffer_tick, state), metadata)| {
+                    (*buffer_tick <= tick && state.is_confirmed()).then_some((
+                        buffer_tick,
+                        state,
+                        metadata,
+                    ))
+                })
         else {
             return false;
         };
@@ -267,17 +311,8 @@ impl<C> PredictionHistory<C> {
             return false;
         }
 
-        self.insert_at_tick(tick, existing_state.clone());
+        self.insert_at_tick_with_metadata(tick, existing_state.clone(), metadata.clone());
         true
-    }
-
-    /// Add a confirmed value (received from the server)
-    pub fn add_confirmed(&mut self, tick: Tick, value: Option<C>) {
-        let state = match value {
-            Some(value) => PredictionState::Confirmed(value),
-            None => PredictionState::ConfirmedRemoved,
-        };
-        self.insert_at_tick(tick, state);
     }
 
     #[doc(hidden)]
@@ -293,61 +328,134 @@ impl<C> PredictionHistory<C> {
         if len < 2 {
             return None;
         }
-        self.buffer.get(len - 2).and_then(|(_, x)| x.into())
+        self.buffer.get(len - 2).and_then(|((_, x), _)| x.into())
     }
 
     /// Add a value with a specific state (for predicted values, appends to end)
-    fn add_state(&mut self, tick: Tick, state: PredictionState<C>) {
-        if let Some((last_tick, _)) = self.buffer.back()
+    fn add_state_with_metadata(&mut self, tick: Tick, state: PredictionState<C>, metadata: M) {
+        if let Some(((last_tick, _), _)) = self.buffer.back()
             && *last_tick == tick
         {
             // Replace the existing value at this tick
             self.buffer.pop_back();
         }
-        self.buffer.push_back((tick, state));
+        self.buffer.push_back(((tick, state), metadata));
     }
 
     /// Insert a value at the correct position in the buffer (maintaining tick order).
     /// This is used for confirmed values which might arrive out of order.
     /// If a value already exists at this tick, it will be replaced.
-    fn insert_at_tick(&mut self, tick: Tick, state: PredictionState<C>) {
+    fn insert_at_tick_with_metadata(&mut self, tick: Tick, state: PredictionState<C>, metadata: M) {
         // Find the position where this tick should be inserted
-        let pos = self.buffer.partition_point(|(t, _)| *t < tick);
+        let pos = self.buffer.partition_point(|((t, _), _)| *t < tick);
 
         // Check if there's already a value at this exact tick
-        if pos < self.buffer.len() && self.buffer[pos].0 == tick {
+        if pos < self.buffer.len() && self.buffer[pos].0.0 == tick {
             // Replace the existing value
-            self.buffer[pos] = (tick, state);
+            self.buffer[pos] = ((tick, state), metadata);
         } else {
             // Insert at the correct position
-            self.buffer.insert(pos, (tick, state));
+            self.buffer.insert(pos, ((tick, state), metadata));
         }
     }
 
     /// Update ticks in case of a TickEvent (client tick changed)
     pub fn update_ticks(&mut self, delta: i32) {
-        self.buffer.iter_mut().for_each(|(tick, _)| {
+        self.buffer.iter_mut().for_each(|((tick, _), _)| {
             *tick = *tick + delta;
         });
     }
 
     /// Pop the oldest value in the history
     pub fn pop(&mut self) -> Option<(Tick, PredictionState<C>)> {
-        self.buffer.pop_front()
+        self.buffer.pop_front().map(|(entry, _)| entry)
     }
 
     /// Clear all values strictly older than the specified tick
     pub fn clear_until_tick(&mut self, tick: Tick) {
         let partition = self
             .buffer
-            .partition_point(|(buffer_tick, _)| buffer_tick < &tick);
+            .partition_point(|((buffer_tick, _), _)| buffer_tick < &tick);
         if partition > 0 {
             self.buffer.drain(0..partition);
         }
     }
+
+    /// Clear old values while retaining confirmed metadata anchors.
+    ///
+    /// Diff receive paths prune stale cursor anchors when patches arrive, so this only needs to
+    /// preserve the remaining distinct confirmed anchors while normal rollback pruning runs.
+    pub fn clear_until_tick_retaining_confirmed_metadata(&mut self, tick: Tick)
+    where
+        C: Clone,
+        M: Clone + PartialEq,
+    {
+        let partition = self
+            .buffer
+            .partition_point(|((buffer_tick, _), _)| buffer_tick < &tick);
+        if partition == 0 {
+            return;
+        }
+
+        let retained = self.confirmed_entries_with_distinct_metadata(partition);
+        self.buffer.drain(0..partition);
+        for entry in retained.into_iter().rev() {
+            self.buffer.push_front(entry);
+        }
+    }
+
+    fn confirmed_entries_with_distinct_metadata(
+        &self,
+        end: usize,
+    ) -> Vec<((Tick, PredictionState<C>), M)>
+    where
+        C: Clone,
+        M: Clone + PartialEq,
+    {
+        let mut retained = Vec::new();
+        let mut retained_metadata = Vec::new();
+        for ((tick, state), metadata) in self.buffer.iter().take(end).rev() {
+            if !matches!(state, PredictionState::Confirmed(_)) {
+                continue;
+            }
+            if retained_metadata.iter().any(|stored| stored == metadata) {
+                continue;
+            }
+            retained_metadata.push(metadata.clone());
+            retained.push(((*tick, state.clone()), metadata.clone()));
+        }
+        retained
+    }
 }
 
-impl<C: Clone> PredictionHistory<C> {
+impl<C> PredictionHistory<C, Option<PatchIndex>> {
+    pub(crate) fn prune_confirmed_metadata_before_cursor(&mut self, min_cursor: PatchIndex) {
+        self.buffer.retain(|((_, state), metadata)| {
+            !state.is_confirmed() || retain_diff_metadata_anchor(metadata, min_cursor)
+        });
+    }
+}
+
+impl<C, M: Default> PredictionHistory<C, M> {
+    /// Add a predicted value (computed locally)
+    pub fn add_predicted(&mut self, tick: Tick, value: Option<C>) {
+        self.add_state_with_metadata(
+            tick,
+            match value {
+                Some(value) => PredictionState::Predicted(value),
+                None => PredictionState::Removed,
+            },
+            M::default(),
+        );
+    }
+
+    /// Add a confirmed value (received from the server)
+    pub fn add_confirmed(&mut self, tick: Tick, value: Option<C>) {
+        self.add_confirmed_with_metadata(tick, value, M::default());
+    }
+}
+
+impl<C: Clone, M: Clone> PredictionHistory<C, M> {
     /// Clear the history of values strictly older than the specified tick,
     /// and return the value at the specified tick.
     ///
@@ -355,7 +463,7 @@ impl<C: Clone> PredictionHistory<C> {
     pub fn pop_until_tick(&mut self, tick: Tick) -> Option<PredictionState<C>> {
         let partition = self
             .buffer
-            .partition_point(|(buffer_tick, _)| buffer_tick <= &tick);
+            .partition_point(|((buffer_tick, _), _)| buffer_tick <= &tick);
 
         if partition == 0 {
             return None;
@@ -363,11 +471,44 @@ impl<C: Clone> PredictionHistory<C> {
 
         // Drain all elements strictly older than the tick
         self.buffer.drain(0..(partition - 1));
-        let res = self.buffer.pop_front().map(|(_, state)| state);
+        let popped = self.buffer.pop_front();
+        let res = popped.as_ref().map(|((_, state), _)| state.clone());
 
         // Re-add the value at tick to the buffer
-        if let Some(ref state) = res {
-            self.buffer.push_front((tick, state.clone()));
+        if let Some(((_, state), metadata)) = popped {
+            self.buffer.push_front(((tick, state), metadata));
+        }
+
+        res
+    }
+
+    /// Like [`Self::pop_until_tick`], but retains confirmed metadata anchors.
+    pub fn pop_until_tick_retaining_confirmed_metadata(
+        &mut self,
+        tick: Tick,
+    ) -> Option<PredictionState<C>>
+    where
+        M: PartialEq,
+    {
+        let partition = self
+            .buffer
+            .partition_point(|((buffer_tick, _), _)| buffer_tick <= &tick);
+
+        if partition == 0 {
+            return None;
+        }
+
+        let retained = self.confirmed_entries_with_distinct_metadata(partition.saturating_sub(1));
+
+        self.buffer.drain(0..(partition - 1));
+        let popped = self.buffer.pop_front();
+        let res = popped.as_ref().map(|((_, state), _)| state.clone());
+
+        if let Some(((_, state), metadata)) = popped {
+            self.buffer.push_front(((tick, state), metadata));
+        }
+        for entry in retained.into_iter().rev() {
+            self.buffer.push_front(entry);
         }
 
         res
@@ -377,7 +518,14 @@ impl<C: Clone> PredictionHistory<C> {
     /// while preserving confirmed values.
     pub fn clear_predicted_from(&mut self, rollback_tick: Tick) {
         self.buffer
-            .retain(|(tick, state)| *tick <= rollback_tick || state.is_confirmed());
+            .retain(|((tick, state), _)| *tick <= rollback_tick || state.is_confirmed());
+    }
+}
+
+fn retain_diff_metadata_anchor(metadata: &Option<PatchIndex>, min_cursor: PatchIndex) -> bool {
+    match metadata {
+        Some(cursor) => *cursor >= min_cursor,
+        None => min_cursor == 0,
     }
 }
 
@@ -388,10 +536,13 @@ impl<C: Clone> PredictionHistory<C> {
 /// We store every update on the predicted entity in the PredictionHistory
 ///
 /// This system only handles changes, removals are handled in `apply_component_removal`
-pub(crate) fn update_prediction_history<T: Component + Clone + Debug>(
-    mut query: Query<(Entity, Ref<T>, &mut PredictionHistory<T>)>,
+pub(crate) fn update_prediction_history<T, M>(
+    mut query: Query<(Entity, Ref<T>, &mut PredictionHistory<T, M>)>,
     timeline: Res<LocalTimeline>,
-) {
+) where
+    T: Component + Clone + Debug,
+    M: Default + Send + Sync + 'static,
+{
     // tick for which we will record the history (either the current client tick or the current rollback tick)
     let tick = timeline.tick();
 
@@ -422,10 +573,13 @@ pub(crate) fn update_prediction_history<T: Component + Clone + Debug>(
 
 /// If there is a TickEvent and the client tick suddenly changes, we need
 /// to update the ticks in the history buffer.
-pub(crate) fn handle_tick_event_prediction_history<C: Component>(
+pub(crate) fn handle_tick_event_prediction_history<C, M>(
     trigger: On<SyncEvent<InputTimelineConfig>>,
-    mut query: Query<&mut PredictionHistory<C>>,
-) {
+    mut query: Query<&mut PredictionHistory<C, M>>,
+) where
+    C: Component,
+    M: Send + Sync + 'static,
+{
     for mut history in query.iter_mut() {
         trace!(
             "Prediction history updated for {:?} with tick delta {:?}",
@@ -448,11 +602,14 @@ pub(crate) fn handle_tick_event_prediction_history<C: Component>(
 }
 
 /// If a predicted component is removed on the [`Predicted`] entity, add the removal to the history.
-pub(crate) fn apply_component_removal_predicted<C: Component>(
+pub(crate) fn apply_component_removal_predicted<C, M>(
     trigger: On<Remove, C>,
-    mut predicted_query: Query<&mut PredictionHistory<C>>,
+    mut predicted_query: Query<&mut PredictionHistory<C, M>>,
     timeline: Res<LocalTimeline>,
-) {
+) where
+    C: Component,
+    M: Default + Send + Sync + 'static,
+{
     let tick = timeline.tick();
     if let Ok(mut history) = predicted_query.get_mut(trigger.entity) {
         history.add_predicted(tick, None);
@@ -490,7 +647,7 @@ pub(crate) fn apply_component_removal_predicted<C: Component>(
 /// in a different order (e.g. after the component was first added and then
 /// mutated by local prediction) and we must not overwrite those predicted
 /// values with a stale confirmed snapshot.
-pub(crate) fn add_prediction_history<C: SyncComponent>(
+pub(crate) fn add_prediction_history<C, M>(
     trigger: On<Add, (C, Predicted, PreSpawned, DeterministicPredicted)>,
     query: Query<
         (),
@@ -504,7 +661,10 @@ pub(crate) fn add_prediction_history<C: SyncComponent>(
         ),
     >,
     mut commands: Commands,
-) {
+) where
+    C: SyncComponent,
+    M: Default + Send + Sync + 'static,
+{
     if query.get(trigger.entity).is_err() {
         return;
     }
@@ -528,7 +688,7 @@ pub(crate) fn add_prediction_history<C: SyncComponent>(
         // Skip if history already exists — either another observer run
         // created it, or local prediction already populated it and we
         // must not overwrite predicted values.
-        if entity_mut.contains::<PredictionHistory<C>>() {
+        if entity_mut.contains::<PredictionHistory<C, M>>() {
             return;
         }
         // Try to capture a confirmed entry from the current C value + the
@@ -552,7 +712,7 @@ pub(crate) fn add_prediction_history<C: SyncComponent>(
         let Ok(mut entity_mut) = world.get_entity_mut(entity) else {
             return;
         };
-        let mut history = PredictionHistory::<C>::default();
+        let mut history = PredictionHistory::<C, M>::default();
         if let Some((tick, component)) = seed {
             trace!(
                 ?entity,
@@ -566,16 +726,85 @@ pub(crate) fn add_prediction_history<C: SyncComponent>(
     });
 }
 
+pub(crate) fn add_prediction_history_diff<C>(
+    trigger: On<Add, (C, Predicted, PreSpawned, DeterministicPredicted)>,
+    query: Query<
+        (),
+        (
+            With<C>,
+            Or<(
+                With<Predicted>,
+                With<PreSpawned>,
+                With<DeterministicPredicted>,
+            )>,
+        ),
+    >,
+    mut commands: Commands,
+) where
+    C: SyncComponent + RepliconDiffable,
+{
+    if query.get(trigger.entity).is_err() {
+        return;
+    }
+    trace!(
+        "Add diff prediction history for {:?} on entity {:?}",
+        DebugName::type_name::<C>(),
+        trigger.entity
+    );
+    let entity = trigger.entity;
+    commands.queue(move |world: &mut World| {
+        let Ok(entity_mut) = world.get_entity_mut(entity) else {
+            return;
+        };
+        if entity_mut.contains::<PredictionHistory<C, Option<PatchIndex>>>() {
+            return;
+        }
+        let seed: Option<(Tick, C, Option<PatchIndex>)> = {
+            let component = entity_mut.get::<C>().cloned();
+            let cursor = entity_mut
+                .get::<DiffReceiver<C>>()
+                .map(DiffReceiver::last_applied)
+                .unwrap_or(None);
+            let confirm_last = entity_mut
+                .get::<lightyear_replication::prelude::ConfirmHistory>()
+                .map(lightyear_replication::prelude::ConfirmHistory::last_tick);
+            match (component, confirm_last) {
+                (Some(component), Some(confirm_tick)) => world
+                    .resource::<lightyear_replication::checkpoint::ReplicationCheckpointMap>()
+                    .get(confirm_tick)
+                    .map(|tick| (tick, component, cursor)),
+                _ => None,
+            }
+        };
+        let Ok(mut entity_mut) = world.get_entity_mut(entity) else {
+            return;
+        };
+        let mut history = PredictionHistory::<C, Option<PatchIndex>>::default();
+        if let Some((tick, component, cursor)) = seed {
+            trace!(
+                ?entity,
+                ?tick,
+                cursor,
+                component = ?DebugName::type_name::<C>(),
+                "seeding diff PredictionHistory with confirmed value from init message"
+            );
+            history.add_confirmed_with_metadata(tick, Some(component), cursor);
+        }
+        entity_mut.insert(history);
+    });
+}
+
 /// During rollback re-simulation, check if we have a confirmed value for this tick.
 /// If so, snap the component to the confirmed value instead of using the predicted value.
 pub(crate) fn snap_to_confirmed_during_rollback<
     C: Component<Mutability = Mutable> + Clone + PartialEq + Debug,
+    M: Send + Sync + 'static,
 >(
     mut commands: Commands,
     timeline: Res<LocalTimeline>,
     // Only run during rollback
     rollback: Single<&Rollback>,
-    mut query: Query<(Entity, Option<&mut C>, &PredictionHistory<C>), With<Predicted>>,
+    mut query: Query<(Entity, Option<&mut C>, &PredictionHistory<C, M>), With<Predicted>>,
 ) {
     let tick = timeline.tick();
     query.iter_mut().for_each(|(entity, component, history)| {
@@ -700,8 +929,8 @@ mod tests {
 
         // Predicted values at tick 5 and 9 should be removed
         // (we can check by seeing the buffer doesn't have them)
-        let has_tick_5 = history.buffer.iter().any(|(t, _)| *t == Tick(5));
-        let has_tick_9 = history.buffer.iter().any(|(t, _)| *t == Tick(9));
+        let has_tick_5 = history.buffer.iter().any(|((t, _), _)| *t == Tick(5));
+        let has_tick_9 = history.buffer.iter().any(|((t, _), _)| *t == Tick(9));
         assert!(!has_tick_5);
         assert!(!has_tick_9);
     }

--- a/lightyear_prediction/src/registry.rs
+++ b/lightyear_prediction/src/registry.rs
@@ -2,11 +2,11 @@ use crate::SyncComponent;
 use crate::checkpoint_ticks::resolve_message_tick;
 use crate::manager::{PredictionResource, RollbackMode, StateRollbackMetadata};
 use crate::plugin::{
-    add_non_networked_rollback_systems, add_prediction_systems, add_resource_rollback_systems,
+    add_non_networked_rollback_systems, add_prediction_systems_with_diff_metadata,
+    add_prediction_systems_with_metadata, add_resource_rollback_systems,
 };
 use crate::predicted_history::PredictionHistory;
 use crate::prelude::PredictionManager;
-#[cfg(feature = "metrics")]
 use alloc::format;
 use bevy_app::App;
 use bevy_ecs::component::ComponentId;
@@ -18,10 +18,15 @@ use bevy_math::{
     curve::{Ease, EaseFunction, EasingCurve},
 };
 use bevy_replicon::bytes::Bytes;
-use bevy_replicon::prelude::{AppMarkerExt, RepliconTick, RuleFns};
+use bevy_replicon::postcard_utils;
+use bevy_replicon::prelude::{
+    AppMarkerExt, Diffable as RepliconDiffable, PatchIndex, RepliconTick, RuleFns,
+};
 use bevy_replicon::shared::replication::deferred_entity::DeferredEntity;
+use bevy_replicon::shared::replication::diff::{DiffReceiver, DiffWire};
 use bevy_replicon::shared::replication::receive_markers::MarkerConfig;
 use bevy_replicon::shared::replication::registry::ctx::{RemoveCtx, WriteCtx};
+use bevy_replicon::shared::replication::registry::receive_fns::{RemoveFn, WriteFn};
 use bevy_utils::prelude::DebugName;
 use core::fmt::Debug;
 use lightyear_core::prediction::Predicted;
@@ -32,6 +37,8 @@ use lightyear_replication::registry::replication::ComponentRegistration;
 use lightyear_replication::registry::{ComponentError, ComponentKind, ComponentRegistry, LerpFn};
 use lightyear_utils::collections::HashMap;
 use tracing::{debug, error, trace, trace_span};
+
+const DIFF_CURSOR_RETENTION: PatchIndex = 10;
 
 fn lerp<C: Ease + Clone>(start: C, other: C, t: f32) -> C {
     let curve = EasingCurve::new(start, other, EaseFunction::Linear);
@@ -73,7 +80,11 @@ type CheckRollbackFn =
 pub type PopUntilTickAndHashFn = fn(PtrMut, Tick, &mut seahash::SeaHasher, fn());
 
 impl PredictionMetadata {
-    fn new<C: SyncComponent>(history_id: ComponentId) -> Self {
+    fn new<C, M>(history_id: ComponentId) -> Self
+    where
+        C: SyncComponent,
+        M: Default + Clone + Send + Sync + 'static,
+    {
         let should_rollback: ShouldRollbackFn<C> = <C as PartialEq>::ne;
         Self {
             history_id,
@@ -84,9 +95,31 @@ impl PredictionMetadata {
                     should_rollback,
                 )
             },
-            check_rollback: PredictionRegistry::check_rollback_empty_mutate::<C>,
+            check_rollback: PredictionRegistry::check_rollback_empty_mutate::<C, M>,
             #[cfg(feature = "deterministic")]
-            pop_until_tick_and_hash: Some(PredictionRegistry::pop_until_tick_and_hash::<C>),
+            pop_until_tick_and_hash: Some(PredictionRegistry::pop_until_tick_and_hash::<C, M>),
+        }
+    }
+
+    fn new_diff<C>(history_id: ComponentId) -> Self
+    where
+        C: SyncComponent + RepliconDiffable,
+    {
+        let should_rollback: ShouldRollbackFn<C> = <C as PartialEq>::ne;
+        Self {
+            history_id,
+            correction: false,
+            correction_fn: None,
+            should_rollback: unsafe {
+                core::mem::transmute::<for<'a, 'b> fn(&'a C, &'b C) -> bool, unsafe fn()>(
+                    should_rollback,
+                )
+            },
+            check_rollback: PredictionRegistry::check_rollback_empty_mutate_diff::<C>,
+            #[cfg(feature = "deterministic")]
+            pop_until_tick_and_hash: Some(
+                PredictionRegistry::pop_until_tick_and_hash::<C, Option<PatchIndex>>,
+            ),
         }
     }
 }
@@ -104,15 +137,28 @@ pub struct PredictionRegistry {
 }
 
 impl PredictionRegistry {
-    fn oldest_retained_tick<C>(history: &PredictionHistory<C>) -> Option<Tick> {
+    fn oldest_retained_tick<C, M>(history: &PredictionHistory<C, M>) -> Option<Tick> {
         history.oldest().map(|(tick, _)| *tick)
     }
 
-    fn register<C: SyncComponent>(&mut self, history_id: ComponentId) {
+    fn register<C, M>(&mut self, history_id: ComponentId)
+    where
+        C: SyncComponent,
+        M: Default + Clone + Send + Sync + 'static,
+    {
         let kind = ComponentKind::of::<C>();
         self.prediction_map
             .entry(kind)
-            .or_insert_with(|| PredictionMetadata::new::<C>(history_id));
+            .or_insert_with(|| PredictionMetadata::new::<C, M>(history_id));
+    }
+
+    fn register_diff<C>(&mut self, history_id: ComponentId)
+    where
+        C: SyncComponent + RepliconDiffable,
+    {
+        let kind = ComponentKind::of::<C>();
+        self.prediction_map
+            .insert(kind, PredictionMetadata::new_diff::<C>(history_id));
     }
 
     fn set_should_rollback<C: SyncComponent>(&mut self, should_rollback: ShouldRollbackFn<C>) {
@@ -276,11 +322,15 @@ impl PredictionRegistry {
     ///
     /// # Arguments
     /// * `confirmed_tick` - Latest authoritative tick with complete mutate messages.
-    fn check_rollback_empty_mutate<C: SyncComponent>(
+    fn check_rollback_empty_mutate<C, M>(
         &self,
         confirmed_tick: Tick,
         entity_mut: &mut FilteredEntityMut,
-    ) -> bool {
+    ) -> bool
+    where
+        C: SyncComponent,
+        M: Default + Clone + Send + Sync + 'static,
+    {
         let entity = entity_mut.id();
         let name = DebugName::type_name::<C>();
         let _span = trace_span!(
@@ -290,7 +340,7 @@ impl PredictionRegistry {
             ?confirmed_tick
         )
         .entered();
-        let Some(mut prediction_history) = entity_mut.get_mut::<PredictionHistory<C>>() else {
+        let Some(mut prediction_history) = entity_mut.get_mut::<PredictionHistory<C, M>>() else {
             // No history means no predicted value to compare against
             return false;
         };
@@ -318,10 +368,51 @@ impl PredictionRegistry {
 
         // Mark this value as confirmed at confirmed_tick.
         // This is safe because we know the value at confirmed_tick = last confirmed value.
-        // Use add_confirmed which will insert at the correct position (not overwriting
+        // Use add_confirmed_unchanged which will insert at the correct position (not overwriting
         // any future confirmed values that might already exist).
-        prediction_history.add_confirmed(confirmed_tick, confirmed_value);
+        prediction_history.add_confirmed_unchanged(confirmed_tick);
         prediction_history.clear_until_tick(confirmed_tick);
+
+        should_rollback
+    }
+
+    fn check_rollback_empty_mutate_diff<C>(
+        &self,
+        confirmed_tick: Tick,
+        entity_mut: &mut FilteredEntityMut,
+    ) -> bool
+    where
+        C: SyncComponent + RepliconDiffable,
+    {
+        let entity = entity_mut.id();
+        let name = DebugName::type_name::<C>();
+        let _span = trace_span!(
+            "check_rollback_empty_mutate_diff",
+            ?name,
+            %entity,
+            ?confirmed_tick
+        )
+        .entered();
+        let Some(mut prediction_history) =
+            entity_mut.get_mut::<PredictionHistory<C, Option<PatchIndex>>>()
+        else {
+            return false;
+        };
+
+        let Some(last_confirmed_state) = prediction_history.last_confirmed() else {
+            trace!(
+                "No confirmed value in diff history for entity {:?}, skipping rollback check",
+                entity
+            );
+            return false;
+        };
+
+        let confirmed_value: Option<C> = last_confirmed_state.value().cloned();
+        let predicted_value = prediction_history.get(confirmed_tick);
+        let should_rollback = self.should_rollback_check(confirmed_value.as_ref(), predicted_value);
+
+        prediction_history.add_confirmed_unchanged(confirmed_tick);
+        prediction_history.clear_until_tick_retaining_confirmed_metadata(confirmed_tick);
 
         should_rollback
     }
@@ -334,13 +425,18 @@ impl PredictionRegistry {
     ///
     /// The confirmed value is stored in the history as `Confirmed`, which means it will be preserved
     /// during rollback (we know the real server value).
-    fn add_confirmed_and_check_rollback<C: SyncComponent>(
+    fn add_confirmed_and_check_rollback<C, M>(
         &self,
         confirmed_tick: Tick,
         confirmed_component: Option<C>,
+        metadata: M,
         entity_mut: &mut DeferredEntity,
         check_mismatch: bool,
-    ) -> bool {
+    ) -> bool
+    where
+        C: SyncComponent,
+        M: Default + Clone + Send + Sync + 'static,
+    {
         let entity = entity_mut.id();
         let name = DebugName::type_name::<C>();
         let _span = trace_span!(
@@ -352,8 +448,8 @@ impl PredictionRegistry {
         )
         .entered();
 
-        let Some(mut predicted_history) = entity_mut.get_mut::<PredictionHistory<C>>() else {
-            let mut history = PredictionHistory::<C>::default();
+        let Some(mut predicted_history) = entity_mut.get_mut::<PredictionHistory<C, M>>() else {
+            let mut history = PredictionHistory::<C, M>::default();
             trace!(
                 target: "lightyear_debug::prediction",
                 kind = "confirmed_history_insert",
@@ -366,7 +462,7 @@ impl PredictionRegistry {
                 "created prediction history from confirmed value"
             );
             // Mark as confirmed since this came from the server
-            history.add_confirmed(confirmed_tick, confirmed_component);
+            history.add_confirmed_with_metadata(confirmed_tick, confirmed_component, metadata);
             entity_mut.insert(history);
             // If there was no history, we can't compare, so we should rollback to be safe
             return check_mismatch;
@@ -418,7 +514,11 @@ impl PredictionRegistry {
             value = ?confirmed_component.as_ref(),
             "recorded confirmed value in prediction history"
         );
-        predicted_history.add_confirmed(confirmed_tick, confirmed_component);
+        predicted_history.add_confirmed_with_metadata(
+            confirmed_tick,
+            confirmed_component,
+            metadata,
+        );
         should_rollback
     }
 
@@ -428,16 +528,19 @@ impl PredictionRegistry {
     ///
     /// - The PtrMut must point to a valid [`PredictionHistory<C>`] component.
     /// - The function `f` must be a valid function of type `fn(&C, &mut seahash::SeaHasher)`.
-    fn pop_until_tick_and_hash<C: Debug + Clone + 'static>(
+    fn pop_until_tick_and_hash<C, M>(
         ptr: PtrMut,
         tick: Tick,
         hasher: &mut seahash::SeaHasher,
         f: fn(),
-    ) {
+    ) where
+        C: Debug + Clone + 'static,
+        M: Clone + Send + Sync + 'static,
+    {
         // SAFETY: the caller must ensure that the function has the correct type
         let f = unsafe { core::mem::transmute::<fn(), fn(&C, &mut seahash::SeaHasher)>(f) };
-        // SAFETY: the caller must ensure that the pointer is valid and points to a PredictionHistory<C>
-        let history = unsafe { ptr.deref_mut::<PredictionHistory<C>>() };
+        // SAFETY: the caller must ensure that the pointer is valid and points to a PredictionHistory<C, M>
+        let history = unsafe { ptr.deref_mut::<PredictionHistory<C, M>>() };
         if let Some(v) = history.get(tick) {
             trace!(
                 "Read value from PredictionHistory<{:?}> at tick {:?}: {:?} for hashing",
@@ -455,6 +558,11 @@ pub trait PredictionRegistrationExt<C> {
     fn add_prediction(self) -> Self
     where
         C: SyncComponent;
+
+    /// Enable prediction for a component replicated with Replicon's patch-based diff mode.
+    fn add_prediction_diff(self) -> Self
+    where
+        C: SyncComponent + RepliconDiffable;
 
     /// Register `write_history` as the default replicon receive function for
     /// this component, so that replicated values are stored in
@@ -563,50 +671,36 @@ impl<C> PredictionRegistrationExt<C> for ComponentRegistration<'_, C> {
     where
         C: SyncComponent,
     {
-        if !self.app.world().contains_resource::<PredictionRegistry>() {
-            trace!(
-                "Skipping prediction registration for component {:?} because PredictionPlugin is not present",
-                DebugName::type_name::<C>()
-            );
-            return self;
-        }
-        self.app.register_marker_with::<Predicted>(MarkerConfig {
-            priority: 100,
-            need_history: true,
-        });
-        self.app
-            .set_marker_fns::<Predicted, C>(write_history::<C>, remove_history::<C>);
-        // A prespawned entity can receive replicated component data before the
-        // server match has inserted `Predicted`. Keep that authoritative data in
-        // history so it cannot overwrite the live locally-predicted component.
-        self.app.register_marker_with::<PreSpawned>(MarkerConfig {
-            priority: 100,
-            need_history: true,
-        });
-        self.app
-            .set_marker_fns::<PreSpawned, C>(write_history::<C>, remove_history::<C>);
-        let history_id = self
+        add_prediction_with_receive_fns::<C, ()>(
+            self,
+            write_history::<C>,
+            remove_history::<C, ()>,
+            add_prediction_systems_with_metadata::<C, ()>,
+        )
+    }
+
+    fn add_prediction_diff(self) -> Self
+    where
+        C: SyncComponent + RepliconDiffable,
+    {
+        let registration = add_prediction_with_receive_fns::<C, Option<PatchIndex>>(
+            self,
+            write_history_diff::<C>,
+            remove_history_diff::<C>,
+            add_prediction_systems_with_diff_metadata::<C>,
+        );
+        let history_id = registration
             .app
             .world_mut()
-            .register_component::<PredictionHistory<C>>();
-        let mut registry = self.app.world_mut().resource_mut::<PredictionRegistry>();
-        trace!(
-            "Adding prediction for component {:?}",
-            DebugName::type_name::<C>()
-        );
-        registry.register::<C>(history_id);
-        // TODO: how do we avoid the server adding the prediction systems?
-        //   do we need to make sure that the Protocol runs after the client/server plugins are added?
-        add_prediction_systems::<C>(self.app);
-
-        let mut registry = self.app.world_mut().resource_mut::<ComponentRegistry>();
-        let metadata = registry
-            .component_metadata_map
-            .get_mut(&ComponentKind::of::<C>())
-            .unwrap();
-        metadata.replication.as_mut().unwrap().set_predicted(true);
-        // metadata.serialization.as_mut().unwrap().add_clone::<C>();
-        self
+            .register_component::<PredictionHistory<C, Option<PatchIndex>>>();
+        if let Some(mut registry) = registration
+            .app
+            .world_mut()
+            .get_resource_mut::<PredictionRegistry>()
+        {
+            registry.register_diff::<C>(history_id);
+        }
+        registration
     }
 
     fn enable_correction(self) -> Self
@@ -673,10 +767,82 @@ impl<C> PredictionRegistrationExt<C> for ComponentRegistration<'_, C> {
         else {
             return self;
         };
-        registry.register::<C>(history_id);
+        registry.register::<C, ()>(history_id);
         registry.set_should_rollback::<C>(should_rollback);
         self
     }
+}
+
+fn add_prediction_with_receive_fns<'a, C, M>(
+    registration: ComponentRegistration<'a, C>,
+    write: WriteFn<C>,
+    remove: RemoveFn,
+    add_systems: fn(&mut App),
+) -> ComponentRegistration<'a, C>
+where
+    C: SyncComponent,
+    M: Default + Clone + Send + Sync + 'static,
+{
+    if !registration
+        .app
+        .world()
+        .contains_resource::<PredictionRegistry>()
+    {
+        trace!(
+            "Skipping prediction registration for component {:?} because PredictionPlugin is not present",
+            DebugName::type_name::<C>()
+        );
+        return registration;
+    }
+    registration
+        .app
+        .register_marker_with::<Predicted>(MarkerConfig {
+            priority: 100,
+            need_history: true,
+        });
+    registration
+        .app
+        .set_marker_fns::<Predicted, C>(write, remove);
+    // A prespawned entity can receive replicated component data before the
+    // server match has inserted `Predicted`. Keep that authoritative data in
+    // history so it cannot overwrite the live locally-predicted component.
+    registration
+        .app
+        .register_marker_with::<PreSpawned>(MarkerConfig {
+            priority: 100,
+            need_history: true,
+        });
+    registration
+        .app
+        .set_marker_fns::<PreSpawned, C>(write, remove);
+    let history_id = registration
+        .app
+        .world_mut()
+        .register_component::<PredictionHistory<C, M>>();
+    let mut registry = registration
+        .app
+        .world_mut()
+        .resource_mut::<PredictionRegistry>();
+    trace!(
+        "Adding prediction for component {:?}",
+        DebugName::type_name::<C>()
+    );
+    registry.register::<C, M>(history_id);
+    // TODO: how do we avoid the server adding the prediction systems?
+    //   do we need to make sure that the Protocol runs after the client/server plugins are added?
+    add_systems(registration.app);
+
+    let mut registry = registration
+        .app
+        .world_mut()
+        .resource_mut::<ComponentRegistry>();
+    let metadata = registry
+        .component_metadata_map
+        .get_mut(&ComponentKind::of::<C>())
+        .unwrap();
+    metadata.replication.as_mut().unwrap().set_predicted(true);
+    // metadata.serialization.as_mut().unwrap().add_clone::<C>();
+    registration
 }
 
 pub trait PredictionAppRegistrationExt {
@@ -695,7 +861,7 @@ impl PredictionAppRegistrationExt for App {
         let Some(mut registry) = self.world_mut().get_resource_mut::<PredictionRegistry>() else {
             return ComponentRegistration::<C>::new(self);
         };
-        registry.register::<C>(history_id);
+        registry.register::<C, ()>(history_id);
         add_non_networked_rollback_systems::<C>(self);
         ComponentRegistration::<C>::new(self)
     }
@@ -721,9 +887,11 @@ fn write_history<C: SyncComponent>(
     entity: &mut DeferredEntity,
     message: &mut Bytes,
 ) -> Result<()> {
-    let component: C = rule_fns.deserialize(ctx, message)?;
+    let Some(component) = prediction_history_component(ctx, rule_fns, entity, message)? else {
+        return Ok(());
+    };
     let (tick, should_rollback) =
-        add_confirmed_to_history(ctx.message_tick, Some(component), entity, true)?;
+        add_confirmed_to_history(ctx.message_tick, Some(component), (), entity, true)?;
     if should_rollback {
         // SAFETY: we only access resources, which don't alias with the DeferredEntity's component access
         unsafe { entity.world_mut() }
@@ -733,12 +901,119 @@ fn write_history<C: SyncComponent>(
     Ok(())
 }
 
-fn add_confirmed_to_history<C: SyncComponent>(
+fn prediction_history_component<C: SyncComponent>(
+    ctx: &mut WriteCtx,
+    rule_fns: &RuleFns<C>,
+    entity: &mut DeferredEntity,
+    message: &mut Bytes,
+) -> Result<Option<C>> {
+    rule_fns.deserialize(ctx, message).map(Some)
+}
+
+fn write_history_diff<C: SyncComponent + RepliconDiffable>(
+    ctx: &mut WriteCtx,
+    _rule_fns: &RuleFns<C>,
+    entity: &mut DeferredEntity,
+    message: &mut Bytes,
+) -> Result<()> {
+    let Some((cursor, component)) = prediction_history_component_diff::<C>(ctx, entity, message)?
+    else {
+        return Ok(());
+    };
+    let (tick, should_rollback) =
+        add_confirmed_to_history(ctx.message_tick, Some(component), cursor, entity, true)?;
+    if should_rollback {
+        // SAFETY: we only access resources, which don't alias with the DeferredEntity's component access
+        unsafe { entity.world_mut() }
+            .resource_mut::<StateRollbackMetadata>()
+            .record_mismatch(tick);
+    }
+    Ok(())
+}
+
+fn prediction_history_component_diff<C: SyncComponent + RepliconDiffable>(
+    ctx: &mut WriteCtx,
+    entity: &mut DeferredEntity,
+    message: &mut Bytes,
+) -> Result<Option<(Option<PatchIndex>, C)>> {
+    let wire: DiffWire<C, C::Patch> = postcard_utils::from_buf(message)?;
+    let (cursor, value) = match wire {
+        DiffWire::Snapshot { cursor, mut value } => {
+            C::map_entities(&mut value, ctx);
+            entity.insert(DiffReceiver::<C>::new(cursor));
+            (cursor, value)
+        }
+        DiffWire::Patches {
+            first_patch_index,
+            patches,
+        } => {
+            if patches.is_empty() {
+                return Ok(None);
+            }
+            let base_cursor = first_patch_index.checked_sub(1);
+            let cursor = Some(first_patch_index + patches.len() as PatchIndex - 1);
+            let live_receiver_cursor = entity
+                .get::<DiffReceiver<C>>()
+                .map(|receiver| receiver.last_applied());
+            let live_is_base = live_receiver_cursor == Some(base_cursor);
+            let has_history = entity
+                .get::<PredictionHistory<C, Option<PatchIndex>>>()
+                .is_some();
+            let has_live_component = entity.get::<C>().is_some();
+            let mut value = entity
+                .get::<PredictionHistory<C, Option<PatchIndex>>>()
+                .and_then(|history| {
+                    history
+                        .last_confirmed_value_with_metadata(&base_cursor)
+                        .map(|(_, value, _)| value)
+                        .cloned()
+                })
+                .or_else(|| {
+                    live_is_base
+                        .then(|| entity.get::<C>().map(|value| value.clone()))
+                        .flatten()
+                })
+                .ok_or_else(|| {
+                    format!(
+                        "received diff patches for `{}` without a confirmed base: base_cursor={:?}, cursor={:?}, batch_count={}, live_receiver_cursor={:?}, has_history={}, has_live_component={}",
+                        DebugName::type_name::<C>(),
+                        base_cursor,
+                        cursor,
+                        patches.len(),
+                        live_receiver_cursor,
+                        has_history,
+                        has_live_component,
+                    )
+                })?;
+            for batch in patches {
+                for patch in batch.iter() {
+                    value.apply_patch(patch)?;
+                }
+            }
+            if let Some(mut history) = entity.get_mut::<PredictionHistory<C, Option<PatchIndex>>>()
+            {
+                history.prune_confirmed_metadata_before_cursor(
+                    first_patch_index.saturating_sub(DIFF_CURSOR_RETENTION),
+                );
+            }
+            (cursor, value)
+        }
+    };
+
+    Ok(Some((cursor, value)))
+}
+
+fn add_confirmed_to_history<C, M>(
     message_tick: RepliconTick,
     confirmed_component: Option<C>,
+    metadata: M,
     entity: &mut DeferredEntity,
     check_state_rollback: bool,
-) -> Result<(Tick, bool)> {
+) -> Result<(Tick, bool)>
+where
+    C: SyncComponent,
+    M: Default + Clone + Send + Sync + 'static,
+{
     // SAFETY: we only access resources, which don't alias with the DeferredEntity's component access.
     // We extract all needed values and drop the world borrow before using `entity` again.
     let (registry, checkpoints, should_check) = {
@@ -772,9 +1047,10 @@ fn add_confirmed_to_history<C: SyncComponent>(
 
     // Always add confirmed values to history (needed for rollback in any mode).
     // If RollbackMode::Check, also check for mismatch.
-    let should_rollback = registry.add_confirmed_and_check_rollback(
+    let should_rollback = registry.add_confirmed_and_check_rollback::<C, M>(
         tick,
         confirmed_component,
+        metadata,
         entity,
         check_state_rollback && should_check,
     );
@@ -786,7 +1062,11 @@ fn add_confirmed_to_history<C: SyncComponent>(
 /// This function:
 /// 1. Always adds the confirmed removal to the prediction history (needed for rollback in any mode)
 /// 2. If `RollbackMode::Check`, also checks for mismatch and records it
-fn remove_history<C: SyncComponent>(ctx: &mut RemoveCtx, entity: &mut DeferredEntity) {
+fn remove_history<C, M>(ctx: &mut RemoveCtx, entity: &mut DeferredEntity)
+where
+    C: SyncComponent,
+    M: Default + Clone + Send + Sync + 'static,
+{
     // SAFETY: we only access resources, which don't alias with the DeferredEntity's component access.
     // We extract all needed values and drop the world borrow before using `entity` again.
     let (registry, checkpoints, should_check) = {
@@ -820,14 +1100,27 @@ fn remove_history<C: SyncComponent>(ctx: &mut RemoveCtx, entity: &mut DeferredEn
 
     // Always add confirmed removal to history (needed for rollback in any mode).
     // If RollbackMode::Check, also check for mismatch.
-    let should_rollback =
-        registry.add_confirmed_and_check_rollback::<C>(tick, None, entity, should_check);
+    let should_rollback = registry.add_confirmed_and_check_rollback::<C, M>(
+        tick,
+        None,
+        M::default(),
+        entity,
+        should_check,
+    );
     if should_rollback {
         // SAFETY: we only access resources, which don't alias with the DeferredEntity's component access
         unsafe { entity.world_mut() }
             .resource_mut::<StateRollbackMetadata>()
             .record_mismatch(tick);
     }
+}
+
+fn remove_history_diff<C: SyncComponent + RepliconDiffable>(
+    ctx: &mut RemoveCtx,
+    entity: &mut DeferredEntity,
+) {
+    entity.remove::<DiffReceiver<C>>();
+    remove_history::<C, Option<PatchIndex>>(ctx, entity);
 }
 
 /// Variant of [`write_history`] used by `add_confirmed_write`.
@@ -856,7 +1149,7 @@ fn write_history_gated_by_catchup<C: SyncComponent>(
     let component: C = rule_fns.deserialize(ctx, message)?;
     let live_component = component.clone();
     let (_, should_rollback) =
-        add_confirmed_to_history(ctx.message_tick, Some(component), entity, false)?;
+        add_confirmed_to_history(ctx.message_tick, Some(component), (), entity, false)?;
     debug_assert!(!should_rollback);
     if let Some(mut component) = entity.get_mut::<C>() {
         *component = live_component;
@@ -894,10 +1187,31 @@ fn remove_history_gated_by_catchup<C: SyncComponent>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::vec;
+    use alloc::vec::Vec;
+    use bevy_replicon::prelude::RepliconPlugins;
+    use bevy_replicon::shared::replication::registry::{
+        FnsId, ReplicationRegistry, test_fns::TestFnsEntityExt,
+    };
+    use bevy_state::app::StatesPlugin;
     use core::hash::Hasher;
+    use lightyear_replication::checkpoint::ReplicationCheckpointMap;
+    use serde::{Deserialize, Serialize};
 
     #[derive(Clone, PartialEq, Debug)]
     struct TestComponent(u32);
+
+    #[derive(Component, Clone, Debug, Deserialize, PartialEq, Serialize)]
+    struct DiffTestValue(u32);
+
+    impl RepliconDiffable for DiffTestValue {
+        type Patch = u32;
+
+        fn apply_patch(&mut self, patch: &Self::Patch) -> bevy_ecs::error::Result<()> {
+            self.0 = *patch;
+            Ok(())
+        }
+    }
 
     fn hash_test_component(value: &TestComponent, hasher: &mut seahash::SeaHasher) {
         hasher.write_u32(value.0);
@@ -936,7 +1250,7 @@ mod tests {
                 hash_test_component,
             )
         };
-        PredictionRegistry::pop_until_tick_and_hash::<TestComponent>(
+        PredictionRegistry::pop_until_tick_and_hash::<TestComponent, ()>(
             PtrMut::from(&mut history),
             Tick(11),
             &mut hasher,
@@ -948,5 +1262,174 @@ mod tests {
         assert_eq!(history.get(Tick(10)).unwrap().0, 10);
         assert_eq!(history.get(Tick(11)).unwrap().0, 11);
         assert_eq!(history.get(Tick(12)).unwrap().0, 12);
+    }
+
+    #[test]
+    fn prediction_diff_records_older_subset_after_cumulative_patch() {
+        let (mut app, fns_id) = setup_diff_prediction_app();
+        record_checkpoints(&mut app);
+
+        let entity = app.world_mut().spawn(Predicted).id();
+
+        apply_diff_write(
+            &mut app,
+            entity,
+            fns_id,
+            RepliconTick::new(10),
+            DiffWire::Snapshot {
+                cursor: None,
+                value: DiffTestValue(0),
+            },
+        );
+        apply_diff_write(
+            &mut app,
+            entity,
+            fns_id,
+            RepliconTick::new(12),
+            DiffWire::Patches {
+                first_patch_index: 0,
+                patches: vec![vec![1], vec![2]],
+            },
+        );
+        apply_diff_write(
+            &mut app,
+            entity,
+            fns_id,
+            RepliconTick::new(11),
+            DiffWire::Patches {
+                first_patch_index: 0,
+                patches: vec![vec![1]],
+            },
+        );
+
+        let history = app
+            .world()
+            .entity(entity)
+            .get::<PredictionHistory<DiffTestValue, Option<PatchIndex>>>()
+            .unwrap();
+        assert_eq!(history.get(Tick(0)).cloned(), Some(DiffTestValue(0)));
+        assert_eq!(history.get(Tick(1)).cloned(), Some(DiffTestValue(1)));
+        assert_eq!(history.get(Tick(2)).cloned(), Some(DiffTestValue(2)));
+        assert_eq!(
+            history
+                .last_confirmed_value_with_metadata(&Some(0))
+                .map(|(tick, value, _)| (tick, value.clone())),
+            Some((Tick(1), DiffTestValue(1)))
+        );
+    }
+
+    #[test]
+    fn prediction_diff_prunes_bases_older_than_cursor_window() {
+        let (mut app, fns_id) = setup_diff_prediction_app();
+        {
+            let mut checkpoints = app.world_mut().resource_mut::<ReplicationCheckpointMap>();
+            for tick in 10..=37 {
+                checkpoints.record(RepliconTick::new(tick), Tick(tick - 10));
+            }
+        }
+
+        let entity = app.world_mut().spawn(Predicted).id();
+        apply_diff_write(
+            &mut app,
+            entity,
+            fns_id,
+            RepliconTick::new(10),
+            DiffWire::Snapshot {
+                cursor: None,
+                value: DiffTestValue(0),
+            },
+        );
+        for patch_index in 0..=26 {
+            apply_diff_write(
+                &mut app,
+                entity,
+                fns_id,
+                RepliconTick::new(11 + patch_index),
+                DiffWire::Patches {
+                    first_patch_index: patch_index as PatchIndex,
+                    patches: vec![vec![patch_index + 1]],
+                },
+            );
+        }
+
+        let history = app
+            .world()
+            .entity(entity)
+            .get::<PredictionHistory<DiffTestValue, Option<PatchIndex>>>()
+            .unwrap();
+        assert!(
+            history.last_confirmed_value_with_metadata(&None).is_none(),
+            "pre-patch base should be pruned once the received patch window starts at 26"
+        );
+        assert!(
+            history
+                .last_confirmed_value_with_metadata(&Some(0))
+                .is_none(),
+            "cursor 0 is older than 26 - 10"
+        );
+        assert_eq!(
+            history
+                .last_confirmed_value_with_metadata(&Some(16))
+                .map(|(tick, value, _)| (tick, value.clone())),
+            Some((Tick(17), DiffTestValue(17)))
+        );
+        assert_eq!(
+            history
+                .last_confirmed_value_with_metadata(&Some(26))
+                .map(|(tick, value, _)| (tick, value.clone())),
+            Some((Tick(27), DiffTestValue(27)))
+        );
+    }
+
+    fn setup_diff_prediction_app() -> (App, FnsId) {
+        let mut app = App::new();
+        app.add_plugins((StatesPlugin, RepliconPlugins));
+        app.insert_resource(ReplicationCheckpointMap::default());
+        app.insert_resource(PredictionRegistry::default());
+        app.insert_resource(StateRollbackMetadata::default());
+        let link_entity = app.world_mut().spawn_empty().id();
+        app.world_mut()
+            .insert_resource(PredictionResource { link_entity });
+        app.register_marker_with::<Predicted>(MarkerConfig {
+            priority: 100,
+            need_history: true,
+        });
+        app.set_marker_fns::<Predicted, DiffTestValue>(
+            write_history_diff::<DiffTestValue>,
+            remove_history_diff::<DiffTestValue>,
+        );
+        let history_id = app
+            .world_mut()
+            .register_component::<PredictionHistory<DiffTestValue, Option<PatchIndex>>>();
+        app.world_mut()
+            .resource_mut::<PredictionRegistry>()
+            .register::<DiffTestValue, Option<PatchIndex>>(history_id);
+        let (_, fns_id) =
+            app.world_mut()
+                .resource_scope(|world, mut registry: Mut<ReplicationRegistry>| {
+                    registry.register_rule_fns(world, RuleFns::<DiffTestValue>::new_diff())
+                });
+        (app, fns_id)
+    }
+
+    fn record_checkpoints(app: &mut App) {
+        let mut checkpoints = app.world_mut().resource_mut::<ReplicationCheckpointMap>();
+        checkpoints.record(RepliconTick::new(10), Tick(0));
+        checkpoints.record(RepliconTick::new(11), Tick(1));
+        checkpoints.record(RepliconTick::new(12), Tick(2));
+    }
+
+    fn apply_diff_write(
+        app: &mut App,
+        entity: Entity,
+        fns_id: FnsId,
+        message_tick: RepliconTick,
+        wire: DiffWire<DiffTestValue, u32>,
+    ) {
+        let mut message = Vec::new();
+        postcard_utils::to_extend_mut(&wire, &mut message).unwrap();
+        app.world_mut()
+            .entity_mut(entity)
+            .apply_write(message, fns_id, message_tick);
     }
 }

--- a/lightyear_prediction/src/rollback.rs
+++ b/lightyear_prediction/src/rollback.rs
@@ -53,7 +53,9 @@ use bevy_ecs::schedule::ScheduleLabel;
 use bevy_ecs::system::{ParamBuilder, QueryParamBuilder};
 use bevy_ecs::world::{DeferredWorld, FilteredEntityMut};
 use bevy_reflect::Reflect;
-use bevy_replicon::prelude::{ClientMessages, ClientSystems};
+use bevy_replicon::prelude::{
+    ClientMessages, ClientSystems, Diffable as RepliconDiffable, PatchIndex,
+};
 use bevy_replicon::shared::backend::channels::ServerChannel;
 use bevy_time::{Fixed, Time};
 use bevy_utils::prelude::DebugName;
@@ -877,7 +879,7 @@ pub(crate) fn remove_prediction_disable(
 /// 3. Reverts the component to the value at rollback_tick
 #[allow(clippy::type_complexity)]
 #[allow(clippy::too_many_arguments)]
-pub(crate) fn prepare_rollback<C: SyncComponent>(
+pub(crate) fn prepare_rollback<C, M>(
     timeline: Res<LocalTimeline>,
     prediction_registry: Res<PredictionRegistry>,
     checkpoints: Res<lightyear_replication::checkpoint::ReplicationCheckpointMap>,
@@ -890,13 +892,16 @@ pub(crate) fn prepare_rollback<C: SyncComponent>(
             Entity,
             Option<&mut C>,
             Option<&ConfirmHistory>,
-            &mut PredictionHistory<C>,
+            &mut PredictionHistory<C, M>,
             AnyOf<(&Predicted, &PreSpawned, &DeterministicPredicted)>,
         ),
         Without<DisableRollback>,
     >,
     manager_query: Single<(&PredictionManager, &Rollback)>,
-) {
+) where
+    C: SyncComponent,
+    M: Clone + Send + Sync + 'static,
+{
     let kind = DebugName::type_name::<C>();
     let (manager, rollback) = manager_query.into_inner();
     let current_tick = timeline.tick();
@@ -1036,6 +1041,146 @@ pub(crate) fn prepare_rollback<C: SyncComponent>(
                     }
                 };
             }
+        };
+    }
+}
+
+/// Diff-specific rollback preparation that keeps recent patch-cursor bases in history.
+#[allow(clippy::type_complexity)]
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn prepare_rollback_diff<C>(
+    timeline: Res<LocalTimeline>,
+    prediction_registry: Res<PredictionRegistry>,
+    checkpoints: Res<lightyear_replication::checkpoint::ReplicationCheckpointMap>,
+    server_mutate_ticks: Res<ServerMutateTicks>,
+    mut commands: Commands,
+    mut predicted_query: Query<
+        (
+            Entity,
+            Option<&mut C>,
+            Option<&ConfirmHistory>,
+            &mut PredictionHistory<C, Option<PatchIndex>>,
+            AnyOf<(&Predicted, &PreSpawned, &DeterministicPredicted)>,
+        ),
+        Without<DisableRollback>,
+    >,
+    manager_query: Single<(&PredictionManager, &Rollback)>,
+) where
+    C: SyncComponent + RepliconDiffable,
+{
+    let kind = DebugName::type_name::<C>();
+    let (manager, rollback) = manager_query.into_inner();
+    let current_tick = timeline.tick();
+    let _span = trace_span!("prepare_rollback_diff", tick = ?current_tick, kind = ?kind).entered();
+    let rollback_tick = manager.get_rollback_start_tick().unwrap();
+
+    let Some(server_confirmed_tick) =
+        resolve_server_last_confirmed_tick(&checkpoints, &server_mutate_ticks)
+    else {
+        return;
+    };
+
+    for (
+        entity,
+        predicted_component,
+        confirm_history,
+        mut predicted_history,
+        (predicted, _prespawned, _disable_state_rollback),
+    ) in predicted_query.iter_mut()
+    {
+        if matches!(rollback, Rollback::FromState)
+            && !matches!(manager.rollback_policy.state, RollbackMode::Disabled)
+            && let Some(confirm_history) = confirm_history
+        {
+            let Some(confirm_tick) = resolve_confirm_history_tick(&checkpoints, confirm_history)
+            else {
+                debug!(
+                    entity = ?entity,
+                    replicon_tick = ?confirm_history.last_tick(),
+                    "Skipping unchanged confirmation for entity with missing ConfirmHistory checkpoint mapping during rollback preparation"
+                );
+                continue;
+            };
+            if confirm_tick < server_confirmed_tick {
+                predicted_history.add_confirmed_unchanged(server_confirmed_tick);
+            }
+        }
+
+        let restore_value = if matches!(manager.rollback_policy.state, RollbackMode::Always) {
+            predicted_history
+                .pop_until_tick_retaining_confirmed_metadata(server_confirmed_tick)
+                .and_then(|s| s.into_value())
+        } else {
+            let restore_value = predicted_history.get(rollback_tick).cloned();
+            let clear_until_tick =
+                if matches!(manager.rollback_policy.state, RollbackMode::Disabled) {
+                    rollback_tick
+                } else {
+                    server_confirmed_tick
+                };
+            predicted_history.clear_until_tick_retaining_confirmed_metadata(clear_until_tick);
+            predicted_history.clear_predicted_from(rollback_tick);
+            restore_value
+        };
+        trace!(
+            ?entity,
+            ?rollback_tick,
+            ?restore_value,
+            "Prepared rollback for diff component {:?}. History after clear: {:?}",
+            kind,
+            predicted_history.len()
+        );
+        trace!(
+            target: "lightyear_debug::prediction",
+            kind = "prepare_rollback_component",
+            schedule = "PreUpdate",
+            sample_point = "PreUpdate",
+            entity = ?entity,
+            component = ?kind,
+            local_tick = current_tick.0,
+            rollback_tick = rollback_tick.0,
+            confirmed_tick = server_confirmed_tick.0,
+            rollback = ?rollback,
+            restore_value = ?restore_value,
+            history_len = predicted_history.len(),
+            "prepared diff component rollback"
+        );
+
+        let mut entity_mut = commands.entity(entity);
+        match restore_value {
+            None => {
+                entity_mut.try_remove::<C>();
+                trace!("Removing diff component from predicted entity for rollback");
+            }
+            Some(correct) => match predicted_component {
+                None => {
+                    debug!("Re-adding deleted diff component to predicted");
+                    entity_mut.insert(correct);
+                }
+                Some(mut predicted_component) => {
+                    if prediction_registry.has_correction::<C>() {
+                        entity_mut.insert(PreviousVisual(predicted_component.clone()));
+                        trace!(
+                            ?entity,
+                            previous_visual = ?predicted_component,
+                            "Storing PreviousVisual for diff correction"
+                        );
+                        trace!(
+                            target: "lightyear_debug::prediction",
+                            kind = "previous_visual_stored",
+                            schedule = "PreUpdate",
+                            sample_point = "PreUpdate",
+                            entity = ?entity,
+                            component = ?kind,
+                            local_tick = current_tick.0,
+                            rollback_tick = rollback_tick.0,
+                            previous_visual = ?predicted_component,
+                            "stored previous visual for diff correction"
+                        );
+                    }
+                    *predicted_component = correct;
+                }
+            },
         };
     }
 }

--- a/lightyear_prediction/src/rollback.rs
+++ b/lightyear_prediction/src/rollback.rs
@@ -35,7 +35,7 @@ We need:
 use super::predicted_history::PredictionHistory;
 use super::resource_history::ResourceHistory;
 use super::{Predicted, SyncComponent};
-use crate::checkpoint_ticks::{resolve_confirm_history_tick, resolve_message_tick};
+use crate::checkpoint_ticks::{resolve_confirm_history_tick, resolve_server_last_confirmed_tick};
 use crate::correction::PreviousVisual;
 use crate::despawn::PredictionDisable;
 use crate::diagnostics::PredictionMetrics;
@@ -53,7 +53,6 @@ use bevy_ecs::schedule::ScheduleLabel;
 use bevy_ecs::system::{ParamBuilder, QueryParamBuilder};
 use bevy_ecs::world::{DeferredWorld, FilteredEntityMut};
 use bevy_reflect::Reflect;
-use bevy_replicon::client::server_mutate_ticks::MutateTickReceived;
 use bevy_replicon::prelude::{ClientMessages, ClientSystems};
 use bevy_replicon::shared::backend::channels::ServerChannel;
 use bevy_time::{Fixed, Time};
@@ -66,7 +65,7 @@ use lightyear_core::prelude::LocalTimeline;
 use lightyear_core::tick::Tick;
 use lightyear_core::timeline::{Rollback, is_in_rollback};
 use lightyear_frame_interpolation::FrameInterpolationSystems;
-use lightyear_replication::prelude::ConfirmHistory;
+use lightyear_replication::prelude::{ConfirmHistory, ServerMutateTicks};
 use lightyear_replication::prespawn::{PreSpawned, PreSpawnedReceiver};
 use lightyear_replication::registry::ComponentRegistry;
 use lightyear_sync::prelude::{InputTimeline, IsSynced};
@@ -145,13 +144,10 @@ impl Plugin for RollbackPlugin {
         app.add_systems(
             PreUpdate,
             (
-                reset_state_rollback_metadata_if_disconnected.before(update_last_confirmed_tick),
+                reset_state_rollback_metadata_if_disconnected.before(RollbackSystems::Check),
                 check_received_replication_messages
                     .after(ClientSystems::ReceivePackets)
                     .before(ClientSystems::Receive),
-                update_last_confirmed_tick
-                    .after(ClientSystems::Receive)
-                    .before(RollbackSystems::Check),
                 reset_input_rollback_tracker.after(RollbackSystems::Check),
                 remove_prediction_disable.in_set(RollbackSystems::RemoveDisable),
                 run_rollback.in_set(RollbackSystems::Rollback),
@@ -218,6 +214,7 @@ impl Plugin for RollbackPlugin {
                     }
                 });
             }),
+            ParamBuilder,
             ParamBuilder,
             ParamBuilder,
             ParamBuilder,
@@ -358,28 +355,6 @@ fn check_received_replication_messages(
     }
 }
 
-/// Cache the latest authoritative tick for which Replicon completed all mutate messages.
-fn update_last_confirmed_tick(
-    mut received_mutate_ticks: MessageReader<MutateTickReceived>,
-    checkpoints: Res<lightyear_replication::checkpoint::ReplicationCheckpointMap>,
-    mut metadata: ResMut<StateRollbackMetadata>,
-) {
-    for event in received_mutate_ticks.read() {
-        let Some(authoritative_tick) = resolve_message_tick(&checkpoints, event.tick) else {
-            error!(
-                replicon_tick = ?event.tick,
-                "missing authoritative checkpoint mapping for completed mutate tick"
-            );
-            debug_assert!(
-                false,
-                "missing authoritative checkpoint mapping for completed mutate tick"
-            );
-            continue;
-        };
-        metadata.record_last_confirmed_tick(authoritative_tick);
-    }
-}
-
 fn reset_state_rollback_metadata_if_disconnected(
     query: Query<
         (),
@@ -397,69 +372,11 @@ fn reset_state_rollback_metadata_if_disconnected(
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use bevy_replicon::prelude::RepliconTick;
-    use lightyear_replication::checkpoint::ReplicationCheckpointMap;
-
-    #[test]
-    fn update_last_confirmed_tick_tracks_latest_completed_mutate_message() {
-        let older_replicon_tick = RepliconTick::new(9);
-        let newer_replicon_tick = RepliconTick::new(10);
-
-        let mut app = App::new();
-        app.add_message::<MutateTickReceived>();
-        app.init_resource::<ReplicationCheckpointMap>();
-        app.init_resource::<StateRollbackMetadata>();
-        app.add_systems(Update, update_last_confirmed_tick);
-
-        {
-            let mut checkpoints = app.world_mut().resource_mut::<ReplicationCheckpointMap>();
-            checkpoints.record(older_replicon_tick, Tick(90));
-            checkpoints.record(newer_replicon_tick, Tick(100));
-        }
-
-        app.world_mut().write_message(MutateTickReceived {
-            tick: newer_replicon_tick,
-        });
-        app.world_mut().write_message(MutateTickReceived {
-            tick: older_replicon_tick,
-        });
-        app.update();
-
-        assert_eq!(
-            app.world()
-                .resource::<StateRollbackMetadata>()
-                .last_confirmed_tick(),
-            Some(Tick(100))
-        );
-    }
-
-    #[test]
-    fn update_last_confirmed_tick_without_messages_leaves_tick_unset() {
-        let mut app = App::new();
-        app.add_message::<MutateTickReceived>();
-        app.init_resource::<ReplicationCheckpointMap>();
-        app.init_resource::<StateRollbackMetadata>();
-        app.add_systems(Update, update_last_confirmed_tick);
-
-        app.update();
-
-        assert_eq!(
-            app.world()
-                .resource::<StateRollbackMetadata>()
-                .last_confirmed_tick(),
-            None
-        );
-    }
-}
-
 /// Check if we need to do a rollback.
 /// We do this separately from `prepare_rollback` because even if we stop the `check_rollback` function
 /// early as soon as we find a mismatch, but we need to rollback all components to the original state.
 ///
-/// Key invariant: `StateRollbackMetadata.last_confirmed_tick = T` guarantees that for all entities,
+/// Key invariant: Replicon's latest confirmed mutate tick T guarantees that for all entities,
 /// we have complete information at tick T:
 /// - Entities that received an update at T: their confirmed value is in the message
 /// - Entities that didn't receive an update: their value at T = their last confirmed value
@@ -470,6 +387,7 @@ fn check_rollback(
     timeline: Res<LocalTimeline>,
     mut state_metadata: ResMut<StateRollbackMetadata>,
     checkpoints: Res<lightyear_replication::checkpoint::ReplicationCheckpointMap>,
+    server_mutate_ticks: Res<ServerMutateTicks>,
     receiver_query: Single<
         (
             Entity,
@@ -495,7 +413,9 @@ fn check_rollback(
     let received_state = state_metadata.received_messages_this_frame;
 
     // The tick where ALL messages have been received (guaranteed complete information)
-    let Some(server_confirmed_tick) = state_metadata.last_confirmed_tick() else {
+    let Some(server_confirmed_tick) =
+        resolve_server_last_confirmed_tick(&checkpoints, &server_mutate_ticks)
+    else {
         return;
     };
 
@@ -960,8 +880,8 @@ pub(crate) fn remove_prediction_disable(
 pub(crate) fn prepare_rollback<C: SyncComponent>(
     timeline: Res<LocalTimeline>,
     prediction_registry: Res<PredictionRegistry>,
-    state_metadata: Res<StateRollbackMetadata>,
     checkpoints: Res<lightyear_replication::checkpoint::ReplicationCheckpointMap>,
+    server_mutate_ticks: Res<ServerMutateTicks>,
     mut commands: Commands,
     // We also snap the value of the component to the server state if we are in rollback
     // We use Option<> because the predicted component could have been removed while it still exists in Confirmed
@@ -984,7 +904,9 @@ pub(crate) fn prepare_rollback<C: SyncComponent>(
     let rollback_tick = manager.get_rollback_start_tick().unwrap();
 
     // The tick where ALL messages have been received (guaranteed complete information)
-    let Some(server_confirmed_tick) = state_metadata.last_confirmed_tick() else {
+    let Some(server_confirmed_tick) =
+        resolve_server_last_confirmed_tick(&checkpoints, &server_mutate_ticks)
+    else {
         return;
     };
 

--- a/lightyear_replication/src/checkpoint.rs
+++ b/lightyear_replication/src/checkpoint.rs
@@ -140,11 +140,70 @@ pub fn resolve_confirm_history_tick(
     resolve_message_tick(checkpoints, history.last_tick())
 }
 
-pub fn resolve_server_mutate_tick(
+/// Resolve Replicon's latest fully confirmed server mutation checkpoint into
+/// Lightyear simulation time.
+///
+/// `ServerMutateTicks::last_confirmed_tick` is a Replicon tick, not a
+/// Lightyear [`Tick`]. Use this helper before using the completed mutation
+/// tick for rollback, interpolation, or any other simulation-time logic.
+///
+/// Returns `None` if Replicon has not reported a fully received mutation tick
+/// yet, or if Lightyear has no checkpoint mapping for that Replicon tick.
+///
+/// In `test_utils` builds, this also supports tests that manually seed
+/// [`ServerMutateTicks`] with `confirm`, because Replicon only updates
+/// `last_confirmed_tick` from its private receive path.
+pub fn resolve_server_last_confirmed_tick(
     checkpoints: &ReplicationCheckpointMap,
     ticks: &ServerMutateTicks,
 ) -> Option<Tick> {
-    resolve_message_tick(checkpoints, ticks.last_tick())
+    #[cfg(feature = "test_utils")]
+    {
+        let replicon_tick = ticks
+            .last_confirmed_tick()
+            .and_then(|tick| resolve_message_tick(checkpoints, tick));
+        let seeded_tick = resolve_server_last_confirmed_tick_for_tests(checkpoints, ticks);
+
+        return match (replicon_tick, seeded_tick) {
+            (Some(replicon_tick), Some(seeded_tick)) => Some(replicon_tick.max(seeded_tick)),
+            (Some(tick), None) | (None, Some(tick)) => Some(tick),
+            (None, None) => None,
+        };
+    }
+
+    #[cfg(not(feature = "test_utils"))]
+    {
+        ticks
+            .last_confirmed_tick()
+            .and_then(|tick| resolve_message_tick(checkpoints, tick))
+    }
+}
+
+/// Test-only resolver for synthetic tests that manually seed
+/// `ServerMutateTicks` through `confirm`.
+///
+/// Production code uses [`resolve_server_last_confirmed_tick`], which relies on
+/// Replicon's `last_confirmed_tick`. The fallback here exists because
+/// Replicon's setter for that field is intentionally private and only the
+/// Replicon receive path can update it.
+#[cfg(feature = "test_utils")]
+pub fn resolve_server_last_confirmed_tick_for_tests(
+    checkpoints: &ReplicationCheckpointMap,
+    ticks: &ServerMutateTicks,
+) -> Option<Tick> {
+    let mut tick = ticks.last_tick();
+    for _ in 0..=u64::BITS {
+        if ticks.contains(tick)
+            && let Some(server_tick) = resolve_message_tick(checkpoints, tick)
+        {
+            return Some(server_tick);
+        }
+        if tick == RepliconTick::default() {
+            break;
+        }
+        tick = tick - 1;
+    }
+    None
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/lightyear_replication/src/client.rs
+++ b/lightyear_replication/src/client.rs
@@ -15,6 +15,7 @@ use crate::channels::RepliconChannelMap;
 use crate::checkpoint::{
     ReplicationCheckpointMap, extract_server_replicon_tick, unwrap_server_payload,
 };
+use crate::prelude::Replicated;
 use crate::send::Replicate;
 use lightyear_messages::plugin::MessageSystems;
 use tracing::{debug, error};
@@ -160,8 +161,8 @@ fn send_client_packets(
 ///
 /// This matches the old `ReplicationReceivePlugin::handle_disconnection` behavior:
 /// all entities that were spawned from replication are despawned on disconnect.
-/// In the new replicon flow, predicted and interpolated entities also have `Replicated`
-/// since they arrive as replicated components.
+/// In the Replicon flow, received entities have `Remote`, which Lightyear exposes
+/// as its receiver-side `Replicated` marker.
 fn despawn_replicated_on_disconnect(
     mut commands: Commands,
     replicated: Query<Entity, (With<Replicated>, Without<Replicate>)>,

--- a/lightyear_replication/src/lib.rs
+++ b/lightyear_replication/src/lib.rs
@@ -90,7 +90,6 @@ extern crate alloc;
 extern crate std;
 
 use bevy_app::PluginGroupBuilder;
-use bevy_app::prelude::Plugin;
 use bevy_app::prelude::PluginGroup;
 use bevy_ecs::prelude::SystemSet;
 
@@ -121,7 +120,8 @@ mod impls;
 pub mod prelude {
     pub use bevy_replicon::client::confirm_history::ConfirmHistory;
     pub use bevy_replicon::client::server_mutate_ticks::ServerMutateTicks;
-    pub use bevy_replicon::prelude::Replicated;
+    pub use bevy_replicon::prelude::Remote;
+    pub use bevy_replicon::prelude::Remote as Replicated;
 
     pub use crate::ReplicationSystems;
     pub use crate::authority::{AuthorityBroker, GiveAuthority, HasAuthority, RequestAuthority};
@@ -150,6 +150,7 @@ pub mod prelude {
     #[cfg(feature = "client")]
     pub mod client {
         pub use bevy_replicon::prelude::Remote;
+        pub use bevy_replicon::prelude::Remote as Replicated;
     }
 }
 
@@ -216,7 +217,7 @@ impl PluginGroup for LightyearRepliconBackend {
 pub struct LightyearRepliconServerBackend;
 
 #[cfg(feature = "server")]
-impl Plugin for LightyearRepliconServerBackend {
+impl bevy_app::prelude::Plugin for LightyearRepliconServerBackend {
     fn build(&self, app: &mut bevy_app::prelude::App) {
         app.add_plugins(bevy_replicon::server::ServerPlugin {
             tick_schedule: None,
@@ -236,7 +237,7 @@ impl Plugin for LightyearRepliconServerBackend {
 pub struct LightyearRepliconClientBackend;
 
 #[cfg(feature = "client")]
-impl Plugin for LightyearRepliconClientBackend {
+impl bevy_app::prelude::Plugin for LightyearRepliconClientBackend {
     fn build(&self, app: &mut bevy_app::prelude::App) {
         app.add_plugins(bevy_replicon::client::ClientPlugin);
         app.add_plugins(client::RepliconClientPlugin);

--- a/lightyear_replication/src/receive.rs
+++ b/lightyear_replication/src/receive.rs
@@ -2,13 +2,13 @@ use crate::ReplicationSystems;
 use bevy_app::prelude::*;
 use bevy_ecs::prelude::*;
 use bevy_replicon::client::ClientSystems;
-use bevy_replicon::client::confirm_history::ConfirmHistory;
 // TODO: add special rules so that entities with Predicted/Interpolation apply components differently
 
 /// Replicated is used as a marker component to find entities that were replicated from a remote.
 ///
-/// replicon always adds a [`ConfirmHistory`] component on replicated entities, so we can just use that.
-pub type Replicated = ConfirmHistory;
+/// Replicon adds [`Remote`](bevy_replicon::prelude::Remote) on entities spawned
+/// from a remote, and Lightyear keeps `Replicated` as its receiver-side name.
+pub use bevy_replicon::prelude::Remote as Replicated;
 
 /// Marker component added to a link entity to enable incoming replication.
 ///

--- a/lightyear_tests/src/client_server/prediction/history.rs
+++ b/lightyear_tests/src/client_server/prediction/history.rs
@@ -128,7 +128,7 @@ fn test_prediction_history_seeded_from_init_message() {
         "PredictionHistory should have a confirmed entry at server tick {:?}, \
          but found buffer contents: {:?}",
         s_tick,
-        history.buffer().iter().collect::<Vec<_>>()
+        history.buffer().collect::<Vec<_>>()
     );
 }
 
@@ -147,7 +147,7 @@ fn test_update_history() {
             .get::<PredictionHistory<CompFull>>(entity)
             .expect("Expected prediction history to be added");
         let mut last_tick: Option<Tick> = None;
-        for (tick, _) in history.buffer().iter() {
+        for (tick, _) in history.buffer() {
             if let Some(last) = last_tick {
                 assert_eq!(
                     tick.0,

--- a/lightyear_tests/src/client_server/prediction/prespawn.rs
+++ b/lightyear_tests/src/client_server/prediction/prespawn.rs
@@ -76,7 +76,7 @@ fn test_compute_hash() {
             .get::<PredictionHistory<CompFull>>()
             .unwrap()
             .most_recent(),
-        Some(&(current_tick, PredictionState::Predicted(CompFull(1.0)),))
+        Some(&(current_tick, PredictionState::Predicted(CompFull(1.0))))
     );
 }
 
@@ -516,9 +516,9 @@ fn test_prespawn_confirmed_init_goes_to_history_without_overwriting_live_value()
         .get::<PredictionHistory<CompFull>>(client_prespawn)
         .unwrap();
     assert!(
-        history.buffer().iter().any(
-            |(_, state)| matches!(state, PredictionState::Confirmed(value) if value == &CompFull(1.0))
-        ),
+        history.buffer().any(|(_, state)| {
+            matches!(state, PredictionState::Confirmed(value) if value == &CompFull(1.0))
+        }),
         "server init value should be recorded as confirmed history: {:?}",
         history
     );

--- a/lightyear_tests/src/client_server/prediction/rollback.rs
+++ b/lightyear_tests/src/client_server/prediction/rollback.rs
@@ -450,9 +450,6 @@ fn test_completed_mutate_tick_checks_unchanged_entities() {
     world
         .resource_mut::<lightyear_replication::checkpoint::ReplicationCheckpointMap>()
         .record(previous_replicon_tick, previous_confirmed_tick);
-    world
-        .resource_mut::<StateRollbackMetadata>()
-        .record_last_confirmed_tick(completed_tick);
     {
         let mut server_mutate_ticks = world.resource_mut::<ServerMutateTicks>();
         assert!(server_mutate_ticks.confirm(updated_replicon_tick, 1));
@@ -497,11 +494,16 @@ fn test_future_completed_mutate_tick_is_not_marked_processed() {
 
     stepper.frame_step(3);
     let future_tick = stepper.client_tick(0) + 1_000;
-    stepper
-        .client_app()
-        .world_mut()
-        .resource_mut::<StateRollbackMetadata>()
-        .record_last_confirmed_tick(future_tick);
+    let future_replicon_tick = RepliconTick::new(900);
+    let world = stepper.client_app().world_mut();
+    world
+        .resource_mut::<lightyear_replication::checkpoint::ReplicationCheckpointMap>()
+        .record(future_replicon_tick, future_tick);
+    assert!(
+        world
+            .resource_mut::<ServerMutateTicks>()
+            .confirm(future_replicon_tick, 1)
+    );
 
     stepper.frame_step(1);
 
@@ -524,11 +526,16 @@ fn test_explicit_mismatch_newer_than_completed_tick_rolls_back_from_mismatch_tic
     stepper.frame_step(5);
     let completed_tick = stepper.client_tick(0) - 4;
     let mismatch_tick = stepper.client_tick(0) - 2;
-    stepper
-        .client_app()
-        .world_mut()
-        .resource_mut::<StateRollbackMetadata>()
-        .record_last_confirmed_tick(completed_tick);
+    let completed_replicon_tick = RepliconTick::new(901);
+    let world = stepper.client_app().world_mut();
+    world
+        .resource_mut::<lightyear_replication::checkpoint::ReplicationCheckpointMap>()
+        .record(completed_replicon_tick, completed_tick);
+    assert!(
+        world
+            .resource_mut::<ServerMutateTicks>()
+            .confirm(completed_replicon_tick, 1)
+    );
 
     trigger_rollback_check(&mut stepper, mismatch_tick);
     stepper.frame_step(1);
@@ -593,9 +600,11 @@ fn test_completed_mutate_tick_rollback_preserves_later_confirmed_values() {
     world
         .resource_mut::<lightyear_replication::checkpoint::ReplicationCheckpointMap>()
         .record(same_replicon_tick, rollback_tick);
-    world
-        .resource_mut::<StateRollbackMetadata>()
-        .record_last_confirmed_tick(rollback_tick);
+    assert!(
+        world
+            .resource_mut::<ServerMutateTicks>()
+            .confirm(same_replicon_tick, 1)
+    );
 
     world
         .entity_mut(predicted_a)

--- a/lightyear_tests/src/client_server/replication.rs
+++ b/lightyear_tests/src/client_server/replication.rs
@@ -3,7 +3,7 @@
 use crate::protocol::{CompA, CompCustomInterp, CompCustomReplicateOnce, CompReplicateOnce};
 use crate::stepper::*;
 use bevy::prelude::{Bundle, Entity, Name, With, World};
-use bevy_replicon::prelude::Replicated;
+use bevy_replicon::prelude::Replicated as RepliconReplicated;
 use lightyear::prelude::ConfirmedHistory;
 use lightyear_connection::network_target::NetworkTarget;
 use lightyear_core::interpolation::Interpolated;
@@ -627,7 +627,7 @@ fn test_component_remove_not_replicating() {
         .world_mut()
         .entity_mut(client_entity)
         // TODO: removing Replicated will pause the replication instead of sending a despawn
-        .remove::<Replicated>();
+        .remove::<RepliconReplicated>();
     stepper
         .client_app()
         .world_mut()


### PR DESCRIPTION
This is only compatibly with a future version of replicon with https://github.com/simgine/bevy_replicon/pull/700

Handle diff-enabled components in prediction/interpolation. The diffs must be deserialized on the last confirmed component.