### PR TITLE
Add runtime headless mode for GUI examples

### DIFF
--- a/examples/avian_2d/src/main.rs
+++ b/examples/avian_2d/src/main.rs
@@ -26,6 +26,7 @@ mod shared;
 
 fn main() {
     let cli = Cli::default();
+    let headless = cli.headless();
 
     let mut app = cli.build_app(Duration::from_secs_f64(1.0 / FIXED_TIMESTEP_HZ), true);
 
@@ -53,7 +54,9 @@ fn main() {
 
     #[cfg(feature = "gui")]
     {
-        app.add_plugins(renderer::ExampleRendererPlugin);
+        if !headless {
+            app.add_plugins(renderer::ExampleRendererPlugin);
+        }
     }
 
     // run the app

--- a/examples/avian_3d/src/main.rs
+++ b/examples/avian_3d/src/main.rs
@@ -25,6 +25,7 @@ mod shared;
 
 fn main() {
     let cli = Cli::default();
+    let headless = cli.headless();
 
     let mut app = cli.build_app(Duration::from_secs_f64(1.0 / FIXED_TIMESTEP_HZ), true);
 
@@ -52,7 +53,9 @@ fn main() {
     }
 
     #[cfg(feature = "gui")]
-    app.add_plugins(renderer::ExampleRendererPlugin);
+    if !headless {
+        app.add_plugins(renderer::ExampleRendererPlugin);
+    }
 
     app.run();
 }

--- a/examples/bevy_enhanced_inputs/src/main.rs
+++ b/examples/bevy_enhanced_inputs/src/main.rs
@@ -36,6 +36,7 @@ mod shared;
 /// When running the example as a binary, we only support Client or Server mode.
 fn main() {
     let cli = Cli::default();
+    let headless = cli.headless();
 
     let mut app = cli.build_app(Duration::from_secs_f64(1.0 / FIXED_TIMESTEP_HZ), true);
 
@@ -63,7 +64,9 @@ fn main() {
     }
 
     #[cfg(feature = "gui")]
-    app.add_plugins(renderer::ExampleRendererPlugin);
+    if !headless {
+        app.add_plugins(renderer::ExampleRendererPlugin);
+    }
 
     app.run();
 }

--- a/examples/common/src/cli.rs
+++ b/examples/common/src/cli.rs
@@ -40,6 +40,10 @@ use {
 #[derive(Parser, Debug)]
 #[command(version, about)]
 pub struct Cli {
+    /// Run without windowing/rendering plugins even when the example was built
+    /// with a GUI feature.
+    #[arg(long, global = true)]
+    pub headless: bool,
     #[command(subcommand)]
     pub mode: Option<Mode>,
 }
@@ -71,34 +75,36 @@ impl Cli {
         }
     }
 
-    pub fn create_app(add_inspector: bool, mode: Option<&Mode>) -> App {
+    pub fn headless(&self) -> bool {
+        self.headless || !cfg!(any(feature = "gui2d", feature = "gui3d"))
+    }
+
+    pub fn create_app(add_inspector: bool, mode: Option<&Mode>, headless: bool) -> App {
         #[cfg(any(feature = "gui2d", feature = "gui3d"))]
         {
-            let _ = mode;
-            new_gui_app(add_inspector)
+            if !headless {
+                return new_gui_app(add_inspector);
+            }
         }
-        #[cfg(not(any(feature = "gui2d", feature = "gui3d")))]
-        {
-            // For client-side apps (Client / HostClient), pace the main loop
-            // to ~60 FPS so that headless automation behaves closer to a
-            // real windowed client. Dedicated servers stay unthrottled.
-            let loop_wait = match mode {
-                #[cfg(feature = "client")]
-                Some(Mode::Client { .. }) => {
-                    Some(Duration::from_secs_f64(1.0 / HEADLESS_CLIENT_LOOP_HZ))
-                }
-                #[cfg(all(feature = "client", feature = "server"))]
-                Some(Mode::HostClient { .. }) | Some(Mode::Separate { .. }) => {
-                    Some(Duration::from_secs_f64(1.0 / HEADLESS_CLIENT_LOOP_HZ))
-                }
-                _ => None,
-            };
-            new_headless_app(loop_wait)
-        }
+        // For client-side apps (Client / HostClient), pace the main loop
+        // to ~60 FPS so that headless automation behaves closer to a
+        // real windowed client. Dedicated servers stay unthrottled.
+        let loop_wait = match mode {
+            #[cfg(feature = "client")]
+            Some(Mode::Client { .. }) => {
+                Some(Duration::from_secs_f64(1.0 / HEADLESS_CLIENT_LOOP_HZ))
+            }
+            #[cfg(all(feature = "client", feature = "server"))]
+            Some(Mode::HostClient { .. }) | Some(Mode::Separate { .. }) => {
+                Some(Duration::from_secs_f64(1.0 / HEADLESS_CLIENT_LOOP_HZ))
+            }
+            _ => None,
+        };
+        new_headless_app(loop_wait)
     }
 
     pub fn build_app(&self, tick_duration: Duration, add_inspector: bool) -> App {
-        let mut app = Cli::create_app(add_inspector, self.mode.as_ref());
+        let mut app = Cli::create_app(add_inspector, self.mode.as_ref(), self.headless());
         #[cfg(feature = "server")]
         app.add_observer(apply_server_link_conditioner);
         match self.mode {
@@ -106,22 +112,24 @@ impl Cli {
             Some(Mode::Client { client_id }) => {
                 #[cfg(feature = "steam")]
                 app.add_steam_resources(STEAM_APP_ID);
-                app.add_plugins((
-                    lightyear::prelude::client::ClientPlugins { tick_duration },
-                    #[cfg(any(feature = "gui2d", feature = "gui3d"))]
-                    ExampleClientRendererPlugin::new(format!("Client {client_id:?}")),
-                ));
+                app.add_plugins(lightyear::prelude::client::ClientPlugins { tick_duration });
+                #[cfg(any(feature = "gui2d", feature = "gui3d"))]
+                if !self.headless() {
+                    app.add_plugins(ExampleClientRendererPlugin::new(format!(
+                        "Client {client_id:?}"
+                    )));
+                }
                 app
             }
             #[cfg(feature = "server")]
             Some(Mode::Server) => {
                 #[cfg(feature = "steam")]
                 app.add_steam_resources(STEAM_APP_ID);
-                app.add_plugins((
-                    lightyear::prelude::server::ServerPlugins { tick_duration },
-                    #[cfg(any(feature = "gui2d", feature = "gui3d"))]
-                    ExampleServerRendererPlugin::new("Server".to_string()),
-                ));
+                app.add_plugins(lightyear::prelude::server::ServerPlugins { tick_duration });
+                #[cfg(any(feature = "gui2d", feature = "gui3d"))]
+                if !self.headless() {
+                    app.add_plugins(ExampleServerRendererPlugin::new("Server".to_string()));
+                }
                 app
             }
             #[cfg(all(feature = "client", feature = "server"))]
@@ -131,11 +139,14 @@ impl Cli {
                 app.add_plugins((
                     lightyear::prelude::server::ServerPlugins { tick_duration },
                     lightyear::prelude::client::ClientPlugins { tick_duration },
-                    #[cfg(any(feature = "gui2d", feature = "gui3d"))]
-                    ExampleClientRendererPlugin::new(format!("Host-Client {client_id:?}")),
-                    #[cfg(any(feature = "gui2d", feature = "gui3d"))]
-                    ExampleServerRendererPlugin::new("Host-Server".to_string()),
                 ));
+                #[cfg(any(feature = "gui2d", feature = "gui3d"))]
+                if !self.headless() {
+                    app.add_plugins((
+                        ExampleClientRendererPlugin::new(format!("Host-Client {client_id:?}")),
+                        ExampleServerRendererPlugin::new("Host-Server".to_string()),
+                    ));
+                }
                 app
             }
             None => {
@@ -311,6 +322,7 @@ pub fn cli() -> Cli {
         if #[cfg(target_family = "wasm")] {
             let client_id = rand::random::<u64>();
             Cli {
+                headless: false,
                 mode: Some(Mode::Client {
                     client_id: Some(client_id),
                 })

--- a/examples/delta_compression/src/main.rs
+++ b/examples/delta_compression/src/main.rs
@@ -35,6 +35,7 @@ mod shared;
 
 fn main() {
     let cli = Cli::default();
+    let headless = cli.headless();
 
     let mut app = cli.build_app(Duration::from_secs_f64(1.0 / FIXED_TIMESTEP_HZ), true);
 
@@ -57,7 +58,9 @@ fn main() {
         _ => {}
     }
     #[cfg(feature = "gui")]
-    app.add_plugins(renderer::ExampleRendererPlugin);
+    if !headless {
+        app.add_plugins(renderer::ExampleRendererPlugin);
+    }
 
     // run the app
     app.run();

--- a/examples/deterministic_replication/src/main.rs
+++ b/examples/deterministic_replication/src/main.rs
@@ -32,6 +32,7 @@ mod shared;
 
 fn main() {
     let cli = Cli::default();
+    let headless = cli.headless();
 
     let mut app = cli.build_app(Duration::from_secs_f64(1.0 / FIXED_TIMESTEP_HZ), true);
 
@@ -59,7 +60,9 @@ fn main() {
 
     #[cfg(feature = "gui")]
     {
-        app.add_plugins(renderer::ExampleRendererPlugin);
+        if !headless {
+            app.add_plugins(renderer::ExampleRendererPlugin);
+        }
     }
 
     app.run();

--- a/examples/fps/src/main.rs
+++ b/examples/fps/src/main.rs
@@ -27,6 +27,7 @@ mod shared;
 
 fn main() {
     let cli = Cli::default();
+    let headless = cli.headless();
 
     let mut app = cli.build_app(Duration::from_secs_f64(1.0 / FIXED_TIMESTEP_HZ), true);
 
@@ -52,7 +53,9 @@ fn main() {
     }
 
     #[cfg(feature = "gui")]
-    app.add_plugins(renderer::ExampleRendererPlugin);
+    if !headless {
+        app.add_plugins(renderer::ExampleRendererPlugin);
+    }
 
     // run the app
     app.run();

--- a/examples/lobby/src/main.rs
+++ b/examples/lobby/src/main.rs
@@ -43,6 +43,7 @@ pub fn host_server_port(host: PeerId) -> u16 {
 
 fn main() {
     let cli = Cli::default();
+    let headless = cli.headless();
 
     let tick_duration = Duration::from_secs_f64(1.0 / FIXED_TIMESTEP_HZ);
     let mut app = cli.build_app(tick_duration, true);
@@ -132,7 +133,9 @@ fn main() {
     }
 
     #[cfg(feature = "gui")]
-    app.add_plugins(renderer::ExampleRendererPlugin);
+    if !headless {
+        app.add_plugins(renderer::ExampleRendererPlugin);
+    }
 
     app.run();
 }

--- a/examples/network_visibility/src/main.rs
+++ b/examples/network_visibility/src/main.rs
@@ -35,6 +35,7 @@ mod shared;
 /// When running the example as a binary, we only support Client or Server mode.
 fn main() {
     let cli = Cli::default();
+    let headless = cli.headless();
 
     let mut app = cli.build_app(Duration::from_secs_f64(1.0 / FIXED_TIMESTEP_HZ), true);
 
@@ -60,7 +61,9 @@ fn main() {
     }
 
     #[cfg(feature = "gui")]
-    app.add_plugins(renderer::ExampleRendererPlugin);
+    if !headless {
+        app.add_plugins(renderer::ExampleRendererPlugin);
+    }
 
     app.run();
 }

--- a/examples/priority/src/main.rs
+++ b/examples/priority/src/main.rs
@@ -24,6 +24,7 @@ mod shared;
 
 fn main() {
     let cli = Cli::default();
+    let headless = cli.headless();
 
     let mut app = cli.build_app(Duration::from_secs_f64(1.0 / FIXED_TIMESTEP_HZ), true);
 
@@ -49,7 +50,9 @@ fn main() {
     }
 
     #[cfg(feature = "gui")]
-    app.add_plugins(renderer::ExampleRendererPlugin);
+    if !headless {
+        app.add_plugins(renderer::ExampleRendererPlugin);
+    }
 
     app.run();
 }

--- a/examples/projectiles/src/main.rs
+++ b/examples/projectiles/src/main.rs
@@ -35,6 +35,7 @@ pub(crate) struct HostClientMode;
 
 fn main() {
     let cli = Cli::default();
+    let headless = cli.headless();
 
     let mut app = cli.build_app(Duration::from_secs_f64(1.0 / FIXED_TIMESTEP_HZ), false);
 
@@ -63,7 +64,9 @@ fn main() {
     }
 
     #[cfg(feature = "gui")]
-    app.add_plugins(renderer::ExampleRendererPlugin);
+    if !headless {
+        app.add_plugins(renderer::ExampleRendererPlugin);
+    }
 
     // run the app
     app.run();

--- a/examples/replication_groups/src/main.rs
+++ b/examples/replication_groups/src/main.rs
@@ -26,6 +26,7 @@ mod shared;
 
 fn main() {
     let cli = Cli::default();
+    let headless = cli.headless();
 
     let mut app = cli.build_app(Duration::from_secs_f64(1.0 / FIXED_TIMESTEP_HZ), true);
 
@@ -51,7 +52,9 @@ fn main() {
     }
 
     #[cfg(feature = "gui")]
-    app.add_plugins(renderer::ExampleRendererPlugin);
+    if !headless {
+        app.add_plugins(renderer::ExampleRendererPlugin);
+    }
 
     app.run();
 }

--- a/examples/simple_box/src/main.rs
+++ b/examples/simple_box/src/main.rs
@@ -36,6 +36,7 @@ mod shared;
 /// When running the example as a binary, we only support Client or Server mode.
 fn main() {
     let cli = Cli::default();
+    let headless = cli.headless();
 
     let mut app = cli.build_app(Duration::from_secs_f64(1.0 / FIXED_TIMESTEP_HZ), true);
 
@@ -61,7 +62,9 @@ fn main() {
     }
 
     #[cfg(feature = "gui")]
-    app.add_plugins(renderer::ExampleRendererPlugin);
+    if !headless {
+        app.add_plugins(renderer::ExampleRendererPlugin);
+    }
 
     app.run();
 }


### PR DESCRIPTION
## Summary
- add a global `--headless` flag to the shared example CLI
- create a headless Bevy app at runtime even when GUI features are compiled
- skip common and example-specific renderer plugins when headless is requested

## Validation
- `cargo check -p simple_box --all-features`
- `cargo check -p bevy_enhanced_inputs --all-features`
- `cargo check -p avian_3d --all-features`
- `cargo check -p lightyear_examples_common --all-features`
- `cargo run -p bevy_enhanced_inputs --all-features -- --help`
- `target/debug/bevy_enhanced_inputs host-client --headless --help`