### PR TITLE
Propagate Disabled from BEI contexts to actions

### DIFF
--- a/crates/inputs/input_bei/src/disable.rs
+++ b/crates/inputs/input_bei/src/disable.rs
@@ -1,0 +1,38 @@
+//! Propagates Bevy's [`Disabled`] component from BEI contexts to their actions.
+
+use bevy_ecs::entity_disabling::Disabled;
+use bevy_ecs::prelude::*;
+use bevy_enhanced_input::prelude::Actions;
+
+/// Disables every action belonging to a newly-disabled BEI context.
+///
+/// Bevy's default query filtering only skips the entity that directly carries [`Disabled`]. BEI
+/// stores a context and its actions on separate entities, so disabling the context alone would not
+/// exclude the action entities queried by Lightyear's input buffering and message preparation.
+/// Propagating the standard marker lets those existing queries skip the actions naturally.
+pub(crate) fn disable_context_actions<C: Component>(
+    trigger: On<Add, Disabled>,
+    mut commands: Commands,
+    contexts: Query<&Actions<C>, (With<C>, Allow<Disabled>)>,
+) {
+    let Ok(actions) = contexts.get(trigger.entity) else {
+        return;
+    };
+    for action in actions.iter() {
+        commands.entity(action).insert(Disabled);
+    }
+}
+
+/// Re-enables the actions belonging to a BEI context when that context is re-enabled.
+pub(crate) fn enable_context_actions<C: Component>(
+    trigger: On<Remove, Disabled>,
+    mut commands: Commands,
+    contexts: Query<&Actions<C>, (With<C>, Allow<Disabled>)>,
+) {
+    let Ok(actions) = contexts.get(trigger.entity) else {
+        return;
+    };
+    for action in actions.iter() {
+        commands.entity(action).remove::<Disabled>();
+    }
+}

--- a/crates/inputs/input_bei/src/lib.rs
+++ b/crates/inputs/input_bei/src/lib.rs
@@ -10,6 +10,8 @@ extern crate std;
 
 pub mod input_message;
 
+#[cfg(feature = "client")]
+mod disable;
 mod marker;
 mod plugin;
 mod setup;

--- a/crates/inputs/input_bei/src/marker.rs
+++ b/crates/inputs/input_bei/src/marker.rs
@@ -1,5 +1,6 @@
 //! Add an [`InputMarker<C>`] component automatically to [`Action`] entities that need it
 
+use bevy_ecs::entity_disabling::Disabled;
 use bevy_ecs::prelude::*;
 use bevy_ecs::relationship::Relationship;
 use bevy_enhanced_input::context::ExternallyMocked;
@@ -41,21 +42,29 @@ pub(crate) fn propagate_input_marker<C: Component>(
     }
 }
 
