### PR TITLE
Fix BEI host-client input rebroadcast

### DIFF
--- a/crates/inputs/input_bei/src/marker.rs
+++ b/crates/inputs/input_bei/src/marker.rs
@@ -5,7 +5,7 @@ use bevy_ecs::relationship::Relationship;
 use bevy_enhanced_input::prelude::*;
 use bevy_replicon::client::confirm_history::ConfirmHistory;
 use lightyear_connection::client::Client;
-use lightyear_replication::prelude::{Controlled, ControlledBy};
+use lightyear_replication::prelude::{Controlled, ControlledBy, PreSpawned};
 
 /// Marker component that indicates that the entity is actively listening for physical user inputs.
 ///
@@ -28,13 +28,24 @@ impl<C> Default for InputMarker<C> {
 fn action_targets_local_client<C: Component>(
     action_of: &ActionOf<C>,
     contexts: &Query<Option<&ControlledBy>, With<Controlled>>,
+    server_contexts: &Query<&ControlledBy>,
     clients: &Query<(), With<Client>>,
 ) -> bool {
     match contexts.get(action_of.get()) {
         Ok(Some(controlled_by)) => clients.get(controlled_by.owner).is_ok(),
         Ok(None) => true,
-        Err(_) => false,
+        Err(_) => server_context_owned_by_local_client(action_of, server_contexts, clients),
     }
+}
+
+fn server_context_owned_by_local_client<C: Component>(
+    action_of: &ActionOf<C>,
+    server_contexts: &Query<&ControlledBy>,
+    clients: &Query<(), With<Client>>,
+) -> bool {
+    server_contexts
+        .get(action_of.get())
+        .is_ok_and(|controlled_by| clients.get(controlled_by.owner).is_ok())
 }
 
 /// Propagate the InputMarker component from the Context entity to the Action entities
@@ -76,20 +87,28 @@ pub(crate) fn add_input_marker_from_parent<C: Component>(
 /// If Bindings or ActionMock is added to an Action entity, add the InputMarker
 /// to that Action entity once the action has a network-resolvable identity.
 ///
-/// Replicated/prespawned actions become resolvable when [`ConfirmHistory`] is
-/// present, because the client's action entity can then be mapped back to the
-/// server action entity when an input message is sent.
+/// Replicated actions become resolvable when [`ConfirmHistory`] is present,
+/// because the client's action entity can then be mapped back to the server
+/// action entity when an input message is sent. Prespawned actions are also
+/// resolvable via their hash. Host-owned authoritative server actions are
+/// already server-world entities, so the host client can send them directly to
+/// the in-app server for rebroadcasting.
 pub(crate) fn add_input_marker_from_binding<C: Component>(
     trigger: On<Add, (Bindings, ActionMock)>,
-    action: Query<&ActionOf<C>, (With<ConfirmHistory>, Without<InputMarker<C>>)>,
+    action: Query<(&ActionOf<C>, Has<ConfirmHistory>, Has<PreSpawned>), Without<InputMarker<C>>>,
     contexts: Query<Option<&ControlledBy>, With<Controlled>>,
+    server_contexts: Query<&ControlledBy>,
     clients: Query<(), With<Client>>,
     mut commands: Commands,
 ) {
-    let Ok(action_of) = action.get(trigger.entity) else {
+    let Ok((action_of, has_confirm_history, has_prespawned)) = action.get(trigger.entity) else {
         return;
     };
-    if action_targets_local_client(action_of, &contexts, &clients) {
+    let is_host_owned_server_action =
+        server_context_owned_by_local_client(action_of, &server_contexts, &clients);
+    if (has_confirm_history || has_prespawned || is_host_owned_server_action)
+        && action_targets_local_client(action_of, &contexts, &server_contexts, &clients)
+    {
         commands
             .entity(trigger.entity)
             .insert(InputMarker::<C>::default());
@@ -109,13 +128,41 @@ pub(crate) fn add_input_marker_when_action_becomes_ready<C: Component>(
         ),
     >,
     contexts: Query<Option<&ControlledBy>, With<Controlled>>,
+    server_contexts: Query<&ControlledBy>,
     clients: Query<(), With<Client>>,
     mut commands: Commands,
 ) {
     let Ok(action_of) = action.get(trigger.entity) else {
         return;
     };
-    if action_targets_local_client(action_of, &contexts, &clients) {
+    if action_targets_local_client(action_of, &contexts, &server_contexts, &clients) {
+        commands
+            .entity(trigger.entity)
+            .insert(InputMarker::<C>::default());
+    }
+}
+
+/// If an existing bound action becomes prespawn-resolvable, add the
+/// InputMarker once it targets the local client.
+pub(crate) fn add_input_marker_when_prespawned_action_becomes_ready<C: Component>(
+    trigger: On<Add, PreSpawned>,
+    action: Query<
+        &ActionOf<C>,
+        (
+            With<PreSpawned>,
+            Or<(With<Bindings>, With<ActionMock>)>,
+            Without<InputMarker<C>>,
+        ),
+    >,
+    contexts: Query<Option<&ControlledBy>, With<Controlled>>,
+    server_contexts: Query<&ControlledBy>,
+    clients: Query<(), With<Client>>,
+    mut commands: Commands,
+) {
+    let Ok(action_of) = action.get(trigger.entity) else {
+        return;
+    };
+    if action_targets_local_client(action_of, &contexts, &server_contexts, &clients) {
         commands
             .entity(trigger.entity)
             .insert(InputMarker::<C>::default());

--- a/crates/inputs/input_bei/src/plugin.rs
+++ b/crates/inputs/input_bei/src/plugin.rs
@@ -127,7 +127,8 @@ impl<
         {
             use crate::marker::{
                 add_input_marker_from_binding, add_input_marker_from_parent,
-                add_input_marker_when_action_becomes_ready, propagate_input_marker,
+                add_input_marker_when_action_becomes_ready,
+                add_input_marker_when_prespawned_action_becomes_ready, propagate_input_marker,
             };
             // for rebroadcasting inputs, we insert TriggerState (which inserts the InputBuffer) when ActionOf<C> is added
             // on an entity
@@ -137,6 +138,7 @@ impl<
             app.add_observer(add_input_marker_from_parent::<C>);
             app.add_observer(add_input_marker_from_binding::<C>);
             app.add_observer(add_input_marker_when_action_becomes_ready::<C>);
+            app.add_observer(add_input_marker_when_prespawned_action_becomes_ready::<C>);
             app.add_systems(PreUpdate, resolve_pending_action_of::<C>);
 
             if self.config.rebroadcast_inputs {

--- a/crates/tests/src/host_server/input/bei.rs
+++ b/crates/tests/src/host_server/input/bei.rs
@@ -5,9 +5,11 @@ use bevy_enhanced_input::action::mock::{ActionMock, MockSpan};
 use bevy_enhanced_input::action::{Action, TriggerState};
 use bevy_enhanced_input::prelude::{ActionOf, ActionValue, Actions};
 use lightyear::input::bei::input_message::BEIBuffer;
+use lightyear::input::bei::prelude::InputMarker;
+use lightyear::input::input_buffer::Compressed;
 use lightyear_connection::network_target::NetworkTarget;
 use lightyear_messages::MessageManager;
-use lightyear_replication::prelude::{PreSpawned, PredictionTarget, Replicate};
+use lightyear_replication::prelude::{ControlledBy, PreSpawned, PredictionTarget, Replicate};
 
 const TEST_HASH: u64 = 42;
 
@@ -61,7 +63,8 @@ fn test_rebroadcast() {
         .get_local(server_entity)
         .expect("entity not replicated to client 2");
 
-    // Spawn matching action entity on client 0 with PreSpawned + input mock
+    // Spawn matching action entity on client 0 with PreSpawned, then let the
+    // ActionOf/InputMarker relationship settle before mocking input.
     stepper.client_apps[0]
         .world_mut()
         .spawn((
@@ -73,23 +76,20 @@ fn test_rebroadcast() {
                 MockSpan::Manual,
             ),
             PreSpawned::new(TEST_HASH),
+            InputMarker::<BEIContext>::default(),
         ))
         .id();
     stepper.frame_step(4);
 
     // Check that client 1 received the rebroadcasted action and has input buffer
-    let action1 = stepper.client_apps[1]
+    let action1 =
+        find_action_with_fired_input(stepper.client_apps[1].world(), client1_entity, "client 1");
+    let remote_buffer = stepper.client_apps[1]
         .world()
-        .get::<Actions<BEIContext>>(client1_entity)
-        .unwrap()
-        .collection()[0];
-    assert!(
-        stepper.client_apps[1]
-            .world()
-            .entity(action1)
-            .get::<BEIBuffer<BEIContext>>()
-            .is_some()
-    );
+        .entity(action1)
+        .get::<BEIBuffer<BEIContext>>()
+        .expect("Client 1 should have a BEI input buffer for the rebroadcasted action");
+    assert_buffer_contains_fired_input(remote_buffer, "client 1 rebroadcast buffer");
 
     // Verify the server has the action entity
     let action_host = stepper
@@ -106,6 +106,13 @@ fn test_rebroadcast() {
             .contains::<Action<BEIAction1>>(),
         "Action entity on server should have the Action component"
     );
+    let server_buffer = stepper
+        .server_app
+        .world()
+        .entity(action_host)
+        .get::<BEIBuffer<BEIContext>>()
+        .expect("Server should buffer client 0's input before rebroadcasting it");
+    assert_buffer_contains_fired_input(server_buffer, "server input buffer");
 }
 
 /// Minimal host-server topology: host client fires an action and the remote client
@@ -120,6 +127,10 @@ fn test_host_client_action_rebroadcasts_to_remote_client() {
         .spawn((
             Replicate::to_clients(NetworkTarget::All),
             PredictionTarget::to_clients(NetworkTarget::All),
+            ControlledBy {
+                owner: stepper.host_client_entity.unwrap(),
+                lifetime: Default::default(),
+            },
             BEIContext,
         ))
         .id();
@@ -130,7 +141,6 @@ fn test_host_client_action_rebroadcasts_to_remote_client() {
         .spawn((
             ActionOf::<BEIContext>::new(server_entity),
             Action::<BEIAction1>::default(),
-            PreSpawned::new(TEST_HASH),
             Replicate::to_clients(NetworkTarget::All),
         ))
         .id();
@@ -159,11 +169,11 @@ fn test_host_client_action_rebroadcasts_to_remote_client() {
 
     stepper.frame_step(4);
 
-    let remote_action = stepper.client_apps[0]
-        .world()
-        .get::<Actions<BEIContext>>(remote_entity)
-        .unwrap()
-        .collection()[0];
+    let remote_action = find_action_with_fired_input(
+        stepper.client_apps[0].world(),
+        remote_entity,
+        "remote client",
+    );
     assert!(
         stepper.client_apps[0]
             .world()
@@ -171,14 +181,12 @@ fn test_host_client_action_rebroadcasts_to_remote_client() {
             .contains::<Action<BEIAction1>>(),
         "Remote client should receive the rebroadcast action entity"
     );
-    assert!(
-        stepper.client_apps[0]
-            .world()
-            .entity(remote_action)
-            .get::<BEIBuffer<BEIContext>>()
-            .is_some(),
-        "Remote client should buffer the host client's rebroadcast input"
-    );
+    let remote_buffer = stepper.client_apps[0]
+        .world()
+        .entity(remote_action)
+        .get::<BEIBuffer<BEIContext>>()
+        .expect("Remote client should buffer the host client's rebroadcast input");
+    assert_buffer_contains_fired_input(remote_buffer, "remote host-client rebroadcast buffer");
 
     let server_action = stepper
         .server_app
@@ -194,4 +202,56 @@ fn test_host_client_action_rebroadcasts_to_remote_client() {
             .contains::<Action<BEIAction1>>(),
         "Server should also have the host action entity"
     );
+    let server_buffer = stepper
+        .server_app
+        .world()
+        .entity(server_action)
+        .get::<BEIBuffer<BEIContext>>()
+        .expect("Server should buffer the host client's input before rebroadcasting it");
+    assert_buffer_contains_fired_input(server_buffer, "host-server input buffer");
+}
+
+fn assert_buffer_contains_fired_input(buffer: &BEIBuffer<BEIContext>, label: &str) {
+    assert!(
+        buffer_contains_fired_input(buffer),
+        "{label} should contain a fired bool input, got {buffer:?}"
+    );
+}
+
+fn buffer_contains_fired_input(buffer: &BEIBuffer<BEIContext>) -> bool {
+    buffer.buffer.iter().any(|input| {
+        matches!(
+            input,
+            Compressed::Input(snapshot)
+                if snapshot.state == TriggerState::Fired
+                    && snapshot.value == ActionValue::Bool(true)
+        )
+    })
+}
+
+fn find_action_with_fired_input(world: &World, context: Entity, label: &str) -> Entity {
+    let actions = world
+        .get::<Actions<BEIContext>>(context)
+        .unwrap_or_else(|| panic!("{label} context should have BEI actions"));
+    for action in actions.collection().iter().copied() {
+        if world
+            .entity(action)
+            .get::<BEIBuffer<BEIContext>>()
+            .is_some_and(buffer_contains_fired_input)
+        {
+            return action;
+        }
+    }
+    let buffers: Vec<_> = actions
+        .collection()
+        .iter()
+        .copied()
+        .map(|action| {
+            format!(
+                "{action:?}: {:?}",
+                world.entity(action).get::<BEIBuffer<BEIContext>>()
+            )
+        })
+        .collect();
+    panic!("{label} should have an action with fired rebroadcast input, got {buffers:?}");
 }


### PR DESCRIPTION
## Summary
- allow host-owned BEI server actions to become input producers for host-client rebroadcasting
- recognize prespawned BEI actions as network-resolvable for input markers
- harden host-server BEI tests to assert fired input reaches server and remote buffers

## Validation
- cargo test -p lightyear_inputs_bei --all-features
- cargo test -p lightyear_tests host_server::input::bei --all-features -- --test-threads=1
- cargo check -p bevy_enhanced_inputs --all-features
- cargo test -p lightyear_tests test_input_broadcasting_prediction --all-features -- --test-threads=1