### PR TITLE
fix: improve handling of connection state transitions

### DIFF
--- a/crates/connection/connection/src/identity.rs
+++ b/crates/connection/connection/src/identity.rs
@@ -1,6 +1,7 @@
 use crate::client::Client;
-use crate::host::HostClient;
-use bevy_ecs::query::{With, Without};
+use crate::host::{HostClient, HostServer};
+use crate::server::{Started, Starting};
+use bevy_ecs::query::{Or, With, Without};
 use bevy_ecs::system::Query;
 use lightyear_link::server::Server;
 
@@ -9,18 +10,23 @@ pub fn is_client(query: Query<(), (With<Client>, Without<HostClient>)>) -> bool 
     !query.is_empty()
 }
 
-/// Returns true if the peer is a server
-pub fn is_server(query: Query<(), With<Server>>) -> bool {
+/// Returns true if the peer is starting or running a server.
+pub fn is_server(query: Query<(), (With<Server>, Or<(With<Starting>, With<Started>)>)>) -> bool {
     !query.is_empty()
+}
+
+/// Returns true if the peer is starting or running a server without any client entities.
+pub fn is_headless_server(
+    server_query: Query<(), (With<Server>, Or<(With<Starting>, With<Started>)>)>,
+    client_query: Query<(), With<Client>>,
+) -> bool {
+    !server_query.is_empty() && client_query.is_empty()
 }
 
 /// Returns true if we are running in host-server mode, i.e. the server is acting as a client
 /// (in which case we can disable the networking/prediction/interpolation systems on the client)
 ///
-/// We are in HostServer mode if the mode is set to HostServer AND the server is running.
-/// (checking if the mode is set to HostServer is not enough, it just means that the server plugin
-/// and client plugin are running in the same App)
-pub fn is_host_server() -> bool {
-    todo!();
-    // identity.is_some_and(|i| i.get() == &NetworkIdentityState::HostServer)
+/// We are in host-server mode when a running server has been marked as a host server.
+pub fn is_host_server(query: Query<(), (With<Server>, With<Started>, With<HostServer>)>) -> bool {
+    !query.is_empty()
 }

--- a/crates/connection/connection/src/lib.rs
+++ b/crates/connection/connection/src/lib.rs
@@ -77,9 +77,8 @@ pub mod prelude {
     #[cfg(feature = "server")]
     pub mod server {
         pub use crate::client_of::ClientOf;
-        pub use crate::server::{
-            ConnectionError, Start, Started, Starting, Stop, Stopped, is_headless_server,
-        };
+        pub use crate::identity::{is_headless_server, is_host_server, is_server};
+        pub use crate::server::{ConnectionError, Start, Started, Starting, Stop, Stopped};
     }
 }
 

--- a/crates/connection/connection/src/server.rs
+++ b/crates/connection/connection/src/server.rs
@@ -1,4 +1,4 @@
-use crate::client::{Client, Disconnected, Disconnecting, PeerMetadata};
+use crate::client::{Disconnected, Disconnecting, PeerMetadata};
 use crate::client_of::ClientOf;
 use bevy_app::{App, Last, Plugin};
 use bevy_ecs::lifecycle::HookContext;
@@ -35,7 +35,10 @@ pub struct Stop {
 }
 
 #[derive(Component)]
-#[component(on_add = Starting::on_add)]
+#[component(
+    on_add = Starting::on_add,
+    on_despawn = clear_server_mapping_on_despawn
+)]
 pub struct Starting;
 
 impl Starting {
@@ -49,7 +52,10 @@ impl Starting {
 }
 
 #[derive(Component, Event, Reflect)]
-#[component(on_add = Started::on_add)]
+#[component(
+    on_add = Started::on_add,
+    on_despawn = clear_server_mapping_on_despawn
+)]
 pub struct Started;
 
 impl Started {
@@ -67,7 +73,10 @@ impl Started {
 }
 
 #[derive(Component, Event, Reflect)]
-#[component(on_add = Stopping::on_add)]
+#[component(
+    on_add = Stopping::on_add,
+    on_despawn = clear_server_mapping_on_despawn
+)]
 pub struct Stopping;
 
 impl Stopping {
@@ -81,15 +90,15 @@ impl Stopping {
 }
 
 #[derive(Component, Event, Reflect)]
-#[component(on_add = Stopped::on_add)]
+#[component(
+    on_add = Stopped::on_add,
+    on_despawn = clear_server_mapping_on_despawn
+)]
 pub struct Stopped;
 
 impl Stopped {
     fn on_add(mut world: DeferredWorld, context: HookContext) {
-        world
-            .resource_mut::<PeerMetadata>()
-            .mapping
-            .remove(&PeerId::Server);
+        clear_server_mapping(&mut world.resource_mut::<PeerMetadata>(), context.entity);
         trace!("Stopped added: removing Started/Starting");
         world
             .commands()
@@ -146,28 +155,94 @@ impl ConnectionPlugin {
     }
 }
 
-/// RunCondition to check if the app is a server.
-///
-/// Note that the app could also have a host-client
-pub fn is_server(server_query: Query<(), With<Server>>) -> bool {
-    server_query.single().is_ok()
+fn clear_server_mapping(metadata: &mut PeerMetadata, entity: Entity) {
+    if metadata.mapping.get(&PeerId::Server) == Some(&entity) {
+        metadata.mapping.remove(&PeerId::Server);
+    }
 }
 
-/// RunCondition to check if the app is a headless server:
-/// - there is an entity with the `Server` component
-/// - there are no entities with the `Client` component
-pub fn is_headless_server(
-    server_query: Query<(), With<Server>>,
-    query: Query<(), With<Client>>,
-) -> bool {
-    server_query.single().is_ok() && query.is_empty()
+fn clear_server_mapping_on_despawn(mut world: DeferredWorld, context: HookContext) {
+    clear_server_mapping(&mut world.resource_mut::<PeerMetadata>(), context.entity);
 }
+
+#[deprecated(note = "Use `crate::identity::is_server` instead")]
+pub use crate::identity::is_server;
+
+#[deprecated(note = "Use `crate::identity::is_headless_server` instead")]
+pub use crate::identity::is_headless_server;
 
 impl Plugin for ConnectionPlugin {
     fn build(&self, app: &mut App) {
         app.add_observer(Self::start);
         app.add_observer(Self::stop_if_link_fails);
         app.add_systems(Last, Self::disconnect);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Started, Stopped, Stopping};
+    use crate::client::PeerMetadata;
+    use bevy_app::App;
+    use lightyear_core::id::PeerId;
+    use lightyear_link::server::Server;
+
+    #[test]
+    fn server_mapping_is_cleared_when_stopped() {
+        let mut app = App::new();
+        app.init_resource::<PeerMetadata>();
+        let server = app.world_mut().spawn((Server::default(), Started)).id();
+
+        assert_eq!(
+            app.world()
+                .resource::<PeerMetadata>()
+                .mapping
+                .get(&PeerId::Server),
+            Some(&server)
+        );
+
+        app.world_mut().entity_mut(server).insert(Stopping);
+
+        assert_eq!(
+            app.world()
+                .resource::<PeerMetadata>()
+                .mapping
+                .get(&PeerId::Server),
+            Some(&server)
+        );
+
+        app.world_mut().entity_mut(server).insert(Stopped);
+
+        assert!(
+            !app.world()
+                .resource::<PeerMetadata>()
+                .mapping
+                .contains_key(&PeerId::Server)
+        );
+    }
+
+    #[test]
+    fn despawned_server_clears_peer_metadata() {
+        let mut app = App::new();
+        app.init_resource::<PeerMetadata>();
+        let server = app.world_mut().spawn((Server::default(), Started)).id();
+
+        assert_eq!(
+            app.world()
+                .resource::<PeerMetadata>()
+                .mapping
+                .get(&PeerId::Server),
+            Some(&server)
+        );
+
+        app.world_mut().despawn(server);
+
+        assert!(
+            !app.world()
+                .resource::<PeerMetadata>()
+                .mapping
+                .contains_key(&PeerId::Server)
+        );
     }
 }
 

--- a/crates/inputs/input_bei/src/plugin.rs
+++ b/crates/inputs/input_bei/src/plugin.rs
@@ -187,7 +187,7 @@ impl<
                 app.configure_sets(
                     FixedPreUpdate,
                     EnhancedInputSystems::Update
-                        .run_if(not(lightyear_connection::server::is_headless_server)),
+                        .run_if(not(lightyear_connection::identity::is_headless_server)),
                 );
             }
 

--- a/crates/replication/replication/src/server.rs
+++ b/crates/replication/replication/src/server.rs
@@ -8,9 +8,9 @@ use bevy_replicon::shared::backend::connected_client::NetworkId;
 use lightyear_connection::client::Connected;
 use lightyear_connection::client_of::ClientOf;
 use lightyear_connection::host::HostClient;
-use lightyear_connection::server::{Started, Stopped};
+use lightyear_connection::server::Started;
 use lightyear_core::id::RemoteId;
-use lightyear_link::prelude::{Link, Server};
+use lightyear_link::prelude::Link;
 use lightyear_transport::packet::fragment_size_for_min_mtu;
 use lightyear_transport::plugin::TransportSystems;
 use lightyear_transport::prelude::Transport;
@@ -22,7 +22,7 @@ use tracing::{error, trace};
 /// Adds the replicon server-side backend bridge for lightyear.
 ///
 /// Handles:
-/// - `ServerState` transitions (Running when server starts or client connects)
+/// - `ServerState` transitions when `Started` is added or removed
 /// - `ConnectedClient` insertion for replicon visibility
 /// - Sending `ServerMessages` (replication) and receiving `ClientMessages` (acks) via transport
 pub struct RepliconServerPlugin;
@@ -33,10 +33,8 @@ impl Plugin for RepliconServerPlugin {
         app.add_observer(on_client_connected);
 
         // State management
-        app.add_systems(
-            PreUpdate,
-            sync_server_state.before(ServerSystems::ReceivePackets),
-        );
+        app.add_observer(on_server_started);
+        app.add_observer(on_server_stopped);
 
         // Packet bridge: replicon <-> lightyear transport
         app.add_systems(
@@ -98,21 +96,20 @@ fn on_client_connected(
     }
 }
 
-/// Sync replicon's `ServerState` with lightyear lifecycle.
+/// Set replicon's `ServerState` to `Running` when the server starts.
+fn on_server_started(_trigger: On<Add, Started>, mut next_state: ResMut<NextState<ServerState>>) {
+    NextState::set_if_neq(&mut next_state, ServerState::Running);
+}
+
+/// Set replicon's `ServerState` to `Stopped` when the server stops or is despawned.
 ///
-/// Sets `Running` when `Started` is present (server app).
-fn sync_server_state(
-    started: Query<(), (With<Server>, With<Started>)>,
-    stopped: Query<(), (With<Server>, With<Stopped>)>,
-    state: Res<State<ServerState>>,
+/// Bevy emits `Remove` when an entity is despawned, so this also handles teardown that bypasses
+/// the `Stopped` marker entirely.
+fn on_server_stopped(
+    _trigger: On<Remove, Started>,
     mut next_state: ResMut<NextState<ServerState>>,
 ) {
-    if !started.is_empty() && *state.get() != ServerState::Running {
-        next_state.set(ServerState::Running);
-    }
-    if started.is_empty() && !stopped.is_empty() && *state.get() != ServerState::Stopped {
-        next_state.set(ServerState::Stopped);
-    }
+    NextState::set_if_neq(&mut next_state, ServerState::Stopped);
 }
 
 /// Receive packets from transports and populate `ServerMessages` (ack data from peers).
@@ -160,15 +157,15 @@ fn send_server_packets(
 
 #[cfg(test)]
 mod tests {
-    use super::{on_client_connected, sync_server_state};
-    use bevy_app::{App, Update};
+    use super::{on_client_connected, on_server_started, on_server_stopped};
+    use bevy_app::App;
     use bevy_replicon::prelude::ServerState;
     use bevy_replicon::shared::backend::connected_client::{ConnectedClient, NetworkIdMap};
     use bevy_state::app::{AppExtStates, StatesPlugin};
     use bevy_state::state::State;
     use lightyear_connection::client::{Connected, PeerMetadata};
     use lightyear_connection::client_of::ClientOf;
-    use lightyear_connection::server::Stopped;
+    use lightyear_connection::server::{Started, Stopped};
     use lightyear_core::id::{PeerId, RemoteId};
     use lightyear_link::prelude::{Link, LinkMtu, Server};
     use lightyear_transport::packet::fragment_size_for_min_mtu;
@@ -198,38 +195,71 @@ mod tests {
         );
     }
 
-    #[test]
-    fn non_server_stopped_marker_does_not_stop_local_sender() {
+    fn app_with_server_state(state: ServerState) -> App {
         let mut app = App::new();
         app.add_plugins(StatesPlugin)
             .init_resource::<PeerMetadata>()
             .init_state::<ServerState>()
-            .add_systems(Update, sync_server_state)
-            .insert_state(ServerState::Running);
+            .add_observer(on_server_started)
+            .add_observer(on_server_stopped)
+            .insert_state(state);
+        app
+    }
 
-        app.world_mut().spawn(Stopped);
+    #[test]
+    fn started_lifecycle_transitions_server_state() {
+        let mut app = app_with_server_state(ServerState::Stopped);
+        let server = app.world_mut().spawn((Server::default(), Started)).id();
 
-        app.update();
         app.update();
 
         assert_eq!(
             *app.world().resource::<State<ServerState>>().get(),
             ServerState::Running
         );
+
+        app.world_mut().entity_mut(server).insert(Stopped);
+
+        app.update();
+
+        assert_eq!(
+            *app.world().resource::<State<ServerState>>().get(),
+            ServerState::Stopped
+        );
     }
 
     #[test]
-    fn stopped_server_entity_transitions_state_to_stopped() {
-        let mut app = App::new();
-        app.add_plugins(StatesPlugin)
-            .init_resource::<PeerMetadata>()
-            .init_state::<ServerState>()
-            .add_systems(Update, sync_server_state)
-            .insert_state(ServerState::Running);
-
-        app.world_mut().spawn((Server::default(), Stopped));
+    fn despawned_started_entity_transitions_server_state_to_stopped() {
+        let mut app = app_with_server_state(ServerState::Stopped);
+        let server = app.world_mut().spawn((Server::default(), Started)).id();
 
         app.update();
+        assert_eq!(
+            *app.world().resource::<State<ServerState>>().get(),
+            ServerState::Running
+        );
+
+        app.world_mut().despawn(server);
+
+        app.update();
+
+        assert_eq!(
+            *app.world().resource::<State<ServerState>>().get(),
+            ServerState::Stopped
+        );
+    }
+
+    #[test]
+    fn started_and_despawned_in_same_flush_remains_stopped() {
+        let mut app = app_with_server_state(ServerState::Stopped);
+        let server = app.world_mut().spawn(Server::default()).id();
+        app.world_mut()
+            .commands()
+            .entity(server)
+            .insert(Started)
+            .despawn();
+        app.world_mut().flush();
+
         app.update();
 
         assert_eq!(


### PR DESCRIPTION
Fixes https://github.com/cBournhonesque/lightyear/issues/1614

- Server entity getting despawns changes the replicon ServerState
- PeerEntity map is updated on despawn
- clean up the identity run conditions