### PR TITLE
Replace cached client state with query data

### DIFF
--- a/book/src/tutorial/build_client_server.md
+++ b/book/src/tutorial/build_client_server.md
@@ -61,7 +61,7 @@ let auth = Authentication::Manual {
 };
 let client = commands
     .spawn((
-        Client::default(),
+        Client,
         LocalAddr(CLIENT_ADDR),
         PeerAddr(SERVER_ADDR),
         Link::new(None),

--- a/crates/connection/connection/src/client.rs
+++ b/crates/connection/connection/src/client.rs
@@ -2,6 +2,7 @@ use alloc::{format, string::String};
 use bevy_app::{App, Plugin};
 use bevy_ecs::lifecycle::HookContext;
 use bevy_ecs::prelude::*;
+use bevy_ecs::query::QueryData;
 use bevy_ecs::{reflect::ReflectResource, world::DeferredWorld};
 use bevy_platform::collections::HashMap;
 use bevy_reflect::Reflect;
@@ -22,23 +23,9 @@ pub enum ConnectionError {
     NotConnected,
 }
 
-#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Reflect)]
-pub enum ClientState {
-    /// Client is connected to the server
-    Connected,
-    /// Client is connecting to the server
-    Connecting,
-    Disconnecting,
-    #[default]
-    /// Client is disconnected from the server
-    Disconnected,
-}
-
 /// Marker component to identify this entity as a Client
 #[derive(Component, Default, Reflect)]
-pub struct Client {
-    pub state: ClientState,
-}
+pub struct Client;
 
 /// Trigger to connect the client
 #[derive(EntityEvent)]
@@ -71,9 +58,6 @@ impl Connected {
                 )
             })
             .0;
-        if let Some(mut client) = world.get_mut::<Client>(context.entity) {
-            client.state = ClientState::Connected;
-        };
         world
             .commands()
             .entity(context.entity)
