### PR TITLE
fix(deterministic): skip folding empty prediction histories into client checksum

### DIFF
--- a/crates/deterministic/deterministic_replication/src/checksum.rs
+++ b/crates/deterministic/deterministic_replication/src/checksum.rs
@@ -151,9 +151,10 @@ impl ChecksumSendPlugin {
                     let (hash_fn, pop_until_tick_and_hash_fn) = world.state.hash_fns.get(component_id).expect("Component in checksum archetype must have a hash function registered");
 
                     let mut hasher = seahash::SeaHasher::default();
-                    pop_until_tick_and_hash_fn.unwrap()(history_ptr, tick, &mut hasher, hash_fn.inner);
-                    let hash = hasher.finish();
-                    checksum ^= hash; // XOR the hashes together to get an order-independent checksum
+                    if pop_until_tick_and_hash_fn.unwrap()(history_ptr, tick, &mut hasher, hash_fn.inner) {
+                        // XOR the hashes together to get an order-independent checksum
+                        checksum ^= hasher.finish();
+                    }
                 });
             });
         });

--- a/crates/deterministic/deterministic_replication/src/checksum.rs
+++ b/crates/deterministic/deterministic_replication/src/checksum.rs
@@ -327,13 +327,15 @@ fn compute_history_checksum(world: &mut ChecksumWorld<'_, '_, true>, tick: Tick)
                         );
 
                     let mut hasher = seahash::SeaHasher::default();
-                    pop_until_tick_and_hash_fn.unwrap()(
+                    if pop_until_tick_and_hash_fn.unwrap()(
                         history_ptr,
                         tick,
                         &mut hasher,
                         hash_fn.inner,
-                    );
-                    checksum ^= hasher.finish();
+                    ) {
+                        // XOR the hashes together to get an order-independent checksum
+                        checksum ^= hasher.finish();
+                    }
                 });
         });
     });

