### PR TITLE
fix(prediction): seed prediction history when rollback finds no restore state

### DIFF
--- a/crates/replication/prediction/src/rollback.rs
+++ b/crates/replication/prediction/src/rollback.rs
@@ -942,6 +942,11 @@ pub(crate) fn prepare_rollback<C: Component<Mutability = Mutable> + Clone>(
         predicted_history.clear();
         if let Some(state) = restore_state.clone() {
             predicted_history.add_state(rollback_tick, state);
+        } else if let Some(current) = predicted_component.as_deref() {
+            // No state exists at rollback_tick (e.g. the entity was revealed to
+            // this client after the rollback target). The replay starts from the
+            // current component value, so seed the history with it.
+            predicted_history.add_state(rollback_tick, HistoryState::Updated(current.clone()));
         }
         trace!(
             target: "lightyear_debug::prediction",
@@ -1232,6 +1237,8 @@ mod tests {
 
     /// Test that rollback does not remove a predicted component
     /// when the rollback tick predates the first retained history entry.
+    /// The history is then seeded with the current component value at the
+    /// rollback tick, anchoring the replay/checksum base.
     #[test]
     fn test_predicted_component_initial_rollback() {
         let rollback_tick = Tick(10);
@@ -1259,6 +1266,15 @@ mod tests {
         assert_eq!(
             world.get::<TestComponent>(predicted),
             Some(&TestComponent(1.0))
+        );
+        // No history sample existed at-or-before the rollback tick, so the
+        // history is seeded with the current component value.
+        assert_eq!(
+            world
+                .get::<PredictionHistory<TestComponent>>(predicted)
+                .unwrap()
+                .get_state(rollback_tick),
+            Some(&HistoryState::Updated(TestComponent(1.0)))
         );
     }
 }


### PR DESCRIPTION
Fixes #1602.

`prepare_rollback` clears each component's `PredictionHistory` and re-seeds it only when a restore state exists at the rollback tick. For an entity revealed to the client *after* the rollback target (late-join catch-up), the lookup misses and the history stays empty; because `update_prediction_history` only writes on change detection, a never-changing component's history then stays empty forever — permanently diverging the client's checksum fold set from the server's even though the simulation on both peers is bit-identical.

## Change

When no restore state exists, seed the history with the current component value — the value the replay actually starts from (the restore path already keeps that value in place). The `Some` branch is untouched.

Also extends the existing `None`-arm unit test (`test_predicted_component_initial_rollback`) to pin the seeding behavior.

## Testing

- `cargo test -p lightyear_prediction --features deterministic --lib` — 27/27
- `cargo test -p lightyear_tests deterministic` — 9/9
- Downstream validation: before, ~25–40 % of 4-client staggered-join runs produced 750+ contiguous mismatched ticks on some client; after, repeated runs stay within the documented join transient.

Complements the #1601 fix (skip-on-missing is only correct while missing entries are transient — this keeps them transient). Same pre-existing CI-flake caveat as in that PR.
