### PR TITLE
fix(transport): Use ping/pong only for RTT estimates

### DIFF
--- a/crates/core/sync/src/ping/diagnostics.rs
+++ b/crates/core/sync/src/ping/diagnostics.rs
@@ -35,7 +35,7 @@ impl PingDiagnosticsPlugin {
     pub const PONGS_RECEIVED: DiagnosticPath =
         DiagnosticPath::const_new("ping.pong_received_count");
 
-    /// Number of RTT samples received from pongs or packet acknowledgements.
+    /// Number of RTT samples received from pongs.
     pub const LATENCY_SAMPLES_RECEIVED: DiagnosticPath =
         DiagnosticPath::const_new("ping.latency_sample_count");
 

--- a/crates/core/sync/src/ping/manager.rs
+++ b/crates/core/sync/src/ping/manager.rs
@@ -30,7 +30,7 @@ impl Default for PingConfig {
 }
 
 /// The [`PingManager`] is responsible for sending regular pings to the remote machine,
-/// and monitor pongs in order to estimate statistics (rtt, jitter) about the connection.
+/// and monitoring pongs in order to estimate statistics (RTT, jitter) about the connection.
 #[derive(Debug, Component)]
 #[require(MessageSender<Ping>, MessageReceiver<Ping>, MessageSender<Pong>, MessageReceiver<Pong>)]
 pub struct PingManager {
@@ -45,13 +45,13 @@ pub struct PingManager {
     /// (when the connection's send_timer is ready)
     pongs_to_send: Vec<(Pong, Instant)>,
 
-    /// Estimator used to compute RTT/Jitter from pongs and packet acknowledgements.
+    /// Estimator used to compute RTT/Jitter from explicit Ping/Pong messages.
     pub rtt_estimator_ewma: RttEstimatorEwma,
     /// The number of pings we have sent
     pub(crate) pings_sent: u32,
     /// The number of pongs we have received
     pub pongs_recv: u32,
-    /// The number of latency samples received from pongs or packet acknowledgements.
+    /// The number of Ping/Pong latency samples used by the estimator.
     latency_samples_recv: u32,
 }
 
@@ -124,22 +124,6 @@ impl PingManager {
     fn record_rtt_sample(&mut self, rtt_sample: Duration) {
         self.latency_samples_recv += 1;
         self.rtt_estimator_ewma.update_with_new_sample(rtt_sample);
-    }
-
-    /// Process an RTT sample measured from an ordinary packet acknowledgement.
-    pub fn process_packet_rtt_sample(&mut self, rtt_sample: Duration) {
-        self.record_rtt_sample(rtt_sample);
-        trace!(
-            target: "lightyear_debug::sync",
-            kind = "packet_ack_rtt_sample",
-            schedule = "PreUpdate",
-            sample_point = "PreUpdate",
-            rtt_sample_ms = rtt_sample.as_secs_f64() * 1000.0,
-            latency_samples_recv = self.latency_samples_recv,
-            estimated_rtt_ms = self.rtt().as_secs_f64() * 1000.0,
-            jitter_ms = self.jitter().as_secs_f64() * 1000.0,
-            "processed packet ack RTT sample"
-        );
     }
 
     /// Check if we are ready to send a ping to the remote
@@ -234,123 +218,4 @@ impl PingManager {
     pub(crate) fn take_pending_pongs(&mut self) -> Vec<(Pong, Instant)> {
         core::mem::take(&mut self.pongs_to_send)
     }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn packet_ack_rtt_samples_update_latency_stats_without_pongs() {
-        let mut ping_manager = PingManager::default();
-
-        ping_manager.process_packet_rtt_sample(Duration::from_millis(50));
-
-        assert_eq!(ping_manager.pongs_recv, 0);
-        assert_eq!(ping_manager.latency_samples_recv(), 1);
-        assert_eq!(ping_manager.rtt(), Duration::from_millis(50));
-        assert_eq!(
-            ping_manager.jitter(),
-            Duration::from_millis(12) + Duration::from_micros(500)
-        );
-    }
-
-    // #[test]
-    // fn test_send_pings() {
-    //     let config = PingConfig {
-    //         ping_interval: Duration::from_millis(100),
-    //         stats_buffer_duration: Duration::from_secs(4),
-    //     };
-    //     let mut ping_manager = PingManager::new(config, Duration::default());
-    //     let mut real = Time::<Real>::default();
-    //     real.update();
-    //
-    //     assert_eq!(ping_manager.maybe_prepare_ping(real.last_update().unwrap()), None);
-    //
-    //     let delta = Duration::from_millis(100);
-    //     real.update_with_duration(delta);
-    //     ping_manager.update(&real);
-    //
-    //     // send pings
-    //     assert_eq!(
-    //         ping_manager.maybe_prepare_ping(real.last_update().unwrap()),
-    //         Some(Ping { id: PingId(0) })
-    //     );
-    //     let delta = Duration::from_millis(60);
-    //     real.update_with_duration(delta);
-    //     ping_manager.update(&real);
-    //
-    //     // ping timer hasn't gone off yet, send nothing
-    //     assert_eq!(ping_manager.maybe_prepare_ping(real.last_update().unwrap()), None);
-    //     real.update_with_duration(delta);
-    //     ping_manager.update(&real);
-    //     assert_eq!(
-    //         ping_manager.maybe_prepare_ping(real.last_update().unwrap()),
-    //         Some(Ping { id: PingId(1) })
-    //     );
-    //
-    //     let delta = Duration::from_millis(100);
-    //     real.update_with_duration(delta);
-    //     ping_manager.update(&real);
-    //     assert_eq!(
-    //         ping_manager.maybe_prepare_ping(real.last_update().unwrap()),
-    //         Some(Ping { id: PingId(2) })
-    //     );
-    //
-    //     // we sent all the pings we need
-    //     assert_eq!(ping_manager.maybe_prepare_ping(real.last_update().unwrap()), None);
-    //
-    //     // check ping store
-    //     assert_eq!(
-    //         ping_manager.ping_store.remove(PingId(0)),
-    //         Some(Duration::from_millis(100))
-    //     );
-    //     assert_eq!(
-    //         ping_manager.ping_store.remove(PingId(1)),
-    //         Some(Duration::from_millis(220))
-    //     );
-    //     assert_eq!(
-    //         ping_manager.ping_store.remove(PingId(2)),
-    //         Some(Duration::from_millis(320))
-    //     );
-    //
-    //     // receive pongs
-    //     // TODO
-    // }
-
-    // #[test]
-    // fn test_ping_manager() {
-    //     let ping_config = PingConfig {
-    //         ping_interval_ms: Duration::from_millis(100),
-    //         rtt_ms_initial_estimate: Duration::from_millis(10),
-    //         jitter_ms_initial_estimate: Default::default(),
-    //         rtt_smoothing_factor: 0.0,
-    //     };
-    //     let mut ping_manager = PingManager::new(&ping_config);
-    //     // let tick_config = TickConfig::new(Duration::from_millis(16));
-    //     let mut time_manager = TimeManager::new(Duration::default());
-    //
-    //     assert!(!ping_manager.should_send_ping());
-    //     let delta = Duration::from_millis(100);
-    //     ping_manager.update(delta);
-    //     time_manager.update(delta, Duration::default());
-    //     assert!(ping_manager.should_send_ping());
-    //
-    //     let ping_message = ping_manager.prepare_ping(&time_manager);
-    //     assert!(!ping_manager.should_send_ping());
-    //     assert_eq!(ping_message.id, PingId(0));
-    //
-    //     let delta = Duration::from_millis(20);
-    //     ping_manager.update(delta);
-    //     time_manager.update(delta, Duration::default());
-    //     let pong_message = Pong {
-    //         ping_id: PingId(0),
-    //         tick: Default::default(),
-    //         offset_sec: 0.0,
-    //     };
-    //     ping_manager.process_pong(pong_message, &time_manager);
-    //
-    //     assert_eq!(ping_manager.rtt_ms_average, 0.9 * 10.0 + 0.1 * 20.0);
-    //     assert_eq!(ping_manager.jitter_ms_average, 0.9 * 0.0 + 0.1 * 5.0);
-    // }
 }

--- a/crates/core/sync/src/ping/plugin.rs
+++ b/crates/core/sync/src/ping/plugin.rs
@@ -16,7 +16,6 @@ use lightyear_messages::plugin::MessageSystems;
 use lightyear_messages::prelude::AppMessageExt;
 use lightyear_messages::receive::MessageReceiver;
 use lightyear_messages::send::MessageSender;
-use lightyear_transport::plugin::PacketAcked;
 use lightyear_transport::prelude::{AppChannelExt, ChannelMode, ChannelSettings};
 #[allow(unused_imports)]
 use tracing::{info, trace};
@@ -140,12 +139,6 @@ impl PingPlugin {
             manager.reset();
         }
     }
-
-    pub(crate) fn process_packet_ack(trigger: On<PacketAcked>, mut query: Query<&mut PingManager>) {
-        if let Ok(mut manager) = query.get_mut(trigger.entity) {
-            manager.process_packet_rtt_sample(trigger.rtt_sample);
-        }
-    }
 }
 
 impl Plugin for PingPlugin {
@@ -163,10 +156,10 @@ impl Plugin for PingPlugin {
         app.register_message_to_bytes::<Pong>()
             .add_direction(NetworkDirection::Bidirectional);
 
-        // NOTE: the Transport's PacketBuilder needs accurate LinkStats to function correctly.
-        //   Theoretically anything can modify the LinkStats but in practice it's done in the PingManager
-        //   so we make the Transport require a PingManager.
-        //   Maybe we should error if TransportPlugin is added without PingPlugin?
+        // NOTE: LinkStats are derived from explicit Ping/Pong messages, not transport packet ACKs.
+        // Traffic packet ACKs are piggybacked on the peer's next outbound packet; if the peer has
+        // nothing to send on the frame it receives a packet, the ACK is delayed and the measured
+        // RTT includes that wait. Keep ACK timing as transport telemetry, not canonical RTT.
 
         // We used to have Client -> InputTimeline -> PingManager -> MessageSender<Ping> -> MessageManager -> Transport -> [Link, LocalTimeline]
         // but it is not possible anymore since we also have a Transport -> PingManager dependency and cyclic dependencies are not allowed anymore.
@@ -189,6 +182,35 @@ impl Plugin for PingPlugin {
         app.add_systems(PostUpdate, Self::send.in_set(PingSystems::Send));
 
         app.add_observer(Self::handle_connect);
-        app.add_observer(Self::process_packet_ack);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lightyear_transport::plugin::PacketAcked;
+
+    #[test]
+    fn traffic_packet_ack_bursts_do_not_update_ping_rtt() {
+        let mut app = App::new();
+        app.add_plugins(PingPlugin);
+
+        let entity = app.world_mut().spawn(PingManager::default()).id();
+
+        // Turn-heavy gameplay can acknowledge many ordinary transport packets. These ACK RTT
+        // samples are intentionally ignored by the ping estimator; only explicit Ping/Pong samples
+        // should drive `LinkStats`.
+        for packet_id in 1..=120 {
+            app.world_mut().trigger(PacketAcked {
+                entity,
+                packet_id,
+                rtt_sample: Duration::from_millis(50 + u64::from(packet_id)),
+            });
+        }
+
+        let manager = app.world().entity(entity).get::<PingManager>().unwrap();
+        assert_eq!(manager.pongs_recv, 0);
+        assert_eq!(manager.latency_samples_recv(), 0);
+        assert_eq!(manager.rtt(), Duration::ZERO);
     }
 }

--- a/crates/tests/src/timeline/sync_tests.rs
+++ b/crates/tests/src/timeline/sync_tests.rs
@@ -73,10 +73,9 @@ fn input_timeline_initial_sync_resyncs_to_objective() {
 }
 
 #[test_log::test]
-fn input_timeline_sync_uses_packet_latency_samples_without_pongs() {
+fn input_timeline_sync_waits_for_ping_latency_samples() {
     let remote = remote_timeline_at(100);
-    let mut ping_manager = PingManager::default();
-    ping_manager.process_packet_rtt_sample(Duration::ZERO);
+    let ping_manager = PingManager::default();
     let config = InputTimelineConfig::default().with_sync_config(SyncConfig {
         handshake_pings: 1,
         ..Default::default()
@@ -86,9 +85,9 @@ fn input_timeline_sync_uses_packet_latency_samples_without_pongs() {
     let tick_delta = timeline.sync(&remote, &config, &ping_manager, TICK_DURATION);
 
     assert_eq!(ping_manager.pongs_recv, 0);
-    assert_eq!(ping_manager.latency_samples_recv(), 1);
-    assert_eq!(tick_delta, Some(103));
-    assert!(timeline.is_synced());
+    assert_eq!(ping_manager.latency_samples_recv(), 0);
+    assert_eq!(tick_delta, None);
+    assert!(!timeline.is_synced());
 }
 
 #[test_log::test]

--- a/crates/transport/transport/src/packet/priority_manager.rs
+++ b/crates/transport/transport/src/packet/priority_manager.rs
@@ -228,3 +228,55 @@ impl PriorityManager {
         true
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::channel::builder::{ChannelMode, ChannelSettings};
+    use bytes::Bytes;
+
+    struct PingLikeChannel;
+    struct TurnTrafficChannel;
+
+    #[test]
+    fn infinite_priority_messages_are_ordered_before_traffic_bursts() {
+        let mut registry = ChannelRegistry::default();
+        let (_, ping_channel) = registry.add_channel::<PingLikeChannel>(ChannelSettings {
+            mode: ChannelMode::UnorderedUnreliable,
+            priority: f32::INFINITY,
+            ..Default::default()
+        });
+        let (_, traffic_channel) = registry.add_channel::<TurnTrafficChannel>(ChannelSettings {
+            mode: ChannelMode::UnorderedUnreliable,
+            priority: 1.0,
+            ..Default::default()
+        });
+        let mut manager = PriorityManager::new(PriorityConfig::new(1024));
+
+        manager.buffer_messages(
+            traffic_channel,
+            (0..120)
+                .map(|index| SendMessage {
+                    priority: 1.0,
+                    data: SingleData::new(None, Bytes::from(vec![index as u8; 8])).into(),
+                })
+                .collect(),
+            VecDeque::new(),
+        );
+        manager.buffer_messages(
+            ping_channel,
+            VecDeque::from([SendMessage {
+                priority: 1.0,
+                data: SingleData::new(None, Bytes::from_static(b"ping")).into(),
+            }]),
+            VecDeque::new(),
+        );
+
+        let (single_data, fragment_data) = manager.prioritize(&registry);
+
+        assert!(fragment_data.is_empty());
+        let (channel, messages) = single_data.first().expect("expected at least one message");
+        assert_eq!(*channel, ping_channel);
+        assert_eq!(messages[0].bytes, Bytes::from_static(b"ping"));
+    }
+}


### PR DESCRIPTION
We had switched in the past to computing RTT from all packets, but that was incorrect. The server might wait an inderteminate amount of time before sending back a packet, so the estimation won't be accurate.

Reverting to only computing RTT from ping/pong packets.