### PR TITLE
Simplify CatchUpGated catch-up activation

### DIFF
--- a/crates/deterministic/deterministic_replication/src/late_join/client.rs
+++ b/crates/deterministic/deterministic_replication/src/late_join/client.rs
@@ -1,4 +1,5 @@
 use crate::mode::CatchUpMode;
+use alloc::vec::Vec;
 use bevy_app::{App, PreUpdate};
 use bevy_ecs::entity::Entity;
 use bevy_ecs::prelude::*;
@@ -8,12 +9,14 @@ use core::time::Duration;
 use lightyear_connection::client::{Client, Disconnect};
 use lightyear_core::prelude::LocalTimeline;
 use lightyear_core::tick::Tick;
+use lightyear_core::timeline::Rollback;
 use lightyear_inputs::client::InputSystems;
 use lightyear_messages::prelude::{MessageSender, RemoteEvent};
 use lightyear_prediction::prelude::{
-    LastConfirmedInput, PredictionManager, PredictionSystems, StateRollbackMetadata,
+    LastConfirmedInput, PredictionManager, PredictionSystems, RollbackSystems,
+    StateRollbackMetadata,
 };
-use lightyear_prediction::rollback::CatchUpGated;
+use lightyear_prediction::rollback::{CatchUpGated, DisableRollback};
 use lightyear_replication::metadata::MetadataChannel;
 use lightyear_replication::prelude::ReplicationSystems;
 use lightyear_sync::prelude::{InputTimeline, IsSynced};
@@ -57,10 +60,9 @@ pub(crate) struct PendingCatchUpSnapshot {
 pub struct CatchUpManager {
     pub(crate) completed: bool,
     pub(crate) pending_snapshot: Option<PendingCatchUpSnapshot>,
+    pub(crate) activating_snapshot: Option<PendingCatchUpSnapshot>,
     pub(crate) requests_sent: u8,
     pub(crate) request_sent_at_tick: Option<Tick>,
-    pub(crate) request_input_safe_tick: Option<Tick>,
-    pub(crate) last_emitted_replicon_tick: Option<RepliconTick>,
     pub(crate) suppress_checksums: bool,
 }
 
@@ -87,11 +89,19 @@ pub(crate) fn build(app: &mut App) {
             .after(ReplicationSystems::Receive)
             .before(PredictionSystems::Rollback),
     );
+    app.configure_sets(
+        PreUpdate,
+        CatchUpSystems::ActivateCatchUp
+            .run_if(initial_catchup_is_active)
+            .after(RollbackSystems::Prepare)
+            .before(RollbackSystems::Rollback),
+    );
     app.add_systems(
         PreUpdate,
         (
             send_catchup_request.in_set(CatchUpSystems::SendCatchUpRequest),
             trigger_snapshot_rollback.in_set(CatchUpSystems::TriggerCatchUpRollback),
+            activate_catch_up_snapshot.in_set(CatchUpSystems::ActivateCatchUp),
         ),
     );
 }
