### PR TITLE
Keep unchanged interpolation history anchors

### DIFF
--- a/lightyear_core/src/confirmed_history.rs
+++ b/lightyear_core/src/confirmed_history.rs
@@ -320,11 +320,11 @@ impl<C> ConfirmedHistory<C> {
     ///
     /// Use this only when `tick` comes from a monotonic completeness signal,
     /// such as the latest completed mutate tick. Consecutive unchanged ticks
-    /// update the same unchanged newest anchor instead of appending another
-    /// marker.
+    /// are stored as separate anchors so custom interpolation systems can
+    /// align multiple component histories at the same confirmed tick.
     pub fn push_unchanged(&mut self, tick: Tick) -> Option<Tick> {
         let newest_index = self.buffer.len().checked_sub(1)?;
-        let (newest_tick, newest_state) = self.buffer.get(newest_index)?;
+        let (newest_tick, _) = self.buffer.get(newest_index)?;
         let newest_tick = *newest_tick;
         if tick <= newest_tick
             || self
@@ -335,9 +335,7 @@ impl<C> ConfirmedHistory<C> {
             return None;
         }
 
-        if newest_state.is_same_as_precedent() {
-            self.buffer.back_mut().unwrap().0 = tick;
-        } else if !self.add_unchanged(tick) {
+        if !self.add_unchanged(tick) {
             return None;
         }
         Some(newest_tick)
@@ -623,7 +621,7 @@ mod tests {
     }
 
     #[test]
-    fn push_unchanged_slides_newest_anchor() {
+    fn push_unchanged_appends_newest_anchor() {
         let mut history = ConfirmedHistory::<TestValue>::default();
         history.insert_present(Tick(2), TestValue(2.0));
 
@@ -631,7 +629,11 @@ mod tests {
         assert_eq!(history.push_unchanged(Tick(8)), Some(Tick(5)));
         assert_eq!(
             history.buffer_raw(),
-            &VecDeque::from(vec![(Tick(2), explicit(2.0)), (Tick(8), same()),])
+            &VecDeque::from(vec![
+                (Tick(2), explicit(2.0)),
+                (Tick(5), same()),
+                (Tick(8), same()),
+            ])
         );
         assert_eq!(effective_value_at(&history, Tick(8)), Some(2.0));
     }
@@ -660,6 +662,7 @@ mod tests {
             &VecDeque::from(vec![
                 (Tick(1), explicit(1.0)),
                 (Tick(2), explicit(2.0)),
+                (Tick(5), same()),
                 (Tick(8), same()),
             ])
         );
@@ -690,6 +693,7 @@ mod tests {
             &VecDeque::from(vec![
                 (Tick(2), explicit(2.0)),
                 (Tick(3), explicit(3.0)),
+                (Tick(5), same()),
                 (Tick(8), same()),
             ])
         );

--- a/lightyear_interpolation/src/interpolate.rs
+++ b/lightyear_interpolation/src/interpolate.rs
@@ -218,8 +218,8 @@ mod tests {
     }
 
     #[test]
-    fn update_confirmed_history_coalesces_repeated_empty_mutate_ticks() {
-        let mut app = setup_app(Tick(30), 40);
+    fn update_confirmed_history_records_repeated_empty_mutate_ticks() {
+        let mut app = setup_app(Tick(25), 40);
         app.add_systems(Update, update_confirmed_history::<TestComp>);
         confirm_server_tick(&mut app, 1, Tick(30));
 
@@ -236,13 +236,17 @@ mod tests {
             .world()
             .get::<ConfirmedHistory<TestComp>>(entity)
             .unwrap();
-        assert_eq!(history.len(), 2);
+        assert_eq!(history.len(), 3);
         assert_eq!(
             history.start_present().map(|(t, v)| (t, v.clone())),
             Some((Tick(20), TestComp(10.0)))
         );
         assert_eq!(
             history.get_nth_present(1).map(|(t, v)| (t, v.clone())),
+            Some((Tick(30), TestComp(10.0)))
+        );
+        assert_eq!(
+            history.get_nth_present(2).map(|(t, v)| (t, v.clone())),
             Some((Tick(31), TestComp(10.0)))
         );
     }


### PR DESCRIPTION
## Summary
- keep consecutive unchanged confirmed-history ticks as separate anchors instead of sliding the newest marker
- update interpolation history coverage to assert repeated empty mutate ticks are preserved

## Tests
- CARGO_TARGET_DIR=/spare/local/cbournhonesque/cargo-target cargo test -j 4 -p lightyear_core confirmed_history
- CARGO_TARGET_DIR=/spare/local/cbournhonesque/cargo-target cargo test -j 4 -p lightyear_interpolation update_confirmed_history