### PR TITLE
Emit event on packet lost

### DIFF
--- a/crates/core/lightyear/src/lib.rs
+++ b/crates/core/lightyear/src/lib.rs
@@ -282,6 +282,10 @@ pub mod steam {
     pub use lightyear_steam::*;
 }
 
+pub mod transport {
+    pub use lightyear_transport::*;
+}
+
 #[cfg(feature = "webtransport")]
 pub mod webtransport {
     pub use lightyear_webtransport::*;

--- a/crates/transport/transport/src/plugin.rs
+++ b/crates/transport/transport/src/plugin.rs
@@ -61,6 +61,14 @@ pub struct PacketAcked {
     pub rtt_sample: Duration,
 }
 
+/// Event triggered on a [`Transport`] entity when a sent packet is presumed lost
+/// (its acknowledgement did not arrive before the nack timeout).
+#[derive(EntityEvent)]
+pub struct PacketLost {
+    pub entity: Entity,
+    pub packet_id: u32,
+}
+
 pub struct TransportPlugin;
 
 impl TransportPlugin {
@@ -122,6 +130,18 @@ impl TransportPlugin {
                             packet_loss = true,
                             "transport packet marked lost"
                         );
+                        #[cfg(feature = "std")]
+                        par_commands.command_scope(|mut commands| {
+                            commands.trigger(PacketLost {
+                                entity,
+                                packet_id: lost_packet.0,
+                            });
+                        });
+                        #[cfg(not(feature = "std"))]
+                        commands.trigger(PacketLost {
+                            entity,
+                            packet_id: lost_packet.0,
+                        });
                         if let Some(message_map) =
                             transport.packet_to_message_map.remove(&lost_packet)
                         {


### PR DESCRIPTION
Create a `PacketLost` event that gets emitted when lightyear believes that packet is lost. A packet is lost when its ack does not arrive before the nack timeout.

Also re-export lightyear_transport as `lightyear::transport` so the packet events are reachable through the facade crate.

Fixes #1548.