### PR TITLE
Simplify component registration API

### DIFF
--- a/benches/compiletime/src/main.rs
+++ b/benches/compiletime/src/main.rs
@@ -9,7 +9,7 @@ macro_rules! register_components {
                 #[derive(Component, Serialize, Deserialize, PartialEq, Clone)]
                 struct $component;
 
-                app.register_component::<$component>();
+                app.component::<$component>().replicate();
             )*
 
             $(

--- a/book/src/concepts/replication/protocol.md
+++ b/book/src/concepts/replication/protocol.md
@@ -27,9 +27,10 @@ A `Protocol` contains multiple sub-parts:
   the client and server. Each component must be `Serializable + Clone + Component`.
   You can register a component with:
   ```rust,noplayground
-  app.register_component::<PlayerId>(ChannelDirection::ServerToClient)
-    .add_prediction::<PlayerId>(ComponentSyncMode::Once)
-    .add_interpolation::<PlayerId>(ComponentSyncMode::Once);
+  app.component::<PlayerId>()
+    .replicate()
+    .predict()
+    .add_linear_interpolation();
   ```
   (You can specify additional behaviour for the component, such as prediction or interpolation.)
 

--- a/book/src/tutorial/advanced_systems.md
+++ b/book/src/tutorial/advanced_systems.md
@@ -21,8 +21,8 @@ when we receive the actual state of the entity from the server. (if there is a m
 To do this in lightyear, you will need to change a few things.
 
 ```rust,ignore
-app.register_component::<PlayerPosition>()
-    .add_prediction();
+app.component::<PlayerPosition>().replicate()
+    .predict();
 ```
 
 Then, when replicating the entity, you can also specify which clients should predict the entity by adding a `PredictionTarget` component.
@@ -113,7 +113,7 @@ impl Ease for PlayerPosition {
     }
 }
 
-app.register_component::<PlayerPosition>()
+app.component::<PlayerPosition>().replicate()
     .add_linear_interpolation_fn();
 ```
 

--- a/book/src/tutorial/setup.md
+++ b/book/src/tutorial/setup.md
@@ -73,11 +73,11 @@ pub struct ProtocolPlugin;
 
 impl Plugin for ProtocolPlugin{
     fn build(&self, app: &mut App) {
-        app.register_component::<PlayerId>();
+        app.component::<PlayerId>().replicate();
 
-        app.register_component::<PlayerPosition>();
+        app.component::<PlayerPosition>().replicate();
 
-        app.register_component::<PlayerColor>();
+        app.component::<PlayerColor>().replicate();
     }
 }
 ```

--- a/crates/deterministic/deterministic_replication/src/late_join/mod.rs
+++ b/crates/deterministic/deterministic_replication/src/late_join/mod.rs
@@ -145,7 +145,7 @@ impl Plugin for LateJoinCatchUpPlugin {
             .add_direction(NetworkDirection::ServerToClient);
         app.init_resource::<CatchUpRegistry>();
         app.init_resource::<CatchUpMode>();
-        app.register_component_once::<CatchUpGated>();
+        app.component::<CatchUpGated>().replicate_once();
 
         #[cfg(feature = "client")]
         client::build(app);

--- a/crates/integration/avian/src/plugin.rs
+++ b/crates/integration/avian/src/plugin.rs
@@ -354,11 +354,11 @@ impl Plugin for LightyearAvianPlugin {
             app.init_resource::<ConstraintGraph>();
             app.add_resource_rollback::<ContactGraph>();
             app.add_resource_rollback::<ConstraintGraph>();
-            app.add_rollback::<CollidingEntities>();
+            app.local_rollback::<CollidingEntities>();
             // `ColliderTrees` cannot be cloned for rollback, but its leaf AABBs
             // are derived from these cloneable collider components.
-            app.add_rollback::<ColliderAabb>();
-            app.add_rollback::<EnlargedAabb>();
+            app.local_rollback::<ColliderAabb>();
+            app.local_rollback::<EnlargedAabb>();
             app.init_resource::<RollbackMovedProxies>();
             app.add_resource_rollback::<RollbackMovedProxies>();
             app.add_systems(
@@ -388,10 +388,10 @@ impl Plugin for LightyearAvianPlugin {
 impl LightyearAvianPlugin {
     fn add_island_rollback(app: &mut App, rollback_sleeping: bool) {
         app.add_resource_rollback::<PhysicsIslands>();
-        app.add_rollback::<BodyIslandNode>();
+        app.local_rollback::<BodyIslandNode>();
         if rollback_sleeping {
-            app.add_rollback::<Sleeping>();
-            app.add_rollback::<SleepTimer>();
+            app.local_rollback::<Sleeping>();
+            app.local_rollback::<SleepTimer>();
         }
     }
 

--- a/crates/replication/interpolation/src/registry.rs
+++ b/crates/replication/interpolation/src/registry.rs
@@ -1,5 +1,6 @@
 use crate::SyncComponent;
 use crate::plugin::{add_interpolation_systems, add_prepare_interpolation_systems};
+use bevy_app::App;
 use bevy_ecs::prelude::*;
 use bevy_math::{
     Curve,
@@ -17,7 +18,7 @@ use bevy_utils::prelude::DebugName;
 use lightyear_core::history_buffer::HistoryState;
 use lightyear_core::prelude::{ConfirmedHistory, Interpolated, Tick};
 use lightyear_replication::checkpoint::{ReplicationCheckpointMap, resolve_message_tick};
-use lightyear_replication::registry::replication::ComponentRegistration;
+use lightyear_replication::registry::replication::{ComponentRegistration, ComponentRegistrator};
 use lightyear_replication::registry::{ComponentKind, ComponentRegistry, LerpFn};
 use tracing::{error, trace};
 
@@ -206,7 +207,7 @@ pub(crate) fn insert_confirmed_history_on_interpolated<C: SyncComponent>(
         .try_remove::<C>();
 }
 
-pub trait InterpolationRegistrationExt<C> {
+pub trait InterpolationRegistrationExt<'a, C>: ComponentRegistrator<'a, C> {
     /// Register an interpolation function for this component using the provided [`LerpFn`]
     ///
     /// This does NOT mean that interpolation systems are added, it simply registers a function to
@@ -245,24 +246,18 @@ pub trait InterpolationRegistrationExt<C> {
         C: SyncComponent;
 }
 
-impl<C> InterpolationRegistrationExt<C> for ComponentRegistration<'_, C> {
+impl<'a, C, R> InterpolationRegistrationExt<'a, C> for R
+where
+    R: ComponentRegistrator<'a, C>,
+{
     fn register_interpolation_fn(self, interpolation_fn: LerpFn<C>) -> Self
     where
         C: SyncComponent,
     {
-        register_interpolated_marker_fns::<C>(self.app);
-        if !self
-            .app
-            .world()
-            .contains_resource::<InterpolationRegistry>()
-        {
-            self.app
-                .world_mut()
-                .insert_resource(InterpolationRegistry::default());
-        }
-        let mut registry = self.app.world_mut().resource_mut::<InterpolationRegistry>();
-        registry.set_interpolation::<C>(interpolation_fn);
-        self
+        Self::from_component_registration(register_interpolation_fn_impl(
+            self.into_component_registration(),
+            interpolation_fn,
+        ))
     }
 
     fn register_linear_interpolation(self) -> Self
@@ -272,24 +267,14 @@ impl<C> InterpolationRegistrationExt<C> for ComponentRegistration<'_, C> {
         self.register_interpolation_fn(lerp::<C>)
     }
 
-    fn add_interpolation_with(mut self, interpolation_fn: LerpFn<C>) -> Self
+    fn add_interpolation_with(self, interpolation_fn: LerpFn<C>) -> Self
     where
         C: SyncComponent,
     {
-        self = self.register_interpolation_fn(interpolation_fn);
-        add_prepare_interpolation_systems::<C>(self.app);
-        add_interpolation_systems::<C>(self.app);
-
-        let mut registry = self.app.world_mut().resource_mut::<ComponentRegistry>();
-        registry
-            .component_metadata_map
-            .get_mut(&ComponentKind::of::<C>())
-            .unwrap()
-            .replication
-            .as_mut()
-            .unwrap()
-            .set_interpolated(true);
-        self
+        Self::from_component_registration(add_interpolation_with_impl(
+            self.into_component_registration(),
+            interpolation_fn,
+        ))
     }
 
     fn add_linear_interpolation(self) -> Self
@@ -303,39 +288,86 @@ impl<C> InterpolationRegistrationExt<C> for ComponentRegistration<'_, C> {
     where
         C: SyncComponent,
     {
-        let kind = ComponentKind::of::<C>();
-        register_interpolated_marker_fns::<C>(self.app);
-        if !self
-            .app
-            .world()
-            .contains_resource::<InterpolationRegistry>()
-        {
-            self.app
-                .world_mut()
-                .insert_resource(InterpolationRegistry::default());
-        }
-        let mut registry = self.app.world_mut().resource_mut::<InterpolationRegistry>();
-        registry
-            .interpolation_map
-            .entry(kind)
-            .and_modify(|r| r.custom_interpolation = true)
-            .or_insert_with(|| InterpolationMetadata {
-                interpolation: None,
-                custom_interpolation: true,
-            });
-        add_prepare_interpolation_systems::<C>(self.app);
-
-        let mut registry = self.app.world_mut().resource_mut::<ComponentRegistry>();
-        registry
-            .component_metadata_map
-            .get_mut(&ComponentKind::of::<C>())
-            .unwrap()
-            .replication
-            .as_mut()
-            .unwrap()
-            .set_interpolated(true);
-        self
+        Self::from_component_registration(add_custom_interpolation_impl(
+            self.into_component_registration(),
+        ))
     }
+}
+
+fn ensure_interpolation_registry(app: &mut App) {
+    if !app.world().contains_resource::<InterpolationRegistry>() {
+        app.world_mut()
+            .insert_resource(InterpolationRegistry::default());
+    }
+}
+
+fn mark_interpolated<C: SyncComponent>(app: &mut App) {
+    let mut registry = app.world_mut().resource_mut::<ComponentRegistry>();
+    registry
+        .component_metadata_map
+        .get_mut(&ComponentKind::of::<C>())
+        .unwrap()
+        .replication
+        .as_mut()
+        .unwrap()
+        .set_interpolated(true);
+}
+
+fn register_interpolation_fn_impl<'a, C>(
+    registration: ComponentRegistration<'a, C>,
+    interpolation_fn: LerpFn<C>,
+) -> ComponentRegistration<'a, C>
+where
+    C: SyncComponent,
+{
+    register_interpolated_marker_fns::<C>(registration.app);
+    ensure_interpolation_registry(registration.app);
+    let mut registry = registration
+        .app
+        .world_mut()
+        .resource_mut::<InterpolationRegistry>();
+    registry.set_interpolation::<C>(interpolation_fn);
+    registration
+}
+
+fn add_interpolation_with_impl<'a, C>(
+    registration: ComponentRegistration<'a, C>,
+    interpolation_fn: LerpFn<C>,
+) -> ComponentRegistration<'a, C>
+where
+    C: SyncComponent,
+{
+    let registration = register_interpolation_fn_impl(registration, interpolation_fn);
+    add_prepare_interpolation_systems::<C>(registration.app);
+    add_interpolation_systems::<C>(registration.app);
+    mark_interpolated::<C>(registration.app);
+    registration
+}
+
+fn add_custom_interpolation_impl<C>(
+    registration: ComponentRegistration<'_, C>,
+) -> ComponentRegistration<'_, C>
+where
+    C: SyncComponent,
+{
+    let kind = ComponentKind::of::<C>();
+    register_interpolated_marker_fns::<C>(registration.app);
+    ensure_interpolation_registry(registration.app);
+    let mut registry = registration
+        .app
+        .world_mut()
+        .resource_mut::<InterpolationRegistry>();
+    registry
+        .interpolation_map
+        .entry(kind)
+        .and_modify(|r| r.custom_interpolation = true)
+        .or_insert_with(|| InterpolationMetadata {
+            interpolation: None,
+            custom_interpolation: true,
+        });
+    add_prepare_interpolation_systems::<C>(registration.app);
+    mark_interpolated::<C>(registration.app);
+    registration
 }
 
 /// Instead of writing into a component directly, it writes data into [`ConfirmedHistory<C>`].

--- a/crates/replication/prediction/src/lib.rs
+++ b/crates/replication/prediction/src/lib.rs
@@ -33,7 +33,9 @@ pub mod prelude {
     pub use crate::plugin::{PredictionPlugin, PredictionSystems};
     pub use crate::predicted_history::PredictionHistory;
     pub use crate::registry::{
-        PredictionAppRegistrationExt, PredictionRegistrationExt, PredictionRegistry,
+        LocalRollbackComponentRegistration, PredictedComponentRegistration,
+        PredictionAppRegistrationExt, PredictionBuilderExt, PredictionRegistrationExt,
+        PredictionRegistry,
     };
     pub use crate::rollback::{
         CatchUpGated, DeterministicPredicted, DisableRollback, DisabledDuringRollback,

--- a/crates/replication/prediction/src/registry.rs
+++ b/crates/replication/prediction/src/registry.rs
@@ -30,7 +30,7 @@ use lightyear_core::tick::Tick;
 use lightyear_replication::checkpoint::resolve_message_tick;
 use lightyear_replication::delta::Diffable;
 use lightyear_replication::prelude::PreSpawned;
-use lightyear_replication::registry::replication::ComponentRegistration;
+use lightyear_replication::registry::replication::{ComponentRegistration, ComponentRegistrator};
 use lightyear_replication::registry::{ComponentError, ComponentKind, ComponentRegistry, LerpFn};
 use lightyear_utils::collections::HashMap;
 use tracing::{debug, error, trace, trace_span};
@@ -105,7 +105,7 @@ impl PredictionMetadata {
 /// Function called when comparing the confirmed component value (received from the remote) with the
 /// predicted component value (from the local [`PredictionHistory`]).
 ///
-/// In general we use [`PartialEq::ne`] by default, but you can provide your own function with [`ComponentRegistration::add_should_rollback`] to customize
+/// In general we use [`PartialEq::ne`] by default, but you can provide your own function with [`PredictedComponentRegistration::with_rollback_condition`] to customize
 /// the rollback behavior. (for example, you might want to ignore small floating point differences)
 pub type ShouldRollbackFn<C> = fn(confirmed: &C, predicted: &C) -> bool;
 
@@ -132,38 +132,49 @@ impl PredictionRegistry {
 
     fn set_should_rollback<C: SyncComponent>(&mut self, should_rollback: ShouldRollbackFn<C>) {
         self.prediction_map
-                .get_mut(&ComponentKind::of::<C>())
-                .expect("The component has not been registered for prediction. Did you call `.add_prediction(PredictionMode::Full)`")
-                .should_rollback = unsafe {
-                core::mem::transmute::<for<'a, 'b> fn(&'a C, &'b C) -> bool, unsafe fn()>(
-                    should_rollback,
-                )
-            };
+            .get_mut(&ComponentKind::of::<C>())
+            .expect(
+                "The component has not been registered for prediction. Did you call `.predict()`?",
+            )
+            .should_rollback = unsafe {
+            core::mem::transmute::<for<'a, 'b> fn(&'a C, &'b C) -> bool, unsafe fn()>(
+                should_rollback,
+            )
+        };
     }
 
     #[doc(hidden)]
     pub fn apply_correction<C: SyncComponent, D: Default>(&self, error: D, r: f32) -> Option<D> {
         self.prediction_map
             .get(&ComponentKind::of::<C>())
-            .expect("The component has not been registered for prediction. Did you call `.add_prediction(PredictionMode::Full)`")
+            .expect(
+                "The component has not been registered for prediction. Did you call `.predict()`?",
+            )
             .correction_fn
             .map(|correction_fn| {
-            // SAFETY: the correction_fn was registered as a LerpFn<D>
-            let lerp_fn = unsafe { core::mem::transmute::<unsafe fn(), LerpFn<D>>(correction_fn) };
-            lerp_fn(D::default(), error, r)
-        })
+                // SAFETY: the correction_fn was registered as a LerpFn<D>
+                let lerp_fn =
+                    unsafe { core::mem::transmute::<unsafe fn(), LerpFn<D>>(correction_fn) };
+                lerp_fn(D::default(), error, r)
+            })
     }
 
     fn enable_correction<C: SyncComponent>(&mut self) {
         self.prediction_map
             .get_mut(&ComponentKind::of::<C>())
-            .expect("The component has not been registered for prediction. Did you call `.add_prediction(PredictionMode::Full)`").correction = true;
+            .expect(
+                "The component has not been registered for prediction. Did you call `.predict()`?",
+            )
+            .correction = true;
     }
 
     fn set_correction_fn<C: SyncComponent, D>(&mut self, correction_fn: LerpFn<D>) {
-        let metadata = self.prediction_map
+        let metadata = self
+            .prediction_map
             .get_mut(&ComponentKind::of::<C>())
-            .expect("The component has not been registered for prediction. Did you call `.add_prediction(PredictionMode::Full)`");
+            .expect(
+                "The component has not been registered for prediction. Did you call `.predict()`?",
+            );
         metadata.correction = true;
         metadata.correction_fn = Some(unsafe { core::mem::transmute(correction_fn) });
     }
@@ -498,6 +509,7 @@ impl PredictionRegistry {
 
 pub trait PredictionRegistrationExt<C> {
     /// Enable prediction for this component.
+    #[deprecated(note = "use `app.component::<C>().predict()` instead")]
     fn add_prediction(self) -> Self
     where
         C: SyncComponent;
@@ -507,7 +519,7 @@ pub trait PredictionRegistrationExt<C> {
     /// `ConfirmedHistory<C>` as authoritative state (and optionally trigger a
     /// state rollback) rather than overwriting the component directly.
     ///
-    /// Use this alongside `add_rollback` when the component is normally
+    /// Use this alongside `local_rollback` when the component is normally
     /// non-networked (computed from deterministic inputs) but needs an initial
     /// value from replication (e.g. `replicate_once` on a physics component
     /// for late-joining clients).
@@ -547,9 +559,203 @@ pub trait PredictionRegistrationExt<C> {
 
     /// Add a custom comparison function to determine if we should rollback by comparing the
     /// confirmed component with the predicted component's history.
+    ///
+    /// Kept for backwards compatibility. Prefer
+    /// [`PredictionBuilderExt::predict`] or
+    /// [`PredictionAppRegistrationExt::local_rollback`] followed by
+    /// `with_rollback_condition`, so the call order is explicit in the type.
+    #[deprecated(
+        note = "use `.predict().with_rollback_condition(...)` or `local_rollback::<C>().with_rollback_condition(...)` instead"
+    )]
     fn add_should_rollback(self, should_rollback: ShouldRollbackFn<C>) -> Self
     where
         C: SyncComponent;
+}
+
+/// Registration state returned after prediction has been enabled for a component.
+///
+/// New code should prefer:
+///
+/// ```rust,ignore
+/// app.component::<Position>()
+///     .predict()
+///     .with_rollback_condition(position_should_rollback);
+/// ```
+///
+/// This makes it clear that custom rollback comparison is only meaningful after
+/// prediction has been enabled. Most registration extension traits can operate
+/// on this builder state directly; [`Self::into_component_registration`] is
+/// kept as an escape hatch for custom integrations.
+pub struct PredictedComponentRegistration<'a, C> {
+    registration: ComponentRegistration<'a, C>,
+}
+
+impl<'a, C> PredictedComponentRegistration<'a, C> {
+    fn new(registration: ComponentRegistration<'a, C>) -> Self {
+        Self { registration }
+    }
+
+    /// Add a custom comparison function to determine if we should rollback by
+    /// comparing the confirmed component with the predicted component's history.
+    #[allow(deprecated)]
+    pub fn with_rollback_condition(mut self, should_rollback: ShouldRollbackFn<C>) -> Self
+    where
+        C: SyncComponent,
+    {
+        self.registration = self.registration.add_should_rollback(should_rollback);
+        self
+    }
+
+    /// Backwards-compatible spelling for [`Self::with_rollback_condition`].
+    #[deprecated(note = "use `.with_rollback_condition(...)` instead")]
+    pub fn should_rollback(self, should_rollback: ShouldRollbackFn<C>) -> Self
+    where
+        C: SyncComponent,
+    {
+        self.with_rollback_condition(should_rollback)
+    }
+
+    /// Backwards-compatible spelling for [`Self::with_rollback_condition`].
+    #[deprecated(note = "use `.with_rollback_condition(...)` instead")]
+    pub fn add_should_rollback(self, should_rollback: ShouldRollbackFn<C>) -> Self
+    where
+        C: SyncComponent,
+    {
+        self.with_rollback_condition(should_rollback)
+    }
+
+    /// Enables correction for this component, without adding the correction systems.
+    pub fn enable_correction(mut self) -> Self
+    where
+        C: SyncComponent,
+    {
+        self.registration = self.registration.enable_correction();
+        self
+    }
+
+    /// Add correction for this component where interpolation uses the
+    /// [`Ease`] trait.
+    pub fn add_linear_correction_fn<D>(mut self) -> Self
+    where
+        C: SyncComponent + Diffable<D>,
+        D: Ease + Debug + Clone + Default + Send + Sync + 'static,
+    {
+        self.registration = self.registration.add_linear_correction_fn::<D>();
+        self
+    }
+
+    /// Add correction for this component using a custom interpolation function.
+    pub fn add_correction_fn<D>(mut self, correction_fn: LerpFn<D>) -> Self
+    where
+        C: SyncComponent + Diffable<D>,
+        D: Ease + Debug + Clone + Default + Send + Sync + 'static,
+    {
+        self.registration = self.registration.add_correction_fn::<D>(correction_fn);
+        self
+    }
+
+    /// Return to the general component registration builder.
+    pub fn into_component_registration(self) -> ComponentRegistration<'a, C> {
+        self.registration
+    }
+}
+
+impl<'a, C> ComponentRegistrator<'a, C> for PredictedComponentRegistration<'a, C> {
+    fn into_component_registration(self) -> ComponentRegistration<'a, C> {
+        self.registration
+    }
+
+    fn from_component_registration(registration: ComponentRegistration<'a, C>) -> Self {
+        Self::new(registration)
+    }
+}
+
+/// Extension trait for the new prediction registration builder.
+pub trait PredictionBuilderExt<'a, C>: ComponentRegistrator<'a, C> {
+    /// Enable prediction and return a state that exposes prediction-only
+    /// configuration methods.
+    fn predict(self) -> PredictedComponentRegistration<'a, C>
+    where
+        C: SyncComponent;
+}
+
+impl<'a, C, R> PredictionBuilderExt<'a, C> for R
+where
+    R: ComponentRegistrator<'a, C>,
+{
+    #[allow(deprecated)]
+    fn predict(self) -> PredictedComponentRegistration<'a, C>
+    where
+        C: SyncComponent,
+    {
+        PredictedComponentRegistration::new(self.into_component_registration().add_prediction())
+    }
+}
+
+/// Registration state returned after local rollback has been enabled for a
+/// non-networked component.
+pub struct LocalRollbackComponentRegistration<'a, C> {
+    registration: ComponentRegistration<'a, C>,
+}
+
+impl<'a, C> LocalRollbackComponentRegistration<'a, C> {
+    fn new(registration: ComponentRegistration<'a, C>) -> Self {
+        Self { registration }
+    }
+
+    /// Add a custom comparison function to determine if we should rollback by
+    /// comparing the confirmed component with the predicted component's history.
+    #[allow(deprecated)]
+    pub fn with_rollback_condition(mut self, should_rollback: ShouldRollbackFn<C>) -> Self
+    where
+        C: SyncComponent,
+    {
+        self.registration = self.registration.add_should_rollback(should_rollback);
+        self
+    }
+
+    /// Backwards-compatible spelling for [`Self::with_rollback_condition`].
+    #[deprecated(note = "use `.with_rollback_condition(...)` instead")]
+    pub fn should_rollback(self, should_rollback: ShouldRollbackFn<C>) -> Self
+    where
+        C: SyncComponent,
+    {
+        self.with_rollback_condition(should_rollback)
+    }
+
+    /// Backwards-compatible spelling for [`Self::with_rollback_condition`].
+    #[deprecated(note = "use `.with_rollback_condition(...)` instead")]
+    pub fn add_should_rollback(self, should_rollback: ShouldRollbackFn<C>) -> Self
+    where
+        C: SyncComponent,
+    {
+        self.with_rollback_condition(should_rollback)
+    }
+
+    /// Route replicated writes into confirmed history while an entity is
+    /// waiting for deterministic catch-up.
+    pub fn add_confirmed_write(mut self) -> Self
+    where
+        C: SyncComponent,
+    {
+        self.registration = self.registration.add_confirmed_write();
+        self
+    }
+
+    /// Return to the general component registration builder.
+    pub fn into_component_registration(self) -> ComponentRegistration<'a, C> {
+        self.registration
+    }
+}
+
+impl<'a, C> ComponentRegistrator<'a, C> for LocalRollbackComponentRegistration<'a, C> {
+    fn into_component_registration(self) -> ComponentRegistration<'a, C> {
+        self.registration
+    }
+
+    fn from_component_registration(registration: ComponentRegistration<'a, C>) -> Self {
+        Self::new(registration)
+    }
 }
 
 impl<C> PredictionRegistrationExt<C> for ComponentRegistration<'_, C> {
@@ -733,25 +939,36 @@ impl<C> PredictionRegistrationExt<C> for ComponentRegistration<'_, C> {
 }
 
 pub trait PredictionAppRegistrationExt {
+    /// Enable rollback for a component that is local-only and is not replicated
+    /// by Replicon.
+    fn local_rollback<C: SyncComponent>(&mut self) -> LocalRollbackComponentRegistration<'_, C>;
+
     /// Enable rollbacks for a component that is not networked.
+    #[deprecated(note = "use `app.local_rollback::<C>()` instead")]
     fn add_rollback<C: SyncComponent>(&mut self) -> ComponentRegistration<'_, C>;
 
     fn add_resource_rollback<R: Resource + Clone>(&mut self);
 }
 
