### PR TITLE
refactor(transport): apply wrapping-ID map changes to main

### DIFF
--- a/crates/core/utils/src/wrapping_id.rs
+++ b/crates/core/utils/src/wrapping_id.rs
@@ -1,4 +1,4 @@
-//! u32 that wraps around when it reaches the maximum value.
+//! `u32` identifier with wrapping sequence-number arithmetic.
 //!
 //! In practice with u32, wrapping never occurs during a game session
 //! (~828 days at 60 Hz). The wrapping arithmetic is kept for correctness
@@ -22,8 +22,14 @@ macro_rules! wrapping_id {
             use core::cmp::Ordering;
             use bevy_reflect::Reflect;
             use lightyear_serde::{SerializationError, reader::{Reader, ReadInteger}, writer::WriteInteger, ToBytes};
-            use lightyear_utils::wrapping_id::WrappedId;
+            use lightyear_utils::wrapping_id::{WrappedId, wrapping_diff};
 
+            /// A wrapping sequence identifier.
+            ///
+            /// This type intentionally does not implement [`Ord`]: circular sequence order is
+            /// meaningful only relative to a nearby anchor and cannot satisfy a global ordering
+            /// contract. Use equality-based containers for lookup and keep chronological order in
+            /// the owning data structure.
             #[derive(Serialize, Deserialize, Clone, Copy, Debug, Eq, Hash, PartialEq, Default, Reflect
             )]
             pub struct $struct_name(pub u32);
@@ -64,15 +70,17 @@ macro_rules! wrapping_id {
                 }
             }
 
-            impl Ord for $struct_name {
-                fn cmp(&self, other: &Self) -> Ordering {
-                    self.0.cmp(&other.0)
-                }
-            }
-
             impl PartialOrd for $struct_name {
                 fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-                    Some(self.cmp(other))
+                    // Relative comparisons require the caller to keep both sequence numbers
+                    // within a window smaller than half the u32 range. Values immediately after
+                    // rollover therefore compare newer than values immediately before rollover.
+                    Some(match wrapping_diff(self.0, other.0) {
+                        0 => Ordering::Equal,
+                        x if x > 0 => Ordering::Less,
+                        x if x < 0 => Ordering::Greater,
+                        _ => unreachable!(),
+                    })
                 }
             }
 
@@ -80,7 +88,7 @@ macro_rules! wrapping_id {
                 type Output = i32;
 
                 fn sub(self, rhs: Self) -> Self::Output {
-                    (self.0 as i64 - rhs.0 as i64) as i32
+                    self.0.wrapping_sub(rhs.0) as i32
                 }
             }
 
@@ -88,7 +96,7 @@ macro_rules! wrapping_id {
                 type Output = Self;
 
                 fn sub(self, rhs: u32) -> Self::Output {
-                    Self(self.0.saturating_sub(rhs))
+                    Self(self.0.wrapping_sub(rhs))
                 }
             }
 
@@ -96,13 +104,13 @@ macro_rules! wrapping_id {
                 type Output = Self;
 
                 fn add(self, rhs: Self) -> Self::Output {
-                    Self(self.0.saturating_add(rhs.0))
+                    Self(self.0.wrapping_add(rhs.0))
                 }
             }
 
             impl AddAssign<u32> for $struct_name {
                 fn add_assign(&mut self, rhs: u32) {
-                    self.0 = self.0.saturating_add(rhs);
+                    self.0 = self.0.wrapping_add(rhs);
                 }
             }
 
@@ -110,7 +118,7 @@ macro_rules! wrapping_id {
                 type Output = Self;
 
                 fn add(self, rhs: i32) -> Self::Output {
-                    Self(self.0.saturating_add_signed(rhs))
+                    Self(self.0.wrapping_add_signed(rhs))
                 }
             }
         }

