### PR TITLE
feat(inputs): opt-in authorize_controlled_targets helper (spoofed-target defense)

### DIFF
--- a/crates/inputs/inputs/src/lib.rs
+++ b/crates/inputs/inputs/src/lib.rs
@@ -43,7 +43,7 @@ pub mod prelude {
     pub mod server {
         pub use crate::server::{
             InputRebroadcaster, InputSystems, InputValidationAppExt, ServerInputConfig,
-            ServerInputPlugin,
+            ServerInputPlugin, authorize_controlled_targets,
         };
     }
 }

--- a/crates/inputs/inputs/src/server.rs
+++ b/crates/inputs/inputs/src/server.rs
@@ -13,6 +13,7 @@ use alloc::format;
 use bevy_app::{App, FixedPreUpdate, Plugin, PreUpdate};
 use bevy_ecs::component::Component;
 use bevy_ecs::prelude::Has;
+use bevy_ecs::relationship::RelationshipTarget;
 use bevy_ecs::{
     entity::{Entity, MapEntities},
     error::Result,
@@ -35,6 +36,7 @@ use lightyear_link::prelude::{LinkOf, Server};
 use lightyear_messages::plugin::MessageSystems;
 use lightyear_messages::prelude::MessageReceiver;
 use lightyear_messages::server::ServerMultiMessageSender;
+use lightyear_replication::control::ControlledByRemote;
 use lightyear_replication::prelude::{PreSpawned, RoomId, Rooms};
 use tracing::{debug, error, trace};
 
@@ -155,6 +157,51 @@ impl InputValidationAppExt for App {
     ) -> &mut Self {
         self.add_systems(PreUpdate, systems.in_set(InputSystems::ValidateInputs));
         self
+    }
+}
+
+/// Opt-in [`InputSystems::ValidateInputs`] system that drops every
+/// `InputTarget::Entity` the sending peer is **not** authorized to control —
+/// i.e. not a member of its [`ControlledByRemote`]. A message left with no
+/// targets is dropped entirely. This is the spoofed-target defense: a modified
+/// client cannot forge `InputTarget::Entity(other_player)` to drive an entity
+/// it doesn't own.
+///
+/// lightyear does **not** enable this by default. `ControlledBy` is an optional
+/// helper for modeling input ownership, not a mandatory component, and some
+/// games legitimately let several clients drive one entity. Register this only
+/// if your game uses `ControlledBy` and wants the check:
+///
+/// ```ignore
+/// app.add_input_validator(authorize_controlled_targets::<MySequence>);
+/// ```
+///
+/// - Host-client inputs (`RemoteId::is_local`) are trusted in-process and
+///   skipped.
+/// - `InputTarget::PreSpawned` is identified by a hash, not an entity id, so it
+///   is passed through here (binding a prespawn to an owner is out of scope).
+pub fn authorize_controlled_targets<S: ActionStateSequence>(
+    mut receivers: Query<
+        (
+            &RemoteId,
+            Option<&ControlledByRemote>,
+            &mut MessageReceiver<InputMessage<S>>,
+        ),
+        With<Connected>,
+    >,
+) {
+    for (client_id, controlled_by_remote, mut receiver) in receivers.iter_mut() {
+        if client_id.is_local() {
+            continue;
+        }
+        receiver.retain_messages(|message| {
+            message.inputs.retain(|data| match data.target {
+                InputTarget::Entity(entity) => controlled_by_remote
+                    .is_some_and(|controlled| controlled.collection().contains(&entity)),
+                InputTarget::PreSpawned(_) => true,
+            });
+            !message.inputs.is_empty()
+        });
     }
 }
 

