### PR TITLE
Compute RTT estimate on every packet

### DIFF
--- a/crates/core/sync/src/ping/diagnostics.rs
+++ b/crates/core/sync/src/ping/diagnostics.rs
@@ -35,11 +35,18 @@ impl PingDiagnosticsPlugin {
     pub const PONGS_RECEIVED: DiagnosticPath =
         DiagnosticPath::const_new("ping.pong_received_count");
 
+    /// Number of RTT samples received from pongs or packet acknowledgements.
+    pub const LATENCY_SAMPLES_RECEIVED: DiagnosticPath =
+        DiagnosticPath::const_new("ping.latency_sample_count");
+
     pub(crate) fn add_measurements(manager: &PingManager, mut diagnostics: Diagnostics) {
         diagnostics.add_measurement(&Self::JITTER, || manager.jitter().as_secs_f64() * 1000.0);
         diagnostics.add_measurement(&Self::RTT, || manager.rtt().as_secs_f64() * 1000.0);
         diagnostics.add_measurement(&Self::PINGS_SENT, || manager.pings_sent as f64);
         diagnostics.add_measurement(&Self::PONGS_RECEIVED, || manager.pongs_recv as f64);
+        diagnostics.add_measurement(&Self::LATENCY_SAMPLES_RECEIVED, || {
+            manager.latency_samples_recv() as f64
+        });
     }
 }
 
@@ -62,6 +69,11 @@ impl Plugin for PingDiagnosticsPlugin {
         );
         app.register_diagnostic(
             Diagnostic::new(Self::PONGS_RECEIVED)
+                .with_suffix("")
+                .with_max_history_length(self.history_len),
+        );
+        app.register_diagnostic(
+            Diagnostic::new(Self::LATENCY_SAMPLES_RECEIVED)
                 .with_suffix("")
                 .with_max_history_length(self.history_len),
         );

--- a/crates/core/sync/src/ping/manager.rs
+++ b/crates/core/sync/src/ping/manager.rs
@@ -45,13 +45,14 @@ pub struct PingManager {
     /// (when the connection's send_timer is ready)
     pongs_to_send: Vec<(Pong, Instant)>,
 
-    // TODO: we could actually compute stats from every single packet, not just pings/pongs
-    /// Estimator used to compute RTT/Jitter from the pongs received
+    /// Estimator used to compute RTT/Jitter from pongs and packet acknowledgements.
     pub rtt_estimator_ewma: RttEstimatorEwma,
     /// The number of pings we have sent
     pub(crate) pings_sent: u32,
     /// The number of pongs we have received
     pub pongs_recv: u32,
+    /// The number of latency samples received from pongs or packet acknowledgements.
+    latency_samples_recv: u32,
 }
 
 impl Default for PingManager {
@@ -65,6 +66,7 @@ impl Default for PingManager {
             rtt_estimator_ewma: RttEstimatorEwma::default(),
             pings_sent: 0,
             pongs_recv: 0,
+            latency_samples_recv: 0,
         }
     }
 }
@@ -78,6 +80,7 @@ impl PingManager {
         self.rtt_estimator_ewma.reset();
         self.pings_sent = 0;
         self.pongs_recv = 0;
+        self.latency_samples_recv = 0;
     }
 }
 
@@ -94,6 +97,7 @@ impl PingManager {
             rtt_estimator_ewma: RttEstimatorEwma::default(),
             pings_sent: 0,
             pongs_recv: 0,
+            latency_samples_recv: 0,
         }
     }
 
@@ -107,9 +111,35 @@ impl PingManager {
         self.rtt_estimator_ewma.final_stats.jitter
     }
 
