### PR TITLE
feat(inputs): pluggable validation hook for received input messages

### DIFF
--- a/crates/inputs/inputs/src/lib.rs
+++ b/crates/inputs/inputs/src/lib.rs
@@ -19,6 +19,8 @@ pub mod input_message;
 pub mod plugin;
 #[cfg(feature = "server")]
 pub mod server;
+#[cfg(feature = "server")]
+pub mod validation;
 
 pub(crate) const HISTORY_DEPTH: u32 = 20;
 
@@ -43,6 +45,10 @@ pub mod prelude {
     pub mod server {
         pub use crate::server::{
             InputRebroadcaster, InputSystems, ServerInputConfig, ServerInputPlugin,
+        };
+        pub use crate::validation::{
+            InputMessageValidator, InputMessageValidators, InputValidation, InputValidatorAppExt,
+            InputValidationContext,
         };
     }
 }

--- a/crates/inputs/inputs/src/lib.rs
+++ b/crates/inputs/inputs/src/lib.rs
@@ -47,8 +47,8 @@ pub mod prelude {
             InputRebroadcaster, InputSystems, ServerInputConfig, ServerInputPlugin,
         };
         pub use crate::validation::{
-            InputMessageValidator, InputMessageValidators, InputValidation, InputValidatorAppExt,
-            InputValidationContext,
+            InputBufferProvider, InputMessageValidator, InputMessageValidators, InputValidation,
+            InputValidationContext, InputValidatorAppExt, named,
         };
     }
 }

--- a/crates/inputs/inputs/src/server.rs
+++ b/crates/inputs/inputs/src/server.rs
@@ -38,6 +38,8 @@ use lightyear_messages::server::ServerMultiMessageSender;
 use lightyear_replication::prelude::{PreSpawned, RoomId, Rooms};
 use tracing::{debug, error, trace};
 
+use crate::validation::{InputMessageValidators, InputValidationContext};
+
 /// Server-side plugin that receives input messages from clients and applies
 /// them to [`InputBuffer`] components.
 ///
@@ -116,6 +118,11 @@ impl<S: ActionStateSequence + MapEntities> Plugin for ServerInputPlugin<S> {
             marker: core::marker::PhantomData,
         });
 
+        // The validator chain runs on every received `InputMessage` after
+        // deserialization and before it is handled. Empty by default; register
+        // validators via `InputValidatorAppExt`.
+        app.init_resource::<InputMessageValidators<S>>();
+
         // SETS
         // TODO:
         //  - could there be an issue because, client updates `state` and `fixed_update_state` and sends it to server