+fn add_local_rollback<C: SyncComponent>(app: &mut App) -> ComponentRegistration<'_, C> {
+    let prediction_history_id = app.world_mut().register_component::<PredictionHistory<C>>();
+    let confirmed_history_id = app.world_mut().register_component::<ConfirmedHistory<C>>();
+    // skip if there is no PredictionRegistry (i.e. the PredictionPlugin wasn't added)
+    let Some(mut registry) = app.world_mut().get_resource_mut::<PredictionRegistry>() else {
+        return ComponentRegistration::<C>::new(app);
+    };
+    registry.register::<C>(prediction_history_id, confirmed_history_id);
+    add_non_networked_rollback_systems::<C>(app);
+    ComponentRegistration::<C>::new(app)
+}
+
 impl PredictionAppRegistrationExt for App {
+    fn local_rollback<C: SyncComponent>(&mut self) -> LocalRollbackComponentRegistration<'_, C> {
+        LocalRollbackComponentRegistration::new(add_local_rollback::<C>(self))
+    }
+
     fn add_rollback<C: SyncComponent>(&mut self) -> ComponentRegistration<'_, C> {
-        let prediction_history_id = self
-            .world_mut()
-            .register_component::<PredictionHistory<C>>();
-        let confirmed_history_id = self.world_mut().register_component::<ConfirmedHistory<C>>();
-        // skip if there is no PredictionRegistry (i.e. the PredictionPlugin wasn't added)
-        let Some(mut registry) = self.world_mut().get_resource_mut::<PredictionRegistry>() else {
-            return ComponentRegistration::<C>::new(self);
-        };
-        registry.register::<C>(prediction_history_id, confirmed_history_id);
-        add_non_networked_rollback_systems::<C>(self);
-        ComponentRegistration::<C>::new(self)
+        add_local_rollback::<C>(self)
     }
 
     fn add_resource_rollback<R: Resource + Clone>(&mut self) {
@@ -969,13 +1186,111 @@ fn remove_history_gated_by_catchup<C: SyncComponent>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bevy_replicon::prelude::{AuthMethod, RepliconSharedPlugin};
+    use bevy_state::app::StatesPlugin;
     use core::hash::Hasher;
+    use lightyear_interpolation::prelude::{InterpolationRegistrationExt, InterpolationRegistry};
+    use lightyear_replication::prelude::AppComponentExt;
 
     #[derive(Clone, PartialEq, Debug)]
     struct TestComponent(u32);
 
+    #[derive(Component, Clone, PartialEq, Debug)]
+    struct BuilderComponent(u32);
+
+    #[derive(Component, Clone, PartialEq, Debug)]
+    struct LocalRollbackComponent(u32);
+
+    fn prediction_app() -> App {
+        let mut app = App::new();
+        app.add_plugins((
+            StatesPlugin,
+            RepliconSharedPlugin {
+                auth_method: AuthMethod::None,
+            },
+        ));
+        app.init_resource::<PredictionRegistry>();
+        app
+    }
+
     fn hash_test_component(value: &TestComponent, hasher: &mut seahash::SeaHasher) {
         hasher.write_u32(value.0);
+    }
+
+    fn parity_should_rollback(confirmed: &BuilderComponent, predicted: &BuilderComponent) -> bool {
+        confirmed.0 % 2 != predicted.0 % 2
+    }
+
+    fn local_should_rollback(
+        confirmed: &LocalRollbackComponent,
+        predicted: &LocalRollbackComponent,
+    ) -> bool {
+        confirmed.0 / 10 != predicted.0 / 10
+    }
+
+    #[test]
+    fn predict_builder_enables_prediction_before_rollback_condition() {
+        let mut app = prediction_app();
+
+        app.component::<BuilderComponent>()
+            .predict()
+            .with_rollback_condition(parity_should_rollback);
+
+        let registry = app.world().resource::<PredictionRegistry>();
+        assert!(registry.predicted::<BuilderComponent>());
+        assert!(!registry.should_rollback(&BuilderComponent(1), &BuilderComponent(3)));
+        assert!(registry.should_rollback(&BuilderComponent(1), &BuilderComponent(2)));
+    }
+
+    #[test]
+    fn predicted_builder_can_add_custom_interpolation() {
+        let mut app = prediction_app();
+
+        app.component::<BuilderComponent>()
+            .predict()
+            .add_custom_interpolation()
+            .with_rollback_condition(parity_should_rollback);
+
+        let prediction_registry = app.world().resource::<PredictionRegistry>();
+        assert!(prediction_registry.predicted::<BuilderComponent>());
+
+        let interpolation_registry = app.world().resource::<InterpolationRegistry>();
+        assert!(interpolation_registry.interpolated::<BuilderComponent>());
+        assert!(prediction_registry.should_rollback(&BuilderComponent(1), &BuilderComponent(2)));
+    }
+
+    #[test]
+    fn interpolated_builder_can_add_prediction() {
+        let mut app = prediction_app();
+
+        app.component::<BuilderComponent>()
+            .add_custom_interpolation()
+            .predict()
+            .with_rollback_condition(parity_should_rollback);
+
+        let prediction_registry = app.world().resource::<PredictionRegistry>();
+        assert!(prediction_registry.predicted::<BuilderComponent>());
+
+        let interpolation_registry = app.world().resource::<InterpolationRegistry>();
+        assert!(interpolation_registry.interpolated::<BuilderComponent>());
+        assert!(prediction_registry.should_rollback(&BuilderComponent(1), &BuilderComponent(2)));
+    }
+
+    #[test]
+    fn local_rollback_builder_registers_non_networked_rollback() {
+        let mut app = App::new();
+        app.init_resource::<PredictionRegistry>();
+
+        app.local_rollback::<LocalRollbackComponent>()
+            .with_rollback_condition(local_should_rollback);
+
+        let registry = app.world().resource::<PredictionRegistry>();
+        assert!(registry.predicted::<LocalRollbackComponent>());
+        assert!(
+            !registry.should_rollback(&LocalRollbackComponent(10), &LocalRollbackComponent(19))
+        );
+        assert!(registry.should_rollback(&LocalRollbackComponent(10), &LocalRollbackComponent(20)));
+        assert!(app.world().get_resource::<ComponentRegistry>().is_none());
     }
 
     #[test]

--- a/crates/replication/replication/src/REPLICON_INTEGRATION.md
+++ b/crates/replication/replication/src/REPLICON_INTEGRATION.md
@@ -18,7 +18,7 @@ This branch (`cb/lightyear-replicon`) replaces lightyear's custom replication in
 
 2. **Replication targets** (`send.rs`): `Replicate`, `PredictionTarget`, and `InterpolationTarget` use bevy component hooks (`on_insert`/`on_replace`) to configure replicon's `ClientVisibility` and `VisibilityFilter` per-entity per-client. This replaces the old `ReplicationSender` change-tracking approach.
 
-3. **Prediction integration** (`registry.rs` in `lightyear_prediction`): Components registered with `.add_prediction()` use replicon's marker system — `Predicted` is registered as a marker with custom `write_history` / `remove_history` functions that store confirmed values in `PredictionHistory<C>` and detect mismatches for rollback.
+3. **Prediction integration** (`registry.rs` in `lightyear_prediction`): Components registered with `.predict()` use replicon's marker system — `Predicted` is registered as a marker with custom `write_history` / `remove_history` functions that store confirmed values in `PredictionHistory<C>` and detect mismatches for rollback.
 
 4. **State management**: `ServerState::Running` and `ClientState::Connected` are transitioned at appropriate times so replicon's internal systems run.
 

--- a/crates/replication/replication/src/lib.rs
+++ b/crates/replication/replication/src/lib.rs
@@ -136,7 +136,7 @@ pub mod prelude {
 
     pub use crate::registry::ComponentRegistry;
     pub use crate::registry::TransformLinearInterpolation;
-    pub use crate::registry::replication::AppComponentExt;
+    pub use crate::registry::replication::{AppComponentExt, ComponentRegistrator};
     pub use crate::visibility::immediate::{NetworkVisibilityPlugin, VisibilityExt};
     pub use crate::visibility::room::{RoomAllocator, RoomId, RoomPlugin, Rooms};
 

--- a/crates/replication/replication/src/registry/mod.rs
+++ b/crates/replication/replication/src/registry/mod.rs
@@ -63,15 +63,35 @@ impl From<TypeId> for ComponentKind {
 ///
 /// ### Adding Components
 ///
-/// You register components by calling the `register_component` method directly on the App.
+/// You register components by composing Lightyear's component builder with the
+/// desired Replicon rule:
 ///
-/// By default, a component needs to implement `Serialize` and `Deserialize`, but you can also provide your own
-/// serialization functions by using the `register_component_with` method.
+/// ```rust,ignore
+/// # use bevy_app::App;
+/// # use bevy_replicon::prelude::AppRuleExt;
+/// # use lightyear_replication::prelude::AppComponentExt;
+/// #
+/// app.component::<MyComponent>().replicate();
+/// ```
+///
+/// This also supports custom Replicon registration APIs, including priority,
+/// filters, custom rule functions, and `replicate_as`.
+///
+/// If you prefer to call Replicon's APIs directly, that still works: call the
+/// Replicon API first, then
+/// [`component`](crate::registry::replication::AppComponentExt::component) to
+/// make Lightyear prediction/interpolation metadata available for that same
+/// component type.
+///
+/// By default, a component needs to implement `Serialize` and `Deserialize`, but
+/// you can also provide your own serialization functions with
+/// [`ComponentRegistration::replicate_with`](crate::registry::replication::ComponentRegistration::replicate_with).
 ///
 /// Components that should only send insertions and removals can use
-/// `register_component_once`. For
+/// [`ComponentRegistration::replicate_once`](crate::registry::replication::ComponentRegistration::replicate_once).
+/// For
 /// once-replicated components with custom serialization, use
-/// `register_component_once_with`.
+/// [`ComponentRegistration::replicate_once_with`](crate::registry::replication::ComponentRegistration::replicate_once_with).
 ///
 /// ```rust
 /// # use bevy_app::App;
@@ -83,7 +103,7 @@ impl From<TypeId> for ComponentKind {
 /// struct MyComponent;
 ///
 /// fn add_components(app: &mut App) {
-///   app.register_component::<MyComponent>();
+///   app.component::<MyComponent>().replicate();
 /// }
 /// ```
 ///
@@ -95,13 +115,13 @@ impl From<TypeId> for ComponentKind {
 /// If the component contains any [`Entity`], you need to specify how those entities
 /// will be mapped from the remote world to the local world.
 ///
-/// Provided that your type implements [`MapEntities`](bevy_ecs::entity::MapEntities), you can extend the protocol to support this behaviour, by
+/// Provided that your type implements `MapEntities`, you can extend the protocol to support this behaviour by
 /// calling the `add_map_entities` method.
 ///
 /// #### Prediction
 /// When client-prediction is enabled, a predicted entity is one that has the [`Predicted`](lightyear_core::prelude::Predicted) component.
 ///
-/// You have to specify which components are predicted by calling the `add_prediction` method.
+/// You have to specify which components are predicted by calling `predict()`.
 ///
 /// #### Correction
 /// When client-prediction is enabled, there might be cases where there is a mismatch between the state of the Predicted entity
@@ -139,10 +159,10 @@ impl From<TypeId> for ComponentKind {
 /// }
 ///
 /// fn add_messages(app: &mut App) {
-///   app.register_component::<MyComponent>()
-///       .add_prediction(PredictionMode::Full)
-///       .add_interpolation(InterpolationMode::Full)
-///       .add_interpolation_fn(my_lerp_fn);
+///   app.component::<MyComponent>().replicate()
+///       .predict()
+///       .into_component_registration()
+///       .add_interpolation_with(my_lerp_fn);
 /// }
 /// ```
 #[derive(Debug, Default, Clone, Resource, TypePath)]
@@ -192,10 +212,7 @@ impl ComponentRegistry {
             .entry(component_kind)
             .or_insert(ComponentMetadata {
                 component_id,
-                replication: Some(ReplicationMetadata {
-                    predicted: false,
-                    interpolated: false,
-                }),
+                replication: Some(ReplicationMetadata::default()),
                 // #[cfg(feature = "delta")]
                 // delta: None,
                 #[cfg(feature = "deterministic")]

--- a/crates/replication/replication/src/registry/replication.rs
+++ b/crates/replication/replication/src/registry/replication.rs
@@ -5,12 +5,33 @@ use bevy_ecs::component::Component;
 use bevy_replicon::prelude::{AppRuleExt, ReplicationMode, RuleFns};
 use bevy_replicon::shared::replication::registry::receive_fns::MutWrite;
 use bevy_replicon::shared::replication::registry::rule_fns::{DeserializeFn, SerializeFn};
+use bevy_replicon::shared::replication::rules::filter::FilterRules;
 use serde::{Serialize, de::DeserializeOwned};
 
 /// Add a component to the list of components that can be sent
 pub trait AppComponentExt {
+    /// Registers the component in Lightyear's component metadata registry only.
+    ///
+    /// This does not add any Replicon replication rule. Use this when you want
+    /// to call Replicon's replication APIs directly or through this builder:
+    ///
+    /// ```rust,ignore
+    /// app.replicate::<MyComponent>();
+    /// app.component::<MyComponent>().predict();
+    ///
+    /// app.component::<MyComponent>()
+    ///     .replicate()
+    ///     .predict();
+    /// ```
+    ///
+    /// This also works with Replicon's custom registration APIs such as
+    /// `replicate_with_priority`, `replicate_with_priority_filtered`,
+    /// `replicate_as`, and `replicate_with`.
+    fn component<C: Component>(&mut self) -> ComponentRegistration<'_, C>;
+
     /// Registers the component in the Registry
     /// This component can now be sent over the network.
+    #[deprecated(note = "use `app.component::<C>().replicate()` instead")]
     fn register_component<C: Component<Mutability: MutWrite<C>> + Serialize + DeserializeOwned>(
         &mut self,
     ) -> ComponentRegistration<'_, C>;
@@ -19,6 +40,7 @@ pub trait AppComponentExt {
     ///
     /// This component can now be sent over the network, but only insertions and
     /// removals are replicated. Component mutations are not sent.
+    #[deprecated(note = "use `app.component::<C>().replicate_once()` instead")]
     fn register_component_once<
         C: Component<Mutability: MutWrite<C>> + Serialize + DeserializeOwned,
     >(
@@ -28,6 +50,7 @@ pub trait AppComponentExt {
     /// Registers the component in the Registry: this component can now be sent over the network.
     ///
     /// You need to provide your own serialization functions.
+    #[deprecated(note = "use `app.component::<C>().replicate_with(...)` instead")]
     fn register_component_with<C: Component<Mutability: MutWrite<C>>>(
         &mut self,
         serialize_fn: SerializeFn<C>,
@@ -36,6 +59,7 @@ pub trait AppComponentExt {
 
     /// Registers the component in the Registry with custom serialization and
     /// `ReplicationMode::Once`.
+    #[deprecated(note = "use `app.component::<C>().replicate_once_with(...)` instead")]
     fn register_component_once_with<C: Component<Mutability: MutWrite<C>>>(
         &mut self,
         serialize_fn: SerializeFn<C>,
@@ -47,18 +71,22 @@ pub trait AppComponentExt {
     /// This can be useful for components that are not networked but that you still need
     /// to sync to predicted or interpolated entities; or for which you need to enable
     /// rollback.
+    #[deprecated(note = "use `app.local_rollback::<C>()` for non-networked rollback")]
     fn non_networked_component<C: Component<Mutability: MutWrite<C>>>(
         &mut self,
     ) -> ComponentRegistration<'_, C>;
 }
 
 impl AppComponentExt for App {
+    fn component<C: Component>(&mut self) -> ComponentRegistration<'_, C> {
+        register_component_metadata::<C>(self);
+        ComponentRegistration::new(self)
+    }
+
     fn register_component<C: Component<Mutability: MutWrite<C>> + Serialize + DeserializeOwned>(
         &mut self,
     ) -> ComponentRegistration<'_, C> {
-        register_component_metadata::<C>(self);
-        self.replicate::<C>();
-        ComponentRegistration::new(self)
+        self.component::<C>().replicate()
     }
 
     fn register_component_once<
@@ -66,9 +94,7 @@ impl AppComponentExt for App {
     >(
         &mut self,
     ) -> ComponentRegistration<'_, C> {
-        register_component_metadata::<C>(self);
-        self.replicate_once::<C>();
-        ComponentRegistration::new(self)
+        self.component::<C>().replicate_once()
     }
 
     fn register_component_with<C: Component<Mutability: MutWrite<C>>>(
@@ -76,9 +102,8 @@ impl AppComponentExt for App {
         serialize_fn: SerializeFn<C>,
         deserialize_fn: DeserializeFn<C>,
     ) -> ComponentRegistration<'_, C> {
-        register_component_metadata::<C>(self);
-        self.replicate_with(RuleFns::new(serialize_fn, deserialize_fn));
-        ComponentRegistration::new(self)
+        self.component::<C>()
+            .replicate_with(RuleFns::new(serialize_fn, deserialize_fn))
     }
 
     fn register_component_once_with<C: Component<Mutability: MutWrite<C>>>(
@@ -86,12 +111,8 @@ impl AppComponentExt for App {
         serialize_fn: SerializeFn<C>,
         deserialize_fn: DeserializeFn<C>,
     ) -> ComponentRegistration<'_, C> {
-        register_component_metadata::<C>(self);
-        self.replicate_with((
-            RuleFns::new(serialize_fn, deserialize_fn),
-            ReplicationMode::Once,
-        ));
-        ComponentRegistration::new(self)
+        self.component::<C>()
+            .replicate_once_with(RuleFns::new(serialize_fn, deserialize_fn))
     }
 
     fn non_networked_component<C: Component<Mutability: MutWrite<C>>>(
@@ -122,6 +143,26 @@ pub struct ComponentRegistration<'a, C> {
     _phantom: core::marker::PhantomData<C>,
 }
 
+/// A builder state that can be converted to and from the base component
+/// registration builder.
+///
+/// Extension traits use this to compose registration domains without requiring
+/// callers to manually unwrap typed builder states.
+pub trait ComponentRegistrator<'a, C>: Sized {
+    fn into_component_registration(self) -> ComponentRegistration<'a, C>;
+    fn from_component_registration(registration: ComponentRegistration<'a, C>) -> Self;
+}
+
+impl<'a, C> ComponentRegistrator<'a, C> for ComponentRegistration<'a, C> {
+    fn into_component_registration(self) -> ComponentRegistration<'a, C> {
+        self
+    }
+
+    fn from_component_registration(registration: ComponentRegistration<'a, C>) -> Self {
+        registration
+    }
+}
+
 impl<C> ComponentRegistration<'_, C> {
     pub fn new(app: &mut App) -> ComponentRegistration<'_, C> {
         ComponentRegistration {
@@ -129,9 +170,174 @@ impl<C> ComponentRegistration<'_, C> {
             _phantom: core::marker::PhantomData,
         }
     }
+
+    /// Register this component with Replicon's default `OnChange` replication.
+    pub fn replicate(self) -> Self
+    where
+        C: Component<Mutability: MutWrite<C>> + Serialize + DeserializeOwned,
+    {
+        self.app.replicate::<C>();
+        self
+    }
+
+    /// Register this component with Replicon's `Once` replication mode.
+    pub fn replicate_once(self) -> Self
+    where
+        C: Component<Mutability: MutWrite<C>> + Serialize + DeserializeOwned,
+    {
+        self.app.replicate_once::<C>();
+        self
+    }
+
+    /// Register this component with Replicon's default replication and an
+    /// archetype filter.
+    pub fn replicate_filtered<F: FilterRules>(self) -> Self
+    where
+        C: Component<Mutability: MutWrite<C>> + Serialize + DeserializeOwned,
+    {
+        self.app.replicate_filtered::<C, F>();
+        self
+    }
+
+    /// Register this component with Replicon's `Once` replication mode and an
+    /// archetype filter.
+    pub fn replicate_once_filtered<F: FilterRules>(self) -> Self
+    where
+        C: Component<Mutability: MutWrite<C>> + Serialize + DeserializeOwned,
+    {
+        self.app.replicate_once_filtered::<C, F>();
+        self
+    }
+
+    /// Register this component with Replicon's `replicate_as` conversion API.
+    pub fn replicate_as<T>(self) -> Self
+    where
+        C: Component<Mutability: MutWrite<C>> + Clone + Into<T> + From<T>,
+        T: Serialize + DeserializeOwned,
+    {
+        self.app.replicate_as::<C, T>();
+        self
+    }
+
+    /// Register this component with Replicon's `replicate_once_as` conversion API.
+    pub fn replicate_once_as<T>(self) -> Self
+    where
+        C: Component<Mutability: MutWrite<C>> + Clone + Into<T> + From<T>,
+        T: Serialize + DeserializeOwned,
+    {
+        self.app.replicate_once_as::<C, T>();
+        self
+    }
+
+    /// Register this component with Replicon's filtered conversion API.
+    pub fn replicate_filtered_as<T, F: FilterRules>(self) -> Self
+    where
+        C: Component<Mutability: MutWrite<C>> + Clone + Into<T> + From<T>,
+        T: Serialize + DeserializeOwned,
+    {
+        self.app.replicate_filtered_as::<C, T, F>();
+        self
+    }
+
+    /// Register this component with Replicon's filtered `Once` conversion API.
+    pub fn replicate_once_filtered_as<T, F: FilterRules>(self) -> Self
+    where
+        C: Component<Mutability: MutWrite<C>> + Clone + Into<T> + From<T>,
+        T: Serialize + DeserializeOwned,
+    {
+        self.app.replicate_once_filtered_as::<C, T, F>();
+        self
+    }
+
+    /// Register this component with custom Replicon rule functions.
+    pub fn replicate_with(self, rule_fns: RuleFns<C>) -> Self
+    where
+        C: Component<Mutability: MutWrite<C>>,
+    {
+        self.app.replicate_with(rule_fns);
+        self
+    }
+
+    /// Register this component with custom Replicon rule functions and
+    /// `ReplicationMode::Once`.
+    pub fn replicate_once_with(self, rule_fns: RuleFns<C>) -> Self
+    where
+        C: Component<Mutability: MutWrite<C>>,
+    {
+        self.app.replicate_with((rule_fns, ReplicationMode::Once));
+        self
+    }
+
+    /// Register this component with custom Replicon rule functions and an
+    /// archetype filter.
+    pub fn replicate_with_filtered<F: FilterRules>(self, rule_fns: RuleFns<C>) -> Self
+    where
+        C: Component<Mutability: MutWrite<C>>,
+    {
+        self.app.replicate_with_filtered::<_, F>(rule_fns);
+        self
+    }
+
+    /// Register this component with custom Replicon rule functions,
+    /// `ReplicationMode::Once`, and an archetype filter.
+    pub fn replicate_once_with_filtered<F: FilterRules>(self, rule_fns: RuleFns<C>) -> Self
+    where
+        C: Component<Mutability: MutWrite<C>>,
+    {
+        self.app
+            .replicate_with_filtered::<_, F>((rule_fns, ReplicationMode::Once));
+        self
+    }
+
+    /// Register this component with Replicon's default rule functions and a
+    /// custom priority.
+    pub fn replicate_with_priority(self, priority: usize) -> Self
+    where
+        C: Component<Mutability: MutWrite<C>> + Serialize + DeserializeOwned,
+    {
+        self.app
+            .replicate_with_priority(priority, RuleFns::<C>::default());
+        self
+    }
+
+    /// Register this component with Replicon's default rule functions, a custom
+    /// priority, and an archetype filter.
+    pub fn replicate_with_priority_filtered<F: FilterRules>(self, priority: usize) -> Self
+    where
+        C: Component<Mutability: MutWrite<C>> + Serialize + DeserializeOwned,
+    {
+        self.app
+            .replicate_with_priority_filtered::<_, F>(priority, RuleFns::<C>::default());
+        self
+    }
+
+    /// Register this component with custom Replicon rule functions and a custom
+    /// priority.
+    pub fn replicate_custom_with_priority(self, priority: usize, rule_fns: RuleFns<C>) -> Self
+    where
+        C: Component<Mutability: MutWrite<C>>,
+    {
+        self.app.replicate_with_priority(priority, rule_fns);
+        self
+    }
+
+    /// Register this component with custom Replicon rule functions, a custom
+    /// priority, and an archetype filter.
+    pub fn replicate_custom_with_priority_filtered<F: FilterRules>(
+        self,
+        priority: usize,
+        rule_fns: RuleFns<C>,
+    ) -> Self
+    where
+        C: Component<Mutability: MutWrite<C>>,
+    {
+        self.app
+            .replicate_with_priority_filtered::<_, F>(priority, rule_fns);
+        self
+    }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Default, Clone)]
 pub struct ReplicationMetadata {
     pub(crate) predicted: bool,
     pub(crate) interpolated: bool,
@@ -148,5 +354,73 @@ impl ReplicationMetadata {
     /// Mark the component as being interpolated.
     pub fn set_interpolated(&mut self, interpolated: bool) {
         self.interpolated = interpolated;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bevy_ecs::prelude::With;
+    use bevy_replicon::prelude::{AuthMethod, RepliconSharedPlugin};
+    use bevy_replicon::shared::replication::rules::ReplicationRules;
+    use bevy_state::app::StatesPlugin;
+
+    #[derive(Component, Serialize, serde::Deserialize)]
+    struct DirectRepliconComponent;
+
+    #[derive(Component, Serialize, serde::Deserialize)]
+    struct PriorityComponent;
+
+    #[derive(Component)]
+    struct PriorityFilter;
+
+    #[derive(Component)]
+    struct MetadataOnlyComponent;
+
+    #[test]
+    fn component_registers_lightyear_metadata_without_replicon_rule() {
+        let mut app = App::new();
+
+        app.component::<MetadataOnlyComponent>();
+
+        let registry = app.world().resource::<ComponentRegistry>();
+        assert!(registry.is_registered::<MetadataOnlyComponent>());
+    }
+
+    #[test]
+    fn component_can_be_used_after_direct_replicon_registration() {
+        let mut app = App::new();
+        app.add_plugins((
+            StatesPlugin,
+            RepliconSharedPlugin {
+                auth_method: AuthMethod::None,
+            },
+        ));
+
+        app.replicate::<DirectRepliconComponent>();
+        app.component::<DirectRepliconComponent>();
+
+        let registry = app.world().resource::<ComponentRegistry>();
+        assert!(registry.is_registered::<DirectRepliconComponent>());
+    }
+
+    #[test]
+    fn component_can_be_used_after_custom_direct_replicon_registration() {
+        let mut app = App::new();
+        app.add_plugins((
+            StatesPlugin,
+            RepliconSharedPlugin {
+                auth_method: AuthMethod::None,
+            },
+        ));
+
+        app.component::<PriorityComponent>()
+            .replicate_with_priority_filtered::<With<PriorityFilter>>(7);
+
+        let registry = app.world().resource::<ComponentRegistry>();
+        assert!(registry.is_registered::<PriorityComponent>());
+
+        let rules = app.world().resource::<ReplicationRules>();
+        assert!(rules.iter().any(|rule| rule.priority == 7));
     }
 }

--- a/crates/tests/src/client_server/deterministic/protocol.rs
+++ b/crates/tests/src/client_server/deterministic/protocol.rs
@@ -140,28 +140,31 @@ impl Plugin for DetProtocolPlugin {
         app.add_plugins(FrameInterpolationPlugin::<Rotation>::default());
         app.add_observer(add_frame_interpolation);
 
-        app.register_component::<DetPlayerId>();
-        app.register_component::<DetPlayerActivationTick>();
+        app.component::<DetPlayerId>().replicate();
+        app.component::<DetPlayerActivationTick>().replicate();
 
-        app.register_component_once::<Position>();
-        app.add_rollback::<Position>()
+        app.component::<Position>().replicate_once();
+        app.local_rollback::<Position>()
             .add_confirmed_write()
+            .into_component_registration()
             .add_custom_hash(lightyear_avian2d::types::position::hash)
             .register_linear_interpolation()
             .add_linear_correction_fn();
 
-        app.register_component_once::<Rotation>();
-        app.add_rollback::<Rotation>()
+        app.component::<Rotation>().replicate_once();
+        app.local_rollback::<Rotation>()
             .add_confirmed_write()
+            .into_component_registration()
             .add_custom_hash(lightyear_avian2d::types::rotation::hash)
             .register_linear_interpolation()
             .add_linear_correction_fn();
 
-        app.register_component_once::<LinearVelocity>();
-        app.add_rollback::<LinearVelocity>().add_confirmed_write();
+        app.component::<LinearVelocity>().replicate_once();
+        app.local_rollback::<LinearVelocity>().add_confirmed_write();
 
-        app.register_component_once::<AngularVelocity>();
-        app.add_rollback::<AngularVelocity>().add_confirmed_write();
+        app.component::<AngularVelocity>().replicate_once();
+        app.local_rollback::<AngularVelocity>()
+            .add_confirmed_write();
 
         // Apply movement via a Fire observer on the action.
         app.add_observer(apply_movement);

--- a/crates/tests/src/protocol.rs
+++ b/crates/tests/src/protocol.rs
@@ -199,27 +199,31 @@ impl Plugin for ProtocolPlugin {
         })
         .add_direction(NetworkDirection::Bidirectional);
         // components
-        app.register_component::<CompA>();
-        app.register_component::<CompS>();
-        app.register_component_once::<CompReplicateOnce>();
-        app.register_component_once_with::<CompCustomReplicateOnce>(
-            serialize_custom_replicate_once,
-            deserialize_custom_replicate_once,
-        );
-        app.register_component::<CompFull>()
-            .add_prediction()
+        app.component::<CompA>().replicate();
+        app.component::<CompS>().replicate();
+        app.component::<CompReplicateOnce>().replicate_once();
+        app.component::<CompCustomReplicateOnce>()
+            .replicate_once_with(bevy_replicon::prelude::RuleFns::new(
+                serialize_custom_replicate_once,
+                deserialize_custom_replicate_once,
+            ));
+        app.component::<CompFull>()
+            .replicate()
+            .predict()
             .add_linear_interpolation();
-        app.register_component::<CompSimple>();
-        app.register_component::<CompCustomInterp>()
+        app.component::<CompSimple>().replicate();
+        app.component::<CompCustomInterp>()
+            .replicate()
             .add_custom_interpolation();
-        app.register_component::<CompOnce>();
-        app.register_component::<CompCorr>()
-            .add_prediction()
+        app.component::<CompOnce>().replicate();
+        app.component::<CompCorr>()
+            .replicate()
+            .predict()
             .add_linear_correction_fn()
             .add_linear_interpolation();
-        app.register_component::<CompMap>().add_prediction();
-        app.add_rollback::<CompNotNetworked>();
-        app.register_component::<CompDelta>();
+        app.component::<CompMap>().replicate().predict();
+        app.local_rollback::<CompNotNetworked>();
+        app.component::<CompDelta>().replicate();
         // .add_delta_compression();
         // inputs
         app.add_plugins(native::InputPlugin::<NativeInput> {
@@ -254,7 +258,7 @@ impl Plugin for ProtocolPlugin {
                 .disable::<IslandSleepingPlugin>()
                 .disable::<PhysicsInterpolationPlugin>(),
         );
-        // app.register_component::<Collider>();
+        // app.component::<Collider>().replicate();
 
         match self.avian_mode {
             AvianReplicationMode::Position => {
@@ -270,19 +274,22 @@ impl Plugin for ProtocolPlugin {
         match self.avian_mode {
             AvianReplicationMode::Position
             | AvianReplicationMode::PositionButInterpolateTransform => {
-                app.register_component::<Position>()
-                    .add_prediction()
+                app.component::<Position>()
+                    .replicate()
+                    .predict()
                     .add_linear_correction_fn()
                     .add_linear_interpolation();
 
-                app.register_component::<Rotation>()
-                    .add_prediction()
+                app.component::<Rotation>()
+                    .replicate()
+                    .predict()
                     .add_linear_correction_fn()
                     .add_linear_interpolation();
             }
             AvianReplicationMode::Transform => {
-                app.register_component::<Transform>()
-                    .add_prediction()
+                app.component::<Transform>()
+                    .replicate()
+                    .predict()
                     .add_linear_correction_fn::<Isometry2d>()
                     .add_interpolation_with(TransformLinearInterpolation::lerp);
             }

--- a/demos/spaceships/src/protocol.rs
+++ b/demos/spaceships/src/protocol.rs
@@ -170,45 +170,49 @@ impl Plugin for ProtocolPlugin {
             },
         });
 
-        app.register_component::<Player>();
+        app.component::<Player>().replicate();
 
-        app.register_component::<ColorComponent>();
+        app.component::<ColorComponent>().replicate();
 
-        app.register_component::<Name>();
+        app.component::<Name>().replicate();
 
-        app.register_component::<BallMarker>();
+        app.component::<BallMarker>().replicate();
 
-        app.register_component::<BulletMarker>();
+        app.component::<BulletMarker>().replicate();
 
-        app.register_component::<BulletLifetime>();
+        app.component::<BulletLifetime>().replicate();
 
-        app.register_component::<Score>();
+        app.component::<Score>().replicate();
 
         // Fully replicated, but not visual, so no need for lerp/corrections:
-        app.register_component::<LinearVelocity>()
-            .add_prediction()
-            .add_should_rollback(linear_velocity_should_rollback);
+        app.component::<LinearVelocity>()
+            .replicate()
+            .predict()
+            .with_rollback_condition(linear_velocity_should_rollback);
 
-        app.register_component::<AngularVelocity>()
-            .add_prediction()
-            .add_should_rollback(angular_velocity_should_rollback);
+        app.component::<AngularVelocity>()
+            .replicate()
+            .predict()
+            .with_rollback_condition(angular_velocity_should_rollback);
 
-        app.register_component::<Weapon>().add_prediction();
+        app.component::<Weapon>().replicate().predict();
 
         // Position and Rotation have a `correction_fn` set, which is used to smear rollback errors
         // over a few frames, just for the rendering part in postudpate.
         //
         // They also set `interpolation_fn` which is used by the VisualInterpolationPlugin to smooth
         // out rendering between fixedupdate ticks.
-        app.register_component::<Position>()
-            .add_prediction()
-            .add_should_rollback(position_should_rollback)
+        app.component::<Position>()
+            .replicate()
+            .predict()
+            .with_rollback_condition(position_should_rollback)
             .add_linear_interpolation()
             .add_linear_correction_fn();
 
-        app.register_component::<Rotation>()
-            .add_prediction()
-            .add_should_rollback(rotation_should_rollback)
+        app.component::<Rotation>()
+            .replicate()
+            .predict()
+            .with_rollback_condition(rotation_should_rollback)
             .add_linear_interpolation()
             .add_linear_correction_fn();
     }

--- a/examples/avian_3d_character/src/protocol.rs
+++ b/examples/avian_3d_character/src/protocol.rs
@@ -55,43 +55,47 @@ impl Plugin for ProtocolPlugin {
             },
         });
 
-        app.register_component::<ColorComponent>();
+        app.component::<ColorComponent>().replicate();
 
-        app.register_component::<Name>();
+        app.component::<Name>().replicate();
 
-        app.register_component::<CharacterMarker>();
+        app.component::<CharacterMarker>().replicate();
 
-        app.register_component::<ProjectileMarker>();
+        app.component::<ProjectileMarker>().replicate();
 
-        app.register_component::<FloorMarker>();
+        app.component::<FloorMarker>().replicate();
 
-        app.register_component::<BlockMarker>();
+        app.component::<BlockMarker>().replicate();
 
         // Fully replicated, but not visual, so no need for lerp/corrections:
-        app.register_component::<LinearVelocity>()
-            .add_prediction()
-            .add_should_rollback(linear_velocity_should_rollback);
+        app.component::<LinearVelocity>()
+            .replicate()
+            .predict()
+            .with_rollback_condition(linear_velocity_should_rollback);
 
-        app.register_component::<AngularVelocity>()
-            .add_prediction()
-            .add_should_rollback(angular_velocity_should_rollback);
+        app.component::<AngularVelocity>()
+            .replicate()
+            .predict()
+            .with_rollback_condition(angular_velocity_should_rollback);
 
-        // app.register_component::<ComputedMass>().add_prediction();
+        // app.component::<ComputedMass>().replicate().predict();
 
         // Position and Rotation have a `correction_fn` set, which is used to smear rollback errors
         // over a few frames, just for the rendering part in postudpate.
         //
         // They also set `interpolation_fn` which is used by the VisualInterpolationPlugin to smooth
         // out rendering between fixedupdate ticks.
-        app.register_component::<Position>()
-            .add_prediction()
-            .add_should_rollback(position_should_rollback)
+        app.component::<Position>()
+            .replicate()
+            .predict()
+            .with_rollback_condition(position_should_rollback)
             .add_linear_correction_fn()
             .add_linear_interpolation();
 
-        app.register_component::<Rotation>()
-            .add_prediction()
-            .add_should_rollback(rotation_should_rollback)
+        app.component::<Rotation>()
+            .replicate()
+            .predict()
+            .with_rollback_condition(rotation_should_rollback)
             .add_linear_correction_fn()
             .add_linear_interpolation();
     }

--- a/examples/avian_physics/src/protocol.rs
+++ b/examples/avian_physics/src/protocol.rs
@@ -72,29 +72,31 @@ impl Plugin for ProtocolPlugin {
         });
 
         // components
-        app.register_component::<PlayerId>();
+        app.component::<PlayerId>().replicate();
 
-        app.register_component::<ColorComponent>();
+        app.component::<ColorComponent>().replicate();
 
-        app.register_component::<BallMarker>();
+        app.component::<BallMarker>().replicate();
 
-        app.register_component::<Position>()
-            .add_prediction()
-            .add_should_rollback(position_should_rollback)
+        app.component::<Position>()
+            .replicate()
+            .predict()
+            .with_rollback_condition(position_should_rollback)
             .add_linear_interpolation()
             .add_linear_correction_fn();
 
-        app.register_component::<Rotation>()
-            .add_prediction()
-            .add_should_rollback(rotation_should_rollback)
+        app.component::<Rotation>()
+            .replicate()
+            .predict()
+            .with_rollback_condition(rotation_should_rollback)
             .add_linear_interpolation()
             .add_linear_correction_fn();
 
         // NOTE: interpolation/correction is only needed for components that are visually displayed!
         // we still need prediction to be able to correctly predict the physics on the client
-        app.register_component::<LinearVelocity>().add_prediction();
+        app.component::<LinearVelocity>().replicate().predict();
 
-        app.register_component::<AngularVelocity>().add_prediction();
+        app.component::<AngularVelocity>().replicate().predict();
     }
 }
 

--- a/examples/bevy_enhanced_inputs/src/protocol.rs
+++ b/examples/bevy_enhanced_inputs/src/protocol.rs
@@ -43,12 +43,13 @@ impl Plugin for ProtocolPlugin {
         app.register_input_action::<Movement>();
 
         // components
-        app.register_component::<PlayerId>();
+        app.component::<PlayerId>().replicate();
 
-        app.register_component::<PlayerPosition>()
-            .add_prediction()
+        app.component::<PlayerPosition>()
+            .replicate()
+            .predict()
             .add_linear_interpolation();
 
-        app.register_component::<PlayerColor>();
+        app.component::<PlayerColor>().replicate();
     }
 }

--- a/examples/client_replication/src/protocol.rs
+++ b/examples/client_replication/src/protocol.rs
@@ -66,20 +66,22 @@ impl Plugin for ProtocolPlugin {
         app.register_input_action::<DespawnPlayer>();
 
         // components
-        app.register_component::<PlayerId>();
+        app.component::<PlayerId>().replicate();
 
-        app.register_component::<Name>();
-        app.register_component::<Admin>();
-        app.register_component::<Player>();
+        app.component::<Name>().replicate();
+        app.component::<Admin>().replicate();
+        app.component::<Player>().replicate();
 
-        app.register_component::<PlayerPosition>()
-            .add_prediction()
+        app.component::<PlayerPosition>()
+            .replicate()
+            .predict()
             .add_linear_interpolation();
 
-        app.register_component::<PlayerColor>();
+        app.component::<PlayerColor>().replicate();
 
-        app.register_component::<CursorPosition>()
-            .add_prediction()
+        app.component::<CursorPosition>()
+            .replicate()
+            .predict()
             .add_linear_interpolation();
     }
 }

--- a/examples/delta_compression/src/protocol.rs
+++ b/examples/delta_compression/src/protocol.rs
@@ -136,14 +136,13 @@ impl Plugin for ProtocolPlugin {
         app.add_plugins(lightyear::prelude::input::native::InputPlugin::<Inputs>::default());
         // components
         // Use PredictionMode and InterpolationMode
-        app.register_component::<PlayerId>();
+        app.component::<PlayerId>().replicate();
 
-        app.register_component::<PlayerPosition>()
-            .add_prediction()
-            .add_linear_interpolation()
-            // NOTE: currently there is a limitation that DeltaCompression must be added AFTER prediction/interpolation
-            .add_delta_compression::<(i8, i8)>();
+        app.component::<PlayerPosition>()
+            .replicate()
+            .predict()
+            .add_linear_interpolation();
 
-        app.register_component::<PlayerColor>();
+        app.component::<PlayerColor>().replicate();
     }
 }

--- a/examples/deterministic_replication/src/protocol.rs
+++ b/examples/deterministic_replication/src/protocol.rs
@@ -99,32 +99,35 @@ impl Plugin for ProtocolPlugin {
         >();
 
         // components
-        app.register_component::<PlayerId>();
-        app.register_component::<PlayerActivationTick>();
+        app.component::<PlayerId>().replicate();
+        app.component::<PlayerActivationTick>().replicate();
         // Physics components are replicated once (initial value on entity spawn)
         // so that late-joining clients get the correct starting state.
-        // add_rollback registers PredictionHistory for rollback/checksums.
+        // local_rollback registers PredictionHistory for rollback/checksums.
         // add_confirmed_write ensures the replicated value goes to
         // PredictionHistory as confirmed state (instead of overwriting the
         // component), so input-triggered rollbacks snap to the correct value.
-        app.register_component_once::<Position>();
-        app.add_rollback::<Position>()
+        app.component::<Position>().replicate_once();
+        app.local_rollback::<Position>()
             .add_confirmed_write()
+            .into_component_registration()
             .add_custom_hash(lightyear_avian2d::types::position::hash)
             .register_linear_interpolation()
             .add_linear_correction_fn();
 
-        app.register_component_once::<Rotation>();
-        app.add_rollback::<Rotation>()
+        app.component::<Rotation>().replicate_once();
+        app.local_rollback::<Rotation>()
             .add_confirmed_write()
+            .into_component_registration()
             .add_custom_hash(lightyear_avian2d::types::rotation::hash)
             .register_linear_interpolation()
             .add_linear_correction_fn();
 
-        app.register_component_once::<LinearVelocity>();
-        app.add_rollback::<LinearVelocity>().add_confirmed_write();
+        app.component::<LinearVelocity>().replicate_once();
+        app.local_rollback::<LinearVelocity>().add_confirmed_write();
 
-        app.register_component_once::<AngularVelocity>();
-        app.add_rollback::<AngularVelocity>().add_confirmed_write();
+        app.component::<AngularVelocity>().replicate_once();
+        app.local_rollback::<AngularVelocity>()
+            .add_confirmed_write();
     }
 }

--- a/examples/distributed_authority/src/protocol.rs
+++ b/examples/distributed_authority/src/protocol.rs
@@ -85,18 +85,20 @@ impl Plugin for ProtocolPlugin {
         // inputs
         app.add_plugins(input::native::InputPlugin::<Inputs>::default());
         // components
-        app.register_component::<PlayerId>();
+        app.component::<PlayerId>().replicate();
 
-        app.register_component::<BallMarker>();
+        app.component::<BallMarker>().replicate();
 
-        app.register_component::<Position>()
-            .add_prediction()
+        app.component::<Position>()
+            .replicate()
+            .predict()
             .add_linear_interpolation();
 
-        app.register_component::<Speed>()
-            .add_prediction()
+        app.component::<Speed>()
+            .replicate()
+            .predict()
             .add_linear_interpolation();
 
-        app.register_component::<PlayerColor>();
+        app.component::<PlayerColor>().replicate();
     }
 }

--- a/examples/fps/src/protocol.rs
+++ b/examples/fps/src/protocol.rs
@@ -91,39 +91,41 @@ impl Plugin for ProtocolPlugin {
             },
         });
         // components
-        app.register_component::<Name>();
-        app.register_component::<PlayerId>();
-        app.register_component::<PlayerMarker>();
+        app.component::<Name>().replicate();
+        app.component::<PlayerId>().replicate();
+        app.component::<PlayerMarker>().replicate();
 
-        app.register_component::<Position>()
-            .add_prediction()
+        app.component::<Position>()
+            .replicate()
+            .predict()
             .add_linear_interpolation()
             // we enable correction without applying Correction on Position.
             // Instead we will apply Correction/FrameInterpolation on Transform directly.
             .enable_correction();
 
-        app.register_component::<Rotation>()
-            .add_prediction()
-            .add_linear_interpolation()
+        app.component::<Rotation>()
+            .replicate()
+            .predict()
+            .with_rollback_condition(rotation_should_rollback)
             .enable_correction()
-            .add_should_rollback(rotation_should_rollback);
+            .add_linear_interpolation();
 
         // Bullet motion is simulated by Avian from LinearVelocity. Predicted bullets need the same
         // velocity in rollback history as the server entity, otherwise replay re-simulates from stale
         // or missing physics state and repeatedly corrects bullet positions.
-        app.register_component::<LinearVelocity>().add_prediction();
+        app.component::<LinearVelocity>().replicate().predict();
 
-        app.register_component::<ColorComponent>();
+        app.component::<ColorComponent>().replicate();
 
-        app.register_component::<Score>();
+        app.component::<Score>().replicate();
 
-        app.register_component::<RigidBody>();
+        app.component::<RigidBody>().replicate();
 
-        app.register_component::<BulletMarker>();
+        app.component::<BulletMarker>().replicate();
 
-        app.register_component::<PredictedBot>();
+        app.component::<PredictedBot>().replicate();
 
-        app.register_component::<InterpolatedBot>();
+        app.component::<InterpolatedBot>().replicate();
     }
 }
 