--- a/crates/inputs/inputs/src/server.rs
+++ b/crates/inputs/inputs/src/server.rs
@@ -177,6 +177,15 @@ impl InputValidationAppExt for App {
 /// app.add_input_validator(authorize_controlled_targets::<MySequence>);
 /// ```
 ///
+/// To run **your own** validation after this one — so it only sees authorized
+/// targets — order it with `.after(authorize_controlled_targets::<S>)`
+/// (validators in [`InputSystems::ValidateInputs`] are otherwise unordered):
+///
+/// ```ignore
+/// app.add_input_validator(authorize_controlled_targets::<MySequence>);
+/// app.add_input_validator(my_validator.after(authorize_controlled_targets::<MySequence>));
+/// ```
+///
 /// - Host-client inputs (`RemoteId::is_local`) are trusted in-process and
 ///   skipped.
 /// - `InputTarget::PreSpawned` is identified by a hash, not an entity id, so it

--- a/crates/inputs/inputs/src/server.rs
+++ b/crates/inputs/inputs/src/server.rs
@@ -160,12 +160,13 @@ impl InputValidationAppExt for App {
     }
 }
 
-/// Opt-in [`InputSystems::ValidateInputs`] system that drops every
+/// Opt-in [`InputSystems::ValidateInputs`] system that strips every
 /// `InputTarget::Entity` the sending peer is **not** authorized to control —
-/// i.e. not a member of its [`ControlledByRemote`]. A message left with no
-/// targets is dropped entirely. This is the spoofed-target defense: a modified
-/// client cannot forge `InputTarget::Entity(other_player)` to drive an entity
-/// it doesn't own.
+/// i.e. not a member of its [`ControlledByRemote`]. This is the spoofed-target
+/// defense: a modified client cannot forge `InputTarget::Entity(other_player)`
+/// to drive an entity it doesn't own. The message itself is kept (even if
+/// filtering emptied it) — an empty input message is a legitimate keepalive the
+/// receive path relies on; only the unauthorized targets are removed.
 ///
 /// lightyear does **not** enable this by default. `ControlledBy` is an optional
 /// helper for modeling input ownership, not a mandatory component, and some
@@ -195,12 +196,26 @@ pub fn authorize_controlled_targets<S: ActionStateSequence>(
             continue;
         }
         receiver.retain_messages(|message| {
+            let before = message.inputs.len();
             message.inputs.retain(|data| match data.target {
                 InputTarget::Entity(entity) => controlled_by_remote
                     .is_some_and(|controlled| controlled.collection().contains(&entity)),
                 InputTarget::PreSpawned(_) => true,
             });
-            !message.inputs.is_empty()
+            let dropped = before - message.inputs.len();
+            if dropped > 0 {
+                trace!(
+                    ?client_id,
+                    dropped, "authorize_controlled_targets: stripped unauthorized input targets"
+                );
+            }
+            // Keep the message even if filtering emptied it. An empty input
+            // message is a legitimate keepalive (it still carries `end_tick`,
+            // which the receive path needs — dropping it stalls the confirmed
+            // tick and can trigger a large rollback). Only the unauthorized
+            // *targets* are removed; the spoofed entries are already gone before
+            // any rebroadcast.
+            true
         });
     }
 }

--- a/crates/tests/src/client_server/input/leafwing.rs
+++ b/crates/tests/src/client_server/input/leafwing.rs
@@ -977,3 +977,113 @@ fn test_authorize_controlled_targets_passes_through_prespawned() {
         "authorize_controlled_targets stripped a PreSpawned target — it must pass through",
     );
 }
