### PR TITLE
Clarify LinkState::Linked docs

### DIFF
--- a/crates/io/link/src/lib.rs
+++ b/crates/io/link/src/lib.rs
@@ -73,7 +73,7 @@ pub type SendPayload = Bytes;
 /// directly, because the marker hooks also remove the other lifecycle markers.
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LinkState {
-    /// The link is established and can exchange payloads.
+    /// The link is established and ready to exchange payloads.
     Linked,
     /// The link is being established by the transport.
     Linking,


### PR DESCRIPTION
## Summary
- Clarify the `LinkState::Linked` documentation to state that the link is established and ready to exchange payloads.

Fixes #1176

## Validation
- `cargo check -p lightyear_link --all-features`

Note: the original typo reported in the issue was already corrected on current `main`; this PR keeps the wording explicit and closes the still-open issue.