### PR TITLE
feat(perf): remove steady-state allocations in transport crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -193,6 +193,8 @@ async-compat = "0.2"
 # dev deps
 mock_instant = "0.6"
 approx = "0.5.1"
+dhat = "0.3.3"
+stats_alloc = "0.1.10"
 
 # Bevy
 # (the full app is used for examples)

--- a/crates/inputs/input_bei/src/plugin.rs
+++ b/crates/inputs/input_bei/src/plugin.rs
@@ -1,13 +1,11 @@
 #[cfg(any(feature = "client", feature = "server"))]
 use crate::input_message::{BEIBuffer, BEIStateSequence};
 
-#[cfg(feature = "client")]
-use crate::setup::resolve_pending_action_of;
 #[cfg(any(feature = "client", feature = "server"))]
 use crate::setup::InputRegistryPlugin;
-use crate::setup::{
-    deserialize_action_of, remove_action_of, serialize_action_of, write_action_of,
-};
+#[cfg(feature = "client")]
+use crate::setup::resolve_pending_action_of;
+use crate::setup::{deserialize_action_of, remove_action_of, serialize_action_of, write_action_of};
 use bevy_app::prelude::*;
 use bevy_ecs::prelude::*;
 #[cfg(any(feature = "client", feature = "server"))]

