### PR TITLE
feat: add hermitian interpolation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -245,6 +245,7 @@ bevy_replicon = { git = "https://github.com/simgine/bevy_replicon", branch = "ma
 # physics
 avian2d = { version = "0.7", default-features = false }
 avian3d = { version = "0.7", default-features = false }
+bevy_transform_interpolation = { version = "0.5", default-features = false }
 
 # gui debug ui
 bevy-inspector-egui = { version = "0.37", default-features = false, features = [

--- a/crates/core/core/src/ecs_utils.rs
+++ b/crates/core/core/src/ecs_utils.rs
@@ -2,22 +2,11 @@
 
 use bevy_ecs::{
     archetype::Archetype,
-    component::{Component, ComponentId, StorageType},
+    component::{Component, ComponentId, Mutable, StorageType},
     storage::Table,
     world::unsafe_world_cell::UnsafeWorldCell,
 };
 use core::cell::UnsafeCell;
-
-/// Component column state for table-optimized archetype scans.
-#[derive(Clone, Copy)]
-pub enum ComponentTableColumn<'w, C> {
-    /// The component is present and table-stored on this archetype.
-    Table(&'w [UnsafeCell<C>]),
-    /// The component type is not registered or not present on this archetype.
-    Missing,
-    /// The component is present but not table-stored.
-    NonTable,
-}
 
 /// Returns the table backing `archetype`.
 pub fn table_for_archetype<'w>(
@@ -52,21 +41,34 @@ pub fn table_component_slice_if_table<C: Component>(
     }
 }
 
-/// Returns table-column state for component `C` on `archetype`.
-pub fn component_table_column<'w, C: Component>(
-    world: UnsafeWorldCell<'w>,
-    archetype: &Archetype,
-    table: &'w Table,
-) -> ComponentTableColumn<'w, C> {
-    let Some(component_id) = world.components().component_id::<C>() else {
-        return ComponentTableColumn::Missing;
+/// Replaces an entity's component value through Bevy's change-detection-aware
+/// mutable access.
+///
+/// Type-erased systems often read histories directly from table columns for
+/// efficient archetype scans. Writing a live component through the same raw
+/// column access would update its value without updating its change tick. This
+/// helper preserves normal `Mut<C>` semantics while keeping the surrounding
+/// scan type-erased.
+///
+/// Returns `false` when the entity no longer exists or does not contain `C`.
+///
+/// # Safety
+///
+/// The caller must have exclusive access to `C` and must not hold any other
+/// reference to this entity's `C`.
+pub unsafe fn write_component_with_change_detection<C: Component<Mutability = Mutable>>(
+    world: UnsafeWorldCell,
+    entity: bevy_ecs::entity::Entity,
+    value: C,
+) -> bool {
+    let Ok(entity) = world.get_entity(entity) else {
+        return false;
     };
-    if !archetype.contains(component_id) {
-        return ComponentTableColumn::Missing;
-    }
-    let Some(StorageType::Table) = archetype.get_storage_type(component_id) else {
-        return ComponentTableColumn::NonTable;
+    // SAFETY: upheld by the caller. `get_mut` returns Bevy's `Mut<C>`, so
+    // assigning through it updates the component's change tick and caller.
+    let Some(mut component) = (unsafe { entity.get_mut::<C>() }) else {
+        return false;
     };
-    table_component_slice::<C>(table, component_id)
-        .map_or(ComponentTableColumn::NonTable, ComponentTableColumn::Table)
+    *component = value;
+    true
 }

--- a/crates/core/frame_interpolation/src/lib.rs
+++ b/crates/core/frame_interpolation/src/lib.rs
@@ -18,6 +18,10 @@
 //!   [`InterpolationFns::no_history`](lightyear_interpolation::rules::InterpolationFns::no_history).
 //! - FrameInterpolation is not enabled by default; add [`FrameInterpolationPlugin`] manually
 //! - To enable FrameInterpolation on a given entity, add the type-erased [`FrameInterpolate`] marker to it manually
+//!
+//! Frame interpolation writes through Bevy's change-detection-aware component
+//! access. Systems ordered after [`FrameInterpolationSystems::Interpolate`] can
+//! therefore use `Changed<C>` to react to the visual value.
 //! ```rust,ignore
 //! # use lightyear_frame_interpolation::prelude::*;
 //! # use lightyear_interpolation::prelude::*;
@@ -298,6 +302,7 @@ pub(crate) fn apply_frame_interpolation(
     let mut deferred_apply = DeferredEntityCommands::default();
     let ctx = FrameInterpolationContext {
         overstep: time.overstep_fraction().clamp(0.0, 1.0),
+        sample_delta_secs: Some(time.timestep().as_secs_f32()),
     };
 
     frame_world.update_archetypes(&interpolation_registry);
@@ -339,7 +344,9 @@ mod unit_tests {
     use core::time::Duration;
     use lightyear_core::prelude::ConfirmedHistory;
     use lightyear_interpolation::registry::AppInterpolationExt;
-    use lightyear_interpolation::rules::{InterpolationFns, InterpolationFnsExt};
+    use lightyear_interpolation::rules::{
+        InterpolationFns, InterpolationFnsExt, InterpolationSampleContext,
+    };
     use lightyear_replication::prelude::AppComponentExt;
     use serde::{Deserialize, Serialize};
 
@@ -372,6 +379,17 @@ mod unit_tests {
         (
             FrameA(100.0 + start.0.0 + (end.0.0 - start.0.0) * t),
             FrameB(200.0 + start.1.0 + (end.1.0 - start.1.0) * t),
+        )
+    }
+
+    fn bundle_context_lerp(
+        _start: (FrameA, FrameB),
+        _end: (FrameA, FrameB),
+        context: InterpolationSampleContext,
+    ) -> (FrameA, FrameB) {
+        (
+            FrameA(context.t),
+            FrameB(context.sample_delta_secs.unwrap_or_default()),
         )
     }
 
@@ -505,11 +523,75 @@ mod unit_tests {
                 },
             ))
             .id();
+        app.world_mut().clear_trackers();
+        let first_changed = app
+            .world()
+            .entity(entity)
+            .get_change_ticks::<FrameA>()
+            .unwrap()
+            .changed;
+        let second_changed = app
+            .world()
+            .entity(entity)
+            .get_change_ticks::<FrameB>()
+            .unwrap()
+            .changed;
 
         app.world_mut().run_schedule(PostUpdate);
 
         assert_eq!(app.world().get::<FrameA>(entity), Some(&FrameA(105.0)));
         assert_eq!(app.world().get::<FrameB>(entity), Some(&FrameB(210.0)));
+        assert_ne!(
+            app.world()
+                .entity(entity)
+                .get_change_ticks::<FrameA>()
+                .unwrap()
+                .changed,
+            first_changed
+        );
+        assert_ne!(
+            app.world()
+                .entity(entity)
+                .get_change_ticks::<FrameB>()
+                .unwrap()
+                .changed,
+            second_changed
+        );
+    }
+
+    #[test]
+    fn frame_bundle_interpolation_receives_fixed_timestep() {
+        let mut app = App::new();
+        app.insert_resource(Time::<Fixed>::from_duration(Duration::from_secs(2)));
+        app.world_mut()
+            .resource_mut::<Time<Fixed>>()
+            .accumulate_overstep(Duration::from_millis(500));
+        app.add_plugins(FrameInterpolationPlugin);
+        app.interpolate_bundle_with::<(FrameA, FrameB)>(InterpolationFns::no_history_with_context(
+            bundle_context_lerp,
+        ));
+
+        let entity = app
+            .world_mut()
+            .spawn((
+                FrameInterpolate,
+                FrameA(-1.0),
+                FrameB(-1.0),
+                FrameInterpolationHistory::<FrameA> {
+                    previous_value: Some(FrameA(0.0)),
+                    current_value: Some(FrameA(10.0)),
+                },
+                FrameInterpolationHistory::<FrameB> {
+                    previous_value: Some(FrameB(0.0)),
+                    current_value: Some(FrameB(20.0)),
+                },
+            ))
+            .id();
+
+        app.world_mut().run_schedule(PostUpdate);
+
+        assert_eq!(app.world().get::<FrameA>(entity), Some(&FrameA(0.25)));
+        assert_eq!(app.world().get::<FrameB>(entity), Some(&FrameB(2.0)));
     }
 
     #[test]
@@ -542,10 +624,25 @@ mod unit_tests {
                 },
             ))
             .id();
+        app.world_mut().clear_trackers();
+        let changed = app
+            .world()
+            .entity(entity)
+            .get_change_ticks::<FrameA>()
+            .unwrap()
+            .changed;
 
         app.world_mut().run_schedule(PostUpdate);
 
         assert_eq!(app.world().get::<FrameA>(entity), Some(&FrameA(12.0)));
+        assert_ne!(
+            app.world()
+                .entity(entity)
+                .get_change_ticks::<FrameA>()
+                .unwrap()
+                .changed,
+            changed
+        );
     }
 
     #[test]
