### PR TITLE
fix(bei): fix bei in host-client mode

### DIFF
--- a/crates/inputs/input_bei/src/input_message.rs
+++ b/crates/inputs/input_bei/src/input_message.rs
@@ -498,7 +498,7 @@ mod tests {
     }
 
     #[test]
-    fn test_update_buffer_skip_ticks_before_previous_end() {
+    fn test_update_buffer_keeps_matching_overlap_before_previous_end() {
         let mut input_buffer = BEIBuffer::<Context1>::default();
 
         // Set up buffer with actions at ticks 5 and 6
@@ -506,8 +506,10 @@ mod tests {
         state.state = TriggerState::Fired;
         state.value = ActionValue::Bool(true);
         let first_state = state;
+        let mut first_state_decayed = first_state;
+        first_state_decayed.decay_tick(Duration::default());
         input_buffer.set(Tick(5), first_state);
-        input_buffer.set(Tick(6), first_state);
+        input_buffer.set(Tick(6), first_state_decayed);
         input_buffer.last_remote_tick = Some(Tick(6));
 
         // Create a different action
@@ -515,7 +517,8 @@ mod tests {
         state.value = ActionValue::Bool(false);
         let mut second_state = state;
 
-        // Message covers ticks 5-8, but we should only process ticks 7-8
+        // Message covers ticks 5-8. The overlap matches the existing buffer,
+        // so the old ticks remain unchanged and the new mismatch starts at tick 7.
         let sequence = BEIStateSequence::<Context1> {
             start_state: first_state,
             diffs: vec![
@@ -536,11 +539,54 @@ mod tests {
         assert_eq!(earliest_mismatch, Some(Tick(7)));
         // Ticks 5 and 6 should remain unchanged
         assert_eq!(input_buffer.get(Tick(5)), Some(&first_state));
-        assert_eq!(input_buffer.get(Tick(6)), Some(&first_state));
+        assert_eq!(input_buffer.get(Tick(6)), Some(&first_state_decayed));
         // Ticks 7 and 8 should be updated
         second_state.events = ActionEvents::ONGOING;
         assert_eq!(input_buffer.get(Tick(7)), Some(&second_state));
         assert_eq!(input_buffer.get(Tick(8)), Some(&second_state));
+    }
+
+    #[test]
+    fn test_update_buffer_rewrites_future_overlap_before_last_remote_tick() {
+        let mut input_buffer = BEIBuffer::<Context1>::default();
+
+        let neutral = ActionsSnapshot {
+            value: ActionValue::Bool(false),
+            ..Default::default()
+        };
+        let fired = ActionsSnapshot {
+            state: TriggerState::Fired,
+            value: ActionValue::Bool(true),
+            events: ActionEvents::FIRE,
+            ..Default::default()
+        };
+
+        // Earlier input-delay packets predicted ticks 10..=14 as neutral.
+        for tick in 10..=14 {
+            input_buffer.set(Tick(tick), neutral);
+        }
+        input_buffer.last_remote_tick = Some(Tick(14));
+
+        // A newer packet overlaps those ticks and corrects them to the real input.
+        let sequence = BEIStateSequence::<Context1> {
+            start_state: fired,
+            diffs: vec![
+                Compressed::SameAsPrecedent,
+                Compressed::SameAsPrecedent,
+                Compressed::SameAsPrecedent,
+                Compressed::SameAsPrecedent,
+            ],
+            marker: Default::default(),
+        };
+
+        let earliest_mismatch =
+            sequence.update_buffer(&mut input_buffer, Tick(15), Duration::default());
+
+        assert_eq!(earliest_mismatch, Some(Tick(11)));
+        for tick in 11..=15 {
+            assert_eq!(input_buffer.get(Tick(tick)), Some(&fired));
+        }
+        assert_eq!(input_buffer.last_remote_tick, Some(Tick(15)));
     }
 
     /// Even if last_remote_tick < end_tick, we should correctly compute the mismatch

--- a/crates/inputs/input_bei/src/marker.rs
+++ b/crates/inputs/input_bei/src/marker.rs
@@ -3,9 +3,6 @@
 use bevy_ecs::prelude::*;
 use bevy_ecs::relationship::Relationship;
 use bevy_enhanced_input::prelude::*;
-use bevy_replicon::client::confirm_history::ConfirmHistory;
-use lightyear_connection::client::Client;
-use lightyear_replication::prelude::{Controlled, ControlledBy, PreSpawned};
 
 /// Marker component that indicates that the entity is actively listening for physical user inputs.
 ///
@@ -25,35 +22,8 @@ impl<C> Default for InputMarker<C> {
     }
 }
 
-fn action_targets_local_client<C: Component>(
-    action_of: &ActionOf<C>,
-    contexts: &Query<Option<&ControlledBy>, With<Controlled>>,
-    server_contexts: &Query<&ControlledBy>,
-    clients: &Query<(), With<Client>>,
-) -> bool {
-    match contexts.get(action_of.get()) {
-        Ok(Some(controlled_by)) => clients.get(controlled_by.owner).is_ok(),
-        Ok(None) => true,
-        Err(_) => server_context_owned_by_local_client(action_of, server_contexts, clients),
-    }
-}
-
-fn server_context_owned_by_local_client<C: Component>(
-    action_of: &ActionOf<C>,
-    server_contexts: &Query<&ControlledBy>,
-    clients: &Query<(), With<Client>>,
-) -> bool {
-    server_contexts
-        .get(action_of.get())
-        .is_ok_and(|controlled_by| clients.get(controlled_by.owner).is_ok())
-}
-
 /// Propagate the InputMarker component from the Context entity to the Action entities
 /// whenever an InputMarker is added to a Context entity.
-///
-/// `InputMarker<C>` on the context is the explicit local-input signal, so
-/// confirmed prespawned owner actions should still receive it. Remote
-/// rebroadcasted actions should be attached to contexts without this marker.
 pub(crate) fn propagate_input_marker<C: Component>(
     trigger: On<Add, InputMarker<C>>,
     actions: Query<&Actions<C>>,
@@ -84,87 +54,38 @@ pub(crate) fn add_input_marker_from_parent<C: Component>(
     }
 }
 
-/// If Bindings or ActionMock is added to an Action entity, add the InputMarker
-/// to that Action entity once the action has a network-resolvable identity.
-///
-/// Replicated actions become resolvable when [`ConfirmHistory`] is present,
-/// because the client's action entity can then be mapped back to the server
-/// action entity when an input message is sent. Prespawned actions are also
-/// resolvable via their hash. Host-owned authoritative server actions are
-/// already server-world entities, so the host client can send them directly to
-/// the in-app server for rebroadcasting.
+/// If Bindings are added to an Action entity, add the InputMarker to that
+/// Action entity.
 pub(crate) fn add_input_marker_from_binding<C: Component>(
-    trigger: On<Add, (Bindings, ActionMock)>,
-    action: Query<(&ActionOf<C>, Has<ConfirmHistory>, Has<PreSpawned>), Without<InputMarker<C>>>,
-    contexts: Query<Option<&ControlledBy>, With<Controlled>>,
-    server_contexts: Query<&ControlledBy>,
-    clients: Query<(), With<Client>>,
+    trigger: On<Add, Bindings>,
+    action: Query<&Bindings, (With<ActionOf<C>>, Without<InputMarker<C>>)>,
     mut commands: Commands,
 ) {
-    let Ok((action_of, has_confirm_history, has_prespawned)) = action.get(trigger.entity) else {
+    let Ok(bindings) = action.get(trigger.entity) else {
         return;
     };
-    let is_host_owned_server_action =
-        server_context_owned_by_local_client(action_of, &server_contexts, &clients);
-    if (has_confirm_history || has_prespawned || is_host_owned_server_action)
-        && action_targets_local_client(action_of, &contexts, &server_contexts, &clients)
-    {
-        commands
-            .entity(trigger.entity)
-            .insert(InputMarker::<C>::default());
+    if bindings.is_empty() {
+        return;
     }
+    commands
+        .entity(trigger.entity)
+        .insert(InputMarker::<C>::default());
 }
 
-/// If an existing bound action becomes network-resolvable, add the InputMarker
-/// once it targets the local client.
-pub(crate) fn add_input_marker_when_action_becomes_ready<C: Component>(
-    trigger: On<Add, ConfirmHistory>,
-    action: Query<
-        &ActionOf<C>,
-        (
-            With<ConfirmHistory>,
-            Or<(With<Bindings>, With<ActionMock>)>,
-            Without<InputMarker<C>>,
-        ),
-    >,
-    contexts: Query<Option<&ControlledBy>, With<Controlled>>,
-    server_contexts: Query<&ControlledBy>,
-    clients: Query<(), With<Client>>,
+/// If an active ActionMock is inserted on an Action entity, add the InputMarker
+/// to that Action entity.
+pub(crate) fn add_input_marker_from_mock<C: Component>(
+    trigger: On<Insert, ActionMock>,
+    action: Query<&ActionMock, (With<ActionOf<C>>, Without<InputMarker<C>>)>,
     mut commands: Commands,
 ) {
-    let Ok(action_of) = action.get(trigger.entity) else {
+    let Ok(mock) = action.get(trigger.entity) else {
         return;
     };
-    if action_targets_local_client(action_of, &contexts, &server_contexts, &clients) {
-        commands
-            .entity(trigger.entity)
-            .insert(InputMarker::<C>::default());
-    }
-}
-
-/// If an existing bound action becomes prespawn-resolvable, add the
-/// InputMarker once it targets the local client.
-pub(crate) fn add_input_marker_when_prespawned_action_becomes_ready<C: Component>(
-    trigger: On<Add, PreSpawned>,
-    action: Query<
-        &ActionOf<C>,
-        (
-            With<PreSpawned>,
-            Or<(With<Bindings>, With<ActionMock>)>,
-            Without<InputMarker<C>>,
-        ),
-    >,
-    contexts: Query<Option<&ControlledBy>, With<Controlled>>,
-    server_contexts: Query<&ControlledBy>,
-    clients: Query<(), With<Client>>,
-    mut commands: Commands,
-) {
-    let Ok(action_of) = action.get(trigger.entity) else {
+    if !mock.enabled {
         return;
-    };
-    if action_targets_local_client(action_of, &contexts, &server_contexts, &clients) {
-        commands
-            .entity(trigger.entity)
-            .insert(InputMarker::<C>::default());
     }
+    commands
+        .entity(trigger.entity)
+        .insert(InputMarker::<C>::default());
 }

--- a/crates/inputs/input_bei/src/marker.rs
+++ b/crates/inputs/input_bei/src/marker.rs
@@ -5,7 +5,7 @@ use bevy_ecs::relationship::Relationship;
 use bevy_enhanced_input::prelude::*;
 use bevy_replicon::client::confirm_history::ConfirmHistory;
 use lightyear_connection::client::Client;
-use lightyear_replication::prelude::{Controlled, ControlledBy};
+use lightyear_replication::prelude::{Controlled, ControlledBy, PreSpawned};
 
 /// Marker component that indicates that the entity is actively listening for physical user inputs.
 ///
@@ -28,13 +28,24 @@ impl<C> Default for InputMarker<C> {
 fn action_targets_local_client<C: Component>(
     action_of: &ActionOf<C>,
     contexts: &Query<Option<&ControlledBy>, With<Controlled>>,
+    server_contexts: &Query<&ControlledBy>,
     clients: &Query<(), With<Client>>,
 ) -> bool {
     match contexts.get(action_of.get()) {
         Ok(Some(controlled_by)) => clients.get(controlled_by.owner).is_ok(),
         Ok(None) => true,
-        Err(_) => false,
+        Err(_) => server_context_owned_by_local_client(action_of, server_contexts, clients),
     }
+}
+
+fn server_context_owned_by_local_client<C: Component>(
+    action_of: &ActionOf<C>,
+    server_contexts: &Query<&ControlledBy>,
+    clients: &Query<(), With<Client>>,
+) -> bool {
+    server_contexts
+        .get(action_of.get())
+        .is_ok_and(|controlled_by| clients.get(controlled_by.owner).is_ok())
 }
 
 /// Propagate the InputMarker component from the Context entity to the Action entities
@@ -76,20 +87,28 @@ pub(crate) fn add_input_marker_from_parent<C: Component>(
 /// If Bindings or ActionMock is added to an Action entity, add the InputMarker
 /// to that Action entity once the action has a network-resolvable identity.
 ///
-/// Replicated/prespawned actions become resolvable when [`ConfirmHistory`] is
-/// present, because the client's action entity can then be mapped back to the
-/// server action entity when an input message is sent.
+/// Replicated actions become resolvable when [`ConfirmHistory`] is present,
+/// because the client's action entity can then be mapped back to the server
+/// action entity when an input message is sent. Prespawned actions are also
+/// resolvable via their hash. Host-owned authoritative server actions are
+/// already server-world entities, so the host client can send them directly to
+/// the in-app server for rebroadcasting.
 pub(crate) fn add_input_marker_from_binding<C: Component>(
     trigger: On<Add, (Bindings, ActionMock)>,
-    action: Query<&ActionOf<C>, (With<ConfirmHistory>, Without<InputMarker<C>>)>,
+    action: Query<(&ActionOf<C>, Has<ConfirmHistory>, Has<PreSpawned>), Without<InputMarker<C>>>,
     contexts: Query<Option<&ControlledBy>, With<Controlled>>,
+    server_contexts: Query<&ControlledBy>,
     clients: Query<(), With<Client>>,
     mut commands: Commands,
 ) {
-    let Ok(action_of) = action.get(trigger.entity) else {
+    let Ok((action_of, has_confirm_history, has_prespawned)) = action.get(trigger.entity) else {
         return;
     };
-    if action_targets_local_client(action_of, &contexts, &clients) {
+    let is_host_owned_server_action =
+        server_context_owned_by_local_client(action_of, &server_contexts, &clients);
+    if (has_confirm_history || has_prespawned || is_host_owned_server_action)
+        && action_targets_local_client(action_of, &contexts, &server_contexts, &clients)
+    {
         commands
             .entity(trigger.entity)
             .insert(InputMarker::<C>::default());
@@ -109,13 +128,41 @@ pub(crate) fn add_input_marker_when_action_becomes_ready<C: Component>(
         ),
     >,
     contexts: Query<Option<&ControlledBy>, With<Controlled>>,
+    server_contexts: Query<&ControlledBy>,
     clients: Query<(), With<Client>>,
     mut commands: Commands,
 ) {
     let Ok(action_of) = action.get(trigger.entity) else {
         return;
     };
-    if action_targets_local_client(action_of, &contexts, &clients) {
+    if action_targets_local_client(action_of, &contexts, &server_contexts, &clients) {
+        commands
+            .entity(trigger.entity)
+            .insert(InputMarker::<C>::default());
+    }
+}
+
+/// If an existing bound action becomes prespawn-resolvable, add the
+/// InputMarker once it targets the local client.
+pub(crate) fn add_input_marker_when_prespawned_action_becomes_ready<C: Component>(
+    trigger: On<Add, PreSpawned>,
+    action: Query<
+        &ActionOf<C>,
+        (
+            With<PreSpawned>,
+            Or<(With<Bindings>, With<ActionMock>)>,
+            Without<InputMarker<C>>,
+        ),
+    >,
+    contexts: Query<Option<&ControlledBy>, With<Controlled>>,
+    server_contexts: Query<&ControlledBy>,
+    clients: Query<(), With<Client>>,
+    mut commands: Commands,
+) {
+    let Ok(action_of) = action.get(trigger.entity) else {
+        return;
+    };
+    if action_targets_local_client(action_of, &contexts, &server_contexts, &clients) {
         commands
             .entity(trigger.entity)
             .insert(InputMarker::<C>::default());

--- a/crates/inputs/input_bei/src/marker.rs
+++ b/crates/inputs/input_bei/src/marker.rs
@@ -2,6 +2,7 @@
 
 use bevy_ecs::prelude::*;
 use bevy_ecs::relationship::Relationship;
+use bevy_enhanced_input::context::ExternallyMocked;
 use bevy_enhanced_input::prelude::*;
 
 /// Marker component that indicates that the entity is actively listening for physical user inputs.
@@ -27,10 +28,14 @@ impl<C> Default for InputMarker<C> {
 pub(crate) fn propagate_input_marker<C: Component>(
     trigger: On<Add, InputMarker<C>>,
     actions: Query<&Actions<C>>,
+    mocked: Query<(), With<ExternallyMocked>>,
     mut commands: Commands,
 ) {
     if let Ok(actions) = actions.get(trigger.entity) {
         actions.iter().for_each(|action| {
+            if mocked.contains(action) {
+                return;
+            }
             commands.entity(action).insert(InputMarker::<C>::default());
         });
     }
@@ -40,7 +45,7 @@ pub(crate) fn propagate_input_marker<C: Component>(
 /// add the InputMarker to the Action entity as well.
 pub(crate) fn add_input_marker_from_parent<C: Component>(
     trigger: On<Add, ActionOf<C>>,
-    action_of: Query<&ActionOf<C>>,
+    action_of: Query<&ActionOf<C>, Without<ExternallyMocked>>,
     context: Query<(), With<InputMarker<C>>>,
     mut commands: Commands,
 ) {
@@ -58,33 +63,19 @@ pub(crate) fn add_input_marker_from_parent<C: Component>(
 /// Action entity.
 pub(crate) fn add_input_marker_from_binding<C: Component>(
     trigger: On<Add, Bindings>,
-    action: Query<&Bindings, (With<ActionOf<C>>, Without<InputMarker<C>>)>,
+    action: Query<
+        (),
+        (
+            With<ActionOf<C>>,
+            Without<InputMarker<C>>,
+            Without<ExternallyMocked>,
+        ),
+    >,
     mut commands: Commands,
 ) {
-    let Ok(bindings) = action.get(trigger.entity) else {
+    if action.get(trigger.entity).is_err() {
         return;
     };
-    if bindings.is_empty() {
-        return;
-    }
-    commands
-        .entity(trigger.entity)
-        .insert(InputMarker::<C>::default());
-}
-
-/// If an active ActionMock is inserted on an Action entity, add the InputMarker
-/// to that Action entity.
-pub(crate) fn add_input_marker_from_mock<C: Component>(
-    trigger: On<Insert, ActionMock>,
-    action: Query<&ActionMock, (With<ActionOf<C>>, Without<InputMarker<C>>)>,
-    mut commands: Commands,
-) {
-    let Ok(mock) = action.get(trigger.entity) else {
-        return;
-    };
-    if !mock.enabled {
-        return;
-    }
     commands
         .entity(trigger.entity)
         .insert(InputMarker::<C>::default());

--- a/crates/inputs/input_bei/src/plugin.rs
+++ b/crates/inputs/input_bei/src/plugin.rs
@@ -127,7 +127,8 @@ impl<
         {
             use crate::marker::{
                 add_input_marker_from_binding, add_input_marker_from_parent,
-                add_input_marker_when_action_becomes_ready, propagate_input_marker,
+                add_input_marker_when_action_becomes_ready,
+                add_input_marker_when_prespawned_action_becomes_ready, propagate_input_marker,
             };
             // for rebroadcasting inputs, we insert TriggerState (which inserts the InputBuffer) when ActionOf<C> is added
             // on an entity
@@ -137,6 +138,7 @@ impl<
             app.add_observer(add_input_marker_from_parent::<C>);
             app.add_observer(add_input_marker_from_binding::<C>);
             app.add_observer(add_input_marker_when_action_becomes_ready::<C>);
+            app.add_observer(add_input_marker_when_prespawned_action_becomes_ready::<C>);
             app.add_systems(PreUpdate, resolve_pending_action_of::<C>);
 
             if self.config.rebroadcast_inputs {

--- a/crates/inputs/input_bei/src/plugin.rs
+++ b/crates/inputs/input_bei/src/plugin.rs
@@ -5,9 +5,6 @@ use crate::input_message::BEIStateSequence;
 
 #[cfg(any(feature = "client", feature = "server"))]
 use crate::setup::InputRegistryPlugin;
-#[cfg(feature = "client")]
-use crate::setup::resolve_pending_action_of;
-use crate::setup::{deserialize_action_of, remove_action_of, serialize_action_of, write_action_of};
 use bevy_app::prelude::*;
 use bevy_ecs::prelude::*;
 #[cfg(any(feature = "client", feature = "server"))]
@@ -21,7 +18,7 @@ use bevy_enhanced_input::action::TriggerState;
 use bevy_enhanced_input::context::InputContextAppExt;
 use bevy_enhanced_input::prelude::ActionOf;
 use bevy_reflect::TypePath;
-use bevy_replicon::prelude::{AppMarkerExt, AppRuleExt, ReplicationMode, RuleFns};
+use bevy_replicon::prelude::AppRuleExt;
 use bevy_replicon::shared::replication::registry::receive_fns::MutWrite;
 use core::fmt::Debug;
 #[cfg(feature = "client")]
@@ -63,11 +60,7 @@ use serde::de::DeserializeOwned;
 /// The replicated [`Action`] component is structural: it recreates the typed BEI
 /// action entity on the receiver, but does not carry runtime input state. The
 /// action relationship is replicated directly through [`ActionOf<C>`].
-/// Lightyear uses a custom receive path for [`ActionOf<C>`] so the context
-/// entity is only inserted into Bevy's relationship component once Replicon's
-/// server-to-client entity map already contains it. If the action arrives first,
-/// the relationship is held as a local pending marker and resolved after the
-/// context mapping is available.
+
 /// Live action state is sent by [`BEIStateSequence`] input messages. The owning
 /// client adds [`InputMarker`] to local action entities, buffers BEI trigger
 /// state/value/time each tick, and sends those snapshots to the server. If input
@@ -118,16 +111,11 @@ impl<
         app.add_input_context_to::<FixedPreUpdate, C>();
         // we register the context C entity so that it can be replicated from the server to the client
         app.replicate::<C>();
-        app.replicate_with((
-            RuleFns::new(serialize_action_of::<C>, deserialize_action_of::<C>),
-            ReplicationMode::Once,
-        ))
-        .set_receive_fns::<ActionOf<C>>(write_action_of::<C>, remove_action_of::<C>);
+        app.replicate_once::<ActionOf<C>>();
         #[cfg(feature = "client")]
         {
             use crate::marker::{
-                add_input_marker_from_binding, add_input_marker_from_mock,
-                add_input_marker_from_parent, propagate_input_marker,
+                add_input_marker_from_binding, add_input_marker_from_parent, propagate_input_marker,
             };
             // for rebroadcasting inputs, we insert TriggerState (which inserts the InputBuffer) when ActionOf<C> is added
             // on an entity
@@ -136,8 +124,6 @@ impl<
             app.add_observer(propagate_input_marker::<C>);
             app.add_observer(add_input_marker_from_parent::<C>);
             app.add_observer(add_input_marker_from_binding::<C>);
-            app.add_observer(add_input_marker_from_mock::<C>);
-            app.add_systems(PreUpdate, resolve_pending_action_of::<C>);
 
             if self.config.rebroadcast_inputs {
                 app.add_observer(InputRegistryPlugin::on_rebroadcast_action_received::<C>);

--- a/crates/inputs/input_bei/src/plugin.rs
+++ b/crates/inputs/input_bei/src/plugin.rs
@@ -126,11 +126,9 @@ impl<
             app.add_observer(add_input_marker_from_binding::<C>);
 
             if self.config.rebroadcast_inputs {
-                app.add_systems(
-                    PostUpdate,
-                    InputRegistryPlugin::update_rebroadcast_action_mocking::<C>
-                        .after(lightyear_replication::ReplicationSystems::Receive),
-                );
+                app.add_observer(InputRegistryPlugin::on_rebroadcast_action_received::<C>);
+                app.add_observer(InputRegistryPlugin::on_rebroadcast_context_received::<C>);
+                app.add_observer(InputRegistryPlugin::on_rebroadcast_context_controlled::<C>);
                 #[cfg(feature = "server")]
                 app.add_observer(InputRegistryPlugin::add_action_of_host_server_rebroadcast::<C>);
             }

--- a/crates/inputs/input_bei/src/plugin.rs
+++ b/crates/inputs/input_bei/src/plugin.rs
@@ -126,9 +126,8 @@ impl<
         #[cfg(feature = "client")]
         {
             use crate::marker::{
-                add_input_marker_from_binding, add_input_marker_from_parent,
-                add_input_marker_when_action_becomes_ready,
-                add_input_marker_when_prespawned_action_becomes_ready, propagate_input_marker,
+                add_input_marker_from_binding, add_input_marker_from_mock,
+                add_input_marker_from_parent, propagate_input_marker,
             };
             // for rebroadcasting inputs, we insert TriggerState (which inserts the InputBuffer) when ActionOf<C> is added
             // on an entity
@@ -137,8 +136,7 @@ impl<
             app.add_observer(propagate_input_marker::<C>);
             app.add_observer(add_input_marker_from_parent::<C>);
             app.add_observer(add_input_marker_from_binding::<C>);
-            app.add_observer(add_input_marker_when_action_becomes_ready::<C>);
-            app.add_observer(add_input_marker_when_prespawned_action_becomes_ready::<C>);
+            app.add_observer(add_input_marker_from_mock::<C>);
             app.add_systems(PreUpdate, resolve_pending_action_of::<C>);
 
             if self.config.rebroadcast_inputs {

--- a/crates/inputs/input_bei/src/plugin.rs
+++ b/crates/inputs/input_bei/src/plugin.rs
@@ -126,7 +126,11 @@ impl<
             app.add_observer(add_input_marker_from_binding::<C>);
 
             if self.config.rebroadcast_inputs {
-                app.add_observer(InputRegistryPlugin::on_rebroadcast_action_received::<C>);
+                app.add_systems(
+                    PostUpdate,
+                    InputRegistryPlugin::update_rebroadcast_action_mocking::<C>
+                        .after(lightyear_replication::ReplicationSystems::Receive),
+                );
                 #[cfg(feature = "server")]
                 app.add_observer(InputRegistryPlugin::add_action_of_host_server_rebroadcast::<C>);
             }

--- a/crates/inputs/input_bei/src/setup.rs
+++ b/crates/inputs/input_bei/src/setup.rs
@@ -163,45 +163,141 @@ impl InputRegistryPlugin {
         }
     }
 
-    /// Keep replicated remote action entities mocked unless they belong to a
-    /// locally controlled context.
+    /// When a remote ActionOf arrives, update its mocked state if its context
+    /// is already present. If the context has not arrived yet, a context
+    /// observer will handle it later.
     #[cfg(feature = "client")]
-    pub(crate) fn update_rebroadcast_action_mocking<C: Component>(
+    pub(crate) fn on_rebroadcast_action_received<C: Component>(
+        trigger: On<Add, ActionOf<C>>,
         clients: Query<(), (With<Client>, Without<HostClient>)>,
-        actions: Query<(Entity, &ActionOf<C>, Has<ExternallyMocked>, Has<Bindings>), With<Remote>>,
+        actions: Query<(&ActionOf<C>, Has<ExternallyMocked>, Has<Bindings>), With<Remote>>,
+        contexts: Query<(), With<C>>,
         controlled: Query<(), With<Controlled>>,
         mut commands: Commands,
     ) {
         if clients.is_empty() {
             return;
         }
+        let entity = trigger.entity;
+        let Ok((action_of, is_mocked, has_bindings)) = actions.get(entity) else {
+            return;
+        };
+        update_rebroadcast_action_mocking::<C>(
+            entity,
+            is_mocked,
+            has_bindings,
+            contexts.contains(action_of.get()),
+            controlled.contains(action_of.get()),
+            &mut commands,
+        );
+    }
 
-        for (entity, action_of, is_mocked, has_bindings) in &actions {
-            if controlled.contains(action_of.get()) {
-                if is_mocked {
-                    let mut entity_commands = commands.entity(entity);
-                    entity_commands.remove::<ExternallyMocked>();
-                    if has_bindings {
-                        entity_commands.insert(InputMarker::<C>::default());
-                    }
-                }
-                continue;
-            }
+    /// When the context arrives after one or more remote action entities, mock
+    /// or unmock those actions now that the control state can be inspected.
+    #[cfg(feature = "client")]
+    pub(crate) fn on_rebroadcast_context_received<C: Component>(
+        trigger: On<Add, C>,
+        clients: Query<(), (With<Client>, Without<HostClient>)>,
+        contexts: Query<(&Actions<C>, Has<Controlled>), With<C>>,
+        actions: Query<(&ActionOf<C>, Has<ExternallyMocked>, Has<Bindings>), With<Remote>>,
+        mut commands: Commands,
+    ) {
+        if clients.is_empty() {
+            return;
+        }
+        let Ok((context_actions, has_controlled)) = contexts.get(trigger.entity) else {
+            return;
+        };
+        update_rebroadcast_actions_for_context::<C>(
+            context_actions,
+            has_controlled,
+            &actions,
+            &mut commands,
+        );
+    }
 
-            if !is_mocked {
-                debug!(
-                    ?entity,
-                    "On client, mocked remote ActionOf({:?}) for action entity ActionOf<{:?}> from input rebroadcast",
-                    action_of.get(),
-                    DebugName::type_name::<C>()
-                );
-                commands
-                    .entity(entity)
-                    // Make sure that the action is only updated via input messages.
-                    .remove::<(Bindings, InputMarker<C>)>()
-                    .insert(ExternallyMocked);
+    /// When Controlled arrives after a remote context/action relationship,
+    /// remove mocking from locally controlled actions.
+    #[cfg(feature = "client")]
+    pub(crate) fn on_rebroadcast_context_controlled<C: Component>(
+        trigger: On<Add, Controlled>,
+        clients: Query<(), (With<Client>, Without<HostClient>)>,
+        contexts: Query<(&Actions<C>, Has<Controlled>), With<C>>,
+        actions: Query<(&ActionOf<C>, Has<ExternallyMocked>, Has<Bindings>), With<Remote>>,
+        mut commands: Commands,
+    ) {
+        if clients.is_empty() {
+            return;
+        }
+        let Ok((context_actions, has_controlled)) = contexts.get(trigger.entity) else {
+            return;
+        };
+        update_rebroadcast_actions_for_context::<C>(
+            context_actions,
+            has_controlled,
+            &actions,
+            &mut commands,
+        );
+    }
+}
+
+#[cfg(feature = "client")]
+fn update_rebroadcast_actions_for_context<C: Component>(
+    context_actions: &Actions<C>,
+    has_controlled: bool,
+    actions: &Query<(&ActionOf<C>, Has<ExternallyMocked>, Has<Bindings>), With<Remote>>,
+    commands: &mut Commands,
+) {
+    for action_entity in context_actions.iter() {
+        let Ok((_, is_mocked, has_bindings)) = actions.get(action_entity) else {
+            continue;
+        };
+        update_rebroadcast_action_mocking::<C>(
+            action_entity,
+            is_mocked,
+            has_bindings,
+            true,
+            has_controlled,
+            commands,
+        );
+    }
+}
+
+#[cfg(feature = "client")]
+fn update_rebroadcast_action_mocking<C: Component>(
+    entity: Entity,
+    is_mocked: bool,
+    has_bindings: bool,
+    context_is_ready: bool,
+    context_is_controlled: bool,
+    commands: &mut Commands,
+) {
+    if !context_is_ready {
+        return;
+    }
+
+    if context_is_controlled {
+        if is_mocked {
+            let mut entity_commands = commands.entity(entity);
+            entity_commands.remove::<ExternallyMocked>();
+            if has_bindings {
+                entity_commands.insert(InputMarker::<C>::default());
             }
         }
+        return;
+    }
+
+    if !is_mocked {
+        debug!(
+            ?entity,
+            "On client, mocked remote action entity ActionOf<{:?}> from input rebroadcast",
+            DebugName::type_name::<C>()
+        );
+        commands
+            .entity(entity)
+            // Make sure that the action is only updated via input messages.
+            .remove::<(Bindings, InputMarker<C>)>()
+            .insert(ExternallyMocked);
     }
 }
 
@@ -248,7 +344,6 @@ impl InputRegistryExt for &mut App {
 #[cfg(all(test, feature = "client"))]
 mod tests {
     use super::*;
-    use bevy_app::PostUpdate;
     use lightyear_connection::client::Client;
     use lightyear_replication::prelude::Controlled;
 
@@ -257,10 +352,9 @@ mod tests {
 
     fn app_with_rebroadcast_mocking() -> App {
         let mut app = App::new();
-        app.add_systems(
-            PostUpdate,
-            InputRegistryPlugin::update_rebroadcast_action_mocking::<TestContext>,
-        );
+        app.add_observer(InputRegistryPlugin::on_rebroadcast_action_received::<TestContext>);
+        app.add_observer(InputRegistryPlugin::on_rebroadcast_context_received::<TestContext>);
+        app.add_observer(InputRegistryPlugin::on_rebroadcast_context_controlled::<TestContext>);
         app.world_mut().spawn(Client);
         app
     }
@@ -307,5 +401,58 @@ mod tests {
         assert!(action.contains::<ExternallyMocked>());
         assert!(!action.contains::<Bindings>());
         assert!(!action.contains::<InputMarker<TestContext>>());
+    }
+
+    #[test]
+    fn remote_action_waits_for_context_before_mocking() {
+        let mut app = app_with_rebroadcast_mocking();
+        let context = app.world_mut().spawn_empty().id();
+        let action = app
+            .world_mut()
+            .spawn((
+                ActionOf::<TestContext>::new(context),
+                Remote,
+                Bindings::default(),
+                InputMarker::<TestContext>::default(),
+            ))
+            .id();
+
+        app.update();
+
+        let action_ref = app.world().entity(action);
+        assert!(!action_ref.contains::<ExternallyMocked>());
+        assert!(action_ref.contains::<Bindings>());
+        assert!(action_ref.contains::<InputMarker<TestContext>>());
+
+        app.world_mut().entity_mut(context).insert(TestContext);
+        app.update();
+
+        let action_ref = app.world().entity(action);
+        assert!(action_ref.contains::<ExternallyMocked>());
+        assert!(!action_ref.contains::<Bindings>());
+        assert!(!action_ref.contains::<InputMarker<TestContext>>());
+    }
+
+    #[test]
+    fn controlled_context_added_later_unmocks_remote_action() {
+        let mut app = app_with_rebroadcast_mocking();
+        let context = app.world_mut().spawn(TestContext).id();
+        let action = app
+            .world_mut()
+            .spawn((
+                ActionOf::<TestContext>::new(context),
+                Remote,
+                Bindings::default(),
+                InputMarker::<TestContext>::default(),
+            ))
+            .id();
+
+        app.update();
+        assert!(app.world().entity(action).contains::<ExternallyMocked>());
+
+        app.world_mut().entity_mut(context).insert(Controlled);
+        app.update();
+
+        assert!(!app.world().entity(action).contains::<ExternallyMocked>());
     }
 }

--- a/crates/inputs/input_bei/src/setup.rs
+++ b/crates/inputs/input_bei/src/setup.rs
@@ -163,35 +163,44 @@ impl InputRegistryPlugin {
         }
     }
 
-    /// When the client receives a rebroadcast Action entity with [`Remote`],
-    ///
-    /// Attach ExternallyMocked to it to signify that the ActionState should only be updated
-    /// from rebroadcasted input messages. (in particular, BEI doesn't tick the time for those actions)
+    /// Keep replicated remote action entities mocked unless they belong to a
+    /// locally controlled context.
     #[cfg(feature = "client")]
-    pub(crate) fn on_rebroadcast_action_received<C: Component>(
-        trigger: On<Add, ActionOf<C>>,
-        single: Single<(), (With<Client>, Without<HostClient>)>,
-        query: Query<&ActionOf<C>, With<Remote>>,
+    pub(crate) fn update_rebroadcast_action_mocking<C: Component>(
+        clients: Query<(), (With<Client>, Without<HostClient>)>,
+        actions: Query<(Entity, &ActionOf<C>, Has<ExternallyMocked>, Has<Bindings>), With<Remote>>,
         controlled: Query<(), With<Controlled>>,
         mut commands: Commands,
     ) {
-        if let Ok(action_of) = query.get(trigger.entity) {
-            if controlled.contains(action_of.get()) {
-                return;
-            }
-            let entity = trigger.entity;
-            debug!(
-                ?entity,
-                "On client, received ActionOf({:?}) for action entity ActionOf<{:?}> from input rebroadcast",
-                action_of.get(),
-                DebugName::type_name::<C>()
-            );
+        if clients.is_empty() {
+            return;
+        }
 
-            commands
-                .entity(entity)
-                // Make sure that the action is only updated via input messages.
-                .remove::<(Bindings, InputMarker<C>)>()
-                .insert(ExternallyMocked);
+        for (entity, action_of, is_mocked, has_bindings) in &actions {
+            if controlled.contains(action_of.get()) {
+                if is_mocked {
+                    let mut entity_commands = commands.entity(entity);
+                    entity_commands.remove::<ExternallyMocked>();
+                    if has_bindings {
+                        entity_commands.insert(InputMarker::<C>::default());
+                    }
+                }
+                continue;
+            }
+
+            if !is_mocked {
+                debug!(
+                    ?entity,
+                    "On client, mocked remote ActionOf({:?}) for action entity ActionOf<{:?}> from input rebroadcast",
+                    action_of.get(),
+                    DebugName::type_name::<C>()
+                );
+                commands
+                    .entity(entity)
+                    // Make sure that the action is only updated via input messages.
+                    .remove::<(Bindings, InputMarker<C>)>()
+                    .insert(ExternallyMocked);
+            }
         }
     }
 }
@@ -233,5 +242,70 @@ impl InputRegistryExt for &mut App {
             ReplicationMode::Once,
         ));
         self
+    }
+}
+
+#[cfg(all(test, feature = "client"))]
+mod tests {
+    use super::*;
+    use bevy_app::PostUpdate;
+    use lightyear_connection::client::Client;
+    use lightyear_replication::prelude::Controlled;
+
+    #[derive(Component)]
+    struct TestContext;
+
+    fn app_with_rebroadcast_mocking() -> App {
+        let mut app = App::new();
+        app.add_systems(
+            PostUpdate,
+            InputRegistryPlugin::update_rebroadcast_action_mocking::<TestContext>,
+        );
+        app.world_mut().spawn(Client);
+        app
+    }
+
+    #[test]
+    fn controlled_remote_action_is_not_left_externally_mocked() {
+        let mut app = app_with_rebroadcast_mocking();
+        let context = app.world_mut().spawn((TestContext, Controlled)).id();
+        let action = app
+            .world_mut()
+            .spawn((
+                ActionOf::<TestContext>::new(context),
+                Remote,
+                ExternallyMocked,
+                Bindings::default(),
+            ))
+            .id();
+
+        app.update();
+
+        let action = app.world().entity(action);
+        assert!(!action.contains::<ExternallyMocked>());
+        assert!(action.contains::<Bindings>());
+        assert!(action.contains::<InputMarker<TestContext>>());
+    }
+
+    #[test]
+    fn uncontrolled_remote_action_is_externally_mocked() {
+        let mut app = app_with_rebroadcast_mocking();
+        let context = app.world_mut().spawn(TestContext).id();
+        let action = app
+            .world_mut()
+            .spawn((
+                ActionOf::<TestContext>::new(context),
+                Remote,
+                Bindings::default(),
+                InputMarker::<TestContext>::default(),
+            ))
+            .id();
+
+        app.update();
+
+        let action = app.world().entity(action);
+        assert!(action.contains::<ExternallyMocked>());
+        assert!(!action.contains::<Bindings>());
+        assert!(!action.contains::<InputMarker<TestContext>>());
     }
 }

--- a/crates/inputs/input_bei/src/setup.rs
+++ b/crates/inputs/input_bei/src/setup.rs
@@ -1,13 +1,14 @@
+#[cfg(feature = "client")]
+use crate::marker::InputMarker;
 use alloc::vec::Vec;
 use bevy_app::App;
+#[cfg(any(feature = "client", feature = "server"))]
 use bevy_ecs::prelude::*;
+#[cfg(any(feature = "client", feature = "server"))]
 use bevy_ecs::relationship::Relationship;
+use bevy_replicon::bytes::Bytes;
 use bevy_replicon::prelude::*;
-use bevy_replicon::shared::replication::deferred_entity::DeferredEntity;
-use bevy_replicon::shared::replication::registry::ctx::{RemoveCtx, SerializeCtx, WriteCtx};
-#[cfg(feature = "client")]
-use bevy_replicon::shared::server_entity_map::ServerEntityMap;
-use bevy_replicon::{bytes::Bytes, postcard_utils};
+use bevy_replicon::shared::replication::registry::ctx::{SerializeCtx, WriteCtx};
 #[cfg(all(feature = "client", feature = "server"))]
 use lightyear_replication::prelude::ControlledBy;
 #[cfg(feature = "client")]
@@ -39,27 +40,6 @@ use {
     lightyear_replication::prelude::{InterpolationTarget, PredictionTarget, ReplicateLike},
 };
 
-/// Client-side placeholder for a replicated [`ActionOf<C>`] whose context
-/// entity has not been mapped yet.
-///
-/// This is deliberately local-only. Once the context entity appears in
-/// Replicon's server-to-client entity map, [`resolve_pending_action_of`]
-/// replaces this component with the real BEI relationship.
-#[derive(Component)]
-pub(crate) struct PendingActionOf<C: Component> {
-    server_context: Entity,
-    marker: core::marker::PhantomData<C>,
-}
-
-impl<C: Component> PendingActionOf<C> {
-    fn new(server_context: Entity) -> Self {
-        Self {
-            server_context,
-            marker: core::marker::PhantomData,
-        }
-    }
-}
-
 pub struct InputRegistryPlugin;
 
 impl InputRegistryPlugin {
@@ -69,10 +49,13 @@ impl InputRegistryPlugin {
     #[cfg(all(feature = "client", feature = "server"))]
     pub(crate) fn add_action_of_host_server_rebroadcast<C: Component>(
         trigger: On<Add, ActionOf<C>>,
-        host_server: Single<(), With<HostServer>>,
+        host_server: Query<(), With<HostServer>>,
         action: Query<&ActionOf<C>, Or<(Without<Remote>, With<PreSpawned>)>>,
         mut commands: Commands,
     ) {
+        if host_server.is_empty() {
+            return;
+        }
         let entity = trigger.entity;
         if let Ok(action_of) = action.get(entity) {
             let context_entity = action_of.get();
@@ -109,31 +92,34 @@ impl InputRegistryPlugin {
         if host_clients.get(controlled_by.owner).is_ok() {
             return;
         }
-        commands.entity(entity).insert(ExternallyMocked);
+        commands
+            .entity(entity)
+            .remove::<(Bindings, InputMarker<C>)>()
+            .insert(ExternallyMocked);
     }
 
     #[cfg(all(feature = "client", feature = "server"))]
     pub(crate) fn mock_non_host_owned_actions_on_controlled_by<C: Component>(
         trigger: On<Add, ControlledBy>,
         host_server: Query<(), With<HostServer>>,
-        controlled: Query<&ControlledBy>,
+        context: Query<(&Actions<C>, &ControlledBy)>,
         host_clients: Query<(), With<HostClient>>,
-        actions: Query<(Entity, &ActionOf<C>), Without<ExternallyMocked>>,
         mut commands: Commands,
     ) {
         if host_server.is_empty() {
             return;
         }
-        let Ok(controlled_by) = controlled.get(trigger.entity) else {
+        let Ok((actions, controlled_by)) = context.get(trigger.entity) else {
             return;
         };
         if host_clients.get(controlled_by.owner).is_ok() {
             return;
         }
-        for (action_entity, action_of) in &actions {
-            if action_of.get() == trigger.entity {
-                commands.entity(action_entity).insert(ExternallyMocked);
-            }
+        for action_entity in actions.iter() {
+            commands
+                .entity(action_entity)
+                .remove::<(Bindings, InputMarker<C>)>()
+                .insert(ExternallyMocked);
         }
     }
 
@@ -201,91 +187,12 @@ impl InputRegistryPlugin {
                 DebugName::type_name::<C>()
             );
 
-            commands.entity(entity).insert(
-                // Make sure that the actions are only updated via input messages
-                ExternallyMocked,
-            );
+            commands
+                .entity(entity)
+                // Make sure that the action is only updated via input messages.
+                .remove::<(Bindings, InputMarker<C>)>()
+                .insert(ExternallyMocked);
         }
-    }
-}
-
-/// Serializes the server context entity targeted by [`ActionOf<C>`].
-///
-/// This uses a custom rule instead of Replicon's default component
-/// serialization because [`ActionOf<C>`] is a relationship component. The
-/// default receive path would call [`EntityMapper::get_mapped`] for the context
-/// entity and create a placeholder if the context has not been mapped yet. That
-/// placeholder is unsafe for a relationship component: Bevy relationship hooks
-/// can observe the target during insertion, and Replicon also asserts if that
-/// buffered placeholder is still pending when the next component in the same
-/// entity bundle is decoded.
-pub(crate) fn serialize_action_of<C: Component>(
-    _ctx: &mut SerializeCtx,
-    action_of: &ActionOf<C>,
-    message: &mut Vec<u8>,
-) -> bevy_ecs::error::Result<()> {
-    postcard_utils::entity_to_extend_mut(&action_of.get(), message)?;
-    Ok(())
-}
-
-/// Deserializes the raw server context entity for stale-message consumption.
-///
-/// The active receive path uses [`write_action_of`] below. This function exists
-/// for Replicon's `RuleFns` contract and for consuming stale updates without
-/// creating mapped placeholder entities.
-pub(crate) fn deserialize_action_of<C: Component>(
-    _ctx: &mut WriteCtx,
-    message: &mut Bytes,
-) -> bevy_ecs::error::Result<ActionOf<C>> {
-    let server_context = postcard_utils::entity_from_buf(message)?;
-    Ok(ActionOf::new(server_context))
-}
-
-/// Receives [`ActionOf<C>`] without using Replicon's placeholder entity mapper.
-///
-/// If the context entity is already mapped, this inserts the real BEI
-/// relationship immediately. If not, it stores [`PendingActionOf<C>`] so the
-/// relationship can be attached later by [`resolve_pending_action_of`].
-pub(crate) fn write_action_of<C: Component>(
-    ctx: &mut WriteCtx,
-    _rule_fns: &RuleFns<ActionOf<C>>,
-    entity: &mut DeferredEntity,
-    message: &mut Bytes,
-) -> bevy_ecs::error::Result<()> {
-    let server_context = postcard_utils::entity_from_buf(message)?;
-    if let Some(&client_context) = ctx.entity_map.to_client().get(&server_context) {
-        entity.insert(ActionOf::<C>::new(client_context));
-        entity.remove::<PendingActionOf<C>>();
-    } else {
-        entity.insert(PendingActionOf::<C>::new(server_context));
-        entity.remove::<ActionOf<C>>();
-    }
-    Ok(())
-}
-
-pub(crate) fn remove_action_of<C: Component>(_ctx: &mut RemoveCtx, entity: &mut DeferredEntity) {
-    entity.remove::<ActionOf<C>>();
-    entity.remove::<PendingActionOf<C>>();
-}
-
-/// Attach delayed BEI relationships once Replicon has mapped their context.
-#[cfg(feature = "client")]
-pub(crate) fn resolve_pending_action_of<C: Component>(
-    entity_map: Option<Res<ServerEntityMap>>,
-    pending: Query<(Entity, &PendingActionOf<C>)>,
-    mut commands: Commands,
-) {
-    let Some(entity_map) = entity_map else {
-        return;
-    };
-    for (entity, pending) in &pending {
-        let Some(&client_context) = entity_map.to_client().get(&pending.server_context) else {
-            continue;
-        };
-        commands
-            .entity(entity)
-            .insert(ActionOf::<C>::new(client_context))
-            .remove::<PendingActionOf<C>>();
     }
 }
 
@@ -295,13 +202,9 @@ pub(crate) fn resolve_pending_action_of<C: Component>(
 /// sends that state through [`BEIStateSequence`](crate::input_message::BEIStateSequence),
 /// whose snapshots include the trigger state, action value, events, and timing.
 /// The [`Action<A>`] component also does not carry the context relationship:
-/// [`ActionOf<C>`] is replicated as its own component, and Replicon's default
-/// mapping path is avoided there because it can create placeholder relationship
-/// targets when the context has not been mapped yet. Instead, Lightyear defers
-/// inserting [`ActionOf<C>`] until the context entity is present in the
-/// server-to-client map. Therefore component replication only needs to create
-/// the correctly typed action component on the receiver, and
-/// [`deserialize_action`] can rebuild it from `Default`.
+/// [`ActionOf<C>`] is replicated as its own component. Therefore component
+/// replication only needs to create the correctly typed action component on the
+/// receiver, and [`deserialize_action`] can rebuild it from `Default`.
 ///
 /// [`ActionOf<C>`]: bevy_enhanced_input::prelude::ActionOf
 fn serialize_action<A: InputAction>(

--- a/crates/inputs/inputs/src/client.rs
+++ b/crates/inputs/inputs/src/client.rs
@@ -559,28 +559,6 @@ fn input_history_depth(prediction_manager: Option<&PredictionManager>) -> u32 {
         .max(HISTORY_DEPTH)
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn input_history_depth_covers_prediction_rollback_window() {
-        assert_eq!(input_history_depth(None), HISTORY_DEPTH);
-
-        let mut manager = PredictionManager {
-            rollback_policy: RollbackPolicy {
-                max_rollback_ticks: 100,
-                ..Default::default()
-            },
-            ..Default::default()
-        };
-        assert_eq!(input_history_depth(Some(&manager)), 101);
-
-        manager.rollback_policy.max_rollback_ticks = 5;
-        assert_eq!(input_history_depth(Some(&manager)), HISTORY_DEPTH);
-    }
-}
-
 // TODO: is this actually necessary? The sync happens in PostUpdate,
 //  so maybe it's ok if the InputMessages contain the pre-sync tick! (since those inputs happened
 //  before the sync). If it's not needed, send the messages directly in FixedPostUpdate!
@@ -1188,5 +1166,27 @@ fn receive_tick_events<S: ActionStateSequence>(
     }
     for message in message_buffer.0.iter_mut() {
         message.end_tick = message.end_tick + delta;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn input_history_depth_covers_prediction_rollback_window() {
+        assert_eq!(input_history_depth(None), HISTORY_DEPTH);
+
+        let mut manager = PredictionManager {
+            rollback_policy: RollbackPolicy {
+                max_rollback_ticks: 100,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        assert_eq!(input_history_depth(Some(&manager)), 101);
+
+        manager.rollback_policy.max_rollback_ticks = 5;
+        assert_eq!(input_history_depth(Some(&manager)), HISTORY_DEPTH);
     }
 }

--- a/crates/inputs/inputs/src/input_message.rs
+++ b/crates/inputs/inputs/src/input_message.rs
@@ -157,6 +157,9 @@ pub trait ActionStateSequence:
         tick_duration: Duration,
     ) -> Option<Tick> {
         let last_remote_tick = input_buffer.last_remote_tick;
+        if last_remote_tick.is_some_and(|tick| end_tick <= tick) {
+            return None;
+        }
         let previous_end_tick = input_buffer.end_tick();
 
         let mut previous_predicted_input =
@@ -191,28 +194,24 @@ pub trait ActionStateSequence:
                     Compressed::Input(latest) => latest_received_input = Some(latest),
                     _ => {}
                 }
-                // only try to detect mismatches after the last_remote_tick
-                if last_remote_tick.is_none_or(|t| tick > t) {
-                    if match (&previous_predicted_input, &latest_received_input) {
-                        (Some(prev), Some(latest)) => prev == latest,
-                        (None, None) => true,
-                        _ => false,
-                    } {
-                        if previous_end_tick.is_none_or(|end_tick| tick > end_tick) {
-                            input_buffer
-                                .set_raw(tick, Compressed::from(latest_received_input.clone()));
-                        }
-                        continue;
+                if match (&previous_predicted_input, &latest_received_input) {
+                    (Some(prev), Some(latest)) => prev == latest,
+                    (None, None) => true,
+                    _ => false,
+                } {
+                    if previous_end_tick.is_none_or(|end_tick| tick > end_tick) {
+                        input_buffer.set_raw(tick, Compressed::from(latest_received_input.clone()));
                     }
-                    // first mismatch tick! set the new value for the mismatch tick
-                    debug!(
-                        "Mismatch detected at tick {tick:?} for new_input {latest_received_input:?}. Previous predicted input: {previous_predicted_input:?}"
-                    );
-                    input_buffer.set_raw(tick, Compressed::from(latest_received_input.clone()));
-                    // remove all existing inputs in the buffer that come after `tick`
-                    input_buffer.clip_after(tick);
-                    earliest_mismatch = Some(tick);
+                    continue;
                 }
+                // first mismatch tick! set the new value for the mismatch tick
+                debug!(
+                    "Mismatch detected at tick {tick:?} for new_input {latest_received_input:?}. Previous predicted input: {previous_predicted_input:?}"
+                );
+                input_buffer.set_raw(tick, Compressed::from(latest_received_input.clone()));
+                // remove all existing inputs in the buffer that come after `tick`
+                input_buffer.clip_after(tick);
+                earliest_mismatch = Some(tick);
             }
         }
         input_buffer.last_remote_tick = Some(end_tick);

--- a/crates/replication/replication/src/control.rs
+++ b/crates/replication/replication/src/control.rs
@@ -4,11 +4,14 @@ use bevy_app::{App, Plugin};
 use bevy_derive::Deref;
 use bevy_ecs::prelude::*;
 use bevy_reflect::Reflect;
-use bevy_replicon::prelude::SingleComponent;
+use bevy_replicon::bytes::Bytes;
+use bevy_replicon::prelude::{RuleFns, SingleComponent};
 use bevy_replicon::server::visibility::client_visibility::ClientVisibility;
 use bevy_replicon::server::visibility::filters_mask::FilterBit;
 use bevy_replicon::server::visibility::registry::FilterRegistry;
+use bevy_replicon::shared::replication::deferred_entity::DeferredEntity;
 use bevy_replicon::shared::replication::registry::ReplicationRegistry;
+use bevy_replicon::shared::replication::registry::ctx::{RemoveCtx, WriteCtx};
 use lightyear_connection::client::Disconnected;
 use lightyear_connection::host::HostClient;
 use serde::{Deserialize, Serialize};
@@ -23,9 +26,15 @@ use tracing::trace;
 ///
 /// You can use `With<Controlled>` in queries to distinguish locally
 /// controlled entities from remote ones.
-// TODO: currently we add Controlled on the sender for replication but this could cause issues with authority changes.
 #[derive(Component, Clone, PartialEq, Debug, Default, Reflect, Serialize, Deserialize)]
 pub struct Controlled;
+
+/// Sender-side marker that replicates as [`Controlled`] on the owning receiver.
+///
+/// This keeps [`Controlled`] receiver-local. In host-server mode, server-owned
+/// entities for remote clients carry [`ControlledSend`] but not [`Controlled`].
+#[derive(Component, Clone, PartialEq, Debug, Default, Reflect, Serialize, Deserialize)]
+pub struct ControlledSend;
 
 /// Component on the sender side that lists the entities controlled by the remote peer
 #[derive(Component, Clone, PartialEq, Debug, Reflect)]
@@ -41,8 +50,7 @@ pub struct ControlledByRemote(Vec<Entity>);
 /// despawn the entity. If you want to persist an entity on the receiver side even after the link is disconnected,
 /// see [`Lifetime::Persistent`].
 #[derive(Component, Clone, Copy, PartialEq, Debug, Reflect)]
-// TODO: we add Controlled on the sender side to replicate it to the remote, but this could cause issues with client authority!
-#[require(Controlled)]
+#[require(ControlledSend)]
 #[reflect(Component)]
 #[component(immutable)]
 #[relationship(relationship_target = ControlledByRemote)]
@@ -63,7 +71,7 @@ impl ControlledBy {
     ) {
         let visibility_bit = control_bit.0;
         let owner_entity = controlled_by.get(trigger.entity).unwrap().owner;
-        // Two-pass: first hide Controlled for all clients, then show for owner only
+        // ControlledSend is receiver-local: only the owning client should see it.
         for (sender_entity, mut visibility) in sender.iter_mut() {
             if sender_entity == owner_entity {
                 visibility.set(trigger.entity, visibility_bit, true);
@@ -112,6 +120,21 @@ impl ControlledBy {
     }
 }
 
+pub(crate) fn write_controlled(
+    ctx: &mut WriteCtx,
+    rule_fns: &RuleFns<ControlledSend>,
+    entity: &mut DeferredEntity,
+    message: &mut Bytes,
+) -> bevy_ecs::error::Result<()> {
+    let _ = rule_fns.deserialize(ctx, message)?;
+    entity.insert(Controlled);
+    Ok(())
+}
+
+pub(crate) fn remove_controlled(_ctx: &mut RemoveCtx, entity: &mut DeferredEntity) {
+    entity.remove::<Controlled>();
+}
+
 /// Host-server local emulation for control when a client becomes a host client after entities
 /// already exist.
 fn emulate_controlled_on_host_client_added(
@@ -150,7 +173,7 @@ pub enum Lifetime {
     Persistent,
 }
 
-/// Component-level visibility for [`Controlled`]
+/// Component-level visibility for [`ControlledSend`]
 #[derive(Resource, Deref)]
 pub struct ControlBit(FilterBit);
 
@@ -158,7 +181,8 @@ impl FromWorld for ControlBit {
     fn from_world(world: &mut World) -> Self {
         let bit = world.resource_scope(|world, mut filter_registry: Mut<FilterRegistry>| {
             world.resource_scope(|world, mut registry: Mut<ReplicationRegistry>| {
-                filter_registry.register_scope::<SingleComponent<Controlled>>(world, &mut registry)
+                filter_registry
+                    .register_scope::<SingleComponent<ControlledSend>>(world, &mut registry)
             })
         });
         Self(bit)

--- a/crates/replication/replication/src/lib.rs
+++ b/crates/replication/replication/src/lib.rs
@@ -134,7 +134,7 @@ pub mod prelude {
     pub use crate::ReplicationSystems;
     pub use crate::authority::{AuthorityBroker, GiveAuthority, HasAuthority, RequestAuthority};
     pub use crate::checkpoint::ReplicationCheckpointMap;
-    pub use crate::control::{Controlled, ControlledBy, Lifetime};
+    pub use crate::control::{Controlled, ControlledBy, ControlledSend, Lifetime};
     pub use crate::deferred_entity::DeferredEntityCommands;
     pub use crate::diff_history::HistoryDiffReceiver;
     pub use crate::hierarchy::{DisableReplicateHierarchy, ReplicateLike};
@@ -175,7 +175,7 @@ pub enum ReplicationSystems {
     Send,
 }
 
-/// Plugin that registers replicated marker components (`Predicted`, `Interpolated`, `Controlled`)
+/// Plugin that registers replicated marker components (`Predicted`, `Interpolated`, `ControlledSend`)
 /// with replicon on both client and server. This ensures the component ID registry matches
 /// on both sides, which is required for correct deserialization.
 struct SharedComponentRegistrationPlugin;
@@ -190,7 +190,11 @@ impl Plugin for SharedComponentRegistrationPlugin {
         app.replicate::<lightyear_core::prediction::Predicted>();
         #[cfg(feature = "interpolation")]
         app.replicate::<lightyear_core::interpolation::Interpolated>();
-        app.replicate::<control::Controlled>();
+        app.replicate::<control::ControlledSend>()
+            .set_receive_fns::<control::ControlledSend>(
+                control::write_controlled,
+                control::remove_controlled,
+            );
         // ChildOf is registered for replication in HierarchySendPlugin (server-only),
         // but must also be registered on the client so FnsIds match.
         app.replicate_with(RuleFns::new(

--- a/crates/replication/replication/src/prespawn.rs
+++ b/crates/replication/replication/src/prespawn.rs
@@ -1,6 +1,6 @@
 //! Handles spawning entities that are predicted
 
-use crate::control::{Controlled, ControlledBy};
+use crate::control::{Controlled, ControlledBy, ControlledSend};
 #[cfg(feature = "interpolation")]
 use crate::prelude::InterpolationTarget;
 #[cfg(feature = "prediction")]
@@ -574,6 +574,7 @@ pub(crate) fn compute_default_hash(
                 // ignore some book-keeping components that are included in the component registry
                 #[allow(unused_mut)]
                 let mut keep = type_id != TypeId::of::<PreSpawned>()
+                    && type_id != TypeId::of::<ControlledSend>()
                     && type_id != TypeId::of::<Controlled>()
                     && type_id != TypeId::of::<Replicate>()
                     && type_id != TypeId::of::<ControlledBy>();

--- a/crates/replication/replication/src/send.rs
+++ b/crates/replication/replication/src/send.rs
@@ -1056,7 +1056,8 @@ pub(crate) fn handle_new_client_visibility(
         }
     }
 
-    // Hide Controlled for entities not owned by this client
+    // Hide ControlledSend for entities not owned by this client. Receivers
+    // materialize this marker as Controlled.
     for (entity, controlled_by) in controlled_entities.iter() {
         if controlled_by.owner != sender_entity {
             trace!(

--- a/crates/tests/src/client_server/input/bei.rs
+++ b/crates/tests/src/client_server/input/bei.rs
@@ -1,5 +1,5 @@
 use crate::client_server::prediction::trigger_state_rollback;
-use crate::protocol::{BEIAction1, BEIContext};
+use crate::protocol::{BEIAction1, BEIActionVec2, BEIContext};
 use crate::stepper::*;
 use bevy::app::{App, FixedPostUpdate, FixedPreUpdate};
 use bevy::ecs::relationship::Relationship;
@@ -466,6 +466,10 @@ fn test_buffer_inputs_with_delay() {
             .contains::<Action<BEIAction1>>()
     );
 
+    stepper.client_apps[0].init_resource::<Counter>();
+    stepper.client_apps[0]
+        .add_observer(|_: On<Fire<BEIAction1>>, mut counter: ResMut<Counter>| counter.0 += 1);
+
     // mock press on a key
     info!("Mocking press on BEIAction1");
     stepper
@@ -493,6 +497,11 @@ fn test_buffer_inputs_with_delay() {
 
     let action_state = get_action_state_for_tick(client_tick, stepper.client_app());
     assert_eq!(action_state, TriggerState::None);
+    assert_eq!(
+        stepper.client_app().world().resource::<Counter>().0,
+        0,
+        "delayed local input should not fire on the same tick it is sampled"
+    );
     // if we check the next tick (delay of 1), we can see that the InputBuffer contains the ActionState with a press
     let action_state = get_action_state_for_tick(client_tick + 1, stepper.client_app());
     assert_eq!(action_state, TriggerState::Fired);
@@ -510,6 +519,11 @@ fn test_buffer_inputs_with_delay() {
     assert_eq!(action_state, TriggerState::Fired);
     let action_state = get_action_state_for_tick(client_tick + 2, stepper.client_app());
     assert_eq!(action_state, TriggerState::None);
+    assert_eq!(
+        stepper.client_app().world().resource::<Counter>().0,
+        1,
+        "delayed local input should fire when the delayed tick is simulated"
+    );
 
     assert_eq!(
         stepper
@@ -520,6 +534,69 @@ fn test_buffer_inputs_with_delay() {
             .unwrap(),
         &TriggerState::None
     );
+}
+
+#[test]
+fn test_buffer_vec2_inputs_with_delay_preserves_buffered_action_value_dimension() {
+    let mut config = StepperConfig::single();
+    config.init = false;
+    let mut stepper = ClientServerStepper::from_config(config);
+    stepper.client_mut(0).insert(
+        InputTimelineConfig::default().with_input_delay(InputDelayConfig::fixed_input_delay(1)),
+    );
+    stepper.init();
+
+    let server_entity = stepper
+        .server_app
+        .world_mut()
+        .spawn((BEIContext, Replicate::to_clients(NetworkTarget::All)))
+        .id();
+    stepper.frame_step(2);
+
+    let client_entity = stepper
+        .client(0)
+        .get::<MessageManager>()
+        .unwrap()
+        .entity_mapper
+        .get_local(server_entity)
+        .expect("entity is not present in entity map");
+
+    stepper.server_app.world_mut().spawn((
+        ActionOf::<BEIContext>::new(server_entity),
+        Action::<BEIActionVec2>::default(),
+        PreSpawned::new(TEST_HASH + 1),
+        Replicate::to_clients(NetworkTarget::All),
+    ));
+
+    let client_action = stepper
+        .client_app()
+        .world_mut()
+        .spawn((
+            ActionOf::<BEIContext>::new(client_entity),
+            Action::<BEIActionVec2>::default(),
+            PreSpawned::new(TEST_HASH + 1),
+            bei::prelude::InputMarker::<BEIContext>::default(),
+        ))
+        .id();
+
+    stepper.frame_step(1);
+
+    stepper
+        .client_app()
+        .world_mut()
+        .entity_mut(client_action)
+        .insert(ActionMock::once(TriggerState::Fired, Vec2::X));
+    stepper.frame_step(1);
+    let client_tick = stepper.client_tick(0);
+
+    let action = stepper.client_app().world().entity(client_action);
+    let delayed_snapshot = action
+        .get::<BEIBuffer<BEIContext>>()
+        .unwrap()
+        .get(client_tick + 1)
+        .expect("the sampled Vec2 input should be buffered at the delayed tick");
+    assert_eq!(delayed_snapshot.state, TriggerState::Fired);
+    assert_eq!(delayed_snapshot.value, ActionValue::Axis2D(Vec2::X));
 }
 
 /// Check that Actions<C> is restored correctly after a rollback

--- a/crates/tests/src/host_server/input/bei.rs
+++ b/crates/tests/src/host_server/input/bei.rs
@@ -5,9 +5,11 @@ use bevy_enhanced_input::action::mock::{ActionMock, MockSpan};
 use bevy_enhanced_input::action::{Action, TriggerState};
 use bevy_enhanced_input::prelude::{ActionOf, ActionValue, Actions};
 use lightyear::input::bei::input_message::BEIBuffer;
+use lightyear::input::bei::prelude::InputMarker;
+use lightyear::input::input_buffer::Compressed;
 use lightyear_connection::network_target::NetworkTarget;
 use lightyear_messages::MessageManager;
-use lightyear_replication::prelude::{PreSpawned, PredictionTarget, Replicate};
+use lightyear_replication::prelude::{ControlledBy, PreSpawned, PredictionTarget, Replicate};
 
 const TEST_HASH: u64 = 42;
 
@@ -61,7 +63,8 @@ fn test_rebroadcast() {
         .get_local(server_entity)
         .expect("entity not replicated to client 2");
 
-    // Spawn matching action entity on client 0 with PreSpawned + input mock
+    // Spawn matching action entity on client 0 with PreSpawned, then let the
+    // ActionOf/InputMarker relationship settle before mocking input.
     stepper.client_apps[0]
         .world_mut()
         .spawn((
@@ -73,23 +76,20 @@ fn test_rebroadcast() {
                 MockSpan::Manual,
             ),
             PreSpawned::new(TEST_HASH),
+            InputMarker::<BEIContext>::default(),
         ))
         .id();
     stepper.frame_step(4);
 
     // Check that client 1 received the rebroadcasted action and has input buffer
-    let action1 = stepper.client_apps[1]
+    let action1 =
+        find_action_with_fired_input(stepper.client_apps[1].world(), client1_entity, "client 1");
+    let remote_buffer = stepper.client_apps[1]
         .world()
-        .get::<Actions<BEIContext>>(client1_entity)
-        .unwrap()
-        .collection()[0];
-    assert!(
-        stepper.client_apps[1]
-            .world()
-            .entity(action1)
-            .get::<BEIBuffer<BEIContext>>()
-            .is_some()
-    );
+        .entity(action1)
+        .get::<BEIBuffer<BEIContext>>()
+        .expect("Client 1 should have a BEI input buffer for the rebroadcasted action");
+    assert_buffer_contains_fired_input(remote_buffer, "client 1 rebroadcast buffer");
 
     // Verify the server has the action entity
     let action_host = stepper
@@ -106,6 +106,13 @@ fn test_rebroadcast() {
             .contains::<Action<BEIAction1>>(),
         "Action entity on server should have the Action component"
     );
+    let server_buffer = stepper
+        .server_app
+        .world()
+        .entity(action_host)
+        .get::<BEIBuffer<BEIContext>>()
+        .expect("Server should buffer client 0's input before rebroadcasting it");
+    assert_buffer_contains_fired_input(server_buffer, "server input buffer");
 }
 
 /// Minimal host-server topology: host client fires an action and the remote client
@@ -120,6 +127,10 @@ fn test_host_client_action_rebroadcasts_to_remote_client() {
         .spawn((
             Replicate::to_clients(NetworkTarget::All),
             PredictionTarget::to_clients(NetworkTarget::All),
+            ControlledBy {
+                owner: stepper.host_client_entity.unwrap(),
+                lifetime: Default::default(),
+            },
             BEIContext,
         ))
         .id();
@@ -130,7 +141,6 @@ fn test_host_client_action_rebroadcasts_to_remote_client() {
         .spawn((
             ActionOf::<BEIContext>::new(server_entity),
             Action::<BEIAction1>::default(),
-            PreSpawned::new(TEST_HASH),
             Replicate::to_clients(NetworkTarget::All),
         ))
         .id();
@@ -159,11 +169,11 @@ fn test_host_client_action_rebroadcasts_to_remote_client() {
 
     stepper.frame_step(4);
 
-    let remote_action = stepper.client_apps[0]
-        .world()
-        .get::<Actions<BEIContext>>(remote_entity)
-        .unwrap()
-        .collection()[0];
+    let remote_action = find_action_with_fired_input(
+        stepper.client_apps[0].world(),
+        remote_entity,
+        "remote client",
+    );
     assert!(
         stepper.client_apps[0]
             .world()
@@ -171,14 +181,12 @@ fn test_host_client_action_rebroadcasts_to_remote_client() {
             .contains::<Action<BEIAction1>>(),
         "Remote client should receive the rebroadcast action entity"
     );
-    assert!(
-        stepper.client_apps[0]
-            .world()
-            .entity(remote_action)
-            .get::<BEIBuffer<BEIContext>>()
-            .is_some(),
-        "Remote client should buffer the host client's rebroadcast input"
-    );
+    let remote_buffer = stepper.client_apps[0]
+        .world()
+        .entity(remote_action)
+        .get::<BEIBuffer<BEIContext>>()
+        .expect("Remote client should buffer the host client's rebroadcast input");
+    assert_buffer_contains_fired_input(remote_buffer, "remote host-client rebroadcast buffer");
 
     let server_action = stepper
         .server_app
@@ -194,4 +202,56 @@ fn test_host_client_action_rebroadcasts_to_remote_client() {
             .contains::<Action<BEIAction1>>(),
         "Server should also have the host action entity"
     );
+    let server_buffer = stepper
+        .server_app
+        .world()
+        .entity(server_action)
+        .get::<BEIBuffer<BEIContext>>()
+        .expect("Server should buffer the host client's input before rebroadcasting it");
+    assert_buffer_contains_fired_input(server_buffer, "host-server input buffer");
+}
+
+fn assert_buffer_contains_fired_input(buffer: &BEIBuffer<BEIContext>, label: &str) {
+    assert!(
+        buffer_contains_fired_input(buffer),
+        "{label} should contain a fired bool input, got {buffer:?}"
+    );
+}
+
+fn buffer_contains_fired_input(buffer: &BEIBuffer<BEIContext>) -> bool {
+    buffer.buffer.iter().any(|input| {
+        matches!(
+            input,
+            Compressed::Input(snapshot)
+                if snapshot.state == TriggerState::Fired
+                    && snapshot.value == ActionValue::Bool(true)
+        )
+    })
+}
+
+fn find_action_with_fired_input(world: &World, context: Entity, label: &str) -> Entity {
+    let actions = world
+        .get::<Actions<BEIContext>>(context)
+        .unwrap_or_else(|| panic!("{label} context should have BEI actions"));
+    for action in actions.collection().iter().copied() {
+        if world
+            .entity(action)
+            .get::<BEIBuffer<BEIContext>>()
+            .is_some_and(buffer_contains_fired_input)
+        {
+            return action;
+        }
+    }
+    let buffers: Vec<_> = actions
+        .collection()
+        .iter()
+        .copied()
+        .map(|action| {
+            format!(
+                "{action:?}: {:?}",
+                world.entity(action).get::<BEIBuffer<BEIContext>>()
+            )
+        })
+        .collect();
+    panic!("{label} should have an action with fired rebroadcast input, got {buffers:?}");
 }

--- a/crates/tests/src/host_server/input/bei.rs
+++ b/crates/tests/src/host_server/input/bei.rs
@@ -3,7 +3,7 @@ use crate::stepper::*;
 use bevy::prelude::*;
 use bevy_enhanced_input::action::mock::{ActionMock, MockSpan};
 use bevy_enhanced_input::action::{Action, TriggerState};
-use bevy_enhanced_input::prelude::{ActionOf, ActionValue, Actions};
+use bevy_enhanced_input::prelude::{ActionOf, ActionValue, Actions, Fire};
 use lightyear::input::bei::input_message::BEIBuffer;
 use lightyear::input::bei::prelude::InputMarker;
 use lightyear::input::input_buffer::Compressed;
@@ -161,10 +161,13 @@ fn test_host_client_action_rebroadcasts_to_remote_client() {
         .server_app
         .world_mut()
         .entity_mut(server_action)
-        .insert(ActionMock::new(
-            TriggerState::Fired,
-            ActionValue::Bool(true),
-            MockSpan::Manual,
+        .insert((
+            ActionMock::new(
+                TriggerState::Fired,
+                ActionValue::Bool(true),
+                MockSpan::Manual,
+            ),
+            InputMarker::<BEIContext>::default(),
         ));
 
     stepper.frame_step(4);
@@ -209,6 +212,93 @@ fn test_host_client_action_rebroadcasts_to_remote_client() {
         .get::<BEIBuffer<BEIContext>>()
         .expect("Server should buffer the host client's input before rebroadcasting it");
     assert_buffer_contains_fired_input(server_buffer, "host-server input buffer");
+}
+
+#[derive(Resource, Default)]
+struct BeiFireCount(usize);
+
+/// Regression for host-server mode with a remote netcode client driving its
+/// own action. The remote client's input should update the shared host-server
+/// action state and emit BEI events on the server.
+#[test]
+fn test_remote_client_action_updates_server_action_state_in_host_server() {
+    let mut stepper = ClientServerStepper::from_config(StepperConfig::host_server());
+    stepper.server_app.init_resource::<BeiFireCount>();
+    stepper
+        .server_app
+        .add_observer(|_: On<Fire<BEIAction1>>, mut count: ResMut<BeiFireCount>| {
+            count.0 += 1;
+        });
+
+    let remote_owner = stepper.client_of_entities[0];
+    let server_entity = stepper
+        .server_app
+        .world_mut()
+        .spawn((
+            Replicate::to_clients(NetworkTarget::All),
+            PredictionTarget::to_clients(NetworkTarget::All),
+            ControlledBy {
+                owner: remote_owner,
+                lifetime: Default::default(),
+            },
+            BEIContext,
+        ))
+        .id();
+
+    let server_action = stepper
+        .server_app
+        .world_mut()
+        .spawn((
+            ActionOf::<BEIContext>::new(server_entity),
+            Action::<BEIAction1>::default(),
+            Replicate::to_clients(NetworkTarget::All),
+        ))
+        .id();
+
+    stepper.frame_step_server_first(1);
+
+    let remote_entity = stepper
+        .client(0)
+        .get::<MessageManager>()
+        .unwrap()
+        .entity_mapper
+        .get_local(server_entity)
+        .expect("entity not replicated to remote client");
+    let remote_action = stepper.client_apps[0]
+        .world()
+        .get::<Actions<BEIContext>>(remote_entity)
+        .expect("remote context should have BEI actions")
+        .collection()[0];
+
+    stepper.client_apps[0]
+        .world_mut()
+        .entity_mut(remote_action)
+        .insert((
+            ActionMock::new(
+                TriggerState::Fired,
+                ActionValue::Bool(true),
+                MockSpan::Manual,
+            ),
+            InputMarker::<BEIContext>::default(),
+        ));
+
+    stepper.frame_step(24);
+
+    let state = stepper
+        .server_app
+        .world()
+        .entity(server_action)
+        .get::<TriggerState>()
+        .expect("server action should have BEI trigger state");
+    assert_eq!(
+        *state,
+        TriggerState::Fired,
+        "server action state should apply the remote client's BEI input"
+    );
+    assert!(
+        stepper.server_app.world().resource::<BeiFireCount>().0 > 0,
+        "server should emit Fire<BEIAction1> for the remote client's input"
+    );
 }
 
 fn assert_buffer_contains_fired_input(buffer: &BEIBuffer<BEIContext>, label: &str) {

--- a/crates/tests/src/host_server/replication.rs
+++ b/crates/tests/src/host_server/replication.rs
@@ -9,7 +9,7 @@ use lightyear_core::interpolation::Interpolated;
 use lightyear_core::prediction::Predicted;
 use lightyear_messages::MessageManager;
 use lightyear_replication::authority::HasAuthority;
-use lightyear_replication::control::{Controlled, ControlledBy};
+use lightyear_replication::control::{Controlled, ControlledBy, ControlledSend};
 use lightyear_replication::prelude::*;
 use lightyear_replication::send::ReplicatedFrom;
 use test_log::test;
@@ -107,10 +107,10 @@ fn test_interpolation_target_adds_interpolated() {
     );
 }
 
-/// Spawning an entity with `ControlledBy` should automatically add the
-/// `Controlled` marker component via `#[require(Controlled)]`.
+/// Spawning a host-owned entity with `ControlledBy` should add the sender
+/// marker and the host-local receiver marker.
 #[test]
-fn test_controlled_by_adds_controlled() {
+fn test_host_owned_controlled_by_adds_local_controlled() {
     let mut stepper = ClientServerStepper::from_config(StepperConfig::host_server());
 
     let host_client_entity = stepper.host_client_entity.unwrap();
@@ -129,8 +129,41 @@ fn test_controlled_by_adds_controlled() {
 
     let entity_ref = stepper.server_app.world().entity(server_entity);
     assert!(
+        entity_ref.contains::<ControlledSend>(),
+        "entity should have ControlledSend via #[require(ControlledSend)] on ControlledBy"
+    );
+    assert!(
         entity_ref.contains::<Controlled>(),
-        "entity should have Controlled via #[require(Controlled)] on ControlledBy"
+        "host-owned entity should have host-local Controlled in host-server mode"
+    );
+}
+
+#[test]
+fn test_remote_owned_controlled_by_does_not_add_local_controlled_on_host_server() {
+    let mut stepper = ClientServerStepper::from_config(StepperConfig::host_server());
+
+    let remote_client_entity = stepper.client_of_entities[0];
+    let server_entity = stepper
+        .server_app
+        .world_mut()
+        .spawn((
+            Replicate::to_clients(NetworkTarget::All),
+            ControlledBy {
+                owner: remote_client_entity,
+                lifetime: Default::default(),
+            },
+        ))
+        .id();
+    stepper.frame_step(1);
+
+    let entity_ref = stepper.server_app.world().entity(server_entity);
+    assert!(
+        entity_ref.contains::<ControlledSend>(),
+        "entity should have ControlledSend via #[require(ControlledSend)] on ControlledBy"
+    );
+    assert!(
+        !entity_ref.contains::<Controlled>(),
+        "remote-owned server entity should not have host-local Controlled"
     );
 }
 
@@ -264,8 +297,16 @@ fn test_controlled_backfills_when_client_becomes_host_client() {
             .server_app
             .world()
             .entity(server_entity)
+            .contains::<ControlledSend>(),
+        "ControlledSend is added by ControlledBy before the host-local observer runs"
+    );
+    assert!(
+        !stepper
+            .server_app
+            .world()
+            .entity(server_entity)
             .contains::<Controlled>(),
-        "Controlled is currently added before the host-local observer runs"
+        "Controlled should not be present before the owner becomes a HostClient"
     );
 
     connect_host(&mut stepper);

--- a/crates/tests/src/protocol.rs
+++ b/crates/tests/src/protocol.rs
@@ -199,6 +199,10 @@ pub struct BEIContext;
 #[action_output(bool)]
 pub struct BEIAction1;
 
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Copy, Hash, Reflect, InputAction)]
+#[action_output(Vec2)]
+pub struct BEIActionVec2;
+
 // Protocol
 pub struct ProtocolPlugin {
     pub avian_mode: AvianReplicationMode,
@@ -284,6 +288,7 @@ impl Plugin for ProtocolPlugin {
             ..default()
         }));
         app.register_input_action::<BEIAction1>();
+        app.register_input_action::<BEIActionVec2>();
 
         app.add_plugins(lightyear::avian2d::plugin::LightyearAvianPlugin {
             replication_mode: self.avian_mode,

--- a/examples/avian_2d/src/client.rs
+++ b/examples/avian_2d/src/client.rs
@@ -100,17 +100,11 @@ pub(crate) fn handle_predicted_spawn(
 fn handle_controlled_spawn(
     trigger: On<Add, Controlled>,
     mut commands: Commands,
-    player_query: Query<(&PlayerId, Option<&ControlledBy>), Without<InputMap<PlayerActions>>>,
-    clients: Query<(), With<Client>>,
+    player_query: Query<&PlayerId, Without<InputMap<PlayerActions>>>,
 ) {
-    let Ok((_player_id, controlled_by)) = player_query.get(trigger.entity) else {
+    if player_query.get(trigger.entity).is_err() {
         return;
     };
-    if let Some(controlled_by) = controlled_by {
-        if clients.get(controlled_by.owner).is_err() {
-            return;
-        }
-    }
     commands.entity(trigger.entity).insert(InputMap::new([
         (PlayerActions::Up, KeyCode::KeyW),
         (PlayerActions::Down, KeyCode::KeyS),

--- a/examples/avian_3d/src/client.rs
+++ b/examples/avian_3d/src/client.rs
@@ -81,21 +81,12 @@ fn handle_new_character(
 fn handle_controlled_character(
     trigger: On<Add, Controlled>,
     mut commands: Commands,
-    character_query: Query<
-        Option<&ControlledBy>,
-        (With<CharacterMarker>, Without<InputMap<CharacterAction>>),
-    >,
-    clients: Query<(), With<Client>>,
+    character_query: Query<(), (With<CharacterMarker>, Without<InputMap<CharacterAction>>)>,
 ) {
     let entity = trigger.entity;
-    let Ok(controlled_by) = character_query.get(entity) else {
+    if character_query.get(entity).is_err() {
         return;
     };
-    if let Some(controlled_by) = controlled_by {
-        if clients.get(controlled_by.owner).is_err() {
-            return;
-        }
-    }
     info!("Adding InputMap to controlled character {entity:?}");
     commands.entity(entity).insert(
         InputMap::new([(CharacterAction::Jump, KeyCode::Space)])

--- a/examples/bevy_enhanced_inputs/src/client.rs
+++ b/examples/bevy_enhanced_inputs/src/client.rs
@@ -10,7 +10,12 @@ use crate::protocol::*;
 use crate::shared;
 use bevy::ecs::relationship::Relationship;
 use bevy::prelude::*;
-use lightyear::input::bei::prelude::{Action, ActionOf, Bindings, Cardinal, Fire};
+use bevy_enhanced_input::context::ExternallyMocked;
+#[cfg(feature = "server")]
+use lightyear::connection::host::HostServer;
+#[cfg(test)]
+use lightyear::input::bei::prelude::InputMarker;
+use lightyear::input::bei::prelude::{Action, ActionOf, Actions, Bindings, Cardinal, Fire};
 use lightyear::prelude::client::{InputDelayConfig, InputTimelineConfig};
 use lightyear::prelude::*;
 
@@ -20,8 +25,9 @@ impl Plugin for ExampleClientPlugin {
     fn build(&self, app: &mut App) {
         app.add_plugins(AutomationClientPlugin);
         app.add_systems(Startup, configure_input_delay);
+        app.add_observer(add_bindings_to_controlled_action);
+        app.add_observer(add_bindings_to_controlled_player_actions);
         app.add_observer(handle_predicted_spawn);
-        app.add_observer(add_bindings_to_controlled_actions);
         app.add_observer(handle_interpolated_spawn);
         app.add_observer(player_movement);
     }
@@ -34,14 +40,19 @@ fn configure_input_delay(client: Single<Entity, With<Client>>, mut commands: Com
 }
 
 /// Applies local movement only to predicted entities owned by this client.
-///
-/// If this example predicted remote entities, ownership would need to be checked before movement.
+/// In host-server mode the server observer runs in the same app, so the client
+/// observer is disabled.
 fn player_movement(
     trigger: On<Fire<Movement>>,
     synced_client: Query<(), (With<Client>, With<IsSynced<InputTimeline>>)>,
+    #[cfg(feature = "server")] host_server: Query<(), With<HostServer>>,
     mut position_query: Query<&mut PlayerPosition, With<Predicted>>,
 ) {
     if synced_client.is_empty() {
+        return;
+    }
+    #[cfg(feature = "server")]
+    if !host_server.is_empty() {
         return;
     }
     if let Ok(position) = position_query.get_mut(trigger.context) {
@@ -65,23 +76,55 @@ pub(crate) fn handle_predicted_spawn(
     }
 }
 
-/// Add local movement bindings when we receive an Action entity for a player
-/// that we control.
-fn add_bindings_to_controlled_actions(
-    trigger: On<Add, (Action<Movement>, ActionOf<Player>)>,
-    actions: Query<(&ActionOf<Player>, Has<Bindings>), With<Action<Movement>>>,
+/// Add local movement bindings once the replicated action entity is fully
+/// ready for a player that we control.
+fn add_bindings_to_controlled_action(
+    trigger: On<Insert, (Action<Movement>, ActionOf<Player>)>,
+    actions: Query<
+        (&ActionOf<Player>, Has<Bindings>, Has<ExternallyMocked>),
+        With<Action<Movement>>,
+    >,
     controlled_players: Query<(), (With<Player>, With<Controlled>)>,
     mut commands: Commands,
 ) {
-    let Ok((action_of, has_bindings)) = actions.get(trigger.entity) else {
+    let Ok((action_of, has_bindings, is_mocked)) = actions.get(trigger.entity) else {
         return;
     };
-    if has_bindings || controlled_players.get(action_of.get()).is_err() {
+    if controlled_players.get(action_of.get()).is_err() {
         return;
     }
-    commands
-        .entity(trigger.entity)
-        .insert(Bindings::spawn(Cardinal::wasd_keys()));
+    let mut entity = commands.entity(trigger.entity);
+    if is_mocked {
+        entity.remove::<ExternallyMocked>();
+    }
+    if !has_bindings {
+        entity.insert(Bindings::spawn(Cardinal::wasd_keys()));
+    }
+}
+
+/// Add local movement bindings if the controlled player becomes ready after
+/// its action entities.
+fn add_bindings_to_controlled_player_actions(
+    trigger: On<Add, (Player, Controlled, Actions<Player>)>,
+    players: Query<&Actions<Player>, (With<Player>, With<Controlled>)>,
+    actions: Query<(Has<Bindings>, Has<ExternallyMocked>), With<Action<Movement>>>,
+    mut commands: Commands,
+) {
+    let Ok(player_actions) = players.get(trigger.entity) else {
+        return;
+    };
+    for action in player_actions.iter() {
+        let Ok((has_bindings, is_mocked)) = actions.get(action) else {
+            continue;
+        };
+        let mut entity = commands.entity(action);
+        if is_mocked {
+            entity.remove::<ExternallyMocked>();
+        }
+        if !has_bindings {
+            entity.insert(Bindings::spawn(Cardinal::wasd_keys()));
+        }
+    }
 }
 
 /// Lower the saturation on interpolated entities so they are visually distinct.
@@ -95,5 +138,121 @@ pub(crate) fn handle_interpolated_spawn(
             ..Hsva::from(color.0)
         };
         color.0 = Color::from(hsva);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn add_binding_system(app: &mut App) {
+        app.add_observer(add_bindings_to_controlled_action);
+        app.add_observer(add_bindings_to_controlled_player_actions);
+    }
+
+    fn assert_action_has_bindings(world: &World, action: Entity) {
+        let action = world.entity(action);
+        assert!(action.contains::<Bindings>());
+    }
+
+    #[test]
+    fn bindings_are_added_when_action_of_is_added_for_controlled_player() {
+        let mut app = App::new();
+        add_binding_system(&mut app);
+
+        let player = app.world_mut().spawn((Player, Controlled)).id();
+        let action = app.world_mut().spawn(Action::<Movement>::new()).id();
+        app.update();
+
+        app.world_mut()
+            .entity_mut(action)
+            .insert(ActionOf::<Player>::new(player));
+        app.update();
+
+        assert_action_has_bindings(app.world(), action);
+    }
+
+    #[test]
+    fn bindings_are_not_added_for_uncontrolled_player() {
+        let mut app = App::new();
+        add_binding_system(&mut app);
+
+        let player = app.world_mut().spawn(Player).id();
+        let action = app
+            .world_mut()
+            .spawn((ActionOf::<Player>::new(player), Action::<Movement>::new()))
+            .id();
+        app.update();
+
+        assert!(!app.world().entity(action).contains::<Bindings>());
+        assert!(!app.world().entity(action).contains::<InputMarker<Player>>());
+    }
+
+    #[test]
+    fn bindings_are_added_when_action_arrives_after_action_of() {
+        let mut app = App::new();
+        add_binding_system(&mut app);
+
+        let player = app.world_mut().spawn((Player, Controlled)).id();
+        let action = app.world_mut().spawn(ActionOf::<Player>::new(player)).id();
+        app.update();
+
+        assert!(!app.world().entity(action).contains::<Bindings>());
+
+        app.world_mut()
+            .entity_mut(action)
+            .insert(Action::<Movement>::new());
+        app.update();
+
+        assert_action_has_bindings(app.world(), action);
+    }
+
+    #[test]
+    fn bindings_are_added_when_context_arrives_after_action_of() {
+        let mut app = App::new();
+        add_binding_system(&mut app);
+
+        let player = app.world_mut().spawn_empty().id();
+        let action = app
+            .world_mut()
+            .spawn((ActionOf::<Player>::new(player), Action::<Movement>::new()))
+            .id();
+        app.update();
+
+        assert!(!app.world().entity(action).contains::<Bindings>());
+
+        app.world_mut()
+            .entity_mut(player)
+            .insert((Player, Controlled));
+        app.update();
+
+        assert_action_has_bindings(app.world(), action);
+    }
+
+    #[test]
+    fn bindings_are_not_added_for_server_side_controlled_by() {
+        let mut app = App::new();
+        add_binding_system(&mut app);
+
+        let remote_link = app.world_mut().spawn_empty().id();
+        let player = app
+            .world_mut()
+            .spawn((
+                Player,
+                ControlledBy {
+                    owner: remote_link,
+                    lifetime: Default::default(),
+                },
+            ))
+            .id();
+        assert!(!app.world().entity(player).contains::<Controlled>());
+        let action = app
+            .world_mut()
+            .spawn((ActionOf::<Player>::new(player), Action::<Movement>::new()))
+            .id();
+        app.update();
+
+        assert!(!app.world().entity(action).contains::<Bindings>());
+        assert!(!app.world().entity(action).contains::<InputMarker<Player>>());
     }
 }

--- a/examples/bevy_enhanced_inputs/src/client.rs
+++ b/examples/bevy_enhanced_inputs/src/client.rs
@@ -10,11 +10,8 @@ use crate::protocol::*;
 use crate::shared;
 use bevy::ecs::relationship::Relationship;
 use bevy::prelude::*;
-use bevy_enhanced_input::context::ExternallyMocked;
 #[cfg(feature = "server")]
 use lightyear::connection::host::HostServer;
-#[cfg(test)]
-use lightyear::input::bei::prelude::InputMarker;
 use lightyear::input::bei::prelude::{Action, ActionOf, Actions, Bindings, Cardinal, Fire};
 use lightyear::prelude::client::{InputDelayConfig, InputTimelineConfig};
 use lightyear::prelude::*;
@@ -80,26 +77,19 @@ pub(crate) fn handle_predicted_spawn(
 /// ready for a player that we control.
 fn add_bindings_to_controlled_action(
     trigger: On<Insert, (Action<Movement>, ActionOf<Player>)>,
-    actions: Query<
-        (&ActionOf<Player>, Has<Bindings>, Has<ExternallyMocked>),
-        With<Action<Movement>>,
-    >,
+    actions: Query<&ActionOf<Player>, (With<Action<Movement>>, Without<Bindings>)>,
     controlled_players: Query<(), (With<Player>, With<Controlled>)>,
     mut commands: Commands,
 ) {
-    let Ok((action_of, has_bindings, is_mocked)) = actions.get(trigger.entity) else {
+    let Ok(action_of) = actions.get(trigger.entity) else {
         return;
     };
     if controlled_players.get(action_of.get()).is_err() {
         return;
     }
-    let mut entity = commands.entity(trigger.entity);
-    if is_mocked {
-        entity.remove::<ExternallyMocked>();
-    }
-    if !has_bindings {
-        entity.insert(Bindings::spawn(Cardinal::wasd_keys()));
-    }
+    commands
+        .entity(trigger.entity)
+        .insert(Bindings::spawn(Cardinal::wasd_keys()));
 }
 
 /// Add local movement bindings if the controlled player becomes ready after
@@ -107,23 +97,19 @@ fn add_bindings_to_controlled_action(
 fn add_bindings_to_controlled_player_actions(
     trigger: On<Add, (Player, Controlled, Actions<Player>)>,
     players: Query<&Actions<Player>, (With<Player>, With<Controlled>)>,
-    actions: Query<(Has<Bindings>, Has<ExternallyMocked>), With<Action<Movement>>>,
+    actions: Query<(), (With<Action<Movement>>, Without<Bindings>)>,
     mut commands: Commands,
 ) {
     let Ok(player_actions) = players.get(trigger.entity) else {
         return;
     };
     for action in player_actions.iter() {
-        let Ok((has_bindings, is_mocked)) = actions.get(action) else {
+        if actions.get(action).is_err() {
             continue;
-        };
-        let mut entity = commands.entity(action);
-        if is_mocked {
-            entity.remove::<ExternallyMocked>();
         }
-        if !has_bindings {
-            entity.insert(Bindings::spawn(Cardinal::wasd_keys()));
-        }
+        commands
+            .entity(action)
+            .insert(Bindings::spawn(Cardinal::wasd_keys()));
     }
 }
 
@@ -138,121 +124,5 @@ pub(crate) fn handle_interpolated_spawn(
             ..Hsva::from(color.0)
         };
         color.0 = Color::from(hsva);
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn add_binding_system(app: &mut App) {
-        app.add_observer(add_bindings_to_controlled_action);
-        app.add_observer(add_bindings_to_controlled_player_actions);
-    }
-
-    fn assert_action_has_bindings(world: &World, action: Entity) {
-        let action = world.entity(action);
-        assert!(action.contains::<Bindings>());
-    }
-
-    #[test]
-    fn bindings_are_added_when_action_of_is_added_for_controlled_player() {
-        let mut app = App::new();
-        add_binding_system(&mut app);
-
-        let player = app.world_mut().spawn((Player, Controlled)).id();
-        let action = app.world_mut().spawn(Action::<Movement>::new()).id();
-        app.update();
-
-        app.world_mut()
-            .entity_mut(action)
-            .insert(ActionOf::<Player>::new(player));
-        app.update();
-
-        assert_action_has_bindings(app.world(), action);
-    }
-
-    #[test]
-    fn bindings_are_not_added_for_uncontrolled_player() {
-        let mut app = App::new();
-        add_binding_system(&mut app);
-
-        let player = app.world_mut().spawn(Player).id();
-        let action = app
-            .world_mut()
-            .spawn((ActionOf::<Player>::new(player), Action::<Movement>::new()))
-            .id();
-        app.update();
-
-        assert!(!app.world().entity(action).contains::<Bindings>());
-        assert!(!app.world().entity(action).contains::<InputMarker<Player>>());
-    }
-
-    #[test]
-    fn bindings_are_added_when_action_arrives_after_action_of() {
-        let mut app = App::new();
-        add_binding_system(&mut app);
-
-        let player = app.world_mut().spawn((Player, Controlled)).id();
-        let action = app.world_mut().spawn(ActionOf::<Player>::new(player)).id();
-        app.update();
-
-        assert!(!app.world().entity(action).contains::<Bindings>());
-
-        app.world_mut()
-            .entity_mut(action)
-            .insert(Action::<Movement>::new());
-        app.update();
-
-        assert_action_has_bindings(app.world(), action);
-    }
-
-    #[test]
-    fn bindings_are_added_when_context_arrives_after_action_of() {
-        let mut app = App::new();
-        add_binding_system(&mut app);
-
-        let player = app.world_mut().spawn_empty().id();
-        let action = app
-            .world_mut()
-            .spawn((ActionOf::<Player>::new(player), Action::<Movement>::new()))
-            .id();
-        app.update();
-
-        assert!(!app.world().entity(action).contains::<Bindings>());
-
-        app.world_mut()
-            .entity_mut(player)
-            .insert((Player, Controlled));
-        app.update();
-
-        assert_action_has_bindings(app.world(), action);
-    }
-
-    #[test]
-    fn bindings_are_not_added_for_server_side_controlled_by() {
-        let mut app = App::new();
-        add_binding_system(&mut app);
-
-        let remote_link = app.world_mut().spawn_empty().id();
-        let player = app
-            .world_mut()
-            .spawn((
-                Player,
-                ControlledBy {
-                    owner: remote_link,
-                    lifetime: Default::default(),
-                },
-            ))
-            .id();
-        assert!(!app.world().entity(player).contains::<Controlled>());
-        let action = app
-            .world_mut()
-            .spawn((ActionOf::<Player>::new(player), Action::<Movement>::new()))
-            .id();
-        app.update();
-
-        assert!(!app.world().entity(action).contains::<Bindings>());
-        assert!(!app.world().entity(action).contains::<InputMarker<Player>>());
     }
 }

--- a/examples/bevy_enhanced_inputs/src/client.rs
+++ b/examples/bevy_enhanced_inputs/src/client.rs
@@ -10,7 +10,6 @@ use crate::protocol::*;
 use crate::shared;
 use bevy::ecs::relationship::Relationship;
 use bevy::prelude::*;
-use lightyear::connection::host::HostServer;
 use lightyear::input::bei::prelude::{Action, ActionOf, Bindings, Cardinal, Fire};
 use lightyear::prelude::client::{InputDelayConfig, InputTimelineConfig};
 use lightyear::prelude::*;
@@ -40,18 +39,9 @@ fn configure_input_delay(client: Single<Entity, With<Client>>, mut commands: Com
 fn player_movement(
     trigger: On<Fire<Movement>>,
     synced_client: Query<(), (With<Client>, With<IsSynced<InputTimeline>>)>,
-    _host_server: Query<(), With<HostServer>>,
-    #[cfg(feature = "server")] server_actions: Query<
-        (),
-        (With<Action<Movement>>, With<crate::server::ServerAction>),
-    >,
     mut position_query: Query<&mut PlayerPosition, With<Predicted>>,
 ) {
     if synced_client.is_empty() {
-        return;
-    }
-    #[cfg(feature = "server")]
-    if !_host_server.is_empty() && server_actions.contains(trigger.action) {
         return;
     }
     if let Ok(position) = position_query.get_mut(trigger.context) {

--- a/examples/bevy_enhanced_inputs/src/protocol.rs
+++ b/examples/bevy_enhanced_inputs/src/protocol.rs
@@ -1,6 +1,7 @@
 use bevy::math::Curve;
 use bevy::prelude::*;
 use lightyear::prelude::input::bei::*;
+use lightyear::prelude::input::InputConfig;
 use lightyear::prelude::*;
 use serde::{Deserialize, Serialize};
 
@@ -39,7 +40,10 @@ pub struct ProtocolPlugin;
 impl Plugin for ProtocolPlugin {
     fn build(&self, app: &mut App) {
         // inputs
-        app.add_plugins(InputPlugin::<Player>::default());
+        app.add_plugins(InputPlugin::<Player>::new(InputConfig {
+            rebroadcast_inputs: true,
+            ..default()
+        }));
         app.register_input_action::<Movement>();
 
         // components

--- a/examples/bevy_enhanced_inputs/src/server.rs
+++ b/examples/bevy_enhanced_inputs/src/server.rs
@@ -12,15 +12,11 @@ use crate::shared;
 use bevy::prelude::*;
 use bevy_enhanced_input::prelude::{Action, ActionOf, Fire};
 use lightyear::connection::client::Connected;
-use lightyear::connection::host::{HostClient, HostServer};
 use lightyear::prelude::server::*;
 use lightyear::prelude::*;
 use lightyear_examples_common::shared::SEND_INTERVAL;
 
 pub struct ExampleServerPlugin;
-
-#[derive(Component)]
-pub(crate) struct ServerAction;
 
 impl Plugin for ExampleServerPlugin {
     fn build(&self, app: &mut App) {
@@ -104,24 +100,14 @@ fn spawn_action_entities(commands: &mut Commands, player_entity: Entity) {
         ReplicateLike {
             root: player_entity,
         },
-        ServerAction,
     ));
 }
 
 /// Applies received client inputs on the server so other clients can observe the result.
 fn movement(
     trigger: On<Fire<Movement>>,
-    host_server: Query<(), With<HostServer>>,
-    server_actions: Query<(), (With<Action<Movement>>, With<ServerAction>)>,
-    controlled_by: Query<&ControlledBy>,
-    host_clients: Query<(), With<HostClient>>,
-    mut position_query: Query<&mut PlayerPosition>,
+    mut position_query: Query<&mut PlayerPosition, With<ControlledBy>>,
 ) {
-    let is_host_server = !host_server.is_empty();
-    if is_host_server && !server_actions.contains(trigger.action) {
-        return;
-    }
-
     if let Ok(position) = position_query.get_mut(trigger.context) {
         shared::shared_movement_behaviour(position, trigger.value);
     }

--- a/examples/bevy_enhanced_inputs/src/server.rs
+++ b/examples/bevy_enhanced_inputs/src/server.rs
@@ -104,10 +104,7 @@ fn spawn_action_entities(commands: &mut Commands, player_entity: Entity) {
 }
 
 /// Applies received client inputs on the server so other clients can observe the result.
-fn movement(
-    trigger: On<Fire<Movement>>,
-    mut position_query: Query<&mut PlayerPosition, With<ControlledBy>>,
-) {
+fn movement(trigger: On<Fire<Movement>>, mut position_query: Query<&mut PlayerPosition>) {
     if let Ok(position) = position_query.get_mut(trigger.context) {
         shared::shared_movement_behaviour(position, trigger.value);
     }

--- a/examples/common/src/cli.rs
+++ b/examples/common/src/cli.rs
@@ -12,7 +12,7 @@ use bevy::prelude::*;
 use bevy::DefaultPlugins;
 use bevy::diagnostic::DiagnosticsPlugin;
 use bevy::state::app::StatesPlugin;
-use clap::{Parser, Subcommand};
+use clap::{ArgAction, Parser, Subcommand};
 
 #[cfg(feature = "client")]
 use crate::client::{ClientTransports, ExampleClient, connect};
@@ -36,13 +36,32 @@ use {
     bevy::winit::{UpdateMode, WinitSettings},
 };
 
+fn parse_bool_arg(value: &str) -> Result<bool, String> {
+    if value.eq_ignore_ascii_case("true") {
+        Ok(true)
+    } else if value.eq_ignore_ascii_case("false") {
+        Ok(false)
+    } else {
+        Err("expected `true` or `false`".to_string())
+    }
+}
+
 /// CLI options to create an [`App`]
 #[derive(Parser, Debug)]
 #[command(version, about)]
 pub struct Cli {
     /// Run without windowing/rendering plugins even when the example was built
     /// with a GUI feature.
-    #[arg(long, global = true)]
+    #[arg(
+        long,
+        global = true,
+        action = ArgAction::Set,
+        default_value_t = false,
+        default_missing_value = "true",
+        num_args = 0..=1,
+        require_equals = true,
+        value_parser = parse_bool_arg
+    )]
     pub headless: bool,
     #[command(subcommand)]
     pub mode: Option<Mode>,

--- a/examples/delta_compression/src/client.rs
+++ b/examples/delta_compression/src/client.rs
@@ -102,18 +102,12 @@ pub(crate) fn handle_predicted_spawn(
 pub(crate) fn handle_controlled_spawn(
     trigger: On<Add, Controlled>,
     mut commands: Commands,
-    players: Query<Option<&ControlledBy>, (With<PlayerId>, Without<InputMarker<Inputs>>)>,
-    clients: Query<(), With<Client>>,
+    players: Query<(), (With<PlayerId>, Without<InputMarker<Inputs>>)>,
 ) {
     let entity = trigger.entity;
-    let Ok(controlled_by) = players.get(entity) else {
+    if players.get(entity).is_err() {
         return;
     };
-    if let Some(controlled_by) = controlled_by {
-        if clients.get(controlled_by.owner).is_err() {
-            return;
-        }
-    }
     commands
         .entity(entity)
         .insert(InputMarker::<Inputs>::default());

--- a/examples/fps/src/client.rs
+++ b/examples/fps/src/client.rs
@@ -138,21 +138,12 @@ pub(crate) fn handle_predicted_spawn(
 pub(crate) fn handle_controlled_spawn(
     trigger: On<Add, Controlled>,
     mut commands: Commands,
-    player_query: Query<
-        Option<&ControlledBy>,
-        (With<PlayerMarker>, Without<InputMap<PlayerActions>>),
-    >,
-    clients: Query<(), With<Client>>,
+    player_query: Query<(), (With<PlayerMarker>, Without<InputMap<PlayerActions>>)>,
 ) {
     let entity = trigger.entity;
-    let Ok(controlled_by) = player_query.get(entity) else {
+    if player_query.get(entity).is_err() {
         return;
     };
-    if let Some(controlled_by) = controlled_by {
-        if clients.get(controlled_by.owner).is_err() {
-            return;
-        }
-    }
     commands.entity(entity).insert(InputMap::new([
         (PlayerActions::Up, KeyCode::KeyW),
         (PlayerActions::Down, KeyCode::KeyS),

--- a/examples/lobby/src/client.rs
+++ b/examples/lobby/src/client.rs
@@ -172,25 +172,16 @@ mod game {
     /// Add the local input marker once ownership is known.
     pub(crate) fn handle_controlled_spawn(
         controlled: Query<
-            (Entity, Option<&ControlledBy>),
+            Entity,
             (
                 With<Controlled>,
                 With<PlayerId>,
                 Without<InputMarker<Inputs>>,
             ),
         >,
-        local_clients: Query<(), With<Client>>,
         mut commands: Commands,
     ) {
-        for (entity, controlled_by) in controlled.iter() {
-            // In host-client mode, server-owned entities also carry `Controlled`
-            // because `ControlledBy` requires it on the sender side. Only the
-            // entity owned by the local host-client should receive local input.
-            if controlled_by
-                .is_some_and(|controlled_by| local_clients.get(controlled_by.owner).is_err())
-            {
-                continue;
-            }
+        for entity in controlled.iter() {
             commands
                 .entity(entity)
                 .insert(InputMarker::<Inputs>::default());

--- a/examples/network_visibility/src/client.rs
+++ b/examples/network_visibility/src/client.rs
@@ -79,18 +79,12 @@ pub(crate) fn handle_predicted_spawn(
 fn handle_controlled_spawn(
     trigger: On<Add, Controlled>,
     mut commands: Commands,
-    players: Query<(&PlayerId, Option<&ControlledBy>), Without<InputMarker<Inputs>>>,
-    clients: Query<(), With<Client>>,
+    players: Query<&PlayerId, Without<InputMarker<Inputs>>>,
 ) {
     let entity = trigger.entity;
-    let Ok((player_id, controlled_by)) = players.get(entity) else {
+    let Ok(player_id) = players.get(entity) else {
         return;
     };
-    if let Some(controlled_by) = controlled_by {
-        if clients.get(controlled_by.owner).is_err() {
-            return;
-        }
-    }
     info!("Adding InputMarker to controlled player {entity:?} {player_id:?}");
     commands
         .entity(entity)

--- a/examples/replication_groups/src/client.rs
+++ b/examples/replication_groups/src/client.rs
@@ -107,18 +107,12 @@ pub(crate) fn handle_predicted_spawn(
 pub(crate) fn handle_controlled_spawn(
     trigger: On<Add, Controlled>,
     mut commands: Commands,
-    players: Query<Option<&ControlledBy>, (With<PlayerId>, Without<InputMarker<Inputs>>)>,
-    clients: Query<(), With<Client>>,
+    players: Query<(), (With<PlayerId>, Without<InputMarker<Inputs>>)>,
 ) {
     let entity = trigger.entity;
-    let Ok(controlled_by) = players.get(entity) else {
+    if players.get(entity).is_err() {
         return;
     };
-    if let Some(controlled_by) = controlled_by {
-        if clients.get(controlled_by.owner).is_err() {
-            return;
-        }
-    }
     commands
         .entity(entity)
         .insert(InputMarker::<Inputs>::default());

--- a/examples/simple_box/src/client.rs
+++ b/examples/simple_box/src/client.rs
@@ -136,18 +136,12 @@ pub(crate) fn handle_predicted_spawn(
 fn handle_controlled_spawn(
     trigger: On<Add, Controlled>,
     mut commands: Commands,
-    players: Query<(&PlayerId, Option<&ControlledBy>), Without<InputMarker<Inputs>>>,
-    clients: Query<(), With<Client>>,
+    players: Query<&PlayerId, Without<InputMarker<Inputs>>>,
 ) {
     let entity = trigger.entity;
-    let Ok((player_id, controlled_by)) = players.get(entity) else {
+    let Ok(player_id) = players.get(entity) else {
         return;
     };
-    if let Some(controlled_by) = controlled_by {
-        if clients.get(controlled_by.owner).is_err() {
-            return;
-        }
-    }
     info!("Adding InputMarker to controlled player {entity:?} {player_id:?}");
     commands
         .entity(entity)

--- a/justfile
+++ b/justfile
@@ -38,6 +38,7 @@ clippy_examples:
     # cargo clippy -p simple_setup --all-features -- -D warnings --no-deps
 
 # jq filters shared by the example/demo build recipe.
+_example_demo_pkgs_filter := '.packages[] | select((.manifest_path | test("/(examples|demos)/")) and (.manifest_path | test("/examples/common/") | not) and (.manifest_path | test("/examples/launcher/") | not) and (.name != "simple_setup")) | .name'
 _example_demo_non_projectiles_pkgs_filter := '.packages[] | select((.manifest_path | test("/(examples|demos)/")) and (.manifest_path | test("/examples/common/") | not) and (.manifest_path | test("/examples/launcher/") | not) and (.name != "simple_setup") and (.name != "projectiles")) | .name'
 # simple_setup is excluded from explicit feature builds because it has no client/server/gui feature gates.
 
@@ -127,9 +128,16 @@ build_examples *args:
     fi
 
     echo "Building examples: release=$release headless=$headless features=$feature_mode cargo_features=$cargo_features"
-    pkgs=$(cargo metadata --no-deps --format-version 1 | jq -r '{{ _example_demo_non_projectiles_pkgs_filter }}' | sort | sed 's/^/-p /' | tr "\n" " ")
+    if [ "$projectiles_features" = "$cargo_features" ]; then
+        pkgs_filter='{{ _example_demo_pkgs_filter }}'
+    else
+        pkgs_filter='{{ _example_demo_non_projectiles_pkgs_filter }}'
+    fi
+    pkgs=$(cargo metadata --no-deps --format-version 1 | jq -r "$pkgs_filter" | sort | sed 's/^/-p /' | tr "\n" " ")
     "${cargo_build[@]}" --no-default-features --features="$cargo_features" $pkgs
-    "${cargo_build[@]}" --no-default-features --features="$projectiles_features" -p projectiles
+    if [ "$projectiles_features" != "$cargo_features" ]; then
+        "${cargo_build[@]}" --no-default-features --features="$projectiles_features" -p projectiles
+    fi
 
 test:
     # Can´t do --workspace because of feature unification with the packages in examples.


### PR DESCRIPTION
Greatly simplify the process of input replication in BEI.
The server should spawn the Action entities and replicate them to the client, then the client adds Binding.

1) The issue is that a lot of the observers rely on `Controlled` to identify if the entity is the locally controlled one. But the host-server would add 'Controlled' on all entities in order to replicate the component to the remote. Now the server adds 'ControlledSend', which gets replicated as 'Controlled' on the receiver.

2) In lightyear it was guaranteed that a child entity would get replicated before a parent. This is not the case in replicon, so the Action entity could be replicated before the parent Context entity. We need to add more observers to handle both cases.