### PR TITLE
refactor(transport): make packet assembly transactional

### DIFF
--- a/crates/core/lightyear/src/protocol.rs
+++ b/crates/core/lightyear/src/protocol.rs
@@ -88,6 +88,7 @@ impl Plugin for ProtocolCheckPlugin {
             mode: ChannelMode::UnorderedReliable(ReliableSettings::default()),
             send_frequency: Duration::default(),
             priority: 10.0,
+            ..Default::default()
         })
         .add_direction(NetworkDirection::Bidirectional);
 

--- a/crates/core/sync/src/ping/plugin.rs
+++ b/crates/core/sync/src/ping/plugin.rs
@@ -149,6 +149,7 @@ impl Plugin for PingPlugin {
             send_frequency: Duration::default(),
             // we always want to include the ping in the packet
             priority: f32::INFINITY,
+            ..Default::default()
         })
         .add_direction(NetworkDirection::Bidirectional);
         app.register_message_to_bytes::<Ping>()

--- a/crates/inputs/inputs/src/plugin.rs
+++ b/crates/inputs/inputs/src/plugin.rs
@@ -37,6 +37,8 @@ impl<S: ActionStateSequence + MapEntities> Plugin for InputPlugin<S> {
             send_frequency: Duration::default(),
             // we always want to include the inputs in the packet
             priority: f32::INFINITY,
+            // Inputs produced on a later frame supersede a locally unsent input message.
+            retry_unsent_messages: false,
         })
         // bidirectional in case of rebroadcasting inputs
         .add_direction(NetworkDirection::Bidirectional);

--- a/crates/replication/replication/src/authority.rs
+++ b/crates/replication/replication/src/authority.rs
@@ -197,6 +197,7 @@ impl Plugin for AuthorityPlugin {
             mode: ChannelMode::SequencedReliable(ReliableSettings::default()),
             send_frequency: Default::default(),
             priority: 10.0,
+            ..Default::default()
         })
         .add_direction(NetworkDirection::Bidirectional);
         app.register_event::<AuthorityTransferEvent>()

--- a/crates/replication/replication/src/channels.rs
+++ b/crates/replication/replication/src/channels.rs
@@ -57,10 +57,13 @@ impl Plugin for RepliconChannelRegistrationPlugin {
         .add_direction(NetworkDirection::Bidirectional);
 
         // ServerChannel::Mutations - Unreliable, Bidirectional
-        // Low priority: component mutations can be delayed if bandwidth is limited
+        // Low priority: component mutations can be dropped if bandwidth is limited because a
+        // later mutation contains fresher state.
         app.add_channel::<RepliconMutationsChannel>(ChannelSettings {
             mode: ChannelMode::UnorderedUnreliable,
             priority: 1.0,
+            // A later mutation contains fresher component state, so do not build a stale backlog.
+            retry_unsent_messages: false,
             ..Default::default()
         })
         .add_direction(NetworkDirection::Bidirectional);

--- a/crates/replication/replication/src/metadata.rs
+++ b/crates/replication/replication/src/metadata.rs
@@ -134,6 +134,7 @@ impl Plugin for MetadataPlugin {
             mode: ChannelMode::UnorderedReliable(ReliableSettings::default()),
             send_frequency: Duration::default(),
             priority: 10.0,
+            ..Default::default()
         });
         app.register_event_to_bytes::<SenderMetadata>()
             .add_direction(NetworkDirection::Bidirectional);

--- a/crates/transport/transport/src/channel/builder.rs
+++ b/crates/transport/transport/src/channel/builder.rs
@@ -7,7 +7,7 @@ use crate::packet::compression::CompressionConfig;
 use crate::packet::message::{MessageAck, MessageId};
 use crate::packet::packet::PacketId;
 use crate::packet::packet_builder::{PacketBuilder, RecvPayload};
-use crate::packet::priority_manager::PriorityManager;
+use crate::packet::priority_manager::{BandwidthLimiter, PriorityManager};
 use bevy_ecs::component::Component;
 use bevy_platform::collections::HashMap;
 use bytes::Bytes;
@@ -42,6 +42,15 @@ pub struct ChannelSettings {
     ///
     /// See [`PriorityManager`] for more information.
     pub priority: f32,
+    /// Whether unreliable messages that could not be admitted by the bandwidth limiter should
+    /// remain queued for a later send flush.
+    ///
+    /// This only controls local bandwidth admission. Once a message enters `Link.send`, network
+    /// retransmission behavior is determined by [`ChannelMode`]. Reliable channels always retain
+    /// locally unsent messages regardless of this setting. If any fragment of an unreliable
+    /// message has already been admitted, its remaining fragments are also retained to avoid
+    /// guaranteeing an incomplete local send.
+    pub retry_unsent_messages: bool,
 }
 
 impl Default for ChannelSettings {
@@ -50,6 +59,7 @@ impl Default for ChannelSettings {
             mode: ChannelMode::UnorderedUnreliable,
             send_frequency: Duration::default(),
             priority: 1.0,
+            retry_unsent_messages: true,
         }
     }
 }