+    /// Return the number of RTT samples used to estimate latency.
+    pub fn latency_samples_recv(&self) -> u32 {
+        self.latency_samples_recv
+    }
+
     /// Update the ping manager after a delta update
     pub(crate) fn update(&mut self, time: &Time<Real>) {
         self.ping_timer.tick(time.delta());
+    }
+
+    fn record_rtt_sample(&mut self, rtt_sample: Duration) {
+        self.latency_samples_recv += 1;
+        self.rtt_estimator_ewma.update_with_new_sample(rtt_sample);
+    }
+
+    /// Process an RTT sample measured from an ordinary packet acknowledgement.
+    pub fn process_packet_rtt_sample(&mut self, rtt_sample: Duration) {
+        self.record_rtt_sample(rtt_sample);
+        trace!(
+            target: "lightyear_debug::sync",
+            kind = "packet_ack_rtt_sample",
+            schedule = "PreUpdate",
+            sample_point = "PreUpdate",
+            rtt_sample_ms = rtt_sample.as_secs_f64() * 1000.0,
+            latency_samples_recv = self.latency_samples_recv,
+            estimated_rtt_ms = self.rtt().as_secs_f64() * 1000.0,
+            jitter_ms = self.jitter().as_secs_f64() * 1000.0,
+            "processed packet ack RTT sample"
+        );
     }
 
     /// Check if we are ready to send a ping to the remote
