### PR TITLE
Round TickDelta integer conversion

### DIFF
--- a/crates/core/core/src/time.rs
+++ b/crates/core/core/src/time.rs
@@ -351,9 +351,9 @@ impl TickDelta {
     }
 
     /// Returns the number of tick difference (positive or negative) that this TickDelta represents,
-    /// rounding to the closes integer value
+    /// rounding to the closest integer value
     pub fn to_i32(&self) -> i32 {
-        self.value.to_num()
+        self.value.round().to_num()
     }
 
     pub fn from_time_delta(mut delta: TimeDelta, tick_duration: Duration) -> Self {
@@ -756,6 +756,17 @@ mod tests {
         assert_eq!((delta + (-delta)).to_i32(), 0);
         assert_eq!(((-delta) + delta).to_i32(), 0);
         assert_eq!(((-delta) + (-delta)).to_i32(), -20);
+    }
+
+    #[test]
+    fn test_tickdelta_to_i32_rounds_to_nearest_tick() {
+        assert_eq!(TickDelta::lit("0.49").to_i32(), 0);
+        assert_eq!(TickDelta::lit("0.5").to_i32(), 1);
+        assert_eq!(TickDelta::lit("0.61").to_i32(), 1);
+
+        assert_eq!(TickDelta::lit("-0.49").to_i32(), 0);
+        assert_eq!(TickDelta::lit("-0.5").to_i32(), -1);
+        assert_eq!(TickDelta::lit("-0.61").to_i32(), -1);
     }
 
     #[test]

--- a/crates/tests/src/client_server/input/leafwing.rs
+++ b/crates/tests/src/client_server/input/leafwing.rs
@@ -268,23 +268,28 @@ fn test_server_just_pressed() {
         .resource_mut::<ButtonInput<KeyCode>>()
         .press(KeyCode::KeyA);
 
-    // The input timeline sends inputs one tick ahead of the server input pipeline.
-    // Step until the server applies the first pressed snapshot, not just until it receives it.
-    stepper.frame_step(4);
+    // The input timeline sends inputs ahead of the server input pipeline. Sync
+    // resyncs can shift buffered inputs by a rounded tick, so step until the
+    // server applies the first pressed snapshot, not just until it receives it.
+    let mut observed_transition = false;
+    for _ in 0..8 {
+        stepper.frame_step(1);
+        let server_action = stepper
+            .server_app
+            .world()
+            .entity(server_entity)
+            .get::<ActionState<LeafwingInput1>>()
+            .unwrap();
+        if server_action.pressed(&LeafwingInput1::Jump)
+            && server_action.just_pressed(&LeafwingInput1::Jump)
+        {
+            observed_transition = true;
+            break;
+        }
+    }
 
-    let server_action = stepper
-        .server_app
-        .world()
-        .entity(server_entity)
-        .get::<ActionState<LeafwingInput1>>()
-        .unwrap();
     assert!(
-        server_action.pressed(&LeafwingInput1::Jump),
-        "Server should see the button as pressed"
-    );
-
-    assert!(
-        server_action.just_pressed(&LeafwingInput1::Jump),
+        observed_transition,
         "Server should reconstruct JustPressed from the received input transition"
     );
 }

--- a/crates/tests/src/client_server/prediction/despawn.rs
+++ b/crates/tests/src/client_server/prediction/despawn.rs
@@ -101,9 +101,25 @@ fn test_despawned_predicted_rollback() {
         .get_mut::<CompFull>(server_entity)
         .unwrap()
         .0 = 2.0;
-    // 3 frames: 1 for server to send, 1 for client to receive (mismatch detected),
-    // 1 for check_rollback to consume the mismatch and run rollback
-    stepper.frame_step(3);
+    // Step until the client receives the mismatch and rollback re-enables the
+    // predicted entity. Rounded timeline resyncs can shift this by a frame.
+    let mut rollback_completed = false;
+    for _ in 0..8 {
+        stepper.frame_step(1);
+        let world = stepper.client_app().world();
+        let disable_removed = world.get::<PredictionDisable>(predicted_entity).is_none();
+        let state_updated = world
+            .get::<CompFull>(predicted_entity)
+            .is_some_and(|value| value == &CompFull(2.0));
+        if disable_removed && state_updated {
+            rollback_completed = true;
+            break;
+        }
+    }
+    assert!(
+        rollback_completed,
+        "predicted entity should be re-enabled and updated after rollback"
+    );
 
     // Check that the entity was rolled back and the PredictionDisable marker was removed
     assert!(


### PR DESCRIPTION
## Summary
- Make `TickDelta::to_i32` round to the nearest integer instead of truncating toward zero.
- Add regression coverage for positive and negative fractional deltas around the half-tick threshold.
- Update two timing-sensitive integration tests to wait for the expected transition/rollback within a bounded window after rounded resyncs.

Fixes #1336

## Validation
- `cargo fmt --check`
- `cargo test -p lightyear_tests --all-features client_server::input::leafwing::test_server_just_pressed -- --test-threads=1`
- `cargo test -p lightyear_tests --all-features client_server::prediction::despawn::test_despawned_predicted_rollback -- --test-threads=1`
- `cargo clippy --features=lightyear_core/not_mock,avian3d/f32 --workspace --exclude=compiletime --exclude=avian_3d --exclude=launcher --exclude=delta_compression --exclude=distributed_authority --no-deps -- -D warnings -A clippy::needless_lifetimes`
- `cargo test -p lightyear_tests --all-features -- --test-threads=1`