--- a/crates/replication/prediction/src/registry.rs
+++ b/crates/replication/prediction/src/registry.rs
@@ -87,7 +87,9 @@ type CheckRollbackFn = unsafe fn(
 /// Type-erased function for hashing the value in a [`PredictionHistory<C>`] component at a tick.
 /// The function fn should be of type fn(&C, &mut seahash::SeaHasher) and will be called with the
 /// value returned by the history buffer lookup.
-pub type PopUntilTickAndHashFn = fn(PtrMut, Tick, &mut seahash::SeaHasher, fn());
+/// Returns `true` if an entry was found at that tick and hashed, `false` if the history
+/// had no entry at that tick (in which case nothing was hashed).
+pub type PopUntilTickAndHashFn = fn(PtrMut, Tick, &mut seahash::SeaHasher, fn()) -> bool;
 
 impl PredictionMetadata {
     fn new<C: SyncComponent>(
@@ -500,6 +502,9 @@ impl PredictionRegistry {
 
     /// Type-erased function for hashing the value in a [`PredictionHistory<C>`] at `tick`.
     ///
+    /// Returns `true` if an entry was found at `tick` and hashed, `false` if the history
+    /// had no entry at that tick (in which case nothing was hashed).
+    ///
     /// Safety
     ///
     /// - The PtrMut must point to a valid [`PredictionHistory<C>`] component.
@@ -509,7 +514,7 @@ impl PredictionRegistry {
         tick: Tick,
         hasher: &mut seahash::SeaHasher,
         f: fn(),
-    ) {
+    ) -> bool {
         // SAFETY: the caller must ensure that the function has the correct type
         let f = unsafe { core::mem::transmute::<fn(), fn(&C, &mut seahash::SeaHasher)>(f) };
         // SAFETY: the caller must ensure that the pointer is valid and points to a PredictionHistory<C>
@@ -522,6 +527,9 @@ impl PredictionRegistry {
                 v
             );
             f(v, hasher);
+            true
+        } else {
+            false
         }
     }
 }

--- a/crates/replication/prediction/src/registry.rs
+++ b/crates/replication/prediction/src/registry.rs
@@ -140,8 +140,8 @@ type CheckRollbackFn = unsafe fn(
 /// Type-erased function for hashing the value in a [`PredictionHistory<C>`] component at a tick.
 /// The function fn should be of type fn(&C, &mut seahash::SeaHasher) and will be called with the
 /// value returned by the history buffer lookup.
-/// Returns `true` if an entry was found at that tick and hashed, `false` if the history
-/// had no entry at that tick (in which case nothing was hashed).
+/// Returns `true` if the history resolves to a component value at that tick and hashes it.
+/// Returns `false` if no component value exists at that tick, in which case nothing is hashed.
 pub type PopUntilTickAndHashFn = fn(PtrMut, Tick, &mut seahash::SeaHasher, fn()) -> bool;
 
 impl PredictionMetadata {
@@ -553,8 +553,8 @@ impl PredictionRegistry {
 
     /// Type-erased function for hashing the value in a [`PredictionHistory<C>`] at `tick`.
     ///
-    /// Returns `true` if an entry was found at `tick` and hashed, `false` if the history
-    /// had no entry at that tick (in which case nothing was hashed).
+    /// Returns `true` if the history resolves to a component value at `tick` and hashes it.
+    /// Returns `false` if no component value exists at `tick`, in which case nothing is hashed.
     ///
     /// Safety
     ///
@@ -1853,18 +1853,41 @@ mod tests {
                 hash_test_component,
             )
         };
-        PredictionRegistry::pop_until_tick_and_hash::<TestComponent>(
+        let hashed = PredictionRegistry::pop_until_tick_and_hash::<TestComponent>(
             PtrMut::from(&mut history),
             Tick(11),
             &mut hasher,
             hash_fn,
         );
 
+        assert!(hashed);
         assert_ne!(hasher.finish(), 0);
         assert_eq!(history.len(), before_len);
         assert_eq!(history.get(Tick(10)).unwrap().0, 10);
         assert_eq!(history.get(Tick(11)).unwrap().0, 11);
         assert_eq!(history.get(Tick(12)).unwrap().0, 12);
+    }
+
+    #[test]
+    fn deterministic_hash_reports_missing_prediction_history_value() {
+        let mut history = PredictionHistory::<TestComponent>::default();
+        let mut hasher = seahash::SeaHasher::default();
+        let initial_hash = hasher.finish();
+        let hash_fn = unsafe {
+            core::mem::transmute::<fn(&TestComponent, &mut seahash::SeaHasher), fn()>(
+                hash_test_component,
+            )
+        };
+
+        let hashed = PredictionRegistry::pop_until_tick_and_hash::<TestComponent>(
+            PtrMut::from(&mut history),
+            Tick(11),
+            &mut hasher,
+            hash_fn,
+        );
+
+        assert!(!hashed);
+        assert_eq!(hasher.finish(), initial_hash);
     }
 
     #[test]

--- a/crates/replication/prediction/src/registry.rs
+++ b/crates/replication/prediction/src/registry.rs
@@ -140,7 +140,9 @@ type CheckRollbackFn = unsafe fn(
 /// Type-erased function for hashing the value in a [`PredictionHistory<C>`] component at a tick.
 /// The function fn should be of type fn(&C, &mut seahash::SeaHasher) and will be called with the
 /// value returned by the history buffer lookup.
-pub type PopUntilTickAndHashFn = fn(PtrMut, Tick, &mut seahash::SeaHasher, fn());
+/// Returns `true` if an entry was found at that tick and hashed, `false` if the history
+/// had no entry at that tick (in which case nothing was hashed).
+pub type PopUntilTickAndHashFn = fn(PtrMut, Tick, &mut seahash::SeaHasher, fn()) -> bool;
 
 impl PredictionMetadata {
     fn new<C: SyncComponent>(
@@ -551,6 +553,9 @@ impl PredictionRegistry {
 
     /// Type-erased function for hashing the value in a [`PredictionHistory<C>`] at `tick`.
     ///
+    /// Returns `true` if an entry was found at `tick` and hashed, `false` if the history
+    /// had no entry at that tick (in which case nothing was hashed).
+    ///
     /// Safety
     ///
     /// - The PtrMut must point to a valid [`PredictionHistory<C>`] component.
@@ -560,7 +565,7 @@ impl PredictionRegistry {
         tick: Tick,
         hasher: &mut seahash::SeaHasher,
         f: fn(),
-    ) {
+    ) -> bool {
         // SAFETY: the caller must ensure that the function has the correct type
         let f = unsafe { core::mem::transmute::<fn(), fn(&C, &mut seahash::SeaHasher)>(f) };
         // SAFETY: the caller must ensure that the pointer is valid and points to a PredictionHistory<C>
@@ -573,6 +578,9 @@ impl PredictionRegistry {
                 v
             );
             f(v, hasher);
+            true
+        } else {
+            false
         }
     }
 }


### PR DESCRIPTION
Fixes #1601.

In deterministic replication, the client checksum folds `SeaHasher::default().finish()` — a nonzero constant — for every `(entity, PredictionHistory<C>)` whose history does not resolve to a component value at the hashed tick, while the server only hashes entities that actually hold the component. A missing client-side value (for example, an empty history attached through the `CatchUpGated` reveal path for a component the entity never holds) therefore adds a phantom checksum contribution and can permanently desync client/server checksums.

## Change

- `lightyear_prediction`: `pop_until_tick_and_hash` now reports whether it hashed an effective history value.
- `lightyear_deterministic_replication`: the client checksum only folds when a value was actually hashed — "missing value ⇒ no contribution", matching the server's component-presence semantics.
- Regression coverage asserts both sides of the contract: present history values return `true`, while missing values return `false` and leave the hasher unchanged.

The current catch-up reveal design uses `PredictionHistory<C>` as rollback membership, so it can intentionally attach histories that never resolve to a component value. Regardless of whether the missing value comes from catch-up, component lifetime, or another transient history state, checksum calculation must tolerate it.

## Testing

- `cargo test -p lightyear_prediction --features deterministic --lib` — 37/37
- `cargo test -p lightyear_deterministic_replication --lib` — 2/2
- `cargo test -p lightyear_tests deterministic -- --test-threads=1` — 9/9, including all state-based catch-up scenarios
- Downstream validation in a real deterministic-replication game: all clients match the server bit-for-bit across thousands of ticks, including late-join catch-up.

Note: the deterministic integration suite has a pre-existing wall-clock-sensitive flake (`test_state_based_catchup_late_join_after_movement`, small position epsilon under load); it reproduces on pristine `main` without this change.