+
+/// Documents the recommended way to run your own validator *after* the
+/// `authorize_controlled_targets` helper, so it only sees authorized targets:
+/// register it with `.after(authorize_controlled_targets::<S>)`.
+///
+/// Client 0 controls A and forges a target on uncontrolled B. The custom
+/// validator, ordered after the helper, records the targets it sees: it must
+/// see A but never the spoofed B (already stripped). Were it unordered (or
+/// before), it could observe B.
+#[test]
+fn test_custom_validator_ordered_after_authorize() {
+    use bevy::ecs::resource::Resource;
+    use bevy::ecs::schedule::IntoScheduleConfigs;
+    use bevy::ecs::system::{Query, ResMut};
+    use bevy::prelude::Entity;
+    use lightyear::input::leafwing::input_message::LeafwingSequence;
+    use lightyear_inputs::input_message::{InputMessage, InputTarget};
+    use lightyear_inputs::prelude::server::{InputValidationAppExt, authorize_controlled_targets};
+    use lightyear_messages::prelude::MessageReceiver;
+    use lightyear_replication::prelude::ControlledBy;
+
+    #[derive(Resource, Default)]
+    struct SeenAfterAuth(Vec<Entity>);
+
+    fn record_after_auth(
+        mut seen: ResMut<SeenAfterAuth>,
+        mut receivers: Query<&mut MessageReceiver<InputMessage<LeafwingSequence<LeafwingInput1>>>>,
+    ) {
+        for mut receiver in &mut receivers {
+            receiver.retain_messages(|msg| {
+                for data in &msg.inputs {
+                    if let InputTarget::Entity(e) = data.target {
+                        seen.0.push(e);
+                    }
+                }
+                true
+            });
+        }
+    }
+
+    let mut stepper = ClientServerStepper::from_config(StepperConfig::with_netcode_clients(1));
+    stepper.server_app.init_resource::<SeenAfterAuth>();
+    // Recommended ordering: register your validator `.after` the helper.
+    stepper
+        .server_app
+        .add_input_validator(authorize_controlled_targets::<LeafwingSequence<LeafwingInput1>>);
+    stepper.server_app.add_input_validator(
+        record_after_auth.after(authorize_controlled_targets::<LeafwingSequence<LeafwingInput1>>),
+    );
+
+    let client_of_0 = stepper.client_of(0).id();
+    let entity_a = stepper
+        .server_app
+        .world_mut()
+        .spawn((
+            ActionState::<LeafwingInput1>::default(),
+            Replicate::to_clients(NetworkTarget::All),
+            ControlledBy {
+                owner: client_of_0,
+                lifetime: Default::default(),
+            },
+        ))
+        .id();
+    let entity_b = stepper
+        .server_app
+        .world_mut()
+        .spawn((
+            ActionState::<LeafwingInput1>::default(),
+            Replicate::to_clients(NetworkTarget::All),
+        ))
+        .id();
+    stepper.frame_step(10);
+
+    let local_a = stepper
+        .client(0)
+        .get::<MessageManager>()
+        .unwrap()
+        .entity_mapper
+        .get_local(entity_a)
+        .expect("A replicated");
+    let local_b = stepper
+        .client(0)
+        .get::<MessageManager>()
+        .unwrap()
+        .entity_mapper
+        .get_local(entity_b)
+        .expect("B replicated");
+    for local in [local_a, local_b] {
+        stepper.client_apps[0].world_mut().entity_mut(local).insert(
+            InputMap::<LeafwingInput1>::new([(LeafwingInput1::Jump, KeyCode::KeyA)]),
+        );
+    }
+    stepper.frame_step(1);
+    stepper.client_apps[0]
+        .world_mut()
+        .resource_mut::<ButtonInput<KeyCode>>()
+        .press(KeyCode::KeyA);
+    stepper.frame_step(10);
+
+    let seen = &stepper.server_app.world().resource::<SeenAfterAuth>().0;
+    assert!(
+        seen.contains(&entity_a),
+        "custom validator never saw the authorized target A — setup/ordering issue",
+    );
+    assert!(
+        !seen.contains(&entity_b),
+        "custom validator saw the spoofed target B; it ran before authorize_controlled_targets \
+         (the `.after(authorize_controlled_targets::<S>)` ordering didn't take effect)",
+    );
+}

--- a/crates/tests/src/client_server/input/leafwing.rs
+++ b/crates/tests/src/client_server/input/leafwing.rs
@@ -647,52 +647,23 @@ fn test_input_validator_system_can_drop_messages() {
     );
 }
 
