### PR TITLE
feat(inputs): server-side input-validation seam (ValidateInputs)

### DIFF
--- a/crates/inputs/inputs/src/lib.rs
+++ b/crates/inputs/inputs/src/lib.rs
@@ -42,7 +42,8 @@ pub mod prelude {
     #[cfg(feature = "server")]
     pub mod server {
         pub use crate::server::{
-            InputRebroadcaster, InputSystems, ServerInputConfig, ServerInputPlugin,
+            InputRebroadcaster, InputSystems, InputValidationAppExt, ServerInputConfig,
+            ServerInputPlugin,
         };
     }
 }

--- a/crates/inputs/inputs/src/server.rs
+++ b/crates/inputs/inputs/src/server.rs
@@ -13,7 +13,6 @@ use alloc::format;
 use bevy_app::{App, FixedPreUpdate, Plugin, PreUpdate};
 use bevy_ecs::component::Component;
 use bevy_ecs::prelude::Has;
-use bevy_ecs::relationship::RelationshipTarget;
 use bevy_ecs::{
     entity::{Entity, MapEntities},
     error::Result,
@@ -36,7 +35,6 @@ use lightyear_link::prelude::{LinkOf, Server};
 use lightyear_messages::plugin::MessageSystems;
 use lightyear_messages::prelude::MessageReceiver;
 use lightyear_messages::server::ServerMultiMessageSender;
-use lightyear_replication::control::ControlledByRemote;
 use lightyear_replication::prelude::{PreSpawned, RoomId, Rooms};
 use tracing::{debug, error, trace};
 
@@ -118,15 +116,12 @@ pub type InputSet = InputSystems;
 
 #[derive(SystemSet, Debug, Hash, PartialEq, Eq, Clone, Copy)]
 pub enum InputSystems {
-    /// lightyear-owned authorization: drop `InputTarget::Entity` entries the
-    /// sender is not authorized to control (`ControlledByRemote`). Runs after
-    /// `MessageSystems::Receive` and **before** [`Self::ValidateInputs`], so
-    /// user validation systems never see spoofed targets.
-    AuthorizeInputs,
-    /// Validate / sanitize received [`InputMessage`]s before they are buffered.
-    /// Runs after [`Self::AuthorizeInputs`] and before [`Self::ReceiveInputs`].
-    /// Empty by default — add systems here (see [`InputValidationAppExt::add_input_validator`])
-    /// that mutate or drop messages via [`MessageReceiver::retain_messages`].
+    /// Validate / sanitize received [`InputMessage`]s before they are applied to
+    /// the [`InputBuffer`]. Runs after `MessageSystems::Receive` and before
+    /// [`Self::ReceiveInputs`]. Empty by default — add systems here (see
+    /// [`InputValidationAppExt::add_input_validator`]) that mutate or drop
+    /// messages via [`MessageReceiver::retain_messages`]. A game that wants to
+    /// authorize input targets against `ControlledBy` can do so here.
     ValidateInputs,
     /// Receive the latest ActionDiffs from the client
     ReceiveInputs,
@@ -208,7 +203,6 @@ impl<S: ActionStateSequence + MapEntities> Plugin for ServerInputPlugin<S> {
             PreUpdate,
             (
                 MessageSystems::Receive,
-                InputSystems::AuthorizeInputs,
                 InputSystems::ValidateInputs,
                 InputSystems::ReceiveInputs,
             )
@@ -226,59 +220,12 @@ impl<S: ActionStateSequence + MapEntities> Plugin for ServerInputPlugin<S> {
         // SYSTEMS
         app.add_systems(
             PreUpdate,
-            authorize_input_targets::<S>.in_set(InputSystems::AuthorizeInputs),
-        );
-        app.add_systems(
-            PreUpdate,
             receive_input_message::<S>.in_set(InputSystems::ReceiveInputs),
         );
         app.add_systems(
             FixedPreUpdate,
             update_action_state::<S>.in_set(InputSystems::UpdateActionState),
         );
-    }
-}
-
-/// lightyear-owned authorization pass (runs in [`InputSystems::AuthorizeInputs`],
-/// before user [`InputSystems::ValidateInputs`]).
-///
-/// Drops every `InputTarget::Entity` the sending peer is not authorized to
-/// control — i.e. not a member of its [`ControlledByRemote`]. A message left
-/// with no targets is removed entirely. This runs the [`#1526`] target-spoof
-/// defense *before* the validation seam, so user validation systems only ever
-/// see authorized `(sender, target)` pairs and never have to reason about
-/// spoofed targets.
-///
-/// - Host-client inputs (`RemoteId::is_local`) are trusted in-process and
-///   skipped.
-/// - `InputTarget::PreSpawned` is identified by hash, not entity id, so it is
-///   passed through here (out of scope for this gate).
-///
-/// [`#1526`]: https://github.com/cBournhonesque/lightyear/pull/1526
-fn authorize_input_targets<S: ActionStateSequence>(
-    mut receivers: Query<
-        (
-            &RemoteId,
-            Option<&ControlledByRemote>,
-            &mut MessageReceiver<InputMessage<S>>,
-        ),
-        With<Connected>,
-    >,
-) {
-    for (client_id, controlled_by_remote, mut receiver) in receivers.iter_mut() {
-        // Host-client inputs are authored in-process; trust them.
-        if client_id.is_local() {
-            continue;
-        }
-        receiver.retain_messages(|message| {
-            message.inputs.retain(|data| match data.target {
-                InputTarget::Entity(entity) => controlled_by_remote
-                    .is_some_and(|controlled| controlled.collection().contains(&entity)),
-                InputTarget::PreSpawned(_) => true,
-            });
-            // Drop the whole message once all of its targets were unauthorized.
-            !message.inputs.is_empty()
-        });
     }
 }
 

--- a/crates/inputs/inputs/src/server.rs
+++ b/crates/inputs/inputs/src/server.rs
@@ -13,6 +13,7 @@ use alloc::format;
 use bevy_app::{App, FixedPreUpdate, Plugin, PreUpdate};
 use bevy_ecs::component::Component;
 use bevy_ecs::prelude::Has;
+use bevy_ecs::relationship::RelationshipTarget;
 use bevy_ecs::{
     entity::{Entity, MapEntities},
     error::Result,
@@ -35,6 +36,7 @@ use lightyear_link::prelude::{LinkOf, Server};
 use lightyear_messages::plugin::MessageSystems;
 use lightyear_messages::prelude::MessageReceiver;
 use lightyear_messages::server::ServerMultiMessageSender;
+use lightyear_replication::control::ControlledByRemote;
 use lightyear_replication::prelude::{PreSpawned, RoomId, Rooms};
 use tracing::{debug, error, trace};
 
@@ -116,10 +118,45 @@ pub type InputSet = InputSystems;
 
 #[derive(SystemSet, Debug, Hash, PartialEq, Eq, Clone, Copy)]
 pub enum InputSystems {
+    /// lightyear-owned authorization: drop `InputTarget::Entity` entries the
+    /// sender is not authorized to control (`ControlledByRemote`). Runs after
+    /// `MessageSystems::Receive` and **before** [`Self::ValidateInputs`], so
+    /// user validation systems never see spoofed targets.
+    AuthorizeInputs,
+    /// Validate / sanitize received [`InputMessage`]s before they are buffered.
+    /// Runs after [`Self::AuthorizeInputs`] and before [`Self::ReceiveInputs`].
+    /// Empty by default — add systems here (see [`InputValidationAppExt::add_input_validator`])
+    /// that mutate or drop messages via [`MessageReceiver::retain_messages`].
+    ValidateInputs,
     /// Receive the latest ActionDiffs from the client
     ReceiveInputs,
     /// Use the ActionDiff received from the client to update the `ActionState`
     UpdateActionState,
+}
+
+/// App-builder helper to register a server-side input-validation system.
+///
+/// The system runs in [`InputSystems::ValidateInputs`] — after messages are
+/// received, before they are buffered — so it can mutate or drop them with full
+/// ECS access (any `SystemParam`). It typically queries
+/// `Query<&mut MessageReceiver<InputMessage<S>>>` and calls
+/// [`MessageReceiver::retain_messages`]. This is sugar for
+/// `app.add_systems(PreUpdate, system.in_set(InputSystems::ValidateInputs))`.
+pub trait InputValidationAppExt {
+    fn add_input_validator<M>(
+        &mut self,
+        systems: impl IntoScheduleConfigs<bevy_ecs::system::ScheduleSystem, M>,
+    ) -> &mut Self;
+}
+
+impl InputValidationAppExt for App {
+    fn add_input_validator<M>(
+        &mut self,
+        systems: impl IntoScheduleConfigs<bevy_ecs::system::ScheduleSystem, M>,
+    ) -> &mut Self {
+        self.add_systems(PreUpdate, systems.in_set(InputSystems::ValidateInputs));
+        self
+    }
 }
 
 /// Component that is used to customize how inputs will be rebroadcasted
@@ -169,7 +206,13 @@ impl<S: ActionStateSequence + MapEntities> Plugin for ServerInputPlugin<S> {
         //  - but host-server broadcasting their inputs only updates `state`
         app.configure_sets(
             PreUpdate,
-            (MessageSystems::Receive, InputSystems::ReceiveInputs).chain(),
+            (
+                MessageSystems::Receive,
+                InputSystems::AuthorizeInputs,
+                InputSystems::ValidateInputs,
+                InputSystems::ReceiveInputs,
+            )
+                .chain(),
         );
         app.configure_sets(FixedPreUpdate, InputSystems::UpdateActionState);
 
@@ -183,12 +226,59 @@ impl<S: ActionStateSequence + MapEntities> Plugin for ServerInputPlugin<S> {
         // SYSTEMS
         app.add_systems(
             PreUpdate,
+            authorize_input_targets::<S>.in_set(InputSystems::AuthorizeInputs),
+        );
+        app.add_systems(
+            PreUpdate,
             receive_input_message::<S>.in_set(InputSystems::ReceiveInputs),
         );
         app.add_systems(
             FixedPreUpdate,
             update_action_state::<S>.in_set(InputSystems::UpdateActionState),
         );
+    }
+}
+
+/// lightyear-owned authorization pass (runs in [`InputSystems::AuthorizeInputs`],
+/// before user [`InputSystems::ValidateInputs`]).
+///
+/// Drops every `InputTarget::Entity` the sending peer is not authorized to
+/// control — i.e. not a member of its [`ControlledByRemote`]. A message left
+/// with no targets is removed entirely. This runs the [`#1526`] target-spoof
+/// defense *before* the validation seam, so user validation systems only ever
+/// see authorized `(sender, target)` pairs and never have to reason about
+/// spoofed targets.
+///
+/// - Host-client inputs (`RemoteId::is_local`) are trusted in-process and
+///   skipped.
+/// - `InputTarget::PreSpawned` is identified by hash, not entity id, so it is
+///   passed through here (out of scope for this gate).
+///
+/// [`#1526`]: https://github.com/cBournhonesque/lightyear/pull/1526
+fn authorize_input_targets<S: ActionStateSequence>(
+    mut receivers: Query<
+        (
+            &RemoteId,
+            Option<&ControlledByRemote>,
+            &mut MessageReceiver<InputMessage<S>>,
+        ),
+        With<Connected>,
+    >,
+) {
+    for (client_id, controlled_by_remote, mut receiver) in receivers.iter_mut() {
+        // Host-client inputs are authored in-process; trust them.
+        if client_id.is_local() {
+            continue;
+        }
+        receiver.retain_messages(|message| {
+            message.inputs.retain(|data| match data.target {
+                InputTarget::Entity(entity) => controlled_by_remote
+                    .is_some_and(|controlled| controlled.collection().contains(&entity)),
+                InputTarget::PreSpawned(_) => true,
+            });
+            // Drop the whole message once all of its targets were unauthorized.
+            !message.inputs.is_empty()
+        });
     }
 }
 

--- a/crates/inputs/inputs/src/server.rs
+++ b/crates/inputs/inputs/src/server.rs
@@ -137,6 +137,10 @@ pub enum InputSystems {
 /// `Query<&mut MessageReceiver<InputMessage<S>>>` and calls
 /// [`MessageReceiver::retain_messages`]. This is sugar for
 /// `app.add_systems(PreUpdate, system.in_set(InputSystems::ValidateInputs))`.
+///
+/// Validators in the set are unordered relative to each other. To make one run
+/// before another, pass an ordered config — e.g.
+/// `app.add_input_validator(my_validator.after(other_validator))`.
 pub trait InputValidationAppExt {
     fn add_input_validator<M>(
         &mut self,

--- a/crates/tests/src/client_server/input/leafwing.rs
+++ b/crates/tests/src/client_server/input/leafwing.rs
@@ -562,3 +562,207 @@ fn test_input_message_with_huge_end_tick_does_not_allocate_unbounded_buffer() {
          `is_input_within_lookahead` in lightyear_inputs::server.",
     );
 }
+
+/// Example + test for the game-side input-validation seam: a normal Bevy system
+/// registered with `add_input_validator` runs in `InputSystems::ValidateInputs`
+/// (after receive, before buffering) with **full ECS access**, and mutates/drops
+/// received `InputMessage`s in place via `MessageReceiver::retain_messages`.
+///
+/// Here the validator reads a `Res<RejectInputs>` (proving arbitrary `SystemParam`
+/// access) and drops every input message while the flag is set, so a legitimate,
+/// authorized key press never reaches the server's `ActionState`.
+#[test]
+fn test_input_validator_system_can_drop_messages() {
+    use bevy::ecs::resource::Resource;
+    use bevy::ecs::system::{Query, Res};
+    use lightyear::input::leafwing::input_message::LeafwingSequence;
+    use lightyear_inputs::input_message::InputMessage;
+    use lightyear_inputs::prelude::server::InputValidationAppExt;
+    use lightyear_messages::prelude::MessageReceiver;
+
+    #[derive(Resource)]
+    struct RejectInputs(bool);
+
+    // A game-side validation system: full ECS access (reads a resource), drops
+    // the input messages in place. A real validator would clamp/inspect against
+    // game state rather than reject wholesale.
+    fn reject_inputs(
+        reject: Res<RejectInputs>,
+        mut receivers: Query<&mut MessageReceiver<InputMessage<LeafwingSequence<LeafwingInput1>>>>,
+    ) {
+        if !reject.0 {
+            return;
+        }
+        for mut receiver in &mut receivers {
+            receiver.retain_messages(|_msg| false);
+        }
+    }
+
+    let mut stepper = ClientServerStepper::from_config(StepperConfig::with_netcode_clients(1));
+    stepper.server_app.insert_resource(RejectInputs(true));
+    stepper.server_app.add_input_validator(reject_inputs);
+
+    let server_entity = stepper
+        .server_app
+        .world_mut()
+        .spawn((
+            ActionState::<LeafwingInput1>::default(),
+            Replicate::to_clients(NetworkTarget::All),
+        ))
+        .id();
+    stepper.frame_step(2);
+
+    let local = stepper
+        .client(0)
+        .get::<MessageManager>()
+        .unwrap()
+        .entity_mapper
+        .get_local(server_entity)
+        .expect("entity replicated to client 0");
+    stepper.client_apps[0]
+        .world_mut()
+        .entity_mut(local)
+        .insert(InputMap::<LeafwingInput1>::new([(
+            LeafwingInput1::Jump,
+            KeyCode::KeyA,
+        )]));
+    stepper.frame_step(1);
+    stepper.client_apps[0]
+        .world_mut()
+        .resource_mut::<ButtonInput<KeyCode>>()
+        .press(KeyCode::KeyA);
+    stepper.frame_step(10);
+
+    let server_state = stepper
+        .server_app
+        .world()
+        .entity(server_entity)
+        .get::<ActionState<LeafwingInput1>>()
+        .expect("entity has ActionState");
+    assert!(
+        !server_state.pressed(&LeafwingInput1::Jump),
+        "input reached the server even though the validation system dropped \
+         every message in ValidateInputs — the seam isn't running before \
+         ReceiveInputs, or retain_messages didn't take effect.",
+    );
+}
+
+/// The lightyear-owned `AuthorizeInputs` pass runs *before* the user
+/// `ValidateInputs` seam, so a validation system never sees spoofed targets.
+///
+/// Client 0 controls entity A and forges an input also targeting entity B
+/// (which it does not control). A validation system records every target it
+/// observes; it must see A but never B — B's target was stripped by
+/// `authorize_input_targets` before the seam ran. B's server `ActionState`
+/// must also be unaffected.
+#[test]
+fn test_authorization_runs_before_validation() {
+    use bevy::ecs::resource::Resource;
+    use bevy::ecs::system::{Query, ResMut};
+    use lightyear::input::leafwing::input_message::LeafwingSequence;
+    use lightyear_inputs::input_message::{InputMessage, InputTarget};
+    use lightyear_inputs::prelude::server::InputValidationAppExt;
+    use lightyear_messages::prelude::MessageReceiver;
+    use lightyear_replication::prelude::ControlledBy;
+
+    #[derive(Resource, Default)]
+    struct ObservedTargets(Vec<bevy::prelude::Entity>);
+
+    // A validation system: records (without dropping) every entity target it
+    // sees in the received messages. Reads non-destructively via retain_messages
+    // returning `true`.
+    fn observe_targets(
+        mut observed: ResMut<ObservedTargets>,
+        mut receivers: Query<&mut MessageReceiver<InputMessage<LeafwingSequence<LeafwingInput1>>>>,
+    ) {
+        for mut receiver in &mut receivers {
+            receiver.retain_messages(|msg| {
+                for data in &msg.inputs {
+                    if let InputTarget::Entity(e) = data.target {
+                        observed.0.push(e);
+                    }
+                }
+                true
+            });
+        }
+    }
+
+    let mut stepper = ClientServerStepper::from_config(StepperConfig::with_netcode_clients(1));
+    stepper.server_app.init_resource::<ObservedTargets>();
+    stepper.server_app.add_input_validator(observe_targets);
+
+    let client_of_0 = stepper.client_of(0).id();
+    // Entity A: controlled by client 0.
+    let entity_a = stepper
+        .server_app
+        .world_mut()
+        .spawn((
+            ActionState::<LeafwingInput1>::default(),
+            Replicate::to_clients(NetworkTarget::All),
+            ControlledBy {
+                owner: client_of_0,
+                lifetime: Default::default(),
+            },
+        ))
+        .id();
+    // Entity B: replicated to client 0 but NOT controlled by it (the spoof victim).
+    let entity_b = stepper
+        .server_app
+        .world_mut()
+        .spawn((
+            ActionState::<LeafwingInput1>::default(),
+            Replicate::to_clients(NetworkTarget::All),
+        ))
+        .id();
+    stepper.frame_step(10);
+
+    let local_a = stepper
+        .client(0)
+        .get::<MessageManager>()
+        .unwrap()
+        .entity_mapper
+        .get_local(entity_a)
+        .expect("A replicated to client 0");
+    let local_b = stepper
+        .client(0)
+        .get::<MessageManager>()
+        .unwrap()
+        .entity_mapper
+        .get_local(entity_b)
+        .expect("B replicated to client 0");
+
+    // Client 0 puts an InputMap on BOTH its own entity and the victim's, so its
+    // outgoing message targets A (legit) and B (spoofed).
+    for local in [local_a, local_b] {
+        stepper.client_apps[0].world_mut().entity_mut(local).insert(
+            InputMap::<LeafwingInput1>::new([(LeafwingInput1::Jump, KeyCode::KeyA)]),
+        );
+    }
+    stepper.frame_step(1);
+    stepper.client_apps[0]
+        .world_mut()
+        .resource_mut::<ButtonInput<KeyCode>>()
+        .press(KeyCode::KeyA);
+    stepper.frame_step(10);
+
+    let observed = &stepper.server_app.world().resource::<ObservedTargets>().0;
+    assert!(
+        observed.contains(&entity_a),
+        "the validation system never saw the authorized target A — setup issue",
+    );
+    assert!(
+        !observed.contains(&entity_b),
+        "the validation system saw spoofed target B; AuthorizeInputs must strip \
+         unauthorized targets before ValidateInputs runs",
+    );
+    assert!(
+        !stepper
+            .server_app
+            .world()
+            .entity(entity_b)
+            .get::<ActionState<LeafwingInput1>>()
+            .unwrap()
+            .pressed(&LeafwingInput1::Jump),
+        "spoofed input landed on victim B's ActionState",
+    );
+}

--- a/crates/tests/src/client_server/input/leafwing.rs
+++ b/crates/tests/src/client_server/input/leafwing.rs
@@ -771,3 +771,89 @@ fn test_user_validator_can_authorize_targets() {
         "spoofed input landed on victim B's ActionState",
     );
 }
+
+/// `retain_received_messages` exposes per-message metadata (`remote_tick`,
+/// `channel_kind`, `message_id`) that `retain_messages` hides — needed for
+/// rate-limit / tick-window / replay validators. Here a validator reads
+/// `remote_tick` and drops the message; we assert both that the metadata was
+/// readable and that the drop took effect.
+#[test]
+fn test_validator_can_read_message_metadata() {
+    use bevy::ecs::resource::Resource;
+    use bevy::ecs::system::{Query, ResMut};
+    use lightyear::input::leafwing::input_message::LeafwingSequence;
+    use lightyear_inputs::input_message::InputMessage;
+    use lightyear_inputs::prelude::server::InputValidationAppExt;
+    use lightyear_messages::prelude::MessageReceiver;
+
+    #[derive(Resource, Default)]
+    struct SeenRemoteTick(Option<u32>);
+
+    fn inspect_metadata(
+        mut seen: ResMut<SeenRemoteTick>,
+        mut receivers: Query<&mut MessageReceiver<InputMessage<LeafwingSequence<LeafwingInput1>>>>,
+    ) {
+        for mut receiver in &mut receivers {
+            receiver.retain_received_messages(|received| {
+                // Metadata is reachable here (unlike `retain_messages`).
+                seen.0 = Some(received.remote_tick.0);
+                false // drop the message
+            });
+        }
+    }
+
+    let mut stepper = ClientServerStepper::from_config(StepperConfig::with_netcode_clients(1));
+    stepper.server_app.init_resource::<SeenRemoteTick>();
+    stepper.server_app.add_input_validator(inspect_metadata);
+
+    let server_entity = stepper
+        .server_app
+        .world_mut()
+        .spawn((
+            ActionState::<LeafwingInput1>::default(),
+            Replicate::to_clients(NetworkTarget::All),
+        ))
+        .id();
+    stepper.frame_step(2);
+
+    let local = stepper
+        .client(0)
+        .get::<MessageManager>()
+        .unwrap()
+        .entity_mapper
+        .get_local(server_entity)
+        .expect("entity replicated to client 0");
+    stepper.client_apps[0]
+        .world_mut()
+        .entity_mut(local)
+        .insert(InputMap::<LeafwingInput1>::new([(
+            LeafwingInput1::Jump,
+            KeyCode::KeyA,
+        )]));
+    stepper.frame_step(1);
+    stepper.client_apps[0]
+        .world_mut()
+        .resource_mut::<ButtonInput<KeyCode>>()
+        .press(KeyCode::KeyA);
+    stepper.frame_step(10);
+
+    assert!(
+        stepper
+            .server_app
+            .world()
+            .resource::<SeenRemoteTick>()
+            .0
+            .is_some(),
+        "validator never observed a message's remote_tick metadata",
+    );
+    assert!(
+        !stepper
+            .server_app
+            .world()
+            .entity(server_entity)
+            .get::<ActionState<LeafwingInput1>>()
+            .unwrap()
+            .pressed(&LeafwingInput1::Jump),
+        "input landed even though retain_received_messages dropped the message",
+    );
+}

--- a/crates/tests/src/client_server/input/leafwing.rs
+++ b/crates/tests/src/client_server/input/leafwing.rs
@@ -794,9 +794,9 @@ fn test_validator_can_read_message_metadata() {
         mut receivers: Query<&mut MessageReceiver<InputMessage<LeafwingSequence<LeafwingInput1>>>>,
     ) {
         for mut receiver in &mut receivers {
-            receiver.retain_received_messages(|received| {
-                // Metadata is reachable here (unlike `retain_messages`).
-                seen.0 = Some(received.remote_tick.0);
+            receiver.retain_received_messages(|metadata, _data| {
+                // Metadata is reachable here (read-only), unlike `retain_messages`.
+                seen.0 = Some(metadata.remote_tick.0);
                 false // drop the message
             });
         }

--- a/crates/tests/src/client_server/input/leafwing.rs
+++ b/crates/tests/src/client_server/input/leafwing.rs
@@ -647,49 +647,52 @@ fn test_input_validator_system_can_drop_messages() {
     );
 }
 
-/// The lightyear-owned `AuthorizeInputs` pass runs *before* the user
-/// `ValidateInputs` seam, so a validation system never sees spoofed targets.
+/// Example: a *game-supplied* `ValidateInputs` system implements input-target
+/// authorization itself — lightyear does not enforce `ControlledBy` (it's an
+/// optional helper). The validator drops any `InputTarget::Entity` the sender
+/// doesn't control (via `ControlledByRemote` + `retain_messages`).
 ///
 /// Client 0 controls entity A and forges an input also targeting entity B
-/// (which it does not control). A validation system records every target it
-/// observes; it must see A but never B — B's target was stripped by
-/// `authorize_input_targets` before the seam ran. B's server `ActionState`
-/// must also be unaffected.
+/// (uncontrolled). The validator must let A's input through (non-overblocking)
+/// and drop B's — so A's server `ActionState` is pressed and B's is not.
 #[test]
-fn test_authorization_runs_before_validation() {
-    use bevy::ecs::resource::Resource;
-    use bevy::ecs::system::{Query, ResMut};
+fn test_user_validator_can_authorize_targets() {
+    use bevy::ecs::relationship::RelationshipTarget;
+    use bevy::ecs::system::Query;
     use lightyear::input::leafwing::input_message::LeafwingSequence;
+    use lightyear_core::id::RemoteId;
     use lightyear_inputs::input_message::{InputMessage, InputTarget};
     use lightyear_inputs::prelude::server::InputValidationAppExt;
     use lightyear_messages::prelude::MessageReceiver;
+    use lightyear_replication::control::ControlledByRemote;
     use lightyear_replication::prelude::ControlledBy;
 
-    #[derive(Resource, Default)]
-    struct ObservedTargets(Vec<bevy::prelude::Entity>);
-
-    // A validation system: records (without dropping) every entity target it
-    // sees in the received messages. Reads non-destructively via retain_messages
-    // returning `true`.
-    fn observe_targets(
-        mut observed: ResMut<ObservedTargets>,
-        mut receivers: Query<&mut MessageReceiver<InputMessage<LeafwingSequence<LeafwingInput1>>>>,
+    // Game-side authorization, expressed as an ordinary ValidateInputs system.
+    fn authorize_targets(
+        mut receivers: Query<(
+            &RemoteId,
+            Option<&ControlledByRemote>,
+            &mut MessageReceiver<InputMessage<LeafwingSequence<LeafwingInput1>>>,
+        )>,
     ) {
-        for mut receiver in &mut receivers {
+        for (client_id, controlled, mut receiver) in &mut receivers {
+            if client_id.is_local() {
+                continue;
+            }
             receiver.retain_messages(|msg| {
-                for data in &msg.inputs {
-                    if let InputTarget::Entity(e) = data.target {
-                        observed.0.push(e);
+                msg.inputs.retain(|data| match data.target {
+                    InputTarget::Entity(e) => {
+                        controlled.is_some_and(|c| c.collection().contains(&e))
                     }
-                }
-                true
+                    InputTarget::PreSpawned(_) => true,
+                });
+                !msg.inputs.is_empty()
             });
         }
     }
 
     let mut stepper = ClientServerStepper::from_config(StepperConfig::with_netcode_clients(1));
-    stepper.server_app.init_resource::<ObservedTargets>();
-    stepper.server_app.add_input_validator(observe_targets);
+    stepper.server_app.add_input_validator(authorize_targets);
 
     let client_of_0 = stepper.client_of(0).id();
     // Entity A: controlled by client 0.
@@ -745,16 +748,18 @@ fn test_authorization_runs_before_validation() {
         .press(KeyCode::KeyA);
     stepper.frame_step(10);
 
-    let observed = &stepper.server_app.world().resource::<ObservedTargets>().0;
+    // Non-overblocking: A's authorized input reached the server.
     assert!(
-        observed.contains(&entity_a),
-        "the validation system never saw the authorized target A — setup issue",
+        stepper
+            .server_app
+            .world()
+            .entity(entity_a)
+            .get::<ActionState<LeafwingInput1>>()
+            .unwrap()
+            .pressed(&LeafwingInput1::Jump),
+        "the authorized input for A did not land — the validator over-stripped",
     );
-    assert!(
-        !observed.contains(&entity_b),
-        "the validation system saw spoofed target B; AuthorizeInputs must strip \
-         unauthorized targets before ValidateInputs runs",
-    );
+    // The spoofed input for B was dropped by the validator.
     assert!(
         !stepper
             .server_app

--- a/crates/transport/messages/src/receive.rs
+++ b/crates/transport/messages/src/receive.rs
@@ -103,6 +103,21 @@ impl<M: Message> MessageReceiver<M> {
         self.recv.retain_mut(|received| keep(&mut received.data));
     }
 
+    /// Like [`retain_messages`](Self::retain_messages), but the predicate also
+    /// gets the per-message metadata on [`ReceivedMessage`] — `remote_tick`,
+    /// `channel_kind`, `message_id` — which `retain_messages` hides.
+    ///
+    /// Use this when validation needs the metadata, e.g. rate limiting,
+    /// tick-window / staleness checks, replay diagnostics, or per-channel
+    /// policy. Mutate `received.data` to rewrite the message; return `false` to
+    /// drop it.
+    pub fn retain_received_messages(
+        &mut self,
+        mut keep: impl FnMut(&mut ReceivedMessage<M>) -> bool,
+    ) {
+        self.recv.retain_mut(|received| keep(received));
+    }
+
     pub fn num_messages(&self) -> usize {
         self.recv.len()
     }

--- a/crates/transport/messages/src/receive.rs
+++ b/crates/transport/messages/src/receive.rs
@@ -90,6 +90,19 @@ impl<M: Message> MessageReceiver<M> {
         self.recv.drain(..)
     }
 
+    /// Mutate and/or drop the buffered messages in place, *before* they are
+    /// consumed by the receiving system.
+    ///
+    /// This is the hook for validation/sanitization systems that run between
+    /// message receipt and whatever consumes the messages (e.g. server-side
+    /// input validation between `MessageSystems::Receive` and the input-buffer
+    /// apply). Returning `false` from `keep` drops that message; mutating the
+    /// `&mut M` rewrites it. Per-message metadata (remote tick, channel,
+    /// message id) is preserved automatically — unlike drain-then-re-push.
+    pub fn retain_messages(&mut self, mut keep: impl FnMut(&mut M) -> bool) {
+        self.recv.retain_mut(|received| keep(&mut received.data));
+    }
+
     pub fn num_messages(&self) -> usize {
         self.recv.len()
     }

--- a/crates/transport/messages/src/receive.rs
+++ b/crates/transport/messages/src/receive.rs
@@ -67,6 +67,19 @@ pub struct ReceivedMessage<M: Message> {
     pub message_id: Option<MessageId>,
 }
 
+/// Read-only per-message metadata handed to
+/// [`MessageReceiver::retain_received_messages`] validators alongside `&mut`
+/// access to the message data.
+#[derive(Debug, Clone, Copy)]
+pub struct MessageMetadata {
+    /// Tick on the remote peer when the message was sent.
+    pub remote_tick: Tick,
+    /// Channel the message was sent on.
+    pub channel_kind: ChannelKind,
+    /// MessageId of the message, if the channel assigns one.
+    pub message_id: Option<MessageId>,
+}
+
 impl<M: Message> Default for MessageReceiver<M> {
     fn default() -> Self {
         Self { recv: Vec::new() }
@@ -104,18 +117,26 @@ impl<M: Message> MessageReceiver<M> {
     }
 
     /// Like [`retain_messages`](Self::retain_messages), but the predicate also
-    /// gets the per-message metadata on [`ReceivedMessage`] — `remote_tick`,
-    /// `channel_kind`, `message_id` — which `retain_messages` hides.
+    /// gets the per-message [`MessageMetadata`] (`remote_tick`, `channel_kind`,
+    /// `message_id`) that `retain_messages` hides.
     ///
     /// Use this when validation needs the metadata, e.g. rate limiting,
     /// tick-window / staleness checks, replay diagnostics, or per-channel
-    /// policy. Mutate `received.data` to rewrite the message; return `false` to
-    /// drop it.
+    /// policy. The metadata is passed **by value (read-only)** — only the
+    /// message data is `&mut` (mutate to rewrite, return `false` to drop) — so a
+    /// validator can't accidentally rewrite the wire metadata.
     pub fn retain_received_messages(
         &mut self,
-        mut keep: impl FnMut(&mut ReceivedMessage<M>) -> bool,
+        mut keep: impl FnMut(MessageMetadata, &mut M) -> bool,
     ) {
-        self.recv.retain_mut(|received| keep(received));
+        self.recv.retain_mut(|received| {
+            let metadata = MessageMetadata {
+                remote_tick: received.remote_tick,
+                channel_kind: received.channel_kind,
+                message_id: received.message_id,
+            };
+            keep(metadata, &mut received.data)
+        });
     }
 
     pub fn num_messages(&self) -> usize {


### PR DESCRIPTION
## Summary

A minimal, ECS-capable seam for **game-side input validation** on the server, per the design discussed in #1531. A normal Bevy system, with full `SystemParam` access, runs between message receipt and input buffering and may mutate or drop received `InputMessage`s in place.

```
MessageSystems::Receive  →  InputSystems::ValidateInputs (user systems)  →  InputSystems::ReceiveInputs (buffer apply)
```

No new resource and no rewrite of `receive_input_message` — systems intercept the existing `MessageReceiver<InputMessage<S>>` (a `Vec` of received messages). **No behavior change by default**: the seam is empty until a game registers a validator.

> **This PR is an API seam, not a spoofed-target security fix.** It does **not** enforce target authorization by default — `ControlledBy` stays an optional, non-authoritative helper (per the maintainer on #1531). A game that wants target authorization implements it on the seam (see the test below). **#1526 remains unresolved** — the decision there is whether lightyear ships *default* protection, an *opt-in helper*, or *docs/example* only. An interim revision of this PR had a compulsory `AuthorizeInputs` pass; it was removed (it made `ControlledBy` required and broke existing input tests).

## What's here

- **`MessageReceiver::retain_messages(|&mut M| -> bool)`** — mutate and/or drop buffered messages in place, before they're consumed. In-place preserves per-message metadata (`remote_tick`, `channel_kind`, `message_id`) — unlike drain-then-re-push.
- **`MessageReceiver::retain_received_messages(|MessageMetadata, &mut M| -> bool)`** — same, but the predicate also gets the per-message metadata (`remote_tick` / `channel_kind` / `message_id`) **read-only** (only the data is `&mut`), for rate-limit / tick-window / replay / per-channel validators.
- **`InputSystems::ValidateInputs`** — empty-by-default set, ordered after `MessageSystems::Receive` and before `InputSystems::ReceiveInputs`.
- **`app.add_input_validator(system)`** — schedules a plain system into `ValidateInputs` (full ECS access).

```rust
fn reject_inputs(
    reject: Res<RejectInputs>,                        // arbitrary game state
    mut receivers: Query<&mut MessageReceiver<InputMessage<MySequence>>>,
) {
    if !reject.0 { return; }
    for mut r in &mut receivers {
        r.retain_messages(|_msg| false);              // clamp/inspect instead, normally
    }
}
app.add_input_validator(reject_inputs);
```

## Tests

- `test_input_validator_system_can_drop_messages` — a validator with ECS access (`Res`) drops messages via `retain_messages`; the input never reaches the server `ActionState`.
- `test_user_validator_can_authorize_targets` — a **game-supplied** validator implements `ControlledBy`-based target authorization (drops `InputTarget::Entity` the sender doesn't control). Client 0 forges a target on an uncontrolled entity: the authorized input still lands (non-overblocking) and the spoofed one is dropped. Demonstrates the maintainer's "users can implement authorization themselves in `ValidateInputs`" point.
- `test_validator_can_read_message_metadata` — a validator reads a message's `remote_tick` via `retain_received_messages` (read-only `MessageMetadata`) and drops it; asserts the metadata was observable and the drop took effect.

## Notes

- `receive_input_message` is unchanged, so the rebroadcast and rollback-mismatch machinery is untouched.
- #1525 (`end_tick` bound) is merged and stays inline. #1526 (target authorization) remains the place to decide whether lightyear enforces target ownership by default.
- Supersedes the closed #1529 (in-system `Box<dyn>` chain) — this gives full ECS access.

Discussion / rationale: #1531.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-authored with Claude Opus 4.8
