### PR TITLE
fix(inputs): simplify BEI input replication

### DIFF
--- a/crates/inputs/input_bei/src/marker.rs
+++ b/crates/inputs/input_bei/src/marker.rs
@@ -78,15 +78,15 @@ pub(crate) fn add_input_marker_from_parent<C: Component>(
 
 /// If Bindings or ActionMock is added to an Action entity, add the InputMarker to that Action entity.
 /// Only add the marker on locally controlled action entities that already have a network-facing
-/// action mapping. This avoids emitting inputs for entities that the server cannot resolve yet.
+/// action mapping, or on confirmed prespawned actions that already resolved through replication.
+/// This avoids emitting inputs for entities that the server cannot resolve yet.
 pub(crate) fn add_input_marker_from_binding<C: Component>(
     trigger: On<Add, (Bindings, ActionMock)>,
     action: Query<
         &ActionOf<C>,
         (
-            With<ActionOf<C>>,
-            With<NetworkActionOf<C>>,
-            Without<ConfirmHistory>,
+            Or<(With<NetworkActionOf<C>>, With<ConfirmHistory>)>,
+            Without<InputMarker<C>>,
         ),
     >,
     contexts: Query<Option<&ControlledBy>, With<Controlled>>,
@@ -102,63 +102,23 @@ pub(crate) fn add_input_marker_from_binding<C: Component>(
     }
 }
 
-/// If authority is granted after the action entity already exists, add the InputMarker
-/// once the entity becomes locally controlled.
-pub(crate) fn add_input_marker_from_authority<C: Component>(
-    trigger: On<Add, HasAuthority>,
+/// If an existing bound action becomes network-ready, authority-ready, or is
+/// confirmed through prespawn matching, add the InputMarker once it targets the
+/// local client.
+pub(crate) fn add_input_marker_when_action_becomes_ready<C: Component>(
+    trigger: On<Add, (NetworkActionOf<C>, HasAuthority, ConfirmHistory)>,
     action: Query<
         &ActionOf<C>,
         (
-            With<ActionOf<C>>,
-            With<NetworkActionOf<C>>,
+            // This is only a real guard for the HasAuthority trigger. The
+            // NetworkActionOf and ConfirmHistory triggers satisfy it by
+            // construction, but HasAuthority alone is not enough to send
+            // inputs: the action also needs a target the receiver can resolve.
+            Or<(With<NetworkActionOf<C>>, With<ConfirmHistory>)>,
             Or<(With<Bindings>, With<ActionMock>)>,
-            Without<ConfirmHistory>,
+            Without<InputMarker<C>>,
         ),
     >,
-    contexts: Query<Option<&ControlledBy>, With<Controlled>>,
-    clients: Query<(), With<Client>>,
-    mut commands: Commands,
-) {
-    if let Ok(action_of) = action.get(trigger.entity)
-        && action_targets_local_client(action_of, &contexts, &clients)
-    {
-        commands
-            .entity(trigger.entity)
-            .insert(InputMarker::<C>::default());
-    }
-}
-
-/// If the network-facing action mapping becomes available after the entity already has bindings,
-/// start treating it as a local input source at that point.
-pub(crate) fn add_input_marker_from_network_action<C: Component>(
-    trigger: On<Add, NetworkActionOf<C>>,
-    action: Query<
-        &ActionOf<C>,
-        (
-            With<ActionOf<C>>,
-            With<NetworkActionOf<C>>,
-            Or<(With<Bindings>, With<ActionMock>)>,
-            Without<ConfirmHistory>,
-        ),
-    >,
-    contexts: Query<Option<&ControlledBy>, With<Controlled>>,
-    clients: Query<(), With<Client>>,
-    mut commands: Commands,
-) {
-    if let Ok(action_of) = action.get(trigger.entity)
-        && action_targets_local_client(action_of, &contexts, &clients)
-    {
-        commands
-            .entity(trigger.entity)
-            .insert(InputMarker::<C>::default());
-    }
-}
-
-/// If a prespawned action entity is confirmed but still targets a locally controlled context,
-/// keep using it as a local input source.
-pub(crate) fn add_input_marker_from_confirmed_controlled_action<C: Component>(
-    trigger: On<Add, ConfirmHistory>,
-    action: Query<&ActionOf<C>, (With<ConfirmHistory>, Or<(With<Bindings>, With<ActionMock>)>)>,
     contexts: Query<Option<&ControlledBy>, With<Controlled>>,
     clients: Query<(), With<Client>>,
     mut commands: Commands,

--- a/crates/inputs/input_bei/src/marker.rs
+++ b/crates/inputs/input_bei/src/marker.rs
@@ -1,12 +1,11 @@
 //! Add an [`InputMarker<C>`] component automatically to [`Action`] entities that need it
 
-use crate::setup::NetworkActionOf;
 use bevy_ecs::prelude::*;
 use bevy_ecs::relationship::Relationship;
 use bevy_enhanced_input::prelude::*;
 use bevy_replicon::client::confirm_history::ConfirmHistory;
 use lightyear_connection::client::Client;
-use lightyear_replication::prelude::{Controlled, ControlledBy, HasAuthority};
+use lightyear_replication::prelude::{Controlled, ControlledBy};
 
 /// Marker component that indicates that the entity is actively listening for physical user inputs.
 ///
@@ -40,18 +39,17 @@ fn action_targets_local_client<C: Component>(
 
 /// Propagate the InputMarker component from the Context entity to the Action entities
 /// whenever an InputMarker is added to a Context entity.
-/// Skip replicated action entities (those received from remote clients).
+///
+/// `InputMarker<C>` on the context is the explicit local-input signal, so
+/// confirmed prespawned owner actions should still receive it. Remote
+/// rebroadcasted actions should be attached to contexts without this marker.
 pub(crate) fn propagate_input_marker<C: Component>(
     trigger: On<Add, InputMarker<C>>,
     actions: Query<&Actions<C>>,
-    confirm: Query<(), With<ConfirmHistory>>,
     mut commands: Commands,
 ) {
     if let Ok(actions) = actions.get(trigger.entity) {
         actions.iter().for_each(|action| {
-            if confirm.get(action).is_ok() {
-                return;
-            }
             commands.entity(action).insert(InputMarker::<C>::default());
         });
     }
@@ -59,62 +57,53 @@ pub(crate) fn propagate_input_marker<C: Component>(
 
 /// When an Action entity is added to a Context entity that has an InputMarker,
 /// add the InputMarker to the Action entity as well.
-/// Skip replicated entities — those are received from remote clients and should not
-/// be marked as local input sources.
 pub(crate) fn add_input_marker_from_parent<C: Component>(
     trigger: On<Add, ActionOf<C>>,
-    action_of: Query<&ActionOf<C>, Without<ConfirmHistory>>,
+    action_of: Query<&ActionOf<C>>,
     context: Query<(), With<InputMarker<C>>>,
     mut commands: Commands,
 ) {
-    if let Ok(action_of) = action_of.get(trigger.entity)
-        && context.get(action_of.get()).is_ok()
-    {
+    let Ok(action_of) = action_of.get(trigger.entity) else {
+        return;
+    };
+    if context.get(action_of.get()).is_ok() {
         commands
             .entity(trigger.entity)
             .insert(InputMarker::<C>::default());
     }
 }
 
-/// If Bindings or ActionMock is added to an Action entity, add the InputMarker to that Action entity.
-/// Only add the marker on locally controlled action entities that already have a network-facing
-/// action mapping, or on confirmed prespawned actions that already resolved through replication.
-/// This avoids emitting inputs for entities that the server cannot resolve yet.
+/// If Bindings or ActionMock is added to an Action entity, add the InputMarker
+/// to that Action entity once the action has a network-resolvable identity.
+///
+/// Replicated/prespawned actions become resolvable when [`ConfirmHistory`] is
+/// present, because the client's action entity can then be mapped back to the
+/// server action entity when an input message is sent.
 pub(crate) fn add_input_marker_from_binding<C: Component>(
     trigger: On<Add, (Bindings, ActionMock)>,
-    action: Query<
-        &ActionOf<C>,
-        (
-            Or<(With<NetworkActionOf<C>>, With<ConfirmHistory>)>,
-            Without<InputMarker<C>>,
-        ),
-    >,
+    action: Query<&ActionOf<C>, (With<ConfirmHistory>, Without<InputMarker<C>>)>,
     contexts: Query<Option<&ControlledBy>, With<Controlled>>,
     clients: Query<(), With<Client>>,
     mut commands: Commands,
 ) {
-    if let Ok(action_of) = action.get(trigger.entity)
-        && action_targets_local_client(action_of, &contexts, &clients)
-    {
+    let Ok(action_of) = action.get(trigger.entity) else {
+        return;
+    };
+    if action_targets_local_client(action_of, &contexts, &clients) {
         commands
             .entity(trigger.entity)
             .insert(InputMarker::<C>::default());
     }
 }
 
-/// If an existing bound action becomes network-ready, authority-ready, or is
-/// confirmed through prespawn matching, add the InputMarker once it targets the
-/// local client.
+/// If an existing bound action becomes network-resolvable, add the InputMarker
+/// once it targets the local client.
 pub(crate) fn add_input_marker_when_action_becomes_ready<C: Component>(
-    trigger: On<Add, (NetworkActionOf<C>, HasAuthority, ConfirmHistory)>,
+    trigger: On<Add, ConfirmHistory>,
     action: Query<
         &ActionOf<C>,
         (
-            // This is only a real guard for the HasAuthority trigger. The
-            // NetworkActionOf and ConfirmHistory triggers satisfy it by
-            // construction, but HasAuthority alone is not enough to send
-            // inputs: the action also needs a target the receiver can resolve.
-            Or<(With<NetworkActionOf<C>>, With<ConfirmHistory>)>,
+            With<ConfirmHistory>,
             Or<(With<Bindings>, With<ActionMock>)>,
             Without<InputMarker<C>>,
         ),
@@ -123,9 +112,10 @@ pub(crate) fn add_input_marker_when_action_becomes_ready<C: Component>(
     clients: Query<(), With<Client>>,
     mut commands: Commands,
 ) {
-    if let Ok(action_of) = action.get(trigger.entity)
-        && action_targets_local_client(action_of, &contexts, &clients)
-    {
+    let Ok(action_of) = action.get(trigger.entity) else {
+        return;
+    };
+    if action_targets_local_client(action_of, &contexts, &clients) {
         commands
             .entity(trigger.entity)
             .insert(InputMarker::<C>::default());

--- a/crates/inputs/input_bei/src/plugin.rs
+++ b/crates/inputs/input_bei/src/plugin.rs
@@ -1,9 +1,11 @@
 #[cfg(any(feature = "client", feature = "server"))]
 use crate::input_message::{BEIBuffer, BEIStateSequence};
 
+#[cfg(any(feature = "client", feature = "server"))]
 use crate::setup::InputRegistryPlugin;
-use bevy_app::{PreUpdate, prelude::*};
+use bevy_app::prelude::*;
 use bevy_ecs::prelude::*;
+#[cfg(any(feature = "client", feature = "server"))]
 use bevy_ecs::schedule::IntoScheduleConfigs;
 #[cfg(all(feature = "client", feature = "server"))]
 use bevy_ecs::schedule::common_conditions::not;
@@ -12,10 +14,9 @@ use bevy_enhanced_input::EnhancedInputSystems;
 #[cfg(feature = "client")]
 use bevy_enhanced_input::action::TriggerState;
 use bevy_enhanced_input::context::InputContextAppExt;
-#[cfg(any(feature = "client", feature = "server"))]
 use bevy_enhanced_input::prelude::ActionOf;
 use bevy_reflect::TypePath;
-use bevy_replicon::prelude::{AppRuleExt, ReplicationMode, RuleFns};
+use bevy_replicon::prelude::AppRuleExt;
 use bevy_replicon::shared::replication::registry::receive_fns::MutWrite;
 use core::fmt::Debug;
 #[cfg(feature = "client")]
@@ -23,8 +24,6 @@ use lightyear_core::prelude::is_in_rollback;
 #[cfg(feature = "client")]
 use lightyear_inputs::client::InputSystems;
 use lightyear_inputs::config::InputConfig;
-use lightyear_messages::plugin::MessageSystems;
-use lightyear_replication::ReplicationSystems;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 
@@ -45,33 +44,35 @@ use serde::de::DeserializeOwned;
 /// # Action entities
 ///
 /// BEI uses separate "action entities" with [`ActionOf<C>`] to represent
-/// individual actions. These entities need to exist on both client and server.
-/// Spawn them on both sides with [`PreSpawned`] so they can be matched via a
-/// deterministic hash; this plugin does not create action entities through
-/// client-to-server entity replication.
+/// individual actions. In the server-authoritative flow, spawn those action
+/// entities on the server and replicate them to clients along with the context
+/// entity. The owning client should add local-only [`Bindings`] once its local
+/// controlled context has the replicated [`Action`] entity in its
+/// [`ActionOf<C>`]/`Actions<C>` relationship.
 ///
-/// Server-to-client action entity replication is still useful. It confirms the
-/// owner's prespawned action entity and populates the entity maps used by input
-/// messages. If input rebroadcasting is enabled, it also lets other clients
-/// discover the remote player's action entity, its typed [`Action`] component,
-/// and its [`ActionOf<C>`] relationship so rebroadcasted input state has a
-/// local action buffer to target.
+/// Replicating the action entity is also what lets remote clients receive
+/// rebroadcasted BEI input. Rebroadcasted [`BEIStateSequence`] messages target
+/// action entities, so a remote client needs a corresponding replicated action
+/// entity to resolve the target and buffer the remote player's input state.
 ///
 /// The replicated [`Action`] component is structural: it recreates the typed BEI
 /// action entity on the receiver, but does not carry runtime input state. The
-/// action relationship is replicated through an internal network wrapper for
-/// [`ActionOf<C>`], and live action state is sent by [`BEIStateSequence`] input
-/// messages. The owning client adds [`InputMarker`] to local action entities,
-/// buffers BEI trigger state/value/time each tick, and sends those snapshots to
-/// the server. If input rebroadcasting is enabled, the server forwards those
-/// input messages to other clients so they can update remote action buffers for
-/// prediction.
+/// action relationship is replicated directly through [`ActionOf<C>`]. Bevy's
+/// relationship component maps the inner context entity through
+/// [`Component::map_entities`], and Replicon's default deserialize path calls
+/// that mapping after replication has populated the entity map.
+/// Live action state is sent by [`BEIStateSequence`] input messages. The owning
+/// client adds [`InputMarker`] to local action entities, buffers BEI trigger
+/// state/value/time each tick, and sends those snapshots to the server. If input
+/// rebroadcasting is enabled, the server forwards those input messages to other
+/// clients so they can update remote action buffers for prediction.
 ///
 /// [`Action`]: bevy_enhanced_input::prelude::Action
+/// [`Bindings`]: bevy_enhanced_input::prelude::Bindings
 /// [`BEIStateSequence`]: crate::input_message::BEIStateSequence
 /// [`ActionOf<C>`]: bevy_enhanced_input::prelude::ActionOf
 /// [`InputMarker`]: crate::marker::InputMarker
-/// [`PreSpawned`]: lightyear_replication::prelude::PreSpawned
+/// [`Replicate`]: lightyear_replication::prelude::Replicate
 pub struct InputPlugin<C> {
     pub config: InputConfig<C>,
 }
@@ -110,30 +111,7 @@ impl<
         app.add_input_context_to::<FixedPreUpdate, C>();
         // we register the context C entity so that it can be replicated from the server to the client
         app.replicate::<C>();
-
-        // We mirror ActionOf<C> into a separate component that stores the authoritative
-        // remote entity. That avoids depending on sender-side entity mapping in replicon's
-        // SerializeCtx.
-        app.replicate_with((
-            RuleFns::new(
-                crate::setup::serialize_network_action_of::<C>,
-                crate::setup::deserialize_network_action_of::<C>,
-            ),
-            ReplicationMode::default(),
-        ));
-        app.add_observer(InputRegistryPlugin::mirror_action_of_for_replication::<C>);
-        app.add_observer(InputRegistryPlugin::insert_action_of_from_network::<C>);
-        app.add_systems(
-            PreUpdate,
-            (
-                InputRegistryPlugin::resolve_pending_network_action_of::<C>,
-                InputRegistryPlugin::resolve_pending_action_of::<C>,
-            )
-                .chain()
-                .after(ReplicationSystems::Receive)
-                .before(MessageSystems::Receive),
-        );
-
+        app.replicate::<ActionOf<C>>();
         #[cfg(feature = "client")]
         {
             use crate::marker::{

--- a/crates/inputs/input_bei/src/plugin.rs
+++ b/crates/inputs/input_bei/src/plugin.rs
@@ -46,12 +46,31 @@ use serde::de::DeserializeOwned;
 ///
 /// BEI uses separate "action entities" with [`ActionOf<C>`] to represent
 /// individual actions. These entities need to exist on both client and server.
-/// The recommended approach is to use [`PreSpawned`] so both sides spawn them
-/// independently and match via a deterministic hash — this avoids the need
-/// for client-to-server entity replication.
+/// Spawn them on both sides with [`PreSpawned`] so they can be matched via a
+/// deterministic hash; this plugin does not create action entities through
+/// client-to-server entity replication.
 ///
+/// Server-to-client action entity replication is still useful. It confirms the
+/// owner's prespawned action entity and populates the entity maps used by input
+/// messages. If input rebroadcasting is enabled, it also lets other clients
+/// discover the remote player's action entity, its typed [`Action`] component,
+/// and its [`ActionOf<C>`] relationship so rebroadcasted input state has a
+/// local action buffer to target.
+///
+/// The replicated [`Action`] component is structural: it recreates the typed BEI
+/// action entity on the receiver, but does not carry runtime input state. The
+/// action relationship is replicated through an internal network wrapper for
+/// [`ActionOf<C>`], and live action state is sent by [`BEIStateSequence`] input
+/// messages. The owning client adds [`InputMarker`] to local action entities,
+/// buffers BEI trigger state/value/time each tick, and sends those snapshots to
+/// the server. If input rebroadcasting is enabled, the server forwards those
+/// input messages to other clients so they can update remote action buffers for
+/// prediction.
+///
+/// [`Action`]: bevy_enhanced_input::prelude::Action
 /// [`BEIStateSequence`]: crate::input_message::BEIStateSequence
 /// [`ActionOf<C>`]: bevy_enhanced_input::prelude::ActionOf
+/// [`InputMarker`]: crate::marker::InputMarker
 /// [`PreSpawned`]: lightyear_replication::prelude::PreSpawned
 pub struct InputPlugin<C> {
     pub config: InputConfig<C>,
@@ -118,10 +137,8 @@ impl<
         #[cfg(feature = "client")]
         {
             use crate::marker::{
-                add_input_marker_from_authority, add_input_marker_from_binding,
-                add_input_marker_from_confirmed_controlled_action,
-                add_input_marker_from_network_action, add_input_marker_from_parent,
-                propagate_input_marker,
+                add_input_marker_from_binding, add_input_marker_from_parent,
+                add_input_marker_when_action_becomes_ready, propagate_input_marker,
             };
             // for rebroadcasting inputs, we insert TriggerState (which inserts the InputBuffer) when ActionOf<C> is added
             // on an entity
@@ -130,9 +147,7 @@ impl<
             app.add_observer(propagate_input_marker::<C>);
             app.add_observer(add_input_marker_from_parent::<C>);
             app.add_observer(add_input_marker_from_binding::<C>);
-            app.add_observer(add_input_marker_from_authority::<C>);
-            app.add_observer(add_input_marker_from_network_action::<C>);
-            app.add_observer(add_input_marker_from_confirmed_controlled_action::<C>);
+            app.add_observer(add_input_marker_when_action_becomes_ready::<C>);
 
             if self.config.rebroadcast_inputs {
                 app.add_observer(InputRegistryPlugin::on_rebroadcast_action_received::<C>);
@@ -146,8 +161,6 @@ impl<
                     InputRegistryPlugin::mock_non_host_owned_actions_on_controlled_by::<C>,
                 );
             }
-
-            app.add_observer(InputRegistryPlugin::add_action_of_replicate::<C>);
 
             app.add_plugins(lightyear_inputs::client::ClientInputPlugin::<
                 BEIStateSequence<C>,

--- a/crates/inputs/input_bei/src/plugin.rs
+++ b/crates/inputs/input_bei/src/plugin.rs
@@ -1,8 +1,13 @@
 #[cfg(any(feature = "client", feature = "server"))]
 use crate::input_message::{BEIBuffer, BEIStateSequence};
 
+#[cfg(feature = "client")]
+use crate::setup::resolve_pending_action_of;
 #[cfg(any(feature = "client", feature = "server"))]
-use crate::setup::InputRegistryPlugin;
+use crate::setup::{
+    InputRegistryPlugin, deserialize_action_of, remove_action_of, serialize_action_of,
+    write_action_of,
+};
 use bevy_app::prelude::*;
 use bevy_ecs::prelude::*;
 #[cfg(any(feature = "client", feature = "server"))]
@@ -16,7 +21,7 @@ use bevy_enhanced_input::action::TriggerState;
 use bevy_enhanced_input::context::InputContextAppExt;
 use bevy_enhanced_input::prelude::ActionOf;
 use bevy_reflect::TypePath;
-use bevy_replicon::prelude::AppRuleExt;
+use bevy_replicon::prelude::{AppMarkerExt, AppRuleExt, ReplicationMode, RuleFns};
 use bevy_replicon::shared::replication::registry::receive_fns::MutWrite;
 use core::fmt::Debug;
 #[cfg(feature = "client")]
@@ -57,10 +62,12 @@ use serde::de::DeserializeOwned;
 ///
 /// The replicated [`Action`] component is structural: it recreates the typed BEI
 /// action entity on the receiver, but does not carry runtime input state. The
-/// action relationship is replicated directly through [`ActionOf<C>`]. Bevy's
-/// relationship component maps the inner context entity through
-/// [`Component::map_entities`], and Replicon's default deserialize path calls
-/// that mapping after replication has populated the entity map.
+/// action relationship is replicated directly through [`ActionOf<C>`].
+/// Lightyear uses a custom receive path for [`ActionOf<C>`] so the context
+/// entity is only inserted into Bevy's relationship component once Replicon's
+/// server-to-client entity map already contains it. If the action arrives first,
+/// the relationship is held as a local pending marker and resolved after the
+/// context mapping is available.
 /// Live action state is sent by [`BEIStateSequence`] input messages. The owning
 /// client adds [`InputMarker`] to local action entities, buffers BEI trigger
 /// state/value/time each tick, and sends those snapshots to the server. If input
@@ -111,7 +118,11 @@ impl<
         app.add_input_context_to::<FixedPreUpdate, C>();
         // we register the context C entity so that it can be replicated from the server to the client
         app.replicate::<C>();
-        app.replicate::<ActionOf<C>>();
+        app.replicate_with((
+            RuleFns::new(serialize_action_of::<C>, deserialize_action_of::<C>),
+            ReplicationMode::Once,
+        ))
+        .set_receive_fns::<ActionOf<C>>(write_action_of::<C>, remove_action_of::<C>);
         #[cfg(feature = "client")]
         {
             use crate::marker::{
@@ -126,6 +137,7 @@ impl<
             app.add_observer(add_input_marker_from_parent::<C>);
             app.add_observer(add_input_marker_from_binding::<C>);
             app.add_observer(add_input_marker_when_action_becomes_ready::<C>);
+            app.add_systems(PreUpdate, resolve_pending_action_of::<C>);
 
             if self.config.rebroadcast_inputs {
                 app.add_observer(InputRegistryPlugin::on_rebroadcast_action_received::<C>);

--- a/crates/inputs/input_bei/src/setup.rs
+++ b/crates/inputs/input_bei/src/setup.rs
@@ -2,11 +2,13 @@ use alloc::vec::Vec;
 use bevy_app::App;
 #[cfg(any(feature = "client", feature = "server"))]
 use bevy_ecs::prelude::*;
-#[cfg(any(feature = "client", feature = "server"))]
 use bevy_ecs::relationship::Relationship;
-use bevy_replicon::bytes::Bytes;
 use bevy_replicon::prelude::*;
-use bevy_replicon::shared::replication::registry::ctx::{SerializeCtx, WriteCtx};
+use bevy_replicon::shared::replication::deferred_entity::DeferredEntity;
+use bevy_replicon::shared::replication::registry::ctx::{RemoveCtx, SerializeCtx, WriteCtx};
+#[cfg(feature = "client")]
+use bevy_replicon::shared::server_entity_map::ServerEntityMap;
+use bevy_replicon::{bytes::Bytes, postcard_utils};
 #[cfg(feature = "client")]
 use {
     bevy_enhanced_input::context::ExternallyMocked,
@@ -36,6 +38,27 @@ use {
     lightyear_inputs::server::ServerInputConfig,
     lightyear_replication::prelude::{InterpolationTarget, PredictionTarget, ReplicateLike},
 };
+
+/// Client-side placeholder for a replicated [`ActionOf<C>`] whose context
+/// entity has not been mapped yet.
+///
+/// This is deliberately local-only. Once the context entity appears in
+/// Replicon's server-to-client entity map, [`resolve_pending_action_of`]
+/// replaces this component with the real BEI relationship.
+#[derive(Component)]
+pub(crate) struct PendingActionOf<C: Component> {
+    server_context: Entity,
+    marker: core::marker::PhantomData<C>,
+}
+
+impl<C: Component> PendingActionOf<C> {
+    fn new(server_context: Entity) -> Self {
+        Self {
+            server_context,
+            marker: core::marker::PhantomData,
+        }
+    }
+}
 
 pub struct InputRegistryPlugin;
 
@@ -186,6 +209,86 @@ impl InputRegistryPlugin {
     }
 }
 
+/// Serializes the server context entity targeted by [`ActionOf<C>`].
+///
+/// This uses a custom rule instead of Replicon's default component
+/// serialization because [`ActionOf<C>`] is a relationship component. The
+/// default receive path would call [`EntityMapper::get_mapped`] for the context
+/// entity and create a placeholder if the context has not been mapped yet. That
+/// placeholder is unsafe for a relationship component: Bevy relationship hooks
+/// can observe the target during insertion, and Replicon also asserts if that
+/// buffered placeholder is still pending when the next component in the same
+/// entity bundle is decoded.
+pub(crate) fn serialize_action_of<C: Component>(
+    _ctx: &SerializeCtx,
+    action_of: &ActionOf<C>,
+    message: &mut Vec<u8>,
+) -> bevy_ecs::error::Result<()> {
+    postcard_utils::entity_to_extend_mut(&action_of.get(), message)?;
+    Ok(())
+}
+
+/// Deserializes the raw server context entity for stale-message consumption.
+///
+/// The active receive path uses [`write_action_of`] below. This function exists
+/// for Replicon's `RuleFns` contract and for consuming stale updates without
+/// creating mapped placeholder entities.
+pub(crate) fn deserialize_action_of<C: Component>(
+    _ctx: &mut WriteCtx,
+    message: &mut Bytes,
+) -> bevy_ecs::error::Result<ActionOf<C>> {
+    let server_context = postcard_utils::entity_from_buf(message)?;
+    Ok(ActionOf::new(server_context))
+}
+
+/// Receives [`ActionOf<C>`] without using Replicon's placeholder entity mapper.
+///
+/// If the context entity is already mapped, this inserts the real BEI
+/// relationship immediately. If not, it stores [`PendingActionOf<C>`] so the
+/// relationship can be attached later by [`resolve_pending_action_of`].
+pub(crate) fn write_action_of<C: Component>(
+    ctx: &mut WriteCtx,
+    _rule_fns: &RuleFns<ActionOf<C>>,
+    entity: &mut DeferredEntity,
+    message: &mut Bytes,
+) -> bevy_ecs::error::Result<()> {
+    let server_context = postcard_utils::entity_from_buf(message)?;
+    if let Some(&client_context) = ctx.entity_map.to_client().get(&server_context) {
+        entity.insert(ActionOf::<C>::new(client_context));
+        entity.remove::<PendingActionOf<C>>();
+    } else {
+        entity.insert(PendingActionOf::<C>::new(server_context));
+        entity.remove::<ActionOf<C>>();
+    }
+    Ok(())
+}
+
+pub(crate) fn remove_action_of<C: Component>(_ctx: &mut RemoveCtx, entity: &mut DeferredEntity) {
+    entity.remove::<ActionOf<C>>();
+    entity.remove::<PendingActionOf<C>>();
+}
+
+/// Attach delayed BEI relationships once Replicon has mapped their context.
+#[cfg(feature = "client")]
+pub(crate) fn resolve_pending_action_of<C: Component>(
+    entity_map: Option<Res<ServerEntityMap>>,
+    pending: Query<(Entity, &PendingActionOf<C>)>,
+    mut commands: Commands,
+) {
+    let Some(entity_map) = entity_map else {
+        return;
+    };
+    for (entity, pending) in &pending {
+        let Some(&client_context) = entity_map.to_client().get(&pending.server_context) else {
+            continue;
+        };
+        commands
+            .entity(entity)
+            .insert(ActionOf::<C>::new(client_context))
+            .remove::<PendingActionOf<C>>();
+    }
+}
+
 /// Serializes only the presence and type of [`Action<A>`].
 ///
 /// The value stored inside BEI's [`Action<A>`] is local runtime state. Lightyear
@@ -193,11 +296,12 @@ impl InputRegistryPlugin {
 /// whose snapshots include the trigger state, action value, events, and timing.
 /// The [`Action<A>`] component also does not carry the context relationship:
 /// [`ActionOf<C>`] is replicated as its own component, and Replicon's default
-/// deserialize path calls [`Component::map_entities`] so Bevy's relationship
-/// entity is mapped through the prespawn/replication entity map. Therefore
-/// component replication only needs to create the correctly typed action
-/// component on the receiver, and [`deserialize_action`] can rebuild it from
-/// `Default`.
+/// mapping path is avoided there because it can create placeholder relationship
+/// targets when the context has not been mapped yet. Instead, Lightyear defers
+/// inserting [`ActionOf<C>`] until the context entity is present in the
+/// server-to-client map. Therefore component replication only needs to create
+/// the correctly typed action component on the receiver, and
+/// [`deserialize_action`] can rebuild it from `Default`.
 ///
 /// [`ActionOf<C>`]: bevy_enhanced_input::prelude::ActionOf
 fn serialize_action<A: InputAction>(

--- a/crates/inputs/input_bei/src/setup.rs
+++ b/crates/inputs/input_bei/src/setup.rs
@@ -1,11 +1,12 @@
 use alloc::vec::Vec;
 use bevy_app::App;
+#[cfg(any(feature = "client", feature = "server"))]
 use bevy_ecs::prelude::*;
+#[cfg(any(feature = "client", feature = "server"))]
 use bevy_ecs::relationship::Relationship;
 use bevy_replicon::bytes::Bytes;
 use bevy_replicon::prelude::*;
 use bevy_replicon::shared::replication::registry::ctx::{SerializeCtx, WriteCtx};
-use bevy_replicon::shared::server_entity_map::ServerEntityMap;
 #[cfg(feature = "client")]
 use {
     bevy_enhanced_input::context::ExternallyMocked,
@@ -16,245 +17,29 @@ use {
 use bevy_enhanced_input::prelude::*;
 #[cfg(any(feature = "client", feature = "server"))]
 use bevy_utils::prelude::DebugName;
+#[cfg(any(feature = "client", feature = "server"))]
+use lightyear_connection::host::HostClient;
 #[cfg(all(feature = "client", feature = "server"))]
 use lightyear_connection::host::HostServer;
-use lightyear_connection::{host::HostClient, server::Started};
+#[cfg(feature = "server")]
+use lightyear_connection::server::Started;
+#[cfg(feature = "server")]
 use lightyear_link::prelude::Server;
+#[cfg(feature = "server")]
 use lightyear_messages::MessageManager;
-#[cfg(feature = "client")]
+#[cfg(all(feature = "client", feature = "server"))]
 use lightyear_replication::prelude::PreSpawned;
 #[allow(unused_imports)]
-use tracing::{debug, info};
+use tracing::{debug, warn};
 #[cfg(feature = "server")]
 use {
     lightyear_inputs::server::ServerInputConfig,
     lightyear_replication::prelude::{InterpolationTarget, PredictionTarget, ReplicateLike},
 };
-// TODO: ideally we would have an entity-mapped that is PreSpawn aware. If you include an entity
-//   that is PreSpawned, then in the entity-mapper we use a Query<Entity, With<PreSpawned>> to check the hash
-//   of the entity and serialize it as the hash. Then the receiving entity mapper could look up the corresponding
-//   entity by the PreSpawn hash to apply entity mapping.
-//   1. In common case, server sends P1,C1. It does NOT need to change ChildOf(P1) because client will match P1/C1 on receipt, then
-//        update its entity maps, then the component map entity will work correctly. We just need to make sure that C1 is also Prespawned,
-//        which we could do in ReplicateLike Propagation? (but how to do it on the receiver side?)
-//
 
 pub struct InputRegistryPlugin;
 
-/// Replication-facing mirror of [`ActionOf<C>`].
-///
-/// BEI's [`ActionOf<C>`] stores the context entity in the local world's entity
-/// namespace. That is not always the entity the receiver needs: a client-side
-/// action may point at a client-local predicted or prespawned context, while
-/// the server must receive the corresponding server entity.
-///
-/// Before replication, [`mirror_action_of_for_replication`] resolves the local
-/// context through the available entity maps and stores the remote-side context
-/// entity here. After replication, [`insert_action_of_from_network`] maps this
-/// value back into the receiver's local world and recreates [`ActionOf<C>`].
-///
-/// This component intentionally does not implement `MapEntities`. Replicon's
-/// serializer only has Replicon's mapping context, while this path may need
-/// Lightyear's message entity map or the server entity map, and some action
-/// entities are created before those maps are populated. Mapping is therefore
-/// done explicitly by the mirror/resolve systems instead of by component-level
-/// `MapEntities`.
-///
-/// [`mirror_action_of_for_replication`]: InputRegistryPlugin::mirror_action_of_for_replication
-/// [`insert_action_of_from_network`]: InputRegistryPlugin::insert_action_of_from_network
-#[derive(Component, Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) struct NetworkActionOf<C> {
-    entity: Entity,
-    marker: core::marker::PhantomData<C>,
-}
-
-impl<C> NetworkActionOf<C> {
-    fn new(entity: Entity) -> Self {
-        Self {
-            entity,
-            marker: core::marker::PhantomData,
-        }
-    }
-
-    fn get(&self) -> Entity {
-        self.entity
-    }
-}
-
 impl InputRegistryPlugin {
-    /// Mirrors a local [`ActionOf<C>`] into [`NetworkActionOf<C>`] so action
-    /// entities can be replicated with an entity reference the receiver can
-    /// resolve.
-    ///
-    /// The mirrored entity is deliberately the remote-side context entity, not
-    /// the raw [`ActionOf<C>`] target from this world. For example, when a
-    /// client spawns a prespawned action for a replicated context, its
-    /// [`ActionOf<C>`] points at the client's local context entity, but the
-    /// server needs the server entity. If that mapping is not available when
-    /// the component is added, [`resolve_pending_network_action_of`] retries
-    /// after replication receive has had a chance to populate the maps.
-    ///
-    /// [`resolve_pending_network_action_of`]: InputRegistryPlugin::resolve_pending_network_action_of
-    pub(crate) fn mirror_action_of_for_replication<C: Component>(
-        trigger: On<Add, ActionOf<C>>,
-        action_of: Query<&ActionOf<C>, Without<Remote>>,
-        remote_contexts: Query<(), With<Remote>>,
-        entity_map: Option<Res<ServerEntityMap>>,
-        managers: Query<&MessageManager>,
-        mut commands: Commands,
-    ) {
-        let entity = trigger.entity;
-        let Ok(action_of) = action_of.get(entity) else {
-            return;
-        };
-
-        let context_entity = action_of.get();
-        let remote_entity = resolve_remote_action_context(
-            context_entity,
-            remote_contexts.contains(context_entity),
-            entity_map.as_deref(),
-            managers.iter(),
-        );
-        let Some(remote_entity) = remote_entity else {
-            return;
-        };
-        commands
-            .entity(entity)
-            .insert(NetworkActionOf::<C>::new(remote_entity));
-    }
-
-    /// Retries [`ActionOf<C>`] -> [`NetworkActionOf<C>`] mirroring for local
-    /// action entities whose context could not be mapped when [`ActionOf<C>`]
-    /// was first added.
-    ///
-    /// This commonly happens when the action is spawned against a replicated or
-    /// prespawned context before Replicon/Lightyear have populated the relevant
-    /// entity maps for that context. The observer path only runs once, so this
-    /// system runs after replication receive and fills in [`NetworkActionOf<C>`]
-    /// as soon as the remote-side context entity becomes known.
-    ///
-    /// For purely local contexts we may mirror the context entity directly. For
-    /// contexts carrying [`Remote`], identity fallback is not allowed because the
-    /// local entity id is explicitly a receiver-local id and would not be
-    /// meaningful to the peer.
-    ///
-    /// This retry was less important in the old client-to-server action
-    /// replication flow, where [`ActionOf<C>`] itself was serialized as part of
-    /// a concrete outgoing replication message. In that setup, entity mapping
-    /// happened at send time with that connection's mapper, and the receiver
-    /// created the action entity from the replicated component. With the
-    /// prespawned flow, both worlds can spawn the action entity before the
-    /// prespawn/context mapping has settled, while [`NetworkActionOf<C>`] is an
-    /// ordinary component that must exist before the action relationship can be
-    /// replicated or rebroadcast. The add-observer only fires once, so this
-    /// system fills in the mirror once the mapping appears.
-    pub(crate) fn resolve_pending_network_action_of<C: Component>(
-        pending: Query<(Entity, &ActionOf<C>), (Without<NetworkActionOf<C>>, Without<Remote>)>,
-        remote_contexts: Query<(), With<Remote>>,
-        entity_map: Option<Res<ServerEntityMap>>,
-        managers: Query<&MessageManager>,
-        mut commands: Commands,
-    ) {
-        for (entity, action_of) in pending.iter() {
-            let context_entity = action_of.get();
-            let remote_entity = resolve_remote_action_context(
-                context_entity,
-                remote_contexts.contains(context_entity),
-                entity_map.as_deref(),
-                managers.iter(),
-            );
-            let Some(remote_entity) = remote_entity else {
-                continue;
-            };
-
-            commands
-                .entity(entity)
-                .insert(NetworkActionOf::<C>::new(remote_entity));
-        }
-    }
-
-    /// Recreates BEI's local [`ActionOf<C>`] relationship when a replicated
-    /// action entity receives [`NetworkActionOf<C>`].
-    ///
-    /// [`NetworkActionOf<C>`] stores the sender/authoritative context entity.
-    /// This observer maps that entity into this world's local context entity and
-    /// inserts [`ActionOf<C>`], allowing BEI's relationship hooks to add the
-    /// action to the context's [`Actions<C>`] collection.
-    ///
-    /// If the context mapping is not known yet, the observer leaves the entity
-    /// unchanged and [`resolve_pending_action_of`] retries after replication
-    /// receive. The query is limited to replicated action entities (`With<Remote>`)
-    /// because local action entities already have their own [`ActionOf<C>`].
-    ///
-    /// [`resolve_pending_action_of`]: InputRegistryPlugin::resolve_pending_action_of
-    pub(crate) fn insert_action_of_from_network<C: Component>(
-        trigger: On<Add, NetworkActionOf<C>>,
-        query: Query<&NetworkActionOf<C>, (Without<ActionOf<C>>, With<Remote>)>,
-        entity_map: Option<Res<ServerEntityMap>>,
-        managers: Query<&MessageManager>,
-        all_entities: Query<(), ()>,
-        host_clients: Query<(), With<HostClient>>,
-        servers: Query<(), (With<Server>, With<Started>)>,
-        mut commands: Commands,
-    ) {
-        let entity = trigger.entity;
-        let Ok(network_action_of) = query.get(entity) else {
-            return;
-        };
-
-        let allow_identity = !host_clients.is_empty() || !servers.is_empty();
-        if let Some(mapped) = resolve_local_entity(
-            network_action_of.get(),
-            entity_map.as_deref(),
-            managers.iter(),
-            &all_entities,
-            allow_identity,
-        )
-        .filter(|mapped| *mapped != entity)
-        {
-            commands.entity(entity).insert(ActionOf::<C>::new(mapped));
-        }
-    }
-
-    /// Retries [`NetworkActionOf<C>`] -> [`ActionOf<C>`] reconstruction for
-    /// replicated action entities whose context could not be mapped when
-    /// [`NetworkActionOf<C>`] was first received.
-    ///
-    /// The serialized [`NetworkActionOf<C>`] stores the sender/authoritative
-    /// context entity. The receiver needs a local context entity before BEI can
-    /// attach the action to an [`Actions<C>`] collection. Replication can create
-    /// the action entity before the corresponding context mapping is visible, so
-    /// the add-observer may have to defer and this system retries after
-    /// replication receive has updated the maps.
-    ///
-    /// Host-client and server worlds may use identity mapping for entities that
-    /// already live in the same world. Remote clients do not, because an
-    /// unmapped remote entity id must not be interpreted as a local context.
-    pub(crate) fn resolve_pending_action_of<C: Component>(
-        pending: Query<(Entity, &NetworkActionOf<C>), (Without<ActionOf<C>>, With<Remote>)>,
-        entity_map: Option<Res<ServerEntityMap>>,
-        managers: Query<&MessageManager>,
-        all_entities: Query<(), ()>,
-        host_clients: Query<(), With<HostClient>>,
-        servers: Query<(), (With<Server>, With<Started>)>,
-        mut commands: Commands,
-    ) {
-        let allow_identity = !host_clients.is_empty() || !servers.is_empty();
-        for (entity, network_action_of) in pending.iter() {
-            if let Some(mapped) = resolve_local_entity(
-                network_action_of.get(),
-                entity_map.as_deref(),
-                managers.iter(),
-                &all_entities,
-                allow_identity,
-            )
-            .filter(|mapped| *mapped != entity)
-            {
-                commands.entity(entity).insert(ActionOf::<C>::new(mapped));
-            }
-        }
-    }
-
     /// For Host-Server, if an ActionOf is spawned directly on the HostClient.
     /// (without being received from replication, or with Prespawned)
     /// Then we initiate rebroadcast
@@ -401,70 +186,20 @@ impl InputRegistryPlugin {
     }
 }
 
-fn resolve_remote_entity<'a>(
-    local_entity: Entity,
-    entity_map: Option<&ServerEntityMap>,
-    mut managers: impl Iterator<Item = &'a MessageManager>,
-) -> Option<Entity> {
-    if let Some(entity_map) = entity_map
-        && let Some(remote_entity) = entity_map.to_server().get(&local_entity)
-    {
-        return Some(*remote_entity);
-    }
-
-    // There can be several connections in one world: a server has one
-    // MessageManager per ClientOf, and host-server worlds also have the
-    // HostClient manager. The action-context entity may have been mapped by any
-    // active connection, so use the first manager that knows it.
-    managers.find_map(|manager| manager.entity_mapper.get_remote(local_entity))
-}
-
-fn resolve_remote_action_context<'a>(
-    local_entity: Entity,
-    remote_context: bool,
-    entity_map: Option<&ServerEntityMap>,
-    managers: impl Iterator<Item = &'a MessageManager>,
-) -> Option<Entity> {
-    resolve_remote_entity(local_entity, entity_map, managers)
-        .or_else(|| (!remote_context).then_some(local_entity))
-}
-
-fn resolve_local_entity<'a>(
-    remote_entity: Entity,
-    entity_map: Option<&ServerEntityMap>,
-    mut managers: impl Iterator<Item = &'a MessageManager>,
-    all_entities: &Query<(), ()>,
-    allow_identity: bool,
-) -> Option<Entity> {
-    if let Some(entity_map) = entity_map
-        && let Some(local_entity) = entity_map.to_client().get(&remote_entity)
-    {
-        return Some(*local_entity);
-    }
-
-    // See resolve_remote_entity: this system is topology-agnostic and can run
-    // in worlds with multiple per-connection MessageManagers.
-    let local_entity = managers.find_map(|manager| manager.entity_mapper.get_local(remote_entity));
-    if let Some(local_entity) = local_entity {
-        return Some(local_entity);
-    }
-
-    allow_identity
-        .then(|| all_entities.get(remote_entity).ok().map(|()| remote_entity))
-        .flatten()
-}
-
 /// Serializes only the presence and type of [`Action<A>`].
 ///
 /// The value stored inside BEI's [`Action<A>`] is local runtime state. Lightyear
 /// sends that state through [`BEIStateSequence`](crate::input_message::BEIStateSequence),
 /// whose snapshots include the trigger state, action value, events, and timing.
-/// Relationship data is handled separately by mirroring [`ActionOf`] into
-/// [`NetworkActionOf`]. Therefore component replication only needs to create
-/// the correctly typed action component on the receiver, and
-/// [`deserialize_action`] can rebuild it from `Default`.
+/// The [`Action<A>`] component also does not carry the context relationship:
+/// [`ActionOf<C>`] is replicated as its own component, and Replicon's default
+/// deserialize path calls [`Component::map_entities`] so Bevy's relationship
+/// entity is mapped through the prespawn/replication entity map. Therefore
+/// component replication only needs to create the correctly typed action
+/// component on the receiver, and [`deserialize_action`] can rebuild it from
+/// `Default`.
 ///
-/// [`ActionOf`]: bevy_enhanced_input::prelude::ActionOf
+/// [`ActionOf<C>`]: bevy_enhanced_input::prelude::ActionOf
 fn serialize_action<A: InputAction>(
     _ctx: &mut SerializeCtx,
     _: &Action<A>,
@@ -477,31 +212,6 @@ fn deserialize_action<A: InputAction>(
     _: &mut Bytes,
 ) -> bevy_ecs::error::Result<Action<A>> {
     Ok(Action::<A>::default())
-}
-
-/// Serialize the authoritative remote entity for an action context.
-///
-/// Entity mapping is handled out-of-band before replication by mirroring [`ActionOf<C>`]
-/// into [`NetworkActionOf<C>`].
-pub(crate) fn serialize_network_action_of<C: Component>(
-    _ctx: &mut SerializeCtx,
-    action_of: &NetworkActionOf<C>,
-    message: &mut Vec<u8>,
-) -> bevy_ecs::error::Result<()> {
-    bevy_replicon::postcard_utils::entity_to_extend_mut(&action_of.get(), message)?;
-    Ok(())
-}
-
-/// Deserialize the authoritative remote entity for an action context.
-///
-/// We intentionally do not apply replicon's entity mapping here because the authoritative
-/// entity may come from either the replicon server map or lightyear's message entity map.
-pub(crate) fn deserialize_network_action_of<C: Component>(
-    _: &mut WriteCtx,
-    message: &mut Bytes,
-) -> bevy_ecs::error::Result<NetworkActionOf<C>> {
-    let entity = bevy_replicon::postcard_utils::entity_from_buf(message)?;
-    Ok(NetworkActionOf::<C>::new(entity))
 }
 
 pub trait InputRegistryExt {

--- a/crates/inputs/input_bei/src/setup.rs
+++ b/crates/inputs/input_bei/src/setup.rs
@@ -10,7 +10,7 @@ use bevy_replicon::shared::server_entity_map::ServerEntityMap;
 use {
     bevy_enhanced_input::context::ExternallyMocked,
     lightyear_connection::client::Client,
-    lightyear_replication::prelude::{Controlled, ControlledBy, Replicate},
+    lightyear_replication::prelude::{Controlled, ControlledBy},
 };
 
 use bevy_enhanced_input::prelude::*;
@@ -41,6 +41,27 @@ use {
 
 pub struct InputRegistryPlugin;
 
+/// Replication-facing mirror of [`ActionOf<C>`].
+///
+/// BEI's [`ActionOf<C>`] stores the context entity in the local world's entity
+/// namespace. That is not always the entity the receiver needs: a client-side
+/// action may point at a client-local predicted or prespawned context, while
+/// the server must receive the corresponding server entity.
+///
+/// Before replication, [`mirror_action_of_for_replication`] resolves the local
+/// context through the available entity maps and stores the remote-side context
+/// entity here. After replication, [`insert_action_of_from_network`] maps this
+/// value back into the receiver's local world and recreates [`ActionOf<C>`].
+///
+/// This component intentionally does not implement `MapEntities`. Replicon's
+/// serializer only has Replicon's mapping context, while this path may need
+/// Lightyear's message entity map or the server entity map, and some action
+/// entities are created before those maps are populated. Mapping is therefore
+/// done explicitly by the mirror/resolve systems instead of by component-level
+/// `MapEntities`.
+///
+/// [`mirror_action_of_for_replication`]: InputRegistryPlugin::mirror_action_of_for_replication
+/// [`insert_action_of_from_network`]: InputRegistryPlugin::insert_action_of_from_network
 #[derive(Component, Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) struct NetworkActionOf<C> {
     entity: Entity,
@@ -61,6 +82,19 @@ impl<C> NetworkActionOf<C> {
 }
 
 impl InputRegistryPlugin {
+    /// Mirrors a local [`ActionOf<C>`] into [`NetworkActionOf<C>`] so action
+    /// entities can be replicated with an entity reference the receiver can
+    /// resolve.
+    ///
+    /// The mirrored entity is deliberately the remote-side context entity, not
+    /// the raw [`ActionOf<C>`] target from this world. For example, when a
+    /// client spawns a prespawned action for a replicated context, its
+    /// [`ActionOf<C>`] points at the client's local context entity, but the
+    /// server needs the server entity. If that mapping is not available when
+    /// the component is added, [`resolve_pending_network_action_of`] retries
+    /// after replication receive has had a chance to populate the maps.
+    ///
+    /// [`resolve_pending_network_action_of`]: InputRegistryPlugin::resolve_pending_network_action_of
     pub(crate) fn mirror_action_of_for_replication<C: Component>(
         trigger: On<Add, ActionOf<C>>,
         action_of: Query<&ActionOf<C>, Without<Remote>>,
@@ -89,6 +123,31 @@ impl InputRegistryPlugin {
             .insert(NetworkActionOf::<C>::new(remote_entity));
     }
 
+    /// Retries [`ActionOf<C>`] -> [`NetworkActionOf<C>`] mirroring for local
+    /// action entities whose context could not be mapped when [`ActionOf<C>`]
+    /// was first added.
+    ///
+    /// This commonly happens when the action is spawned against a replicated or
+    /// prespawned context before Replicon/Lightyear have populated the relevant
+    /// entity maps for that context. The observer path only runs once, so this
+    /// system runs after replication receive and fills in [`NetworkActionOf<C>`]
+    /// as soon as the remote-side context entity becomes known.
+    ///
+    /// For purely local contexts we may mirror the context entity directly. For
+    /// contexts carrying [`Remote`], identity fallback is not allowed because the
+    /// local entity id is explicitly a receiver-local id and would not be
+    /// meaningful to the peer.
+    ///
+    /// This retry was less important in the old client-to-server action
+    /// replication flow, where [`ActionOf<C>`] itself was serialized as part of
+    /// a concrete outgoing replication message. In that setup, entity mapping
+    /// happened at send time with that connection's mapper, and the receiver
+    /// created the action entity from the replicated component. With the
+    /// prespawned flow, both worlds can spawn the action entity before the
+    /// prespawn/context mapping has settled, while [`NetworkActionOf<C>`] is an
+    /// ordinary component that must exist before the action relationship can be
+    /// replicated or rebroadcast. The add-observer only fires once, so this
+    /// system fills in the mirror once the mapping appears.
     pub(crate) fn resolve_pending_network_action_of<C: Component>(
         pending: Query<(Entity, &ActionOf<C>), (Without<NetworkActionOf<C>>, Without<Remote>)>,
         remote_contexts: Query<(), With<Remote>>,
@@ -114,6 +173,20 @@ impl InputRegistryPlugin {
         }
     }
 
+    /// Recreates BEI's local [`ActionOf<C>`] relationship when a replicated
+    /// action entity receives [`NetworkActionOf<C>`].
+    ///
+    /// [`NetworkActionOf<C>`] stores the sender/authoritative context entity.
+    /// This observer maps that entity into this world's local context entity and
+    /// inserts [`ActionOf<C>`], allowing BEI's relationship hooks to add the
+    /// action to the context's [`Actions<C>`] collection.
+    ///
+    /// If the context mapping is not known yet, the observer leaves the entity
+    /// unchanged and [`resolve_pending_action_of`] retries after replication
+    /// receive. The query is limited to replicated action entities (`With<Remote>`)
+    /// because local action entities already have their own [`ActionOf<C>`].
+    ///
+    /// [`resolve_pending_action_of`]: InputRegistryPlugin::resolve_pending_action_of
     pub(crate) fn insert_action_of_from_network<C: Component>(
         trigger: On<Add, NetworkActionOf<C>>,
         query: Query<&NetworkActionOf<C>, (Without<ActionOf<C>>, With<Remote>)>,
@@ -143,6 +216,20 @@ impl InputRegistryPlugin {
         }
     }
 
+    /// Retries [`NetworkActionOf<C>`] -> [`ActionOf<C>`] reconstruction for
+    /// replicated action entities whose context could not be mapped when
+    /// [`NetworkActionOf<C>`] was first received.
+    ///
+    /// The serialized [`NetworkActionOf<C>`] stores the sender/authoritative
+    /// context entity. The receiver needs a local context entity before BEI can
+    /// attach the action to an [`Actions<C>`] collection. Replication can create
+    /// the action entity before the corresponding context mapping is visible, so
+    /// the add-observer may have to defer and this system retries after
+    /// replication receive has updated the maps.
+    ///
+    /// Host-client and server worlds may use identity mapping for entities that
+    /// already live in the same world. Remote clients do not, because an
+    /// unmapped remote entity id must not be interpreted as a local context.
     pub(crate) fn resolve_pending_action_of<C: Component>(
         pending: Query<(Entity, &NetworkActionOf<C>), (Without<ActionOf<C>>, With<Remote>)>,
         entity_map: Option<Res<ServerEntityMap>>,
@@ -242,40 +329,6 @@ impl InputRegistryPlugin {
         }
     }
 
-    /// When an [`ActionOf<C>`] component is added to an entity (usually on the client),
-    /// we add Replicate to it so that the action entity is also created on the server.
-    ///
-    /// PreSpawned Actions must be replicated from server to client.
-    /// No need to change anything about ActionOf because the Context and Action will be received at the same time,
-    /// so the entity mapping in ActionOf will work properly.
-    #[cfg(feature = "client")]
-    pub(crate) fn add_action_of_replicate<C: Component>(
-        trigger: On<Add, NetworkActionOf<C>>,
-        server: Query<(), (With<Server>, With<Started>)>,
-        // we don't want to add Replicate on action entities that were already received
-        // PreSpawned entities are replicated from server to client
-        action: Query<
-            &ActionOf<C>,
-            (
-                With<NetworkActionOf<C>>,
-                Without<Remote>,
-                Without<PreSpawned>,
-            ),
-        >,
-        mut commands: Commands,
-    ) {
-        if server.single().is_ok() {
-            // we're on the server, don't do anything
-            return;
-        }
-        let entity = trigger.entity;
-        if let Ok(action_of) = action.get(entity) {
-            let context_entity = action_of.get();
-            debug!(action_entity = ?entity, "Replicating ActionOf<{:?}> for context entity {context_entity:?} from client to server", DebugName::type_name::<C>());
-            commands.entity(entity).insert((Replicate::to_server(),));
-        }
-    }
-
     /// When the server receives [`ActionOf`], optionally rebroadcast to other clients if rebroadcast_inputs is enabled
     #[cfg(feature = "server")]
     pub(crate) fn on_action_of_replicated<C: Component>(
@@ -359,6 +412,10 @@ fn resolve_remote_entity<'a>(
         return Some(*remote_entity);
     }
 
+    // There can be several connections in one world: a server has one
+    // MessageManager per ClientOf, and host-server worlds also have the
+    // HostClient manager. The action-context entity may have been mapped by any
+    // active connection, so use the first manager that knows it.
     managers.find_map(|manager| manager.entity_mapper.get_remote(local_entity))
 }
 
@@ -385,9 +442,10 @@ fn resolve_local_entity<'a>(
         return Some(*local_entity);
     }
 
-    if let Some(local_entity) =
-        managers.find_map(|manager| manager.entity_mapper.get_local(remote_entity))
-    {
+    // See resolve_remote_entity: this system is topology-agnostic and can run
+    // in worlds with multiple per-connection MessageManagers.
+    let local_entity = managers.find_map(|manager| manager.entity_mapper.get_local(remote_entity));
+    if let Some(local_entity) = local_entity {
         return Some(local_entity);
     }
 
@@ -396,7 +454,17 @@ fn resolve_local_entity<'a>(
         .flatten()
 }
 
-// we don't care about the actual data in Action<A>, so nothing to serialize
+/// Serializes only the presence and type of [`Action<A>`].
+///
+/// The value stored inside BEI's [`Action<A>`] is local runtime state. Lightyear
+/// sends that state through [`BEIStateSequence`](crate::input_message::BEIStateSequence),
+/// whose snapshots include the trigger state, action value, events, and timing.
+/// Relationship data is handled separately by mirroring [`ActionOf`] into
+/// [`NetworkActionOf`]. Therefore component replication only needs to create
+/// the correctly typed action component on the receiver, and
+/// [`deserialize_action`] can rebuild it from `Default`.
+///
+/// [`ActionOf`]: bevy_enhanced_input::prelude::ActionOf
 fn serialize_action<A: InputAction>(
     _ctx: &mut SerializeCtx,
     _: &Action<A>,

--- a/crates/inputs/input_bei/src/setup.rs
+++ b/crates/inputs/input_bei/src/setup.rs
@@ -220,7 +220,7 @@ impl InputRegistryPlugin {
 /// buffered placeholder is still pending when the next component in the same
 /// entity bundle is decoded.
 pub(crate) fn serialize_action_of<C: Component>(
-    _ctx: &SerializeCtx,
+    _ctx: &mut SerializeCtx,
     action_of: &ActionOf<C>,
     message: &mut Vec<u8>,
 ) -> bevy_ecs::error::Result<()> {

--- a/crates/inputs/inputs/src/client.rs
+++ b/crates/inputs/inputs/src/client.rs
@@ -696,7 +696,6 @@ fn prepare_input_message<S: ActionStateSequence>(
             input_buffer
         );
 
-        // PreSpawned: the include the Prespawned Hash
         let target = if let Some(prespawned) = pre_spawned
             && let Some(hash) = prespawned.hash
         {

--- a/crates/inputs/inputs/src/input_message.rs
+++ b/crates/inputs/inputs/src/input_message.rs
@@ -30,7 +30,7 @@ pub enum InputTarget {
     /// (Also when rebroadcast from server to client)
     Entity(Entity),
     /// The input is for a prespawned entity.
-    /// We wan the client to be able to send inputs for a prespawned entity before it gets matched with a server entity.
+    /// We want the client to be able to send inputs for a prespawned entity before it gets matched with a server entity.
     /// To achieve this, the client sends the PreSpawned hash and the server will map it to the correct server entity.
     /// When rebroadcasting from server to other client, we rebroadcast it as a normal Entity?
     PreSpawned(u64),

--- a/crates/inputs/inputs/src/server.rs
+++ b/crates/inputs/inputs/src/server.rs
@@ -470,11 +470,8 @@ fn receive_input_message<S: ActionStateSequence>(
                     },
                     InputTarget::PreSpawned(hash) => {
                         debug!(?hash, "Received input for prespawned entity");
-                        // we cannot match using the PreSpawnedReceiver since it only stores hashes for entities
-                        // with no Replicate component.
-                        // Instead, since there shouldn't be many entities with inputs and PreSpawned, we just iterate
-                        // through the query. We don't need to do entity-mapping because as soon as the entity is mapped
-                        // on the client, PreSpawned is removed and the input will contain the mapped entity.
+                        // We cannot match using the PreSpawnedReceiver since it only stores hashes for entities
+                        // with no Replicate component, so resolve the input target against server-side input entities.
                         prespawned
                             .iter()
                             .filter_map(|(e, p)| p.hash.is_some_and(|h| h == hash).then_some(e)).next()

--- a/crates/replication/prediction/src/plugin.rs
+++ b/crates/replication/prediction/src/plugin.rs
@@ -5,9 +5,9 @@ use crate::diagnostics::PredictionDiagnosticsPlugin;
 use crate::manager::PredictionManager;
 use crate::predicted_history::{
     PredictionHistory, add_history_diff_receiver, add_prediction_history,
-    apply_component_removal_predicted, handle_tick_event_confirmed_history,
-    handle_tick_event_history_diff_receiver, handle_tick_event_prediction_history,
-    prune_history_diff_receiver, snap_to_confirmed_during_rollback, update_prediction_history,
+    apply_component_removal_predicted, handle_tick_event_history_diff_receiver,
+    handle_tick_event_prediction_history, prune_history_diff_receiver,
+    snap_to_confirmed_during_rollback, update_prediction_history,
 };
 use crate::registry::PredictionRegistry;
 use crate::rollback::DisabledDuringRollback;
@@ -83,8 +83,12 @@ pub fn add_non_networked_rollback_systems<C: Component<Mutability = Mutable> + C
     // would not get its tick values shifted on timeline-sync, so any
     // history entries accumulated pre-sync would point to stale
     // (pre-sync) ticks after the client clock jumps forward.
+    //
+    // Do not shift `ConfirmedHistory<C>` here: confirmed samples are resolved
+    // through `ReplicationCheckpointMap` and are already in authoritative
+    // server tick space. Shifting them can move an init-message seed into the
+    // future and make rollback prefer stale state over later server updates.
     app.add_observer(handle_tick_event_prediction_history::<C>);
-    app.add_observer(handle_tick_event_confirmed_history::<C>);
     app.add_systems(
         PreUpdate,
         prepare_rollback::<C>.in_set(RollbackSystems::Prepare),
@@ -152,7 +156,6 @@ pub(crate) fn add_prediction_systems<C: SyncComponent>(app: &mut App) {
 
     app.add_observer(apply_component_removal_predicted::<C>);
     app.add_observer(handle_tick_event_prediction_history::<C>);
-    app.add_observer(handle_tick_event_confirmed_history::<C>);
     app.add_observer(add_prediction_history::<C>);
 
     app.add_systems(

--- a/crates/replication/prediction/src/predicted_history.rs
+++ b/crates/replication/prediction/src/predicted_history.rs
@@ -144,27 +144,6 @@ pub(crate) fn handle_tick_event_prediction_history<C: Component>(
     }
 }
 
-/// If there is a TickEvent and the client tick suddenly changes, update confirmed-history ticks too.
-pub(crate) fn handle_tick_event_confirmed_history<C: Component>(
-    trigger: On<SyncEvent<InputTimelineConfig>>,
-    mut query: Query<&mut ConfirmedHistory<C>>,
-) {
-    for mut history in query.iter_mut() {
-        history.update_ticks(trigger.tick_delta);
-        trace!(
-            target: "lightyear_debug::prediction",
-            kind = "confirmed_history_tick_delta",
-            schedule = "PostUpdate",
-            sample_point = "PostUpdate",
-            entity = ?trigger.entity,
-            component = ?DebugName::type_name::<C>(),
-            tick_delta = trigger.tick_delta,
-            history_len = history.len(),
-            "shifted confirmed history ticks"
-        );
-    }
-}
-
 pub(crate) fn handle_tick_event_history_diff_receiver<C: RepliconDiffable>(
     trigger: On<SyncEvent<InputTimelineConfig>>,
     mut storage: ResMut<ReplicationStorage>,
@@ -212,7 +191,6 @@ pub(crate) fn prune_history_diff_receiver<C: RepliconDiffable>(
         }
     }
 }
-
 /// If a predicted component is removed on the [`Predicted`] entity, add the removal to the history.
 pub(crate) fn apply_component_removal_predicted<C: Component>(
     trigger: On<Remove, C>,

--- a/crates/replication/replication/src/hierarchy.rs
+++ b/crates/replication/replication/src/hierarchy.rs
@@ -124,7 +124,7 @@ impl Plugin for HierarchyPlugin {
 /// yet, the receiver defers inserting the relationship instead of letting
 /// Replicon create a placeholder entity inside the relationship component.
 pub(crate) fn serialize_child_of(
-    _ctx: &SerializeCtx,
+    _ctx: &mut SerializeCtx,
     child_of: &ChildOf,
     message: &mut Vec<u8>,
 ) -> bevy_ecs::error::Result<()> {

--- a/crates/replication/replication/src/hierarchy.rs
+++ b/crates/replication/replication/src/hierarchy.rs
@@ -14,7 +14,13 @@ use bevy_ecs::query::QueryData;
 use bevy_ecs::reflect::ReflectMapEntities;
 use bevy_ecs::relationship::Relationship;
 use bevy_reflect::Reflect;
-use bevy_replicon::prelude::SyncRelatedAppExt;
+use bevy_replicon::bytes::Bytes;
+use bevy_replicon::postcard_utils;
+use bevy_replicon::prelude::{RuleFns, SyncRelatedAppExt};
+use bevy_replicon::shared::replication::deferred_entity::DeferredEntity;
+use bevy_replicon::shared::replication::registry::ctx::{RemoveCtx, SerializeCtx, WriteCtx};
+#[cfg(feature = "client")]
+use bevy_replicon::shared::server_entity_map::ServerEntityMap;
 use core::fmt::Debug;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
@@ -32,6 +38,26 @@ pub enum RelationshipSystems {
 }
 
 pub(crate) struct HierarchyPlugin;
+
+/// Client-side placeholder for a replicated [`ChildOf`] whose parent entity
+/// has not been mapped yet.
+///
+/// Replicon's default entity mapping creates a buffered placeholder when a
+/// replicated component references an entity that has not appeared in the
+/// server-to-client map yet. That is unsafe for relationship components like
+/// [`ChildOf`], because inserting the relationship immediately runs Bevy's
+/// relationship hooks and leaves Replicon's placeholder buffer alive while the
+/// next component in the same entity bundle is decoded.
+#[derive(Component)]
+pub(crate) struct PendingChildOf {
+    server_parent: Entity,
+}
+
+impl PendingChildOf {
+    fn new(server_parent: Entity) -> Self {
+        Self { server_parent }
+    }
+}
 
 #[derive(QueryData)]
 struct PropagationQuery {
@@ -88,6 +114,82 @@ impl HierarchyPlugin {
 impl Plugin for HierarchyPlugin {
     fn build(&self, app: &mut App) {
         app.add_observer(Self::propagate_when_replicate_like_added);
+    }
+}
+
+/// Serializes the server parent entity targeted by [`ChildOf`].
+///
+/// Lightyear registers a custom rule for [`ChildOf`] so the receive path can
+/// inspect the raw server entity before mapping it. If the parent is not mapped
+/// yet, the receiver defers inserting the relationship instead of letting
+/// Replicon create a placeholder entity inside the relationship component.
+pub(crate) fn serialize_child_of(
+    _ctx: &SerializeCtx,
+    child_of: &ChildOf,
+    message: &mut Vec<u8>,
+) -> bevy_ecs::error::Result<()> {
+    postcard_utils::entity_to_extend_mut(&child_of.parent(), message)?;
+    Ok(())
+}
+
+/// Deserializes the raw server parent entity for stale-message consumption.
+///
+/// The active receive path uses [`write_child_of`] so it can defer insertion
+/// until the parent is mapped.
+pub(crate) fn deserialize_child_of(
+    _ctx: &mut WriteCtx,
+    message: &mut Bytes,
+) -> bevy_ecs::error::Result<ChildOf> {
+    let server_parent = postcard_utils::entity_from_buf(message)?;
+    Ok(ChildOf(server_parent))
+}
+
+/// Receives [`ChildOf`] without using Replicon's placeholder entity mapper.
+///
+/// If the parent has already been mapped, this inserts the real Bevy hierarchy
+/// relationship. If not, it stores [`PendingChildOf`] and waits for
+/// [`resolve_pending_child_of`] to attach the relationship once the parent
+/// mapping is available.
+pub(crate) fn write_child_of(
+    ctx: &mut WriteCtx,
+    _rule_fns: &RuleFns<ChildOf>,
+    entity: &mut DeferredEntity,
+    message: &mut Bytes,
+) -> bevy_ecs::error::Result<()> {
+    let server_parent = postcard_utils::entity_from_buf(message)?;
+    if let Some(&client_parent) = ctx.entity_map.to_client().get(&server_parent) {
+        entity.insert(ChildOf(client_parent));
+        entity.remove::<PendingChildOf>();
+    } else {
+        entity.insert(PendingChildOf::new(server_parent));
+        entity.remove::<ChildOf>();
+    }
+    Ok(())
+}
+
+pub(crate) fn remove_child_of(_ctx: &mut RemoveCtx, entity: &mut DeferredEntity) {
+    entity.remove::<ChildOf>();
+    entity.remove::<PendingChildOf>();
+}
+
+/// Attach delayed hierarchy relationships once Replicon has mapped the parent.
+#[cfg(feature = "client")]
+pub(crate) fn resolve_pending_child_of(
+    entity_map: Option<Res<ServerEntityMap>>,
+    pending: Query<(Entity, &PendingChildOf)>,
+    mut commands: Commands,
+) {
+    let Some(entity_map) = entity_map else {
+        return;
+    };
+    for (entity, pending) in &pending {
+        let Some(&client_parent) = entity_map.to_client().get(&pending.server_parent) else {
+            continue;
+        };
+        commands
+            .entity(entity)
+            .insert(ChildOf(client_parent))
+            .remove::<PendingChildOf>();
     }
 }
 

--- a/crates/replication/replication/src/lib.rs
+++ b/crates/replication/replication/src/lib.rs
@@ -175,7 +175,8 @@ struct SharedComponentRegistrationPlugin;
 
 impl Plugin for SharedComponentRegistrationPlugin {
     fn build(&self, app: &mut bevy_app::prelude::App) {
-        use bevy_replicon::prelude::AppRuleExt;
+        use bevy_ecs::prelude::ChildOf;
+        use bevy_replicon::prelude::{AppMarkerExt, AppRuleExt, RuleFns};
         // The order of app.replicate() calls must be identical on client and server.
         // These marker components are sent from server to client as part of entity replication.
         #[cfg(feature = "prediction")]
@@ -185,7 +186,11 @@ impl Plugin for SharedComponentRegistrationPlugin {
         app.replicate::<control::Controlled>();
         // ChildOf is registered for replication in HierarchySendPlugin (server-only),
         // but must also be registered on the client so FnsIds match.
-        app.replicate::<bevy_ecs::prelude::ChildOf>();
+        app.replicate_with(RuleFns::new(
+            hierarchy::serialize_child_of,
+            hierarchy::deserialize_child_of,
+        ))
+        .set_receive_fns::<ChildOf>(hierarchy::write_child_of, hierarchy::remove_child_of);
 
         // ServerMutateTicks is normally only initialized by bevy_replicon's ClientPlugin,
         // but prediction systems on server-only builds also reference it. Init it here
@@ -244,5 +249,9 @@ impl Plugin for LightyearRepliconClientBackend {
     fn build(&self, app: &mut bevy_app::prelude::App) {
         app.add_plugins(bevy_replicon::client::ClientPlugin);
         app.add_plugins(client::RepliconClientPlugin);
+        app.add_systems(
+            bevy_app::prelude::PreUpdate,
+            hierarchy::resolve_pending_child_of,
+        );
     }
 }

--- a/crates/tests/src/client_server/input/bei.rs
+++ b/crates/tests/src/client_server/input/bei.rs
@@ -17,7 +17,9 @@ use lightyear_link::Link;
 use lightyear_link::prelude::LinkConditionerConfig;
 use lightyear_messages::MessageManager;
 use lightyear_prediction::diagnostics::PredictionMetrics;
-use lightyear_replication::prelude::{PreSpawned, PredictionTarget, Replicate};
+use lightyear_replication::prelude::{
+    ControlledBy, PreSpawned, PredictionTarget, Replicate, ReplicateLike,
+};
 use lightyear_sync::prelude::client::{InputDelayConfig, InputTimelineConfig};
 use test_log::test;
 use tracing::info;
@@ -77,26 +79,35 @@ fn spawn_action_pair(
     (client_action, server_action)
 }
 
-/// Check that we can insert actions on the client entity using PreSpawned
+/// Check that we can insert actions on a replicated client context using PreSpawned
 #[test]
-fn test_actions_on_client_entity() {
+fn test_actions_on_replicated_context_entity() {
     let mut stepper = ClientServerStepper::from_config(StepperConfig::single());
-    let client_entity = stepper.client(0).id();
-    let client_of_entity = stepper.client_of(0).id();
+    let server_entity = stepper
+        .server_app
+        .world_mut()
+        .spawn((BEIContext, Replicate::to_clients(NetworkTarget::All)))
+        .id();
+    stepper.frame_step(3);
+
+    let client_entity = stepper
+        .client(0)
+        .get::<MessageManager>()
+        .unwrap()
+        .entity_mapper
+        .get_local(server_entity)
+        .expect("context entity should be replicated to client");
 
     let (client_action, server_action) =
-        spawn_action_pair(&mut stepper, client_entity, client_of_entity, TEST_HASH);
-    stepper.frame_step(1);
+        spawn_action_pair(&mut stepper, client_entity, server_entity, TEST_HASH);
+    stepper.frame_step(2);
 
     // Add an InputMarker to the Context entity on the client
     stepper
         .client_app()
         .world_mut()
         .entity_mut(client_entity)
-        .insert((
-            BEIContext,
-            bei::prelude::InputMarker::<BEIContext>::default(),
-        ));
+        .insert(bei::prelude::InputMarker::<BEIContext>::default());
 
     // Check that the ActionOf component points to the correct entity on the server
     assert_eq!(
@@ -107,7 +118,19 @@ fn test_actions_on_client_entity() {
             .get::<ActionOf<BEIContext>>()
             .unwrap()
             .get(),
-        client_of_entity
+        server_entity
+    );
+
+    // Check that the replicated ActionOf component maps back to the local context on the client
+    assert_eq!(
+        stepper
+            .client_app()
+            .world()
+            .entity(client_action)
+            .get::<ActionOf<BEIContext>>()
+            .unwrap()
+            .get(),
+        client_entity
     );
 
     info!("Mocking press on BEIAction1");
@@ -260,6 +283,84 @@ fn test_bound_action_spawned_from_received_context_sends_inputs_after_mapping() 
             .resource::<SawServerFiredAction>()
             .0,
         "server should eventually receive the fired action state via input messages"
+    );
+}
+
+/// Check that the owner can drive a server-spawned replicated action entity.
+///
+/// The client receives the action entity from replication, adds local-only
+/// bindings/input mock to that replicated entity, and input messages target the
+/// action entity through the normal client-to-server entity map.
+#[test]
+fn test_server_replicated_action_sends_inputs_after_client_adds_bindings() {
+    let mut stepper = ClientServerStepper::from_config(StepperConfig::single());
+    stepper.server_app.init_resource::<SawServerFiredAction>();
+    stepper.server_app.add_systems(
+        FixedPreUpdate,
+        record_server_fired_action
+            .before(lightyear::input::server::InputSystems::UpdateActionState),
+    );
+
+    let client_of_entity = stepper.client_of(0).id();
+    let client_id = stepper
+        .client_of(0)
+        .get::<lightyear_core::id::RemoteId>()
+        .unwrap()
+        .0;
+    let server_entity = stepper
+        .server_app
+        .world_mut()
+        .spawn((
+            BEIContext,
+            Replicate::to_clients(NetworkTarget::All),
+            PredictionTarget::to_clients(NetworkTarget::Single(client_id)),
+            ControlledBy {
+                owner: client_of_entity,
+                lifetime: Default::default(),
+            },
+        ))
+        .id();
+
+    let server_action = stepper
+        .server_app
+        .world_mut()
+        .spawn((
+            ActionOf::<BEIContext>::new(server_entity),
+            Action::<BEIAction1>::default(),
+            ReplicateLike {
+                root: server_entity,
+            },
+        ))
+        .id();
+
+    stepper.frame_step(5);
+
+    let client_action = stepper
+        .client(0)
+        .get::<MessageManager>()
+        .unwrap()
+        .entity_mapper
+        .get_local(server_action)
+        .expect("action entity should be replicated to client");
+
+    stepper
+        .client_app()
+        .world_mut()
+        .entity_mut(client_action)
+        .insert((
+            ActionMock::once(TriggerState::Fired, true),
+            bindings![KeyCode::Space,],
+        ));
+
+    stepper.frame_step(5);
+
+    assert!(
+        stepper
+            .server_app
+            .world()
+            .resource::<SawServerFiredAction>()
+            .0,
+        "server should eventually receive the fired action state via mapped entity input messages"
     );
 }
 

--- a/crates/tests/src/client_server/prediction/rollback.rs
+++ b/crates/tests/src/client_server/prediction/rollback.rs
@@ -552,6 +552,62 @@ fn test_future_confirmed_insert_is_not_checked_by_unchanged_completed_tick() {
     );
 }
 
+#[test]
+fn test_input_timeline_sync_does_not_shift_confirmed_history() {
+    use lightyear_sync::prelude::InputTimelineConfig;
+
+    let (mut stepper, predicted) = setup();
+
+    let confirmed_tick = Tick(10);
+    insert_confirmed(
+        stepper.client_app().world_mut(),
+        predicted,
+        confirmed_tick,
+        Some(CompFull(10.0)),
+    );
+
+    let predicted_tick = Tick(5);
+    let mut prediction_history = PredictionHistory::<CompFull>::default();
+    prediction_history.add_predicted(predicted_tick, Some(CompFull(5.0)));
+    stepper
+        .client_app()
+        .world_mut()
+        .entity_mut(predicted)
+        .insert(prediction_history);
+
+    stepper
+        .client_app()
+        .world_mut()
+        .trigger(lightyear_core::timeline::SyncEvent::<InputTimelineConfig>::new(predicted, 100));
+
+    let world = stepper.client_app().world();
+    let confirmed_history = world
+        .get::<ConfirmedHistory<CompFull>>(predicted)
+        .expect("confirmed history should still be present");
+    assert!(
+        confirmed_history.get_state_at(confirmed_tick).is_some(),
+        "confirmed history is already in authoritative server tick space and must not shift"
+    );
+    assert!(
+        confirmed_history
+            .get_state_at(confirmed_tick + 100)
+            .is_none(),
+        "timeline sync must not move authoritative confirmed samples into the future"
+    );
+
+    let prediction_history = world
+        .get::<PredictionHistory<CompFull>>(predicted)
+        .expect("prediction history should still be present");
+    assert!(
+        prediction_history.get_state(predicted_tick).is_none(),
+        "local prediction samples from before sync should be shifted"
+    );
+    assert!(
+        prediction_history.get_state(predicted_tick + 100).is_some(),
+        "prediction history should follow the input timeline sync"
+    );
+}
+
 /// A completed mutate tick is a global confirmation point. If one entity receives an
 /// explicit update at that tick and another entity does not, the unchanged entity should
 /// still be checked against its last confirmed value at the completed tick.

--- a/examples/bevy_enhanced_inputs/src/automation.rs
+++ b/examples/bevy_enhanced_inputs/src/automation.rs
@@ -1,5 +1,6 @@
 use bevy::prelude::*;
 use lightyear::prelude::*;
+#[cfg(feature = "client")]
 use lightyear_examples_common::automation::{env_string, sync_pressed_keys, HeadlessInputPlugin};
 
 use crate::protocol::{PlayerId, PlayerPosition};

--- a/examples/bevy_enhanced_inputs/src/client.rs
+++ b/examples/bevy_enhanced_inputs/src/client.rs
@@ -8,12 +8,10 @@
 use crate::automation::AutomationClientPlugin;
 use crate::protocol::*;
 use crate::shared;
-use bevy::ecs::relationship::Relationship;
 use bevy::prelude::*;
 use lightyear::connection::host::HostServer;
-use lightyear::input::bei::prelude::{Action, ActionOf, Fire};
+use lightyear::input::bei::prelude::{Action, Actions, Bindings, Cardinal, Fire};
 use lightyear::prelude::client::{InputDelayConfig, InputTimelineConfig};
-use lightyear::prelude::input::bei::InputMarker;
 use lightyear::prelude::*;
 
 pub struct ExampleClientPlugin;
@@ -23,7 +21,7 @@ impl Plugin for ExampleClientPlugin {
         app.add_plugins(AutomationClientPlugin);
         app.add_systems(Startup, configure_input_delay);
         app.add_observer(handle_predicted_spawn);
-        app.add_observer(handle_controlled_spawn);
+        app.add_observer(add_bindings_to_controlled_actions);
         app.add_observer(handle_interpolated_spawn);
         app.add_observer(player_movement);
     }
@@ -41,14 +39,18 @@ fn configure_input_delay(client: Single<Entity, With<Client>>, mut commands: Com
 fn player_movement(
     trigger: On<Fire<Movement>>,
     synced_client: Query<(), (With<Client>, With<IsSynced<InputTimeline>>)>,
-    host_server: Query<(), With<HostServer>>,
-    server_actions: Query<(), (With<Action<Movement>>, With<Replicate>)>,
+    _host_server: Query<(), With<HostServer>>,
+    #[cfg(feature = "server")] server_actions: Query<
+        (),
+        (With<Action<Movement>>, With<crate::server::ServerAction>),
+    >,
     mut position_query: Query<&mut PlayerPosition, With<Predicted>>,
 ) {
     if synced_client.is_empty() {
         return;
     }
-    if !host_server.is_empty() && server_actions.contains(trigger.action) {
+    #[cfg(feature = "server")]
+    if !_host_server.is_empty() && server_actions.contains(trigger.action) {
         return;
     }
     if let Ok(position) = position_query.get_mut(trigger.context) {
@@ -74,46 +76,38 @@ pub(crate) fn handle_predicted_spawn(
     }
 }
 
-/// Spawn local action entities once the local player is actually controlled by this client.
+/// Add local movement bindings when a player becomes controlled by this client.
 ///
-/// We intentionally key this off `Add<Controlled>`, not `Add<Predicted>`.
-/// In dedicated client/server mode the replicated entity often ends up with both markers,
-/// but in host-server mode the local entity is created in the same world through local
-/// insertion paths, not through Replicon's deferred receive bundle. In that mode there is no
-/// reliable guarantee that `Controlled` will already exist when `Predicted` is added, so
-/// checking `Has<Controlled>` inside `Add<Predicted>` is brittle.
-///
-/// `Controlled` is the actual semantic signal we care about for local input setup: once this
-/// marker appears, the entity belongs to this local client and it is safe to attach the
-/// `InputMarker` and spawn the local BEI action entities.
-fn handle_controlled_spawn(
+/// The movement action is spawned on the server and replicated with the player.
+/// Once the local predicted player is marked `Controlled`, its BEI `Actions`
+/// relationship contains the replicated movement action that should receive
+/// local-only bindings. Binding from `ActionOf<Player>`'s add event is too
+/// early for the local prediction/control path: the relationship can already be
+/// mapped while the predicted context has not yet been marked as controlled.
+fn add_bindings_to_controlled_actions(
     trigger: On<Add, Controlled>,
-    controlled_players: Query<
-        (&PlayerId, Has<InputMarker<Player>>, Option<&ControlledBy>),
-        With<Player>,
-    >,
+    controlled_players: Query<(Option<&ControlledBy>, Option<&Actions<Player>>), With<Player>>,
+    unbound_movement_actions: Query<(), (With<Action<Movement>>, Without<Bindings>)>,
     clients: Query<(), With<Client>>,
-    actions: Query<&ActionOf<Player>, With<Action<Movement>>>,
     mut commands: Commands,
 ) {
-    let entity = trigger.entity;
-    let Ok((player_id, has_input_marker, controlled_by)) = controlled_players.get(entity) else {
+    let Ok((controlled_by, Some(actions))) = controlled_players.get(trigger.entity) else {
         return;
     };
-    if let Some(controlled_by) = controlled_by {
-        if clients.get(controlled_by.owner).is_err() {
-            return;
-        }
-    }
-    if has_input_marker {
+    if controlled_by.is_some_and(|controlled_by| clients.get(controlled_by.owner).is_err()) {
         return;
     }
-    commands
-        .entity(entity)
-        .insert(InputMarker::<Player>::default());
-    if !actions.iter().any(|action_of| action_of.get() == entity) {
-        shared::spawn_action_entities(&mut commands, entity, player_id.0, false);
+    for action_entity in actions.iter() {
+        if unbound_movement_actions.contains(action_entity) {
+            add_bindings(action_entity, &mut commands);
+        }
     }
+}
+
+fn add_bindings(action_entity: Entity, commands: &mut Commands) {
+    commands
+        .entity(action_entity)
+        .insert(Bindings::spawn(Cardinal::wasd_keys()));
 }
 
 /// When the predicted copy of the client-owned entity is spawned, do stuff

--- a/examples/bevy_enhanced_inputs/src/renderer.rs
+++ b/examples/bevy_enhanced_inputs/src/renderer.rs
@@ -7,8 +7,6 @@ pub struct ExampleRendererPlugin;
 impl Plugin for ExampleRendererPlugin {
     fn build(&self, app: &mut App) {
         app.add_systems(Startup, init);
-        #[cfg(feature = "client")]
-        app.add_systems(Startup, rollback_button);
         app.add_systems(Update, draw_boxes);
     }
 }
@@ -27,42 +25,4 @@ pub(crate) fn draw_boxes(mut gizmos: Gizmos, players: Query<(&PlayerPosition, &P
             color.0,
         );
     }
-}
-
-#[cfg(feature = "client")]
-pub(crate) fn rollback_button(mut commands: Commands) {
-    use lightyear::prelude::{LocalTimeline, PredictionManager, Rollback};
-    commands
-        .spawn((
-            Text("Rollback".to_string()),
-            TextColor(Color::srgb(0.9, 0.9, 0.9)),
-            TextFont::from_font_size(20.0),
-            Node {
-                width: Val::Px(150.0),
-                height: Val::Px(65.0),
-                border: UiRect::all(Val::Px(5.0)),
-                left: Val::Percent(45.0),
-                // horizontally center child text
-                justify_content: JustifyContent::Center,
-                // vertically center child text
-                align_items: AlignItems::Center,
-                ..default()
-            },
-            Button,
-        ))
-        .observe(
-            |_: On<Pointer<Click>>,
-             mut commands: Commands,
-             timeline: Res<LocalTimeline>,
-             client: Single<(Entity, &PredictionManager)>| {
-                let (client, prediction_manager) = client.into_inner();
-
-                // rollback the client to 5 ticks before the current tick
-                let tick = timeline.tick();
-                let rollback_tick = tick - 5;
-                info!("Manual rollback to tick {rollback_tick:?}. Current tick: {tick:?}");
-                commands.entity(client).insert(Rollback::FromInputs);
-                prediction_manager.set_rollback_tick(rollback_tick);
-            },
-        );
 }

--- a/examples/bevy_enhanced_inputs/src/server.rs
+++ b/examples/bevy_enhanced_inputs/src/server.rs
@@ -10,7 +10,7 @@ use crate::automation::AutomationServerPlugin;
 use crate::protocol::*;
 use crate::shared;
 use bevy::prelude::*;
-use bevy_enhanced_input::prelude::{Action, Fire};
+use bevy_enhanced_input::prelude::{Action, ActionOf, Fire};
 use lightyear::connection::client::Connected;
 use lightyear::connection::host::{HostClient, HostServer};
 use lightyear::prelude::server::*;
@@ -18,6 +18,9 @@ use lightyear::prelude::*;
 use lightyear_examples_common::shared::SEND_INTERVAL;
 
 pub struct ExampleServerPlugin;
+
+#[derive(Component)]
+pub(crate) struct ServerAction;
 
 impl Plugin for ExampleServerPlugin {
     fn build(&self, app: &mut App) {
@@ -65,7 +68,7 @@ pub(crate) fn handle_connected(
             // Add the context component on the server; it will be replicated to the client
             Player,
             PlayerId(client_id),
-            PlayerPosition(Vec2::ZERO),
+            PlayerPosition(initial_player_position(client_id)),
             PlayerColor(color),
             // we replicate the Player entity to all clients that are connected to this server
             Replicate::to_clients(NetworkTarget::All),
@@ -81,14 +84,35 @@ pub(crate) fn handle_connected(
         "Create player entity {:?} for client {:?}",
         player_entity, client_id
     );
-    shared::spawn_action_entities(&mut commands, player_entity, client_id, true);
+    spawn_action_entities(&mut commands, player_entity);
+}
+
+fn initial_player_position(client_id: PeerId) -> Vec2 {
+    let slot = (client_id.to_bits() % 6) as f32;
+    Vec2::new((slot - 2.5) * 90.0, 0.0)
+}
+
+/// Spawn the BEI action entities for a player.
+///
+/// The server owns and replicates action entities so the owning client can
+/// target them in input messages and remote clients can receive rebroadcasted
+/// input for prediction.
+fn spawn_action_entities(commands: &mut Commands, player_entity: Entity) {
+    commands.spawn((
+        ActionOf::<Player>::new(player_entity),
+        Action::<Movement>::new(),
+        ReplicateLike {
+            root: player_entity,
+        },
+        ServerAction,
+    ));
 }
 
 /// Read client inputs and move players in server therefore giving a basis for other clients
 fn movement(
     trigger: On<Fire<Movement>>,
     host_server: Query<(), With<HostServer>>,
-    server_actions: Query<(), (With<Action<Movement>>, With<shared::ServerAction>)>,
+    server_actions: Query<(), (With<Action<Movement>>, With<ServerAction>)>,
     controlled_by: Query<&ControlledBy>,
     host_clients: Query<(), With<HostClient>>,
     mut position_query: Query<&mut PlayerPosition>,

--- a/examples/bevy_enhanced_inputs/src/shared.rs
+++ b/examples/bevy_enhanced_inputs/src/shared.rs
@@ -4,7 +4,6 @@
 //! mispredictions/rollbacks.
 use crate::protocol::*;
 use bevy::prelude::*;
-use lightyear::input::bei::prelude::{Action, ActionOf, Bindings, Cardinal};
 use lightyear::prelude::*;
 use lightyear_examples_common::shared::SharedSettings;
 
@@ -16,52 +15,6 @@ impl Plugin for SharedPlugin {
         app.add_systems(FixedPostUpdate, emit_fixed_post_positions);
         app.add_systems(Update, emit_confirmed_positions);
         app.add_systems(PostUpdate, emit_interpolated_positions);
-    }
-}
-
-/// Deterministic hash for PreSpawned action entities.
-/// Uses the client's PeerId and a salt to produce the same hash on both client and server,
-/// regardless of spawn tick.
-pub(crate) fn action_prespawn_hash(client_id: PeerId, salt: u64) -> u64 {
-    client_id
-        .to_bits()
-        .wrapping_mul(6364136223846793005)
-        .wrapping_add(salt)
-}
-
-#[derive(Component)]
-pub(crate) struct ServerAction;
-
-/// Spawn action entities for a player. Called on both client and server.
-pub(crate) fn spawn_action_entities(
-    commands: &mut Commands,
-    player_entity: Entity,
-    client_id: PeerId,
-    is_server: bool,
-) {
-    let hash = action_prespawn_hash(client_id, 1);
-    let prespawned = if is_server {
-        PreSpawned::new(hash)
-    } else {
-        // The local action entity uses the hash as a stable input target, but it
-        // is not a predicted gameplay object that should be cleaned up if the
-        // server action replication arrived before the local action was spawned.
-        PreSpawned::new(hash).for_receiver(player_entity)
-    };
-    let mut action = commands.spawn((
-        ActionOf::<Player>::new(player_entity),
-        Action::<Movement>::new(),
-        Bindings::spawn(Cardinal::wasd_keys()),
-        prespawned,
-    ));
-    if is_server {
-        #[cfg(feature = "server")]
-        action.insert((
-            Replicate::to_clients(NetworkTarget::Single(client_id)),
-            ServerAction,
-        ));
-    } else {
-        action.insert(lightyear::prelude::input::bei::InputMarker::<Player>::default());
     }
 }
 

--- a/examples/projectiles/src/client.rs
+++ b/examples/projectiles/src/client.rs
@@ -8,7 +8,6 @@ use bevy::ecs::relationship::Relationship;
 use bevy::prelude::*;
 use bevy_enhanced_input::EnhancedInputSystems;
 use bevy_enhanced_input::action::TriggerState;
-use bevy_enhanced_input::bindings;
 use bevy_enhanced_input::context::ExternallyMocked;
 use bevy_enhanced_input::prelude::{
     ActionMock, ActionValue, ActionValueDim, Binding, Bindings, Cardinal, MockSpan,
@@ -27,7 +26,6 @@ impl Plugin for ExampleClientPlugin {
         app.add_observer(handle_predicted_spawn);
         app.add_observer(handle_interpolated_spawn);
         app.add_observer(handle_deterministic_spawn);
-        app.add_observer(add_global_actions);
         app.add_systems(
             FixedPreUpdate,
             (
@@ -45,13 +43,10 @@ impl Plugin for ExampleClientPlugin {
 // - add physics components so that its movement can be predicted
 pub(crate) fn handle_predicted_spawn(
     trigger: On<Add, (PlayerMarker, Predicted)>,
-    client: Single<&LocalId, With<Client>>,
-    host_client: Option<Res<HostClientMode>>,
     mut commands: Commands,
-    mut player_query: Query<(&PlayerId, &Position, &GameReplicationMode), With<Predicted>>,
+    mut player_query: Query<&GameReplicationMode, With<Predicted>>,
 ) {
-    let client_id = client.into_inner().0;
-    if let Ok((player_id, pos, mode)) = player_query.get_mut(trigger.entity) {
+    if let Ok(mode) = player_query.get_mut(trigger.entity) {
         if mode == &GameReplicationMode::AllInterpolated {
             return;
         };
@@ -66,45 +61,20 @@ pub(crate) fn handle_predicted_spawn(
             }
             _ => {}
         };
-        if player_id.0 != client_id {
-            return;
-        }
-        // add actions on the local entity (remote predicted entities will have actions propagated by the server)
-        if should_spawn_client_actions(&host_client) {
-            info!(
-                ?pos,
-                "Adding actions to predicted player {:?}", trigger.entity
-            );
-            shared::spawn_player_actions(&mut commands, trigger.entity, player_id.0, *mode, false);
-        }
     }
 }
 
 pub(crate) fn handle_interpolated_spawn(
     trigger: On<Add, (PlayerMarker, Interpolated)>,
-    client: Single<&LocalId, With<Client>>,
-    host_client: Option<Res<HostClientMode>>,
-    mut interpolated: Query<
-        (&PlayerId, &Interpolated, &GameReplicationMode),
-        (With<Interpolated>, With<PlayerMarker>),
-    >,
+    mut interpolated: Query<&GameReplicationMode, (With<Interpolated>, With<PlayerMarker>)>,
     mut commands: Commands,
 ) {
-    let client_id = client.into_inner();
-    if let Ok((player_id, interpolated, mode)) = interpolated.get_mut(trigger.entity) {
+    if let Ok(mode) = interpolated.get_mut(trigger.entity) {
         if mode == &GameReplicationMode::ClientSideHitDetection {
             // add these so we can do hit-detection on the client
             commands
                 .entity(trigger.entity)
                 .insert((Collider::rectangle(PLAYER_SIZE, PLAYER_SIZE),));
-        }
-        // In the interpolated case, the client sends inputs but doesn't apply them.
-        // Only the server applies the inputs, and the position changes are replicated back
-        if let GameReplicationMode::AllInterpolated = mode
-            && client_id.0 == player_id.0
-            && should_spawn_client_actions(&host_client)
-        {
-            shared::spawn_player_actions(&mut commands, trigger.entity, player_id.0, *mode, false);
         }
     }
 }
@@ -112,11 +82,8 @@ pub(crate) fn handle_interpolated_spawn(
 pub(crate) fn handle_deterministic_spawn(
     trigger: On<Add, PlayerMarker>,
     query: Query<(&PlayerId, &GameReplicationMode)>,
-    client: Single<&LocalId, With<Client>>,
-    host_client: Option<Res<HostClientMode>>,
     mut commands: Commands,
 ) {
-    let client_id = client.into_inner();
     if let Ok((player_id, mode)) = query.get(trigger.entity)
         && mode == &GameReplicationMode::OnlyInputsReplicated
     {
@@ -129,30 +96,7 @@ pub(crate) fn handle_deterministic_spawn(
             },
         ));
         info!("Adding PlayerContext for player {:?}", player_id);
-
-        // add actions for the local client
-        if player_id.0 == client_id.0 && should_spawn_client_actions(&host_client) {
-            info!(
-                "Spawning actions for DeterministicPredicted player {:?}",
-                player_id
-            );
-            shared::spawn_player_actions(&mut commands, trigger.entity, player_id.0, *mode, false);
-        }
     }
-}
-
-pub(crate) fn add_global_actions(
-    trigger: On<Add, ClientContext>,
-    host_client: Option<Res<HostClientMode>>,
-    mut commands: Commands,
-) {
-    if should_spawn_client_actions(&host_client) {
-        shared::spawn_global_actions(&mut commands, trigger.entity, false);
-    }
-}
-
-fn should_spawn_client_actions(host_client: &Option<Res<HostClientMode>>) -> bool {
-    host_client.is_none()
 }
 
 fn update_active_player_action_markers(

--- a/examples/projectiles/src/renderer.rs
+++ b/examples/projectiles/src/renderer.rs
@@ -50,7 +50,15 @@ impl Plugin for ExampleRendererPlugin {
                 // mock the action before BEI evaluates it. BEI evaluated actions mocks in FixedPreUpdate
                 update_cursor_state_from_window,
             );
-            app.add_systems(Update, (display_score, render_hitscan_lines, display_info));
+            app.add_systems(
+                Update,
+                (
+                    display_score,
+                    render_hitscan_lines,
+                    display_info,
+                    sync_active_mode_visibility.after(add_player_visuals),
+                ),
+            );
         }
 
         #[cfg(feature = "server")]
@@ -153,13 +161,59 @@ fn display_info(
     );
 }
 
+fn is_active_mode(mode: Option<&GameReplicationMode>, active_mode: &GameReplicationMode) -> bool {
+    mode.is_some_and(|mode| mode == active_mode)
+}
+
 #[cfg(feature = "client")]
-fn render_hitscan_lines(query: Query<(&HitscanVisual, &ColorComponent)>, mut gizmos: Gizmos) {
-    for (visual, color) in query.iter() {
+fn render_hitscan_lines(
+    active_mode: Query<&GameReplicationMode, With<ClientContext>>,
+    shooters: Query<&GameReplicationMode, With<PlayerMarker>>,
+    query: Query<(&HitscanVisual, &ColorComponent, &BulletMarker)>,
+    mut gizmos: Gizmos,
+) {
+    let Ok(active_mode) = active_mode.single() else {
+        return;
+    };
+    for (visual, color, marker) in query.iter() {
+        if !is_active_mode(shooters.get(marker.shooter).ok(), active_mode) {
+            continue;
+        }
         let progress = visual.lifetime / visual.max_lifetime;
         let alpha = (1.0 - progress).max(0.0);
         let line_color = color.0.with_alpha(alpha);
         gizmos.line_2d(visual.start, visual.end, line_color);
+    }
+}
+
+#[cfg(feature = "client")]
+fn sync_active_mode_visibility(
+    active_mode: Query<&GameReplicationMode, With<ClientContext>>,
+    shooters: Query<&GameReplicationMode, With<PlayerMarker>>,
+    mut players: Query<
+        (&GameReplicationMode, &mut Visibility),
+        (With<PlayerMarker>, With<PlayerId>, Without<BulletMarker>),
+    >,
+    mut projectiles: Query<(&BulletMarker, &mut Visibility), Without<PlayerMarker>>,
+) {
+    let Ok(active_mode) = active_mode.single() else {
+        return;
+    };
+
+    for (mode, mut visibility) in &mut players {
+        *visibility = if mode == active_mode {
+            Visibility::Visible
+        } else {
+            Visibility::Hidden
+        };
+    }
+
+    for (marker, mut visibility) in &mut projectiles {
+        *visibility = if is_active_mode(shooters.get(marker.shooter).ok(), active_mode) {
+            Visibility::Visible
+        } else {
+            Visibility::Hidden
+        };
     }
 }
 

--- a/examples/projectiles/src/server.rs
+++ b/examples/projectiles/src/server.rs
@@ -327,7 +327,7 @@ pub(crate) fn spawn_player(
         if is_bot {
             commands.entity(player_entity).insert(Bot);
         }
-        shared::spawn_player_actions(&mut commands, player_entity);
+        shared::spawn_player_actions(&mut commands, player_entity, room_id);
         info!("Spawning player {player_entity:?} for room: {room_id:?}");
     }
 }

--- a/examples/projectiles/src/server.rs
+++ b/examples/projectiles/src/server.rs
@@ -22,6 +22,7 @@ use lightyear::crossbeam::CrossbeamIo;
 use lightyear::input::config::InputConfig;
 use lightyear::input::server::{InputSystems as ServerInputSystems, ServerInputConfig};
 use lightyear::interpolation::plugin::InterpolationDelay;
+#[cfg(feature = "client")]
 use lightyear::netcode::NetcodeClient;
 use lightyear::prelude::server::*;
 use lightyear::prelude::*;
@@ -70,13 +71,9 @@ pub(crate) fn handle_new_client(trigger: On<Add, LinkOf>, mut commands: Commands
         "Adding ReplicationSender to new ClientOf entity: {:?}",
         trigger.entity
     );
-    commands.entity(trigger.entity).insert((
-        ReplicationSender,
-        // We need a ReplicationReceiver on the server side because the Action entities are spawned
-        // on the client and replicated to the server.
-        ReplicationReceiver,
-        Name::from("ClientOf"),
-    ));
+    commands
+        .entity(trigger.entity)
+        .insert((ReplicationSender, Name::from("ClientOf")));
 }
 
 pub(crate) fn spawn_global_control(mut commands: Commands) {
@@ -99,7 +96,7 @@ pub(crate) fn spawn_global_control(mut commands: Commands) {
             Name::new("ClientContext"),
         ))
         .id();
-    shared::spawn_global_actions(&mut commands, global, true);
+    shared::spawn_global_actions(&mut commands, global);
 }
 
 fn apply_initial_input_config(
@@ -330,13 +327,7 @@ pub(crate) fn spawn_player(
         if is_bot {
             commands.entity(player_entity).insert(Bot);
         }
-        shared::spawn_player_actions(
-            &mut commands,
-            player_entity,
-            client_id,
-            replication_mode,
-            true,
-        );
+        shared::spawn_player_actions(&mut commands, player_entity);
         info!("Spawning player {player_entity:?} for room: {room_id:?}");
     }
 }

--- a/examples/projectiles/src/shared.rs
+++ b/examples/projectiles/src/shared.rs
@@ -124,24 +124,30 @@ pub(crate) fn spawn_global_actions(commands: &mut Commands, context: Entity) {
 /// Spawn the server-owned BEI player action entities.
 ///
 /// Clients receive these through replication and add local-only bindings/input
-/// markers to the active local player's actions.
-pub(crate) fn spawn_player_actions(commands: &mut Commands, player: Entity) {
+/// markers to the active local player's actions. The actions carry the same
+/// room filter as the player because [`ReplicateLike`] copies replication
+/// targets, but not room-based visibility filter components.
+#[cfg(feature = "server")]
+pub(crate) fn spawn_player_actions(commands: &mut Commands, player: Entity, room_id: RoomId) {
     commands.spawn((
         ActionOf::<PlayerContext>::new(player),
         Action::<MovePlayer>::new(),
         ReplicateLike { root: player },
+        Rooms::single(room_id),
     ));
 
     commands.spawn((
         ActionOf::<PlayerContext>::new(player),
         Action::<MoveCursor>::new(),
         ReplicateLike { root: player },
+        Rooms::single(room_id),
     ));
 
     commands.spawn((
         ActionOf::<PlayerContext>::new(player),
         Action::<Shoot>::new(),
         ReplicateLike { root: player },
+        Rooms::single(room_id),
     ));
 }
 

--- a/examples/projectiles/src/shared.rs
+++ b/examples/projectiles/src/shared.rs
@@ -5,8 +5,6 @@ use bevy::platform::collections::HashMap;
 use bevy::prelude::*;
 use bevy::time::Stopwatch;
 use bevy_enhanced_input::action::Action;
-use bevy_enhanced_input::action::TriggerState;
-use bevy_enhanced_input::action::mock::ActionMock;
 use bevy_enhanced_input::prelude::*;
 use core::ops::DerefMut;
 use core::time::Duration;
@@ -103,136 +101,48 @@ pub(crate) fn color_from_id(client_id: PeerId) -> Color {
     Color::hsl(h, s, l)
 }
 
-/// Deterministic hash for BEI action entities spawned on both client and server.
-pub(crate) fn player_action_prespawn_hash(
-    client_id: PeerId,
-    replication_mode: GameReplicationMode,
-    salt: u64,
-) -> u64 {
-    client_id
-        .to_bits()
-        .wrapping_mul(6364136223846793005)
-        .wrapping_add((replication_mode.room_id() as u64).wrapping_mul(31))
-        .wrapping_add(salt)
-}
-
-pub(crate) fn global_action_prespawn_hash(salt: u64) -> u64 {
-    0xC11E_1175_0000_0000u64.wrapping_add(salt)
-}
-
-pub(crate) fn spawn_global_actions(commands: &mut Commands, context: Entity, is_server: bool) {
-    let mut projectile_mode = commands.spawn((
+pub(crate) fn spawn_global_actions(commands: &mut Commands, context: Entity) {
+    commands.spawn((
         ActionOf::<ClientContext>::new(context),
         Action::<CycleProjectileMode>::new(),
-        bindings![KeyCode::KeyE],
-        PreSpawned::new(global_action_prespawn_hash(1)),
+        ReplicateLike { root: context },
     ));
-    if is_server {
-        projectile_mode.insert((
-            Replicate::to_clients(NetworkTarget::All),
-            PredictionTarget::manual(Vec::new()),
-            InterpolationTarget::manual(Vec::new()),
-        ));
-    } else {
-        projectile_mode
-            .insert(lightyear::prelude::input::bei::InputMarker::<ClientContext>::default());
-    }
 
-    let mut replication_mode = commands.spawn((
+    commands.spawn((
         ActionOf::<ClientContext>::new(context),
         Action::<CycleReplicationMode>::new(),
-        bindings![KeyCode::KeyR],
-        PreSpawned::new(global_action_prespawn_hash(2)),
+        ReplicateLike { root: context },
     ));
-    if is_server {
-        replication_mode.insert((
-            Replicate::to_clients(NetworkTarget::All),
-            PredictionTarget::manual(Vec::new()),
-            InterpolationTarget::manual(Vec::new()),
-        ));
-    } else {
-        replication_mode
-            .insert(lightyear::prelude::input::bei::InputMarker::<ClientContext>::default());
-    }
 
-    let mut weapon = commands.spawn((
+    commands.spawn((
         ActionOf::<ClientContext>::new(context),
         Action::<CycleWeapon>::new(),
-        bindings![KeyCode::KeyQ],
-        PreSpawned::new(global_action_prespawn_hash(3)),
+        ReplicateLike { root: context },
     ));
-    if is_server {
-        weapon.insert((
-            Replicate::to_clients(NetworkTarget::All),
-            PredictionTarget::manual(Vec::new()),
-            InterpolationTarget::manual(Vec::new()),
-        ));
-    } else {
-        weapon.insert(lightyear::prelude::input::bei::InputMarker::<ClientContext>::default());
-    }
 }
 
-/// Spawn the BEI player action entities on both sides so input messages can use PreSpawned targets.
-pub(crate) fn spawn_player_actions(
-    commands: &mut Commands,
-    player: Entity,
-    client_id: PeerId,
-    replication_mode: GameReplicationMode,
-    is_server: bool,
-) {
-    let mut movement = commands.spawn((
+/// Spawn the server-owned BEI player action entities.
+///
+/// Clients receive these through replication and add local-only bindings/input
+/// markers to the active local player's actions.
+pub(crate) fn spawn_player_actions(commands: &mut Commands, player: Entity) {
+    commands.spawn((
         ActionOf::<PlayerContext>::new(player),
         Action::<MovePlayer>::new(),
-        Bindings::spawn(Cardinal::wasd_keys()),
-        PreSpawned::new(player_action_prespawn_hash(client_id, replication_mode, 1)),
+        ReplicateLike { root: player },
     ));
-    if is_server {
-        movement.insert((
-            Replicate::to_clients(NetworkTarget::All),
-            PredictionTarget::manual(Vec::new()),
-            InterpolationTarget::manual(Vec::new()),
-        ));
-    } else {
-        movement.insert(lightyear::prelude::input::bei::InputMarker::<PlayerContext>::default());
-    }
 
-    let mut cursor = commands.spawn((
+    commands.spawn((
         ActionOf::<PlayerContext>::new(player),
         Action::<MoveCursor>::new(),
-        PreSpawned::new(player_action_prespawn_hash(client_id, replication_mode, 2)),
+        ReplicateLike { root: player },
     ));
-    if is_server {
-        cursor.insert((
-            Replicate::to_clients(NetworkTarget::All),
-            PredictionTarget::manual(Vec::new()),
-            InterpolationTarget::manual(Vec::new()),
-        ));
-    } else {
-        cursor.insert((
-            ActionMock::new(
-                TriggerState::Fired,
-                ActionValue::zero(ActionValueDim::Axis2D),
-                MockSpan::Manual,
-            ),
-            lightyear::prelude::input::bei::InputMarker::<PlayerContext>::default(),
-        ));
-    }
 
-    let mut shoot = commands.spawn((
+    commands.spawn((
         ActionOf::<PlayerContext>::new(player),
         Action::<Shoot>::new(),
-        Bindings::spawn_one((Binding::from(KeyCode::Space), Name::from("Binding"))),
-        PreSpawned::new(player_action_prespawn_hash(client_id, replication_mode, 3)),
+        ReplicateLike { root: player },
     ));
-    if is_server {
-        shoot.insert((
-            Replicate::to_clients(NetworkTarget::All),
-            PredictionTarget::manual(Vec::new()),
-            InterpolationTarget::manual(Vec::new()),
-        ));
-    } else {
-        shoot.insert(lightyear::prelude::input::bei::InputMarker::<PlayerContext>::default());
-    }
 }
 
 fn projectile_prespawn_salt(player_id: PeerId, salt: u64) -> u64 {


### PR DESCRIPTION
BEI input replication had some weird tricks to make up for the lack of client-to-server replication.
There was a 'NetworkActionOf', a bunch of weird observers, etc.

This PR greatly simplifies the flow of setting up BEI input replication:
- you need to spawn the Context and Action entities on the server, and replicate them to the client
- on the client, you need to add the Bindings that you need on the replicated Action entity

In the future it will be possible to directly spawn Action entities on the client directly when replicon supports client to server replication.