-/// Example: a *game-supplied* `ValidateInputs` system implements input-target
-/// authorization itself — lightyear does not enforce `ControlledBy` (it's an
-/// optional helper). The validator drops any `InputTarget::Entity` the sender
-/// doesn't control (via `ControlledByRemote` + `retain_messages`).
+/// lightyear's opt-in `authorize_controlled_targets` helper, when a game
+/// registers it in `ValidateInputs`, drops `InputTarget::Entity` the sender
+/// doesn't control — without lightyear enforcing it by default.
 ///
 /// Client 0 controls entity A and forges an input also targeting entity B
-/// (uncontrolled). The validator must let A's input through (non-overblocking)
+/// (uncontrolled). The helper must let A's input through (non-overblocking)
 /// and drop B's — so A's server `ActionState` is pressed and B's is not.
 #[test]
-fn test_user_validator_can_authorize_targets() {
-    use bevy::ecs::relationship::RelationshipTarget;
-    use bevy::ecs::system::Query;
+fn test_authorize_controlled_targets_helper() {
     use lightyear::input::leafwing::input_message::LeafwingSequence;
-    use lightyear_core::id::RemoteId;
-    use lightyear_inputs::input_message::{InputMessage, InputTarget};
-    use lightyear_inputs::prelude::server::InputValidationAppExt;
-    use lightyear_messages::prelude::MessageReceiver;
-    use lightyear_replication::control::ControlledByRemote;
+    use lightyear_inputs::prelude::server::{InputValidationAppExt, authorize_controlled_targets};
     use lightyear_replication::prelude::ControlledBy;
 
-    // Game-side authorization, expressed as an ordinary ValidateInputs system.
-    fn authorize_targets(
-        mut receivers: Query<(
-            &RemoteId,
-            Option<&ControlledByRemote>,
-            &mut MessageReceiver<InputMessage<LeafwingSequence<LeafwingInput1>>>,
-        )>,
-    ) {
-        for (client_id, controlled, mut receiver) in &mut receivers {
-            if client_id.is_local() {
-                continue;
-            }
-            receiver.retain_messages(|msg| {
-                msg.inputs.retain(|data| match data.target {
-                    InputTarget::Entity(e) => {
-                        controlled.is_some_and(|c| c.collection().contains(&e))
-                    }
-                    InputTarget::PreSpawned(_) => true,
-                });
-                !msg.inputs.is_empty()
-            });
-        }
-    }
-
     let mut stepper = ClientServerStepper::from_config(StepperConfig::with_netcode_clients(1));
-    stepper.server_app.add_input_validator(authorize_targets);
+    stepper
+        .server_app
+        .add_input_validator(authorize_controlled_targets::<LeafwingSequence<LeafwingInput1>>);
 
     let client_of_0 = stepper.client_of(0).id();
     // Entity A: controlled by client 0.

--- a/crates/tests/src/client_server/input/leafwing.rs
+++ b/crates/tests/src/client_server/input/leafwing.rs
@@ -891,3 +891,89 @@ fn test_validator_can_read_message_metadata() {
         "input landed even though retain_received_messages dropped the message",
     );
 }
+
+/// `authorize_controlled_targets` passes `InputTarget::PreSpawned` through (it's
+/// identified by hash, not entity id, so the `ControlledByRemote` check doesn't
+/// apply). A client forges a message with a PreSpawned target; an observer
+/// validator chained *after* the helper confirms the target survived.
+#[test]
+fn test_authorize_controlled_targets_passes_through_prespawned() {
+    use bevy::ecs::resource::Resource;
+    use bevy::ecs::schedule::IntoScheduleConfigs;
+    use bevy::ecs::system::{Query, ResMut};
+    use lightyear::input::leafwing::input_message::{LeafwingSequence, LeafwingSnapshot};
+    use lightyear_inputs::input_buffer::InputBuffer;
+    use lightyear_inputs::input_message::{
+        ActionStateSequence, InputMessage, InputTarget, PerTargetData,
+    };
+    use lightyear_inputs::prelude::InputChannel;
+    use lightyear_inputs::prelude::server::{InputSystems, authorize_controlled_targets};
+    use lightyear_messages::prelude::{MessageReceiver, MessageSender};
+
+    #[derive(Resource, Default)]
+    struct SawPrespawn(bool);
+
+    // Observer chained after the helper: records whether a PreSpawned target
+    // survived the authorization pass (read-only — returns true).
+    fn observe_prespawn(
+        mut saw: ResMut<SawPrespawn>,
+        mut receivers: Query<&mut MessageReceiver<InputMessage<LeafwingSequence<LeafwingInput1>>>>,
+    ) {
+        for mut receiver in &mut receivers {
+            receiver.retain_messages(|msg| {
+                if msg
+                    .inputs
+                    .iter()
+                    .any(|d| matches!(d.target, InputTarget::PreSpawned(_)))
+                {
+                    saw.0 = true;
+                }
+                true
+            });
+        }
+    }
+
+    let mut stepper = ClientServerStepper::from_config(StepperConfig::with_netcode_clients(1));
+    stepper.server_app.init_resource::<SawPrespawn>();
+    stepper.server_app.add_systems(
+        bevy::app::PreUpdate,
+        (
+            authorize_controlled_targets::<LeafwingSequence<LeafwingInput1>>,
+            observe_prespawn,
+        )
+            .chain()
+            .in_set(InputSystems::ValidateInputs),
+    );
+    stepper.frame_step(5);
+
+    // Forge a message whose only target is a PreSpawned hash (client 0 controls
+    // nothing — an `Entity` target here would be stripped, but PreSpawned passes).
+    let end_tick = stepper.server_tick() + 1;
+    let mut seq_buf = InputBuffer::<LeafwingSnapshot<LeafwingInput1>, LeafwingInput1>::default();
+    let mut snap = ActionState::<LeafwingInput1>::default();
+    snap.press(&LeafwingInput1::Jump);
+    seq_buf.set(end_tick, LeafwingSnapshot(snap));
+    let sequence =
+        LeafwingSequence::<LeafwingInput1>::build_from_input_buffer(&seq_buf, 1, end_tick)
+            .expect("sequence built from non-empty buffer");
+    let mut forged: InputMessage<LeafwingSequence<LeafwingInput1>> = InputMessage::new(end_tick);
+    forged.inputs.push(PerTargetData {
+        target: InputTarget::PreSpawned(0xDEAD_BEEF),
+        states: sequence,
+    });
+    {
+        let mut client_entity_mut = stepper.client_apps[0]
+            .world_mut()
+            .entity_mut(stepper.client_entities[0]);
+        let mut sender = client_entity_mut
+            .get_mut::<MessageSender<InputMessage<LeafwingSequence<LeafwingInput1>>>>()
+            .expect("client has a MessageSender for InputMessage<LeafwingSequence>");
+        sender.send::<InputChannel>(forged);
+    }
+    stepper.frame_step(3);
+
+    assert!(
+        stepper.server_app.world().resource::<SawPrespawn>().0,
+        "authorize_controlled_targets stripped a PreSpawned target — it must pass through",
+    );
+}

--- a/crates/tests/src/client_server/input/leafwing.rs
+++ b/crates/tests/src/client_server/input/leafwing.rs
@@ -743,6 +743,69 @@ fn test_authorize_controlled_targets_helper() {
     );
 }
 