-/// When an Action entity is added to a Context entity that has an InputMarker,
-/// add the InputMarker to the Action entity as well.
-pub(crate) fn add_input_marker_from_parent<C: Component>(
+/// Inherits client-side markers when an action is added to a context.
+///
+/// [`InputMarker`] makes a locally-controlled action available to Lightyear's input pipeline.
+/// [`Disabled`] ensures that actions created after their context was disabled are skipped too.
+pub(crate) fn add_action_markers_from_context<C: Component>(
     trigger: On<Add, ActionOf<C>>,
-    action_of: Query<&ActionOf<C>, Without<ExternallyMocked>>,
-    context: Query<(), With<InputMarker<C>>>,
+    action_of: Query<&ActionOf<C>, (Without<ExternallyMocked>, Allow<Disabled>)>,
+    context: Query<(Has<InputMarker<C>>, Has<Disabled>), (With<C>, Allow<Disabled>)>,
     mut commands: Commands,
 ) {
     let Ok(action_of) = action_of.get(trigger.entity) else {
         return;
     };
-    if context.get(action_of.get()).is_ok() {
+    let Ok((has_input_marker, disabled)) = context.get(action_of.get()) else {
+        return;
+    };
+    if has_input_marker {
         commands
             .entity(trigger.entity)
             .insert(InputMarker::<C>::default());
+    }
+    if disabled {
+        commands.entity(trigger.entity).insert(Disabled);
     }
 }
 

--- a/crates/inputs/input_bei/src/plugin.rs
+++ b/crates/inputs/input_bei/src/plugin.rs
@@ -114,16 +114,20 @@ impl<
         app.replicate_once::<ActionOf<C>>();
         #[cfg(feature = "client")]
         {
+            use crate::disable::{disable_context_actions, enable_context_actions};
             use crate::marker::{
-                add_input_marker_from_binding, add_input_marker_from_parent, propagate_input_marker,
+                add_action_markers_from_context, add_input_marker_from_binding,
+                propagate_input_marker,
             };
             // for rebroadcasting inputs, we insert TriggerState (which inserts the InputBuffer) when ActionOf<C> is added
             // on an entity
             app.register_required_components::<ActionOf<C>, TriggerState>();
 
             app.add_observer(propagate_input_marker::<C>);
-            app.add_observer(add_input_marker_from_parent::<C>);
+            app.add_observer(add_action_markers_from_context::<C>);
             app.add_observer(add_input_marker_from_binding::<C>);
+            app.add_observer(disable_context_actions::<C>);
+            app.add_observer(enable_context_actions::<C>);
 
             if self.config.rebroadcast_inputs {
                 app.add_observer(InputRegistryPlugin::on_rebroadcast_action_received::<C>);

--- a/crates/tests/src/client_server/input/bei.rs
+++ b/crates/tests/src/client_server/input/bei.rs
@@ -2,6 +2,7 @@ use crate::client_server::prediction::trigger_state_rollback;
 use crate::protocol::{BEIAction1, BEIActionVec2, BEIContext};
 use crate::stepper::*;
 use bevy::app::{App, FixedPostUpdate, FixedPreUpdate};
+use bevy::ecs::entity_disabling::Disabled;
 use bevy::ecs::relationship::Relationship;
 use bevy::prelude::*;
 use bevy_enhanced_input::action::TriggerState;
@@ -357,6 +358,86 @@ fn test_server_replicated_action_sends_inputs_after_client_adds_bindings() {
             .resource::<SawServerFiredAction>()
             .0,
         "server should eventually receive the fired action state via mapped entity input messages"
+    );
+}
+
+#[test]
+fn test_disabled_context_propagates_to_actions() {
+    let mut stepper = ClientServerStepper::from_config(StepperConfig::single());
+    let server_entity = stepper
+        .server_app
+        .world_mut()
+        .spawn((BEIContext, Replicate::to_clients(NetworkTarget::All)))
+        .id();
+    stepper.frame_step(3);
+
+    let client_entity = stepper
+        .client(0)
+        .get::<MessageManager>()
+        .unwrap()
+        .entity_mapper
+        .get_local(server_entity)
+        .expect("entity is not present in entity map");
+    let (client_action, server_action) =
+        spawn_action_pair(&mut stepper, client_entity, server_entity, TEST_HASH + 1);
+    stepper.frame_step(1);
+    stepper
+        .client_app()
+        .world_mut()
+        .entity_mut(client_action)
+        .insert((
+            ActionMock::new(
+                TriggerState::Fired,
+                ActionValue::Bool(true),
+                MockSpan::Manual,
+            ),
+            bei::prelude::InputMarker::<BEIContext>::default(),
+        ));
+    stepper.frame_step(5);
+
+    let server_end_before_disable = stepper
+        .server_app
+        .world()
+        .entity(server_action)
+        .get::<BEIBuffer<BEIContext>>()
+        .unwrap()
+        .end_tick()
+        .expect("active input should have reached the server");
+
+    stepper
+        .client_app()
+        .world_mut()
+        .entity_mut(client_entity)
+        .insert(Disabled);
+    stepper.frame_step(1);
+
+    let client_action_ref = stepper.client_app().world().entity(client_action);
+    assert!(client_action_ref.contains::<Disabled>());
+
+    stepper.frame_step(4);
+    assert_eq!(
+        stepper
+            .server_app
+            .world()
+            .entity(server_action)
+            .get::<BEIBuffer<BEIContext>>()
+            .unwrap()
+            .end_tick(),
+        Some(server_end_before_disable)
+    );
+
+    stepper
+        .client_app()
+        .world_mut()
+        .entity_mut(client_entity)
+        .remove::<Disabled>();
+    stepper.frame_step(1);
+    assert!(
+        !stepper
+            .client_app()
+            .world()
+            .entity(client_action)
+            .contains::<Disabled>()
     );
 }
 


### PR DESCRIPTION
## Summary
- Propagate Bevy `Disabled` from a BEI context entity to its separate action entities when the context is disabled.
- Remove `Disabled` from those actions when the context is re-enabled.
- Extend the existing `ActionOf` observer so actions created under an already-disabled context inherit `Disabled` immediately.
- Rely on Bevy default query filtering to skip disabled action entities; empty input message envelopes remain unchanged.

This uses two new, documented observers in `disable.rs`. It does not add generic input-sender state or a `DisableInputSending` component.

Fixes #507

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check -p lightyear_inputs_bei --all-features`
- `cargo test -p lightyear_tests --all-features test_disabled_context_propagates_to_actions -- --test-threads=1`
- `cargo clippy -p lightyear_inputs_bei --all-features --no-deps -- -D warnings`