### PR TITLE
Propagate server link conditioners to child links

### DIFF
--- a/crates/io/link/src/server.rs
+++ b/crates/io/link/src/server.rs
@@ -5,7 +5,7 @@
 //! each child link entity to point back to the server. Transport crates can use this to keep the
 //! server endpoint independent from the concrete links used for each connected peer.
 
-use crate::{LinkPlugin, Linked, Linking, Unlink, Unlinked};
+use crate::{Link, LinkPlugin, Linked, Linking, RecvLinkConditioner, Unlink, Unlinked};
 use alloc::{format, string::String, vec::Vec};
 use bevy_app::{App, Plugin};
 use bevy_ecs::lifecycle::HookContext;
@@ -18,6 +18,7 @@ use bevy_ecs::{
 };
 use bevy_reflect::Reflect;
 use bevy_utils::prelude::DebugName;
+use lightyear_core::time::Instant;
 #[allow(unused_imports)]
 use tracing::{trace, warn};
 
@@ -28,14 +29,29 @@ use tracing::{trace, warn};
 /// child links when the server disconnects.
 /// The target collection uses `linked_spawn`, so spawning a link with [`LinkOf`] can establish
 /// the relationship at spawn time.
-#[derive(Component, Default, Debug, PartialEq, Eq, Reflect)]
+#[derive(Component, Default, Debug, Reflect)]
 #[component(on_add = Server::on_add)]
 #[relationship_target(relationship = LinkOf, linked_spawn)]
 pub struct Server {
+    #[relationship]
     links: Vec<Entity>,
+    /// Receive conditioner cloned into each new [`LinkOf`] child.
+    ///
+    /// The server endpoint does not receive packets itself. This conditioner is a template; each
+    /// child link receives an independent clone whose runtime state lives in [`Link::recv`].
+    #[reflect(ignore)]
+    pub conditioner: Option<RecvLinkConditioner>,
 }
 
 impl Server {
+    /// Creates a server with an optional receive conditioner for its child links.
+    pub fn new(conditioner: Option<RecvLinkConditioner>) -> Self {
+        Self {
+            links: Vec::new(),
+            conditioner,
+        }
+    }
+
     fn on_add(mut world: DeferredWorld, context: HookContext) {
         let entity_ref = world.entity(context.entity);
         if !entity_ref.contains::<Unlinked>()
@@ -178,6 +194,38 @@ impl LinkOf {
     }
 }
 
+/// Copies a server's receive conditioner into each newly-created client link.
+///
+/// A server entity is only the listening endpoint; packets are received by its [`LinkOf`] child
+/// entities. Keeping the conditioner in [`Link::recv`] lets all IO backends use their existing
+/// receive path unchanged.
+fn add_server_link_conditioner(
+    trigger: On<Add, LinkOf>,
+    mut links: Query<(&LinkOf, &mut Link)>,
+    servers: Query<&Server>,
+) {
+    let Ok((link_of, mut link)) = links.get_mut(trigger.entity) else {
+        return;
+    };
+    let Ok(server) = servers.get(link_of.server) else {
+        return;
+    };
+    let Some(conditioner) = &server.conditioner else {
+        return;
+    };
+    if link.recv.conditioner.is_some() {
+        return;
+    }
+
+    // The link can receive packets before deferred observers run. Reinsert any such packets so
+    // that they are conditioned too.
+    let queued_packets: Vec<_> = link.recv.drain().collect();
+    link.recv.conditioner = Some(conditioner.clone());
+    for packet in queued_packets {
+        link.recv.push(packet, Instant::now());
+    }
+}
+
 /// Plugin that installs server/link relationship support.
 ///
 /// The plugin ensures [`LinkPlugin`] is present and adds the observer that reacts to [`Unlinked`]
@@ -191,5 +239,43 @@ impl Plugin for ServerLinkPlugin {
             app.add_plugins(LinkPlugin);
         }
         app.add_observer(Server::unlinked);
+        app.add_observer(add_server_link_conditioner);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::conditioner::LinkConditionerConfig;
+    use core::time::Duration;
+
+    #[test]
+    fn link_of_inherits_server_conditioner() {
+        let mut app = App::new();
+        app.add_plugins(ServerLinkPlugin);
+        let server = app
+            .world_mut()
+            .spawn(Server::new(Some(RecvLinkConditioner::new(
+                LinkConditionerConfig {
+                    incoming_latency: Duration::from_millis(100),
+                    ..Default::default()
+                },
+            ))))
+            .id();
+
+        let link = app
+            .world_mut()
+            .spawn((LinkOf { server }, Link::default()))
+            .id();
+
+        assert!(
+            app.world()
+                .entity(link)
+                .get::<Link>()
+                .unwrap()
+                .recv
+                .conditioner
+                .is_some()
+        );
     }
 }