+/// Regression guard for the empty-after-filter path: a client that controls
+/// nothing forges an input targeting an entity it doesn't own. Every target is
+/// stripped, but the helper must keep the (now-empty) message — dropping it
+/// would eat the keepalive the receive path relies on. We assert the spoofed
+/// input doesn't land and the pipeline keeps running (no panic / no stall).
+#[test]
+fn test_authorize_controlled_targets_keeps_emptied_message() {
+    use lightyear::input::leafwing::input_message::LeafwingSequence;
+    use lightyear_inputs::prelude::server::{InputValidationAppExt, authorize_controlled_targets};
+
+    let mut stepper = ClientServerStepper::from_config(StepperConfig::with_netcode_clients(1));
+    stepper
+        .server_app
+        .add_input_validator(authorize_controlled_targets::<LeafwingSequence<LeafwingInput1>>);
+
+    // Entity replicated to client 0 but controlled by nobody — client 0's
+    // `ControlledByRemote` is empty, so its input for this entity is fully
+    // unauthorized.
+    let victim = stepper
+        .server_app
+        .world_mut()
+        .spawn((
+            ActionState::<LeafwingInput1>::default(),
+            Replicate::to_clients(NetworkTarget::All),
+        ))
+        .id();
+    stepper.frame_step(5);
+
+    let local = stepper
+        .client(0)
+        .get::<MessageManager>()
+        .unwrap()
+        .entity_mapper
+        .get_local(victim)
+        .expect("victim replicated to client 0");
+    stepper.client_apps[0]
+        .world_mut()
+        .entity_mut(local)
+        .insert(InputMap::<LeafwingInput1>::new([(
+            LeafwingInput1::Jump,
+            KeyCode::KeyA,
+        )]));
+    stepper.frame_step(1);
+    stepper.client_apps[0]
+        .world_mut()
+        .resource_mut::<ButtonInput<KeyCode>>()
+        .press(KeyCode::KeyA);
+    // Keep stepping: the receive pipeline must stay healthy across many ticks
+    // even though every input message from this client is fully stripped.
+    stepper.frame_step(20);
+
+    assert!(
+        !stepper
+            .server_app
+            .world()
+            .entity(victim)
+            .get::<ActionState<LeafwingInput1>>()
+            .unwrap()
+            .pressed(&LeafwingInput1::Jump),
+        "fully-unauthorized input landed on the victim's ActionState",
+    );
+}
+
 /// `retain_received_messages` exposes per-message metadata (`remote_tick`,
 /// `channel_kind`, `message_id`) that `retain_messages` hides — needed for
 /// rate-limit / tick-window / replay validators. Here a validator reads

