### PR TITLE
Use Replicon userdata for checkpoint ticks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -240,7 +240,7 @@ leafwing-input-manager = { version = "0.21", default-features = false, features 
 ] }
 
 # replication
-bevy_replicon = { version = "0.41" }
+bevy_replicon = { git = "https://github.com/simgine/bevy_replicon", branch = "master" }
 
 # physics
 avian2d = { version = "0.7", default-features = false }

--- a/crates/replication/interpolation/src/plugin.rs
+++ b/crates/replication/interpolation/src/plugin.rs
@@ -13,7 +13,6 @@ use bevy_ecs::{
 };
 use bevy_reflect::Reflect;
 use bevy_replicon::shared::replication::diff::Diffable as RepliconDiffable;
-use bevy_replicon::shared::replication::track_mutate_messages::TrackAppExt;
 use lightyear_connection::host::HostClient;
 use lightyear_core::prelude::Tick;
 use lightyear_core::time::PositiveTickDelta;
@@ -135,9 +134,6 @@ pub fn add_interpolation_systems<C: SyncComponent>(app: &mut App) {
 impl Plugin for InterpolationPlugin {
     fn build(&self, app: &mut App) {
         app.add_plugins(TimelinePlugin);
-
-        // REPLICON
-        app.track_mutate_messages();
 
         // RESOURCES
         app.init_resource::<InterpolationRegistry>();

--- a/crates/replication/prediction/src/plugin.rs
+++ b/crates/replication/prediction/src/plugin.rs
@@ -19,7 +19,6 @@ use bevy_ecs::component::Mutable;
 use bevy_ecs::entity_disabling::DefaultQueryFilters;
 use bevy_ecs::prelude::*;
 use bevy_replicon::shared::replication::diff::Diffable as RepliconDiffable;
-use bevy_replicon::shared::replication::track_mutate_messages::TrackAppExt;
 #[cfg(feature = "metrics")]
 use bevy_utils::prelude::DebugName;
 use lightyear_connection::client::{Client, Connected};
@@ -192,9 +191,6 @@ impl Plugin for PredictionPlugin {
     fn build(&self, app: &mut App) {
         // RESOURCES
         app.init_resource::<PredictionRegistry>();
-
-        // REPLICON
-        app.track_mutate_messages();
 
         // Custom entity disabling
         let rollback_disable_id = app

--- a/crates/replication/replication/src/checkpoint.rs
+++ b/crates/replication/replication/src/checkpoint.rs
@@ -14,19 +14,15 @@
 //! authoritative server simulation.
 //!
 //! # How the mapping is carried
-//! Lightyear does not modify Replicon's internal message format. Instead, the Lightyear transport
-//! bridge wraps Replicon server payloads on the wire:
+//! Lightyear stores the authoritative [`Tick`] in Replicon's replication userdata:
 //!
-//! 1. On the server, [`wrap_server_payload`] prefixes the raw Replicon bytes with a lightweight
-//!    Lightyear header containing the authoritative [`Tick`].
-//! 2. On the client, [`unwrap_server_payload`] strips that header back off before forwarding the
-//!    original bytes to Replicon.
-//! 3. Before forwarding, [`extract_server_replicon_tick`] reads the Replicon checkpoint identifier
-//!    from the inner payload and [`ReplicationCheckpointMap::record`] stores the
-//!    `RepliconTick -> Tick` association.
-//!
-//! The wrapped bytes are only used at the Lightyear bridge boundary. Replicon still receives the
-//! original payload unchanged.
+//! 1. On the server, [`write_authoritative_tick_userdata`] writes the current Lightyear tick into
+//!    [`ReplicationUserdata`](bevy_replicon::server::ReplicationUserdata) before Replicon builds
+//!    replication messages.
+//! 2. Replicon serializes those bytes into its update and mutation messages.
+//! 3. On the client, Replicon triggers
+//!    [`UserdataReceived`](bevy_replicon::client::UserdataReceived) before applying the message,
+//!    and [`record_authoritative_tick_userdata`] stores the `RepliconTick -> Tick` association.
 //!
 //! # Which tick to use
 //! - Use [`RepliconTick`] for Replicon protocol concerns only: packet ordering, completeness, and
@@ -39,49 +35,39 @@
 //! [`ConfirmHistory`]: bevy_replicon::client::confirm_history::ConfirmHistory
 //! [`ServerMutateTicks`]: bevy_replicon::client::server_mutate_ticks::ServerMutateTicks
 use alloc::collections::VecDeque;
-use bytes::{Buf, Bytes, BytesMut};
 
+#[cfg(feature = "client")]
+use bevy_ecs::prelude::On;
+#[cfg(feature = "server")]
+use bevy_ecs::prelude::Res;
+#[cfg(any(feature = "client", feature = "server"))]
+use bevy_ecs::prelude::ResMut;
 use bevy_ecs::prelude::Resource;
 use bevy_platform::collections::HashMap;
+#[cfg(feature = "client")]
+use bevy_replicon::client::UserdataReceived;
 use bevy_replicon::client::confirm_history::ConfirmHistory;
 use bevy_replicon::prelude::RepliconTick;
+#[cfg(feature = "server")]
+use bevy_replicon::server::ReplicationUserdata;
+#[cfg(feature = "server")]
+use lightyear_core::prelude::LocalTimeline;
 use lightyear_core::tick::Tick;
+#[cfg(feature = "client")]
+use tracing::error;
 
-const CHECKPOINT_MAGIC: [u8; 2] = *b"LY";
-const CHECKPOINT_VERSION: u8 = 1;
-pub const SERVER_PAYLOAD_HEADER_LEN: usize = 7;
+pub const CHECKPOINT_USERDATA_LEN: usize = core::mem::size_of::<Tick>();
 const MAX_STORED_CHECKPOINTS: usize = 256;
-
-/// Lightyear-owned header prepended to wrapped Replicon server payloads.
-///
-/// This header is carried only across the Lightyear transport bridge. Replicon never sees it:
-/// the client unwraps the payload and forwards the original inner bytes to Replicon unchanged.
-///
-/// `authoritative_tick` is the server-side Lightyear simulation tick that the wrapped Replicon
-/// checkpoint represents.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct ReplicationCheckpointHeader {
-    pub version: u8,
-    pub authoritative_tick: Tick,
-}
-
-impl ReplicationCheckpointHeader {
-    pub const fn new(authoritative_tick: Tick) -> Self {
-        Self {
-            version: CHECKPOINT_VERSION,
-            authoritative_tick,
-        }
-    }
-}
 
 /// Receiver-side translation table from Replicon checkpoint ticks to authoritative server ticks.
 ///
-/// This resource is populated when the client receives wrapped Replicon server packets. For each
-/// payload on Replicon's update/mutation channels, the bridge:
+/// This resource is populated when Replicon triggers
+/// [`UserdataReceived`](bevy_replicon::client::UserdataReceived). For each payload on Replicon's
+/// update/mutation channels, the bridge:
 ///
-/// 1. reads the Lightyear header to recover the authoritative server [`Tick`]
-/// 2. reads the inner Replicon payload to recover the corresponding [`RepliconTick`]
-/// 3. records the association here before handing the original bytes to Replicon
+/// 1. reads the Lightyear [`Tick`] from the Replicon userdata bytes
+/// 2. uses Replicon's `message_tick` as the corresponding [`RepliconTick`]
+/// 3. records the association here before Replicon applies the message
 ///
 /// Prediction and rollback code should use this resource whenever they need to interpret
 /// [`ConfirmHistory`] or
@@ -180,97 +166,58 @@ pub fn resolve_confirm_history_tick(
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CheckpointError {
-    MissingHeader,
-    InvalidMagic,
-    UnsupportedVersion(u8),
-    UnsupportedChannel(usize),
-    InvalidPayload,
+    InvalidUserdataLength(usize),
 }
 
-/// Prefix a Replicon server payload with the authoritative Lightyear simulation tick.
-///
-/// This is done in the Lightyear server bridge immediately before the payload is handed to the
-/// transport layer. Replicon's serialized bytes are preserved verbatim after the header.
-pub fn wrap_server_payload(authoritative_tick: Tick, payload: Bytes) -> Bytes {
-    let mut wrapped = BytesMut::with_capacity(SERVER_PAYLOAD_HEADER_LEN + payload.len());
-    wrapped.extend_from_slice(&CHECKPOINT_MAGIC);
-    wrapped.extend_from_slice(&[CHECKPOINT_VERSION]);
-    wrapped.extend_from_slice(&authoritative_tick.0.to_le_bytes());
-    wrapped.extend_from_slice(&payload);
-    wrapped.freeze()
+pub fn encode_authoritative_tick(authoritative_tick: Tick) -> [u8; CHECKPOINT_USERDATA_LEN] {
+    authoritative_tick.0.to_le_bytes()
 }
 
-/// Remove the Lightyear checkpoint header from a wrapped Replicon server payload.
-///
-/// The returned [`Bytes`] are the original Replicon payload and should be forwarded to Replicon
-/// unchanged.
-pub fn unwrap_server_payload(
-    payload: Bytes,
-) -> Result<(ReplicationCheckpointHeader, Bytes), CheckpointError> {
-    if payload.len() < SERVER_PAYLOAD_HEADER_LEN {
-        return Err(CheckpointError::MissingHeader);
+pub fn decode_authoritative_tick(bytes: &[u8]) -> Result<Tick, CheckpointError> {
+    if bytes.len() != CHECKPOINT_USERDATA_LEN {
+        return Err(CheckpointError::InvalidUserdataLength(bytes.len()));
     }
-    if payload[0..2] != CHECKPOINT_MAGIC {
-        return Err(CheckpointError::InvalidMagic);
-    }
-    let version = payload[2];
-    if version != CHECKPOINT_VERSION {
-        return Err(CheckpointError::UnsupportedVersion(version));
-    }
-    let authoritative_tick = Tick(u32::from_le_bytes([
-        payload[3], payload[4], payload[5], payload[6],
-    ]));
-    Ok((
-        ReplicationCheckpointHeader {
-            version,
-            authoritative_tick,
-        },
-        payload.slice(SERVER_PAYLOAD_HEADER_LEN..),
-    ))
+    Ok(Tick(u32::from_le_bytes([
+        bytes[0], bytes[1], bytes[2], bytes[3],
+    ])))
 }
 
-/// Extract the Replicon checkpoint identifier from a wrapped server payload's inner bytes.
-///
-/// Replicon uses different payload layouts on its server update and mutation channels:
-///
-/// - channel `0` carries update packets whose leading Replicon tick is the checkpoint id
-/// - channel `1` carries mutation packets with both `update_tick` and `message_tick`; the latter
-///   is the completeness checkpoint used by [`ConfirmHistory`] /
-///   [`ServerMutateTicks`](bevy_replicon::client::server_mutate_ticks::ServerMutateTicks)
-///
-/// The returned [`RepliconTick`] should not be used directly for rollback or prediction. It is
-/// only the lookup key into [`ReplicationCheckpointMap`].
-pub fn extract_server_replicon_tick(
-    channel_idx: usize,
-    payload: &Bytes,
-) -> Result<RepliconTick, CheckpointError> {
-    let mut payload = payload.clone();
-    match channel_idx {
-        0 => {
-            if payload.is_empty() {
-                return Err(CheckpointError::InvalidPayload);
-            }
-            payload.advance(1);
-            bevy_replicon::postcard_utils::from_buf(&mut payload)
-                .map_err(|_| CheckpointError::InvalidPayload)
+/// Write the authoritative Lightyear simulation tick into Replicon's replication userdata.
+#[cfg(feature = "server")]
+pub(crate) fn write_authoritative_tick_userdata(
+    timeline: Res<LocalTimeline>,
+    mut userdata: ResMut<ReplicationUserdata>,
+) {
+    userdata.clear();
+    userdata.extend_from_slice(&encode_authoritative_tick(timeline.tick()));
+}
+
+/// Record the authoritative Lightyear simulation tick carried by Replicon userdata.
+#[cfg(feature = "client")]
+pub(crate) fn record_authoritative_tick_userdata(
+    received: On<UserdataReceived>,
+    mut checkpoints: ResMut<ReplicationCheckpointMap>,
+) {
+    match decode_authoritative_tick(received.bytes.as_ref()) {
+        Ok(authoritative_tick) => checkpoints.record(received.message_tick, authoritative_tick),
+        Err(error_kind) => {
+            error!(
+                ?error_kind,
+                replicon_tick = ?received.message_tick,
+                userdata_len = received.bytes.len(),
+                "dropping invalid replicon checkpoint userdata"
+            );
+            debug_assert!(
+                false,
+                "invalid authoritative checkpoint userdata: {error_kind:?}"
+            );
         }
-        1 => {
-            let _: RepliconTick = bevy_replicon::postcard_utils::from_buf(&mut payload)
-                .map_err(|_| CheckpointError::InvalidPayload)?;
-            let message_tick: RepliconTick = bevy_replicon::postcard_utils::from_buf(&mut payload)
-                .map_err(|_| CheckpointError::InvalidPayload)?;
-            Ok(message_tick)
-        }
-        _ => Err(CheckpointError::UnsupportedChannel(channel_idx)),
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloc::vec::Vec;
-
-    use bevy_replicon::postcard_utils;
 
     #[test]
     fn checkpoint_map_prunes_old_entries() {
@@ -331,54 +278,17 @@ mod tests {
     }
 
     #[test]
-    fn update_payload_roundtrip_preserves_bytes_and_tick() {
-        let replicon_tick = RepliconTick::new(77);
-        let mut payload = Vec::new();
-        payload.push(0b0000_1000);
-        postcard_utils::to_extend_mut(&replicon_tick, &mut payload).unwrap();
-        payload.extend_from_slice(&[1, 2, 3, 4]);
-        let payload = Bytes::from(payload);
+    fn authoritative_tick_userdata_roundtrips() {
+        let bytes = encode_authoritative_tick(Tick(42));
 
-        let wrapped = wrap_server_payload(Tick(42), payload.clone());
-        let (header, inner) = unwrap_server_payload(wrapped).unwrap();
-
-        assert_eq!(header, ReplicationCheckpointHeader::new(Tick(42)));
-        assert_eq!(inner, payload);
-        assert_eq!(
-            extract_server_replicon_tick(0, &inner).unwrap(),
-            replicon_tick
-        );
+        assert_eq!(decode_authoritative_tick(&bytes), Ok(Tick(42)));
     }
 
     #[test]
-    fn mutation_payload_roundtrip_preserves_bytes_and_tick() {
-        let update_tick = RepliconTick::new(10);
-        let message_tick = RepliconTick::new(11);
-        let mut payload = Vec::new();
-        postcard_utils::to_extend_mut(&update_tick, &mut payload).unwrap();
-        postcard_utils::to_extend_mut(&message_tick, &mut payload).unwrap();
-        postcard_utils::to_extend_mut(&3usize, &mut payload).unwrap();
-        payload.extend_from_slice(&[9, 8, 7]);
-        let payload = Bytes::from(payload);
-
-        let wrapped = wrap_server_payload(Tick(55), payload.clone());
-        let (header, inner) = unwrap_server_payload(wrapped).unwrap();
-
-        assert_eq!(header, ReplicationCheckpointHeader::new(Tick(55)));
-        assert_eq!(inner, payload);
+    fn invalid_authoritative_tick_userdata_is_rejected() {
         assert_eq!(
-            extract_server_replicon_tick(1, &inner).unwrap(),
-            message_tick
-        );
-    }
-
-    #[test]
-    fn malformed_payload_is_rejected() {
-        let payload = Bytes::from_static(b"bad");
-
-        assert_eq!(
-            unwrap_server_payload(payload),
-            Err(CheckpointError::MissingHeader)
+            decode_authoritative_tick(&[1, 2, 3]),
+            Err(CheckpointError::InvalidUserdataLength(3))
         );
     }
 }

--- a/crates/replication/replication/src/client.rs
+++ b/crates/replication/replication/src/client.rs
@@ -16,9 +16,7 @@ use lightyear_transport::prelude::Transport;
 #[cfg(any(feature = "prediction", feature = "interpolation"))]
 use crate::ReplicationSystems;
 use crate::channels::RepliconChannelMap;
-use crate::checkpoint::{
-    ReplicationCheckpointMap, extract_server_replicon_tick, unwrap_server_payload,
-};
+use crate::checkpoint::ReplicationCheckpointMap;
 use crate::prelude::Replicated;
 use crate::send::Replicate;
 use lightyear_messages::plugin::MessageSystems;
@@ -35,11 +33,7 @@ pub struct RepliconClientPlugin;
 
 impl Plugin for RepliconClientPlugin {
     fn build(&self, app: &mut App) {
-        #[cfg(any(feature = "prediction", feature = "interpolation"))]
-        {
-            use bevy_replicon::shared::replication::track_mutate_messages::TrackAppExt;
-            app.track_mutate_messages();
-        }
+        app.add_observer(crate::checkpoint::record_authoritative_tick_userdata);
 
         // State management
         app.add_systems(
@@ -149,37 +143,13 @@ fn sync_client_state(
 fn receive_client_packets(
     channel_map: Res<RepliconChannelMap>,
     mut client_messages: ResMut<ClientMessages>,
-    mut checkpoints: ResMut<ReplicationCheckpointMap>,
     mut transports: Query<&mut Transport, With<Client>>,
 ) {
     for mut transport in transports.iter_mut() {
         for (idx, &(_, channel_id)) in channel_map.server_channels.iter().enumerate() {
             if let Some(receiver) = transport.receivers.get_mut(&channel_id) {
                 while let Some((_, message, _)) = receiver.receiver.read_message() {
-                    if idx <= 1 {
-                        // Server update / mutation packets are wrapped by Lightyear with the
-                        // authoritative simulation tick. We unwrap, record the
-                        // RepliconTick -> Tick mapping for prediction/rollback, then hand the
-                        // original inner bytes back to Replicon unchanged.
-                        match unwrap_server_payload(message).and_then(|(header, inner)| {
-                            let replicon_tick = extract_server_replicon_tick(idx, &inner)?;
-                            Ok((header, inner, replicon_tick))
-                        }) {
-                            Ok((header, inner, replicon_tick)) => {
-                                checkpoints.record(replicon_tick, header.authoritative_tick);
-                                client_messages.insert_received(idx, inner);
-                            }
-                            Err(error_kind) => {
-                                error!(
-                                    ?error_kind,
-                                    channel_idx = idx,
-                                    "dropping malformed wrapped replicon server payload"
-                                );
-                            }
-                        }
-                    } else {
-                        client_messages.insert_received(idx, message);
-                    }
+                    client_messages.insert_received(idx, message);
                 }
             }
         }

--- a/crates/replication/replication/src/diff_history.rs
+++ b/crates/replication/replication/src/diff_history.rs
@@ -110,19 +110,18 @@ impl<C: RepliconDiffable> HistoryDiffReceiver<C> {
         match cursor {
             Some(cursor) => {
                 if let Some(base_cursor) = self.base_cursor {
-                    if cursor != base_cursor && !cursor.is_newer_than(base_cursor) {
+                    if cursor != base_cursor && !cursor.is_newer(base_cursor) {
                         return;
                     }
                     if cursor == base_cursor {
                         if self.base_tick.is_none_or(|base_tick| tick >= base_tick) {
                             self.base_tick = Some(tick);
                         }
-                        self.diff_ticks
-                            .retain(|(index, _)| index.is_newer_than(cursor));
+                        self.diff_ticks.retain(|(index, _)| index.is_newer(cursor));
                         self.pending.retain(|pending| {
                             pending
                                 .cursor()
-                                .is_ok_and(|pending_cursor| pending_cursor.is_newer_than(cursor))
+                                .is_ok_and(|pending_cursor| pending_cursor.is_newer(cursor))
                         });
                         return;
                     }
@@ -139,7 +138,7 @@ impl<C: RepliconDiffable> HistoryDiffReceiver<C> {
                 self.pending.retain(|pending| {
                     pending
                         .cursor()
-                        .is_ok_and(|pending_cursor| pending_cursor.is_newer_than(cursor))
+                        .is_ok_and(|pending_cursor| pending_cursor.is_newer(cursor))
                 });
             }
             None => {
@@ -221,14 +220,14 @@ impl<C: RepliconDiffable> HistoryDiffReceiver<C> {
         }
         if let Some(base_cursor) = self.base_cursor {
             self.diff_ticks
-                .retain(|(cursor, _)| cursor.is_newer_than(base_cursor));
+                .retain(|(cursor, _)| cursor.is_newer(base_cursor));
         }
         self.diff_ticks
             .retain(|(_, cursor_tick)| *cursor_tick >= tick);
         let base_cursor = self.base_cursor;
         self.pending.retain(|pending| {
             pending.cursor().is_ok_and(|cursor| {
-                base_cursor.is_none_or(|base_cursor| cursor.is_newer_than(base_cursor))
+                base_cursor.is_none_or(|base_cursor| cursor.is_newer(base_cursor))
             })
         });
     }
@@ -278,7 +277,7 @@ impl<C: RepliconDiffable> HistoryDiffReceiver<C> {
         }
 
         if let Some(base_cursor) = self.base_cursor
-            && base_cursor.is_newer_than(pending.base_cursor())
+            && base_cursor.is_newer(pending.base_cursor())
         {
             let retained_first_diff = base_cursor + 1;
             let drop_count = retained_first_diff.distance_after(pending.first_diff_index) as usize;
@@ -359,7 +358,7 @@ impl<C: RepliconDiffable> HistoryDiffReceiver<C> {
 
     fn is_retired_cursor(&self, cursor: DiffIndex) -> bool {
         self.base_cursor
-            .is_some_and(|base_cursor| cursor == base_cursor || !cursor.is_newer_than(base_cursor))
+            .is_some_and(|base_cursor| cursor == base_cursor || !cursor.is_newer(base_cursor))
     }
 
     fn has_removal_between(

--- a/crates/replication/replication/src/lib.rs
+++ b/crates/replication/replication/src/lib.rs
@@ -227,8 +227,15 @@ pub struct LightyearRepliconServerBackend;
 #[cfg(feature = "server")]
 impl Plugin for LightyearRepliconServerBackend {
     fn build(&self, app: &mut bevy_app::prelude::App) {
+        // We enable this Replicon setting when prediction/interpolation is active:
+        // - replication mutations are sent every RepliconTick, even if there were 0 mutations.
+        //   This avoids situations where a client mispredicted something, and the sender does
+        //   not send any further corrections because nothing changed.
+        // - it adds a `ServerMutateTicks` resource on the receiver that keeps track of the ticks
+        //   where the receiver received any messages.
         app.add_plugins(bevy_replicon::server::ServerPlugin {
             tick_schedule: None,
+            track_mutate_messages: cfg!(any(feature = "prediction", feature = "interpolation")),
             ..Default::default()
         });
         app.add_plugins(server::RepliconServerPlugin);

--- a/crates/replication/replication/src/send.rs
+++ b/crates/replication/replication/src/send.rs
@@ -27,8 +27,6 @@ use bevy_replicon::server::visibility::client_visibility::ClientVisibility;
 use bevy_replicon::server::visibility::filters_mask::FilterBit;
 use bevy_replicon::server::visibility::registry::FilterRegistry;
 use bevy_replicon::shared::replication::registry::ReplicationRegistry;
-#[cfg(any(feature = "prediction", feature = "interpolation"))]
-use bevy_replicon::shared::replication::track_mutate_messages::TrackAppExt;
 use bevy_time::Time;
 use core::ops::Deref;
 use lightyear_connection::client::PeerMetadata;
@@ -1088,15 +1086,6 @@ impl Plugin for SendPlugin {
         );
         #[cfg(feature = "server")]
         app.add_observer(emulate_replicate_on_host_client_added);
-
-        #[cfg(any(feature = "prediction", feature = "interpolation"))]
-        // We enable this replicon setting that does a few things:
-        // - replication mutations are sent every RepliconTick, even if there were 0 mutations. This is to avoid
-        //   situations where a client mispredicted something, and there is no correct since the sender didn't send
-        //   any further updates
-        // - it adds a `ServerMutateTicks` resource on the receiver that keeps track of the ticks where the receiver
-        //   received any messages
-        app.track_mutate_messages();
 
         // make sure that any ordering relative to ReplicationSystems is also applied to ServerSystems
         app.configure_sets(

--- a/crates/replication/replication/src/server.rs
+++ b/crates/replication/replication/src/server.rs
@@ -10,14 +10,12 @@ use lightyear_connection::client_of::ClientOf;
 use lightyear_connection::host::HostClient;
 use lightyear_connection::server::{Started, Stopped};
 use lightyear_core::id::RemoteId;
-use lightyear_core::prelude::LocalTimeline;
 use lightyear_link::prelude::Server;
 use lightyear_transport::channel::receivers::ChannelReceive;
 use lightyear_transport::plugin::TransportSystems;
 use lightyear_transport::prelude::Transport;
 
 use crate::channels::RepliconChannelMap;
-use crate::checkpoint::{SERVER_PAYLOAD_HEADER_LEN, wrap_server_payload};
 use lightyear_messages::plugin::MessageSystems;
 use tracing::trace;
 
@@ -47,7 +45,10 @@ impl Plugin for RepliconServerPlugin {
         );
         app.add_systems(
             PostUpdate,
-            send_server_packets.in_set(ServerSystems::SendPackets),
+            (
+                crate::checkpoint::write_authoritative_tick_userdata.before(ServerSystems::Send),
+                send_server_packets.in_set(ServerSystems::SendPackets),
+            ),
         );
 
         app.configure_sets(
@@ -80,8 +81,8 @@ fn on_client_connected(
     for (entity, remote_id) in remotes.iter() {
         commands.entity(entity).insert((
             ConnectedClient {
-                max_size: lightyear_transport::packet::packet_builder::MAX_UNFRAGMENTED_PAYLOAD_SIZE
-                    - SERVER_PAYLOAD_HEADER_LEN,
+                max_size:
+                    lightyear_transport::packet::packet_builder::MAX_UNFRAGMENTED_PAYLOAD_SIZE,
             },
             NetworkId::new(remote_id.to_bits()),
         ));
@@ -133,19 +134,11 @@ fn receive_server_packets(
 /// Drains `ServerMessages` and sends on server_channels (Updates, Mutations).
 fn send_server_packets(
     channel_map: Res<RepliconChannelMap>,
-    timeline: Res<LocalTimeline>,
     mut server_messages: ResMut<ServerMessages>,
     mut transports: Query<&mut Transport, With<ClientOf>>,
 ) {
     for (client, channel_idx, message) in server_messages.drain_sent() {
         let (channel_kind, _) = channel_map.server_channels[channel_idx];
-        let message = match channel_idx {
-            // Replicon channels 0/1 feed ConfirmHistory / ServerMutateTicks on the client.
-            // Prefix them with the authoritative server Lightyear tick so prediction can later
-            // translate Replicon checkpoint ticks back into simulation time.
-            0 | 1 => wrap_server_payload(timeline.tick(), message),
-            _ => message,
-        };
         trace!(
             "send_server_packets: sending {} bytes on channel_idx={} to {:?}",
             message.len(),

--- a/crates/replication/replication/tests/checkpoint.rs
+++ b/crates/replication/replication/tests/checkpoint.rs
@@ -1,12 +1,8 @@
-use alloc::vec::Vec;
-use bytes::Bytes;
 use lightyear_core::tick::Tick;
 use lightyear_replication::checkpoint::{
-    CheckpointError, ReplicationCheckpointHeader, ReplicationCheckpointMap,
-    extract_server_replicon_tick, unwrap_server_payload, wrap_server_payload,
+    CheckpointError, ReplicationCheckpointMap, decode_authoritative_tick, encode_authoritative_tick,
 };
 
-use bevy_replicon::postcard_utils;
 use bevy_replicon::prelude::RepliconTick;
 
 extern crate alloc;
@@ -24,53 +20,16 @@ fn checkpoint_map_prunes_old_entries() {
 }
 
 #[test]
-fn update_payload_roundtrip_preserves_bytes_and_tick() {
-    let replicon_tick = RepliconTick::new(77);
-    let mut payload = Vec::new();
-    payload.push(0b0000_1000);
-    postcard_utils::to_extend_mut(&replicon_tick, &mut payload).unwrap();
-    payload.extend_from_slice(&[1, 2, 3, 4]);
-    let payload = Bytes::from(payload);
+fn authoritative_tick_userdata_roundtrips() {
+    let bytes = encode_authoritative_tick(Tick(55));
 
-    let wrapped = wrap_server_payload(Tick(42), payload.clone());
-    let (header, inner) = unwrap_server_payload(wrapped).unwrap();
-
-    assert_eq!(header, ReplicationCheckpointHeader::new(Tick(42)));
-    assert_eq!(inner, payload);
-    assert_eq!(
-        extract_server_replicon_tick(0, &inner).unwrap(),
-        replicon_tick
-    );
+    assert_eq!(decode_authoritative_tick(&bytes), Ok(Tick(55)));
 }
 
 #[test]
-fn mutation_payload_roundtrip_preserves_bytes_and_tick() {
-    let update_tick = RepliconTick::new(10);
-    let message_tick = RepliconTick::new(11);
-    let mut payload = Vec::new();
-    postcard_utils::to_extend_mut(&update_tick, &mut payload).unwrap();
-    postcard_utils::to_extend_mut(&message_tick, &mut payload).unwrap();
-    postcard_utils::to_extend_mut(&3usize, &mut payload).unwrap();
-    payload.extend_from_slice(&[9, 8, 7]);
-    let payload = Bytes::from(payload);
-
-    let wrapped = wrap_server_payload(Tick(55), payload.clone());
-    let (header, inner) = unwrap_server_payload(wrapped).unwrap();
-
-    assert_eq!(header, ReplicationCheckpointHeader::new(Tick(55)));
-    assert_eq!(inner, payload);
+fn invalid_authoritative_tick_userdata_is_rejected() {
     assert_eq!(
-        extract_server_replicon_tick(1, &inner).unwrap(),
-        message_tick
-    );
-}
-
-#[test]
-fn malformed_payload_is_rejected() {
-    let payload = Bytes::from_static(b"bad");
-
-    assert_eq!(
-        unwrap_server_payload(payload),
-        Err(CheckpointError::MissingHeader)
+        decode_authoritative_tick(&[1, 2, 3]),
+        Err(CheckpointError::InvalidUserdataLength(3))
     );
 }

--- a/crates/tests/src/client_server/input/bei.rs
+++ b/crates/tests/src/client_server/input/bei.rs
@@ -234,17 +234,6 @@ fn test_bound_action_spawned_from_received_context_sends_inputs_after_mapping() 
         .spawn((BEIContext, Replicate::to_clients(NetworkTarget::All)))
         .id();
 
-    let server_action = stepper
-        .server_app
-        .world_mut()
-        .spawn((
-            ActionOf::<BEIContext>::new(server_entity),
-            Action::<BEIAction1>::default(),
-            PreSpawned::new(TEST_HASH),
-            Replicate::to_clients(NetworkTarget::All),
-        ))
-        .id();
-
     stepper.frame_step(3);
 
     let client_entity = stepper
@@ -254,6 +243,13 @@ fn test_bound_action_spawned_from_received_context_sends_inputs_after_mapping() 
         .entity_mapper
         .get_local(server_entity)
         .expect("context entity should be replicated to client");
+
+    stepper.server_app.world_mut().spawn((
+        ActionOf::<BEIContext>::new(server_entity),
+        Action::<BEIAction1>::default(),
+        PreSpawned::new(TEST_HASH),
+        Replicate::to_clients(NetworkTarget::All),
+    ));
 
     let client_action = stepper
         .client_app()


### PR DESCRIPTION
## Summary
- point `bevy_replicon` at `simgine/bevy_replicon` `master` for the replication userdata API
- write Lightyear `Tick` values through Replicon `ReplicationUserdata` and read them from `UserdataReceived`
- remove Lightyear payload wrapping/parsing and centralize `track_mutate_messages` configuration
- update the BEI prespawn input test to wait for the replicated context before spawning the matched action

## Tests
- `cargo fmt --check`
- `git diff --check`
- `cargo test -p lightyear_replication --features client,server,prediction,interpolation`
- `cargo test -p lightyear_prediction`
- `cargo test -p lightyear_interpolation`
- `cargo test -p lightyear_tests --lib -- --test-threads=1`