### PR TITLE
fix(avian): restore persistent physics state on rollback

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -244,6 +244,7 @@ bevy_replicon = { git = "https://github.com/simgine/bevy_replicon", branch = "ma
 # physics
 avian2d = { version = "0.7", default-features = false }
 avian3d = { version = "0.7", default-features = false }
+obvhs = { version = "0.3" }
 # Avian 0.7's 2D `serialize` feature derives Serde for an ArrayVec without enabling this feature.
 arrayvec = { version = "0.7", features = ["serde"] }
 bevy_transform_interpolation = { version = "0.5", default-features = false }

--- a/crates/core/lightyear/Cargo.toml
+++ b/crates/core/lightyear/Cargo.toml
@@ -153,6 +153,11 @@ input_bei = ["dep:lightyear_inputs", "dep:lightyear_inputs_bei"]
 avian2d = ["dep:lightyear_avian2d", "lightyear_replication?/avian2d"]
 ## Use avian3d
 avian3d = ["dep:lightyear_avian3d", "lightyear_replication?/avian3d"]
+## Enable Avian's XPBD joint solver and rollback its persistent motor warm-start state
+avian_xpbd_joints = [
+  "lightyear_avian2d?/xpbd_joints",
+  "lightyear_avian3d?/xpbd_joints",
+]
 
 # IO LAYERS
 ## Enables UDP as an IO layer

--- a/crates/integration/avian/src/lib.rs
+++ b/crates/integration/avian/src/lib.rs
@@ -39,6 +39,8 @@ pub use types_3d as types;
 
 #[cfg(any(feature = "2d", feature = "3d"))]
 pub mod plugin;
+#[cfg(any(feature = "2d", feature = "3d"))]
+mod rollback;
 
 /// Commonly used items for Lightyear Avian integration.
 pub mod prelude {

--- a/crates/integration/avian/src/plugin.rs
+++ b/crates/integration/avian/src/plugin.rs
@@ -79,39 +79,10 @@ registrations, for example to use
 `app.component::<C>().replicate().predict().with_rollback_condition(...)` or deterministic
 input-only replication.
 !*/
-use alloc::vec::Vec;
 #[cfg(all(feature = "2d", not(feature = "3d")))]
-use avian2d::{
-    collider_tree::{
-        ColliderTreeProxyFlags, ColliderTreeProxyKey, ColliderTreeType, ColliderTrees, MovedProxies,
-    },
-    collision::collider::{ColliderAabb, EnlargedAabb},
-    collision::contact_types::ContactEdgeFlags,
-    dynamics::solver::{
-        constraint_graph::ConstraintGraph,
-        islands::{BodyIslandNode, PhysicsIslands},
-        joint_graph::JointGraph,
-    },
-    math::*,
-    physics_transform::*,
-    prelude::*,
-};
+use avian2d::{math::*, physics_transform::*, prelude::*};
 #[cfg(all(feature = "3d", not(feature = "2d")))]
-use avian3d::{
-    collider_tree::{
-        ColliderTreeProxyFlags, ColliderTreeProxyKey, ColliderTreeType, ColliderTrees, MovedProxies,
-    },
-    collision::collider::{ColliderAabb, EnlargedAabb},
-    collision::contact_types::ContactEdgeFlags,
-    dynamics::solver::{
-        constraint_graph::ConstraintGraph,
-        islands::{BodyIslandNode, PhysicsIslands},
-        joint_graph::JointGraph,
-    },
-    math::*,
-    physics_transform::*,
-    prelude::*,
-};
+use avian3d::{math::*, physics_transform::*, prelude::*};
 use bevy_app::prelude::*;
 use bevy_ecs::prelude::*;
 use bevy_ecs::schedule::{IntoScheduleConfigs, ScheduleLabel};
@@ -124,15 +95,12 @@ use bevy_transform::{TransformSystems, components::Transform};
 use tracing::info;
 use tracing::trace;
 
-use lightyear_core::timeline::is_in_rollback;
 use lightyear_frame_interpolation::FrameInterpolationSystems;
 use lightyear_interpolation::prelude::{
     AppInterpolationExt, Interpolated, InterpolationFns, InterpolationRegistrationExt,
 };
 use lightyear_prediction::plugin::PredictionSystems;
-use lightyear_prediction::prelude::{
-    PredictionAppRegistrationExt, PredictionBuilderExt, PredictionManager, RollbackSystems,
-};
+use lightyear_prediction::prelude::{PredictionBuilderExt, RollbackSystems};
 use lightyear_replication::prelude::{
     AppComponentExt, ComponentRegistry, TransformLinearInterpolation,
 };
@@ -196,8 +164,26 @@ pub struct LightyearAvianPlugin {
     /// Add the Lightyear networking plugins or another component protocol before this plugin so
     /// the replication registry exists when these defaults are installed.
     pub register_physics_components: bool,
-    /// If True, the plugin will rollback resources that are not replicated, such as Collisions.
-    /// Enable this if you are using deterministic replication (i.e. are not replicating state).
+    /// Roll back Avian's persistent derived simulation state.
+    ///
+    /// This includes contact and constraint graphs (including cached impulses), the joint graph,
+    /// persistent collider-tree and moved-proxy state, collider AABBs and proxy keys, the
+    /// physics/substep clocks, joint-motor warm-start state when the integration's `xpbd_joints`
+    /// feature is enabled
+    /// (`avian_xpbd_joints` on the `lightyear` facade), and optional island/sleeping state.
+    /// `CollidingEntities` is rebuilt from the restored contact graph before replay.
+    ///
+    /// Enable this for deterministic or input-only replication. Persistent collider-tree data is
+    /// cloned into prediction history every tick, which can still be expensive for very large
+    /// scenes. Avian's collider-tree workspaces are scratch allocation caches and are excluded from
+    /// history. The integration uses a custom snapshot only for that exclusion; directly storing
+    /// `ColliderTrees` and `MovedProxies` would otherwise provide equivalent rollback state.
+    ///
+    /// This does not register authoritative body or application-owned state such as `RigidBody`,
+    /// `Position`, `Rotation`, velocities, forces, impulses, collider/joint configuration, or
+    /// gameplay side effects. Register or deterministically recreate every such value that can
+    /// change during predicted simulation. Collision events can be emitted again during replay, so
+    /// irreversible event consumers must also be rollback-aware.
     ///
     /// If Avian's `IslandPlugin` is enabled, island rollback state is registered automatically
     /// during `finish()`. If `IslandSleepingPlugin` is also enabled, sleeping state is rolled back too.
@@ -213,23 +199,6 @@ impl Default for LightyearAvianPlugin {
             rollback_resources: false,
         }
     }
-}
-
-#[derive(Resource, Clone, Debug, Default)]
-struct RollbackMovedProxies {
-    // Avian's `MovedProxies` resource is not `Clone`; keep a cloneable snapshot
-    // so rollback replay uses the same broad-phase update set as the first run.
-    proxies: Vec<ColliderTreeProxyKey>,
-}
-
-#[derive(Clone, Copy)]
-struct RollbackColliderProxy {
-    proxy_key: ColliderTreeProxyKey,
-    collider: Entity,
-    body: Option<Entity>,
-    aabb: ColliderAabb,
-    layers: CollisionLayers,
-    flags: ColliderTreeProxyFlags,
 }
 
 const DEFAULT_ROLLBACK_TOLERANCE: f32 = 0.01;
@@ -415,38 +384,14 @@ impl Plugin for LightyearAvianPlugin {
             .ok();
 
         if self.rollback_resources {
-            app.resource::<ContactGraph>().local_rollback();
-            app.resource::<ConstraintGraph>().local_rollback();
-            app.resource::<RollbackMovedProxies>().local_rollback();
-            app.resource::<PhysicsIslands>().local_rollback();
-            app.init_resource::<ContactGraph>();
-            app.init_resource::<ConstraintGraph>();
-            app.local_rollback::<CollidingEntities>();
-            // `ColliderTrees` cannot be cloned for rollback, but its leaf AABBs
-            // are derived from these cloneable collider components.
-            app.local_rollback::<ColliderAabb>();
-            app.local_rollback::<EnlargedAabb>();
-            app.init_resource::<RollbackMovedProxies>();
-            app.add_systems(
-                FixedPostUpdate,
-                Self::record_moved_proxies_for_rollback
-                    .after(PhysicsSystems::StepSimulation)
-                    .before(PredictionSystems::UpdateHistory),
-            );
-            app.add_systems(
-                PreUpdate,
-                Self::restore_collider_tree_from_enlarged_aabbs
-                    .after(RollbackSystems::Prepare)
-                    .before(RollbackSystems::Rollback)
-                    .run_if(is_in_rollback),
-            );
+            crate::rollback::register_rollback(app);
         }
     }
 
     fn finish(&self, app: &mut App) {
         if self.rollback_resources && app.is_plugin_added::<IslandPlugin>() {
             let rollback_sleeping = app.is_plugin_added::<IslandSleepingPlugin>();
-            Self::add_island_rollback(app, rollback_sleeping);
+            crate::rollback::register_island_rollback(app, rollback_sleeping);
         }
     }
 }