@@ -160,8 +190,7 @@ impl PingManager {
             let round_trip_delay = rtt.saturating_sub(server_process_time);
 
             // recompute stats whenever we get a new pong
-            self.rtt_estimator_ewma
-                .update_with_new_sample(round_trip_delay);
+            self.record_rtt_sample(round_trip_delay);
             trace!(
                 target: "lightyear_debug::sync",
                 kind = "pong_recv",
@@ -169,6 +198,7 @@ impl PingManager {
                 sample_point = "PreUpdate",
                 ping_id = pong.ping_id.0,
                 pongs_recv = self.pongs_recv,
+                latency_samples_recv = self.latency_samples_recv,
                 rtt_ms = rtt.as_secs_f64() * 1000.0,
                 server_process_ms = server_process_time.as_secs_f64() * 1000.0,
                 round_trip_delay_ms = round_trip_delay.as_secs_f64() * 1000.0,
@@ -208,6 +238,22 @@ impl PingManager {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+
+    #[test]
+    fn packet_ack_rtt_samples_update_latency_stats_without_pongs() {
+        let mut ping_manager = PingManager::default();
+
+        ping_manager.process_packet_rtt_sample(Duration::from_millis(50));
+
+        assert_eq!(ping_manager.pongs_recv, 0);
+        assert_eq!(ping_manager.latency_samples_recv(), 1);
+        assert_eq!(ping_manager.rtt(), Duration::from_millis(50));
+        assert_eq!(
+            ping_manager.jitter(),
+            Duration::from_millis(12) + Duration::from_micros(500)
+        );
+    }
 
     // #[test]
     // fn test_send_pings() {

--- a/crates/core/sync/src/ping/plugin.rs
+++ b/crates/core/sync/src/ping/plugin.rs
@@ -16,6 +16,7 @@ use lightyear_messages::plugin::MessageSystems;
 use lightyear_messages::prelude::AppMessageExt;
 use lightyear_messages::receive::MessageReceiver;
 use lightyear_messages::send::MessageSender;
+use lightyear_transport::plugin::PacketAcked;
 use lightyear_transport::prelude::{AppChannelExt, ChannelMode, ChannelSettings};
 #[allow(unused_imports)]
 use tracing::{info, trace};
@@ -139,6 +140,12 @@ impl PingPlugin {
             manager.reset();
         }
     }
+
+    pub(crate) fn process_packet_ack(trigger: On<PacketAcked>, mut query: Query<&mut PingManager>) {
+        if let Ok(mut manager) = query.get_mut(trigger.entity) {
+            manager.process_packet_rtt_sample(trigger.rtt_sample);
+        }
+    }
 }
 
 impl Plugin for PingPlugin {
@@ -182,5 +189,6 @@ impl Plugin for PingPlugin {
         app.add_systems(PostUpdate, Self::send.in_set(PingSystems::Send));
 
         app.add_observer(Self::handle_connect);
+        app.add_observer(Self::process_packet_ack);
     }
 }

--- a/crates/core/sync/src/timeline/input.rs
+++ b/crates/core/sync/src/timeline/input.rs
@@ -345,7 +345,7 @@ impl SyncedTimeline for InputTimeline {
         tick_duration: Duration,
     ) -> Option<i32> {
         // skip syncing if we haven't received enough information
-        if ping_manager.pongs_recv < config.sync.handshake_pings as u32 {
+        if ping_manager.latency_samples_recv() < config.sync.handshake_pings as u32 {
             return None;
         }
         let now = self.now();

--- a/crates/core/sync/src/timeline/remote.rs
+++ b/crates/core/sync/src/timeline/remote.rs
@@ -112,16 +112,16 @@ impl RemoteTimeline {
         ping_manager: &PingManager,
         tick_duration: Duration,
     ) {
-        if ping_manager.pongs_recv < self.handshake_pings {
+        if ping_manager.latency_samples_recv() < self.handshake_pings {
             trace!(
                 target: "lightyear_debug::sync",
-                kind = "remote_estimate_waiting_for_handshake",
+                kind = "remote_estimate_waiting_for_latency_samples",
                 schedule = "PreUpdate",
                 sample_point = "PreUpdate",
                 remote_tick = remote_tick.0,
-                pongs_recv = ping_manager.pongs_recv,
-                handshake_pings = self.handshake_pings,
-                "remote timeline estimate skipped until handshake pongs are available"
+                latency_samples_recv = ping_manager.latency_samples_recv(),
+                required_latency_samples = self.handshake_pings,
+                "remote timeline estimate skipped until latency samples are available"
             );
             return;
         }

--- a/crates/replication/interpolation/src/timeline.rs
+++ b/crates/replication/interpolation/src/timeline.rs
@@ -135,7 +135,7 @@ impl SyncedTimeline for InterpolationTimeline {
         tick_duration: Duration,
     ) -> Option<i32> {
         // skip syncing if we haven't received enough information
-        if ping_manager.pongs_recv < config.sync.handshake_pings as u32 {
+        if ping_manager.latency_samples_recv() < config.sync.handshake_pings as u32 {
             return None;
         }
         // TODO: should we call current_estimate()? now() should basically return the same thing

--- a/crates/tests/src/timeline/sync_tests.rs
+++ b/crates/tests/src/timeline/sync_tests.rs
@@ -73,6 +73,25 @@ fn input_timeline_initial_sync_resyncs_to_objective() {
 }
 
 #[test_log::test]
+fn input_timeline_sync_uses_packet_latency_samples_without_pongs() {
+    let remote = remote_timeline_at(100);
+    let mut ping_manager = PingManager::default();
+    ping_manager.process_packet_rtt_sample(Duration::ZERO);
+    let config = InputTimelineConfig::default().with_sync_config(SyncConfig {
+        handshake_pings: 1,
+        ..Default::default()
+    });
+    let mut timeline = InputTimeline::default();
+
+    let tick_delta = timeline.sync(&remote, &config, &ping_manager, TICK_DURATION);
+
+    assert_eq!(ping_manager.pongs_recv, 0);
+    assert_eq!(ping_manager.latency_samples_recv(), 1);
+    assert_eq!(tick_delta, Some(103));
+    assert!(timeline.is_synced());
+}
+
+#[test_log::test]
 fn input_timeline_adjusts_speed_after_repeated_error() {
     let remote = remote_timeline_at(100);
     let ping_manager = ping_manager(Duration::ZERO, Duration::ZERO);

--- a/crates/transport/transport/src/packet/header.rs
+++ b/crates/transport/transport/src/packet/header.rs
@@ -1,7 +1,7 @@
 use alloc::{vec, vec::Vec};
 use bevy_platform::hash::FixedHasher;
 use core::time::Duration;
-use indexmap::{IndexMap, IndexSet};
+use indexmap::IndexMap;
 use ringbuffer::{ConstGenericRingBuffer, RingBuffer};
 #[allow(unused_imports)]
 use tracing::{info, trace};
@@ -112,7 +112,7 @@ pub struct PacketHeaderManager {
     sent_packets_not_acked: IndexMap<PacketId, Duration, FixedHasher>,
     stats_manager: PacketStatsManager,
     pub(crate) lost_packets: Vec<PacketId>,
-    pub(crate) newly_acked_packets: IndexSet<PacketId, FixedHasher>,
+    pub(crate) newly_acked_packets: IndexMap<PacketId, Duration, FixedHasher>,
 
     // keep track of the packets that were received (last packet received and the
     // `ACK_BITFIELD_SIZE` packets before that)
@@ -137,7 +137,7 @@ impl PacketHeaderManager {
             stats_manager: PacketStatsManager::default(),
             sent_packets_not_acked: IndexMap::default(),
             lost_packets: vec![],
-            newly_acked_packets: IndexSet::default(),
+            newly_acked_packets: IndexMap::default(),
             recv_buffer: ReceiveBuffer::new(),
             nack_rtt_multiple,
         }
@@ -169,41 +169,58 @@ impl PacketHeaderManager {
     /// Process the header of a received packet (update ack metadata)
     ///
     /// Returns the list of packets that have been newly acked by the remote
-    pub(crate) fn process_recv_packet_header(&mut self, header: &PacketHeader) {
+    pub(crate) fn process_recv_packet_header(
+        &mut self,
+        header: &PacketHeader,
+        real: Duration,
+    ) -> Vec<(PacketId, Duration)> {
+        let mut newly_acked_packets = vec![];
         // update the receive buffer
         self.stats_manager.received_packet();
         self.recv_buffer.recv_packet(header.packet_id);
 
         // read the ack information (ack id + ack bitfield) from the received header, and update
         // the list of our sent packets that have not been acked yet
-        if let Some(packet) = self.update_sent_packets_not_acked(&header.last_ack_packet_id) {
-            self.stats_manager.sent_packet_acked();
-            self.newly_acked_packets.insert(packet);
+        if let Some((packet, time_sent)) =
+            self.update_sent_packets_not_acked(&header.last_ack_packet_id)
+        {
+            self.record_newly_acked_packet(packet, real, time_sent, &mut newly_acked_packets);
         }
         for i in 1..=ACK_BITFIELD_SIZE {
             let packet_id = PacketId(header.last_ack_packet_id.wrapping_sub(i as u32));
             if header.get_bitfield_bit(i - 1)
-                && let Some(packet) = self.update_sent_packets_not_acked(&packet_id)
+                && let Some((packet, time_sent)) = self.update_sent_packets_not_acked(&packet_id)
             {
-                self.stats_manager.sent_packet_acked();
-                self.newly_acked_packets.insert(packet);
+                self.record_newly_acked_packet(packet, real, time_sent, &mut newly_acked_packets);
             }
         }
+        newly_acked_packets
+    }
+
+    fn record_newly_acked_packet(
+        &mut self,
+        packet: PacketId,
+        real: Duration,
+        time_sent: Duration,
+        newly_acked_packets: &mut Vec<(PacketId, Duration)>,
+    ) {
+        self.stats_manager.sent_packet_acked();
+        let rtt_sample = real.saturating_sub(time_sent);
+        self.newly_acked_packets.insert(packet, rtt_sample);
+        newly_acked_packets.push((packet, rtt_sample));
     }
 
     /// Update the list of sent packets that have not been acked yet
     /// when we receive confirmation that packet_id was delivered
     ///
     /// Also potentially notify the channels/etc. that the packet was delivered.
-    fn update_sent_packets_not_acked(&mut self, packet_id: &PacketId) -> Option<PacketId> {
+    fn update_sent_packets_not_acked(
+        &mut self,
+        packet_id: &PacketId,
+    ) -> Option<(PacketId, Duration)> {
         if self.sent_packets_not_acked.contains_key(packet_id) {
-            // TODO: make this non-blocking, but keep trying until it works?
-            // notify that one of the packets we sent got acked
-            // TODO: important to compute RTT
-            // self.ack_notification_sender.send(*packet_id)?;
-
-            self.sent_packets_not_acked.swap_remove(packet_id);
-            return Some(*packet_id);
+            let time_sent = self.sent_packets_not_acked.swap_remove(packet_id)?;
+            return Some((*packet_id, time_sent));
         }
         None
     }
@@ -324,9 +341,10 @@ impl ReceiveBuffer {
     }
 }
 
-// TODO: add test for notification of packet delivered
 #[cfg(test)]
 mod tests {
+    use alloc::vec;
+    use core::time::Duration;
     use lightyear_serde::ToBytes;
 
     use super::*;
@@ -399,5 +417,69 @@ mod tests {
         let read_header = PacketHeader::from_bytes(&mut reader)?;
         assert_eq!(header, read_header);
         Ok(())
+    }
+
+    #[test]
+    fn packet_ack_produces_rtt_sample_from_latest_ack() {
+        let mut sender = PacketHeaderManager::new(1.5);
+        let mut receiver = PacketHeaderManager::new(1.5);
+
+        let sent_header =
+            sender.prepare_send_packet_header(PacketType::Data, Duration::from_millis(10), Tick(1));
+        assert!(
+            receiver
+                .process_recv_packet_header(&sent_header, Duration::from_millis(25))
+                .is_empty()
+        );
+
+        let ack_header = receiver.prepare_send_packet_header(
+            PacketType::Data,
+            Duration::from_millis(25),
+            Tick(2),
+        );
+        let acked_packets =
+            sender.process_recv_packet_header(&ack_header, Duration::from_millis(60));
+
+        assert_eq!(
+            acked_packets,
+            vec![(PacketId(0), Duration::from_millis(50))]
+        );
+        assert_eq!(
+            sender.newly_acked_packets.get(&PacketId(0)),
+            Some(&Duration::from_millis(50))
+        );
+    }
+
+    #[test]
+    fn packet_ack_bitfield_produces_rtt_samples_for_older_packets() {
+        let mut sender = PacketHeaderManager::new(1.5);
+        let mut receiver = PacketHeaderManager::new(1.5);
+
+        let sent_0 =
+            sender.prepare_send_packet_header(PacketType::Data, Duration::from_millis(10), Tick(1));
+        let _sent_1 =
+            sender.prepare_send_packet_header(PacketType::Data, Duration::from_millis(20), Tick(2));
+        let sent_2 =
+            sender.prepare_send_packet_header(PacketType::Data, Duration::from_millis(30), Tick(3));
+
+        receiver.process_recv_packet_header(&sent_0, Duration::from_millis(15));
+        receiver.process_recv_packet_header(&sent_2, Duration::from_millis(35));
+
+        let ack_header = receiver.prepare_send_packet_header(
+            PacketType::Data,
+            Duration::from_millis(40),
+            Tick(4),
+        );
+        let acked_packets =
+            sender.process_recv_packet_header(&ack_header, Duration::from_millis(80));
+
+        assert_eq!(
+            acked_packets,
+            vec![
+                (PacketId(2), Duration::from_millis(50)),
+                (PacketId(0), Duration::from_millis(70)),
+            ]
+        );
+        assert!(!sender.newly_acked_packets.contains_key(&PacketId(1)));
     }
 }

--- a/crates/transport/transport/src/plugin.rs
+++ b/crates/transport/transport/src/plugin.rs
@@ -18,6 +18,7 @@ use bevy_time::{Real, Time};
 #[cfg(feature = "test_utils")]
 use bevy_utils::default;
 use bytes::Bytes;
+use core::time::Duration;
 use lightyear_connection::host::HostClient;
 #[cfg(any(feature = "client", feature = "server"))]
 use lightyear_connection::prelude::Disconnected;
@@ -50,6 +51,14 @@ pub enum TransportSystems {
 pub struct PacketReceived {
     pub entity: Entity,
     pub remote_tick: Tick,
+}
+
+/// Event triggered on a [`Transport`] entity when a sent packet is acknowledged.
+#[derive(EntityEvent)]
+pub struct PacketAcked {
+    pub entity: Entity,
+    pub packet_id: u32,
+    pub rtt_sample: Duration,
 }
 
 pub struct TransportPlugin;
@@ -94,7 +103,7 @@ impl TransportPlugin {
                 transport
                     .packet_manager
                     .header_manager
-                    .update(time.delta(), &link.stats);
+                    .update(time.elapsed(), &link.stats);
                 transport
                     .packet_manager
                     .header_manager
@@ -163,19 +172,35 @@ impl TransportPlugin {
                             "received transport packet"
                         );
 
-                        // TODO: maybe switch to event buffer instead of triggers?
+                        // Update the packet acks before triggering PacketReceived, so timeline
+                        // observers can consume RTT samples from this packet first.
+                        let newly_acked_packets = transport
+                            .packet_manager
+                            .header_manager
+                            .process_recv_packet_header(&header, time.elapsed());
+
                         #[cfg(feature = "std")]
                         par_commands.command_scope(|mut commands| {
+                            newly_acked_packets.iter().for_each(|(packet_id, rtt_sample)| {
+                                commands.trigger(PacketAcked {
+                                    entity,
+                                    packet_id: packet_id.0,
+                                    rtt_sample: *rtt_sample,
+                                });
+                            });
                             commands.trigger(PacketReceived { entity, remote_tick: tick });
                         });
                         #[cfg(not(feature = "std"))]
-                        commands.trigger(PacketReceived { entity, remote_tick: tick });
-
-                        // Update the packet acks
-                        transport
-                            .packet_manager
-                            .header_manager
-                            .process_recv_packet_header(&header);
+                        {
+                            newly_acked_packets.iter().for_each(|(packet_id, rtt_sample)| {
+                                commands.trigger(PacketAcked {
+                                    entity,
+                                    packet_id: packet_id.0,
+                                    rtt_sample: *rtt_sample,
+                                });
+                            });
+                            commands.trigger(PacketReceived { entity, remote_tick: tick });
+                        }
 
                         let mut packet_type = header.get_packet_type();
                         if packet_type.is_compressed() {
@@ -287,7 +312,7 @@ impl TransportPlugin {
                     .header_manager
                     .newly_acked_packets
                     .drain(..)
-                    .try_for_each(|acked_packet| {
+                    .try_for_each(|(acked_packet, rtt_sample)| {
                         trace!("Acked packet {:?}", acked_packet);
                         trace!(
                             target: "lightyear_debug::transport",
@@ -296,6 +321,7 @@ impl TransportPlugin {
                             sample_point = "PreUpdate",
                             entity = ?entity,
                             packet_id = ?acked_packet,
+                            rtt_sample_ms = rtt_sample.as_secs_f64() * 1000.0,
                             "transport packet acked"
                         );
                         if let Some(message_acks) =
@@ -362,6 +388,19 @@ impl TransportPlugin {
             }
             transport.recv_channel.try_iter().try_for_each(|(channel_kind, bytes, priority)| {
                 let sender_metadata = transport.senders.get_mut(&channel_kind).ok_or(TransportError::ChannelNotFound(channel_kind))?;
+                trace!(
+                    target: "lightyear_debug::transport",
+                    kind = "channel_send_buffer",
+                    schedule = "PostUpdate",
+                    sample_point = "PostUpdate",
+                    tick = ?tick,
+                    tick_id = u64::from(tick.0),
+                    channel = %sender_metadata.name,
+                    channel_kind = ?channel_kind,
+                    bytes = bytes.len(),
+                    priority = priority,
+                    "buffered channel message for transport send"
+                );
                 // TODO: do we need the message_id?
                 sender_metadata
                     .sender


### PR DESCRIPTION
We were only computing the estimate on ping/pong packets, let's update RTT estimates using every packet.