--- a/crates/tests/src/host_server/input/leafwing.rs
+++ b/crates/tests/src/host_server/input/leafwing.rs
@@ -164,3 +164,81 @@ fn test_buffer_inputs_with_delay() {
             .just_released(&LeafwingInput1::Jump)
     );
 }
+
+/// `authorize_controlled_targets` exempts host-client inputs (`RemoteId::is_local`):
+/// they are trusted in-process and must not be filtered against `ControlledByRemote`.
+/// The host-client drives an entity with **no** `ControlledBy`; an observer chained
+/// after the helper must still see the host-client's input target (the helper
+/// skipped it). Were the `is_local` guard dropped, the target would be stripped
+/// (the host-client controls nothing) and the observer would see nothing.
+#[test]
+fn test_authorize_controlled_targets_exempts_host_client() {
+    use bevy::ecs::resource::Resource;
+    use bevy::ecs::schedule::IntoScheduleConfigs;
+    use bevy::ecs::system::{Query, ResMut};
+    use bevy::prelude::Entity;
+    use lightyear::input::leafwing::input_message::LeafwingSequence;
+    use lightyear_inputs::input_message::{InputMessage, InputTarget};
+    use lightyear_inputs::prelude::server::{InputSystems, authorize_controlled_targets};
+    use lightyear_messages::prelude::MessageReceiver;
+
+    #[derive(Resource, Default)]
+    struct ObservedTargets(Vec<Entity>);
+
+    fn observe(
+        mut observed: ResMut<ObservedTargets>,
+        mut receivers: Query<&mut MessageReceiver<InputMessage<LeafwingSequence<LeafwingInput1>>>>,
+    ) {
+        for mut receiver in &mut receivers {
+            receiver.retain_messages(|msg| {
+                for data in &msg.inputs {
+                    if let InputTarget::Entity(e) = data.target {
+                        observed.0.push(e);
+                    }
+                }
+                true
+            });
+        }
+    }
+
+    let mut stepper = ClientServerStepper::from_config(StepperConfig::host_server());
+    stepper.server_app.init_resource::<ObservedTargets>();
+    stepper.server_app.add_systems(
+        bevy::app::PreUpdate,
+        (
+            authorize_controlled_targets::<LeafwingSequence<LeafwingInput1>>,
+            observe,
+        )
+            .chain()
+            .in_set(InputSystems::ValidateInputs),
+    );
+
+    // Host-client-controlled entity with NO `ControlledBy`.
+    let server_entity = stepper
+        .server_app
+        .world_mut()
+        .spawn((
+            ActionState::<LeafwingInput1>::default(),
+            Replicate::to_clients(NetworkTarget::All),
+            InputMap::<LeafwingInput1>::new([(LeafwingInput1::Jump, KeyCode::KeyA)]),
+        ))
+        .id();
+    stepper.frame_step(2);
+    stepper
+        .server_app
+        .world_mut()
+        .resource_mut::<ButtonInput<KeyCode>>()
+        .press(KeyCode::KeyA);
+    stepper.frame_step(5);
+
+    assert!(
+        stepper
+            .server_app
+            .world()
+            .resource::<ObservedTargets>()
+            .0
+            .contains(&server_entity),
+        "the host-client's input target was stripped (or never reached validation); \
+         the is_local exemption is broken",
+    );
+}