--- a/crates/tests/src/client_server/avian/transform_replication.rs
+++ b/crates/tests/src/client_server/avian/transform_replication.rs
@@ -156,19 +156,9 @@ fn test_replicate_transform_child_collider() {
     config.frame_duration = Duration::from_millis(5);
     let mut stepper = ClientServerStepper::from_config(config);
 
-    // add colliders on the client to make sure that collider hierarchy systems work
-    stepper.client_app().add_observer(
-        |trigger: On<Add, Replicated>, q: Query<(), With<ChildOf>>, mut commands: Commands| {
-            if let Ok(()) = q.get(trigger.entity) {
-                commands
-                    .entity(trigger.entity)
-                    .insert(Collider::circle(1.0));
-            } else {
-                commands
-                    .entity(trigger.entity)
-                    .insert((Collider::circle(1.0), RigidBody::Kinematic));
-            }
-        },
+    stepper.client_app().add_systems(
+        PostUpdate,
+        add_client_physics_after_transform_propagate.after(TransformSystems::Propagate),
     );
 
     let server_parent = stepper
@@ -327,6 +317,12 @@ fn test_replicate_transform_child_collider() {
         .get_local(server_child)
         .unwrap();
     info!(?client_parent, ?client_child, "Received entities on client");
+
+    // The replicated ChildOf can be applied after the client's transform propagation for the
+    // frame that receives the spawn. Step one render frame so GlobalTransform reflects the
+    // replicated hierarchy before checking the collider setup.
+    stepper.frame_step_server_first(1);
+
     assert_relative_eq!(
         stepper
             .client_app()
@@ -369,4 +365,34 @@ fn test_replicate_transform_child_collider() {
             .x,
         4.0
     );
+}
+
+#[derive(Component)]
+struct ClientPhysicsAdded;
+
+fn add_client_physics_after_transform_propagate(
+    mut commands: Commands,
+    query: Query<
+        (Entity, Option<&ChildOf>),
+        (
+            With<Remote>,
+            With<Transform>,
+            With<GlobalTransform>,
+            Without<ClientPhysicsAdded>,
+        ),
+    >,
+) {
+    for (entity, child_of) in &query {
+        if child_of.is_some() {
+            commands
+                .entity(entity)
+                .insert((Collider::circle(1.0), ClientPhysicsAdded));
+        } else {
+            commands.entity(entity).insert((
+                Collider::circle(1.0),
+                RigidBody::Kinematic,
+                ClientPhysicsAdded,
+            ));
+        }
+    }
 }

--- a/crates/transport/transport/Cargo.toml
+++ b/crates/transport/transport/Cargo.toml
@@ -52,6 +52,10 @@ ringbuffer.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 
+[dev-dependencies]
+dhat.workspace = true
+stats_alloc.workspace = true
+
 [lints]
 workspace = true
 

--- a/crates/transport/transport/src/packet/header.rs
+++ b/crates/transport/transport/src/packet/header.rs
@@ -1,5 +1,6 @@
 use alloc::{vec, vec::Vec};
 use bevy_platform::hash::FixedHasher;
+use core::convert::TryInto;
 use core::time::Duration;
 use indexmap::IndexMap;
 use ringbuffer::{ConstGenericRingBuffer, RingBuffer};
@@ -74,6 +75,26 @@ impl PacketHeader {
     pub(crate) const BYTES: usize = 17;
     /// Offset of the packet type byte inside the serialized header.
     pub(crate) const PACKET_TYPE_OFFSET: usize = 0;
+
+    /// Parses a packet header from the start of a borrowed packet payload without taking ownership
+    /// of the payload or constructing a [`Reader`].
+    ///
+    /// This is used by allocation-sensitive tests that parse a sent packet from `&[u8]` and then
+    /// return the original `Vec<u8>` to `PacketBuilder`'s buffer pool. Normal receive code should
+    /// keep using [`PacketHeader::from_bytes`], which advances a `Reader` past the header.
+    #[doc(hidden)]
+    pub(crate) fn read_from_prefix(bytes: &[u8]) -> Result<Self, SerializationError> {
+        if bytes.len() < Self::BYTES {
+            return Err(SerializationError::InvalidValue);
+        }
+        Ok(Self {
+            packet_type: PacketType::try_from(bytes[Self::PACKET_TYPE_OFFSET])?,
+            packet_id: PacketId(u32::from_be_bytes(bytes[1..5].try_into().unwrap())),
+            last_ack_packet_id: PacketId(u32::from_be_bytes(bytes[5..9].try_into().unwrap())),
+            ack_bitfield: u32::from_be_bytes(bytes[9..13].try_into().unwrap()),
+            tick: Tick(u32::from_be_bytes(bytes[13..17].try_into().unwrap())),
+        })
+    }
 
     /// Get the value of the i-th bit in the bitfield (starting from the right-most bit, which is
     /// one PacketId below `last_ack_packet_id`

--- a/crates/transport/transport/src/packet/mod.rs
+++ b/crates/transport/transport/src/packet/mod.rs
@@ -35,3 +35,6 @@ pub mod packet_builder;
 pub(crate) mod packet_type;
 pub mod priority_manager;
 pub(crate) mod stats_manager;
+
+#[cfg(feature = "test_utils")]
+pub mod test_utils;

--- a/crates/transport/transport/src/packet/packet_builder.rs
+++ b/crates/transport/transport/src/packet/packet_builder.rs
@@ -7,10 +7,10 @@ use crate::packet::compression::{
 use crate::packet::error::PacketError;
 use crate::packet::header::PacketHeaderManager;
 use crate::packet::message::{FragmentData, SingleData};
-use crate::packet::packet::{FRAGMENT_SIZE, HEADER_BYTES, Packet};
+use crate::packet::packet::{FRAGMENT_SIZE, HEADER_BYTES, MessageMetadata, Packet};
 use crate::packet::packet_type::PacketType;
 use alloc::collections::VecDeque;
-use alloc::{vec, vec::Vec};
+use alloc::vec::Vec;
 use bytes::Bytes;
 use core::time::Duration;
 use lightyear_core::network::NetId;
@@ -26,6 +26,8 @@ pub const MAX_UNFRAGMENTED_PAYLOAD_SIZE: usize = FRAGMENT_SIZE;
 pub type Payload = Vec<u8>;
 
 const MAX_MESSAGES_PER_CHANNEL_BATCH: usize = u8::MAX as usize;
+const MAX_RETAINED_PACKET_LIST_CAPACITY: usize = 100;
+const MAX_RETAINED_MESSAGE_METADATA_CAPACITY: usize = 100;
 
 /// We use `Bytes` on the receive side because we want to be able to refer to sub-slices of the original
 /// packet without allocating.
@@ -40,8 +42,7 @@ pub type RecvPayload = Bytes;
 pub(crate) struct PacketBuilder {
     pub(crate) header_manager: PacketHeaderManager,
     current_packet: Option<Packet>,
-    /// Max size for a single packet
-    mtu: usize,
+    buffer_pool: BufferPool,
     // Pre-allocated buffer to encode/decode without allocation.
     // TODO: should this be associated with Packet?
     // cursor: Vec<u8>,
@@ -49,6 +50,98 @@ pub(crate) struct PacketBuilder {
     // How many bytes we know we are going to have to write in the packet, but haven't written yet
     // prewritten_size: usize,
     // mid_packet: bool,
+}
+
+/// Reusable packet-builder buffers.
+///
+/// Packet building needs short-lived payloads and metadata vectors every send tick. Keeping them
+/// here lets the builder clear and reuse their heap allocations after warmup instead of allocating
+/// new buffers for each packet.
+#[derive(Debug)]
+pub(crate) struct BufferPool {
+    payload_capacity: usize,
+    payloads: Vec<Payload>,
+    packet_lists: Vec<Vec<Packet>>,
+    message_metadata: Vec<Vec<MessageMetadata>>,
+}
+
+impl BufferPool {
+    pub(crate) fn new(payload_capacity: usize) -> Self {
+        Self {
+            payload_capacity,
+            payloads: Vec::new(),
+            packet_lists: Vec::new(),
+            message_metadata: Vec::new(),
+        }
+    }
+
+    pub(crate) fn take_payload(&mut self) -> Payload {
+        self.payloads
+            .pop()
+            .map(|mut payload| {
+                debug_assert_eq!(payload.capacity(), self.payload_capacity);
+                payload.clear();
+                payload
+            })
+            .unwrap_or_else(|| Vec::with_capacity(self.payload_capacity))
+    }
+
+    pub(crate) fn take_packet_list(&mut self) -> Vec<Packet> {
+        self.packet_lists
+            .pop()
+            .map(|mut packets| {
+                packets.clear();
+                packets
+            })
+            .unwrap_or_default()
+    }
+
+    pub(crate) fn take_message_metadata(&mut self) -> Vec<MessageMetadata> {
+        self.message_metadata
+            .pop()
+            .map(|mut messages| {
+                messages.clear();
+                messages
+            })
+            .unwrap_or_default()
+    }
+
+    pub(crate) fn recycle_packet(&mut self, packet: Packet) {
+        let Packet {
+            payload, messages, ..
+        } = packet;
+        self.recycle_payload(payload);
+        self.recycle_message_metadata(messages);
+    }
+
+    pub(crate) fn recycle_packets(&mut self, packets: impl IntoIterator<Item = Packet>) {
+        for packet in packets {
+            self.recycle_packet(packet);
+        }
+    }
+
+    fn recycle_payload(&mut self, mut payload: Payload) {
+        if payload.capacity() == self.payload_capacity {
+            payload.clear();
+            self.payloads.push(payload);
+        }
+    }
+
+    pub(crate) fn recycle_message_metadata(&mut self, mut messages: Vec<MessageMetadata>) {
+        let capacity = messages.capacity();
+        if (1..=MAX_RETAINED_MESSAGE_METADATA_CAPACITY).contains(&capacity) {
+            messages.clear();
+            self.message_metadata.push(messages);
+        }
+    }
+
+    pub(crate) fn recycle_packet_list(&mut self, mut packets: Vec<Packet>) {
+        self.recycle_packets(packets.drain(..));
+        let capacity = packets.capacity();
+        if (1..=MAX_RETAINED_PACKET_LIST_CAPACITY).contains(&capacity) {
+            self.packet_lists.push(packets);
+        }
+    }
 }
 
 impl Default for PacketBuilder {
@@ -62,7 +155,7 @@ impl PacketBuilder {
         Self {
             header_manager: PacketHeaderManager::new(nack_rtt_multiple),
             current_packet: None,
-            mtu: MAX_PACKET_SIZE,
+            buffer_pool: BufferPool::new(MAX_PACKET_SIZE),
             // cursor: Vec::with_capacity(PACKET_BUFFER_CAPACITY),
             // acks: Vec::new(),
 
@@ -73,9 +166,20 @@ impl PacketBuilder {
         }
     }
 
-    // TODO: get the vec from a pool of preallocated buffers
-    fn get_new_buffer(&self) -> Payload {
-        Vec::with_capacity(self.mtu)
+    pub(crate) fn recycle_packet(&mut self, packet: Packet) {
+        self.buffer_pool.recycle_packet(packet);
+    }
+
+    pub(crate) fn recycle_packets(&mut self, packets: impl IntoIterator<Item = Packet>) {
+        self.buffer_pool.recycle_packets(packets);
+    }
+
+    pub(crate) fn recycle_message_metadata_list(&mut self, messages: Vec<MessageMetadata>) {
+        self.buffer_pool.recycle_message_metadata(messages);
+    }
+
+    pub(crate) fn recycle_packet_list(&mut self, packets: Vec<Packet>) {
+        self.buffer_pool.recycle_packet_list(packets);
     }
 
     /// Start building new packet, we start with an empty packet
@@ -85,7 +189,8 @@ impl PacketBuilder {
         real: Duration,
         current_tick: Tick,
     ) -> Result<(), SerializationError> {
-        let mut cursor = self.get_new_buffer();
+        let mut cursor = self.buffer_pool.take_payload();
+        let messages = self.buffer_pool.take_message_metadata();
 
         // write the header
         let header =
@@ -94,7 +199,7 @@ impl PacketBuilder {
         header.to_bytes(&mut cursor)?;
         self.current_packet = Some(Packet {
             payload: cursor,
-            messages: vec![],
+            messages,
             packet_id: header.packet_id,
             prewritten_size: 0,
             compression: None,
@@ -109,7 +214,8 @@ impl PacketBuilder {
         fragment_data: &FragmentData,
         current_tick: Tick,
     ) -> Result<(), SerializationError> {
-        let mut cursor = self.get_new_buffer();
+        let mut cursor = self.buffer_pool.take_payload();
+        let messages = self.buffer_pool.take_message_metadata();
         // writer the header
         let header = self.header_manager.prepare_send_packet_header(
             PacketType::DataFragment,
@@ -121,8 +227,7 @@ impl PacketBuilder {
         fragment_data.to_bytes(&mut cursor)?;
         let mut packet = Packet {
             payload: cursor,
-            // TODO(perf): reuse this vec allocation instead of newly allocating!
-            messages: vec![],
+            messages,
             packet_id: header.packet_id,
             prewritten_size: 0,
             compression: None,
@@ -164,8 +269,7 @@ impl PacketBuilder {
         Self::finalize_packet(self.current_packet.take().unwrap())
     }
 
-    fn finalize_packet(mut packet: Packet) -> Packet {
-        packet.payload.shrink_to_fit();
+    fn finalize_packet(packet: Packet) -> Packet {
         packet
     }
 
@@ -240,7 +344,7 @@ impl PacketBuilder {
         fragment_data: Vec<(ChannelId, VecDeque<FragmentData>)>,
         compression: CompressionConfig,
     ) -> Result<Vec<Packet>, PacketError> {
-        let mut packets: Vec<Packet> = vec![];
+        let mut packets = self.buffer_pool.take_packet_list();
 
         // indices in the main vec
         let mut single_data_idx = 0;
@@ -841,6 +945,7 @@ impl PacketBuilder {
 #[cfg(test)]
 mod tests {
     use alloc::collections::VecDeque;
+    use alloc::vec;
     use bevy_app::App;
     use bevy_reflect::TypePath;
     use bevy_utils::default;
@@ -912,6 +1017,46 @@ mod tests {
             payload.push((state & 0xff) as u8);
         }
         payload
+    }
+
+    #[test]
+    fn buffer_pool_reuses_message_metadata_up_to_retained_capacity() {
+        let mut pool = BufferPool::new(MAX_PACKET_SIZE);
+
+        pool.recycle_message_metadata(Vec::with_capacity(MAX_RETAINED_MESSAGE_METADATA_CAPACITY));
+        assert_eq!(
+            pool.take_message_metadata().capacity(),
+            MAX_RETAINED_MESSAGE_METADATA_CAPACITY
+        );
+    }
+
+    #[test]
+    fn buffer_pool_drops_oversized_message_metadata() {
+        let mut pool = BufferPool::new(MAX_PACKET_SIZE);
+
+        pool.recycle_message_metadata(Vec::with_capacity(
+            MAX_RETAINED_MESSAGE_METADATA_CAPACITY + 1,
+        ));
+        assert_eq!(pool.take_message_metadata().capacity(), 0);
+    }
+
+    #[test]
+    fn buffer_pool_reuses_packet_lists_up_to_retained_capacity() {
+        let mut pool = BufferPool::new(MAX_PACKET_SIZE);
+
+        pool.recycle_packet_list(Vec::with_capacity(MAX_RETAINED_PACKET_LIST_CAPACITY));
+        assert_eq!(
+            pool.take_packet_list().capacity(),
+            MAX_RETAINED_PACKET_LIST_CAPACITY
+        );
+    }
+
+    #[test]
+    fn buffer_pool_drops_oversized_packet_lists() {
+        let mut pool = BufferPool::new(MAX_PACKET_SIZE);
+
+        pool.recycle_packet_list(Vec::with_capacity(MAX_RETAINED_PACKET_LIST_CAPACITY + 1));
+        assert_eq!(pool.take_packet_list().capacity(), 0);
     }
 
     /// A bunch of small messages that all fit in the same packet

--- a/crates/transport/transport/src/packet/stats_manager.rs
+++ b/crates/transport/transport/src/packet/stats_manager.rs
@@ -70,10 +70,8 @@ pub(crate) mod packet {
 
         pub(crate) fn update(&mut self, real: Duration) {
             // remove stats older than stats buffer duration
-            let removed = self
-                .stats_buffer
-                .drain_until(&(real.saturating_sub(self.stats_buffer_duration)));
-            for (_, stats) in removed {
+            let oldest_retained = real.saturating_sub(self.stats_buffer_duration);
+            while let Some((_, stats)) = self.stats_buffer.pop_item(&oldest_retained) {
                 self.rolling_stats -= stats;
             }
             // add the current stats to the rolling stats

--- a/crates/transport/transport/src/packet/test_utils.rs
+++ b/crates/transport/transport/src/packet/test_utils.rs
@@ -1,0 +1,255 @@
+use alloc::collections::VecDeque;
+use alloc::{vec, vec::Vec};
+use core::convert::TryInto;
+use core::time::Duration;
+
+use bytes::Bytes;
+use lightyear_core::prelude::Tick;
+use lightyear_link::LinkStats;
+use lightyear_serde::SerializationError;
+use lightyear_serde::varint::varint_parse_len;
+
+use crate::channel::registry::ChannelId;
+use crate::packet::compression::CompressionConfig;
+use crate::packet::error::PacketError;
+use crate::packet::header::PacketHeader;
+use crate::packet::message::SingleData;
+use crate::packet::packet_builder::PacketBuilder;
+use crate::packet::packet_type::PacketType;
+
+/// Opaque packet-builder input prepared outside allocation measurements.
+pub struct PacketLoopBatch {
+    single_data: Vec<(ChannelId, VecDeque<SingleData>)>,
+}
+
+/// Summary of a completed packet build and parse pass.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct PacketLoopStats {
+    pub packets: usize,
+    pub messages: usize,
+    pub payload_bytes: usize,
+}
+
+struct SlicePacketReader<'a> {
+    bytes: &'a [u8],
+    position: usize,
+}
+
+impl<'a> SlicePacketReader<'a> {
+    fn new(bytes: &'a [u8]) -> Self {
+        Self { bytes, position: 0 }
+    }
+
+    fn has_remaining(&self) -> bool {
+        self.position < self.bytes.len()
+    }
+
+    fn take(&mut self, len: usize) -> Result<&'a [u8], SerializationError> {
+        let end = self
+            .position
+            .checked_add(len)
+            .ok_or(SerializationError::InvalidValue)?;
+        let bytes = self
+            .bytes
+            .get(self.position..end)
+            .ok_or(SerializationError::InvalidValue)?;
+        self.position = end;
+        Ok(bytes)
+    }
+
+    fn skip(&mut self, len: usize) -> Result<(), SerializationError> {
+        self.take(len).map(drop)
+    }
+
+    fn read_u8(&mut self) -> Result<u8, SerializationError> {
+        Ok(self.take(1)?[0])
+    }
+
+    fn read_varint(&mut self) -> Result<u64, SerializationError> {
+        let first = *self
+            .bytes
+            .get(self.position)
+            .ok_or(SerializationError::InvalidValue)?;
+        let len = varint_parse_len(first);
+        let bytes = self.take(len)?;
+        match len {
+            1 => Ok(u64::from(bytes[0])),
+            2 => Ok(u64::from(
+                u16::from_be_bytes(bytes.try_into().unwrap()) & 0x3fff,
+            )),
+            4 => Ok(u64::from(
+                u32::from_be_bytes(bytes.try_into().unwrap()) & 0x3fff_ffff,
+            )),
+            8 => Ok(u64::from_be_bytes(bytes.try_into().unwrap()) & 0x3fff_ffff_ffff_ffff),
+            _ => Err(SerializationError::InvalidValue),
+        }
+    }
+}
+
+/// Focused test fixture for the packet send/receive loop.
+///
+/// This intentionally bypasses Bevy schedules, typed message serialization, IO, and connection
+/// layers. Call [`prepare_batch`](Self::prepare_batch) before starting an allocation measurement,
+/// then call [`run_batch`](Self::run_batch) inside the measured region.
+pub struct PacketLoopFixture {
+    packet_builder: PacketBuilder,
+    channel_id: ChannelId,
+    payloads: Vec<Bytes>,
+    current_tick: Tick,
+    current_real: Duration,
+}
+
+impl PacketLoopFixture {
+    pub fn new(message_count: usize, payload_len: usize) -> Self {
+        assert!(message_count > 0);
+        let payloads = (0..message_count)
+            .map(|message_index| {
+                let value = (message_index % (u8::MAX as usize + 1)) as u8;
+                Bytes::from(vec![value; payload_len])
+            })
+            .collect();
+        Self {
+            packet_builder: PacketBuilder::new(1.5),
+            channel_id: 0,
+            payloads,
+            current_tick: Tick(0),
+            current_real: Duration::default(),
+        }
+    }
+
+    pub fn expected_messages(&self) -> usize {
+        self.payloads.len()
+    }
+
+    pub fn expected_payload_bytes(&self) -> usize {
+        self.payloads.iter().map(Bytes::len).sum()
+    }
+
+    pub fn expected_packets_for_messages(&self, total_messages: usize) -> usize {
+        total_messages.div_ceil(self.expected_messages())
+    }
+
+    pub fn expected_payload_bytes_for_messages(&self, total_messages: usize) -> usize {
+        let full_batches = total_messages / self.expected_messages();
+        let remaining = total_messages % self.expected_messages();
+        full_batches * self.expected_payload_bytes()
+            + self
+                .payloads
+                .iter()
+                .take(remaining)
+                .map(Bytes::len)
+                .sum::<usize>()
+    }
+
+    pub fn prepare_batch(&self) -> PacketLoopBatch {
+        self.prepare_batch_with_message_count(self.expected_messages())
+    }
+
+    pub fn prepare_batches(&self, total_messages: usize) -> Vec<PacketLoopBatch> {
+        let mut batches = Vec::with_capacity(self.expected_packets_for_messages(total_messages));
+        let mut remaining = total_messages;
+        while remaining > 0 {
+            let batch_messages = remaining.min(self.expected_messages());
+            batches.push(self.prepare_batch_with_message_count(batch_messages));
+            remaining -= batch_messages;
+        }
+        batches
+    }
+
+    fn prepare_batch_with_message_count(&self, message_count: usize) -> PacketLoopBatch {
+        let single_data = VecDeque::from_iter(
+            self.payloads
+                .iter()
+                .take(message_count)
+                .cloned()
+                .map(|payload| SingleData::new(None, payload)),
+        );
+        PacketLoopBatch {
+            single_data: vec![(self.channel_id, single_data)],
+        }
+    }
+
+    pub fn run_batch(&mut self, batch: PacketLoopBatch) -> Result<PacketLoopStats, PacketError> {
+        let real = self.current_real;
+        self.packet_builder
+            .header_manager
+            .update(real, &LinkStats::default());
+        self.packet_builder.header_manager.lost_packets.clear();
+
+        let mut packets = self.packet_builder.build_packets_with_compression(
+            real,
+            self.current_tick,
+            batch.single_data,
+            Vec::new(),
+            CompressionConfig::DISABLED,
+        )?;
+        self.current_tick += 1;
+        self.current_real += Duration::from_millis(16);
+
+        let mut stats = PacketLoopStats {
+            packets: packets.len(),
+            ..Default::default()
+        };
+        for packet in packets.drain(..) {
+            self.parse_packet_payload(packet.payload.as_slice(), real, &mut stats)?;
+            self.packet_builder.recycle_packet(packet);
+        }
+        self.packet_builder.recycle_packet_list(packets);
+        Ok(stats)
+    }
+
+    fn parse_packet_payload(
+        &mut self,
+        payload: &[u8],
+        real: Duration,
+        stats: &mut PacketLoopStats,
+    ) -> Result<(), PacketError> {
+        let header = PacketHeader::read_from_prefix(payload)?;
+        assert_eq!(header.get_packet_type(), PacketType::Data);
+        let _ = self
+            .packet_builder
+            .header_manager
+            .process_recv_packet_header(&header, real);
+        self.packet_builder
+            .header_manager
+            .newly_acked_packets
+            .clear();
+
+        let mut reader = SlicePacketReader::new(
+            payload
+                .get(PacketHeader::BYTES..)
+                .ok_or(SerializationError::InvalidValue)?,
+        );
+        while reader.has_remaining() {
+            let channel_id = reader.read_varint()? as ChannelId;
+            assert_eq!(channel_id, self.channel_id);
+            let num_messages = reader.read_u8()?;
+            for _ in 0..num_messages {
+                match reader.read_u8()? {
+                    0 => {}
+                    1 => reader.skip(4)?,
+                    _ => return Err(SerializationError::InvalidValue.into()),
+                }
+                let payload_len = reader.read_varint()? as usize;
+                reader.skip(payload_len)?;
+                stats.messages += 1;
+                stats.payload_bytes += payload_len;
+            }
+        }
+        Ok(())
+    }
+
+    pub fn run_batches(
+        &mut self,
+        batches: Vec<PacketLoopBatch>,
+    ) -> Result<PacketLoopStats, PacketError> {
+        let mut total = PacketLoopStats::default();
+        for batch in batches {
+            let stats = self.run_batch(batch)?;
+            total.packets += stats.packets;
+            total.messages += stats.messages;
+            total.payload_bytes += stats.payload_bytes;
+        }
+        Ok(total)
+    }
+}

--- a/crates/transport/transport/src/plugin.rs
+++ b/crates/transport/transport/src/plugin.rs
@@ -425,7 +425,7 @@ impl TransportPlugin {
 
             // build actual packets from these messages
             // TODO: swap to try_for_each when available
-            let Ok(packets) =
+            let Ok(mut packets) =
                 transport.packet_manager
                     .build_packets_with_compression(real_time.elapsed(), tick, single_data, fragment_data, transport.compression) else {
                 error!("Failed to build packets");
@@ -433,7 +433,8 @@ impl TransportPlugin {
             };
 
             let mut total_bytes_sent = 0;
-            for mut packet in packets {
+            let mut packet_drain = packets.drain(..);
+            while let Some(mut packet) = packet_drain.next() {
                 trace!(packet_id = ?packet.packet_id, num_messages = ?packet.num_messages(), "sending packet");
                 let packet_id = packet.packet_id;
                 let num_messages = packet.num_messages();
@@ -450,6 +451,8 @@ impl TransportPlugin {
                     // Unsent unreliable messages are dropped for this tick. Reliable messages will
                     // be retried by their channel sender because their ack bookkeeping is only
                     // updated after a packet is accepted below.
+                    let rejected_packets = core::iter::once(packet).chain(packet_drain.by_ref());
+                    transport.packet_manager.recycle_packets(rejected_packets);
                     break;
                 }
                 #[cfg(feature = "metrics")]
@@ -493,8 +496,9 @@ impl TransportPlugin {
 
                 // TODO: should we update this to include fragment info as well?
                 // Update the packet_to_message_id_map (only for channels that care about acks)
-                core::mem::take(&mut packet.messages)
-                    .into_iter()
+                let mut packet_messages = core::mem::take(&mut packet.messages);
+                packet_messages
+                    .drain(..)
                     .try_for_each(|metadata| {
                         let channel_id = metadata.channel;
                         let channel_kind = channel_registry
@@ -529,12 +533,19 @@ impl TransportPlugin {
                             trace!(?transport.packet_to_message_map, "packet to message");
                         }
                         Ok::<(), PacketError>(())
-                    }).inspect_err(|e| error!("Error updating packet to message ack: {e:?}")).ok();
+                    })
+                    .inspect_err(|e| error!("Error updating packet to message ack: {e:?}"))
+                    .ok();
+                transport
+                    .packet_manager
+                    .recycle_message_metadata_list(packet_messages);
 
                 // Upload the packets to the link
                 total_bytes_sent += packet.payload.len() as u32;
                 link.send.push(Bytes::from(packet.payload));
             }
+            drop(packet_drain);
+            transport.packet_manager.recycle_packet_list(packets);
             if total_bytes_sent > 0 {
                 trace!(
                     target: "lightyear_debug::transport",

--- a/crates/transport/transport/tests/allocation_regression.rs
+++ b/crates/transport/transport/tests/allocation_regression.rs
@@ -1,0 +1,61 @@
+#![cfg(feature = "test_utils")]
+
+use std::alloc::System;
+
+use lightyear_transport::packet::test_utils::PacketLoopFixture;
+use stats_alloc::{INSTRUMENTED_SYSTEM, Region, StatsAlloc};
+
+#[global_allocator]
+static GLOBAL: &StatsAlloc<System> = &INSTRUMENTED_SYSTEM;
+
+const MESSAGES_PER_BATCH: usize = 4;
+const PAYLOAD_BYTES: usize = 64;
+const WARMUP_MESSAGES: usize = 1_500;
+const MEASURED_MESSAGES: usize = 1_000;
+
+#[test]
+fn packet_send_receive_loop_allocation_budget() {
+    let mut fixture = PacketLoopFixture::new(MESSAGES_PER_BATCH, PAYLOAD_BYTES);
+
+    let warmup = fixture.prepare_batches(WARMUP_MESSAGES);
+    let warmup_stats = fixture.run_batches(warmup).unwrap();
+    assert_eq!(
+        warmup_stats.packets,
+        fixture.expected_packets_for_messages(WARMUP_MESSAGES)
+    );
+    assert_eq!(warmup_stats.messages, WARMUP_MESSAGES);
+    assert_eq!(
+        warmup_stats.payload_bytes,
+        fixture.expected_payload_bytes_for_messages(WARMUP_MESSAGES)
+    );
+
+    let batches = fixture.prepare_batches(MEASURED_MESSAGES);
+    let region = Region::new(GLOBAL);
+    let stats = fixture.run_batches(batches).unwrap();
+    let allocation_stats = region.change();
+
+    assert_eq!(
+        stats.packets,
+        fixture.expected_packets_for_messages(MEASURED_MESSAGES)
+    );
+    assert_eq!(stats.messages, MEASURED_MESSAGES);
+    assert_eq!(
+        stats.payload_bytes,
+        fixture.expected_payload_bytes_for_messages(MEASURED_MESSAGES)
+    );
+
+    eprintln!("packet loop allocation stats: {allocation_stats:#?}");
+
+    assert_eq!(
+        allocation_stats.allocations, 0,
+        "packet loop allocation count regressed: {allocation_stats:#?}"
+    );
+    assert_eq!(
+        allocation_stats.reallocations, 0,
+        "packet loop reallocation count regressed: {allocation_stats:#?}"
+    );
+    assert_eq!(
+        allocation_stats.bytes_allocated, 0,
+        "packet loop allocated-byte budget regressed: {allocation_stats:#?}"
+    );
+}

--- a/crates/transport/transport/tests/dhat_packet_loop.rs
+++ b/crates/transport/transport/tests/dhat_packet_loop.rs
@@ -1,0 +1,37 @@
+#![cfg(feature = "test_utils")]
+
+use lightyear_transport::packet::test_utils::PacketLoopFixture;
+
+#[global_allocator]
+static ALLOC: dhat::Alloc = dhat::Alloc;
+
+const MESSAGES_PER_BATCH: usize = 4;
+const PAYLOAD_BYTES: usize = 64;
+const WARMUP_MESSAGES: usize = 1_500;
+const MEASURED_MESSAGES: usize = 1_000;
+
+#[test]
+#[ignore = "manual heap profile; writes target/dhat-packet-loop.json"]
+fn dhat_packet_send_receive_loop() {
+    let mut fixture = PacketLoopFixture::new(MESSAGES_PER_BATCH, PAYLOAD_BYTES);
+
+    let warmup = fixture.prepare_batches(WARMUP_MESSAGES);
+    fixture.run_batches(warmup).unwrap();
+
+    let batches = fixture.prepare_batches(MEASURED_MESSAGES);
+    let profile_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../target/dhat-packet-loop.json");
+    std::fs::create_dir_all(profile_path.parent().unwrap()).unwrap();
+    let _profiler = dhat::Profiler::builder().file_name(&profile_path).build();
+
+    let stats = fixture.run_batches(batches).unwrap();
+    assert_eq!(
+        stats.packets,
+        fixture.expected_packets_for_messages(MEASURED_MESSAGES)
+    );
+    assert_eq!(stats.messages, MEASURED_MESSAGES);
+    assert_eq!(
+        stats.payload_bytes,
+        fixture.expected_payload_bytes_for_messages(MEASURED_MESSAGES)
+    );
+}


### PR DESCRIPTION
We were allocating new buffers on each packet received.
Now we recycle buffers from a pool.

Added tests to check that there are 0 allocations in a steady-state.