### PR TITLE
Replace direct paste dependency with pastey

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,7 +126,7 @@ hashbrown = { version = "0.17", default-features = false }
 indexmap = { version = "2.9.0", default-features = false }
 nonzero_ext = "0.3.0"
 parking_lot = "0.12.3"
-paste = { version = "1.0", default-features = false }
+pastey = { version = "0.2.3", default-features = false }
 rand = "0.10"
 ringbuffer = "0.16"
 thiserror = "2.0.3"

--- a/crates/core/utils/Cargo.toml
+++ b/crates/core/utils/Cargo.toml
@@ -17,7 +17,7 @@ metrics = ["dep:metrics", "std"]
 # utils
 metrics = { workspace = true, optional = true }
 hashbrown.workspace = true
-paste.workspace = true
+pastey.workspace = true
 seahash.workspace = true
 tracing.workspace = true
 

--- a/crates/core/utils/src/wrapping_id.rs
+++ b/crates/core/utils/src/wrapping_id.rs
@@ -8,7 +8,7 @@ pub trait WrappedId {
     fn rem(&self, total: usize) -> usize;
 }
 
-pub use paste::paste;
+pub use pastey::paste;
 
 /// Index that wraps around 2^32
 #[macro_export]


### PR DESCRIPTION
## Summary
- Replace Lightyear's direct `paste` dependency in `lightyear_utils` with `pastey` 0.2.3.
- Keep the existing `lightyear_utils::wrapping_id::paste` re-export so macro call sites do not need to change.

Refs #1363

## Notes
This removes Lightyear's owned/direct `paste` use. Whole-workspace `cargo tree` still shows upstream transitive audit paths that are not controlled by Lightyear manifests without broader upstream updates:
- `paste` via `parry` -> `simba 0.9`
- `paste` via `aeronet_steam` -> `steamworks 0.12.2`
- `rustls-pemfile` via `aeronet_webtransport` -> `wtransport 0.6.1`

## Validation
- `cargo check -p lightyear_utils --all-features`
- `cargo tree -p lightyear_utils -i pastey@0.2.3 -e normal,build,dev --target all`