### PR DESCRIPTION
## Summary

Reframes this PR as an **opt-in helper** for the spoofed-target defense, built on the validation seam in #1535 — rather than a compulsory, inline authorization check.

Per the discussion on #1531, `Controlled` / `ControlledBy` are **optional, non-authoritative** helpers (some games legitimately let several clients drive one entity), so lightyear should **not** enforce target authorization by default. Instead it offers a ready-made check a game can switch on:

```rust
app.add_input_validator(authorize_controlled_targets::<MySequence>);
```

## The defense

`receive_input_message` reads `InputTarget::Entity(entity)` off the wire and applies it to that entity's `InputBuffer` with no ownership check — so a modified client can send `InputTarget::Entity(other_player)` to drive an entity it doesn't control.

`authorize_controlled_targets::<S>` is a public `InputSystems::ValidateInputs` system that strips every `InputTarget::Entity` the sender isn't authorized to control (not in its `ControlledByRemote`). The message itself is **kept** even if filtering removes all its targets — an empty `InputMessage` is a legitimate keepalive that still carries `end_tick` and advances confirmation; dropping it would stall the confirmed tick and risk a large rollback. Only the unauthorized targets are removed (before any rebroadcast). Host-client inputs (`is_local`) are exempt; `InputTarget::PreSpawned` (hash-identified) is passed through. It logs (`trace!`) when it strips targets, so a missing `ControlledBy` is diagnosable.

To run your own validation after this helper, order it with `.after(authorize_controlled_targets::<S>)`.

## Tests

- `test_authorize_controlled_targets_helper` — client 0 controls A and forges a target on uncontrolled B; A's authorized input lands (non-overblocking), B's spoofed input is dropped.
- `test_authorize_controlled_targets_keeps_emptied_message` — a fully-unauthorized message is stripped but **kept** (the keepalive isn't dropped); input doesn't land and the pipeline stays healthy.
- `test_authorize_controlled_targets_exempts_host_client` (host-server) — a host-client's inputs are not stripped (`is_local` bypass); verified discriminating.
- `test_authorize_controlled_targets_passes_through_prespawned` — a forged `PreSpawned` target survives the filter.
- `test_custom_validator_ordered_after_authorize` — a custom validator ordered `.after` the helper sees only authorized targets.

## Notes

- **Stacked on #1535** (the `ValidateInputs` seam + `MessageReceiver::retain_messages` this builds on). Once #1535 merges this rebases down to just the helper + test.
- Default-on enforcement was deliberately **not** chosen (it would make `ControlledBy` mandatory and break games/tests that don't use it — see the audit on #1535). This is the opt-in middle ground: lightyear ships the check and documents the security tradeoff, the game decides.
- Design discussion: #1531. Supersedes this PR's earlier inline implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-authored with Claude Opus 4.8