@@ -142,7 +152,10 @@ pub(crate) fn send_catchup_request(
     let Some(input_safe_tick) = last_confirmed_input.get() else {
         return;
     };
-    if awaiting.is_empty() || manager.pending_snapshot.is_some() {
+    if awaiting.is_empty()
+        || manager.pending_snapshot.is_some()
+        || manager.activating_snapshot.is_some()
+    {
         return;
     }
     if manager
@@ -154,7 +167,6 @@ pub(crate) fn send_catchup_request(
     debug!(
         ?client_entity,
         ?input_safe_tick,
-        previous_input_safe_tick = ?manager.request_input_safe_tick,
         "sending CatchUpRequest to server"
     );
     sender.send::<MetadataChannel>(CatchUpRequest { input_safe_tick });
@@ -168,7 +180,6 @@ pub(crate) fn send_catchup_request(
         );
     }
     manager.request_sent_at_tick = Some(local_tick);
-    manager.request_input_safe_tick = Some(input_safe_tick);
     manager.suppress_checksums = true;
 }
 
@@ -243,12 +254,14 @@ pub(crate) fn trigger_snapshot_rollback(
     >,
     server_mutate_ticks: Res<ServerMutateTicks>,
     mut state_metadata: ResMut<StateRollbackMetadata>,
-    gated: Query<Entity, With<CatchUpGated>>,
     mut commands: Commands,
 ) {
     let (client_entity, mut manager, last_confirmed_input, prediction_manager) =
         manager.into_inner();
     if manager.completed {
+        return;
+    }
+    if manager.activating_snapshot.is_some() {
         return;
     }
     let Some(snapshot) = manager.pending_snapshot.clone() else {
@@ -261,12 +274,8 @@ pub(crate) fn trigger_snapshot_rollback(
     if rollback_delta < 0 {
         return;
     }
-    // Local activation observers run before the forced rollback is requested,
-    // so the snapshot must still fit the rollback window on the next pass.
-    let activation_headroom =
-        i32::from(manager.last_emitted_replicon_tick != Some(snapshot_replicon_tick));
     let max_rollback_ticks = i32::from(prediction_manager.rollback_policy.max_rollback_ticks);
-    if rollback_delta + activation_headroom > max_rollback_ticks {
+    if rollback_delta > max_rollback_ticks {
         warn!(
             ?client_entity,
             ?local_tick,
@@ -281,27 +290,93 @@ pub(crate) fn trigger_snapshot_rollback(
         });
         return;
     }
-    if !last_confirmed_input.received_for_all_clients
-        || last_confirmed_input
-            .get()
-            .is_none_or(|t| t < snapshot_server_tick)
-    {
+    let Some(input_safe_tick) = catch_up_input_safe_tick(last_confirmed_input, local_tick) else {
         return;
-    }
-    if manager.last_emitted_replicon_tick == Some(snapshot_replicon_tick) {
-        state_metadata.request_forced_rollback(snapshot_server_tick);
-        info!("Triggering catchup rollback since snapshot tick: {snapshot_server_tick:?}");
-        complete_catch_up(&mut manager, &gated, &mut commands);
+    };
+    if input_safe_tick < snapshot_server_tick {
         return;
     }
     if !server_mutate_ticks.contains(snapshot_replicon_tick) {
         return;
     }
-    manager.last_emitted_replicon_tick = Some(snapshot_replicon_tick);
-    commands.trigger(CatchUpSnapshotReady {
-        replicon_tick: snapshot_replicon_tick,
-        server_tick: snapshot_server_tick,
+    state_metadata.request_forced_rollback(snapshot_server_tick);
+    state_metadata.clear_mismatch_history();
+    manager.pending_snapshot = None;
+    manager.activating_snapshot = Some(snapshot);
+    info!("Triggering catchup rollback since snapshot tick: {snapshot_server_tick:?}");
+}
+
+fn catch_up_input_safe_tick(
+    last_confirmed_input: &LastConfirmedInput,
+    local_tick: Tick,
+) -> Option<Tick> {
+    if !last_confirmed_input.received_for_all_clients {
+        return None;
+    }
+    // No remote input buffers means there are no remote inputs to wait for.
+    // The synced local timeline is safe to use as the catch-up coverage tick.
+    Some(last_confirmed_input.get().unwrap_or(local_tick))
+}
+
+fn activate_catch_up_snapshot(world: &mut World) {
+    let Some((client_entity, snapshot)) = catch_up_snapshot_to_activate(world) else {
+        return;
+    };
+
+    world.trigger(CatchUpSnapshotReady {
+        replicon_tick: snapshot.replicon_tick,
+        server_tick: snapshot.server_tick,
     });
+    // Apply local activation observer commands before rollback replay starts.
+    world.flush();
+
+    let mut gated_query = world.query_filtered::<Entity, With<CatchUpGated>>();
+    let gated = gated_query.iter(world).collect::<Vec<_>>();
+    for entity in gated {
+        if let Ok(mut entity_mut) = world.get_entity_mut(entity) {
+            entity_mut.remove::<CatchUpGated>();
+        }
+    }
+
+    let skip_despawn_entities = world
+        .get_mut::<PredictionManager>(client_entity)
+        .map(|mut prediction_manager| {
+            prediction_manager
+                .deterministic_skip_despawn
+                .drain(..)
+                .map(|(_, entity)| entity)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    for entity in skip_despawn_entities {
+        if let Ok(mut entity_mut) = world.get_entity_mut(entity) {
+            entity_mut.remove::<DisableRollback>();
+        }
+    }
+
+    if let Some(mut manager) = world.get_mut::<CatchUpManager>(client_entity) {
+        manager.completed = true;
+        manager.pending_snapshot = None;
+        manager.requests_sent = 0;
+        manager.request_sent_at_tick = None;
+        manager.activating_snapshot = None;
+        manager.suppress_checksums = false;
+    }
+    world.flush();
+}
+
+fn catch_up_snapshot_to_activate(world: &mut World) -> Option<(Entity, PendingCatchUpSnapshot)> {
+    let mut query = world.query_filtered::<(Entity, &Rollback, &CatchUpManager), With<Client>>();
+    let Ok((client_entity, rollback, manager)) = query.single(world) else {
+        return None;
+    };
+    if manager.completed || !matches!(*rollback, Rollback::FromState) {
+        return None;
+    }
+    manager
+        .activating_snapshot
+        .clone()
+        .map(|snapshot| (client_entity, snapshot))
 }
 
 fn complete_catch_up(
@@ -316,7 +391,6 @@ fn complete_catch_up(
     manager.pending_snapshot = None;
     manager.requests_sent = 0;
     manager.request_sent_at_tick = None;
-    manager.request_input_safe_tick = None;
-    manager.last_emitted_replicon_tick = None;
+    manager.activating_snapshot = None;
     manager.suppress_checksums = false;
 }

--- a/crates/deterministic/deterministic_replication/src/late_join/client.rs
+++ b/crates/deterministic/deterministic_replication/src/late_join/client.rs
@@ -1,5 +1,4 @@
 use crate::mode::CatchUpMode;
-use alloc::vec::Vec;
 use bevy_app::{App, PreUpdate};
 use bevy_ecs::entity::Entity;
 use bevy_ecs::prelude::*;
@@ -60,6 +59,9 @@ pub(crate) struct PendingCatchUpSnapshot {
 pub struct CatchUpManager {
     pub(crate) completed: bool,
     pub(crate) pending_snapshot: Option<PendingCatchUpSnapshot>,
+    /// Snapshot whose forced rollback has been requested and is waiting for
+    /// local activation after [`RollbackSystems::Prepare`] restores the
+    /// snapshot state.
     pub(crate) activating_snapshot: Option<PendingCatchUpSnapshot>,
     pub(crate) requests_sent: u8,
     pub(crate) request_sent_at_tick: Option<Tick>,
@@ -92,7 +94,7 @@ pub(crate) fn build(app: &mut App) {
     app.configure_sets(
         PreUpdate,
         CatchUpSystems::ActivateCatchUp
-            .run_if(initial_catchup_is_active)
+            .run_if(catchup_snapshot_is_activating)
             .after(RollbackSystems::Prepare)
             .before(RollbackSystems::Rollback),
     );
@@ -101,8 +103,19 @@ pub(crate) fn build(app: &mut App) {
         (
             send_catchup_request.in_set(CatchUpSystems::SendCatchUpRequest),
             trigger_snapshot_rollback.in_set(CatchUpSystems::TriggerCatchUpRollback),
-            activate_catch_up_snapshot.in_set(CatchUpSystems::ActivateCatchUp),
         ),
+    );
+    app.add_systems(
+        PreUpdate,
+        // We first run RollbackSystems::Prepare when the catchup rollback is triggered
+        // and then we trigger `CatchUpSnapshotReady`. This is to only notify the user
+        // after the components have been restored to the snapshot state, but before the rollback replay starts.
+        (
+            trigger_catch_up_snapshot_activation,
+            finish_catch_up_snapshot_activation,
+        )
+            .chain()
+            .in_set(CatchUpSystems::ActivateCatchUp),
     );
 }
 
@@ -114,6 +127,10 @@ fn initial_catchup_is_active(
         return false;
     };
     *mode != CatchUpMode::InputOnly && manager.is_some_and(|manager| !manager.completed)
+}
+
+fn catchup_snapshot_is_activating(manager: Option<Single<&CatchUpManager, With<Client>>>) -> bool {
+    manager.is_some_and(|manager| !manager.completed && manager.activating_snapshot.is_some())
 }
 
 /// Client system: sends a [`CatchUpRequest`] once replicated input state is
@@ -290,9 +307,12 @@ pub(crate) fn trigger_snapshot_rollback(
         });
         return;
     }
-    let Some(input_safe_tick) = catch_up_input_safe_tick(last_confirmed_input, local_tick) else {
+    if !last_confirmed_input.received_for_all_clients {
         return;
-    };
+    }
+    // No remote input buffers (last_confirmed_input is not set) means there are no remote inputs to wait for.
+    // The synced local timeline is safe to use as the catch-up coverage tick.
+    let input_safe_tick = last_confirmed_input.get().unwrap_or(local_tick);
     if input_safe_tick < snapshot_server_tick {
         return;
     }
@@ -306,77 +326,47 @@ pub(crate) fn trigger_snapshot_rollback(
     info!("Triggering catchup rollback since snapshot tick: {snapshot_server_tick:?}");
 }
 
-fn catch_up_input_safe_tick(
-    last_confirmed_input: &LastConfirmedInput,
-    local_tick: Tick,
-) -> Option<Tick> {
-    if !last_confirmed_input.received_for_all_clients {
-        return None;
+/// Trigger local activation observers after rollback preparation has restored
+/// the snapshot components, but before rollback replay starts.
+/// This is so that when CatchUpSnapshotReady is observed, the CatchUpGated components are already restored
+/// to their snapshot state.
+fn trigger_catch_up_snapshot_activation(
+    client: Query<(&Rollback, &CatchUpManager), With<Client>>,
+    mut commands: Commands,
+) {
+    let Ok((rollback, manager)) = client.single() else {
+        return;
+    };
+    if manager.completed || !matches!(*rollback, Rollback::FromState) {
+        return;
     }
-    // No remote input buffers means there are no remote inputs to wait for.
-    // The synced local timeline is safe to use as the catch-up coverage tick.
-    Some(last_confirmed_input.get().unwrap_or(local_tick))
-}
-
-fn activate_catch_up_snapshot(world: &mut World) {
-    let Some((client_entity, snapshot)) = catch_up_snapshot_to_activate(world) else {
+    let Some(snapshot) = manager.activating_snapshot.clone() else {
         return;
     };
 
-    world.trigger(CatchUpSnapshotReady {
+    commands.trigger(CatchUpSnapshotReady {
         replicon_tick: snapshot.replicon_tick,
         server_tick: snapshot.server_tick,
     });
-    // Apply local activation observer commands before rollback replay starts.
-    world.flush();
-
-    let mut gated_query = world.query_filtered::<Entity, With<CatchUpGated>>();
-    let gated = gated_query.iter(world).collect::<Vec<_>>();
-    for entity in gated {
-        if let Ok(mut entity_mut) = world.get_entity_mut(entity) {
-            entity_mut.remove::<CatchUpGated>();
-        }
-    }
-
-    let skip_despawn_entities = world
-        .get_mut::<PredictionManager>(client_entity)
-        .map(|mut prediction_manager| {
-            prediction_manager
-                .deterministic_skip_despawn
-                .drain(..)
-                .map(|(_, entity)| entity)
-                .collect::<Vec<_>>()
-        })
-        .unwrap_or_default();
-    for entity in skip_despawn_entities {
-        if let Ok(mut entity_mut) = world.get_entity_mut(entity) {
-            entity_mut.remove::<DisableRollback>();
-        }
-    }
-
-    if let Some(mut manager) = world.get_mut::<CatchUpManager>(client_entity) {
-        manager.completed = true;
-        manager.pending_snapshot = None;
-        manager.requests_sent = 0;
-        manager.request_sent_at_tick = None;
-        manager.activating_snapshot = None;
-        manager.suppress_checksums = false;
-    }
-    world.flush();
 }
 
-fn catch_up_snapshot_to_activate(world: &mut World) -> Option<(Entity, PendingCatchUpSnapshot)> {
-    let mut query = world.query_filtered::<(Entity, &Rollback, &CatchUpManager), With<Client>>();
-    let Ok((client_entity, rollback, manager)) = query.single(world) else {
-        return None;
+fn finish_catch_up_snapshot_activation(
+    mut client: Query<(&mut CatchUpManager, &mut PredictionManager), With<Client>>,
+    gated: Query<Entity, With<CatchUpGated>>,
+    mut commands: Commands,
+) {
+    let Ok((mut manager, mut prediction_manager)) = client.single_mut() else {
+        return;
     };
-    if manager.completed || !matches!(*rollback, Rollback::FromState) {
-        return None;
+    if manager.completed || manager.activating_snapshot.is_none() {
+        return;
     }
-    manager
-        .activating_snapshot
-        .clone()
-        .map(|snapshot| (client_entity, snapshot))
+
+    for (_, entity) in prediction_manager.deterministic_skip_despawn.drain(..) {
+        commands.entity(entity).try_remove::<DisableRollback>();
+    }
+
+    complete_catch_up(&mut manager, &gated, &mut commands);
 }
 
 fn complete_catch_up(

--- a/crates/deterministic/deterministic_replication/src/late_join/server.rs
+++ b/crates/deterministic/deterministic_replication/src/late_join/server.rs
@@ -57,7 +57,9 @@ pub(crate) fn register_catchup<T: FilterScope + Send + Sync + 'static>(app: &mut
 }
 
 pub(crate) fn build(app: &mut App) {
+    app.init_resource::<CatchUpServerState>();
     app.add_observer(mark_client_caught_up_if_no_gated_on_connect);
+    app.add_observer(mark_server_has_revealed_catchup_state);
     app.add_systems(
         PostUpdate,
         (
@@ -100,6 +102,11 @@ impl ServerCatchUpMetadata {
     }
 }
 
+#[derive(Resource, Default)]
+struct CatchUpServerState {
+    has_revealed_catchup_state: bool,
+}
+
 /// If a client is the only connected client, or joins before any server-owned
 /// catch-up-gated entities exist, it is already part of the deterministic
 /// simulation and does not need the late-join snapshot flow. Mark it caught up
@@ -116,7 +123,9 @@ fn mark_client_caught_up_if_no_gated_on_connect(
             With<HasCaughtUp>,
         ),
     >,
+    catchup_gated: Query<(), With<CatchUpGated>>,
     gated_requiring_catchup: Query<(), (With<CatchUpGated>, Without<PreSpawned>)>,
+    server_state: Res<CatchUpServerState>,
     mut commands: Commands,
 ) {
     let client = trigger.entity;
@@ -124,18 +133,47 @@ fn mark_client_caught_up_if_no_gated_on_connect(
         return;
     }
     let no_caught_up_clients = caught_up_clients.is_empty();
-    if !no_caught_up_clients && !gated_requiring_catchup.is_empty() {
+    let has_any_gated = !catchup_gated.is_empty();
+    let has_non_prespawn_gated = !gated_requiring_catchup.is_empty();
+    if server_state.has_revealed_catchup_state && no_caught_up_clients && has_any_gated {
+        debug!(
+            ?client,
+            "client is first reconnect after catch-up state was revealed; buffering immediate catch-up snapshot"
+        );
+        commands
+            .entity(client)
+            .insert(ServerCatchUpMetadata::new(Tick(0)));
+        return;
+    }
+    let needs_catchup = if server_state.has_revealed_catchup_state {
+        has_any_gated
+    } else {
+        !no_caught_up_clients && has_non_prespawn_gated
+    };
+    if needs_catchup {
         return;
     }
     debug!(
         ?client,
         no_caught_up_clients,
-        gated_requiring_catchup = !gated_requiring_catchup.is_empty(),
+        has_any_gated,
+        has_non_prespawn_gated,
+        has_revealed_catchup_state = server_state.has_revealed_catchup_state,
         "client does not need initial catch-up; marking caught up"
     );
     commands
         .entity(client)
         .insert((HasCaughtUp, ServerCatchUpMetadata::not_required()));
+}
+
+fn mark_server_has_revealed_catchup_state(
+    trigger: On<Add, HasCaughtUp>,
+    clients: Query<(), (With<ClientOf>, With<LinkOf>)>,
+    mut server_state: ResMut<CatchUpServerState>,
+) {
+    if clients.get(trigger.entity).is_ok() {
+        server_state.has_revealed_catchup_state = true;
+    }
 }
 
 /// Server system: buffer catch-up requests until they become safe to accept.

--- a/crates/deterministic/deterministic_replication/src/late_join/server.rs
+++ b/crates/deterministic/deterministic_replication/src/late_join/server.rs
@@ -9,11 +9,12 @@ use bevy_replicon::server::server_tick::ServerTick;
 use bevy_replicon::server::visibility::registry::FilterRegistry;
 use bevy_replicon::shared::replication::registry::ReplicationRegistry;
 use core::marker::PhantomData;
-use lightyear_connection::client::Connected;
+use lightyear_connection::client::{Connected, Disconnected};
 use lightyear_connection::client_of::ClientOf;
+use lightyear_connection::server::Stopped;
 use lightyear_core::prelude::LocalTimeline;
 use lightyear_core::tick::Tick;
-use lightyear_link::server::LinkOf;
+use lightyear_link::server::{LinkOf, Server};
 use lightyear_messages::plugin::MessageSystems;
 use lightyear_messages::prelude::EventSender;
 use lightyear_messages::receive::MessageReceiver;
@@ -57,12 +58,14 @@ pub(crate) fn register_catchup<T: FilterScope + Send + Sync + 'static>(app: &mut
 }
 
 pub(crate) fn build(app: &mut App) {
-    app.init_resource::<CatchUpServerState>();
     app.add_observer(mark_client_caught_up_if_no_gated_on_connect);
     app.add_observer(mark_server_has_revealed_catchup_state);
+    app.add_observer(reset_server_catchup_state_on_stop);
+    app.add_observer(reset_server_catchup_state_without_connected_clients);
     app.add_systems(
         PostUpdate,
         (
+            ensure_server_catchup_state,
             buffer_catch_up_requests,
             accept_buffered_catch_up_requests,
             ApplyDeferred,
@@ -75,11 +78,23 @@ pub(crate) fn build(app: &mut App) {
     app.add_systems(
         PostUpdate,
         emit_catch_up_snapshot_ready
+            .run_if(resource_exists_and_changed::<ServerTick>)
             .after(ReplicationSystems::Send)
             .before(MessageSystems::Send),
     );
 }
 
+/// Server-side catch-up request state stored on the server's client link
+/// entity, i.e. the entity carrying [`ClientOf`].
+///
+/// When a client sends [`CatchUpRequest`], the server stores the latest
+/// client-advertised [`CatchUpRequest::input_safe_tick`] here. The server does
+/// not reveal gated snapshot state immediately: it waits until its local
+/// simulation tick has advanced beyond that input-safe tick, so the client has
+/// enough rebroadcast input coverage to replay from the accepted snapshot tick.
+///
+/// Once accepted, `snapshot_ready` is filled and emitted only after Replicon's
+/// send set has revealed the gated components for this client.
 #[derive(Component, Debug, Clone)]
 struct ServerCatchUpMetadata {
     input_safe_tick: Tick,
@@ -102,8 +117,16 @@ impl ServerCatchUpMetadata {
     }
 }
 
-#[derive(Resource, Default)]
+#[derive(Component, Default)]
 struct CatchUpServerState {
+    /// True after this server has ever revealed catch-up-gated state to a
+    /// client.
+    ///
+    /// This distinguishes the first client in a fresh connected session from
+    /// later clients after any gated state has already been revealed. It is
+    /// reset when the server stops or when the server has no connected
+    /// clients, so a later empty-server session starts from the initial
+    /// catch-up rules again.
     has_revealed_catchup_state: bool,
 }
 
@@ -113,29 +136,31 @@ struct CatchUpServerState {
 /// so gated components replicate normally to it.
 fn mark_client_caught_up_if_no_gated_on_connect(
     trigger: On<Add, Connected>,
-    clients: Query<Entity, (With<ClientOf>, With<LinkOf>, With<Connected>)>,
-    caught_up_clients: Query<
-        (),
-        (
-            With<ClientOf>,
-            With<LinkOf>,
-            With<Connected>,
-            With<HasCaughtUp>,
-        ),
-    >,
+    clients: Query<(Entity, &LinkOf), (With<ClientOf>, With<Connected>)>,
+    caught_up_clients: Query<&LinkOf, (With<ClientOf>, With<Connected>, With<HasCaughtUp>)>,
     catchup_gated: Query<(), With<CatchUpGated>>,
     gated_requiring_catchup: Query<(), (With<CatchUpGated>, Without<PreSpawned>)>,
-    server_state: Res<CatchUpServerState>,
+    server_states: Query<&CatchUpServerState, With<Server>>,
     mut commands: Commands,
 ) {
-    let client = trigger.entity;
-    if clients.get(client).is_err() {
+    let Ok((client, link_of)) = clients.get(trigger.entity) else {
         return;
-    }
-    let no_caught_up_clients = caught_up_clients.is_empty();
+    };
+    let has_revealed_catchup_state = match server_states.get(link_of.server) {
+        Ok(server_state) => server_state.has_revealed_catchup_state,
+        Err(_) => {
+            commands
+                .entity(link_of.server)
+                .insert(CatchUpServerState::default());
+            false
+        }
+    };
+    let no_caught_up_clients = !caught_up_clients
+        .iter()
+        .any(|caught_up_link| caught_up_link.server == link_of.server);
     let has_any_gated = !catchup_gated.is_empty();
     let has_non_prespawn_gated = !gated_requiring_catchup.is_empty();
-    if server_state.has_revealed_catchup_state && no_caught_up_clients && has_any_gated {
+    if has_revealed_catchup_state && no_caught_up_clients && has_any_gated {
         debug!(
             ?client,
             "client is first reconnect after catch-up state was revealed; buffering immediate catch-up snapshot"
@@ -145,7 +170,7 @@ fn mark_client_caught_up_if_no_gated_on_connect(
             .insert(ServerCatchUpMetadata::new(Tick(0)));
         return;
     }
-    let needs_catchup = if server_state.has_revealed_catchup_state {
+    let needs_catchup = if has_revealed_catchup_state {
         has_any_gated
     } else {
         !no_caught_up_clients && has_non_prespawn_gated
@@ -158,7 +183,7 @@ fn mark_client_caught_up_if_no_gated_on_connect(
         no_caught_up_clients,
         has_any_gated,
         has_non_prespawn_gated,
-        has_revealed_catchup_state = server_state.has_revealed_catchup_state,
+        has_revealed_catchup_state,
         "client does not need initial catch-up; marking caught up"
     );
     commands
@@ -168,11 +193,62 @@ fn mark_client_caught_up_if_no_gated_on_connect(
 
 fn mark_server_has_revealed_catchup_state(
     trigger: On<Add, HasCaughtUp>,
-    clients: Query<(), (With<ClientOf>, With<LinkOf>)>,
-    mut server_state: ResMut<CatchUpServerState>,
+    clients: Query<&LinkOf, With<ClientOf>>,
+    mut server_state: Query<&mut CatchUpServerState, With<Server>>,
+    mut commands: Commands,
 ) {
-    if clients.get(trigger.entity).is_ok() {
+    let Ok(link_of) = clients.get(trigger.entity) else {
+        return;
+    };
+    if let Ok(mut server_state) = server_state.get_mut(link_of.server) {
         server_state.has_revealed_catchup_state = true;
+    } else {
+        commands.entity(link_of.server).insert(CatchUpServerState {
+            has_revealed_catchup_state: true,
+        });
+    }
+}
+
+fn ensure_server_catchup_state(
+    servers: Query<Entity, (With<Server>, Without<CatchUpServerState>)>,
+    mut commands: Commands,
+) {
+    for server in &servers {
+        commands
+            .entity(server)
+            .insert(CatchUpServerState::default());
+    }
+}
+
+fn reset_server_catchup_state_on_stop(
+    trigger: On<Add, Stopped>,
+    mut server_state: Query<&mut CatchUpServerState, With<Server>>,
+) {
+    if let Ok(mut server_state) = server_state.get_mut(trigger.entity) {
+        server_state.has_revealed_catchup_state = false;
+    }
+}
+
+fn reset_server_catchup_state_without_connected_clients(
+    trigger: On<Add, Disconnected>,
+    clients: Query<&LinkOf, With<ClientOf>>,
+    mut server_states: Query<&mut CatchUpServerState, With<Server>>,
+    connected_clients: Query<(Entity, &LinkOf), (With<ClientOf>, With<Connected>)>,
+) {
+    let Ok(link_of) = clients.get(trigger.entity) else {
+        return;
+    };
+    let Ok(mut state) = server_states.get_mut(link_of.server) else {
+        return;
+    };
+    if !state.has_revealed_catchup_state {
+        return;
+    }
+    let has_connected_client = connected_clients.iter().any(|(client, connected_link)| {
+        client != trigger.entity && connected_link.server == link_of.server
+    });
+    if !has_connected_client {
+        state.has_revealed_catchup_state = false;
     }
 }
 
@@ -270,9 +346,12 @@ fn accept_buffered_catch_up_requests(
     }
 }
 
-/// Send the metadata event only after the accepted visibility reveal has gone
-/// through Replicon's send set. This keeps the event's Replicon checkpoint
-/// causally tied to the snapshot data the client waits for.
+/// Send the CatchUpSnapshotReady message only on a Replicon send pass, after
+/// the accepted visibility reveal has gone through Replicon's send set.
+///
+/// The `snapshot_tick` must be the Replicon tick where the catch-up snapshot is
+/// actually sent, so this system is gated by
+/// `resource_exists_and_changed::<ServerTick>`.
 fn emit_catch_up_snapshot_ready(
     mut query: Query<(
         Entity,

--- a/crates/deterministic/deterministic_replication/src/late_join/shared.rs
+++ b/crates/deterministic/deterministic_replication/src/late_join/shared.rs
@@ -23,12 +23,14 @@ pub struct CatchUpRequest {
 ///
 /// The server sends this as a replicated event when it accepts a catch-up
 /// request. The client stores that metadata, waits for the matching Replicon
-/// checkpoint to be confirmed, then triggers this same event locally. If the
-/// server sends [`CatchUpSnapshotReady::not_required`], the client skips the
-/// forced rollback and triggers this event locally before removing
-/// `CatchUpGated`. User code should observe `On<CatchUpSnapshotReady>` and
-/// query `CatchUpGated` entities to add application-specific local
-/// components before the forced rollback or skip completes.
+/// checkpoint to be confirmed, requests the forced rollback, and then triggers
+/// this same event locally after rollback preparation has restored the snapshot
+/// components but before rollback replay begins. If the server sends
+/// [`CatchUpSnapshotReady::not_required`], the client skips the forced rollback
+/// and triggers this event locally before removing `CatchUpGated`. User code
+/// should observe `On<CatchUpSnapshotReady>` and query `CatchUpGated` entities
+/// to add application-specific local components before replay or skip
+/// completes.
 #[derive(Event, Serialize, Deserialize, Clone, Debug)]
 pub struct CatchUpSnapshotReady {
     /// The accepted Replicon checkpoint tick that revealed the bundled
@@ -118,4 +120,7 @@ pub enum CatchUpSystems {
     /// Client-side: after we receive the catchup tick from the server, trigger a forced
     /// rollback to perform the catchup.
     TriggerCatchUpRollback,
+    /// Client-side: after rollback preparation has restored the snapshot
+    /// components, activate local-only application state before replay begins.
+    ActivateCatchUp,
 }

--- a/crates/replication/prediction/src/manager.rs
+++ b/crates/replication/prediction/src/manager.rs
@@ -279,7 +279,7 @@ impl StateRollbackMetadata {
     }
 
     /// Clear all retained mismatch evidence.
-    pub(crate) fn clear_mismatch_history(&mut self) {
+    pub fn clear_mismatch_history(&mut self) {
         self.mismatch_mask = 0;
     }
 

--- a/crates/replication/prediction/src/predicted_history.rs
+++ b/crates/replication/prediction/src/predicted_history.rs
@@ -4,7 +4,7 @@
 //! 1. Compare local predicted values with confirmed values from the server to detect mismatches
 //! 2. Rollback to a past local state and replay the simulation
 
-use crate::rollback::DeterministicPredicted;
+use crate::rollback::{CatchUpGated, DeterministicPredicted};
 use crate::{Predicted, SyncComponent};
 use bevy_ecs::component::Mutable;
 use bevy_ecs::prelude::*;
@@ -177,10 +177,10 @@ pub(crate) fn apply_component_removal_predicted<C: Component>(
     }
 }
 
-/// When any of `C`, [`Predicted`], [`PreSpawned`], or [`DeterministicPredicted`]
-/// is added to an entity, ensure [`PredictionHistory<C>`] is present, and if
-/// `C` has just been applied via an init message, seed [`ConfirmedHistory<C>`]
-/// at the server tick that produced the init.
+/// When any of `C`, [`Predicted`], [`PreSpawned`], [`DeterministicPredicted`],
+/// or [`CatchUpGated`] is added to an entity, ensure [`PredictionHistory<C>`]
+/// is present, and if `C` has just been applied via an init message, seed
+/// [`ConfirmedHistory<C>`] at the server tick that produced the init.
 ///
 /// # Why seeding is needed
 ///
@@ -197,21 +197,31 @@ pub(crate) fn apply_component_removal_predicted<C: Component>(
 /// samples. If there is no authoritative seed, no confirmed history is inserted:
 /// receive paths create it when a confirmed sample actually arrives.
 pub(crate) fn add_prediction_history<C: SyncComponent>(
-    trigger: On<Add, (C, Predicted, PreSpawned, DeterministicPredicted)>,
-    query: Query<
-        (),
+    trigger: On<
+        Add,
         (
-            With<C>,
-            Or<(
-                With<Predicted>,
-                With<PreSpawned>,
-                With<DeterministicPredicted>,
-            )>,
+            C,
+            Predicted,
+            PreSpawned,
+            DeterministicPredicted,
+            CatchUpGated,
         ),
     >,
+    query: Query<(
+        Has<C>,
+        Has<Predicted>,
+        Has<PreSpawned>,
+        Has<DeterministicPredicted>,
+        Has<CatchUpGated>,
+    )>,
     mut commands: Commands,
 ) {
-    if query.get(trigger.entity).is_err() {
+    let Ok((has_component, predicted, prespawned, deterministic, catchup_gated)) =
+        query.get(trigger.entity)
+    else {
+        return;
+    };
+    if !catchup_gated && !(has_component && (predicted || prespawned || deterministic)) {
         return;
     }
     trace!(

--- a/crates/replication/prediction/src/registry.rs
+++ b/crates/replication/prediction/src/registry.rs
@@ -4,7 +4,7 @@ use crate::plugin::{
     add_non_networked_rollback_systems, add_prediction_systems, add_resource_rollback_systems,
 };
 use crate::predicted_history::PredictionHistory;
-use crate::prelude::{CatchUpGated, PredictionManager};
+use crate::prelude::PredictionManager;
 #[cfg(feature = "metrics")]
 use alloc::format;
 use bevy_app::App;
@@ -766,47 +766,24 @@ impl<C> PredictionRegistrationExt<C> for ComponentRegistration<'_, C> {
         if !self.app.world().contains_resource::<PredictionRegistry>() {
             return self;
         }
-        // Gate keyed on both `AwaitingCatchUpSnapshot` and
-        // `DeterministicPredicted` (backwards-compatible). The Awaiting
-        // marker is important for init messages: Replicon chooses the
-        // receive function before applying the incoming components, so a
-        // late-join catch-up snapshot must be routed to history while the
-        // entity is still awaiting catch-up, before `DeterministicPredicted`
-        // is inserted by user code.
+        // Only `CatchUpGated` routes replicated component state into history.
+        // Initial values for non-gated deterministic entities should use the
+        // default Replicon write path.
         //
-        // - StateBasedCatchUp: while the client is expecting the bundled
-        //   snapshot, the late-join catch-up plugin inserts
-        //   `AwaitingCatchUpSnapshot` on catch-up-gated entities. Writes
-        //   land in `ConfirmedHistory<C>`. The plugin removes the marker
-        //   once the forced rollback is scheduled.
+        // Replicon chooses the receive function before applying incoming
+        // components. `CatchUpGated` is therefore the marker that can catch the
+        // component write while the entity is awaiting catch-up.
         //
-        // - InputOnly: `DeterministicPredicted` is present from spawn but
-        //   `AwaitingCatchUpSnapshot` is never inserted. The initial
-        //   `replicate_once` value lands directly on the live component
-        //   via the default replicon write path.
-        //
-        // The `DeterministicPredicted` marker remains registered for older
-        // flows where the entity is already deterministic when the
-        // authoritative value arrives.
+        // `DeterministicPredicted` is intentionally not registered here. Outside
+        // catch-up there is no forced state rollback that would insert a
+        // `ConfirmedHistory<C>` value back into the live entity.
         use crate::rollback::CatchUpGated;
-        use crate::rollback::DeterministicPredicted;
         self.app.register_marker_with::<CatchUpGated>(MarkerConfig {
             priority: 110,
             need_history: true,
         });
-        self.app.set_marker_fns::<CatchUpGated, C>(
-            write_history_gated_by_catchup::<C>,
-            remove_history_gated_by_catchup::<C>,
-        );
         self.app
-            .register_marker_with::<DeterministicPredicted>(MarkerConfig {
-                priority: 100,
-                need_history: true,
-            });
-        self.app.set_marker_fns::<DeterministicPredicted, C>(
-            write_history_gated_by_catchup::<C>,
-            remove_history_gated_by_catchup::<C>,
-        );
+            .set_marker_fns::<CatchUpGated, C>(write_history::<C>, remove_history::<C>);
         self
     }
 
@@ -1120,67 +1097,6 @@ fn remove_history<C: SyncComponent>(ctx: &mut RemoveCtx, entity: &mut DeferredEn
             .resource_mut::<StateRollbackMetadata>()
             .record_mismatch(tick);
     }
-}
-
-/// Variant of [`write_history`] used by `add_confirmed_write`.
-///
-/// Checks for `AwaitingCatchUpSnapshot` on the entity at write time:
-/// - If absent (e.g. InputOnly mode, or post-catch-up), performs a normal
-///   replicon default write directly to the live component.
-/// - If present (StateBasedCatchUp bundled snapshot en route), records the
-///   write in `ConfirmedHistory<C>` and updates the live component so
-///   activation systems can see that the bundled component has landed.
-fn write_history_gated_by_catchup<C: SyncComponent>(
-    ctx: &mut WriteCtx,
-    rule_fns: &RuleFns<C>,
-    entity: &mut DeferredEntity,
-    message: &mut Bytes,
-) -> Result<()> {
-    if !entity.contains::<CatchUpGated>() {
-        if let Some(mut component) = entity.get_mut::<C>() {
-            rule_fns.deserialize_in_place(ctx, &mut *component, message)?;
-        } else {
-            let component: C = rule_fns.deserialize(ctx, message)?;
-            entity.insert(component);
-        }
-        return Ok(());
-    }
-    let component: C = rule_fns.deserialize(ctx, message)?;
-    let live_component = component.clone();
-    let (_, should_rollback) =
-        add_confirmed_to_history(ctx.message_tick, Some(component), entity, false)?;
-    debug_assert!(!should_rollback);
-    if let Some(mut component) = entity.get_mut::<C>() {
-        *component = live_component;
-    } else {
-        entity.insert(live_component);
-    }
-    Ok(())
-}
-
-/// Variant of [`remove_history`] used by `add_confirmed_write`.
-///
-/// Mirrors [`write_history_gated_by_catchup`], but treats removals from
-/// deterministic catch-up-gated components as visibility-reset noise.
-/// Replicon resends `replicate_once` components by hiding and showing them;
-/// the hide half can arrive as a component removal even though the server did
-/// not authoritatively remove the simulation component.
-fn remove_history_gated_by_catchup<C: SyncComponent>(
-    ctx: &mut RemoveCtx,
-    entity: &mut DeferredEntity,
-) {
-    let awaiting_catchup = entity.contains::<crate::rollback::CatchUpGated>();
-    if awaiting_catchup || entity.contains::<crate::rollback::DeterministicPredicted>() {
-        trace!(
-            component = ?DebugName::type_name::<C>(),
-            entity = ?entity.id(),
-            message_tick = ?ctx.message_tick,
-            awaiting_catchup,
-            "Ignoring deterministic catch-up component removal"
-        );
-        return;
-    }
-    entity.remove::<C>();
 }
 
 #[cfg(test)]

--- a/crates/replication/prediction/src/rollback.rs
+++ b/crates/replication/prediction/src/rollback.rs
@@ -878,7 +878,12 @@ pub(crate) fn prepare_rollback<C: SyncComponent>(
             Option<&mut C>,
             &mut PredictionHistory<C>,
             Option<&mut ConfirmedHistory<C>>,
-            AnyOf<(&Predicted, &PreSpawned, &DeterministicPredicted)>,
+            AnyOf<(
+                &Predicted,
+                &PreSpawned,
+                &DeterministicPredicted,
+                &CatchUpGated,
+            )>,
         ),
         Without<DisableRollback>,
     >,
@@ -898,7 +903,7 @@ pub(crate) fn prepare_rollback<C: SyncComponent>(
         predicted_component,
         mut predicted_history,
         confirmed_history,
-        (predicted, _prespawned, _disable_state_rollback),
+        (_predicted, _prespawned, _deterministic_predicted, _catchup_gated),
     ) in predicted_query.iter_mut()
     {
         let is_state_rollback = matches!(rollback, Rollback::FromState);

--- a/crates/tests/src/client_server/deterministic/state_based_catchup.rs
+++ b/crates/tests/src/client_server/deterministic/state_based_catchup.rs
@@ -1544,3 +1544,82 @@ fn test_state_based_catchup_late_join_reconnect_after_movement() {
     );
     compare_deterministic_motion_to_server(&mut stepper, &[peer_a, peer_b]);
 }
+
+/// Covers the deterministic_replication example sequence where every client
+/// disconnects, then peer 0 reconnects first and peer 1 late-joins afterward.
+#[test]
+fn test_state_based_catchup_reconnect_after_all_clients_disconnect() {
+    let mut stepper = DetStepper::new_server();
+    let _c0 = stepper.new_client();
+    let _c1 = stepper.new_client();
+
+    configure_stepper(&mut stepper, 50);
+
+    stepper.start();
+    stepper.connect_all();
+
+    let peer_a = PeerId::Netcode(0);
+    let peer_b = PeerId::Netcode(1);
+    let server_player_a =
+        spawn_player_on_server(&mut stepper.server_app, peer_a, Vec2::new(-20.0, 0.0), true);
+    let server_player_b =
+        spawn_player_on_server(&mut stepper.server_app, peer_b, Vec2::new(20.0, 0.0), true);
+    spawn_local_action_after_mapping(&mut stepper, 0, server_player_a, peer_a);
+    spawn_local_action_after_mapping(&mut stepper, 1, server_player_b, peer_b);
+
+    stepper.frame_step(200);
+    assert_clean_stepper_player_entities(&mut stepper, &[peer_a, peer_b]);
+    assert_clean_stepper_ball_entities(&mut stepper);
+    assert_stepper_catchup_complete(&mut stepper);
+
+    despawn_server_player_and_action(&mut stepper, server_player_b);
+    despawn_server_player_and_action(&mut stepper, server_player_a);
+    stepper.disconnect_last_client();
+    stepper.disconnect_last_client();
+    stepper.frame_step(30);
+    assert_clean_stepper_player_entities(&mut stepper, &[]);
+    assert_clean_stepper_ball_entities(&mut stepper);
+
+    let reconnected_a = stepper.new_client();
+    assert_eq!(reconnected_a, 0);
+    configure_client_app(stepper.client_app(reconnected_a), 3, 50);
+    stepper.connect_single(reconnected_a);
+
+    stepper.frame_step(120);
+    assert_clean_stepper_player_entities(&mut stepper, &[]);
+    assert_clean_stepper_ball_entities(&mut stepper);
+    assert_stepper_catchup_complete(&mut stepper);
+
+    let server_player_a_reconnect =
+        spawn_player_on_server(&mut stepper.server_app, peer_a, Vec2::new(-20.0, 0.0), true);
+    spawn_local_action_after_mapping(
+        &mut stepper,
+        reconnected_a,
+        server_player_a_reconnect,
+        peer_a,
+    );
+    stepper.frame_step(120);
+    assert_clean_stepper_player_entities(&mut stepper, &[peer_a]);
+    assert_clean_stepper_ball_entities(&mut stepper);
+    assert_stepper_catchup_complete(&mut stepper);
+
+    let reconnected_b = stepper.new_client();
+    assert_eq!(reconnected_b, 1);
+    configure_client_app(stepper.client_app(reconnected_b), 4, 50);
+    stepper.connect_single(reconnected_b);
+    let server_player_b_reconnect =
+        spawn_player_on_server(&mut stepper.server_app, peer_b, Vec2::new(20.0, 0.0), true);
+    spawn_local_action_after_mapping(
+        &mut stepper,
+        reconnected_b,
+        server_player_b_reconnect,
+        peer_b,
+    );
+
+    stepper.frame_step(220);
+    assert_clean_stepper_player_entities(&mut stepper, &[peer_a, peer_b]);
+    assert_server_entity_unmapped(&mut stepper, server_player_a);
+    assert_server_entity_unmapped(&mut stepper, server_player_b);
+    assert_clean_stepper_ball_entities(&mut stepper);
+    assert_stepper_catchup_complete(&mut stepper);
+}


### PR DESCRIPTION
## Summary
- isolate the CatchUpGated simplification from 949f21c without the diff-component replication changes
- route CatchUpGated writes through normal confirmed history and activate catch-up after rollback preparation restores snapshot state
- track post-catch-up reconnects and add a regression test for reconnect-after-all-disconnects

## Validation
- cargo test -p lightyear_tests state_based_catchup -- --nocapture
- cargo check -p lightyear_prediction --features deterministic

Note: cargo test -p lightyear_prediction --features deterministic currently fails before running tests because the crate tests import bevy_state without declaring it; this branch leaves that unrelated dependency issue untouched.