### PR TITLE
feat(avian): fix avian for child colliders of a rigid body

### DIFF
--- a/book/src/concepts/advanced_replication/avian.md
+++ b/book/src/concepts/advanced_replication/avian.md
@@ -93,6 +93,26 @@ When `sync_to_transform` is `true`, Lightyear synchronizes the restored canonica
 
 This authority rule applies to rigid-body poses. A child collider without its own `RigidBody` still
 uses its local `Transform`/`ColliderTransform` to describe its offset from the parent body.
+Its `Position` and `Rotation` are derived world state and should not be replicated independently.
+Replicate physics poses only for entities with their own rigid body:
+
+```rust,ignore
+app.component::<Position>()
+    .replicate_filtered::<With<RigidBody>>()
+    .predict()
+    .add_linear_interpolation()
+    .add_correction();
+
+app.component::<Rotation>()
+    .replicate_filtered::<With<RigidBody>>()
+    .predict()
+    .add_linear_interpolation()
+    .add_correction();
+```
+
+This excludes child colliders that do not have a `RigidBody`. Their pose is computed from the
+rigid-body root and their fixed local `Transform`, so sending their derived `Position` and
+`Rotation` would duplicate state and could apply samples from a different visual timeline.
 
 To smooth a predicted entity between fixed ticks from the moment it spawns, add the type-erased marker:
 

--- a/crates/integration/avian/src/plugin.rs
+++ b/crates/integration/avian/src/plugin.rs
@@ -1225,6 +1225,24 @@ mod tests {
     }
 
     fn add_dynamic_proxy(app: &mut App, collider: Entity, body: Entity, aabb: ColliderAabb) {
+        add_dynamic_proxy_with(
+            app,
+            collider,
+            body,
+            aabb,
+            CollisionLayers::default(),
+            ColliderTreeProxyFlags::empty(),
+        );
+    }
+
+    fn add_dynamic_proxy_with(
+        app: &mut App,
+        collider: Entity,
+        body: Entity,
+        aabb: ColliderAabb,
+        layers: CollisionLayers,
+        flags: ColliderTreeProxyFlags,
+    ) {
         let proxy_id = app
             .world_mut()
             .resource_mut::<ColliderTrees>()
@@ -1234,8 +1252,8 @@ mod tests {
                 ColliderTreeProxy {
                     collider,
                     body: Some(body),
-                    layers: CollisionLayers::default(),
-                    flags: ColliderTreeProxyFlags::empty(),
+                    layers,
+                    flags,
                 },
             );
         let proxy_key = ColliderTreeProxyKey::new(proxy_id, ColliderTreeType::Dynamic);
@@ -1289,6 +1307,235 @@ mod tests {
             app.world()
                 .resource::<ContactGraph>()
                 .contains(collider1, collider2)
+        );
+    }
+
+    fn overlapping_aabb(center: Vector) -> ColliderAabb {
+        ColliderAabb::new(center, Vector::splat(1.0))
+    }
+
+    fn repair_fixture() -> (App, Entity, Entity, Entity, Entity) {
+        let mut app = App::new();
+        app.init_resource::<ColliderTrees>();
+        app.init_resource::<ContactGraph>();
+        let body1 = app.world_mut().spawn_empty().id();
+        let body2 = app.world_mut().spawn_empty().id();
+        let collider1 = app.world_mut().spawn_empty().id();
+        let collider2 = app.world_mut().spawn_empty().id();
+        (app, body1, body2, collider1, collider2)
+    }
+
+    #[test]
+    fn repair_respects_collision_layers() {
+        let (mut app, body1, body2, collider1, collider2) = repair_fixture();
+        add_dynamic_proxy_with(
+            &mut app,
+            collider1,
+            body1,
+            overlapping_aabb(Vector::ZERO),
+            CollisionLayers::from_bits(0b0001, 0b0001),
+            ColliderTreeProxyFlags::empty(),
+        );
+        add_dynamic_proxy_with(
+            &mut app,
+            collider2,
+            body2,
+            overlapping_aabb(Vector::new(1.5, 0.0)),
+            CollisionLayers::from_bits(0b0010, 0b0010),
+            ColliderTreeProxyFlags::empty(),
+        );
+
+        app.world_mut()
+            .run_system_once(repair_contact_graph_system)
+            .unwrap();
+
+        assert!(
+            !app.world()
+                .resource::<ContactGraph>()
+                .contains(collider1, collider2)
+        );
+    }
+
+    #[test]
+    fn repair_restores_sensor_pair_without_constraints() {
+        let (mut app, body1, body2, collider1, collider2) = repair_fixture();
+        add_dynamic_proxy_with(
+            &mut app,
+            collider1,
+            body1,
+            overlapping_aabb(Vector::ZERO),
+            CollisionLayers::default(),
+            ColliderTreeProxyFlags::SENSOR,
+        );
+        add_dynamic_proxy(
+            &mut app,
+            collider2,
+            body2,
+            overlapping_aabb(Vector::new(1.5, 0.0)),
+        );
+
+        app.world_mut()
+            .run_system_once(repair_contact_graph_system)
+            .unwrap();
+
+        let graph = app.world().resource::<ContactGraph>();
+        let (_, pair) = graph
+            .get(collider1, collider2)
+            .expect("sensor pair not repaired");
+        assert!(!pair.generates_constraints());
+    }
+
+    #[test]
+    fn repair_skips_custom_filter_pairs() {
+        let (mut app, body1, body2, collider1, collider2) = repair_fixture();
+        add_dynamic_proxy_with(
+            &mut app,
+            collider1,
+            body1,
+            overlapping_aabb(Vector::ZERO),
+            CollisionLayers::default(),
+            ColliderTreeProxyFlags::CUSTOM_FILTER,
+        );
+        add_dynamic_proxy(
+            &mut app,
+            collider2,
+            body2,
+            overlapping_aabb(Vector::new(1.5, 0.0)),
+        );
+
+        app.world_mut()
+            .run_system_once(repair_contact_graph_system)
+            .unwrap();
+
+        assert!(
+            !app.world()
+                .resource::<ContactGraph>()
+                .contains(collider1, collider2)
+        );
+    }
+
+    #[test]
+    fn repair_skips_colliders_on_same_compound_body() {
+        let (mut app, body, _, collider1, collider2) = repair_fixture();
+        add_dynamic_proxy(&mut app, collider1, body, overlapping_aabb(Vector::ZERO));
+        add_dynamic_proxy(
+            &mut app,
+            collider2,
+            body,
+            overlapping_aabb(Vector::new(1.5, 0.0)),
+        );
+
+        app.world_mut()
+            .run_system_once(repair_contact_graph_system)
+            .unwrap();
+
+        assert!(
+            !app.world()
+                .resource::<ContactGraph>()
+                .contains(collider1, collider2)
+        );
+    }
+
+    #[test]
+    fn repair_excludes_disabled_colliders() {
+        let (mut app, body1, body2, collider1, collider2) = repair_fixture();
+        add_dynamic_proxy(&mut app, collider1, body1, overlapping_aabb(Vector::ZERO));
+        add_dynamic_proxy(
+            &mut app,
+            collider2,
+            body2,
+            overlapping_aabb(Vector::new(1.5, 0.0)),
+        );
+        app.world_mut()
+            .entity_mut(collider2)
+            .insert(ColliderDisabled);
+
+        app.world_mut()
+            .run_system_once(repair_contact_graph_system)
+            .unwrap();
+
+        assert!(
+            !app.world()
+                .resource::<ContactGraph>()
+                .contains(collider1, collider2)
+        );
+    }
+
+    #[test]
+    fn child_position_tracks_local_transform_and_reparenting() {
+        let mut app = App::new();
+        let body1_position = Position(Vector::new(10.0, 0.0));
+        let body1_rotation = Rotation::radians(core::f32::consts::FRAC_PI_2);
+        let body1 = app
+            .world_mut()
+            .spawn((
+                RigidBody::Dynamic,
+                body1_position,
+                body1_rotation,
+                GlobalTransform::IDENTITY,
+            ))
+            .id();
+        let body2_position = Position(Vector::new(-5.0, 3.0));
+        let body2_rotation = Rotation::radians(-0.5);
+        let body2 = app
+            .world_mut()
+            .spawn((
+                RigidBody::Dynamic,
+                body2_position,
+                body2_rotation,
+                GlobalTransform::IDENTITY,
+            ))
+            .id();
+        let local1 = ColliderTransform {
+            translation: Vector::new(2.0, 0.0),
+            rotation: Rotation::radians(0.25),
+            scale: Vector::ONE,
+        };
+        let child = app
+            .world_mut()
+            .spawn((
+                ChildOf(body1),
+                GlobalTransform::IDENTITY,
+                Position::default(),
+                Rotation::default(),
+                ColliderOf { body: body1 },
+            ))
+            .id();
+        app.world_mut().entity_mut(child).insert(local1);
+
+        app.world_mut()
+            .run_system_once(LightyearAvianPlugin::update_child_collider_position)
+            .unwrap();
+
+        assert_eq!(
+            *app.world().get::<Position>(child).unwrap(),
+            Position(body1_position.0 + body1_rotation * local1.translation)
+        );
+        assert_eq!(
+            *app.world().get::<Rotation>(child).unwrap(),
+            body1_rotation * local1.rotation
+        );
+
+        let local2 = ColliderTransform {
+            translation: Vector::new(-1.0, 4.0),
+            rotation: Rotation::radians(-0.3),
+            scale: Vector::ONE,
+        };
+        app.world_mut()
+            .entity_mut(child)
+            .insert((ChildOf(body2), ColliderOf { body: body2 }));
+        app.world_mut().entity_mut(child).insert(local2);
+        app.world_mut()
+            .run_system_once(LightyearAvianPlugin::update_child_collider_position)
+            .unwrap();
+
+        assert_eq!(
+            *app.world().get::<Position>(child).unwrap(),
+            Position(body2_position.0 + body2_rotation * local2.translation)
+        );
+        assert_eq!(
+            *app.world().get::<Rotation>(child).unwrap(),
+            body2_rotation * local2.rotation
         );
     }
 }

--- a/crates/integration/avian/src/plugin.rs
+++ b/crates/integration/avian/src/plugin.rs
@@ -120,7 +120,7 @@ use tracing::trace;
 
 use lightyear_core::timeline::is_in_rollback;
 use lightyear_frame_interpolation::FrameInterpolationSystems;