@@ -159,6 +166,7 @@ fn receive_input_message<S: ActionStateSequence>(
     tick_duration: Res<TickDuration>,
     rooms_query: Query<(Entity, &Rooms), With<Connected>>,
     timeline: Res<LocalTimeline>,
+    validators: Res<InputMessageValidators<S>>,
     mut receivers: Query<
         (
             Entity,
@@ -187,9 +195,7 @@ fn receive_input_message<S: ActionStateSequence>(
         //  should we just read instead?
         let server_entity = link_of.server;
         let tick = timeline.tick();
-        receiver.receive().try_for_each(|message| {
-            #[cfg(feature = "prediction")]
-            let mut message = message;
+        receiver.receive().try_for_each(|mut message| {
             // ignore input messages from the local client (if running in host-server mode)
             // if we're not doing rebroadcasting
             if client_id.is_local() && !config.rebroadcast_inputs {
@@ -218,6 +224,22 @@ fn receive_input_message<S: ActionStateSequence>(
                 message = ?message,
                 "server received input message"
             );
+
+            // Run the validation chain on the freshly-deserialized message
+            // before anything reads or rebroadcasts it. Validators may mutate
+            // the message (e.g. drop individual targets) or reject it whole.
+            // Running here — *before* the rebroadcast block — means dropped
+            // targets are also not relayed to other clients. The chain is empty
+            // unless the user registers validators; see `crate::validation`.
+            let validation_ctx = InputValidationContext {
+                sender: client_entity,
+                client_id: *client_id,
+                server_tick: tick,
+            };
+            if !validators.validate(&validation_ctx, &mut message) {
+                trace!(?tick, ?client_id, "Input message rejected by validator chain");
+                return Ok(())
+            }
 
             // TODO: or should we try to store in a buffer the interpolation delay for the exact tick
             //  that the message was intended for?

--- a/crates/inputs/inputs/src/server.rs
+++ b/crates/inputs/inputs/src/server.rs
@@ -38,7 +38,7 @@ use lightyear_messages::server::ServerMultiMessageSender;
 use lightyear_replication::prelude::{PreSpawned, RoomId, Rooms};
 use tracing::{debug, error, trace};
 
-use crate::validation::{InputMessageValidators, InputValidationContext};
+use crate::validation::{InputBufferProvider, InputMessageValidators, InputValidationContext};
 
 /// Server-side plugin that receives input messages from clients and applies
 /// them to [`InputBuffer`] components.
@@ -156,6 +156,25 @@ impl<S: ActionStateSequence + MapEntities> Plugin for ServerInputPlugin<S> {
 // TODO: why do we need the Server? we could just run this on any receiver.
 //  (apart from rebroadcast inputs)
 
+/// Read-only [`InputBuffer`] accessor handed to input-message validators,
+/// backed by the receive system's buffer query. Resolves `InputTarget::Entity`
+/// targets; `InputTarget::PreSpawned` returns `None` (validators that need
+/// prespawn buffers should run inline for now).
+struct ReceiveBufferProvider<'a, 'w, 's, 'd, S: ActionStateSequence> {
+    buffers: &'a Query<'w, 's, Option<&'d mut InputBuffer<S::Snapshot, S::Action>>>,
+}
+
+impl<'a, 'w, 's, 'd, S: ActionStateSequence> InputBufferProvider<S>
+    for ReceiveBufferProvider<'a, 'w, 's, 'd, S>
+{
+    fn input_buffer(&self, target: InputTarget) -> Option<&InputBuffer<S::Snapshot, S::Action>> {
+        match target {
+            InputTarget::Entity(entity) => self.buffers.get(entity).ok().flatten(),
+            InputTarget::PreSpawned(_) => None,
+        }
+    }
+}
+
 /// Read the input messages from the server events to update the InputBuffers
 fn receive_input_message<S: ActionStateSequence>(
     config: Res<ServerInputConfig<S::Action>>,
@@ -231,14 +250,34 @@ fn receive_input_message<S: ActionStateSequence>(
             // Running here — *before* the rebroadcast block — means dropped
             // targets are also not relayed to other clients. The chain is empty
             // unless the user registers validators; see `crate::validation`.
-            let validation_ctx = InputValidationContext {
-                sender: client_entity,
-                client_id: *client_id,
-                server_tick: tick,
-            };
-            if !validators.validate(&validation_ctx, &mut message) {
-                trace!(?tick, ?client_id, "Input message rejected by validator chain");
-                return Ok(())
+            //
+            // NOTE: host-client / rebroadcast-disabled messages already returned
+            // above, so the validator chain does not see host-client inputs.
+            {
+                let buffer_provider = ReceiveBufferProvider { buffers: &query };
+                let validation_ctx = InputValidationContext::new(
+                    client_entity,
+                    *client_id,
+                    tick,
+                    &buffer_provider,
+                );
+                if let Some(rejected_by) = validators.validate(&validation_ctx, &mut message) {
+                    trace!(
+                        target: "lightyear_debug::input",
+                        kind = "server_input_message_rejected",
+                        schedule = "PreUpdate",
+                        sample_point = "PreUpdate",
+                        entity = ?client_entity,
+                        server_entity = ?server_entity,
+                        client_id = ?client_id.0,
+                        action = ?DebugName::type_name::<S::Action>(),
+                        local_tick = tick.0,
+                        end_tick = message.end_tick.0,
+                        validator = rejected_by,
+                        "input message rejected by validator",
+                    );
+                    return Ok(())
+                }
             }
 
             // TODO: or should we try to store in a buffer the interpolation delay for the exact tick

--- a/crates/inputs/inputs/src/validation.rs
+++ b/crates/inputs/inputs/src/validation.rs
@@ -1,0 +1,236 @@
+//! Pluggable validation for server-side input messages.
+//!
+//! Input messages arrive untrusted from remote clients. After they are
+//! deserialized and *before* the server applies them to any
+//! [`InputBuffer`](crate::input_buffer::InputBuffer), each message is run
+//! through an ordered chain of [`InputMessageValidator`]s. A validator may
+//!
+//! - **mutate** the message — e.g. drop unwanted [`InputTarget`]s via
+//!   [`InputMessage::inputs`]`.retain(..)`, or
+//! - **reject** the whole message — returning [`InputValidation::Reject`],
+//!   which skips it entirely (no buffer writes, no rebroadcast).
+//!
+//! This module provides *only* the extension point; lightyear ships no
+//! validators by default, so the chain is empty (a no-op) until you register
+//! one. A validator can be any type implementing [`InputMessageValidator`], or
+//! simply a closure (see the blanket impl):
+//!
+//! ```ignore
+//! app.add_input_validator::<MySequence>(|ctx, msg| {
+//!     if msg.inputs.len() > 8 { InputValidation::Reject } else { InputValidation::Continue }
+//! });
+//! ```
+//!
+//! Register, group, replace, or remove validators through
+//! [`InputValidatorAppExt`].
+
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+use bevy_app::App;
+use bevy_ecs::entity::Entity;
+use bevy_ecs::resource::Resource;
+use lightyear_core::id::RemoteId;
+use lightyear_core::tick::Tick;
+
+use crate::input_message::{ActionStateSequence, InputMessage};
+
+/// Read-only context handed to every [`InputMessageValidator`].
+///
+/// Validators run *inside* the input-receive system, so they cannot issue
+/// their own ECS queries; everything they are expected to need is exposed
+/// here. The set of fields is intentionally small and is expected to grow as
+/// new validators need more context (see the module docs and the PR
+/// discussion on scope).
+pub struct InputValidationContext {
+    /// The sender's connection entity on the server (the `ClientOf` / link
+    /// entity the message was received on).
+    pub sender: Entity,
+    /// The sender's network id. `client_id.is_local()` is the host client.
+    pub client_id: RemoteId,
+    /// The server's current tick.
+    pub server_tick: Tick,
+}
+
+/// The outcome of validating a single [`InputMessage`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InputValidation {
+    /// Keep the (possibly mutated) message and run the next validator.
+    Continue,
+    /// Drop the whole message: stop the chain and skip handling it.
+    Reject,
+}
+
+/// A check applied to each received [`InputMessage`] before it is handled.
+///
+/// Implementations are registered per action-state-sequence type `S` via
+/// [`InputValidatorAppExt`] and stored in an [`InputMessageValidators<S>`]
+/// resource. They run in registration order; the first [`InputValidation::Reject`]
+/// drops the message.
+///
+/// Any matching closure also implements this trait (see the blanket impl
+/// below), so simple one-off checks need no dedicated type.
+pub trait InputMessageValidator<S: ActionStateSequence>: Send + Sync + 'static {
+    /// Inspect (and optionally mutate) `message`. Return
+    /// [`InputValidation::Reject`] to drop it.
+    fn validate(
+        &self,
+        ctx: &InputValidationContext,
+        message: &mut InputMessage<S>,
+    ) -> InputValidation;
+
+    /// A stable identifier used to remove or replace this validator (see
+    /// [`InputValidatorAppExt::remove_input_validator`]). Defaults to the
+    /// concrete type name.
+    fn name(&self) -> &'static str {
+        core::any::type_name::<Self>()
+    }
+}
+
+/// Any `Fn(&InputValidationContext, &mut InputMessage<S>) -> InputValidation`
+/// is an [`InputMessageValidator`], so one-off checks can be registered as a
+/// closure without defining a type.
+///
+/// Closures take the default [`name`](InputMessageValidator::name) (their
+/// opaque type name), so they are not practical to remove by name — define a
+/// named type if you need [`InputValidatorAppExt::remove_input_validator`].
+impl<S, F> InputMessageValidator<S> for F
+where
+    S: ActionStateSequence,
+    F: Fn(&InputValidationContext, &mut InputMessage<S>) -> InputValidation
+        + Send
+        + Sync
+        + 'static,
+{
+    fn validate(
+        &self,
+        ctx: &InputValidationContext,
+        message: &mut InputMessage<S>,
+    ) -> InputValidation {
+        self(ctx, message)
+    }
+}
+
+/// Resource holding the ordered validator chain for [`InputMessage<S>`].
+///
+/// Inserted (empty) by `ServerInputPlugin`; mutate it through
+/// [`InputValidatorAppExt`].
+#[derive(Resource)]
+pub struct InputMessageValidators<S: ActionStateSequence> {
+    validators: Vec<Box<dyn InputMessageValidator<S>>>,
+}
+
+impl<S: ActionStateSequence> Default for InputMessageValidators<S> {
+    fn default() -> Self {
+        Self {
+            validators: Vec::new(),
+        }
+    }
+}
+
+impl<S: ActionStateSequence> InputMessageValidators<S> {
+    /// Append a single validator (a type or a closure).
+    pub fn push(&mut self, validator: impl InputMessageValidator<S>) {
+        self.validators.push(Box::new(validator));
+    }
+
+    /// Append several already-boxed validators (a group).
+    pub fn extend(
+        &mut self,
+        validators: impl IntoIterator<Item = Box<dyn InputMessageValidator<S>>>,
+    ) {
+        self.validators.extend(validators);
+    }
+
+    /// Remove every validator.
+    pub fn clear(&mut self) {
+        self.validators.clear();
+    }
+
+    /// Remove every validator whose [`InputMessageValidator::name`] matches.
+    pub fn remove(&mut self, name: &str) {
+        self.validators.retain(|v| v.name() != name);
+    }
+
+    /// Number of registered validators.
+    pub fn len(&self) -> usize {
+        self.validators.len()
+    }
+
+    /// Whether the chain is empty.
+    pub fn is_empty(&self) -> bool {
+        self.validators.is_empty()
+    }
+
+    /// Run the chain over `message`. Returns `false` if any validator rejected
+    /// it (the caller should then skip the message).
+    pub fn validate(
+        &self,
+        ctx: &InputValidationContext,
+        message: &mut InputMessage<S>,
+    ) -> bool {
+        for validator in &self.validators {
+            if validator.validate(ctx, message) == InputValidation::Reject {
+                return false;
+            }
+        }
+        true
+    }
+}
+
+/// App-builder extension for registering, grouping, and removing
+/// [`InputMessageValidator`]s.
+pub trait InputValidatorAppExt {
+    /// Append one validator (type or closure) to the chain for `S`.
+    fn add_input_validator<S: ActionStateSequence>(
+        &mut self,
+        validator: impl InputMessageValidator<S>,
+    ) -> &mut Self;
+
+    /// Append a group of already-boxed validators to the chain for `S`.
+    fn add_input_validators<S: ActionStateSequence>(
+        &mut self,
+        validators: impl IntoIterator<Item = Box<dyn InputMessageValidator<S>>>,
+    ) -> &mut Self;
+
+    /// Remove all validators for `S`.
+    fn clear_input_validators<S: ActionStateSequence>(&mut self) -> &mut Self;
+
+    /// Remove the validator(s) named `name` for `S`.
+    fn remove_input_validator<S: ActionStateSequence>(&mut self, name: &str) -> &mut Self;
+}
+
+impl InputValidatorAppExt for App {
+    fn add_input_validator<S: ActionStateSequence>(
+        &mut self,
+        validator: impl InputMessageValidator<S>,
+    ) -> &mut Self {
+        self.world_mut()
+            .get_resource_or_init::<InputMessageValidators<S>>()
+            .push(validator);
+        self
+    }
+
+    fn add_input_validators<S: ActionStateSequence>(
+        &mut self,
+        validators: impl IntoIterator<Item = Box<dyn InputMessageValidator<S>>>,
+    ) -> &mut Self {
+        self.world_mut()
+            .get_resource_or_init::<InputMessageValidators<S>>()
+            .extend(validators);
+        self
+    }
+
+    fn clear_input_validators<S: ActionStateSequence>(&mut self) -> &mut Self {
+        self.world_mut()
+            .get_resource_or_init::<InputMessageValidators<S>>()
+            .clear();
+        self
+    }
+
+    fn remove_input_validator<S: ActionStateSequence>(&mut self, name: &str) -> &mut Self {
+        self.world_mut()
+            .get_resource_or_init::<InputMessageValidators<S>>()
+            .remove(name);
+        self
+    }
+}

--- a/crates/inputs/inputs/src/validation.rs
+++ b/crates/inputs/inputs/src/validation.rs
@@ -32,16 +32,37 @@ use bevy_ecs::resource::Resource;
 use lightyear_core::id::RemoteId;
 use lightyear_core::tick::Tick;
 
-use crate::input_message::{ActionStateSequence, InputMessage};
+use crate::input_buffer::InputBuffer;
+use crate::input_message::{ActionStateSequence, InputMessage, InputTarget};
+
+/// Read-only access to the server-side [`InputBuffer`] of an input target.
+///
+/// Validators run *inside* the input-receive system and cannot issue their own
+/// ECS queries, so the receive system supplies this accessor (built from the
+/// query it already holds). It lets a validator look at a target's *current*
+/// buffer state — e.g. its `last_remote_tick` — which is what buffer-aware
+/// checks (staleness, history-rewrite) need.
+pub trait InputBufferProvider<S: ActionStateSequence> {
+    /// The target's current input buffer, if it exists and can be resolved.
+    fn input_buffer(&self, target: InputTarget) -> Option<&InputBuffer<S::Snapshot, S::Action>>;
+}
+
+/// A provider that resolves nothing — useful for tests or receive paths that
+/// don't (yet) expose buffer access.
+impl<S: ActionStateSequence> InputBufferProvider<S> for () {
+    fn input_buffer(&self, _target: InputTarget) -> Option<&InputBuffer<S::Snapshot, S::Action>> {
+        None
+    }
+}
 
 /// Read-only context handed to every [`InputMessageValidator`].
 ///
 /// Validators run *inside* the input-receive system, so they cannot issue
 /// their own ECS queries; everything they are expected to need is exposed
-/// here. The set of fields is intentionally small and is expected to grow as
-/// new validators need more context (see the module docs and the PR
-/// discussion on scope).
-pub struct InputValidationContext {
+/// here. It is `#[non_exhaustive]` and accessed through methods so new context
+/// can be added without breaking existing validators.
+#[non_exhaustive]
+pub struct InputValidationContext<'a, S: ActionStateSequence> {
     /// The sender's connection entity on the server (the `ClientOf` / link
     /// entity the message was received on).
     pub sender: Entity,
@@ -49,6 +70,36 @@ pub struct InputValidationContext {
     pub client_id: RemoteId,
     /// The server's current tick.
     pub server_tick: Tick,
+    buffers: &'a dyn InputBufferProvider<S>,
+}
+
+impl<'a, S: ActionStateSequence> InputValidationContext<'a, S> {
+    /// Build a context. Called by the input-receive systems; `buffers` is the
+    /// read-only buffer accessor (pass `&()` if buffer access is unavailable).
+    pub fn new(
+        sender: Entity,
+        client_id: RemoteId,
+        server_tick: Tick,
+        buffers: &'a dyn InputBufferProvider<S>,
+    ) -> Self {
+        Self {
+            sender,
+            client_id,
+            server_tick,
+            buffers,
+        }
+    }
+
+    /// Read-only access to a target's current server-side [`InputBuffer`].
+    ///
+    /// Returns `None` if the target has no buffer, or for targets the active
+    /// provider can't resolve (e.g. `InputTarget::PreSpawned`).
+    pub fn input_buffer(
+        &self,
+        target: InputTarget,
+    ) -> Option<&InputBuffer<S::Snapshot, S::Action>> {
+        self.buffers.input_buffer(target)
+    }
 }
 
 /// The outcome of validating a single [`InputMessage`].
@@ -74,7 +125,7 @@ pub trait InputMessageValidator<S: ActionStateSequence>: Send + Sync + 'static {
     /// [`InputValidation::Reject`] to drop it.
     fn validate(
         &self,
-        ctx: &InputValidationContext,
+        ctx: &InputValidationContext<'_, S>,
         message: &mut InputMessage<S>,
     ) -> InputValidation;
 
@@ -96,17 +147,49 @@ pub trait InputMessageValidator<S: ActionStateSequence>: Send + Sync + 'static {
 impl<S, F> InputMessageValidator<S> for F
 where
     S: ActionStateSequence,
-    F: Fn(&InputValidationContext, &mut InputMessage<S>) -> InputValidation
+    F: for<'a> Fn(&InputValidationContext<'a, S>, &mut InputMessage<S>) -> InputValidation
         + Send
         + Sync
         + 'static,
 {
     fn validate(
         &self,
-        ctx: &InputValidationContext,
+        ctx: &InputValidationContext<'_, S>,
         message: &mut InputMessage<S>,
     ) -> InputValidation {
         self(ctx, message)
+    }
+}
+
+/// Wrap a validator (typically a closure) with an explicit [`name`] so it can
+/// be removed via [`InputValidatorAppExt::remove_input_validator`]. Bare
+/// closures all share an opaque `name()`, so without this they cannot be
+/// removed individually.
+///
+/// [`name`]: InputMessageValidator::name
+pub fn named<S: ActionStateSequence>(
+    name: &'static str,
+    validator: impl InputMessageValidator<S>,
+) -> impl InputMessageValidator<S> {
+    Named { name, validator }
+}
+
+struct Named<V> {
+    name: &'static str,
+    validator: V,
+}
+
+impl<S: ActionStateSequence, V: InputMessageValidator<S>> InputMessageValidator<S> for Named<V> {
+    fn validate(
+        &self,
+        ctx: &InputValidationContext<'_, S>,
+        message: &mut InputMessage<S>,
+    ) -> InputValidation {
+        self.validator.validate(ctx, message)
+    }
+
+    fn name(&self) -> &'static str {
+        self.name
     }
 }
 
@@ -161,19 +244,20 @@ impl<S: ActionStateSequence> InputMessageValidators<S> {
         self.validators.is_empty()
     }
 
-    /// Run the chain over `message`. Returns `false` if any validator rejected
-    /// it (the caller should then skip the message).
+    /// Run the chain over `message`. Returns `Some(name)` of the first
+    /// validator that rejected it (the caller should then skip the message), or
+    /// `None` if every validator accepted.
     pub fn validate(
         &self,
-        ctx: &InputValidationContext,
+        ctx: &InputValidationContext<'_, S>,
         message: &mut InputMessage<S>,
-    ) -> bool {
+    ) -> Option<&'static str> {
         for validator in &self.validators {
             if validator.validate(ctx, message) == InputValidation::Reject {
-                return false;
+                return Some(validator.name());
             }
         }
-        true
+        None
     }
 }
 

--- a/crates/tests/src/client_server/input/leafwing.rs
+++ b/crates/tests/src/client_server/input/leafwing.rs
@@ -466,7 +466,7 @@ fn test_registered_validator_can_reject_input() {
     stepper
         .server_app
         .add_input_validator::<LeafwingSequence<LeafwingInput1>>(
-            |_ctx: &InputValidationContext,
+            |_ctx: &InputValidationContext<LeafwingSequence<LeafwingInput1>>,
              _msg: &mut InputMessage<LeafwingSequence<LeafwingInput1>>| {
                 InputValidation::Reject
             },
@@ -532,7 +532,7 @@ fn test_validator_can_drop_targets_by_mutation() {
     stepper
         .server_app
         .add_input_validator::<LeafwingSequence<LeafwingInput1>>(
-            |_ctx: &InputValidationContext,
+            |_ctx: &InputValidationContext<LeafwingSequence<LeafwingInput1>>,
              msg: &mut InputMessage<LeafwingSequence<LeafwingInput1>>| {
                 // Drop every entity target; keep the message otherwise intact.
                 msg.inputs.clear();
@@ -601,7 +601,7 @@ fn test_remove_input_validator_restores_handling() {
     impl InputMessageValidator<LeafwingSequence<LeafwingInput1>> for BlockAll {
         fn validate(
             &self,
-            _ctx: &InputValidationContext,
+            _ctx: &InputValidationContext<'_, LeafwingSequence<LeafwingInput1>>,
             _msg: &mut InputMessage<LeafwingSequence<LeafwingInput1>>,
         ) -> InputValidation {
             InputValidation::Reject
@@ -673,5 +673,86 @@ fn test_remove_input_validator_restores_handling() {
         now_pressed,
         "after remove_input_validator, the input should reach the server, but \
          it is still being dropped.",
+    );
+}
+
+/// A validator can read a target's current server-side `InputBuffer` through
+/// the context accessor. The validator records (via a captured flag) whether it
+/// ever resolved a buffer, and returns `Continue` so the input still lands —
+/// proving the accessor resolves real targets without altering behavior.
+#[test]
+fn test_validator_can_read_target_input_buffer() {
+    use lightyear::input::leafwing::input_message::LeafwingSequence;
+    use lightyear_inputs::input_message::InputMessage;
+    use lightyear_inputs::prelude::server::{
+        InputValidation, InputValidationContext, InputValidatorAppExt,
+    };
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    let saw_buffer = Arc::new(AtomicBool::new(false));
+    let flag = saw_buffer.clone();
+
+    let mut stepper = ClientServerStepper::from_config(StepperConfig::with_netcode_clients(1));
+    stepper
+        .server_app
+        .add_input_validator::<LeafwingSequence<LeafwingInput1>>(
+            move |ctx: &InputValidationContext<LeafwingSequence<LeafwingInput1>>,
+                  msg: &mut InputMessage<LeafwingSequence<LeafwingInput1>>| {
+                for data in &msg.inputs {
+                    if ctx.input_buffer(data.target).is_some() {
+                        flag.store(true, Ordering::SeqCst);
+                    }
+                }
+                InputValidation::Continue
+            },
+        );
+
+    let server_entity = stepper
+        .server_app
+        .world_mut()
+        .spawn((
+            ActionState::<LeafwingInput1>::default(),
+            Replicate::to_clients(NetworkTarget::All),
+        ))
+        .id();
+    stepper.frame_step(2);
+
+    let local = stepper
+        .client(0)
+        .get::<MessageManager>()
+        .unwrap()
+        .entity_mapper
+        .get_local(server_entity)
+        .expect("entity replicated to client 0");
+    stepper.client_apps[0]
+        .world_mut()
+        .entity_mut(local)
+        .insert(InputMap::<LeafwingInput1>::new([(
+            LeafwingInput1::Jump,
+            KeyCode::KeyA,
+        )]));
+    stepper.frame_step(1);
+    stepper.client_apps[0]
+        .world_mut()
+        .resource_mut::<ButtonInput<KeyCode>>()
+        .press(KeyCode::KeyA);
+    stepper.frame_step(10);
+
+    assert!(
+        saw_buffer.load(Ordering::SeqCst),
+        "validator never resolved a target's InputBuffer via ctx.input_buffer — \
+         the read-only buffer accessor is not wired.",
+    );
+    let pressed = stepper
+        .server_app
+        .world()
+        .entity(server_entity)
+        .get::<ActionState<LeafwingInput1>>()
+        .unwrap()
+        .pressed(&LeafwingInput1::Jump);
+    assert!(
+        pressed,
+        "validator returned Continue, so the legitimate input should still land.",
     );
 }

--- a/crates/tests/src/client_server/input/leafwing.rs
+++ b/crates/tests/src/client_server/input/leafwing.rs
@@ -443,3 +443,235 @@ fn test_leafwing_input_rebroadcast() {
         );
     }
 }
+
+// --- Input-message validation framework --------------------------------------
+//
+// These exercise the pluggable validator chain (lightyear ships no validators
+// by default, so without registration the chain is a no-op). They demonstrate:
+// rejecting a whole message, mutating a message (dropping targets), and
+// removing a registered validator by name.
+
+/// A registered validator that returns `Reject` drops the message: a
+/// legitimate, authorized input never reaches the server's `ActionState`.
+/// Registered here as a plain closure (blanket `Fn` impl).
+#[test]
+fn test_registered_validator_can_reject_input() {
+    use lightyear::input::leafwing::input_message::LeafwingSequence;
+    use lightyear_inputs::input_message::InputMessage;
+    use lightyear_inputs::prelude::server::{
+        InputValidation, InputValidationContext, InputValidatorAppExt,
+    };
+
+    let mut stepper = ClientServerStepper::from_config(StepperConfig::with_netcode_clients(1));
+    stepper
+        .server_app
+        .add_input_validator::<LeafwingSequence<LeafwingInput1>>(
+            |_ctx: &InputValidationContext,
+             _msg: &mut InputMessage<LeafwingSequence<LeafwingInput1>>| {
+                InputValidation::Reject
+            },
+        );
+
+    let server_entity = stepper
+        .server_app
+        .world_mut()
+        .spawn((
+            ActionState::<LeafwingInput1>::default(),
+            Replicate::to_clients(NetworkTarget::All),
+        ))
+        .id();
+    stepper.frame_step(2);
+
+    let local = stepper
+        .client(0)
+        .get::<MessageManager>()
+        .unwrap()
+        .entity_mapper
+        .get_local(server_entity)
+        .expect("entity replicated to client 0");
+    stepper.client_apps[0]
+        .world_mut()
+        .entity_mut(local)
+        .insert(InputMap::<LeafwingInput1>::new([(
+            LeafwingInput1::Jump,
+            KeyCode::KeyA,
+        )]));
+    stepper.frame_step(1);
+    stepper.client_apps[0]
+        .world_mut()
+        .resource_mut::<ButtonInput<KeyCode>>()
+        .press(KeyCode::KeyA);
+    stepper.frame_step(10);
+
+    let server_state = stepper
+        .server_app
+        .world()
+        .entity(server_entity)
+        .get::<ActionState<LeafwingInput1>>()
+        .expect("entity has ActionState");
+    assert!(
+        !server_state.pressed(&LeafwingInput1::Jump),
+        "input reached the server even though a registered validator rejected \
+         every message — the validator chain is not being run.",
+    );
+}
+
+/// A validator may mutate the message instead of rejecting it. Here it drops
+/// the message's `InputTarget::Entity` entries via `retain` (returning
+/// `Continue`), so the authorized input still never lands — exercising the
+/// mutate path and the empty-after-mutation no-op.
+#[test]
+fn test_validator_can_drop_targets_by_mutation() {
+    use lightyear::input::leafwing::input_message::LeafwingSequence;
+    use lightyear_inputs::input_message::InputMessage;
+    use lightyear_inputs::prelude::server::{
+        InputValidation, InputValidationContext, InputValidatorAppExt,
+    };
+
+    let mut stepper = ClientServerStepper::from_config(StepperConfig::with_netcode_clients(1));
+    stepper
+        .server_app
+        .add_input_validator::<LeafwingSequence<LeafwingInput1>>(
+            |_ctx: &InputValidationContext,
+             msg: &mut InputMessage<LeafwingSequence<LeafwingInput1>>| {
+                // Drop every entity target; keep the message otherwise intact.
+                msg.inputs.clear();
+                InputValidation::Continue
+            },
+        );
+
+    let server_entity = stepper
+        .server_app
+        .world_mut()
+        .spawn((
+            ActionState::<LeafwingInput1>::default(),
+            Replicate::to_clients(NetworkTarget::All),
+        ))
+        .id();
+    stepper.frame_step(2);
+
+    let local = stepper
+        .client(0)
+        .get::<MessageManager>()
+        .unwrap()
+        .entity_mapper
+        .get_local(server_entity)
+        .expect("entity replicated to client 0");
+    stepper.client_apps[0]
+        .world_mut()
+        .entity_mut(local)
+        .insert(InputMap::<LeafwingInput1>::new([(
+            LeafwingInput1::Jump,
+            KeyCode::KeyA,
+        )]));
+    stepper.frame_step(1);
+    stepper.client_apps[0]
+        .world_mut()
+        .resource_mut::<ButtonInput<KeyCode>>()
+        .press(KeyCode::KeyA);
+    stepper.frame_step(10);
+
+    let server_state = stepper
+        .server_app
+        .world()
+        .entity(server_entity)
+        .get::<ActionState<LeafwingInput1>>()
+        .expect("entity has ActionState");
+    assert!(
+        !server_state.pressed(&LeafwingInput1::Jump),
+        "input landed even though the validator cleared the message's targets.",
+    );
+}
+
+/// `remove_input_validator(name)` takes a previously-registered validator back
+/// out of the chain: the same input that was blocked now flows through.
+#[test]
+fn test_remove_input_validator_restores_handling() {
+    use lightyear::input::leafwing::input_message::LeafwingSequence;
+    use lightyear_inputs::input_message::InputMessage;
+    use lightyear_inputs::prelude::server::{
+        InputMessageValidator, InputValidation, InputValidationContext, InputValidatorAppExt,
+    };
+
+    /// A named validator that rejects everything.
+    struct BlockAll;
+    impl BlockAll {
+        const NAME: &'static str = "test::BlockAll";
+    }
+    impl InputMessageValidator<LeafwingSequence<LeafwingInput1>> for BlockAll {
+        fn validate(
+            &self,
+            _ctx: &InputValidationContext,
+            _msg: &mut InputMessage<LeafwingSequence<LeafwingInput1>>,
+        ) -> InputValidation {
+            InputValidation::Reject
+        }
+        fn name(&self) -> &'static str {
+            Self::NAME
+        }
+    }
+
+    let mut stepper = ClientServerStepper::from_config(StepperConfig::with_netcode_clients(1));
+    stepper
+        .server_app
+        .add_input_validator::<LeafwingSequence<LeafwingInput1>>(BlockAll);
+
+    let server_entity = stepper
+        .server_app
+        .world_mut()
+        .spawn((
+            ActionState::<LeafwingInput1>::default(),
+            Replicate::to_clients(NetworkTarget::All),
+        ))
+        .id();
+    stepper.frame_step(2);
+
+    let local = stepper
+        .client(0)
+        .get::<MessageManager>()
+        .unwrap()
+        .entity_mapper
+        .get_local(server_entity)
+        .expect("entity replicated to client 0");
+    stepper.client_apps[0]
+        .world_mut()
+        .entity_mut(local)
+        .insert(InputMap::<LeafwingInput1>::new([(
+            LeafwingInput1::Jump,
+            KeyCode::KeyA,
+        )]));
+    stepper.frame_step(1);
+    stepper.client_apps[0]
+        .world_mut()
+        .resource_mut::<ButtonInput<KeyCode>>()
+        .press(KeyCode::KeyA);
+    stepper.frame_step(10);
+
+    let blocked = stepper
+        .server_app
+        .world()
+        .entity(server_entity)
+        .get::<ActionState<LeafwingInput1>>()
+        .unwrap()
+        .pressed(&LeafwingInput1::Jump);
+    assert!(!blocked, "BlockAll should have rejected the input");
+
+    // Remove the validator; the same held key should now reach the server.
+    stepper
+        .server_app
+        .remove_input_validator::<LeafwingSequence<LeafwingInput1>>(BlockAll::NAME);
+    stepper.frame_step(10);
+
+    let now_pressed = stepper
+        .server_app
+        .world()
+        .entity(server_entity)
+        .get::<ActionState<LeafwingInput1>>()
+        .unwrap()
+        .pressed(&LeafwingInput1::Jump);
+    assert!(
+        now_pressed,
+        "after remove_input_validator, the input should reach the server, but \
+         it is still being dropped.",
+    );
+}


### PR DESCRIPTION
## Summary

Adds a **pluggable validation hook** for server-side input messages — the
extension point you asked about in #1525 ("a hook that would run on the
`InputMessage`s after deserialization but before they are handled").

Each received `InputMessage<S>` is run through an ordered chain of
user-registered validators **after deserialization and before** it is applied
to any `InputBuffer` (and before rebroadcast). A validator may:

- **mutate** the message — e.g. drop individual `InputTarget`s via
  `inputs.retain(..)`, or
- **reject** it whole — `InputValidation::Reject` skips it entirely.

**No behavior change by default.** lightyear ships no validators here, so the
chain is empty (a no-op) until something is registered. This PR is the
*framework only* — see "Relationship to #1525/#1526" below.

## API

```rust
// implement the trait…
pub trait InputMessageValidator<S: ActionStateSequence>: Send + Sync + 'static {
    fn validate(&self, ctx: &InputValidationContext, msg: &mut InputMessage<S>) -> InputValidation;
    fn name(&self) -> &'static str { core::any::type_name::<Self>() } // for removal
}

// …or just pass a closure (blanket `Fn` impl):
app.add_input_validator::<S>(|ctx, msg| {
    if msg.inputs.len() > 8 { InputValidation::Reject } else { InputValidation::Continue }
});

app.add_input_validators::<S>([Box::new(A), Box::new(B)]); // a group
app.remove_input_validator::<S>(MyValidator::NAME);         // by name
app.clear_input_validators::<S>();                          // all
```

`InputValidationContext` is intentionally small and read-only (validators run
*inside* the receive system, so they can't issue their own queries):
`{ sender, client_id, server_tick }`.

The hook fires once per message in `receive_input_message`, right after the
trace logging and before the interpolation-delay / rebroadcast / apply steps.

## Design options considered

I'd like your steer on the shape before polishing. What this PR implements is
**Option A**.

| | Approach | Pros | Cons |
|---|---|---|---|
| **A (this PR)** | Ordered `Vec<Box<dyn InputMessageValidator<S>>>` resource + `App` ext; closures work via a blanket `Fn` impl | Composable chain; stateful validators; remove/replace by name; closures keep one-off checks terse | Introduces a `Vec<Box<dyn _>>` chain (not used elsewhere in the crate); validators can't run arbitrary ECS queries |
| **B** | A `ValidateInputs` `SystemSet`: stage messages into a resource, let users add **normal systems** that filter/reject before handling | Full `SystemParam`/ECS access (rate-limit on arbitrary components, look at world state); very Bevy-idiomatic | Restructures the drain path; needs a staging resource; ordering/short-circuit semantics are fuzzier across systems |
| **C** | A single `Box<dyn Fn(.., &mut Ctx)>` hook (à la the netcode `on_connect` callback) | Matches an existing lightyear idiom; minimal surface | One hook only — no composition, grouping, or removal |

A and C are "run inside the receive system with a fixed context"; B is "expose
the messages to user systems with full ECS access." They trade conciseness
against power.

## Open question: server-only + thin context, or go generic?

This PR is deliberately **server-only** with a **thin context**. The bigger
design question is whether the framework should be **more generic** — and
whether that would *simplify* the codebase by absorbing checks that are
currently bespoke (see below). Going generic mainly means:

1. giving validators access to the target's `InputBuffer` (state, not just the
   message), and
2. a **client-side** twin for the remote-player input receive path.

I'm inclined toward the more generic form **iff it removes special-cased code**
rather than adding a parallel mechanism. Hence Option B is on the table.

## Refactoring candidates (what could move onto this hook)

Existing, currently-bespoke checks on received input messages that *could*
become validators — with what each would require:

- **`detect_input_history_rewrite` + the late-input-mismatch branch**
  (`crates/inputs/inputs/src/server.rs`). Anomaly detection on inbound inputs;
  today it logs but never rejects. **Requires:** validator access to the
  target's `InputBuffer` (not in the current context).
- **Remote-player input staleness/ordering drop**
  (`crates/inputs/inputs/src/client.rs`, `receive_remote_player_input_messages`
  — drops a message when `last_remote_tick >= end_tick`). Conceptually the same
  "validate an inbound `InputMessage`," but on the **client** receive path.
  **Requires:** a client-side validator chain + `InputBuffer` access.

Explicitly **out of scope** (different domain — should *not* move here):
authority request/response (`replication/.../authority.rs`), `ControlledBy`
visibility (`control.rs`), prespawn hash-collision (`prespawn.rs`),
malformed-packet drops and deserialization errors (message/transport layer).

If we adopt the generic form (buffer access + client side), the two candidates
above could be unified onto one mechanism — that's the "simplifies the
codebase" case for going generic.

## Relationship to #1525 / #1526

This framework is the generalization of the two specific protections; their
merits stay up for review in their own PRs:

- **#1525** (unbounded `end_tick` → memory-exhaustion DoS) becomes an
  `EndTickLookahead` validator. I'll drop the ~10-line validator form in a
  comment below so you can see how it plugs in (it needs only `server_tick`,
  already in the context).
- **#1526** (spoofed `InputTarget::Entity`) becomes a `ControlledByAuthorization`
  validator. It needs the sender's `ControlledByRemote`, which would extend
  `InputValidationContext` with one field.

## Tests

Framework mechanics (no default validators, so input handling is otherwise
unchanged):

- `test_registered_validator_can_reject_input` — a closure that rejects drops the message.
- `test_validator_can_drop_targets_by_mutation` — mutating the message (clearing targets) is honored.
- `test_remove_input_validator_restores_handling` — `remove_input_validator(NAME)` puts handling back.

The full existing input + rollback suites pass unchanged.