@@ -655,11 +752,26 @@ mod unit_tests {
             .unwrap();
         assert_eq!(history.previous_value, Some(SparseFrame(1.0)));
         assert_eq!(history.current_value, Some(SparseFrame(3.0)));
+        app.world_mut().clear_trackers();
+        let changed = app
+            .world()
+            .entity(entity)
+            .get_change_ticks::<SparseFrame>()
+            .unwrap()
+            .changed;
 
         app.world_mut().run_schedule(PostUpdate);
         assert_eq!(
             app.world().get::<SparseFrame>(entity),
             Some(&SparseFrame(2.0))
+        );
+        assert_ne!(
+            app.world()
+                .entity(entity)
+                .get_change_ticks::<SparseFrame>()
+                .unwrap()
+                .changed,
+            changed
         );
 
         app.world_mut().run_schedule(RunFixedMainLoop);

--- a/crates/integration/avian/src/plugin.rs
+++ b/crates/integration/avian/src/plugin.rs
@@ -65,6 +65,13 @@ Visual correction uses frame-interpolation rules and history. Registering correc
 [`FrameInterpolate`](lightyear_frame_interpolation::FrameInterpolate) when it stores the previous
 visual value. If neither visual feature is wanted, omit correction; rollback then snaps directly
 to canonical physics state.
+
+Position mode automatically registers velocity-aware Hermite interpolation for the
+`(Position, Rotation, LinearVelocity, AngularVelocity)` bundle. Delayed interpolation, frame
+interpolation, and visual correction select it whenever all four components are present. The
+per-component rules remain useful for archetypes that do not contain the complete bundle. This
+does not implicitly replicate those components; the application protocol still chooses which
+components are sent over the network.
 !*/
 use alloc::vec::Vec;
 #[cfg(all(feature = "2d", not(feature = "3d")))]
@@ -199,6 +206,7 @@ impl Plugin for LightyearAvianPlugin {
         app.init_resource::<PhysicsTransformConfig>();
         match self.replication_mode {
             AvianReplicationMode::Position { sync_to_transform } => {
+                Self::add_position_rotation_hermite_rule(app);
                 if !self.update_syncs_manually {
                     let mut config = app.world_mut().resource_mut::<PhysicsTransformConfig>();
                     config.position_to_transform = true;
@@ -377,6 +385,16 @@ impl Plugin for LightyearAvianPlugin {
 }
 
 impl LightyearAvianPlugin {
+    /// Register the canonical Avian pose and velocity bundle once for every
+    /// Position-mode application. The bundle's default priority is its four
+    /// members, so it wins over ordinary single-component rules whenever the
+    /// complete bundle is present.
+    fn add_position_rotation_hermite_rule(app: &mut App) {
+        app.interpolate_bundle_with::<(Position, Rotation, LinearVelocity, AngularVelocity)>(
+            InterpolationFns::interpolate_with_context(crate::types::position_rotation::hermite),
+        );
+    }
+
     // Add a low-priority interpolation function for Transform
     // (that could be used for Correction or FrameInterpolation)
     fn add_transform_frame_interpolation_rule(app: &mut App) {
@@ -950,7 +968,9 @@ impl LightyearAvianPlugin {
 
 #[cfg(test)]
 mod mode_tests {
-    use super::AvianReplicationMode;
+    use super::*;
+    use lightyear_core::prelude::ConfirmedHistory;
+    use lightyear_interpolation::registry::InterpolationRegistry;
 
     #[test]
     fn position_mode_defaults_to_sync_to_transform_disabled() {
@@ -959,6 +979,31 @@ mod mode_tests {
             AvianReplicationMode::Position {
                 sync_to_transform: false
             }
+        );
+    }
+
+    #[test]
+    fn position_mode_registers_pose_velocity_hermite_rule() {
+        let mut app = App::new();
+        app.add_plugins(LightyearAvianPlugin {
+            replication_mode: AvianReplicationMode::Position {
+                sync_to_transform: false,
+            },
+            update_syncs_manually: true,
+            ..Default::default()
+        });
+
+        let registry = app.world().resource::<InterpolationRegistry>();
+        assert!(registry.interpolated::<Position>());
+        assert!(registry.interpolated::<Rotation>());
+        assert!(registry.interpolated::<LinearVelocity>());
+        assert!(registry.interpolated::<AngularVelocity>());
+        assert!(
+            app.world()
+                .components()
+                .component_id::<ConfirmedHistory<Position>>()
+                .is_some(),
+            "the automatic rule must own delayed-interpolation history"
         );
     }
 }
@@ -974,6 +1019,25 @@ mod tests {
     use lightyear_frame_interpolation::{
         FrameInterpolate, FrameInterpolationHistory, FrameInterpolationPlugin,
     };
+
+    fn seed_stationary_hermite_histories(app: &mut App, entity: Entity, include_previous: bool) {
+        let mut entity = app.world_mut().entity_mut(entity);
+        let mut rotation = entity
+            .get_mut::<FrameInterpolationHistory<Rotation>>()
+            .unwrap();
+        rotation.current_value = Some(Rotation::default());
+        rotation.previous_value = include_previous.then(Rotation::default);
+        let mut linear = entity
+            .get_mut::<FrameInterpolationHistory<LinearVelocity>>()
+            .unwrap();
+        linear.current_value = Some(LinearVelocity::default());
+        linear.previous_value = include_previous.then(LinearVelocity::default);
+        let mut angular = entity
+            .get_mut::<FrameInterpolationHistory<AngularVelocity>>()
+            .unwrap();
+        angular.current_value = Some(AngularVelocity::default());
+        angular.previous_value = include_previous.then(AngularVelocity::default);
+    }
 
     #[test]
     fn position_mode_does_not_copy_stale_transform_into_physics() {
@@ -1065,6 +1129,7 @@ mod tests {
             .get_mut::<FrameInterpolationHistory<Position>>()
             .unwrap()
             .current_value = Some(visual_position);
+        seed_stationary_hermite_histories(&mut app, entity, false);
         app.world_mut().run_schedule(PostUpdate);
 
         let transform = app.world().get::<Transform>(entity).unwrap();
@@ -1117,6 +1182,8 @@ mod tests {
                 },
             ))
             .id();
+
+        seed_stationary_hermite_histories(&mut app, entity, true);
 
         // PostUpdate leaves the interpolated visual pose in both Position and Transform.
         app.world_mut().run_schedule(PostUpdate);
@@ -1236,6 +1303,25 @@ mod tests_3d {
         FrameInterpolate, FrameInterpolationHistory, FrameInterpolationPlugin,
     };
 
+    fn seed_stationary_hermite_histories(app: &mut App, entity: Entity, include_previous: bool) {
+        let mut entity = app.world_mut().entity_mut(entity);
+        let mut rotation = entity
+            .get_mut::<FrameInterpolationHistory<Rotation>>()
+            .unwrap();
+        rotation.current_value = Some(Rotation::default());
+        rotation.previous_value = include_previous.then(Rotation::default);
+        let mut linear = entity
+            .get_mut::<FrameInterpolationHistory<LinearVelocity>>()
+            .unwrap();
+        linear.current_value = Some(LinearVelocity::default());
+        linear.previous_value = include_previous.then(LinearVelocity::default);
+        let mut angular = entity
+            .get_mut::<FrameInterpolationHistory<AngularVelocity>>()
+            .unwrap();
+        angular.current_value = Some(AngularVelocity::default());
+        angular.previous_value = include_previous.then(AngularVelocity::default);
+    }
+
     #[test]
     fn position_mode_does_not_copy_stale_transform_into_physics() {
         let mut app = App::new();
@@ -1323,6 +1409,7 @@ mod tests_3d {
             .get_mut::<FrameInterpolationHistory<Position>>()
             .unwrap()
             .current_value = Some(visual_position);
+        seed_stationary_hermite_histories(&mut app, entity, false);
         app.world_mut().run_schedule(PostUpdate);
 
         let transform = app.world().get::<Transform>(entity).unwrap();
@@ -1375,6 +1462,8 @@ mod tests_3d {
                 },
             ))
             .id();
+
+        seed_stationary_hermite_histories(&mut app, entity, true);
 
         app.world_mut().run_schedule(PostUpdate);
         assert_eq!(

--- a/crates/integration/avian/src/types_2d.rs
+++ b/crates/integration/avian/src/types_2d.rs
@@ -1,6 +1,10 @@
 //! Implement lightyear traits for some common bevy types
-use avian2d::math::Scalar;
+use avian2d::math::{AdjustPrecision, AsF32, Quaternion, Scalar};
 use avian2d::prelude::*;
+use bevy_math::Vec3;
+use bevy_transform::components::Transform;
+use bevy_transform_interpolation::hermite::{hermite_quat, hermite_vec3};
+use lightyear_interpolation::prelude::InterpolationSampleContext;
 use tracing::trace;
 
 #[cfg(feature = "deterministic")]
@@ -82,5 +86,315 @@ pub mod angular_velocity {
             start, other, t, res
         );
         res
+    }
+}
+
+pub mod position_rotation {
+    use super::*;
+
+    /// Interpolates `(Position, Rotation, LinearVelocity, AngularVelocity)`
+    /// using Hermite interpolation for position and rotation.
+    ///
+    /// This is intended for [`FrameInterpolate`](lightyear_core::prelude::FrameInterpolate)
+    /// and prediction correction in
+    /// [`AvianReplicationMode::Position`](crate::plugin::AvianReplicationMode::Position).
+    /// Avian velocities are expressed per second, so
+    /// [`InterpolationSampleContext::sample_delta_secs`] scales the endpoint
+    /// tangents to the bracketing sample interval. If that interval is
+    /// unavailable, position falls back to linear interpolation and rotation
+    /// falls back to shortest-path interpolation.
+    ///
+    /// [`LightyearAvianPlugin`](crate::plugin::LightyearAvianPlugin)
+    /// automatically registers this as a full bundle rule in
+    /// [`AvianReplicationMode::Position`](crate::plugin::AvianReplicationMode::Position).
+    pub fn hermite(
+        start: (Position, Rotation, LinearVelocity, AngularVelocity),
+        end: (Position, Rotation, LinearVelocity, AngularVelocity),
+        ctx: InterpolationSampleContext,
+    ) -> (Position, Rotation, LinearVelocity, AngularVelocity) {
+        let (position, rotation) = if let Some(sample_delta_secs) = ctx.sample_delta_secs {
+            let position = hermite_vec3(
+                start.0.0.f32().extend(0.0),
+                end.0.0.f32().extend(0.0),
+                start.2.0.f32().extend(0.0) * sample_delta_secs,
+                end.2.0.f32().extend(0.0) * sample_delta_secs,
+                ctx.t,
+            );
+            let rotation = hermite_quat(
+                Quaternion::from(start.1).f32(),
+                Quaternion::from(end.1).f32(),
+                Vec3::Z * scalar_to_f32(start.3.0) * sample_delta_secs,
+                Vec3::Z * scalar_to_f32(end.3.0) * sample_delta_secs,
+                ctx.t,
+                true,
+            );
+            (
+                Position(position.truncate().adjust_precision()),
+                Rotation::from(rotation),
+            )
+        } else {
+            (
+                super::position::lerp(&start.0, &end.0, ctx.t),
+                super::rotation::lerp(&start.1, &end.1, ctx.t),
+            )
+        };
+
+        (
+            position,
+            rotation,
+            super::linear_velocity::lerp(&start.2, &end.2, ctx.t),
+            super::angular_velocity::lerp(&start.3, &end.3, ctx.t),
+        )
+    }
+
+    fn scalar_to_f32(value: Scalar) -> f32 {
+        #[allow(clippy::unnecessary_cast)]
+        {
+            value as f32
+        }
+    }
+}
+
+pub mod transform {
+    use super::*;
+
+    /// Interpolates `(Transform, AngularVelocity, LinearVelocity)` using
+    /// Hermite interpolation for translation and rotation.
+    ///
+    /// Avian velocities are expressed per second, so this function uses
+    /// [`InterpolationSampleContext::sample_delta_secs`] to scale the endpoint
+    /// velocities to the bracketing sample interval. If the sample interval is
+    /// unavailable, it falls back to linear translation/scale interpolation and
+    /// spherical rotation interpolation.
+    ///
+    /// Bundle interpolation requires all three component histories to have the
+    /// same bracketing ticks. The returned velocity components are linearly
+    /// interpolated over the same fraction.
+    ///
+    /// Register it as a higher-priority bundle rule when Transform-mode
+    /// smoothing should use velocity-aware Hermite interpolation:
+    ///
+    /// ```rust,ignore
+    /// app.interpolate_bundle_with_priority::<(Transform, AngularVelocity, LinearVelocity)>(
+    ///     100,
+    ///     InterpolationFns::interpolate_with_context(
+    ///         lightyear_avian2d::types::transform::hermite,
+    ///     ),
+    /// );
+    /// ```
+    pub fn hermite(
+        start: (Transform, AngularVelocity, LinearVelocity),
+        end: (Transform, AngularVelocity, LinearVelocity),
+        ctx: InterpolationSampleContext,
+    ) -> (Transform, AngularVelocity, LinearVelocity) {
+        let transform = if let Some(sample_delta_secs) = ctx.sample_delta_secs {
+            let start_linear_velocity = start.2.0.f32().extend(0.0) * sample_delta_secs;
+            let end_linear_velocity = end.2.0.f32().extend(0.0) * sample_delta_secs;
+            let start_angular_velocity = Vec3::Z * scalar_to_f32(start.1.0) * sample_delta_secs;
+            let end_angular_velocity = Vec3::Z * scalar_to_f32(end.1.0) * sample_delta_secs;
+            Transform {
+                translation: hermite_vec3(
+                    start.0.translation,
+                    end.0.translation,
+                    start_linear_velocity,
+                    end_linear_velocity,
+                    ctx.t,
+                ),
+                rotation: hermite_quat(
+                    start.0.rotation,
+                    end.0.rotation,
+                    start_angular_velocity,
+                    end_angular_velocity,
+                    ctx.t,
+                    true,
+                ),
+                scale: start.0.scale.lerp(end.0.scale, ctx.t),
+            }
+        } else {
+            linear(start.0, end.0, ctx.t)
+        };
+
+        (
+            transform,
+            super::angular_velocity::lerp(&start.1, &end.1, ctx.t),
+            super::linear_velocity::lerp(&start.2, &end.2, ctx.t),
+        )
+    }
+
+    fn linear(start: Transform, end: Transform, t: f32) -> Transform {
+        Transform {
+            translation: start.translation.lerp(end.translation, t),
+            rotation: start.rotation.slerp(end.rotation, t),
+            scale: start.scale.lerp(end.scale, t),
+        }
+    }
+
+    fn scalar_to_f32(value: Scalar) -> f32 {
+        #[allow(clippy::unnecessary_cast)]
+        {
+            value as f32
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use avian2d::math::Vector;
+    use bevy_math::Quat;
+
+    fn state(
+        transform: Transform,
+        angular_velocity: f32,
+        linear_velocity: (f32, f32),
+    ) -> (Transform, AngularVelocity, LinearVelocity) {
+        (
+            transform,
+            AngularVelocity(Scalar::from(angular_velocity)),
+            LinearVelocity(Vector::new(
+                Scalar::from(linear_velocity.0),
+                Scalar::from(linear_velocity.1),
+            )),
+        )
+    }
+
+    fn position_rotation_state(
+        position: (f32, f32),
+        rotation: f32,
+        linear_velocity: (f32, f32),
+        angular_velocity: f32,
+    ) -> (Position, Rotation, LinearVelocity, AngularVelocity) {
+        (
+            Position(Vector::new(
+                Scalar::from(position.0),
+                Scalar::from(position.1),
+            )),
+            Rotation::radians(Scalar::from(rotation)),
+            LinearVelocity(Vector::new(
+                Scalar::from(linear_velocity.0),
+                Scalar::from(linear_velocity.1),
+            )),
+            AngularVelocity(Scalar::from(angular_velocity)),
+        )
+    }
+
+    fn assert_vec3_close(actual: Vec3, expected: Vec3) {
+        assert!(
+            actual.distance(expected) <= 1e-5,
+            "expected {expected:?}, got {actual:?}"
+        );
+    }
+
+    fn assert_quat_close(actual: Quat, expected: Quat) {
+        assert!(
+            actual.dot(expected).abs() >= 1.0 - 1e-5,
+            "expected {expected:?}, got {actual:?}"
+        );
+    }
+
+    #[test]
+    fn hermite_preserves_endpoints() {
+        let start = state(
+            Transform::from_xyz(1.0, 2.0, 0.0)
+                .with_rotation(Quat::from_rotation_z(0.25))
+                .with_scale(Vec3::splat(2.0)),
+            3.0,
+            (4.0, 5.0),
+        );
+        let end = state(
+            Transform::from_xyz(6.0, 7.0, 0.0)
+                .with_rotation(Quat::from_rotation_z(1.25))
+                .with_scale(Vec3::splat(4.0)),
+            -2.0,
+            (8.0, 9.0),
+        );
+
+        let at_start =
+            transform::hermite(start, end, InterpolationSampleContext::new(0.0, Some(0.5)));
+        let at_end =
+            transform::hermite(start, end, InterpolationSampleContext::new(1.0, Some(0.5)));
+
+        assert_vec3_close(at_start.0.translation, start.0.translation);
+        assert_quat_close(at_start.0.rotation, start.0.rotation);
+        assert_vec3_close(at_start.0.scale, start.0.scale);
+        assert_vec3_close(at_end.0.translation, end.0.translation);
+        assert_quat_close(at_end.0.rotation, end.0.rotation);
+        assert_vec3_close(at_end.0.scale, end.0.scale);
+    }
+
+    #[test]
+    fn hermite_scales_velocity_by_sample_interval() {
+        let start = state(Transform::default(), 0.0, (4.0, 0.0));
+        let end = state(Transform::default(), 0.0, (0.0, 0.0));
+
+        let one_second =
+            transform::hermite(start, end, InterpolationSampleContext::new(0.5, Some(1.0)));
+        let two_seconds =
+            transform::hermite(start, end, InterpolationSampleContext::new(0.5, Some(2.0)));
+
+        assert_vec3_close(one_second.0.translation, Vec3::X * 0.5);
+        assert_vec3_close(two_seconds.0.translation, Vec3::X);
+    }
+
+    #[test]
+    fn hermite_unwraps_full_revolution() {
+        let start = state(Transform::default(), core::f32::consts::TAU, (0.0, 0.0));
+        let end = start;
+        let midpoint =
+            transform::hermite(start, end, InterpolationSampleContext::new(0.5, Some(1.0)));
+
+        assert_vec3_close(midpoint.0.rotation * Vec3::X, -Vec3::X);
+    }
+
+    #[test]
+    fn hermite_without_sample_interval_falls_back_to_linear() {
+        let start = state(Transform::default(), 0.0, (100.0, 0.0));
+        let end_transform = Transform::from_xyz(8.0, 4.0, 0.0)
+            .with_rotation(Quat::from_rotation_z(core::f32::consts::FRAC_PI_2))
+            .with_scale(Vec3::splat(3.0));
+        let end = state(end_transform, 0.0, (0.0, 0.0));
+        let result = transform::hermite(start, end, InterpolationSampleContext::from_t(0.25));
+
+        assert_vec3_close(
+            result.0.translation,
+            start.0.translation.lerp(end.0.translation, 0.25),
+        );
+        assert_quat_close(
+            result.0.rotation,
+            start.0.rotation.slerp(end.0.rotation, 0.25),
+        );
+        assert_vec3_close(result.0.scale, start.0.scale.lerp(end.0.scale, 0.25));
+    }
+
+    #[test]
+    fn position_rotation_hermite_uses_velocity_tangents() {
+        let start = position_rotation_state((0.0, 0.0), 0.0, (4.0, 0.0), core::f32::consts::TAU);
+        let end = position_rotation_state((0.0, 0.0), 0.0, (0.0, 0.0), core::f32::consts::TAU);
+
+        let midpoint =
+            position_rotation::hermite(start, end, InterpolationSampleContext::new(0.5, Some(1.0)));
+
+        assert_vec3_close(midpoint.0.0.f32().extend(0.0), Vec3::X * 0.5);
+        assert_vec3_close(Quaternion::from(midpoint.1).f32() * Vec3::X, -Vec3::X);
+        assert_vec3_close(midpoint.2.0.f32().extend(0.0), Vec3::X * 2.0);
+        #[allow(clippy::unnecessary_cast)]
+        let angular_velocity = midpoint.3.0 as f32;
+        assert!((angular_velocity - core::f32::consts::TAU).abs() <= 1e-5);
+    }
+
+    #[test]
+    fn position_rotation_hermite_without_interval_falls_back_to_lerp() {
+        let start = position_rotation_state((0.0, 0.0), 0.0, (100.0, 0.0), 10.0);
+        let end =
+            position_rotation_state((8.0, 4.0), core::f32::consts::FRAC_PI_2, (0.0, 0.0), 0.0);
+
+        let result =
+            position_rotation::hermite(start, end, InterpolationSampleContext::from_t(0.25));
+
+        assert_vec3_close(result.0.0.f32().extend(0.0), Vec3::new(2.0, 1.0, 0.0));
+        assert_vec3_close(
+            Quaternion::from(result.1).f32() * Vec3::X,
+            Quat::from_rotation_z(core::f32::consts::FRAC_PI_8) * Vec3::X,
+        );
     }
 }

--- a/crates/integration/avian/src/types_3d.rs
+++ b/crates/integration/avian/src/types_3d.rs
@@ -1,6 +1,9 @@
 //! Implement lightyear traits for some common bevy types
-use avian3d::math::Scalar;
+use avian3d::math::{AdjustPrecision, AsF32, Scalar};
 use avian3d::prelude::*;
+use bevy_transform::components::Transform;
+use bevy_transform_interpolation::hermite::{hermite_quat, hermite_vec3};
+use lightyear_interpolation::prelude::InterpolationSampleContext;
 use tracing::trace;
 
 #[cfg(feature = "deterministic")]
@@ -71,5 +74,329 @@ pub mod angular_velocity {
             start, other, t, res
         );
         res
+    }
+}
+
+pub mod position_rotation {
+    use super::*;
+
+    /// Interpolates `(Position, Rotation, LinearVelocity, AngularVelocity)`
+    /// using Hermite interpolation for position and rotation.
+    ///
+    /// This is intended for [`FrameInterpolate`](lightyear_core::prelude::FrameInterpolate)
+    /// and prediction correction in
+    /// [`AvianReplicationMode::Position`](crate::plugin::AvianReplicationMode::Position).
+    /// Avian velocities are expressed per second, so
+    /// [`InterpolationSampleContext::sample_delta_secs`] scales the endpoint
+    /// tangents to the bracketing sample interval. If that interval is
+    /// unavailable, position falls back to linear interpolation and rotation
+    /// falls back to spherical interpolation.
+    ///
+    /// [`LightyearAvianPlugin`](crate::plugin::LightyearAvianPlugin)
+    /// automatically registers this as a full bundle rule in
+    /// [`AvianReplicationMode::Position`](crate::plugin::AvianReplicationMode::Position).
+    pub fn hermite(
+        start: (Position, Rotation, LinearVelocity, AngularVelocity),
+        end: (Position, Rotation, LinearVelocity, AngularVelocity),
+        ctx: InterpolationSampleContext,
+    ) -> (Position, Rotation, LinearVelocity, AngularVelocity) {
+        let (position, rotation) = if let Some(sample_delta_secs) = ctx.sample_delta_secs {
+            let position = hermite_vec3(
+                start.0.0.f32(),
+                end.0.0.f32(),
+                start.2.0.f32() * sample_delta_secs,
+                end.2.0.f32() * sample_delta_secs,
+                ctx.t,
+            );
+            let rotation = hermite_quat(
+                start.1.0.f32(),
+                end.1.0.f32(),
+                start.3.0.f32() * sample_delta_secs,
+                end.3.0.f32() * sample_delta_secs,
+                ctx.t,
+                true,
+            );
+            (
+                Position(position.adjust_precision()),
+                Rotation::from(rotation),
+            )
+        } else {
+            (
+                super::position::lerp(&start.0, &end.0, ctx.t),
+                super::rotation::lerp(&start.1, &end.1, ctx.t),
+            )
+        };
+
+        (
+            position,
+            rotation,
+            super::linear_velocity::lerp(&start.2, &end.2, ctx.t),
+            super::angular_velocity::lerp(&start.3, &end.3, ctx.t),
+        )
+    }
+}
+
+pub mod transform {
+    use super::*;
+
+    /// Interpolates `(Transform, AngularVelocity, LinearVelocity)` using
+    /// Hermite interpolation for translation and rotation.
+    ///
+    /// Avian velocities are expressed per second, so this function uses
+    /// [`InterpolationSampleContext::sample_delta_secs`] to scale the endpoint
+    /// velocities to the bracketing sample interval. If the sample interval is
+    /// unavailable, it falls back to linear translation/scale interpolation and
+    /// spherical rotation interpolation.
+    ///
+    /// Bundle interpolation requires all three component histories to have the
+    /// same bracketing ticks. The returned velocity components are linearly
+    /// interpolated over the same fraction.
+    ///
+    /// Register it as a higher-priority bundle rule when Transform-mode
+    /// smoothing should use velocity-aware Hermite interpolation:
+    ///
+    /// ```rust,ignore
+    /// app.interpolate_bundle_with_priority::<(Transform, AngularVelocity, LinearVelocity)>(
+    ///     100,
+    ///     InterpolationFns::interpolate_with_context(
+    ///         lightyear_avian3d::types::transform::hermite,
+    ///     ),
+    /// );
+    /// ```
+    pub fn hermite(
+        start: (Transform, AngularVelocity, LinearVelocity),
+        end: (Transform, AngularVelocity, LinearVelocity),
+        ctx: InterpolationSampleContext,
+    ) -> (Transform, AngularVelocity, LinearVelocity) {
+        let transform = if let Some(sample_delta_secs) = ctx.sample_delta_secs {
+            let start_linear_velocity = start.2.0.f32() * sample_delta_secs;
+            let end_linear_velocity = end.2.0.f32() * sample_delta_secs;
+            let start_angular_velocity = start.1.0.f32() * sample_delta_secs;
+            let end_angular_velocity = end.1.0.f32() * sample_delta_secs;
+            Transform {
+                translation: hermite_vec3(
+                    start.0.translation,
+                    end.0.translation,
+                    start_linear_velocity,
+                    end_linear_velocity,
+                    ctx.t,
+                ),
+                rotation: hermite_quat(
+                    start.0.rotation,
+                    end.0.rotation,
+                    start_angular_velocity,
+                    end_angular_velocity,
+                    ctx.t,
+                    true,
+                ),
+                scale: start.0.scale.lerp(end.0.scale, ctx.t),
+            }
+        } else {
+            linear(start.0, end.0, ctx.t)
+        };
+
+        (
+            transform,
+            super::angular_velocity::lerp(&start.1, &end.1, ctx.t),
+            super::linear_velocity::lerp(&start.2, &end.2, ctx.t),
+        )
+    }
+
+    fn linear(start: Transform, end: Transform, t: f32) -> Transform {
+        Transform {
+            translation: start.translation.lerp(end.translation, t),
+            rotation: start.rotation.slerp(end.rotation, t),
+            scale: start.scale.lerp(end.scale, t),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use avian3d::math::Vector;
+    use bevy_math::{Quat, Vec3};
+
+    fn state(
+        transform: Transform,
+        angular_velocity: Vec3,
+        linear_velocity: Vec3,
+    ) -> (Transform, AngularVelocity, LinearVelocity) {
+        (
+            transform,
+            AngularVelocity(Vector::new(
+                Scalar::from(angular_velocity.x),
+                Scalar::from(angular_velocity.y),
+                Scalar::from(angular_velocity.z),
+            )),
+            LinearVelocity(Vector::new(
+                Scalar::from(linear_velocity.x),
+                Scalar::from(linear_velocity.y),
+                Scalar::from(linear_velocity.z),
+            )),
+        )
+    }
+
+    fn position_rotation_state(
+        position: Vec3,
+        rotation: Quat,
+        linear_velocity: Vec3,
+        angular_velocity: Vec3,
+    ) -> (Position, Rotation, LinearVelocity, AngularVelocity) {
+        (
+            Position(Vector::new(
+                Scalar::from(position.x),
+                Scalar::from(position.y),
+                Scalar::from(position.z),
+            )),
+            Rotation::from(rotation),
+            LinearVelocity(Vector::new(
+                Scalar::from(linear_velocity.x),
+                Scalar::from(linear_velocity.y),
+                Scalar::from(linear_velocity.z),
+            )),
+            AngularVelocity(Vector::new(
+                Scalar::from(angular_velocity.x),
+                Scalar::from(angular_velocity.y),
+                Scalar::from(angular_velocity.z),
+            )),
+        )
+    }
+
+    fn assert_vec3_close(actual: Vec3, expected: Vec3) {
+        assert!(
+            actual.distance(expected) <= 1e-5,
+            "expected {expected:?}, got {actual:?}"
+        );
+    }
+
+    fn assert_quat_close(actual: Quat, expected: Quat) {
+        assert!(
+            actual.dot(expected).abs() >= 1.0 - 1e-5,
+            "expected {expected:?}, got {actual:?}"
+        );
+    }
+
+    #[test]
+    fn hermite_preserves_endpoints() {
+        let start = state(
+            Transform::from_xyz(1.0, 2.0, 3.0)
+                .with_rotation(Quat::from_rotation_y(0.25))
+                .with_scale(Vec3::splat(2.0)),
+            Vec3::new(1.0, 2.0, 3.0),
+            Vec3::new(4.0, 5.0, 6.0),
+        );
+        let end = state(
+            Transform::from_xyz(6.0, 7.0, 8.0)
+                .with_rotation(Quat::from_rotation_y(1.25))
+                .with_scale(Vec3::splat(4.0)),
+            Vec3::new(-1.0, -2.0, -3.0),
+            Vec3::new(8.0, 9.0, 10.0),
+        );
+
+        let at_start =
+            transform::hermite(start, end, InterpolationSampleContext::new(0.0, Some(0.5)));
+        let at_end =
+            transform::hermite(start, end, InterpolationSampleContext::new(1.0, Some(0.5)));
+
+        assert_vec3_close(at_start.0.translation, start.0.translation);
+        assert_quat_close(at_start.0.rotation, start.0.rotation);
+        assert_vec3_close(at_start.0.scale, start.0.scale);
+        assert_vec3_close(at_end.0.translation, end.0.translation);
+        assert_quat_close(at_end.0.rotation, end.0.rotation);
+        assert_vec3_close(at_end.0.scale, end.0.scale);
+    }
+
+    #[test]
+    fn hermite_scales_velocity_by_sample_interval() {
+        let start = state(Transform::default(), Vec3::ZERO, Vec3::X * 4.0);
+        let end = state(Transform::default(), Vec3::ZERO, Vec3::ZERO);
+
+        let one_second =
+            transform::hermite(start, end, InterpolationSampleContext::new(0.5, Some(1.0)));
+        let two_seconds =
+            transform::hermite(start, end, InterpolationSampleContext::new(0.5, Some(2.0)));
+
+        assert_vec3_close(one_second.0.translation, Vec3::X * 0.5);
+        assert_vec3_close(two_seconds.0.translation, Vec3::X);
+    }
+
+    #[test]
+    fn hermite_unwraps_full_revolution() {
+        let start = state(
+            Transform::default(),
+            Vec3::Z * core::f32::consts::TAU,
+            Vec3::ZERO,
+        );
+        let end = start;
+        let midpoint =
+            transform::hermite(start, end, InterpolationSampleContext::new(0.5, Some(1.0)));
+
+        assert_vec3_close(midpoint.0.rotation * Vec3::X, -Vec3::X);
+    }
+
+    #[test]
+    fn hermite_without_sample_interval_falls_back_to_linear() {
+        let start = state(Transform::default(), Vec3::ZERO, Vec3::X * 100.0);
+        let end_transform = Transform::from_xyz(8.0, 4.0, 2.0)
+            .with_rotation(Quat::from_rotation_y(core::f32::consts::FRAC_PI_2))
+            .with_scale(Vec3::splat(3.0));
+        let end = state(end_transform, Vec3::ZERO, Vec3::ZERO);
+        let result = transform::hermite(start, end, InterpolationSampleContext::from_t(0.25));
+
+        assert_vec3_close(
+            result.0.translation,
+            start.0.translation.lerp(end.0.translation, 0.25),
+        );
+        assert_quat_close(
+            result.0.rotation,
+            start.0.rotation.slerp(end.0.rotation, 0.25),
+        );
+        assert_vec3_close(result.0.scale, start.0.scale.lerp(end.0.scale, 0.25));
+    }
+
+    #[test]
+    fn position_rotation_hermite_uses_velocity_tangents() {
+        let start = position_rotation_state(
+            Vec3::ZERO,
+            Quat::IDENTITY,
+            Vec3::X * 4.0,
+            Vec3::Z * core::f32::consts::TAU,
+        );
+        let end = position_rotation_state(
+            Vec3::ZERO,
+            Quat::IDENTITY,
+            Vec3::ZERO,
+            Vec3::Z * core::f32::consts::TAU,
+        );
+
+        let midpoint =
+            position_rotation::hermite(start, end, InterpolationSampleContext::new(0.5, Some(1.0)));
+
+        assert_vec3_close(midpoint.0.0.f32(), Vec3::X * 0.5);
+        assert_vec3_close(midpoint.1.0.f32() * Vec3::X, -Vec3::X);
+        assert_vec3_close(midpoint.2.0.f32(), Vec3::X * 2.0);
+        assert_vec3_close(midpoint.3.0.f32(), Vec3::Z * core::f32::consts::TAU);
+    }
+
+    #[test]
+    fn position_rotation_hermite_without_interval_falls_back_to_lerp() {
+        let start =
+            position_rotation_state(Vec3::ZERO, Quat::IDENTITY, Vec3::X * 100.0, Vec3::Y * 10.0);
+        let end = position_rotation_state(
+            Vec3::new(8.0, 4.0, 2.0),
+            Quat::from_rotation_y(core::f32::consts::FRAC_PI_2),
+            Vec3::ZERO,
+            Vec3::ZERO,
+        );
+
+        let result =
+            position_rotation::hermite(start, end, InterpolationSampleContext::from_t(0.25));
+
+        assert_vec3_close(result.0.0.f32(), Vec3::new(2.0, 1.0, 0.5));
+        assert_vec3_close(
+            result.1.0.f32() * Vec3::X,
+            Quat::from_rotation_y(core::f32::consts::FRAC_PI_8) * Vec3::X,
+        );
     }
 }

--- a/crates/integration/avian2d/Cargo.toml
+++ b/crates/integration/avian2d/Cargo.toml
@@ -35,6 +35,7 @@ lightyear_frame_interpolation.workspace = true
 lightyear_replication = { workspace = true, features = ["avian2d"] }
 
 avian2d.workspace = true
+bevy_transform_interpolation.workspace = true
 
 tracing.workspace = true
 

--- a/crates/integration/avian3d/Cargo.toml
+++ b/crates/integration/avian3d/Cargo.toml
@@ -35,6 +35,7 @@ lightyear_frame_interpolation.workspace = true
 lightyear_replication = { workspace = true, features = ["avian3d"] }
 
 avian3d.workspace = true
+bevy_transform_interpolation.workspace = true
 
 
 # bevy

--- a/crates/replication/interpolation/src/interpolate.rs
+++ b/crates/replication/interpolation/src/interpolate.rs
@@ -14,11 +14,12 @@ use bevy_replicon::shared::replication::diff::Diffable as RepliconDiffable;
 use bevy_replicon::shared::replication::storage::ReplicationStorage;
 use bevy_utils::prelude::DebugName;
 use lightyear_core::ecs_utils::{
-    ComponentTableColumn, component_table_column, table_component_slice, table_for_archetype,
+    table_component_slice, table_for_archetype, write_component_with_change_detection,
 };
 use lightyear_core::history_buffer::HistoryState;
 use lightyear_core::prelude::{ConfirmedHistory, Interpolated, NetworkTimeline};
 use lightyear_core::tick::Tick;
+use lightyear_core::tick::TickDuration;
 use lightyear_replication::checkpoint::ReplicationCheckpointMap;
 use lightyear_replication::deferred_entity::DeferredEntityCommands;
 use lightyear_replication::diff_history::HistoryDiffReceiver;
@@ -45,6 +46,7 @@ pub(crate) fn update_interpolation_history(
     clients: Query<&InterpolationTimeline, Without<Interpolated>>,
     interpolation_registry: Res<InterpolationRegistry>,
     checkpoints: Res<ReplicationCheckpointMap>,
+    tick_duration: Option<Res<TickDuration>>,
     mut replication_storage: Option<ResMut<ReplicationStorage>>,
     mut commands: Commands,
 ) {
@@ -56,6 +58,7 @@ pub(crate) fn update_interpolation_history(
     let current_interpolate_tick = timeline.now().tick();
     let interpolation_overstep = timeline.overstep().to_f32();
     let server_complete_tick = checkpoints.last_confirmed_tick();
+    let tick_duration = tick_duration.as_deref().map(|duration| duration.0);
 
     let mut deferred_apply = DeferredEntityCommands::default();
 
@@ -67,13 +70,14 @@ pub(crate) fn update_interpolation_history(
                 server_complete_tick,
                 current_interpolate_tick,
                 interpolation_overstep,
-                interpolation: component.interpolation(),
+                tick_duration,
             };
             (component.update_history())(
                 world,
                 archetype,
+                &interpolation_registry,
                 component,
-                ctx,
+                &ctx,
                 replication_storage.as_deref_mut(),
                 &mut deferred_apply,
             );
@@ -92,6 +96,7 @@ pub(crate) fn apply_interpolation(
     mut interpolation_world: InterpolationWorld,
     clients: Query<&InterpolationTimeline, Without<Interpolated>>,
     interpolation_registry: Res<InterpolationRegistry>,
+    tick_duration: Option<Res<TickDuration>>,
 ) {
     // TODO: handle multiple interpolation timelines
     // TODO: exclude host-server
@@ -103,6 +108,7 @@ pub(crate) fn apply_interpolation(
     let ctx = ApplyInterpolationContext {
         interpolation_tick: current_interpolate_tick,
         interpolation_overstep,
+        tick_duration: tick_duration.as_deref().map(|duration| duration.0),
     };
 
     interpolation_world.update_archetypes(&interpolation_registry);
@@ -123,8 +129,9 @@ pub(crate) fn apply_interpolation(
 pub(crate) fn update_history_archetype_erased<C: Component + Clone>(
     world: UnsafeWorldCell,
     archetype: &Archetype,
+    interpolation_registry: &InterpolationRegistry,
     component: &CachedInterpolationComponent,
-    ctx: UpdateHistoryContext,
+    ctx: &UpdateHistoryContext,
     _replication_storage: Option<&mut ReplicationStorage>,
     deferred_apply: &mut DeferredEntityCommands,
 ) {
@@ -144,16 +151,18 @@ pub(crate) fn update_history_archetype_erased<C: Component + Clone>(
         return;
     };
     let present = component.live_component_present();
+    let interpolation = interpolation_registry.interpolation_for_rule::<C>(component.rule_id());
     for entity in archetype.entities() {
         let entity_id = entity.id();
         let row = entity.table_row().index();
         let history = unsafe { &mut *histories.get_unchecked(row).get() };
         update_history_inner::<C>(history, entity_id, ctx);
         let sample = sample_history_with_interpolation(
-            ctx.interpolation,
+            interpolation,
             history,
             ctx.current_interpolate_tick,
             ctx.interpolation_overstep,
+            ctx.tick_duration,
         );
         queue_history_presence::<C>(deferred_apply, entity_id, present, sample);
     }
@@ -162,8 +171,9 @@ pub(crate) fn update_history_archetype_erased<C: Component + Clone>(
 pub(crate) fn update_history_diff_archetype_erased<C>(
     world: UnsafeWorldCell,
     archetype: &Archetype,
+    interpolation_registry: &InterpolationRegistry,
     component: &CachedInterpolationComponent,
-    ctx: UpdateHistoryContext,
+    ctx: &UpdateHistoryContext,
     replication_storage: Option<&mut ReplicationStorage>,
     deferred_apply: &mut DeferredEntityCommands,
 ) where
@@ -188,6 +198,7 @@ pub(crate) fn update_history_diff_archetype_erased<C>(
         return;
     };
     let present = component.live_component_present();
+    let interpolation = interpolation_registry.interpolation_for_rule::<C>(component.rule_id());
     for entity in archetype.entities() {
         let entity_id = entity.id();
         let Some(history_diff_receiver) = storage.get_mut::<HistoryDiffReceiver<C>>(entity_id)
@@ -224,10 +235,11 @@ pub(crate) fn update_history_diff_archetype_erased<C>(
         }
 
         let sample = sample_history_with_interpolation(
-            ctx.interpolation,
+            interpolation,
             history,
             ctx.current_interpolate_tick,
             ctx.interpolation_overstep,
+            ctx.tick_duration,
         );
         queue_history_presence::<C>(deferred_apply, entity_id, present, sample);
     }
@@ -236,7 +248,7 @@ pub(crate) fn update_history_diff_archetype_erased<C>(
 fn update_history_inner<C: Component + Clone>(
     history: &mut ConfirmedHistory<C>,
     entity: Entity,
-    ctx: UpdateHistoryContext,
+    ctx: &UpdateHistoryContext,
 ) {
     // Replicon's marker fns already ran before this system. If this component received an
     // explicit update or removal at the completed server tick T, `write_history` /
@@ -330,16 +342,17 @@ pub(crate) fn apply_interpolation_archetype_erased<C: SyncComponent>(
     else {
         return;
     };
-    let components = component_table_column::<C>(world, archetype, table);
+    let interpolation = interpolation_registry.interpolation_for_rule::<C>(rule_id);
 
     for entity in archetype.entities() {
         let row = entity.table_row().index();
         let history = unsafe { &*histories.get_unchecked(row).get() };
-        let Some(HistoryState::Updated(interpolated)) = interpolation_registry.sample_for_rule(
-            rule_id,
+        let Some(HistoryState::Updated(interpolated)) = sample_history_with_interpolation(
+            interpolation,
             history,
             ctx.interpolation_tick,
             ctx.interpolation_overstep,
+            ctx.tick_duration,
         ) else {
             continue;
         };
@@ -355,13 +368,10 @@ pub(crate) fn apply_interpolation_archetype_erased<C: SyncComponent>(
             history_len = history.len(),
             "applied interpolation"
         );
-        match components {
-            ComponentTableColumn::Table(components) => {
-                let component = unsafe { &mut *components.get_unchecked(row).get() };
-                *component = interpolated;
-            }
-            ComponentTableColumn::Missing => {}
-            ComponentTableColumn::NonTable => {}
+        // SAFETY: the erased interpolation system declares write access to C,
+        // and no reference to this entity's live C is held here.
+        unsafe {
+            write_component_with_change_detection::<C>(world, entity.id(), interpolated);
         }
     }
 }
@@ -398,7 +408,9 @@ mod tests {
     use super::*;
     use crate::registry::AppInterpolationExt;
     use crate::registry::{InterpolationRegistry, InterpolationRuleComponentIds};
-    use crate::rules::{InterpolationFns, InterpolationFnsExt, InterpolationRuleConfig};
+    use crate::rules::{
+        InterpolationFns, InterpolationFnsExt, InterpolationRuleConfig, InterpolationSampleContext,
+    };
     use alloc::vec;
     use bevy_app::{App, Update};
     use bevy_ecs::archetype::Archetype;
@@ -417,6 +429,7 @@ mod tests {
     use bevy_time::TimePlugin;
     use core::sync::atomic::{AtomicUsize, Ordering};
     use lightyear_core::prelude::Interpolated;
+    use lightyear_core::tick::TickDuration;
     use lightyear_core::time::TickInstant;
     use lightyear_replication::checkpoint::ReplicationCheckpointMap;
     use lightyear_replication::diff_history::HistoryDiffReceiver;
@@ -470,6 +483,10 @@ mod tests {
         TestComp(start.0 + (end.0 - start.0) * t)
     }
 
+    fn context_lerp(_start: TestComp, _end: TestComp, ctx: InterpolationSampleContext) -> TestComp {
+        TestComp(ctx.t + ctx.sample_delta_secs.unwrap_or_default())
+    }
+
     fn marker_lerp(_start: TestComp, _end: TestComp, _t: f32) -> TestComp {
         TestComp(42.0)
     }
@@ -482,6 +499,17 @@ mod tests {
         (
             TestComp(100.0 + start.0.0 + (end.0.0 - start.0.0) * t),
             TestComp2(200.0 + start.1.0 + (end.1.0 - start.1.0) * t),
+        )
+    }
+
+    fn bundle_context_lerp(
+        _start: (TestComp, TestComp2),
+        _end: (TestComp, TestComp2),
+        ctx: InterpolationSampleContext,
+    ) -> (TestComp, TestComp2) {
+        (
+            TestComp(ctx.t),
+            TestComp2(ctx.sample_delta_secs.unwrap_or_default()),
         )
     }
 
@@ -673,6 +701,19 @@ mod tests {
         insert_confirmed_history(&mut app, default_entity, two_point_history());
         let filtered_entity = app.world_mut().spawn((TestComp(0.0), SmoothRule)).id();
         insert_confirmed_history(&mut app, filtered_entity, two_point_history());
+        app.world_mut().clear_trackers();
+        let default_changed = app
+            .world()
+            .entity(default_entity)
+            .get_change_ticks::<TestComp>()
+            .unwrap()
+            .changed;
+        let filtered_changed = app
+            .world()
+            .entity(filtered_entity)
+            .get_change_ticks::<TestComp>()
+            .unwrap()
+            .changed;
 
         app.update();
 
@@ -683,6 +724,22 @@ mod tests {
         assert_eq!(
             app.world().get::<TestComp>(filtered_entity),
             Some(&TestComp(42.0))
+        );
+        assert_ne!(
+            app.world()
+                .entity(default_entity)
+                .get_change_ticks::<TestComp>()
+                .unwrap()
+                .changed,
+            default_changed
+        );
+        assert_ne!(
+            app.world()
+                .entity(filtered_entity)
+                .get_change_ticks::<TestComp>()
+                .unwrap()
+                .changed,
+            filtered_changed
         );
     }
 
@@ -739,6 +796,26 @@ mod tests {
     }
 
     #[test]
+    fn contextual_interpolation_receives_sample_delta() {
+        let mut app = setup_app(Tick(15), 40);
+        app.world_mut()
+            .insert_resource(TickDuration(core::time::Duration::from_millis(50)));
+        insert_rule::<TestComp, ()>(
+            &mut app,
+            InterpolationFns::interpolate_with_context(context_lerp),
+            InterpolationRuleConfig { priority: 100 },
+        );
+        add_interpolation_test_systems(&mut app);
+
+        let entity = app.world_mut().spawn(TestComp(0.0)).id();
+        insert_confirmed_history(&mut app, entity, two_point_history());
+
+        app.update();
+
+        assert_eq!(app.world().get::<TestComp>(entity), Some(&TestComp(1.0)));
+    }
+
+    #[test]
     fn selected_history_only_rule_suppresses_default_apply() {
         let mut app = setup_app(Tick(15), 40);
         add_interpolation_test_systems(&mut app);
@@ -784,6 +861,7 @@ mod tests {
         let mut app = App::new();
         app.add_plugins((TimePlugin, StatesPlugin, RepliconPlugins));
         app.insert_resource(ReplicationCheckpointMap::default());
+        app.insert_resource(TickDuration(core::time::Duration::from_millis(100)));
         app.configure_sets(
             Update,
             (
@@ -815,6 +893,19 @@ mod tests {
                 two_point_history2(),
             ))
             .id();
+        app.world_mut().clear_trackers();
+        let first_changed = app
+            .world()
+            .entity(entity)
+            .get_change_ticks::<TestComp>()
+            .unwrap()
+            .changed;
+        let second_changed = app
+            .world()
+            .entity(entity)
+            .get_change_ticks::<TestComp2>()
+            .unwrap()
+            .changed;
 
         app.update();
 
@@ -823,6 +914,66 @@ mod tests {
             app.world().get::<TestComp2>(entity),
             Some(&TestComp2(205.0))
         );
+        assert_ne!(
+            app.world()
+                .entity(entity)
+                .get_change_ticks::<TestComp>()
+                .unwrap()
+                .changed,
+            first_changed
+        );
+        assert_ne!(
+            app.world()
+                .entity(entity)
+                .get_change_ticks::<TestComp2>()
+                .unwrap()
+                .changed,
+            second_changed
+        );
+    }
+
+    #[test]
+    fn bundle_contextual_interpolation_receives_sample_delta() {
+        let mut app = App::new();
+        app.add_plugins((TimePlugin, StatesPlugin, RepliconPlugins));
+        app.insert_resource(ReplicationCheckpointMap::default());
+        app.insert_resource(TickDuration(core::time::Duration::from_millis(100)));
+        app.configure_sets(
+            Update,
+            (
+                crate::plugin::InterpolationSystems::Prepare,
+                crate::plugin::InterpolationSystems::Interpolate,
+            )
+                .chain(),
+        );
+        add_interpolation_test_systems(&mut app);
+        app.component::<TestComp>().replicate();
+        app.component::<TestComp2>().replicate();
+        app.interpolate_bundle_with::<(TestComp, TestComp2)>(
+            InterpolationFns::interpolate_with_context(bundle_context_lerp),
+        );
+
+        let mut timeline = InterpolationTimeline::default();
+        timeline.set_now(TickInstant::from(Tick(15)));
+        timeline.remote_send_interval = core::time::Duration::from_millis(40);
+        app.world_mut()
+            .spawn((timeline, IsSynced::<InterpolationTimeline>::default()));
+
+        let entity = app
+            .world_mut()
+            .spawn((
+                Interpolated,
+                TestComp(-1.0),
+                TestComp2(-1.0),
+                two_point_history(),
+                two_point_history2(),
+            ))
+            .id();
+
+        app.update();
+
+        assert_eq!(app.world().get::<TestComp>(entity), Some(&TestComp(0.5)));
+        assert_eq!(app.world().get::<TestComp2>(entity), Some(&TestComp2(1.0)));
     }
 
     #[test]

--- a/crates/replication/interpolation/src/lib.rs
+++ b/crates/replication/interpolation/src/lib.rs
@@ -19,6 +19,9 @@
 //! - the history is sampled at the client's [`timeline::InterpolationTimeline`],
 //! - and the sampled value is written back to the live component.
 //!
+//! Applying a sampled value uses Bevy's normal component change detection, so
+//! systems ordered after interpolation can observe it with `Changed<C>`.
+//!
 //! ```rust,ignore
 //! use bevy_app::App;
 //! use bevy_ecs::prelude::*;
@@ -88,6 +91,14 @@
 //!
 //! Components used with these rules must implement [`SyncComponent`]:
 //! `Component<Mutability = Mutable> + Clone + PartialEq`.
+//!
+//! Most interpolation functions use the simple `fn(start, end, fraction)`
+//! shape. Functions that need sample timing can be registered with
+//! [`rules::InterpolationFns::interpolate_with_context`]; they receive
+//! [`rules::InterpolationSampleContext`], which includes the normalized fraction
+//! plus sample duration when it is available. This is useful for interpolation
+//! methods such as Hermite curves that need to scale velocities by the interval
+//! between samples.
 //!
 //! # Custom interpolation systems
 //!
@@ -269,7 +280,8 @@ pub mod prelude {
         AppInterpolationExt, InterpolationRegistrationExt, InterpolationRegistry,
     };
     pub use crate::rules::{
-        InterpolationBundle, InterpolationFns, InterpolationFnsExt, InterpolationRuleConfig,
+        ContextInterpolationFn, InterpolationBundle, InterpolationFn, InterpolationFns,
+        InterpolationFnsExt, InterpolationRuleConfig, InterpolationSampleContext,
     };
     pub use crate::timeline::InterpolationTimeline;
 }

--- a/crates/replication/interpolation/src/plugin.rs
+++ b/crates/replication/interpolation/src/plugin.rs
@@ -1,6 +1,6 @@
 use crate::despawn::configure_delayed_interpolated_despawn;
 use crate::interpolate::{apply_interpolation, update_interpolation_history};
-use crate::registry::InterpolationRegistry;
+use crate::registry::{InterpolationRegistry, finalize_interpolation_registry};
 use crate::timeline::TimelinePlugin;
 use bevy_app::{App, Plugin, Update};
 use bevy_ecs::{
@@ -146,9 +146,7 @@ impl Plugin for InterpolationPlugin {
     }
 
     fn finish(&self, app: &mut App) {
-        app.world_mut()
-            .resource_mut::<InterpolationRegistry>()
-            .finalize();
+        finalize_interpolation_registry(app);
     }
 }
 

--- a/crates/replication/interpolation/src/registry.rs
+++ b/crates/replication/interpolation/src/registry.rs
@@ -11,10 +11,11 @@ use crate::rules::frame_interpolate::{
     restore_frame_history_archetype_erased, update_frame_history_archetype_erased,
 };
 use crate::rules::{
-    CachedInterpolationApply, CachedInterpolationComponent, ErasedApplyInterpolationFn,
-    ErasedBackfillConfirmedHistoryFn, ErasedInterpolationFns, ErasedLerpFn, ErasedUpdateHistoryFn,
-    InterpolationBundle, InterpolationFns, InterpolationRule, InterpolationRuleConfig,
-    InterpolationRuleId, RuleKind, TupleInterpolationBundle, matches_filter,
+    CachedInterpolationApply, CachedInterpolationComponent, ContextInterpolationFn,
+    ErasedApplyInterpolationFn, ErasedBackfillConfirmedHistoryFn, ErasedInterpolationFns,
+    ErasedUpdateHistoryFn, InterpolationBundle, InterpolationFn, InterpolationFns,
+    InterpolationRule, InterpolationRuleConfig, InterpolationRuleId, InterpolationSampleContext,
+    RuleKind, TupleInterpolationBundle, matches_filter,
 };
 use alloc::vec::Vec;
 use bevy_app::App;
@@ -40,6 +41,7 @@ use bevy_replicon::shared::replication::registry::ctx::{RemoveCtx, WriteCtx};
 use bevy_replicon::shared::replication::storage::{EntityStorageCtx, ReplicationStorage};
 use bevy_utils::prelude::DebugName;
 use core::cmp::Ordering;
+use core::time::Duration;
 use indexmap::IndexMap;
 use lightyear_core::history_buffer::HistoryState;
 use lightyear_core::prelude::{ConfirmedHistory, FrameInterpolationHistory, Interpolated, Tick};
@@ -160,6 +162,13 @@ pub struct InterpolationRegistry {
     rules_by_kind: IndexMap<RuleKind, Vec<InterpolationRuleId>>,
     /// Component kinds whose Replicon receive marker functions have been installed.
     interpolated_marker_fns: HashSet<ComponentKind>,
+    /// Marker registrations deferred until every plugin has finished building.
+    ///
+    /// Interpolation rules may be installed by an integration plugin before
+    /// the application's replication protocol registers the corresponding
+    /// components. Deferring the Replicon receive hooks makes that plugin order
+    /// independent without implicitly adding components to the protocol.
+    pending_interpolated_marker_fns: Vec<(ComponentKind, fn(&mut App))>,
     /// Whether plugin finalization has run.
     ///
     /// Rule registration after finalization is rejected so the type-erased
@@ -171,7 +180,7 @@ impl InterpolationRegistry {
     const FINALIZED_RULE_REGISTRATION_ERROR: &'static str =
         "cannot register interpolation rules after InterpolationRegistry has been finalized";
 
-    pub(crate) fn finalize(&mut self) {
+    fn finalize(&mut self) {
         self.finalized = true;
     }
 
@@ -347,8 +356,8 @@ impl InterpolationRegistry {
             history_component_id,
             history_storage,
             live_component_present,
+            rule_id,
             update_history: rule.fns.update_history?,
-            interpolation: rule.fns.interpolation,
         })
     }
 
@@ -611,7 +620,7 @@ impl InterpolationRegistry {
     /// per-archetype rule cache. It does not support tuple rules; systems that
     /// need bundle priority should select rules for the current archetype.
     #[doc(hidden)]
-    pub fn interpolation_for<C: Component + Clone>(&self) -> Option<LerpFn<C>> {
+    pub fn interpolation_for<C: Component + Clone>(&self) -> Option<&InterpolationFn<C>> {
         self.rules_by_kind
             .get(&RuleKind::of::<C>())?
             .iter()
@@ -619,7 +628,8 @@ impl InterpolationRegistry {
             .find_map(|rule| {
                 rule.fns
                     .interpolation
-                    .map(|interpolation| unsafe { core::mem::transmute(interpolation) })
+                    .as_ref()
+                    .map(|interpolation| interpolation.typed::<C>())
             })
     }
 
@@ -629,34 +639,76 @@ impl InterpolationRegistry {
         history: &ConfirmedHistory<C>,
         interpolation_tick: Tick,
         interpolation_overstep: f32,
+        tick_duration: Option<Duration>,
     ) -> Option<HistoryState<C>> {
         let rule = &self.rules[rule_id.0];
         debug_assert_eq!(rule.kind, RuleKind::of::<C>());
         sample_history_with_interpolation(
-            rule.fns.interpolation,
+            self.interpolation_for_rule::<C>(rule_id),
             history,
             interpolation_tick,
             interpolation_overstep,
+            tick_duration,
         )
     }
 
     pub(crate) fn interpolation_for_rule<S: 'static>(
         &self,
         rule_id: InterpolationRuleId,
-    ) -> Option<LerpFn<S>> {
+    ) -> Option<&InterpolationFn<S>> {
         let rule = &self.rules[rule_id.0];
         debug_assert_eq!(rule.kind, RuleKind::of::<S>());
         rule.fns
             .interpolation
-            .map(|interpolation| unsafe { core::mem::transmute(interpolation) })
+            .as_ref()
+            .map(|interpolation| interpolation.typed::<S>())
     }
 }
 
+/// Installs deferred receive hooks, reconciles interpolation metadata with the
+/// completed replication protocol, and freezes the registry.
+pub(crate) fn finalize_interpolation_registry(app: &mut App) {
+    let pending_marker_fns = {
+        let mut registry = app.world_mut().resource_mut::<InterpolationRegistry>();
+        core::mem::take(&mut registry.pending_interpolated_marker_fns)
+    };
+    for (_, register) in pending_marker_fns {
+        register(app);
+    }
+
+    let interpolated_components = {
+        let registry = app.world().resource::<InterpolationRegistry>();
+        registry
+            .rules
+            .iter()
+            .filter(|rule| rule.owns_history() || rule.applies_component())
+            .flat_map(|rule| rule.members.iter().copied())
+            .collect::<HashSet<_>>()
+    };
+    if let Some(mut component_registry) = app.world_mut().get_resource_mut::<ComponentRegistry>() {
+        for kind in interpolated_components {
+            let Some(replication) = component_registry
+                .component_metadata_map
+                .get_mut(&kind)
+                .and_then(|metadata| metadata.replication.as_mut())
+            else {
+                continue;
+            };
+            replication.set_interpolated(true);
+        }
+    }
+
+    app.world_mut()
+        .resource_mut::<InterpolationRegistry>()
+        .finalize();
+}
+
 pub(crate) fn sample_history_with_interpolation<C: Component + Clone>(
-    interpolation: Option<ErasedLerpFn>,
+    interpolation: Option<&InterpolationFn<C>>,
     history: &ConfirmedHistory<C>,
     interpolation_tick: Tick,
     interpolation_overstep: f32,
+    tick_duration: Option<Duration>,
 ) -> Option<HistoryState<C>> {
     let previous_index = (0..history.len())
         .take_while(|i| {
@@ -683,9 +735,13 @@ pub(crate) fn sample_history_with_interpolation<C: Component + Clone>(
     // Clamp rather than extrapolate beyond the newest confirmed value. This
     // makes late packets converge to the freshest server state instead of
     // overshooting when motion changes direction.
-    let fraction = (((interpolation_tick - start_tick) as f32 + interpolation_overstep)
-        / (end_tick - start_tick) as f32)
-        .clamp(0.0, 1.0);
+    let context = InterpolationSampleContext::from_ticks(
+        start_tick,
+        end_tick,
+        interpolation_tick,
+        interpolation_overstep,
+        tick_duration,
+    );
     trace!(
         target: "lightyear_debug::interpolation",
         kind = "confirmed_history_sample",
@@ -694,15 +750,14 @@ pub(crate) fn sample_history_with_interpolation<C: Component + Clone>(
         start_tick = start_tick.0,
         end_tick = end_tick.0,
         interpolation_overstep,
-        fraction,
+        fraction = context.t,
         history_len = history.len(),
         "sampled confirmed history for interpolation"
     );
-    let interpolation_fn: LerpFn<C> = unsafe { core::mem::transmute(interpolation) };
-    Some(HistoryState::Updated(interpolation_fn(
+    Some(HistoryState::Updated(interpolation.interpolate(
         start.clone(),
         end.clone(),
-        fraction,
+        context,
     )))
 }
 
@@ -1088,13 +1143,32 @@ impl AppInterpolationExt for App {
 fn register_interpolated_marker_fns<C: SyncComponent>(app: &mut bevy_app::App) {
     ensure_interpolation_registry(app);
     let kind = ComponentKind::of::<C>();
-    let already_registered = {
-        let registry = app.world().resource::<InterpolationRegistry>();
-        registry.interpolated_marker_fns.contains(&kind)
-    };
-    if already_registered {
-        return;
+    let component_registered = app
+        .world()
+        .get_resource::<ComponentRegistry>()
+        .is_some_and(|registry| registry.is_registered::<C>());
+    {
+        let mut registry = app.world_mut().resource_mut::<InterpolationRegistry>();
+        if registry.interpolated_marker_fns.contains(&kind)
+            || registry
+                .pending_interpolated_marker_fns
+                .iter()
+                .any(|(pending_kind, _)| *pending_kind == kind)
+        {
+            return;
+        }
+        if !component_registered {
+            registry
+                .pending_interpolated_marker_fns
+                .push((kind, install_interpolated_marker_fns::<C>));
+            return;
+        }
     }
+    install_interpolated_marker_fns::<C>(app);
+}
+
+fn install_interpolated_marker_fns<C: SyncComponent>(app: &mut bevy_app::App) {
+    let kind = ComponentKind::of::<C>();
     app.register_marker_with::<Interpolated>(MarkerConfig {
         priority: 100,
         need_history: true,
@@ -1110,6 +1184,37 @@ fn register_interpolated_diff_marker_fns<C: SyncComponent + RepliconDiffable>(
     app: &mut bevy_app::App,
 ) {
     ensure_interpolation_registry(app);
+    let kind = ComponentKind::of::<C>();
+    let component_registered = app
+        .world()
+        .get_resource::<ComponentRegistry>()
+        .is_some_and(|registry| registry.is_registered::<C>());
+    {
+        let mut registry = app.world_mut().resource_mut::<InterpolationRegistry>();
+        if registry.interpolated_marker_fns.contains(&kind) {
+            return;
+        }
+        if let Some((_, register)) = registry
+            .pending_interpolated_marker_fns
+            .iter_mut()
+            .find(|(pending_kind, _)| *pending_kind == kind)
+        {
+            *register = install_interpolated_diff_marker_fns::<C>;
+            return;
+        }
+        if !component_registered {
+            registry
+                .pending_interpolated_marker_fns
+                .push((kind, install_interpolated_diff_marker_fns::<C>));
+            return;
+        }
+    }
+    install_interpolated_diff_marker_fns::<C>(app);
+}
+
+fn install_interpolated_diff_marker_fns<C: SyncComponent + RepliconDiffable>(
+    app: &mut bevy_app::App,
+) {
     let kind = ComponentKind::of::<C>();
     app.register_marker_with::<Interpolated>(MarkerConfig {
         priority: 100,
@@ -1256,16 +1361,30 @@ pub(crate) fn backfill_confirmed_history_diff<C: SyncComponent + RepliconDiffabl
 }
 
 pub trait InterpolationRegistrationExt<'a, C>: ComponentRegistrator<'a, C> {
-    /// Add interpolation for this component using the provided [`LerpFn`]
+    /// Add interpolation for this component using the provided [`LerpFn`].
     ///
     /// This will register interpolation systems to interpolate between two confirmed states.
     fn add_interpolation_with(self, interpolation_fn: LerpFn<C>) -> Self
     where
         C: SyncComponent;
 
+    /// Add interpolation that receives sample timing in addition to the
+    /// normalized interpolation fraction.
+    fn add_interpolation_with_context(self, interpolation_fn: ContextInterpolationFn<C>) -> Self
+    where
+        C: SyncComponent;
+
     /// Like [`Self::add_interpolation_with`], but for components replicated with
     /// Replicon's diff-based mode.
     fn add_interpolation_diff_with(self, interpolation_fn: LerpFn<C>) -> Self
+    where
+        C: SyncComponent + RepliconDiffable;
+
+    /// Diff-based counterpart to [`Self::add_interpolation_with_context`].
+    fn add_interpolation_diff_with_context(
+        self,
+        interpolation_fn: ContextInterpolationFn<C>,
+    ) -> Self
     where
         C: SyncComponent + RepliconDiffable;
 
@@ -1310,11 +1429,34 @@ where
         ))
     }
 
+    fn add_interpolation_with_context(self, interpolation_fn: ContextInterpolationFn<C>) -> Self
+    where
+        C: SyncComponent,
+    {
+        Self::from_component_registration(add_interpolation_with_context_impl(
+            self.into_component_registration(),
+            interpolation_fn,
+        ))
+    }
+
     fn add_interpolation_diff_with(self, interpolation_fn: LerpFn<C>) -> Self
     where
         C: SyncComponent + RepliconDiffable,
     {
         Self::from_component_registration(add_interpolation_diff_with_impl(
+            self.into_component_registration(),
+            interpolation_fn,
+        ))
+    }
+
+    fn add_interpolation_diff_with_context(
+        self,
+        interpolation_fn: ContextInterpolationFn<C>,
+    ) -> Self
+    where
+        C: SyncComponent + RepliconDiffable,
+    {
+        Self::from_component_registration(add_interpolation_diff_with_context_impl(
             self.into_component_registration(),
             interpolation_fn,
         ))
@@ -1361,15 +1503,17 @@ fn ensure_interpolation_registry(app: &mut App) {
 }
 
 pub(crate) fn mark_interpolated<C: SyncComponent>(app: &mut App) {
-    let mut registry = app.world_mut().resource_mut::<ComponentRegistry>();
-    registry
+    let Some(mut registry) = app.world_mut().get_resource_mut::<ComponentRegistry>() else {
+        return;
+    };
+    let Some(replication) = registry
         .component_metadata_map
         .get_mut(&ComponentKind::of::<C>())
-        .unwrap()
-        .replication
-        .as_mut()
-        .unwrap()
-        .set_interpolated(true);
+        .and_then(|metadata| metadata.replication.as_mut())
+    else {
+        return;
+    };
+    replication.set_interpolated(true);
 }
 
 pub(crate) fn add_interpolation_rule<C, F>(
@@ -1499,6 +1643,23 @@ where
     registration
 }
 
+fn add_interpolation_with_context_impl<'a, C>(
+    registration: ComponentRegistration<'a, C>,
+    interpolation_fn: ContextInterpolationFn<C>,
+) -> ComponentRegistration<'a, C>
+where
+    C: SyncComponent,
+{
+    add_interpolation_rule::<C, ()>(
+        registration.app,
+        InterpolationFns::interpolate_with_context(interpolation_fn),
+        InterpolationRuleConfig {
+            priority: SINGLE_COMPONENT_RULE_PRIORITY,
+        },
+    );
+    registration
+}
+
 fn add_interpolation_diff_with_impl<'a, C>(
     registration: ComponentRegistration<'a, C>,
     interpolation_fn: LerpFn<C>,
@@ -1509,6 +1670,23 @@ where
     add_interpolation_diff_rule::<C, ()>(
         registration.app,
         InterpolationFns::interpolate(interpolation_fn),
+        InterpolationRuleConfig {
+            priority: SINGLE_COMPONENT_RULE_PRIORITY,
+        },
+    );
+    registration
+}
+
+fn add_interpolation_diff_with_context_impl<'a, C>(
+    registration: ComponentRegistration<'a, C>,
+    interpolation_fn: ContextInterpolationFn<C>,
+) -> ComponentRegistration<'a, C>
+where
+    C: SyncComponent + RepliconDiffable,
+{
+    add_interpolation_diff_rule::<C, ()>(
+        registration.app,
+        InterpolationFns::interpolate_with_context(interpolation_fn),
         InterpolationRuleConfig {
             priority: SINGLE_COMPONENT_RULE_PRIORITY,
         },
@@ -1829,6 +2007,29 @@ mod tests {
     }
 
     #[test]
+    fn interpolation_rule_can_precede_replication_component_registration() {
+        let mut app = App::new();
+        app.add_plugins((
+            StatesPlugin,
+            RepliconPlugins,
+            crate::plugin::InterpolationPlugin,
+        ));
+
+        app.interpolate_with::<TestComp>(InterpolationFns::interpolate(lerp));
+        app.component::<TestComp>().replicate();
+        app.finish();
+
+        let registry = app.world().resource::<InterpolationRegistry>();
+        assert!(registry.finalized);
+        assert!(registry.pending_interpolated_marker_fns.is_empty());
+        assert!(
+            registry
+                .interpolated_marker_fns
+                .contains(&ComponentKind::of::<TestComp>())
+        );
+    }
+
+    #[test]
     #[should_panic(
         expected = "cannot register interpolation rules after InterpolationRegistry has been finalized"
     )]
@@ -1862,11 +2063,11 @@ mod tests {
 
         let (registry, rule_id) = registry();
         assert_eq!(
-            registry.sample_for_rule(rule_id, &history, Tick(30), 0.0),
+            registry.sample_for_rule(rule_id, &history, Tick(30), 0.0, None),
             Some(HistoryState::Updated(TestComp(10.0)))
         );
         assert_eq!(
-            registry.sample_for_rule(rule_id, &history, Tick(20), 0.5),
+            registry.sample_for_rule(rule_id, &history, Tick(20), 0.5, None),
             Some(HistoryState::Updated(TestComp(10.0)))
         );
     }
@@ -1878,15 +2079,15 @@ mod tests {
 
         let (registry, rule_id) = registry();
         assert_eq!(
-            registry.sample_for_rule(rule_id, &history, Tick(5), 0.0),
+            registry.sample_for_rule(rule_id, &history, Tick(5), 0.0, None),
             None
         );
         assert_eq!(
-            registry.sample_for_rule(rule_id, &history, Tick(10), 0.0),
+            registry.sample_for_rule(rule_id, &history, Tick(10), 0.0, None),
             Some(HistoryState::Updated(TestComp(42.0)))
         );
         assert_eq!(
-            registry.sample_for_rule(rule_id, &history, Tick(50), 0.5),
+            registry.sample_for_rule(rule_id, &history, Tick(50), 0.5, None),
             Some(HistoryState::Updated(TestComp(42.0)))
         );
     }

--- a/crates/replication/interpolation/src/rules.rs
+++ b/crates/replication/interpolation/src/rules.rs
@@ -13,7 +13,7 @@ pub(crate) use bundle::TupleInterpolationBundle;
 
 use self::frame_interpolate::{FrameHistoryComponent, FrameInterpolationFns};
 use crate::registry::InterpolationRegistry;
-use alloc::vec::Vec;
+use alloc::{boxed::Box, vec::Vec};
 use bevy_ecs::archetype::Archetype;
 use bevy_ecs::component::{ComponentId, Components, StorageType};
 use bevy_ecs::prelude::{Commands, Entity};
@@ -23,11 +23,131 @@ use bevy_math::{
     Curve,
     curve::{Ease, EaseFunction, EasingCurve},
 };
-use core::any::TypeId;
+use core::any::{Any, TypeId};
+use core::fmt;
 use core::marker::PhantomData;
+use core::time::Duration;
 use lightyear_core::prelude::Tick;
 use lightyear_replication::deferred_entity::DeferredEntityCommands;
 use lightyear_replication::registry::{ComponentKind, LerpFn};
+
+/// Context passed to interpolation functions that need more than a normalized fraction.
+///
+/// Most interpolation functions only need [`Self::t`] and can use the
+/// existing [`LerpFn`] shape. More advanced functions, such as Hermite
+/// interpolation with endpoint velocities, can use [`Self::sample_delta_secs`]
+/// to scale velocities by the actual sample interval.
+///
+/// Delayed interpolation computes [`Self::sample_delta_secs`] from the
+/// bracketing history ticks and the configured tick duration. Frame
+/// interpolation and visual correction populate it from the fixed timestep.
+///
+/// # Examples
+///
+/// ```rust,ignore
+/// use lightyear_interpolation::prelude::*;
+/// fn interpolate_position(
+///     start: Position,
+///     end: Position,
+///     ctx: InterpolationSampleContext,
+/// ) -> Position {
+///     let _sample_delta_secs = ctx.sample_delta_secs;
+///     Position(start.0 + (end.0 - start.0) * ctx.t)
+/// }
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct InterpolationSampleContext {
+    /// Normalized interpolation fraction in `[0.0, 1.0]`.
+    pub t: f32,
+    /// Duration between the bracketing samples, in seconds, when available.
+    pub sample_delta_secs: Option<f32>,
+}
+
+impl InterpolationSampleContext {
+    /// Creates a context from a normalized interpolation fraction and an
+    /// optional sample interval.
+    pub fn new(t: f32, sample_delta_secs: Option<f32>) -> Self {
+        Self {
+            t,
+            sample_delta_secs,
+        }
+    }
+
+    /// Creates a context when only a normalized interpolation fraction is known.
+    pub fn from_t(t: f32) -> Self {
+        Self {
+            t,
+            sample_delta_secs: None,
+        }
+    }
+
+    pub(crate) fn from_ticks(
+        start_tick: Tick,
+        end_tick: Tick,
+        interpolation_tick: Tick,
+        interpolation_overstep: f32,
+        tick_duration: Option<Duration>,
+    ) -> Self {
+        let tick_delta = end_tick - start_tick;
+        let t = if tick_delta > 0 {
+            (((interpolation_tick - start_tick) as f32 + interpolation_overstep)
+                / tick_delta as f32)
+                .clamp(0.0, 1.0)
+        } else {
+            0.0
+        };
+        let sample_delta_secs = tick_duration
+            .and_then(|tick_duration| sample_delta_secs(start_tick, end_tick, tick_duration));
+        Self {
+            t,
+            sample_delta_secs,
+        }
+    }
+}
+
+fn sample_delta_secs(start_tick: Tick, end_tick: Tick, tick_duration: Duration) -> Option<f32> {
+    let ticks = end_tick - start_tick;
+    (ticks > 0).then_some(tick_duration.as_secs_f32() * ticks as f32)
+}
+
+/// Context-aware interpolation callback stored by a rule.
+///
+/// Unlike [`LerpFn`], this receives the duration between the sampled states
+/// when the caller can determine it.
+pub type ContextInterpolationFn<C> =
+    fn(start: C, other: C, context: InterpolationSampleContext) -> C;
+
+/// Interpolation function stored by a rule.
+///
+/// `Lerp` preserves the `fn(start, end, t)` API. `Contextual` is used
+/// for interpolation that needs sample timing, such as Hermite interpolation
+/// with velocities.
+#[derive(Clone, Copy)]
+pub enum InterpolationFn<C> {
+    /// Interpolation function that receives a normalized interpolation fraction.
+    Lerp(LerpFn<C>),
+    /// Context-aware interpolation function.
+    Contextual(ContextInterpolationFn<C>),
+}
+
+impl<C> fmt::Debug for InterpolationFn<C> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Lerp(_) => f.write_str("InterpolationFn::Lerp(..)"),
+            Self::Contextual(_) => f.write_str("InterpolationFn::Contextual(..)"),
+        }
+    }
+}
+
+impl<C> InterpolationFn<C> {
+    /// Applies the interpolation function using the provided context.
+    pub fn interpolate(&self, start: C, other: C, context: InterpolationSampleContext) -> C {
+        match self {
+            Self::Lerp(interpolation) => interpolation(start, other, context.t),
+            Self::Contextual(interpolation) => interpolation(start, other, context),
+        }
+    }
+}
 
 /// Configuration for an interpolation rule.
 ///
@@ -129,7 +249,7 @@ pub struct InterpolationRuleConfig {
 /// ```
 #[derive(Debug, Clone, Copy)]
 pub struct InterpolationFns<C> {
-    pub(crate) interpolation: Option<LerpFn<C>>,
+    pub(crate) interpolation: Option<InterpolationFn<C>>,
     pipeline: InterpolationPipeline,
     _marker: PhantomData<fn(C)>,
 }
@@ -166,7 +286,20 @@ impl<C> InterpolationFns<C> {
     /// ```
     pub fn interpolate(interpolation: LerpFn<C>) -> Self {
         Self {
-            interpolation: Some(interpolation),
+            interpolation: Some(InterpolationFn::Lerp(interpolation)),
+            pipeline: InterpolationPipeline::Full,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Enables the full Lightyear interpolation pipeline with a callback that
+    /// receives the sample interval.
+    ///
+    /// Use this for interpolation such as Hermite curves whose endpoint
+    /// derivatives must be scaled by the duration between the sampled states.
+    pub fn interpolate_with_context(interpolation: ContextInterpolationFn<C>) -> Self {
+        Self {
+            interpolation: Some(InterpolationFn::Contextual(interpolation)),
             pipeline: InterpolationPipeline::Full,
             _marker: PhantomData,
         }
@@ -220,7 +353,17 @@ impl<C> InterpolationFns<C> {
     /// ```
     pub fn no_history(interpolation: LerpFn<C>) -> Self {
         Self {
-            interpolation: Some(interpolation),
+            interpolation: Some(InterpolationFn::Lerp(interpolation)),
+            pipeline: InterpolationPipeline::NoHistory,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Registers a context-aware interpolation function without delayed
+    /// interpolation history.
+    pub fn no_history_with_context(interpolation: ContextInterpolationFn<C>) -> Self {
+        Self {
+            interpolation: Some(InterpolationFn::Contextual(interpolation)),
             pipeline: InterpolationPipeline::NoHistory,
             _marker: PhantomData,
         }
@@ -338,6 +481,10 @@ pub trait InterpolationFnsExt<C> {
     /// stages the rule owns.
     fn interpolate(self, interpolation: LerpFn<C>) -> Self;
 
+    /// Stores a context-aware interpolation callback on this rule without
+    /// changing which pipeline stages the rule owns.
+    fn interpolate_with_context(self, interpolation: ContextInterpolationFn<C>) -> Self;
+
     /// Stores a linear [`Ease`] interpolation function on this rule.
     fn linear_interpolate(self) -> Self
     where
@@ -346,7 +493,12 @@ pub trait InterpolationFnsExt<C> {
 
 impl<C> InterpolationFnsExt<C> for InterpolationFns<C> {
     fn interpolate(mut self, interpolation: LerpFn<C>) -> Self {
-        self.interpolation = Some(interpolation);
+        self.interpolation = Some(InterpolationFn::Lerp(interpolation));
+        self
+    }
+
+    fn interpolate_with_context(mut self, interpolation: ContextInterpolationFn<C>) -> Self {
+        self.interpolation = Some(InterpolationFn::Contextual(interpolation));
         self
     }
 
@@ -381,16 +533,36 @@ pub(crate) struct UpdateHistoryContext {
     pub(crate) server_complete_tick: Option<Tick>,
     pub(crate) current_interpolate_tick: Tick,
     pub(crate) interpolation_overstep: f32,
-    pub(crate) interpolation: Option<ErasedLerpFn>,
+    pub(crate) tick_duration: Option<Duration>,
 }
 
 /// Type-erased interpolation function stored by the interpolation registry.
 ///
-/// Typed functions are registered as [`LerpFn<C>`] and erased internally so
-/// rules for different components and bundles can share the same cache.
-pub type ErasedInterpolationFn = unsafe fn();
+/// Typed functions are erased internally so rules for different components and
+/// bundles can share the same cache.
+pub(crate) struct ErasedInterpolationFn {
+    inner: Box<dyn Any + Send + Sync + 'static>,
+}
 
-pub(crate) type ErasedLerpFn = ErasedInterpolationFn;
+impl fmt::Debug for ErasedInterpolationFn {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("ErasedInterpolationFn(..)")
+    }
+}
+
+impl ErasedInterpolationFn {
+    fn from_typed<S: 'static>(interpolation: InterpolationFn<S>) -> Self {
+        Self {
+            inner: Box::new(interpolation),
+        }
+    }
+
+    pub(crate) fn typed<S: 'static>(&self) -> &InterpolationFn<S> {
+        self.inner
+            .downcast_ref::<InterpolationFn<S>>()
+            .expect("interpolation rule kind and interpolation function type should match")
+    }
+}
 
 /// Returns whether a cached interpolation rule matches an archetype.
 pub(crate) type MatchesArchetypeFn = fn(&Components, &Archetype) -> bool;
@@ -402,8 +574,9 @@ pub(crate) type MatchesArchetypeFn = fn(&Components, &Archetype) -> bool;
 pub(crate) type ErasedUpdateHistoryFn = fn(
     UnsafeWorldCell,
     &Archetype,
+    &InterpolationRegistry,
     &CachedInterpolationComponent,
-    UpdateHistoryContext,
+    &UpdateHistoryContext,
     Option<&mut bevy_replicon::shared::replication::storage::ReplicationStorage>,
     &mut DeferredEntityCommands,
 );
@@ -421,6 +594,7 @@ pub(crate) type ErasedBackfillConfirmedHistoryFn = fn(Entity, &mut Commands);
 pub struct ApplyInterpolationContext {
     pub(crate) interpolation_tick: Tick,
     pub(crate) interpolation_overstep: f32,
+    pub(crate) tick_duration: Option<Duration>,
 }
 
 /// Type-erased function that applies one selected interpolation rule to one archetype.
@@ -441,7 +615,7 @@ pub(crate) type ErasedApplyInterpolationFn = fn(
 /// One value is stored per selected history-owning rule on each cached
 /// interpolated archetype. It lets the update system decide whether the
 /// corresponding live component is currently present on that archetype.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub(crate) struct CachedInterpolationComponent {
     /// Component kind whose history is updated.
     pub(crate) kind: ComponentKind,
@@ -451,10 +625,10 @@ pub(crate) struct CachedInterpolationComponent {
     pub(crate) history_storage: StorageType,
     /// Whether the live component `C` is present on the cached archetype.
     pub(crate) live_component_present: bool,
+    /// ID of the selected rule whose interpolation function samples this history.
+    pub(crate) rule_id: InterpolationRuleId,
     /// Type-erased history update function for `C`.
     pub(crate) update_history: ErasedUpdateHistoryFn,
-    /// Optional interpolation function used when sampling the history.
-    pub(crate) interpolation: Option<ErasedLerpFn>,
 }
 
 impl CachedInterpolationComponent {
@@ -474,12 +648,12 @@ impl CachedInterpolationComponent {
         self.live_component_present
     }
 
-    pub(crate) fn update_history(&self) -> ErasedUpdateHistoryFn {
-        self.update_history
+    pub(crate) fn rule_id(&self) -> InterpolationRuleId {
+        self.rule_id
     }
 
-    pub(crate) fn interpolation(&self) -> Option<ErasedLerpFn> {
-        self.interpolation
+    pub(crate) fn update_history(&self) -> ErasedUpdateHistoryFn {
+        self.update_history
     }
 }
 
@@ -505,9 +679,9 @@ impl CachedInterpolationApply {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub(crate) struct ErasedInterpolationFns {
-    pub(crate) interpolation: Option<ErasedLerpFn>,
+    pub(crate) interpolation: Option<ErasedInterpolationFn>,
     pub(crate) update_history: Option<ErasedUpdateHistoryFn>,
     pub(crate) backfill_confirmed_history: Option<ErasedBackfillConfirmedHistoryFn>,
     pub(crate) apply_interpolation: Option<ErasedApplyInterpolationFn>,
@@ -531,7 +705,7 @@ impl ErasedInterpolationFns {
         Self {
             interpolation: fns
                 .interpolation
-                .map(|f| unsafe { core::mem::transmute::<LerpFn<S>, unsafe fn()>(f) }),
+                .map(ErasedInterpolationFn::from_typed::<S>),
             update_history,
             backfill_confirmed_history,
             apply_interpolation,
@@ -568,7 +742,7 @@ impl RuleKind {
 /// kind, so
 /// [`InterpolationRegistry::select_rule_for_archetype`] can return the first
 /// matching rule.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct InterpolationRule {
     /// Rule key used when selecting a rule for a component or bundle target.
     pub(crate) kind: RuleKind,

--- a/crates/replication/interpolation/src/rules/bundle.rs
+++ b/crates/replication/interpolation/src/rules/bundle.rs
@@ -6,6 +6,7 @@
 
 use super::{
     ApplyInterpolationContext, InterpolationFns, InterpolationRuleConfig, InterpolationRuleId,
+    InterpolationSampleContext,
 };
 use crate::SyncComponent;
 use crate::interpolate::present_history_bracket;
@@ -20,9 +21,7 @@ use bevy_ecs::component::ComponentId;
 use bevy_ecs::query::QueryFilter;
 use bevy_ecs::world::unsafe_world_cell::UnsafeWorldCell;
 use bevy_utils::prelude::DebugName;
-use lightyear_core::ecs_utils::{
-    ComponentTableColumn, component_table_column, table_for_archetype,
-};
+use lightyear_core::ecs_utils::{table_for_archetype, write_component_with_change_detection};
 use lightyear_core::prelude::{ConfirmedHistory, FrameInterpolationHistory};
 use lightyear_replication::deferred_entity::DeferredEntityCommands;
 use lightyear_replication::registry::ComponentKind;
@@ -215,7 +214,6 @@ macro_rules! impl_interpolation_bundle {
                 }) else {
                     return;
                 };
-                let $component0 = component_table_column::<$C0>(world, archetype, table);
                 $(
                     let Some($history) = components.component_id::<ConfirmedHistory<$C>>() else {
                         return;
@@ -225,9 +223,10 @@ macro_rules! impl_interpolation_bundle {
                     }) else {
                         return;
                     };
-                    let $component = component_table_column::<$C>(world, archetype, table);
                 )+
 
+                let interpolation =
+                    interpolation_registry.interpolation_for_rule::<($C0, $($C,)+)>(rule_id);
                 for entity in archetype.entities() {
                     let row = entity.table_row().index();
                     let $history0 = unsafe { &*$history0.get_unchecked(row).get() };
@@ -253,18 +252,17 @@ macro_rules! impl_interpolation_bundle {
                             Some(($end_tick0, $end_value0)),
                             $(Some(($end_tick, $end_value)),)+
                         ) if true $(&& $end_tick0 == $end_tick)+ => {
-                            let fraction = (((ctx.interpolation_tick - $start_tick0) as f32
-                                + ctx.interpolation_overstep)
-                                / ($end_tick0 - $start_tick0) as f32)
-                                .clamp(0.0, 1.0);
-                            if let Some(interpolation) =
-                                interpolation_registry
-                                    .interpolation_for_rule::<($C0, $($C,)+)>(rule_id)
-                            {
-                                interpolation(
+                            if let Some(interpolation) = interpolation {
+                                interpolation.interpolate(
                                     ($start0, $($start,)+),
                                     ($end_value0, $($end_value,)+),
-                                    fraction,
+                                    InterpolationSampleContext::from_ticks(
+                                        $start_tick0,
+                                        $end_tick0,
+                                        ctx.interpolation_tick,
+                                        ctx.interpolation_overstep,
+                                        ctx.tick_duration,
+                                    ),
                                 )
                             } else {
                                 ($start0, $($start,)+)
@@ -277,22 +275,24 @@ macro_rules! impl_interpolation_bundle {
                     };
 
                     let ($output0, $($output,)+) = interpolated;
-                    match $component0 {
-                        ComponentTableColumn::Table($component0) => {
-                            let $component0 = unsafe { &mut *$component0.get_unchecked(row).get() };
-                            *$component0 = $output0;
-                        }
-                        ComponentTableColumn::Missing => {}
-                        ComponentTableColumn::NonTable => {}
+                    // SAFETY: the erased interpolation system declares write
+                    // access to every bundle member, and no live-component
+                    // references are held while these writes occur.
+                    unsafe {
+                        write_component_with_change_detection::<$C0>(
+                            world,
+                            entity.id(),
+                            $output0,
+                        );
                     }
                     $(
-                        match $component {
-                            ComponentTableColumn::Table($component) => {
-                                let $component = unsafe { &mut *$component.get_unchecked(row).get() };
-                                *$component = $output;
-                            }
-                            ComponentTableColumn::Missing => {}
-                            ComponentTableColumn::NonTable => {}
+                        // SAFETY: same as for the first bundle member above.
+                        unsafe {
+                            write_component_with_change_detection::<$C>(
+                                world,
+                                entity.id(),
+                                $output,
+                            );
                         }
                     )+
                 }
@@ -329,11 +329,14 @@ macro_rules! impl_interpolation_bundle {
                         return;
                     };
                 )+
-                let $component0 = component_table_column::<$C0>(world, archetype, table);
+                let $component0 = components
+                    .component_id::<$C0>()
+                    .is_some_and(|component_id| archetype.contains(component_id));
                 $(
-                    let $component = component_table_column::<$C>(world, archetype, table);
+                    let $component = components
+                        .component_id::<$C>()
+                        .is_some_and(|component_id| archetype.contains(component_id));
                 )+
-
                 let interpolation =
                     interpolation_registry.interpolation_for_rule::<($C0, $($C,)+)>(rule_id);
                 for entity in archetype.entities() {
@@ -370,10 +373,10 @@ macro_rules! impl_interpolation_bundle {
                         $($history.previous_value.clone(),)+
                         interpolation,
                     ) {
-                        interpolation(
+                        interpolation.interpolate(
                             ($start0, $($start,)+),
                             ($end_value0, $($end_value,)+),
-                            ctx.overstep,
+                            InterpolationSampleContext::new(ctx.overstep, ctx.sample_delta_secs),
                         )
                     } else {
                         trace!(
@@ -385,22 +388,34 @@ macro_rules! impl_interpolation_bundle {
                     };
 
                     let ($output0, $($output,)+) = interpolated;
-                    match $component0 {
-                        ComponentTableColumn::Table($component0) => {
-                            let $component0 = unsafe { &mut *$component0.get_unchecked(row).get() };
-                            *$component0 = $output0;
+                    // SAFETY: the erased frame-interpolation system declares
+                    // write access to every bundle member, and no references
+                    // to their live values are held while these writes occur.
+                    if $component0 {
+                        // SAFETY: explained above. Component presence was
+                        // resolved from the cached archetype.
+                        unsafe {
+                            write_component_with_change_detection::<$C0>(
+                                world,
+                                entity.id(),
+                                $output0,
+                            );
                         }
-                        ComponentTableColumn::Missing => deferred_apply.insert(entity.id(), $output0),
-                        ComponentTableColumn::NonTable => {}
+                    } else {
+                        deferred_apply.insert(entity.id(), $output0);
                     }
                     $(
-                        match $component {
-                            ComponentTableColumn::Table($component) => {
-                                let $component = unsafe { &mut *$component.get_unchecked(row).get() };
-                                *$component = $output;
+                        // SAFETY: same as for the first bundle member above.
+                        if $component {
+                            unsafe {
+                                write_component_with_change_detection::<$C>(
+                                    world,
+                                    entity.id(),
+                                    $output,
+                                );
                             }
-                            ComponentTableColumn::Missing => deferred_apply.insert(entity.id(), $output),
-                            ComponentTableColumn::NonTable => {}
+                        } else {
+                            deferred_apply.insert(entity.id(), $output);
                         }
                     )+
                 }

--- a/crates/replication/interpolation/src/rules/frame_interpolate.rs
+++ b/crates/replication/interpolation/src/rules/frame_interpolate.rs
@@ -5,7 +5,7 @@
 
 use crate::SyncComponent;
 use crate::registry::InterpolationRegistry;
-use crate::rules::InterpolationRuleId;
+use crate::rules::{InterpolationRuleId, InterpolationSampleContext};
 use alloc::vec::Vec;
 use bevy_ecs::archetype::Archetype;
 use bevy_ecs::component::{ComponentId, StorageType};
@@ -14,11 +14,12 @@ use bevy_ecs::world::unsafe_world_cell::UnsafeWorldCell;
 use bevy_utils::prelude::DebugName;
 use lightyear_core::ecs_utils::{
     table_component_slice, table_component_slice_if_table, table_for_archetype,
+    write_component_with_change_detection,
 };
 use lightyear_core::prelude::FrameInterpolationHistory;
 use lightyear_replication::deferred_entity::DeferredEntityCommands;
 use lightyear_replication::registry::ComponentKind;
-use lightyear_utils::ecs::{get_component_unchecked, get_component_unchecked_mut};
+use lightyear_utils::ecs::get_component_unchecked;
 use tracing::trace;
 
 #[derive(Debug, Clone, Copy)]
@@ -26,6 +27,8 @@ use tracing::trace;
 pub struct FrameInterpolationContext {
     #[doc(hidden)]
     pub overstep: f32,
+    #[doc(hidden)]
+    pub sample_delta_secs: Option<f32>,
 }
 
 /// Type-erased function that updates one component's frame interpolation history.
@@ -377,41 +380,18 @@ pub(crate) fn restore_frame_history_archetype_erased<C: SyncComponent>(
     ) else {
         return;
     };
-    let live_component_id = component.live_component_id();
-    let live_component_storage = archetype.get_storage_type(live_component_id);
-    let live_components =
-        table_component_slice_if_table::<C>(table, live_component_id, live_component_storage);
-
     for entity in archetype.entities() {
         let row = entity.table_row().index();
         let history = unsafe { &*histories.get_unchecked(row).get() };
         let Some(current_value) = &history.current_value else {
             continue;
         };
-        match live_component_storage {
-            Some(StorageType::Table) => {
-                let Some(live_components) = live_components else {
-                    continue;
-                };
-                let component = unsafe { &mut *live_components.get_unchecked(row).get() };
-                *component = current_value.clone();
-            }
-            Some(StorageType::SparseSet) => {
-                // SAFETY: this cached archetype contains `component_id`, and
-                // the system param declares write access to all frame components.
-                let component = unsafe {
-                    get_component_unchecked_mut(
-                        world,
-                        entity,
-                        archetype.table_id(),
-                        StorageType::SparseSet,
-                        live_component_id,
-                    )
-                    .deref_mut::<C>()
-                };
-                *component = current_value.clone();
-            }
-            None => continue,
+        // SAFETY: this erased system declares write access to C, and the only
+        // other live reference here is to FrameInterpolationHistory<C>.
+        if !unsafe {
+            write_component_with_change_detection::<C>(world, entity.id(), current_value.clone())
+        } {
+            continue;
         }
         trace!(
             target: "lightyear_debug::frame_interpolation",
@@ -458,9 +438,10 @@ pub(crate) fn apply_frame_interpolation_archetype_erased<C: SyncComponent>(
     else {
         return;
     };
-    let live_component_id = world.components().component_id::<C>();
-    let live_component_storage =
-        live_component_id.and_then(|component_id| archetype.get_storage_type(component_id));
+    let live_component_present = world
+        .components()
+        .component_id::<C>()
+        .is_some_and(|component_id| archetype.contains(component_id));
 
     let interpolation = interpolation_registry.interpolation_for_rule::<C>(rule_id);
     for entity in archetype.entities() {
@@ -485,7 +466,11 @@ pub(crate) fn apply_frame_interpolation_archetype_erased<C: SyncComponent>(
         } else if let (Some(previous_value), Some(interpolation)) =
             (&history.previous_value, interpolation)
         {
-            interpolation(previous_value.clone(), current_value, ctx.overstep)
+            interpolation.interpolate(
+                previous_value.clone(),
+                current_value,
+                InterpolationSampleContext::new(ctx.overstep, ctx.sample_delta_secs),
+            )
         } else {
             trace!(
                 component = ?DebugName::type_name::<C>(),
@@ -504,25 +489,14 @@ pub(crate) fn apply_frame_interpolation_archetype_erased<C: SyncComponent>(
             overstep = ctx.overstep,
             "applied frame interpolation"
         );
-        match live_component_storage {
-            Some(_) => {
-                let Some(component_id) = live_component_id else {
-                    continue;
-                };
-                let Ok(entity_cell) = world.get_entity(entity.id()) else {
-                    continue;
-                };
-                // SAFETY: the cached rule declares write access to `component_id`, `C` is a
-                // mutable component, and the history slice refers to a different component id.
-                // `into_inner` deliberately marks the live component as changed before exposing
-                // its pointer, matching an ordinary `Mut<C>` assignment for both storage types.
-                let Ok(component) = (unsafe { entity_cell.get_mut_by_id(component_id) }) else {
-                    continue;
-                };
-                let component = unsafe { component.into_inner().deref_mut::<C>() };
-                *component = interpolated;
+        if live_component_present {
+            // SAFETY: this erased system declares write access to C, and the
+            // only other live reference here is to FrameInterpolationHistory<C>.
+            unsafe {
+                write_component_with_change_detection::<C>(world, entity.id(), interpolated);
             }
-            None => deferred_apply.insert(entity.id(), interpolated),
+        } else {
+            deferred_apply.insert(entity.id(), interpolated);
         }
     }
 }

--- a/crates/replication/prediction/src/correction.rs
+++ b/crates/replication/prediction/src/correction.rs
@@ -40,13 +40,16 @@
 //!   tick entry in [`PredictionHistory`].
 //! - `update_frame_interpolation_post_rollback` then calls the selected
 //!   frame-interpolation rule from [`InterpolationRegistry`] for archetypes
-//!   that contain [`PreviousVisual`]. This temporarily writes the corrected
-//!   visual sample into the live component, using the same component or bundle
-//!   rule that normal frame interpolation would use.
+//!   that contain at least one [`PreviousVisual`]. This temporarily writes the
+//!   corrected visual sample into the live components, using the same component
+//!   or bundle rule that normal frame interpolation would use. A bundle member
+//!   does not need its own `PreviousVisual`: its repaired predicted frame
+//!   history can still contribute to another member's corrected sample.
 //! - It compares that corrected visual sample with [`PreviousVisual`], inserts
 //!   [`VisualCorrection`] with the resulting visual error, removes
-//!   [`PreviousVisual`], and restores the live component back to the corrected
-//!   simulation value from [`FrameInterpolationHistory`].
+//!   [`PreviousVisual`], and restores every live component temporarily written
+//!   by the rule back to the corrected simulation value from
+//!   [`FrameInterpolationHistory`].
 //!
 //! Finally, `add_visual_correction` runs in
 //! [`RollbackSystems::VisualCorrection`], ordered after
@@ -78,12 +81,14 @@ use bevy_reflect::Reflect;
 use bevy_time::{Fixed, Time, Virtual};
 use bevy_utils::prelude::DebugName;
 use core::fmt::Debug;
-use lightyear_core::ecs_utils::{table_component_slice, table_for_archetype};
+use lightyear_core::ecs_utils::{
+    table_component_slice, table_for_archetype, write_component_with_change_detection,
+};
 use lightyear_core::prelude::*;
 use lightyear_frame_interpolation::FrameInterpolationSystems;
 use lightyear_interpolation::registry::InterpolationRegistry;
 use lightyear_interpolation::rules::frame_interpolate::{
-    CachedFrameInterpolationApply, FrameInterpolationContext,
+    CachedFrameInterpolationApply, CachedFrameInterpolationComponent, FrameInterpolationContext,
 };
 use lightyear_interpolation::rules::{InterpolationRuleId, RuleKind};
 use lightyear_replication::deferred_entity::DeferredEntityCommands;
@@ -108,6 +113,7 @@ pub struct VisualCorrection<D> {
 pub(crate) struct PostRollbackCorrectionContext {
     tick: Tick,
     overstep: f32,
+    sample_delta_secs: f32,
 }
 
 /// Type-erased visual correction handler registered per corrected component.
@@ -260,10 +266,12 @@ impl PostRollbackCorrectionArchetypes {
 
     /// Refreshes the correction cache for newly-created archetypes.
     ///
-    /// Rule selection mirrors frame interpolation, except rule members must all
-    /// have an active `PreviousVisual<C>` correction marker on the archetype.
-    /// A high-priority no-apply rule still claims its members, so it blocks
-    /// lower-priority rules just like normal interpolation rule selection.
+    /// Rule selection mirrors frame interpolation. A selected rule participates
+    /// when at least one of its members has an active `PreviousVisual<C>`
+    /// correction marker; other bundle members still provide their repaired
+    /// predicted frame-history samples. A high-priority no-apply rule still
+    /// claims its members, so it blocks lower-priority rules just like normal
+    /// interpolation rule selection.
     fn update(
         &mut self,
         archetypes: &Archetypes,
@@ -292,6 +300,11 @@ impl PostRollbackCorrectionArchetypes {
                     interpolation_registry.select_rule_for_archetype(components, archetype, kind)
                 {
                     cached.selected_rules.insert(kind, rule_id);
+                    if let Some(component) = interpolation_registry
+                        .cached_frame_history_component(components, archetype, rule_id)
+                    {
+                        cached.frame_history_components.push(component);
+                    }
                 }
             }
 
@@ -314,6 +327,8 @@ struct CachedPostRollbackCorrectionArchetype {
     covered_members: Vec<ComponentKind>,
     selected_rules: HashMap<RuleKind, InterpolationRuleId>,
     apply_rules: Vec<CachedFrameInterpolationApply>,
+    frame_history_components: Vec<CachedFrameInterpolationComponent>,
+    restore_components: Vec<CachedFrameInterpolationComponent>,
 }
 
 impl CachedPostRollbackCorrectionArchetype {
@@ -324,6 +339,8 @@ impl CachedPostRollbackCorrectionArchetype {
             covered_members: Vec::new(),
             selected_rules: HashMap::default(),
             apply_rules: Vec::new(),
+            frame_history_components: Vec::new(),
+            restore_components: Vec::new(),
         }
     }
 
@@ -333,6 +350,10 @@ impl CachedPostRollbackCorrectionArchetype {
 
     fn apply_rules(&self) -> &[CachedFrameInterpolationApply] {
         &self.apply_rules
+    }
+
+    fn restore_components(&self) -> &[CachedFrameInterpolationComponent] {
+        &self.restore_components
     }
 
     fn collect_active_members(
@@ -351,13 +372,14 @@ impl CachedPostRollbackCorrectionArchetype {
     fn resolve_apply_rules(&mut self, registry: &InterpolationRegistry) {
         self.apply_rules.clear();
         self.covered_members.clear();
+        self.restore_components.clear();
 
         // `selected_rules` contains the best matching rule for each rule kind
         // on this archetype, for example `A`, `B`, and `(A, B)`. Correction
-        // only cares about members that have `PreviousVisual<C>` on this
-        // archetype. We walk selected rules by precedence and let each
-        // applicable rule claim all of its active members so higher-priority
-        // bundle rules can suppress overlapping single-component rules.
+        // only creates correction errors for members that have
+        // `PreviousVisual<C>` on this archetype. Rule ownership must still
+        // match normal frame interpolation: a bundle is atomic and may use
+        // non-corrected members as inputs to the corrected member's sample.
         let mut candidates = self
             .selected_rules
             .iter()
@@ -373,22 +395,40 @@ impl CachedPostRollbackCorrectionArchetype {
             if rule
                 .members()
                 .iter()
-                .any(|member| !self.active_members.contains(member))
-            {
-                continue;
-            }
-            if rule
-                .members()
-                .iter()
                 .any(|member| claimed_members.contains(member))
             {
                 continue;
             }
 
             claimed_members.extend(rule.members().iter().copied());
+            let active_rule_members = rule
+                .members()
+                .iter()
+                .filter(|member| self.active_members.contains(member))
+                .copied()
+                .collect::<Vec<_>>();
+            if active_rule_members.is_empty() {
+                continue;
+            }
             if let Some(apply) = registry.cached_frame_apply_component(rule_id) {
-                self.covered_members.extend(rule.members().iter().copied());
+                self.covered_members.extend(active_rule_members);
                 self.apply_rules.push(apply);
+                for member in rule.members() {
+                    if self
+                        .restore_components
+                        .iter()
+                        .any(|component| component.kind() == *member)
+                    {
+                        continue;
+                    }
+                    if let Some(component) = self
+                        .frame_history_components
+                        .iter()
+                        .find(|component| component.kind() == *member)
+                    {
+                        self.restore_components.push(*component);
+                    }
+                }
             }
         }
     }
@@ -465,6 +505,7 @@ pub(crate) fn update_frame_interpolation_post_rollback(
         // NOTE: this is the overstep from the previous frame since we are running this before RunFixedMainLoop
         overstep: time.overstep_fraction(),
         tick: timeline.tick(),
+        sample_delta_secs: time.timestep().as_secs_f32(),
     };
     let mut deferred_apply = DeferredEntityCommands::default();
     let world = correction_world.world;
@@ -496,6 +537,7 @@ pub(crate) fn update_frame_interpolation_post_rollback(
         correction.create_visual_correction(world, ctx, &mut deferred_apply);
         correction.restore_history(world);
     }
+    restore_applied_frame_interpolation_components(world, &correction_archetypes);
     deferred_apply.apply(&mut commands);
 }
 
@@ -547,10 +589,31 @@ fn apply_frame_interpolation_for_visual_correction(
                 apply.rule_id(),
                 FrameInterpolationContext {
                     overstep: ctx.overstep,
+                    sample_delta_secs: Some(ctx.sample_delta_secs),
                 },
                 false,
                 deferred_apply,
             );
+        }
+    }
+}
+
+/// Restores every component temporarily written by a correction-time apply rule.
+///
+/// Bundle interpolation can write members that do not have correction enabled
+/// and therefore have no typed post-rollback correction handler of their own.
+/// Those members still need to return to their authoritative predicted value
+/// before simulation continues.
+fn restore_applied_frame_interpolation_components(
+    world: UnsafeWorldCell,
+    correction_archetypes: &PostRollbackCorrectionArchetypes,
+) {
+    for cached_archetype in correction_archetypes.iter() {
+        let Some(archetype) = world.archetypes().get(cached_archetype.id()) else {
+            continue;
+        };
+        for component in cached_archetype.restore_components() {
+            (component.restore_frame_history())(world, archetype, component);
         }
     }
 }
@@ -672,9 +735,6 @@ pub(crate) fn restore_frame_history_post_rollback_erased<
         let Some(table) = table_for_archetype(world, archetype) else {
             continue;
         };
-        let Some(components) = table_component_slice::<C>(table, component_id) else {
-            continue;
-        };
         let Some(frame_histories) =
             table_component_slice::<FrameInterpolationHistory<C>>(table, frame_history_id)
         else {
@@ -687,8 +747,15 @@ pub(crate) fn restore_frame_history_post_rollback_erased<
             let Some(current_value) = &interpolate.current_value else {
                 continue;
             };
-            let component = unsafe { &mut *components.get_unchecked(row).get() };
-            *component = current_value.clone();
+            // SAFETY: the erased correction system declares write access to C,
+            // and no reference to this entity's live C is held here.
+            unsafe {
+                write_component_with_change_detection::<C>(
+                    world,
+                    entity.id(),
+                    current_value.clone(),
+                );
+            }
         }
     }
 }
@@ -741,7 +808,7 @@ pub(crate) fn add_visual_correction<
             let new_error = prediction
                 .apply_correction::<C, D>(previous_error.clone(), r)
                 .expect("No correction function was found. Call add_correction, add_linear_correction, or add_correction_fn for this component.");
-            component.bypass_change_detection().apply_diff(&new_error);
+            component.apply_diff(&new_error);
             trace!(
                 target: "lightyear_debug::prediction",
                 kind = "visual_correction_apply",
@@ -814,7 +881,7 @@ mod tests {
     use bevy_state::app::StatesPlugin;
     use lightyear_interpolation::{
         registry::{AppInterpolationExt, InterpolationRegistry},
-        rules::InterpolationFns,
+        rules::{InterpolationFns, InterpolationSampleContext},
     };
     use lightyear_replication::checkpoint::ReplicationCheckpointMap;
     use lightyear_replication::delta::Diffable as LightyearDiffable;
@@ -909,15 +976,74 @@ mod tests {
         );
     }
 
-    fn bundle_lerp(
+    fn bundle_context_lerp(
         start: (CorrectionA, CorrectionB),
         end: (CorrectionA, CorrectionB),
-        t: f32,
+        context: InterpolationSampleContext,
     ) -> (CorrectionA, CorrectionB) {
+        let sample_delta_secs = context.sample_delta_secs.unwrap_or_default();
         (
-            CorrectionA(100.0 + start.0.0 + (end.0.0 - start.0.0) * t),
-            CorrectionB(200.0 + start.1.0 + (end.1.0 - start.1.0) * t),
+            CorrectionA(100.0 + start.0.0 + (end.0.0 - start.0.0) * context.t + sample_delta_secs),
+            CorrectionB(200.0 + start.1.0 + (end.1.0 - start.1.0) * context.t + sample_delta_secs),
         )
+    }
+
+    fn bundle_lerp_uses_uncorrected_member(
+        start: (CorrectionA, CorrectionB),
+        end: (CorrectionA, CorrectionB),
+        context: InterpolationSampleContext,
+    ) -> (CorrectionA, CorrectionB) {
+        let a = start.0.0 + (end.0.0 - start.0.0) * context.t;
+        let b = start.1.0 + (end.1.0 - start.1.0) * context.t;
+        (
+            CorrectionA(a + b + context.sample_delta_secs.unwrap_or_default()),
+            // Make it obvious if the temporary bundle output is not restored.
+            CorrectionB(10_000.0),
+        )
+    }
+
+    #[test]
+    fn visual_correction_marks_component_changed() {
+        let mut app = App::new();
+        app.add_plugins((
+            StatesPlugin,
+            RepliconSharedPlugin {
+                auth_method: AuthMethod::None,
+            },
+        ));
+        app.init_resource::<PredictionRegistry>();
+        app.insert_resource(Time::<Virtual>::default());
+        app.component::<CorrectionA>().predict().add_correction();
+        app.world_mut().spawn(PredictionManager::default());
+        let entity = app
+            .world_mut()
+            .spawn((
+                CorrectionA(10.0),
+                VisualCorrection {
+                    error: CorrectionA(1.0),
+                },
+            ))
+            .id();
+        app.world_mut().clear_trackers();
+        let changed = app
+            .world()
+            .entity(entity)
+            .get_change_ticks::<CorrectionA>()
+            .unwrap()
+            .changed;
+
+        app.world_mut()
+            .run_system_once(add_visual_correction::<CorrectionA, CorrectionA>)
+            .unwrap();
+
+        assert_ne!(
+            app.world()
+                .entity(entity)
+                .get_change_ticks::<CorrectionA>()
+                .unwrap()
+                .changed,
+            changed
+        );
     }
 
     // Verifies that repair handles both surviving and removed components
@@ -1230,9 +1356,9 @@ mod tests {
         app.interpolate_with::<CorrectionB>(InterpolationFns::no_history(|_, _, _| {
             CorrectionB(2_000.0)
         }));
-        app.interpolate_bundle_with::<(CorrectionA, CorrectionB)>(InterpolationFns::no_history(
-            bundle_lerp,
-        ));
+        app.interpolate_bundle_with::<(CorrectionA, CorrectionB)>(
+            InterpolationFns::no_history_with_context(bundle_context_lerp),
+        );
 
         let mut history_a = PredictionHistory::<CorrectionA>::default();
         history_a.add_predicted(Tick(9), Some(CorrectionA(0.0)));
@@ -1276,13 +1402,13 @@ mod tests {
             app.world()
                 .get::<VisualCorrection<CorrectionA>>(entity)
                 .map(|correction| &correction.error),
-            Some(&CorrectionA(-104.0))
+            Some(&CorrectionA(-105.0))
         );
         assert_eq!(
             app.world()
                 .get::<VisualCorrection<CorrectionB>>(entity)
                 .map(|correction| &correction.error),
-            Some(&CorrectionB(-208.0))
+            Some(&CorrectionB(-209.0))
         );
         assert!(
             app.world()
@@ -1292,6 +1418,96 @@ mod tests {
         assert!(
             app.world()
                 .get::<PreviousVisual<CorrectionB>>(entity)
+                .is_none()
+        );
+    }
+
+    // A bundle member without `PreviousVisual` still supplies its repaired
+    // predicted samples to the bundle rule, but does not get its own visual
+    // correction. Its temporary bundle output is restored after sampling.
+    #[test]
+    fn post_rollback_bundle_uses_member_without_previous_visual() {
+        let mut app = App::new();
+        app.add_plugins((
+            StatesPlugin,
+            RepliconSharedPlugin {
+                auth_method: AuthMethod::None,
+            },
+        ));
+        app.init_resource::<PredictionRegistry>();
+        app.insert_resource(Time::<Fixed>::from_duration(Duration::from_secs(1)));
+        app.world_mut()
+            .resource_mut::<Time<Fixed>>()
+            .accumulate_overstep(Duration::from_millis(500));
+        app.insert_resource(LocalTimeline::default());
+        app.world_mut()
+            .resource_mut::<LocalTimeline>()
+            .apply_delta(10);
+
+        app.component::<CorrectionA>().predict().add_correction();
+        app.component::<CorrectionB>().predict();
+
+        app.interpolate_with::<CorrectionA>(InterpolationFns::no_history(|_, _, _| {
+            CorrectionA(1_000.0)
+        }));
+        app.interpolate_with::<CorrectionB>(InterpolationFns::no_history(|_, _, _| {
+            CorrectionB(2_000.0)
+        }));
+        app.interpolate_bundle_with::<(CorrectionA, CorrectionB)>(
+            InterpolationFns::no_history_with_context(bundle_lerp_uses_uncorrected_member),
+        );
+
+        let mut history_a = PredictionHistory::<CorrectionA>::default();
+        history_a.add_predicted(Tick(9), Some(CorrectionA(0.0)));
+        let mut history_b = PredictionHistory::<CorrectionB>::default();
+        history_b.add_predicted(Tick(9), Some(CorrectionB(4.0)));
+
+        let entity = app
+            .world_mut()
+            .spawn((
+                CorrectionA(10.0),
+                CorrectionB(20.0),
+                PreviousVisual(CorrectionA(1.0)),
+                history_a,
+                history_b,
+                FrameInterpolationHistory::<CorrectionA>::default(),
+                FrameInterpolationHistory::<CorrectionB>::default(),
+            ))
+            .id();
+
+        app.world_mut()
+            .run_system_once(repair_frame_interpolation_history::<CorrectionA>)
+            .unwrap();
+        app.world_mut()
+            .run_system_once(repair_frame_interpolation_history::<CorrectionB>)
+            .unwrap();
+        app.world_mut()
+            .run_system_once(update_frame_interpolation_post_rollback)
+            .unwrap();
+        app.world_mut().flush();
+
+        assert_eq!(
+            app.world().get::<CorrectionA>(entity),
+            Some(&CorrectionA(10.0))
+        );
+        assert_eq!(
+            app.world().get::<CorrectionB>(entity),
+            Some(&CorrectionB(20.0))
+        );
+        assert_eq!(
+            app.world()
+                .get::<VisualCorrection<CorrectionA>>(entity)
+                .map(|correction| &correction.error),
+            Some(&CorrectionA(-17.0))
+        );
+        assert!(
+            app.world()
+                .get::<VisualCorrection<CorrectionB>>(entity)
+                .is_none()
+        );
+        assert!(
+            app.world()
+                .get::<PreviousVisual<CorrectionA>>(entity)
                 .is_none()
         );
     }

--- a/crates/replication/prediction/src/registry.rs
+++ b/crates/replication/prediction/src/registry.rs
@@ -584,6 +584,9 @@ pub trait PredictionRegistrationExt<C> {
     /// `C` must have an applicable interpolation rule with an interpolation
     /// function when correction runs. That rule may be a component rule for
     /// `C`, or a bundle rule such as `(A, B)` that contains `C`.
+    /// Other members of the selected bundle do not need correction enabled or
+    /// their own `PreviousVisual`; their repaired predicted frame histories are
+    /// still available as inputs when computing the corrected sample for `C`.
     fn add_correction(self) -> Self
     where
         C: SyncComponent + Diffable<C> + Ease + Default;
@@ -601,6 +604,9 @@ pub trait PredictionRegistrationExt<C> {
     /// `C` must have an applicable interpolation rule with an interpolation
     /// function when correction runs. That rule may be a component rule for
     /// `C`, or a bundle rule such as `(A, B)` that contains `C`.
+    /// Other members of the selected bundle do not need correction enabled or
+    /// their own `PreviousVisual`; their repaired predicted frame histories are
+    /// still available as inputs when computing the corrected sample for `C`.
     fn add_linear_correction<D>(self) -> Self
     where
         C: SyncComponent + Diffable<D>,
@@ -617,6 +623,9 @@ pub trait PredictionRegistrationExt<C> {
     /// `C` must have an applicable interpolation rule with an interpolation
     /// function when correction runs. That rule may be a component rule for
     /// `C`, or a bundle rule such as `(A, B)` that contains `C`.
+    /// Other members of the selected bundle do not need correction enabled or
+    /// their own `PreviousVisual`; their repaired predicted frame histories are
+    /// still available as inputs when computing the corrected sample for `C`.
     fn add_correction_fn<D>(self, correction_fn: LerpFn<D>) -> Self
     where
         C: SyncComponent + Diffable<D>,

--- a/crates/tests/src/client_server/avian/transform_replication.rs
+++ b/crates/tests/src/client_server/avian/transform_replication.rs
@@ -12,13 +12,9 @@ use lightyear_replication::prelude::*;
 use test_log::test;
 
 /// The order is:
-/// - RunFixedMainLoop: Transform -> GlobalTransform THEN GlobalTransform -> Position/Rotation
-/// - PostUpdate: Position/Rotation -> Transform THEN Transform -> GlobalTransform
-/// - PostUpdate: add Transform based on Position/Rotation THEN Transform -> GlobalTransforms
-///
-/// One thing to watch out for is that if FrameInterpolation is not enabled, the Position/Rotation
-/// in FixedUpdate is not correct, since it gets updated via TransformToPosition.
-/// FrameInterpolation restores the correct value of Position/Rotation before FixedUpdate.
+/// - RunFixedMainLoop: restore the canonical Transform before fixed simulation
+/// - FixedPostUpdate: Transform -> Position/Rotation, physics, then Position/Rotation -> Transform
+/// - PostUpdate: interpolate/correct and propagate Transform
 #[test]
 fn test_replicate_transform_rigid_body() {
     let mut config = StepperConfig::single();

--- a/examples/avian_2d/src/protocol.rs
+++ b/examples/avian_2d/src/protocol.rs
@@ -94,8 +94,8 @@ impl Plugin for ProtocolPlugin {
             .add_linear_interpolation()
             .add_correction();
 
-        // LinearVelocity is predicted for client physics, but it does not need
-        // interpolation/correction because it is not rendered directly.
+        // The Avian integration automatically combines these with Position
+        // and Rotation in its velocity-aware Hermite interpolation rule.
         app.component::<LinearVelocity>().replicate().predict();
 
         app.component::<AngularVelocity>().replicate().predict();


### PR DESCRIPTION
- Add hermitian interpolation for (Position, Rotation, LinearVelocity, AngularVelocity)
- Handle functions that take in InterpolationCtx instead of simply `t`
- Correction uses a rule if any of the components in the bundle as a `PreviousVisual<C>` (In case only one component in the bundle got mispredicted)