@@ -62,6 +72,8 @@ pub struct Transport {
     pub senders: HashMap<ChannelKind, SenderMetadata>,
     /// PriorityManager shared between all channels of this transport
     pub priority_manager: PriorityManager,
+    /// Bandwidth admission is separate from priority ordering and uses final packet bytes.
+    pub(crate) bandwidth_limiter: BandwidthLimiter,
     /// PacketBuilder shared between all channels of this transport
     pub(crate) packet_manager: PacketBuilder,
     pub compression: CompressionConfig,
@@ -92,10 +104,12 @@ pub struct Transport {
 impl Transport {
     pub fn new(priority_config: PriorityConfig) -> Self {
         let (send_channel, recv_channel) = crossbeam_channel::unbounded();
+        let bandwidth_limiter = BandwidthLimiter::new(priority_config.clone());
         Self {
             receivers: Default::default(),
             senders: Default::default(),
             priority_manager: PriorityManager::new(priority_config),
+            bandwidth_limiter,
             packet_manager: PacketBuilder::default(),
             compression: CompressionConfig::default(),
             packet_to_message_map: Default::default(),
@@ -272,9 +286,12 @@ impl Transport {
                 name: s.name.clone(),
             };
         });
-        self.priority_manager = Default::default();
+        let priority_config = self.priority_manager.config.clone();
+        self.priority_manager = PriorityManager::new(priority_config.clone());
+        self.bandwidth_limiter = BandwidthLimiter::new(priority_config);
         self.packet_manager = Default::default();
         self.packet_to_message_map = Default::default();
+        self.fragment_acks.clear();
         let (send_channel, recv_channel) = crossbeam_channel::unbounded();
         self.send_channel = send_channel;
         self.recv_channel = recv_channel;
@@ -441,7 +458,6 @@ mod tests {
     };
     use crate::packet::packet::{FRAGMENT_SIZE, Packet};
     use crate::packet::packet_type::PacketType;
-    use alloc::collections::VecDeque;
     use bytes::Bytes;
     use lightyear_core::tick::Tick;
     use lightyear_serde::reader::{ReadInteger, Reader};
@@ -482,22 +498,22 @@ mod tests {
             .unwrap()
             .unwrap();
 
-        let sender = &mut sender_transport
+        let mut candidates = vec![];
+        sender_transport
             .senders
             .get_mut(&channel_kind)
             .unwrap()
-            .sender;
-        let (single_messages, fragment_messages) = sender.send_packet();
-        assert!(single_messages.is_empty());
-        assert!(!fragment_messages.is_empty());
+            .sender
+            .collect_send_candidates(channel_kind, channel_id, &mut candidates);
+        assert!(!candidates.is_empty());
 
-        let fragments = fragment_messages
-            .into_iter()
-            .map(|message| match message.data {
+        let fragments = candidates
+            .iter()
+            .map(|candidate| match &candidate.message.data {
                 MessageData::Fragment(fragment) => fragment,
                 MessageData::Single(_) => panic!("oversized message should be fragmented"),
             })
-            .collect::<VecDeque<_>>();
+            .collect::<Vec<_>>();
         assert!(fragments.len() < 3);
         assert_eq!(fragments[0].compression, Some(FragmentCompression::Lz4));
         assert!(
@@ -507,15 +523,20 @@ mod tests {
                 .all(|fragment| fragment.compression.is_none())
         );
 
-        let packets = sender_transport
-            .packet_manager
-            .build_packets_with_compression(
-                Duration::default(),
-                Tick(0),
-                vec![],
-                vec![(channel_id, fragments)],
-                compression,
-            )?;
+        let mut cursor = crate::packet::packet_builder::CandidateCursor::default();
+        let mut packets = vec![];
+        while let Some(packet) = sender_transport.packet_manager.build_next_packet(
+            Tick(0),
+            &candidates,
+            &mut cursor,
+            compression,
+        )? {
+            sender_transport
+                .packet_manager
+                .header_manager
+                .commit_send_packet(packet.packet_id, Duration::default());
+            packets.push(packet);
+        }
         assert!(!packets.is_empty());
 
         for packet in packets {
@@ -555,31 +576,33 @@ mod tests {
                 .unwrap();
         }
 
-        let sender = &mut transport.senders.get_mut(&channel_kind).unwrap().sender;
-        let (single_messages, fragment_messages) = sender.send_packet();
-        assert_eq!(single_messages.len(), 8);
-        assert!(fragment_messages.is_empty());
+        let candidates = transport.priority_manager.candidates_mut();
         transport
-            .priority_manager
-            .buffer_messages(channel_id, single_messages, fragment_messages);
+            .senders
+            .get_mut(&channel_kind)
+            .unwrap()
+            .sender
+            .collect_send_candidates(channel_kind, channel_id, candidates);
+        assert_eq!(transport.priority_manager.candidates().len(), 8);
+        transport.priority_manager.prioritize(&registry);
+        let mut cursor = crate::packet::packet_builder::CandidateCursor::default();
+        let packet = transport
+            .packet_manager
+            .build_next_packet(
+                Tick(0),
+                transport.priority_manager.candidates(),
+                &mut cursor,
+                compression,
+            )?
+            .unwrap();
 
-        let (single_data, fragment_data) = transport.priority_manager.prioritize(&registry);
-        let packets = transport.packet_manager.build_packets_with_compression(
-            Duration::default(),
-            Tick(0),
-            single_data,
-            fragment_data,
-            compression,
-        )?;
-
-        assert_eq!(packets.len(), 1);
-        assert_eq!(packets[0].num_messages(), 8);
-        assert!(packets[0].compression.is_some());
-        assert!(packets[0].payload.len() <= 600);
+        assert_eq!(packet.num_messages(), 8);
+        assert!(packet.compression.is_some());
+        assert!(packet.payload.len() <= 600);
         assert!(
             transport
-                .priority_manager
-                .consume_packet_quota(packets[0].payload.len() as u32)
+                .bandwidth_limiter
+                .consume_packet_quota(packet.payload.len() as u32)
         );
         Ok(())
     }

--- a/crates/transport/transport/src/channel/builder.rs
+++ b/crates/transport/transport/src/channel/builder.rs
@@ -322,53 +322,6 @@ pub struct SenderMetadata {
     pub(crate) name: DebugName,
 }
 
-// fn on_add<C: Channel>(mut world: DeferredWorld, context: HookContext) {
-//     let entity = context.entity;
-//     let mut registry = world.resource_mut::<ChannelRegistry>();
-//     // TODO: merge settings and SenderId in a SenderMetadata so that we don't fetch twice
-//     let Some(settings) = registry.settings::<C>() else {
-//         panic!("ChannelSettings not found for channel {}", DebugName::type_name::<C>());
-//     };
-//     let sender_id = registry.get_sender_id::<C>().unwrap();
-//     let channel_id = *registry.get_net_from_kind(&ChannelKind::of::<C>()).unwrap();
-//     let receiver: ChannelReceiverEnum;
-//     let sender: ChannelSenderEnum;
-//     let mode = settings.mode;
-//     match settings.mode {
-//         ChannelMode::UnorderedUnreliableWithAcks => {
-//             receiver = UnorderedUnreliableReceiver::new().into();
-//             sender = UnorderedUnreliableWithAcksSender::new(settings.send_frequency).into();
-//         }
-//         ChannelMode::UnorderedUnreliable => {
-//             receiver = UnorderedUnreliableReceiver::new().into();
-//             sender = UnorderedUnreliableSender::new(settings.send_frequency).into();
-//         }
-//         ChannelMode::SequencedUnreliable => {
-//             receiver = SequencedUnreliableReceiver::new().into();
-//             sender = SequencedUnreliableSender::new(settings.send_frequency).into();
-//         }
-//         ChannelMode::UnorderedReliable(reliable_settings) => {
-//             receiver = UnorderedReliableReceiver::new().into();
-//             sender = ReliableSender::new(reliable_settings, settings.send_frequency).into();
-//         }
-//         ChannelMode::SequencedReliable(reliable_settings) => {
-//             receiver = SequencedReliableReceiver::new().into();
-//             sender = ReliableSender::new(reliable_settings, settings.send_frequency).into();
-//         }
-//         ChannelMode::OrderedReliable(reliable_settings) => {
-//             receiver = OrderedReliableReceiver::new().into();
-//             sender = ReliableSender::new(reliable_settings, settings.send_frequency).into();
-//         }
-//     }
-//     let mut entity_mut = world.entity_mut(entity);
-//     let mut channel_sender = entity_mut.get_mut::<ChannelSender<C>>().unwrap();
-//     channel_sender.sender = sender;
-//     channel_sender.channel_id = channel_id;
-//     let mut transport = entity_mut.get_mut::<Transport>().unwrap();
-//     transport.add_sender::<C>(sender_id, mode);
-//     transport.receivers.insert(channel_id, receiver);
-// }
-
 #[derive(Clone, Copy, Debug, PartialEq)]
 /// ChannelMode specifies how messages are sent and received
 /// See more information [here](https://web.archive.org/web/20250113064633/http://www.jenkinssoftware.com/raknet/manual/reliabilitytypes.html)
@@ -438,13 +391,6 @@ impl ReliableSettings {
         core::cmp::max(delay, self.rtt_resend_min_delay)
     }
 }
-
-/// Default channel to send inputs from client to server. This is a Sequenced Unreliable channel.
-pub struct InputChannel;
-
-/// Channel to send messages related to Authority transfers
-/// This is an Ordered Reliable channel
-pub struct AuthorityChannel;
 
 #[cfg(all(test, feature = "compression_lz4"))]
 mod tests {

--- a/crates/transport/transport/src/channel/senders/fragment_ack_receiver.rs
+++ b/crates/transport/transport/src/channel/senders/fragment_ack_receiver.rs
@@ -23,6 +23,10 @@ impl FragmentAckReceiver {
             .or_insert_with(|| FragmentAckTracker::new(num_fragments));
     }
 
+    pub fn discard_message(&mut self, message_id: MessageId) {
+        self.fragment_messages.remove(&message_id);
+    }
+
     /// Discard all messages for which the latest ack was received before the cleanup time
     /// (i.e. we probably lost some fragments and we will never get all the acks for this fragmented message)
     ///

--- a/crates/transport/transport/src/channel/senders/mod.rs
+++ b/crates/transport/transport/src/channel/senders/mod.rs
@@ -1,13 +1,18 @@
+use crate::channel::registry::{ChannelId, ChannelKind};
 use crate::channel::senders::reliable::ReliableSender;
 use crate::channel::senders::sequenced_unreliable::SequencedUnreliableSender;
 use crate::channel::senders::unordered_unreliable::UnorderedUnreliableSender;
 use crate::channel::senders::unordered_unreliable_with_acks::UnorderedUnreliableWithAcksSender;
 use crate::packet::compression::CompressionConfig;
-use crate::packet::message::{MessageAck, MessageId, SendMessage};
+use crate::packet::message::{
+    MessageAck, MessageData, MessageId, SendCandidate, SendMessage, SendMessageKey,
+};
 use crate::prelude::{ChannelMode, ChannelSettings};
 use alloc::collections::VecDeque;
+use alloc::vec::Vec;
 use bevy_time::{Real, Time};
 use bytes::Bytes;
+use core::time::Duration;
 use enum_dispatch::enum_dispatch;
 use lightyear_link::LinkStats;
 
@@ -18,13 +23,20 @@ pub(crate) mod sequenced_unreliable;
 pub(crate) mod unordered_unreliable;
 pub(crate) mod unordered_unreliable_with_acks;
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum SendFlushOutcome {
+    Complete,
+    BandwidthLimited,
+    StagingFailed,
+}
+
 // TODO: separate trait into multiple traits
 // - buffer send should be public
 // - all other methods should be private
 /// A trait for sending messages to a channel.
 /// A channel is a buffer over packets to be able to add ordering/reliability
 #[enum_dispatch]
-pub trait ChannelSend {
+pub(crate) trait ChannelSend {
     /// Bookkeeping for the channel
     fn update(&mut self, real_time: &Time<Real>, link_stats: &LinkStats);
 
@@ -39,12 +51,92 @@ pub trait ChannelSend {
         compression: CompressionConfig,
     ) -> Option<MessageId>;
 
-    /// Reads from the buffer of messages to send to prepare a list of Packets
-    /// that can be sent over the network for this channel
-    fn send_packet(&mut self) -> (VecDeque<SendMessage>, VecDeque<SendMessage>);
+    /// Append cheap snapshots of the messages which are currently eligible for packet staging.
+    ///
+    /// This must not remove messages or mark them as sent. Packet building and bandwidth admission
+    /// are speculative until [`Self::commit_send`] is called.
+    fn collect_send_candidates(
+        &mut self,
+        channel_kind: ChannelKind,
+        channel_id: ChannelId,
+        output: &mut Vec<SendCandidate>,
+    );
+
+    /// Commit one candidate after the packet containing it has entered `Link.send`.
+    fn commit_send(&mut self, key: SendMessageKey, sent_at: Duration);
+
+    /// Finish a send flush and apply the channel's local admission policy.
+    fn finish_send(&mut self, outcome: SendFlushOutcome);
 
     /// Called when we receive acknowledgement that a Message has been received
     fn receive_ack(&mut self, message_ack: &MessageAck);
+}
+
+/// Channel-owned state for an unreliable message during speculative packet staging.
+///
+/// A completed flush removes admitted entries and either retains or discards unadmitted entries
+/// according to [`ChannelSettings::retry_unsent_messages`].
+#[derive(Debug)]
+pub(super) struct PendingSendMessage {
+    pub(super) message: SendMessage,
+    pub(super) stable_order: u64,
+    pub(super) committed: bool,
+    /// Once one fragment is admitted, retain the rest even on a discard-unsent channel so the
+    /// local sender does not guarantee an incomplete fragmented message.
+    pub(super) fragment_started: bool,
+}
+
+impl PendingSendMessage {
+    pub(super) fn new(message: SendMessage, stable_order: u64) -> Self {
+        Self {
+            message,
+            stable_order,
+            committed: false,
+            fragment_started: false,
+        }
+    }
+
+    pub(super) fn fragment_message_id(&self) -> Option<MessageId> {
+        let MessageData::Fragment(fragment) = &self.message.data else {
+            return None;
+        };
+        Some(fragment.message_id)
+    }
+}
+
+pub(super) fn commit_unreliable_candidate(
+    single_messages: &mut VecDeque<PendingSendMessage>,
+    fragmented_messages: &mut VecDeque<PendingSendMessage>,
+    key: SendMessageKey,
+) -> bool {
+    match key {
+        SendMessageKey::UnreliableSingle(index) => {
+            let Some(pending) = single_messages.get_mut(index) else {
+                return false;
+            };
+            pending.committed = true;
+        }
+        SendMessageKey::UnreliableFragment(index) => {
+            let Some(pending) = fragmented_messages.get_mut(index) else {
+                return false;
+            };
+            let message_id = pending
+                .fragment_message_id()
+                .expect("fragment queue must contain fragment data");
+            let mark_message_started = !pending.fragment_started;
+            pending.committed = true;
+
+            if mark_message_started {
+                for pending in fragmented_messages {
+                    if pending.fragment_message_id() == Some(message_id) {
+                        pending.fragment_started = true;
+                    }
+                }
+            }
+        }
+        _ => return false,
+    }
+    true
 }
 
 /// Enum dispatch lets us derive ChannelSend on each enum variant
@@ -60,15 +152,21 @@ pub enum ChannelSenderEnum {
 impl From<&ChannelSettings> for ChannelSenderEnum {
     fn from(settings: &ChannelSettings) -> Self {
         match settings.mode {
-            ChannelMode::UnorderedUnreliableWithAcks => {
-                UnorderedUnreliableWithAcksSender::new(settings.send_frequency).into()
-            }
-            ChannelMode::UnorderedUnreliable => {
-                UnorderedUnreliableSender::new(settings.send_frequency).into()
-            }
-            ChannelMode::SequencedUnreliable => {
-                SequencedUnreliableSender::new(settings.send_frequency).into()
-            }
+            ChannelMode::UnorderedUnreliableWithAcks => UnorderedUnreliableWithAcksSender::new(
+                settings.send_frequency,
+                settings.retry_unsent_messages,
+            )
+            .into(),
+            ChannelMode::UnorderedUnreliable => UnorderedUnreliableSender::new(
+                settings.send_frequency,
+                settings.retry_unsent_messages,
+            )
+            .into(),
+            ChannelMode::SequencedUnreliable => SequencedUnreliableSender::new(
+                settings.send_frequency,
+                settings.retry_unsent_messages,
+            )
+            .into(),
             ChannelMode::UnorderedReliable(reliable_settings) => {
                 ReliableSender::new(reliable_settings, settings.send_frequency).into()
             }
@@ -79,5 +177,72 @@ impl From<&ChannelSettings> for ChannelSenderEnum {
                 ReliableSender::new(reliable_settings, settings.send_frequency).into()
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::channel::builder::ReliableSettings;
+
+    struct TestChannel;
+
+    #[test]
+    fn retry_unsent_messages_defaults_to_true() {
+        assert!(ChannelSettings::default().retry_unsent_messages);
+    }
+
+    #[test]
+    fn channel_setting_discards_unadmitted_unreliable_messages() {
+        for mode in [
+            ChannelMode::UnorderedUnreliable,
+            ChannelMode::SequencedUnreliable,
+            ChannelMode::UnorderedUnreliableWithAcks,
+        ] {
+            let settings = ChannelSettings {
+                mode,
+                retry_unsent_messages: false,
+                ..Default::default()
+            };
+            let mut sender = ChannelSenderEnum::from(&settings);
+            sender.buffer_send(
+                Bytes::from_static(b"stale"),
+                1.0,
+                CompressionConfig::DISABLED,
+            );
+
+            let mut candidates = Vec::new();
+            sender.collect_send_candidates(ChannelKind::of::<TestChannel>(), 0, &mut candidates);
+            assert_eq!(candidates.len(), 1);
+            sender.finish_send(SendFlushOutcome::BandwidthLimited);
+
+            candidates.clear();
+            sender.collect_send_candidates(ChannelKind::of::<TestChannel>(), 0, &mut candidates);
+            assert!(candidates.is_empty());
+        }
+    }
+
+    #[test]
+    fn reliable_messages_ignore_the_unreliable_discard_policy() {
+        let settings = ChannelSettings {
+            mode: ChannelMode::UnorderedReliable(ReliableSettings::default()),
+            retry_unsent_messages: false,
+            ..Default::default()
+        };
+        let mut sender = ChannelSenderEnum::from(&settings);
+        sender.buffer_send(
+            Bytes::from_static(b"reliable"),
+            1.0,
+            CompressionConfig::DISABLED,
+        );
+
+        let mut candidates = Vec::new();
+        sender.collect_send_candidates(ChannelKind::of::<TestChannel>(), 0, &mut candidates);
+        assert_eq!(candidates.len(), 1);
+        sender.finish_send(SendFlushOutcome::BandwidthLimited);
+
+        candidates.clear();
+        sender.collect_send_candidates(ChannelKind::of::<TestChannel>(), 0, &mut candidates);
+        assert_eq!(candidates.len(), 1);
     }
 }

--- a/crates/transport/transport/src/channel/senders/mod.rs
+++ b/crates/transport/transport/src/channel/senders/mod.rs
@@ -10,7 +10,7 @@ use crate::packet::message::{
 use crate::prelude::{ChannelMode, ChannelSettings};
 use alloc::collections::VecDeque;
 use alloc::vec::Vec;
-use bevy_time::{Real, Time};
+use bevy_time::{Real, Time, Timer};
 use bytes::Bytes;
 use core::time::Duration;
 use enum_dispatch::enum_dispatch;
@@ -79,7 +79,6 @@ pub(crate) trait ChannelSend {
 #[derive(Debug)]
 pub(super) struct PendingSendMessage {
     pub(super) message: SendMessage,
-    pub(super) stable_order: u64,
     pub(super) committed: bool,
     /// Once one fragment is admitted, retain the rest even on a discard-unsent channel so the
     /// local sender does not guarantee an incomplete fragmented message.
@@ -87,10 +86,9 @@ pub(super) struct PendingSendMessage {
 }
 
 impl PendingSendMessage {
-    pub(super) fn new(message: SendMessage, stable_order: u64) -> Self {
+    pub(super) fn new(message: SendMessage) -> Self {
         Self {
             message,
-            stable_order,
             committed: false,
             fragment_started: false,
         }
@@ -102,6 +100,10 @@ impl PendingSendMessage {
         };
         Some(fragment.message_id)
     }
+}
+
+pub(super) fn is_ready_to_send(timer: Option<&Timer>) -> bool {
+    timer.is_none_or(Timer::is_finished)
 }
 
 pub(super) fn commit_unreliable_candidate(

--- a/crates/transport/transport/src/channel/senders/reliable.rs
+++ b/crates/transport/transport/src/channel/senders/reliable.rs
@@ -5,7 +5,7 @@ use bevy_time::{Real, Time, Timer, TimerMode};
 use crate::channel::builder::ReliableSettings;
 use crate::channel::registry::{ChannelId, ChannelKind};
 use crate::channel::senders::fragment_sender::FragmentSender;
-use crate::channel::senders::{ChannelSend, SendFlushOutcome};
+use crate::channel::senders::{ChannelSend, SendFlushOutcome, is_ready_to_send};
 use crate::packet::compression::CompressionConfig;
 use crate::packet::message::{
     FragmentData, MessageAck, MessageId, SendCandidate, SendMessage, SendMessageKey, SingleData,
@@ -147,7 +147,7 @@ impl ChannelSend for ReliableSender {
         channel_id: ChannelId,
         output: &mut Vec<SendCandidate>,
     ) {
-        if self.timer.as_ref().is_some_and(|t| !t.is_finished()) {
+        if !is_ready_to_send(self.timer.as_ref()) {
             return;
         }
 
@@ -189,7 +189,6 @@ impl ChannelSend for ReliableSender {
                             channel_kind,
                             channel_id,
                             SendMessageKey::ReliableSingle(*message_id),
-                            u64::from(message_id.0),
                             SendMessage {
                                 data: SingleData::new(Some(*message_id), bytes.clone()).into(),
                                 priority: unacked_message_with_priority.accumulated_priority,
@@ -207,7 +206,6 @@ impl ChannelSend for ReliableSender {
                                 channel_kind,
                                 channel_id,
                                 SendMessageKey::ReliableFragment(*message_id, f.data.fragment_id),
-                                u64::from(message_id.0),
                                 SendMessage {
                                     data: f.data.clone().into(),
                                     priority: unacked_message_with_priority.accumulated_priority,

--- a/crates/transport/transport/src/channel/senders/reliable.rs
+++ b/crates/transport/transport/src/channel/senders/reliable.rs
@@ -1,13 +1,15 @@
-use alloc::collections::{BTreeMap, VecDeque};
+use alloc::collections::BTreeMap;
 use alloc::vec::Vec;
-use bevy_platform::collections::HashSet;
 use bevy_time::{Real, Time, Timer, TimerMode};
 
 use crate::channel::builder::ReliableSettings;
-use crate::channel::senders::ChannelSend;
+use crate::channel::registry::{ChannelId, ChannelKind};
 use crate::channel::senders::fragment_sender::FragmentSender;
+use crate::channel::senders::{ChannelSend, SendFlushOutcome};
 use crate::packet::compression::CompressionConfig;
-use crate::packet::message::{FragmentData, MessageAck, MessageId, SendMessage, SingleData};
+use crate::packet::message::{
+    FragmentData, MessageAck, MessageId, SendCandidate, SendMessage, SendMessageKey, SingleData,
+};
 use bytes::Bytes;
 use core::time::Duration;
 use lightyear_link::LinkStats;
@@ -51,15 +53,6 @@ pub struct ReliableSender {
     /// Message id to use for the next message to be sent
     next_send_message_id: MessageId,
 
-    /// list of single messages that we want to fit into packets and send
-    single_messages_to_send: VecDeque<SendMessage>,
-    /// list of fragmented messages that we want to fit into packets and send
-    fragmented_messages_to_send: VecDeque<SendMessage>,
-
-    /// Set of message ids that we want to send (to prevent sending the same message twice)
-    /// (includes the [`FragmentIndex`](crate::packet::message::FragmentIndex) for fragments)
-    message_ids_to_send: HashSet<MessageAck>,
-
     /// Used to split a message into fragments if the message is too big
     fragment_sender: FragmentSender,
     current_rtt: Duration,
@@ -82,9 +75,6 @@ impl ReliableSender {
             reliable_settings,
             unacked_messages: Default::default(),
             next_send_message_id: MessageId(0),
-            single_messages_to_send: Default::default(),
-            fragmented_messages_to_send: Default::default(),
-            message_ids_to_send: Default::default(),
             fragment_sender: FragmentSender::new(),
             current_rtt: Duration::default(),
             current_time: Duration::default(),
@@ -151,12 +141,14 @@ impl ChannelSend for ReliableSender {
         Some(message_id)
     }
 
-    /// Take messages from the buffer of messages to be sent, and build a list of packets
-    /// to be sent
-    /// The messages to be sent need to have been collected prior to this point.
-    fn send_packet(&mut self) -> (VecDeque<SendMessage>, VecDeque<SendMessage>) {
+    fn collect_send_candidates(
+        &mut self,
+        channel_kind: ChannelKind,
+        channel_id: ChannelId,
+        output: &mut Vec<SendCandidate>,
+    ) {
         if self.timer.as_ref().is_some_and(|t| !t.is_finished()) {
-            return (VecDeque::new(), VecDeque::new());
+            return;
         }
 
         // Collect the list of messages that need to be sent
@@ -171,7 +163,7 @@ impl ChannelSend for ReliableSender {
                 // or if we sent it a while back but didn't get an ack
                 Some(last_sent) => {
                     resend_delay != Duration::default()
-                        && self.current_time - *last_sent > resend_delay
+                        && self.current_time.saturating_sub(*last_sent) > resend_delay
                 }
             }
         };
@@ -193,19 +185,16 @@ impl ChannelSend for ReliableSender {
                 UnackedMessage::Single { bytes, last_sent } => {
                     if should_send(last_sent) {
                         trace!(?last_sent, ?self.current_time, "Should send message {:?}", message_id);
-                        let message_info = MessageAck {
-                            message_id: *message_id,
-                            fragment_id: None,
-                        };
-                        if !self.message_ids_to_send.contains(&message_info) {
-                            let message = SingleData::new(Some(*message_id), bytes.clone());
-                            self.single_messages_to_send.push_back(SendMessage {
-                                data: message.into(),
+                        output.push(SendCandidate::new(
+                            channel_kind,
+                            channel_id,
+                            SendMessageKey::ReliableSingle(*message_id),
+                            u64::from(message_id.0),
+                            SendMessage {
+                                data: SingleData::new(Some(*message_id), bytes.clone()).into(),
                                 priority: unacked_message_with_priority.accumulated_priority,
-                            });
-                            self.message_ids_to_send.insert(message_info);
-                            *last_sent = Some(self.current_time);
-                        }
+                            },
+                        ));
                     }
                 }
                 UnackedMessage::Fragmented(fragment_acks) => {
@@ -214,54 +203,58 @@ impl ChannelSend for ReliableSender {
                         .iter_mut()
                         .filter(|f| !f.acked && should_send(&f.last_sent))
                         .for_each(|f| {
-                            let message_info = MessageAck {
-                                message_id: *message_id,
-                                fragment_id: Some(f.data.fragment_id),
-                            };
-                            if !self.message_ids_to_send.contains(&message_info) {
-                                let message = f.data.clone();
-                                self.fragmented_messages_to_send.push_back(SendMessage {
-                                    data: message.into(),
+                            output.push(SendCandidate::new(
+                                channel_kind,
+                                channel_id,
+                                SendMessageKey::ReliableFragment(*message_id, f.data.fragment_id),
+                                u64::from(message_id.0),
+                                SendMessage {
+                                    data: f.data.clone().into(),
                                     priority: unacked_message_with_priority.accumulated_priority,
-                                });
-                                self.message_ids_to_send.insert(message_info);
-                                f.last_sent = Some(self.current_time);
-                            }
+                                },
+                            ));
                         })
                 }
             }
         }
-
-        // TODO: is this message_ids_to_send even useful? in which situation would we send the same message twice?
-        // right now, we send everything; so we can reset
-        self.message_ids_to_send.clear();
-        if !self.single_messages_to_send.is_empty() {
-            trace!(
-                "Single messages to send: {:?}",
-                self.single_messages_to_send
-            );
-        }
-
-        // TODO: use double-buffer to reuse allocated memory?
-        (
-            core::mem::take(&mut self.single_messages_to_send),
-            core::mem::take(&mut self.fragmented_messages_to_send),
-        )
-
-        // TODO: handle if we couldn't send all messages?
-        // TODO: update message_ids_to_send?
-        // TODO: get back the list of messages we could not send?
-
-        // // build the packets from those messages
-        // let single_messages_to_send = core::mem::take(&mut self.single_messages_to_send);
-        // let (remaining_messages_to_send, sent_message_ids) =
-        //     packet_manager.pack_messages_within_channel(messages_to_send);
-        // self.messages_to_send = remaining_messages_to_send;
-        //
-        // for message_id in sent_message_ids {
-        //     self.message_ids_to_send.remove(&message_id);
-        // }
     }
+
+    fn commit_send(&mut self, key: SendMessageKey, sent_at: Duration) {
+        match key {
+            SendMessageKey::ReliableSingle(message_id) => {
+                let Some(message) = self.unacked_messages.get_mut(&message_id) else {
+                    debug_assert!(false, "missing reliable message during send commit");
+                    return;
+                };
+                let UnackedMessage::Single { last_sent, .. } = &mut message.unacked_message else {
+                    debug_assert!(false, "reliable send key did not match message shape");
+                    return;
+                };
+                *last_sent = Some(sent_at);
+            }
+            SendMessageKey::ReliableFragment(message_id, fragment_id) => {
+                let Some(message) = self.unacked_messages.get_mut(&message_id) else {
+                    debug_assert!(
+                        false,
+                        "missing fragmented reliable message during send commit"
+                    );
+                    return;
+                };
+                let UnackedMessage::Fragmented(fragments) = &mut message.unacked_message else {
+                    debug_assert!(false, "reliable fragment key did not match message shape");
+                    return;
+                };
+                let Some(fragment) = fragments.get_mut(fragment_id.0 as usize) else {
+                    debug_assert!(false, "missing reliable fragment during send commit");
+                    return;
+                };
+                fragment.last_sent = Some(sent_at);
+            }
+            _ => debug_assert!(false, "unreliable key committed to reliable sender"),
+        }
+    }
+
+    fn finish_send(&mut self, _: SendFlushOutcome) {}
 
     fn receive_ack(&mut self, message_ack: &MessageAck) {
         if let Some(unacked_message) = self.unacked_messages.get_mut(&message_ack.message_id) {
@@ -308,6 +301,8 @@ mod tests {
 
     use super::*;
 
+    struct TestChannel;
+
     #[test]
     fn test_reliable_sender_internals() {
         let mut sender = ReliableSender::new(
@@ -328,21 +323,32 @@ mod tests {
         assert_eq!(sender.unacked_messages.len(), 1);
         assert_eq!(sender.next_send_message_id, MessageId(1));
         // Collect the messages to be sent
-        let (single, _) = sender.send_packet();
-        assert_eq!(single.len(), 1);
+        let mut candidates = Vec::new();
+        sender.collect_send_candidates(ChannelKind::of::<TestChannel>(), 0, &mut candidates);
+        assert_eq!(candidates.len(), 1);
+        assert!(matches!(
+            sender.unacked_messages[&MessageId(0)].unacked_message,
+            UnackedMessage::Single {
+                last_sent: None,
+                ..
+            }
+        ));
+        sender.commit_send(candidates[0].key, sender.current_time);
 
         // Advance by a time that is below the resend threshold
         sender.current_time += Duration::from_millis(100);
-        let (single, _) = sender.send_packet();
-        assert_eq!(single.len(), 0);
+        candidates.clear();
+        sender.collect_send_candidates(ChannelKind::of::<TestChannel>(), 0, &mut candidates);
+        assert!(candidates.is_empty());
 
         // Advance by a time that is above the resend threshold
         sender.current_time += Duration::from_millis(200);
-        let (single, _) = sender.send_packet();
-        assert_eq!(single.len(), 1);
+        candidates.clear();
+        sender.collect_send_candidates(ChannelKind::of::<TestChannel>(), 0, &mut candidates);
+        assert_eq!(candidates.len(), 1);
         assert_eq!(
-            single.front().unwrap(),
-            &SendMessage {
+            candidates[0].message,
+            SendMessage {
                 data: SingleData::new(Some(MessageId(0)), message1.clone()).into(),
                 // priority is accumulated every time the message is not sent
                 priority: 3.0
@@ -358,7 +364,8 @@ mod tests {
 
         // Advance by a time that is above the resend threshold
         sender.current_time += Duration::from_millis(200);
-        let (single, _) = sender.send_packet();
-        assert_eq!(single.len(), 0);
+        candidates.clear();
+        sender.collect_send_candidates(ChannelKind::of::<TestChannel>(), 0, &mut candidates);
+        assert!(candidates.is_empty());
     }
 }

--- a/crates/transport/transport/src/channel/senders/sequenced_unreliable.rs
+++ b/crates/transport/transport/src/channel/senders/sequenced_unreliable.rs
@@ -2,6 +2,7 @@ use crate::channel::registry::{ChannelId, ChannelKind};
 use crate::channel::senders::fragment_sender::FragmentSender;
 use crate::channel::senders::{
     ChannelSend, PendingSendMessage, SendFlushOutcome, commit_unreliable_candidate,
+    is_ready_to_send,
 };
 use crate::packet::compression::CompressionConfig;
 use crate::packet::message::{
@@ -25,13 +26,11 @@ pub struct SequencedUnreliableSender {
 
     /// Message id to use for the next message to be sent
     next_send_message_id: MessageId,
-    next_send_order: u64,
     /// Used to split a message into fragments if the message is too big
     fragment_sender: FragmentSender,
     /// Internal timer to determine if the channel is ready to send messages
     timer: Option<Timer>,
     retry_unsent_messages: bool,
-    eligible_this_flush: bool,
 }
 
 impl SequencedUnreliableSender {
@@ -45,11 +44,9 @@ impl SequencedUnreliableSender {
             single_messages_to_send: VecDeque::new(),
             fragmented_messages_to_send: VecDeque::new(),
             next_send_message_id: MessageId(0),
-            next_send_order: 0,
             fragment_sender: FragmentSender::new(),
             timer,
             retry_unsent_messages,
-            eligible_this_flush: false,
         }
     }
 }
@@ -70,32 +67,24 @@ impl ChannelSend for SequencedUnreliableSender {
         compression: CompressionConfig,
     ) -> Option<MessageId> {
         let message_id = self.next_send_message_id;
-        let stable_order = self.next_send_order;
-        self.next_send_order = self.next_send_order.wrapping_add(1);
         if message.len() > self.fragment_sender.fragment_size {
             for fragment in
                 self.fragment_sender
                     .build_fragments_for_message(message_id, message, compression)
             {
                 self.fragmented_messages_to_send
-                    .push_back(PendingSendMessage::new(
-                        SendMessage {
-                            data: MessageData::Fragment(fragment),
-                            priority,
-                        },
-                        stable_order,
-                    ));
+                    .push_back(PendingSendMessage::new(SendMessage {
+                        data: MessageData::Fragment(fragment),
+                        priority,
+                    }));
             }
         } else {
             let single_data = SingleData::new(Some(message_id), message);
             self.single_messages_to_send
-                .push_back(PendingSendMessage::new(
-                    SendMessage {
-                        data: MessageData::Single(single_data),
-                        priority,
-                    },
-                    stable_order,
-                ));
+                .push_back(PendingSendMessage::new(SendMessage {
+                    data: MessageData::Single(single_data),
+                    priority,
+                }));
         }
         self.next_send_message_id += 1;
         Some(message_id)
@@ -107,10 +96,9 @@ impl ChannelSend for SequencedUnreliableSender {
         channel_id: ChannelId,
         output: &mut Vec<SendCandidate>,
     ) {
-        if self.timer.as_ref().is_some_and(|t| !t.is_finished()) {
+        if !is_ready_to_send(self.timer.as_ref()) {
             return;
         }
-        self.eligible_this_flush = true;
         output.extend(
             self.single_messages_to_send
                 .iter()
@@ -121,7 +109,6 @@ impl ChannelSend for SequencedUnreliableSender {
                         channel_kind,
                         channel_id,
                         SendMessageKey::UnreliableSingle(index),
-                        pending.stable_order,
                         pending.message.clone(),
                     )
                 }),
@@ -136,7 +123,6 @@ impl ChannelSend for SequencedUnreliableSender {
                         channel_kind,
                         channel_id,
                         SendMessageKey::UnreliableFragment(index),
-                        pending.stable_order,
                         pending.message.clone(),
                     )
                 }),
@@ -153,7 +139,7 @@ impl ChannelSend for SequencedUnreliableSender {
     }
 
     fn finish_send(&mut self, outcome: SendFlushOutcome) {
-        let discard_unsent = self.eligible_this_flush
+        let discard_unsent = is_ready_to_send(self.timer.as_ref())
             && !self.retry_unsent_messages
             && outcome == SendFlushOutcome::BandwidthLimited;
         if discard_unsent {
@@ -166,7 +152,6 @@ impl ChannelSend for SequencedUnreliableSender {
             self.fragmented_messages_to_send
                 .retain(|pending| !pending.committed);
         }
-        self.eligible_this_flush = false;
     }
 
     fn receive_ack(&mut self, _message_ack: &MessageAck) {}

--- a/crates/transport/transport/src/channel/senders/sequenced_unreliable.rs
+++ b/crates/transport/transport/src/channel/senders/sequenced_unreliable.rs
@@ -1,8 +1,14 @@
-use crate::channel::senders::ChannelSend;
+use crate::channel::registry::{ChannelId, ChannelKind};
 use crate::channel::senders::fragment_sender::FragmentSender;
+use crate::channel::senders::{
+    ChannelSend, PendingSendMessage, SendFlushOutcome, commit_unreliable_candidate,
+};
 use crate::packet::compression::CompressionConfig;
-use crate::packet::message::{MessageAck, MessageData, MessageId, SendMessage, SingleData};
+use crate::packet::message::{
+    MessageAck, MessageData, MessageId, SendCandidate, SendMessage, SendMessageKey, SingleData,
+};
 use alloc::collections::VecDeque;
+use alloc::vec::Vec;
 use bevy_time::{Real, Time, Timer, TimerMode};
 use bytes::Bytes;
 use core::time::Duration;
@@ -13,20 +19,23 @@ use lightyear_link::LinkStats;
 #[derive(Debug)]
 pub struct SequencedUnreliableSender {
     /// list of single messages that we want to fit into packets and send
-    single_messages_to_send: VecDeque<SendMessage>,
+    single_messages_to_send: VecDeque<PendingSendMessage>,
     /// list of fragmented messages that we want to fit into packets and send
-    fragmented_messages_to_send: VecDeque<SendMessage>,
+    fragmented_messages_to_send: VecDeque<PendingSendMessage>,
 
     /// Message id to use for the next message to be sent
     next_send_message_id: MessageId,
+    next_send_order: u64,
     /// Used to split a message into fragments if the message is too big
     fragment_sender: FragmentSender,
     /// Internal timer to determine if the channel is ready to send messages
     timer: Option<Timer>,
+    retry_unsent_messages: bool,
+    eligible_this_flush: bool,
 }
 
 impl SequencedUnreliableSender {
-    pub(crate) fn new(send_frequency: Duration) -> Self {
+    pub(crate) fn new(send_frequency: Duration, retry_unsent_messages: bool) -> Self {
         let timer = if send_frequency == Duration::default() {
             None
         } else {
@@ -36,8 +45,11 @@ impl SequencedUnreliableSender {
             single_messages_to_send: VecDeque::new(),
             fragmented_messages_to_send: VecDeque::new(),
             next_send_message_id: MessageId(0),
+            next_send_order: 0,
             fragment_sender: FragmentSender::new(),
             timer,
+            retry_unsent_messages,
+            eligible_this_flush: false,
         }
     }
 }
@@ -58,41 +70,103 @@ impl ChannelSend for SequencedUnreliableSender {
         compression: CompressionConfig,
     ) -> Option<MessageId> {
         let message_id = self.next_send_message_id;
+        let stable_order = self.next_send_order;
+        self.next_send_order = self.next_send_order.wrapping_add(1);
         if message.len() > self.fragment_sender.fragment_size {
             for fragment in
                 self.fragment_sender
                     .build_fragments_for_message(message_id, message, compression)
             {
-                self.fragmented_messages_to_send.push_back(SendMessage {
-                    data: MessageData::Fragment(fragment),
-                    priority,
-                });
+                self.fragmented_messages_to_send
+                    .push_back(PendingSendMessage::new(
+                        SendMessage {
+                            data: MessageData::Fragment(fragment),
+                            priority,
+                        },
+                        stable_order,
+                    ));
             }
         } else {
             let single_data = SingleData::new(Some(message_id), message);
-            self.single_messages_to_send.push_back(SendMessage {
-                data: MessageData::Single(single_data),
-                priority,
-            });
+            self.single_messages_to_send
+                .push_back(PendingSendMessage::new(
+                    SendMessage {
+                        data: MessageData::Single(single_data),
+                        priority,
+                    },
+                    stable_order,
+                ));
         }
         self.next_send_message_id += 1;
         Some(message_id)
     }
 
-    /// Take messages from the buffer of messages to be sent, and build a list of packets
-    /// to be sent
-    fn send_packet(&mut self) -> (VecDeque<SendMessage>, VecDeque<SendMessage>) {
+    fn collect_send_candidates(
+        &mut self,
+        channel_kind: ChannelKind,
+        channel_id: ChannelId,
+        output: &mut Vec<SendCandidate>,
+    ) {
         if self.timer.as_ref().is_some_and(|t| !t.is_finished()) {
-            return (VecDeque::new(), VecDeque::new());
+            return;
         }
-        (
-            core::mem::take(&mut self.single_messages_to_send),
-            core::mem::take(&mut self.fragmented_messages_to_send),
-        )
-        // let messages_to_send = core::mem::take(&mut self.messages_to_send);
-        // let (remaining_messages_to_send, _) =
-        //     packet_manager.pack_messages_within_channel(messages_to_send);
-        // self.messages_to_send = remaining_messages_to_send;
+        self.eligible_this_flush = true;
+        output.extend(
+            self.single_messages_to_send
+                .iter()
+                .enumerate()
+                .filter(|(_, pending)| !pending.committed)
+                .map(|(index, pending)| {
+                    SendCandidate::new(
+                        channel_kind,
+                        channel_id,
+                        SendMessageKey::UnreliableSingle(index),
+                        pending.stable_order,
+                        pending.message.clone(),
+                    )
+                }),
+        );
+        output.extend(
+            self.fragmented_messages_to_send
+                .iter()
+                .enumerate()
+                .filter(|(_, pending)| !pending.committed)
+                .map(|(index, pending)| {
+                    SendCandidate::new(
+                        channel_kind,
+                        channel_id,
+                        SendMessageKey::UnreliableFragment(index),
+                        pending.stable_order,
+                        pending.message.clone(),
+                    )
+                }),
+        );
+    }
+
+    fn commit_send(&mut self, key: SendMessageKey, _: Duration) {
+        let committed = commit_unreliable_candidate(
+            &mut self.single_messages_to_send,
+            &mut self.fragmented_messages_to_send,
+            key,
+        );
+        debug_assert!(committed, "invalid sequenced-unreliable send candidate");
+    }
+
+    fn finish_send(&mut self, outcome: SendFlushOutcome) {
+        let discard_unsent = self.eligible_this_flush
+            && !self.retry_unsent_messages
+            && outcome == SendFlushOutcome::BandwidthLimited;
+        if discard_unsent {
+            self.single_messages_to_send.clear();
+            self.fragmented_messages_to_send
+                .retain(|pending| !pending.committed && pending.fragment_started);
+        } else {
+            self.single_messages_to_send
+                .retain(|pending| !pending.committed);
+            self.fragmented_messages_to_send
+                .retain(|pending| !pending.committed);
+        }
+        self.eligible_this_flush = false;
     }
 
     fn receive_ack(&mut self, _message_ack: &MessageAck) {}
@@ -101,9 +175,10 @@ impl ChannelSend for SequencedUnreliableSender {
 #[cfg(test)]
 mod tests {
     use super::*;
+    struct TestChannel;
     #[test]
     fn test_sequenced_unreliable_sender_internals() {
-        let mut sender = SequencedUnreliableSender::new(Duration::from_secs(1));
+        let mut sender = SequencedUnreliableSender::new(Duration::from_secs(1), true);
         assert!(sender.timer.as_ref().is_some_and(|t| !t.is_finished()));
 
         sender
@@ -111,8 +186,9 @@ mod tests {
             .unwrap();
 
         // we do not send because we didn't reach the timer
-        let (single, _) = sender.send_packet();
-        assert!(single.is_empty());
+        let mut candidates = Vec::new();
+        sender.collect_send_candidates(ChannelKind::of::<TestChannel>(), 0, &mut candidates);
+        assert!(candidates.is_empty());
 
         // update with a delta of 1 second
         let mut real = Time::<Real>::default();
@@ -121,7 +197,7 @@ mod tests {
         sender.update(&real, &link_stats);
 
         // this time, we send the packet
-        let (single, _) = sender.send_packet();
-        assert_eq!(single.len(), 1);
+        sender.collect_send_candidates(ChannelKind::of::<TestChannel>(), 0, &mut candidates);
+        assert_eq!(candidates.len(), 1);
     }
 }

--- a/crates/transport/transport/src/channel/senders/unordered_unreliable.rs
+++ b/crates/transport/transport/src/channel/senders/unordered_unreliable.rs
@@ -1,11 +1,17 @@
 use alloc::collections::VecDeque;
+use alloc::vec::Vec;
 use bevy_time::{Real, Time, Timer, TimerMode};
 use core::time::Duration;
 
-use crate::channel::senders::ChannelSend;
+use crate::channel::registry::{ChannelId, ChannelKind};
 use crate::channel::senders::fragment_sender::FragmentSender;
+use crate::channel::senders::{
+    ChannelSend, PendingSendMessage, SendFlushOutcome, commit_unreliable_candidate,
+};
 use crate::packet::compression::CompressionConfig;
-use crate::packet::message::{MessageAck, MessageData, MessageId, SendMessage, SingleData};
+use crate::packet::message::{
+    MessageAck, MessageData, MessageId, SendCandidate, SendMessage, SendMessageKey, SingleData,
+};
 use bytes::Bytes;
 use lightyear_link::LinkStats;
 
@@ -14,20 +20,23 @@ use lightyear_link::LinkStats;
 #[derive(Debug)]
 pub struct UnorderedUnreliableSender {
     /// list of single messages that we want to fit into packets and send
-    single_messages_to_send: VecDeque<SendMessage>,
+    single_messages_to_send: VecDeque<PendingSendMessage>,
     /// list of fragmented messages that we want to fit into packets and send
-    fragmented_messages_to_send: VecDeque<SendMessage>,
+    fragmented_messages_to_send: VecDeque<PendingSendMessage>,
     /// Fragmented messages need an id (so they can be reconstructed), this keeps track
     /// of the next id to use
     next_send_fragmented_message_id: MessageId,
+    next_send_order: u64,
     /// Used to split a message into fragments if the message is too big
     fragment_sender: FragmentSender,
     /// Internal timer to determine if the channel is ready to send messages
     timer: Option<Timer>,
+    retry_unsent_messages: bool,
+    eligible_this_flush: bool,
 }
 
 impl UnorderedUnreliableSender {
-    pub(crate) fn new(send_frequency: Duration) -> Self {
+    pub(crate) fn new(send_frequency: Duration, retry_unsent_messages: bool) -> Self {
         let timer = if send_frequency == Duration::default() {
             None
         } else {
@@ -37,8 +46,11 @@ impl UnorderedUnreliableSender {
             single_messages_to_send: VecDeque::new(),
             fragmented_messages_to_send: VecDeque::new(),
             next_send_fragmented_message_id: MessageId::default(),
+            next_send_order: 0,
             fragment_sender: FragmentSender::new(),
             timer,
+            retry_unsent_messages,
+            eligible_this_flush: false,
         }
     }
 }
@@ -58,42 +70,105 @@ impl ChannelSend for UnorderedUnreliableSender {
         priority: f32,
         compression: CompressionConfig,
     ) -> Option<MessageId> {
+        let stable_order = self.next_send_order;
+        self.next_send_order = self.next_send_order.wrapping_add(1);
         if message.len() > self.fragment_sender.fragment_size {
             for fragment in self.fragment_sender.build_fragments_for_message(
                 self.next_send_fragmented_message_id,
                 message,
                 compression,
             ) {
-                self.fragmented_messages_to_send.push_back(SendMessage {
-                    data: MessageData::Fragment(fragment),
-                    priority,
-                });
+                self.fragmented_messages_to_send
+                    .push_back(PendingSendMessage::new(
+                        SendMessage {
+                            data: MessageData::Fragment(fragment),
+                            priority,
+                        },
+                        stable_order,
+                    ));
             }
             self.next_send_fragmented_message_id += 1;
             Some(self.next_send_fragmented_message_id - 1)
         } else {
             let single_data = SingleData::new(None, message);
-            self.single_messages_to_send.push_back(SendMessage {
-                data: MessageData::Single(single_data),
-                priority,
-            });
+            self.single_messages_to_send
+                .push_back(PendingSendMessage::new(
+                    SendMessage {
+                        data: MessageData::Single(single_data),
+                        priority,
+                    },
+                    stable_order,
+                ));
             None
         }
     }
 
-    /// Take messages from the buffer of messages to be sent, and build a list of packets to be sent
-    fn send_packet(&mut self) -> (VecDeque<SendMessage>, VecDeque<SendMessage>) {
+    fn collect_send_candidates(
+        &mut self,
+        channel_kind: ChannelKind,
+        channel_id: ChannelId,
+        output: &mut Vec<SendCandidate>,
+    ) {
         if self.timer.as_ref().is_some_and(|t| !t.is_finished()) {
-            return (VecDeque::new(), VecDeque::new());
+            return;
         }
-        (
-            core::mem::take(&mut self.single_messages_to_send),
-            core::mem::take(&mut self.fragmented_messages_to_send),
-        )
-        // let messages_to_send = core::mem::take(&mut self.messages_to_send);
-        // let (remaining_messages_to_send, _) =
-        //     packet_manager.pack_messages_within_channel(messages_to_send);
-        // self.messages_to_send = remaining_messages_to_send;
+        self.eligible_this_flush = true;
+        output.extend(
+            self.single_messages_to_send
+                .iter()
+                .enumerate()
+                .filter(|(_, pending)| !pending.committed)
+                .map(|(index, pending)| {
+                    SendCandidate::new(
+                        channel_kind,
+                        channel_id,
+                        SendMessageKey::UnreliableSingle(index),
+                        pending.stable_order,
+                        pending.message.clone(),
+                    )
+                }),
+        );
+        output.extend(
+            self.fragmented_messages_to_send
+                .iter()
+                .enumerate()
+                .filter(|(_, pending)| !pending.committed)
+                .map(|(index, pending)| {
+                    SendCandidate::new(
+                        channel_kind,
+                        channel_id,
+                        SendMessageKey::UnreliableFragment(index),
+                        pending.stable_order,
+                        pending.message.clone(),
+                    )
+                }),
+        );
+    }
+
+    fn commit_send(&mut self, key: SendMessageKey, _: Duration) {
+        let committed = commit_unreliable_candidate(
+            &mut self.single_messages_to_send,
+            &mut self.fragmented_messages_to_send,
+            key,
+        );
+        debug_assert!(committed, "invalid unreliable send candidate");
+    }
+
+    fn finish_send(&mut self, outcome: SendFlushOutcome) {
+        let discard_unsent = self.eligible_this_flush
+            && !self.retry_unsent_messages
+            && outcome == SendFlushOutcome::BandwidthLimited;
+        if discard_unsent {
+            self.single_messages_to_send.clear();
+            self.fragmented_messages_to_send
+                .retain(|pending| !pending.committed && pending.fragment_started);
+        } else {
+            self.single_messages_to_send
+                .retain(|pending| !pending.committed);
+            self.fragmented_messages_to_send
+                .retain(|pending| !pending.committed);
+        }
+        self.eligible_this_flush = false;
     }
 
     fn receive_ack(&mut self, _: &MessageAck) {}
@@ -101,8 +176,123 @@ impl ChannelSend for UnorderedUnreliableSender {
 
 #[cfg(test)]
 mod tests {
-    // #[test]
-    // fn test_unordered_unreliable_sender_internals() {
-    //     todo!()
-    // }
+    use alloc::vec;
+
+    use super::*;
+
+    struct TestChannel;
+
+    #[test]
+    fn candidates_remain_pending_until_committed() {
+        let mut sender = UnorderedUnreliableSender::new(Duration::default(), true);
+        sender.buffer_send(
+            Bytes::from_static(b"pending"),
+            1.0,
+            CompressionConfig::DISABLED,
+        );
+
+        let mut candidates = Vec::new();
+        sender.collect_send_candidates(ChannelKind::of::<TestChannel>(), 0, &mut candidates);
+        assert_eq!(candidates.len(), 1);
+
+        // A rejected staged packet calls finish without committing and must not consume data.
+        sender.finish_send(SendFlushOutcome::BandwidthLimited);
+        candidates.clear();
+        sender.collect_send_candidates(ChannelKind::of::<TestChannel>(), 0, &mut candidates);
+        assert_eq!(candidates.len(), 1);
+
+        sender.commit_send(candidates[0].key, Duration::default());
+        sender.finish_send(SendFlushOutcome::Complete);
+        candidates.clear();
+        sender.collect_send_candidates(ChannelKind::of::<TestChannel>(), 0, &mut candidates);
+        assert!(candidates.is_empty());
+    }
+
+    #[test]
+    fn retry_unsent_policy_only_discards_after_bandwidth_limit() {
+        let mut sender = UnorderedUnreliableSender::new(Duration::default(), false);
+        sender.buffer_send(
+            Bytes::from_static(b"stale"),
+            1.0,
+            CompressionConfig::DISABLED,
+        );
+
+        let mut candidates = Vec::new();
+        sender.collect_send_candidates(ChannelKind::of::<TestChannel>(), 0, &mut candidates);
+        assert_eq!(candidates.len(), 1);
+
+        sender.finish_send(SendFlushOutcome::StagingFailed);
+        candidates.clear();
+        sender.collect_send_candidates(ChannelKind::of::<TestChannel>(), 0, &mut candidates);
+        assert_eq!(candidates.len(), 1);
+
+        sender.finish_send(SendFlushOutcome::BandwidthLimited);
+        candidates.clear();
+        sender.collect_send_candidates(ChannelKind::of::<TestChannel>(), 0, &mut candidates);
+        assert!(candidates.is_empty());
+    }
+
+    #[test]
+    fn discard_policy_finishes_started_fragmented_messages() {
+        let mut wholly_unsent = UnorderedUnreliableSender::new(Duration::default(), false);
+        let message_len = wholly_unsent.fragment_sender.fragment_size * 2 + 1;
+        wholly_unsent.buffer_send(
+            Bytes::from(vec![0; message_len]),
+            1.0,
+            CompressionConfig::DISABLED,
+        );
+
+        let mut candidates = Vec::new();
+        wholly_unsent.collect_send_candidates(ChannelKind::of::<TestChannel>(), 0, &mut candidates);
+        assert!(candidates.len() > 1);
+
+        wholly_unsent.finish_send(SendFlushOutcome::BandwidthLimited);
+        candidates.clear();
+        wholly_unsent.collect_send_candidates(ChannelKind::of::<TestChannel>(), 0, &mut candidates);
+        assert!(candidates.is_empty());
+
+        let mut partially_sent = UnorderedUnreliableSender::new(Duration::default(), false);
+        partially_sent.buffer_send(
+            Bytes::from(vec![0; message_len]),
+            1.0,
+            CompressionConfig::DISABLED,
+        );
+        partially_sent.collect_send_candidates(
+            ChannelKind::of::<TestChannel>(),
+            0,
+            &mut candidates,
+        );
+        let fragment_count = candidates.len();
+
+        partially_sent.commit_send(candidates[0].key, Duration::default());
+        partially_sent.finish_send(SendFlushOutcome::BandwidthLimited);
+        candidates.clear();
+        partially_sent.collect_send_candidates(
+            ChannelKind::of::<TestChannel>(),
+            0,
+            &mut candidates,
+        );
+        assert_eq!(candidates.len(), fragment_count - 1);
+    }
+
+    #[test]
+    fn bandwidth_limit_does_not_discard_messages_before_send_frequency() {
+        let mut sender = UnorderedUnreliableSender::new(Duration::from_secs(1), false);
+        sender.buffer_send(
+            Bytes::from_static(b"not-yet-eligible"),
+            1.0,
+            CompressionConfig::DISABLED,
+        );
+
+        let mut candidates = Vec::new();
+        sender.collect_send_candidates(ChannelKind::of::<TestChannel>(), 0, &mut candidates);
+        assert!(candidates.is_empty());
+        sender.finish_send(SendFlushOutcome::BandwidthLimited);
+
+        let mut real = Time::<Real>::default();
+        real.advance_by(Duration::from_secs(1));
+        sender.update(&real, &LinkStats::default());
+        sender.collect_send_candidates(ChannelKind::of::<TestChannel>(), 0, &mut candidates);
+        assert_eq!(candidates.len(), 1);
+    }
 }

--- a/crates/transport/transport/src/channel/senders/unordered_unreliable.rs
+++ b/crates/transport/transport/src/channel/senders/unordered_unreliable.rs
@@ -7,6 +7,7 @@ use crate::channel::registry::{ChannelId, ChannelKind};
 use crate::channel::senders::fragment_sender::FragmentSender;
 use crate::channel::senders::{
     ChannelSend, PendingSendMessage, SendFlushOutcome, commit_unreliable_candidate,
+    is_ready_to_send,
 };
 use crate::packet::compression::CompressionConfig;
 use crate::packet::message::{
@@ -26,13 +27,11 @@ pub struct UnorderedUnreliableSender {
     /// Fragmented messages need an id (so they can be reconstructed), this keeps track
     /// of the next id to use
     next_send_fragmented_message_id: MessageId,
-    next_send_order: u64,
     /// Used to split a message into fragments if the message is too big
     fragment_sender: FragmentSender,
     /// Internal timer to determine if the channel is ready to send messages
     timer: Option<Timer>,
     retry_unsent_messages: bool,
-    eligible_this_flush: bool,
 }
 
 impl UnorderedUnreliableSender {
@@ -46,11 +45,9 @@ impl UnorderedUnreliableSender {
             single_messages_to_send: VecDeque::new(),
             fragmented_messages_to_send: VecDeque::new(),
             next_send_fragmented_message_id: MessageId::default(),
-            next_send_order: 0,
             fragment_sender: FragmentSender::new(),
             timer,
             retry_unsent_messages,
-            eligible_this_flush: false,
         }
     }
 }
@@ -70,8 +67,6 @@ impl ChannelSend for UnorderedUnreliableSender {
         priority: f32,
         compression: CompressionConfig,
     ) -> Option<MessageId> {
-        let stable_order = self.next_send_order;
-        self.next_send_order = self.next_send_order.wrapping_add(1);
         if message.len() > self.fragment_sender.fragment_size {
             for fragment in self.fragment_sender.build_fragments_for_message(
                 self.next_send_fragmented_message_id,
@@ -79,26 +74,20 @@ impl ChannelSend for UnorderedUnreliableSender {
                 compression,
             ) {
                 self.fragmented_messages_to_send
-                    .push_back(PendingSendMessage::new(
-                        SendMessage {
-                            data: MessageData::Fragment(fragment),
-                            priority,
-                        },
-                        stable_order,
-                    ));
+                    .push_back(PendingSendMessage::new(SendMessage {
+                        data: MessageData::Fragment(fragment),
+                        priority,
+                    }));
             }
             self.next_send_fragmented_message_id += 1;
             Some(self.next_send_fragmented_message_id - 1)
         } else {
             let single_data = SingleData::new(None, message);
             self.single_messages_to_send
-                .push_back(PendingSendMessage::new(
-                    SendMessage {
-                        data: MessageData::Single(single_data),
-                        priority,
-                    },
-                    stable_order,
-                ));
+                .push_back(PendingSendMessage::new(SendMessage {
+                    data: MessageData::Single(single_data),
+                    priority,
+                }));
             None
         }
     }
@@ -109,10 +98,9 @@ impl ChannelSend for UnorderedUnreliableSender {
         channel_id: ChannelId,
         output: &mut Vec<SendCandidate>,
     ) {
-        if self.timer.as_ref().is_some_and(|t| !t.is_finished()) {
+        if !is_ready_to_send(self.timer.as_ref()) {
             return;
         }
-        self.eligible_this_flush = true;
         output.extend(
             self.single_messages_to_send
                 .iter()
@@ -123,7 +111,6 @@ impl ChannelSend for UnorderedUnreliableSender {
                         channel_kind,
                         channel_id,
                         SendMessageKey::UnreliableSingle(index),
-                        pending.stable_order,
                         pending.message.clone(),
                     )
                 }),
@@ -138,7 +125,6 @@ impl ChannelSend for UnorderedUnreliableSender {
                         channel_kind,
                         channel_id,
                         SendMessageKey::UnreliableFragment(index),
-                        pending.stable_order,
                         pending.message.clone(),
                     )
                 }),
@@ -155,7 +141,7 @@ impl ChannelSend for UnorderedUnreliableSender {
     }
 
     fn finish_send(&mut self, outcome: SendFlushOutcome) {
-        let discard_unsent = self.eligible_this_flush
+        let discard_unsent = is_ready_to_send(self.timer.as_ref())
             && !self.retry_unsent_messages
             && outcome == SendFlushOutcome::BandwidthLimited;
         if discard_unsent {
@@ -168,7 +154,6 @@ impl ChannelSend for UnorderedUnreliableSender {
             self.fragmented_messages_to_send
                 .retain(|pending| !pending.committed);
         }
-        self.eligible_this_flush = false;
     }
 
     fn receive_ack(&mut self, _: &MessageAck) {}

--- a/crates/transport/transport/src/channel/senders/unordered_unreliable_with_acks.rs
+++ b/crates/transport/transport/src/channel/senders/unordered_unreliable_with_acks.rs
@@ -8,6 +8,7 @@ use crate::channel::senders::fragment_ack_receiver::FragmentAckReceiver;
 use crate::channel::senders::fragment_sender::FragmentSender;
 use crate::channel::senders::{
     ChannelSend, PendingSendMessage, SendFlushOutcome, commit_unreliable_candidate,
+    is_ready_to_send,
 };
 use crate::packet::compression::CompressionConfig;
 use crate::packet::message::{
@@ -29,7 +30,6 @@ pub struct UnorderedUnreliableWithAcksSender {
     fragmented_messages_to_send: VecDeque<PendingSendMessage>,
     /// Message id to use for the next message to be sent
     next_send_message_id: MessageId,
-    next_send_order: u64,
     /// Used to split a message into fragments if the message is too big
     fragment_sender: FragmentSender,
     /// Keep track of which fragments were acked, so we can know when the entire fragment message
@@ -38,7 +38,6 @@ pub struct UnorderedUnreliableWithAcksSender {
     /// Internal timer to determine if the channel is ready to send messages
     timer: Option<Timer>,
     retry_unsent_messages: bool,
-    eligible_this_flush: bool,
 }
 
 impl UnorderedUnreliableWithAcksSender {
@@ -52,12 +51,10 @@ impl UnorderedUnreliableWithAcksSender {
             single_messages_to_send: VecDeque::new(),
             fragmented_messages_to_send: VecDeque::new(),
             next_send_message_id: MessageId::default(),
-            next_send_order: 0,
             fragment_sender: FragmentSender::new(),
             fragment_ack_receiver: FragmentAckReceiver::new(),
             timer,
             retry_unsent_messages,
-            eligible_this_flush: false,
         }
     }
 }
@@ -80,8 +77,6 @@ impl ChannelSend for UnorderedUnreliableWithAcksSender {
         compression: CompressionConfig,
     ) -> Option<MessageId> {
         let message_id = self.next_send_message_id;
-        let stable_order = self.next_send_order;
-        self.next_send_order = self.next_send_order.wrapping_add(1);
         if message.len() > self.fragment_sender.fragment_size {
             let fragments =
                 self.fragment_sender
@@ -90,24 +85,18 @@ impl ChannelSend for UnorderedUnreliableWithAcksSender {
                 .add_new_fragment_to_wait_for(message_id, fragments.len());
             for fragment in fragments {
                 self.fragmented_messages_to_send
-                    .push_back(PendingSendMessage::new(
-                        SendMessage {
-                            data: MessageData::Fragment(fragment),
-                            priority,
-                        },
-                        stable_order,
-                    ));
+                    .push_back(PendingSendMessage::new(SendMessage {
+                        data: MessageData::Fragment(fragment),
+                        priority,
+                    }));
             }
         } else {
             let single_data = SingleData::new(Some(message_id), message);
             self.single_messages_to_send
-                .push_back(PendingSendMessage::new(
-                    SendMessage {
-                        data: MessageData::Single(single_data),
-                        priority,
-                    },
-                    stable_order,
-                ));
+                .push_back(PendingSendMessage::new(SendMessage {
+                    data: MessageData::Single(single_data),
+                    priority,
+                }));
         }
         self.next_send_message_id += 1;
         Some(message_id)
@@ -119,10 +108,9 @@ impl ChannelSend for UnorderedUnreliableWithAcksSender {
         channel_id: ChannelId,
         output: &mut Vec<SendCandidate>,
     ) {
-        if self.timer.as_ref().is_some_and(|t| !t.is_finished()) {
+        if !is_ready_to_send(self.timer.as_ref()) {
             return;
         }
-        self.eligible_this_flush = true;
         output.extend(
             self.single_messages_to_send
                 .iter()
@@ -133,7 +121,6 @@ impl ChannelSend for UnorderedUnreliableWithAcksSender {
                         channel_kind,
                         channel_id,
                         SendMessageKey::UnreliableSingle(index),
-                        pending.stable_order,
                         pending.message.clone(),
                     )
                 }),
@@ -148,7 +135,6 @@ impl ChannelSend for UnorderedUnreliableWithAcksSender {
                         channel_kind,
                         channel_id,
                         SendMessageKey::UnreliableFragment(index),
-                        pending.stable_order,
                         pending.message.clone(),
                     )
                 }),
@@ -165,7 +151,7 @@ impl ChannelSend for UnorderedUnreliableWithAcksSender {
     }
 
     fn finish_send(&mut self, outcome: SendFlushOutcome) {
-        let discard_unsent = self.eligible_this_flush
+        let discard_unsent = is_ready_to_send(self.timer.as_ref())
             && !self.retry_unsent_messages
             && outcome == SendFlushOutcome::BandwidthLimited;
         if discard_unsent {
@@ -190,7 +176,6 @@ impl ChannelSend for UnorderedUnreliableWithAcksSender {
             self.fragmented_messages_to_send
                 .retain(|pending| !pending.committed);
         }
-        self.eligible_this_flush = false;
     }
 
     /// Notify any subscribers that a message was acked

--- a/crates/transport/transport/src/channel/senders/unordered_unreliable_with_acks.rs
+++ b/crates/transport/transport/src/channel/senders/unordered_unreliable_with_acks.rs
@@ -1,12 +1,18 @@
 use alloc::collections::VecDeque;
+use alloc::vec::Vec;
 use bevy_time::{Real, Time, Timer, TimerMode};
 use core::time::Duration;
 
-use crate::channel::senders::ChannelSend;
+use crate::channel::registry::{ChannelId, ChannelKind};
 use crate::channel::senders::fragment_ack_receiver::FragmentAckReceiver;
 use crate::channel::senders::fragment_sender::FragmentSender;
+use crate::channel::senders::{
+    ChannelSend, PendingSendMessage, SendFlushOutcome, commit_unreliable_candidate,
+};
 use crate::packet::compression::CompressionConfig;
-use crate::packet::message::{MessageAck, MessageData, MessageId, SendMessage, SingleData};
+use crate::packet::message::{
+    MessageAck, MessageData, MessageId, SendCandidate, SendMessage, SendMessageKey, SingleData,
+};
 use bytes::Bytes;
 use lightyear_link::LinkStats;
 
@@ -18,11 +24,12 @@ const DISCARD_AFTER: Duration = Duration::from_millis(3000);
 #[derive(Debug)]
 pub struct UnorderedUnreliableWithAcksSender {
     /// list of single messages that we want to fit into packets and send
-    single_messages_to_send: VecDeque<SendMessage>,
+    single_messages_to_send: VecDeque<PendingSendMessage>,
     /// list of fragmented messages that we want to fit into packets and send
-    fragmented_messages_to_send: VecDeque<SendMessage>,
+    fragmented_messages_to_send: VecDeque<PendingSendMessage>,
     /// Message id to use for the next message to be sent
     next_send_message_id: MessageId,
+    next_send_order: u64,
     /// Used to split a message into fragments if the message is too big
     fragment_sender: FragmentSender,
     /// Keep track of which fragments were acked, so we can know when the entire fragment message
@@ -30,10 +37,12 @@ pub struct UnorderedUnreliableWithAcksSender {
     fragment_ack_receiver: FragmentAckReceiver,
     /// Internal timer to determine if the channel is ready to send messages
     timer: Option<Timer>,
+    retry_unsent_messages: bool,
+    eligible_this_flush: bool,
 }
 
 impl UnorderedUnreliableWithAcksSender {
-    pub(crate) fn new(send_frequency: Duration) -> Self {
+    pub(crate) fn new(send_frequency: Duration, retry_unsent_messages: bool) -> Self {
         let timer = if send_frequency == Duration::default() {
             None
         } else {
@@ -43,9 +52,12 @@ impl UnorderedUnreliableWithAcksSender {
             single_messages_to_send: VecDeque::new(),
             fragmented_messages_to_send: VecDeque::new(),
             next_send_message_id: MessageId::default(),
+            next_send_order: 0,
             fragment_sender: FragmentSender::new(),
             fragment_ack_receiver: FragmentAckReceiver::new(),
             timer,
+            retry_unsent_messages,
+            eligible_this_flush: false,
         }
     }
 }
@@ -68,6 +80,8 @@ impl ChannelSend for UnorderedUnreliableWithAcksSender {
         compression: CompressionConfig,
     ) -> Option<MessageId> {
         let message_id = self.next_send_message_id;
+        let stable_order = self.next_send_order;
+        self.next_send_order = self.next_send_order.wrapping_add(1);
         if message.len() > self.fragment_sender.fragment_size {
             let fragments =
                 self.fragment_sender
@@ -75,35 +89,108 @@ impl ChannelSend for UnorderedUnreliableWithAcksSender {
             self.fragment_ack_receiver
                 .add_new_fragment_to_wait_for(message_id, fragments.len());
             for fragment in fragments {
-                self.fragmented_messages_to_send.push_back(SendMessage {
-                    data: MessageData::Fragment(fragment),
-                    priority,
-                });
+                self.fragmented_messages_to_send
+                    .push_back(PendingSendMessage::new(
+                        SendMessage {
+                            data: MessageData::Fragment(fragment),
+                            priority,
+                        },
+                        stable_order,
+                    ));
             }
         } else {
             let single_data = SingleData::new(Some(message_id), message);
-            self.single_messages_to_send.push_back(SendMessage {
-                data: MessageData::Single(single_data),
-                priority,
-            });
+            self.single_messages_to_send
+                .push_back(PendingSendMessage::new(
+                    SendMessage {
+                        data: MessageData::Single(single_data),
+                        priority,
+                    },
+                    stable_order,
+                ));
         }
         self.next_send_message_id += 1;
         Some(message_id)
     }
 
-    /// Take messages from the buffer of messages to be sent, and build a list of packets to be sent
-    fn send_packet(&mut self) -> (VecDeque<SendMessage>, VecDeque<SendMessage>) {
+    fn collect_send_candidates(
+        &mut self,
+        channel_kind: ChannelKind,
+        channel_id: ChannelId,
+        output: &mut Vec<SendCandidate>,
+    ) {
         if self.timer.as_ref().is_some_and(|t| !t.is_finished()) {
-            return (VecDeque::new(), VecDeque::new());
+            return;
         }
-        (
-            core::mem::take(&mut self.single_messages_to_send),
-            core::mem::take(&mut self.fragmented_messages_to_send),
-        )
-        // let messages_to_send = core::mem::take(&mut self.messages_to_send);
-        // let (remaining_messages_to_send, _) =
-        //     packet_manager.pack_messages_within_channel(messages_to_send);
-        // self.messages_to_send = remaining_messages_to_send;
+        self.eligible_this_flush = true;
+        output.extend(
+            self.single_messages_to_send
+                .iter()
+                .enumerate()
+                .filter(|(_, pending)| !pending.committed)
+                .map(|(index, pending)| {
+                    SendCandidate::new(
+                        channel_kind,
+                        channel_id,
+                        SendMessageKey::UnreliableSingle(index),
+                        pending.stable_order,
+                        pending.message.clone(),
+                    )
+                }),
+        );
+        output.extend(
+            self.fragmented_messages_to_send
+                .iter()
+                .enumerate()
+                .filter(|(_, pending)| !pending.committed)
+                .map(|(index, pending)| {
+                    SendCandidate::new(
+                        channel_kind,
+                        channel_id,
+                        SendMessageKey::UnreliableFragment(index),
+                        pending.stable_order,
+                        pending.message.clone(),
+                    )
+                }),
+        );
+    }
+
+    fn commit_send(&mut self, key: SendMessageKey, _: Duration) {
+        let committed = commit_unreliable_candidate(
+            &mut self.single_messages_to_send,
+            &mut self.fragmented_messages_to_send,
+            key,
+        );
+        debug_assert!(committed, "invalid unreliable-with-acks send candidate");
+    }
+
+    fn finish_send(&mut self, outcome: SendFlushOutcome) {
+        let discard_unsent = self.eligible_this_flush
+            && !self.retry_unsent_messages
+            && outcome == SendFlushOutcome::BandwidthLimited;
+        if discard_unsent {
+            for pending in self
+                .fragmented_messages_to_send
+                .iter()
+                .filter(|pending| !pending.committed && !pending.fragment_started)
+            {
+                if let MessageData::Fragment(fragment) = &pending.message.data
+                    && fragment.fragment_id.0 == 0
+                {
+                    self.fragment_ack_receiver
+                        .discard_message(fragment.message_id);
+                }
+            }
+            self.single_messages_to_send.clear();
+            self.fragmented_messages_to_send
+                .retain(|pending| !pending.committed && pending.fragment_started);
+        } else {
+            self.single_messages_to_send
+                .retain(|pending| !pending.committed);
+            self.fragmented_messages_to_send
+                .retain(|pending| !pending.committed);
+        }
+        self.eligible_this_flush = false;
     }
 
     /// Notify any subscribers that a message was acked
@@ -112,5 +199,33 @@ impl ChannelSend for UnorderedUnreliableWithAcksSender {
             self.fragment_ack_receiver
                 .receive_fragment_ack(ack.message_id, fragment_index, None);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec;
+
+    use super::*;
+
+    struct TestChannel;
+
+    #[test]
+    fn discarding_wholly_unsent_fragments_clears_ack_tracking() {
+        let mut sender = UnorderedUnreliableWithAcksSender::new(Duration::default(), false);
+        let message_len = sender.fragment_sender.fragment_size * 2 + 1;
+        sender.buffer_send(
+            Bytes::from(vec![0; message_len]),
+            1.0,
+            CompressionConfig::DISABLED,
+        );
+
+        let mut candidates = Vec::new();
+        sender.collect_send_candidates(ChannelKind::of::<TestChannel>(), 0, &mut candidates);
+        assert!(candidates.len() > 1);
+
+        sender.finish_send(SendFlushOutcome::BandwidthLimited);
+        assert!(sender.fragmented_messages_to_send.is_empty());
+        assert_eq!(sender.fragment_ack_receiver, FragmentAckReceiver::new());
     }
 }

--- a/crates/transport/transport/src/packet/compression.rs
+++ b/crates/transport/transport/src/packet/compression.rs
@@ -317,12 +317,7 @@ mod tests {
     use lightyear_serde::ToBytes;
 
     fn packet_with_body(packet_type: PacketType, body: &[u8]) -> Packet {
-        let mut header_manager = PacketHeaderManager::new(1.5);
-        let header = header_manager.prepare_send_packet_header(
-            packet_type,
-            core::time::Duration::default(),
-            Tick(0),
-        );
+        let header = PacketHeaderManager::new(1.5).preview_send_packet_header(packet_type, Tick(0));
         let mut payload = Vec::new();
         header.to_bytes(&mut payload).unwrap();
         payload.extend_from_slice(body);
@@ -331,7 +326,6 @@ mod tests {
             payload,
             messages: Vec::<MessageMetadata>::new(),
             packet_id: PacketId(0),
-            prewritten_size: 0,
             compression: None,
         }
     }

--- a/crates/transport/transport/src/packet/header.rs
+++ b/crates/transport/transport/src/packet/header.rs
@@ -246,11 +246,10 @@ impl PacketHeaderManager {
         None
     }
 
-    /// Prepare the header of the next packet to send
-    pub(crate) fn prepare_send_packet_header(
-        &mut self,
+    /// Preview the header of the next packet without changing sent-packet state.
+    pub(crate) fn preview_send_packet_header(
+        &self,
         packet_type: PacketType,
-        real: Duration,
         tick: Tick,
     ) -> PacketHeader {
         // if we didn't have a last packet id, start with the maximum value
@@ -259,21 +258,40 @@ impl PacketHeaderManager {
             .recv_buffer
             .last_recv_packet_id
             .unwrap_or(PacketId(u32::MAX));
-        let outgoing_header = PacketHeader {
+        PacketHeader {
             packet_type,
             packet_id: self.next_packet_id,
             last_ack_packet_id,
             ack_bitfield: self.recv_buffer.get_bitfield(),
             tick,
-        };
-        // we build the header only when we actually send the packet, so computing the stats here is valid
+        }
+    }
+
+    /// Commit a previewed packet after its final payload has entered `Link.send`.
+    pub(crate) fn commit_send_packet(&mut self, packet_id: PacketId, real: Duration) {
+        debug_assert_eq!(
+            packet_id, self.next_packet_id,
+            "packets must be committed in preview order"
+        );
         self.stats_manager.sent_packet();
         trace!(?self.next_packet_id, "Sent packet");
-        // keep track of when we sent the packet (so that if we don't get an ack after a certain amount of time we can consider it lost)
-        self.sent_packets_not_acked
-            .insert(self.next_packet_id, real);
+        self.sent_packets_not_acked.insert(packet_id, real);
         self.next_packet_id += 1;
-        outgoing_header
+    }
+
+    /// Prepare and immediately commit a header.
+    ///
+    /// This remains for focused packet-builder tests. The production send path previews during
+    /// staging and commits only after bandwidth and Link admission.
+    pub(crate) fn prepare_send_packet_header(
+        &mut self,
+        packet_type: PacketType,
+        real: Duration,
+        tick: Tick,
+    ) -> PacketHeader {
+        let header = self.preview_send_packet_header(packet_type, tick);
+        self.commit_send_packet(header.packet_id, real);
+        header
     }
 }
 
@@ -438,6 +456,25 @@ mod tests {
         let read_header = PacketHeader::from_bytes(&mut reader)?;
         assert_eq!(header, read_header);
         Ok(())
+    }
+
+    #[test]
+    fn preview_does_not_advance_packet_state_until_commit() {
+        let mut manager = PacketHeaderManager::new(1.5);
+
+        let first = manager.preview_send_packet_header(PacketType::Data, Tick(1));
+        let repeated = manager.preview_send_packet_header(PacketType::Data, Tick(2));
+        assert_eq!(first.packet_id, PacketId(0));
+        assert_eq!(repeated.packet_id, PacketId(0));
+        assert!(manager.sent_packets_not_acked.is_empty());
+
+        manager.commit_send_packet(first.packet_id, Duration::from_millis(10));
+        let next = manager.preview_send_packet_header(PacketType::Data, Tick(3));
+        assert_eq!(next.packet_id, PacketId(1));
+        assert_eq!(
+            manager.sent_packets_not_acked.get(&PacketId(0)),
+            Some(&Duration::from_millis(10))
+        );
     }
 
     #[test]

--- a/crates/transport/transport/src/packet/header.rs
+++ b/crates/transport/transport/src/packet/header.rs
@@ -278,21 +278,6 @@ impl PacketHeaderManager {
         self.sent_packets_not_acked.insert(packet_id, real);
         self.next_packet_id += 1;
     }
-
-    /// Prepare and immediately commit a header.
-    ///
-    /// This remains for focused packet-builder tests. The production send path previews during
-    /// staging and commits only after bandwidth and Link admission.
-    pub(crate) fn prepare_send_packet_header(
-        &mut self,
-        packet_type: PacketType,
-        real: Duration,
-        tick: Tick,
-    ) -> PacketHeader {
-        let header = self.preview_send_packet_header(packet_type, tick);
-        self.commit_send_packet(header.packet_id, real);
-        header
-    }
 }
 
 /// Data structure to keep track of the ids of the received packets
@@ -388,6 +373,17 @@ mod tests {
 
     use super::*;
 
+    fn prepare_send_packet_header(
+        manager: &mut PacketHeaderManager,
+        packet_type: PacketType,
+        real: Duration,
+        tick: Tick,
+    ) -> PacketHeader {
+        let header = manager.preview_send_packet_header(packet_type, tick);
+        manager.commit_send_packet(header.packet_id, real);
+        header
+    }
+
     #[test]
     fn test_recv_buffer() {
         let recv_buffer = ReceiveBuffer::new();
@@ -482,15 +478,20 @@ mod tests {
         let mut sender = PacketHeaderManager::new(1.5);
         let mut receiver = PacketHeaderManager::new(1.5);
 
-        let sent_header =
-            sender.prepare_send_packet_header(PacketType::Data, Duration::from_millis(10), Tick(1));
+        let sent_header = prepare_send_packet_header(
+            &mut sender,
+            PacketType::Data,
+            Duration::from_millis(10),
+            Tick(1),
+        );
         assert!(
             receiver
                 .process_recv_packet_header(&sent_header, Duration::from_millis(25))
                 .is_empty()
         );
 
-        let ack_header = receiver.prepare_send_packet_header(
+        let ack_header = prepare_send_packet_header(
+            &mut receiver,
             PacketType::Data,
             Duration::from_millis(25),
             Tick(2),
@@ -513,17 +514,30 @@ mod tests {
         let mut sender = PacketHeaderManager::new(1.5);
         let mut receiver = PacketHeaderManager::new(1.5);
 
-        let sent_0 =
-            sender.prepare_send_packet_header(PacketType::Data, Duration::from_millis(10), Tick(1));
-        let _sent_1 =
-            sender.prepare_send_packet_header(PacketType::Data, Duration::from_millis(20), Tick(2));
-        let sent_2 =
-            sender.prepare_send_packet_header(PacketType::Data, Duration::from_millis(30), Tick(3));
+        let sent_0 = prepare_send_packet_header(
+            &mut sender,
+            PacketType::Data,
+            Duration::from_millis(10),
+            Tick(1),
+        );
+        let _sent_1 = prepare_send_packet_header(
+            &mut sender,
+            PacketType::Data,
+            Duration::from_millis(20),
+            Tick(2),
+        );
+        let sent_2 = prepare_send_packet_header(
+            &mut sender,
+            PacketType::Data,
+            Duration::from_millis(30),
+            Tick(3),
+        );
 
         receiver.process_recv_packet_header(&sent_0, Duration::from_millis(15));
         receiver.process_recv_packet_header(&sent_2, Duration::from_millis(35));
 
-        let ack_header = receiver.prepare_send_packet_header(
+        let ack_header = prepare_send_packet_header(
+            &mut receiver,
             PacketType::Data,
             Duration::from_millis(40),
             Tick(4),

--- a/crates/transport/transport/src/packet/header.rs
+++ b/crates/transport/transport/src/packet/header.rs
@@ -1,5 +1,6 @@
 use alloc::{vec, vec::Vec};
 use bevy_platform::hash::FixedHasher;
+#[cfg(feature = "test_utils")]
 use core::convert::TryInto;
 use core::time::Duration;
 use indexmap::IndexMap;
@@ -82,6 +83,7 @@ impl PacketHeader {
     /// This is used by allocation-sensitive tests that parse a sent packet from `&[u8]` and then
     /// return the original `Vec<u8>` to `PacketBuilder`'s buffer pool. Normal receive code should
     /// keep using [`PacketHeader::from_bytes`], which advances a `Reader` past the header.
+    #[cfg(feature = "test_utils")]
     #[doc(hidden)]
     pub(crate) fn read_from_prefix(bytes: &[u8]) -> Result<Self, SerializationError> {
         if bytes.len() < Self::BYTES {

--- a/crates/transport/transport/src/packet/message.rs
+++ b/crates/transport/transport/src/packet/message.rs
@@ -36,18 +36,29 @@ pub(crate) enum SendMessageKey {
     ReliableFragment(MessageId, FragmentIndex),
 }
 
+impl SendMessageKey {
+    /// Position of this message in its channel's current pending order.
+    pub(crate) fn send_order(self) -> u64 {
+        match self {
+            Self::UnreliableSingle(index) | Self::UnreliableFragment(index) => index as u64,
+            Self::ReliableSingle(message_id) | Self::ReliableFragment(message_id, _) => {
+                u64::from(message_id.0)
+            }
+        }
+    }
+}
+
 /// A cheap snapshot of a channel-owned message which is eligible for packet staging.
 ///
-/// Cloning a candidate only clones its [`Bytes`] handle. The underlying message allocation remains
-/// owned by the channel until [`ChannelSend::commit_send`](crate::channel::senders::ChannelSend::commit_send)
-/// is called after the final packet enters `Link.send`.
-#[derive(Clone, Debug, PartialEq)]
+/// Creating a candidate clones only its [`Bytes`] handle. The underlying message allocation
+/// remains owned by the channel until
+/// [`ChannelSend::commit_send`](crate::channel::senders::ChannelSend::commit_send) is called after
+/// the final packet enters `Link.send`.
+#[derive(Debug)]
 pub(crate) struct SendCandidate {
     pub(crate) channel_kind: ChannelKind,
     pub(crate) channel_id: ChannelId,
     pub(crate) key: SendMessageKey,
-    /// Per-channel enqueue order used as a deterministic priority tie-breaker.
-    pub(crate) stable_order: u64,
     pub(crate) message: SendMessage,
     pub(crate) effective_priority: f32,
 }
@@ -57,14 +68,12 @@ impl SendCandidate {
         channel_kind: ChannelKind,
         channel_id: ChannelId,
         key: SendMessageKey,
-        stable_order: u64,
         message: SendMessage,
     ) -> Self {
         Self {
             channel_kind,
             channel_id,
             key,
-            stable_order,
             effective_priority: message.priority,
             message,
         }
@@ -120,26 +129,10 @@ impl MessageData {
         }
     }
 
-    #[allow(unused)]
-    pub fn set_id(&mut self, id: MessageId) {
-        match self {
-            MessageData::Single(data) => data.id = Some(id),
-            MessageData::Fragment(data) => data.message_id = id,
-        };
-    }
-
     pub fn bytes_len(&self) -> usize {
         match self {
             MessageData::Single(data) => data.bytes_len(),
             MessageData::Fragment(data) => data.bytes_len(),
-        }
-    }
-
-    #[allow(unused)]
-    pub fn bytes(&self) -> Bytes {
-        match self {
-            MessageData::Single(data) => data.bytes.clone(),
-            MessageData::Fragment(data) => data.bytes.clone(),
         }
     }
 }

--- a/crates/transport/transport/src/packet/message.rs
+++ b/crates/transport/transport/src/packet/message.rs
@@ -10,6 +10,7 @@ use lightyear_serde::writer::WriteInteger;
 use lightyear_serde::{SerializationError, ToBytes};
 use lightyear_utils::wrapping_id;
 
+use crate::channel::registry::{ChannelId, ChannelKind};
 use crate::packet::compression::CompressionConfig;
 
 // Internal id that we assign to each message sent over the network
@@ -20,8 +21,55 @@ wrapping_id!(MessageId);
 /// It will be serialized as a varint, so it will take only 1 byte if there
 /// are less than 64 fragments in the message.
 // TODO: as an optimization, we could do a varint up to u16, so that we use 1 byte for the first 128 fragments
-#[derive(Hash, Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Hash, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) struct FragmentIndex(pub(crate) u64);
+
+/// Identifies a pending message inside its channel for the duration of one send flush.
+///
+/// Queue indices remain valid because unreliable channels only compact their queues after packet
+/// staging and commit have completed. Reliable messages already have a stable [`MessageId`].
+#[derive(Hash, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) enum SendMessageKey {
+    UnreliableSingle(usize),
+    UnreliableFragment(usize),
+    ReliableSingle(MessageId),
+    ReliableFragment(MessageId, FragmentIndex),
+}
+
+/// A cheap snapshot of a channel-owned message which is eligible for packet staging.
+///
+/// Cloning a candidate only clones its [`Bytes`] handle. The underlying message allocation remains
+/// owned by the channel until [`ChannelSend::commit_send`](crate::channel::senders::ChannelSend::commit_send)
+/// is called after the final packet enters `Link.send`.
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct SendCandidate {
+    pub(crate) channel_kind: ChannelKind,
+    pub(crate) channel_id: ChannelId,
+    pub(crate) key: SendMessageKey,
+    /// Per-channel enqueue order used as a deterministic priority tie-breaker.
+    pub(crate) stable_order: u64,
+    pub(crate) message: SendMessage,
+    pub(crate) effective_priority: f32,
+}
+
+impl SendCandidate {
+    pub(crate) fn new(
+        channel_kind: ChannelKind,
+        channel_id: ChannelId,
+        key: SendMessageKey,
+        stable_order: u64,
+        message: SendMessage,
+    ) -> Self {
+        Self {
+            channel_kind,
+            channel_id,
+            key,
+            stable_order,
+            effective_priority: message.priority,
+            message,
+        }
+    }
+}
 
 /// Struct to keep track of which messages/slices have been received by the remote
 #[derive(Hash, PartialEq, Eq, Debug, Clone, Copy)]
@@ -41,7 +89,7 @@ pub struct MessageAck {
 ///
 /// In the message container, we already store the serialized representation of the message.
 /// The main reason is so that we can avoid copies, by directly serializing references into raw bits
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 #[doc(hidden)]
 pub struct SendMessage {
     pub(crate) data: MessageData,
@@ -57,7 +105,7 @@ pub struct ReceiveMessage {
     pub(crate) compression: CompressionConfig,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub(crate) enum MessageData {
     Single(SingleData),
     Fragment(FragmentData),

--- a/crates/transport/transport/src/packet/packet.rs
+++ b/crates/transport/transport/src/packet/packet.rs
@@ -5,7 +5,7 @@ use crate::packet::header::PacketHeader;
 use crate::packet::message::{FragmentIndex, MessageId, SendMessageKey};
 use crate::packet::packet_builder::Payload;
 use alloc::vec::Vec;
-use lightyear_serde::{ToBytes, varint::varint_len};
+use lightyear_serde::varint::varint_len;
 use lightyear_utils::wrapping_id;
 
 // Internal id that we assign to each packet sent over the network
@@ -41,12 +41,9 @@ pub(crate) const FRAGMENT_SIZE: usize =
 
 /// Metadata about messages included in a packet.
 ///
-/// With the `metrics` feature enabled, this contains every message written into the packet so
-/// channel metrics can be emitted after the final packet passes the bandwidth limiter.
-///
-/// Production-staged packets also record id-less unreliable messages because their commit handles
-/// remove channel-owned pending data only after Link admission. Legacy test builders omit id-less
-/// metadata when metrics are disabled.
+/// There is one entry per staged message. The commit handle updates channel-owned pending data only
+/// after the packet enters `Link.send`; with `metrics`, the same entry also carries the byte count
+/// used for post-admission metrics.
 #[derive(Debug, PartialEq)]
 pub(crate) struct MessageMetadata {
     pub(crate) channel: ChannelId,
@@ -55,10 +52,7 @@ pub(crate) struct MessageMetadata {
     pub(crate) fragment_index: Option<FragmentIndex>,
     pub(crate) num_fragments: Option<u64>,
     /// Channel-owned pending state to update after this packet is admitted to `Link.send`.
-    ///
-    /// Legacy packet-builder entry points used by focused tests do not originate from a channel
-    /// and therefore leave this as `None`.
-    pub(crate) commit: Option<SendCommit>,
+    pub(crate) commit: SendCommit,
     // Size of the message in bytes (for fragments, it's only the size of the fragment)
     #[cfg(feature = "metrics")]
     pub(crate) num_bytes: usize,
@@ -80,35 +74,13 @@ pub(crate) struct PacketCompressionInfo {
 #[derive(Debug)]
 pub(crate) struct Packet {
     pub(crate) payload: Payload,
-    /// Packet-local message metadata.
-    ///
-    /// See [`MessageMetadata`] for the rule that decides whether id-less messages are recorded.
+    /// One packet-local metadata entry per staged message.
     pub(crate) messages: Vec<MessageMetadata>,
     pub(crate) packet_id: PacketId,
-    // How many bytes we know we are going to have to write in the packet, but haven't written yet
-    pub(crate) prewritten_size: usize,
     pub(crate) compression: Option<PacketCompressionInfo>,
 }
 
 impl Packet {
-    /// Check that we can still fit some data in the buffer
-    pub(crate) fn can_fit(&self, size: usize) -> bool {
-        self.payload.len() + size + self.prewritten_size <= MAX_PACKET_SIZE
-    }
-
-    /// Check if we can write a channel_id + the number of messages in the packet.
-    /// If we can, reserve some space for it
-    pub(crate) fn can_fit_channel(&mut self, channel_id: ChannelId) -> bool {
-        let size = channel_id.bytes_len() + 1;
-        // size of the channel + 1 for the number of messages
-        let can_fit = self.can_fit(channel_id.bytes_len() + 1);
-        if can_fit {
-            // reserve the space to write the channel
-            self.prewritten_size += size;
-        }
-        can_fit
-    }
-
     pub(crate) fn num_messages(&self) -> usize {
         self.messages.len()
     }
@@ -119,27 +91,18 @@ impl Packet {
         message: Option<MessageId>,
         fragment_index: Option<FragmentIndex>,
         num_fragments: Option<u64>,
-        commit: Option<SendCommit>,
+        commit: SendCommit,
         #[cfg(feature = "metrics")] num_bytes: usize,
     ) {
-        // Production candidates always carry commit metadata. Legacy focused builders retain the
-        // old optimization of omitting id-less entries when metrics are disabled.
-        if cfg!(feature = "metrics") || message.is_some() || commit.is_some() {
-            self.messages.push(MessageMetadata {
-                channel,
-                message,
-                fragment_index,
-                num_fragments,
-                commit,
-                #[cfg(feature = "metrics")]
-                num_bytes,
-            });
-        }
-    }
-
-    #[allow(unused)]
-    pub(crate) fn is_empty(&self) -> bool {
-        self.messages.is_empty()
+        self.messages.push(MessageMetadata {
+            channel,
+            message,
+            fragment_index,
+            num_fragments,
+            commit,
+            #[cfg(feature = "metrics")]
+            num_bytes,
+        });
     }
 }
 
@@ -216,11 +179,8 @@ mod tests {
 
     #[test]
     fn header_bytes_constant_matches_packet_header_encoding() {
-        let header = PacketHeaderManager::new(1.5).prepare_send_packet_header(
-            PacketType::Data,
-            core::time::Duration::default(),
-            Tick(3),
-        );
+        let header =
+            PacketHeaderManager::new(1.5).preview_send_packet_header(PacketType::Data, Tick(3));
 
         let mut writer = Vec::new();
         header.to_bytes(&mut writer).unwrap();

--- a/crates/transport/transport/src/packet/packet.rs
+++ b/crates/transport/transport/src/packet/packet.rs
@@ -1,7 +1,8 @@
 /// Defines the [`Packet`] struct
 use crate::channel::registry::ChannelId;
+use crate::channel::registry::ChannelKind;
 use crate::packet::header::PacketHeader;
-use crate::packet::message::{FragmentIndex, MessageId};
+use crate::packet::message::{FragmentIndex, MessageId, SendMessageKey};
 use crate::packet::packet_builder::Payload;
 use alloc::vec::Vec;
 use lightyear_serde::{ToBytes, varint::varint_len};
@@ -43,8 +44,9 @@ pub(crate) const FRAGMENT_SIZE: usize =
 /// With the `metrics` feature enabled, this contains every message written into the packet so
 /// channel metrics can be emitted after the final packet passes the bandwidth limiter.
 ///
-/// Without `metrics`, this only contains messages with an id, because the send path only needs
-/// packet-local metadata for ack/retry bookkeeping.
+/// Production-staged packets also record id-less unreliable messages because their commit handles
+/// remove channel-owned pending data only after Link admission. Legacy test builders omit id-less
+/// metadata when metrics are disabled.
 #[derive(Debug, PartialEq)]
 pub(crate) struct MessageMetadata {
     pub(crate) channel: ChannelId,
@@ -52,9 +54,20 @@ pub(crate) struct MessageMetadata {
     // if the message is fragmented, we store the total number of fragments
     pub(crate) fragment_index: Option<FragmentIndex>,
     pub(crate) num_fragments: Option<u64>,
+    /// Channel-owned pending state to update after this packet is admitted to `Link.send`.
+    ///
+    /// Legacy packet-builder entry points used by focused tests do not originate from a channel
+    /// and therefore leave this as `None`.
+    pub(crate) commit: Option<SendCommit>,
     // Size of the message in bytes (for fragments, it's only the size of the fragment)
     #[cfg(feature = "metrics")]
     pub(crate) num_bytes: usize,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct SendCommit {
+    pub(crate) channel_kind: ChannelKind,
+    pub(crate) key: SendMessageKey,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -69,8 +82,7 @@ pub(crate) struct Packet {
     pub(crate) payload: Payload,
     /// Packet-local message metadata.
     ///
-    /// See [`MessageMetadata`] for the feature-dependent rule that decides whether id-less
-    /// messages are recorded.
+    /// See [`MessageMetadata`] for the rule that decides whether id-less messages are recorded.
     pub(crate) messages: Vec<MessageMetadata>,
     pub(crate) packet_id: PacketId,
     // How many bytes we know we are going to have to write in the packet, but haven't written yet
@@ -107,17 +119,18 @@ impl Packet {
         message: Option<MessageId>,
         fragment_index: Option<FragmentIndex>,
         num_fragments: Option<u64>,
+        commit: Option<SendCommit>,
         #[cfg(feature = "metrics")] num_bytes: usize,
     ) {
-        // In metrics builds, every message needs metadata so channel/send_* can be emitted only
-        // after the final packet passes bandwidth quota. In non-metrics builds, id-less entries
-        // are skipped to keep packet metadata limited to ack/retry bookkeeping.
-        if cfg!(feature = "metrics") || message.is_some() {
+        // Production candidates always carry commit metadata. Legacy focused builders retain the
+        // old optimization of omitting id-less entries when metrics are disabled.
+        if cfg!(feature = "metrics") || message.is_some() || commit.is_some() {
             self.messages.push(MessageMetadata {
                 channel,
                 message,
                 fragment_index,
                 num_fragments,
+                commit,
                 #[cfg(feature = "metrics")]
                 num_bytes,
             });

--- a/crates/transport/transport/src/packet/packet.rs
+++ b/crates/transport/transport/src/packet/packet.rs
@@ -111,16 +111,11 @@ mod tests {
     use crate::packet::header::{PacketHeader, PacketHeaderManager};
     use crate::packet::message::{FragmentData, SingleData};
     use crate::packet::packet_type::PacketType;
-    use bevy_app::App;
     use bevy_platform::collections::HashMap;
-    use bevy_reflect::Reflect;
-    use bevy_utils::default;
     use bytes::Bytes;
     use lightyear_core::prelude::Tick;
 
     use super::*;
-    use crate::channel::builder::{ChannelMode, ChannelSettings};
-    use crate::channel::registry::{AppChannelExt, ChannelRegistry};
     use crate::packet::error::PacketError;
     use lightyear_serde::reader::ReadInteger;
     use lightyear_serde::{SerializationError, ToBytes};
@@ -156,27 +151,6 @@ mod tests {
         }
     }
 
-    #[derive(Reflect)]
-    struct Channel1;
-
-    #[derive(Reflect)]
-    struct Channel2;
-
-    fn get_channel_registry() -> ChannelRegistry {
-        let mut app = App::new();
-
-        let settings = ChannelSettings {
-            mode: ChannelMode::UnorderedUnreliable,
-            ..default()
-        };
-        app.init_resource::<ChannelRegistry>();
-        app.add_channel::<Channel1>(settings);
-        app.add_channel::<Channel2>(settings);
-        app.world_mut()
-            .remove_resource::<ChannelRegistry>()
-            .unwrap()
-    }
-
     #[test]
     fn header_bytes_constant_matches_packet_header_encoding() {
         let header =
@@ -188,141 +162,4 @@ mod tests {
         assert_eq!(writer.len(), HEADER_BYTES);
         assert_eq!(header.bytes_len(), HEADER_BYTES);
     }
-
-    // #[test]
-    // fn test_single_packet_add_messages() {
-    //     let channel_registry = get_channel_registry();
-    //     let manager = PacketBuilder::new(1.5);
-    //     let mut packet = SinglePacket::new();
-    //
-    //     packet.add_message(0, SingleData::new(None, Bytes::from("hello")));
-    //     packet.add_message(0, SingleData::new(None, Bytes::from("world")));
-    //     packet.add_message(1, SingleData::new(None, Bytes::from("!")));
-    //
-    //     assert_eq!(packet.num_messages(), 3);
-    // }
-    //
-    // #[test]
-    // fn test_encode_single_packet() -> anyhow::Result<()> {
-    //     let channel_registry = get_channel_registry();
-    //     let manager = PacketBuilder::new(1.5);
-    //     let mut packet = SinglePacket::new();
-    //
-    //     let mut write_buffer = BitcodeWriter::with_capacity(50);
-    //     let message1 = SingleData::new(None, Bytes::from("hello"));
-    //     let message2 = SingleData::new(None, Bytes::from("world"));
-    //     let message3 = SingleData::new(None, Bytes::from("!"));
-    //
-    //     packet.add_message(0, message1.clone());
-    //     packet.add_message(0, message2.clone());
-    //     packet.add_message(1, message3.clone());
-    //     // add a channel with no messages
-    //     packet.add_channel(2);
-    //
-    //     packet.encode(&mut write_buffer)?;
-    //     let packet_bytes = write_buffer.finish_write();
-    //
-    //     // Encode manually
-    //     let mut expected_write_buffer = BitcodeWriter::with_capacity(50);
-    //     // channel id
-    //     expected_write_buffer.encode(&0u16, Gamma)?;
-    //     // messages, with continuation bit
-    //     expected_write_buffer.serialize(&true)?;
-    //     message1.encode(&mut expected_write_buffer)?;
-    //     expected_write_buffer.serialize(&true)?;
-    //     message2.encode(&mut expected_write_buffer)?;
-    //     expected_write_buffer.serialize(&false)?;
-    //     // channel continue bit
-    //     expected_write_buffer.serialize(&true)?;
-    //     // channel id
-    //     expected_write_buffer.encode(&1u16, Gamma)?;
-    //     // messages with continuation bit
-    //     expected_write_buffer.serialize(&true)?;
-    //     message3.encode(&mut expected_write_buffer)?;
-    //     expected_write_buffer.serialize(&false)?;
-    //     // channel continue bit
-    //     expected_write_buffer.serialize(&true)?;
-    //     // channel id
-    //     expected_write_buffer.encode(&2u16, Gamma)?;
-    //     // messages with continuation bit
-    //     expected_write_buffer.serialize(&false)?;
-    //     // channel continue bit
-    //     expected_write_buffer.serialize(&false)?;
-    //
-    //     let expected_packet_bytes = expected_write_buffer.finish_write();
-    //
-    //     assert_eq!(packet_bytes, expected_packet_bytes);
-    //
-    //     let mut reader = BitcodeReader::start_read(packet_bytes);
-    //     let decoded_packet = SinglePacket::decode(&mut reader)?;
-    //
-    //     assert_eq!(decoded_packet.num_messages(), 3);
-    //     assert_eq!(packet, decoded_packet);
-    //     Ok(())
-    // }
-    //
-    // #[test]
-    // fn test_encode_fragmented_packet() -> anyhow::Result<()> {
-    //     let channel_registry = get_channel_registry();
-    //     let manager = PacketBuilder::new(1.5);
-    //     let channel_kind = ChannelKind::of::<Channel1>();
-    //     let channel_id = channel_registry.get_net_from_kind(&channel_kind).unwrap();
-    //     let bytes = Bytes::from(vec![0; 10]);
-    //     let fragment = FragmentData {
-    //         message_id: MessageId(0),
-    //         fragment_id: 2,
-    //         num_fragments: 3,
-    //         bytes: bytes.clone(),
-    //     };
-    //     let mut packet = FragmentedPacket::new(*channel_id, fragment.clone());
-    //
-    //     let mut write_buffer = BitcodeWriter::with_capacity(100);
-    //     let message1 = SingleData::new(None, Bytes::from("hello"));
-    //     let message2 = SingleData::new(None, Bytes::from("world"));
-    //     let message3 = SingleData::new(None, Bytes::from("!"));
-    //
-    //     packet.packet.add_message(0, message1.clone());
-    //     packet.packet.add_message(0, message2.clone());
-    //     packet.packet.add_message(1, message3.clone());
-    //     // add a channel with no messages
-    //     packet.packet.add_channel(2);
-    //
-    //     packet.encode(&mut write_buffer)?;
-    //     let packet_bytes = write_buffer.finish_write();
-    //
-    //     let mut reader = BitcodeReader::start_read(packet_bytes);
-    //     let decoded_packet = FragmentedPacket::decode(&mut reader)?;
-    //
-    //     assert_eq!(decoded_packet.packet.num_messages(), 3);
-    //     assert_eq!(packet, decoded_packet);
-    //     Ok(())
-    // }
-    //
-    // #[test]
-    // fn test_encode_fragmented_packet_no_single_data() -> anyhow::Result<()> {
-    //     let channel_registry = get_channel_registry();
-    //     let manager = PacketBuilder::new(1.5);
-    //     let channel_kind = ChannelKind::of::<Channel1>();
-    //     let channel_id = channel_registry.get_net_from_kind(&channel_kind).unwrap();
-    //     let bytes = Bytes::from(vec![0; 10]);
-    //     let fragment = FragmentData {
-    //         message_id: MessageId(0),
-    //         fragment_id: 2,
-    //         num_fragments: 3,
-    //         bytes: bytes.clone(),
-    //     };
-    //     let packet = FragmentedPacket::new(*channel_id, fragment.clone());
-    //
-    //     let mut write_buffer = BitcodeWriter::with_capacity(100);
-    //
-    //     packet.encode(&mut write_buffer)?;
-    //     let packet_bytes = write_buffer.finish_write();
-    //
-    //     let mut reader = BitcodeReader::start_read(packet_bytes);
-    //     let decoded_packet = FragmentedPacket::decode(&mut reader)?;
-    //
-    //     assert_eq!(decoded_packet.packet.num_messages(), 0);
-    //     assert_eq!(packet, decoded_packet);
-    //     Ok(())
-    // }
 }

--- a/crates/transport/transport/src/packet/packet_builder.rs
+++ b/crates/transport/transport/src/packet/packet_builder.rs
@@ -530,7 +530,6 @@ mod tests {
             channel_kind,
             channel_id,
             SendMessageKey::UnreliableSingle(index),
-            index as u64,
             SendMessage {
                 data: SingleData::new(None, bytes).into(),
                 priority: 1.0,
@@ -551,7 +550,6 @@ mod tests {
                     channel_kind,
                     channel_id,
                     SendMessageKey::UnreliableFragment(index),
-                    u64::from(fragment.message_id.0),
                     SendMessage {
                         data: fragment.into(),
                         priority: 1.0,
@@ -816,7 +814,6 @@ mod tests {
                     channel_kind,
                     channel_id,
                     SendMessageKey::UnreliableFragment(key_offset + fragment_index),
-                    u64::from(message_id.0),
                     SendMessage {
                         data: FragmentData {
                             message_id,
@@ -836,7 +833,6 @@ mod tests {
                 channel_kind,
                 channel_id,
                 SendMessageKey::UnreliableSingle(index),
-                (index + 2) as u64,
                 SendMessage {
                     data: SingleData::new(None, Bytes::from(vec![index as u8; 100])).into(),
                     priority: 1.0,
@@ -886,7 +882,6 @@ mod tests {
                     channel_kind,
                     channel_id,
                     SendMessageKey::UnreliableSingle(index),
-                    index as u64,
                     SendMessage {
                         data: SingleData::new(None, Bytes::new()).into(),
                         priority: 1.0,

--- a/crates/transport/transport/src/packet/packet_builder.rs
+++ b/crates/transport/transport/src/packet/packet_builder.rs
@@ -40,6 +40,7 @@ pub type RecvPayload = Bytes;
 #[derive(Debug, Default)]
 pub(crate) struct CandidateCursor {
     index: usize,
+    single_index: usize,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -207,12 +208,22 @@ impl PacketBuilder {
         cursor: &mut CandidateCursor,
         compression: CompressionConfig,
     ) -> Result<Option<Packet>, PacketError> {
+        // Final fragments can consume singles which appear later in their priority group. Skip
+        // those candidates once the main cursor reaches the single portion of the group.
+        while cursor.index < cursor.single_index
+            && candidates
+                .get(cursor.index)
+                .is_some_and(|candidate| matches!(candidate.message.data, MessageData::Single(_)))
+        {
+            cursor.index += 1;
+        }
         let Some(first) = candidates.get(cursor.index) else {
             return Ok(None);
         };
 
         match &first.message.data {
             MessageData::Fragment(fragment) => {
+                let effective_priority = first.effective_priority;
                 let mut packet = self.new_staged_packet(PacketType::DataFragment, current_tick)?;
                 first.channel_id.to_bytes(&mut packet.payload)?;
                 fragment.to_bytes(&mut packet.payload)?;
@@ -231,21 +242,31 @@ impl PacketBuilder {
                 cursor.index += 1;
 
                 // The wire format permits singles after the final fragment. Preserve the current
-                // behavior of fitting that tail against the uncompressed MTU.
+                // behavior of fitting that tail against the uncompressed MTU. The separate
+                // single cursor can look past other fragments in the same priority group, letting
+                // every fragmented message use its final packet's remaining space.
                 if fragment.is_last_fragment() {
                     let mut batch = None;
-                    while let Some(candidate) = candidates.get(cursor.index) {
-                        if !matches!(candidate.message.data, MessageData::Single(_))
-                            || !Self::try_append_single_candidate(
-                                &mut packet,
-                                candidate,
-                                &mut batch,
-                                CompressionConfig::DISABLED,
-                            )?
+                    cursor.single_index = cursor.single_index.max(cursor.index);
+                    while let Some(candidate) = candidates.get(cursor.single_index) {
+                        if candidate.effective_priority.total_cmp(&effective_priority)
+                            != core::cmp::Ordering::Equal
                         {
                             break;
                         }
-                        cursor.index += 1;
+                        if matches!(candidate.message.data, MessageData::Fragment(_)) {
+                            cursor.single_index += 1;
+                            continue;
+                        }
+                        if !Self::try_append_single_candidate(
+                            &mut packet,
+                            candidate,
+                            &mut batch,
+                            CompressionConfig::DISABLED,
+                        )? {
+                            break;
+                        }
+                        cursor.single_index += 1;
                     }
                 }
 
@@ -274,6 +295,7 @@ impl PacketBuilder {
                     }
                     cursor.index += 1;
                 }
+                cursor.single_index = cursor.single_index.max(cursor.index);
 
                 if packet.messages.is_empty() {
                     let candidate = &candidates[cursor.index];
@@ -1189,9 +1211,7 @@ mod tests {
     use crate::packet::error::PacketError;
     #[cfg(feature = "compression_lz4")]
     use crate::packet::header::PacketHeader;
-    #[cfg(feature = "compression_lz4")]
-    use crate::packet::message::FragmentCompression;
-    use crate::packet::message::{FragmentIndex, MessageId};
+    use crate::packet::message::{FragmentCompression, FragmentIndex, MessageId};
     use crate::packet::message::{SendMessage, SendMessageKey};
     #[cfg(feature = "compression_lz4")]
     use crate::packet::packet::HEADER_BYTES;
@@ -1937,6 +1957,78 @@ mod tests {
 
         let contents = decompress_packet_for_test(packet)?.parse_packet_payload()?;
         assert_eq!(contents.get(channel_id).unwrap(), &vec![fragment.bytes]);
+        Ok(())
+    }
+
+    #[test]
+    fn staged_builder_fills_each_final_fragment_with_singles() -> Result<(), PacketError> {
+        let channel_registry = get_channel_registry();
+        let channel_kind = ChannelKind::of::<Channel1>();
+        let channel_id = *channel_registry.get_net_from_kind(&channel_kind).unwrap();
+        let mut candidates = Vec::new();
+
+        for (message_id, key_offset) in [(MessageId(0), 0), (MessageId(1), 2)] {
+            for fragment_index in 0..2 {
+                candidates.push(SendCandidate::new(
+                    channel_kind,
+                    channel_id,
+                    SendMessageKey::UnreliableFragment(key_offset + fragment_index),
+                    u64::from(message_id.0),
+                    SendMessage {
+                        data: FragmentData {
+                            message_id,
+                            fragment_id: FragmentIndex(fragment_index as u64),
+                            num_fragments: FragmentIndex(2),
+                            compression: (fragment_index == 0).then_some(FragmentCompression::None),
+                            bytes: Bytes::from(vec![fragment_index as u8; 900]),
+                        }
+                        .into(),
+                        priority: 1.0,
+                    },
+                ));
+            }
+        }
+        candidates.extend((0..5).map(|index| {
+            SendCandidate::new(
+                channel_kind,
+                channel_id,
+                SendMessageKey::UnreliableSingle(index),
+                (index + 2) as u64,
+                SendMessage {
+                    data: SingleData::new(None, Bytes::from(vec![index as u8; 100])).into(),
+                    priority: 1.0,
+                },
+            )
+        }));
+
+        let mut builder = PacketBuilder::new(1.5);
+        let mut cursor = CandidateCursor::default();
+        let mut packets = Vec::new();
+        while let Some(packet) = builder.build_next_packet(
+            Tick(0),
+            &candidates,
+            &mut cursor,
+            CompressionConfig::DISABLED,
+        )? {
+            builder
+                .header_manager
+                .commit_send_packet(packet.packet_id, Duration::default());
+            packets.push(packet);
+        }
+
+        assert_eq!(packets.len(), 5);
+        for packet_index in [1, 3] {
+            let packet = &packets[packet_index];
+            assert_eq!(packet.messages.len(), 3);
+            assert_eq!(packet.messages[0].fragment_index, Some(FragmentIndex(1)));
+            assert!(
+                packet.messages[1..]
+                    .iter()
+                    .all(|metadata| metadata.fragment_index.is_none())
+            );
+        }
+        assert_eq!(packets[4].messages.len(), 1);
+        assert!(packets[4].messages[0].fragment_index.is_none());
         Ok(())
     }
 

--- a/crates/transport/transport/src/packet/packet_builder.rs
+++ b/crates/transport/transport/src/packet/packet_builder.rs
@@ -6,19 +6,14 @@ use crate::packet::compression::{
 };
 use crate::packet::error::PacketError;
 use crate::packet::header::PacketHeaderManager;
-use crate::packet::message::{FragmentData, MessageData, SendCandidate, SingleData};
+use crate::packet::message::{MessageData, SendCandidate};
 use crate::packet::packet::{FRAGMENT_SIZE, HEADER_BYTES, MessageMetadata, Packet, SendCommit};
 use crate::packet::packet_type::PacketType;
-use alloc::collections::VecDeque;
 use alloc::vec::Vec;
 use bytes::Bytes;
-use core::time::Duration;
-use lightyear_core::network::NetId;
 use lightyear_core::tick::Tick;
-use lightyear_serde::{SerializationError, ToBytes, varint::varint_len, writer::WriteInteger};
+use lightyear_serde::{SerializationError, ToBytes};
 use tracing::trace;
-#[cfg(feature = "trace")]
-use tracing::{Level, instrument};
 
 pub const MAX_PACKET_SIZE: usize = 1200;
 pub const MAX_UNFRAGMENTED_PAYLOAD_SIZE: usize = FRAGMENT_SIZE;
@@ -26,7 +21,6 @@ pub const MAX_UNFRAGMENTED_PAYLOAD_SIZE: usize = FRAGMENT_SIZE;
 pub type Payload = Vec<u8>;
 
 const MAX_MESSAGES_PER_CHANNEL_BATCH: usize = u8::MAX as usize;
-const MAX_RETAINED_PACKET_LIST_CAPACITY: usize = 100;
 const MAX_RETAINED_MESSAGE_METADATA_CAPACITY: usize = 100;
 
 /// We use `Bytes` on the receive side because we want to be able to refer to sub-slices of the original
@@ -55,15 +49,7 @@ struct SingleBatchState {
 #[derive(Debug)]
 pub(crate) struct PacketBuilder {
     pub(crate) header_manager: PacketHeaderManager,
-    current_packet: Option<Packet>,
     buffer_pool: BufferPool,
-    // Pre-allocated buffer to encode/decode without allocation.
-    // TODO: should this be associated with Packet?
-    // cursor: Vec<u8>,
-    // acks: Vec<(ChannelId, Vec<MessageAck>)>,
-    // How many bytes we know we are going to have to write in the packet, but haven't written yet
-    // prewritten_size: usize,
-    // mid_packet: bool,
 }
 
 /// Reusable packet-builder buffers.
@@ -75,7 +61,6 @@ pub(crate) struct PacketBuilder {
 pub(crate) struct BufferPool {
     payload_capacity: usize,
     payloads: Vec<Payload>,
-    packet_lists: Vec<Vec<Packet>>,
     message_metadata: Vec<Vec<MessageMetadata>>,
 }
 
@@ -84,7 +69,6 @@ impl BufferPool {
         Self {
             payload_capacity,
             payloads: Vec::new(),
-            packet_lists: Vec::new(),
             message_metadata: Vec::new(),
         }
     }
@@ -98,16 +82,6 @@ impl BufferPool {
                 payload
             })
             .unwrap_or_else(|| Vec::with_capacity(self.payload_capacity))
-    }
-
-    pub(crate) fn take_packet_list(&mut self) -> Vec<Packet> {
-        self.packet_lists
-            .pop()
-            .map(|mut packets| {
-                packets.clear();
-                packets
-            })
-            .unwrap_or_default()
     }
 
     pub(crate) fn take_message_metadata(&mut self) -> Vec<MessageMetadata> {
@@ -128,12 +102,6 @@ impl BufferPool {
         self.recycle_message_metadata(messages);
     }
 
-    pub(crate) fn recycle_packets(&mut self, packets: impl IntoIterator<Item = Packet>) {
-        for packet in packets {
-            self.recycle_packet(packet);
-        }
-    }
-
     fn recycle_payload(&mut self, mut payload: Payload) {
         if payload.capacity() == self.payload_capacity {
             payload.clear();
@@ -148,14 +116,6 @@ impl BufferPool {
             self.message_metadata.push(messages);
         }
     }
-
-    pub(crate) fn recycle_packet_list(&mut self, mut packets: Vec<Packet>) {
-        self.recycle_packets(packets.drain(..));
-        let capacity = packets.capacity();
-        if (1..=MAX_RETAINED_PACKET_LIST_CAPACITY).contains(&capacity) {
-            self.packet_lists.push(packets);
-        }
-    }
 }
 
 impl Default for PacketBuilder {
@@ -168,15 +128,7 @@ impl PacketBuilder {
     pub fn new(nack_rtt_multiple: f32) -> Self {
         Self {
             header_manager: PacketHeaderManager::new(nack_rtt_multiple),
-            current_packet: None,
             buffer_pool: BufferPool::new(MAX_PACKET_SIZE),
-            // cursor: Vec::with_capacity(PACKET_BUFFER_CAPACITY),
-            // acks: Vec::new(),
-
-            // we start with 1 extra byte for the final ChannelId = 0 that marks the end of the packet
-            // prewritten_size: 0,
-            // are we in the middle of writing a packet?
-            // mid_packet: false,
         }
     }
 
@@ -184,16 +136,8 @@ impl PacketBuilder {
         self.buffer_pool.recycle_packet(packet);
     }
 
-    pub(crate) fn recycle_packets(&mut self, packets: impl IntoIterator<Item = Packet>) {
-        self.buffer_pool.recycle_packets(packets);
-    }
-
     pub(crate) fn recycle_message_metadata_list(&mut self, messages: Vec<MessageMetadata>) {
         self.buffer_pool.recycle_message_metadata(messages);
-    }
-
-    pub(crate) fn recycle_packet_list(&mut self, packets: Vec<Packet>) {
-        self.buffer_pool.recycle_packet_list(packets);
     }
 
     /// Stage the next packet from globally ordered, channel-owned candidates.
@@ -232,10 +176,10 @@ impl PacketBuilder {
                     Some(fragment.message_id),
                     Some(fragment.fragment_id),
                     Some(fragment.num_fragments.0),
-                    Some(SendCommit {
+                    SendCommit {
                         channel_kind: first.channel_kind,
                         key: first.key,
-                    }),
+                    },
                     #[cfg(feature = "metrics")]
                     fragment.bytes.len(),
                 );
@@ -276,7 +220,7 @@ impl PacketBuilder {
                         mtu: MAX_PACKET_SIZE,
                     });
                 }
-                Ok(Some(Self::finalize_packet(packet)))
+                Ok(Some(packet))
             }
             MessageData::Single(_) => {
                 let mut packet = self.new_staged_packet(PacketType::Data, current_tick)?;
@@ -330,7 +274,6 @@ impl PacketBuilder {
             payload,
             messages,
             packet_id: header.packet_id,
-            prewritten_size: 0,
             compression: None,
         })
     }
@@ -375,10 +318,10 @@ impl PacketBuilder {
             message.id,
             None,
             None,
-            Some(SendCommit {
+            SendCommit {
                 channel_kind: candidate.channel_kind,
                 key: candidate.key,
-            }),
+            },
             #[cfg(feature = "metrics")]
             message.bytes_len(),
         );
@@ -405,589 +348,6 @@ impl PacketBuilder {
         packet.messages.truncate(metadata_len);
         *batch = previous_batch;
         Ok(false)
-    }
-
-    /// Start building new packet, we start with an empty packet
-    /// that can write to a given channel
-    pub(crate) fn build_new_single_packet(
-        &mut self,
-        real: Duration,
-        current_tick: Tick,
-    ) -> Result<(), SerializationError> {
-        let mut cursor = self.buffer_pool.take_payload();
-        let messages = self.buffer_pool.take_message_metadata();
-
-        // write the header
-        let header =
-            self.header_manager
-                .prepare_send_packet_header(PacketType::Data, real, current_tick);
-        header.to_bytes(&mut cursor)?;
-        self.current_packet = Some(Packet {
-            payload: cursor,
-            messages,
-            packet_id: header.packet_id,
-            prewritten_size: 0,
-            compression: None,
-        });
-        Ok(())
-    }
-
-    pub(crate) fn build_new_fragment_packet(
-        &mut self,
-        real: Duration,
-        channel_id: NetId,
-        fragment_data: &FragmentData,
-        current_tick: Tick,
-    ) -> Result<(), SerializationError> {
-        let mut cursor = self.buffer_pool.take_payload();
-        let messages = self.buffer_pool.take_message_metadata();
-        // writer the header
-        let header = self.header_manager.prepare_send_packet_header(
-            PacketType::DataFragment,
-            real,
-            current_tick,
-        );
-        header.to_bytes(&mut cursor)?;
-        channel_id.to_bytes(&mut cursor)?;
-        fragment_data.to_bytes(&mut cursor)?;
-        let mut packet = Packet {
-            payload: cursor,
-            messages,
-            packet_id: header.packet_id,
-            prewritten_size: 0,
-            compression: None,
-        };
-        packet.record_message_metadata(
-            ChannelId::from(channel_id),
-            Some(fragment_data.message_id),
-            Some(fragment_data.fragment_id),
-            Some(fragment_data.num_fragments.0),
-            None,
-            #[cfg(feature = "metrics")]
-            fragment_data.bytes.len(),
-        );
-        self.current_packet = Some(packet);
-        Ok(())
-
-        //
-        // let is_last_fragment = fragment_data.is_last_fragment();
-        // let packet = FragmentedPacket::new(channel_id, fragment_data);
-        //
-        // debug_assert!(packet.fragment.bytes.len() <= FRAGMENT_SIZE);
-        // if is_last_fragment {
-        //     packet.encode(&mut self.try_write_buffer).unwrap();
-        //     // reserve one extra bit for the continuation bit between fragment/single packet data
-        //     self.try_write_buffer.reserve_bits(1);
-        //
-        //     // let num_bits_written = self.try_write_buffer.num_bits_written();
-        //     // no need to reserve bits, since we already just wrote in the try buffer!
-        //     // self.try_write_buffer.reserve_bits(num_bits_written);
-        //     debug_assert!(!self.try_write_buffer.overflowed())
-        // }
-        //
-        // Packet {
-        //     header,
-        //     data: PacketData::Fragmented(packet),
-        // }
-    }
-
-    pub fn finish_packet(&mut self) -> Packet {
-        Self::finalize_packet(self.current_packet.take().unwrap())
-    }
-
-    fn finalize_packet(packet: Packet) -> Packet {
-        packet
-    }
-
-    /// Pack messages into packets
-    ///
-    /// In general the strategy is:
-    /// - sort the single data messages from smallest to largest
-    /// - write the fragment data first. Big fragments take the entire packet. Small fragments have
-    ///   some room to spare for small messages
-    #[cfg_attr(feature = "trace", instrument(level = Level::INFO, skip_all))]
-    pub fn build_packets(
-        &mut self,
-        real: Duration,
-        current_tick: Tick,
-        single_data: Vec<(ChannelId, VecDeque<SingleData>)>,
-        fragment_data: Vec<(ChannelId, VecDeque<FragmentData>)>,
-    ) -> Result<Vec<Packet>, SerializationError> {
-        self.build_packets_uncompressed(real, current_tick, single_data, fragment_data)
-    }
-
-    #[cfg_attr(feature = "trace", instrument(level = Level::INFO, skip_all))]
-    pub fn build_packets_with_compression(
-        &mut self,
-        real: Duration,
-        current_tick: Tick,
-        single_data: Vec<(ChannelId, VecDeque<SingleData>)>,
-        fragment_data: Vec<(ChannelId, VecDeque<FragmentData>)>,
-        compression: CompressionConfig,
-    ) -> Result<Vec<Packet>, PacketError> {
-        if !compression.is_enabled() {
-            let packets =
-                self.build_packets_uncompressed(real, current_tick, single_data, fragment_data)?;
-            for packet in &packets {
-                Self::trace_compression_outcome(
-                    packet,
-                    "disabled",
-                    packet.payload.len(),
-                    None,
-                    None,
-                );
-            }
-            return Ok(packets);
-        }
-        self.build_packets_internal(real, current_tick, single_data, fragment_data, compression)
-    }
-
-    fn build_packets_uncompressed(
-        &mut self,
-        real: Duration,
-        current_tick: Tick,
-        single_data: Vec<(ChannelId, VecDeque<SingleData>)>,
-        fragment_data: Vec<(ChannelId, VecDeque<FragmentData>)>,
-    ) -> Result<Vec<Packet>, SerializationError> {
-        self.build_packets_internal(
-            real,
-            current_tick,
-            single_data,
-            fragment_data,
-            CompressionConfig::DISABLED,
-        )
-        .map_err(|error| match error {
-            PacketError::Serialization(error) => error,
-            other => panic!("unexpected packet builder error without compression: {other:?}"),
-        })
-    }
-
-    fn build_packets_internal(
-        &mut self,
-        real: Duration,
-        current_tick: Tick,
-        mut single_data: Vec<(ChannelId, VecDeque<SingleData>)>,
-        fragment_data: Vec<(ChannelId, VecDeque<FragmentData>)>,
-        compression: CompressionConfig,
-    ) -> Result<Vec<Packet>, PacketError> {
-        let mut packets = self.buffer_pool.take_packet_list();
-
-        // indices in the main vec
-        let mut single_data_idx = 0;
-
-        for (_, single_messages) in single_data.iter_mut() {
-            // sort from smallest to largest each array of small messages
-            single_messages
-                .make_contiguous()
-                .sort_by_key(|message| message.bytes.len());
-        }
-
-        // try to fill the packet with fragment messages first
-        for (channel_id, mut fragment_messages) in fragment_data.into_iter() {
-            while let Some(fragment_data) = fragment_messages.pop_front() {
-                debug_assert!(fragment_data.bytes.len() <= FRAGMENT_SIZE);
-                self.build_new_fragment_packet(real, channel_id, &fragment_data, current_tick)?;
-                if !fragment_data.is_last_fragment() {
-                    // big fragment, write packet immediately
-                    packets.push(self.finish_packet());
-                } else {
-                    let mut packet = self.current_packet.take().unwrap();
-                    // it's a smaller fragment, fill it with small messages
-                    'out: while single_data_idx < single_data.len() {
-                        let (channel_id, single_messages) = &mut single_data[single_data_idx];
-                        // if we don't even have space for a new channel, return the packet immediately
-                        if !packet.can_fit_channel(*channel_id) {
-                            break;
-                        }
-
-                        // number of messages for this channel that we will write
-                        // (we wait until we know the full number, because we want to write that)
-                        let mut num_messages = 0;
-                        // fill with messages from the current channel
-                        loop {
-                            if num_messages == MAX_MESSAGES_PER_CHANNEL_BATCH
-                                && num_messages < single_messages.len()
-                            {
-                                Self::write_single_messages(
-                                    &mut packet,
-                                    single_messages,
-                                    &mut num_messages,
-                                    *channel_id,
-                                )?;
-                                break 'out;
-                            }
-                            // no more messages to send in this channel, try to fill with messages from the next channels
-                            if num_messages == single_messages.len() {
-                                Self::write_single_messages(
-                                    &mut packet,
-                                    single_messages,
-                                    &mut num_messages,
-                                    *channel_id,
-                                )?;
-                                single_data_idx += 1;
-                                break;
-                            }
-
-                            if packet.can_fit(single_messages[num_messages].bytes_len()) {
-                                packet.prewritten_size += single_messages[num_messages].bytes_len();
-                                num_messages += 1;
-                            } else {
-                                // can't add any more messages (since we sorted messages from smallest to largest)
-                                // finish packet and go back to trying to write fragment messages
-                                Self::write_single_messages(
-                                    &mut packet,
-                                    single_messages,
-                                    &mut num_messages,
-                                    *channel_id,
-                                )?;
-                                break 'out;
-                            }
-                        }
-                    }
-                    // no more single messages to send, finish the fragment packet
-                    self.current_packet = Some(packet);
-                    packets.push(self.finish_packet());
-                }
-            }
-        }
-
-        debug_assert!(self.current_packet.is_none());
-
-        // all fragment messages have been written, now write small messages
-        if compression.is_enabled() {
-            self.build_single_packets_compression_aware(
-                real,
-                current_tick,
-                &mut single_data,
-                single_data_idx,
-                &mut packets,
-                compression,
-            )?;
-            return Ok(packets);
-        }
-
-        'out: while single_data_idx < single_data.len() {
-            let (channel_id, single_messages) = &mut single_data[single_data_idx];
-            // start a new packet if we aren't already writing one
-            if self.current_packet.is_none() {
-                self.build_new_single_packet(real, current_tick)?;
-            }
-
-            let mut packet = self.current_packet.take().unwrap();
-            // we need to call this to preassign the channel_id
-            if !packet.can_fit_channel(*channel_id) {
-                // can't add any more messages (since we sorted messages from smallest to largest)
-                // finish packet and go back to trying to write fragment messages
-                self.current_packet = Some(packet);
-                packets.push(self.finish_packet());
-                continue 'out;
-            }
-            // number of messages for this channel that we will write
-            // (we wait until we know the full number, because we want to write that)
-            let mut num_messages = 0;
-            // fill with messages from the current channel
-            loop {
-                if num_messages == MAX_MESSAGES_PER_CHANNEL_BATCH
-                    && num_messages < single_messages.len()
-                {
-                    Self::write_single_messages(
-                        &mut packet,
-                        single_messages,
-                        &mut num_messages,
-                        *channel_id,
-                    )?;
-                    self.current_packet = Some(packet);
-                    packets.push(self.finish_packet());
-                    continue 'out;
-                }
-                // no more messages to send in this channel, try to fill with messages from the next channels
-                if num_messages == single_messages.len() {
-                    Self::write_single_messages(
-                        &mut packet,
-                        single_messages,
-                        &mut num_messages,
-                        *channel_id,
-                    )?;
-                    // we make sure we keep writing the current packet
-                    self.current_packet = Some(packet);
-                    single_data_idx += 1;
-                    break;
-                }
-
-                if packet.can_fit(single_messages[num_messages].bytes_len()) {
-                    packet.prewritten_size += single_messages[num_messages].bytes_len();
-                    num_messages += 1;
-                } else {
-                    // can't add any more messages (since we sorted messages from smallest to largest)
-                    // finish packet and go back to trying to write fragment messages
-                    Self::write_single_messages(
-                        &mut packet,
-                        single_messages,
-                        &mut num_messages,
-                        *channel_id,
-                    )?;
-                    self.current_packet = Some(packet);
-                    packets.push(self.finish_packet());
-                    continue 'out;
-                }
-            }
-        }
-
-        // if we had a packet we were working on, push it
-        if self.current_packet.is_some() {
-            packets.push(self.finish_packet());
-        }
-        Ok(packets)
-    }
-
-    /// Helper function to fill the current packet with single data message from the current channel
-    fn write_single_messages(
-        packet: &mut Packet,
-        messages: &mut VecDeque<SingleData>,
-        num_messages: &mut usize,
-        channel_id: ChannelId,
-    ) -> Result<(), SerializationError> {
-        debug_assert!(*num_messages <= MAX_MESSAGES_PER_CHANNEL_BATCH);
-        packet.prewritten_size = packet
-            .prewritten_size
-            .checked_sub(varint_len(channel_id as u64) + 1)
-            .ok_or(SerializationError::SubtractionOverflow)?;
-        if *num_messages > 0 {
-            trace!("Writing packet with {} messages", *num_messages);
-            channel_id.to_bytes(&mut packet.payload)?;
-            // write the number of messages for the current channel
-            packet.payload.write_u8(*num_messages as u8)?;
-            // write the messages
-            for _ in 0..*num_messages {
-                // TODO: deal with error
-                let message = messages.pop_front().unwrap();
-                #[cfg(feature = "metrics")]
-                let message_bytes = message.bytes_len();
-                message.to_bytes(&mut packet.payload)?;
-                packet.prewritten_size = packet
-                    .prewritten_size
-                    .checked_sub(message.bytes_len())
-                    .ok_or(SerializationError::SubtractionOverflow)?;
-                packet.record_message_metadata(
-                    channel_id,
-                    message.id,
-                    None,
-                    None,
-                    None,
-                    #[cfg(feature = "metrics")]
-                    message_bytes,
-                );
-            }
-            *num_messages = 0;
-        }
-        Ok(())
-    }
-
-    fn build_single_packets_compression_aware(
-        &mut self,
-        real: Duration,
-        current_tick: Tick,
-        single_data: &mut [(ChannelId, VecDeque<SingleData>)],
-        mut single_data_idx: usize,
-        packets: &mut Vec<Packet>,
-        compression: CompressionConfig,
-    ) -> Result<(), PacketError> {
-        while single_data_idx < single_data.len() {
-            if single_data[single_data_idx].1.is_empty() {
-                single_data_idx += 1;
-                continue;
-            }
-
-            if self.current_packet.is_none() {
-                self.build_new_single_packet(real, current_tick)?;
-            }
-
-            let mut packet = self.current_packet.take().unwrap();
-            let (channel_id, single_messages) = &mut single_data[single_data_idx];
-            let max_count = single_messages.len().min(MAX_MESSAGES_PER_CHANNEL_BATCH);
-            let fit_count = Self::find_compression_aware_message_count(
-                &packet,
-                *channel_id,
-                single_messages,
-                max_count,
-                compression,
-            )?;
-
-            if fit_count == 0 {
-                if Self::packet_has_body(&packet) {
-                    packets.push(Self::finish_compression_aware_packet(packet, compression)?);
-                    continue;
-                }
-                let candidate_len =
-                    Self::candidate_packet_len(&packet, *channel_id, single_messages, 1)?;
-                return Err(PacketError::PacketTooLarge {
-                    actual: candidate_len,
-                    mtu: MAX_PACKET_SIZE,
-                });
-            }
-
-            Self::append_single_messages(
-                &mut packet,
-                *channel_id,
-                single_messages,
-                fit_count,
-                true,
-            )?;
-            for _ in 0..fit_count {
-                single_messages.pop_front();
-            }
-
-            let channel_drained = single_messages.is_empty();
-            let hit_channel_batch_limit =
-                fit_count == MAX_MESSAGES_PER_CHANNEL_BATCH && !channel_drained;
-            let packet_full = fit_count < max_count || hit_channel_batch_limit;
-
-            if channel_drained {
-                single_data_idx += 1;
-            }
-
-            if packet_full {
-                packets.push(Self::finish_compression_aware_packet(packet, compression)?);
-            } else {
-                self.current_packet = Some(packet);
-            }
-        }
-
-        if let Some(packet) = self.current_packet.take()
-            && Self::packet_has_body(&packet)
-        {
-            packets.push(Self::finish_compression_aware_packet(packet, compression)?);
-        }
-        Ok(())
-    }
-
-    fn find_compression_aware_message_count(
-        packet: &Packet,
-        channel_id: ChannelId,
-        messages: &VecDeque<SingleData>,
-        max_count: usize,
-        compression: CompressionConfig,
-    ) -> Result<usize, PacketError> {
-        if max_count == 0 {
-            return Ok(0);
-        }
-
-        if !Self::candidate_packet_fits(packet, channel_id, messages, 1, compression)? {
-            return Ok(0);
-        }
-
-        let mut best = 1;
-        let mut next = 2;
-
-        while next <= max_count {
-            if Self::candidate_packet_fits(packet, channel_id, messages, next, compression)? {
-                best = next;
-                if next == max_count {
-                    return Ok(best);
-                }
-                next = next.saturating_mul(2).min(max_count);
-            } else {
-                break;
-            }
-        }
-
-        let mut low = best + 1;
-        let mut high = next.min(max_count);
-        while low <= high {
-            let mid = low + (high - low) / 2;
-            if Self::candidate_packet_fits(packet, channel_id, messages, mid, compression)? {
-                best = mid;
-                low = mid + 1;
-            } else if mid == 0 {
-                break;
-            } else {
-                high = mid - 1;
-            }
-        }
-
-        Ok(best)
-    }
-
-    fn candidate_packet_fits(
-        packet: &Packet,
-        channel_id: ChannelId,
-        messages: &VecDeque<SingleData>,
-        count: usize,
-        compression: CompressionConfig,
-    ) -> Result<bool, PacketError> {
-        let candidate = Self::candidate_packet(packet, channel_id, messages, count)?;
-        let uncompressed_fits = candidate.payload.len() <= MAX_PACKET_SIZE;
-        let compression_candidate =
-            try_build_compressed_packet_payload(&candidate.payload, compression)?;
-        #[cfg(feature = "metrics")]
-        if matches!(
-            compression_candidate,
-            CompressionCandidate::Compressed { .. } | CompressionCandidate::NotSmaller { .. }
-        ) {
-            metrics::counter!("transport/compression_abandoned").increment(1);
-        }
-        Ok(uncompressed_fits
-            || matches!(
-                compression_candidate,
-                CompressionCandidate::Compressed { .. }
-            ))
-    }
-
-    fn candidate_packet_len(
-        packet: &Packet,
-        channel_id: ChannelId,
-        messages: &VecDeque<SingleData>,
-        count: usize,
-    ) -> Result<usize, SerializationError> {
-        Ok(Self::candidate_packet(packet, channel_id, messages, count)?
-            .payload
-            .len())
-    }
-
-    fn candidate_packet(
-        packet: &Packet,
-        channel_id: ChannelId,
-        messages: &VecDeque<SingleData>,
-        count: usize,
-    ) -> Result<Packet, SerializationError> {
-        let mut candidate = Packet {
-            payload: packet.payload.clone(),
-            messages: Vec::new(),
-            packet_id: packet.packet_id,
-            prewritten_size: 0,
-            compression: None,
-        };
-        Self::append_single_messages(&mut candidate, channel_id, messages, count, false)?;
-        Ok(candidate)
-    }
-
-    fn append_single_messages(
-        packet: &mut Packet,
-        channel_id: ChannelId,
-        messages: &VecDeque<SingleData>,
-        count: usize,
-        record_metadata: bool,
-    ) -> Result<(), SerializationError> {
-        debug_assert!(count <= MAX_MESSAGES_PER_CHANNEL_BATCH);
-        channel_id.to_bytes(&mut packet.payload)?;
-        packet.payload.write_u8(count as u8)?;
-        for message in messages.iter().take(count) {
-            #[cfg(feature = "metrics")]
-            let message_bytes = message.bytes_len();
-            message.to_bytes(&mut packet.payload)?;
-            if record_metadata {
-                packet.record_message_metadata(
-                    channel_id,
-                    message.id,
-                    None,
-                    None,
-                    None,
-                    #[cfg(feature = "metrics")]
-                    message_bytes,
-                );
-            }
-        }
-        Ok(())
     }
 
     fn finish_compression_aware_packet(
@@ -1084,7 +444,7 @@ impl PacketBuilder {
                 }
             }
         }
-        Ok(Self::finalize_packet(packet))
+        Ok(packet)
     }
 
     fn trace_compression_outcome(
@@ -1106,99 +466,13 @@ impl PacketBuilder {
             "transport packet compression outcome"
         );
     }
-
-    fn packet_has_body(packet: &Packet) -> bool {
-        packet.payload.len() > HEADER_BYTES
-    }
-
-    // /// Uses multiple exponential searches to fill a packet. Has a good worst case runtime and doesn't
-    // /// create any extraneous extension packets.
-    // fn pack_multiple_exponential(mut messages: &[Message]) -> Vec<Packet> {
-    //     /// A Vec<u8> prefixed by its length as a u32. Each [`Packet`] contains 1 or more [`Section`]s.
-    //     struct Section(Vec<u8>);
-    //     impl Section {
-    //         fn len(&self) -> usize {
-    //             self.0.len() + core::mem::size_of::<u32>()
-    //         }
-    //         fn write(&self, out: &mut Vec<u8>) {
-    //             out.reserve(self.len());
-    //             out.extend_from_slice(&u32::try_from(self.0.len()).unwrap().to_le_bytes()); // TODO use varint.
-    //             out.extend_from_slice(&self.0);
-    //         }
-    //     }
-    //
-    //     let mut buffer = bitcode::Buffer::new(); // TODO save between calls.
-    //     let mut packets = vec![];
-    //
-    //     while !messages.is_empty() {
-    //         let mut remaining = Packet::MAX_SIZE;
-    //         let mut bytes = vec![];
-    //
-    //         while remaining > 0 && !messages.is_empty() {
-    //             let mut i = 0;
-    //             let mut previous = None;
-    //
-    //             loop {
-    //                 i = (i * 2).clamp(1, messages.len());
-    //                 const COMPRESS: bool = true;
-    //                 let b = Section(if COMPRESS {
-    //                     lz4_flex::compress_prepend_size(&buffer.encode(&messages[..i]))
-    //                 } else {
-    //                     buffer.encode(&messages[..i]).to_vec()
-    //                 });
-    //
-    //                 let (i, b) = if b.len() <= remaining {
-    //                     if i == messages.len() {
-    //                         // No more messages.
-    //                         (i, b)
-    //                     } else {
-    //                         // Try to fit more.
-    //                         previous = Some((i, b));
-    //                         continue;
-    //                     }
-    //                 } else if let Some((i, b)) = previous {
-    //                     // Current failed, so use previous.
-    //                     (i, b)
-    //                 } else {
-    //                     assert_eq!(i, 1);
-    //                     // 1 message doesn't fit. If starting a new packet would result in fewer
-    //                     // fragments, flush the current packet.
-    //                     let flush_fragments = b.len().div_ceil(Packet::MAX_SIZE) - 1;
-    //                     let keep_fragments = (b.len() - remaining).div_ceil(Packet::MAX_SIZE);
-    //                     if flush_fragments < keep_fragments {
-    //                         // TODO try to fill current packet by with packets after the single large packet.
-    //                         packets.push(Packet(core::mem::take(&mut bytes)));
-    //                         remaining = Packet::MAX_SIZE;
-    //                     }
-    //                     (i, b)
-    //                 };
-    //
-    //                 messages = &messages[i..];
-    //                 if bytes.is_empty() && b.len() < Packet::MAX_SIZE {
-    //                     bytes = Vec::with_capacity(Packet::MAX_SIZE); // Assume we'll fill the packet.
-    //                 }
-    //                 b.write(&mut bytes);
-    //                 if b.len() > remaining {
-    //                     assert_eq!(i, 1);
-    //                     // TODO fill extension packets. We would need to know where the section ends
-    //                     // within the packet in case previous packets are lost.
-    //                     remaining = 0;
-    //                 } else {
-    //                     remaining -= b.len();
-    //                 }
-    //                 break;
-    //             }
-    //         }
-    //         packets.push(Packet(bytes));
-    //     }
-    //     packets
-    // }
 }
 
 #[cfg(test)]
 mod tests {
-    use alloc::collections::VecDeque;
     use alloc::vec;
+    use core::time::Duration;
+
     use bevy_app::App;
     use bevy_reflect::TypePath;
     use bevy_utils::default;
@@ -1207,15 +481,16 @@ mod tests {
     use crate::channel::registry::{AppChannelExt, ChannelKind, ChannelRegistry};
     use crate::channel::senders::fragment_sender::FragmentSender;
     #[cfg(feature = "compression_lz4")]
-    use crate::packet::compression::{CompressionConfig, decompress_payload, try_compress_packet};
+    use crate::packet::compression::decompress_payload;
     use crate::packet::error::PacketError;
     #[cfg(feature = "compression_lz4")]
     use crate::packet::header::PacketHeader;
-    use crate::packet::message::{FragmentCompression, FragmentIndex, MessageId};
-    use crate::packet::message::{SendMessage, SendMessageKey};
+    use crate::packet::message::{
+        FragmentCompression, FragmentData, FragmentIndex, MessageId, SendMessage, SendMessageKey,
+        SingleData,
+    };
     #[cfg(feature = "compression_lz4")]
     use crate::packet::packet::HEADER_BYTES;
-    use crate::packet::packet::MessageMetadata;
     use bytes::Bytes;
 
     use super::*;
@@ -1243,6 +518,65 @@ mod tests {
         app.world_mut()
             .remove_resource::<ChannelRegistry>()
             .unwrap()
+    }
+
+    fn single_candidate(
+        channel_kind: ChannelKind,
+        channel_id: ChannelId,
+        index: usize,
+        bytes: Bytes,
+    ) -> SendCandidate {
+        SendCandidate::new(
+            channel_kind,
+            channel_id,
+            SendMessageKey::UnreliableSingle(index),
+            index as u64,
+            SendMessage {
+                data: SingleData::new(None, bytes).into(),
+                priority: 1.0,
+            },
+        )
+    }
+
+    fn fragment_candidates(
+        channel_kind: ChannelKind,
+        channel_id: ChannelId,
+        fragments: Vec<FragmentData>,
+    ) -> Vec<SendCandidate> {
+        fragments
+            .into_iter()
+            .enumerate()
+            .map(|(index, fragment)| {
+                SendCandidate::new(
+                    channel_kind,
+                    channel_id,
+                    SendMessageKey::UnreliableFragment(index),
+                    u64::from(fragment.message_id.0),
+                    SendMessage {
+                        data: fragment.into(),
+                        priority: 1.0,
+                    },
+                )
+            })
+            .collect()
+    }
+
+    fn build_staged_packets(
+        builder: &mut PacketBuilder,
+        candidates: &[SendCandidate],
+        compression: CompressionConfig,
+    ) -> Result<Vec<Packet>, PacketError> {
+        let mut cursor = CandidateCursor::default();
+        let mut packets = Vec::new();
+        while let Some(packet) =
+            builder.build_next_packet(Tick(0), candidates, &mut cursor, compression)?
+        {
+            builder
+                .header_manager
+                .commit_send_packet(packet.packet_id, Duration::default());
+            packets.push(packet);
+        }
+        Ok(packets)
     }
 
     #[cfg(feature = "compression_lz4")]
@@ -1293,337 +627,164 @@ mod tests {
     }
 
     #[test]
-    fn buffer_pool_reuses_packet_lists_up_to_retained_capacity() {
-        let mut pool = BufferPool::new(MAX_PACKET_SIZE);
-
-        pool.recycle_packet_list(Vec::with_capacity(MAX_RETAINED_PACKET_LIST_CAPACITY));
-        assert_eq!(
-            pool.take_packet_list().capacity(),
-            MAX_RETAINED_PACKET_LIST_CAPACITY
-        );
-    }
-
-    #[test]
-    fn buffer_pool_drops_oversized_packet_lists() {
-        let mut pool = BufferPool::new(MAX_PACKET_SIZE);
-
-        pool.recycle_packet_list(Vec::with_capacity(MAX_RETAINED_PACKET_LIST_CAPACITY + 1));
-        assert_eq!(pool.take_packet_list().capacity(), 0);
-    }
-
-    /// A bunch of small messages that all fit in the same packet
-    #[test]
-    fn test_pack_small_messages() -> Result<(), PacketError> {
+    fn staged_builder_packs_singles_across_channels() -> Result<(), PacketError> {
         let channel_registry = get_channel_registry();
-        let mut manager = PacketBuilder::new(1.5);
-        let channel_kind1 = ChannelKind::of::<Channel1>();
-        let channel_id1 = channel_registry.get_net_from_kind(&channel_kind1).unwrap();
-        let channel_kind2 = ChannelKind::of::<Channel2>();
-        let channel_id2 = channel_registry.get_net_from_kind(&channel_kind2).unwrap();
-        let channel_kind3 = ChannelKind::of::<Channel3>();
-        let channel_id3 = channel_registry.get_net_from_kind(&channel_kind3).unwrap();
+        let channels = [
+            ChannelKind::of::<Channel1>(),
+            ChannelKind::of::<Channel2>(),
+            ChannelKind::of::<Channel3>(),
+        ]
+        .map(|kind| {
+            let id = *channel_registry.get_net_from_kind(&kind).unwrap();
+            (kind, id)
+        });
+        let candidates = [
+            (channels[0], Bytes::from_static(b"one")),
+            (channels[1], Bytes::from_static(b"two")),
+            (channels[1], Bytes::from_static(b"three")),
+            (channels[2], Bytes::from_static(b"four")),
+        ]
+        .into_iter()
+        .enumerate()
+        .map(|(index, ((kind, id), bytes))| single_candidate(kind, id, index, bytes))
+        .collect::<Vec<_>>();
 
-        let small_bytes = Bytes::from(vec![7u8; 10]);
-        let small_message = SingleData::new(None, small_bytes.clone());
-
-        let single_data = vec![
-            (*channel_id1, VecDeque::from(vec![small_message.clone()])),
-            (
-                *channel_id2,
-                VecDeque::from(vec![small_message.clone(), small_message.clone()]),
-            ),
-            (*channel_id3, VecDeque::from(vec![small_message.clone()])),
-        ];
-        let fragment_data = vec![];
-        let mut packets =
-            manager.build_packets(Duration::default(), Tick(0), single_data, fragment_data)?;
+        let mut packets = build_staged_packets(
+            &mut PacketBuilder::new(1.5),
+            &candidates,
+            CompressionConfig::DISABLED,
+        )?;
         assert_eq!(packets.len(), 1);
-        let packet = packets.pop().unwrap();
-        #[cfg(not(feature = "metrics"))]
-        assert_eq!(packet.messages, vec![]);
-        #[cfg(feature = "metrics")]
+        let contents = packets.pop().unwrap().parse_packet_payload()?;
+        assert_eq!(contents[&channels[0].1], [Bytes::from_static(b"one")]);
         assert_eq!(
-            packet.messages,
-            vec![
-                MessageMetadata {
-                    channel: *channel_id1,
-                    message: None,
-                    fragment_index: None,
-                    num_fragments: None,
-                    commit: None,
-                    num_bytes: small_message.bytes_len(),
-                },
-                MessageMetadata {
-                    channel: *channel_id2,
-                    message: None,
-                    fragment_index: None,
-                    num_fragments: None,
-                    commit: None,
-                    num_bytes: small_message.bytes_len(),
-                },
-                MessageMetadata {
-                    channel: *channel_id2,
-                    message: None,
-                    fragment_index: None,
-                    num_fragments: None,
-                    commit: None,
-                    num_bytes: small_message.bytes_len(),
-                },
-                MessageMetadata {
-                    channel: *channel_id3,
-                    message: None,
-                    fragment_index: None,
-                    num_fragments: None,
-                    commit: None,
-                    num_bytes: small_message.bytes_len(),
-                },
-            ]
+            contents[&channels[1].1],
+            [Bytes::from_static(b"two"), Bytes::from_static(b"three")]
         );
-        let contents = packet.parse_packet_payload()?;
-        assert_eq!(
-            contents.get(channel_id1).unwrap(),
-            &vec![small_bytes.clone()]
-        );
-        assert_eq!(
-            contents.get(channel_id2).unwrap(),
-            &vec![small_bytes.clone(), small_bytes.clone()]
-        );
-        assert_eq!(
-            contents.get(channel_id3).unwrap(),
-            &vec![small_bytes.clone()]
-        );
-        Ok(())
-    }
-
-    /// We cannot write the channel id of the next channel in the packet, so we need to finish the current
-    /// packet and start a new one.
-    /// The message fills the packet after the current header and message encoding overhead,
-    /// leaving no space for another message or channel.
-    ///
-    /// Test both with different channels and same channels
-    #[test]
-    fn test_pack_cannot_write_channel_id() -> Result<(), PacketError> {
-        let channel_registry = get_channel_registry();
-        let mut manager = PacketBuilder::new(1.5);
-        let channel_kind1 = ChannelKind::of::<Channel1>();
-        let channel_id1 = channel_registry.get_net_from_kind(&channel_kind1).unwrap();
-        let channel_kind2 = ChannelKind::of::<Channel2>();
-        let channel_id2 = channel_registry.get_net_from_kind(&channel_kind2).unwrap();
-
-        let small_bytes = Bytes::from(vec![7u8; 1178]);
-        let small_message = SingleData::new(None, small_bytes.clone());
-
-        {
-            let single_data = vec![(
-                *channel_id1,
-                VecDeque::from(vec![small_message.clone(), small_message.clone()]),
-            )];
-            let fragment_data = vec![];
-            let packets =
-                manager.build_packets(Duration::default(), Tick(0), single_data, fragment_data)?;
-            assert_eq!(packets.len(), 2);
-        }
-        {
-            let single_data = vec![
-                (*channel_id1, VecDeque::from(vec![small_message.clone()])),
-                (*channel_id2, VecDeque::from(vec![small_message.clone()])),
-            ];
-            let fragment_data = vec![];
-            let packets =
-                manager.build_packets(Duration::default(), Tick(0), single_data, fragment_data)?;
-            assert_eq!(packets.len(), 2);
-        }
-        Ok(())
-    }
-
-    /// A bunch of small messages that all fit in the same packet
-    #[test]
-    fn test_pack_many_small_messages() -> Result<(), PacketError> {
-        let channel_registry = get_channel_registry();
-        let mut manager = PacketBuilder::new(1.5);
-        let channel_kind1 = ChannelKind::of::<Channel1>();
-        let channel_id1 = channel_registry.get_net_from_kind(&channel_kind1).unwrap();
-        let channel_kind2 = ChannelKind::of::<Channel2>();
-        let channel_id2 = channel_registry.get_net_from_kind(&channel_kind2).unwrap();
-        let channel_kind3 = ChannelKind::of::<Channel3>();
-        let channel_id3 = channel_registry.get_net_from_kind(&channel_kind3).unwrap();
-
-        let small_bytes = Bytes::from(vec![7u8; 10]);
-        let small_message = SingleData::new(None, small_bytes.clone());
-
-        let single_data = vec![
-            (
-                *channel_id1,
-                VecDeque::from(vec![small_message.clone(); 200]),
-            ),
-            (
-                *channel_id2,
-                VecDeque::from(vec![small_message.clone(); 200]),
-            ),
-            (
-                *channel_id3,
-                VecDeque::from(vec![small_message.clone(); 200]),
-            ),
-        ];
-        let fragment_data = vec![];
-        let packets =
-            manager.build_packets(Duration::default(), Tick(0), single_data, fragment_data)?;
-        assert_eq!(packets.len(), 7);
+        assert_eq!(contents[&channels[2].1], [Bytes::from_static(b"four")]);
         Ok(())
     }
 
     #[test]
-    fn compression_candidate_packets_do_not_record_message_metadata() {
+    fn staged_builder_splits_singles_at_mtu() -> Result<(), PacketError> {
         let channel_registry = get_channel_registry();
+        let channels = [
+            ChannelKind::of::<Channel1>(),
+            ChannelKind::of::<Channel2>(),
+            ChannelKind::of::<Channel3>(),
+        ]
+        .map(|kind| {
+            let id = *channel_registry.get_net_from_kind(&kind).unwrap();
+            (kind, id)
+        });
+        let candidates = [channels[0], channels[1], channels[1], channels[2]]
+            .into_iter()
+            .enumerate()
+            .map(|(index, (kind, id))| {
+                single_candidate(kind, id, index, Bytes::from(vec![index as u8; 500]))
+            })
+            .collect::<Vec<_>>();
+
+        let packets = build_staged_packets(
+            &mut PacketBuilder::new(1.5),
+            &candidates,
+            CompressionConfig::DISABLED,
+        )?;
+        assert_eq!(packets.len(), 2);
+        assert!(
+            packets
+                .iter()
+                .all(|packet| packet.payload.len() <= MAX_PACKET_SIZE)
+        );
+        let message_count = packets
+            .into_iter()
+            .map(Packet::parse_packet_payload)
+            .collect::<Result<Vec<_>, _>>()?
+            .into_iter()
+            .map(|contents| contents.values().map(Vec::len).sum::<usize>())
+            .sum::<usize>();
+        assert_eq!(message_count, 4);
+        Ok(())
+    }
+
+    #[test]
+    fn staged_fragment_packets_respect_worst_case_mtu_overhead() -> Result<(), PacketError> {
         let channel_kind = ChannelKind::of::<Channel1>();
-        let channel_id = channel_registry.get_net_from_kind(&channel_kind).unwrap();
-        let messages = VecDeque::from(vec![
-            SingleData::new(Some(MessageId(99)), Bytes::from(vec![7u8; 32])),
-            SingleData::new(None, Bytes::from(vec![8u8; 32])),
-        ]);
+        let channel_id = 64;
+        let fragments = FragmentSender::new().build_fragments(
+            MessageId(1024),
+            Bytes::from(vec![9u8; FRAGMENT_SIZE * 64 + 1]),
+        );
+        let expected_packet_count = fragments.len();
+        let candidates = fragment_candidates(channel_kind, channel_id, fragments);
 
-        let mut manager = PacketBuilder::new(1.5);
-        manager
-            .build_new_single_packet(Duration::default(), Tick(0))
-            .unwrap();
-        let packet = manager.current_packet.take().unwrap();
-        let candidate = PacketBuilder::candidate_packet(&packet, *channel_id, &messages, 2)
-            .expect("candidate packet should serialize");
-
-        assert!(candidate.messages.is_empty());
+        let packets = build_staged_packets(
+            &mut PacketBuilder::new(1.5),
+            &candidates,
+            CompressionConfig::DISABLED,
+        )?;
+        assert_eq!(packets.len(), expected_packet_count);
+        assert!(
+            packets
+                .iter()
+                .all(|packet| packet.payload.len() <= MAX_PACKET_SIZE)
+        );
+        Ok(())
     }
 
     #[cfg(feature = "compression_lz4")]
     #[test]
-    fn compression_aware_packing_compresses_under_mtu_packet() -> Result<(), PacketError> {
+    fn staged_compression_can_pack_beyond_uncompressed_mtu() -> Result<(), PacketError> {
         let channel_registry = get_channel_registry();
         let channel_kind = ChannelKind::of::<Channel1>();
-        let channel_id = channel_registry.get_net_from_kind(&channel_kind).unwrap();
-        let bytes = Bytes::from(vec![7u8; 512]);
-        let single_message = SingleData::new(None, bytes.clone());
+        let channel_id = *channel_registry.get_net_from_kind(&channel_kind).unwrap();
+        let candidates = (0..128)
+            .map(|index| {
+                single_candidate(channel_kind, channel_id, index, Bytes::from(vec![7u8; 64]))
+            })
+            .collect::<Vec<_>>();
+        let compression = CompressionConfig {
+            min_payload_size: 0,
+            ..CompressionConfig::LZ4
+        };
 
-        let uncompressed_packets = PacketBuilder::new(1.5).build_packets(
-            Duration::default(),
-            Tick(0),
-            vec![(*channel_id, VecDeque::from(vec![single_message.clone()]))],
-            vec![],
-        )?;
-        assert_eq!(uncompressed_packets.len(), 1);
-        assert!(uncompressed_packets[0].payload.len() < MAX_PACKET_SIZE);
-
-        let mut packets = PacketBuilder::new(1.5).build_packets_with_compression(
-            Duration::default(),
-            Tick(0),
-            vec![(*channel_id, VecDeque::from(vec![single_message]))],
-            vec![],
-            CompressionConfig {
-                min_payload_size: 0,
-                ..CompressionConfig::LZ4
-            },
-        )?;
-
+        let mut packets =
+            build_staged_packets(&mut PacketBuilder::new(1.5), &candidates, compression)?;
         assert_eq!(packets.len(), 1);
         let packet = packets.pop().unwrap();
-        let compression_info = packet
-            .compression
-            .expect("under-MTU packet should still be compressed");
+        assert!(packet.payload.len() <= MAX_PACKET_SIZE);
         assert_eq!(
             PacketType::try_from(packet.payload[PacketHeader::PACKET_TYPE_OFFSET])?,
             PacketType::DataCompressed
         );
-        assert!(compression_info.original_len < MAX_PACKET_SIZE);
-        assert!(compression_info.compressed_len < compression_info.original_len);
-        assert_eq!(packet.payload.len(), compression_info.compressed_len);
-
-        let packet = decompress_packet_for_test(packet)?;
-        let contents = packet.parse_packet_payload()?;
-        assert_eq!(contents.get(channel_id).unwrap(), &vec![bytes]);
+        let contents = decompress_packet_for_test(packet)?.parse_packet_payload()?;
+        assert_eq!(contents[&channel_id].len(), 128);
         Ok(())
     }
 
     #[cfg(feature = "compression_lz4")]
     #[test]
-    fn compression_aware_packing_can_pack_beyond_uncompressed_mtu() -> Result<(), PacketError> {
+    fn staged_compression_preserves_mtu_for_incompressible_data() -> Result<(), PacketError> {
         let channel_registry = get_channel_registry();
         let channel_kind = ChannelKind::of::<Channel1>();
-        let channel_id = channel_registry.get_net_from_kind(&channel_kind).unwrap();
-        let small_bytes = Bytes::from(vec![7u8; 64]);
-        let small_message = SingleData::new(None, small_bytes.clone());
+        let channel_id = *channel_registry.get_net_from_kind(&channel_kind).unwrap();
+        let candidates = (0..128)
+            .map(|index| {
+                single_candidate(
+                    channel_kind,
+                    channel_id,
+                    index,
+                    random_payload(128, index).into(),
+                )
+            })
+            .collect::<Vec<_>>();
+        let compression = CompressionConfig {
+            min_payload_size: 0,
+            ..CompressionConfig::LZ4
+        };
 
-        let uncompressed_packets = PacketBuilder::new(1.5).build_packets(
-            Duration::default(),
-            Tick(0),
-            vec![(
-                *channel_id,
-                VecDeque::from(vec![small_message.clone(); 128]),
-            )],
-            vec![],
-        )?;
-        assert!(uncompressed_packets.len() > 1);
-
-        let mut manager = PacketBuilder::new(1.5);
-        let mut packets = manager.build_packets_with_compression(
-            Duration::default(),
-            Tick(0),
-            vec![(
-                *channel_id,
-                VecDeque::from(vec![small_message.clone(); 128]),
-            )],
-            vec![],
-            CompressionConfig {
-                min_payload_size: 0,
-                ..CompressionConfig::LZ4
-            },
-        )?;
-
-        assert_eq!(packets.len(), 1);
-        assert!(packets[0].payload.len() <= MAX_PACKET_SIZE);
-        #[cfg(feature = "metrics")]
-        {
-            assert_eq!(packets[0].messages.len(), 128);
-            assert!(packets[0].messages.iter().all(|metadata| {
-                metadata.channel == *channel_id
-                    && metadata.message.is_none()
-                    && metadata.fragment_index.is_none()
-                    && metadata.num_fragments.is_none()
-                    && metadata.num_bytes == small_message.bytes_len()
-            }));
-        }
-        assert_eq!(
-            PacketType::try_from(packets[0].payload[PacketHeader::PACKET_TYPE_OFFSET])?,
-            PacketType::DataCompressed
-        );
-        let packet = decompress_packet_for_test(packets.pop().unwrap())?;
-        let contents = packet.parse_packet_payload()?;
-        assert_eq!(contents.get(channel_id).unwrap().len(), 128);
-        assert_eq!(contents.get(channel_id).unwrap()[0], small_bytes);
-        Ok(())
-    }
-
-    #[cfg(feature = "compression_lz4")]
-    #[test]
-    fn compression_aware_packing_preserves_mtu_for_incompressible_data() -> Result<(), PacketError>
-    {
-        let channel_registry = get_channel_registry();
-        let channel_kind = ChannelKind::of::<Channel1>();
-        let channel_id = channel_registry.get_net_from_kind(&channel_kind).unwrap();
-        let messages = (0..128)
-            .map(|message_index| SingleData::new(None, random_payload(128, message_index).into()))
-            .collect();
-
-        let mut manager = PacketBuilder::new(1.5);
-        let packets = manager.build_packets_with_compression(
-            Duration::default(),
-            Tick(0),
-            vec![(*channel_id, messages)],
-            vec![],
-            CompressionConfig {
-                min_payload_size: 0,
-                ..CompressionConfig::LZ4
-            },
-        )?;
-
-        let mut total_messages = 0;
+        let packets = build_staged_packets(&mut PacketBuilder::new(1.5), &candidates, compression)?;
+        let mut message_count = 0;
         for packet in packets {
             assert!(packet.payload.len() <= MAX_PACKET_SIZE);
             let packet_type =
@@ -1633,330 +794,12 @@ mod tests {
             } else {
                 packet
             };
-            let contents = packet.parse_packet_payload()?;
-            total_messages += contents.get(channel_id).map_or(0, Vec::len);
+            message_count += packet
+                .parse_packet_payload()?
+                .get(&channel_id)
+                .map_or(0, Vec::len);
         }
-        assert_eq!(total_messages, 128);
-        Ok(())
-    }
-
-    /// A bunch of small messages that fit in multiple packets
-    #[test]
-    fn test_pack_single_data_multiple_packets() -> Result<(), PacketError> {
-        let channel_registry = get_channel_registry();
-        let mut manager = PacketBuilder::new(1.5);
-        let channel_kind1 = ChannelKind::of::<Channel1>();
-        let channel_id1 = channel_registry.get_net_from_kind(&channel_kind1).unwrap();
-        let channel_kind2 = ChannelKind::of::<Channel2>();
-        let channel_id2 = channel_registry.get_net_from_kind(&channel_kind2).unwrap();
-        let channel_kind3 = ChannelKind::of::<Channel3>();
-        let channel_id3 = channel_registry.get_net_from_kind(&channel_kind3).unwrap();
-
-        let small_bytes = Bytes::from(vec![7u8; 500]);
-        let small_message = SingleData::new(None, small_bytes.clone());
-
-        let single_data = vec![
-            (*channel_id1, VecDeque::from(vec![small_message.clone()])),
-            (
-                *channel_id2,
-                VecDeque::from(vec![small_message.clone(), small_message.clone()]),
-            ),
-            (*channel_id3, VecDeque::from(vec![small_message.clone()])),
-        ];
-        let fragment_data = vec![];
-        let packets =
-            manager.build_packets(Duration::default(), Tick(0), single_data, fragment_data)?;
-        assert_eq!(packets.len(), 2);
-        Ok(())
-    }
-
-    /// Channel 1: small_message
-    /// Channel 2: 2 small messages, 1 big fragment, 1 small fragment
-    /// Channel 3: small message
-    ///
-    /// We should get 2 packets: 1 with the 1st big fragment, and 1 packet with the small fragment and all the small messages
-    #[test]
-    fn test_pack_big_messages() -> Result<(), PacketError> {
-        let channel_registry = get_channel_registry();
-        let mut manager = PacketBuilder::new(1.5);
-        let channel_kind1 = ChannelKind::of::<Channel1>();
-        let channel_id1 = channel_registry.get_net_from_kind(&channel_kind1).unwrap();
-        let channel_kind2 = ChannelKind::of::<Channel2>();
-        let channel_id2 = channel_registry.get_net_from_kind(&channel_kind2).unwrap();
-        let channel_kind3 = ChannelKind::of::<Channel3>();
-        let channel_id3 = channel_registry.get_net_from_kind(&channel_kind3).unwrap();
-
-        let num_big_bytes = (1.5 * FRAGMENT_SIZE as f32) as usize;
-        let big_bytes = Bytes::from(vec![1u8; num_big_bytes]);
-        let fragmenter = FragmentSender::new();
-        let fragments = fragmenter.build_fragments(MessageId(3), big_bytes.clone());
-
-        let small_bytes = Bytes::from(vec![7u8; 10]);
-        let small_message = SingleData::new(None, small_bytes.clone());
-
-        let single_data = vec![
-            (*channel_id1, VecDeque::from(vec![small_message.clone()])),
-            (
-                *channel_id2,
-                VecDeque::from(vec![small_message.clone(), small_message.clone()]),
-            ),
-            (*channel_id3, VecDeque::from(vec![small_message.clone()])),
-        ];
-        let fragment_data = vec![(*channel_id2, fragments.clone().into())];
-        let packets =
-            manager.build_packets(Duration::default(), Tick(0), single_data, fragment_data)?;
-        assert_eq!(packets.len(), 2);
-
-        let mut packets_queue: VecDeque<_> = packets.into();
-        // 1st packet
-        let packet = packets_queue.pop_front().unwrap();
-        assert_eq!(
-            packet.messages,
-            vec![MessageMetadata {
-                channel: *channel_id2,
-                message: Some(MessageId(3)),
-                fragment_index: Some(FragmentIndex(0)),
-                num_fragments: Some(fragments.len() as u64),
-                commit: None,
-                #[cfg(feature = "metrics")]
-                num_bytes: fragments[0].bytes.len(),
-            }]
-        );
-        let contents = packet.parse_packet_payload()?;
-        assert_eq!(
-            contents.get(channel_id2).unwrap(),
-            &vec![fragments[0].bytes.clone()]
-        );
-
-        // 2nd packet
-        let packet = packets_queue.pop_front().unwrap();
-        #[cfg(not(feature = "metrics"))]
-        assert_eq!(
-            packet.messages,
-            vec![MessageMetadata {
-                channel: *channel_id2,
-                message: Some(MessageId(3)),
-                fragment_index: Some(FragmentIndex(1)),
-                num_fragments: Some(fragments.len() as u64),
-                commit: None,
-                #[cfg(feature = "metrics")]
-                num_bytes: fragments[1].bytes.len(),
-            }]
-        );
-        #[cfg(feature = "metrics")]
-        assert_eq!(
-            packet.messages,
-            vec![
-                MessageMetadata {
-                    channel: *channel_id2,
-                    message: Some(MessageId(3)),
-                    fragment_index: Some(FragmentIndex(1)),
-                    num_fragments: Some(fragments.len() as u64),
-                    commit: None,
-                    num_bytes: fragments[1].bytes.len(),
-                },
-                MessageMetadata {
-                    channel: *channel_id1,
-                    message: None,
-                    fragment_index: None,
-                    num_fragments: None,
-                    commit: None,
-                    num_bytes: small_message.bytes_len(),
-                },
-                MessageMetadata {
-                    channel: *channel_id2,
-                    message: None,
-                    fragment_index: None,
-                    num_fragments: None,
-                    commit: None,
-                    num_bytes: small_message.bytes_len(),
-                },
-                MessageMetadata {
-                    channel: *channel_id2,
-                    message: None,
-                    fragment_index: None,
-                    num_fragments: None,
-                    commit: None,
-                    num_bytes: small_message.bytes_len(),
-                },
-                MessageMetadata {
-                    channel: *channel_id3,
-                    message: None,
-                    fragment_index: None,
-                    num_fragments: None,
-                    commit: None,
-                    num_bytes: small_message.bytes_len(),
-                },
-            ]
-        );
-        let contents = packet.parse_packet_payload()?;
-        assert_eq!(
-            contents.get(channel_id1).unwrap(),
-            &vec![small_bytes.clone()]
-        );
-        assert_eq!(
-            contents.get(channel_id2).unwrap(),
-            &vec![
-                fragments[1].bytes.clone(),
-                small_bytes.clone(),
-                small_bytes.clone()
-            ]
-        );
-        assert_eq!(
-            contents.get(channel_id3).unwrap(),
-            &vec![small_bytes.clone()]
-        );
-        Ok(())
-    }
-
-    #[test]
-    fn fragmented_packets_never_exceed_max_packet_size() -> Result<(), PacketError> {
-        let channel_registry = get_channel_registry();
-        let mut manager = PacketBuilder::new(1.5);
-        let channel_kind = ChannelKind::of::<Channel1>();
-        let channel_id = channel_registry.get_net_from_kind(&channel_kind).unwrap();
-
-        let bytes = Bytes::from(vec![9u8; FRAGMENT_SIZE + 1]);
-        let fragments = FragmentSender::new().build_fragments(MessageId(1024), bytes);
-
-        let packets = manager.build_packets(
-            Duration::default(),
-            Tick(0),
-            vec![],
-            vec![(*channel_id, VecDeque::from(fragments))],
-        )?;
-
-        assert!(!packets.is_empty());
-        for packet in packets {
-            assert!(
-                packet.payload.len() <= MAX_PACKET_SIZE,
-                "fragment packet exceeded MTU: {} > {}",
-                packet.payload.len(),
-                MAX_PACKET_SIZE
-            );
-        }
-        Ok(())
-    }
-
-    #[test]
-    fn fragmented_packets_fit_with_two_byte_channel_id() -> Result<(), PacketError> {
-        let mut manager = PacketBuilder::new(1.5);
-        let bytes = Bytes::from(vec![9u8; FRAGMENT_SIZE + 1]);
-        let fragments = FragmentSender::new().build_fragments(MessageId(1024), bytes);
-
-        let packets = manager.build_packets(
-            Duration::default(),
-            Tick(0),
-            vec![],
-            vec![(64, VecDeque::from(fragments))],
-        )?;
-
-        assert!(!packets.is_empty());
-        for packet in packets {
-            assert!(
-                packet.payload.len() <= MAX_PACKET_SIZE,
-                "fragment packet exceeded MTU: {} > {}",
-                packet.payload.len(),
-                MAX_PACKET_SIZE
-            );
-        }
-        Ok(())
-    }
-
-    #[test]
-    fn fragmented_packets_fit_with_many_fragments() -> Result<(), PacketError> {
-        let channel_registry = get_channel_registry();
-        let mut manager = PacketBuilder::new(1.5);
-        let channel_kind = ChannelKind::of::<Channel1>();
-        let channel_id = channel_registry.get_net_from_kind(&channel_kind).unwrap();
-
-        let bytes = Bytes::from(vec![9u8; FRAGMENT_SIZE * 64 + 1]);
-        let fragments = FragmentSender::new().build_fragments(MessageId(1024), bytes);
-
-        let packets = manager.build_packets(
-            Duration::default(),
-            Tick(0),
-            vec![],
-            vec![(*channel_id, VecDeque::from(fragments))],
-        )?;
-
-        assert!(!packets.is_empty());
-        for packet in packets {
-            assert!(
-                packet.payload.len() <= MAX_PACKET_SIZE,
-                "fragment packet exceeded MTU: {} > {}",
-                packet.payload.len(),
-                MAX_PACKET_SIZE
-            );
-        }
-        Ok(())
-    }
-
-    #[cfg(feature = "compression_lz4")]
-    #[test]
-    fn compressed_single_packet_decompresses_to_original_messages() -> Result<(), PacketError> {
-        let channel_registry = get_channel_registry();
-        let mut manager = PacketBuilder::new(1.5);
-        let channel_kind = ChannelKind::of::<Channel1>();
-        let channel_id = channel_registry.get_net_from_kind(&channel_kind).unwrap();
-
-        let bytes = Bytes::from(vec![4u8; 512]);
-        let single_data = vec![(
-            *channel_id,
-            VecDeque::from(vec![SingleData::new(None, bytes.clone())]),
-        )];
-        let mut packets =
-            manager.build_packets(Duration::default(), Tick(0), single_data, vec![])?;
-        assert_eq!(packets.len(), 1);
-
-        let mut packet = packets.pop().unwrap();
-        try_compress_packet(
-            &mut packet,
-            CompressionConfig {
-                min_payload_size: 0,
-                ..CompressionConfig::LZ4
-            },
-        )?;
-
-        let contents = decompress_packet_for_test(packet)?.parse_packet_payload()?;
-        assert_eq!(contents.get(channel_id).unwrap(), &vec![bytes]);
-        Ok(())
-    }
-
-    #[cfg(feature = "compression_lz4")]
-    #[test]
-    fn compressed_fragment_packet_decompresses_to_original_fragment() -> Result<(), PacketError> {
-        let channel_registry = get_channel_registry();
-        let mut manager = PacketBuilder::new(1.5);
-        let channel_kind = ChannelKind::of::<Channel1>();
-        let channel_id = channel_registry.get_net_from_kind(&channel_kind).unwrap();
-
-        let fragment = FragmentData {
-            message_id: MessageId(7),
-            fragment_id: FragmentIndex(0),
-            num_fragments: FragmentIndex(1),
-            compression: Some(FragmentCompression::None),
-            bytes: Bytes::from(vec![2u8; 512]),
-        };
-        let mut packets = manager.build_packets(
-            Duration::default(),
-            Tick(0),
-            vec![],
-            vec![(*channel_id, VecDeque::from(vec![fragment.clone()]))],
-        )?;
-        assert_eq!(packets.len(), 1);
-
-        let mut packet = packets.pop().unwrap();
-        try_compress_packet(
-            &mut packet,
-            CompressionConfig {
-                min_payload_size: 0,
-                ..CompressionConfig::LZ4
-            },
-        )?;
-
-        let contents = decompress_packet_for_test(packet)?.parse_packet_payload()?;
-        assert_eq!(contents.get(channel_id).unwrap(), &vec![fragment.bytes]);
+        assert_eq!(message_count, 128);
         Ok(())
     }
 
@@ -2081,36 +924,4 @@ mod tests {
         );
         Ok(())
     }
-
-    #[test]
-    fn legacy_builder_does_not_wrap_channel_batch_count() -> Result<(), PacketError> {
-        let channel_registry = get_channel_registry();
-        let channel_kind = ChannelKind::of::<Channel1>();
-        let channel_id = *channel_registry.get_net_from_kind(&channel_kind).unwrap();
-        let messages = (0..300)
-            .map(|_| SingleData::new(None, Bytes::new()))
-            .collect::<VecDeque<_>>();
-
-        let packets = PacketBuilder::new(1.5).build_packets(
-            Duration::default(),
-            Tick(0),
-            vec![(channel_id, messages)],
-            vec![],
-        )?;
-        let decoded_messages = packets
-            .into_iter()
-            .map(|packet| {
-                packet
-                    .parse_packet_payload()
-                    .map(|contents| contents[&channel_id].len())
-            })
-            .collect::<Result<Vec<_>, _>>()?
-            .into_iter()
-            .sum::<usize>();
-
-        assert_eq!(decoded_messages, 300);
-        Ok(())
-    }
-
-    // TODO: ADD MORE TESTS
 }

--- a/crates/transport/transport/src/packet/packet_builder.rs
+++ b/crates/transport/transport/src/packet/packet_builder.rs
@@ -6,8 +6,8 @@ use crate::packet::compression::{
 };
 use crate::packet::error::PacketError;
 use crate::packet::header::PacketHeaderManager;
-use crate::packet::message::{FragmentData, SingleData};
-use crate::packet::packet::{FRAGMENT_SIZE, HEADER_BYTES, MessageMetadata, Packet};
+use crate::packet::message::{FragmentData, MessageData, SendCandidate, SingleData};
+use crate::packet::packet::{FRAGMENT_SIZE, HEADER_BYTES, MessageMetadata, Packet, SendCommit};
 use crate::packet::packet_type::PacketType;
 use alloc::collections::VecDeque;
 use alloc::vec::Vec;
@@ -35,6 +35,19 @@ const MAX_RETAINED_MESSAGE_METADATA_CAPACITY: usize = 100;
 /// e.g. we receive 1200 bytes from the network, we want to read parts of it (header, channel) but then
 /// store subslices in receiver channels without allocating.
 pub type RecvPayload = Bytes;
+
+/// Position in the ordered send-candidate scratch for the current flush.
+#[derive(Debug, Default)]
+pub(crate) struct CandidateCursor {
+    index: usize,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct SingleBatchState {
+    channel_id: ChannelId,
+    count_offset: usize,
+    count: u8,
+}
 
 /// `PacketBuilder` handles the process of creating a packet (writing the header and packing the
 /// messages into packets)
@@ -182,6 +195,196 @@ impl PacketBuilder {
         self.buffer_pool.recycle_packet_list(packets);
     }
 
+    /// Stage the next packet from globally ordered, channel-owned candidates.
+    ///
+    /// This method only consumes candidate snapshots. It deliberately does not mutate channel
+    /// queues, reliable retry timestamps, packet ids, sent-packet tracking, or bandwidth quota.
+    /// The caller commits those transitions after the returned packet enters `Link.send`.
+    pub(crate) fn build_next_packet(
+        &mut self,
+        current_tick: Tick,
+        candidates: &[SendCandidate],
+        cursor: &mut CandidateCursor,
+        compression: CompressionConfig,
+    ) -> Result<Option<Packet>, PacketError> {
+        let Some(first) = candidates.get(cursor.index) else {
+            return Ok(None);
+        };
+
+        match &first.message.data {
+            MessageData::Fragment(fragment) => {
+                let mut packet = self.new_staged_packet(PacketType::DataFragment, current_tick)?;
+                first.channel_id.to_bytes(&mut packet.payload)?;
+                fragment.to_bytes(&mut packet.payload)?;
+                packet.record_message_metadata(
+                    first.channel_id,
+                    Some(fragment.message_id),
+                    Some(fragment.fragment_id),
+                    Some(fragment.num_fragments.0),
+                    Some(SendCommit {
+                        channel_kind: first.channel_kind,
+                        key: first.key,
+                    }),
+                    #[cfg(feature = "metrics")]
+                    fragment.bytes.len(),
+                );
+                cursor.index += 1;
+
+                // The wire format permits singles after the final fragment. Preserve the current
+                // behavior of fitting that tail against the uncompressed MTU.
+                if fragment.is_last_fragment() {
+                    let mut batch = None;
+                    while let Some(candidate) = candidates.get(cursor.index) {
+                        if !matches!(candidate.message.data, MessageData::Single(_))
+                            || !Self::try_append_single_candidate(
+                                &mut packet,
+                                candidate,
+                                &mut batch,
+                                CompressionConfig::DISABLED,
+                            )?
+                        {
+                            break;
+                        }
+                        cursor.index += 1;
+                    }
+                }
+
+                if packet.payload.len() > MAX_PACKET_SIZE {
+                    return Err(PacketError::PacketTooLarge {
+                        actual: packet.payload.len(),
+                        mtu: MAX_PACKET_SIZE,
+                    });
+                }
+                Ok(Some(Self::finalize_packet(packet)))
+            }
+            MessageData::Single(_) => {
+                let mut packet = self.new_staged_packet(PacketType::Data, current_tick)?;
+                let mut batch = None;
+                while let Some(candidate) = candidates.get(cursor.index) {
+                    if !matches!(candidate.message.data, MessageData::Single(_)) {
+                        break;
+                    }
+                    if !Self::try_append_single_candidate(
+                        &mut packet,
+                        candidate,
+                        &mut batch,
+                        compression,
+                    )? {
+                        break;
+                    }
+                    cursor.index += 1;
+                }
+
+                if packet.messages.is_empty() {
+                    let candidate = &candidates[cursor.index];
+                    return Err(PacketError::PacketTooLarge {
+                        actual: HEADER_BYTES
+                            + candidate.channel_id.bytes_len()
+                            + 1
+                            + candidate.message.data.bytes_len(),
+                        mtu: MAX_PACKET_SIZE,
+                    });
+                }
+                Ok(Some(Self::finish_compression_aware_packet(
+                    packet,
+                    compression,
+                )?))
+            }
+        }
+    }
+
+    fn new_staged_packet(
+        &mut self,
+        packet_type: PacketType,
+        current_tick: Tick,
+    ) -> Result<Packet, SerializationError> {
+        let mut payload = self.buffer_pool.take_payload();
+        let messages = self.buffer_pool.take_message_metadata();
+        let header = self
+            .header_manager
+            .preview_send_packet_header(packet_type, current_tick);
+        header.to_bytes(&mut payload)?;
+        Ok(Packet {
+            payload,
+            messages,
+            packet_id: header.packet_id,
+            prewritten_size: 0,
+            compression: None,
+        })
+    }
+
+    fn try_append_single_candidate(
+        packet: &mut Packet,
+        candidate: &SendCandidate,
+        batch: &mut Option<SingleBatchState>,
+        compression: CompressionConfig,
+    ) -> Result<bool, PacketError> {
+        let MessageData::Single(message) = &candidate.message.data else {
+            return Ok(false);
+        };
+
+        let payload_len = packet.payload.len();
+        let metadata_len = packet.messages.len();
+        let previous_batch = *batch;
+
+        match batch {
+            Some(state)
+                if state.channel_id == candidate.channel_id
+                    && state.count < MAX_MESSAGES_PER_CHANNEL_BATCH as u8 =>
+            {
+                state.count += 1;
+                packet.payload[state.count_offset] = state.count;
+            }
+            _ => {
+                candidate.channel_id.to_bytes(&mut packet.payload)?;
+                let count_offset = packet.payload.len();
+                1u8.to_bytes(&mut packet.payload)?;
+                *batch = Some(SingleBatchState {
+                    channel_id: candidate.channel_id,
+                    count_offset,
+                    count: 1,
+                });
+            }
+        }
+
+        message.to_bytes(&mut packet.payload)?;
+        packet.record_message_metadata(
+            candidate.channel_id,
+            message.id,
+            None,
+            None,
+            Some(SendCommit {
+                channel_kind: candidate.channel_kind,
+                key: candidate.key,
+            }),
+            #[cfg(feature = "metrics")]
+            message.bytes_len(),
+        );
+
+        let fits = if packet.payload.len() <= MAX_PACKET_SIZE {
+            true
+        } else if compression.is_enabled() {
+            matches!(
+                try_build_compressed_packet_payload(&packet.payload, compression)?,
+                CompressionCandidate::Compressed { .. }
+            )
+        } else {
+            false
+        };
+
+        if fits {
+            return Ok(true);
+        }
+
+        if let Some(previous) = previous_batch {
+            packet.payload[previous.count_offset] = previous.count;
+        }
+        packet.payload.truncate(payload_len);
+        packet.messages.truncate(metadata_len);
+        *batch = previous_batch;
+        Ok(false)
+    }
+
     /// Start building new packet, we start with an empty packet
     /// that can write to a given channel
     pub(crate) fn build_new_single_packet(
@@ -237,6 +440,7 @@ impl PacketBuilder {
             Some(fragment_data.message_id),
             Some(fragment_data.fragment_id),
             Some(fragment_data.num_fragments.0),
+            None,
             #[cfg(feature = "metrics")]
             fragment_data.bytes.len(),
         );
@@ -368,17 +572,28 @@ impl PacketBuilder {
                     let mut packet = self.current_packet.take().unwrap();
                     // it's a smaller fragment, fill it with small messages
                     'out: while single_data_idx < single_data.len() {
+                        let (channel_id, single_messages) = &mut single_data[single_data_idx];
                         // if we don't even have space for a new channel, return the packet immediately
-                        if !packet.can_fit_channel(channel_id) {
+                        if !packet.can_fit_channel(*channel_id) {
                             break;
                         }
 
-                        let (channel_id, single_messages) = &mut single_data[single_data_idx];
                         // number of messages for this channel that we will write
                         // (we wait until we know the full number, because we want to write that)
                         let mut num_messages = 0;
                         // fill with messages from the current channel
                         loop {
+                            if num_messages == MAX_MESSAGES_PER_CHANNEL_BATCH
+                                && num_messages < single_messages.len()
+                            {
+                                Self::write_single_messages(
+                                    &mut packet,
+                                    single_messages,
+                                    &mut num_messages,
+                                    *channel_id,
+                                )?;
+                                break 'out;
+                            }
                             // no more messages to send in this channel, try to fill with messages from the next channels
                             if num_messages == single_messages.len() {
                                 Self::write_single_messages(
@@ -450,6 +665,19 @@ impl PacketBuilder {
             let mut num_messages = 0;
             // fill with messages from the current channel
             loop {
+                if num_messages == MAX_MESSAGES_PER_CHANNEL_BATCH
+                    && num_messages < single_messages.len()
+                {
+                    Self::write_single_messages(
+                        &mut packet,
+                        single_messages,
+                        &mut num_messages,
+                        *channel_id,
+                    )?;
+                    self.current_packet = Some(packet);
+                    packets.push(self.finish_packet());
+                    continue 'out;
+                }
                 // no more messages to send in this channel, try to fill with messages from the next channels
                 if num_messages == single_messages.len() {
                     Self::write_single_messages(
@@ -497,6 +725,7 @@ impl PacketBuilder {
         num_messages: &mut usize,
         channel_id: ChannelId,
     ) -> Result<(), SerializationError> {
+        debug_assert!(*num_messages <= MAX_MESSAGES_PER_CHANNEL_BATCH);
         packet.prewritten_size = packet
             .prewritten_size
             .checked_sub(varint_len(channel_id as u64) + 1)
@@ -520,6 +749,7 @@ impl PacketBuilder {
                 packet.record_message_metadata(
                     channel_id,
                     message.id,
+                    None,
                     None,
                     None,
                     #[cfg(feature = "metrics")]
@@ -727,6 +957,7 @@ impl PacketBuilder {
                 packet.record_message_metadata(
                     channel_id,
                     message.id,
+                    None,
                     None,
                     None,
                     #[cfg(feature = "metrics")]
@@ -961,6 +1192,7 @@ mod tests {
     #[cfg(feature = "compression_lz4")]
     use crate::packet::message::FragmentCompression;
     use crate::packet::message::{FragmentIndex, MessageId};
+    use crate::packet::message::{SendMessage, SendMessageKey};
     #[cfg(feature = "compression_lz4")]
     use crate::packet::packet::HEADER_BYTES;
     use crate::packet::packet::MessageMetadata;
@@ -1098,6 +1330,7 @@ mod tests {
                     message: None,
                     fragment_index: None,
                     num_fragments: None,
+                    commit: None,
                     num_bytes: small_message.bytes_len(),
                 },
                 MessageMetadata {
@@ -1105,6 +1338,7 @@ mod tests {
                     message: None,
                     fragment_index: None,
                     num_fragments: None,
+                    commit: None,
                     num_bytes: small_message.bytes_len(),
                 },
                 MessageMetadata {
@@ -1112,6 +1346,7 @@ mod tests {
                     message: None,
                     fragment_index: None,
                     num_fragments: None,
+                    commit: None,
                     num_bytes: small_message.bytes_len(),
                 },
                 MessageMetadata {
@@ -1119,6 +1354,7 @@ mod tests {
                     message: None,
                     fragment_index: None,
                     num_fragments: None,
+                    commit: None,
                     num_bytes: small_message.bytes_len(),
                 },
             ]
@@ -1461,6 +1697,7 @@ mod tests {
                 message: Some(MessageId(3)),
                 fragment_index: Some(FragmentIndex(0)),
                 num_fragments: Some(fragments.len() as u64),
+                commit: None,
                 #[cfg(feature = "metrics")]
                 num_bytes: fragments[0].bytes.len(),
             }]
@@ -1481,6 +1718,7 @@ mod tests {
                 message: Some(MessageId(3)),
                 fragment_index: Some(FragmentIndex(1)),
                 num_fragments: Some(fragments.len() as u64),
+                commit: None,
                 #[cfg(feature = "metrics")]
                 num_bytes: fragments[1].bytes.len(),
             }]
@@ -1494,6 +1732,7 @@ mod tests {
                     message: Some(MessageId(3)),
                     fragment_index: Some(FragmentIndex(1)),
                     num_fragments: Some(fragments.len() as u64),
+                    commit: None,
                     num_bytes: fragments[1].bytes.len(),
                 },
                 MessageMetadata {
@@ -1501,6 +1740,7 @@ mod tests {
                     message: None,
                     fragment_index: None,
                     num_fragments: None,
+                    commit: None,
                     num_bytes: small_message.bytes_len(),
                 },
                 MessageMetadata {
@@ -1508,6 +1748,7 @@ mod tests {
                     message: None,
                     fragment_index: None,
                     num_fragments: None,
+                    commit: None,
                     num_bytes: small_message.bytes_len(),
                 },
                 MessageMetadata {
@@ -1515,6 +1756,7 @@ mod tests {
                     message: None,
                     fragment_index: None,
                     num_fragments: None,
+                    commit: None,
                     num_bytes: small_message.bytes_len(),
                 },
                 MessageMetadata {
@@ -1522,6 +1764,7 @@ mod tests {
                     message: None,
                     fragment_index: None,
                     num_fragments: None,
+                    commit: None,
                     num_bytes: small_message.bytes_len(),
                 },
             ]
@@ -1694,6 +1937,86 @@ mod tests {
 
         let contents = decompress_packet_for_test(packet)?.parse_packet_payload()?;
         assert_eq!(contents.get(channel_id).unwrap(), &vec![fragment.bytes]);
+        Ok(())
+    }
+
+    #[test]
+    fn staged_builder_splits_channel_batches_at_u8_limit() -> Result<(), PacketError> {
+        let channel_registry = get_channel_registry();
+        let channel_kind = ChannelKind::of::<Channel1>();
+        let channel_id = *channel_registry.get_net_from_kind(&channel_kind).unwrap();
+        let candidates = (0..300)
+            .map(|index| {
+                SendCandidate::new(
+                    channel_kind,
+                    channel_id,
+                    SendMessageKey::UnreliableSingle(index),
+                    index as u64,
+                    SendMessage {
+                        data: SingleData::new(None, Bytes::new()).into(),
+                        priority: 1.0,
+                    },
+                )
+            })
+            .collect::<Vec<_>>();
+
+        let mut builder = PacketBuilder::new(1.5);
+        let mut cursor = CandidateCursor::default();
+        let packet = builder
+            .build_next_packet(
+                Tick(0),
+                &candidates,
+                &mut cursor,
+                CompressionConfig::DISABLED,
+            )?
+            .unwrap();
+        assert_eq!(packet.messages.len(), 300);
+        let packet_id = packet.packet_id;
+        let contents = packet.parse_packet_payload()?;
+        assert_eq!(contents[&channel_id].len(), 300);
+        builder
+            .header_manager
+            .commit_send_packet(packet_id, Duration::default());
+        assert!(
+            builder
+                .build_next_packet(
+                    Tick(0),
+                    &candidates,
+                    &mut cursor,
+                    CompressionConfig::DISABLED,
+                )?
+                .is_none()
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn legacy_builder_does_not_wrap_channel_batch_count() -> Result<(), PacketError> {
+        let channel_registry = get_channel_registry();
+        let channel_kind = ChannelKind::of::<Channel1>();
+        let channel_id = *channel_registry.get_net_from_kind(&channel_kind).unwrap();
+        let messages = (0..300)
+            .map(|_| SingleData::new(None, Bytes::new()))
+            .collect::<VecDeque<_>>();
+
+        let packets = PacketBuilder::new(1.5).build_packets(
+            Duration::default(),
+            Tick(0),
+            vec![(channel_id, messages)],
+            vec![],
+        )?;
+        let decoded_messages = packets
+            .into_iter()
+            .map(|packet| {
+                packet
+                    .parse_packet_payload()
+                    .map(|contents| contents[&channel_id].len())
+            })
+            .collect::<Result<Vec<_>, _>>()?
+            .into_iter()
+            .sum::<usize>();
+
+        assert_eq!(decoded_messages, 300);
         Ok(())
     }
 

--- a/crates/transport/transport/src/packet/priority_manager.rs
+++ b/crates/transport/transport/src/packet/priority_manager.rs
@@ -1,9 +1,10 @@
 use crate::channel::registry::ChannelRegistry;
-use crate::packet::message::SendCandidate;
+use crate::packet::message::{MessageData, SendCandidate};
 use crate::packet::packet::MAX_PACKET_SIZE;
 use alloc::vec::Vec;
 use core::num::NonZeroU32;
 use governor::{DefaultDirectRateLimiter, Quota};
+use lightyear_serde::ToBytes;
 use nonzero_ext::*;
 #[cfg(feature = "trace")]
 use tracing::{Level, instrument};
@@ -92,15 +93,21 @@ impl PriorityManager {
         self.candidates.clear();
     }
 
-    /// Apply priority ordering without taking ownership of channel queues.
+    /// Apply priority and packet-packing order without taking ownership of channel queues.
     ///
-    /// When priority management is disabled, this leaves collection order untouched.
+    /// Fragments precede singles within each priority group so the packet builder can fill the
+    /// final fragment packets with the smallest remaining singles. When priority management is
+    /// disabled, every candidate belongs to one packing group.
     #[cfg_attr(feature = "trace", instrument(level = Level::INFO, skip_all))]
     pub(crate) fn prioritize(&mut self, channel_registry: &ChannelRegistry) {
         if !self.config.enabled {
+            for candidate in &mut self.candidates {
+                candidate.effective_priority = 0.0;
+            }
+            self.candidates.sort_unstable_by(Self::packing_order);
             debug!(
                 num_candidates = self.candidates.len(),
-                "priority disabled; preserving candidate collection order"
+                "priority disabled; applied fragment-first packing order"
             );
             return;
         }
@@ -118,14 +125,24 @@ impl PriorityManager {
         self.candidates.sort_unstable_by(|a, b| {
             b.effective_priority
                 .total_cmp(&a.effective_priority)
-                .then_with(|| a.stable_order.cmp(&b.stable_order))
-                .then_with(|| a.channel_id.cmp(&b.channel_id))
-                .then_with(|| a.key.cmp(&b.key))
+                .then_with(|| Self::packing_order(a, b))
         });
         debug!(
             num_candidates = self.candidates.len(),
             "priority ordering complete"
         );
+    }
+
+    fn packing_order(a: &SendCandidate, b: &SendCandidate) -> core::cmp::Ordering {
+        match (&a.message.data, &b.message.data) {
+            (MessageData::Fragment(_), MessageData::Single(_)) => core::cmp::Ordering::Less,
+            (MessageData::Single(_), MessageData::Fragment(_)) => core::cmp::Ordering::Greater,
+            (MessageData::Single(a), MessageData::Single(b)) => a.bytes_len().cmp(&b.bytes_len()),
+            (MessageData::Fragment(_), MessageData::Fragment(_)) => core::cmp::Ordering::Equal,
+        }
+        .then_with(|| a.stable_order.cmp(&b.stable_order))
+        .then_with(|| a.channel_id.cmp(&b.channel_id))
+        .then_with(|| a.key.cmp(&b.key))
     }
 }
 
@@ -176,7 +193,7 @@ mod tests {
     struct FragmentChannel;
 
     #[test]
-    fn disabled_priority_preserves_candidate_collection_order() {
+    fn disabled_priority_uses_fragment_first_size_ascending_packing_order() {
         let registry = ChannelRegistry::default();
         let mut manager = PriorityManager::default();
         manager.candidates_mut().push(SendCandidate::new(
@@ -186,7 +203,24 @@ mod tests {
             1,
             SendMessage {
                 priority: 100.0,
-                data: SingleData::new(None, Bytes::from_static(b"first")).into(),
+                data: SingleData::new(None, Bytes::from_static(b"larger-single")).into(),
+            },
+        ));
+        manager.candidates_mut().push(SendCandidate::new(
+            ChannelKind::of::<FragmentChannel>(),
+            5,
+            SendMessageKey::UnreliableFragment(0),
+            2,
+            SendMessage {
+                priority: 0.1,
+                data: FragmentData {
+                    message_id: MessageId(0),
+                    fragment_id: FragmentIndex(0),
+                    num_fragments: FragmentIndex(1),
+                    compression: Some(FragmentCompression::None),
+                    bytes: Bytes::from_static(b"fragment"),
+                }
+                .into(),
             },
         ));
         manager.candidates_mut().push(SendCandidate::new(
@@ -196,14 +230,18 @@ mod tests {
             0,
             SendMessage {
                 priority: 1.0,
-                data: SingleData::new(None, Bytes::from_static(b"second")).into(),
+                data: SingleData::new(None, Bytes::from_static(b"small")).into(),
             },
         ));
 
         manager.prioritize(&registry);
 
-        assert_eq!(manager.candidates()[0].channel_id, 10);
+        assert!(matches!(
+            manager.candidates()[0].message.data,
+            MessageData::Fragment(_)
+        ));
         assert_eq!(manager.candidates()[1].channel_id, 1);
+        assert_eq!(manager.candidates()[2].channel_id, 10);
     }
 
     #[test]
@@ -256,7 +294,7 @@ mod tests {
     }
 
     #[test]
-    fn singles_and_fragments_share_one_priority_order() {
+    fn higher_priority_single_precedes_lower_priority_fragment() {
         let mut registry = ChannelRegistry::default();
         let (fragment_kind, fragment_channel) =
             registry.add_channel::<FragmentChannel>(ChannelSettings {
@@ -304,6 +342,65 @@ mod tests {
             manager.candidates()[0].message.data,
             MessageData::Single(_)
         ));
+    }
+
+    #[test]
+    fn equal_priority_uses_fragment_first_size_ascending_packing_order() {
+        let mut registry = ChannelRegistry::default();
+        let (kind, channel) = registry.add_channel::<FragmentChannel>(ChannelSettings {
+            mode: ChannelMode::UnorderedUnreliable,
+            priority: 1.0,
+            ..Default::default()
+        });
+        let mut manager = PriorityManager::new(PriorityConfig::new(1024));
+        manager.candidates_mut().push(SendCandidate::new(
+            kind,
+            channel,
+            SendMessageKey::UnreliableSingle(0),
+            0,
+            SendMessage {
+                priority: 1.0,
+                data: SingleData::new(None, Bytes::from_static(b"larger-single")).into(),
+            },
+        ));
+        manager.candidates_mut().push(SendCandidate::new(
+            kind,
+            channel,
+            SendMessageKey::UnreliableSingle(1),
+            1,
+            SendMessage {
+                priority: 1.0,
+                data: SingleData::new(None, Bytes::from_static(b"small")).into(),
+            },
+        ));
+        manager.candidates_mut().push(SendCandidate::new(
+            kind,
+            channel,
+            SendMessageKey::UnreliableFragment(0),
+            2,
+            SendMessage {
+                priority: 1.0,
+                data: FragmentData {
+                    message_id: MessageId(0),
+                    fragment_id: FragmentIndex(0),
+                    num_fragments: FragmentIndex(1),
+                    compression: Some(FragmentCompression::None),
+                    bytes: Bytes::from_static(b"fragment"),
+                }
+                .into(),
+            },
+        ));
+
+        manager.prioritize(&registry);
+
+        assert!(matches!(
+            manager.candidates()[0].message.data,
+            MessageData::Fragment(_)
+        ));
+        let [small, large] = &manager.candidates()[1..] else {
+            panic!("expected two single candidates")
+        };
+        assert!(small.message.data.bytes_len() < large.message.data.bytes_len());
     }
 
     #[test]

--- a/crates/transport/transport/src/packet/priority_manager.rs
+++ b/crates/transport/transport/src/packet/priority_manager.rs
@@ -137,10 +137,14 @@ impl PriorityManager {
         match (&a.message.data, &b.message.data) {
             (MessageData::Fragment(_), MessageData::Single(_)) => core::cmp::Ordering::Less,
             (MessageData::Single(_), MessageData::Fragment(_)) => core::cmp::Ordering::Greater,
-            (MessageData::Single(a), MessageData::Single(b)) => a.bytes_len().cmp(&b.bytes_len()),
-            (MessageData::Fragment(_), MessageData::Fragment(_)) => core::cmp::Ordering::Equal,
+            (MessageData::Single(a_message), MessageData::Single(b_message)) => a_message
+                .bytes_len()
+                .cmp(&b_message.bytes_len())
+                .then_with(|| a.key.send_order().cmp(&b.key.send_order())),
+            (MessageData::Fragment(a_fragment), MessageData::Fragment(b_fragment)) => {
+                a_fragment.message_id.cmp(&b_fragment.message_id)
+            }
         }
-        .then_with(|| a.stable_order.cmp(&b.stable_order))
         .then_with(|| a.channel_id.cmp(&b.channel_id))
         .then_with(|| a.key.cmp(&b.key))
     }
@@ -200,7 +204,6 @@ mod tests {
             ChannelKind::of::<TurnTrafficChannel>(),
             10,
             SendMessageKey::UnreliableSingle(0),
-            1,
             SendMessage {
                 priority: 100.0,
                 data: SingleData::new(None, Bytes::from_static(b"larger-single")).into(),
@@ -210,7 +213,6 @@ mod tests {
             ChannelKind::of::<FragmentChannel>(),
             5,
             SendMessageKey::UnreliableFragment(0),
-            2,
             SendMessage {
                 priority: 0.1,
                 data: FragmentData {
@@ -227,7 +229,6 @@ mod tests {
             ChannelKind::of::<PingLikeChannel>(),
             1,
             SendMessageKey::UnreliableSingle(0),
-            0,
             SendMessage {
                 priority: 1.0,
                 data: SingleData::new(None, Bytes::from_static(b"small")).into(),
@@ -265,7 +266,6 @@ mod tests {
                 traffic_kind,
                 traffic_channel,
                 SendMessageKey::UnreliableSingle(index),
-                index as u64,
                 SendMessage {
                     priority: 1.0,
                     data: SingleData::new(None, Bytes::from(vec![index as u8; 8])).into(),
@@ -276,7 +276,6 @@ mod tests {
             ping_kind,
             ping_channel,
             SendMessageKey::UnreliableSingle(0),
-            0,
             SendMessage {
                 priority: 1.0,
                 data: SingleData::new(None, Bytes::from_static(b"ping")).into(),
@@ -312,7 +311,6 @@ mod tests {
             fragment_kind,
             fragment_channel,
             SendMessageKey::UnreliableFragment(0),
-            0,
             SendMessage {
                 data: FragmentData {
                     message_id: MessageId(0),
@@ -329,7 +327,6 @@ mod tests {
             ping_kind,
             ping_channel,
             SendMessageKey::UnreliableSingle(0),
-            0,
             SendMessage {
                 data: SingleData::new(None, Bytes::from_static(b"urgent")).into(),
                 priority: 1.0,
@@ -357,7 +354,6 @@ mod tests {
             kind,
             channel,
             SendMessageKey::UnreliableSingle(0),
-            0,
             SendMessage {
                 priority: 1.0,
                 data: SingleData::new(None, Bytes::from_static(b"larger-single")).into(),
@@ -367,7 +363,6 @@ mod tests {
             kind,
             channel,
             SendMessageKey::UnreliableSingle(1),
-            1,
             SendMessage {
                 priority: 1.0,
                 data: SingleData::new(None, Bytes::from_static(b"small")).into(),
@@ -377,7 +372,6 @@ mod tests {
             kind,
             channel,
             SendMessageKey::UnreliableFragment(0),
-            2,
             SendMessage {
                 priority: 1.0,
                 data: FragmentData {
@@ -401,6 +395,49 @@ mod tests {
             panic!("expected two single candidates")
         };
         assert!(small.message.data.bytes_len() < large.message.data.bytes_len());
+    }
+
+    #[test]
+    fn fragment_order_uses_existing_message_and_fragment_ids() {
+        let mut registry = ChannelRegistry::default();
+        let (kind, channel) = registry.add_channel::<FragmentChannel>(ChannelSettings {
+            mode: ChannelMode::UnorderedUnreliable,
+            priority: 1.0,
+            ..Default::default()
+        });
+        let mut manager = PriorityManager::new(PriorityConfig::new(1024));
+        for (queue_index, message_id, fragment_id) in [(3, 1, 1), (1, 0, 1), (2, 1, 0), (0, 0, 0)] {
+            manager.candidates_mut().push(SendCandidate::new(
+                kind,
+                channel,
+                SendMessageKey::UnreliableFragment(queue_index),
+                SendMessage {
+                    priority: 1.0,
+                    data: FragmentData {
+                        message_id: MessageId(message_id),
+                        fragment_id: FragmentIndex(fragment_id),
+                        num_fragments: FragmentIndex(2),
+                        compression: (fragment_id == 0).then_some(FragmentCompression::None),
+                        bytes: Bytes::new(),
+                    }
+                    .into(),
+                },
+            ));
+        }
+
+        manager.prioritize(&registry);
+
+        let order = manager
+            .candidates()
+            .iter()
+            .map(|candidate| {
+                let MessageData::Fragment(fragment) = &candidate.message.data else {
+                    panic!("expected fragment candidate")
+                };
+                (fragment.message_id.0, fragment.fragment_id.0)
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(order, [(0, 0), (0, 1), (1, 0), (1, 1)]);
     }
 
     #[test]

--- a/crates/transport/transport/src/packet/priority_manager.rs
+++ b/crates/transport/transport/src/packet/priority_manager.rs
@@ -1,22 +1,14 @@
-use crate::channel::registry::{ChannelId, ChannelRegistry};
-use crate::packet::message::{FragmentData, MessageData, SendMessage, SingleData};
-use alloc::collections::VecDeque;
-use alloc::{vec, vec::Vec};
+use crate::channel::registry::ChannelRegistry;
+use crate::packet::message::SendCandidate;
+use crate::packet::packet::MAX_PACKET_SIZE;
+use alloc::vec::Vec;
 use core::num::NonZeroU32;
 use governor::{DefaultDirectRateLimiter, Quota};
-use lightyear_core::network::NetId;
 use nonzero_ext::*;
 #[cfg(feature = "trace")]
 use tracing::{Level, instrument};
 #[allow(unused_imports)]
 use tracing::{debug, error, info, trace};
-
-#[derive(Debug)]
-pub struct BufferedMessage {
-    priority: f32,
-    channel_net_id: NetId,
-    data: MessageData,
-}
 
 #[derive(Debug, Clone)]
 pub struct PriorityConfig {
@@ -38,31 +30,40 @@ impl Default for PriorityConfig {
 }
 
 impl PriorityConfig {
+    /// Enable a sustained byte rate while allowing at least one maximum-sized packet per burst.
+    ///
+    /// Governor cannot admit an item larger than its burst capacity. Keeping the burst at least
+    /// one transport MTU prevents low byte rates from making every valid packet permanently
+    /// inadmissible; it does not change the configured sustained refill rate.
     pub fn new(bytes_per_second_quota: u32) -> Self {
         let cap = bytes_per_second_quota.try_into().unwrap();
+        let burst = bytes_per_second_quota
+            .max(MAX_PACKET_SIZE as u32)
+            .try_into()
+            .unwrap();
         Self {
-            bandwidth_quota: Quota::per_second(cap).allow_burst(cap),
+            bandwidth_quota: Quota::per_second(cap).allow_burst(burst),
             enabled: true,
         }
     }
 }
 
-/// Responsible for restricting the bandwidth used by messages sent over the network.
+/// Reusable scheduler scratch for ordering channel-owned send candidates.
 ///
-/// The messages will be filtered by priority until we reach the bandwidth quota.
-///
-/// Messages that were not sent will have increased priority, which means that they have a higher chance of
-/// being sent in the future.
+/// This type never owns channel queues and does not decide whether a packet was sent. Bandwidth is
+/// consumed separately by [`BandwidthLimiter`] after packet staging and compression.
 #[derive(Debug)]
 pub struct PriorityManager {
     pub(crate) config: PriorityConfig,
-    // TODO: can I do without this limiter?
-    pub(crate) limiter: DefaultDirectRateLimiter,
-    // Internal buffer of data that we want to send
-    // TODO: improve this
-    data_to_send: Vec<(NetId, (VecDeque<SendMessage>, VecDeque<SendMessage>))>,
-    // Messages that could not be sent because of the bandwidth quota
-    // buffered_data: Vec<BufferedMessage>,
+    /// Reused scratch containing cheap snapshots of channel-owned pending messages.
+    candidates: Vec<SendCandidate>,
+}
+
+/// Consumes the configured bandwidth quota using final packet bytes.
+#[derive(Debug)]
+pub(crate) struct BandwidthLimiter {
+    enabled: bool,
+    limiter: DefaultDirectRateLimiter,
 }
 
 impl Default for PriorityManager {
@@ -73,138 +74,67 @@ impl Default for PriorityManager {
 
 impl PriorityManager {
     pub fn new(config: PriorityConfig) -> Self {
-        let quota = config.bandwidth_quota;
         Self {
             config,
-            data_to_send: Vec::new(),
-            limiter: DefaultDirectRateLimiter::direct(quota),
-            // data_to_send: BTreeMap::new(),
-            // buffered_data: Vec::new(),
+            candidates: Vec::new(),
         }
     }
 
-    pub(crate) fn buffer_messages(
-        &mut self,
-        net_id: NetId,
-        single: VecDeque<SendMessage>,
-        fragment: VecDeque<SendMessage>,
-    ) {
-        self.data_to_send.push((net_id, (single, fragment)));
+    pub(crate) fn candidates_mut(&mut self) -> &mut Vec<SendCandidate> {
+        &mut self.candidates
     }
 
-    /// Sort queued messages by priority and return the data to packetize.
+    pub(crate) fn candidates(&self) -> &[SendCandidate] {
+        &self.candidates
+    }
+
+    pub(crate) fn clear(&mut self) {
+        self.candidates.clear();
+    }
+
+    /// Apply priority ordering without taking ownership of channel queues.
     ///
-    /// Bandwidth quota is intentionally consumed after packet building, because packet building
-    /// can compress selected messages and the limiter should use final packet bytes.
+    /// When priority management is disabled, this leaves collection order untouched.
     #[cfg_attr(feature = "trace", instrument(level = Level::INFO, skip_all))]
-    pub(crate) fn prioritize(
-        &mut self,
-        channel_registry: &ChannelRegistry,
-    ) -> (
-        Vec<(ChannelId, VecDeque<SingleData>)>,
-        Vec<(ChannelId, VecDeque<FragmentData>)>,
-    ) {
-        // if the bandwidth quota is disabled, just pass all messages through
-        // As an optimization: no need to send the tick of the message, it is the same as the header tick
+    pub(crate) fn prioritize(&mut self, channel_registry: &ChannelRegistry) {
         if !self.config.enabled {
-            let mut single_data = vec![];
-            let mut fragment_data = vec![];
-            for (net_id, (single, fragment)) in self.data_to_send.drain(..) {
-                single_data.push((
-                    net_id,
-                    single
-                        .into_iter()
-                        .map(|message| {
-                            let MessageData::Single(single) = message.data else {
-                                unreachable!()
-                            };
-                            single
-                        })
-                        .collect(),
-                ));
-                fragment_data.push((
-                    net_id,
-                    fragment
-                        .into_iter()
-                        .map(|message| {
-                            let MessageData::Fragment(fragment) = message.data else {
-                                unreachable!()
-                            };
-                            fragment
-                        })
-                        .collect(),
-                ));
-            }
-            return (single_data, fragment_data);
+            debug!(
+                num_candidates = self.candidates.len(),
+                "priority disabled; preserving candidate collection order"
+            );
+            return;
         }
 
-        // compute the priority of each new message
-        let mut all_messages = self
-            .data_to_send
-            .drain(..)
-            .flat_map(|(net_id, (single, fragment))| {
-                let channel_priority = channel_registry
-                    .settings_from_net_id(net_id)
-                    .unwrap()
-                    .priority;
-                trace!(?channel_priority, num_single=?single.len(), "channel priority");
-                single
-                    .into_iter()
-                    .map(move |single| BufferedMessage {
-                        priority: single.priority * channel_priority,
-                        channel_net_id: net_id,
-                        data: single.data,
-                    })
-                    .chain(fragment.into_iter().map(move |fragment| {
-                        // TODO (IMPORTANT): we should split fragments AFTER priority filtering
-                        //  because if we don't send one fragment, it's over..
-                        BufferedMessage {
-                            priority: fragment.priority * channel_priority,
-                            channel_net_id: net_id,
-                            data: fragment.data,
-                        }
-                    }))
-            })
-            .collect::<Vec<_>>();
+        for candidate in &mut self.candidates {
+            let channel_priority = channel_registry
+                .settings_from_net_id(candidate.channel_id)
+                .expect("candidate channel must be registered")
+                .priority;
+            candidate.effective_priority = candidate.message.priority * channel_priority;
+        }
 
-        // sort from highest priority to lower
-        all_messages.sort_by(|a, b| a.priority.partial_cmp(&b.priority).unwrap());
+        // Every candidate has deterministic tie-breakers, so the in-place unstable sort has
+        // stable observable output without allocating temporary sort storage.
+        self.candidates.sort_unstable_by(|a, b| {
+            b.effective_priority
+                .total_cmp(&a.effective_priority)
+                .then_with(|| a.stable_order.cmp(&b.stable_order))
+                .then_with(|| a.channel_id.cmp(&b.channel_id))
+                .then_with(|| a.key.cmp(&b.key))
+        });
         debug!(
-            "all messages to send, sorted by priority: {:?}",
-            all_messages
+            num_candidates = self.candidates.len(),
+            "priority ordering complete"
         );
+    }
+}
 
-        // Return messages in priority order. Keep each message as its own channel batch so the
-        // packet builder sees priority ordering instead of a grouping hash-map order.
-        let mut single_data: Vec<(ChannelId, VecDeque<SingleData>)> = vec![];
-        let mut fragment_data: Vec<(ChannelId, VecDeque<FragmentData>)> = vec![];
-        while let Some(buffered_message) = all_messages.pop() {
-            trace!(channel=?buffered_message.channel_net_id, "Selected message with priority {:?}", buffered_message.priority);
-
-            // the message is allowed, add it to the list of messages to send
-            match buffered_message.data {
-                MessageData::Single(single) => {
-                    single_data.push((buffered_message.channel_net_id, VecDeque::from([single])));
-                }
-                MessageData::Fragment(fragment) => {
-                    fragment_data
-                        .push((buffered_message.channel_net_id, VecDeque::from([fragment])));
-                }
-            }
+impl BandwidthLimiter {
+    pub(crate) fn new(config: PriorityConfig) -> Self {
+        Self {
+            enabled: config.enabled,
+            limiter: DefaultDirectRateLimiter::direct(config.bandwidth_quota),
         }
-
-        let num_messages_sent = single_data
-            .iter()
-            .map(|(_, data)| data.len())
-            .sum::<usize>()
-            + fragment_data
-                .iter()
-                .map(|(_, data)| data.len())
-                .sum::<usize>();
-        debug!(?num_messages_sent, "priority ordering complete.");
-
-        self.data_to_send.clear();
-        (single_data, fragment_data)
     }
 
     /// Consume bandwidth quota for a final packet payload.
@@ -212,7 +142,7 @@ impl PriorityManager {
     /// Returns false when this packet cannot currently fit. The caller should stop sending for
     /// this tick, because subsequent packets are not higher priority than this one.
     pub(crate) fn consume_packet_quota(&mut self, packet_bytes: u32) -> bool {
-        if !self.config.enabled {
+        if !self.enabled {
             return true;
         }
 
@@ -233,50 +163,152 @@ impl PriorityManager {
 mod tests {
     use super::*;
     use crate::channel::builder::{ChannelMode, ChannelSettings};
+    use crate::channel::registry::ChannelKind;
+    use crate::packet::message::{
+        FragmentCompression, FragmentData, FragmentIndex, MessageData, MessageId, SendCandidate,
+        SendMessage, SendMessageKey, SingleData,
+    };
+    use alloc::vec;
     use bytes::Bytes;
 
     struct PingLikeChannel;
     struct TurnTrafficChannel;
+    struct FragmentChannel;
+
+    #[test]
+    fn disabled_priority_preserves_candidate_collection_order() {
+        let registry = ChannelRegistry::default();
+        let mut manager = PriorityManager::default();
+        manager.candidates_mut().push(SendCandidate::new(
+            ChannelKind::of::<TurnTrafficChannel>(),
+            10,
+            SendMessageKey::UnreliableSingle(0),
+            1,
+            SendMessage {
+                priority: 100.0,
+                data: SingleData::new(None, Bytes::from_static(b"first")).into(),
+            },
+        ));
+        manager.candidates_mut().push(SendCandidate::new(
+            ChannelKind::of::<PingLikeChannel>(),
+            1,
+            SendMessageKey::UnreliableSingle(0),
+            0,
+            SendMessage {
+                priority: 1.0,
+                data: SingleData::new(None, Bytes::from_static(b"second")).into(),
+            },
+        ));
+
+        manager.prioritize(&registry);
+
+        assert_eq!(manager.candidates()[0].channel_id, 10);
+        assert_eq!(manager.candidates()[1].channel_id, 1);
+    }
 
     #[test]
     fn infinite_priority_messages_are_ordered_before_traffic_bursts() {
         let mut registry = ChannelRegistry::default();
-        let (_, ping_channel) = registry.add_channel::<PingLikeChannel>(ChannelSettings {
+        let (ping_kind, ping_channel) = registry.add_channel::<PingLikeChannel>(ChannelSettings {
             mode: ChannelMode::UnorderedUnreliable,
             priority: f32::INFINITY,
             ..Default::default()
         });
-        let (_, traffic_channel) = registry.add_channel::<TurnTrafficChannel>(ChannelSettings {
+        let (traffic_kind, traffic_channel) =
+            registry.add_channel::<TurnTrafficChannel>(ChannelSettings {
+                mode: ChannelMode::UnorderedUnreliable,
+                priority: 1.0,
+                ..Default::default()
+            });
+        let mut manager = PriorityManager::new(PriorityConfig::new(1024));
+
+        manager.candidates_mut().extend((0..120).map(|index| {
+            SendCandidate::new(
+                traffic_kind,
+                traffic_channel,
+                SendMessageKey::UnreliableSingle(index),
+                index as u64,
+                SendMessage {
+                    priority: 1.0,
+                    data: SingleData::new(None, Bytes::from(vec![index as u8; 8])).into(),
+                },
+            )
+        }));
+        manager.candidates_mut().push(SendCandidate::new(
+            ping_kind,
+            ping_channel,
+            SendMessageKey::UnreliableSingle(0),
+            0,
+            SendMessage {
+                priority: 1.0,
+                data: SingleData::new(None, Bytes::from_static(b"ping")).into(),
+            },
+        ));
+
+        manager.prioritize(&registry);
+
+        let candidate = manager.candidates().first().expect("expected a candidate");
+        assert_eq!(candidate.channel_id, ping_channel);
+        let crate::packet::message::MessageData::Single(message) = &candidate.message.data else {
+            panic!("expected a single message")
+        };
+        assert_eq!(message.bytes, Bytes::from_static(b"ping"));
+    }
+
+    #[test]
+    fn singles_and_fragments_share_one_priority_order() {
+        let mut registry = ChannelRegistry::default();
+        let (fragment_kind, fragment_channel) =
+            registry.add_channel::<FragmentChannel>(ChannelSettings {
+                mode: ChannelMode::UnorderedUnreliable,
+                priority: 1.0,
+                ..Default::default()
+            });
+        let (ping_kind, ping_channel) = registry.add_channel::<PingLikeChannel>(ChannelSettings {
             mode: ChannelMode::UnorderedUnreliable,
-            priority: 1.0,
+            priority: 10.0,
             ..Default::default()
         });
         let mut manager = PriorityManager::new(PriorityConfig::new(1024));
-
-        manager.buffer_messages(
-            traffic_channel,
-            (0..120)
-                .map(|index| SendMessage {
-                    priority: 1.0,
-                    data: SingleData::new(None, Bytes::from(vec![index as u8; 8])).into(),
-                })
-                .collect(),
-            VecDeque::new(),
-        );
-        manager.buffer_messages(
-            ping_channel,
-            VecDeque::from([SendMessage {
+        manager.candidates_mut().push(SendCandidate::new(
+            fragment_kind,
+            fragment_channel,
+            SendMessageKey::UnreliableFragment(0),
+            0,
+            SendMessage {
+                data: FragmentData {
+                    message_id: MessageId(0),
+                    fragment_id: FragmentIndex(0),
+                    num_fragments: FragmentIndex(1),
+                    compression: Some(FragmentCompression::None),
+                    bytes: Bytes::from_static(b"fragment"),
+                }
+                .into(),
                 priority: 1.0,
-                data: SingleData::new(None, Bytes::from_static(b"ping")).into(),
-            }]),
-            VecDeque::new(),
-        );
+            },
+        ));
+        manager.candidates_mut().push(SendCandidate::new(
+            ping_kind,
+            ping_channel,
+            SendMessageKey::UnreliableSingle(0),
+            0,
+            SendMessage {
+                data: SingleData::new(None, Bytes::from_static(b"urgent")).into(),
+                priority: 1.0,
+            },
+        ));
 
-        let (single_data, fragment_data) = manager.prioritize(&registry);
+        manager.prioritize(&registry);
 
-        assert!(fragment_data.is_empty());
-        let (channel, messages) = single_data.first().expect("expected at least one message");
-        assert_eq!(*channel, ping_channel);
-        assert_eq!(messages[0].bytes, Bytes::from_static(b"ping"));
+        assert!(matches!(
+            manager.candidates()[0].message.data,
+            MessageData::Single(_)
+        ));
+    }
+
+    #[test]
+    fn bandwidth_burst_can_always_admit_one_mtu_packet() {
+        let mut limiter = BandwidthLimiter::new(PriorityConfig::new(1));
+        assert!(limiter.consume_packet_quota(MAX_PACKET_SIZE as u32));
     }
 }

--- a/crates/transport/transport/src/packet/test_utils.rs
+++ b/crates/transport/transport/src/packet/test_utils.rs
@@ -1,4 +1,3 @@
-use alloc::collections::VecDeque;
 use alloc::{vec, vec::Vec};
 use core::convert::TryInto;
 use core::time::Duration;
@@ -9,18 +8,20 @@ use lightyear_link::LinkStats;
 use lightyear_serde::SerializationError;
 use lightyear_serde::varint::varint_parse_len;
 
-use crate::channel::registry::ChannelId;
+use crate::channel::registry::{ChannelId, ChannelKind};
 use crate::packet::compression::CompressionConfig;
 use crate::packet::error::PacketError;
 use crate::packet::header::PacketHeader;
-use crate::packet::message::SingleData;
-use crate::packet::packet_builder::PacketBuilder;
+use crate::packet::message::{SendCandidate, SendMessage, SendMessageKey, SingleData};
+use crate::packet::packet_builder::{CandidateCursor, PacketBuilder};
 use crate::packet::packet_type::PacketType;
 
 /// Opaque packet-builder input prepared outside allocation measurements.
 pub struct PacketLoopBatch {
-    single_data: Vec<(ChannelId, VecDeque<SingleData>)>,
+    candidates: Vec<SendCandidate>,
 }
+
+struct PacketLoopChannel;
 
 /// Summary of a completed packet build and parse pass.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -93,6 +94,7 @@ impl<'a> SlicePacketReader<'a> {
 /// then call [`run_batch`](Self::run_batch) inside the measured region.
 pub struct PacketLoopFixture {
     packet_builder: PacketBuilder,
+    channel_kind: ChannelKind,
     channel_id: ChannelId,
     payloads: Vec<Bytes>,
     current_tick: Tick,
@@ -110,6 +112,7 @@ impl PacketLoopFixture {
             .collect();
         Self {
             packet_builder: PacketBuilder::new(1.5),
+            channel_kind: ChannelKind::of::<PacketLoopChannel>(),
             channel_id: 0,
             payloads,
             current_tick: Tick(0),
@@ -157,16 +160,26 @@ impl PacketLoopFixture {
     }
 
     fn prepare_batch_with_message_count(&self, message_count: usize) -> PacketLoopBatch {
-        let single_data = VecDeque::from_iter(
+        let candidates = Vec::from_iter(
             self.payloads
                 .iter()
                 .take(message_count)
                 .cloned()
-                .map(|payload| SingleData::new(None, payload)),
+                .enumerate()
+                .map(|(index, payload)| {
+                    SendCandidate::new(
+                        self.channel_kind,
+                        self.channel_id,
+                        SendMessageKey::UnreliableSingle(index),
+                        index as u64,
+                        SendMessage {
+                            data: SingleData::new(None, payload).into(),
+                            priority: 1.0,
+                        },
+                    )
+                }),
         );
-        PacketLoopBatch {
-            single_data: vec![(self.channel_id, single_data)],
-        }
+        PacketLoopBatch { candidates }
     }
 
     pub fn run_batch(&mut self, batch: PacketLoopBatch) -> Result<PacketLoopStats, PacketError> {
@@ -176,25 +189,26 @@ impl PacketLoopFixture {
             .update(real, &LinkStats::default());
         self.packet_builder.header_manager.lost_packets.clear();
 
-        let mut packets = self.packet_builder.build_packets_with_compression(
-            real,
-            self.current_tick,
-            batch.single_data,
-            Vec::new(),
-            CompressionConfig::DISABLED,
-        )?;
+        let mut cursor = CandidateCursor::default();
+        let current_tick = self.current_tick;
         self.current_tick += 1;
         self.current_real += Duration::from_millis(16);
 
-        let mut stats = PacketLoopStats {
-            packets: packets.len(),
-            ..Default::default()
-        };
-        for packet in packets.drain(..) {
+        let mut stats = PacketLoopStats::default();
+        while let Some(packet) = self.packet_builder.build_next_packet(
+            current_tick,
+            &batch.candidates,
+            &mut cursor,
+            CompressionConfig::DISABLED,
+        )? {
+            stats.packets += 1;
+            let packet_id = packet.packet_id;
+            self.packet_builder
+                .header_manager
+                .commit_send_packet(packet_id, real);
             self.parse_packet_payload(packet.payload.as_slice(), real, &mut stats)?;
             self.packet_builder.recycle_packet(packet);
         }
-        self.packet_builder.recycle_packet_list(packets);
         Ok(stats)
     }
 

--- a/crates/transport/transport/src/packet/test_utils.rs
+++ b/crates/transport/transport/src/packet/test_utils.rs
@@ -171,7 +171,6 @@ impl PacketLoopFixture {
                         self.channel_kind,
                         self.channel_id,
                         SendMessageKey::UnreliableSingle(index),
-                        index as u64,
                         SendMessage {
                             data: SingleData::new(None, payload).into(),
                             priority: 1.0,

--- a/crates/transport/transport/src/plugin.rs
+++ b/crates/transport/transport/src/plugin.rs
@@ -1,7 +1,7 @@
 use crate::channel::builder::Transport;
 use crate::channel::receivers::ChannelReceive;
 use crate::channel::registry::{ChannelId, ChannelRegistry};
-use crate::channel::senders::ChannelSend;
+use crate::channel::senders::{ChannelSend, SendFlushOutcome};
 use crate::error::TransportError;
 use crate::packet::compression::decompress_payload;
 use crate::packet::error::PacketError;
@@ -428,69 +428,57 @@ impl TransportPlugin {
                 Ok::<(), TransportError>(())
             }).inspect_err(|e| error!("error sending message: {e:?}")).ok();
 
-            // flush messages from the Sender to the priority manager
-            transport.senders.values_mut().for_each(|sender_metadata| {
-                let channel_id = sender_metadata.channel_id;
-                let sender = &mut sender_metadata.sender;
-                let (single_data, fragment_data) = sender.send_packet();
-                if !single_data.is_empty() || !fragment_data.is_empty() {
-                    trace!(?channel_id, "send message with channel_id");
-                    transport.priority_manager.buffer_messages(channel_id, single_data, fragment_data);
-                }
-            });
+            // Collect cheap snapshots while each channel retains ownership of its pending queues.
+            transport.priority_manager.clear();
+            {
+                let candidates = transport.priority_manager.candidates_mut();
+                transport.senders.iter_mut().for_each(|(channel_kind, metadata)| {
+                    metadata.sender.collect_send_candidates(
+                        *channel_kind,
+                        metadata.channel_id,
+                        candidates,
+                    );
+                });
+            }
+            transport.priority_manager.prioritize(&channel_registry);
 
-            // get the list of messages to pack, ordered by priority
-            let (single_data, fragment_data) =
-                transport.priority_manager.prioritize(&channel_registry);
-
-            // build actual packets from these messages
-            // TODO: swap to try_for_each when available
-            let Ok(mut packets) =
-                transport.packet_manager
-                    .build_packets_with_compression(real_time.elapsed(), tick, single_data, fragment_data, transport.compression) else {
-                error!("Failed to build packets");
-                return
-            };
-
+            let mut candidate_cursor = crate::packet::packet_builder::CandidateCursor::default();
             let mut total_bytes_sent = 0;
-            let mut packet_drain = packets.drain(..);
-            while let Some(mut packet) = packet_drain.next() {
+            let mut flush_outcome = SendFlushOutcome::Complete;
+            loop {
+                let staged = transport.packet_manager.build_next_packet(
+                    tick,
+                    transport.priority_manager.candidates(),
+                    &mut candidate_cursor,
+                    transport.compression,
+                );
+                let mut packet = match staged {
+                    Ok(Some(packet)) => packet,
+                    Ok(None) => break,
+                    Err(error) => {
+                        flush_outcome = SendFlushOutcome::StagingFailed;
+                        error!(?error, "failed to stage transport packet");
+                        break;
+                    }
+                };
                 trace!(packet_id = ?packet.packet_id, num_messages = ?packet.num_messages(), "sending packet");
                 let packet_id = packet.packet_id;
                 let num_messages = packet.num_messages();
                 let packet_len = packet.payload.len();
                 let packet_compression = packet.compression;
                 if !transport
-                    .priority_manager
+                    .bandwidth_limiter
                     .consume_packet_quota(packet_len as u32)
                 {
-                    // Packets are built from messages ordered by priority. The limiter is checked
-                    // here, after packet building/compression, so quota is charged on final packet
-                    // bytes. Once this packet does not fit, later packets are not higher priority.
-                    //
-                    // Unsent unreliable messages are dropped for this tick. Reliable messages will
-                    // be retried by their channel sender because their ack bookkeeping is only
-                    // updated after a packet is accepted below.
-                    let rejected_packets = core::iter::once(packet).chain(packet_drain.by_ref());
-                    transport.packet_manager.recycle_packets(rejected_packets);
+                    // Staging has no channel or packet-header side effects. Reliable messages are
+                    // retained; each unreliable channel applies its retry-unsent policy when this
+                    // flush finishes. Since bandwidth limiting also enables priority ordering,
+                    // later candidates are not higher priority than this packet.
+                    flush_outcome = SendFlushOutcome::BandwidthLimited;
+                    transport.packet_manager.recycle_packet(packet);
                     break;
                 }
-                #[cfg(feature = "metrics")]
-                for metadata in packet.messages.iter() {
-                    let channel_name = channel_registry.get_name_from_net_id(metadata.channel);
-                    metrics::gauge!("channel/send_messages", "channel" => channel_name)
-                        .increment(1);
-                    metrics::gauge!("channel/send_bytes", "channel" => channel_name)
-                        .increment(metadata.num_bytes as f64);
-                }
                 if let Some(compression_info) = packet.compression {
-                    #[cfg(feature = "metrics")]
-                    {
-                        metrics::counter!("transport/compression_saved_bytes").increment(
-                            (compression_info.original_len - compression_info.compressed_len)
-                                as u64,
-                        );
-                    }
                     trace!(
                         original_len = compression_info.original_len,
                         compressed_len = compression_info.compressed_len,
@@ -514,58 +502,84 @@ impl TransportPlugin {
                     "sending transport packet"
                 );
 
-                // TODO: should we update this to include fragment info as well?
-                // Update the packet_to_message_id_map (only for channels that care about acks)
+                // Acceptance into Link.send is the transactional boundary. Packet ids, retry
+                // timestamps, ack maps, and metrics are committed only after this point.
+                total_bytes_sent += packet.payload.len() as u32;
+                link.send.push(Bytes::from(core::mem::take(&mut packet.payload)));
+                transport
+                    .packet_manager
+                    .header_manager
+                    .commit_send_packet(packet_id, real_time.elapsed());
+
+                #[cfg(feature = "metrics")]
+                if let Some(compression_info) = packet.compression {
+                    metrics::counter!("transport/compression_saved_bytes").increment(
+                        (compression_info.original_len - compression_info.compressed_len) as u64,
+                    );
+                }
+
                 let mut packet_messages = core::mem::take(&mut packet.messages);
-                packet_messages
-                    .drain(..)
-                    .try_for_each(|metadata| {
-                        let channel_id = metadata.channel;
-                        let channel_kind = channel_registry
-                            .get_kind_from_net_id(channel_id)
-                            .ok_or(PacketError::ChannelNotFound)?;
-                        let sender_metadata = transport.senders
-                            .get_mut(channel_kind)
-                            .ok_or(PacketError::ChannelNotFound)?;
-                        let Some(message_id) = metadata.message else {
-                            return Ok(());
-                        };
+                for metadata in packet_messages.drain(..) {
+                    let commit = metadata
+                        .commit
+                        .expect("staged channel candidate must carry commit metadata");
+                    let sender_metadata = transport
+                        .senders
+                        .get_mut(&commit.channel_kind)
+                        .expect("staged candidate channel must remain registered during flush");
+                    sender_metadata
+                        .sender
+                        .commit_send(commit.key, real_time.elapsed());
 
-                        sender_metadata.messages_sent.push(message_id);
-                        if sender_metadata.mode.is_watching_acks() {
-                            trace!(
-                                "Registering message ack (ChannelId:{:?} {:?}) for packet {:?}",
-                                channel_id,
-                                metadata,
-                                packet.packet_id
-                            );
+                    #[cfg(feature = "metrics")]
+                    {
+                        let channel_name =
+                            channel_registry.get_name_from_net_id(metadata.channel);
+                        metrics::gauge!("channel/send_messages", "channel" => channel_name)
+                            .increment(1);
+                        metrics::gauge!("channel/send_bytes", "channel" => channel_name)
+                            .increment(metadata.num_bytes as f64);
+                    }
 
-                            if let Some(num_fragments) = metadata.num_fragments {
-                                transport.fragment_acks.insert(message_id, num_fragments);
-                            }
-                            transport.packet_to_message_map
-                                .entry(packet.packet_id)
-                                .or_default()
-                                .push((*channel_kind, MessageAck {
+                    let Some(message_id) = metadata.message else {
+                        continue;
+                    };
+                    sender_metadata.messages_sent.push(message_id);
+                    if sender_metadata.mode.is_watching_acks() {
+                        trace!(
+                            "Registering message ack (ChannelId:{:?} {:?}) for packet {:?}",
+                            metadata.channel, metadata, packet.packet_id
+                        );
+
+                        if let Some(num_fragments) = metadata.num_fragments {
+                            transport
+                                .fragment_acks
+                                .entry(message_id)
+                                .or_insert(num_fragments);
+                        }
+                        transport
+                            .packet_to_message_map
+                            .entry(packet.packet_id)
+                            .or_default()
+                            .push((
+                                commit.channel_kind,
+                                MessageAck {
                                     message_id,
                                     fragment_id: metadata.fragment_index,
-                                }));
-                            trace!(?transport.packet_to_message_map, "packet to message");
-                        }
-                        Ok::<(), PacketError>(())
-                    })
-                    .inspect_err(|e| error!("Error updating packet to message ack: {e:?}"))
-                    .ok();
+                                },
+                            ));
+                        trace!(?transport.packet_to_message_map, "packet to message");
+                    }
+                }
                 transport
                     .packet_manager
                     .recycle_message_metadata_list(packet_messages);
-
-                // Upload the packets to the link
-                total_bytes_sent += packet.payload.len() as u32;
-                link.send.push(Bytes::from(packet.payload));
             }
-            drop(packet_drain);
-            transport.packet_manager.recycle_packet_list(packets);
+            transport
+                .senders
+                .values_mut()
+                .for_each(|metadata| metadata.sender.finish_send(flush_outcome));
+            transport.priority_manager.clear();
             if total_bytes_sent > 0 {
                 trace!(
                     target: "lightyear_debug::transport",

--- a/crates/transport/transport/src/plugin.rs
+++ b/crates/transport/transport/src/plugin.rs
@@ -520,9 +520,7 @@ impl TransportPlugin {
 
                 let mut packet_messages = core::mem::take(&mut packet.messages);
                 for metadata in packet_messages.drain(..) {
-                    let commit = metadata
-                        .commit
-                        .expect("staged channel candidate must carry commit metadata");
+                    let commit = metadata.commit;
                     let sender_metadata = transport
                         .senders
                         .get_mut(&commit.channel_kind)

--- a/crates/transport/transport/src/plugin.rs
+++ b/crates/transport/transport/src/plugin.rs
@@ -656,3 +656,87 @@ impl Plugin for TestTransportPlugin {
         app.add_plugins(TransportPlugin);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use alloc::{vec, vec::Vec};
+
+    use super::*;
+    use crate::channel::builder::{ChannelMode, ChannelSettings};
+    use crate::channel::registry::ChannelKind;
+    use crate::packet::priority_manager::PriorityConfig;
+    use bevy_ecs::system::RunSystemOnce;
+
+    struct RetryChannel;
+    struct DiscardChannel;
+
+    fn spawn_transport<C: crate::channel::Channel>(
+        world: &mut World,
+        settings: ChannelSettings,
+        channel_kind: ChannelKind,
+        channel_id: ChannelId,
+    ) -> Entity {
+        let mut transport = Transport::new(PriorityConfig::new(1));
+        transport.add_sender::<C>((&settings).into(), settings.mode, channel_id);
+        for value in [1, 2] {
+            transport
+                .send_mut_erased(channel_kind, Bytes::from(vec![value; 1000]), 1.0)
+                .unwrap();
+        }
+        world.spawn((Link::default(), Linked, transport)).id()
+    }
+
+    fn pending_candidates<C: crate::channel::Channel>(world: &mut World, entity: Entity) -> usize {
+        let mut entity = world.entity_mut(entity);
+        let mut transport = entity.get_mut::<Transport>().unwrap();
+        let channel_kind = ChannelKind::of::<C>();
+        let mut candidates = Vec::new();
+        let metadata = transport.senders.get_mut(&channel_kind).unwrap();
+        metadata
+            .sender
+            .collect_send_candidates(channel_kind, metadata.channel_id, &mut candidates);
+        candidates.len()
+    }
+
+    #[test]
+    fn bandwidth_limited_flush_applies_each_channels_retry_policy() {
+        let retry_settings = ChannelSettings {
+            mode: ChannelMode::UnorderedUnreliable,
+            retry_unsent_messages: true,
+            ..Default::default()
+        };
+        let discard_settings = ChannelSettings {
+            retry_unsent_messages: false,
+            ..retry_settings
+        };
+        let mut registry = ChannelRegistry::default();
+        let (retry_kind, retry_id) = registry.add_channel::<RetryChannel>(retry_settings);
+        let (discard_kind, discard_id) = registry.add_channel::<DiscardChannel>(discard_settings);
+
+        let mut world = World::new();
+        world.insert_resource(registry);
+        world.init_resource::<Time<Real>>();
+        world.init_resource::<LocalTimeline>();
+        let retry_entity =
+            spawn_transport::<RetryChannel>(&mut world, retry_settings, retry_kind, retry_id);
+        let discard_entity = spawn_transport::<DiscardChannel>(
+            &mut world,
+            discard_settings,
+            discard_kind,
+            discard_id,
+        );
+
+        world.run_system_once(TransportPlugin::buffer_send).unwrap();
+
+        assert_eq!(world.get::<Link>(retry_entity).unwrap().send.len(), 1);
+        assert_eq!(world.get::<Link>(discard_entity).unwrap().send.len(), 1);
+        assert_eq!(
+            pending_candidates::<RetryChannel>(&mut world, retry_entity),
+            1
+        );
+        assert_eq!(
+            pending_candidates::<DiscardChannel>(&mut world, discard_entity),
+            0
+        );
+    }
+}


### PR DESCRIPTION
Keep pending messages owned by their channels through packet staging and bandwidth limiting, and only acknowledge thta the message is sent after Link.send accepts the packet.
