### PR TITLE
Support fitting `LinkConditionerConfig` over real network data

### DIFF
--- a/crates/io/link/src/conditioner.rs
+++ b/crates/io/link/src/conditioner.rs
@@ -1,10 +1,12 @@
 //! Receive-side packet conditioning for simulated network latency, jitter, and loss.
 
+use alloc::vec::Vec;
 use bevy_reflect::Reflect;
 use core::time::Duration;
 use lightyear_core::time::Instant;
 use lightyear_utils::ready_buffer::ReadyBuffer;
-use rand::RngExt;
+use rand::{RngExt, SeedableRng, rngs::Xoshiro256PlusPlus};
+use tracing::debug;
 
 /// The simulated link's current condition. Used as the good/bad state in the
 /// Gilbert–Elliott model for determining probability of packet loss (See
@@ -85,14 +87,14 @@ pub enum LinkConditionerState {
 pub struct LinkConditionerConfig {
     /// Base delay applied to incoming payloads.
     ///
-    /// The conditioner currently schedules packets with millisecond precision by using
-    /// [`Duration::as_millis`]. For symmetric client/server simulations this is usually configured
+    /// The conditioner schedules packets with microsecond precision by using
+    /// [`Duration::as_micros`]. For symmetric client/server simulations this is usually configured
     /// as half of the desired round-trip time.
     pub incoming_latency: Duration,
 
     /// Maximum random delay variation applied around [`incoming_latency`](Self::incoming_latency).
     ///
-    /// For each payload, a random millisecond offset in `[-incoming_jitter, incoming_jitter)` is
+    /// For each payload, a random microsecond offset in `[-incoming_jitter, incoming_jitter)` is
     /// added to the base latency. Negative results are clamped by scheduling the packet at the
     /// current instant rather than in the past.
     pub incoming_jitter: Duration,
@@ -114,12 +116,58 @@ pub struct LinkConditionerConfig {
     pub bad_to_good: f32,
 }
 
+/// The resolved fate of one sent packet, as observed by the sender.
+///
+/// If you're trying to capture network data to feed into
+/// [`LinkConditionerConfig::fit`], construct one `ResolvedPacket` every time a
+/// packet gets acknowledged or presumed lost.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ResolvedPacket {
+    /// Transport-level sequence number. Consecutive per link.
+    pub packet_id: u32,
+
+    /// Measured round-trip time if the packet was acknowledged. Set to
+    /// `None` if it was presumed lost.
+    pub rtt: Option<Duration>,
+}
+
+/// Minimum number of observed loss runs (groups of one or more consecutive
+/// lost packets) before [`fit`](LinkConditionerConfig::fit) will treat
+/// clumped losses as real bursts rather than independent losses that
+/// happened to land next to each other. With fewer runs,
+/// [`fit`](LinkConditionerConfig::fit) falls back to
+/// [`with_fixed_loss`](LinkConditionerConfig::with_fixed_loss).
+const MIN_LOSS_RUNS: usize = 20;
+
+/// Minimum number of pairs whose packets were both lost before
+/// [`fit`](LinkConditionerConfig::fit) trusts its estimate of how often the
+/// packet right after a lost packet is also lost (Gilbert's `P(1|1)`).
+///
+/// A "pair" is two packets with consecutive ids `n` and `n + 1`.
+const MIN_GILBERT_PAIRS: usize = 50;
+
+/// Minimum number of triples whose first and third packets were lost (ignoring
+/// the second packet's fate) before [`fit`](LinkConditionerConfig::fit) trusts
+/// its estimate of how often that middle packet is also lost (Gilbert's triple
+/// ratio).
+///
+/// A "triple" is three packets with consecutive ids `n`, `n + 1`, and `n + 2`.
+const MIN_GILBERT_TRIPLES: usize = 20;
+
 /// Generic receive-side packet conditioner.
 ///
-/// `LinkConditioner` delays and drops payloads according to a [`LinkConditionerConfig`].
+/// `LinkConditioner` delays and drops payloads according to a
+/// [`LinkConditionerConfig`].
 #[derive(Debug, Clone)]
 pub struct LinkConditioner<P: Eq> {
     config: LinkConditionerConfig,
+
+    /// Source of the loss, transition, and jitter draws. Owned by the
+    /// conditioner so a seeded one (see [`with_seed`](Self::with_seed))
+    /// produces reproducible packet outcomes.
+    ///
+    /// Xoshiro256++ chosen for its high performance and implements `Clone`.
+    rng: Xoshiro256PlusPlus,
 
     /// The simulated link's current Gilbert–Elliott condition, stepped once
     /// per packet by the chain probabilities in [`LinkConditionerConfig`].
@@ -136,10 +184,22 @@ pub struct LinkConditioner<P: Eq> {
 }
 
 impl<P: Eq> LinkConditioner<P> {
-    /// Creates an empty conditioner using `config`.
+    /// Creates an empty conditioner using `config`, with entropy-seeded
+    /// randomness.
     pub fn new(config: LinkConditionerConfig) -> Self {
+        Self::with_seed_internal(config, Xoshiro256PlusPlus::from_rng(&mut rand::rng()))
+    }
+
+    /// Creates an empty conditioner using `config` whose randomness is derived
+    /// from `seed`, so the packet outcomes are reproducible.
+    pub fn with_seed(config: LinkConditionerConfig, seed: u64) -> Self {
+        Self::with_seed_internal(config, Xoshiro256PlusPlus::seed_from_u64(seed))
+    }
+
+    fn with_seed_internal(config: LinkConditionerConfig, rng: Xoshiro256PlusPlus) -> Self {
         LinkConditioner {
             config,
+            rng,
             state: LinkConditionerState::default(),
             time_queue: ReadyBuffer::new(),
         }
@@ -147,11 +207,10 @@ impl<P: Eq> LinkConditioner<P> {
 
     /// Applies latency, jitter, and loss to `packet` relative to `instant`.
     ///
-    /// Dropped packets are discarded immediately. Delivered packets are queued by their simulated
-    /// delivery instant.
-    pub(crate) fn condition_packet(&mut self, packet: P, instant: Instant) {
-        let mut rng = rand::rng();
-
+    /// Dropped packets are discarded immediately and reported as `None`.
+    /// Delivered packets are queued by their simulated delivery instant, which
+    /// is returned.
+    pub(crate) fn condition_packet(&mut self, packet: P, instant: Instant) -> Option<Instant> {
         // Execute the Gilbert–Elliott model to decide packet loss. See
         // `LinkConditionerConfig` for details.
         let config = &self.config;
@@ -159,27 +218,31 @@ impl<P: Eq> LinkConditioner<P> {
             LinkConditionerState::Good => (config.good_loss, config.good_to_bad),
             LinkConditionerState::Bad => (config.bad_loss, config.bad_to_good),
         };
-        if rng.random_range(0.0..1.0) < state_transition_probability {
+        if self.rng.random_range(0.0..1.0) < state_transition_probability {
             self.state = match self.state {
                 LinkConditionerState::Good => LinkConditionerState::Bad,
                 LinkConditionerState::Bad => LinkConditionerState::Good,
             };
         }
-        if rng.random_range(0.0..1.0) < packet_loss_probability {
+        if self.rng.random_range(0.0..1.0) < packet_loss_probability {
             // Packet lost.
-            return;
+            return None;
         }
 
-        let mut latency: i32 = self.config.incoming_latency.as_millis() as i32;
+        let mut delay_us: i64 = self.config.incoming_latency.as_micros() as i64;
         let mut packet_timestamp = instant;
-        if self.config.incoming_jitter > Duration::default() {
-            let jitter: i32 = self.config.incoming_jitter.as_millis() as i32;
-            latency += rng.random_range(-jitter..jitter);
+        let jitter_us: i64 = self.config.incoming_jitter.as_micros() as i64;
+        // Check against the integer and not the `Duration`. A sub-microsecond jitter
+        // would otherwise reach random_range as the empty range 0..0,
+        // which panics.
+        if jitter_us > 0 {
+            delay_us += self.rng.random_range(-jitter_us..jitter_us);
         }
-        if latency > 0 {
-            packet_timestamp += Duration::from_millis(latency as u64);
+        if delay_us > 0 {
+            packet_timestamp += Duration::from_micros(delay_us as u64);
         }
         self.time_queue.push(packet_timestamp, packet);
+        Some(packet_timestamp)
     }
 
     /// Returns the next packet whose delivery instant has elapsed.
@@ -358,6 +421,298 @@ impl LinkConditionerConfig {
         (1.0 - stationary_bad) * self.good_loss + stationary_bad * self.bad_loss
     }
 
+    /// Fits a **one-way** configuration to `sent_packets`, the recorded
+    /// outcomes of packets sent over a single link. In other words, the
+    /// returned [`LinkConditionerConfig`] will try to simulate the network
+    /// behavior that resulted in the outcomes of `sent_packets`.
+    ///
+    /// `sent_packets` does not need to be ordered. Gaps in the packet ID
+    /// sequence are packets still unresolved at capture end and are
+    /// skipped. Lost packets at the start and end of `sent_packets` are
+    /// ignored because they are lost due to link connection/disconnection
+    /// reasons and not from the network behavior that this function is
+    /// trying to fit to.
+    ///
+    /// `rtt_overhead` is the delay introduced by lightyear's own logic
+    /// that is part of every packet's RTT:
+    ///
+    /// * The delay between lightyear receiving a packet and lightyear sending
+    ///   the ack for it (the ack is not sent until the next scheduled outgoing
+    ///   packet).
+    /// * The delay between lightyear receiving an ack and lightyear actually
+    ///   processing it.
+    ///
+    /// To simulate the captured link, install the returned configuration as
+    /// the simulated *receiver*'s [`RecvLinkConditioner`](crate::RecvLinkConditioner):
+    /// the capture observes packets sent from A to B, and a conditioner
+    /// shapes *received* traffic, so the fitted configuration belongs on B's
+    /// link.
+    ///
+    /// Returns `None` when `sent_packets` contains no acknowledged packets.
+    pub fn fit(mut sent_packets: Vec<ResolvedPacket>, rtt_overhead: Duration) -> Option<Self> {
+        sent_packets.sort_unstable_by_key(|outcome| outcome.packet_id);
+
+        Some(
+            Self::default()
+                .fit_delay(&sent_packets, rtt_overhead)?
+                .fit_loss(&sent_packets),
+        )
+    }
+
+    /// Fits the one-way latency and jitter to the acknowledged packets of
+    /// `sent_packets`, after deducting `rtt_overhead` (see [`fit`](Self::fit))
+    /// from each RTT.
+    ///
+    /// Returns `None` if none of the packets in `sent_packets` were
+    /// acknowledged. `sent_packets` does not need to be sorted.
+    fn fit_delay(self, sent_packets: &[ResolvedPacket], rtt_overhead: Duration) -> Option<Self> {
+        let mut rtts: Vec<Duration> = sent_packets
+            .iter()
+            .filter_map(|outcome| Some(outcome.rtt?.saturating_sub(rtt_overhead)))
+            .collect();
+        if rtts.is_empty() {
+            // No packets were acknowledged.
+            return None;
+        }
+        rtts.sort_unstable();
+
+        // Returns the nth percentile RTT of `rtts`.
+        //
+        // `percentile(1, 2)` returns the median RTT.
+        // `percentile(19, 20)` returns the 95th percentile RTT.
+        //
+        // Percentile defined as a ratio so the `rtts` index math is performed in
+        // integers.
+        let percentile =
+            |numerator: usize, denominator: usize| rtts[(rtts.len() - 1) * numerator / denominator];
+
+        // Half the median round trip approximates the one-way base delay.
+        //
+        // We use median rather than mean because real packet captures contain a few
+        // extreme RTTs (acks that arrived hundreds of milliseconds late), and a
+        // mean folds every one of them into the estimate, increasing the base delay
+        // above what a typical packet experiences. The median only ranks values, so
+        // a handful of stragglers cannot move it.
+        let latency = percentile(1, 2) / 2;
+
+        // The conditioner adds a random value from the range `[-jitter, jitter)`
+        // to `latency` when deciding a packet's delay. To calculate jitter we:
+        //
+        // 1. Gather the 5th and 95th percentile RTTs to filter out extreme RTTs. That's
+        //    the range of RTTs we want to simulate.
+        // 2. Measure the width of that middle-90% band using `p95 − p5`.
+        // 3. Halve it so the range reflects a one-way trip time.
+        // 4. Divide by 1.8 to solve for `jitter`. The range `[-jitter, +jitter)` has a
+        //    width of `2 * jitter`, and the conditioner takes values from it uniformly,
+        //    so *its* middle-90% band has a width of `0.9 * 2 * jitter` or `1.8 *
+        //    jitter`. Step 3 produced the width that `[-jitter, +jitter)` must match,
+        //    so `1.8 * jitter = step 3`.
+        //
+        // `(1 / 2) * (1 / 1.8) = 5 / 18`
+        let jitter = (percentile(19, 20) - percentile(1, 20)) * 5 / 18;
+
+        Some(LinkConditionerConfig {
+            incoming_latency: latency,
+            incoming_jitter: jitter,
+            ..self
+        })
+    }
+
+    /// Fits the packet loss statistics onto the most realistic loss model the
+    /// data (`sent_packets`) supports. The candidate models, from least to
+    /// most demanding of data:
+    ///
+    /// 1. Lost: Used when `sent_packets` contains no acked packets.
+    /// 2. Fixed loss probability: Used when `sample_packets` doesn't contain
+    ///    enough runs (See [`MIN_LOSS_RUNS`]).
+    /// 3. Simple Gilbert loss model: Used when `sent_packets` does not meet the
+    ///    criterias defined in [`MIN_GILBERT_PAIRS`] and
+    ///    [`MIN_GILBERT_TRIPLES`] *or* the bad-state isn't leaky.
+    /// 4. Gilbert loss model: Used when `sent_packets` meets the criterias
+    ///    defined in [`MIN_GILBERT_PAIRS`] and [`MIN_GILBERT_TRIPLES`] and the
+    ///    bad-state is leaky.
+    ///
+    /// We don't try to fit the full Gilbert–Elliott model. Estimating its
+    /// extra parameter, the packet-loss probability floor that gets applied
+    /// even in the good state, requires an unrealistic amount of captured
+    /// data, because a small floor is nearly indistinguishable from
+    /// frequent, short bad-state visits. Callers who know the floor from an
+    /// independent source can apply
+    /// [`with_gilbert_elliott_loss`](Self::with_gilbert_elliott_loss) to the
+    /// fitted configuration themselves.
+    fn fit_loss(self, sent_packets: &[ResolvedPacket]) -> Self {
+        // Trim the initial and last lost packets because their loss isn't the result of
+        // network traffic and so they shouldn't be considered. The link is not in a
+        // steady state while connecting and a disconnection triggers nacks for
+        // every pending packet.
+        let Some(first) = sent_packets
+            .iter()
+            .position(|outcome| outcome.rtt.is_some())
+        else {
+            // All packets were lost.
+            debug!("All packets were lost; fitting total fixed loss");
+            return self.with_fixed_loss(1.0);
+        };
+        let last = sent_packets
+            .iter()
+            .rposition(|outcome| outcome.rtt.is_some())
+            .expect("Failed to find last packet despite finding a first packet");
+        let sent_packets = &sent_packets[first..=last];
+
+        // A "run" is a maximal stretch of lost packets with consecutive
+        // packet ids, bounded on each side by a delivered packet or an id
+        // gap (an unresolved packet).
+        let mut run_count = 0usize;
+        let mut in_run = false;
+        let mut lost_count = 0usize;
+        let mut prev_id: Option<u32> = None;
+        for outcome in sent_packets {
+            if prev_id.is_none_or(|id| id.wrapping_add(1) != outcome.packet_id) {
+                in_run = false;
+            }
+            if outcome.rtt.is_none() {
+                lost_count += 1;
+                if !in_run {
+                    run_count += 1;
+                    in_run = true;
+                }
+            } else {
+                in_run = false;
+            }
+            prev_id = Some(outcome.packet_id);
+        }
+
+        if lost_count == 0 {
+            // No packets were lost so there's no probability of losing a packet.
+            return self.with_fixed_loss(0.0);
+        }
+        let mean_loss = lost_count as f64 / sent_packets.len() as f64;
+        if run_count < MIN_LOSS_RUNS {
+            // With this few runs, clumped losses can't be told apart from independent
+            // losses that landed next to each other by chance, so stick to a
+            // fixed loss probability.
+            debug!(
+                run_count,
+                MIN_LOSS_RUNS,
+                "Too few loss runs to trust burst statistics; fitting a fixed loss probability"
+            );
+            return self.with_fixed_loss(mean_loss as f32);
+        }
+
+        // Number of pairs whose first packet was lost. The second packet may or may not
+        // be lost.
+        let mut pairs_1x_count = 0usize;
+
+        // Number of pairs whose both packets were lost.
+        let mut pairs_11_count = 0usize;
+
+        // Collect statistics on "pairs". A "pair" is two packets with ids `n, n + 1`.
+        for window in sent_packets.windows(2) {
+            if window[0].packet_id.wrapping_add(1) != window[1].packet_id {
+                continue;
+            }
+            if window[0].rtt.is_none() {
+                pairs_1x_count += 1;
+                if window[1].rtt.is_none() {
+                    pairs_11_count += 1;
+                }
+            }
+        }
+
+        // Number of triples whose first and third packets were lost. The second packet
+        // may or may not be lost.
+        let mut triples_1x1_count = 0usize;
+
+        // Number of triples whose packets were all lost.
+        let mut triples_111_count = 0usize;
+
+        // Collect statistics on "triples". A "triple" is three packets with ids `n, n +
+        // 1, n + 2`.
+        for window in sent_packets.windows(3) {
+            if window[0].packet_id.wrapping_add(1) != window[1].packet_id
+                || window[1].packet_id.wrapping_add(1) != window[2].packet_id
+            {
+                continue;
+            }
+            if window[0].rtt.is_none() && window[2].rtt.is_none() {
+                triples_1x1_count += 1;
+                if window[1].rtt.is_none() {
+                    triples_111_count += 1;
+                }
+            }
+        }
+
+        if pairs_11_count >= MIN_GILBERT_PAIRS && triples_1x1_count >= MIN_GILBERT_TRIPLES {
+            // There is enough data to fit the Gilbert model, which allows a leaky bad state
+            // (a bad state that may deliver some packets instead of dropping them all). If
+            // the bad state is leaky, the size of a run may be less than the stretch of
+            // packets the chain spent in the bad state (a bad-state visit). If
+            // the bad state weren't leaky (an assumption that the simple Gilbert model
+            // makes), a run would be exactly a visit, so run sizes alone would determine
+            // the visit length. Since leakiness can't be ruled out just yet, the visit
+            // length and the bad-state loss probability are recovered from conditional
+            // statistics rather than from the runs.
+
+            // Gilbert's measured statistics (Hasslinger & Hohlfeld, MMB 2008,
+            // Eq. 3).
+            let a = mean_loss;
+            let b = pairs_11_count as f64 / pairs_1x_count as f64;
+            let c = triples_111_count as f64 / triples_1x1_count as f64;
+
+            // Gilbert's closed-form solve (Hasslinger & Hohlfeld, MMB 2008,
+            // Eq. 4). The paper solves for `h` (the bad state's *delivery* probability).
+            // `bad_loss` is the complement, `1 - h = b / (1 - r)`.
+            let one_minus_r = (a * c - b * b) / (2.0 * a * c - b * (a + c));
+            let bad_loss = (b / one_minus_r) as f32;
+
+            // Bad-state visits are geometrically distributed, so the mean
+            // visit length is `1 / r` (Hasslinger & Hohlfeld, MMB 2008, Sec. 3:
+            // `r = 1/ABEL`). The loss constructor turns it back into the chain
+            // probabilities.
+            let mean_bad_len = (1.0 / (1.0 - one_minus_r)) as f32;
+
+            // Short or irregular traces are known to solve outside the valid
+            // ranges (Gilbert notes this; the estimators are ratios of small
+            // counts). Fall through to the burst-only rung when they do.
+            if one_minus_r.is_finite()
+                && mean_bad_len.is_finite()
+                && mean_bad_len >= 1.0
+                && bad_loss > mean_loss as f32
+                && bad_loss <= 1.0
+            {
+                debug!(
+                    mean_loss,
+                    mean_bad_len, bad_loss, "Fitting a Gilbert loss model"
+                );
+                return self.with_gilbert_loss(mean_loss as f32, mean_bad_len, bad_loss);
+            }
+            debug!(
+                one_minus_r,
+                bad_loss,
+                mean_bad_len,
+                "The Gilbert solve fell outside valid probabilities; falling back to simple Gilbert"
+            );
+        } else {
+            debug!(
+                pairs_11_count,
+                triples_1x1_count,
+                "Too few samples for the Gilbert estimators; falling back to simple Gilbert"
+            );
+        }
+
+        // At this point, we assume that the bad state is not leaky (all packets get
+        // lost when in a bad state). In that case, an observed run *is* a bad-state
+        // visit and its mean length is the parameter directly. Every lost packet
+        // belongs to exactly one run, so the mean run length is the lost total spread
+        // across the runs.
+        let mean_run_len = lost_count as f64 / run_count as f64;
+        debug!(
+            mean_loss,
+            mean_run_len, "Fitting a simple Gilbert loss model"
+        );
+        self.with_simple_gilbert_loss(mean_loss as f32, mean_run_len as f32)
+    }
+
     /// Returns an approximate one-way half of this configuration.
     ///
     /// This divides latency, jitter, and loss probabilities by two.
@@ -395,6 +750,138 @@ impl LinkConditionerConfig {
             .with_incoming_latency(Duration::from_millis(200))
             .with_incoming_jitter(Duration::from_millis(30))
             .with_fixed_loss(0.10)
+    }
+
+    /// Returns a conditioner that simulates the link conditions from an
+    /// ethernet connection in New York, New York USA to a WiFi connection
+    /// in Beaverton, Oregon USA.
+    ///
+    /// This was created using [`fit`](Self::fit) provided with 57,129
+    /// packets (~9 minutes) of real network data and an `rtt_overhead` of
+    /// 33.5 ms.
+    ///
+    /// This preset is one direction. To simulate the full pair, install
+    /// this on the peer receiving the New York to Beaverton direction and
+    /// [`beaverton_to_ny`](Self::beaverton_to_ny) on the other peer.
+    pub fn ny_to_beaverton() -> Self {
+        Self {
+            incoming_latency: Duration::from_micros(50_177),
+            incoming_jitter: Duration::from_micros(9_333),
+            good_loss: 0.0,
+            bad_loss: 0.991_008_9,
+            good_to_bad: 0.002_257_159_2,
+            bad_to_good: 0.128_858_07,
+        }
+    }
+
+    /// Returns a conditioner that simulates the link conditions from a
+    /// WiFi connection in Beaverton, Oregon USA to an ethernet connection
+    /// in New York, New York USA.
+    ///
+    /// This was created using [`fit`](Self::fit) provided with 34,836
+    /// packets (~9 minutes) of real network data and an `rtt_overhead` of
+    /// 33.5 ms.
+    ///
+    /// This preset is one direction. To simulate the full pair, install
+    /// this on the peer receiving the Beaverton to New York direction and
+    /// [`ny_to_beaverton`](Self::ny_to_beaverton) on the other peer.
+    pub fn beaverton_to_ny() -> Self {
+        Self {
+            incoming_latency: Duration::from_micros(55_847),
+            incoming_jitter: Duration::from_micros(17_000),
+            good_loss: 0.0,
+            bad_loss: 1.0,
+            good_to_bad: 0.040_261_284,
+            bad_to_good: 0.636_890_35,
+        }
+    }
+
+    /// Returns a conditioner that simulates the link conditions from an
+    /// ethernet connection in New York, New York USA to a WiFi connection
+    /// in Reno, Nevada USA.
+    ///
+    /// This was created using [`fit`](Self::fit) provided with 62,608
+    /// packets (~10 minutes) of real network data and an `rtt_overhead` of
+    /// 33.5 ms.
+    ///
+    /// This preset is one direction. To simulate the full pair, install
+    /// this on the peer receiving the New York to Reno direction and
+    /// [`reno_to_ny`](Self::reno_to_ny) on the other peer.
+    pub fn ny_to_reno() -> Self {
+        Self {
+            incoming_latency: Duration::from_micros(49_695),
+            incoming_jitter: Duration::from_micros(5_141),
+            good_loss: 0.0,
+            bad_loss: 1.0,
+            good_to_bad: 0.000_483_582_4,
+            bad_to_good: 0.131_578_95,
+        }
+    }
+
+    /// Returns a conditioner that simulates the link conditions from a
+    /// WiFi connection in Reno, Nevada USA to an ethernet connection in
+    /// New York, New York USA.
+    ///
+    /// This was created using [`fit`](Self::fit) provided with 34,829
+    /// packets (~10 minutes) of real network data and an `rtt_overhead` of
+    /// 33.5 ms.
+    ///
+    /// This preset is one direction. To simulate the full pair, install
+    /// this on the peer receiving the Reno to New York direction and
+    /// [`ny_to_reno`](Self::ny_to_reno) on the other peer.
+    pub fn reno_to_ny() -> Self {
+        Self {
+            incoming_latency: Duration::from_micros(51_411),
+            incoming_jitter: Duration::from_micros(14_481),
+            good_loss: 0.0,
+            bad_loss: 1.0,
+            good_to_bad: 0.055_427_25,
+            bad_to_good: 0.764_980_85,
+        }
+    }
+
+    /// Returns a conditioner that simulates the link conditions from an
+    /// ethernet connection in New York, New York USA to a WiFi connection
+    /// in Pahrump, Nevada USA.
+    ///
+    /// This was created using [`fit`](Self::fit) provided with 53,101
+    /// packets (~8.5 minutes) of real network data and an `rtt_overhead`
+    /// of 33.5 ms.
+    ///
+    /// This preset is one direction. To simulate the full pair, install
+    /// this on the peer receiving the New York to Pahrump direction and
+    /// [`pahrump_to_ny`](Self::pahrump_to_ny) on the other peer.
+    pub fn ny_to_pahrump() -> Self {
+        Self {
+            incoming_latency: Duration::from_micros(33_663),
+            incoming_jitter: Duration::from_micros(8_985),
+            good_loss: 0.0,
+            bad_loss: 0.984_078_6,
+            good_to_bad: 0.000_684_733_44,
+            bad_to_good: 0.061_043_583,
+        }
+    }
+
+    /// Returns a conditioner that simulates the link conditions from a
+    /// WiFi connection in Pahrump, Nevada USA to an ethernet connection in
+    /// New York, New York USA.
+    ///
+    /// This was created using [`fit`](Self::fit) provided with 39,043
+    /// packets (~8.5 minutes) of real network data and an `rtt_overhead`
+    /// of 33.5 ms.
+    ///
+    /// This preset is one direction. To simulate the full pair, install
+    /// this on the peer receiving the Pahrump to New York direction and
+    /// [`ny_to_pahrump`](Self::ny_to_pahrump) on the other peer.
+    pub fn pahrump_to_ny() -> Self {
+        Self {
+            incoming_latency: Duration::from_micros(39_821),
+            incoming_jitter: Duration::from_micros(14_321),
+            good_loss: 0.0,
+            bad_loss: 1.0,
+            good_to_bad: 0.068_795_934,
+            bad_to_good: 0.591_445_45,
+        }
     }
 }
 
@@ -468,6 +955,170 @@ mod tests {
             assert_eq!(config.good_loss, min_loss);
             assert_eq!(config.bad_loss, bad_loss);
         }
+    }
+
+    /// Runs `count` packets through a real seeded [`LinkConditioner`] and
+    /// records each packet's outcome, so a fit of the output is a true round
+    /// trip through the runtime model. A delivered packet's RTT is twice its
+    /// simulated one-way delay.
+    fn simulate_packet_outcomes(
+        config: &LinkConditionerConfig,
+        count: u32,
+        seed: u64,
+    ) -> Vec<ResolvedPacket> {
+        let mut conditioner = LinkConditioner::with_seed(config.clone(), seed);
+        let sent_at = Instant::now();
+        (0..count)
+            .map(|packet_id| ResolvedPacket {
+                packet_id,
+                rtt: conditioner
+                    .condition_packet(packet_id, sent_at)
+                    .map(|delivered_at| delivered_at.duration_since(sent_at) * 2),
+            })
+            .collect()
+    }
+
+    #[test]
+    fn fit_empty_returns_none() {
+        assert!(LinkConditionerConfig::fit(Vec::new(), Duration::ZERO).is_none());
+    }
+
+    #[test]
+    fn fit_loss_fits_all_lost_capture_as_total_loss() {
+        let lost_packets: Vec<ResolvedPacket> = (0..100)
+            .map(|packet_id| ResolvedPacket {
+                packet_id,
+                rtt: None,
+            })
+            .collect();
+
+        // `fit` cannot work with only lost packets.
+        assert!(LinkConditionerConfig::fit(lost_packets.clone(), Duration::ZERO).is_none());
+
+        // `fit_loss` should return a 100% packet loss probability because every packet
+        // was lost.
+        let config = LinkConditionerConfig::default().fit_loss(&lost_packets);
+        assert_eq!(config.mean_loss(), 1.0);
+    }
+
+    #[test]
+    fn fit_recovers_delay_and_reports_lossless() {
+        // Generate network traffic with a latency of 80ms ± 20ms.
+        let config = LinkConditionerConfig::default()
+            .with_incoming_latency(Duration::from_millis(80))
+            .with_incoming_jitter(Duration::from_millis(20));
+        let sent_packets = simulate_packet_outcomes(&config, 20_000, 7);
+        let fitted = LinkConditionerConfig::fit(sent_packets, Duration::ZERO).unwrap();
+
+        // Verify `fit` determined the correct latency and jitter.
+        assert_relative_eq!(fitted.incoming_latency.as_secs_f64(), 0.080, epsilon = 3e-3);
+        assert_relative_eq!(fitted.incoming_jitter.as_secs_f64(), 0.020, epsilon = 3e-3);
+        assert_eq!(fitted.mean_loss(), 0.0);
+    }
+
+    #[test]
+    fn fit_deducts_rtt_overhead_from_latency_only() {
+        // Generate network traffic with a latency of 80ms ± 20ms.
+        let config = LinkConditionerConfig::default()
+            .with_incoming_latency(Duration::from_millis(80))
+            .with_incoming_jitter(Duration::from_millis(20));
+        let sent_packets = simulate_packet_outcomes(&config, 20_000, 7);
+
+        // Pretend that 30ms of the RTT was due to RTT overhead then verify `fit`
+        // determined the correct latency and jitter.
+        let fitted = LinkConditionerConfig::fit(sent_packets, Duration::from_millis(30)).unwrap();
+
+        // `fit` should remove the RTT overhead from its `incoming_latency` estimate.
+        assert_relative_eq!(fitted.incoming_latency.as_secs_f64(), 0.065, epsilon = 3e-3);
+        assert_relative_eq!(fitted.incoming_jitter.as_secs_f64(), 0.020, epsilon = 3e-3);
+    }
+
+    #[test]
+    fn fit_sparse_loss_falls_back_to_fixed() {
+        // 10 isolated losses is too few runs to claim burst structure.
+        let sent_packets = (0..5_000u32).map(|packet_id| ResolvedPacket {
+            packet_id,
+            rtt: (packet_id % 500 != 250).then_some(Duration::from_millis(100)),
+        });
+        let loss = LinkConditionerConfig::fit(sent_packets.collect(), Duration::ZERO).unwrap();
+        assert_eq!(loss.good_to_bad, 0.0);
+        assert_relative_eq!(loss.mean_loss(), 10.0 / 5_000.0, epsilon = 1e-4);
+    }
+
+    #[test]
+    fn fit_round_trips_simple_gilbert() {
+        let truth = LinkConditionerConfig::default().with_simple_gilbert_loss(0.02, 8.0);
+        let sent_packets = simulate_packet_outcomes(&truth, 400_000, 11);
+        let fitted = LinkConditionerConfig::fit(sent_packets, Duration::ZERO).unwrap();
+        assert_relative_eq!(fitted.mean_loss(), 0.02, max_relative = 0.1);
+        assert_relative_eq!(1.0 / fitted.bad_to_good, 8.0, max_relative = 0.2);
+        // Total loss inside bursts must be recovered as near-total.
+        assert!(fitted.bad_loss > 0.85, "bad_loss = {}", fitted.bad_loss);
+    }
+
+    #[test]
+    fn fit_round_trips_gilbert() {
+        let truth = LinkConditionerConfig::default().with_gilbert_loss(0.05, 6.0, 0.5);
+        let sent_packets = simulate_packet_outcomes(&truth, 400_000, 13);
+        let fitted = LinkConditionerConfig::fit(sent_packets, Duration::ZERO).unwrap();
+        assert_relative_eq!(fitted.mean_loss(), 0.05, max_relative = 0.1);
+        assert_relative_eq!(1.0 / fitted.bad_to_good, 6.0, max_relative = 0.3);
+        assert_relative_eq!(fitted.bad_loss, 0.5, epsilon = 0.15);
+    }
+
+    #[test]
+    fn fit_trims_boundary_loss_runs() {
+        // A leading connect burst and a trailing teardown burst around an
+        // otherwise clean body must fit as lossless.
+        let sent_packets = (0..10_000u32).map(|packet_id| ResolvedPacket {
+            packet_id,
+            rtt: (packet_id >= 5 && packet_id < 9_700).then_some(Duration::from_millis(100)),
+        });
+        let loss = LinkConditionerConfig::fit(sent_packets.collect(), Duration::ZERO).unwrap();
+        assert_eq!(loss.mean_loss(), 0.0);
+    }
+
+    #[test]
+    fn fit_does_not_merge_runs_across_id_gaps() {
+        // Generate network traffic comprised of repeated blocks of packets where [20
+        // acked, 2 lost, gap, 2 lost, 20 acked].
+        let mut sent_packets = Vec::new();
+        let mut packet_id = 0u32;
+        for _ in 0..40 {
+            for _ in 0..20 {
+                sent_packets.push(ResolvedPacket {
+                    packet_id,
+                    rtt: Some(Duration::from_millis(100)),
+                });
+                packet_id += 1;
+            }
+            for _ in 0..2 {
+                sent_packets.push(ResolvedPacket {
+                    packet_id,
+                    rtt: None,
+                });
+                packet_id += 1;
+            }
+            // The gap (i.e. unresolved packet IDs).
+            packet_id += 3;
+            for _ in 0..2 {
+                sent_packets.push(ResolvedPacket {
+                    packet_id,
+                    rtt: None,
+                });
+                packet_id += 1;
+            }
+            for _ in 0..20 {
+                sent_packets.push(ResolvedPacket {
+                    packet_id,
+                    rtt: Some(Duration::from_millis(100)),
+                });
+                packet_id += 1;
+            }
+        }
+        let loss = LinkConditionerConfig::fit(sent_packets, Duration::ZERO).unwrap();
+        // 80 observed runs of exactly 2 → Simple Gilbert with burst length 2.
+        assert_relative_eq!(1.0 / loss.bad_to_good, 2.0, epsilon = 1e-4);
     }
 
     #[test]

--- a/crates/io/link/src/lib.rs
+++ b/crates/io/link/src/lib.rs
@@ -40,7 +40,7 @@ use core::time::Duration;
 use lightyear_core::time::Instant;
 
 pub mod prelude {
-    pub use crate::conditioner::{LinkConditionerConfig, LinkConditionerState};
+    pub use crate::conditioner::{LinkConditionerConfig, LinkConditionerState, ResolvedPacket};
     pub use crate::server::{LinkOf, Server};
     pub use crate::{
         Link, LinkStart, LinkStats, LinkSystems, Linked, Linking, RecvLinkConditioner, Unlink,

--- a/crates/transport/transport/Cargo.toml
+++ b/crates/transport/transport/Cargo.toml
@@ -23,6 +23,7 @@ test_utils = []
 [dependencies]
 # local crates
 lightyear_core.workspace = true
+lightyear_crossbeam.workspace = true
 lightyear_link.workspace = true
 lightyear_serde.workspace = true
 lightyear_utils.workspace = true

--- a/crates/transport/transport/src/lib.rs
+++ b/crates/transport/transport/src/lib.rs
@@ -10,6 +10,7 @@ extern crate alloc;
 extern crate std;
 
 pub mod channel;
+pub mod rtt_overhead;
 
 pub mod error;
 
@@ -27,4 +28,7 @@ pub mod prelude {
     pub use crate::channel::registry::ChannelRegistry;
     pub use crate::packet::compression::{CompressionAlgorithm, CompressionConfig};
     pub use crate::packet::priority_manager::{PriorityConfig, PriorityManager};
+    pub use crate::rtt_overhead::{
+        EstimateRttOverhead, EstimatorEndpoint, RttOverheadEstimated, RttOverheadEstimatorPlugin,
+    };
 }

--- a/crates/transport/transport/src/plugin.rs
+++ b/crates/transport/transport/src/plugin.rs
@@ -24,6 +24,7 @@ use lightyear_connection::host::HostClient;
 use lightyear_connection::prelude::Disconnected;
 use lightyear_core::prelude::LocalTimeline;
 use lightyear_core::tick::Tick;
+use lightyear_link::prelude::ResolvedPacket;
 use lightyear_link::{Link, LinkPlugin, LinkSystems, Linked};
 use lightyear_serde::reader::{ReadInteger, Reader};
 use lightyear_serde::{SerializationError, ToBytes};
@@ -54,19 +55,37 @@ pub struct PacketReceived {
 }
 
 /// Event triggered on a [`Transport`] entity when a sent packet is acknowledged.
-#[derive(EntityEvent)]
+#[derive(EntityEvent, Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct PacketAcked {
     pub entity: Entity,
     pub packet_id: u32,
     pub rtt_sample: Duration,
 }
 
+impl From<PacketAcked> for ResolvedPacket {
+    fn from(event: PacketAcked) -> Self {
+        ResolvedPacket {
+            packet_id: event.packet_id,
+            rtt: Some(event.rtt_sample),
+        }
+    }
+}
+
 /// Event triggered on a [`Transport`] entity when a sent packet is presumed lost
 /// (its acknowledgement did not arrive before the nack timeout).
-#[derive(EntityEvent)]
+#[derive(EntityEvent, Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct PacketLost {
     pub entity: Entity,
     pub packet_id: u32,
+}
+
+impl From<PacketLost> for ResolvedPacket {
+    fn from(event: PacketLost) -> Self {
+        ResolvedPacket {
+            packet_id: event.packet_id,
+            rtt: None,
+        }
+    }
 }
 
 pub struct TransportPlugin;

--- a/crates/transport/transport/src/rtt_overhead.rs
+++ b/crates/transport/transport/src/rtt_overhead.rs
@@ -1,0 +1,341 @@
+//! Real time estimation of the packet RTT (round-trip time) overhead introduced
+//! by lightyear. Include [`RttOverheadEstimatorPlugin`] in your app and trigger
+//! [`EstimateRttOverhead`] to calculate an estimation. The estimation is
+//! published once as an [`RttOverheadEstimated`] event. You can use this as
+//! the RTT estimate required by
+//! [`LinkConditionerConfig::fit`](lightyear_link::prelude::LinkConditionerConfig::fit).
+//!
+//! RTT overhead is comprised of:
+//!
+//! * The delay between lightyear receiving a packet and lightyear sending the
+//!   ack for it (the ack is not sent until the next scheduled outgoing packet).
+//! * The delay between lightyear receiving an ack and lightyear actually
+//!   processing it.
+//!
+//! To estimate the RTT overhead, the estimator spawns two endpoints (marked
+//! with [`EstimatorEndpoint`]), connects them over an in-process
+//! [`CrossbeamIo`] pair, and sends packets between them through lightyear until
+//! it collects enough packet RTTs. The endpoints are in the same process, so
+//! there is no network latency between them, and the RTT overhead is the only
+//! thing that can make a packet's RTT greater than zero. The RTT overhead
+//! estimate is the median of those packets' RTTs.
+//!
+//! The overhead is dominated by frame/tick-boundary scheduling, so it reflects
+//! the process's current frame rate. Trigger [`EstimateRttOverhead`] once the
+//! app is running at its steady-state cadence rather than mid-startup.
+//!
+//! Most likely you are requesting this estimate in order to pass it into
+//! [`fit`](lightyear_link::prelude::LinkConditionerConfig::fit). If that's the
+//! case, you will also need to collect the packets sent by a [`Transport`]. You
+//! can do this by creating
+//! [`ResolvedPacket`](lightyear_link::prelude::ResolvedPacket)s whenever a
+//! [`PacketAcked`](crate::plugin::PacketAcked) or
+//! [`PacketLost`](crate::plugin::PacketLost) is triggered (both events convert
+//! via `Into`). Remember to ignore the [`EstimatorEndpoint`]s when collecting
+//! because their packets aren't sent across a real network thus their RTTs are
+//! not what you want.
+//!
+//! ```
+//! use std::collections::HashMap;
+//!
+//! use bevy_ecs::prelude::*;
+//! use lightyear_link::prelude::ResolvedPacket;
+//! use lightyear_transport::plugin::{PacketAcked, PacketLost};
+//! use lightyear_transport::prelude::EstimatorEndpoint;
+//!
+//! /// Captures packets sent per link.
+//! #[derive(Resource, Default)]
+//! struct ResolvedPackets(HashMap<Entity, Vec<ResolvedPacket>>);
+//!
+//! fn record_acked(
+//!     trigger: On<PacketAcked>,
+//!     estimator_endpoints: Query<(), With<EstimatorEndpoint>>,
+//!     mut sent: ResMut<ResolvedPackets>,
+//! ) {
+//!     let event = trigger.event();
+//!     if estimator_endpoints.contains(event.entity) {
+//!         // Ignore packets from RTT-overhead-estimator endpoints. Their
+//!         // packets aren't sent over a real network.
+//!         return;
+//!     }
+//!     sent.0.entry(event.entity).or_default().push((*event).into());
+//! }
+//!
+//! fn record_lost(
+//!     trigger: On<PacketLost>,
+//!     estimator_endpoints: Query<(), With<EstimatorEndpoint>>,
+//!     mut sent: ResMut<ResolvedPackets>,
+//! ) {
+//!     let event = trigger.event();
+//!     if estimator_endpoints.contains(event.entity) {
+//!         // Ignore packets from RTT-overhead-estimator endpoints. Their
+//!         // packets aren't sent over a real network.
+//!         return;
+//!     }
+//!     sent.0.entry(event.entity).or_default().push((*event).into());
+//! }
+//!
+//! let mut app = bevy_app::App::new();
+//! app.init_resource::<ResolvedPackets>();
+//! app.add_observer(record_acked);
+//! app.add_observer(record_lost);
+//! ```
+
+use alloc::vec::Vec;
+use core::time::Duration;
+
+use bevy_app::prelude::*;
+use bevy_ecs::prelude::*;
+use bytes::Bytes;
+use lightyear_crossbeam::{CrossbeamIo, CrossbeamPlugin};
+use lightyear_link::{Link, LinkStart};
+
+use crate::{
+    channel::{
+        builder::{ChannelMode, ChannelSettings, Transport},
+        receivers::ChannelReceive,
+        registry::{AppChannelExt, ChannelRegistry},
+    },
+    plugin::PacketAcked,
+};
+
+/// Default number of loopback packets that [`EstimateRttOverhead`] will gather
+/// RTTs from if not specified otherwise.
+const DEFAULT_PACKET_COUNT: usize = 1024;
+
+/// Registers the RTT overhead estimator. You need to add this plugin before
+/// triggering [`EstimateRttOverhead`] in order to get an RTT overhead estimate.
+pub struct RttOverheadEstimatorPlugin;
+
+impl Plugin for RttOverheadEstimatorPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_channel::<EstimatorChannel>(ChannelSettings {
+            mode: ChannelMode::UnorderedUnreliable,
+            ..Default::default()
+        });
+        if !app.is_plugin_added::<CrossbeamPlugin>() {
+            app.add_plugins(CrossbeamPlugin);
+        }
+        app.add_systems(Update, (send_estimator_traffic, drain_estimator_messages));
+        app.add_observer(start_estimation);
+        app.add_observer(record_endpoint_rtt);
+    }
+}
+
+/// Request to estimate the RTT overhead. The estimate will be returned in an
+/// [`RttOverheadEstimated`]. Ignored if a estimation is currently underway.
+#[derive(Event, Debug, Clone, Copy)]
+pub struct EstimateRttOverhead {
+    /// How many loopback packets to collect RTTs from before estimating their
+    /// median.
+    pub packet_count: usize,
+}
+
+impl Default for EstimateRttOverhead {
+    fn default() -> Self {
+        Self {
+            packet_count: DEFAULT_PACKET_COUNT,
+        }
+    }
+}
+
+/// Estimation of the per-packet RTT overhead. Fired once per completed
+/// [`EstimateRttOverhead`] request.
+///
+/// Pass the carried [`Duration`] to
+/// [`LinkConditionerConfig::fit`](lightyear_link::prelude::LinkConditionerConfig::fit).
+#[derive(Event, Debug, Clone, Copy)]
+pub struct RttOverheadEstimated(pub Duration);
+
+/// The channel that carries the RTT overhead estimator's dummy traffic in order
+/// to generate packet RTTs to feed into the RTT overhead estimate.
+#[derive(Debug)]
+struct EstimatorChannel;
+
+/// Marks a loopback [`Link`] used by the RTT overhead estimator to send packets
+/// and record their RTTs.
+///
+/// Public so packet-capture consumers can exclude these links: their traffic
+/// never crosses a network, so their [`PacketAcked`] RTTs measure only
+/// lightyear's own overhead.
+#[derive(Component, Debug)]
+pub struct EstimatorEndpoint;
+
+/// State information about an RTT estimation in progress. Only exists if there
+/// is an estimation in progress.
+#[derive(Resource)]
+struct RttOverheadState {
+    /// Number of loopback packets to gather RTTs from before estimating their
+    /// median.
+    packet_count: usize,
+
+    /// RTTs of the packets sent by the [`EstimatorEndpoint`]s.
+    packet_rtts: Vec<Duration>,
+}
+
+/// On [`EstimateRttOverhead`], starts an RTT over head estimation. Ignores the
+/// request if one is already running.
+fn start_estimation(
+    trigger: On<EstimateRttOverhead>,
+    registry: Res<ChannelRegistry>,
+    running: Option<Res<RttOverheadState>>,
+    mut commands: Commands,
+) {
+    if running.is_some() {
+        // Estimation already in progress.
+        return;
+    }
+
+    let packet_count = trigger.event().packet_count;
+    commands.insert_resource(RttOverheadState {
+        packet_count,
+        packet_rtts: Vec::with_capacity(packet_count),
+    });
+
+    // Create the endpoints that send the dummy data.
+    let transport = || {
+        let mut transport = Transport::default();
+        transport.add_sender_from_registry::<EstimatorChannel>(&registry);
+        transport.add_receiver_from_registry::<EstimatorChannel>(&registry);
+        transport
+    };
+    let seeded_link = || {
+        let mut link = Link::new(None);
+
+        // Set to 1 second so packets are not declared lost before their acks have
+        // arrived. The transport computes its packet-loss timeout from this field,
+        // and nothing on these links updates the field (no PingManager runs here), so
+        // the timeout would have stayed at 10ms while the loopback ack takes about two
+        // frames worth of wall time.
+        //
+        // `LinkStats::rtt` is not the RTT overhead being estimated, and the
+        // estimate never reads it.
+        link.stats.rtt = Duration::from_secs(1);
+        link
+    };
+    let (io_a, io_b) = CrossbeamIo::new_pair();
+    for io in [io_a, io_b] {
+        let endpoint = commands
+            .spawn((transport(), io, seeded_link(), EstimatorEndpoint))
+            .id();
+        commands.trigger(LinkStart { entity: endpoint });
+    }
+}
+
+/// Records the RTT of packets sent by the [`EstimatorEndpoint`]s that were
+/// acked. Fires [`RttOverheadEstimated`] if there are enough RTTs to calculate
+/// the estimate.
+fn record_endpoint_rtt(
+    trigger: On<PacketAcked>,
+    endpoints: Query<Entity, With<EstimatorEndpoint>>,
+    state: Option<ResMut<RttOverheadState>>,
+    mut commands: Commands,
+) {
+    let Some(mut state) = state else {
+        return;
+    };
+    let acked = trigger.event();
+    if !endpoints.contains(acked.entity) {
+        // Packet was not sent by the endpoints used for RTT overhead estimation.
+        return;
+    }
+    state.packet_rtts.push(acked.rtt_sample);
+    if state.packet_rtts.len() < state.packet_count {
+        return;
+    }
+
+    // Estimate the RTT overhead.
+    state.packet_rtts.sort_unstable();
+    let rtt_overhead = state.packet_rtts[state.packet_rtts.len() / 2];
+    commands.trigger(RttOverheadEstimated(rtt_overhead));
+
+    // The estimation is complete. We no longer need the state information nor the
+    // endpoints.
+    for endpoint in &endpoints {
+        commands.entity(endpoint).despawn();
+    }
+    commands.remove_resource::<RttOverheadState>();
+}
+
+/// Sends one dummy payload per endpoint per frame, matching a real link's
+/// once-per-frame packet flush so the ack wait is the same.
+fn send_estimator_traffic(endpoints: Query<&Transport, With<EstimatorEndpoint>>) {
+    for transport in &endpoints {
+        transport
+            .send::<EstimatorChannel>(Bytes::from_static(&[0]))
+            .ok();
+    }
+}
+
+/// Discards the dummy messages so the estimator's channel receivers don't
+/// grow unboundedly.
+fn drain_estimator_messages(mut endpoints: Query<&mut Transport, With<EstimatorEndpoint>>) {
+    for mut transport in &mut endpoints {
+        for metadata in transport.receivers.values_mut() {
+            while metadata.receiver.read_message().is_some() {}
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use core::time::Duration;
+
+    use lightyear_core::plugin::CorePlugins;
+
+    use super::*;
+    use crate::{channel::registry::ChannelRegistry, plugin::TransportPlugin};
+
+    #[derive(Resource, Default)]
+    struct CapturedOverhead(Option<Duration>);
+
+    #[test]
+    fn estimator_fires_once_the_window_fills() {
+        let mut app = App::new();
+        app.add_plugins(CorePlugins {
+            tick_duration: Duration::from_millis(10),
+        });
+        if !app.is_plugin_added::<bevy_time::TimePlugin>() {
+            app.add_plugins(bevy_time::TimePlugin);
+        }
+        app.init_resource::<ChannelRegistry>();
+        app.add_plugins(TransportPlugin);
+        app.add_plugins(RttOverheadEstimatorPlugin);
+        app.init_resource::<CapturedOverhead>();
+        app.add_observer(
+            |trigger: On<RttOverheadEstimated>, mut captured: ResMut<CapturedOverhead>| {
+                captured.0 = Some(trigger.event().0);
+            },
+        );
+        app.finish();
+
+        // Use a small packet count so the window fills within a few frames.
+        app.world_mut()
+            .trigger(EstimateRttOverhead { packet_count: 64 });
+
+        // The estimate fires once the window fills. Both endpoints contribute
+        // one sample per frame. Cap the loop so a regression fails instead of
+        // hanging.
+        for _ in 0..4096 {
+            app.update();
+            if app.world().resource::<CapturedOverhead>().0.is_some() {
+                break;
+            }
+        }
+
+        let overhead = app
+            .world()
+            .resource::<CapturedOverhead>()
+            .0
+            .expect("Estimator should fire once the window fills");
+
+        // Verify that the RTT overhead estimate is a reasonable value.
+        assert!(overhead < Duration::from_secs(1), "Overhead = {overhead:?}");
+
+        // Verify that the RTT estimator tears itself down when it fires.
+        assert!(
+            !app.world().contains_resource::<RttOverheadState>(),
+            "RTT overhead estimation state should be dropped once the estimate fires"
+        );
+    }
+}


### PR DESCRIPTION
> [!NOTE]
> This PR is stacked on top of #1550 because it is a dependency. The first commit of this PR is actually #1550. Only the second commit is new here.

Closes https://github.com/cBournhonesque/lightyear/issues/1577.

Add `LinkConditionerConfig::fit()`. It constructs a conditioner config using a provided capture of packets sent by a link. This capture includes packet RTT, ID, and if the packet got lost. The conditioner will try to replicate packet-loss probabilities and latency seen in the capture.

Create the `RttOverheadEstimatorPlugin` plugin. It can provide an estimate of the RTT overhead introduced by lightyear. This estimate is needed for `fit()`.

Create `LinkConditionerConfig` presets that simulate network conditions between some US cities.