--- a/examples/lobby/src/protocol.rs
+++ b/examples/lobby/src/protocol.rs
@@ -179,16 +179,17 @@ impl Plugin for ProtocolPlugin {
         // inputs
         app.add_plugins(InputPlugin::<Inputs>::default());
         // components
-        app.register_component::<Name>();
-        app.register_component::<PlayerId>();
+        app.component::<Name>().replicate();
+        app.component::<PlayerId>().replicate();
 
-        app.register_component::<PlayerPosition>()
-            .add_prediction()
+        app.component::<PlayerPosition>()
+            .replicate()
+            .predict()
             .add_linear_interpolation();
 
-        app.register_component::<PlayerColor>();
+        app.component::<PlayerColor>().replicate();
 
-        app.register_component::<Lobbies>();
+        app.component::<Lobbies>().replicate();
 
         // channels
         app.add_channel::<Channel1>(ChannelSettings {

--- a/examples/network_visibility/src/protocol.rs
+++ b/examples/network_visibility/src/protocol.rs
@@ -56,12 +56,13 @@ impl Plugin for ProtocolPlugin {
         // inputs
         app.add_plugins(InputPlugin::<Inputs>::default());
         // components
-        app.register_component::<PlayerId>();
+        app.component::<PlayerId>().replicate();
 
-        app.register_component::<Position>()
-            .add_prediction()
+        app.component::<Position>()
+            .replicate()
+            .predict()
             .add_linear_interpolation();
-        app.register_component::<PlayerColor>();
-        app.register_component::<CircleMarker>();
+        app.component::<PlayerColor>().replicate();
+        app.component::<CircleMarker>().replicate();
     }
 }

--- a/examples/priority/src/protocol.rs
+++ b/examples/priority/src/protocol.rs
@@ -64,14 +64,15 @@ impl Plugin for ProtocolPlugin {
         // inputs
         app.add_plugins(InputPlugin::<Inputs>::default());
         // components
-        app.register_component::<PlayerId>();
+        app.component::<PlayerId>().replicate();
 
-        app.register_component::<Position>()
-            .add_prediction()
+        app.component::<Position>()
+            .replicate()
+            .predict()
             .add_linear_interpolation();
 
-        app.register_component::<PlayerColor>();
+        app.component::<PlayerColor>().replicate();
 
-        app.register_component::<Shape>();
+        app.component::<Shape>().replicate();
     }
 }

--- a/examples/projectiles/src/protocol.rs
+++ b/examples/projectiles/src/protocol.rs
@@ -349,34 +349,37 @@ impl Plugin for ProtocolPlugin {
             .add_direction(NetworkDirection::ClientToServer);
 
         // components
-        app.register_component::<Name>();
-        app.register_component::<PlayerId>();
-        app.register_component::<PlayerMarker>();
+        app.component::<Name>().replicate();
+        app.component::<PlayerId>().replicate();
+        app.component::<PlayerMarker>().replicate();
 
-        app.register_component::<Position>()
-            .add_prediction()
-            .add_should_rollback(position_should_rollback)
+        app.component::<Position>()
+            .replicate()
+            .predict()
+            .with_rollback_condition(position_should_rollback)
             .add_linear_interpolation()
             .add_linear_correction_fn();
 
-        app.register_component::<Rotation>()
-            .add_prediction()
-            .add_should_rollback(rotation_should_rollback)
+        app.component::<Rotation>()
+            .replicate()
+            .predict()
+            .with_rollback_condition(rotation_should_rollback)
             .add_linear_interpolation()
             .add_linear_correction_fn();
 
-        app.register_component::<LinearVelocity>()
-            .add_prediction()
-            .add_should_rollback(linear_velocity_should_rollback);
+        app.component::<LinearVelocity>()
+            .replicate()
+            .predict()
+            .with_rollback_condition(linear_velocity_should_rollback);
 
-        app.register_component::<ColorComponent>();
+        app.component::<ColorComponent>().replicate();
 
-        app.register_component::<Score>();
+        app.component::<Score>().replicate();
 
         // we replicate HitscanVisual for the AllInterpolation mode
         // make sure that we have an Interpolated HitscanVisual entity since we only render entities
         // that are interpolated or predicted
-        app.register_component::<HitscanVisual>();
+        app.component::<HitscanVisual>().replicate();
 
         // We do not need to replicate RigidBody:
         // - for interpolated entities, we just interpolate between Position updates
@@ -384,40 +387,39 @@ impl Plugin for ProtocolPlugin {
         // The issue we want to avoid is that we don't want RigidBody to be included on Interpolated
         // entities because that means that we would be doing expensive simulation work on interpolated
         // entities.
-        app.register_component::<RigidBody>();
+        app.component::<RigidBody>().replicate();
 
-        app.register_component::<BulletMarker>();
+        app.component::<BulletMarker>().replicate();
 
-        app.register_component::<Bot>();
+        app.component::<Bot>().replicate();
 
-        app.register_component::<Score>();
+        app.component::<Score>().replicate();
 
-        app.register_component::<PredictedBot>();
+        app.component::<PredictedBot>().replicate();
 
-        app.register_component::<InterpolatedBot>();
+        app.component::<InterpolatedBot>().replicate();
 
         // Register new weapon and projectile components
-        app.register_component::<WeaponType>();
+        app.component::<WeaponType>().replicate();
 
-        app.register_component::<Weapon>().add_prediction();
+        app.component::<Weapon>().replicate().predict();
 
-        app.register_component::<ProjectileReplicationMode>();
+        app.component::<ProjectileReplicationMode>().replicate();
 
-        app.register_component::<GameReplicationMode>();
+        app.component::<GameReplicationMode>().replicate();
 
-        app.register_component::<PlayerRoom>();
+        app.component::<PlayerRoom>().replicate();
 
-        app.register_component::<PhysicsProjectile>()
-            .add_prediction();
+        app.component::<PhysicsProjectile>().replicate().predict();
 
-        app.register_component::<HomingMissile>().add_prediction();
+        app.component::<HomingMissile>().replicate().predict();
 
-        app.register_component::<ShotgunPellet>();
+        app.component::<ShotgunPellet>().replicate();
 
-        app.register_component::<ProjectileSpawn>();
+        app.component::<ProjectileSpawn>().replicate();
 
         // Make sure that we rollback the DespawnAfter timer in deterministic replication mode
-        app.add_rollback::<DespawnAfter>();
+        app.local_rollback::<DespawnAfter>();
     }
 }
 

--- a/examples/replication_groups/src/protocol.rs
+++ b/examples/replication_groups/src/protocol.rs
@@ -235,11 +235,12 @@ impl Plugin for ProtocolPlugin {
         // inputs
         app.add_plugins(InputPlugin::<Inputs>::default());
         // components
-        app.register_component::<Name>();
-        app.register_component::<PlayerId>();
+        app.component::<Name>().replicate();
+        app.component::<PlayerId>().replicate();
 
-        app.register_component::<PlayerPosition>()
-            .add_prediction()
+        app.component::<PlayerPosition>()
+            .replicate()
+            .predict()
             // NOTE: notice that we use custom interpolation here, this means that we don't run
             //  the interpolation function for this component, so we need to implement our own interpolation system
             //  (we do this because our interpolation system queries multiple components at once)
@@ -247,18 +248,19 @@ impl Plugin for ProtocolPlugin {
             // we still register an interpolation function which will be used for frame interpolation
             .add_linear_interpolation();
 
-        app.register_component::<PlayerColor>();
+        app.component::<PlayerColor>().replicate();
 
-        app.register_component::<TailPoints>()
-            .add_prediction()
+        app.component::<TailPoints>()
+            .replicate()
+            .predict()
             // NOTE: notice that we use custom interpolation here, this means that we don't run
             //  the interpolation function for this component, so we need to implement our own interpolation system
             //  (we do this because our interpolation system queries multiple components at once)
             .add_custom_interpolation();
         // we do not register an interpolation function because we will use a custom interpolation system
 
-        app.register_component::<TailLength>();
+        app.component::<TailLength>().replicate();
 
-        app.register_component::<PlayerParent>();
+        app.component::<PlayerParent>().replicate();
     }
 }

--- a/examples/simple_box/src/protocol.rs
+++ b/examples/simple_box/src/protocol.rs
@@ -119,13 +119,14 @@ impl Plugin for ProtocolPlugin {
         // inputs
         app.add_plugins(input::native::InputPlugin::<Inputs>::default());
         // components
-        app.register_component::<PlayerId>();
+        app.component::<PlayerId>().replicate();
 
-        app.register_component::<PlayerPosition>()
-            .add_prediction()
+        app.component::<PlayerPosition>()
+            .replicate()
+            .predict()
             .add_linear_interpolation();
 
-        app.register_component::<PlayerColor>();
+        app.component::<PlayerColor>().replicate();
 
         // channels
         app.add_channel::<Channel1>(ChannelSettings {


### PR DESCRIPTION
The registration API was confusing in multiple ways:
- unclear naming (add_rollback had to be used in the non-networked case)
- no checks for incompatible API calls (replicate_diff + predict instead of predict_diff)
- possible to call `add_correction` without having enabled prediction
- only support a few of the replicon replication APIs

This PR streamlines the registration process by fixing all the issues above.