### PR TITLE
feat(connection): add cached network topology

### DIFF
--- a/crates/connection/connection/src/app_mode.rs
+++ b/crates/connection/connection/src/app_mode.rs
@@ -1,0 +1,497 @@
+use crate::ConnectionSystems;
+use crate::client::{Client, Connected, Disconnected};
+use crate::host::HostClient;
+use crate::p2p::P2P;
+use crate::server::{Started, Stopped};
+use bevy_app::{App, Plugin, PostUpdate, PreUpdate};
+use bevy_ecs::prelude::*;
+use lightyear_link::LinkSystems;
+use lightyear_link::prelude::{LinkOf, Server};
+use smallvec::SmallVec;
+
+/// The ready networking role of this Bevy application.
+///
+/// This is a derived cache maintained by [`crate::ConnectionPlugin`]. Entities are only included
+/// after their relevant lifecycle has completed: clients and P2P links must be [`Connected`],
+/// and servers must be [`Started`].
+#[derive(Resource, Default, Debug, Clone, PartialEq, Eq)]
+pub enum AppMode {
+    /// No standard Lightyear networking role is currently ready.
+    #[default]
+    Custom,
+    /// A connected client and its server link.
+    Client(Entity),
+    /// A started server.
+    Server(Entity),
+    /// A connected in-process client and its started server.
+    HostClient {
+        /// The started server entity.
+        server: Entity,
+        /// The connected host-client link entity.
+        client: Entity,
+    },
+    /// The connected direct peer links in this P2P session.
+    ///
+    /// This can be empty while the session is waiting for its first peer to connect.
+    P2P(SmallVec<[Entity; 4]>),
+    /// The ready entities do not form one supported application role.
+    Invalid(AppModeError),
+}
+
+/// Why ready networking entities could not be classified into a supported [`AppMode`].
+#[derive(thiserror::Error, Debug, Clone, PartialEq, Eq)]
+pub enum AppModeError {
+    /// More than one conventional client link is connected.
+    #[error("multiple conventional client links are connected: {0:?}")]
+    MultipleConnectedClients(SmallVec<[Entity; 4]>),
+    /// More than one server is started.
+    #[error("multiple servers are started: {0:?}")]
+    MultipleStartedServers(SmallVec<[Entity; 4]>),
+    /// A connected host-client does not have a `Client` marker.
+    #[error("connected host-client {client:?} does not have a Client marker")]
+    HostClientWithoutClient {
+        /// The malformed host-client entity.
+        client: Entity,
+    },
+    /// A connected host-client does not identify its in-process server.
+    #[error("connected host-client {client:?} does not have a LinkOf relationship")]
+    HostClientMissingLinkOf {
+        /// The malformed host-client entity.
+        client: Entity,
+    },
+    /// The server referenced by a connected host-client is not started.
+    #[error(
+        "connected host-client {client:?} references server {server:?}, but that server is not started"
+    )]
+    HostClientServerNotStarted {
+        /// The connected host-client entity.
+        client: Entity,
+        /// The referenced server entity.
+        server: Entity,
+    },
+    /// A conventional client and server are both ready but do not form a host-client pair.
+    #[error(
+        "connected client {client:?} and started server {server:?} do not form a host-client pair"
+    )]
+    MixedClientServer {
+        /// The connected client entity.
+        client: Entity,
+        /// The started server entity.
+        server: Entity,
+    },
+}
+
+/// System set that refreshes the cached [`AppMode`].
+#[derive(SystemSet, Debug, Hash, PartialEq, Eq, Clone, Copy)]
+pub enum AppModeSystems {
+    /// Infer the application mode after networking lifecycle changes.
+    Update,
+}
+
+/// Marks the cached [`AppMode`] as needing to be recomputed.
+#[derive(Resource, Default)]
+struct AppModeDirty;
+
+#[derive(Clone, Copy, Debug)]
+struct ReadyClient {
+    entity: Entity,
+    is_p2p: bool,
+    is_host: bool,
+    server: Option<Entity>,
+}
+
+type ModeComponents = (
+    Client,
+    Server,
+    HostClient,
+    LinkOf,
+    P2P,
+    Connected,
+    Disconnected,
+    Started,
+    Stopped,
+);
+
+pub(crate) struct AppModePlugin;
+
+impl Plugin for AppModePlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<AppMode>();
+        // Start dirty so that entities spawned before this plugin are classified on the first
+        // update too.
+        app.init_resource::<AppModeDirty>();
+
+        app.add_observer(mark_dirty_on_insert);
+        app.add_observer(mark_dirty_on_remove);
+        app.add_observer(mark_dirty_on_discard);
+
+        app.configure_sets(
+            PreUpdate,
+            AppModeSystems::Update
+                .after(LinkSystems::Receive)
+                .after(ConnectionSystems::Receive),
+        );
+        app.add_systems(
+            PreUpdate,
+            refresh_app_mode
+                .in_set(AppModeSystems::Update)
+                .run_if(app_mode_is_dirty),
+        );
+
+        app.configure_sets(
+            PostUpdate,
+            AppModeSystems::Update.before(ConnectionSystems::Send),
+        );
+        app.add_systems(
+            PostUpdate,
+            refresh_app_mode
+                .in_set(AppModeSystems::Update)
+                .run_if(app_mode_is_dirty),
+        );
+    }
+}
+
+fn mark_dirty_on_insert(_trigger: On<Insert, ModeComponents>, mut commands: Commands) {
+    commands.init_resource::<AppModeDirty>();
+}
+
+fn mark_dirty_on_remove(_trigger: On<Remove, ModeComponents>, mut commands: Commands) {
+    commands.init_resource::<AppModeDirty>();
+}
+
+fn mark_dirty_on_discard(_trigger: On<Discard, ModeComponents>, mut commands: Commands) {
+    commands.init_resource::<AppModeDirty>();
+}
+
+fn app_mode_is_dirty(dirty: Option<Res<AppModeDirty>>) -> bool {
+    dirty.is_some()
+}
+
+fn refresh_app_mode(
+    mut app_mode: ResMut<AppMode>,
+    p2p_markers: Query<(), With<P2P>>,
+    ready_clients: Query<
+        (Entity, Has<P2P>, Has<HostClient>, Option<&LinkOf>),
+        (With<Client>, With<Connected>),
+    >,
+    ready_servers: Query<Entity, (With<Server>, With<Started>)>,
+    malformed_hosts: Query<Entity, (With<HostClient>, With<Connected>, Without<Client>)>,
+    mut commands: Commands,
+) {
+    let clients = ready_clients
+        .iter()
+        .map(|(entity, is_p2p, is_host, link_of)| ReadyClient {
+            entity,
+            is_p2p,
+            is_host,
+            server: link_of.map(|link| link.server),
+        })
+        .collect();
+    let servers = ready_servers.iter().collect();
+    let malformed_hosts = malformed_hosts.iter().collect();
+
+    let next = infer_app_mode(!p2p_markers.is_empty(), clients, servers, malformed_hosts);
+    if *app_mode != next {
+        if let AppMode::Invalid(error) = &next {
+            tracing::error!(%error, "invalid Lightyear application mode");
+        }
+        *app_mode = next;
+    }
+    commands.remove_resource::<AppModeDirty>();
+}
+
+fn infer_app_mode(
+    has_p2p_markers: bool,
+    mut clients: SmallVec<[ReadyClient; 4]>,
+    mut servers: SmallVec<[Entity; 4]>,
+    mut malformed_hosts: SmallVec<[Entity; 1]>,
+) -> AppMode {
+    clients.sort_unstable_by_key(|client| client.entity.index_u32());
+    servers.sort_unstable_by_key(|entity| entity.index_u32());
+    malformed_hosts.sort_unstable_by_key(|entity| entity.index_u32());
+
+    if has_p2p_markers {
+        return AppMode::P2P(
+            clients
+                .iter()
+                .filter(|client| client.is_p2p)
+                .map(|client| client.entity)
+                .collect(),
+        );
+    }
+
+    if let Some(&client) = malformed_hosts.first() {
+        return AppMode::Invalid(AppModeError::HostClientWithoutClient { client });
+    }
+
+    let conventional_clients: SmallVec<[ReadyClient; 4]> = clients
+        .into_iter()
+        .filter(|client| !client.is_p2p)
+        .collect();
+
+    if conventional_clients.len() > 1 {
+        return AppMode::Invalid(AppModeError::MultipleConnectedClients(
+            conventional_clients
+                .iter()
+                .map(|client| client.entity)
+                .collect(),
+        ));
+    }
+    if servers.len() > 1 {
+        return AppMode::Invalid(AppModeError::MultipleStartedServers(servers));
+    }
+
+    match (conventional_clients.first(), servers.first().copied()) {
+        (None, None) => AppMode::Custom,
+        (None, Some(server)) => AppMode::Server(server),
+        (Some(client), None) if client.is_host => match client.server {
+            Some(server) => AppMode::Invalid(AppModeError::HostClientServerNotStarted {
+                client: client.entity,
+                server,
+            }),
+            None => AppMode::Invalid(AppModeError::HostClientMissingLinkOf {
+                client: client.entity,
+            }),
+        },
+        (Some(client), None) => AppMode::Client(client.entity),
+        (Some(client), Some(server)) if client.is_host => match client.server {
+            Some(linked_server) if linked_server == server => AppMode::HostClient {
+                server,
+                client: client.entity,
+            },
+            Some(linked_server) => AppMode::Invalid(AppModeError::HostClientServerNotStarted {
+                client: client.entity,
+                server: linked_server,
+            }),
+            None => AppMode::Invalid(AppModeError::HostClientMissingLinkOf {
+                client: client.entity,
+            }),
+        },
+        (Some(client), Some(server)) => AppMode::Invalid(AppModeError::MixedClientServer {
+            client: client.entity,
+            server,
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::client::PeerMetadata;
+    use alloc::vec::Vec;
+    use bevy_ecs::change_detection::DetectChanges;
+    use lightyear_core::id::{PeerId, RemoteId};
+
+    fn test_app() -> App {
+        let mut app = App::new();
+        // Connected and Started maintain this existing shared connection resource in their hooks.
+        app.init_resource::<PeerMetadata>();
+        app.add_plugins(crate::ConnectionPlugin);
+        app.update();
+        app
+    }
+
+    fn connect_client(app: &mut App, peer: u64) -> Entity {
+        app.world_mut()
+            .spawn((Client, RemoteId(PeerId::Local(peer)), Connected))
+            .id()
+    }
+
+    fn start_server(app: &mut App) -> Entity {
+        app.world_mut().spawn((Server::default(), Started)).id()
+    }
+
+    #[test]
+    fn only_ready_client_and_server_entities_are_cached() {
+        let mut app = test_app();
+        let client = app.world_mut().spawn(Client).id();
+        app.update();
+        assert_eq!(*app.world().resource::<AppMode>(), AppMode::Custom);
+
+        app.world_mut()
+            .entity_mut(client)
+            .insert((RemoteId(PeerId::Local(1)), Connected));
+        app.update();
+        assert_eq!(*app.world().resource::<AppMode>(), AppMode::Client(client));
+
+        app.world_mut().entity_mut(client).insert(Disconnected {
+            reason: Some("test".into()),
+        });
+        app.update();
+        assert_eq!(*app.world().resource::<AppMode>(), AppMode::Custom);
+
+        let server = app.world_mut().spawn(Server::default()).id();
+        app.update();
+        assert_eq!(*app.world().resource::<AppMode>(), AppMode::Custom);
+
+        app.world_mut().entity_mut(server).insert(Started);
+        app.update();
+        assert_eq!(*app.world().resource::<AppMode>(), AppMode::Server(server));
+
+        app.world_mut().entity_mut(server).insert(Stopped);
+        app.update();
+        assert_eq!(*app.world().resource::<AppMode>(), AppMode::Custom);
+    }
+
+    #[test]
+    fn host_client_requires_a_connected_client_and_its_started_server() {
+        let mut app = test_app();
+        let server = app.world_mut().spawn(Server::default()).id();
+        let client = app
+            .world_mut()
+            .spawn((
+                Client,
+                RemoteId(PeerId::Local(0)),
+                Connected,
+                LinkOf { server },
+                HostClient { buffer: Vec::new() },
+            ))
+            .id();
+
+        app.update();
+        assert_eq!(
+            *app.world().resource::<AppMode>(),
+            AppMode::Invalid(AppModeError::HostClientServerNotStarted { client, server })
+        );
+
+        app.world_mut().entity_mut(server).insert(Started);
+        app.update();
+        assert_eq!(
+            *app.world().resource::<AppMode>(),
+            AppMode::HostClient { server, client }
+        );
+    }
+
+    #[test]
+    fn p2p_mode_exists_before_any_peer_is_connected_and_sorts_ready_links() {
+        let mut app = test_app();
+        let first = app.world_mut().spawn(P2P).id();
+        let second = app.world_mut().spawn(P2P).id();
+
+        app.update();
+        assert_eq!(
+            *app.world().resource::<AppMode>(),
+            AppMode::P2P(SmallVec::new())
+        );
+
+        // Connect in reverse order to prove that insertion order does not affect the cache.
+        app.world_mut()
+            .entity_mut(second)
+            .insert((RemoteId(PeerId::Local(2)), Connected));
+        app.world_mut()
+            .entity_mut(first)
+            .insert((RemoteId(PeerId::Local(1)), Connected));
+        app.update();
+
+        assert_eq!(
+            *app.world().resource::<AppMode>(),
+            AppMode::P2P(SmallVec::from_slice(&[first, second]))
+        );
+
+        app.world_mut().entity_mut(first).insert(Disconnected {
+            reason: Some("test".into()),
+        });
+        app.update();
+        assert_eq!(
+            *app.world().resource::<AppMode>(),
+            AppMode::P2P(SmallVec::from_slice(&[second]))
+        );
+
+        app.world_mut().despawn(second);
+        app.update();
+        assert_eq!(
+            *app.world().resource::<AppMode>(),
+            AppMode::P2P(SmallVec::new())
+        );
+
+        app.world_mut().entity_mut(first).remove::<P2P>();
+        app.update();
+        assert_eq!(*app.world().resource::<AppMode>(), AppMode::Custom);
+    }
+
+    #[test]
+    fn p2p_markers_take_priority_over_conventional_roles() {
+        let mut app = test_app();
+        let peer = app
+            .world_mut()
+            .spawn((P2P, RemoteId(PeerId::Local(1)), Connected))
+            .id();
+        connect_client(&mut app, 2);
+        start_server(&mut app);
+
+        app.update();
+        assert_eq!(
+            *app.world().resource::<AppMode>(),
+            AppMode::P2P(SmallVec::from_slice(&[peer]))
+        );
+    }
+
+    #[test]
+    fn unsupported_ready_role_combinations_are_invalid() {
+        let mut app = test_app();
+        let first = connect_client(&mut app, 1);
+        let second = connect_client(&mut app, 2);
+        app.update();
+        assert_eq!(
+            *app.world().resource::<AppMode>(),
+            AppMode::Invalid(AppModeError::MultipleConnectedClients(
+                SmallVec::from_slice(&[first, second])
+            ))
+        );
+
+        app.world_mut().despawn(second);
+        let server = start_server(&mut app);
+        app.update();
+        assert_eq!(
+            *app.world().resource::<AppMode>(),
+            AppMode::Invalid(AppModeError::MixedClientServer {
+                client: first,
+                server,
+            })
+        );
+
+        let other_server = start_server(&mut app);
+        app.world_mut().despawn(first);
+        app.update();
+        assert_eq!(
+            *app.world().resource::<AppMode>(),
+            AppMode::Invalid(AppModeError::MultipleStartedServers(SmallVec::from_slice(
+                &[server, other_server]
+            )))
+        );
+    }
+
+    #[test]
+    fn connected_host_without_link_relationship_is_invalid() {
+        let mut app = test_app();
+        let client = app
+            .world_mut()
+            .spawn((
+                Client,
+                RemoteId(PeerId::Local(0)),
+                Connected,
+                HostClient { buffer: Vec::new() },
+            ))
+            .id();
+
+        app.update();
+        assert_eq!(
+            *app.world().resource::<AppMode>(),
+            AppMode::Invalid(AppModeError::HostClientMissingLinkOf { client })
+        );
+    }
+
+    #[test]
+    fn unchanged_recomputation_does_not_mark_app_mode_changed() {
+        let mut app = test_app();
+        let last_changed = app.world().resource_ref::<AppMode>().last_changed();
+
+        app.world_mut().insert_resource(AppModeDirty);
+        app.update();
+
+        assert_eq!(
+            app.world().resource_ref::<AppMode>().last_changed(),
+            last_changed
+        );
+    }
+}

--- a/crates/connection/connection/src/app_mode.rs
+++ b/crates/connection/connection/src/app_mode.rs
@@ -11,14 +11,13 @@ use smallvec::SmallVec;
 
 /// The ready networking role of this Bevy application.
 ///
-/// This is a derived cache maintained by [`crate::ConnectionPlugin`]. Entities are only included
-/// after their relevant lifecycle has completed: clients and P2P links must be [`Connected`],
-/// and servers must be [`Started`].
-#[derive(Resource, Default, Debug, Clone, PartialEq, Eq)]
+/// Entities are only included after their relevant lifecycle has completed: clients and P2P links
+/// must be [`Connected`], and servers must be [`Started`].
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 pub enum AppMode {
-    /// No standard Lightyear networking role is currently ready.
+    /// No networking mode has been identified yet.
     #[default]
-    Custom,
+    Undefined,
     /// A connected client and its server link.
     Client(Entity),
     /// A started server.
@@ -36,6 +35,28 @@ pub enum AppMode {
     P2P(SmallVec<[Entity; 4]>),
     /// The ready entities do not form one supported application role.
     Invalid(AppModeError),
+}
+
+/// Cached metadata describing the networking configuration of this Bevy application.
+///
+/// [`crate::ConnectionPlugin`] maintains this resource from role and lifecycle components. Users
+/// can read [`mode`](Self::mode), but do not need to update it themselves.
+#[derive(Resource, Debug, Clone)]
+pub struct NetworkingMetadata {
+    /// The currently identified networking mode.
+    pub mode: AppMode,
+    // This is kept in the same resource as the mode, but mutated without triggering Bevy change
+    // detection. Consumers therefore only observe a change after `mode` itself changes.
+    dirty: bool,
+}
+
+impl Default for NetworkingMetadata {
+    fn default() -> Self {
+        Self {
+            mode: AppMode::Undefined,
+            dirty: true,
+        }
+    }
 }
 
 /// Why ready networking entities could not be classified into a supported [`AppMode`].
@@ -88,14 +109,9 @@ pub enum AppModeSystems {
     Update,
 }
 
-/// Marks the cached [`AppMode`] as needing to be recomputed.
-#[derive(Resource, Default)]
-struct AppModeDirty;
-
 #[derive(Clone, Copy, Debug)]
 struct ReadyClient {
     entity: Entity,
-    is_p2p: bool,
     is_host: bool,
     server: Option<Entity>,
 }
@@ -116,10 +132,9 @@ pub(crate) struct AppModePlugin;
 
 impl Plugin for AppModePlugin {
     fn build(&self, app: &mut App) {
-        app.init_resource::<AppMode>();
-        // Start dirty so that entities spawned before this plugin are classified on the first
-        // update too.
-        app.init_resource::<AppModeDirty>();
+        // NetworkingMetadata starts dirty so that entities spawned before this plugin are
+        // classified on the first update too.
+        app.init_resource::<NetworkingMetadata>();
 
         app.add_observer(mark_dirty_on_insert);
         app.add_observer(mark_dirty_on_remove);
@@ -151,24 +166,33 @@ impl Plugin for AppModePlugin {
     }
 }
 
-fn mark_dirty_on_insert(_trigger: On<Insert, ModeComponents>, mut commands: Commands) {
-    commands.init_resource::<AppModeDirty>();
+fn mark_dirty_on_insert(
+    _trigger: On<Insert, ModeComponents>,
+    mut metadata: ResMut<NetworkingMetadata>,
+) {
+    metadata.bypass_change_detection().dirty = true;
 }
 
-fn mark_dirty_on_remove(_trigger: On<Remove, ModeComponents>, mut commands: Commands) {
-    commands.init_resource::<AppModeDirty>();
+fn mark_dirty_on_remove(
+    _trigger: On<Remove, ModeComponents>,
+    mut metadata: ResMut<NetworkingMetadata>,
+) {
+    metadata.bypass_change_detection().dirty = true;
 }
 
-fn mark_dirty_on_discard(_trigger: On<Discard, ModeComponents>, mut commands: Commands) {
-    commands.init_resource::<AppModeDirty>();
+fn mark_dirty_on_discard(
+    _trigger: On<Discard, ModeComponents>,
+    mut metadata: ResMut<NetworkingMetadata>,
+) {
+    metadata.bypass_change_detection().dirty = true;
 }
 
-fn app_mode_is_dirty(dirty: Option<Res<AppModeDirty>>) -> bool {
-    dirty.is_some()
+fn app_mode_is_dirty(metadata: Res<NetworkingMetadata>) -> bool {
+    metadata.dirty
 }
 
 fn refresh_app_mode(
-    mut app_mode: ResMut<AppMode>,
+    mut metadata: ResMut<NetworkingMetadata>,
     p2p_markers: Query<(), With<P2P>>,
     ready_clients: Query<
         (Entity, Has<P2P>, Has<HostClient>, Option<&LinkOf>),
@@ -176,73 +200,84 @@ fn refresh_app_mode(
     >,
     ready_servers: Query<Entity, (With<Server>, With<Started>)>,
     malformed_hosts: Query<Entity, (With<HostClient>, With<Connected>, Without<Client>)>,
-    mut commands: Commands,
 ) {
-    let clients = ready_clients
+    let next = if !p2p_markers.is_empty() {
+        let mut links: SmallVec<[Entity; 4]> = ready_clients
+            .iter()
+            .filter(|(_, is_p2p, _, _)| *is_p2p)
+            .map(|(entity, _, _, _)| entity)
+            .collect();
+        links.sort_unstable_by_key(|entity| entity.index_u32());
+        AppMode::P2P(links)
+    } else if let Some(client) = malformed_hosts
         .iter()
-        .map(|(entity, is_p2p, is_host, link_of)| ReadyClient {
-            entity,
-            is_p2p,
-            is_host,
-            server: link_of.map(|link| link.server),
-        })
-        .collect();
-    let servers = ready_servers.iter().collect();
-    let malformed_hosts = malformed_hosts.iter().collect();
+        .min_by_key(|entity| entity.index_u32())
+    {
+        AppMode::Invalid(AppModeError::HostClientWithoutClient { client })
+    } else {
+        let client = unique_ready_client(ready_clients.iter().filter_map(
+            |(entity, is_p2p, is_host, link_of)| {
+                (!is_p2p).then_some(ReadyClient {
+                    entity,
+                    is_host,
+                    server: link_of.map(|link| link.server),
+                })
+            },
+        ));
+        match client {
+            Err(error) => AppMode::Invalid(error),
+            Ok(client) => match unique_ready_server(ready_servers.iter()) {
+                Err(error) => AppMode::Invalid(error),
+                Ok(server) => infer_standard_mode(client, server),
+            },
+        }
+    };
 
-    let next = infer_app_mode(!p2p_markers.is_empty(), clients, servers, malformed_hosts);
-    if *app_mode != next {
+    let mode_changed = metadata.mode != next;
+    metadata.bypass_change_detection().dirty = false;
+    if mode_changed {
         if let AppMode::Invalid(error) = &next {
             tracing::error!(%error, "invalid Lightyear application mode");
         }
-        *app_mode = next;
+        metadata.mode = next;
     }
-    commands.remove_resource::<AppModeDirty>();
 }
 
-fn infer_app_mode(
-    has_p2p_markers: bool,
-    mut clients: SmallVec<[ReadyClient; 4]>,
-    mut servers: SmallVec<[Entity; 4]>,
-    mut malformed_hosts: SmallVec<[Entity; 1]>,
-) -> AppMode {
-    clients.sort_unstable_by_key(|client| client.entity.index_u32());
-    servers.sort_unstable_by_key(|entity| entity.index_u32());
-    malformed_hosts.sort_unstable_by_key(|entity| entity.index_u32());
+fn unique_ready_client(
+    mut clients: impl Iterator<Item = ReadyClient>,
+) -> Result<Option<ReadyClient>, AppModeError> {
+    let Some(first) = clients.next() else {
+        return Ok(None);
+    };
+    let Some(second) = clients.next() else {
+        return Ok(Some(first));
+    };
 
-    if has_p2p_markers {
-        return AppMode::P2P(
-            clients
-                .iter()
-                .filter(|client| client.is_p2p)
-                .map(|client| client.entity)
-                .collect(),
-        );
-    }
+    let mut entities: SmallVec<[Entity; 4]> = SmallVec::from_slice(&[first.entity, second.entity]);
+    entities.extend(clients.map(|client| client.entity));
+    entities.sort_unstable_by_key(|entity| entity.index_u32());
+    Err(AppModeError::MultipleConnectedClients(entities))
+}
 
-    if let Some(&client) = malformed_hosts.first() {
-        return AppMode::Invalid(AppModeError::HostClientWithoutClient { client });
-    }
+fn unique_ready_server(
+    mut servers: impl Iterator<Item = Entity>,
+) -> Result<Option<Entity>, AppModeError> {
+    let Some(first) = servers.next() else {
+        return Ok(None);
+    };
+    let Some(second) = servers.next() else {
+        return Ok(Some(first));
+    };
 
-    let conventional_clients: SmallVec<[ReadyClient; 4]> = clients
-        .into_iter()
-        .filter(|client| !client.is_p2p)
-        .collect();
+    let mut entities: SmallVec<[Entity; 4]> = SmallVec::from_slice(&[first, second]);
+    entities.extend(servers);
+    entities.sort_unstable_by_key(|entity| entity.index_u32());
+    Err(AppModeError::MultipleStartedServers(entities))
+}
 
-    if conventional_clients.len() > 1 {
-        return AppMode::Invalid(AppModeError::MultipleConnectedClients(
-            conventional_clients
-                .iter()
-                .map(|client| client.entity)
-                .collect(),
-        ));
-    }
-    if servers.len() > 1 {
-        return AppMode::Invalid(AppModeError::MultipleStartedServers(servers));
-    }
-
-    match (conventional_clients.first(), servers.first().copied()) {
-        (None, None) => AppMode::Custom,
+fn infer_standard_mode(client: Option<ReadyClient>, server: Option<Entity>) -> AppMode {
+    match (client.as_ref(), server) {
+        (None, None) => AppMode::Undefined,
         (None, Some(server)) => AppMode::Server(server),
         (Some(client), None) if client.is_host => match client.server {
             Some(server) => AppMode::Invalid(AppModeError::HostClientServerNotStarted {
@@ -301,36 +336,40 @@ mod tests {
         app.world_mut().spawn((Server::default(), Started)).id()
     }
 
+    fn mode(app: &App) -> &AppMode {
+        &app.world().resource::<NetworkingMetadata>().mode
+    }
+
     #[test]
     fn only_ready_client_and_server_entities_are_cached() {
         let mut app = test_app();
         let client = app.world_mut().spawn(Client).id();
         app.update();
-        assert_eq!(*app.world().resource::<AppMode>(), AppMode::Custom);
+        assert_eq!(mode(&app), &AppMode::Undefined);
 
         app.world_mut()
             .entity_mut(client)
             .insert((RemoteId(PeerId::Local(1)), Connected));
         app.update();
-        assert_eq!(*app.world().resource::<AppMode>(), AppMode::Client(client));
+        assert_eq!(mode(&app), &AppMode::Client(client));
 
         app.world_mut().entity_mut(client).insert(Disconnected {
             reason: Some("test".into()),
         });
         app.update();
-        assert_eq!(*app.world().resource::<AppMode>(), AppMode::Custom);
+        assert_eq!(mode(&app), &AppMode::Undefined);
 
         let server = app.world_mut().spawn(Server::default()).id();
         app.update();
-        assert_eq!(*app.world().resource::<AppMode>(), AppMode::Custom);
+        assert_eq!(mode(&app), &AppMode::Undefined);
 
         app.world_mut().entity_mut(server).insert(Started);
         app.update();
-        assert_eq!(*app.world().resource::<AppMode>(), AppMode::Server(server));
+        assert_eq!(mode(&app), &AppMode::Server(server));
 
         app.world_mut().entity_mut(server).insert(Stopped);
         app.update();
-        assert_eq!(*app.world().resource::<AppMode>(), AppMode::Custom);
+        assert_eq!(mode(&app), &AppMode::Undefined);
     }
 
     #[test]
@@ -350,16 +389,13 @@ mod tests {
 
         app.update();
         assert_eq!(
-            *app.world().resource::<AppMode>(),
-            AppMode::Invalid(AppModeError::HostClientServerNotStarted { client, server })
+            mode(&app),
+            &AppMode::Invalid(AppModeError::HostClientServerNotStarted { client, server })
         );
 
         app.world_mut().entity_mut(server).insert(Started);
         app.update();
-        assert_eq!(
-            *app.world().resource::<AppMode>(),
-            AppMode::HostClient { server, client }
-        );
+        assert_eq!(mode(&app), &AppMode::HostClient { server, client });
     }
 
     #[test]
@@ -369,10 +405,7 @@ mod tests {
         let second = app.world_mut().spawn(P2P).id();
 
         app.update();
-        assert_eq!(
-            *app.world().resource::<AppMode>(),
-            AppMode::P2P(SmallVec::new())
-        );
+        assert_eq!(mode(&app), &AppMode::P2P(SmallVec::new()));
 
         // Connect in reverse order to prove that insertion order does not affect the cache.
         app.world_mut()
@@ -384,29 +417,23 @@ mod tests {
         app.update();
 
         assert_eq!(
-            *app.world().resource::<AppMode>(),
-            AppMode::P2P(SmallVec::from_slice(&[first, second]))
+            mode(&app),
+            &AppMode::P2P(SmallVec::from_slice(&[first, second]))
         );
 
         app.world_mut().entity_mut(first).insert(Disconnected {
             reason: Some("test".into()),
         });
         app.update();
-        assert_eq!(
-            *app.world().resource::<AppMode>(),
-            AppMode::P2P(SmallVec::from_slice(&[second]))
-        );
+        assert_eq!(mode(&app), &AppMode::P2P(SmallVec::from_slice(&[second])));
 
         app.world_mut().despawn(second);
         app.update();
-        assert_eq!(
-            *app.world().resource::<AppMode>(),
-            AppMode::P2P(SmallVec::new())
-        );
+        assert_eq!(mode(&app), &AppMode::P2P(SmallVec::new()));
 
         app.world_mut().entity_mut(first).remove::<P2P>();
         app.update();
-        assert_eq!(*app.world().resource::<AppMode>(), AppMode::Custom);
+        assert_eq!(mode(&app), &AppMode::Undefined);
     }
 
     #[test]
@@ -420,10 +447,7 @@ mod tests {
         start_server(&mut app);
 
         app.update();
-        assert_eq!(
-            *app.world().resource::<AppMode>(),
-            AppMode::P2P(SmallVec::from_slice(&[peer]))
-        );
+        assert_eq!(mode(&app), &AppMode::P2P(SmallVec::from_slice(&[peer])));
     }
 
     #[test]
@@ -433,8 +457,8 @@ mod tests {
         let second = connect_client(&mut app, 2);
         app.update();
         assert_eq!(
-            *app.world().resource::<AppMode>(),
-            AppMode::Invalid(AppModeError::MultipleConnectedClients(
+            mode(&app),
+            &AppMode::Invalid(AppModeError::MultipleConnectedClients(
                 SmallVec::from_slice(&[first, second])
             ))
         );
@@ -443,8 +467,8 @@ mod tests {
         let server = start_server(&mut app);
         app.update();
         assert_eq!(
-            *app.world().resource::<AppMode>(),
-            AppMode::Invalid(AppModeError::MixedClientServer {
+            mode(&app),
+            &AppMode::Invalid(AppModeError::MixedClientServer {
                 client: first,
                 server,
             })
@@ -454,8 +478,8 @@ mod tests {
         app.world_mut().despawn(first);
         app.update();
         assert_eq!(
-            *app.world().resource::<AppMode>(),
-            AppMode::Invalid(AppModeError::MultipleStartedServers(SmallVec::from_slice(
+            mode(&app),
+            &AppMode::Invalid(AppModeError::MultipleStartedServers(SmallVec::from_slice(
                 &[server, other_server]
             )))
         );
@@ -476,21 +500,27 @@ mod tests {
 
         app.update();
         assert_eq!(
-            *app.world().resource::<AppMode>(),
-            AppMode::Invalid(AppModeError::HostClientMissingLinkOf { client })
+            mode(&app),
+            &AppMode::Invalid(AppModeError::HostClientMissingLinkOf { client })
         );
     }
 
     #[test]
-    fn unchanged_recomputation_does_not_mark_app_mode_changed() {
+    fn unchanged_invalidation_does_not_mark_networking_metadata_changed() {
         let mut app = test_app();
-        let last_changed = app.world().resource_ref::<AppMode>().last_changed();
+        let last_changed = app
+            .world()
+            .resource_ref::<NetworkingMetadata>()
+            .last_changed();
 
-        app.world_mut().insert_resource(AppModeDirty);
+        // This invalidates the cache, but a disconnected Client does not change the mode.
+        app.world_mut().spawn(Client);
         app.update();
 
         assert_eq!(
-            app.world().resource_ref::<AppMode>().last_changed(),
+            app.world()
+                .resource_ref::<NetworkingMetadata>()
+                .last_changed(),
             last_changed
         );
     }

--- a/crates/connection/connection/src/lib.rs
+++ b/crates/connection/connection/src/lib.rs
@@ -24,6 +24,7 @@ extern crate core;
 use bevy_app::{App, Plugin};
 use bevy_ecs::schedule::SystemSet;
 
+pub mod app_mode;
 pub mod client;
 
 pub mod server;
@@ -37,6 +38,7 @@ pub mod identity;
 pub mod shared;
 
 pub mod host;
+pub mod p2p;
 
 #[deprecated(note = "Use ConnectionSystems instead")]
 pub type ConnectionSet = ConnectionSystems;
@@ -57,6 +59,7 @@ pub enum ConnectionSystems {
 
 pub mod prelude {
     pub use crate::ConnectionSystems;
+    pub use crate::app_mode::{AppMode, AppModeError, AppModeSystems};
     pub use crate::direction::NetworkDirection;
     pub use crate::network_target::NetworkTarget;
 
@@ -65,6 +68,7 @@ pub mod prelude {
         Client, ClientState, Connect, Connected, Connecting, ConnectionError, Disconnect,
         Disconnected, PeerMetadata,
     };
+    pub use crate::p2p::P2P;
 
     #[cfg(feature = "client")]
     pub mod client {
@@ -87,5 +91,7 @@ pub mod prelude {
 pub struct ConnectionPlugin;
 
 impl Plugin for ConnectionPlugin {
-    fn build(&self, _: &mut App) {}
+    fn build(&self, app: &mut App) {
+        app.add_plugins(app_mode::AppModePlugin);
+    }
 }

--- a/crates/connection/connection/src/lib.rs
+++ b/crates/connection/connection/src/lib.rs
@@ -59,7 +59,7 @@ pub enum ConnectionSystems {
 
 pub mod prelude {
     pub use crate::ConnectionSystems;
-    pub use crate::app_mode::{AppMode, AppModeError, AppModeSystems};
+    pub use crate::app_mode::{AppMode, AppModeError, AppModeSystems, NetworkingMetadata};
     pub use crate::direction::NetworkDirection;
     pub use crate::network_target::NetworkTarget;
 

--- a/crates/connection/connection/src/lib.rs
+++ b/crates/connection/connection/src/lib.rs
@@ -24,7 +24,6 @@ extern crate core;
 use bevy_app::{App, Plugin};
 use bevy_ecs::schedule::SystemSet;
 
-pub mod app_mode;
 pub mod client;
 
 pub mod server;
@@ -38,6 +37,7 @@ pub mod identity;
 pub mod shared;
 
 pub mod host;
+pub mod network_topology;
 pub mod p2p;
 
 #[deprecated(note = "Use ConnectionSystems instead")]
@@ -59,9 +59,11 @@ pub enum ConnectionSystems {
 
 pub mod prelude {
     pub use crate::ConnectionSystems;
-    pub use crate::app_mode::{AppMode, AppModeError, AppModeSystems, NetworkingMetadata};
     pub use crate::direction::NetworkDirection;
     pub use crate::network_target::NetworkTarget;
+    pub use crate::network_topology::{
+        NetworkTopology, NetworkTopologyError, NetworkTopologySystems, NetworkingMetadata,
+    };
 
     // we also export these types at the top level for easier access
     pub use crate::client::{
@@ -92,6 +94,6 @@ pub struct ConnectionPlugin;
 
 impl Plugin for ConnectionPlugin {
     fn build(&self, app: &mut App) {
-        app.add_plugins(app_mode::AppModePlugin);
+        app.add_plugins(network_topology::NetworkTopologyPlugin);
     }
 }

--- a/crates/connection/connection/src/network_topology.rs
+++ b/crates/connection/connection/src/network_topology.rs
@@ -14,8 +14,8 @@ use smallvec::SmallVec;
 /// Entities are only included after their relevant lifecycle has completed: clients and P2P links
 /// must be [`Connected`], and servers must be [`Started`].
 #[derive(Default, Debug, Clone, PartialEq, Eq)]
-pub enum AppMode {
-    /// No networking mode has been identified yet.
+pub enum NetworkTopology {
+    /// No networking topology has been identified yet.
     #[default]
     Undefined,
     /// A connected client and its server link.
@@ -33,8 +33,8 @@ pub enum AppMode {
     ///
     /// This can be empty while the session is waiting for its first peer to connect.
     P2P(SmallVec<[Entity; 4]>),
-    /// The ready entities do not form one supported application role.
-    Invalid(AppModeError),
+    /// The ready entities do not form one supported networking topology.
+    Invalid(NetworkTopologyError),
 }
 
 /// Cached metadata describing the networking configuration of this Bevy application.
@@ -43,8 +43,8 @@ pub enum AppMode {
 /// can read [`mode`](Self::mode), but do not need to update it themselves.
 #[derive(Resource, Debug, Clone)]
 pub struct NetworkingMetadata {
-    /// The currently identified networking mode.
-    pub mode: AppMode,
+    /// The currently identified networking topology.
+    pub mode: NetworkTopology,
     // This is kept in the same resource as the mode, but mutated without triggering Bevy change
     // detection. Consumers therefore only observe a change after `mode` itself changes.
     dirty: bool,
@@ -53,15 +53,15 @@ pub struct NetworkingMetadata {
 impl Default for NetworkingMetadata {
     fn default() -> Self {
         Self {
-            mode: AppMode::Undefined,
+            mode: NetworkTopology::Undefined,
             dirty: true,
         }
     }
 }
 
-/// Why ready networking entities could not be classified into a supported [`AppMode`].
+/// Why ready networking entities could not be classified into a supported [`NetworkTopology`].
 #[derive(thiserror::Error, Debug, Clone, PartialEq, Eq)]
-pub enum AppModeError {
+pub enum NetworkTopologyError {
     /// More than one conventional client link is connected.
     #[error("multiple conventional client links are connected: {0:?}")]
     MultipleConnectedClients(SmallVec<[Entity; 4]>),
@@ -102,10 +102,10 @@ pub enum AppModeError {
     },
 }
 
-/// System set that refreshes the cached [`AppMode`].
+/// System set that refreshes the cached [`NetworkTopology`].
 #[derive(SystemSet, Debug, Hash, PartialEq, Eq, Clone, Copy)]
-pub enum AppModeSystems {
-    /// Infer the application mode after networking lifecycle changes.
+pub enum NetworkTopologySystems {
+    /// Infer the topology after networking lifecycle changes.
     Update,
 }
 
@@ -116,7 +116,7 @@ struct ReadyClient {
     server: Option<Entity>,
 }
 
-type ModeComponents = (
+type TopologyComponents = (
     Client,
     Server,
     HostClient,
@@ -128,9 +128,9 @@ type ModeComponents = (
     Stopped,
 );
 
-pub(crate) struct AppModePlugin;
+pub(crate) struct NetworkTopologyPlugin;
 
-impl Plugin for AppModePlugin {
+impl Plugin for NetworkTopologyPlugin {
     fn build(&self, app: &mut App) {
         // NetworkingMetadata starts dirty so that entities spawned before this plugin are
         // classified on the first update too.
@@ -142,56 +142,56 @@ impl Plugin for AppModePlugin {
 
         app.configure_sets(
             PreUpdate,
-            AppModeSystems::Update
+            NetworkTopologySystems::Update
                 .after(LinkSystems::Receive)
                 .after(ConnectionSystems::Receive),
         );
         app.add_systems(
             PreUpdate,
-            refresh_app_mode
-                .in_set(AppModeSystems::Update)
-                .run_if(app_mode_is_dirty),
+            refresh_network_topology
+                .in_set(NetworkTopologySystems::Update)
+                .run_if(network_topology_is_dirty),
         );
 
         app.configure_sets(
             PostUpdate,
-            AppModeSystems::Update.before(ConnectionSystems::Send),
+            NetworkTopologySystems::Update.before(ConnectionSystems::Send),
         );
         app.add_systems(
             PostUpdate,
-            refresh_app_mode
-                .in_set(AppModeSystems::Update)
-                .run_if(app_mode_is_dirty),
+            refresh_network_topology
+                .in_set(NetworkTopologySystems::Update)
+                .run_if(network_topology_is_dirty),
         );
     }
 }
 
 fn mark_dirty_on_insert(
-    _trigger: On<Insert, ModeComponents>,
+    _trigger: On<Insert, TopologyComponents>,
     mut metadata: ResMut<NetworkingMetadata>,
 ) {
     metadata.bypass_change_detection().dirty = true;
 }
 
 fn mark_dirty_on_remove(
-    _trigger: On<Remove, ModeComponents>,
+    _trigger: On<Remove, TopologyComponents>,
     mut metadata: ResMut<NetworkingMetadata>,
 ) {
     metadata.bypass_change_detection().dirty = true;
 }
 
 fn mark_dirty_on_discard(
-    _trigger: On<Discard, ModeComponents>,
+    _trigger: On<Discard, TopologyComponents>,
     mut metadata: ResMut<NetworkingMetadata>,
 ) {
     metadata.bypass_change_detection().dirty = true;
 }
 
-fn app_mode_is_dirty(metadata: Res<NetworkingMetadata>) -> bool {
+fn network_topology_is_dirty(metadata: Res<NetworkingMetadata>) -> bool {
     metadata.dirty
 }
 
-fn refresh_app_mode(
+fn refresh_network_topology(
     mut metadata: ResMut<NetworkingMetadata>,
     p2p_markers: Query<(), With<P2P>>,
     ready_clients: Query<
@@ -208,12 +208,12 @@ fn refresh_app_mode(
             .map(|(entity, _, _, _)| entity)
             .collect();
         links.sort_unstable_by_key(|entity| entity.index_u32());
-        AppMode::P2P(links)
+        NetworkTopology::P2P(links)
     } else if let Some(client) = malformed_hosts
         .iter()
         .min_by_key(|entity| entity.index_u32())
     {
-        AppMode::Invalid(AppModeError::HostClientWithoutClient { client })
+        NetworkTopology::Invalid(NetworkTopologyError::HostClientWithoutClient { client })
     } else {
         let client = unique_ready_client(ready_clients.iter().filter_map(
             |(entity, is_p2p, is_host, link_of)| {
@@ -225,10 +225,10 @@ fn refresh_app_mode(
             },
         ));
         match client {
-            Err(error) => AppMode::Invalid(error),
+            Err(error) => NetworkTopology::Invalid(error),
             Ok(client) => match unique_ready_server(ready_servers.iter()) {
-                Err(error) => AppMode::Invalid(error),
-                Ok(server) => infer_standard_mode(client, server),
+                Err(error) => NetworkTopology::Invalid(error),
+                Ok(server) => infer_standard_topology(client, server),
             },
         }
     };
@@ -236,8 +236,8 @@ fn refresh_app_mode(
     let mode_changed = metadata.mode != next;
     metadata.bypass_change_detection().dirty = false;
     if mode_changed {
-        if let AppMode::Invalid(error) = &next {
-            tracing::error!(%error, "invalid Lightyear application mode");
+        if let NetworkTopology::Invalid(error) = &next {
+            tracing::error!(%error, "invalid Lightyear networking topology");
         }
         metadata.mode = next;
     }
@@ -245,7 +245,7 @@ fn refresh_app_mode(
 
 fn unique_ready_client(
     mut clients: impl Iterator<Item = ReadyClient>,
-) -> Result<Option<ReadyClient>, AppModeError> {
+) -> Result<Option<ReadyClient>, NetworkTopologyError> {
     let Some(first) = clients.next() else {
         return Ok(None);
     };
@@ -256,12 +256,12 @@ fn unique_ready_client(
     let mut entities: SmallVec<[Entity; 4]> = SmallVec::from_slice(&[first.entity, second.entity]);
     entities.extend(clients.map(|client| client.entity));
     entities.sort_unstable_by_key(|entity| entity.index_u32());
-    Err(AppModeError::MultipleConnectedClients(entities))
+    Err(NetworkTopologyError::MultipleConnectedClients(entities))
 }
 
 fn unique_ready_server(
     mut servers: impl Iterator<Item = Entity>,
-) -> Result<Option<Entity>, AppModeError> {
+) -> Result<Option<Entity>, NetworkTopologyError> {
     let Some(first) = servers.next() else {
         return Ok(None);
     };
@@ -272,40 +272,46 @@ fn unique_ready_server(
     let mut entities: SmallVec<[Entity; 4]> = SmallVec::from_slice(&[first, second]);
     entities.extend(servers);
     entities.sort_unstable_by_key(|entity| entity.index_u32());
-    Err(AppModeError::MultipleStartedServers(entities))
+    Err(NetworkTopologyError::MultipleStartedServers(entities))
 }
 
-fn infer_standard_mode(client: Option<ReadyClient>, server: Option<Entity>) -> AppMode {
+fn infer_standard_topology(client: Option<ReadyClient>, server: Option<Entity>) -> NetworkTopology {
     match (client.as_ref(), server) {
-        (None, None) => AppMode::Undefined,
-        (None, Some(server)) => AppMode::Server(server),
+        (None, None) => NetworkTopology::Undefined,
+        (None, Some(server)) => NetworkTopology::Server(server),
         (Some(client), None) if client.is_host => match client.server {
-            Some(server) => AppMode::Invalid(AppModeError::HostClientServerNotStarted {
-                client: client.entity,
-                server,
-            }),
-            None => AppMode::Invalid(AppModeError::HostClientMissingLinkOf {
+            Some(server) => {
+                NetworkTopology::Invalid(NetworkTopologyError::HostClientServerNotStarted {
+                    client: client.entity,
+                    server,
+                })
+            }
+            None => NetworkTopology::Invalid(NetworkTopologyError::HostClientMissingLinkOf {
                 client: client.entity,
             }),
         },
-        (Some(client), None) => AppMode::Client(client.entity),
+        (Some(client), None) => NetworkTopology::Client(client.entity),
         (Some(client), Some(server)) if client.is_host => match client.server {
-            Some(linked_server) if linked_server == server => AppMode::HostClient {
+            Some(linked_server) if linked_server == server => NetworkTopology::HostClient {
                 server,
                 client: client.entity,
             },
-            Some(linked_server) => AppMode::Invalid(AppModeError::HostClientServerNotStarted {
-                client: client.entity,
-                server: linked_server,
-            }),
-            None => AppMode::Invalid(AppModeError::HostClientMissingLinkOf {
+            Some(linked_server) => {
+                NetworkTopology::Invalid(NetworkTopologyError::HostClientServerNotStarted {
+                    client: client.entity,
+                    server: linked_server,
+                })
+            }
+            None => NetworkTopology::Invalid(NetworkTopologyError::HostClientMissingLinkOf {
                 client: client.entity,
             }),
         },
-        (Some(client), Some(server)) => AppMode::Invalid(AppModeError::MixedClientServer {
-            client: client.entity,
-            server,
-        }),
+        (Some(client), Some(server)) => {
+            NetworkTopology::Invalid(NetworkTopologyError::MixedClientServer {
+                client: client.entity,
+                server,
+            })
+        }
     }
 }
 
@@ -336,7 +342,7 @@ mod tests {
         app.world_mut().spawn((Server::default(), Started)).id()
     }
 
-    fn mode(app: &App) -> &AppMode {
+    fn mode(app: &App) -> &NetworkTopology {
         &app.world().resource::<NetworkingMetadata>().mode
     }
 
@@ -345,31 +351,31 @@ mod tests {
         let mut app = test_app();
         let client = app.world_mut().spawn(Client).id();
         app.update();
-        assert_eq!(mode(&app), &AppMode::Undefined);
+        assert_eq!(mode(&app), &NetworkTopology::Undefined);
 
         app.world_mut()
             .entity_mut(client)
             .insert((RemoteId(PeerId::Local(1)), Connected));
         app.update();
-        assert_eq!(mode(&app), &AppMode::Client(client));
+        assert_eq!(mode(&app), &NetworkTopology::Client(client));
 
         app.world_mut().entity_mut(client).insert(Disconnected {
             reason: Some("test".into()),
         });
         app.update();
-        assert_eq!(mode(&app), &AppMode::Undefined);
+        assert_eq!(mode(&app), &NetworkTopology::Undefined);
 
         let server = app.world_mut().spawn(Server::default()).id();
         app.update();
-        assert_eq!(mode(&app), &AppMode::Undefined);
+        assert_eq!(mode(&app), &NetworkTopology::Undefined);
 
         app.world_mut().entity_mut(server).insert(Started);
         app.update();
-        assert_eq!(mode(&app), &AppMode::Server(server));
+        assert_eq!(mode(&app), &NetworkTopology::Server(server));
 
         app.world_mut().entity_mut(server).insert(Stopped);
         app.update();
-        assert_eq!(mode(&app), &AppMode::Undefined);
+        assert_eq!(mode(&app), &NetworkTopology::Undefined);
     }
 
     #[test]
@@ -390,12 +396,15 @@ mod tests {
         app.update();
         assert_eq!(
             mode(&app),
-            &AppMode::Invalid(AppModeError::HostClientServerNotStarted { client, server })
+            &NetworkTopology::Invalid(NetworkTopologyError::HostClientServerNotStarted {
+                client,
+                server
+            })
         );
 
         app.world_mut().entity_mut(server).insert(Started);
         app.update();
-        assert_eq!(mode(&app), &AppMode::HostClient { server, client });
+        assert_eq!(mode(&app), &NetworkTopology::HostClient { server, client });
     }
 
     #[test]
@@ -405,7 +414,7 @@ mod tests {
         let second = app.world_mut().spawn(P2P).id();
 
         app.update();
-        assert_eq!(mode(&app), &AppMode::P2P(SmallVec::new()));
+        assert_eq!(mode(&app), &NetworkTopology::P2P(SmallVec::new()));
 
         // Connect in reverse order to prove that insertion order does not affect the cache.
         app.world_mut()
@@ -418,22 +427,25 @@ mod tests {
 
         assert_eq!(
             mode(&app),
-            &AppMode::P2P(SmallVec::from_slice(&[first, second]))
+            &NetworkTopology::P2P(SmallVec::from_slice(&[first, second]))
         );
 
         app.world_mut().entity_mut(first).insert(Disconnected {
             reason: Some("test".into()),
         });
         app.update();
-        assert_eq!(mode(&app), &AppMode::P2P(SmallVec::from_slice(&[second])));
+        assert_eq!(
+            mode(&app),
+            &NetworkTopology::P2P(SmallVec::from_slice(&[second]))
+        );
 
         app.world_mut().despawn(second);
         app.update();
-        assert_eq!(mode(&app), &AppMode::P2P(SmallVec::new()));
+        assert_eq!(mode(&app), &NetworkTopology::P2P(SmallVec::new()));
 
         app.world_mut().entity_mut(first).remove::<P2P>();
         app.update();
-        assert_eq!(mode(&app), &AppMode::Undefined);
+        assert_eq!(mode(&app), &NetworkTopology::Undefined);
     }
 
     #[test]
@@ -447,7 +459,10 @@ mod tests {
         start_server(&mut app);
 
         app.update();
-        assert_eq!(mode(&app), &AppMode::P2P(SmallVec::from_slice(&[peer])));
+        assert_eq!(
+            mode(&app),
+            &NetworkTopology::P2P(SmallVec::from_slice(&[peer]))
+        );
     }
 
     #[test]
@@ -458,7 +473,7 @@ mod tests {
         app.update();
         assert_eq!(
             mode(&app),
-            &AppMode::Invalid(AppModeError::MultipleConnectedClients(
+            &NetworkTopology::Invalid(NetworkTopologyError::MultipleConnectedClients(
                 SmallVec::from_slice(&[first, second])
             ))
         );
@@ -468,7 +483,7 @@ mod tests {
         app.update();
         assert_eq!(
             mode(&app),
-            &AppMode::Invalid(AppModeError::MixedClientServer {
+            &NetworkTopology::Invalid(NetworkTopologyError::MixedClientServer {
                 client: first,
                 server,
             })
@@ -479,9 +494,9 @@ mod tests {
         app.update();
         assert_eq!(
             mode(&app),
-            &AppMode::Invalid(AppModeError::MultipleStartedServers(SmallVec::from_slice(
-                &[server, other_server]
-            )))
+            &NetworkTopology::Invalid(NetworkTopologyError::MultipleStartedServers(
+                SmallVec::from_slice(&[server, other_server])
+            ))
         );
     }
 
@@ -501,7 +516,7 @@ mod tests {
         app.update();
         assert_eq!(
             mode(&app),
-            &AppMode::Invalid(AppModeError::HostClientMissingLinkOf { client })
+            &NetworkTopology::Invalid(NetworkTopologyError::HostClientMissingLinkOf { client })
         );
     }
 

--- a/crates/connection/connection/src/network_topology.rs
+++ b/crates/connection/connection/src/network_topology.rs
@@ -35,7 +35,7 @@ pub enum NetworkTopology {
         connected: SmallVec<[Entity; 4]>,
         /// Total number of Link entities carrying the [`P2P`] marker, including disconnected
         /// Links. This lets consumers test startup readiness without rediscovering the roster.
-        declared: u8,
+        declared_links: u8,
     },
     /// The ready entities do not form one supported networking topology.
     Invalid(NetworkTopologyError),
@@ -66,6 +66,18 @@ impl Default for NetworkingMetadata {
 /// Why ready networking entities could not be classified into a supported [`NetworkTopology`].
 #[derive(thiserror::Error, Debug, Clone, PartialEq, Eq)]
 pub enum NetworkTopologyError {
+    /// Ready P2P and conventional networking roles exist in the same application.
+    #[error(
+        "P2P link {p2p:?} is ready alongside conventional roles (client: {conventional_client:?}, server: {server:?})"
+    )]
+    MixedP2PAndConventional {
+        /// One of the application's declared P2P Links.
+        p2p: Entity,
+        /// A connected conventional Client or HostClient, when present.
+        conventional_client: Option<Entity>,
+        /// A started conventional Server, when present.
+        server: Option<Entity>,
+    },
     /// More than one conventional client link is connected.
     #[error("multiple conventional client links are connected: {0:?}")]
     MultipleConnectedClients(SmallVec<[Entity; 4]>),
@@ -197,7 +209,7 @@ fn network_topology_is_dirty(metadata: Res<NetworkingMetadata>) -> bool {
 
 fn refresh_network_topology(
     mut metadata: ResMut<NetworkingMetadata>,
-    p2p_markers: Query<(), With<P2P>>,
+    p2p_markers: Query<Entity, With<P2P>>,
     ready_clients: Query<
         (Entity, Has<P2P>, Has<HostClient>, Option<&LinkOf>),
         (With<Client>, With<Connected>),
@@ -205,29 +217,46 @@ fn refresh_network_topology(
     ready_servers: Query<Entity, (With<Server>, With<Started>)>,
     malformed_hosts: Query<Entity, (With<HostClient>, With<Connected>, Without<Client>)>,
 ) {
-    let next = if !p2p_markers.is_empty() {
-        let declared = u8::try_from(p2p_markers.iter().count()).unwrap_or_else(|_| {
-            tracing::error!(
-                maximum = u8::MAX,
-                "P2P topology declared more Links than its cached count can represent"
-            );
-            u8::MAX
-        });
-        let mut connected: SmallVec<[Entity; 4]> = ready_clients
-            .iter()
-            .filter(|(_, is_p2p, _, _)| *is_p2p)
-            .map(|(entity, _, _, _)| entity)
-            .collect();
-        connected.sort_unstable_by_key(|entity| entity.index_u32());
-        NetworkTopology::P2P {
-            connected,
-            declared,
-        }
-    } else if let Some(client) = malformed_hosts
+    let malformed_host = malformed_hosts
         .iter()
-        .min_by_key(|entity| entity.index_u32())
-    {
+        .min_by_key(|entity| entity.index_u32());
+    let first_p2p = p2p_markers.iter().min_by_key(|entity| entity.index_u32());
+    let next = if let Some(client) = malformed_host {
         NetworkTopology::Invalid(NetworkTopologyError::HostClientWithoutClient { client })
+    } else if let Some(p2p) = first_p2p {
+        // A connected non-P2P Client is conventional. HostClient is conventional even if it was
+        // accidentally combined with P2P on the same Link.
+        let conventional_client = ready_clients
+            .iter()
+            .filter(|(_, is_p2p, is_host, _)| !*is_p2p || *is_host)
+            .map(|(entity, _, _, _)| entity)
+            .min_by_key(|entity| entity.index_u32());
+        let server = ready_servers.iter().min_by_key(|entity| entity.index_u32());
+        if conventional_client.is_some() || server.is_some() {
+            NetworkTopology::Invalid(NetworkTopologyError::MixedP2PAndConventional {
+                p2p,
+                conventional_client,
+                server,
+            })
+        } else {
+            let declared_links = u8::try_from(p2p_markers.iter().count()).unwrap_or_else(|_| {
+                tracing::error!(
+                    maximum = u8::MAX,
+                    "P2P topology declared more Links than its cached count can represent"
+                );
+                u8::MAX
+            });
+            let mut connected: SmallVec<[Entity; 4]> = ready_clients
+                .iter()
+                .filter(|(_, is_p2p, _, _)| *is_p2p)
+                .map(|(entity, _, _, _)| entity)
+                .collect();
+            connected.sort_unstable_by_key(|entity| entity.index_u32());
+            NetworkTopology::P2P {
+                connected,
+                declared_links,
+            }
+        }
     } else {
         let client = unique_ready_client(ready_clients.iter().filter_map(
             |(entity, is_p2p, is_host, link_of)| {
@@ -432,7 +461,7 @@ mod tests {
             mode(&app),
             &NetworkTopology::P2P {
                 connected: SmallVec::new(),
-                declared: 2,
+                declared_links: 2,
             }
         );
 
@@ -449,7 +478,7 @@ mod tests {
             mode(&app),
             &NetworkTopology::P2P {
                 connected: SmallVec::from_slice(&[first, second]),
-                declared: 2,
+                declared_links: 2,
             }
         );
 
@@ -461,7 +490,7 @@ mod tests {
             mode(&app),
             &NetworkTopology::P2P {
                 connected: SmallVec::from_slice(&[second]),
-                declared: 2,
+                declared_links: 2,
             }
         );
 
@@ -471,7 +500,7 @@ mod tests {
             mode(&app),
             &NetworkTopology::P2P {
                 connected: SmallVec::new(),
-                declared: 1,
+                declared_links: 1,
             }
         );
 
@@ -481,21 +510,42 @@ mod tests {
     }
 
     #[test]
-    fn p2p_markers_take_priority_over_conventional_roles() {
+    fn ready_p2p_and_conventional_roles_are_invalid() {
         let mut app = test_app();
         let peer = app
             .world_mut()
             .spawn((P2P, RemoteId(PeerId::Local(1)), Connected))
             .id();
-        connect_client(&mut app, 2);
-        start_server(&mut app);
+        let client = connect_client(&mut app, 2);
+        let server = start_server(&mut app);
+
+        app.update();
+        assert_eq!(
+            mode(&app),
+            &NetworkTopology::Invalid(NetworkTopologyError::MixedP2PAndConventional {
+                p2p: peer,
+                conventional_client: Some(client),
+                server: Some(server),
+            })
+        );
+    }
+
+    #[test]
+    fn unready_conventional_roles_do_not_conflict_with_p2p() {
+        let mut app = test_app();
+        let peer = app
+            .world_mut()
+            .spawn((P2P, RemoteId(PeerId::Local(1)), Connected))
+            .id();
+        app.world_mut().spawn(Client);
+        app.world_mut().spawn(Server::default());
 
         app.update();
         assert_eq!(
             mode(&app),
             &NetworkTopology::P2P {
                 connected: SmallVec::from_slice(&[peer]),
-                declared: 1,
+                declared_links: 1,
             }
         );
     }

--- a/crates/connection/connection/src/network_topology.rs
+++ b/crates/connection/connection/src/network_topology.rs
@@ -29,10 +29,14 @@ pub enum NetworkTopology {
         /// The connected host-client link entity.
         client: Entity,
     },
-    /// The connected direct peer links in this P2P session.
-    ///
-    /// This can be empty while the session is waiting for its first peer to connect.
-    P2P(SmallVec<[Entity; 4]>),
+    /// The declared and currently connected direct peer links in this P2P session.
+    P2P {
+        /// Connected P2P Link entities, sorted by local [`Entity`] ID.
+        connected: SmallVec<[Entity; 4]>,
+        /// Total number of Link entities carrying the [`P2P`] marker, including disconnected
+        /// Links. This lets consumers test startup readiness without rediscovering the roster.
+        declared: u8,
+    },
     /// The ready entities do not form one supported networking topology.
     Invalid(NetworkTopologyError),
 }
@@ -202,13 +206,23 @@ fn refresh_network_topology(
     malformed_hosts: Query<Entity, (With<HostClient>, With<Connected>, Without<Client>)>,
 ) {
     let next = if !p2p_markers.is_empty() {
-        let mut links: SmallVec<[Entity; 4]> = ready_clients
+        let declared = u8::try_from(p2p_markers.iter().count()).unwrap_or_else(|_| {
+            tracing::error!(
+                maximum = u8::MAX,
+                "P2P topology declared more Links than its cached count can represent"
+            );
+            u8::MAX
+        });
+        let mut connected: SmallVec<[Entity; 4]> = ready_clients
             .iter()
             .filter(|(_, is_p2p, _, _)| *is_p2p)
             .map(|(entity, _, _, _)| entity)
             .collect();
-        links.sort_unstable_by_key(|entity| entity.index_u32());
-        NetworkTopology::P2P(links)
+        connected.sort_unstable_by_key(|entity| entity.index_u32());
+        NetworkTopology::P2P {
+            connected,
+            declared,
+        }
     } else if let Some(client) = malformed_hosts
         .iter()
         .min_by_key(|entity| entity.index_u32())
@@ -414,7 +428,13 @@ mod tests {
         let second = app.world_mut().spawn(P2P).id();
 
         app.update();
-        assert_eq!(mode(&app), &NetworkTopology::P2P(SmallVec::new()));
+        assert_eq!(
+            mode(&app),
+            &NetworkTopology::P2P {
+                connected: SmallVec::new(),
+                declared: 2,
+            }
+        );
 
         // Connect in reverse order to prove that insertion order does not affect the cache.
         app.world_mut()
@@ -427,7 +447,10 @@ mod tests {
 
         assert_eq!(
             mode(&app),
-            &NetworkTopology::P2P(SmallVec::from_slice(&[first, second]))
+            &NetworkTopology::P2P {
+                connected: SmallVec::from_slice(&[first, second]),
+                declared: 2,
+            }
         );
 
         app.world_mut().entity_mut(first).insert(Disconnected {
@@ -436,12 +459,21 @@ mod tests {
         app.update();
         assert_eq!(
             mode(&app),
-            &NetworkTopology::P2P(SmallVec::from_slice(&[second]))
+            &NetworkTopology::P2P {
+                connected: SmallVec::from_slice(&[second]),
+                declared: 2,
+            }
         );
 
         app.world_mut().despawn(second);
         app.update();
-        assert_eq!(mode(&app), &NetworkTopology::P2P(SmallVec::new()));
+        assert_eq!(
+            mode(&app),
+            &NetworkTopology::P2P {
+                connected: SmallVec::new(),
+                declared: 1,
+            }
+        );
 
         app.world_mut().entity_mut(first).remove::<P2P>();
         app.update();
@@ -461,7 +493,10 @@ mod tests {
         app.update();
         assert_eq!(
             mode(&app),
-            &NetworkTopology::P2P(SmallVec::from_slice(&[peer]))
+            &NetworkTopology::P2P {
+                connected: SmallVec::from_slice(&[peer]),
+                declared: 1,
+            }
         );
     }
 

--- a/crates/connection/connection/src/p2p.rs
+++ b/crates/connection/connection/src/p2p.rs
@@ -1,0 +1,11 @@
+use crate::client::Client;
+use bevy_ecs::prelude::*;
+use bevy_reflect::Reflect;
+
+/// Marks a client link as a direct connection to another peer in a P2P session.
+///
+/// P2P links remain [`Client`] links so that they can reuse the existing connection,
+/// messaging, input, and prediction pipelines.
+#[derive(Component, Default, Debug, Clone, Copy, PartialEq, Eq, Reflect)]
+#[require(Client)]
+pub struct P2P;


### PR DESCRIPTION
## Summary

- add a library-maintained `NetworkingMetadata` resource with cached `NetworkTopology`
- infer only ready client, server, host-client, and P2P entities after lifecycle changes
- add a `P2P` marker that requires `Client` so peer Links reuse existing connection plumbing
- cache P2P topology as `P2P { connected: SmallVec<[Entity; 4]>, declared_links: u8 }`; consumers can compare the connected subset with the locally declared count without another query or allocation
- reject a ready non-P2P Client, HostClient, or started Server alongside P2P as `Invalid(MixedP2PAndConventional)`
- ignore disconnected conventional clients and unstarted servers when checking for a mixed ready topology
- avoid conventional client/server collections; allocate inline storage only for P2P Links and invalid multi-role diagnostics

## Validation

- `cargo test -p lightyear_connection network_topology --all-features`
- affected-stack unit tests and doctests
- allocation-regression budget test
- warnings-as-errors Clippy for the affected stack
- `cargo fmt --all -- --check`