@@ -91,9 +75,6 @@ pub struct Connecting;
 
 impl Connecting {
     fn on_add(mut world: DeferredWorld, context: HookContext) {
-        if let Some(mut client) = world.get_mut::<Client>(context.entity) {
-            client.state = ClientState::Connecting;
-        }
         world
             .commands()
             .entity(context.entity)
@@ -109,9 +90,6 @@ pub struct Disconnected {
 
 impl Disconnected {
     fn on_add(mut world: DeferredWorld, context: HookContext) {
-        if let Some(mut client) = world.get_mut::<Client>(context.entity) {
-            client.state = ClientState::Disconnected;
-        }
         if let Some(peer_id) = world.get::<RemoteId>(context.entity).map(|c| c.0) {
             world
                 .resource_mut::<PeerMetadata>()
@@ -131,13 +109,40 @@ pub struct Disconnecting;
 
 impl Disconnecting {
     fn on_add(mut world: DeferredWorld, context: HookContext) {
-        if let Some(mut client) = world.get_mut::<Client>(context.entity) {
-            client.state = ClientState::Disconnecting;
-        }
         world
             .commands()
             .entity(context.entity)
             .remove::<(Connected, Connecting, Disconnected)>();
+    }
+}
+
+/// Query view over a connection entity's lifecycle marker components.
+///
+/// Unlike the old cached state on [`Client`], this can be queried on both
+/// client entities and server-side `ClientOf` / `LinkOf` entities.
+#[derive(QueryData)]
+pub struct ClientState {
+    pub connected: Has<Connected>,
+    pub connecting: Has<Connecting>,
+    pub disconnecting: Has<Disconnecting>,
+    pub disconnected: Has<Disconnected>,
+}
+
+impl ClientStateItem<'_, '_> {
+    pub fn is_connected(&self) -> bool {
+        self.connected
+    }
+
+    pub fn is_connecting(&self) -> bool {
+        self.connecting
+    }
+
+    pub fn is_disconnecting(&self) -> bool {
+        self.disconnecting
+    }
+
+    pub fn is_disconnected(&self) -> bool {
+        self.disconnected || !(self.connected || self.connecting || self.disconnecting)
     }
 }
 
@@ -189,6 +194,34 @@ impl Plugin for ConnectionPlugin {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use crate::client_of::ClientOf;
+    use bevy_ecs::world::World;
+
     #[test]
     fn test_connection() {}
+
+    #[test]
+    fn client_state_query_reads_lifecycle_markers() {
+        let mut world = World::new();
+        let client = world.spawn(Client).id();
+        let client_of = world.spawn((ClientOf, Connecting)).id();
+        let connected_client_of = world
+            .spawn((ClientOf, RemoteId(PeerId::Local(0)), Connected))
+            .id();
+
+        let mut query = world.query::<ClientState>();
+
+        let state = query.get(&world, client).unwrap();
+        assert!(state.is_disconnected());
+        assert!(!state.is_connecting());
+
+        let state = query.get(&world, client_of).unwrap();
+        assert!(state.is_connecting());
+        assert!(!state.is_disconnected());
+
+        let state = query.get(&world, connected_client_of).unwrap();
+        assert!(state.is_connected());
+        assert!(!state.is_disconnected());
+    }
 }

--- a/crates/connection/connection/src/lib.rs
+++ b/crates/connection/connection/src/lib.rs
@@ -62,14 +62,15 @@ pub mod prelude {
 
     // we also export these types at the top level for easier access
     pub use crate::client::{
-        Client, Connect, Connected, Connecting, ConnectionError, Disconnect, Disconnected,
-        PeerMetadata,
+        Client, ClientState, Connect, Connected, Connecting, ConnectionError, Disconnect,
+        Disconnected, PeerMetadata,
     };
 
     #[cfg(feature = "client")]
     pub mod client {
         pub use crate::client::{
-            Client, Connect, Connected, Connecting, ConnectionError, Disconnect, Disconnected,
+            Client, ClientState, Connect, Connected, Connecting, ConnectionError, Disconnect,
+            Disconnected,
         };
     }
 

--- a/crates/io/crossbeam/src/lib.rs
+++ b/crates/io/crossbeam/src/lib.rs
@@ -33,7 +33,7 @@
 //!
 //! // Client-side connection entity:
 //! let client = commands
-//!     .spawn((Client::default(), RawClient, Link::new(None), io))
+//!     .spawn((Client, RawClient, Link::new(None), io))
 //!     .id();
 //! commands.trigger(Connect { entity: client });  // Connect → LinkStart internally
 //! ```

--- a/crates/tests/src/client_server/deterministic/stepper.rs
+++ b/crates/tests/src/client_server/deterministic/stepper.rs
@@ -124,7 +124,7 @@ impl DetStepper {
         let client_entity = client_app
             .world_mut()
             .spawn((
-                Client::default(),
+                Client,
                 PingManager::new(PingConfig {
                     ping_interval: Duration::default(),
                 }),

--- a/crates/tests/src/stepper.rs
+++ b/crates/tests/src/stepper.rs
@@ -264,7 +264,7 @@ impl ClientServerStepper {
                     .world_mut()
                     .spawn((
                         // Client + LinkOf = HostServer
-                        Client::default(),
+                        Client,
                         LinkOf {
                             server: self.server_entity,
                         },
@@ -277,7 +277,7 @@ impl ClientServerStepper {
             return 0;
         }
         let mut client = client_app.world_mut().spawn((
-            Client::default(),
+            Client,
             // Send pings every frame, so that the Acks are sent every frame
             PingManager::new(PingConfig {
                 ping_interval: Duration::default(),

--- a/examples/auth/src/client.rs
+++ b/examples/auth/src/client.rs
@@ -190,19 +190,16 @@ pub(crate) fn spawn_connect_button(mut commands: Commands) {
                     |trigger: On<Pointer<Click>>,
                      mut commands: Commands,
                      mut task_state: ResMut<ConnectTokenRequestTask>,
-                     client: Single<(Entity, &Client)>| {
-                        let (client_entity, client) = client.into_inner();
-                        match client.state {
-                            ClientState::Disconnected => {
-                                info!("Starting task to get ConnectToken");
-                                begin_connect_token_request(&mut task_state);
-                            }
-                            _ => {
-                                info!("Disconnecting from server");
-                                commands.trigger(Disconnect {
-                                    entity: client_entity,
-                                });
-                            }
+                     client: Single<(Entity, ClientState), With<Client>>| {
+                        let (client_entity, state) = client.into_inner();
+                        if state.is_disconnected() {
+                            info!("Starting task to get ConnectToken");
+                            begin_connect_token_request(&mut task_state);
+                        } else {
+                            info!("Disconnecting from server");
+                            commands.trigger(Disconnect {
+                                entity: client_entity,
+                            });
                         };
                     },
                 );
@@ -211,23 +208,19 @@ pub(crate) fn spawn_connect_button(mut commands: Commands) {
 
 #[cfg(feature = "gui")]
 fn update_button_text(
-    client: Single<&Client>,
+    client: Single<ClientState, With<Client>>,
     mut text_query: Query<&mut Text, With<AuthConnectButton>>,
 ) {
     if let Ok(mut text) = text_query.single_mut() {
-        match client.state {
-            ClientState::Disconnecting => {
-                text.0 = "Disconnecting".to_string();
-            }
-            ClientState::Disconnected => {
-                text.0 = "Connect".to_string();
-            }
-            ClientState::Connecting => {
-                text.0 = "Connecting".to_string();
-            }
-            ClientState::Connected => {
-                text.0 = "Disconnect".to_string();
-            }
+        let state = client.into_inner();
+        if state.is_disconnecting() {
+            text.0 = "Disconnecting".to_string();
+        } else if state.is_disconnected() {
+            text.0 = "Connect".to_string();
+        } else if state.is_connecting() {
+            text.0 = "Connecting".to_string();
+        } else if state.is_connected() {
+            text.0 = "Disconnect".to_string();
         }
     }
 }

--- a/examples/common/src/cli.rs
+++ b/examples/common/src/cli.rs
@@ -218,11 +218,7 @@ impl Cli {
 
                 let client = app
                     .world_mut()
-                    .spawn((
-                        Client::default(),
-                        Name::new("HostClient"),
-                        LinkOf { server },
-                    ))
+                    .spawn((Client, Name::new("HostClient"), LinkOf { server }))
                     .id();
                 // NOTE: it's ugly but i believe that you need to start the server before
                 //  connecting the host-client for things to work properly

--- a/examples/common/src/client.rs
+++ b/examples/common/src/client.rs
@@ -49,7 +49,7 @@ impl ExampleClient {
             let settings = entity_mut.take::<ExampleClient>().unwrap();
             let client_addr = SocketAddr::new(Ipv4Addr::UNSPECIFIED.into(), settings.client_port);
             entity_mut.insert((
-                Client::default(),
+                Client,
                 Link::new(settings.conditioner.clone()),
                 LocalAddr(client_addr),
                 PeerAddr(settings.server_addr),

--- a/examples/common/src/client_renderer.rs
+++ b/examples/common/src/client_renderer.rs
@@ -104,17 +104,14 @@ pub(crate) fn spawn_connect_button(app: &mut App) {
                 .observe(
                     |_: On<Pointer<Click>>,
                      mut commands: Commands,
-                     query: Query<(Entity, &Client)>| {
-                        let Ok((entity, client)) = query.single() else {
+                     query: Query<(Entity, ClientState), With<Client>>| {
+                        let Ok((entity, state)) = query.single() else {
                             return;
                         };
-                        match client.state {
-                            ClientState::Disconnected => {
-                                commands.trigger(Connect { entity });
-                            }
-                            _ => {
-                                commands.trigger(Disconnect { entity });
-                            }
+                        if state.is_disconnected() {
+                            commands.trigger(Connect { entity });
+                        } else {
+                            commands.trigger(Disconnect { entity });
                         };
                     },
                 );
@@ -122,23 +119,19 @@ pub(crate) fn spawn_connect_button(app: &mut App) {
 }
 
 pub(crate) fn update_button_text(
-    client: Single<&Client>,
+    client: Single<ClientState, With<Client>>,
     mut text_query: Query<&mut Text, (With<Button>, With<ClientButton>)>,
 ) {
     if let Ok(mut text) = text_query.single_mut() {
-        match client.state {
-            ClientState::Disconnecting => {
-                text.0 = "Disconnecting".to_string();
-            }
-            ClientState::Disconnected => {
-                text.0 = "Connect".to_string();
-            }
-            ClientState::Connecting => {
-                text.0 = "Connecting".to_string();
-            }
-            ClientState::Connected => {
-                text.0 = "Disconnect".to_string();
-            }
+        let state = client.into_inner();
+        if state.is_disconnecting() {
+            text.0 = "Disconnecting".to_string();
+        } else if state.is_disconnected() {
+            text.0 = "Connect".to_string();
+        } else if state.is_connecting() {
+            text.0 = "Connecting".to_string();
+        } else if state.is_connected() {
+            text.0 = "Disconnect".to_string();
         }
     }
 }

--- a/examples/lobby/src/client.rs
+++ b/examples/lobby/src/client.rs
@@ -254,17 +254,20 @@ mod lobby {
         mut contexts: EguiContexts,
         mut lobby_table: ResMut<LobbyTable>,
         lobbies: Option<Single<&Lobbies>>,
-        message_sender: Single<(
-            Entity,
-            &Client,
-            &mut MessageSender<StartGame>,
-            &mut MessageSender<JoinLobby>,
-            &mut MessageSender<ExitLobby>,
-        )>,
+        message_sender: Single<
+            (
+                Entity,
+                ClientState,
+                &mut MessageSender<StartGame>,
+                &mut MessageSender<JoinLobby>,
+                &mut MessageSender<ExitLobby>,
+            ),
+            With<Client>,
+        >,
         app_state: Res<State<AppState>>,
         mut next_app_state: ResMut<NextState<AppState>>,
     ) -> Result {
-        let (client_entity, client, mut send_start_game, mut send_join_lobby, mut exit_lobby) =
+        let (client_entity, state, mut send_start_game, mut send_join_lobby, mut exit_lobby) =
             message_sender.into_inner();
         let window_name = match app_state.get() {
             AppState::Lobby { joined_lobby } => {
@@ -389,16 +392,13 @@ mod lobby {
                     }
                     AppState::Game => {}
                 };
-                match client.state {
-                    ClientState::Disconnected | ClientState::Disconnecting => {
+                if state.is_disconnected() || state.is_disconnecting() {
                         if ui.button("Join lobby list").clicked() {
                             commands.trigger(Connect { entity: client_entity });
                         }
-                    }
-                    ClientState::Connecting => {
+                } else if state.is_connecting() {
                         let _ = ui.button("Connecting");
-                    }
-                    ClientState::Connected => {
+                } else if state.is_connected() {
                         match app_state.get() {
                             AppState::Lobby { joined_lobby } => {
                                 if let Some(lobby_id) = joined_lobby {
@@ -430,7 +430,6 @@ mod lobby {
                                 }
                             }
                         }
-                    }
                 }
             });
         Ok(())

--- a/examples/projectiles/src/server.rs
+++ b/examples/projectiles/src/server.rs
@@ -453,7 +453,7 @@ mod bot {
         let conditioner = LinkConditionerConfig::average_condition().half();
 
         app.world_mut().spawn((
-            Client::default(),
+            Client,
             BotClient,
             ReplicationSender,
             ReplicationReceiver,

--- a/examples/simple_setup/src/client.rs
+++ b/examples/simple_setup/src/client.rs
@@ -26,11 +26,7 @@ fn startup(mut commands: Commands, config: Res<ClientStartupConfig>) -> Result {
     }
     let client = if let Some(server) = config.host_server {
         commands
-            .spawn((
-                Client::default(),
-                Name::new("HostClient"),
-                LinkOf { server },
-            ))
+            .spawn((Client, Name::new("HostClient"), LinkOf { server }))
             .id()
     } else {
         let auth = Authentication::Manual {
@@ -41,7 +37,7 @@ fn startup(mut commands: Commands, config: Res<ClientStartupConfig>) -> Result {
         };
         commands
             .spawn((
-                Client::default(),
+                Client,
                 LocalAddr(CLIENT_ADDR),
                 PeerAddr(SERVER_ADDR),
                 Link::new(None),


### PR DESCRIPTION
## Summary
- Remove the cached Lightyear connection `ClientState` enum from the `Client` marker component.
- Reintroduce `ClientState` as `QueryData` over the lifecycle markers: `Connected`, `Connecting`, `Disconnecting`, and `Disconnected`.
- Update example UI code to query the lifecycle state directly, add coverage for server-side `ClientOf` entities, and replace `Client::default()` call sites now that `Client` is a unit marker.

Fixes #1185

## Validation
- `cargo fmt --check`
- `cargo clippy --features=lightyear_core/not_mock,avian3d/f32 --workspace --exclude=compiletime --exclude=avian_3d --exclude=launcher --exclude=delta_compression --exclude=distributed_authority --no-deps -- -D warnings -A clippy::needless_lifetimes`
- `cargo test -p lightyear_connection --all-features`
- `cargo test -p lightyear_tests --all-features -- --test-threads=1`
- `cargo check -p lightyear_examples_common --all-features`
- `cargo check -p auth --all-features`
- `cargo check -p lobby --all-features`