@@ -564,185 +509,6 @@ impl LightyearAvianPlugin {
             0,
             InterpolationFns::no_history(TransformLinearInterpolation::lerp),
         );
-    }
-
-    fn add_island_rollback(app: &mut App, rollback_sleeping: bool) {
-        app.local_rollback::<BodyIslandNode>();
-        if rollback_sleeping {
-            app.local_rollback::<Sleeping>();
-            app.local_rollback::<SleepTimer>();
-        }
-    }
-
-    fn record_moved_proxies_for_rollback(
-        moved_proxies: Res<MovedProxies>,
-        mut rollback_moved_proxies: ResMut<RollbackMovedProxies>,
-    ) {
-        rollback_moved_proxies.proxies.clear();
-        rollback_moved_proxies
-            .proxies
-            .extend_from_slice(moved_proxies.proxies());
-    }
-
-    fn restore_collider_tree_from_enlarged_aabbs(
-        prediction_manager: Single<&PredictionManager, With<lightyear_core::timeline::Rollback>>,
-        mut trees: ResMut<ColliderTrees>,
-        mut moved_proxies: ResMut<MovedProxies>,
-        rollback_moved_proxies: Res<RollbackMovedProxies>,
-        mut contact_graph: ResMut<ContactGraph>,
-        joint_graph: Option<Res<JointGraph>>,
-        colliders: Query<(&ColliderTreeProxyKey, &EnlargedAabb), Without<ColliderDisabled>>,
-    ) {
-        if prediction_manager.get_rollback_start_tick().is_none() {
-            return;
-        }
-        // The rollback just restored `EnlargedAabb`; rebuild Avian's tree
-        // leaves from that state before replaying physics. A stale tree can
-        // miss contacts even when Position/Velocity were rolled back correctly.
-        moved_proxies.clear();
-        for tree in trees.iter_trees_mut() {
-            tree.moved_proxies.clear();
-        }
-
-        for (proxy_key, enlarged_aabb) in &colliders {
-            if *proxy_key == ColliderTreeProxyKey::PLACEHOLDER {
-                continue;
-            }
-            let tree = trees.tree_for_type_mut(proxy_key.tree_type());
-            if tree.get_proxy(proxy_key.id()).is_none() {
-                continue;
-            }
-            tree.set_proxy_aabb(proxy_key.id(), enlarged_aabb.get().into());
-        }
-
-        for tree in trees.iter_trees_mut() {
-            tree.refit_all();
-        }
-
-        Self::repair_missing_contact_pairs_from_restored_aabbs(
-            &trees,
-            &colliders,
-            &mut contact_graph,
-            joint_graph.as_deref(),
-        );
-
-        // Preserve the original moved-proxy set instead of marking every proxy
-        // moved; extra pairs can perturb contact ordering and produce tiny
-        // floating point differences.
-        for proxy_key in rollback_moved_proxies.proxies.iter().copied() {
-            if proxy_key == ColliderTreeProxyKey::PLACEHOLDER {
-                continue;
-            }
-            let tree = trees.tree_for_type_mut(proxy_key.tree_type());
-            if tree.get_proxy(proxy_key.id()).is_some() && moved_proxies.insert(proxy_key) {
-                tree.moved_proxies.push(proxy_key.id());
-            }
-        }
-    }
-
-    fn repair_missing_contact_pairs_from_restored_aabbs(
-        trees: &ColliderTrees,
-        colliders: &Query<(&ColliderTreeProxyKey, &EnlargedAabb), Without<ColliderDisabled>>,
-        contact_graph: &mut ContactGraph,
-        joint_graph: Option<&JointGraph>,
-    ) {
-        // `ColliderTrees` is not cloneable, and a stale or incomplete tree can
-        // miss contacts during replay. Preserve restored graph state and only
-        // repair pairs that should exist according to the restored AABBs.
-
-        let mut proxies = Vec::new();
-        for (proxy_key, enlarged_aabb) in colliders {
-            if *proxy_key == ColliderTreeProxyKey::PLACEHOLDER {
-                continue;
-            }
-            let Some(proxy) = trees.get_proxy(*proxy_key) else {
-                continue;
-            };
-            proxies.push(RollbackColliderProxy {
-                proxy_key: *proxy_key,
-                collider: proxy.collider,
-                body: proxy.body,
-                aabb: enlarged_aabb.get(),
-                layers: proxy.layers,
-                flags: proxy.flags,
-            });
-        }
-
-        proxies.sort_by_key(|proxy| (proxy.proxy_key.tree_type() as u8, proxy.proxy_key.id().id()));
-
-        let mut pairs = Vec::new();
-        for (index, proxy1) in proxies.iter().enumerate() {
-            for proxy2 in &proxies[index + 1..] {
-                if !proxy1.aabb.intersects(&proxy2.aabb) {
-                    continue;
-                }
-                if !proxy1.layers.interacts_with(proxy2.layers) {
-                    continue;
-                }
-                if proxy1.body == proxy2.body {
-                    continue;
-                }
-                let flags_union = proxy1.flags.union(proxy2.flags);
-                if proxy1.proxy_key.tree_type() == ColliderTreeType::Static
-                    && proxy2.proxy_key.tree_type() == ColliderTreeType::Static
-                    && !flags_union.contains(ColliderTreeProxyFlags::SENSOR)
-                {
-                    continue;
-                }
-                if let (Some(joint_graph), Some(body1), Some(body2)) =
-                    (joint_graph, proxy1.body, proxy2.body)
-                    && joint_graph
-                        .joints_between(body1, body2)
-                        .any(|edge| edge.collision_disabled)
-                {
-                    continue;
-                }
-                pairs.push((*proxy1, *proxy2, flags_union));
-            }
-        }
-
-        let mut repaired_pairs = 0;
-        let mut skipped_custom_filter_pairs = 0;
-        for (proxy1, proxy2, flags_union) in pairs {
-            if contact_graph.contains(proxy1.collider, proxy2.collider) {
-                continue;
-            }
-            if flags_union.contains(ColliderTreeProxyFlags::CUSTOM_FILTER) {
-                skipped_custom_filter_pairs += 1;
-                continue;
-            }
-
-            let mut contact_edge = ContactEdge::new(proxy1.collider, proxy2.collider);
-            contact_edge.body1 = proxy1.body;
-            contact_edge.body2 = proxy2.body;
-            contact_edge.flags.set(
-                ContactEdgeFlags::CONTACT_EVENTS,
-                flags_union.contains(ColliderTreeProxyFlags::CONTACT_EVENTS),
-            );
-
-            contact_graph.add_edge_with(contact_edge, |contact_pair| {
-                contact_pair.body1 = proxy1.body;
-                contact_pair.body2 = proxy2.body;
-                contact_pair.flags.set(
-                    ContactPairFlags::MODIFY_CONTACTS,
-                    flags_union.contains(ColliderTreeProxyFlags::MODIFY_CONTACTS),
-                );
-                contact_pair.flags.set(
-                    ContactPairFlags::GENERATE_CONSTRAINTS,
-                    !flags_union.contains(ColliderTreeProxyFlags::BODY_DISABLED)
-                        && !flags_union.contains(ColliderTreeProxyFlags::SENSOR),
-                );
-            });
-            repaired_pairs += 1;
-        }
-
-        if repaired_pairs > 0 || skipped_custom_filter_pairs > 0 {
-            trace!(
-                repaired_pairs,
-                skipped_custom_filter_pairs,
-                "Repaired Avian ContactGraph from restored rollback AABBs"
-            );
-        }
     }
 
     fn propagate_transform(app: &mut App, schedule: impl ScheduleLabel) {
@@ -1409,7 +1175,6 @@ mod mode_tests {
 mod tests {
     use super::*;
 
-    use avian2d::collider_tree::ColliderTreeProxy;
     use bevy_ecs::system::RunSystemOnce;
     use bevy_time::{Fixed, Time};
     use core::time::Duration;
@@ -1618,243 +1383,6 @@ mod tests {
         assert_eq!(
             app.world().get::<Position>(entity),
             Some(&authored_position)
-        );
-    }
-
-    fn add_dynamic_proxy(app: &mut App, collider: Entity, body: Entity, aabb: ColliderAabb) {
-        add_dynamic_proxy_with(
-            app,
-            collider,
-            body,
-            aabb,
-            CollisionLayers::default(),
-            ColliderTreeProxyFlags::empty(),
-        );
-    }
-
-    fn add_dynamic_proxy_with(
-        app: &mut App,
-        collider: Entity,
-        body: Entity,
-        aabb: ColliderAabb,
-        layers: CollisionLayers,
-        flags: ColliderTreeProxyFlags,
-    ) {
-        let proxy_id = app
-            .world_mut()
-            .resource_mut::<ColliderTrees>()
-            .dynamic_tree
-            .add_proxy(
-                aabb.into(),
-                ColliderTreeProxy {
-                    collider,
-                    body: Some(body),
-                    layers,
-                    flags,
-                },
-            );
-        let proxy_key = ColliderTreeProxyKey::new(proxy_id, ColliderTreeType::Dynamic);
-        app.world_mut()
-            .entity_mut(collider)
-            .insert((proxy_key, EnlargedAabb::new(aabb)));
-    }
-
-    fn repair_contact_graph_system(
-        trees: Res<ColliderTrees>,
-        mut contact_graph: ResMut<ContactGraph>,
-        colliders: Query<(&ColliderTreeProxyKey, &EnlargedAabb), Without<ColliderDisabled>>,
-    ) {
-        LightyearAvianPlugin::repair_missing_contact_pairs_from_restored_aabbs(
-            &trees,
-            &colliders,
-            &mut contact_graph,
-            None,
-        );
-    }
-
-    #[test]
-    fn repairs_missing_contact_pair_from_restored_aabbs() {
-        let mut app = App::new();
-        app.init_resource::<ColliderTrees>();
-        app.init_resource::<ContactGraph>();
-
-        let body1 = app.world_mut().spawn_empty().id();
-        let body2 = app.world_mut().spawn_empty().id();
-        let collider1 = app.world_mut().spawn_empty().id();
-        let collider2 = app.world_mut().spawn_empty().id();
-
-        add_dynamic_proxy(
-            &mut app,
-            collider1,
-            body1,
-            ColliderAabb::new(Vector::ZERO, Vector::splat(1.0)),
-        );
-        add_dynamic_proxy(
-            &mut app,
-            collider2,
-            body2,
-            ColliderAabb::new(Vector::new(1.5, 0.0), Vector::splat(1.0)),
-        );
-
-        app.world_mut()
-            .run_system_once(repair_contact_graph_system)
-            .unwrap();
-
-        assert!(
-            app.world()
-                .resource::<ContactGraph>()
-                .contains(collider1, collider2)
-        );
-    }
-
-    fn overlapping_aabb(center: Vector) -> ColliderAabb {
-        ColliderAabb::new(center, Vector::splat(1.0))
-    }
-
-    fn repair_fixture() -> (App, Entity, Entity, Entity, Entity) {
-        let mut app = App::new();
-        app.init_resource::<ColliderTrees>();
-        app.init_resource::<ContactGraph>();
-        let body1 = app.world_mut().spawn_empty().id();
-        let body2 = app.world_mut().spawn_empty().id();
-        let collider1 = app.world_mut().spawn_empty().id();
-        let collider2 = app.world_mut().spawn_empty().id();
-        (app, body1, body2, collider1, collider2)
-    }
-
-    #[test]
-    fn repair_respects_collision_layers() {
-        let (mut app, body1, body2, collider1, collider2) = repair_fixture();
-        add_dynamic_proxy_with(
-            &mut app,
-            collider1,
-            body1,
-            overlapping_aabb(Vector::ZERO),
-            CollisionLayers::from_bits(0b0001, 0b0001),
-            ColliderTreeProxyFlags::empty(),
-        );
-        add_dynamic_proxy_with(
-            &mut app,
-            collider2,
-            body2,
-            overlapping_aabb(Vector::new(1.5, 0.0)),
-            CollisionLayers::from_bits(0b0010, 0b0010),
-            ColliderTreeProxyFlags::empty(),
-        );
-
-        app.world_mut()
-            .run_system_once(repair_contact_graph_system)
-            .unwrap();
-
-        assert!(
-            !app.world()
-                .resource::<ContactGraph>()
-                .contains(collider1, collider2)
-        );
-    }
-
-    #[test]
-    fn repair_restores_sensor_pair_without_constraints() {
-        let (mut app, body1, body2, collider1, collider2) = repair_fixture();
-        add_dynamic_proxy_with(
-            &mut app,
-            collider1,
-            body1,
-            overlapping_aabb(Vector::ZERO),
-            CollisionLayers::default(),
-            ColliderTreeProxyFlags::SENSOR,
-        );
-        add_dynamic_proxy(
-            &mut app,
-            collider2,
-            body2,
-            overlapping_aabb(Vector::new(1.5, 0.0)),
-        );
-
-        app.world_mut()
-            .run_system_once(repair_contact_graph_system)
-            .unwrap();
-
-        let graph = app.world().resource::<ContactGraph>();
-        let (_, pair) = graph
-            .get(collider1, collider2)
-            .expect("sensor pair not repaired");
-        assert!(!pair.generates_constraints());
-    }
-
-    #[test]
-    fn repair_skips_custom_filter_pairs() {
-        let (mut app, body1, body2, collider1, collider2) = repair_fixture();
-        add_dynamic_proxy_with(
-            &mut app,
-            collider1,
-            body1,
-            overlapping_aabb(Vector::ZERO),
-            CollisionLayers::default(),
-            ColliderTreeProxyFlags::CUSTOM_FILTER,
-        );
-        add_dynamic_proxy(
-            &mut app,
-            collider2,
-            body2,
-            overlapping_aabb(Vector::new(1.5, 0.0)),
-        );
-
-        app.world_mut()
-            .run_system_once(repair_contact_graph_system)
-            .unwrap();
-
-        assert!(
-            !app.world()
-                .resource::<ContactGraph>()
-                .contains(collider1, collider2)
-        );
-    }
-
-    #[test]
-    fn repair_skips_colliders_on_same_compound_body() {
-        let (mut app, body, _, collider1, collider2) = repair_fixture();
-        add_dynamic_proxy(&mut app, collider1, body, overlapping_aabb(Vector::ZERO));
-        add_dynamic_proxy(
-            &mut app,
-            collider2,
-            body,
-            overlapping_aabb(Vector::new(1.5, 0.0)),
-        );
-
-        app.world_mut()
-            .run_system_once(repair_contact_graph_system)
-            .unwrap();
-
-        assert!(
-            !app.world()
-                .resource::<ContactGraph>()
-                .contains(collider1, collider2)
-        );
-    }
-
-    #[test]
-    fn repair_excludes_disabled_colliders() {
-        let (mut app, body1, body2, collider1, collider2) = repair_fixture();
-        add_dynamic_proxy(&mut app, collider1, body1, overlapping_aabb(Vector::ZERO));
-        add_dynamic_proxy(
-            &mut app,
-            collider2,
-            body2,
-            overlapping_aabb(Vector::new(1.5, 0.0)),
-        );
-        app.world_mut()
-            .entity_mut(collider2)
-            .insert(ColliderDisabled);
-
-        app.world_mut()
-            .run_system_once(repair_contact_graph_system)
-            .unwrap();
-
-        assert!(
-            !app.world()
-                .resource::<ContactGraph>()
-                .contains(collider1, collider2)
         );
     }
 

--- a/crates/integration/avian/src/rollback.rs
+++ b/crates/integration/avian/src/rollback.rs
@@ -1,0 +1,585 @@
+//! Rollback registration for Avian's persistent simulation state.
+//!
+//! Most cloneable Avian resources can use Lightyear's ordinary component history directly. The
+//! broad phase could also be rolled back by registering both `ColliderTrees` and `MovedProxies`
+//! directly. The custom snapshot here is a storage and copying optimization, not an additional
+//! correctness mechanism: it saves the persistent tree data while leaving the reusable
+//! `ColliderTreeWorkspace` scratch buffers in the live world.
+
+use alloc::{sync::Arc, vec::Vec};
+#[cfg(all(feature = "2d", not(feature = "3d"), feature = "xpbd_joints"))]
+use avian2d::dynamics::solver::xpbd::joints::{PrismaticJointSolverData, RevoluteJointSolverData};
+#[cfg(all(feature = "2d", not(feature = "3d")))]
+use avian2d::{
+    collider_tree::{
+        ColliderTree, ColliderTreeProxy, ColliderTreeProxyKey, ColliderTrees, MovedProxies, ProxyId,
+    },
+    collision::collider::{ColliderAabb, EnlargedAabb},
+    data_structures::stable_vec::StableVec,
+    dynamics::solver::{
+        constraint_graph::ConstraintGraph,
+        islands::{BodyIslandNode, PhysicsIslands},
+        joint_graph::JointGraph,
+    },
+    prelude::*,
+};
+#[cfg(all(feature = "3d", not(feature = "2d"), feature = "xpbd_joints"))]
+use avian3d::dynamics::solver::xpbd::joints::{PrismaticJointSolverData, RevoluteJointSolverData};
+#[cfg(all(feature = "3d", not(feature = "2d")))]
+use avian3d::{
+    collider_tree::{
+        ColliderTree, ColliderTreeProxy, ColliderTreeProxyKey, ColliderTrees, MovedProxies, ProxyId,
+    },
+    collision::collider::{ColliderAabb, EnlargedAabb},
+    data_structures::stable_vec::StableVec,
+    dynamics::solver::{
+        constraint_graph::ConstraintGraph,
+        islands::{BodyIslandNode, PhysicsIslands},
+        joint_graph::JointGraph,
+    },
+    prelude::*,
+};
+use bevy_app::{App, FixedPostUpdate, PreUpdate};
+use bevy_ecs::prelude::*;
+use bevy_time::Time;
+use lightyear_core::timeline::is_in_rollback;
+use lightyear_prediction::plugin::PredictionSystems;
+use lightyear_prediction::prelude::{
+    PredictionAppRegistrationExt, PredictionBuilderExt, PredictionHistory, RollbackSystems,
+};
+use lightyear_replication::prelude::AppComponentExt;
+use obvhs::bvh2::Bvh2;
+
+/// The persistent portion of one Avian collider tree.
+///
+/// [`ColliderTree::workspace`] is deliberately absent. It contains allocation-reuse buffers for
+/// tree construction and insertion, not simulation state that influences the next result.
+#[derive(Clone, Default)]
+struct ColliderTreeSnapshot {
+    bvh: Bvh2,
+    proxies: StableVec<ColliderTreeProxy>,
+    moved_proxies: Vec<ProxyId>,
+}
+
+impl ColliderTreeSnapshot {
+    fn capture(tree: &ColliderTree) -> Self {
+        Self {
+            bvh: tree.bvh.clone(),
+            proxies: tree.proxies.clone(),
+            moved_proxies: tree.moved_proxies.clone(),
+        }
+    }
+
+    fn restore_into(&self, tree: &mut ColliderTree) {
+        tree.bvh.clone_from(&self.bvh);
+        tree.proxies.clone_from(&self.proxies);
+        tree.moved_proxies.clone_from(&self.moved_proxies);
+    }
+}
+
+/// The broad-phase value stored for one history tick.
+///
+/// This is called a snapshot only because it represents the broad phase at one tick; it is not a
+/// keyframe for a delta-compression scheme. The simpler alternative is to put `ColliderTrees` and
+/// `MovedProxies` directly in prediction history. That would be correct, but cloning
+/// `ColliderTrees` also clones allocation-reuse buffers from all four `ColliderTreeWorkspace`s.
+/// This type contains the same persistent state without those buffers. Keeping `MovedProxies` in
+/// the same value also makes it impossible for the tree state and next-tick moved queue to be
+/// restored independently.
+#[derive(Clone, Default)]
+struct ColliderBroadPhaseSnapshot {
+    dynamic_tree: ColliderTreeSnapshot,
+    kinematic_tree: ColliderTreeSnapshot,
+    static_tree: ColliderTreeSnapshot,
+    standalone_tree: ColliderTreeSnapshot,
+    moved_proxies: MovedProxies,
+}
+
+impl ColliderBroadPhaseSnapshot {
+    fn capture(trees: &ColliderTrees, moved_proxies: &MovedProxies) -> Self {
+        Self {
+            dynamic_tree: ColliderTreeSnapshot::capture(&trees.dynamic_tree),
+            kinematic_tree: ColliderTreeSnapshot::capture(&trees.kinematic_tree),
+            static_tree: ColliderTreeSnapshot::capture(&trees.static_tree),
+            standalone_tree: ColliderTreeSnapshot::capture(&trees.standalone_tree),
+            moved_proxies: moved_proxies.clone(),
+        }
+    }
+
+    fn restore_into(&self, trees: &mut ColliderTrees, moved_proxies: &mut MovedProxies) {
+        self.dynamic_tree.restore_into(&mut trees.dynamic_tree);
+        self.kinematic_tree.restore_into(&mut trees.kinematic_tree);
+        self.static_tree.restore_into(&mut trees.static_tree);
+        self.standalone_tree
+            .restore_into(&mut trees.standalone_tree);
+        moved_proxies.clone_from(&self.moved_proxies);
+    }
+}
+
+/// The rollback component recorded by Lightyear's generic prediction history.
+///
+/// The wrapper exists because Lightyear records ordinary cloneable components. Capturing a tick
+/// already performs the one required deep clone of the persistent broad-phase state. Without the
+/// `Arc`, copying this component into `PredictionHistory` would immediately perform a second deep
+/// clone. The `Arc` makes that generic history operation a reference-count increment instead. It
+/// does not turn the history into deltas: every tick still owns one complete persistent snapshot.
+#[derive(Resource, Clone, Default)]
+struct RollbackColliderBroadPhase(Arc<ColliderBroadPhaseSnapshot>);
+
+/// Enrolls collider-local state that cannot be reconstructed from the broad-phase snapshot.
+///
+/// This is independent of the scratch-space optimization above. In particular, `ColliderAabb` is
+/// not recoverable from the enlarged BVH leaf bounds, and child or sensor colliders do not
+/// necessarily carry a normal prediction marker. The bundle lets their ordinary changed-only
+/// histories cover those entities without cloning every collider into another aggregate snapshot.
+#[derive(Bundle, Default)]
+struct ColliderRollbackHistories {
+    proxy_key: PredictionHistory<ColliderTreeProxyKey>,
+    aabb: PredictionHistory<ColliderAabb>,
+    enlarged_aabb: PredictionHistory<EnlargedAabb>,
+}
+
+/// Registers Avian state that persists from one physics tick to the next.
+///
+/// Registering `ColliderTrees` and `MovedProxies` directly would be correct. The custom aggregate
+/// snapshot is used solely to avoid retaining and copying `ColliderTreeWorkspace` allocation
+/// caches for every history tick, and the `Arc` avoids an extra deep clone when the generic history
+/// system records that snapshot. Avian can repopulate moved proxies at the end of a step for the
+/// *next* broad-phase pass, so those queues are persistent state even though Avian clears them
+/// earlier in the same step.
+pub(super) fn register_rollback(app: &mut App) {
+    app.init_resource::<ContactGraph>();
+    app.init_resource::<ConstraintGraph>();
+    app.init_resource::<JointGraph>();
+    app.init_resource::<ColliderTrees>();
+    app.init_resource::<MovedProxies>();
+    app.init_resource::<RollbackColliderBroadPhase>();
+    app.init_resource::<Time<Physics>>();
+    app.init_resource::<Time<Substeps>>();
+
+    app.resource::<ContactGraph>().local_rollback();
+    app.resource::<ConstraintGraph>().local_rollback();
+    app.resource::<JointGraph>().local_rollback();
+    app.resource::<RollbackColliderBroadPhase>()
+        .local_rollback();
+    app.resource::<Time<Physics>>().local_rollback();
+    app.resource::<Time<Substeps>>().local_rollback();
+
+    // These components live on rollback-participating entities rather than resource entities.
+    // Collider AABBs are persistent broad-phase state. The proxy key must agree with the restored
+    // tree, and motor solver data contains the previous tick's warm-start impulse.
+    app.local_rollback::<ColliderAabb>();
+    app.local_rollback::<EnlargedAabb>();
+    app.local_rollback::<ColliderTreeProxyKey>();
+    #[cfg(feature = "xpbd_joints")]
+    {
+        app.local_rollback::<RevoluteJointSolverData>();
+        app.local_rollback::<PrismaticJointSolverData>();
+    }
+
+    app.add_observer(add_collider_rollback_histories);
+    backfill_existing_collider_rollback_histories(app.world_mut());
+    app.add_systems(
+        FixedPostUpdate,
+        record_collider_broad_phase_for_rollback
+            .after(PhysicsSystems::StepSimulation)
+            .before(PredictionSystems::UpdateHistory),
+    );
+    app.add_systems(
+        PreUpdate,
+        (
+            restore_collider_broad_phase,
+            restore_colliding_entities_from_contact_graph,
+        )
+            .after(RollbackSystems::Prepare)
+            .before(RollbackSystems::Rollback)
+            .run_if(is_in_rollback),
+    );
+}
+
+/// Captures the exact broad-phase inputs needed by the next physics tick.
+///
+/// The snapshot combines all four trees with Avian's separate `MovedProxies` resource so a
+/// rollback cannot restore one without the other. It clones only persistent BVH/proxy data; the
+/// live `ColliderTreeWorkspace` buffers are scratch allocation caches and are intentionally not
+/// copied. This runs after Avian's step and before Lightyear records prediction history.
+fn record_collider_broad_phase_for_rollback(
+    trees: Res<ColliderTrees>,
+    moved_proxies: Res<MovedProxies>,
+    mut rollback_state: ResMut<RollbackColliderBroadPhase>,
+) {
+    rollback_state.0 = Arc::new(ColliderBroadPhaseSnapshot::capture(&trees, &moved_proxies));
+}
+
+/// Restores persistent collider-tree state while preserving live scratch allocations.
+///
+/// Lightyear first rolls `RollbackColliderBroadPhase` back to the requested tick. This system then
+/// clones the saved BVHs, proxy slots, and moved-proxy queues into Avian's live resources. It does
+/// not replace `ColliderTrees`, so every tree keeps its current `ColliderTreeWorkspace` capacity
+/// for replay instead of storing and reallocating that scratch memory for every history entry.
+fn restore_collider_broad_phase(
+    rollback_state: Res<RollbackColliderBroadPhase>,
+    mut trees: ResMut<ColliderTrees>,
+    mut moved_proxies: ResMut<MovedProxies>,
+) {
+    rollback_state
+        .0
+        .restore_into(&mut trees, &mut moved_proxies);
+}
+
+/// Registers persistent island state after Avian has finished installing its optional plugins.
+pub(super) fn register_island_rollback(app: &mut App, rollback_sleeping: bool) {
+    app.init_resource::<PhysicsIslands>();
+    app.resource::<PhysicsIslands>().local_rollback();
+    app.local_rollback::<BodyIslandNode>();
+    if rollback_sleeping {
+        app.local_rollback::<Sleeping>();
+        app.local_rollback::<SleepTimer>();
+    }
+}
+
+/// Adds component histories to every collider, including unmarked children and sensors.
+///
+/// These three components must agree with the restored `ColliderTrees` snapshot. Attaching their
+/// normal Lightyear histories once, when Avian finishes creating the collider state, avoids
+/// building and cloning a separate aggregate snapshot of compound colliders every tick. The normal
+/// history systems record only changed components, and `insert_if_new` preserves histories already
+/// installed through an ordinary prediction marker.
+fn add_collider_rollback_histories(
+    trigger: On<Add, (ColliderTreeProxyKey, ColliderAabb, EnlargedAabb)>,
+    colliders: Query<
+        (),
+        (
+            With<ColliderTreeProxyKey>,
+            With<ColliderAabb>,
+            With<EnlargedAabb>,
+        ),
+    >,
+    mut commands: Commands,
+) {
+    if colliders.get(trigger.entity).is_ok() {
+        commands
+            .entity(trigger.entity)
+            .insert_if_new(ColliderRollbackHistories::default());
+    }
+}
+
+/// Adds rollback histories for colliders that existed before rollback registration.
+///
+/// Plugin registration normally happens before gameplay entities are spawned, but supporting an
+/// already-populated `World` makes the enrollment rule complete and mirrors resource backfilling.
+fn backfill_existing_collider_rollback_histories(world: &mut World) {
+    let entities: Vec<Entity> = {
+        let mut colliders = world.query_filtered::<Entity, (
+            With<ColliderTreeProxyKey>,
+            With<ColliderAabb>,
+            With<EnlargedAabb>,
+        )>();
+        colliders.iter(world).collect()
+    };
+    for entity in entities {
+        world
+            .entity_mut(entity)
+            .insert_if_new(ColliderRollbackHistories::default());
+    }
+}
+
+/// Rebuilds `CollidingEntities` from the restored contact graph before physics replay starts.
+///
+/// `CollidingEntities` is a derived cache, and applications commonly place it on collider children
+/// that do not have their own rollback marker. Restoring it as an ordinary component would leave
+/// those children with future-tick entries. Clearing every cache and repopulating touching pairs
+/// from the exact `ContactGraph` snapshot is linear in the number of caches and contacts and avoids
+/// duplicate rollback history for the same information. This system runs once when a rollback is
+/// prepared, not on every replayed physics tick.
+fn restore_colliding_entities_from_contact_graph(
+    contact_graph: Res<ContactGraph>,
+    mut colliding_entities: Query<
+        &mut CollidingEntities,
+        Or<(
+            With<bevy_ecs::entity_disabling::Disabled>,
+            Without<bevy_ecs::entity_disabling::Disabled>,
+        )>,
+    >,
+) {
+    for mut entities in &mut colliding_entities {
+        entities.clear();
+    }
+
+    for pair in contact_graph
+        .iter_active_touching()
+        .chain(contact_graph.iter_sleeping_touching())
+    {
+        if let Ok(mut entities) = colliding_entities.get_mut(pair.collider1) {
+            entities.insert(pair.collider2);
+        }
+        if let Ok(mut entities) = colliding_entities.get_mut(pair.collider2) {
+            entities.insert(pair.collider1);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[cfg(all(feature = "2d", not(feature = "3d")))]
+    use avian2d::collider_tree::ColliderTreeType;
+    #[cfg(all(feature = "3d", not(feature = "2d")))]
+    use avian3d::collider_tree::ColliderTreeType;
+    use bevy_ecs::system::RunSystemOnce;
+    use lightyear_prediction::prelude::{Predicted, PredictionRegistry};
+
+    fn assert_resource_history<R: Resource + Clone>(app: &App) {
+        let component_id = app.world().component_id::<R>().unwrap();
+        let resource_entity = app.world().resource_entities().get(component_id).unwrap();
+        assert!(
+            app.world()
+                .get::<PredictionHistory<R>>(resource_entity)
+                .is_some(),
+            "missing PredictionHistory<{}> on resource entity",
+            core::any::type_name::<R>()
+        );
+    }
+
+    fn assert_collider_histories(app: &App, entity: Entity) {
+        assert!(
+            app.world()
+                .get::<PredictionHistory<ColliderTreeProxyKey>>(entity)
+                .is_some()
+        );
+        assert!(
+            app.world()
+                .get::<PredictionHistory<ColliderAabb>>(entity)
+                .is_some()
+        );
+        assert!(
+            app.world()
+                .get::<PredictionHistory<EnlargedAabb>>(entity)
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn rollback_resources_have_live_histories() {
+        let mut app = App::new();
+        app.init_resource::<PredictionRegistry>();
+        register_rollback(&mut app);
+
+        assert_resource_history::<ContactGraph>(&app);
+        assert_resource_history::<ConstraintGraph>(&app);
+        assert_resource_history::<JointGraph>(&app);
+        assert_resource_history::<RollbackColliderBroadPhase>(&app);
+        assert_resource_history::<Time<Physics>>(&app);
+        assert_resource_history::<Time<Substeps>>(&app);
+
+        let component_id = app.world().component_id::<ColliderTrees>().unwrap();
+        let resource_entity = app.world().resource_entities().get(component_id).unwrap();
+        assert!(
+            app.world()
+                .get::<PredictionHistory<ColliderTrees>>(resource_entity)
+                .is_none(),
+            "ColliderTrees history would also retain ColliderTreeWorkspace scratch buffers"
+        );
+    }
+
+    #[test]
+    fn broad_phase_snapshot_restores_state_but_preserves_live_workspace() {
+        let mut app = App::new();
+        app.init_resource::<ColliderTrees>();
+        app.init_resource::<MovedProxies>();
+        app.init_resource::<RollbackColliderBroadPhase>();
+
+        let collider = app.world_mut().spawn_empty().id();
+        let proxy_id = {
+            let mut trees = app.world_mut().resource_mut::<ColliderTrees>();
+            let tree = &mut trees.dynamic_tree;
+            tree.workspace.insertion_stack.reserve(4_096);
+            tree.bvh.primitive_indices.push(17);
+            let proxy_id = ProxyId::new(tree.proxies.push(ColliderTreeProxy {
+                collider,
+                body: None,
+                layers: CollisionLayers::default(),
+                flags: Default::default(),
+            }) as u32);
+            tree.moved_proxies.push(proxy_id);
+            proxy_id
+        };
+        let proxy_key = ColliderTreeProxyKey::new(proxy_id, ColliderTreeType::Dynamic);
+        app.world_mut()
+            .resource_mut::<MovedProxies>()
+            .insert(proxy_key);
+
+        app.world_mut()
+            .run_system_once(record_collider_broad_phase_for_rollback)
+            .unwrap();
+
+        {
+            let mut trees = app.world_mut().resource_mut::<ColliderTrees>();
+            let tree = &mut trees.dynamic_tree;
+            tree.bvh.primitive_indices.clear();
+            tree.proxies.clear();
+            tree.moved_proxies.clear();
+            tree.workspace.insertion_stack.reserve(8_192);
+        }
+        app.world_mut().resource_mut::<MovedProxies>().clear();
+
+        app.world_mut()
+            .run_system_once(restore_collider_broad_phase)
+            .unwrap();
+
+        let trees = app.world().resource::<ColliderTrees>();
+        let tree = &trees.dynamic_tree;
+        assert_eq!(tree.bvh.primitive_indices, [17]);
+        assert_eq!(
+            tree.proxies.get(proxy_id.index()).unwrap().collider,
+            collider
+        );
+        assert_eq!(tree.moved_proxies, [proxy_id]);
+        assert_eq!(tree.workspace.insertion_stack.cap(), 8_192);
+        assert!(app.world().resource::<MovedProxies>().contains(proxy_key));
+    }
+
+    #[test]
+    fn rollback_registration_backfills_existing_unmarked_colliders() {
+        let mut app = App::new();
+        let child = app
+            .world_mut()
+            .spawn((
+                ColliderTreeProxyKey::PLACEHOLDER,
+                ColliderAabb::default(),
+                EnlargedAabb::default(),
+            ))
+            .id();
+        app.init_resource::<PredictionRegistry>();
+
+        register_rollback(&mut app);
+
+        assert_collider_histories(&app, child);
+    }
+
+    #[test]
+    fn newly_created_unmarked_colliders_receive_histories() {
+        let mut app = App::new();
+        app.init_resource::<PredictionRegistry>();
+        register_rollback(&mut app);
+
+        let child = app
+            .world_mut()
+            .spawn((
+                ColliderTreeProxyKey::PLACEHOLDER,
+                ColliderAabb::default(),
+                EnlargedAabb::default(),
+            ))
+            .id();
+        app.world_mut().flush();
+
+        assert_collider_histories(&app, child);
+    }
+
+    #[test]
+    fn rebuilds_colliding_entities_from_the_contact_graph() {
+        let mut app = App::new();
+        app.init_resource::<ContactGraph>();
+
+        let collider1 = app.world_mut().spawn(CollidingEntities::default()).id();
+        let collider2 = app.world_mut().spawn(CollidingEntities::default()).id();
+        let stale = app.world_mut().spawn_empty().id();
+        app.world_mut()
+            .entity_mut(collider1)
+            .get_mut::<CollidingEntities>()
+            .unwrap()
+            .insert(stale);
+        app.world_mut()
+            .resource_mut::<ContactGraph>()
+            .add_edge_with(ContactEdge::new(collider1, collider2), |pair| {
+                pair.flags.insert(ContactPairFlags::TOUCHING);
+            });
+
+        app.world_mut()
+            .run_system_once(restore_colliding_entities_from_contact_graph)
+            .unwrap();
+
+        let collisions1 = app.world().get::<CollidingEntities>(collider1).unwrap();
+        let collisions2 = app.world().get::<CollidingEntities>(collider2).unwrap();
+        assert!(collisions1.contains(&collider2));
+        assert!(!collisions1.contains(&stale));
+        assert!(collisions2.contains(&collider1));
+    }
+
+    #[test]
+    fn rollback_components_have_live_histories_on_predicted_entities() {
+        let mut app = App::new();
+        app.init_resource::<PredictionRegistry>();
+        register_rollback(&mut app);
+
+        let collider = app
+            .world_mut()
+            .spawn((
+                Predicted,
+                ColliderAabb::default(),
+                EnlargedAabb::default(),
+                ColliderTreeProxyKey::PLACEHOLDER,
+            ))
+            .id();
+        #[cfg(feature = "xpbd_joints")]
+        let joint = app
+            .world_mut()
+            .spawn((
+                Predicted,
+                RevoluteJointSolverData::default(),
+                PrismaticJointSolverData::default(),
+            ))
+            .id();
+        app.world_mut().flush();
+
+        assert_collider_histories(&app, collider);
+        #[cfg(feature = "xpbd_joints")]
+        {
+            assert!(
+                app.world()
+                    .get::<PredictionHistory<RevoluteJointSolverData>>(joint)
+                    .is_some()
+            );
+            assert!(
+                app.world()
+                    .get::<PredictionHistory<PrismaticJointSolverData>>(joint)
+                    .is_some()
+            );
+        }
+    }
+
+    #[test]
+    fn island_resources_and_components_have_live_histories() {
+        let mut app = App::new();
+        app.init_resource::<PredictionRegistry>();
+        register_island_rollback(&mut app, true);
+
+        let body = app
+            .world_mut()
+            .spawn((
+                Predicted,
+                BodyIslandNode::default(),
+                Sleeping,
+                SleepTimer::default(),
+            ))
+            .id();
+        app.world_mut().flush();
+
+        assert_resource_history::<PhysicsIslands>(&app);
+        assert!(
+            app.world()
+                .get::<PredictionHistory<BodyIslandNode>>(body)
+                .is_some()
+        );
+        assert!(
+            app.world()
+                .get::<PredictionHistory<Sleeping>>(body)
+                .is_some()
+        );
+        assert!(
+            app.world()
+                .get::<PredictionHistory<SleepTimer>>(body)
+                .is_some()
+        );
+    }
+}

--- a/crates/integration/avian2d/Cargo.toml
+++ b/crates/integration/avian2d/Cargo.toml
@@ -22,6 +22,7 @@ bench = false
 default = ["std", "2d", "avian2d/parry-f32"]
 f32 = ["avian2d/f32"]
 2d = ["avian2d/2d", "avian2d/serialize"]
+xpbd_joints = ["avian2d/xpbd_joints"]
 std = ["lightyear_prediction/std"]
 deterministic = ["dep:seahash"]
 lag_compensation = []
@@ -35,6 +36,7 @@ lightyear_frame_interpolation.workspace = true
 lightyear_replication = { workspace = true, features = ["avian2d"] }
 
 avian2d.workspace = true
+obvhs.workspace = true
 arrayvec.workspace = true
 bevy_transform_interpolation.workspace = true
 tracing.workspace = true

--- a/crates/integration/avian3d/Cargo.toml
+++ b/crates/integration/avian3d/Cargo.toml
@@ -22,6 +22,7 @@ bench = false
 default = ["std", "3d", "avian3d/parry-f32"]
 f32 = ["avian3d/f32"]
 3d = ["avian3d/3d", "avian3d/serialize"]
+xpbd_joints = ["avian3d/xpbd_joints"]
 std = ["lightyear_prediction/std"]
 deterministic = ["dep:seahash"]
 lag_compensation = []
@@ -35,6 +36,7 @@ lightyear_frame_interpolation.workspace = true
 lightyear_replication = { workspace = true, features = ["avian3d"] }
 
 avian3d.workspace = true
+obvhs.workspace = true
 bevy_transform_interpolation.workspace = true
 # bevy
 bevy_app.workspace = true

--- a/crates/replication/prediction/src/predicted_history.rs
+++ b/crates/replication/prediction/src/predicted_history.rs
@@ -8,6 +8,7 @@ use crate::rollback::{CatchUpGated, DeterministicPredicted};
 use crate::{Predicted, SyncComponent};
 use bevy_ecs::component::Mutable;
 use bevy_ecs::prelude::*;
+use bevy_ecs::resource::IsResource;
 use bevy_reflect::Reflect;
 use bevy_replicon::shared::replication::diff::{DiffBuffer, Diffable as RepliconDiffable};
 use bevy_replicon::shared::replication::storage::ReplicationStorage;
@@ -214,9 +215,13 @@ pub(crate) fn apply_component_removal_predicted<C: Component>(
     }
 }
 
-/// When any of `C`, [`Predicted`], [`PreSpawned`], [`DeterministicPredicted`],
-/// or [`CatchUpGated`] is added to an entity, ensure [`PredictionHistory<C>`]
-/// is present, and if `C` has just been applied via an init message on a
+/// When `C` or one of [`Predicted`], [`PreSpawned`], [`DeterministicPredicted`], or
+/// [`CatchUpGated`] is added to an entity, ensure [`PredictionHistory<C>`] is present for predicted
+/// entities and resource entities. [`IsResource`] is an eligibility check rather than a trigger:
+/// `Add<C>` already fires when a resource is inserted, and triggering on every `IsResource`
+/// addition would wake this observer for unrelated resource types.
+///
+/// If `C` has just been applied via an init message on a
 /// marker that receives confirmed state, seed [`ConfirmedHistory<C>`] at the
 /// server tick that produced the init.
 ///
@@ -251,15 +256,18 @@ pub(crate) fn add_prediction_history<C: Component + Clone>(
         Has<PreSpawned>,
         Has<DeterministicPredicted>,
         Has<CatchUpGated>,
+        Has<IsResource>,
     )>,
     mut commands: Commands,
 ) {
-    let Ok((has_component, predicted, prespawned, deterministic, catchup_gated)) =
+    let Ok((has_component, predicted, prespawned, deterministic, catchup_gated, is_resource)) =
         query.get(trigger.entity)
     else {
         return;
     };
-    if !catchup_gated && !(has_component && (predicted || prespawned || deterministic)) {
+    if !catchup_gated
+        && !(has_component && (predicted || prespawned || deterministic || is_resource))
+    {
         return;
     }
     let should_seed_confirmed_history = has_component && (catchup_gated || predicted || prespawned);

--- a/crates/replication/prediction/src/registry.rs
+++ b/crates/replication/prediction/src/registry.rs
@@ -1158,6 +1158,29 @@ fn add_local_rollback_systems<C: Component<Mutability = Mutable> + Clone>(
         .is_some()
     {
         add_non_networked_rollback_systems::<C>(registration.app);
+
+        // Resources live on dedicated entities in Bevy. If the resource was inserted before
+        // rollback was registered, its `Add<C>` observer has already run, so backfill the history
+        // that marks the resource entity as a rollback participant.
+        let resource_entity =
+            registration
+                .app
+                .world()
+                .component_id::<C>()
+                .and_then(|component_id| {
+                    registration
+                        .app
+                        .world()
+                        .resource_entities()
+                        .get(component_id)
+                });
+        if let Some(resource_entity) = resource_entity {
+            registration
+                .app
+                .world_mut()
+                .entity_mut(resource_entity)
+                .insert_if_new(PredictionHistory::<C>::default());
+        }
     }
     registration
 }
@@ -1421,6 +1444,7 @@ mod tests {
     use super::*;
     use crate::plugin::PredictionPlugin;
     use alloc::vec::Vec;
+    use bevy_ecs::system::RunSystemOnce;
     use bevy_replicon::prelude::{
         AuthMethod, RepliconPlugins, RepliconSharedPlugin, RepliconTick, RuleFns,
     };
@@ -1446,7 +1470,7 @@ mod tests {
     #[derive(Component, Clone, Debug)]
     struct LocalRollbackOnlyComponent(u32);
 
-    #[derive(Resource, Clone, Debug)]
+    #[derive(Resource, Clone, Debug, PartialEq)]
     struct LocalRollbackOnlyResource(u32);
 
     fn prediction_app() -> App {
@@ -1639,10 +1663,17 @@ mod tests {
     }
 
     #[test]
-    fn resource_builder_local_rollback_supports_non_sync_resource() {
+    fn resource_builder_local_rollback_backfills_existing_resource_history() {
         let mut app = prediction_app();
+        app.insert_resource(LocalTimeline::default());
+        app.insert_resource(LocalRollbackOnlyResource(42));
 
         app.resource::<LocalRollbackOnlyResource>().local_rollback();
+        app.world_mut()
+            .run_system_once(
+                crate::predicted_history::update_prediction_history::<LocalRollbackOnlyResource>,
+            )
+            .unwrap();
 
         assert!(
             app.world()
@@ -1658,6 +1689,55 @@ mod tests {
             !app.world()
                 .resource::<PredictionRegistry>()
                 .predicted::<LocalRollbackOnlyResource>()
+        );
+
+        let resource_entity = app
+            .world()
+            .resource_entities()
+            .get(
+                app.world()
+                    .component_id::<LocalRollbackOnlyResource>()
+                    .unwrap(),
+            )
+            .unwrap();
+        assert_eq!(
+            app.world()
+                .get::<PredictionHistory<LocalRollbackOnlyResource>>(resource_entity)
+                .unwrap()
+                .get_state(Tick(0)),
+            Some(&HistoryState::Updated(LocalRollbackOnlyResource(42)))
+        );
+    }
+
+    #[test]
+    fn resource_builder_local_rollback_adds_history_to_late_resource() {
+        let mut app = prediction_app();
+        app.insert_resource(LocalTimeline::default());
+
+        app.resource::<LocalRollbackOnlyResource>().local_rollback();
+        app.insert_resource(LocalRollbackOnlyResource(42));
+        app.world_mut().flush();
+        app.world_mut()
+            .run_system_once(
+                crate::predicted_history::update_prediction_history::<LocalRollbackOnlyResource>,
+            )
+            .unwrap();
+
+        let resource_entity = app
+            .world()
+            .resource_entities()
+            .get(
+                app.world()
+                    .component_id::<LocalRollbackOnlyResource>()
+                    .unwrap(),
+            )
+            .unwrap();
+        assert_eq!(
+            app.world()
+                .get::<PredictionHistory<LocalRollbackOnlyResource>>(resource_entity)
+                .unwrap()
+                .get_state(Tick(0)),
+            Some(&HistoryState::Updated(LocalRollbackOnlyResource(42)))
         );
     }
 


### PR DESCRIPTION
## Summary

- move Avian rollback registration and repair logic into a dedicated rollback module
- snapshot persistent collider-tree and moved-proxy state while excluding collider-tree workspace scratch buffers
- restore contact, constraint, joint, island, sleeping, clock, collider, and XPBD motor warm-start state
- enroll nested and unmarked colliders in changed-only rollback histories and rebuild CollidingEntities from the restored contact graph
- support local rollback registration for resources created either before or after registration

## Broad-phase snapshot trade-off

Registering ColliderTrees and MovedProxies directly would also be correct. The custom snapshot exists to avoid retaining and copying the four ColliderTreeWorkspace allocation caches in every history entry. Its Arc wrapper avoids a second deep clone when generic prediction history records the captured persistent state; each tick still stores one complete persistent snapshot.

## Validation

- cargo test -p lightyear_avian2d --all-features
- cargo test -p lightyear_avian3d --all-features
- cargo clippy -p lightyear_avian2d --all-features --all-targets -- -D warnings
- cargo clippy -p lightyear_avian3d --all-features --all-targets -- -D warnings
- cargo test -p lightyear_prediction --all-features resource_builder_local_rollback --no-fail-fast
- cargo test -p lightyear_tests --all-features --lib test_input_only_two_clients -- --test-threads=1
- cargo test -p lightyear_tests --all-features --lib test_input_only_islands_many_colliders_small_box -- --test-threads=1