-use lightyear_interpolation::prelude::{AppInterpolationExt, InterpolationFns};
+use lightyear_interpolation::prelude::{AppInterpolationExt, Interpolated, InterpolationFns};
 use lightyear_prediction::plugin::PredictionSystems;
 use lightyear_prediction::prelude::{
     PredictionAppRegistrationExt, PredictionBuilderExt, PredictionManager, RollbackSystems,
@@ -204,6 +204,7 @@ struct RollbackColliderProxy {
 impl Plugin for LightyearAvianPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<PhysicsTransformConfig>();
+        Self::install_position_to_transform_markers(app);
         match self.replication_mode {
             AvianReplicationMode::Position { sync_to_transform } => {
                 Self::add_position_rotation_hermite_rule(app);
@@ -385,6 +386,67 @@ impl Plugin for LightyearAvianPlugin {
 }
 
 impl LightyearAvianPlugin {
+    /// Opt non-rigid interpolated entities into Avian's Position-to-Transform sync.
+    ///
+    /// Avian's [`position_to_transform`] normally only synchronizes entities with a
+    /// [`RigidBody`]. Lightyear's render-only [`Interpolated`] entities intentionally do not have
+    /// a rigid body, but their sampled [`Position`] and [`Rotation`] still need to be written to
+    /// [`Transform`] for rendering. [`ApplyPosToTransform`] opts those entities into Avian's
+    /// system.
+    ///
+    /// A non-rigid [`ColliderOf`] is different: its `Position` and `Rotation` are derived world
+    /// state computed from the rigid-body root and its [`ColliderTransform`], while its
+    /// `Transform` stores the fixed local offset from that root. Applying the derived world pose
+    /// to the local transform would apply the hierarchy twice and move the collider away from the
+    /// body. Transform synchronization must therefore start at the rigid-body root, and compound
+    /// child colliders must not receive [`ApplyPosToTransform`]. The removal observer handles
+    /// either component insertion order. Avian can also give the root collider a self-referential
+    /// [`ColliderOf`], but that root is still synchronized by the system's [`RigidBody`] branch and
+    /// does not need the opt-in marker.
+    fn install_position_to_transform_markers(app: &mut App) {
+        app.add_observer(Self::add_apply_pos_to_transform);
+        app.add_observer(Self::remove_apply_pos_to_transform_from_child_collider);
+    }
+
+    fn add_apply_pos_to_transform(
+        trigger: On<Add, (Position, Rotation, Interpolated)>,
+        query: Query<
+            (),
+            (
+                With<Position>,
+                With<Rotation>,
+                With<Interpolated>,
+                Without<ApplyPosToTransform>,
+                Without<RigidBody>,
+                Without<ColliderOf>,
+            ),
+        >,
+        mut commands: Commands,
+    ) {
+        if query.contains(trigger.entity) {
+            commands.entity(trigger.entity).insert(ApplyPosToTransform);
+        }
+    }
+
+    fn remove_apply_pos_to_transform_from_child_collider(
+        trigger: On<Insert, (ColliderOf, ApplyPosToTransform)>,
+        query: Query<
+            (),
+            (
+                With<ColliderOf>,
+                With<ApplyPosToTransform>,
+                Without<RigidBody>,
+            ),
+        >,
+        mut commands: Commands,
+    ) {
+        if query.contains(trigger.entity) {
+            commands
+                .entity(trigger.entity)
+                .remove::<ApplyPosToTransform>();
+        }
+    }
+
     /// Register the canonical Avian pose and velocity bundle once for every
     /// Position-mode application. The bundle's default priority is its four
     /// members, so it wins over ordinary single-component rules whenever the
@@ -703,22 +765,6 @@ impl LightyearAvianPlugin {
     }
 
     fn sync_position_to_transform(app: &mut App, schedule: impl ScheduleLabel) {
-        if app
-            .world()
-            .resource::<PhysicsTransformConfig>()
-            .position_to_transform
-        {
-            // Make sure that PositionToTransform sync also runs for Interpolated entities
-            app.try_register_required_components::<Position, ApplyPosToTransform>()
-                .ok();
-            app.try_register_required_components::<Rotation, ApplyPosToTransform>()
-                .ok();
-
-            // NOTE: we do NOT register Transform as required for Position/Rotation because
-            //  they might not be added at the same time (e.g. on Interpolated entities).
-            //  The `add_transform` system below handles adding Transform when both are present.
-            //  For physics entities, Transform is registered as required for Collider above.
-        }
         let schedule = schedule.intern();
 
         app.configure_sets(

--- a/crates/tests/src/client_server/avian/compound_replication.rs
+++ b/crates/tests/src/client_server/avian/compound_replication.rs
@@ -1,9 +1,17 @@
+use crate::protocol::CompA;
 use crate::stepper::{ClientServerStepper, StepperConfig};
 use approx::assert_relative_eq;
 use avian2d::collision::collider::EnlargedAabb;
+use avian2d::physics_transform::ApplyPosToTransform;
 use avian2d::prelude::*;
 use bevy::prelude::*;
+use core::time::Duration;
 use lightyear::avian2d::plugin::AvianReplicationMode;
+use lightyear::frame_interpolation::{FrameInterpolate, FrameInterpolationHistory};
+use lightyear::prediction::correction::VisualCorrection;
+use lightyear::prediction::diagnostics::PredictionMetrics;
+use lightyear::prediction::rollback::RollbackSystems;
+use lightyear::prelude::{ConfirmedHistory, Interpolated, Predicted};
 use lightyear_connection::network_target::NetworkTarget;
 use lightyear_messages::MessageManager;
 use lightyear_replication::prelude::*;
@@ -11,20 +19,708 @@ use test_log::test;
 
 const ROOT_POSITION: Vec2 = Vec2::new(5.0, -3.0);
 const ROOT_ANGLE: f32 = 0.4;
+const EXAMPLE_PLAYER_SIZE: f32 = 40.0;
+const EXAMPLE_CHILD_SIZE: f32 = 16.0;
+const EXAMPLE_CHILD_OFFSET: Vec2 = Vec2::new((EXAMPLE_PLAYER_SIZE + EXAMPLE_CHILD_SIZE) / 2.0, 0.0);
+
+/// Test-local marker for the deterministic child in the compound-player template.
+#[derive(Component)]
+struct CompoundChildCollider;
 
 #[test]
 fn compound_hierarchy_position_mode() {
-    run_compound_hierarchy(AvianReplicationMode::Position);
-}
-
-#[test]
-fn compound_hierarchy_position_interpolate_transform_mode() {
-    run_compound_hierarchy(AvianReplicationMode::PositionButInterpolateTransform);
+    run_compound_hierarchy(AvianReplicationMode::Position {
+        sync_to_transform: false,
+    });
 }
 
 #[test]
 fn compound_hierarchy_transform_mode() {
     run_compound_hierarchy(AvianReplicationMode::Transform);
+}
+
+/// Exercise the example's intended compound-player contract through the complete
+/// client visual pipeline. The owner's root is predicted and frame-interpolated;
+/// the other client's root is snapshot-interpolated. Each client constructs the
+/// deterministic child locally; it is timeline-neutral and follows whichever root
+/// representation is present. A forced misprediction must trigger
+/// rollback/correction without opening a gap between the two colliders.
+#[test]
+fn touching_child_collider_survives_prediction_interpolation_and_correction() {
+    let mut config = StepperConfig::with_netcode_clients(2);
+    config.frame_duration = Duration::from_millis(5);
+    let mut stepper = ClientServerStepper::from_config(config);
+
+    for client in &mut stepper.client_apps {
+        client.init_resource::<TouchAudit>();
+        client.init_resource::<CorrectionObserved>();
+        client.init_resource::<InjectMisprediction>();
+        client.add_systems(FixedUpdate, inject_fixed_misprediction);
+        client.add_systems(
+            PostUpdate,
+            materialize_example_compound_player.after(TransformSystems::Propagate),
+        );
+        client.add_systems(
+            PostUpdate,
+            record_touching_faces.after(TransformSystems::Propagate),
+        );
+        client.add_systems(
+            PostUpdate,
+            record_visual_correction.after(RollbackSystems::VisualCorrection),
+        );
+    }
+
+    let owner = stepper
+        .client_of(0)
+        .get::<lightyear_core::id::RemoteId>()
+        .unwrap()
+        .0;
+    let root = stepper
+        .server_app
+        .world_mut()
+        .spawn((
+            CompA(1.0),
+            Replicate::to_clients(NetworkTarget::All),
+            DisableReplicateHierarchy,
+            PredictionTarget::to_clients(NetworkTarget::Single(owner)),
+            InterpolationTarget::to_clients(NetworkTarget::AllExceptSingle(owner)),
+            RigidBody::Kinematic,
+            Position::from(ROOT_POSITION),
+            Rotation::radians(ROOT_ANGLE),
+            Transform::from_translation(ROOT_POSITION.extend(0.0))
+                .with_rotation(Quat::from_rotation_z(ROOT_ANGLE)),
+            LinearVelocity(Vec2::new(20.0, 4.0)),
+            AngularVelocity(0.4),
+            Collider::rectangle(EXAMPLE_PLAYER_SIZE, EXAMPLE_PLAYER_SIZE),
+            CollisionLayers::default(),
+        ))
+        .id();
+    let child = stepper
+        .server_app
+        .world_mut()
+        .spawn((
+            CompoundChildCollider,
+            ChildOf(root),
+            Transform::from_translation(EXAMPLE_CHILD_OFFSET.extend(0.0)),
+            Collider::rectangle(EXAMPLE_CHILD_SIZE, EXAMPLE_CHILD_SIZE),
+            ColliderOf { body: root },
+            CollisionLayers::default(),
+        ))
+        .id();
+
+    stepper.frame_step_server_first(20);
+
+    let predicted_root = mapped_entity(&stepper, 0, root);
+    let interpolated_root = mapped_entity(&stepper, 1, root);
+    assert!(
+        stepper
+            .client(0)
+            .get::<MessageManager>()
+            .unwrap()
+            .entity_mapper
+            .get_local(child)
+            .is_none(),
+        "the deterministic child entity must not be replicated"
+    );
+    let predicted_child = local_compound_child(stepper.client_apps[0].world(), predicted_root);
+    let interpolated_child =
+        local_compound_child(stepper.client_apps[1].world(), interpolated_root);
+
+    assert!(
+        stepper.client_apps[0]
+            .world()
+            .get::<Predicted>(predicted_root)
+            .is_some()
+    );
+    assert!(
+        stepper.client_apps[0]
+            .world()
+            .get::<Predicted>(predicted_child)
+            .is_none()
+    );
+    assert!(
+        stepper.client_apps[0]
+            .world()
+            .get::<Interpolated>(predicted_child)
+            .is_none()
+    );
+    assert!(
+        stepper.client_apps[1]
+            .world()
+            .get::<Interpolated>(interpolated_root)
+            .is_some()
+    );
+    assert!(
+        stepper.client_apps[1]
+            .world()
+            .get::<Predicted>(interpolated_child)
+            .is_none()
+    );
+    assert!(
+        stepper.client_apps[1]
+            .world()
+            .get::<Interpolated>(interpolated_child)
+            .is_none()
+    );
+
+    let predicted_world = stepper.client_apps[0].world();
+    assert!(predicted_world.get::<RigidBody>(predicted_root).is_some());
+    assert!(
+        predicted_world
+            .get::<ApplyPosToTransform>(predicted_root)
+            .is_none(),
+        "RigidBody roots are already synchronized by Avian and do not need the opt-in marker"
+    );
+    assert_eq!(
+        predicted_world
+            .get::<ColliderOf>(predicted_root)
+            .unwrap()
+            .body,
+        predicted_root,
+        "the With<RigidBody> replication filter must retain roots even when Avian gives them ColliderOf"
+    );
+    assert!(predicted_world.get::<Collider>(predicted_child).is_some());
+    assert!(predicted_world.get::<RigidBody>(predicted_child).is_none());
+    assert!(predicted_world.get::<Position>(predicted_child).is_some());
+    assert!(predicted_world.get::<Rotation>(predicted_child).is_some());
+    assert!(
+        predicted_world
+            .get::<ApplyPosToTransform>(predicted_child)
+            .is_none(),
+        "a compound child's derived world pose must not overwrite its fixed local Transform"
+    );
+    assert!(
+        predicted_world
+            .get::<ConfirmedHistory<Position>>(predicted_child)
+            .is_none(),
+        "the derived child pose must not acquire an authoritative prediction history"
+    );
+    assert!(
+        predicted_world
+            .get::<FrameInterpolationHistory<Position>>(predicted_child)
+            .is_none(),
+        "only rigid-body roots have a fixed-tick render pose"
+    );
+    assert_eq!(
+        predicted_world
+            .get::<ColliderOf>(predicted_child)
+            .unwrap()
+            .body,
+        predicted_root
+    );
+    assert!(
+        predicted_world
+            .get::<FrameInterpolationHistory<Position>>(predicted_root)
+            .is_some()
+    );
+
+    let interpolated_world = stepper.client_apps[1].world();
+    assert!(
+        interpolated_world
+            .get::<ApplyPosToTransform>(interpolated_root)
+            .is_some(),
+        "a render-only interpolated root still needs Position-to-Transform sync"
+    );
+    assert!(
+        interpolated_world
+            .get::<Position>(interpolated_child)
+            .is_none(),
+        "a non-rigid ColliderOf child's derived Position must not be replicated"
+    );
+    assert!(
+        interpolated_world
+            .get::<Rotation>(interpolated_child)
+            .is_none(),
+        "a non-rigid ColliderOf child's derived Rotation must not be replicated"
+    );
+    assert!(
+        interpolated_world
+            .get::<RigidBody>(interpolated_root)
+            .is_none()
+    );
+    assert!(
+        interpolated_world
+            .get::<Collider>(interpolated_child)
+            .is_none()
+    );
+    assert_touching(
+        interpolated_world,
+        interpolated_root,
+        interpolated_child,
+        "interpolated client",
+    );
+    assert_touching(
+        predicted_world,
+        predicted_root,
+        predicted_child,
+        "predicted client",
+    );
+    assert_touching(stepper.server_app.world(), root, child, "server");
+
+    let rollbacks_before = stepper.client_apps[0]
+        .world()
+        .resource::<PredictionMetrics>()
+        .rollbacks;
+    stepper.client_apps[0]
+        .world_mut()
+        .resource_mut::<InjectMisprediction>()
+        .0 = true;
+
+    stepper.frame_step_server_first(30);
+
+    let predicted_world = stepper.client_apps[0].world();
+    assert!(
+        predicted_world.resource::<PredictionMetrics>().rollbacks > rollbacks_before,
+        "the forced position error did not trigger a rollback"
+    );
+    assert!(
+        predicted_world.resource::<CorrectionObserved>().0,
+        "the rollback did not create a visual correction"
+    );
+
+    for (client_id, client) in stepper.client_apps.iter().enumerate() {
+        let audit = client.world().resource::<TouchAudit>();
+        assert!(audit.samples > 0, "client {client_id} recorded no samples");
+        assert!(
+            audit.maximum_gap < 0.001,
+            "client {client_id} opened a {} unit gap between the compound colliders",
+            audit.maximum_gap
+        );
+        assert!(
+            audit.maximum_local_error < 0.001,
+            "client {client_id} changed the child collider's fixed local transform by {} units",
+            audit.maximum_local_error
+        );
+    }
+    assert_touching(
+        predicted_world,
+        predicted_root,
+        predicted_child,
+        "corrected predicted client",
+    );
+    assert_touching(
+        stepper.client_apps[1].world(),
+        interpolated_root,
+        interpolated_child,
+        "interpolated client after correction",
+    );
+}
+
+/// Both clients must simulate both player rigid-body roots. This specifically
+/// guards against representing the remote player as a render-only interpolated
+/// entity, which lets locally predicted players pass straight through it.
+#[test]
+fn every_client_predicts_both_compound_players_and_resolves_their_contact() {
+    let mut config = StepperConfig::with_netcode_clients(2);
+    config.frame_duration = Duration::from_millis(5);
+    let mut stepper = ClientServerStepper::from_config(config);
+
+    *stepper.server_app.world_mut().resource_mut::<Gravity>() = Gravity::ZERO;
+    stepper.server_app.init_resource::<PlayerContactObserved>();
+    stepper
+        .server_app
+        .add_systems(FixedLast, record_player_contact);
+    for client in &mut stepper.client_apps {
+        *client.world_mut().resource_mut::<Gravity>() = Gravity::ZERO;
+        client.init_resource::<PlayerContactObserved>();
+        client.add_systems(
+            PostUpdate,
+            materialize_all_predicted_compound_players.after(TransformSystems::Propagate),
+        );
+        client.add_systems(FixedLast, record_player_contact);
+    }
+
+    let left = spawn_colliding_player(
+        stepper.server_app.world_mut(),
+        10.0,
+        Vec2::new(-50.0, 0.0),
+        Vec2::new(40.0, 0.0),
+    );
+    let right = spawn_colliding_player(
+        stepper.server_app.world_mut(),
+        20.0,
+        Vec2::new(30.0, 0.0),
+        Vec2::new(-40.0, 0.0),
+    );
+
+    stepper.frame_step_server_first(150);
+
+    assert!(
+        stepper
+            .server_app
+            .world()
+            .resource::<PlayerContactObserved>()
+            .0,
+        "the authoritative compound players never collided"
+    );
+    assert_players_resolved_contact(stepper.server_app.world(), left.0, right.0, "server");
+
+    for (client_id, client) in stepper.client_apps.iter().enumerate() {
+        let left_root = mapped_entity(&stepper, client_id, left.0);
+        let right_root = mapped_entity(&stepper, client_id, right.0);
+        let world = client.world();
+        let left_child = local_compound_child(world, left_root);
+        let right_child = local_compound_child(world, right_root);
+
+        let mapper = stepper.client(client_id).get::<MessageManager>().unwrap();
+        assert!(mapper.entity_mapper.get_local(left.1).is_none());
+        assert!(mapper.entity_mapper.get_local(right.1).is_none());
+
+        assert!(
+            world.resource::<PlayerContactObserved>().0,
+            "client {client_id} never simulated the player-player contact"
+        );
+        for root in [left_root, right_root] {
+            assert!(world.get::<Predicted>(root).is_some());
+            assert!(world.get::<RigidBody>(root).is_some());
+            assert!(world.get::<ApplyPosToTransform>(root).is_none());
+            assert!(
+                world
+                    .get::<FrameInterpolationHistory<Position>>(root)
+                    .is_some()
+            );
+        }
+        for child in [left_child, right_child] {
+            assert!(world.get::<Predicted>(child).is_none());
+            assert!(world.get::<Interpolated>(child).is_none());
+            assert!(world.get::<RigidBody>(child).is_none());
+            assert!(world.get::<Collider>(child).is_some());
+            assert!(world.get::<Position>(child).is_some());
+            assert!(world.get::<Rotation>(child).is_some());
+            assert!(world.get::<ApplyPosToTransform>(child).is_none());
+        }
+        assert_eq!(world.get::<ColliderOf>(left_child).unwrap().body, left_root);
+        assert_eq!(
+            world.get::<ColliderOf>(right_child).unwrap().body,
+            right_root
+        );
+        assert_touching(
+            world,
+            left_root,
+            left_child,
+            &format!("client {client_id} left player"),
+        );
+        assert_touching(
+            world,
+            right_root,
+            right_child,
+            &format!("client {client_id} right player"),
+        );
+        assert_players_resolved_contact(
+            world,
+            left_root,
+            right_root,
+            &format!("client {client_id}"),
+        );
+    }
+}
+
+fn spawn_colliding_player(
+    world: &mut World,
+    id: f32,
+    position: Vec2,
+    velocity: Vec2,
+) -> (Entity, Entity) {
+    let root = world
+        .spawn((
+            CompA(id),
+            Replicate::to_clients(NetworkTarget::All),
+            DisableReplicateHierarchy,
+            PredictionTarget::to_clients(NetworkTarget::All),
+            RigidBody::Dynamic,
+            Position::from(position),
+            Rotation::default(),
+            Transform::from_translation(position.extend(0.0)),
+            LinearVelocity(velocity),
+            AngularVelocity::ZERO,
+            Collider::rectangle(EXAMPLE_PLAYER_SIZE, EXAMPLE_PLAYER_SIZE),
+            Restitution::new(0.3),
+            CollisionLayers::default(),
+        ))
+        .id();
+    let child = world
+        .spawn((
+            CompoundChildCollider,
+            ChildOf(root),
+            Transform::from_translation(EXAMPLE_CHILD_OFFSET.extend(0.0)),
+            Collider::rectangle(EXAMPLE_CHILD_SIZE, EXAMPLE_CHILD_SIZE),
+            ColliderOf { body: root },
+            Restitution::new(0.3),
+            CollisionLayers::default(),
+        ))
+        .id();
+    (root, child)
+}
+
+#[derive(Component)]
+struct AllPredictedPlayerReady;
+
+fn materialize_all_predicted_compound_players(
+    mut commands: Commands,
+    roots: Query<(Entity, &CompA), (With<Predicted>, Without<AllPredictedPlayerReady>)>,
+    physics_children: Query<
+        (Entity, &ChildOf),
+        (
+            With<CompoundChildCollider>,
+            With<ExampleChildTransformReady>,
+            Without<ExampleChildPhysicsReady>,
+        ),
+    >,
+    predicted_roots: Query<(), (With<Predicted>, With<RigidBody>)>,
+) {
+    for (entity, player) in &roots {
+        let velocity = if player.0 < 15.0 {
+            Vec2::new(40.0, 0.0)
+        } else {
+            Vec2::new(-40.0, 0.0)
+        };
+        commands.entity(entity).insert((
+            AllPredictedPlayerReady,
+            RigidBody::Dynamic,
+            LinearVelocity(velocity),
+            AngularVelocity::ZERO,
+            Collider::rectangle(EXAMPLE_PLAYER_SIZE, EXAMPLE_PLAYER_SIZE),
+            Restitution::new(0.3),
+            CollisionLayers::default(),
+            FrameInterpolate,
+        ));
+        commands.spawn((
+            CompoundChildCollider,
+            ChildOf(entity),
+            Transform::from_translation(EXAMPLE_CHILD_OFFSET.extend(0.0)),
+            ExampleChildTransformReady,
+        ));
+    }
+    for (entity, child_of) in &physics_children {
+        if !predicted_roots.contains(child_of.parent()) {
+            continue;
+        }
+        commands.entity(entity).insert((
+            Collider::rectangle(EXAMPLE_CHILD_SIZE, EXAMPLE_CHILD_SIZE),
+            ColliderOf {
+                body: child_of.parent(),
+            },
+            Restitution::new(0.3),
+            CollisionLayers::default(),
+            ExampleChildPhysicsReady,
+        ));
+    }
+}
+
+#[derive(Resource, Default)]
+struct PlayerContactObserved(bool);
+
+fn record_player_contact(
+    graph: Res<ContactGraph>,
+    roots: Query<&CompA>,
+    colliders: Query<Entity, With<Collider>>,
+    mut observed: ResMut<PlayerContactObserved>,
+) {
+    if observed.0 {
+        return;
+    }
+    observed.0 = colliders.iter().any(|collider| {
+        graph.contact_pairs_with(collider).any(|pair| {
+            if !pair.is_touching() {
+                return false;
+            }
+            let (Some(body1), Some(body2)) = (pair.body1, pair.body2) else {
+                return false;
+            };
+            let (Ok(player1), Ok(player2)) = (roots.get(body1), roots.get(body2)) else {
+                return false;
+            };
+            (player1.0 - player2.0).abs() > f32::EPSILON
+        })
+    });
+}
+
+fn assert_players_resolved_contact(world: &World, left: Entity, right: Entity, label: &str) {
+    let left_position = world.get::<Position>(left).unwrap();
+    let right_position = world.get::<Position>(right).unwrap();
+    let left_velocity = world.get::<LinearVelocity>(left).unwrap();
+    let right_velocity = world.get::<LinearVelocity>(right).unwrap();
+    assert!(
+        left_position.x < right_position.x,
+        "{label}: the players passed through each other: left={left_position:?}, right={right_position:?}"
+    );
+    assert!(
+        left_velocity.x < 0.0 && right_velocity.x > 0.0,
+        "{label}: the collision did not reverse their approach: left={left_velocity:?}, right={right_velocity:?}"
+    );
+}
+
+#[derive(Component)]
+struct ExampleRootReady;
+
+#[derive(Component)]
+struct ExampleChildTransformReady;
+
+#[derive(Component)]
+struct ExampleChildPhysicsReady;
+
+#[derive(Resource, Default)]
+struct TouchAudit {
+    samples: usize,
+    maximum_gap: f32,
+    maximum_local_error: f32,
+}
+
+#[derive(Resource, Default)]
+struct CorrectionObserved(bool);
+
+#[derive(Resource, Default)]
+struct InjectMisprediction(bool);
+
+fn inject_fixed_misprediction(
+    mut inject: ResMut<InjectMisprediction>,
+    mut roots: Query<(&mut Position, &mut Transform), (With<CompA>, With<Predicted>)>,
+) {
+    if !core::mem::take(&mut inject.0) {
+        return;
+    }
+    for (mut position, mut transform) in &mut roots {
+        position.x += 100.0;
+        transform.translation.x += 100.0;
+    }
+}
+
+fn materialize_example_compound_player(
+    mut commands: Commands,
+    roots: Query<(Entity, Has<Predicted>), (With<CompA>, Without<ExampleRootReady>)>,
+    predicted_children: Query<
+        (Entity, &ChildOf),
+        (
+            With<CompoundChildCollider>,
+            With<ExampleChildTransformReady>,
+            Without<ExampleChildPhysicsReady>,
+        ),
+    >,
+    predicted_roots: Query<(), (With<Predicted>, With<RigidBody>)>,
+) {
+    for (entity, predicted) in &roots {
+        let mut entity_commands = commands.entity(entity);
+        entity_commands.insert(ExampleRootReady);
+        if predicted {
+            entity_commands.insert((
+                RigidBody::Kinematic,
+                LinearVelocity(Vec2::new(20.0, 4.0)),
+                AngularVelocity(0.4),
+                Collider::rectangle(EXAMPLE_PLAYER_SIZE, EXAMPLE_PLAYER_SIZE),
+                CollisionLayers::default(),
+                FrameInterpolate,
+            ));
+        }
+        commands.spawn((
+            CompoundChildCollider,
+            ChildOf(entity),
+            Transform::from_translation(EXAMPLE_CHILD_OFFSET.extend(0.0)),
+            ExampleChildTransformReady,
+        ));
+    }
+
+    // ColliderOf computes ColliderTransform from the propagated world transforms.
+    // Wait one render frame after installing the local Transform before attaching
+    // predicted physics, matching the example's local template materialization path.
+    for (entity, child_of) in &predicted_children {
+        if !predicted_roots.contains(child_of.parent()) {
+            continue;
+        }
+        commands.entity(entity).insert((
+            Collider::rectangle(EXAMPLE_CHILD_SIZE, EXAMPLE_CHILD_SIZE),
+            ColliderOf {
+                body: child_of.parent(),
+            },
+            CollisionLayers::default(),
+            ExampleChildPhysicsReady,
+        ));
+    }
+}
+
+fn record_touching_faces(
+    roots: Query<&GlobalTransform, (With<CompA>, With<ExampleRootReady>)>,
+    children: Query<
+        (&ChildOf, &Transform, &GlobalTransform),
+        (
+            With<CompoundChildCollider>,
+            With<ExampleChildTransformReady>,
+        ),
+    >,
+    mut audit: ResMut<TouchAudit>,
+) {
+    for (child_of, child_local, child_global) in &children {
+        let Ok(root_global) = roots.get(child_of.parent()) else {
+            continue;
+        };
+        let gap = touching_face_gap(root_global, child_global);
+        let local_error = child_local
+            .translation
+            .distance(EXAMPLE_CHILD_OFFSET.extend(0.0))
+            .max(child_local.rotation.angle_between(Quat::IDENTITY));
+        audit.samples += 1;
+        audit.maximum_gap = audit.maximum_gap.max(gap);
+        audit.maximum_local_error = audit.maximum_local_error.max(local_error);
+    }
+}
+
+fn record_visual_correction(
+    corrections: Query<(), With<VisualCorrection<Position>>>,
+    mut observed: ResMut<CorrectionObserved>,
+) {
+    observed.0 |= !corrections.is_empty();
+}
+
+fn mapped_entity(stepper: &ClientServerStepper, client_id: usize, server: Entity) -> Entity {
+    stepper
+        .client(client_id)
+        .get::<MessageManager>()
+        .unwrap()
+        .entity_mapper
+        .get_local(server)
+        .unwrap()
+}
+
+fn local_compound_child(world: &World, root: Entity) -> Entity {
+    let mut children = world.iter_entities().filter_map(|entity| {
+        let child_of = entity.get::<ChildOf>()?;
+        (entity.contains::<CompoundChildCollider>() && child_of.parent() == root)
+            .then_some(entity.id())
+    });
+    let child = children
+        .next()
+        .unwrap_or_else(|| panic!("no deterministic compound child exists for root {root:?}"));
+    assert!(
+        children.next().is_none(),
+        "more than one deterministic compound child exists for root {root:?}"
+    );
+    child
+}
+
+fn assert_touching(world: &World, root: Entity, child: Entity, label: &str) {
+    let root_global = world.get::<GlobalTransform>(root).unwrap();
+    let child_global = world.get::<GlobalTransform>(child).unwrap();
+    let child_local = world.get::<Transform>(child).unwrap();
+    assert_relative_eq!(
+        child_local.translation,
+        EXAMPLE_CHILD_OFFSET.extend(0.0),
+        epsilon = 0.001
+    );
+    assert_relative_eq!(child_local.rotation, Quat::IDENTITY, epsilon = 0.001);
+    let gap = touching_face_gap(root_global, child_global);
+    assert!(
+        gap < 0.001,
+        "{label}: the compound collider faces are {gap} units apart; root local/global: {:?}/{root_global:?}; child local/global: {:?}/{child_global:?}",
+        world.get::<Transform>(root),
+        world.get::<Transform>(child),
+    );
+}
+
+fn touching_face_gap(root: &GlobalTransform, child: &GlobalTransform) -> f32 {
+    let root = root.compute_transform();
+    let child = child.compute_transform();
+    let root_face = root.transform_point(Vec3::new(EXAMPLE_PLAYER_SIZE / 2.0, 0.0, 0.0));
+    let child_face = child.transform_point(Vec3::new(-EXAMPLE_CHILD_SIZE / 2.0, 0.0, 0.0));
+    root_face.distance(child_face)
 }
 
 fn run_compound_hierarchy(mode: AvianReplicationMode) {
@@ -115,8 +811,8 @@ fn run_compound_hierarchy(mode: AvianReplicationMode) {
         .get_local(child_body)
         .expect("child rigid body was not replicated");
 
-    // The example-style blueprint path reconstructs local-only physics on the
-    // remote hierarchy. Insert ColliderOf explicitly so the nested collider is
+    // This test reconstructs local-only physics on the remote hierarchy. Insert
+    // ColliderOf explicitly so the nested collider is
     // attached correctly even before Avian has observed every deferred parent
     // transform in the replicated hierarchy.
     let client_world = stepper.client_app().world_mut();

--- a/crates/tests/src/client_server/avian/compound_replication.rs
+++ b/crates/tests/src/client_server/avian/compound_replication.rs
@@ -1,0 +1,262 @@
+use crate::stepper::{ClientServerStepper, StepperConfig};
+use approx::assert_relative_eq;
+use avian2d::collision::collider::EnlargedAabb;
+use avian2d::prelude::*;
+use bevy::prelude::*;
+use lightyear::avian2d::plugin::AvianReplicationMode;
+use lightyear_connection::network_target::NetworkTarget;
+use lightyear_messages::MessageManager;
+use lightyear_replication::prelude::*;
+use test_log::test;
+
+const ROOT_POSITION: Vec2 = Vec2::new(5.0, -3.0);
+const ROOT_ANGLE: f32 = 0.4;
+
+#[test]
+fn compound_hierarchy_position_mode() {
+    run_compound_hierarchy(AvianReplicationMode::Position);
+}
+
+#[test]
+fn compound_hierarchy_position_interpolate_transform_mode() {
+    run_compound_hierarchy(AvianReplicationMode::PositionButInterpolateTransform);
+}
+
+#[test]
+fn compound_hierarchy_transform_mode() {
+    run_compound_hierarchy(AvianReplicationMode::Transform);
+}
+
+fn run_compound_hierarchy(mode: AvianReplicationMode) {
+    let mut config = StepperConfig::single();
+    config.avian_mode = mode;
+    let mut stepper = ClientServerStepper::from_config(config);
+
+    let root_bundle = (
+        Replicate::to_clients(NetworkTarget::All),
+        RigidBody::Kinematic,
+        Position::from(ROOT_POSITION),
+        Rotation::radians(ROOT_ANGLE),
+        Transform::from_xyz(ROOT_POSITION.x, ROOT_POSITION.y, 0.0)
+            .with_rotation(Quat::from_rotation_z(ROOT_ANGLE)),
+    );
+    let root = stepper.server_app.world_mut().spawn(root_bundle).id();
+
+    let direct = stepper
+        .server_app
+        .world_mut()
+        .spawn((
+            ChildOf(root),
+            Transform::from_xyz(-2.0, 1.0, 0.0).with_rotation(Quat::from_rotation_z(-0.2)),
+            Collider::rectangle(1.5, 0.75),
+            CollisionLayers::default(),
+        ))
+        .id();
+    let pivot = stepper
+        .server_app
+        .world_mut()
+        .spawn((
+            ChildOf(root),
+            Transform::from_xyz(4.0, -1.0, 0.0).with_rotation(Quat::from_rotation_z(0.3)),
+        ))
+        .id();
+    let nested = stepper
+        .server_app
+        .world_mut()
+        .spawn((
+            ChildOf(pivot),
+            Transform::from_xyz(3.0, 2.0, 0.0).with_rotation(Quat::from_rotation_z(0.15)),
+            Collider::circle(0.8),
+            CollisionLayers::from_bits(0b0010, LayerMask::ALL.0),
+        ))
+        .id();
+    let sensor = stepper
+        .server_app
+        .world_mut()
+        .spawn((
+            ChildOf(root),
+            Transform::from_xyz(0.0, 5.0, 0.0),
+            Collider::circle(1.25),
+            Sensor,
+            CollisionEventsEnabled,
+            CollisionLayers::from_bits(0b0100, LayerMask::ALL.0),
+        ))
+        .id();
+    let child_body = stepper
+        .server_app
+        .world_mut()
+        .spawn((
+            ChildOf(root),
+            RigidBody::Kinematic,
+            Position::from_xy(-1.0, -4.0),
+            Rotation::radians(-0.1),
+            Transform::from_xyz(-6.0, 0.0, 0.0).with_rotation(Quat::from_rotation_z(-0.5)),
+            Collider::circle(0.6),
+        ))
+        .id();
+
+    stepper.frame_step_server_first(2);
+
+    let mapper = &stepper
+        .client(0)
+        .get::<MessageManager>()
+        .unwrap()
+        .entity_mapper;
+    let client_root = mapper.get_local(root).expect("root was not replicated");
+    let client_direct = mapper
+        .get_local(direct)
+        .expect("direct child was not replicated");
+    let client_pivot = mapper.get_local(pivot).expect("pivot was not replicated");
+    let client_nested = mapper
+        .get_local(nested)
+        .expect("nested child was not replicated");
+    let client_sensor = mapper.get_local(sensor).expect("sensor was not replicated");
+    let client_child_body = mapper
+        .get_local(child_body)
+        .expect("child rigid body was not replicated");
+
+    // The example-style blueprint path reconstructs local-only physics on the
+    // remote hierarchy. Insert ColliderOf explicitly so the nested collider is
+    // attached correctly even before Avian has observed every deferred parent
+    // transform in the replicated hierarchy.
+    let client_world = stepper.client_app().world_mut();
+    client_world
+        .entity_mut(client_root)
+        .insert(RigidBody::Kinematic);
+    client_world.entity_mut(client_direct).insert((
+        Transform::from_xyz(-2.0, 1.0, 0.0).with_rotation(Quat::from_rotation_z(-0.2)),
+        Collider::rectangle(1.5, 0.75),
+        ColliderOf { body: client_root },
+        CollisionLayers::default(),
+    ));
+    client_world
+        .entity_mut(client_pivot)
+        .insert(Transform::from_xyz(4.0, -1.0, 0.0).with_rotation(Quat::from_rotation_z(0.3)));
+    client_world.entity_mut(client_nested).insert((
+        Transform::from_xyz(3.0, 2.0, 0.0).with_rotation(Quat::from_rotation_z(0.15)),
+        Collider::circle(0.8),
+        ColliderOf { body: client_root },
+        CollisionLayers::from_bits(0b0010, LayerMask::ALL.0),
+    ));
+    client_world.entity_mut(client_sensor).insert((
+        Transform::from_xyz(0.0, 5.0, 0.0),
+        Collider::circle(1.25),
+        ColliderOf { body: client_root },
+        Sensor,
+        CollisionEventsEnabled,
+        CollisionLayers::from_bits(0b0100, LayerMask::ALL.0),
+    ));
+    client_world.entity_mut(client_child_body).insert((
+        Transform::from_xyz(-6.0, 0.0, 0.0).with_rotation(Quat::from_rotation_z(-0.5)),
+        RigidBody::Kinematic,
+        Collider::circle(0.6),
+    ));
+
+    stepper.frame_step_server_first(4);
+
+    assert_compound_state(
+        stepper.server_app.world(),
+        root,
+        direct,
+        pivot,
+        nested,
+        sensor,
+        child_body,
+        "server",
+    );
+    assert_compound_state(
+        stepper.client_app().world(),
+        client_root,
+        client_direct,
+        client_pivot,
+        client_nested,
+        client_sensor,
+        client_child_body,
+        "client",
+    );
+
+    let server_root_position = *stepper.server_app.world().get::<Position>(root).unwrap();
+    let client_root_position = *stepper
+        .client_app()
+        .world()
+        .get::<Position>(client_root)
+        .unwrap();
+    assert_relative_eq!(
+        client_root_position.0,
+        server_root_position.0,
+        epsilon = 0.001
+    );
+}
+
+#[allow(clippy::too_many_arguments)]
+fn assert_compound_state(
+    world: &World,
+    root: Entity,
+    direct: Entity,
+    pivot: Entity,
+    nested: Entity,
+    sensor: Entity,
+    child_body: Entity,
+    label: &str,
+) {
+    assert!(
+        world.get::<RigidBody>(root).is_some(),
+        "{label}: root rigid body missing"
+    );
+    assert!(
+        world.get::<Collider>(root).is_none(),
+        "{label}: root must not have a collider"
+    );
+
+    assert_eq!(world.get::<ChildOf>(direct).unwrap().parent(), root);
+    assert_eq!(world.get::<ChildOf>(pivot).unwrap().parent(), root);
+    assert_eq!(world.get::<ChildOf>(nested).unwrap().parent(), pivot);
+    assert_eq!(world.get::<ChildOf>(sensor).unwrap().parent(), root);
+    assert_eq!(world.get::<ChildOf>(child_body).unwrap().parent(), root);
+
+    assert!(
+        world.get::<Collider>(pivot).is_none(),
+        "{label}: pivot must be transform-only"
+    );
+    assert!(
+        world.get::<RigidBody>(pivot).is_none(),
+        "{label}: pivot became a rigid body"
+    );
+
+    for collider in [direct, nested, sensor] {
+        assert_eq!(
+            world
+                .get::<ColliderOf>(collider)
+                .map(|collider_of| collider_of.body),
+            Some(root),
+            "{label}: compound collider {collider:?} has the wrong body"
+        );
+        assert!(world.get::<ColliderTransform>(collider).is_some());
+        assert!(world.get::<ColliderAabb>(collider).is_some());
+        assert!(world.get::<EnlargedAabb>(collider).is_some());
+        assert!(world.get::<Position>(collider).is_some());
+        assert!(world.get::<GlobalTransform>(collider).is_some());
+    }
+
+    assert!(
+        world.get::<Sensor>(sensor).is_some(),
+        "{label}: sensor marker missing"
+    );
+    assert_eq!(
+        world.get::<CollisionLayers>(nested).unwrap().memberships,
+        LayerMask(0b0010)
+    );
+    assert_eq!(
+        world.get::<CollisionLayers>(sensor).unwrap().memberships,
+        LayerMask(0b0100)
+    );
+
+    assert!(world.get::<RigidBody>(child_body).is_some());
+    assert_eq!(
+        world
+            .get::<ColliderOf>(child_body)
+            .map(|collider_of| collider_of.body),
+        Some(child_body),
+        "{label}: child rigid body collider must attach to itself"
+    );
+}

--- a/crates/tests/src/client_server/avian/mod.rs
+++ b/crates/tests/src/client_server/avian/mod.rs
@@ -1,2 +1,3 @@
+mod compound_replication;
 mod position_replication;
 mod transform_replication;

--- a/crates/tests/src/client_server/deterministic/input_only.rs
+++ b/crates/tests/src/client_server/deterministic/input_only.rs
@@ -19,6 +19,7 @@ use crate::client_server::deterministic::stepper::{
     DetStepper, spawn_local_action_on_client, spawn_player_on_server,
 };
 use approx::assert_relative_eq;
+use avian2d::collision::contact_types::ContactGraph;
 use avian2d::prelude::*;
 use bevy::prelude::*;
 use bevy_enhanced_input::prelude::{
@@ -28,8 +29,113 @@ use lightyear::prediction::rollback::DeterministicPredicted;
 use lightyear::prelude::*;
 use lightyear_deterministic_replication::prelude::CatchUpMode;
 use lightyear_messages::MessageManager;
+use lightyear_prediction::diagnostics::PredictionMetrics;
 use std::collections::HashMap;
 use test_log::test;
+
+#[derive(Resource, Default)]
+struct ChildContactObserved(bool);
+
+fn track_child_contacts(
+    graph: Res<ContactGraph>,
+    parts: Query<
+        Entity,
+        (
+            With<crate::client_server::deterministic::protocol::DetBallPart>,
+            With<Collider>,
+        ),
+    >,
+    mut observed: ResMut<ChildContactObserved>,
+) {
+    if observed.0 {
+        return;
+    }
+    observed.0 = parts.iter().any(|collider| {
+        graph
+            .contact_pairs_with(collider)
+            .any(|pair| pair.is_touching())
+    });
+}
+
+fn install_child_contact_tracker(app: &mut App) {
+    app.init_resource::<ChildContactObserved>();
+    app.add_systems(FixedLast, track_child_contacts);
+}
+
+fn assert_compound_ball(world: &mut World, label: &str) {
+    use crate::client_server::deterministic::protocol::DetBallPart;
+
+    let root = world
+        .query_filtered::<Entity, With<DetBallMarker>>()
+        .single(world)
+        .expect("expected one deterministic ball");
+    assert!(
+        world.get::<Collider>(root).is_none(),
+        "{label}: compound ball root must not have a collider"
+    );
+
+    let mut query = world.query::<(
+        Entity,
+        &DetBallPart,
+        Option<&ColliderOf>,
+        Option<&ColliderAabb>,
+        Option<&CollisionLayers>,
+        Has<Sensor>,
+        Has<DeterministicPredicted>,
+    )>();
+    let parts = query
+        .iter(world)
+        .map(
+            |(entity, part, collider_of, aabb, layers, sensor, deterministic)| {
+                (
+                    entity,
+                    *part,
+                    collider_of.copied(),
+                    aabb.is_some(),
+                    layers.copied(),
+                    sensor,
+                    deterministic,
+                )
+            },
+        )
+        .collect::<Vec<_>>();
+    assert_eq!(
+        parts.len(),
+        4,
+        "{label}: missing compound ball parts: {parts:?}"
+    );
+    for (_, part, collider_of, has_aabb, layers, sensor, deterministic) in parts {
+        assert!(
+            deterministic,
+            "{label}: explicit rollback membership missing for {part:?}"
+        );
+        if part == DetBallPart::Pivot {
+            assert!(
+                collider_of.is_none(),
+                "{label}: pivot must be transform-only"
+            );
+            continue;
+        }
+        assert_eq!(
+            collider_of.map(|collider_of| collider_of.body),
+            Some(root),
+            "{label}: {part:?} is attached to the wrong rigid body"
+        );
+        assert!(
+            has_aabb,
+            "{label}: {part:?} is missing its broad-phase AABB"
+        );
+        assert!(
+            layers.is_some(),
+            "{label}: {part:?} is missing collision layers"
+        );
+        assert_eq!(
+            sensor,
+            part == DetBallPart::Sensor,
+            "{label}: sensor marker mismatch for {part:?}"
+        );
+    }
+}
 
 #[derive(Resource, Clone)]
 struct RandomDrive {
@@ -304,11 +410,18 @@ fn assert_island_stress_balls_are_finite(world: &mut World) {
 /// rollback state that is not represented by replicated components.
 #[test]
 fn test_input_only_two_clients() {
-    let mut stepper = DetStepper::new_server();
+    let mut stepper = DetStepper::new_server_with_protocol(DetProtocolPlugin {
+        compound_ball: true,
+        ..default()
+    });
     let _c0 = stepper.new_client();
     let _c1 = stepper.new_client();
 
     configure_stepper(&mut stepper, 50);
+    install_child_contact_tracker(&mut stepper.server_app);
+    for client_app in &mut stepper.client_apps {
+        install_child_contact_tracker(client_app);
+    }
 
     stepper.start();
     stepper.connect_all();
@@ -330,6 +443,14 @@ fn test_input_only_two_clients() {
 
     // Let replication settle so clients receive the initial player state.
     stepper.frame_step(15);
+
+    assert_compound_ball(stepper.server_app.world_mut(), "server");
+    for client_id in 0..2 {
+        assert_compound_ball(
+            stepper.client_app(client_id).world_mut(),
+            &format!("client {client_id}"),
+        );
+    }
 
     // On each client, spawn the matching local action entity (PreSpawned).
     for client_id in 0..2 {
@@ -415,7 +536,31 @@ fn test_input_only_two_clients() {
         assert_relative_eq!(c_pos_a.y, server_pos_a.y, epsilon = 0.01);
         assert_relative_eq!(c_pos_b.x, server_pos_b.x, epsilon = 0.01);
         assert_relative_eq!(c_pos_b.y, server_pos_b.y, epsilon = 0.01);
+        let metrics = stepper
+            .client_app(client_id)
+            .world()
+            .resource::<PredictionMetrics>();
+        assert!(
+            metrics.rollbacks > 0,
+            "client {client_id} never rolled back; compound collider rollback path was not exercised"
+        );
+        assert!(
+            stepper
+                .client_app(client_id)
+                .world()
+                .resource::<ChildContactObserved>()
+                .0,
+            "client {client_id} never observed a touching child-collider contact"
+        );
     }
+    assert!(
+        stepper
+            .server_app
+            .world()
+            .resource::<ChildContactObserved>()
+            .0,
+        "server never observed a touching child-collider contact"
+    );
 }
 
 /// Keeps Avian's island graph enabled while rollback replays an input-only
@@ -425,6 +570,7 @@ fn test_input_only_two_clients() {
 fn test_input_only_islands_many_colliders_small_box() {
     let mut stepper = DetStepper::new_server_with_protocol(DetProtocolPlugin {
         enable_islands: true,
+        compound_ball: true,
     });
     let _c0 = stepper.new_client();
     let _c1 = stepper.new_client();

--- a/crates/tests/src/client_server/deterministic/protocol.rs
+++ b/crates/tests/src/client_server/deterministic/protocol.rs
@@ -34,6 +34,7 @@ pub const WALL_HALF_EXTENT: f32 = 80.0;
 pub const MOVE_ACCEL: f32 = 12.0;
 pub const MAX_VELOCITY: f32 = 120.0;
 const BALL_PRESPAWN_HASH: u64 = 0xD37E_12B4_0000_0002;
+const BALL_PART_PRESPAWN_HASH: u64 = 0xD37E_12B4_1000_0000;
 
 #[derive(Component, Serialize, Deserialize, Clone, Debug, PartialEq, Reflect)]
 pub struct DetPlayerId(pub PeerId);
@@ -55,6 +56,14 @@ impl DetPlayerActivationTick {
 
 #[derive(Component, Debug)]
 pub struct DetBallMarker;
+
+#[derive(Component, Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DetBallPart {
+    Core,
+    Pivot,
+    Lobe,
+    Sensor,
+}
 
 #[derive(Component, Debug)]
 pub struct DetWallMarker;
@@ -96,18 +105,42 @@ impl DetPhysicsBundle {
     }
 }
 
+#[derive(Bundle)]
+struct DetBallBodyBundle {
+    rigid_body: RigidBody,
+}
+
+impl DetBallBodyBundle {
+    fn dynamic() -> Self {
+        Self {
+            rigid_body: RigidBody::Dynamic,
+        }
+    }
+}
+
 /// Shared between server and clients — registers everything needed for
 /// deterministic replication: physics, BEI inputs, catch-up,
 /// frame-interpolation on Position/Rotation (required to preserve
 /// post-rollback state under
 /// `AvianReplicationMode::Position { sync_to_transform: false }`).
-#[derive(Clone, Copy, Debug, Default)]
+#[derive(Clone, Copy, Debug)]
 pub struct DetProtocolPlugin {
     pub enable_islands: bool,
+    pub compound_ball: bool,
+}
+
+impl Default for DetProtocolPlugin {
+    fn default() -> Self {
+        Self {
+            enable_islands: false,
+            compound_ball: false,
+        }
+    }
 }
 
 impl Plugin for DetProtocolPlugin {
     fn build(&self, app: &mut App) {
+        app.insert_resource(CompoundBallFixture(self.compound_ball));
         app.add_plugins(bei::InputPlugin::<Player>::new(InputConfig::<Player> {
             rebroadcast_inputs: true,
             ..default()
@@ -188,6 +221,9 @@ impl Plugin for DetProtocolPlugin {
     }
 }
 
+#[derive(Resource)]
+struct CompoundBallFixture(bool);
+
 fn register_avian_catchup_resources(app: &mut App, enable_islands: bool) {
     app.register_catchup::<ContactGraph, BEIStateSequence<Player>>();
     app.register_catchup::<ConstraintGraph, BEIStateSequence<Player>>();
@@ -237,6 +273,7 @@ fn update_player_activation_ticks(
 fn init_shared(
     mut commands: Commands,
     mode: Res<CatchUpMode>,
+    compound_ball: Res<CompoundBallFixture>,
     server: Option<Single<(), With<Server>>>,
     client: Option<Single<(), With<Client>>>,
 ) {
@@ -246,7 +283,6 @@ fn init_shared(
 
     let mut ball = commands.spawn((
         Position::default(),
-        DetPhysicsBundle::ball(),
         DetBallMarker,
         DeterministicPredicted {
             skip_despawn: true,
@@ -254,6 +290,11 @@ fn init_shared(
         },
         Name::from("Ball"),
     ));
+    if compound_ball.0 {
+        ball.insert((DetBallBodyBundle::dynamic(), Rotation::radians(0.2)));
+    } else {
+        ball.insert(DetPhysicsBundle::ball());
+    }
     if is_state_based {
         ball.insert(PreSpawned::new(BALL_PRESPAWN_HASH));
         if is_server {
@@ -261,6 +302,10 @@ fn init_shared(
         } else if is_client {
             ball.insert(CatchUpGated);
         }
+    }
+    let ball = ball.id();
+    if compound_ball.0 {
+        spawn_ball_parts(&mut commands, ball, is_state_based, is_server, is_client);
     }
 
     let w = WALL_HALF_EXTENT;
@@ -279,6 +324,101 @@ fn init_shared(
             Name::from("Wall"),
         ));
     }
+}
+
+fn spawn_ball_parts(
+    commands: &mut Commands,
+    root: Entity,
+    state_based: bool,
+    is_server: bool,
+    is_client: bool,
+) {
+    fn finish_part(
+        entity: &mut EntityCommands,
+        part: DetBallPart,
+        state_based: bool,
+        is_server: bool,
+        is_client: bool,
+    ) {
+        entity.insert(part);
+        entity.insert(DeterministicPredicted {
+            skip_despawn: true,
+            ..default()
+        });
+        if state_based {
+            entity.insert(PreSpawned::new(BALL_PART_PRESPAWN_HASH + part as u64));
+            if is_server {
+                entity.insert((Replicate::to_clients(NetworkTarget::All), CatchUpGated));
+            } else if is_client {
+                entity.insert(CatchUpGated);
+            }
+        }
+    }
+
+    let mut core = commands.spawn((
+        ChildOf(root),
+        Transform::from_xyz(-1.5, -1.0, 0.0).with_rotation(Quat::from_rotation_z(-0.17)),
+        Collider::circle(6.0),
+        ColliderDensity(0.05),
+        Restitution::new(0.8),
+        CollisionLayers::default(),
+        Name::from("BallCoreCollider"),
+    ));
+    finish_part(
+        &mut core,
+        DetBallPart::Core,
+        state_based,
+        is_server,
+        is_client,
+    );
+
+    let mut pivot = commands.spawn((
+        ChildOf(root),
+        Transform::from_xyz(2.0, 1.0, 0.0).with_rotation(Quat::from_rotation_z(0.31)),
+        Name::from("BallColliderPivot"),
+    ));
+    finish_part(
+        &mut pivot,
+        DetBallPart::Pivot,
+        state_based,
+        is_server,
+        is_client,
+    );
+    let pivot = pivot.id();
+
+    let mut lobe = commands.spawn((
+        ChildOf(pivot),
+        Transform::from_xyz(3.0, 0.5, 0.0).with_rotation(Quat::from_rotation_z(0.23)),
+        Collider::circle(4.0),
+        ColliderDensity(0.04),
+        Restitution::new(0.9),
+        CollisionLayers::from_bits(0b0010, LayerMask::ALL.0),
+        Name::from("BallLobeCollider"),
+    ));
+    finish_part(
+        &mut lobe,
+        DetBallPart::Lobe,
+        state_based,
+        is_server,
+        is_client,
+    );
+
+    let mut sensor = commands.spawn((
+        ChildOf(root),
+        Transform::from_xyz(0.5, 1.5, 0.0),
+        Collider::circle(10.0),
+        Sensor,
+        CollisionEventsEnabled,
+        CollisionLayers::from_bits(0b0100, LayerMask::ALL.0),
+        Name::from("BallSensorCollider"),
+    ));
+    finish_part(
+        &mut sensor,
+        DetBallPart::Sensor,
+        state_based,
+        is_server,
+        is_client,
+    );
 }
 
 /// Convert a `Fire<DetMovement>` trigger's Vec2 value into a velocity

--- a/crates/tests/src/client_server/deterministic/state_based_catchup.rs
+++ b/crates/tests/src/client_server/deterministic/state_based_catchup.rs
@@ -13,8 +13,8 @@
 //! `enhanced-determinism` feature + our catch-up machinery).
 
 use crate::client_server::deterministic::protocol::{
-    DetBallMarker, DetBuffer, DetMovement, DetPlayerActivationTick, DetPlayerId, DetWallMarker,
-    Player,
+    DetBallMarker, DetBuffer, DetMovement, DetPlayerActivationTick, DetPlayerId, DetProtocolPlugin,
+    DetWallMarker, Player,
 };
 use crate::client_server::deterministic::stepper::{
     DetStepper, spawn_local_action_on_client, spawn_player_on_server,
@@ -1276,7 +1276,10 @@ fn latest_common_motion_sample_tick(
 /// and sustained random inputs after catch-up has settled.
 #[test]
 fn test_state_based_catchup_two_clients() {
-    let mut stepper = DetStepper::new_server();
+    let mut stepper = DetStepper::new_server_with_protocol(DetProtocolPlugin {
+        compound_ball: true,
+        ..default()
+    });
     let _c0 = stepper.new_client();
     let _c1 = stepper.new_client();
 

--- a/crates/tests/src/protocol.rs
+++ b/crates/tests/src/protocol.rs
@@ -311,13 +311,13 @@ impl Plugin for ProtocolPlugin {
         match self.avian_mode {
             AvianReplicationMode::Position { .. } => {
                 app.component::<Position>()
-                    .replicate()
+                    .replicate_filtered::<With<RigidBody>>()
                     .predict()
                     .add_linear_interpolation()
                     .add_correction();
 
                 app.component::<Rotation>()
-                    .replicate()
+                    .replicate_filtered::<With<RigidBody>>()
                     .predict()
                     .add_linear_interpolation()
                     .add_correction();

--- a/examples/avian_2d/README.md
+++ b/examples/avian_2d/README.md
@@ -14,6 +14,9 @@ This example showcases several things:
   The client will just consider that other players are doing the same thing as the last time it received their inputs.
   You can use the parameter `--predict` on the server to enable this behaviour (if not, other players will be
   interpolated).
+- compound Avian bodies: each player rigid-body root has no collider of its own. Its physical shape uses a direct
+  child collider, a collider below a transform-only intermediate child, and a sensor child on a separate collision
+  layer. Predicted clients reconstruct those local-only physics components from replicated part blueprints.
 - The prediction behaviour can be adjusted by two parameters:
     - `input_delay`: the number of frames it will take for an input to be executed. If the input delay is greater than
       the RTT,

--- a/examples/avian_2d/README.md
+++ b/examples/avian_2d/README.md
@@ -7,16 +7,24 @@ This example showcases several things:
   to an `Entity`, and the `ActionState` for that `Entity` will be replicated automatically
 - an example of how to integrate physics replication with `avian2d`. The physics sets have to be run in `FixedUpdate`
   schedule
-- an example of how to run prediction for entities that are controlled by other players. (this is similar to what
-  RocketLeague does).
-  There is going to be a frequent number of mispredictions because the client is predicting other players without
-  knowing their inputs.
-  The client will just consider that other players are doing the same thing as the last time it received their inputs.
-  You can use the parameter `--predict` on the server to enable this behaviour (if not, other players will be
-  interpolated).
-- compound Avian bodies: each player rigid-body root has no collider of its own. Its physical shape uses a direct
-  child collider, a collider below a transform-only intermediate child, and a sensor child on a separate collision
-  layer. Predicted clients reconstruct those local-only physics components from replicated part blueprints.
+- an example of predicting all dynamically interacting players on every client. Remote inputs are rebroadcast for
+  prediction, while each client's keyboard still controls only its own player.
+- compound collider transform propagation: each player rigid body has a smaller child cube collider immediately beside
+  and touching the main cube, with no rigid body of its own. Its local transform remains at a fixed offset while its
+  world position and rotation follow the player. The child is deterministic template data: an `On<Add, PlayerId>`
+  observer constructs it locally on the server and every client. Both colliders are one physical player
+  body: contacts on the smaller cube apply forces to the main rigid-body root, and player input is applied only to that
+  root.
+
+The child entity and its components are not replicated. `DisableReplicateHierarchy` on the player root prevents its
+locally spawned child from automatically inheriting `ReplicateLike`; adding a separate `Replicate` component is unnecessary.
+The root's predicted/interpolated pose plus the child's fixed local `Transform` are the authoritative state. Bevy transform
+propagation produces `GlobalTransform`, and the Avian integration derives the collider's world-space physics pose from
+that hierarchy, so no additional application-level `Transform`/`Position` sync system is needed. Replicating a second
+world pose for the child would create a redundant timeline that can disagree with
+the root during rollback, correction, or interpolation. A child with its own `RigidBody` would be different: it would
+have independent physics state and should replicate/predict its own pose.
+
 - The prediction behaviour can be adjusted by two parameters:
     - `input_delay`: the number of frames it will take for an input to be executed. If the input delay is greater than
       the RTT,

--- a/examples/avian_2d/src/client.rs
+++ b/examples/avian_2d/src/client.rs
@@ -6,35 +6,32 @@ use leafwing_input_manager::prelude::*;
 use lightyear::connection::host::HostClient;
 use lightyear::prelude::client::*;
 use lightyear::prelude::*;
+use lightyear_frame_interpolation::{FrameInterpolate, FrameInterpolationPlugin};
 
 use crate::automation::AutomationClientPlugin;
 use crate::protocol::*;
 use crate::shared;
-use crate::shared::{
-    color_from_id, materialize_player_part, shared_movement_behaviour, PlayerBodyBundle,
-    SharedPlugin,
-};
+use crate::shared::{shared_movement_behaviour, PlayerChildCollider, SharedPlugin};
 
 pub struct ExampleClientPlugin;
 
 impl Plugin for ExampleClientPlugin {
     fn build(&self, app: &mut App) {
         app.add_plugins(AutomationClientPlugin);
+        // Keep the visual pipeline available in headless clients so prediction,
+        // frame interpolation, and correction can be tested without a window.
+        if !app.is_plugin_added::<FrameInterpolationPlugin>() {
+            app.add_plugins(FrameInterpolationPlugin);
+        }
         // Rollback-capable action systems must run in FixedUpdate.
         app.add_systems(FixedUpdate, player_movement);
         app.add_observer(add_ball_physics);
         app.add_observer(handle_interpolated_spawn);
         app.add_observer(handle_predicted_spawn);
-        app.add_observer(materialize_player_part_transform);
+        app.add_observer(add_frame_interpolation_components);
         app.add_observer(handle_controlled_spawn);
 
-        app.add_systems(
-            PostUpdate,
-            (
-                crate::debug::print_overstep,
-                materialize_predicted_player_parts.after(TransformSystems::Propagate),
-            ),
-        );
+        app.add_systems(PostUpdate, crate::debug::print_overstep);
     }
 }
 
@@ -59,9 +56,8 @@ fn add_ball_physics(
     }
 }
 
-// Apply local input only to predicted entities owned by this client.
-//
-// If this example predicted remote entities, ownership would need to be checked before movement.
+// Apply predicted inputs only to player rigid-body roots. Child colliders do not
+// have PlayerId, LinearVelocity, or ActionState, so input cannot move them independently.
 fn player_movement(
     // In host-server mode, the players are already moved by the server system so we don't want
     // to move them twice.
@@ -69,23 +65,31 @@ fn player_movement(
     mut velocity_query: Query<
         (
             Entity,
-            &PlayerId,
             &Position,
             &mut LinearVelocity,
             &ActionState<PlayerActions>,
         ),
-        With<Predicted>,
+        (With<Predicted>, With<PlayerId>),
     >,
 ) {
     let tick = timeline.tick();
-    for (entity, player_id, position, velocity, action_state) in velocity_query.iter_mut() {
+    for (entity, position, velocity, action_state) in velocity_query.iter_mut() {
         if !action_state.get_pressed().is_empty() {
             trace!(?entity, ?tick, ?position, actions = ?action_state.get_pressed(), "applying movement to predicted player");
-            // note that we also apply the input to the other predicted clients! even though
-            //  their inputs are only replicated with a delay!
-            // TODO: add input decay?
             shared_movement_behaviour(velocity, action_state);
         }
+    }
+}
+
+/// Predicted physics is updated at fixed ticks; interpolate its Position and Rotation
+/// for rendering between those ticks and for post-rollback visual correction.
+fn add_frame_interpolation_components(
+    trigger: On<Add, (Position, RigidBody, Predicted)>,
+    query: Query<Entity, (With<Predicted>, With<RigidBody>)>,
+    mut commands: Commands,
+) {
+    if query.contains(trigger.entity) {
+        commands.entity(trigger.entity).insert(FrameInterpolate);
     }
 }
 
@@ -103,37 +107,7 @@ pub(crate) fn handle_predicted_spawn(
         color.0 = Color::from(hsva);
         commands
             .entity(trigger.entity)
-            .insert(PlayerBodyBundle::dynamic());
-    }
-}
-
-fn materialize_player_part_transform(
-    trigger: On<Add, PlayerPart>,
-    parts: Query<&PlayerPart>,
-    mut commands: Commands,
-) {
-    if let Ok(part) = parts.get(trigger.entity) {
-        materialize_player_part(&mut commands, trigger.entity, *part, false, None);
-    }
-}
-
-#[derive(Component)]
-struct PlayerPartPhysicsReady;
-
-fn materialize_predicted_player_parts(
-    parts: Query<(Entity, &PlayerPart), (With<Predicted>, Without<PlayerPartPhysicsReady>)>,
-    roots: Query<(Entity, &PlayerId), (With<Predicted>, With<RigidBody>)>,
-    mut commands: Commands,
-) {
-    for (entity, part) in &parts {
-        let Some(root) = roots
-            .iter()
-            .find_map(|(entity, player)| (player.0 == part.owner).then_some(entity))
-        else {
-            continue;
-        };
-        materialize_player_part(&mut commands, entity, *part, true, Some(root));
-        commands.entity(entity).insert(PlayerPartPhysicsReady);
+            .insert(PhysicsBundle::player());
     }
 }
 
@@ -164,5 +138,35 @@ pub(crate) fn handle_interpolated_spawn(
             ..Hsva::from(color.0)
         };
         color.0 = Color::from(hsva);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn frame_interpolation_covers_the_predicted_ball_but_not_non_rigid_children() {
+        let mut app = App::new();
+        app.add_observer(add_frame_interpolation_components);
+
+        let ball = app
+            .world_mut()
+            .spawn((Position::default(), RigidBody::Dynamic, Predicted))
+            .id();
+        let child = app
+            .world_mut()
+            .spawn((Position::default(), Predicted, PlayerChildCollider))
+            .id();
+        app.update();
+
+        assert!(
+            app.world().get::<FrameInterpolate>(ball).is_some(),
+            "a predicted ball is a physics root even though it has no PlayerId"
+        );
+        assert!(
+            app.world().get::<FrameInterpolate>(child).is_none(),
+            "a non-rigid child has no fixed-tick pose of its own to frame-interpolate"
+        );
     }
 }

--- a/examples/avian_2d/src/client.rs
+++ b/examples/avian_2d/src/client.rs
@@ -10,7 +10,10 @@ use lightyear::prelude::*;
 use crate::automation::AutomationClientPlugin;
 use crate::protocol::*;
 use crate::shared;
-use crate::shared::{color_from_id, shared_movement_behaviour, SharedPlugin};
+use crate::shared::{
+    color_from_id, materialize_player_part, shared_movement_behaviour, PlayerBodyBundle,
+    SharedPlugin,
+};
 
 pub struct ExampleClientPlugin;
 
@@ -22,9 +25,16 @@ impl Plugin for ExampleClientPlugin {
         app.add_observer(add_ball_physics);
         app.add_observer(handle_interpolated_spawn);
         app.add_observer(handle_predicted_spawn);
+        app.add_observer(materialize_player_part_transform);
         app.add_observer(handle_controlled_spawn);
 
-        app.add_systems(PostUpdate, crate::debug::print_overstep);
+        app.add_systems(
+            PostUpdate,
+            (
+                crate::debug::print_overstep,
+                materialize_predicted_player_parts.after(TransformSystems::Propagate),
+            ),
+        );
     }
 }
 
@@ -93,7 +103,37 @@ pub(crate) fn handle_predicted_spawn(
         color.0 = Color::from(hsva);
         commands
             .entity(trigger.entity)
-            .insert(PhysicsBundle::player());
+            .insert(PlayerBodyBundle::dynamic());
+    }
+}
+
+fn materialize_player_part_transform(
+    trigger: On<Add, PlayerPart>,
+    parts: Query<&PlayerPart>,
+    mut commands: Commands,
+) {
+    if let Ok(part) = parts.get(trigger.entity) {
+        materialize_player_part(&mut commands, trigger.entity, *part, false, None);
+    }
+}
+
+#[derive(Component)]
+struct PlayerPartPhysicsReady;
+
+fn materialize_predicted_player_parts(
+    parts: Query<(Entity, &PlayerPart), (With<Predicted>, Without<PlayerPartPhysicsReady>)>,
+    roots: Query<(Entity, &PlayerId), (With<Predicted>, With<RigidBody>)>,
+    mut commands: Commands,
+) {
+    for (entity, part) in &parts {
+        let Some(root) = roots
+            .iter()
+            .find_map(|(entity, player)| (player.0 == part.owner).then_some(entity))
+        else {
+            continue;
+        };
+        materialize_player_part(&mut commands, entity, *part, true, Some(root));
+        commands.entity(entity).insert(PlayerPartPhysicsReady);
     }
 }
 

--- a/examples/avian_2d/src/main.rs
+++ b/examples/avian_2d/src/main.rs
@@ -71,7 +71,7 @@ fn add_input_delay(app: &mut App) {
         .single(app.world_mut())
         .unwrap();
 
-    // set some input-delay since we are predicting all entities
+    // Optionally add input delay for the locally predicted player.
     // app.world_mut()
     //     .entity_mut(client)
     //     .insert(InputTimeline(Timeline::from(

--- a/examples/avian_2d/src/protocol.rs
+++ b/examples/avian_2d/src/protocol.rs
@@ -27,15 +27,24 @@ impl PhysicsBundle {
             restitution: Restitution::new(0.5),
         }
     }
+}
 
-    pub(crate) fn player() -> Self {
-        Self {
-            collider: Collider::rectangle(PLAYER_SIZE, PLAYER_SIZE),
-            collider_density: ColliderDensity(0.2),
-            rigid_body: RigidBody::Dynamic,
-            restitution: Restitution::new(0.3),
-        }
-    }
+/// The replicated blueprint for one entity in the player's compound collider hierarchy.
+///
+/// The actual Avian components are installed locally. This keeps colliders out of the
+/// network protocol while still replicating the hierarchy and its stable logical identity.
+#[derive(Component, Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Reflect)]
+pub struct PlayerPart {
+    pub(crate) owner: PeerId,
+    pub(crate) kind: PlayerPartKind,
+}
+
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, Reflect)]
+pub enum PlayerPartKind {
+    Hull,
+    Pivot,
+    Nose,
+    Sensor,
 }
 
 // Components
@@ -75,6 +84,8 @@ impl Plugin for ProtocolPlugin {
         app.component::<Name>().replicate();
 
         app.component::<PlayerId>().replicate();
+
+        app.component::<PlayerPart>().replicate_once();
 
         app.component::<ColorComponent>().replicate();
 

--- a/examples/avian_2d/src/protocol.rs
+++ b/examples/avian_2d/src/protocol.rs
@@ -1,4 +1,3 @@
-use crate::shared::color_from_id;
 use avian2d::prelude::*;
 use bevy::prelude::*;
 use leafwing_input_manager::prelude::*;
@@ -9,6 +8,10 @@ use serde::{Deserialize, Serialize};
 
 pub const BALL_SIZE: f32 = 15.0;
 pub const PLAYER_SIZE: f32 = 40.0;
+pub const CHILD_CUBE_SIZE: f32 = 16.0;
+pub const CHILD_CUBE_GAP: f32 = 0.0;
+pub const CHILD_CUBE_OFFSET: Vec2 =
+    Vec2::new((PLAYER_SIZE + CHILD_CUBE_SIZE) / 2.0 + CHILD_CUBE_GAP, 0.0);
 
 #[derive(Bundle)]
 pub(crate) struct PhysicsBundle {
@@ -27,24 +30,15 @@ impl PhysicsBundle {
             restitution: Restitution::new(0.5),
         }
     }
-}
 
-/// The replicated blueprint for one entity in the player's compound collider hierarchy.
-///
-/// The actual Avian components are installed locally. This keeps colliders out of the
-/// network protocol while still replicating the hierarchy and its stable logical identity.
-#[derive(Component, Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Reflect)]
-pub struct PlayerPart {
-    pub(crate) owner: PeerId,
-    pub(crate) kind: PlayerPartKind,
-}
-
-#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, Reflect)]
-pub enum PlayerPartKind {
-    Hull,
-    Pivot,
-    Nose,
-    Sensor,
+    pub(crate) fn player() -> Self {
+        Self {
+            collider: Collider::rectangle(PLAYER_SIZE, PLAYER_SIZE),
+            collider_density: ColliderDensity(0.2),
+            rigid_body: RigidBody::Dynamic,
+            restitution: Restitution::new(0.3),
+        }
+    }
 }
 
 // Components
@@ -85,21 +79,22 @@ impl Plugin for ProtocolPlugin {
 
         app.component::<PlayerId>().replicate();
 
-        app.component::<PlayerPart>().replicate_once();
-
         app.component::<ColorComponent>().replicate();
 
         app.component::<BallMarker>().replicate();
 
         app.component::<Position>()
-            .replicate()
+            // Replicate only authoritative rigid-body poses. A child collider
+            // without its own RigidBody gets its world pose from the root and
+            // its fixed local Transform, so neither pose component should be replicated.
+            .replicate_filtered::<With<RigidBody>>()
             .predict()
             .with_rollback_condition(position_should_rollback)
             .add_linear_interpolation()
             .add_correction();
 
         app.component::<Rotation>()
-            .replicate()
+            .replicate_filtered::<With<RigidBody>>()
             .predict()
             .with_rollback_condition(rotation_should_rollback)
             .add_linear_interpolation()

--- a/examples/avian_2d/src/renderer.rs
+++ b/examples/avian_2d/src/renderer.rs
@@ -1,5 +1,5 @@
 use crate::protocol::*;
-use crate::shared::Wall;
+use crate::shared::{color_from_id, Wall};
 use avian2d::prelude::*;
 use bevy::color::palettes::css;
 use bevy::prelude::*;
@@ -53,11 +53,14 @@ fn init(mut commands: Commands) {
 pub(crate) fn draw_elements(
     mut gizmos: Gizmos,
     players: Query<(&Position, &Rotation, &ColorComponent), With<PlayerId>>,
+    player_parts: Query<(&GlobalTransform, &PlayerPart)>,
     balls: Query<(&Position, &ColorComponent), With<BallMarker>>,
     walls: Query<(&Wall, &ColorComponent), (Without<BallMarker>, Without<PlayerId>)>,
 ) {
     for (position, rotation, color) in &players {
         debug!("Draw player at position {position:?}");
+        // The root has no collider. Keep a faint outline so confirmed and
+        // interpolated roots remain easy to distinguish from their parts.
         gizmos.rect_2d(
             Isometry2d {
                 rotation: Rot2 {
@@ -67,8 +70,28 @@ pub(crate) fn draw_elements(
                 translation: Vec2::new(position.x, position.y),
             },
             Vec2::ONE * PLAYER_SIZE,
-            color.0,
+            color.0.with_alpha(0.18),
         );
+    }
+    for (global, part) in &player_parts {
+        let transform = global.compute_transform();
+        let position = transform.translation.truncate();
+        let rotation = Rot2::radians(2.0 * transform.rotation.z.atan2(transform.rotation.w));
+        let color = color_from_id(part.owner);
+        match part.kind {
+            PlayerPartKind::Hull => gizmos.rect_2d(
+                Isometry2d::new(position, rotation),
+                Vec2::new(28.0, 22.0),
+                color,
+            ),
+            PlayerPartKind::Nose => {
+                gizmos.circle_2d(position, 9.0, color);
+            }
+            PlayerPartKind::Sensor => {
+                gizmos.circle_2d(position, 27.0, color.with_alpha(0.25));
+            }
+            PlayerPartKind::Pivot => {}
+        }
     }
     for (position, color) in &balls {
         gizmos.circle_2d(Vec2::new(position.x, position.y), BALL_SIZE, color.0);

--- a/examples/avian_2d/src/renderer.rs
+++ b/examples/avian_2d/src/renderer.rs
@@ -1,11 +1,9 @@
 use crate::protocol::*;
-use crate::shared::{color_from_id, Wall};
+use crate::shared::{PlayerChildCollider, Wall};
 use avian2d::prelude::*;
 use bevy::color::palettes::css;
 use bevy::prelude::*;
-use lightyear::prediction::Predicted;
 use lightyear::prelude::{InterpolationSystems, RollbackSystems};
-use lightyear_frame_interpolation::{FrameInterpolate, FrameInterpolationPlugin};
 
 #[derive(Clone)]
 pub struct ExampleRendererPlugin;
@@ -18,30 +16,11 @@ impl Plugin for ExampleRendererPlugin {
             PostUpdate,
             draw_elements
                 .after(InterpolationSystems::Interpolate)
-                .after(RollbackSystems::VisualCorrection),
+                .after(RollbackSystems::VisualCorrection)
+                // Child colliders are rendered from GlobalTransform, so drawing before
+                // propagation would show their previous-frame pose next to the current root.
+                .after(TransformSystems::Propagate),
         );
-
-        // add visual interpolation for Position and Rotation
-        // (normally we would interpolate on Transform but here this is fine
-        // since rendering is done via Gizmos that only depend on Position/Rotation)
-        if !app.is_plugin_added::<FrameInterpolationPlugin>() {
-            app.add_plugins(FrameInterpolationPlugin);
-        }
-        app.add_observer(add_frame_interpolation_components);
-    }
-}
-
-/// Predicted entities get updated in FixedUpdate, so we want to smooth/interpolate
-/// their components in PostUpdate
-fn add_frame_interpolation_components(
-    // We use Position because it's added by avian later, and when it's added
-    // we know that Predicted is already present on the entity
-    trigger: On<Add, Position>,
-    query: Query<Entity, With<Predicted>>,
-    mut commands: Commands,
-) {
-    if query.contains(trigger.entity) {
-        commands.entity(trigger.entity).insert(FrameInterpolate);
     }
 }
 
@@ -53,14 +32,12 @@ fn init(mut commands: Commands) {
 pub(crate) fn draw_elements(
     mut gizmos: Gizmos,
     players: Query<(&Position, &Rotation, &ColorComponent), With<PlayerId>>,
-    player_parts: Query<(&GlobalTransform, &PlayerPart)>,
+    player_children: Query<(&GlobalTransform, &ChildOf), With<PlayerChildCollider>>,
     balls: Query<(&Position, &ColorComponent), With<BallMarker>>,
     walls: Query<(&Wall, &ColorComponent), (Without<BallMarker>, Without<PlayerId>)>,
 ) {
     for (position, rotation, color) in &players {
         debug!("Draw player at position {position:?}");
-        // The root has no collider. Keep a faint outline so confirmed and
-        // interpolated roots remain easy to distinguish from their parts.
         gizmos.rect_2d(
             Isometry2d {
                 rotation: Rot2 {
@@ -70,28 +47,21 @@ pub(crate) fn draw_elements(
                 translation: Vec2::new(position.x, position.y),
             },
             Vec2::ONE * PLAYER_SIZE,
-            color.0.with_alpha(0.18),
+            color.0,
         );
     }
-    for (global, part) in &player_parts {
+    for (global, child_of) in &player_children {
+        let Ok((_, _, color)) = players.get(child_of.parent()) else {
+            continue;
+        };
         let transform = global.compute_transform();
         let position = transform.translation.truncate();
         let rotation = Rot2::radians(2.0 * transform.rotation.z.atan2(transform.rotation.w));
-        let color = color_from_id(part.owner);
-        match part.kind {
-            PlayerPartKind::Hull => gizmos.rect_2d(
-                Isometry2d::new(position, rotation),
-                Vec2::new(28.0, 22.0),
-                color,
-            ),
-            PlayerPartKind::Nose => {
-                gizmos.circle_2d(position, 9.0, color);
-            }
-            PlayerPartKind::Sensor => {
-                gizmos.circle_2d(position, 27.0, color.with_alpha(0.25));
-            }
-            PlayerPartKind::Pivot => {}
-        }
+        gizmos.rect_2d(
+            Isometry2d::new(position, rotation),
+            Vec2::splat(CHILD_CUBE_SIZE),
+            color.0.with_alpha(0.7),
+        );
     }
     for (position, color) in &balls {
         gizmos.circle_2d(Vec2::new(position.x, position.y), BALL_SIZE, color.0);

--- a/examples/avian_2d/src/server.rs
+++ b/examples/avian_2d/src/server.rs
@@ -1,7 +1,10 @@
 use crate::automation::AutomationServerPlugin;
 use crate::protocol::*;
 use crate::shared;
-use crate::shared::{color_from_id, shared_movement_behaviour, SharedPlugin, WallBundle};
+use crate::shared::{
+    color_from_id, shared_movement_behaviour, spawn_player_parts, PlayerBodyBundle, SharedPlugin,
+    WallBundle,
+};
 use avian2d::prelude::*;
 use bevy::color::palettes::css;
 use bevy::platform::collections::HashMap;
@@ -102,18 +105,23 @@ pub(crate) fn replicate_players(
     let color = color_from_id(client_id);
     let y = (client_id.to_bits() as f32 * 50.0) % 500.0 - 250.0;
     info!("Spawn player for client {client_id:?}");
-    commands.spawn((
-        PlayerId(client_id),
-        Position::from(Vec2::new(-50.0, y)),
-        ColorComponent(color),
-        Replicate::to_clients(NetworkTarget::All),
-        // Predict to all players
-        PredictionTarget::to_clients(NetworkTarget::All),
-        ControlledBy {
-            owner: entity,
-            lifetime: Default::default(),
-        },
-        PhysicsBundle::player(),
-        Name::from("Player"),
-    ));
+    let player = commands
+        .spawn((
+            PlayerId(client_id),
+            Position::from(Vec2::new(-50.0, y)),
+            Rotation::radians(0.15),
+            AngularVelocity(0.35),
+            ColorComponent(color),
+            Replicate::to_clients(NetworkTarget::All),
+            // Predict to all players
+            PredictionTarget::to_clients(NetworkTarget::All),
+            ControlledBy {
+                owner: entity,
+                lifetime: Default::default(),
+            },
+            PlayerBodyBundle::dynamic(),
+            Name::from("Player"),
+        ))
+        .id();
+    spawn_player_parts(&mut commands, player, client_id);
 }

--- a/examples/avian_2d/src/server.rs
+++ b/examples/avian_2d/src/server.rs
@@ -1,10 +1,7 @@
 use crate::automation::AutomationServerPlugin;
 use crate::protocol::*;
 use crate::shared;
-use crate::shared::{
-    color_from_id, shared_movement_behaviour, spawn_player_parts, PlayerBodyBundle, SharedPlugin,
-    WallBundle,
-};
+use crate::shared::{color_from_id, shared_movement_behaviour, SharedPlugin};
 use avian2d::prelude::*;
 use bevy::color::palettes::css;
 use bevy::platform::collections::HashMap;
@@ -44,40 +41,20 @@ fn setup(mut commands: Commands) {
         BallMarker,
         Name::from("Ball"),
     ));
-
-    // Spawn walls (moved from shared init)
-    const WALL_SIZE: f32 = 350.0; // Define WALL_SIZE locally
-    commands.spawn(WallBundle::new(
-        Vec2::new(-WALL_SIZE, -WALL_SIZE),
-        Vec2::new(-WALL_SIZE, WALL_SIZE),
-        Color::WHITE,
-    ));
-    commands.spawn(WallBundle::new(
-        Vec2::new(-WALL_SIZE, WALL_SIZE),
-        Vec2::new(WALL_SIZE, WALL_SIZE),
-        Color::WHITE,
-    ));
-    commands.spawn(WallBundle::new(
-        Vec2::new(WALL_SIZE, WALL_SIZE),
-        Vec2::new(WALL_SIZE, -WALL_SIZE),
-        Color::WHITE,
-    ));
-    commands.spawn(WallBundle::new(
-        Vec2::new(WALL_SIZE, -WALL_SIZE),
-        Vec2::new(-WALL_SIZE, -WALL_SIZE),
-        Color::WHITE,
-    ));
 }
 
 /// Applies player input to replicated physics bodies.
 pub(crate) fn movement(
     timeline: Res<LocalTimeline>,
-    mut action_query: Query<(
-        Entity,
-        &Position,
-        &mut LinearVelocity,
-        &ActionState<PlayerActions>,
-    )>,
+    mut action_query: Query<
+        (
+            Entity,
+            &Position,
+            &mut LinearVelocity,
+            &ActionState<PlayerActions>,
+        ),
+        With<PlayerId>,
+    >,
 ) {
     let tick = timeline.tick();
     for (entity, position, velocity, action) in action_query.iter_mut() {
@@ -104,24 +81,27 @@ pub(crate) fn replicate_players(
 
     let color = color_from_id(client_id);
     let y = (client_id.to_bits() as f32 * 50.0) % 500.0 - 250.0;
+    let position = Vec2::new(-50.0, y);
+    let rotation = Rotation::radians(0.15);
     info!("Spawn player for client {client_id:?}");
-    let player = commands
-        .spawn((
-            PlayerId(client_id),
-            Position::from(Vec2::new(-50.0, y)),
-            Rotation::radians(0.15),
-            AngularVelocity(0.35),
-            ColorComponent(color),
-            Replicate::to_clients(NetworkTarget::All),
-            // Predict to all players
-            PredictionTarget::to_clients(NetworkTarget::All),
-            ControlledBy {
-                owner: entity,
-                lifetime: Default::default(),
-            },
-            PlayerBodyBundle::dynamic(),
-            Name::from("Player"),
-        ))
-        .id();
-    spawn_player_parts(&mut commands, player, client_id);
+    commands.spawn((
+        PlayerId(client_id),
+        Position::from(position),
+        rotation,
+        AngularVelocity(0.35),
+        ColorComponent(color),
+        Replicate::to_clients(NetworkTarget::All),
+        // The Player template is reconstructed independently on every peer,
+        // so its locally spawned child should not inherit ReplicateLike.
+        DisableReplicateHierarchy,
+        // Every client predicts every dynamically interacting player so
+        // player-player and player-ball contacts exist in every physics world.
+        PredictionTarget::to_clients(NetworkTarget::All),
+        ControlledBy {
+            owner: entity,
+            lifetime: Default::default(),
+        },
+        PhysicsBundle::player(),
+        Name::from("Player"),
+    ));
 }

--- a/examples/avian_2d/src/shared.rs
+++ b/examples/avian_2d/src/shared.rs
@@ -9,155 +9,39 @@ use lightyear::prelude::*;
 pub(crate) const MAX_VELOCITY: f32 = 200.0;
 const WALL_SIZE: f32 = 350.0;
 
-#[derive(Bundle)]
-pub(crate) struct PlayerBodyBundle {
-    rigid_body: RigidBody,
-}
+/// Local-only marker for the deterministic child collider in the `Player` template.
+#[derive(Component)]
+pub(crate) struct PlayerChildCollider;
 
-impl PlayerBodyBundle {
-    pub(crate) fn dynamic() -> Self {
-        Self {
-            rigid_body: RigidBody::Dynamic,
-        }
+impl PlayerChildCollider {
+    pub(crate) fn local_transform() -> Transform {
+        Transform::from_translation(CHILD_CUBE_OFFSET.extend(0.0))
+    }
+
+    pub(crate) fn collider() -> Collider {
+        Collider::rectangle(CHILD_CUBE_SIZE, CHILD_CUBE_SIZE)
     }
 }
 
-impl PlayerPartKind {
-    pub(crate) fn local_transform(self) -> Transform {
-        match self {
-            Self::Hull => {
-                Transform::from_xyz(-5.0, -3.0, 0.0).with_rotation(Quat::from_rotation_z(-0.12))
-            }
-            Self::Pivot => {
-                Transform::from_xyz(10.0, 4.0, 0.0).with_rotation(Quat::from_rotation_z(0.35))
-            }
-            Self::Nose => {
-                Transform::from_xyz(6.0, 1.0, 0.0).with_rotation(Quat::from_rotation_z(0.2))
-            }
-            Self::Sensor => Transform::from_xyz(-7.0, 8.0, 0.0),
-        }
-    }
-
-    pub(crate) fn collider(self) -> Option<Collider> {
-        match self {
-            Self::Hull => Some(Collider::rectangle(28.0, 22.0)),
-            Self::Nose => Some(Collider::circle(9.0)),
-            Self::Sensor => Some(Collider::circle(27.0)),
-            Self::Pivot => None,
-        }
-    }
-
-    pub(crate) fn collision_layers(self) -> CollisionLayers {
-        let memberships = match self {
-            Self::Hull | Self::Pivot => 0b0001,
-            Self::Nose => 0b0010,
-            Self::Sensor => 0b0100,
-        };
-        CollisionLayers::from_bits(memberships, LayerMask::ALL.0)
-    }
-}
-
-/// Spawn an asymmetric compound player collider:
+/// Spawn the fixed-offset collider that is part of a newly added player.
 ///
 /// ```text
-/// rigid-body root (no collider)
-/// ├── hull collider
-/// ├── transform-only pivot
-/// │   └── nose collider
-/// └── sensor collider
+/// player cube (rigid body + collider)
+/// └── smaller cube collider (no rigid body, fixed local offset)
 /// ```
-pub(crate) fn spawn_player_parts(commands: &mut Commands, root: Entity, owner: PeerId) {
-    let hull = PlayerPart {
-        owner,
-        kind: PlayerPartKind::Hull,
-    };
+fn spawn_player_child_collider(trigger: On<Add, PlayerId>, mut commands: Commands) {
+    let player = trigger.entity;
     commands.spawn((
-        ChildOf(root),
-        hull,
-        hull.kind.local_transform(),
-        hull.kind.collider().unwrap(),
-        ColliderDensity(0.2),
+        ChildOf(player),
+        PlayerChildCollider,
+        PlayerChildCollider::local_transform(),
+        PlayerChildCollider::collider(),
+        ColliderOf { body: player },
+        ColliderDensity(0.1),
         Restitution::new(0.3),
-        hull.kind.collision_layers(),
-        Name::from("PlayerHullCollider"),
+        CollisionLayers::default(),
+        Name::from("PlayerOffsetCubeCollider"),
     ));
-
-    let pivot = PlayerPart {
-        owner,
-        kind: PlayerPartKind::Pivot,
-    };
-    let pivot_entity = commands
-        .spawn((
-            ChildOf(root),
-            pivot,
-            pivot.kind.local_transform(),
-            Name::from("PlayerColliderPivot"),
-        ))
-        .id();
-
-    let nose = PlayerPart {
-        owner,
-        kind: PlayerPartKind::Nose,
-    };
-    commands.spawn((
-        ChildOf(pivot_entity),
-        nose,
-        nose.kind.local_transform(),
-        nose.kind.collider().unwrap(),
-        ColliderDensity(0.08),
-        Restitution::new(0.55),
-        nose.kind.collision_layers(),
-        Name::from("PlayerNoseCollider"),
-    ));
-
-    let sensor = PlayerPart {
-        owner,
-        kind: PlayerPartKind::Sensor,
-    };
-    commands.spawn((
-        ChildOf(root),
-        sensor,
-        sensor.kind.local_transform(),
-        sensor.kind.collider().unwrap(),
-        Sensor,
-        CollisionEventsEnabled,
-        sensor.kind.collision_layers(),
-        Name::from("PlayerSensorCollider"),
-    ));
-}
-
-/// Install local transforms and predicted-only Avian collider components from a blueprint.
-pub(crate) fn materialize_player_part(
-    commands: &mut Commands,
-    entity: Entity,
-    part: PlayerPart,
-    with_physics: bool,
-    body: Option<Entity>,
-) {
-    let mut entity_commands = commands.entity(entity);
-    entity_commands.insert(part.kind.local_transform());
-    if !with_physics {
-        return;
-    }
-    let Some(collider) = part.kind.collider() else {
-        return;
-    };
-    entity_commands.insert((collider, part.kind.collision_layers()));
-    if let Some(body) = body {
-        entity_commands.insert(ColliderOf { body });
-    }
-    match part.kind {
-        PlayerPartKind::Hull => {
-            entity_commands.insert((ColliderDensity(0.2), Restitution::new(0.3)));
-        }
-        PlayerPartKind::Nose => {
-            entity_commands.insert((ColliderDensity(0.08), Restitution::new(0.55)));
-        }
-        PlayerPartKind::Sensor => {
-            entity_commands.insert((Sensor, CollisionEventsEnabled));
-        }
-        PlayerPartKind::Pivot => {}
-    }
 }
 
 #[derive(Clone)]
@@ -166,109 +50,8 @@ pub struct SharedPlugin;
 impl Plugin for SharedPlugin {
     fn build(&self, app: &mut App) {
         app.add_plugins(ProtocolPlugin);
+        app.add_observer(spawn_player_child_collider);
         // bundles
         app.add_systems(Startup, init);
 
         // physics
-        app.add_plugins(lightyear::avian2d::plugin::LightyearAvianPlugin {
-            replication_mode: AvianReplicationMode::Position {
-                sync_to_transform: false,
-            },
-            ..default()
-        });
-        app.add_plugins(
-            PhysicsPlugins::default()
-                .build()
-                // disable the position<>transform sync plugins as it is handled by lightyear_avian
-                .disable::<PhysicsTransformPlugin>()
-                .disable::<PhysicsInterpolationPlugin>(),
-        )
-        .insert_resource(Gravity(Vec2::ZERO));
-
-        crate::debug::register_debug_systems(app);
-    }
-}
-
-pub(crate) fn init(mut commands: Commands) {
-    commands.spawn(WallBundle::new(
-        Vec2::new(-WALL_SIZE, -WALL_SIZE),
-        Vec2::new(-WALL_SIZE, WALL_SIZE),
-        Color::WHITE,
-    ));
-    commands.spawn(WallBundle::new(
-        Vec2::new(-WALL_SIZE, WALL_SIZE),
-        Vec2::new(WALL_SIZE, WALL_SIZE),
-        Color::WHITE,
-    ));
-    commands.spawn(WallBundle::new(
-        Vec2::new(WALL_SIZE, WALL_SIZE),
-        Vec2::new(WALL_SIZE, -WALL_SIZE),
-        Color::WHITE,
-    ));
-    commands.spawn(WallBundle::new(
-        Vec2::new(WALL_SIZE, -WALL_SIZE),
-        Vec2::new(-WALL_SIZE, -WALL_SIZE),
-        Color::WHITE,
-    ));
-}
-
-// Generates a pseudo-random color from the peer id.
-pub(crate) fn color_from_id(client_id: PeerId) -> Color {
-    let h = (((client_id.to_bits().wrapping_mul(30)) % 360) as f32) / 360.0;
-    let s = 1.0;
-    let l = 0.5;
-    Color::hsl(h, s, l)
-}
-
-// Applies movement input to a player velocity.
-pub(crate) fn shared_movement_behaviour(
-    mut velocity: Mut<LinearVelocity>,
-    action: &ActionState<PlayerActions>,
-) {
-    trace!(pressed = ?action.get_pressed(), "shared movement");
-    const MOVE_SPEED: f32 = 10.0;
-    if action.pressed(&PlayerActions::Up) {
-        velocity.y += MOVE_SPEED;
-    }
-    if action.pressed(&PlayerActions::Down) {
-        velocity.y -= MOVE_SPEED;
-    }
-    if action.pressed(&PlayerActions::Left) {
-        velocity.x -= MOVE_SPEED;
-    }
-    if action.pressed(&PlayerActions::Right) {
-        velocity.x += MOVE_SPEED;
-    }
-    *velocity = LinearVelocity(velocity.clamp_length_max(MAX_VELOCITY));
-}
-
-// Wall
-#[derive(Bundle)]
-pub(crate) struct WallBundle {
-    color: ColorComponent,
-    physics: PhysicsBundle,
-    wall: Wall,
-    name: Name,
-}
-
-#[derive(Component)]
-pub(crate) struct Wall {
-    pub(crate) start: Vec2,
-    pub(crate) end: Vec2,
-}
-
-impl WallBundle {
-    pub(crate) fn new(start: Vec2, end: Vec2, color: Color) -> Self {
-        Self {
-            color: ColorComponent(color),
-            physics: PhysicsBundle {
-                collider: Collider::segment(start, end),
-                collider_density: ColliderDensity(1.0),
-                rigid_body: RigidBody::Static,
-                restitution: Restitution::new(0.0),
-            },
-            wall: Wall { start, end },
-            name: Name::from("Wall"),
-        }
-    }
-}

--- a/examples/avian_2d/src/shared.rs
+++ b/examples/avian_2d/src/shared.rs
@@ -9,6 +9,157 @@ use lightyear::prelude::*;
 pub(crate) const MAX_VELOCITY: f32 = 200.0;
 const WALL_SIZE: f32 = 350.0;
 
+#[derive(Bundle)]
+pub(crate) struct PlayerBodyBundle {
+    rigid_body: RigidBody,
+}
+
+impl PlayerBodyBundle {
+    pub(crate) fn dynamic() -> Self {
+        Self {
+            rigid_body: RigidBody::Dynamic,
+        }
+    }
+}
+
+impl PlayerPartKind {
+    pub(crate) fn local_transform(self) -> Transform {
+        match self {
+            Self::Hull => {
+                Transform::from_xyz(-5.0, -3.0, 0.0).with_rotation(Quat::from_rotation_z(-0.12))
+            }
+            Self::Pivot => {
+                Transform::from_xyz(10.0, 4.0, 0.0).with_rotation(Quat::from_rotation_z(0.35))
+            }
+            Self::Nose => {
+                Transform::from_xyz(6.0, 1.0, 0.0).with_rotation(Quat::from_rotation_z(0.2))
+            }
+            Self::Sensor => Transform::from_xyz(-7.0, 8.0, 0.0),
+        }
+    }
+
+    pub(crate) fn collider(self) -> Option<Collider> {
+        match self {
+            Self::Hull => Some(Collider::rectangle(28.0, 22.0)),
+            Self::Nose => Some(Collider::circle(9.0)),
+            Self::Sensor => Some(Collider::circle(27.0)),
+            Self::Pivot => None,
+        }
+    }
+
+    pub(crate) fn collision_layers(self) -> CollisionLayers {
+        let memberships = match self {
+            Self::Hull | Self::Pivot => 0b0001,
+            Self::Nose => 0b0010,
+            Self::Sensor => 0b0100,
+        };
+        CollisionLayers::from_bits(memberships, LayerMask::ALL.0)
+    }
+}
+
+/// Spawn an asymmetric compound player collider:
+///
+/// ```text
+/// rigid-body root (no collider)
+/// ├── hull collider
+/// ├── transform-only pivot
+/// │   └── nose collider
+/// └── sensor collider
+/// ```
+pub(crate) fn spawn_player_parts(commands: &mut Commands, root: Entity, owner: PeerId) {
+    let hull = PlayerPart {
+        owner,
+        kind: PlayerPartKind::Hull,
+    };
+    commands.spawn((
+        ChildOf(root),
+        hull,
+        hull.kind.local_transform(),
+        hull.kind.collider().unwrap(),
+        ColliderDensity(0.2),
+        Restitution::new(0.3),
+        hull.kind.collision_layers(),
+        Name::from("PlayerHullCollider"),
+    ));
+
+    let pivot = PlayerPart {
+        owner,
+        kind: PlayerPartKind::Pivot,
+    };
+    let pivot_entity = commands
+        .spawn((
+            ChildOf(root),
+            pivot,
+            pivot.kind.local_transform(),
+            Name::from("PlayerColliderPivot"),
+        ))
+        .id();
+
+    let nose = PlayerPart {
+        owner,
+        kind: PlayerPartKind::Nose,
+    };
+    commands.spawn((
+        ChildOf(pivot_entity),
+        nose,
+        nose.kind.local_transform(),
+        nose.kind.collider().unwrap(),
+        ColliderDensity(0.08),
+        Restitution::new(0.55),
+        nose.kind.collision_layers(),
+        Name::from("PlayerNoseCollider"),
+    ));
+
+    let sensor = PlayerPart {
+        owner,
+        kind: PlayerPartKind::Sensor,
+    };
+    commands.spawn((
+        ChildOf(root),
+        sensor,
+        sensor.kind.local_transform(),
+        sensor.kind.collider().unwrap(),
+        Sensor,
+        CollisionEventsEnabled,
+        sensor.kind.collision_layers(),
+        Name::from("PlayerSensorCollider"),
+    ));
+}
+
+/// Install local transforms and predicted-only Avian collider components from a blueprint.
+pub(crate) fn materialize_player_part(
+    commands: &mut Commands,
+    entity: Entity,
+    part: PlayerPart,
+    with_physics: bool,
+    body: Option<Entity>,
+) {
+    let mut entity_commands = commands.entity(entity);
+    entity_commands.insert(part.kind.local_transform());
+    if !with_physics {
+        return;
+    }
+    let Some(collider) = part.kind.collider() else {
+        return;
+    };
+    entity_commands.insert((collider, part.kind.collision_layers()));
+    if let Some(body) = body {
+        entity_commands.insert(ColliderOf { body });
+    }
+    match part.kind {
+        PlayerPartKind::Hull => {
+            entity_commands.insert((ColliderDensity(0.2), Restitution::new(0.3)));
+        }
+        PlayerPartKind::Nose => {
+            entity_commands.insert((ColliderDensity(0.08), Restitution::new(0.55)));
+        }
+        PlayerPartKind::Sensor => {
+            entity_commands.insert((Sensor, CollisionEventsEnabled));
+        }
+        PlayerPartKind::Pivot => {}
+    }
+}
+
 #[derive(Clone)]
 pub struct SharedPlugin;
 

--- a/examples/deterministic_replication/README.md
+++ b/examples/deterministic_replication/README.md
@@ -1,5 +1,10 @@
 # Features
 
+- The ball is an asymmetric compound Avian body with a direct child collider, a collider below a transform-only
+  intermediate child, and a sensor child on a separate collision layer. The hierarchy is pre-spawned identically on
+  every peer so input rollback and state-based catch-up exercise child-collider broad-phase and contact state.
+- Every physical child is explicitly enrolled in deterministic rollback so its derived collider state is restored
+  during replay.
 
 
 

--- a/examples/deterministic_replication/src/protocol.rs
+++ b/examples/deterministic_replication/src/protocol.rs
@@ -23,21 +23,25 @@ pub(crate) struct PhysicsBundle {
 }
 
 impl PhysicsBundle {
-    pub(crate) fn ball() -> Self {
-        Self {
-            collider: Collider::circle(BALL_SIZE),
-            collider_density: ColliderDensity(0.05),
-            rigid_body: RigidBody::Dynamic,
-            restitution: Restitution::new(1.0),
-        }
-    }
-
     pub(crate) fn player() -> Self {
         Self {
             collider: Collider::rectangle(PLAYER_SIZE, PLAYER_SIZE),
             collider_density: ColliderDensity(0.2),
             rigid_body: RigidBody::Dynamic,
             restitution: Restitution::new(1.0),
+        }
+    }
+}
+
+#[derive(Bundle)]
+pub(crate) struct BallBodyBundle {
+    pub(crate) rigid_body: RigidBody,
+}
+
+impl BallBodyBundle {
+    pub(crate) fn dynamic() -> Self {
+        Self {
+            rigid_body: RigidBody::Dynamic,
         }
     }
 }
@@ -66,6 +70,14 @@ pub struct ColorComponent(pub(crate) Color);
 
 #[derive(Component, Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct BallMarker;
+
+#[derive(Component, Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum BallPart {
+    Core,
+    Pivot,
+    Lobe,
+    Sensor,
+}
 
 // Inputs
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Copy, Hash, Reflect, Actionlike)]

--- a/examples/deterministic_replication/src/renderer.rs
+++ b/examples/deterministic_replication/src/renderer.rs
@@ -1,6 +1,7 @@
 use crate::protocol::*;
 use crate::shared::Wall;
 use avian2d::prelude::{Position, Rotation};
+use bevy::color::palettes::css;
 use bevy::prelude::*;
 use lightyear::prelude::{InterpolationSystems, RollbackSystems};
 use lightyear_deterministic_replication::prelude::CatchUpMode;
@@ -56,6 +57,7 @@ pub(crate) fn draw_elements(
     mut gizmos: Gizmos,
     players: Query<(&Position, &Rotation, &ColorComponent), With<PlayerId>>,
     balls: Query<(&Position, &ColorComponent), With<BallMarker>>,
+    ball_parts: Query<(&GlobalTransform, &BallPart)>,
     walls: Query<(&Wall, &ColorComponent), Without<PlayerId>>,
 ) {
     for (position, rotation, color) in &players {
@@ -72,7 +74,26 @@ pub(crate) fn draw_elements(
         );
     }
     for (position, color) in &balls {
-        gizmos.circle_2d(Vec2::new(position.x, position.y), BALL_SIZE, color.0);
+        gizmos.circle_2d(
+            Vec2::new(position.x, position.y),
+            BALL_SIZE,
+            color.0.with_alpha(0.18),
+        );
+    }
+    for (global, part) in &ball_parts {
+        let position = global.translation().truncate();
+        match part {
+            BallPart::Core => {
+                gizmos.circle_2d(position, 12.0, css::AZURE);
+            }
+            BallPart::Lobe => {
+                gizmos.circle_2d(position, 8.0, css::AZURE);
+            }
+            BallPart::Sensor => {
+                gizmos.circle_2d(position, 20.0, css::AZURE.with_alpha(0.25));
+            }
+            BallPart::Pivot => {}
+        }
     }
     for (wall, color) in &walls {
         gizmos.line_2d(wall.start, wall.end, color.0);

--- a/examples/deterministic_replication/src/shared.rs
+++ b/examples/deterministic_replication/src/shared.rs
@@ -13,6 +13,7 @@ use lightyear_frame_interpolation::{FrameInterpolate, FrameInterpolationPlugin};
 const MAX_VELOCITY: f32 = 200.0;
 const WALL_SIZE: f32 = 350.0;
 const BALL_PRESPAWN_HASH: u64 = 0xD37E_12B4_0000_0001;
+const BALL_PART_PRESPAWN_HASH: u64 = 0xD37E_12B4_1000_0000;
 
 /// SharedPlugin between the client and server.
 #[derive(Clone)]
@@ -145,8 +146,9 @@ pub(crate) fn spawn_ball(
 ) -> Entity {
     let mut ball = commands.spawn((
         Position::default(),
+        Rotation::radians(0.2),
         ColorComponent(css::AZURE.into()),
-        PhysicsBundle::ball(),
+        BallBodyBundle::dynamic(),
         BallMarker,
         DeterministicPredicted {
             skip_despawn: true,
@@ -167,7 +169,86 @@ pub(crate) fn spawn_ball(
             ball.insert(CatchUpGated);
         }
     }
-    ball.id()
+    let ball = ball.id();
+    spawn_ball_parts(commands, ball, mode, is_server, is_client);
+    ball
+}
+
+#[cfg_attr(not(feature = "server"), allow(unused_variables))]
+fn spawn_ball_parts(
+    commands: &mut Commands,
+    root: Entity,
+    mode: &CatchUpMode,
+    is_server: bool,
+    is_client: bool,
+) {
+    fn finish_part(
+        entity: &mut EntityCommands,
+        part: BallPart,
+        mode: &CatchUpMode,
+        is_server: bool,
+        is_client: bool,
+    ) {
+        entity.insert(part);
+        entity.insert(DeterministicPredicted {
+            skip_despawn: true,
+            ..default()
+        });
+        if *mode == CatchUpMode::StateBasedCatchUp {
+            entity.insert(PreSpawned::new(BALL_PART_PRESPAWN_HASH + part as u64));
+            #[cfg(feature = "server")]
+            if is_server {
+                entity.insert((Replicate::to_clients(NetworkTarget::All), CatchUpGated));
+            } else if is_client {
+                entity.insert(CatchUpGated);
+            }
+            #[cfg(not(feature = "server"))]
+            if is_client {
+                entity.insert(CatchUpGated);
+            }
+        }
+    }
+
+    let mut core = commands.spawn((
+        ChildOf(root),
+        Transform::from_xyz(-2.0, -1.0, 0.0).with_rotation(Quat::from_rotation_z(-0.17)),
+        Collider::circle(12.0),
+        ColliderDensity(0.05),
+        Restitution::new(1.0),
+        CollisionLayers::default(),
+        Name::from("BallCoreCollider"),
+    ));
+    finish_part(&mut core, BallPart::Core, mode, is_server, is_client);
+
+    let mut pivot = commands.spawn((
+        ChildOf(root),
+        Transform::from_xyz(4.0, 2.0, 0.0).with_rotation(Quat::from_rotation_z(0.31)),
+        Name::from("BallColliderPivot"),
+    ));
+    finish_part(&mut pivot, BallPart::Pivot, mode, is_server, is_client);
+    let pivot = pivot.id();
+
+    let mut lobe = commands.spawn((
+        ChildOf(pivot),
+        Transform::from_xyz(6.0, 1.0, 0.0).with_rotation(Quat::from_rotation_z(0.23)),
+        Collider::circle(8.0),
+        ColliderDensity(0.04),
+        Restitution::new(1.0),
+        CollisionLayers::from_bits(0b0010, LayerMask::ALL.0),
+        Name::from("BallLobeCollider"),
+    ));
+    finish_part(&mut lobe, BallPart::Lobe, mode, is_server, is_client);
+
+    let mut sensor = commands.spawn((
+        ChildOf(root),
+        Transform::from_xyz(1.0, 3.0, 0.0),
+        Collider::circle(20.0),
+        Sensor,
+        CollisionEventsEnabled,
+        CollisionLayers::from_bits(0b0100, LayerMask::ALL.0),
+        Name::from("BallSensorCollider"),
+    ));
+    finish_part(&mut sensor, BallPart::Sensor, mode, is_server, is_client);
 }
 
 pub(crate) fn player_bundle(peer_id: PeerId) -> impl Bundle {


### PR DESCRIPTION
We don't want to apply ApplyPosToTransform on child colliders.
For child colliders, Position/Rotation should not get replicated at
all since the Pos/Rot will be inferred from the parent RigidBody + the
local Transform