### PR TITLE
fix: fix examples in wasm

### DIFF
--- a/.github/workflows/platform-builds.yaml
+++ b/.github/workflows/platform-builds.yaml
@@ -82,5 +82,5 @@ jobs:
             cargo check -p "${package}" \
               --target wasm32-unknown-unknown \
               --no-default-features \
-              --features client,netcode,webtransport
+              --features client,gui,netcode,webtransport
           done

--- a/book/src/concepts/reliability/packet_header.md
+++ b/book/src/concepts/reliability/packet_header.md
@@ -1,0 +1,1 @@
+# PacketHeader

--- a/crates/core/lightyear/src/client.rs
+++ b/crates/core/lightyear/src/client.rs
@@ -40,11 +40,6 @@ impl PluginGroup for ClientPlugins {
         #[cfg(feature = "replication")]
         let builder = builder.add(LightyearRepliconClientBackend);
 
-        // if the server feature is enabled (e.g. for host-server mode), then we don't need
-        // the client to send checksum messages
-        #[cfg(feature = "deterministic")]
-        let builder = builder.add(lightyear_deterministic_replication::prelude::ChecksumSendPlugin);
-
         #[cfg(feature = "prediction")]
         let builder = builder.add(lightyear_prediction::plugin::PredictionPlugin);
 

--- a/crates/core/lightyear/src/server.rs
+++ b/crates/core/lightyear/src/server.rs
@@ -60,10 +60,6 @@ impl PluginGroup for ServerPlugins {
         #[cfg(feature = "replication")]
         let builder = builder.add(LightyearRepliconServerBackend);
 
-        #[cfg(feature = "deterministic")]
-        let builder =
-            builder.add(lightyear_deterministic_replication::prelude::ChecksumReceivePlugin);
-
         let builder = builder.add(lightyear_connection::host::HostPlugin);
 
         // IO

--- a/crates/deterministic/deterministic_replication/src/checksum.rs
+++ b/crates/deterministic/deterministic_replication/src/checksum.rs
@@ -54,6 +54,43 @@ pub struct ChecksumHistory {
     history: BTreeMap<Tick, u64>,
 }
 
+/// Shared checksum protocol plugin.
+///
+/// Add this from the shared protocol after `ClientPlugins` / `ServerPlugins`
+/// and before spawning networking entities. It installs the client send and/or
+/// server receive checksum plugins based on which Lightyear side plugins are
+/// present.
+pub struct ChecksumPlugin;
+
+impl Plugin for ChecksumPlugin {
+    fn build(&self, app: &mut App) {
+        if !app.is_plugin_added::<DeterministicReplicationPlugin>() {
+            app.add_plugins(DeterministicReplicationPlugin);
+        }
+
+        #[cfg(feature = "client")]
+        if app.is_plugin_added::<lightyear_sync::client::ClientPlugin>()
+            && !app.is_plugin_added::<ChecksumSendPlugin>()
+        {
+            app.add_plugins(ChecksumSendPlugin);
+        }
+
+        #[cfg(feature = "server")]
+        if app.is_plugin_added::<lightyear_sync::server::ServerPlugin>()
+            && !app.is_plugin_added::<ChecksumReceivePlugin>()
+        {
+            app.add_plugins(ChecksumReceivePlugin);
+        }
+    }
+}
+
+fn register_checksum_message(app: &mut App) {
+    if !app.is_message_registered::<ChecksumMessage>() {
+        app.register_message::<ChecksumMessage>()
+            .add_direction(NetworkDirection::ClientToServer);
+    }
+}
+
 /// Plugin that can be added to clients to compute and send checksums for all deterministic entities with hashable components.
 ///
 /// The server will receive these checksums and verify them against its own computed checksums.
@@ -145,10 +182,7 @@ impl Plugin for ChecksumSendPlugin {
         // we need the LastConfirmedInput to compute the checksums
         app.register_required_components::<InputTimeline, LastConfirmedInput>();
 
-        if !app.is_message_registered::<ChecksumMessage>() {
-            app.register_message::<ChecksumMessage>()
-                .add_direction(NetworkDirection::ClientToServer);
-        }
+        register_checksum_message(app);
     }
 
     fn finish(&self, app: &mut App) {
@@ -267,11 +301,10 @@ impl Plugin for ChecksumReceivePlugin {
         // the server will check the checksum validity
         app.register_required_components::<Server, ChecksumHistory>();
 
-        if !app.is_message_registered::<ChecksumMessage>() {
-            app.register_message::<ChecksumMessage>()
-                .add_direction(NetworkDirection::ClientToServer);
-        }
+        register_checksum_message(app);
+    }
 
+    fn finish(&self, app: &mut App) {
         app.add_systems(
             PostUpdate,
             (
@@ -279,9 +312,6 @@ impl Plugin for ChecksumReceivePlugin {
                 ChecksumReceivePlugin::receive_checksum_message,
             ),
         );
-    }
-
-    fn finish(&self, app: &mut App) {
         app.add_systems(FixedLast, ChecksumReceivePlugin::compute_and_store_checksum);
     }
 }

--- a/crates/deterministic/deterministic_replication/src/lib.rs
+++ b/crates/deterministic/deterministic_replication/src/lib.rs
@@ -1,6 +1,9 @@
 //! # Lightyear Deterministic Replication
 //!
 //! Utilities for lockstep-style deterministic simulation on top of Lightyear:
+//! - [`ChecksumPlugin`] registers the checksum protocol and installs the
+//!   client/server checksum systems for whichever Lightyear side plugins are
+//!   present.
 //! - [`ChecksumSendPlugin`] / [`ChecksumReceivePlugin`] compute and verify
 //!   XOR checksums of prediction history across client and server.
 //! - [`LateJoinCatchUpPlugin`] lets a client that connects mid-game request
@@ -9,6 +12,7 @@
 //! - [`DeterministicReplicationPlugin`] wires up the shared archetype
 //!   index used by both features.
 //!
+//! [`ChecksumPlugin`]: crate::prelude::ChecksumPlugin
 //! [`ChecksumSendPlugin`]: crate::prelude::ChecksumSendPlugin
 //! [`ChecksumReceivePlugin`]: crate::prelude::ChecksumReceivePlugin
 //! [`LateJoinCatchUpPlugin`]: crate::prelude::LateJoinCatchUpPlugin
@@ -36,11 +40,11 @@ mod plugin;
 
 /// Commonly used items from the `lightyear_deterministic_replication` crate.
 pub mod prelude {
-    pub use crate::checksum::ChecksumMessage;
     #[cfg(feature = "client")]
     pub use crate::checksum::ChecksumSendPlugin;
     #[cfg(feature = "server")]
     pub use crate::checksum::{ChecksumHistory, ChecksumReceivePlugin};
+    pub use crate::checksum::{ChecksumMessage, ChecksumPlugin};
     #[cfg(feature = "replication")]
     pub use crate::late_join::{
         AppCatchUpExt, CatchUpRegistry, CatchUpRequest, CatchUpSnapshotReady, CatchUpSystems,

--- a/crates/deterministic/deterministic_replication/src/plugin.rs
+++ b/crates/deterministic/deterministic_replication/src/plugin.rs
@@ -2,13 +2,16 @@ use crate::Deterministic;
 use bevy_app::{App, Plugin};
 use lightyear_prediction::rollback::DeterministicPredicted;
 
-/// Shared setup for deterministic replication — automatically inserted by
-/// [`ChecksumSendPlugin`], [`ChecksumReceivePlugin`] and
-/// [`LateJoinCatchUpPlugin`] so users rarely need to add it directly.
+/// Shared setup for deterministic replication.
 ///
+/// This is automatically inserted by [`ChecksumPlugin`],
+/// [`ChecksumSendPlugin`] and [`ChecksumReceivePlugin`], so users normally add
+/// [`ChecksumPlugin`] from their shared protocol when they want checksum
+/// verification.
+///
+/// [`ChecksumPlugin`]: crate::prelude::ChecksumPlugin
 /// [`ChecksumSendPlugin`]: crate::prelude::ChecksumSendPlugin
 /// [`ChecksumReceivePlugin`]: crate::prelude::ChecksumReceivePlugin
-/// [`LateJoinCatchUpPlugin`]: crate::prelude::LateJoinCatchUpPlugin
 pub struct DeterministicReplicationPlugin;
 
 impl Plugin for DeterministicReplicationPlugin {

--- a/crates/inputs/input_bei/src/input_message.rs
+++ b/crates/inputs/input_bei/src/input_message.rs
@@ -276,7 +276,7 @@ mod tests {
     use bevy_enhanced_input::prelude::InputAction;
     use bevy_reflect::Reflect;
     use test_log::test;
-    use tracing::info;
+    use tracing::trace;
 
     struct Context1;
 
@@ -385,7 +385,7 @@ mod tests {
         let earliest_mismatch =
             sequence.update_buffer(&mut input_buffer, Tick(7), Duration::default());
 
-        info!("Input buffer after update: {:?}", input_buffer);
+        trace!("Input buffer after update: {:?}", input_buffer);
 
         // With empty buffer, the first tick received is a mismatch
         assert_eq!(earliest_mismatch, Some(Tick(5)));
@@ -607,7 +607,7 @@ mod tests {
         input_buffer.set(Tick(7), first_state_decay);
         input_buffer.last_remote_tick = Some(Tick(6));
 
-        info!("Input buffer before update: {:?}", input_buffer);
+        trace!("Input buffer before update: {:?}", input_buffer);
 
         let sequence = BEIStateSequence::<Context1> {
             start_state: first_state,

--- a/crates/inputs/input_bei/src/plugin.rs
+++ b/crates/inputs/input_bei/src/plugin.rs
@@ -60,7 +60,7 @@ use serde::de::DeserializeOwned;
 /// The replicated [`Action`] component is structural: it recreates the typed BEI
 /// action entity on the receiver, but does not carry runtime input state. The
 /// action relationship is replicated directly through [`ActionOf<C>`].
-
+///
 /// Live action state is sent by [`BEIStateSequence`] input messages. The owning
 /// client adds [`InputMarker`] to local action entities, buffers BEI trigger
 /// state/value/time each tick, and sends those snapshots to the server. If input

--- a/crates/inputs/inputs/src/input_message.rs
+++ b/crates/inputs/inputs/src/input_message.rs
@@ -157,9 +157,6 @@ pub trait ActionStateSequence:
         tick_duration: Duration,
     ) -> Option<Tick> {
         let last_remote_tick = input_buffer.last_remote_tick;
-        if last_remote_tick.is_some_and(|tick| end_tick <= tick) {
-            return None;
-        }
         let previous_end_tick = input_buffer.end_tick();
 
         let mut previous_predicted_input =
@@ -194,24 +191,29 @@ pub trait ActionStateSequence:
                     Compressed::Input(latest) => latest_received_input = Some(latest),
                     _ => {}
                 }
-                if match (&previous_predicted_input, &latest_received_input) {
-                    (Some(prev), Some(latest)) => prev == latest,
-                    (None, None) => true,
-                    _ => false,
-                } {
-                    if previous_end_tick.is_none_or(|end_tick| tick > end_tick) {
-                        input_buffer.set_raw(tick, Compressed::from(latest_received_input.clone()));
+                // Inputs at or before last_remote_tick were already received. Messages include
+                // overlapping history for reliability, but those inputs are immutable.
+                if last_remote_tick.is_none_or(|t| tick > t) {
+                    if match (&previous_predicted_input, &latest_received_input) {
+                        (Some(prev), Some(latest)) => prev == latest,
+                        (None, None) => true,
+                        _ => false,
+                    } {
+                        if previous_end_tick.is_none_or(|end_tick| tick > end_tick) {
+                            input_buffer
+                                .set_raw(tick, Compressed::from(latest_received_input.clone()));
+                        }
+                        continue;
                     }
-                    continue;
+                    // first mismatch tick! set the new value for the mismatch tick
+                    debug!(
+                        "Mismatch detected at tick {tick:?} for new_input {latest_received_input:?}. Previous predicted input: {previous_predicted_input:?}"
+                    );
+                    input_buffer.set_raw(tick, Compressed::from(latest_received_input.clone()));
+                    // remove all existing inputs in the buffer that come after `tick`
+                    input_buffer.clip_after(tick);
+                    earliest_mismatch = Some(tick);
                 }
-                // first mismatch tick! set the new value for the mismatch tick
-                debug!(
-                    "Mismatch detected at tick {tick:?} for new_input {latest_received_input:?}. Previous predicted input: {previous_predicted_input:?}"
-                );
-                input_buffer.set_raw(tick, Compressed::from(latest_received_input.clone()));
-                // remove all existing inputs in the buffer that come after `tick`
-                input_buffer.clip_after(tick);
-                earliest_mismatch = Some(tick);
             }
         }
         input_buffer.last_remote_tick = Some(end_tick);

--- a/crates/inputs/inputs_leafwing/src/input_message.rs
+++ b/crates/inputs/inputs_leafwing/src/input_message.rs
@@ -192,9 +192,9 @@ mod tests {
 
     use alloc::vec;
     use bevy_reflect::Reflect;
+    use core::time::Duration;
     use leafwing_input_manager::Actionlike;
     use serde::{Deserialize, Serialize};
-    use std::time::Duration;
     use test_log::test;
 
     #[derive(
@@ -568,5 +568,28 @@ mod tests {
         expected.set_update_state_from_state();
         expected.set_fixed_update_state_from_state();
         assert_eq!(input_buffer.get(Tick(3)).unwrap().0, expected);
+    }
+
+    #[test]
+    fn test_update_buffer_ignores_mismatches_at_confirmed_ticks() {
+        let mut input_buffer = InputBuffer::default();
+        let mut confirmed = ActionState::<Action>::default();
+        confirmed.press(&Action::Jump);
+        input_buffer.set(Tick(2), confirmed.clone().into());
+        input_buffer.last_remote_tick = Some(Tick(2));
+
+        let mut overlapping = ActionState::<Action>::default();
+        overlapping.press(&Action::Run);
+        let sequence = LeafwingSequence::<Action> {
+            // Tick 2 is redundant history and must not be compared or overwritten.
+            start_state: overlapping,
+            // Tick 3 is new and is the first tick eligible for mismatch detection.
+            diffs: vec![vec![]],
+        };
+
+        let mismatch = sequence.update_buffer(&mut input_buffer, Tick(3), Duration::default());
+
+        assert_eq!(mismatch, Some(Tick(3)));
+        assert_eq!(input_buffer.get(Tick(2)).unwrap().0, confirmed);
     }
 }

--- a/crates/inputs/inputs_leafwing/src/lib.rs
+++ b/crates/inputs/inputs_leafwing/src/lib.rs
@@ -40,7 +40,7 @@
 
 extern crate alloc;
 extern crate core;
-#[cfg(feature = "std")]
+#[cfg(any(feature = "std", test))]
 extern crate std;
 
 pub(crate) mod action_diff;

--- a/crates/inputs/inputs_leafwing/src/plugin.rs
+++ b/crates/inputs/inputs_leafwing/src/plugin.rs
@@ -14,8 +14,7 @@ use lightyear_sync::client::ClientPlugin as LightyearClientPlugin;
 use crate::input_message::LeafwingSequence;
 #[cfg(any(feature = "client", feature = "server"))]
 use leafwing_input_manager::plugin::InputManagerPlugin;
-#[allow(unused_imports)]
-use tracing::{info, trace};
+use tracing::trace;
 
 pub struct InputPlugin<A> {
     pub config: InputConfig<A>,
@@ -33,6 +32,16 @@ impl<A: LeafwingUserAction> Plugin for InputPlugin<A> {
     fn build(&self, app: &mut App) {
         app.register_type::<InputBuffer<ActionState<A>, A>>();
         app.register_type::<ActionState<A>>();
+
+        #[cfg(feature = "client")]
+        if !app.is_plugin_added::<lightyear_inputs::plugin::InputPlugin<LeafwingSequence<A>>>() {
+            // Message directions register required components on `Client`.
+            // Do that before users can spawn a Client entity, while still
+            // deferring Leafwing's client-only runtime systems to `finish`.
+            app.add_plugins(
+                lightyear_inputs::plugin::InputPlugin::<LeafwingSequence<A>>::default(),
+            );
+        }
 
         #[cfg(feature = "server")]
         {
@@ -79,6 +88,7 @@ impl<A: LeafwingUserAction> Plugin for InputPlugin<A> {
                     lightyear_inputs::client::InputSystems::RestoreInputs
                         .before(InputManagerSystem::Tick),
                 );
+
                 return;
             }
         }

--- a/crates/io/udp/src/lib.rs
+++ b/crates/io/udp/src/lib.rs
@@ -9,7 +9,8 @@
 //! [`server`] module provides [`server::ServerUdpIo`] and `ServerUdpPlugin` for a listening server
 //! socket that creates one child [`Link`] per remote address.
 
-use std::{io::ErrorKind, net::UdpSocket};
+use core::io::ErrorKind;
+use std::net::UdpSocket;
 
 use aeronet_io::connection::{LocalAddr, PeerAddr};
 use bevy_app::prelude::*;

--- a/crates/io/udp/src/lib.rs
+++ b/crates/io/udp/src/lib.rs
@@ -9,7 +9,11 @@
 //! [`server`] module provides [`server::ServerUdpIo`] and `ServerUdpPlugin` for a listening server
 //! socket that creates one child [`Link`] per remote address.
 
-use core::io::ErrorKind;
+// `core::io` is still unstable on the nightly toolchain used to build docs, and this crate already
+// requires `std` for `UdpSocket`.
+#![allow(clippy::std_instead_of_core)]
+
+use std::io::ErrorKind;
 use std::net::UdpSocket;
 
 use aeronet_io::connection::{LocalAddr, PeerAddr};

--- a/crates/tests/src/client_server/deterministic/protocol.rs
+++ b/crates/tests/src/client_server/deterministic/protocol.rs
@@ -21,7 +21,7 @@ use lightyear::prelude::input::InputRegistryExt;
 use lightyear::prelude::input::bei;
 use lightyear::prelude::*;
 use lightyear_deterministic_replication::prelude::{
-    AppCatchUpExt, CatchUpMode, LateJoinCatchUpPlugin,
+    AppCatchUpExt, CatchUpMode, ChecksumPlugin, LateJoinCatchUpPlugin,
 };
 use lightyear_prediction::rollback::{CatchUpGated, DeterministicPredicted};
 use serde::{Deserialize, Serialize};
@@ -112,6 +112,7 @@ impl Plugin for DetProtocolPlugin {
         }));
         app.register_input_action::<DetMovement>();
 
+        app.add_plugins(ChecksumPlugin);
         app.add_plugins(LateJoinCatchUpPlugin);
         app.register_catchup_filter::<
             (Position, Rotation, LinearVelocity, AngularVelocity),

--- a/crates/tests/src/client_server/deterministic/stepper.rs
+++ b/crates/tests/src/client_server/deterministic/stepper.rs
@@ -57,8 +57,8 @@ impl DetStepper {
             MetricsPlugin::new(None),
         ));
         server_app.add_plugins((server::ServerPlugins { tick_duration }, RoomPlugin));
-        // `ChecksumReceivePlugin` is auto-registered by `server::ServerPlugins`
-        // when the `deterministic` feature is enabled on `lightyear`.
+        // `ChecksumPlugin` is registered by the deterministic protocol so
+        // checksum setup stays in the shared protocol registration order.
         server_app.add_plugins(protocol);
 
         let server_entity = server_app
@@ -105,8 +105,8 @@ impl DetStepper {
         client_app.edit_schedule(PostUpdate, |schedule| {
             schedule.set_executor(SingleThreadedExecutor::new());
         });
-        // `ChecksumSendPlugin` is auto-registered by `client::ClientPlugins`
-        // when the `deterministic` feature is enabled on `lightyear`.
+        // `ChecksumPlugin` is registered by the deterministic protocol so
+        // checksum setup stays in the shared protocol registration order.
         client_app.add_plugins(self.protocol);
 
         client_app.finish();

--- a/crates/tools/tools/src/debug/tracing_layer.rs
+++ b/crates/tools/tools/src/debug/tracing_layer.rs
@@ -170,8 +170,10 @@ where
     }
 }
 
-/// Bevy `LogPlugin::custom_layer` hook that installs [`LightyearDebugLayer`].
+/// Bevy `LogPlugin::custom_layer` hook that installs [`LightyearDebugLayer`]
+/// when `LIGHTYEAR_DEBUG_FILE` is set.
 pub fn lightyear_debug_custom_layer(_: &mut App) -> Option<BoxedLayer> {
+    std::env::var_os(LIGHTYEAR_DEBUG_FILE_ENV)?;
     match LightyearDebugLayer::from_env() {
         Ok(layer) => Some(Box::new(layer)),
         Err(error) => {

--- a/demos/spaceships/Cargo.toml
+++ b/demos/spaceships/Cargo.toml
@@ -50,7 +50,7 @@ bevy = { workspace = true, features = ["bevy_state"] }
 [package.metadata.bevy_cli.web]
 rustflags = ["--cfg", "getrandom_backend=\"wasm_js\""]
 default-features = false
-features = ["client", "netcode", "webtransport"]
+features = ["client", "gui", "netcode", "webtransport"]
 
 [lints]
 workspace = true

--- a/docs/allocation-regression.md
+++ b/docs/allocation-regression.md
@@ -1,0 +1,221 @@
+# Allocation Regression Notes
+
+Status date: 2026-06-26
+
+This is a living note for making Lightyear's packet and higher-level hot paths allocation-stable.
+Keep it updated when allocation budgets change, buffers are pooled, or the measured scope changes.
+
+## Scope
+
+The first regression target is the transport packet send/receive loop only:
+
+- packet input is already prepared as `Bytes`;
+- no Bevy schedule execution;
+- no typed `lightyear_messages` serialization;
+- no IO backend;
+- no netcode, replication, or compression;
+- one channel batch per packet-loop iteration, four 64-byte unfragmented messages per batch.
+
+The test warms up with 1,500 messages, then measures 1,000 messages. With four messages per batch
+this currently warms up 375 packet-loop iterations and measures 250 packet-loop iterations. The
+longer warmup lets naturally-grown cached allocations, including the packet stats rolling window,
+settle before measurement. Batch preparation happens before the measured region so the allocator
+count isolates packet build + parse rather than fixture setup. The fixture also processes packet
+headers on receive and clears the ACK/loss buffers that the transport system would normally drain.
+
+The fixture lives behind `lightyear_transport/test_utils` so it can use crate-private packet
+builder/parser APIs without making them production API. It parses packet payloads from borrowed
+slices and returns packet payload buffers to `PacketBuilder` after receive-side parsing.
+
+## Current Tests
+
+Run the allocation budget test:
+
+```sh
+cargo test -p lightyear_transport --features test_utils --test allocation_regression -- --nocapture
+```
+
+Run the DHAT heap profile:
+
+```sh
+cargo test -p lightyear_transport --features test_utils --test dhat_packet_loop -- --ignored --nocapture
+```
+
+The DHAT run writes:
+
+```text
+target/dhat-packet-loop.json
+```
+
+Open that file with DHAT's viewer when call-site attribution is needed.
+
+## Current Implementation
+
+- `PacketBuilder` owns a `BufferPool` so packet-loop payloads and metadata vectors can reuse heap
+  allocations after warmup instead of allocating new buffers for each packet.
+- `BufferPool` owns the MTU-sized packet payload pool, the returned `Vec<Packet>` pool, and the
+  message metadata vector pool used by `metrics` builds.
+- `PacketBuilder::finalize_packet` no longer calls `shrink_to_fit`.
+- `PacketStatsManager` grows its rolling stats buffer naturally and drains old samples without
+  allocating a temporary collection.
+- The production send loop recycles the returned packet list allocation and any packet payloads that
+  are rejected by bandwidth quota. It also recycles drained message metadata vectors after ack and
+  metrics bookkeeping.
+
+Production caveat: accepted packets are still converted into `Bytes` and pushed into `Link`. Once
+that happens, the `Vec<u8>` payload is owned by `Bytes` and cannot be returned to `PacketBuilder`.
+The regression fixture proves the packet builder/parser loop can run without allocations when the
+payload is returned, but the full production IO path still needs a reusable send-payload ownership
+model, or direct IO writes before recycling, to reuse buffers for accepted sent packets.
+
+## Current Budget
+
+Current guardrail:
+
+- allocations: `0`
+- reallocations: `0`
+- allocated bytes: `0`
+
+Observed on 2026-06-26:
+
+- `stats_alloc`: 0 allocations, 0 reallocations, 0 allocated bytes.
+- `dhat-rs`: 0 blocks, 0 total bytes; peak live heap 0 bytes in 0 blocks.
+
+Previous DHAT attribution before packet-buffer recycling:
+
+- `PacketBuilder::get_new_buffer` / `build_new_single_packet`: 500 blocks, 371,750 bytes. This is
+  the per-packet payload buffer path, including the resize/shrink behavior associated with the
+  packet payload allocation.
+- `PacketBuilder::build_packets_internal`: 250 blocks, 88,000 bytes from `Vec<Packet>` output
+  growth.
+- `Reader::split_len` through `Bytes::slice`: 250 blocks, 6,000 bytes. Slicing a Vec-backed packet
+  payload allocates shared `Bytes` backing metadata.
+- `PacketStatsManager::update` / `ReadyBuffer::push`: 4 blocks, 30,720 bytes. This was bounded
+  stats bookkeeping growth rather than per-packet payload churn.
+
+Keep this exact-zero budget for the packet-builder fixture. Add separate budget tests for broader
+paths instead of weakening this one.
+
+## Beyond Transport Scope
+
+The second regression target covers higher-level loops that can be measured without pulling in
+unrelated Bevy schedule or IO allocations:
+
+- `lightyear_messages` queue loop: typed `MessageSender<M>` buffering, draining, typed
+  `MessageReceiver<M>` buffering, and receiver draining. The fixture sends eight messages per
+  batch.
+- `lightyear_messages` serialization loop: fixed-size `ToBytes` message serialization through
+  `MessageRegistry`, reusable `Writer::split`, `Reader`, and typed deserialization.
+- `lightyear_prediction` history loop: `PredictionHistory<C>` appending predicted component states
+  and pruning to a 64-tick rolling window with `clear_until_tick`.
+- `lightyear_interpolation` history loop: `ConfirmedHistory<C>` appending monotonic explicit
+  samples or unchanged anchors, keeping the interpolation bracketing pair with `pop_present`, and
+  applying a registered interpolation function.
+
+These tests warm up with 100 messages/ticks and measure the following 1,000. The warmup lets
+message queues, `Writer`, and `VecDeque` history buffers reach their steady capacities before
+measurement starts.
+
+These tests intentionally do not claim that every component/message type is allocation-free.
+`Vec`, `String`, `Bytes` payload slicing, serde formats, or custom interpolation/prediction code can
+allocate. Component clones in prediction, interpolation, and frame interpolation are only
+heap-allocation-free when the component's `Clone` is heap-allocation-free.
+
+Production prediction now prunes component histories after
+`PredictionManager.rollback_policy.max_rollback_ticks + PREDICTION_HISTORY_TICK_MARGIN`. The prune
+applies to `PredictionHistory<C>` and compacts prediction-side `ConfirmedHistory<C>` to an anchor at
+the cutoff tick, so a component whose authoritative value last changed long before the rollback
+window still has a last-confirmed value for unchanged-state comparisons.
+
+Run the higher-level allocation budget tests:
+
+```sh
+cargo test -p lightyear_messages --features test_utils --test allocation_regression -- --nocapture
+cargo test -p lightyear_prediction --test allocation_regression -- --nocapture
+cargo test -p lightyear_interpolation --test allocation_regression -- --nocapture
+```
+
+Run the higher-level DHAT heap profiles:
+
+```sh
+cargo test -p lightyear_messages --features test_utils --test dhat_message_loop -- --ignored --nocapture
+cargo test -p lightyear_prediction --test dhat_prediction_history_loop -- --ignored --nocapture
+cargo test -p lightyear_interpolation --test dhat_interpolation_history_loop -- --ignored --nocapture
+```
+
+The DHAT runs write:
+
+```text
+target/dhat-message-loop.json
+target/dhat-prediction-history-loop.json
+target/dhat-interpolation-history-loop.json
+```
+
+Higher-level observed results on 2026-06-26:
+
+- message queue loop: `stats_alloc` 0 allocations, 0 reallocations, 0 allocated bytes; `dhat-rs`
+  0 blocks, 0 total bytes.
+- message serialization loop: `stats_alloc` 0 allocations, 0 reallocations, 0 allocated bytes;
+  included in the message DHAT run, which reported 0 blocks and 0 total bytes for the combined
+  message measured region.
+- prediction history loop: `stats_alloc` 0 allocations, 0 reallocations, 0 allocated bytes;
+  `dhat-rs` 0 blocks, 0 total bytes.
+- interpolation history loop: `stats_alloc` 0 allocations, 0 reallocations, 0 allocated bytes;
+  `dhat-rs` 0 blocks, 0 total bytes.
+
+## Full Integration Profile
+
+The focused tests above intentionally isolate hot loops. To measure the actual client/server stack,
+run the ignored integration profile:
+
+```sh
+cargo test -p lightyear_tests --features test_utils --test client_server_allocation -- --ignored --test-threads=1 --nocapture
+```
+
+This warms up 100 client-to-server `StringMessage` frames, then measures 1,000 more frames through
+the real client/server apps, netcode connection, crossbeam IO, link, transport, message
+serialization, and message receive systems. Test message construction happens before the measured
+region.
+
+Observed on 2026-06-26:
+
+- allocations: `849215`
+- reallocations: `5015`
+- allocated bytes: `456338748`
+
+This is a diagnostic profile, not a CI budget. It measures the whole app/update stack, including
+Bevy schedule work, message string deserialization, netcode, metrics/logging infrastructure, and
+transport/link ownership transfers. Use it to spot large regressions or to decide where a DHAT run
+would be useful; keep the focused hot-loop tests as the zero-allocation guardrails.
+
+## Known Hot Sites
+
+- Accepted production packets are converted to `Bytes` before upload to `Link`, so their payload
+  buffers are not returned to the builder pool.
+- `Bytes::from(Vec<u8>)` allocates shared metadata when the vector capacity is larger than its
+  length. Avoiding `shrink_to_fit` removes the large resize/copy, but the accepted production send
+  path still needs a better ownership model for complete reuse.
+- Compression-aware packing clones candidate payloads and compression allocates output buffers.
+- Fragment send/reassembly allocates fragment metadata and a contiguous receive buffer.
+- Message sender/receiver buffers grow to the largest per-frame burst they have seen. That is a
+  cached allocation, but burst sizes above the warm capacity will allocate.
+- The full `MessagePlugin::send` production path continues into transport channel buffering. The
+  higher-level message serialization fixture stops before transport so it can isolate typed message
+  work.
+- Prediction histories are pruned in production according to the configured rollback window. Custom
+  history buffers or callers that bypass the prediction plugin still need their own retention policy.
+- Interpolation histories keep a bracketing pair in steady state. Diff interpolation can retain more
+  state while pending diffs are waiting for an older base.
+- Prediction correction, interpolation sampling, and frame interpolation clone component values.
+  Heap-owning component fields make those clones allocate unless the component uses its own reuse
+  strategy.
+
+## Next Steps
+
+1. Decide whether `Link` should accept a reusable payload type, or whether IO backends should write
+   from the packet buffer before it is recycled.
+2. Add separate budget tests for compression, fragmentation, reliable resend, netcode, and full
+   transport-to-link production send.
+3. Consider replacing compression candidate cloning with reusable scratch buffers.
+4. Add broader but budgeted Bevy schedule allocation tests only after separating expected Bevy
+   scheduler/cache allocations from Lightyear hot-path allocations.

--- a/examples/avian_2d/Cargo.toml
+++ b/examples/avian_2d/Cargo.toml
@@ -46,7 +46,7 @@ bevy.workspace = true
 [package.metadata.bevy_cli.web]
 rustflags = ["--cfg", "getrandom_backend=\"wasm_js\""]
 default-features = false
-features = ["client", "netcode", "webtransport"]
+features = ["client", "gui", "netcode", "webtransport"]
 
 [lints]
 workspace = true

--- a/examples/avian_2d/src/protocol.rs
+++ b/examples/avian_2d/src/protocol.rs
@@ -72,6 +72,8 @@ impl Plugin for ProtocolPlugin {
         });
 
         // components
+        app.component::<Name>().replicate();
+
         app.component::<PlayerId>().replicate();
 
         app.component::<ColorComponent>().replicate();

--- a/examples/avian_3d/Cargo.toml
+++ b/examples/avian_3d/Cargo.toml
@@ -51,7 +51,7 @@ console_error_panic_hook.workspace = true
 [package.metadata.bevy_cli.web]
 rustflags = ["--cfg", "getrandom_backend=\"wasm_js\""]
 default-features = false
-features = ["client", "netcode", "webtransport"]
+features = ["client", "gui", "netcode", "webtransport"]
 
 [lints]
 workspace = true

--- a/examples/bevy_enhanced_inputs/Cargo.toml
+++ b/examples/bevy_enhanced_inputs/Cargo.toml
@@ -43,7 +43,7 @@ bevy.workspace = true
 [package.metadata.bevy_cli.web]
 rustflags = ["--cfg", "getrandom_backend=\"wasm_js\""]
 default-features = false
-features = ["client", "netcode", "webtransport"]
+features = ["client", "gui", "netcode", "webtransport"]
 
 [lints]
 workspace = true

--- a/examples/delta_compression/Cargo.toml
+++ b/examples/delta_compression/Cargo.toml
@@ -38,7 +38,7 @@ bevy_replicon.workspace = true
 [package.metadata.bevy_cli.web]
 rustflags = ["--cfg", "getrandom_backend=\"wasm_js\""]
 default-features = false
-features = ["client", "netcode", "webtransport"]
+features = ["client", "gui", "netcode", "webtransport"]
 
 
 [lints]

--- a/examples/deterministic_replication/Cargo.toml
+++ b/examples/deterministic_replication/Cargo.toml
@@ -50,7 +50,7 @@ bevy_replicon.workspace = true
 [package.metadata.bevy_cli.web]
 rustflags = ["--cfg", "getrandom_backend=\"wasm_js\""]
 default-features = false
-features = ["client", "netcode", "webtransport"]
+features = ["client", "gui", "netcode", "webtransport"]
 
 [lints]
 workspace = true

--- a/examples/deterministic_replication/src/client.rs
+++ b/examples/deterministic_replication/src/client.rs
@@ -14,11 +14,6 @@ pub struct ExampleClientPlugin;
 impl Plugin for ExampleClientPlugin {
     fn build(&self, app: &mut App) {
         app.add_plugins(AutomationClientPlugin);
-        if !app
-            .is_plugin_added::<lightyear_deterministic_replication::prelude::ChecksumSendPlugin>()
-        {
-            app.add_plugins(lightyear_deterministic_replication::prelude::ChecksumSendPlugin);
-        }
         // LateJoinCatchUpPlugin itself is added by ProtocolPlugin (in
         // SharedPlugin) so message registration precedes client-entity
         // spawn in `cli.spawn_connections`.

--- a/examples/deterministic_replication/src/protocol.rs
+++ b/examples/deterministic_replication/src/protocol.rs
@@ -8,7 +8,7 @@ use leafwing_input_manager::prelude::*;
 use lightyear::input::config::InputConfig;
 use lightyear::prelude::input::leafwing;
 use lightyear::prelude::*;
-use lightyear_deterministic_replication::prelude::{AppCatchUpExt, CatchUpGated};
+use lightyear_deterministic_replication::prelude::{AppCatchUpExt, CatchUpGated, ChecksumPlugin};
 use serde::{Deserialize, Serialize};
 
 pub const BALL_SIZE: f32 = 15.0;
@@ -89,6 +89,7 @@ impl Plugin for ProtocolPlugin {
                 ..default()
             },
         });
+        app.add_plugins(ChecksumPlugin);
 
         // Late-join catch-up: shared between client and server so it must
         // be registered before `cli.spawn_connections` adds the Client /

--- a/examples/deterministic_replication/src/server.rs
+++ b/examples/deterministic_replication/src/server.rs
@@ -16,12 +16,6 @@ pub struct ExampleServerPlugin;
 impl Plugin for ExampleServerPlugin {
     fn build(&self, app: &mut App) {
         app.add_plugins(AutomationServerPlugin);
-        if !app
-            .is_plugin_added::<lightyear_deterministic_replication::prelude::ChecksumReceivePlugin>(
-            )
-        {
-            app.add_plugins(lightyear_deterministic_replication::prelude::ChecksumReceivePlugin);
-        }
         app.insert_resource(ReplicationMetadata::new(SEND_INTERVAL));
         app.add_observer(handle_new_client);
         app.add_observer(handle_connected);

--- a/examples/fps/Cargo.toml
+++ b/examples/fps/Cargo.toml
@@ -48,7 +48,7 @@ bevy.workspace = true
 [package.metadata.bevy_cli.web]
 rustflags = ["--cfg", "getrandom_backend=\"wasm_js\""]
 default-features = false
-features = ["client", "netcode", "webtransport"]
+features = ["client", "gui", "netcode", "webtransport"]
 
 [lints]
 workspace = true

--- a/examples/network_visibility/Cargo.toml
+++ b/examples/network_visibility/Cargo.toml
@@ -47,7 +47,7 @@ bevy.workspace = true
 [package.metadata.bevy_cli.web]
 rustflags = ["--cfg", "getrandom_backend=\"wasm_js\""]
 default-features = false
-features = ["client", "netcode", "webtransport"]
+features = ["client", "gui", "netcode", "webtransport"]
 
 [lints]
 workspace = true

--- a/examples/priority/Cargo.toml
+++ b/examples/priority/Cargo.toml
@@ -44,7 +44,7 @@ bevy.workspace = true
 [package.metadata.bevy_cli.web]
 rustflags = ["--cfg", "getrandom_backend=\"wasm_js\""]
 default-features = false
-features = ["client", "netcode", "webtransport"]
+features = ["client", "gui", "netcode", "webtransport"]
 
 [lints]
 workspace = true

--- a/examples/projectiles/Cargo.toml
+++ b/examples/projectiles/Cargo.toml
@@ -46,7 +46,7 @@ bevy.workspace = true
 [package.metadata.bevy_cli.web]
 rustflags = ["--cfg", "getrandom_backend=\"wasm_js\""]
 default-features = false
-features = ["client", "netcode", "webtransport"]
+features = ["client", "gui", "netcode", "webtransport"]
 
 [lints]
 workspace = true

--- a/examples/replication_groups/Cargo.toml
+++ b/examples/replication_groups/Cargo.toml
@@ -50,7 +50,7 @@ bevy.workspace = true
 [package.metadata.bevy_cli.web]
 rustflags = ["--cfg", "getrandom_backend=\"wasm_js\""]
 default-features = false
-features = ["client", "netcode", "webtransport"]
+features = ["client", "gui", "netcode", "webtransport"]
 
 [lints]
 workspace = true

--- a/examples/simple_box/Cargo.toml
+++ b/examples/simple_box/Cargo.toml
@@ -44,7 +44,7 @@ bevy.workspace = true
 [package.metadata.bevy_cli.web]
 rustflags = ["--cfg", "getrandom_backend=\"wasm_js\""]
 default-features = false
-features = ["client", "netcode", "webtransport"]
+features = ["client", "gui", "netcode", "webtransport"]
 
 [lints]
 workspace = true

--- a/examples/simple_setup/Cargo.toml
+++ b/examples/simple_setup/Cargo.toml
@@ -14,6 +14,7 @@ publish = false
 [features]
 default = ["client", "server", "netcode", "webtransport"]
 client = ["lightyear/client"]
+gui = []
 server = ["lightyear/server"]
 netcode = ["lightyear/netcode"]
 webtransport = [
@@ -43,7 +44,7 @@ async-compat.workspace = true
 [package.metadata.bevy_cli.web]
 rustflags = ["--cfg", "getrandom_backend=\"wasm_js\""]
 default-features = false
-features = ["client", "netcode", "webtransport"]
+features = ["client", "gui", "netcode", "webtransport"]
 
 [lints]
 workspace = true

--- a/justfile
+++ b/justfile
@@ -133,8 +133,11 @@ build_examples *args:
     else
         pkgs_filter='{{ _example_demo_non_projectiles_pkgs_filter }}'
     fi
-    pkgs=$(cargo metadata --no-deps --format-version 1 | jq -r "$pkgs_filter" | sort | sed 's/^/-p /' | tr "\n" " ")
-    "${cargo_build[@]}" --no-default-features --features="$cargo_features" $pkgs
+    package_args=()
+    while IFS= read -r pkg; do
+        package_args+=(-p "$pkg")
+    done < <(cargo metadata --no-deps --format-version 1 | jq -r "$pkgs_filter" | sort)
+    "${cargo_build[@]}" --no-default-features --features="$cargo_features" "${package_args[@]}"
     if [ "$projectiles_features" != "$cargo_features" ]; then
         "${cargo_build[@]}" --no-default-features --features="$projectiles_features" -p projectiles
     fi
@@ -144,10 +147,10 @@ test:
     # You can't use `--all-features` because of conflict between `avian2d` and `avian3d`.
     cargo test -p lightyear --no-default-features --features="std client server replication \
     interpolation trace metrics netcode webtransport webtransport_self_signed webtransport_dangerous_configuration \
-    input_native leafwing input_bei avian2d udp websocket crossbeam steam"
+    input_native leafwing input_bei avian2d lightyear_avian2d/f32 udp websocket crossbeam steam"
     cargo test -p lightyear --no-default-features --features="std client server replication \
     interpolation trace metrics netcode webtransport webtransport_self_signed webtransport_dangerous_configuration \
-    input_native leafwing input_bei avian3d udp websocket crossbeam steam"
+    input_native leafwing input_bei avian3d lightyear_avian3d/f32 udp websocket crossbeam steam"
     cargo test -p lightyear_aeronet --all-features
     # You can't use `--all-features` because of conflict between `avian2d` and `avian3d`.
     cargo test -p lightyear_avian --no-default-features --features="std 2d lag_compensation"
@@ -195,8 +198,8 @@ lightyear:
     cargo clippy -p lightyear --no-default-features --features="std input_native" -- -D warnings --no-deps
     cargo clippy -p lightyear --no-default-features --features="std leafwing" -- -D warnings --no-deps
     cargo clippy -p lightyear --no-default-features --features="std input_bei" -- -D warnings --no-deps
-    cargo clippy -p lightyear --no-default-features --features="avian2d" -- -D warnings --no-deps
-    cargo clippy -p lightyear --no-default-features --features="avian3d" -- -D warnings --no-deps
+    cargo clippy -p lightyear --no-default-features --features="avian2d lightyear_avian2d/f32" -- -D warnings --no-deps
+    cargo clippy -p lightyear --no-default-features --features="avian3d lightyear_avian3d/f32" -- -D warnings --no-deps
     cargo clippy -p lightyear --no-default-features --features="udp" -- -D warnings --no-deps
     cargo clippy -p lightyear --no-default-features --features="websocket" -- -D warnings --no-deps
     cargo clippy -p lightyear --no-default-features --features="std crossbeam" -- -D warnings --no-deps
@@ -204,10 +207,10 @@ lightyear:
     # You can't use `--all-features` because of conflict between `avian2d` and `avian3d`
     cargo clippy -p lightyear --no-default-features --features="std client server replication \
     interpolation trace metrics netcode webtransport webtransport_self_signed webtransport_dangerous_configuration \
-    input_native leafwing input_bei avian2d udp websocket crossbeam steam" -- -D warnings --no-deps
+    input_native leafwing input_bei avian2d lightyear_avian2d/f32 udp websocket crossbeam steam" -- -D warnings --no-deps
     cargo clippy -p lightyear --no-default-features --features="std client server replication \
     interpolation trace metrics netcode webtransport webtransport_self_signed webtransport_dangerous_configuration \
-    input_native leafwing input_bei avian3d udp websocket crossbeam steam" -- -D warnings --no-deps
+    input_native leafwing input_bei avian3d lightyear_avian3d/f32 udp websocket crossbeam steam" -- -D warnings --no-deps
     # cargo clippy -p lightyear --tests --no-default-features -- -D warnings --no-deps
     cargo clippy -p lightyear --tests --no-default-features --features="std" -- -D warnings --no-deps
     cargo clippy -p lightyear --tests --no-default-features --features="std client" -- -D warnings --no-deps
@@ -224,8 +227,8 @@ lightyear:
     cargo clippy -p lightyear --tests --no-default-features --features="std input_native" -- -D warnings --no-deps
     cargo clippy -p lightyear --tests --no-default-features --features="std leafwing" -- -D warnings --no-deps
     cargo clippy -p lightyear --tests --no-default-features --features="std input_bei" -- -D warnings --no-deps
-    cargo clippy -p lightyear --tests --no-default-features --features="avian2d" -- -D warnings --no-deps
-    cargo clippy -p lightyear --tests --no-default-features --features="avian3d" -- -D warnings --no-deps
+    cargo clippy -p lightyear --tests --no-default-features --features="avian2d lightyear_avian2d/f32" -- -D warnings --no-deps
+    cargo clippy -p lightyear --tests --no-default-features --features="avian3d lightyear_avian3d/f32" -- -D warnings --no-deps
     cargo clippy -p lightyear --tests --no-default-features --features="udp" -- -D warnings --no-deps
     cargo clippy -p lightyear --tests --no-default-features --features="websocket" -- -D warnings --no-deps
     cargo clippy -p lightyear --tests --no-default-features --features="std crossbeam" -- -D warnings --no-deps
@@ -233,10 +236,10 @@ lightyear:
     # You can't use `--all-features` because of conflict between `avian2d` and `avian3d`
     cargo clippy -p lightyear --tests --no-default-features --features="std client server replication \
     interpolation trace metrics netcode webtransport webtransport_self_signed webtransport_dangerous_configuration \
-    input_native leafwing input_bei avian2d udp websocket crossbeam steam" -- -D warnings --no-deps
+    input_native leafwing input_bei avian2d lightyear_avian2d/f32 udp websocket crossbeam steam" -- -D warnings --no-deps
     cargo clippy -p lightyear --tests --no-default-features --features="std client server replication \
     interpolation trace metrics netcode webtransport webtransport_self_signed webtransport_dangerous_configuration \
-    input_native leafwing input_bei avian3d udp websocket crossbeam steam" -- -D warnings --no-deps
+    input_native leafwing input_bei avian3d lightyear_avian3d/f32 udp websocket crossbeam steam" -- -D warnings --no-deps
 
 lightyear_aeronet:
     cargo clippy -p lightyear_aeronet --no-default-features -- -D warnings --no-deps


### PR DESCRIPTION
- make sure that checksum messages are registered on both client and server when ChecksumPlugin is enabled
- fixed bug that would let older input mismatches get checked again
- make sure that 'gui' is enabled when building wasm
- make sure to register leafwing messages on the client at 'build' time, similar to the server (as opposed to 'finish' time)