### PR TITLE
fix: bei host client input handling

### DIFF
--- a/examples/bevy_enhanced_inputs/src/server.rs
+++ b/examples/bevy_enhanced_inputs/src/server.rs
@@ -121,13 +121,7 @@ fn movement(
     if is_host_server && !server_actions.contains(trigger.action) {
         return;
     }
-    if is_host_server {
-        if let Ok(controlled_by) = controlled_by.get(trigger.context) {
-            if host_clients.get(controlled_by.owner).is_ok() {
-                return;
-            }
-        }
-    }
+
     if let Ok(position) = position_query.get_mut(trigger.context) {
         shared::shared_movement_behaviour(position, trigger.value);
     }


### PR DESCRIPTION
This simply removes a block in the `server.rs` in the bei example:
```rs
if is_host_server {
        if let Ok(controlled_by) = controlled_by.get(trigger.context) {
            if host_clients.get(controlled_by.owner).is_ok() {
                return;
            }
        }
    }
```
This would lead to the host client never firing the shared movement logic on it's own local input.

It works as I expected after applying those changes.