### PR TITLE
fix(deps): disable bevy_replicon's default world_serialization feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -239,7 +239,10 @@ leafwing-input-manager = { version = "0.21", default-features = false, features 
 ] }
 
 # replication
-bevy_replicon = { git = "https://github.com/simgine/bevy_replicon", branch = "master" }
+bevy_replicon = { git = "https://github.com/simgine/bevy_replicon", branch = "master", default-features = false, features = [
+  "client",
+  "server",
+] }
 
 # physics
 avian2d = { version = "0.7", default-features = false }


### PR DESCRIPTION
## Problem

`bevy_replicon` is pulled in with its default features enabled:

```toml
bevy_replicon = { git = "https://github.com/simgine/bevy_replicon", branch = "master" }
```

Its default feature set is ["client", "server", "world_serialization"]. The
world_serialization feature enables bevy/bevy_world_serialization, which
transitively drags in bevy_camera, bevy_window, bevy_image, and bevy_mesh
into every crate that depends on bevy_replicon — including headless/server-only
builds that have no rendering surface at all.

For a dedicated-server binary built with bevy's default features disabled,
this defeats the purpose: bevy_replicon's defaults reintroduce a chain of
graphics-adjacent crates that the server never needs.

## Fix
Scope the dependency down to the features lightyear actually uses:

```toml
bevy_replicon = { git = "https://github.com/simgine/bevy_replicon", branch = "master", default-features = false, features = [
  "client",
  "server",
] }
```

Verified there is no usage of world_serialization, bevy_replicon::scene, or
client_diagnostics anywhere in this workspace (grep -rn across crates/,
examples/, demos/, benches/ — zero hits).