--- a/examples/common/src/cli.rs
+++ b/examples/common/src/cli.rs
@@ -19,10 +19,7 @@ use crate::client::{ClientTransports, ExampleClient, connect};
 #[cfg(all(any(feature = "gui2d", feature = "gui3d"), feature = "client"))]
 use crate::client_renderer::ExampleClientRendererPlugin;
 #[cfg(feature = "server")]
-use crate::server::{
-    ExampleServer, ServerTransports, WebTransportCertificateSettings,
-    apply_server_link_conditioner, start,
-};
+use crate::server::{ExampleServer, ServerTransports, WebTransportCertificateSettings, start};
 #[cfg(all(any(feature = "gui2d", feature = "gui3d"), feature = "server"))]
 use crate::server_renderer::ExampleServerRendererPlugin;
 use crate::shared::{CLIENT_PORT, SERVER_ADDR, SERVER_PORT, SHARED_SETTINGS, STEAM_APP_ID};
@@ -124,8 +121,6 @@ impl Cli {
 
     pub fn build_app(&self, tick_duration: Duration, add_inspector: bool) -> App {
         let mut app = Cli::create_app(add_inspector, self.mode.as_ref(), self.headless());
-        #[cfg(feature = "server")]
-        app.add_observer(apply_server_link_conditioner);
         match self.mode {
             #[cfg(feature = "client")]
             Some(Mode::Client { client_id }) => {

--- a/examples/common/src/server.rs
+++ b/examples/common/src/server.rs
@@ -14,7 +14,6 @@ use bevy::ecs::lifecycle::HookContext;
 use bevy::ecs::world::DeferredWorld;
 #[cfg(not(target_family = "wasm"))]
 use bevy::tasks::IoTaskPool;
-use lightyear::core::time::Instant;
 use lightyear::netcode::{NetcodeServer, PRIVATE_KEY_BYTES};
 use lightyear::prelude::server::*;
 use lightyear::prelude::*;
@@ -50,9 +49,6 @@ pub struct ExampleServer {
     pub shared: SharedSettings,
 }
 
-#[derive(Component, Clone, Debug)]
-pub(crate) struct ServerLinkConditioner(Option<RecvLinkConditioner>);
-
 impl ExampleServer {
     fn on_add(mut world: DeferredWorld, context: HookContext) {
         let entity = context.entity;
@@ -61,7 +57,7 @@ impl ExampleServer {
             let settings = entity_mut.take::<ExampleServer>().unwrap();
             entity_mut.insert((
                 Name::from("Server"),
-                ServerLinkConditioner(settings.conditioner.clone()),
+                Server::new(settings.conditioner.clone()),
             ));
 
             let add_netcode = |entity_mut: &mut EntityWorldMut| {
@@ -124,31 +120,6 @@ impl ExampleServer {
             };
             Ok(())
         });
-    }
-}
-
-pub(crate) fn apply_server_link_conditioner(
-    trigger: On<Add, LinkOf>,
-    mut links: Query<(&LinkOf, &mut Link)>,
-    servers: Query<&ServerLinkConditioner, With<Server>>,
-) {
-    let Ok((link_of, mut link)) = links.get_mut(trigger.entity) else {
-        return;
-    };
-    let Ok(server_conditioner) = servers.get(link_of.server) else {
-        return;
-    };
-    if link.recv.conditioner.is_some() {
-        return;
-    }
-    let Some(conditioner) = server_conditioner.0.clone() else {
-        return;
-    };
-
-    let queued_packets: Vec<_> = link.recv.drain().collect();
-    link.recv.conditioner = Some(conditioner);
-    for packet in queued_packets {
-        link.recv.push(packet, Instant::now());
     }
 }
 


### PR DESCRIPTION
Adding 'link_conditioner' field to Server; if present, the link conditioner will be cloned to any LinkOf attached to the server when the Link gets added