### PR TITLE
fix(prediction): only remove component on explicit ConfirmedState::Removed

### DIFF
--- a/crates/replication/prediction/src/rollback.rs
+++ b/crates/replication/prediction/src/rollback.rs
@@ -31,7 +31,7 @@ We need:
 
  */
 
-use super::predicted_history::PredictionHistory;
+use super::predicted_history::{PredictionHistory, PredictionState};
 use super::resource_history::ResourceHistory;
 use super::{Predicted, SyncComponent};
 use crate::correction::PreviousVisual;
@@ -59,7 +59,7 @@ use core::fmt::Debug;
 use lightyear_connection::client::{Client, Connected};
 use lightyear_connection::host::HostClient;
 use lightyear_core::history_buffer::HistoryState;
-use lightyear_core::prelude::{ConfirmedHistory, LocalTimeline};
+use lightyear_core::prelude::{ConfirmedHistory, ConfirmedState, LocalTimeline};
 use lightyear_core::tick::Tick;
 use lightyear_core::timeline::{Rollback, is_in_rollback};
 use lightyear_frame_interpolation::FrameInterpolationSystems;
@@ -940,7 +940,7 @@ pub(crate) fn prepare_rollback<C: SyncComponent>(
             is_state_rollback && server_confirmed_tick == Some(rollback_tick);
         let is_forced_state_rollback = is_state_rollback && !is_completed_state_rollback;
 
-        let confirmed_restore = if is_state_rollback {
+        let restore_state = if is_state_rollback {
             confirmed_history.as_ref().and_then(|history| {
                 // Completed state rollbacks restore from the latest globally completed
                 // mutate tick. That completed tick proves that a component without an
@@ -960,17 +960,15 @@ pub(crate) fn prepare_rollback<C: SyncComponent>(
                 history.get_state_at_or_before(rollback_tick).cloned()
             })
         } else {
-            None
-        };
-
-        let restore_value = if let Some(confirmed_restore) = confirmed_restore {
-            confirmed_restore.into_value()
-        } else {
             // Input rollbacks restore from predicted history. State rollbacks
-            // only reach this fallback for components without an authoritative
-            // sample at `rollback_tick` (for example non-networked predicted
-            // components, or components with no confirmed state yet).
-            predicted_history.get(rollback_tick).cloned()
+            // use confirmed history instead.
+            predicted_history
+                .get_state(rollback_tick)
+                .cloned()
+                .map(|state| match state {
+                    PredictionState::Removed => ConfirmedState::Removed,
+                    PredictionState::Predicted(value) => ConfirmedState::Confirmed(value),
+                })
         };
         // Keep the prediction history anchored at the actual rollback target.
         // For completed state rollbacks this is the completed mutate tick; for
@@ -989,7 +987,7 @@ pub(crate) fn prepare_rollback<C: SyncComponent>(
             rollback_tick = rollback_tick.0,
             confirmed_tick = server_confirmed_tick.map(|tick| tick.0),
             rollback = ?rollback,
-            restore_value = ?restore_value,
+            restore_state = ?restore_state,
             history_len = predicted_history.len(),
             "prepared component rollback"
         );
@@ -997,14 +995,24 @@ pub(crate) fn prepare_rollback<C: SyncComponent>(
         let mut entity_mut = commands.entity(entity);
 
         // Update the component to the value at rollback_tick
-        match restore_value {
-            // No value exists at rollback_tick, or component was removed
-            None => {
+        match restore_state {
+            // No state exists at rollback_tick. This is not an explicit
+            // removal, so leave the current component value in place.
+            None if is_state_rollback => {
+                trace!(
+                    ?entity,
+                    ?kind,
+                    ?rollback_tick,
+                    "No history entry for component at rollback tick; leaving current value in place"
+                );
+            }
+            // An explicit removal means the component was authoritatively removed at rollback_tick.
+            Some(ConfirmedState::Removed) => {
                 entity_mut.try_remove::<C>();
                 trace!("Removing component from predicted entity for rollback");
             }
             // Value exists at rollback_tick (either predicted or confirmed)
-            Some(correct) => {
+            Some(ConfirmedState::Confirmed(correct)) => {
                 match predicted_component {
                     None => {
                         debug!("Re-adding deleted component to predicted");
@@ -1301,4 +1309,45 @@ pub enum RollbackState {
     ///
     /// i.e. the predicted component values will be reverted to this tick, and we will start running FixedUpdate from the next tick
     RollbackStart(Tick),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bevy_ecs::system::RunSystemOnce;
+
+    #[derive(Component, Clone, PartialEq, Debug)]
+    struct TestComponent(f32);
+
+    /// Test that rollback does not remove a predicted component
+    /// when the rollback tick predates the first retained history entry.
+    #[test]
+    fn test_predicted_component_initial_rollback() {
+        let rollback_tick = Tick(10);
+        let mut world = World::new();
+        world.init_resource::<LocalTimeline>();
+        world.init_resource::<PredictionRegistry>();
+        world.init_resource::<ReplicationCheckpointMap>();
+
+        let manager = world
+            .spawn((PredictionManager::default(), Rollback::FromState))
+            .id();
+        world
+            .get_mut::<PredictionManager>(manager)
+            .unwrap()
+            .set_rollback_tick(rollback_tick);
+
+        let mut history = PredictionHistory::<TestComponent>::default();
+        history.add_predicted(rollback_tick + 5, Some(TestComponent(1.0)));
+        let predicted = world.spawn((Predicted, TestComponent(1.0), history)).id();
+
+        world
+            .run_system_once(prepare_rollback::<TestComponent>)
+            .unwrap();
+
+        assert_eq!(
+            world.get::<TestComponent>(predicted),
+            Some(&TestComponent(1.0))
+        );
+    }
 }

--- a/crates/tests/src/client_server/prediction/rollback.rs
+++ b/crates/tests/src/client_server/prediction/rollback.rs
@@ -88,13 +88,14 @@ fn observe_rollback_start(app: &mut App) {
 }
 
 // =============================================================================
-// Scenario 1: Component predicted-inserted but not from replication → removed on rollback
+// Scenario 1: Non-networked component without confirmed state is not removed on state rollback
 // =============================================================================
 
-/// Client prediction adds a component, but server never has it.
-/// On rollback, the component should be removed.
+/// Client prediction adds a non-networked component.
+/// On state rollback, missing confirmed state should not be treated as
+/// authoritative removal.
 #[test]
-fn test_predicted_insert_reverted_on_rollback() {
+fn test_non_networked_insert_kept_on_state_rollback_without_confirmed_history() {
     let (mut stepper, predicted) = setup();
 
     stepper.frame_step(1);
@@ -119,14 +120,14 @@ fn test_predicted_insert_reverted_on_rollback() {
     trigger_rollback_check(&mut stepper, rollback_tick);
     stepper.frame_step(1);
 
-    // CompNotNetworked should be removed: it wasn't in the history at rollback_tick
+    // CompNotNetworked should remain: there was no authoritative removal.
     assert!(
         stepper
             .client_app()
             .world()
             .get::<CompNotNetworked>(predicted)
-            .is_none(),
-        "Predicted-inserted component should be removed on rollback"
+            .is_some(),
+        "State rollback should not remove a component only because it has no confirmed history"
     );
 }
 
@@ -954,6 +955,47 @@ fn test_remote_remove_applied_on_rollback() {
             .get::<CompFull>(predicted)
             .is_none(),
         "Remotely-removed component should be absent after rollback"
+    );
+}
+
+/// If a predicted component has no history sample at-or-before the rollback
+/// tick, rollback should not treat that absence as an authoritative removal.
+#[test]
+fn test_predicted_component_kept_when_no_history_sample_at_rollback_tick() {
+    let (mut stepper, predicted) = setup();
+
+    stepper.frame_step(3);
+    let tick = stepper.client_tick(0);
+
+    assert!(
+        stepper
+            .client_app()
+            .world()
+            .get::<CompFull>(predicted)
+            .is_some(),
+        "precondition: component is present before the rollback"
+    );
+
+    {
+        let world = stepper.client_app().world_mut();
+        let mut history = world
+            .get_mut::<PredictionHistory<CompFull>>(predicted)
+            .expect("prediction history exists for predicted component");
+        history.clear();
+        history.add_predicted(tick + 5, Some(CompFull(1.0)));
+    }
+
+    let rollback_tick = tick - 2;
+    trigger_state_rollback(&mut stepper, rollback_tick);
+    stepper.frame_step(1);
+
+    assert!(
+        stepper
+            .client_app()
+            .world()
+            .get::<CompFull>(predicted)
+            .is_some(),
+        "present predicted component should not be removed when no history sample exists at-or-before the rollback tick"
     );
 }
 


### PR DESCRIPTION
Fixes https://github.com/cBournhonesque/lightyear/issues/1511