### PR TITLE
Document PredictionManager setup

### DIFF
--- a/book/src/tutorial/advanced_systems.md
+++ b/book/src/tutorial/advanced_systems.md
@@ -18,15 +18,33 @@ The solution is to run the same simulation systems on the client as on the serve
 This is "client-prediction": we move the client-controlled entity immediately according to our user inputs, and then we correct the position
 when we receive the actual state of the entity from the server. (if there is a mismatch)
 
-To do this in lightyear, you will need to change a few things.
+To do this in lightyear, you will need to change a few things:
+
+- enable prediction for the component in your protocol;
+- add a `PredictionManager` component to the local client entity;
+- mark the entity as predicted, either with `PredictionTarget` on the send-side or by adding
+  `Predicted` on the receive-side.
+
+First, in your protocol, specify that the component should be synced from the confirmed entity to the predicted entity:
 
 ```rust,ignore
 app.component::<PlayerPosition>().replicate()
     .predict();
 ```
 
-Then, when replicating the entity, you can also specify which clients should predict the entity by adding a `PredictionTarget` component.
-Usually, the client that 'controls' the entity will be predicting it.
+Then, make sure your client entity has a `PredictionManager`. `ClientPlugins` installs the prediction systems, but the systems only run for a connected client entity that has this component. The shared example helpers insert it in `ExampleClient`; if you spawn your own client entity, add it there:
+
+```rust,ignore
+commands.spawn((
+    Client::default(),
+    PredictionManager::default(),
+    // Link, IO, connection components...
+));
+```
+
+Finally, choose which replicated entities should be predicted. If the sender knows which clients
+should predict the entity, add a `PredictionTarget` component on the send-side. Usually, the client
+that 'controls' the entity will be predicting it.
 ```rust,ignore
 let entity = commands
         .spawn((
@@ -35,10 +53,15 @@ let entity = commands
         ))
         .id();
 ```
-(another way to spawn a predicted entity is to add the `ShouldBePredicted` component to a `Replicated` entity on the client)
 
+If the receiver decides locally that an entity should be predicted, add `Predicted` on the
+receive-side instead:
 
-If prediction is enabled for an entity, the client will add a `Predicted` component on the replicated entity.
+```rust,ignore
+commands.entity(replicated_entity).insert(Predicted);
+```
+
+Once prediction is enabled for an entity, the receive-side entity has a `Predicted` component.
 Non-predicted components will be replicated normally, but predicted components will be inserted on the entity as `Confirmed<PlayerPosition>`. The predicted component value will then be 
 `PlayerPosition`. The reasoning is that it is very rare to want to query the confirmed value, in most cases you just want to use the predicted value.
 Non-predicted 

--- a/crates/core/core/src/prediction.rs
+++ b/crates/core/core/src/prediction.rs
@@ -7,6 +7,10 @@ use serde::{Deserialize, Serialize};
 /// Prediction allows the client to simulate the game state locally without waiting for server confirmation,
 /// reducing perceived latency. This component links the predicted entity to its server-confirmed counterpart.
 ///
+/// An entity can become predicted either because the sender used
+/// `PredictionTarget` for that receiver, or because the receiver inserted
+/// `Predicted` directly on the received entity.
+///
 /// When an entity is marked as `Predicted`, the `PredictionPlugin` will:
 /// - Store its component history.
 /// - Rollback and re-simulate the entity when a server correction is received.

--- a/crates/replication/prediction/src/manager.rs
+++ b/crates/replication/prediction/src/manager.rs
@@ -77,6 +77,12 @@ impl RollbackPolicy {
     }
 }
 
+/// Component that enables prediction and rollback for a local client.
+///
+/// [`PredictionPlugin`](crate::prelude::PredictionPlugin) installs the prediction systems, but
+/// those systems only run for a connected, non-host [`Client`](lightyear_connection::client::Client)
+/// entity that also has `PredictionManager`. Add this to your client entity when it should create
+/// predicted entities, record prediction history, and perform rollback/reconciliation.
 #[derive(Component, Debug, Reflect)]
 #[component(on_insert = PredictionManager::on_insert)]
 #[require(InputTimelineConfig)]

--- a/crates/replication/prediction/src/plugin.rs
+++ b/crates/replication/prediction/src/plugin.rs
@@ -26,7 +26,11 @@ use lightyear_connection::host::HostClient;
 use lightyear_core::prelude::ConfirmedHistory;
 use lightyear_replication::prelude::ReplicationSystems;
 
-/// Plugin that enables client-side prediction
+/// Plugin that installs client-side prediction systems.
+///
+/// The systems run for connected, non-host client entities with a
+/// [`PredictionManager`] component. Add `PredictionManager` to the local client
+/// entity to opt that client into prediction and rollback.
 #[derive(Default)]
 pub struct PredictionPlugin;
 

--- a/crates/replication/replication/src/lib.rs
+++ b/crates/replication/replication/src/lib.rs
@@ -26,6 +26,8 @@
 //! [`Replicate`] (alias for [`ReplicationTarget<()>`]) controls which peers
 //! receive an entity. [`PredictionTarget`] and [`InterpolationTarget`] further
 //! control which clients run prediction or interpolation for that entity.
+//! `PredictionTarget` is the send-side way to enable prediction for an entity;
+//! the receiver can also insert [`Predicted`] directly on the received entity.
 //! Each target uses a [`ReplicationMode`] to specify the set of recipients.
 //!
 //! A [`ReplicationSender`] component must be present on the link entity
@@ -71,6 +73,7 @@
 //! [`ReplicationTarget<()>`]: crate::send::ReplicationTarget
 //! [`PredictionTarget`]: crate::send::PredictionTarget
 //! [`InterpolationTarget`]: crate::send::InterpolationTarget
+//! [`Predicted`]: lightyear_core::prediction::Predicted
 //! [`ReplicationMode`]: crate::send::ReplicationMode
 //! [`ReplicationSender`]: crate::send::ReplicationSender
 //! [`ReplicateLike`]: crate::hierarchy::ReplicateLike

--- a/crates/replication/replication/src/send.rs
+++ b/crates/replication/replication/src/send.rs
@@ -344,6 +344,10 @@ mod prediction {
 
     /// Controls which clients run client-side prediction for this entity.
     ///
+    /// This is the send-side way to enable prediction for an entity. The
+    /// receive-side can also opt an entity into prediction by inserting
+    /// `Predicted` directly on the received entity.
+    ///
     /// Typically set to the owning client so they get a `Predicted` entity,
     /// while other clients receive an `Interpolated` entity instead.
     ///


### PR DESCRIPTION
## Summary
- Update the client prediction tutorial to list `PredictionManager` as required client setup.
- Clarify that an entity can be enabled for prediction either with `PredictionTarget` on the send-side or by inserting `Predicted` on the receive-side.
- Add rustdocs on `PredictionManager`, `PredictionPlugin`, `Predicted`, and `PredictionTarget` explaining the setup requirements.

Fixes #1123

## Validation
- `cargo check -p lightyear_prediction --all-features`
- `cargo check -p lightyear_core --all-features`
- `cargo check -p lightyear_replication --no-default-features --features std,client,server,delta,prediction,interpolation,deterministic,trace,metrics,test_utils`
- `mdbook build book`

Note: `cargo check -p lightyear_core -p lightyear_replication --all-features` was attempted first, but `lightyear_replication --all-features` pulls Avian without the required Avian dimension/scalar features in this workspace configuration, so the narrower non-Avian replication feature set above was used instead.