### PR TITLE
fix(raw): tolerate clients despawned during server stop

### DIFF
--- a/crates/connection/raw_connection/src/server.rs
+++ b/crates/connection/raw_connection/src/server.rs
@@ -85,9 +85,9 @@ impl RawConnectionPlugin {
                             lightyear_connection::server::ConnectionError::InvalidConnectionType,
                         );
                     };
-                    // insert Disconnecting, so that the `Disconnected` component is added on the LinkOf
-                    // before the entity gets despawned
-                    commands.entity(entity).insert(Disconnecting);
+                    // The transport may already have queued a despawn for this link.
+                    // Otherwise, insert Disconnecting so Disconnected is added before despawn.
+                    commands.entity(entity).try_insert(Disconnecting);
                     Ok(())
                 },
             )?;
@@ -115,5 +115,43 @@ impl Plugin for RawConnectionPlugin {
         app.add_observer(Self::on_server_linked);
         app.add_observer(Self::on_link_of_linked);
         app.add_observer(Self::on_stop);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Despawns clients while raw-server stop commands are still deferred.
+    fn despawn_client_on_stop(
+        _trigger: On<Stop>,
+        clients: Query<Entity, With<ClientOf>>,
+        mut commands: Commands,
+    ) {
+        for client in &clients {
+            commands.entity(client).despawn();
+        }
+    }
+
+    #[test]
+    fn stopping_raw_server_tolerates_already_despawned_client() {
+        let mut app = App::new();
+        app.add_observer(despawn_client_on_stop);
+        app.add_plugins(RawConnectionPlugin);
+
+        let server = app.world_mut().spawn(RawServer).id();
+        let client = app
+            .world_mut()
+            .spawn((
+                LinkOf { server },
+                ClientOf,
+                RemoteId(PeerId::Raw("127.0.0.1:5000".parse().unwrap())),
+            ))
+            .id();
+
+        app.world_mut().trigger(Stop { entity: server });
+        app.world_mut().flush();
+
+        assert!(app.world().get_entity(client).is_err());
     }
 }


### PR DESCRIPTION
## Summary

- silence the deferred `Disconnecting` insertion when a raw client link was already despawned
- add a regression test covering a transport despawn queued before raw-server stop commands are applied

## Why

A transport disconnect can queue a client-link despawn in the same observer cycle as `RawConnectionPlugin::on_stop`. With Bevy 0.19, the later deferred `insert(Disconnecting)` panics when applied to that already-despawned entity. The link is already fully disconnected in this case, so treating the insertion as best-effort makes shutdown idempotent.