--- a/crates/transport/transport/src/channel/receivers/ordered_reliable.rs
+++ b/crates/transport/transport/src/channel/receivers/ordered_reliable.rs
@@ -1,4 +1,4 @@
-use alloc::collections::{BTreeMap, btree_map};
+use bevy_platform::collections::{HashMap, hash_map};
 
 use super::error::{ChannelReceiveError, Result};
 use crate::channel::receivers::ChannelReceive;
@@ -15,9 +15,10 @@ pub struct OrderedReliableReceiver {
     /// Next message id that we are waiting to receive
     /// The channel is reliable so we should see all message ids sequentially.
     pending_recv_message_id: MessageId,
-    // TODO: optimize via ring buffer?
     /// Buffer of the messages that we received, but haven't processed yet
-    recv_message_buffer: BTreeMap<MessageId, (Tick, Bytes)>,
+    ///
+    /// Ordering is anchored by `pending_recv_message_id`, not by this map.
+    recv_message_buffer: HashMap<MessageId, (Tick, Bytes)>,
     fragment_receiver: FragmentReceiver,
 }
 
@@ -31,7 +32,7 @@ impl OrderedReliableReceiver {
     pub fn new() -> Self {
         Self {
             pending_recv_message_id: MessageId(0),
-            recv_message_buffer: BTreeMap::new(),
+            recv_message_buffer: HashMap::default(),
             fragment_receiver: FragmentReceiver::new(),
         }
     }
@@ -57,7 +58,7 @@ impl ChannelReceive for OrderedReliableReceiver {
         }
 
         // add the message to the buffer
-        if let btree_map::Entry::Vacant(entry) = self.recv_message_buffer.entry(message_id) {
+        if let hash_map::Entry::Vacant(entry) = self.recv_message_buffer.entry(message_id) {
             match message.data {
                 MessageData::Single(single) => {
                     entry.insert((message.remote_sent_tick, single.bytes));
@@ -158,6 +159,42 @@ mod tests {
         assert_eq!(
             receiver.read_message(),
             Some((Tick(2), single2.bytes.clone(), Some(MessageId(1))))
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn buffers_messages_across_message_id_rollover() -> Result<(), PacketError> {
+        let mut receiver = OrderedReliableReceiver::new();
+        receiver.pending_recv_message_id = MessageId(u32::MAX);
+
+        let mut after_wrap = SingleData::new(Some(MessageId(0)), Bytes::from("after wrap"));
+        receiver.buffer_recv(ReceiveMessage {
+            data: after_wrap.clone().into(),
+            remote_sent_tick: Tick(1),
+            compression: CompressionConfig::DISABLED,
+        })?;
+        assert_eq!(receiver.read_message(), None);
+
+        after_wrap.id = Some(MessageId(u32::MAX));
+        after_wrap.bytes = Bytes::from("before wrap");
+        receiver.buffer_recv(ReceiveMessage {
+            data: after_wrap.clone().into(),
+            remote_sent_tick: Tick(2),
+            compression: CompressionConfig::DISABLED,
+        })?;
+
+        assert_eq!(
+            receiver.read_message(),
+            Some((
+                Tick(2),
+                Bytes::from("before wrap"),
+                Some(MessageId(u32::MAX))
+            ))
+        );
+        assert_eq!(
+            receiver.read_message(),
+            Some((Tick(1), Bytes::from("after wrap"), Some(MessageId(0))))
         );
         Ok(())
     }

--- a/crates/transport/transport/src/channel/receivers/sequenced_reliable.rs
+++ b/crates/transport/transport/src/channel/receivers/sequenced_reliable.rs
@@ -1,4 +1,4 @@
-use alloc::collections::{BTreeMap, btree_map};
+use bevy_platform::collections::{HashMap, hash_map};
 
 use super::error::{ChannelReceiveError, Result};
 use bytes::Bytes;
@@ -13,10 +13,11 @@ use crate::packet::message::{MessageData, MessageId, ReceiveMessage};
 /// do not return them in order, but ignore the messages that are older than the most recent one received
 #[derive(Debug)]
 pub struct SequencedReliableReceiver {
-    // TODO: optimize via ring buffer?
-    // TODO: actually do we even need a buffer? we might just need a buffer of 1
     /// Buffer of the messages that we received, but haven't processed yet
-    recv_message_buffer: BTreeMap<MessageId, (Tick, Bytes)>,
+    ///
+    /// This is an equality lookup only. Sequence order is relative to
+    /// `most_recent_message_id`.
+    recv_message_buffer: HashMap<MessageId, (Tick, Bytes)>,
     /// Highest message id received so far
     most_recent_message_id: MessageId,
     fragment_receiver: FragmentReceiver,
@@ -31,7 +32,7 @@ impl Default for SequencedReliableReceiver {
 impl SequencedReliableReceiver {
     pub fn new() -> Self {
         Self {
-            recv_message_buffer: BTreeMap::new(),
+            recv_message_buffer: HashMap::default(),
             most_recent_message_id: MessageId(0),
             fragment_receiver: FragmentReceiver::new(),
         }
@@ -60,10 +61,11 @@ impl ChannelReceive for SequencedReliableReceiver {
         // update the most recent message id
         if message_id > self.most_recent_message_id {
             self.most_recent_message_id = message_id;
+            self.recv_message_buffer.clear();
         }
 
         // add the message to the buffer
-        if let btree_map::Entry::Vacant(entry) = self.recv_message_buffer.entry(message_id) {
+        if let hash_map::Entry::Vacant(entry) = self.recv_message_buffer.entry(message_id) {
             match message.data {
                 MessageData::Single(single) => {
                     entry.insert((message.remote_sent_tick, single.bytes));
@@ -83,13 +85,10 @@ impl ChannelReceive for SequencedReliableReceiver {
         Ok(())
     }
     fn read_message(&mut self) -> Option<(Tick, Bytes, Option<MessageId>)> {
-        // keep popping messages until we get one that is more recent than the last one we processed
-        loop {
-            let (message_id, (tick, bytes)) = self.recv_message_buffer.pop_first()?;
-            if message_id >= self.most_recent_message_id {
-                return Some((tick, bytes, Some(message_id)));
-            }
-        }
+        let message_id = self.most_recent_message_id;
+        self.recv_message_buffer
+            .remove(&message_id)
+            .map(|(tick, bytes)| (tick, bytes, Some(message_id)))
     }
 }
 
@@ -154,6 +153,26 @@ mod tests {
         })?;
         assert_eq!(receiver.recv_message_buffer.len(), 0);
         assert_eq!(receiver.read_message(), None);
+        Ok(())
+    }
+
+    #[test]
+    fn newest_message_survives_message_id_rollover() -> Result<()> {
+        let mut receiver = SequencedReliableReceiver::new();
+        receiver.most_recent_message_id = MessageId(u32::MAX);
+
+        let after_wrap = SingleData::new(Some(MessageId(0)), Bytes::from("after wrap"));
+        receiver.buffer_recv(ReceiveMessage {
+            data: after_wrap.clone().into(),
+            remote_sent_tick: Tick(1),
+            compression: CompressionConfig::DISABLED,
+        })?;
+
+        assert_eq!(receiver.most_recent_message_id, MessageId(0));
+        assert_eq!(
+            receiver.read_message(),
+            Some((Tick(1), after_wrap.bytes, Some(MessageId(0))))
+        );
         Ok(())
     }
 }

--- a/crates/transport/transport/src/channel/receivers/unordered_reliable.rs
+++ b/crates/transport/transport/src/channel/receivers/unordered_reliable.rs
@@ -1,4 +1,4 @@
-use alloc::collections::{BTreeMap, btree_map};
+use alloc::collections::VecDeque;
 use bevy_platform::collections::HashSet;
 use core::time::Duration;
 
@@ -19,10 +19,8 @@ pub struct UnorderedReliableReceiver {
     /// Next message id that we are waiting to receive
     /// The channel is reliable so we should see all message ids.
     pending_recv_message_id: MessageId,
-    // TODO: optimize via ring buffer?
-    // TODO: actually we could just use a VecDeque here?
     /// Buffer of the messages that we received, but haven't processed yet
-    recv_message_buffer: BTreeMap<MessageId, (Tick, Bytes, MessageId)>,
+    recv_message_buffer: VecDeque<(Tick, Bytes, MessageId)>,
     fragment_receiver: FragmentReceiver,
     /// Keep tracking of the message ids we have received, so we can update the oldest_pending_message_id
     received_message_ids: HashSet<MessageId>,
@@ -38,7 +36,7 @@ impl UnorderedReliableReceiver {
     pub fn new() -> Self {
         Self {
             pending_recv_message_id: MessageId(0),
-            recv_message_buffer: BTreeMap::new(),
+            recv_message_buffer: VecDeque::new(),
             fragment_receiver: FragmentReceiver::new(),
             received_message_ids: HashSet::default(),
         }
@@ -70,29 +68,30 @@ impl ChannelReceive for UnorderedReliableReceiver {
             return Ok(());
         }
 
-        // add the message to the buffer
-        if let btree_map::Entry::Vacant(entry) = self.recv_message_buffer.entry(message_id) {
-            match message.data {
-                MessageData::Single(single) => {
-                    // receive the message if we haven't received it already
-                    if !self.received_message_ids.contains(&message_id) {
-                        self.received_message_ids.insert(message_id);
-                        entry.insert((message.remote_sent_tick, single.bytes, message_id));
-                    }
-                }
-                MessageData::Fragment(fragment) => {
-                    if let Some((tick, bytes)) = self.fragment_receiver.receive_fragment(
-                        fragment,
+        if self.received_message_ids.contains(&message_id) {
+            return Ok(());
+        }
+
+        match message.data {
+            MessageData::Single(single) => {
+                if self.received_message_ids.insert(message_id) {
+                    self.recv_message_buffer.push_back((
                         message.remote_sent_tick,
-                        None,
-                        message.compression,
-                    )? {
-                        // receive the message if we haven't received it already
-                        if !self.received_message_ids.contains(&message_id) {
-                            self.received_message_ids.insert(message_id);
-                            entry.insert((tick, bytes, message_id));
-                        }
-                    }
+                        single.bytes,
+                        message_id,
+                    ));
+                }
+            }
+            MessageData::Fragment(fragment) => {
+                if let Some((tick, bytes)) = self.fragment_receiver.receive_fragment(
+                    fragment,
+                    message.remote_sent_tick,
+                    None,
+                    message.compression,
+                )? && self.received_message_ids.insert(message_id)
+                {
+                    self.recv_message_buffer
+                        .push_back((tick, bytes, message_id));
                 }
             }
         }
@@ -101,7 +100,7 @@ impl ChannelReceive for UnorderedReliableReceiver {
 
     fn read_message(&mut self) -> Option<(Tick, Bytes, Option<MessageId>)> {
         // return if there are no messages in the buffer
-        let (message_id, data) = self.recv_message_buffer.pop_first()?;
+        let (tick, bytes, message_id) = self.recv_message_buffer.pop_front()?;
 
         // this was the message we were waiting for (as a reliable receiver)
         if self.pending_recv_message_id == message_id {
@@ -116,8 +115,6 @@ impl ChannelReceive for UnorderedReliableReceiver {
             }
         }
 
-        // receive oldest message in the buffer
-        let (tick, bytes, message_id) = data;
         Some((tick, bytes, Some(message_id)))
     }
 }
@@ -163,7 +160,12 @@ mod tests {
 
         // we process the message
         assert_eq!(receiver.recv_message_buffer.len(), 1);
-        assert!(receiver.recv_message_buffer.contains_key(&MessageId(1)));
+        assert!(
+            receiver
+                .recv_message_buffer
+                .iter()
+                .any(|(_, _, message_id)| *message_id == MessageId(1))
+        );
         assert_eq!(
             receiver.read_message(),
             Some((Tick(3), single2.bytes.clone(), Some(MessageId(1))))
@@ -182,12 +184,60 @@ mod tests {
 
         // we process the message
         assert_eq!(receiver.recv_message_buffer.len(), 1);
-        assert!(receiver.recv_message_buffer.contains_key(&MessageId(0)));
+        assert!(
+            receiver
+                .recv_message_buffer
+                .iter()
+                .any(|(_, _, message_id)| *message_id == MessageId(0))
+        );
         assert_eq!(
             receiver.read_message(),
             Some((Tick(5), single1.bytes.clone(), Some(MessageId(0))))
         );
         assert_eq!(receiver.pending_recv_message_id, MessageId(2));
+        Ok(())
+    }
+
+    #[test]
+    fn advances_and_deduplicates_across_message_id_rollover() -> Result<(), ChannelReceiveError> {
+        let mut receiver = UnorderedReliableReceiver::new();
+        receiver.pending_recv_message_id = MessageId(u32::MAX);
+
+        let after_wrap = SingleData::new(Some(MessageId(0)), Bytes::from("after wrap"));
+        receiver.buffer_recv(ReceiveMessage {
+            data: after_wrap.clone().into(),
+            remote_sent_tick: Tick(1),
+            compression: CompressionConfig::DISABLED,
+        })?;
+
+        let before_wrap = SingleData::new(Some(MessageId(u32::MAX)), Bytes::from("before wrap"));
+        receiver.buffer_recv(ReceiveMessage {
+            data: before_wrap.clone().into(),
+            remote_sent_tick: Tick(2),
+            compression: CompressionConfig::DISABLED,
+        })?;
+
+        assert_eq!(
+            receiver.read_message(),
+            Some((Tick(1), after_wrap.bytes, Some(MessageId(0))))
+        );
+        assert_eq!(
+            receiver.read_message(),
+            Some((Tick(2), before_wrap.bytes, Some(MessageId(u32::MAX))))
+        );
+        assert_eq!(receiver.pending_recv_message_id, MessageId(1));
+
+        receiver.buffer_recv(ReceiveMessage {
+            data: SingleData::new(Some(MessageId(u32::MAX)), Bytes::from("duplicate")).into(),
+            remote_sent_tick: Tick(3),
+            compression: CompressionConfig::DISABLED,
+        })?;
+        receiver.buffer_recv(ReceiveMessage {
+            data: SingleData::new(Some(MessageId(0)), Bytes::from("duplicate")).into(),
+            remote_sent_tick: Tick(4),
+            compression: CompressionConfig::DISABLED,
+        })?;
+        assert_eq!(receiver.read_message(), None);
         Ok(())
     }
 }

--- a/crates/transport/transport/src/channel/senders/reliable.rs
+++ b/crates/transport/transport/src/channel/senders/reliable.rs
@@ -1,5 +1,5 @@
-use alloc::collections::BTreeMap;
 use alloc::vec::Vec;
+use bevy_platform::collections::HashMap;
 use bevy_time::{Real, Time, Timer, TimerMode};
 
 use crate::channel::builder::ReliableSettings;
@@ -40,6 +40,8 @@ pub struct UnackedMessageWithPriority {
     pub unacked_message: UnackedMessage,
     pub base_priority: f32,
     pub accumulated_priority: f32,
+    /// Stable chronological tie-breaker independent of the wrapping message ID.
+    pub send_order: u64,
 }
 
 /// A sender that makes sure to resend messages until it receives an ack
@@ -47,11 +49,11 @@ pub struct UnackedMessageWithPriority {
 pub struct ReliableSender {
     /// Settings for reliability
     reliable_settings: ReliableSettings,
-    // TODO: maybe optimize by using a RingBuffer
-    /// Ordered map of the messages that haven't been acked yet
-    unacked_messages: BTreeMap<MessageId, UnackedMessageWithPriority>,
+    /// Pending messages keyed by exact wrapping ID. Chronology lives in `send_order`.
+    unacked_messages: HashMap<MessageId, UnackedMessageWithPriority>,
     /// Message id to use for the next message to be sent
     next_send_message_id: MessageId,
+    next_send_order: u64,
 
     /// Used to split a message into fragments if the message is too big
     fragment_sender: FragmentSender,
@@ -75,6 +77,7 @@ impl ReliableSender {
             reliable_settings,
             unacked_messages: Default::default(),
             next_send_message_id: MessageId(0),
+            next_send_order: 0,
             fragment_sender: FragmentSender::new(),
             current_rtt: Duration::default(),
             current_time: Duration::default(),
@@ -142,10 +145,15 @@ impl ChannelSend for ReliableSender {
             // store with 0.0 accumulated priority because priority gets accumulated when we collect the messages
             // for sending (even the first time the message is sent)
             accumulated_priority: 0.0,
+            send_order: self.next_send_order,
         };
         self.unacked_messages
             .insert(message_id, unacked_message_with_priority);
         self.next_send_message_id += 1;
+        self.next_send_order = self
+            .next_send_order
+            .checked_add(1)
+            .expect("reliable message send order exhausted");
         Some(message_id)
     }
 
@@ -176,7 +184,8 @@ impl ChannelSend for ReliableSender {
             }
         };
 
-        // Iterate through all unacked messages, oldest message ids first
+        // Hash-map iteration order is irrelevant: the priority manager uses each message's
+        // non-wrapping `send_order` as its stable chronological tie-breaker.
         for (message_id, unacked_message_with_priority) in self.unacked_messages.iter_mut() {
             // accumulate the priority for all messages (including the ones that were just added, since we set the accumulated priority to 0.0)
             unacked_message_with_priority.accumulated_priority +=
@@ -193,10 +202,11 @@ impl ChannelSend for ReliableSender {
                 UnackedMessage::Single { bytes, last_sent } => {
                     if should_send(last_sent) {
                         trace!(?last_sent, ?self.current_time, "Should send message {:?}", message_id);
-                        output.push(SendCandidate::new(
+                        output.push(SendCandidate::new_reliable(
                             channel_kind,
                             channel_id,
                             SendMessageKey::ReliableSingle(*message_id),
+                            unacked_message_with_priority.send_order,
                             SendMessage {
                                 data: SingleData::new(Some(*message_id), bytes.clone()).into(),
                                 priority: unacked_message_with_priority.accumulated_priority,
@@ -210,10 +220,11 @@ impl ChannelSend for ReliableSender {
                         .iter_mut()
                         .filter(|f| !f.acked && should_send(&f.last_sent))
                         .for_each(|f| {
-                            output.push(SendCandidate::new(
+                            output.push(SendCandidate::new_reliable(
                                 channel_kind,
                                 channel_id,
                                 SendMessageKey::ReliableFragment(*message_id, f.data.fragment_id),
+                                unacked_message_with_priority.send_order,
                                 SendMessage {
                                     data: f.data.clone().into(),
                                     priority: unacked_message_with_priority.accumulated_priority,
@@ -378,5 +389,43 @@ mod tests {
         candidates.clear();
         sender.collect_send_candidates(ChannelKind::of::<TestChannel>(), 0, &mut candidates);
         assert!(candidates.is_empty());
+    }
+
+    #[test]
+    fn pending_order_and_lookup_survive_message_id_rollover() {
+        let mut sender = ReliableSender::new(ReliableSettings::default(), Duration::default());
+        sender.next_send_message_id = MessageId(u32::MAX);
+
+        for bytes in [Bytes::from("before wrap"), Bytes::from("after wrap")] {
+            sender
+                .buffer_send(
+                    bytes,
+                    1.0,
+                    CompressionConfig::DISABLED,
+                    &mut CompressionScratch::default(),
+                )
+                .unwrap();
+        }
+
+        let mut candidates = Vec::new();
+        sender.collect_send_candidates(ChannelKind::of::<TestChannel>(), 0, &mut candidates);
+        candidates.sort_by_key(|candidate| candidate.send_order);
+        let order = candidates
+            .iter()
+            .map(|candidate| {
+                (
+                    candidate.message.data.message_id().unwrap(),
+                    candidate.send_order,
+                )
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(order, [(MessageId(u32::MAX), 0), (MessageId(0), 1)]);
+
+        sender.receive_ack(&MessageAck {
+            message_id: MessageId(u32::MAX),
+            fragment_id: None,
+        });
+        assert!(!sender.unacked_messages.contains_key(&MessageId(u32::MAX)));
+        assert!(sender.unacked_messages.contains_key(&MessageId(0)));
     }
 }

--- a/crates/transport/transport/src/packet/message.rs
+++ b/crates/transport/transport/src/packet/message.rs
@@ -28,7 +28,7 @@ pub(crate) struct FragmentIndex(pub(crate) u64);
 ///
 /// Queue indices remain valid because unreliable channels only compact their queues after packet
 /// staging and commit have completed. Reliable messages already have a stable [`MessageId`].
-#[derive(Hash, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Hash, Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum SendMessageKey {
     UnreliableSingle(usize),
     UnreliableFragment(usize),
@@ -37,13 +37,19 @@ pub(crate) enum SendMessageKey {
 }
 
 impl SendMessageKey {
-    /// Position of this message in its channel's current pending order.
-    pub(crate) fn send_order(self) -> u64 {
+    fn unreliable_send_order(self) -> Option<u64> {
         match self {
-            Self::UnreliableSingle(index) | Self::UnreliableFragment(index) => index as u64,
-            Self::ReliableSingle(message_id) | Self::ReliableFragment(message_id, _) => {
-                u64::from(message_id.0)
-            }
+            Self::UnreliableSingle(index) | Self::UnreliableFragment(index) => Some(index as u64),
+            Self::ReliableSingle(_) | Self::ReliableFragment(_, _) => None,
+        }
+    }
+
+    pub(crate) fn packing_tiebreaker(self) -> (u8, u64) {
+        match self {
+            Self::UnreliableSingle(_) => (0, 0),
+            Self::UnreliableFragment(_) => (1, 0),
+            Self::ReliableSingle(_) => (2, 0),
+            Self::ReliableFragment(_, fragment_id) => (3, fragment_id.0),
         }
     }
 }
@@ -59,6 +65,8 @@ pub(crate) struct SendCandidate {
     pub(crate) channel_kind: ChannelKind,
     pub(crate) channel_id: ChannelId,
     pub(crate) key: SendMessageKey,
+    /// Position in the channel's current pending order, independent of wrapping IDs.
+    pub(crate) send_order: u64,
     pub(crate) message: SendMessage,
     pub(crate) effective_priority: f32,
 }
@@ -70,10 +78,38 @@ impl SendCandidate {
         key: SendMessageKey,
         message: SendMessage,
     ) -> Self {
+        let send_order = key
+            .unreliable_send_order()
+            .expect("reliable candidates require an explicit non-wrapping send order");
+        Self::new_with_send_order(channel_kind, channel_id, key, send_order, message)
+    }
+
+    pub(crate) fn new_reliable(
+        channel_kind: ChannelKind,
+        channel_id: ChannelId,
+        key: SendMessageKey,
+        send_order: u64,
+        message: SendMessage,
+    ) -> Self {
+        debug_assert!(matches!(
+            key,
+            SendMessageKey::ReliableSingle(_) | SendMessageKey::ReliableFragment(_, _)
+        ));
+        Self::new_with_send_order(channel_kind, channel_id, key, send_order, message)
+    }
+
+    fn new_with_send_order(
+        channel_kind: ChannelKind,
+        channel_id: ChannelId,
+        key: SendMessageKey,
+        send_order: u64,
+        message: SendMessage,
+    ) -> Self {
         Self {
             channel_kind,
             channel_id,
             key,
+            send_order,
             effective_priority: message.priority,
             message,
         }
@@ -323,6 +359,22 @@ impl FragmentData {
 mod tests {
     use super::*;
     use alloc::vec;
+
+    #[test]
+    fn message_id_arithmetic_and_order_wrap_at_u32_max() {
+        let last = MessageId(u32::MAX);
+        let first = MessageId(0);
+        let mut next = last;
+
+        next += 1;
+
+        assert_eq!(next, first);
+        assert_eq!(last + MessageId(1), first);
+        assert_eq!(first - 1, last);
+        assert_eq!(first - last, 1);
+        assert!(last < first);
+        assert!(first < MessageId(1));
+    }
 
     #[test]
     fn test_to_bytes_single_data() {

--- a/crates/transport/transport/src/packet/priority_manager.rs
+++ b/crates/transport/transport/src/packet/priority_manager.rs
@@ -142,13 +142,11 @@ impl PriorityManager {
             (MessageData::Single(a_message), MessageData::Single(b_message)) => a_message
                 .bytes_len()
                 .cmp(&b_message.bytes_len())
-                .then_with(|| a.key.send_order().cmp(&b.key.send_order())),
-            (MessageData::Fragment(a_fragment), MessageData::Fragment(b_fragment)) => {
-                a_fragment.message_id.cmp(&b_fragment.message_id)
-            }
+                .then_with(|| a.send_order.cmp(&b.send_order)),
+            (MessageData::Fragment(_), MessageData::Fragment(_)) => a.send_order.cmp(&b.send_order),
         }
         .then_with(|| a.channel_id.cmp(&b.channel_id))
-        .then_with(|| a.key.cmp(&b.key))
+        .then_with(|| a.key.packing_tiebreaker().cmp(&b.key.packing_tiebreaker()))
     }
 }
 
@@ -404,7 +402,7 @@ mod tests {
     }
 
     #[test]
-    fn fragment_order_uses_existing_message_and_fragment_ids() {
+    fn fragment_order_uses_channel_queue_and_fragment_order() {
         let mut registry = ChannelRegistry::default();
         let (kind, channel) = registry.add_channel::<FragmentChannel>(ChannelSettings {
             mode: ChannelMode::UnorderedUnreliable,
@@ -444,6 +442,44 @@ mod tests {
             })
             .collect::<Vec<_>>();
         assert_eq!(order, [(0, 0), (0, 1), (1, 0), (1, 1)]);
+    }
+
+    #[test]
+    fn reliable_fragment_order_survives_message_id_rollover() {
+        let mut registry = ChannelRegistry::default();
+        let (kind, channel) = registry.add_channel::<FragmentChannel>(ChannelSettings {
+            mode: ChannelMode::SequencedReliable(Default::default()),
+            ..Default::default()
+        });
+        let mut manager = PriorityManager::default();
+        for (message_id, send_order) in [(MessageId(0), 1), (MessageId(u32::MAX), 0)] {
+            manager.candidates_mut().push(SendCandidate::new_reliable(
+                kind,
+                channel,
+                SendMessageKey::ReliableFragment(message_id, FragmentIndex(0)),
+                send_order,
+                SendMessage {
+                    priority: 1.0,
+                    data: FragmentData {
+                        message_id,
+                        fragment_id: FragmentIndex(0),
+                        num_fragments: FragmentIndex(1),
+                        compression: Some(FragmentCompression::None),
+                        bytes: Bytes::new(),
+                    }
+                    .into(),
+                },
+            ));
+        }
+
+        manager.prioritize(&registry);
+
+        let ids = manager
+            .candidates()
+            .iter()
+            .map(|candidate| candidate.message.data.message_id().unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(ids, [MessageId(u32::MAX), MessageId(0)]);
     }
 
     #[test]


### PR DESCRIPTION
PR #1610 was merged into its stacked `cb/non-wrapping-tick` base rather than into `main`. This PR reapplies that already-reviewed seven-file patch onto current `main` so the channel send/receive refactor can remain a separate stacked PR.\n\nThis contains only the changes from #1610; there are no additional behavioral changes.