### PR TITLE
refactor(sync): make input timeline application-global

### DIFF
--- a/crates/core/sync/src/client.rs
+++ b/crates/core/sync/src/client.rs
@@ -1,15 +1,28 @@
 /*! Handles syncing the time between the client and the server
 */
+use crate::ping::manager::PingManager;
+use crate::plugin::SyncSystems;
 use crate::plugin::TimelineSyncPlugin;
-use crate::prelude::InputTimeline;
 use crate::prelude::client::RemoteTimeline;
-use crate::timeline::input::InputTimelineConfig;
+use crate::timeline::input::{InputTimeline, InputTimelineConfig, InputTimelineShifted};
 use crate::timeline::remote;
-use crate::timeline::sync::SyncedTimelinePlugin;
+use crate::timeline::sync::{SyncTargetTimeline, SyncedTimeline};
 use bevy_app::prelude::*;
-use bevy_ecs::prelude::IntoScheduleConfigs;
-use lightyear_connection::client::Client;
-use lightyear_core::prelude::{NetworkTimelinePlugin, TimelineSystems};
+use bevy_app::{Last, PostUpdate};
+use bevy_ecs::prelude::*;
+use bevy_time::{Fixed, Time, Virtual};
+use lightyear_connection::client::{Client, Connected, Disconnected};
+use lightyear_connection::host::HostClient;
+use lightyear_connection::network_topology::{
+    NetworkTopology, NetworkTopologySystems, NetworkingMetadata,
+};
+use lightyear_core::prelude::{
+    LocalTimeline, NetworkTimeline, NetworkTimelinePlugin, TimelineSystems,
+};
+use lightyear_core::tick::TickDuration;
+use lightyear_core::time::{Overstep, TickInstant};
+use lightyear_link::{Link, LinkStats};
+use tracing::{debug, trace};
 
 // When a Client is created; we want to add a PredictedTimeline? InterpolatedTimeline?
 //  or should we let the user do it?
@@ -48,14 +61,33 @@ impl Plugin for ClientPlugin {
             app.add_plugins(TimelineSyncPlugin);
         }
 
-        app.register_required_components::<Client, InputTimelineConfig>();
+        app.init_resource::<InputTimeline>();
+        app.init_resource::<InputTimelineConfig>();
+        // The connection plugin is normally added later by SharedPlugins. Initializing this cache
+        // here keeps the standalone sync plugin usable too.
+        app.init_resource::<NetworkingMetadata>();
+
         app.register_required_components::<Client, RemoteTimeline>();
+        app.register_required_components::<Client, PingManager>();
 
-        app.add_observer(InputTimelineConfig::recompute_input_delay_on_sync);
-        app.add_observer(InputTimelineConfig::recompute_input_delay_on_config_update);
-
-        // the client will use the Input timeline as the driving timeline
-        app.add_plugins(SyncedTimelinePlugin::<InputTimeline, RemoteTimeline, true>::default());
+        app.add_observer(handle_connect);
+        app.add_observer(handle_host_client);
+        app.add_observer(handle_disconnect);
+        app.add_observer(recompute_input_delay_on_shift);
+        app.add_observer(handle_input_timeline_shift);
+        app.add_systems(
+            PostUpdate,
+            (
+                sync_from_local_timeline,
+                recompute_input_delay_on_config_update
+                    .run_if(resource_changed::<InputTimelineConfig>),
+                sync_input_timeline,
+            )
+                .chain()
+                .in_set(SyncSystems::Sync)
+                .after(NetworkTopologySystems::Update),
+        );
+        app.add_systems(Last, update_virtual_time);
 
         // remote timeline
         app.add_plugins(NetworkTimelinePlugin::<RemoteTimeline>::default());
@@ -67,6 +99,184 @@ impl Plugin for ClientPlugin {
         );
         app.add_systems(Last, remote::reset_received_packet_remote_timeline);
     }
+}
+
+fn handle_connect(
+    trigger: On<Add, Connected>,
+    local_timeline: Res<LocalTimeline>,
+    config: Res<InputTimelineConfig>,
+    clients: Query<&Link, With<Client>>,
+    tick_duration: Res<TickDuration>,
+    mut timeline: ResMut<InputTimeline>,
+) {
+    let Ok(link) = clients.get(trigger.entity) else {
+        return;
+    };
+    timeline.reset();
+    timeline.set_now(TickInstant::from(local_timeline.tick()));
+    timeline.recompute_input_delay(&config, link.stats, tick_duration.0);
+}
+
+fn handle_host_client(
+    trigger: On<Add, HostClient>,
+    clients: Query<(), With<Client>>,
+    mut timeline: ResMut<InputTimeline>,
+) {
+    if clients.get(trigger.entity).is_ok() {
+        timeline.set_synced(true);
+        timeline.set_relative_speed(1.0);
+    }
+}
+
+fn handle_disconnect(
+    trigger: On<Add, Disconnected>,
+    clients: Query<(), With<Client>>,
+    mut timeline: ResMut<InputTimeline>,
+) {
+    if clients.get(trigger.entity).is_ok() {
+        timeline.reset();
+    }
+}
+
+fn sync_from_local_timeline(
+    local_timeline: Res<LocalTimeline>,
+    fixed_time: Res<Time<Fixed>>,
+    mut timeline: ResMut<InputTimeline>,
+) {
+    let overstep = fixed_time.overstep_fraction();
+    timeline.set_now(TickInstant::from_tick_and_overstep(
+        local_timeline.tick(),
+        Overstep::from_f32(overstep),
+    ));
+    trace!(
+        target: "lightyear_debug::timeline",
+        kind = "sync_from_local_timeline",
+        schedule = "PostUpdate",
+        sample_point = "PostUpdate",
+        timeline = "InputTimeline",
+        local_tick = local_timeline.tick().0,
+        timeline_tick = timeline.tick().0,
+        overstep,
+        "global input timeline synced from LocalTimeline"
+    );
+}
+
+fn configured_link_stats(
+    metadata: &NetworkingMetadata,
+    links: &Query<(Entity, &Link), With<Client>>,
+) -> LinkStats {
+    let entity = match &metadata.mode {
+        NetworkTopology::Client(entity) => Some(*entity),
+        NetworkTopology::HostClient { client, .. } => Some(*client),
+        NetworkTopology::Undefined => links.single().ok().map(|(entity, _)| entity),
+        NetworkTopology::Server(_) | NetworkTopology::P2P(_) | NetworkTopology::Invalid(_) => None,
+    };
+    entity
+        .and_then(|entity| links.get(entity).ok())
+        .map(|(_, link)| link.stats)
+        .unwrap_or_default()
+}
+
+fn recompute_input_delay_on_config_update(
+    config: Res<InputTimelineConfig>,
+    metadata: Res<NetworkingMetadata>,
+    links: Query<(Entity, &Link), With<Client>>,
+    tick_duration: Res<TickDuration>,
+    mut timeline: ResMut<InputTimeline>,
+) {
+    let link_stats = configured_link_stats(&metadata, &links);
+    timeline.recompute_input_delay(&config, link_stats, tick_duration.0);
+    trace!(
+        input_delay_ticks = timeline.input_delay(),
+        config = ?config.input_delay_config,
+        "recomputed global input delay after config update"
+    );
+}
+
+fn recompute_input_delay_on_shift(
+    trigger: On<InputTimelineShifted>,
+    config: Res<InputTimelineConfig>,
+    metadata: Res<NetworkingMetadata>,
+    links: Query<(Entity, &Link), With<Client>>,
+    tick_duration: Res<TickDuration>,
+    mut timeline: ResMut<InputTimeline>,
+) {
+    let before = timeline.input_delay();
+    let link_stats = configured_link_stats(&metadata, &links);
+    timeline.recompute_input_delay(&config, link_stats, tick_duration.0);
+    trace!(
+        target: "lightyear_debug::sync",
+        kind = "input_delay_recomputed_on_sync",
+        schedule = "PostUpdate",
+        sample_point = "PostUpdate",
+        tick_delta = trigger.tick_delta,
+        input_delay_ticks_before = before,
+        input_delay_ticks_after = timeline.input_delay(),
+        rtt_ms = link_stats.rtt.as_secs_f64() * 1000.0,
+        "sync event: recomputed global input delay"
+    );
+}
+
+fn sync_input_timeline(
+    tick_duration: Res<TickDuration>,
+    metadata: Res<NetworkingMetadata>,
+    mut timeline: ResMut<InputTimeline>,
+    config: Res<InputTimelineConfig>,
+    links: Query<
+        (Entity, &RemoteTimeline, &PingManager, Has<HostClient>),
+        (With<Client>, With<Connected>),
+    >,
+    mut commands: Commands,
+) {
+    let selected = match &metadata.mode {
+        NetworkTopology::Client(entity) => links.get(*entity).ok(),
+        NetworkTopology::HostClient { client, .. } => links.get(*client).ok(),
+        // Standalone lightyear_sync tests can run without ConnectionPlugin maintaining the cache.
+        NetworkTopology::Undefined => links.single().ok(),
+        NetworkTopology::Server(_) | NetworkTopology::P2P(_) | NetworkTopology::Invalid(_) => None,
+    };
+    let Some((entity, remote, ping_manager, is_host_client)) = selected else {
+        timeline.set_synced(false);
+        timeline.set_relative_speed(1.0);
+        return;
+    };
+    if is_host_client {
+        timeline.set_synced(true);
+        timeline.set_relative_speed(1.0);
+        return;
+    }
+    if !remote.received_packet() {
+        return;
+    }
+
+    let was_synced = timeline.is_synced();
+    if let Some(tick_delta) = timeline.sync(remote, &config, ping_manager, tick_duration.0) {
+        commands.trigger(InputTimelineShifted { tick_delta });
+    }
+    if !was_synced && timeline.is_synced() {
+        debug!(?entity, "global InputTimeline is synced");
+    }
+}
+
+fn handle_input_timeline_shift(
+    trigger: On<InputTimelineShifted>,
+    mut local_timeline: ResMut<LocalTimeline>,
+) {
+    local_timeline.apply_delta(trigger.tick_delta);
+    debug!(
+        tick_delta = trigger.tick_delta,
+        new_tick = ?local_timeline.tick(),
+        "applied global InputTimeline shift to LocalTimeline"
+    );
+}
+
+fn update_virtual_time(timeline: Res<InputTimeline>, mut virtual_time: ResMut<Time<Virtual>>) {
+    let relative_speed = if timeline.is_synced() {
+        timeline.relative_speed()
+    } else {
+        1.0
+    };
+    virtual_time.set_relative_speed(relative_speed);
 }
 
 #[cfg(test)]

--- a/crates/core/sync/src/client.rs
+++ b/crates/core/sync/src/client.rs
@@ -62,7 +62,6 @@ impl Plugin for ClientPlugin {
         // while every runtime configuration update, connection, and sync event happens after it.
         app.add_observer(InputTimelineConfig::recompute_input_delay_on_sync);
         app.add_observer(InputTimelineConfig::recompute_input_delay_on_config_update);
-        app.add_observer(InputTimelineConfig::recompute_input_delay_on_connect);
 
         // remote timeline
         app.add_plugins(NetworkTimelinePlugin::<RemoteTimeline>::default());
@@ -81,6 +80,7 @@ mod tests {
     use super::*;
     use bevy_time::{TimePlugin, TimeUpdateStrategy};
     use core::time::Duration;
+    use lightyear_connection::network_topology::NetworkingMetadata;
     use lightyear_core::plugin::CorePlugins;
     use lightyear_core::time::TickInstant;
     use lightyear_link::prelude::Linked;
@@ -93,6 +93,7 @@ mod tests {
             .insert_resource(TimeUpdateStrategy::ManualDuration(Duration::from_millis(
                 10,
             )));
+        app.init_resource::<NetworkingMetadata>();
         app.add_plugins((
             TimePlugin,
             CorePlugins {

--- a/crates/core/sync/src/client.rs
+++ b/crates/core/sync/src/client.rs
@@ -4,7 +4,7 @@ use crate::plugin::TimelineSyncPlugin;
 use crate::prelude::client::RemoteTimeline;
 use crate::timeline::input::{InputTimeline, InputTimelineConfig};
 use crate::timeline::remote;
-use crate::timeline::sync::{ResourceTimelineStorage, SyncedTimelinePlugin};
+use crate::timeline::sync::SyncedTimelinePlugin;
 use bevy_app::prelude::*;
 use bevy_ecs::prelude::IntoScheduleConfigs;
 use lightyear_connection::client::Client;
@@ -49,17 +49,20 @@ impl Plugin for ClientPlugin {
 
         app.register_required_components::<Client, RemoteTimeline>();
 
-        app.add_observer(InputTimelineConfig::recompute_input_delay_on_sync);
-        app.add_observer(InputTimelineConfig::recompute_input_delay_on_config_update);
-        app.add_observer(InputTimelineConfig::recompute_input_delay_on_connect);
-
         // The application has one driving input clock even when it has several network links.
         app.add_plugins(SyncedTimelinePlugin::<
             InputTimeline,
             RemoteTimeline,
             true,
-            ResourceTimelineStorage,
+            true,
         >::default());
+
+        // Register these after the resource-backed timeline plugin initializes its default
+        // configuration. `ClientPlugin` can be built before `CorePlugins` installs TickDuration,
+        // while every runtime configuration update, connection, and sync event happens after it.
+        app.add_observer(InputTimelineConfig::recompute_input_delay_on_sync);
+        app.add_observer(InputTimelineConfig::recompute_input_delay_on_config_update);
+        app.add_observer(InputTimelineConfig::recompute_input_delay_on_connect);
 
         // remote timeline
         app.add_plugins(NetworkTimelinePlugin::<RemoteTimeline>::default());

--- a/crates/core/sync/src/client.rs
+++ b/crates/core/sync/src/client.rs
@@ -1,28 +1,14 @@
 /*! Handles syncing the time between the client and the server
 */
-use crate::ping::manager::PingManager;
-use crate::plugin::SyncSystems;
 use crate::plugin::TimelineSyncPlugin;
 use crate::prelude::client::RemoteTimeline;
-use crate::timeline::input::{InputTimeline, InputTimelineConfig, InputTimelineShifted};
+use crate::timeline::input::{InputTimeline, InputTimelineConfig};
 use crate::timeline::remote;
-use crate::timeline::sync::{SyncTargetTimeline, SyncedTimeline};
+use crate::timeline::sync::{ResourceTimelineStorage, SyncedTimelinePlugin};
 use bevy_app::prelude::*;
-use bevy_app::{Last, PostUpdate};
-use bevy_ecs::prelude::*;
-use bevy_time::{Fixed, Time, Virtual};
-use lightyear_connection::client::{Client, Connected, Disconnected};
-use lightyear_connection::host::HostClient;
-use lightyear_connection::network_topology::{
-    NetworkTopology, NetworkTopologySystems, NetworkingMetadata,
-};
-use lightyear_core::prelude::{
-    LocalTimeline, NetworkTimeline, NetworkTimelinePlugin, TimelineSystems,
-};
-use lightyear_core::tick::TickDuration;
-use lightyear_core::time::{Overstep, TickInstant};
-use lightyear_link::{Link, LinkStats};
-use tracing::{debug, trace};
+use bevy_ecs::prelude::IntoScheduleConfigs;
+use lightyear_connection::client::Client;
+use lightyear_core::prelude::{NetworkTimelinePlugin, TimelineSystems};
 
 // When a Client is created; we want to add a PredictedTimeline? InterpolatedTimeline?
 //  or should we let the user do it?
@@ -61,33 +47,19 @@ impl Plugin for ClientPlugin {
             app.add_plugins(TimelineSyncPlugin);
         }
 
-        app.init_resource::<InputTimeline>();
-        app.init_resource::<InputTimelineConfig>();
-        // The connection plugin is normally added later by SharedPlugins. Initializing this cache
-        // here keeps the standalone sync plugin usable too.
-        app.init_resource::<NetworkingMetadata>();
-
         app.register_required_components::<Client, RemoteTimeline>();
-        app.register_required_components::<Client, PingManager>();
 
-        app.add_observer(handle_connect);
-        app.add_observer(handle_host_client);
-        app.add_observer(handle_disconnect);
-        app.add_observer(recompute_input_delay_on_shift);
-        app.add_observer(handle_input_timeline_shift);
-        app.add_systems(
-            PostUpdate,
-            (
-                sync_from_local_timeline,
-                recompute_input_delay_on_config_update
-                    .run_if(resource_changed::<InputTimelineConfig>),
-                sync_input_timeline,
-            )
-                .chain()
-                .in_set(SyncSystems::Sync)
-                .after(NetworkTopologySystems::Update),
-        );
-        app.add_systems(Last, update_virtual_time);
+        app.add_observer(InputTimelineConfig::recompute_input_delay_on_sync);
+        app.add_observer(InputTimelineConfig::recompute_input_delay_on_config_update);
+        app.add_observer(InputTimelineConfig::recompute_input_delay_on_connect);
+
+        // The application has one driving input clock even when it has several network links.
+        app.add_plugins(SyncedTimelinePlugin::<
+            InputTimeline,
+            RemoteTimeline,
+            true,
+            ResourceTimelineStorage,
+        >::default());
 
         // remote timeline
         app.add_plugins(NetworkTimelinePlugin::<RemoteTimeline>::default());
@@ -99,184 +71,6 @@ impl Plugin for ClientPlugin {
         );
         app.add_systems(Last, remote::reset_received_packet_remote_timeline);
     }
-}
-
-fn handle_connect(
-    trigger: On<Add, Connected>,
-    local_timeline: Res<LocalTimeline>,
-    config: Res<InputTimelineConfig>,
-    clients: Query<&Link, With<Client>>,
-    tick_duration: Res<TickDuration>,
-    mut timeline: ResMut<InputTimeline>,
-) {
-    let Ok(link) = clients.get(trigger.entity) else {
-        return;
-    };
-    timeline.reset();
-    timeline.set_now(TickInstant::from(local_timeline.tick()));
-    timeline.recompute_input_delay(&config, link.stats, tick_duration.0);
-}
-
-fn handle_host_client(
-    trigger: On<Add, HostClient>,
-    clients: Query<(), With<Client>>,
-    mut timeline: ResMut<InputTimeline>,
-) {
-    if clients.get(trigger.entity).is_ok() {
-        timeline.set_synced(true);
-        timeline.set_relative_speed(1.0);
-    }
-}
-
-fn handle_disconnect(
-    trigger: On<Add, Disconnected>,
-    clients: Query<(), With<Client>>,
-    mut timeline: ResMut<InputTimeline>,
-) {
-    if clients.get(trigger.entity).is_ok() {
-        timeline.reset();
-    }
-}
-
-fn sync_from_local_timeline(
-    local_timeline: Res<LocalTimeline>,
-    fixed_time: Res<Time<Fixed>>,
-    mut timeline: ResMut<InputTimeline>,
-) {
-    let overstep = fixed_time.overstep_fraction();
-    timeline.set_now(TickInstant::from_tick_and_overstep(
-        local_timeline.tick(),
-        Overstep::from_f32(overstep),
-    ));
-    trace!(
-        target: "lightyear_debug::timeline",
-        kind = "sync_from_local_timeline",
-        schedule = "PostUpdate",
-        sample_point = "PostUpdate",
-        timeline = "InputTimeline",
-        local_tick = local_timeline.tick().0,
-        timeline_tick = timeline.tick().0,
-        overstep,
-        "global input timeline synced from LocalTimeline"
-    );
-}
-
-fn configured_link_stats(
-    metadata: &NetworkingMetadata,
-    links: &Query<(Entity, &Link), With<Client>>,
-) -> LinkStats {
-    let entity = match &metadata.mode {
-        NetworkTopology::Client(entity) => Some(*entity),
-        NetworkTopology::HostClient { client, .. } => Some(*client),
-        NetworkTopology::Undefined => links.single().ok().map(|(entity, _)| entity),
-        NetworkTopology::Server(_) | NetworkTopology::P2P(_) | NetworkTopology::Invalid(_) => None,
-    };
-    entity
-        .and_then(|entity| links.get(entity).ok())
-        .map(|(_, link)| link.stats)
-        .unwrap_or_default()
-}
-
-fn recompute_input_delay_on_config_update(
-    config: Res<InputTimelineConfig>,
-    metadata: Res<NetworkingMetadata>,
-    links: Query<(Entity, &Link), With<Client>>,
-    tick_duration: Res<TickDuration>,
-    mut timeline: ResMut<InputTimeline>,
-) {
-    let link_stats = configured_link_stats(&metadata, &links);
-    timeline.recompute_input_delay(&config, link_stats, tick_duration.0);
-    trace!(
-        input_delay_ticks = timeline.input_delay(),
-        config = ?config.input_delay_config,
-        "recomputed global input delay after config update"
-    );
-}
-
-fn recompute_input_delay_on_shift(
-    trigger: On<InputTimelineShifted>,
-    config: Res<InputTimelineConfig>,
-    metadata: Res<NetworkingMetadata>,
-    links: Query<(Entity, &Link), With<Client>>,
-    tick_duration: Res<TickDuration>,
-    mut timeline: ResMut<InputTimeline>,
-) {
-    let before = timeline.input_delay();
-    let link_stats = configured_link_stats(&metadata, &links);
-    timeline.recompute_input_delay(&config, link_stats, tick_duration.0);
-    trace!(
-        target: "lightyear_debug::sync",
-        kind = "input_delay_recomputed_on_sync",
-        schedule = "PostUpdate",
-        sample_point = "PostUpdate",
-        tick_delta = trigger.tick_delta,
-        input_delay_ticks_before = before,
-        input_delay_ticks_after = timeline.input_delay(),
-        rtt_ms = link_stats.rtt.as_secs_f64() * 1000.0,
-        "sync event: recomputed global input delay"
-    );
-}
-
-fn sync_input_timeline(
-    tick_duration: Res<TickDuration>,
-    metadata: Res<NetworkingMetadata>,
-    mut timeline: ResMut<InputTimeline>,
-    config: Res<InputTimelineConfig>,
-    links: Query<
-        (Entity, &RemoteTimeline, &PingManager, Has<HostClient>),
-        (With<Client>, With<Connected>),
-    >,
-    mut commands: Commands,
-) {
-    let selected = match &metadata.mode {
-        NetworkTopology::Client(entity) => links.get(*entity).ok(),
-        NetworkTopology::HostClient { client, .. } => links.get(*client).ok(),
-        // Standalone lightyear_sync tests can run without ConnectionPlugin maintaining the cache.
-        NetworkTopology::Undefined => links.single().ok(),
-        NetworkTopology::Server(_) | NetworkTopology::P2P(_) | NetworkTopology::Invalid(_) => None,
-    };
-    let Some((entity, remote, ping_manager, is_host_client)) = selected else {
-        timeline.set_synced(false);
-        timeline.set_relative_speed(1.0);
-        return;
-    };
-    if is_host_client {
-        timeline.set_synced(true);
-        timeline.set_relative_speed(1.0);
-        return;
-    }
-    if !remote.received_packet() {
-        return;
-    }
-
-    let was_synced = timeline.is_synced();
-    if let Some(tick_delta) = timeline.sync(remote, &config, ping_manager, tick_duration.0) {
-        commands.trigger(InputTimelineShifted { tick_delta });
-    }
-    if !was_synced && timeline.is_synced() {
-        debug!(?entity, "global InputTimeline is synced");
-    }
-}
-
-fn handle_input_timeline_shift(
-    trigger: On<InputTimelineShifted>,
-    mut local_timeline: ResMut<LocalTimeline>,
-) {
-    local_timeline.apply_delta(trigger.tick_delta);
-    debug!(
-        tick_delta = trigger.tick_delta,
-        new_tick = ?local_timeline.tick(),
-        "applied global InputTimeline shift to LocalTimeline"
-    );
-}
-
-fn update_virtual_time(timeline: Res<InputTimeline>, mut virtual_time: ResMut<Time<Virtual>>) {
-    let relative_speed = if timeline.is_synced() {
-        timeline.relative_speed()
-    } else {
-        1.0
-    };
-    virtual_time.set_relative_speed(relative_speed);
 }
 
 #[cfg(test)]

--- a/crates/core/sync/src/lib.rs
+++ b/crates/core/sync/src/lib.rs
@@ -37,10 +37,7 @@ pub mod prelude {
     pub use crate::ping::manager::{PingConfig, PingManager};
     pub use crate::ping::message::{Ping, Pong};
     pub use crate::plugin::{SyncSystems, TimelineSyncPlugin};
-    pub use crate::timeline::sync::{
-        ComponentTimelineStorage, IsSynced, ResourceTimelineStorage, SyncConfig,
-        SyncedTimelinePlugin,
-    };
+    pub use crate::timeline::sync::{IsSynced, SyncConfig, SyncedTimelinePlugin};
     pub use crate::timeline::{
         DrivingTimeline,
         input::{InputTimeline, InputTimelineConfig, SyncedInputTimeline},

--- a/crates/core/sync/src/lib.rs
+++ b/crates/core/sync/src/lib.rs
@@ -40,12 +40,14 @@ pub mod prelude {
     pub use crate::timeline::sync::{IsSynced, SyncConfig};
     pub use crate::timeline::{
         DrivingTimeline,
-        input::{InputTimeline, InputTimelineConfig},
+        input::{InputTimeline, InputTimelineConfig, InputTimelineShifted},
     };
 
     #[cfg(feature = "client")]
     pub mod client {
-        pub use crate::timeline::input::{InputDelayConfig, InputTimeline, InputTimelineConfig};
+        pub use crate::timeline::input::{
+            InputDelayConfig, InputTimeline, InputTimelineConfig, InputTimelineShifted,
+        };
         pub use crate::timeline::remote::{RemoteEstimate, RemoteTimeline};
         pub use crate::timeline::sync::IsSynced;
     }

--- a/crates/core/sync/src/lib.rs
+++ b/crates/core/sync/src/lib.rs
@@ -37,16 +37,19 @@ pub mod prelude {
     pub use crate::ping::manager::{PingConfig, PingManager};
     pub use crate::ping::message::{Ping, Pong};
     pub use crate::plugin::{SyncSystems, TimelineSyncPlugin};
-    pub use crate::timeline::sync::{IsSynced, SyncConfig};
+    pub use crate::timeline::sync::{
+        ComponentTimelineStorage, IsSynced, ResourceTimelineStorage, SyncConfig,
+        SyncedTimelinePlugin,
+    };
     pub use crate::timeline::{
         DrivingTimeline,
-        input::{InputTimeline, InputTimelineConfig, InputTimelineShifted},
+        input::{InputTimeline, InputTimelineConfig, SyncedInputTimeline},
     };
 
     #[cfg(feature = "client")]
     pub mod client {
         pub use crate::timeline::input::{
-            InputDelayConfig, InputTimeline, InputTimelineConfig, InputTimelineShifted,
+            InputDelayConfig, InputTimeline, InputTimelineConfig, SyncedInputTimeline,
         };
         pub use crate::timeline::remote::{RemoteEstimate, RemoteTimeline};
         pub use crate::timeline::sync::IsSynced;

--- a/crates/core/sync/src/timeline/input.rs
+++ b/crates/core/sync/src/timeline/input.rs
@@ -407,12 +407,12 @@ impl InputTimeline {
         let input_delay_ticks = match topology {
             NetworkTopology::Client(entity) => delay_for(*entity),
             NetworkTopology::HostClient { client, .. } => delay_for(*client),
-            NetworkTopology::P2P(entities) if !entities.is_empty() => entities
+            NetworkTopology::P2P { connected, .. } if !connected.is_empty() => connected
                 .iter()
                 .try_fold(0, |maximum, entity| Some(maximum.max(delay_for(*entity)?))),
             NetworkTopology::Undefined
             | NetworkTopology::Server(_)
-            | NetworkTopology::P2P(_)
+            | NetworkTopology::P2P { .. }
             | NetworkTopology::Invalid(_) => None,
         };
         let Some(input_delay_ticks) = input_delay_ticks else {
@@ -726,7 +726,10 @@ mod tests {
         let slow = app.world_mut().spawn(slow_link).id();
 
         let mut metadata = NetworkingMetadata::default();
-        metadata.mode = NetworkTopology::P2P([fast, slow].into_iter().collect());
+        metadata.mode = NetworkTopology::P2P {
+            connected: [fast, slow].into_iter().collect(),
+            declared: 2,
+        };
         app.insert_resource(metadata);
         app.insert_resource(TickDuration(Duration::from_millis(10)));
         let mut config =

--- a/crates/core/sync/src/timeline/input.rs
+++ b/crates/core/sync/src/timeline/input.rs
@@ -728,7 +728,7 @@ mod tests {
         let mut metadata = NetworkingMetadata::default();
         metadata.mode = NetworkTopology::P2P {
             connected: [fast, slow].into_iter().collect(),
-            declared: 2,
+            declared_links: 2,
         };
         app.insert_resource(metadata);
         app.insert_resource(TickDuration(Duration::from_millis(10)));

--- a/crates/core/sync/src/timeline/input.rs
+++ b/crates/core/sync/src/timeline/input.rs
@@ -7,16 +7,15 @@ use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::prelude::*;
 use bevy_reflect::Reflect;
 use core::time::Duration;
-use lightyear_core::tick::{Tick, TickDuration};
+use lightyear_core::tick::Tick;
 use lightyear_core::time::{TickDelta, TickInstant};
-use lightyear_core::timeline::{NetworkTimeline, SyncEvent, Timeline, TimelineConfig};
-use lightyear_link::{Link, LinkStats};
+use lightyear_core::timeline::{NetworkTimeline, Timeline, TimelineConfig};
+use lightyear_link::LinkStats;
 use tracing::trace;
 
 /// Timeline that is used to make sure that Inputs from this peer will arrive on time
 /// on the remote peer
-#[derive(Debug, Component, Reflect)]
-#[require(InputTimeline)]
+#[derive(Debug, Resource, Reflect)]
 pub struct InputTimelineConfig {
     pub(crate) sync: SyncConfig,
     pub(crate) input_delay_config: InputDelayConfig,
@@ -46,65 +45,9 @@ impl InputTimelineConfig {
     pub fn is_lockstep(&self) -> bool {
         self.input_delay_config.is_lockstep()
     }
-
     /// Maximum number of ticks the local simulation is allowed to predict ahead.
     pub fn maximum_predicted_ticks(&self) -> u16 {
         self.input_delay_config.maximum_predicted_ticks
-    }
-
-    /// Update the input delay based on the current RTT and tick duration
-    /// when there is a SyncEvent
-    pub(crate) fn recompute_input_delay_on_sync(
-        trigger: On<SyncEvent<InputTimelineConfig>>,
-        tick_duration: Res<TickDuration>,
-        mut query: Query<(&Link, &mut InputTimeline, &InputTimelineConfig)>,
-    ) {
-        if let Ok((link, mut timeline, config)) = query.get_mut(trigger.entity) {
-            let before = timeline.input_delay_ticks;
-            timeline.input_delay_ticks = config.input_delay_config.input_delay_ticks(
-                link.stats,
-                &config.sync,
-                tick_duration.0,
-            );
-            trace!(
-                "Recomputing input delay on sync event! Input delay ticks: {}",
-                timeline.input_delay_ticks
-            );
-            trace!(
-                target: "lightyear_debug::sync",
-                kind = "input_delay_recomputed_on_sync",
-                schedule = "PreUpdate",
-                sample_point = "PreUpdate",
-                entity = ?trigger.entity,
-                tick_delta = trigger.tick_delta,
-                input_delay_ticks_before = before,
-                input_delay_ticks_after = timeline.input_delay_ticks,
-                rtt_ms = link.stats.rtt.as_secs_f64() * 1000.0,
-                "sync event: recomputed input delay"
-            );
-        }
-    }
-
-    // TODO: we want to limit this when only the config updates, not the timeline itself!
-    //  disabling this for now
-    /// Update the input delay based on the current RTT and tick duration
-    /// when the InputDelayConfig is updated
-    pub(crate) fn recompute_input_delay_on_config_update(
-        trigger: On<Insert, InputTimelineConfig>,
-        tick_duration: Res<TickDuration>,
-        mut query: Query<(&Link, &mut InputTimeline, &InputTimelineConfig)>,
-    ) {
-        if let Ok((link, mut timeline, config)) = query.get_mut(trigger.entity) {
-            timeline.input_delay_ticks = config.input_delay_config.input_delay_ticks(
-                link.stats,
-                &config.sync,
-                tick_duration.0,
-            );
-            trace!(
-                "Recomputing input delay on config update! Input delay ticks: {}. Config: {:?}",
-                timeline.input_delay_ticks, config.input_delay_config
-            );
-        }
     }
 }
 
@@ -272,8 +215,40 @@ impl InputDelayConfig {
 ///
 /// This timeline is updated in PostUpdate; it CANNOT be used to get accurate `tick` in PreUpdate or Update;
 /// use `LocalTimeline` instead.
-#[derive(Component, Deref, DerefMut, Default, Debug, Reflect)]
+#[derive(Resource, Deref, DerefMut, Default, Debug, Reflect)]
 pub struct InputTimeline(pub Timeline<InputTimelineConfig>);
+
+/// Emitted when the global [`InputTimeline`] is snapped by a whole number of ticks.
+///
+/// Tick-indexed input and prediction histories must apply the same delta.
+#[derive(Event, Debug, Clone, Copy)]
+pub struct InputTimelineShifted {
+    /// Whole-tick delta applied to the input and local timelines.
+    pub tick_delta: i32,
+}
+
+impl InputTimeline {
+    /// Returns whether the global input timeline has completed synchronization.
+    pub fn is_synced(&self) -> bool {
+        self.context.is_synced
+    }
+
+    pub(crate) fn set_synced(&mut self, synced: bool) {
+        self.context.is_synced = synced;
+    }
+
+    pub(crate) fn recompute_input_delay(
+        &mut self,
+        config: &InputTimelineConfig,
+        link_stats: LinkStats,
+        tick_duration: Duration,
+    ) {
+        self.context.input_delay_ticks =
+            config
+                .input_delay_config
+                .input_delay_ticks(link_stats, &config.sync, tick_duration);
+    }
+}
 
 impl TimelineConfig for InputTimelineConfig {
     type Context = InputContext;

--- a/crates/core/sync/src/timeline/input.rs
+++ b/crates/core/sync/src/timeline/input.rs
@@ -1,16 +1,19 @@
 use crate::ping::manager::PingManager;
 use crate::timeline::sync::{
-    SyncAdjustment, SyncConfig, SyncContext, SyncTargetTimeline, SyncedTimeline,
+    IsSynced, SyncAdjustment, SyncConfig, SyncContext, SyncTargetTimeline, SyncedTimeline,
 };
 
 use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::prelude::*;
+use bevy_ecs::resource::IsResource;
+use bevy_ecs::system::SystemParam;
 use bevy_reflect::Reflect;
 use core::time::Duration;
-use lightyear_core::tick::Tick;
+use lightyear_connection::client::{Client, Connected};
+use lightyear_core::tick::{Tick, TickDuration};
 use lightyear_core::time::{TickDelta, TickInstant};
-use lightyear_core::timeline::{NetworkTimeline, Timeline, TimelineConfig};
-use lightyear_link::LinkStats;
+use lightyear_core::timeline::{NetworkTimeline, SyncEvent, Timeline, TimelineConfig};
+use lightyear_link::{Link, LinkStats};
 use tracing::trace;
 
 /// Timeline that is used to make sure that Inputs from this peer will arrive on time
@@ -48,6 +51,70 @@ impl InputTimelineConfig {
     /// Maximum number of ticks the local simulation is allowed to predict ahead.
     pub fn maximum_predicted_ticks(&self) -> u16 {
         self.input_delay_config.maximum_predicted_ticks
+    }
+
+    /// Recompute input delay after the global input timeline snaps by whole ticks.
+    ///
+    /// The [`SyncEvent`] targets the input timeline's resource entity. Link statistics remain on
+    /// the single client link and are deliberately selected independently of that entity.
+    pub(crate) fn recompute_input_delay_on_sync(
+        _trigger: On<SyncEvent<InputTimelineConfig>>,
+        tick_duration: Option<Res<TickDuration>>,
+        links: Query<&Link, With<Client>>,
+        config: Res<InputTimelineConfig>,
+        mut timeline: ResMut<InputTimeline>,
+    ) {
+        let (Some(tick_duration), Ok(link)) = (tick_duration, links.single()) else {
+            return;
+        };
+        let before = timeline.input_delay();
+        timeline.recompute_input_delay(&config, link.stats, tick_duration.0);
+        trace!(
+            target: "lightyear_debug::sync",
+            kind = "input_delay_recomputed_on_sync",
+            schedule = "PostUpdate",
+            sample_point = "PostUpdate",
+            input_delay_ticks_before = before,
+            input_delay_ticks_after = timeline.input_delay(),
+            rtt_ms = link.stats.rtt.as_secs_f64() * 1000.0,
+            "sync event: recomputed global input delay"
+        );
+    }
+
+    /// Recompute input delay when the global configuration resource is inserted or replaced.
+    pub(crate) fn recompute_input_delay_on_config_update(
+        _trigger: On<Insert, InputTimelineConfig>,
+        tick_duration: Option<Res<TickDuration>>,
+        links: Query<&Link, With<Client>>,
+        config: Res<InputTimelineConfig>,
+        mut timeline: ResMut<InputTimeline>,
+    ) {
+        let (Some(tick_duration), Ok(link)) = (tick_duration, links.single()) else {
+            return;
+        };
+        timeline.recompute_input_delay(&config, link.stats, tick_duration.0);
+        trace!(
+            input_delay_ticks = timeline.input_delay(),
+            config = ?config.input_delay_config,
+            "recomputed global input delay after config update"
+        );
+    }
+
+    /// Initialize input delay from the statistics of the client link that just connected.
+    pub(crate) fn recompute_input_delay_on_connect(
+        trigger: On<Add, Connected>,
+        tick_duration: Option<Res<TickDuration>>,
+        links: Query<&Link, With<Client>>,
+        config: Res<InputTimelineConfig>,
+        mut timeline: ResMut<InputTimeline>,
+    ) {
+        let Some(tick_duration) = tick_duration else {
+            return;
+        };
+        let Ok(link) = links.get(trigger.entity) else {
+            return;
+        };
+        timeline.recompute_input_delay(&config, link.stats, tick_duration.0);
     }
 }
 
@@ -207,9 +274,9 @@ impl InputDelayConfig {
     }
 }
 
-/// Timeline that is used to keep track of when the client should buffer inputs.
+/// Application-global timeline used to decide which tick should receive locally buffered input.
 ///
-/// This timeline is synced with the server timeline, and is the main driving timeline:
+/// This timeline is synced with a remote target timeline, and is the main driving timeline:
 /// any speed adjustments applied to this timeline will also be applied to the `Time<Virtual>` timeline.
 /// (and will therefore affect how fast the FixedUpdate loop runs, and how ticks are incremented)
 ///
@@ -218,25 +285,26 @@ impl InputDelayConfig {
 #[derive(Resource, Deref, DerefMut, Default, Debug, Reflect)]
 pub struct InputTimeline(pub Timeline<InputTimelineConfig>);
 
-/// Emitted when the global [`InputTimeline`] is snapped by a whole number of ticks.
+/// Read-only access to the global [`InputTimeline`] after it has synchronized.
 ///
-/// Tick-indexed input and prediction histories must apply the same delta.
-#[derive(Event, Debug, Clone, Copy)]
-pub struct InputTimelineShifted {
-    /// Whole-tick delta applied to the input and local timelines.
-    pub tick_delta: i32,
+/// Systems using this parameter are skipped until [`IsSynced<InputTimeline>`] has been inserted on
+/// the resource entity. This keeps callers from having to spell out Bevy's resource-entity query.
+#[derive(SystemParam)]
+pub struct SyncedInputTimeline<'w, 's> {
+    timeline:
+        Single<'w, 's, &'static InputTimeline, (With<IsResource>, With<IsSynced<InputTimeline>>)>,
+}
+
+impl core::ops::Deref for SyncedInputTimeline<'_, '_> {
+    type Target = InputTimeline;
+
+    fn deref(&self) -> &Self::Target {
+        *self.timeline
+    }
 }
 
 impl InputTimeline {
-    /// Returns whether the global input timeline has completed synchronization.
-    pub fn is_synced(&self) -> bool {
-        self.context.is_synced
-    }
-
-    pub(crate) fn set_synced(&mut self, synced: bool) {
-        self.context.is_synced = synced;
-    }
-
+    /// Recompute the number of delayed input ticks for the selected link statistics.
     pub(crate) fn recompute_input_delay(
         &mut self,
         config: &InputTimelineConfig,

--- a/crates/core/sync/src/timeline/input.rs
+++ b/crates/core/sync/src/timeline/input.rs
@@ -4,11 +4,13 @@ use crate::timeline::sync::{
 };
 
 use bevy_derive::{Deref, DerefMut};
+use bevy_ecs::change_detection::Tick as ChangeTick;
 use bevy_ecs::prelude::*;
-use bevy_ecs::resource::IsResource;
-use bevy_ecs::system::SystemParam;
+use bevy_ecs::query::FilteredAccessSet;
+use bevy_ecs::system::{ReadOnlySystemParam, SystemMeta, SystemParam, SystemParamValidationError};
+use bevy_ecs::world::unsafe_world_cell::UnsafeWorldCell;
 use bevy_reflect::Reflect;
-use core::time::Duration;
+use core::{marker::PhantomData, time::Duration};
 use lightyear_connection::network_topology::{NetworkTopology, NetworkingMetadata};
 use lightyear_core::tick::{Tick, TickDuration};
 use lightyear_core::time::{TickDelta, TickInstant};
@@ -277,20 +279,110 @@ pub struct InputTimeline(pub Timeline<InputTimelineConfig>);
 /// Read-only access to the global [`InputTimeline`] after it has synchronized.
 ///
 /// Systems using this parameter are skipped until [`IsSynced<InputTimeline>`] has been inserted on
-/// the resource entity. This keeps callers from having to spell out Bevy's resource-entity query.
-#[derive(SystemParam)]
+/// the resource entity. The timeline itself uses [`Res`]'s cached resource lookup; readiness is
+/// then checked directly on that entity instead of scanning for a unique matching component.
 pub struct SyncedInputTimeline<'w, 's> {
-    timeline:
-        Single<'w, 's, &'static InputTimeline, (With<IsResource>, With<IsSynced<InputTimeline>>)>,
+    timeline: Res<'w, InputTimeline>,
+    marker: PhantomData<&'s ()>,
 }
 
 impl core::ops::Deref for SyncedInputTimeline<'_, '_> {
     type Target = InputTimeline;
 
     fn deref(&self) -> &Self::Target {
-        *self.timeline
+        &self.timeline
     }
 }
+
+type InputTimelineMarkerQuery<'w, 's> = Query<'w, 's, (), With<IsSynced<InputTimeline>>>;
+
+// SAFETY: Both delegated parameters are read-only. `Res<InputTimeline>` registers the timeline
+// resource access, while the marker query registers access to `IsSynced<InputTimeline>` before
+// `get_param` uses it to inspect the resource entity.
+unsafe impl SystemParam for SyncedInputTimeline<'_, '_> {
+    type State = (
+        <Res<'static, InputTimeline> as SystemParam>::State,
+        <InputTimelineMarkerQuery<'static, 'static> as SystemParam>::State,
+    );
+    type Item<'world, 'state> = SyncedInputTimeline<'world, 'state>;
+
+    fn init_state(world: &mut World) -> Self::State {
+        (
+            <Res<'static, InputTimeline> as SystemParam>::init_state(world),
+            <InputTimelineMarkerQuery<'static, 'static> as SystemParam>::init_state(world),
+        )
+    }
+
+    fn init_access(
+        state: &Self::State,
+        system_meta: &mut SystemMeta,
+        component_access_set: &mut FilteredAccessSet,
+        world: &mut World,
+    ) {
+        <Res<'static, InputTimeline> as SystemParam>::init_access(
+            &state.0,
+            system_meta,
+            component_access_set,
+            world,
+        );
+        <InputTimelineMarkerQuery<'static, 'static> as SystemParam>::init_access(
+            &state.1,
+            system_meta,
+            component_access_set,
+            world,
+        );
+    }
+
+    #[inline]
+    unsafe fn get_param<'world, 'state>(
+        state: &'state mut Self::State,
+        system_meta: &SystemMeta,
+        world: UnsafeWorldCell<'world>,
+        change_tick: ChangeTick,
+    ) -> Result<Self::Item<'world, 'state>, SystemParamValidationError> {
+        // SAFETY: `init_access` delegated to `Res<InputTimeline>`, and the caller guarantees that
+        // this is the same World used by `init_state`.
+        let timeline = unsafe {
+            <Res<'static, InputTimeline> as SystemParam>::get_param(
+                &mut state.0,
+                system_meta,
+                world,
+                change_tick,
+            )
+        }?;
+        // SAFETY: The resource cache is metadata read through a read-only World cell. `state.0` is
+        // the cached ComponentId registered by `Res<InputTimeline>`.
+        let resource_entity = unsafe { world.resource_entities() }
+            .get(state.0)
+            .ok_or_else(|| {
+                SystemParamValidationError::invalid::<Self>(
+                    "InputTimeline resource entity does not exist",
+                )
+            })?;
+        // SAFETY: `init_access` delegated to the read-only marker query, and the caller guarantees
+        // that this is the same World used by `init_state`.
+        let marker_query = unsafe {
+            <InputTimelineMarkerQuery<'static, 'static> as SystemParam>::get_param(
+                &mut state.1,
+                system_meta,
+                world,
+                change_tick,
+            )
+        }?;
+        if marker_query.get(resource_entity).is_err() {
+            return Err(SystemParamValidationError::skipped::<Self>(
+                "InputTimeline is not synchronized",
+            ));
+        }
+        Ok(SyncedInputTimeline {
+            timeline,
+            marker: PhantomData,
+        })
+    }
+}
+
+// SAFETY: `SyncedInputTimeline` only delegates to read-only system parameters.
+unsafe impl ReadOnlySystemParam for SyncedInputTimeline<'_, '_> {}
 
 impl InputTimeline {
     /// Recompute the global input delay from the Links selected by the current topology.
@@ -482,6 +574,38 @@ mod tests {
             error < 0.001,
             "expected {expected:?}, got {actual:?}, error {error}"
         );
+    }
+
+    #[derive(Resource, Default)]
+    struct SyncedParamRuns(u8);
+
+    #[test]
+    fn synced_input_timeline_checks_the_resource_entity_marker() {
+        fn require_synced_timeline(
+            _timeline: SyncedInputTimeline,
+            mut runs: ResMut<SyncedParamRuns>,
+        ) {
+            runs.0 += 1;
+        }
+
+        let mut app = App::new();
+        app.init_resource::<InputTimeline>();
+        app.init_resource::<SyncedParamRuns>();
+        app.add_systems(Update, require_synced_timeline);
+
+        // A marker on an arbitrary entity must not make the resource available as synchronized.
+        app.world_mut().spawn(IsSynced::<InputTimeline>::default());
+        app.update();
+        assert_eq!(app.world().resource::<SyncedParamRuns>().0, 0);
+
+        let timeline_id = app.world().component_id::<InputTimeline>().unwrap();
+        let timeline_entity = app.world().resource_entities().get(timeline_id).unwrap();
+        app.world_mut()
+            .entity_mut(timeline_entity)
+            .insert(IsSynced::<InputTimeline>::default());
+
+        app.update();
+        assert_eq!(app.world().resource::<SyncedParamRuns>().0, 1);
     }
 
     #[test]

--- a/crates/core/sync/src/timeline/input.rs
+++ b/crates/core/sync/src/timeline/input.rs
@@ -59,12 +59,12 @@ impl InputTimelineConfig {
     /// the single client link and are deliberately selected independently of that entity.
     pub(crate) fn recompute_input_delay_on_sync(
         _trigger: On<SyncEvent<InputTimelineConfig>>,
-        tick_duration: Option<Res<TickDuration>>,
+        tick_duration: Res<TickDuration>,
         links: Query<&Link, With<Client>>,
         config: Res<InputTimelineConfig>,
         mut timeline: ResMut<InputTimeline>,
     ) {
-        let (Some(tick_duration), Ok(link)) = (tick_duration, links.single()) else {
+        let Ok(link) = links.single() else {
             return;
         };
         let before = timeline.input_delay();
@@ -84,12 +84,12 @@ impl InputTimelineConfig {
     /// Recompute input delay when the global configuration resource is inserted or replaced.
     pub(crate) fn recompute_input_delay_on_config_update(
         _trigger: On<Insert, InputTimelineConfig>,
-        tick_duration: Option<Res<TickDuration>>,
+        tick_duration: Res<TickDuration>,
         links: Query<&Link, With<Client>>,
         config: Res<InputTimelineConfig>,
         mut timeline: ResMut<InputTimeline>,
     ) {
-        let (Some(tick_duration), Ok(link)) = (tick_duration, links.single()) else {
+        let Ok(link) = links.single() else {
             return;
         };
         timeline.recompute_input_delay(&config, link.stats, tick_duration.0);
@@ -103,14 +103,11 @@ impl InputTimelineConfig {
     /// Initialize input delay from the statistics of the client link that just connected.
     pub(crate) fn recompute_input_delay_on_connect(
         trigger: On<Add, Connected>,
-        tick_duration: Option<Res<TickDuration>>,
+        tick_duration: Res<TickDuration>,
         links: Query<&Link, With<Client>>,
         config: Res<InputTimelineConfig>,
         mut timeline: ResMut<InputTimeline>,
     ) {
-        let Some(tick_duration) = tick_duration else {
-            return;
-        };
         let Ok(link) = links.get(trigger.entity) else {
             return;
         };

--- a/crates/core/sync/src/timeline/input.rs
+++ b/crates/core/sync/src/timeline/input.rs
@@ -9,7 +9,7 @@ use bevy_ecs::resource::IsResource;
 use bevy_ecs::system::SystemParam;
 use bevy_reflect::Reflect;
 use core::time::Duration;
-use lightyear_connection::client::{Client, Connected};
+use lightyear_connection::network_topology::{NetworkTopology, NetworkingMetadata};
 use lightyear_core::tick::{Tick, TickDuration};
 use lightyear_core::time::{TickDelta, TickInstant};
 use lightyear_core::timeline::{NetworkTimeline, SyncEvent, Timeline, TimelineConfig};
@@ -56,19 +56,20 @@ impl InputTimelineConfig {
     /// Recompute input delay after the global input timeline snaps by whole ticks.
     ///
     /// The [`SyncEvent`] targets the input timeline's resource entity. Link statistics remain on
-    /// the single client link and are deliberately selected independently of that entity.
+    /// the topology-selected client Links and are deliberately selected independently of that
+    /// entity.
     pub(crate) fn recompute_input_delay_on_sync(
         _trigger: On<SyncEvent<InputTimelineConfig>>,
         tick_duration: Res<TickDuration>,
-        links: Query<&Link, With<Client>>,
+        metadata: Res<NetworkingMetadata>,
+        links: Query<&Link>,
         config: Res<InputTimelineConfig>,
         mut timeline: ResMut<InputTimeline>,
     ) {
-        let Ok(link) = links.single() else {
-            return;
-        };
         let before = timeline.input_delay();
-        timeline.recompute_input_delay(&config, link.stats, tick_duration.0);
+        if !timeline.recompute_input_delay(&config, &metadata.mode, &links, tick_duration.0) {
+            return;
+        }
         trace!(
             target: "lightyear_debug::sync",
             kind = "input_delay_recomputed_on_sync",
@@ -76,7 +77,7 @@ impl InputTimelineConfig {
             sample_point = "PostUpdate",
             input_delay_ticks_before = before,
             input_delay_ticks_after = timeline.input_delay(),
-            rtt_ms = link.stats.rtt.as_secs_f64() * 1000.0,
+            topology = ?metadata.mode,
             "sync event: recomputed global input delay"
         );
     }
@@ -85,33 +86,24 @@ impl InputTimelineConfig {
     pub(crate) fn recompute_input_delay_on_config_update(
         _trigger: On<Insert, InputTimelineConfig>,
         tick_duration: Res<TickDuration>,
-        links: Query<&Link, With<Client>>,
+        metadata: Res<NetworkingMetadata>,
+        links: Query<&Link>,
         config: Res<InputTimelineConfig>,
         mut timeline: ResMut<InputTimeline>,
     ) {
-        let Ok(link) = links.single() else {
-            return;
-        };
-        timeline.recompute_input_delay(&config, link.stats, tick_duration.0);
+        if !timeline.recompute_input_delay(&config, &metadata.mode, &links, tick_duration.0) {
+            // Configuration is commonly installed before a Client or HostClient connects. The
+            // configured minimum is topology-independent; the first SyncEvent will replace it
+            // with the latency-aware aggregate once the relevant Links are ready.
+            timeline.context.input_delay_ticks =
+                config.input_delay_config.minimum_input_delay_ticks;
+        }
         trace!(
             input_delay_ticks = timeline.input_delay(),
             config = ?config.input_delay_config,
+            topology = ?metadata.mode,
             "recomputed global input delay after config update"
         );
-    }
-
-    /// Initialize input delay from the statistics of the client link that just connected.
-    pub(crate) fn recompute_input_delay_on_connect(
-        trigger: On<Add, Connected>,
-        tick_duration: Res<TickDuration>,
-        links: Query<&Link, With<Client>>,
-        config: Res<InputTimelineConfig>,
-        mut timeline: ResMut<InputTimeline>,
-    ) {
-        let Ok(link) = links.get(trigger.entity) else {
-            return;
-        };
-        timeline.recompute_input_delay(&config, link.stats, tick_duration.0);
     }
 }
 
@@ -301,17 +293,41 @@ impl core::ops::Deref for SyncedInputTimeline<'_, '_> {
 }
 
 impl InputTimeline {
-    /// Recompute the number of delayed input ticks for the selected link statistics.
+    /// Recompute the global input delay from the Links selected by the current topology.
+    ///
+    /// Conventional modes use their sole client Link. P2P uses the maximum required delay across
+    /// all connected peer Links so that one tick-indexed local input stream is safe for every peer.
+    /// Returns `false` when the topology has no complete set of ready Link statistics.
     pub(crate) fn recompute_input_delay(
         &mut self,
         config: &InputTimelineConfig,
-        link_stats: LinkStats,
+        topology: &NetworkTopology,
+        links: &Query<&Link>,
         tick_duration: Duration,
-    ) {
-        self.context.input_delay_ticks =
-            config
-                .input_delay_config
-                .input_delay_ticks(link_stats, &config.sync, tick_duration);
+    ) -> bool {
+        let delay_for = |entity| {
+            links.get(entity).ok().map(|link| {
+                config
+                    .input_delay_config
+                    .input_delay_ticks(link.stats, &config.sync, tick_duration)
+            })
+        };
+        let input_delay_ticks = match topology {
+            NetworkTopology::Client(entity) => delay_for(*entity),
+            NetworkTopology::HostClient { client, .. } => delay_for(*client),
+            NetworkTopology::P2P(entities) if !entities.is_empty() => entities
+                .iter()
+                .try_fold(0, |maximum, entity| Some(maximum.max(delay_for(*entity)?))),
+            NetworkTopology::Undefined
+            | NetworkTopology::Server(_)
+            | NetworkTopology::P2P(_)
+            | NetworkTopology::Invalid(_) => None,
+        };
+        let Some(input_delay_ticks) = input_delay_ticks else {
+            return false;
+        };
+        self.context.input_delay_ticks = input_delay_ticks;
+        true
     }
 }
 
@@ -456,6 +472,7 @@ impl SyncedTimeline for InputTimeline {
 mod tests {
     use super::*;
     use crate::timeline::remote::RemoteTimeline;
+    use bevy_app::{App, Update};
     use bevy_utils::default;
     use lightyear_core::timeline::NetworkTimeline;
 
@@ -572,6 +589,49 @@ mod tests {
              PreUpdate and advancing in FixedFirst, so the packet must contain \
              input for at least {required_input_tick:?} (= remote + 1).",
         );
+    }
+
+    #[test]
+    fn p2p_input_delay_uses_maximum_across_links() {
+        let mut app = App::new();
+        let mut fast_link = Link::default();
+        fast_link.stats.rtt = Duration::from_millis(10);
+        let fast = app.world_mut().spawn(fast_link).id();
+        let mut slow_link = Link::default();
+        slow_link.stats.rtt = Duration::from_millis(50);
+        let slow = app.world_mut().spawn(slow_link).id();
+
+        let mut metadata = NetworkingMetadata::default();
+        metadata.mode = NetworkTopology::P2P([fast, slow].into_iter().collect());
+        app.insert_resource(metadata);
+        app.insert_resource(TickDuration(Duration::from_millis(10)));
+        let mut config =
+            InputTimelineConfig::default().with_input_delay(InputDelayConfig::balanced());
+        config.sync.jitter_multiple = 0;
+        config.sync.jitter_margin = 0.0;
+        app.insert_resource(config);
+        app.init_resource::<InputTimeline>();
+        app.add_systems(
+            Update,
+            |mut timeline: ResMut<InputTimeline>,
+             config: Res<InputTimelineConfig>,
+             metadata: Res<NetworkingMetadata>,
+             links: Query<&Link>,
+             tick_duration: Res<TickDuration>| {
+                assert!(timeline.recompute_input_delay(
+                    &config,
+                    &metadata.mode,
+                    &links,
+                    tick_duration.0,
+                ));
+            },
+        );
+
+        app.update();
+
+        // The 10ms Link needs one delayed tick, while the 50ms Link reaches the balanced
+        // configuration's three-tick pre-prediction cap. The global delay must satisfy both.
+        assert_eq!(app.world().resource::<InputTimeline>().input_delay(), 3);
     }
 
     #[test]

--- a/crates/core/sync/src/timeline/sync.rs
+++ b/crates/core/sync/src/timeline/sync.rs
@@ -9,6 +9,8 @@ use bevy_utils::prelude::DebugName;
 use core::time::Duration;
 use lightyear_connection::client::{Client, Connected, Disconnected};
 use lightyear_connection::host::HostClient;
+use lightyear_connection::network_topology::{NetworkTopology, NetworkingMetadata};
+use lightyear_connection::p2p::P2P;
 use lightyear_core::prelude::{LocalTimeline, NetworkTimelinePlugin};
 use lightyear_core::tick::TickDuration;
 use lightyear_core::time::{Overstep, TickInstant};
@@ -495,7 +497,7 @@ where
     /// Reset the global synchronized timeline when its client link connects.
     fn handle_connect(
         trigger: On<Add, Connected>,
-        clients: Query<(), With<Client>>,
+        clients: Query<(), (With<Client>, Without<P2P>)>,
         local_timeline: Res<LocalTimeline>,
         mut timeline: Single<&mut Synced, With<IsResource>>,
     ) {
@@ -507,7 +509,7 @@ where
     /// Mark the resource entity as synchronized for a host-client session.
     fn handle_host_client(
         trigger: On<Add, HostClient>,
-        clients: Query<(), With<Client>>,
+        clients: Query<(), (With<Client>, Without<P2P>)>,
         timeline_entity: Single<Entity, (With<Synced>, With<IsResource>)>,
         mut commands: Commands,
     ) {
@@ -521,7 +523,7 @@ where
     /// Remove the synchronization marker from the resource entity when its client disconnects.
     fn handle_disconnect(
         trigger: On<Add, Disconnected>,
-        clients: Query<(), With<Client>>,
+        clients: Query<(), (With<Client>, Without<P2P>)>,
         timeline_entity: Single<Entity, (With<Synced>, With<IsResource>)>,
         mut commands: Commands,
     ) {
@@ -549,22 +551,28 @@ where
         Self::apply_relative_speed(&timeline, &mut virtual_time);
     }
 
-    /// Synchronize the resource timeline with the single connected, non-host client link.
+    /// Synchronize the resource timeline with the conventional Client Link cached by the topology.
     ///
     /// P2P aggregation will provide a different remote-target policy while retaining the same
     /// resource timeline and synchronization controller.
     fn sync_timelines(
         tick_duration: Res<TickDuration>,
+        metadata: Res<NetworkingMetadata>,
         config: Res<Synced::Config>,
         timeline: Single<(Entity, &mut Synced, Has<IsSynced<Synced>>), With<IsResource>>,
-        remote: Single<
+        remotes: Query<
             (&Remote, &PingManager),
             (With<Client>, With<Connected>, Without<HostClient>),
         >,
         mut commands: Commands,
     ) {
+        let NetworkTopology::Client(client) = &metadata.mode else {
+            return;
+        };
+        let Ok((remote, ping_manager)) = remotes.get(*client) else {
+            return;
+        };
         let (entity, mut synced, is_synced) = timeline.into_inner();
-        let (remote, ping_manager) = remote.into_inner();
         Self::sync_timeline(
             entity,
             &mut synced,

--- a/crates/core/sync/src/timeline/sync.rs
+++ b/crates/core/sync/src/timeline/sync.rs
@@ -2,11 +2,12 @@ use crate::ping::manager::PingManager;
 use crate::plugin::SyncSystems;
 use bevy_app::{App, Last, Plugin, PostUpdate};
 use bevy_ecs::prelude::*;
+use bevy_ecs::resource::IsResource;
 use bevy_reflect::Reflect;
 use bevy_time::{Fixed, Time, Virtual};
 use bevy_utils::prelude::DebugName;
 use core::time::Duration;
-use lightyear_connection::client::{Connected, Disconnected};
+use lightyear_connection::client::{Client, Connected, Disconnected};
 use lightyear_connection::host::HostClient;
 use lightyear_core::prelude::{LocalTimeline, NetworkTimelinePlugin};
 use lightyear_core::tick::TickDuration;
@@ -205,217 +206,195 @@ impl SyncContext {
     }
 }
 
-/// Plugin to sync the Synced timeline to the Remote timeline
+/// Stores each synchronized timeline on the link whose remote timeline it follows.
 ///
-/// The const generic is used to indicate if the timeline is driving/updating the [`Time<Virtual>`] and [`LocalTimeline`].
-pub struct SyncedTimelinePlugin<Synced, Remote, const DRIVING: bool = false> {
-    pub(crate) _marker: core::marker::PhantomData<(Synced, Remote)>,
+/// This is the default storage used by [`SyncedTimelinePlugin`], and is appropriate for
+/// per-link timelines such as an interpolation timeline.
+pub struct ComponentTimelineStorage;
+
+/// Stores one synchronized timeline as a Bevy resource.
+///
+/// The remote timeline and ping measurements remain on a single connected [`Client`] link. This
+/// storage is appropriate for application-global driving timelines such as the input timeline.
+pub struct ResourceTimelineStorage;
+
+/// Plugin to synchronize one timeline with a remote timeline.
+///
+/// `Storage` determines whether the synchronized timeline and its configuration are components on
+/// the remote link or application-global resources. The const generic indicates whether the
+/// synchronized timeline drives [`Time<Virtual>`] and [`LocalTimeline`].
+pub struct SyncedTimelinePlugin<
+    Synced,
+    Remote,
+    const DRIVING: bool = false,
+    Storage = ComponentTimelineStorage,
+> {
+    pub(crate) _marker: core::marker::PhantomData<(Synced, Remote, Storage)>,
 }
 
-impl<Synced: SyncedTimeline, Remote: SyncTargetTimeline, const DRIVING: bool>
-    SyncedTimelinePlugin<Synced, Remote, DRIVING>
+impl<Synced: SyncedTimeline, Remote: SyncTargetTimeline, const DRIVING: bool, Storage>
+    SyncedTimelinePlugin<Synced, Remote, DRIVING, Storage>
 {
-    /// On connection, reset the Synced timeline.
-    pub(crate) fn handle_connect(
-        trigger: On<Add, Connected>,
-        local_timeline: Res<LocalTimeline>,
-        mut query: Query<&mut Synced>,
-    ) {
-        let local_tick = local_timeline.tick();
-        if let Ok(mut timeline) = query.get_mut(trigger.entity) {
-            timeline.reset();
-            if DRIVING {
-                trace!("Set Driving timeline tick to LocalTimeline");
-                let delta = local_tick - timeline.tick();
-                timeline.apply_delta(delta.into());
-            }
+    /// Reset a timeline when its session starts and align a driving timeline with local time.
+    fn reset_timeline(timeline: &mut Synced, local_timeline: &LocalTimeline) {
+        timeline.reset();
+        if DRIVING {
+            trace!("Set Driving timeline tick to LocalTimeline");
+            let delta = local_timeline.tick() - timeline.tick();
+            timeline.apply_delta(delta.into());
         }
     }
 
-    /// For HostClient, we directly set IsSynced on connection (since there is no messages exchanged) and the
-    /// Synced timeline is always the same as the Remote timeline
-    pub(crate) fn handle_host_client(trigger: On<Add, HostClient>, mut commands: Commands) {
-        commands
-            .entity(trigger.entity)
-            .insert(IsSynced::<Synced>::default());
-    }
-
-    /// On disconnection, remove IsSynced.
-    pub(crate) fn handle_disconnect(trigger: On<Add, Disconnected>, mut commands: Commands) {
-        commands.entity(trigger.entity).remove::<IsSynced<Synced>>();
-    }
-
-    /// Synchronize the driving timeline's phase with the local simulation phase
-    /// derived from [`LocalTimeline`] and [`Time<Fixed>`].
-    ///
-    /// This runs once per frame before `sync_timelines` for driving timelines.
-    pub(crate) fn sync_from_local_timeline(
-        local_timeline: Res<LocalTimeline>,
-        fixed_time: Res<Time<Fixed>>,
-        mut query: Query<&mut Synced>,
+    /// Copy the application's current fixed-update phase into a driving timeline.
+    fn sync_from_local(
+        synced: &mut Synced,
+        local_timeline: &LocalTimeline,
+        fixed_time: &Time<Fixed>,
     ) {
         let local_tick = local_timeline.tick();
         let overstep = fixed_time.overstep_fraction();
-        query.iter_mut().for_each(|mut synced| {
-            // Desired phase: LocalTimeline.tick + Time<Fixed> overstep.
-            synced.set_now(TickInstant::from_tick_and_overstep(
-                local_tick,
-                Overstep::from_f32(overstep),
-            ));
-            trace!(
-                target: "lightyear_debug::timeline",
-                kind = "sync_from_local_timeline",
-                schedule = "PostUpdate",
-                sample_point = "PostUpdate",
-                timeline = ?DebugName::type_name::<Synced>(),
-                local_tick = local_tick.0,
-                timeline_tick = synced.tick().0,
-                overstep,
-                "driving timeline synced from LocalTimeline"
-            );
-        });
+        synced.set_now(TickInstant::from_tick_and_overstep(
+            local_tick,
+            Overstep::from_f32(overstep),
+        ));
+        trace!(
+            target: "lightyear_debug::timeline",
+            kind = "sync_from_local_timeline",
+            schedule = "PostUpdate",
+            sample_point = "PostUpdate",
+            timeline = ?DebugName::type_name::<Synced>(),
+            local_tick = local_tick.0,
+            timeline_tick = synced.tick().0,
+            overstep,
+            "driving timeline synced from LocalTimeline"
+        );
     }
 
-    pub(crate) fn update_virtual_time(
-        mut virtual_time: ResMut<Time<Virtual>>,
-        query: Query<&Synced, (With<IsSynced<Synced>>, With<Connected>, Without<HostClient>)>,
+    /// Apply a synchronized timeline's speed correction to Bevy virtual time.
+    fn apply_relative_speed(timeline: &Synced, virtual_time: &mut Time<Virtual>) {
+        trace!(
+            "Timeline {} sets the virtual time relative speed to {}",
+            DebugName::type_name::<Synced>(),
+            timeline.relative_speed()
+        );
+        trace!(
+            target: "lightyear_debug::sync",
+            kind = "relative_speed",
+            schedule = "Last",
+            sample_point = "Last",
+            timeline = ?DebugName::type_name::<Synced>(),
+            tick = timeline.tick().0,
+            relative_speed = timeline.relative_speed(),
+            "timeline relative speed applied to Virtual time"
+        );
+        // TODO: be able to apply the speed_ratio on top of any speed ratio already applied by the user.
+        virtual_time.set_relative_speed(timeline.relative_speed());
+    }
+
+    /// Synchronize one timeline and emit a [`SyncEvent`] if it snaps by whole ticks.
+    fn sync_timeline(
+        entity: Entity,
+        sync_timeline: &mut Synced,
+        config: &Synced::Config,
+        main_timeline: &Remote,
+        ping_manager: &PingManager,
+        has_is_synced: bool,
+        tick_duration: &TickDuration,
+        commands: &mut Commands,
     ) {
-        if let Ok(timeline) = query.single() {
-            trace!(
-                "Timeline {} sets the virtual time relative speed to {}",
-                DebugName::type_name::<Synced>(),
-                timeline.relative_speed()
-            );
+        trace!(
+            ?entity,
+            ?has_is_synced,
+            "In SyncTimelines from {:?} to {:?}",
+            DebugName::type_name::<Synced>(),
+            DebugName::type_name::<Remote>()
+        );
+        // return early if the remote timeline hasn't received any packets
+        if !main_timeline.received_packet() {
             trace!(
                 target: "lightyear_debug::sync",
-                kind = "relative_speed",
-                schedule = "Last",
-                sample_point = "Last",
+                kind = "sync_skipped_no_packet",
+                schedule = "PostUpdate",
+                sample_point = "PostUpdate",
+                entity = ?entity,
                 timeline = ?DebugName::type_name::<Synced>(),
-                tick = timeline.tick().0,
-                relative_speed = timeline.relative_speed(),
-                "timeline relative speed applied to Virtual time"
+                remote_timeline = ?DebugName::type_name::<Remote>(),
+                timeline_tick = sync_timeline.tick().0,
+                "sync skipped because remote timeline received no packet"
             );
-            // TODO: be able to apply the speed_ratio on top of any speed ratio already applied by the user.
-            virtual_time.set_relative_speed(timeline.relative_speed());
+            return;
+        }
+        if !has_is_synced && sync_timeline.is_synced() {
+            debug!(
+                "Timeline {:?} is synced to {:?}",
+                DebugName::type_name::<Synced>(),
+                DebugName::type_name::<Remote>()
+            );
+            commands
+                .entity(entity)
+                .insert(IsSynced::<Synced>::default());
+            trace!(
+                target: "lightyear_debug::sync",
+                kind = "timeline_synced",
+                schedule = "PostUpdate",
+                sample_point = "PostUpdate",
+                entity = ?entity,
+                timeline = ?DebugName::type_name::<Synced>(),
+                remote_timeline = ?DebugName::type_name::<Remote>(),
+                timeline_tick = sync_timeline.tick().0,
+                "timeline marked synced"
+            );
+        }
+        let before_now = sync_timeline.now();
+        let remote_estimate = main_timeline.current_estimate();
+        if let Some(tick_delta) =
+            sync_timeline.sync(main_timeline, config, ping_manager, tick_duration.0)
+        {
+            trace!(
+                target: "lightyear_debug::sync",
+                kind = "sync_adjustment",
+                schedule = "PostUpdate",
+                sample_point = "PostUpdate",
+                entity = ?entity,
+                timeline = ?DebugName::type_name::<Synced>(),
+                remote_timeline = ?DebugName::type_name::<Remote>(),
+                timeline_tick = sync_timeline.tick().0,
+                remote_tick = main_timeline.tick().0,
+                before = ?before_now,
+                after = ?sync_timeline.now(),
+                remote_estimate = ?remote_estimate,
+                tick_delta,
+                relative_speed = sync_timeline.relative_speed(),
+                rtt_ms = ping_manager.rtt().as_secs_f64() * 1000.0,
+                jitter_ms = ping_manager.jitter().as_secs_f64() * 1000.0,
+                "timeline sync emitted SyncEvent"
+            );
+            // if it's the driving pipeline, also update the LocalTimeline in `handle_sync_event`
+            commands.trigger(SyncEvent::<Synced::Config>::new(entity, tick_delta));
+        } else {
+            trace!(
+                target: "lightyear_debug::sync",
+                kind = "sync_sample",
+                schedule = "PostUpdate",
+                sample_point = "PostUpdate",
+                entity = ?entity,
+                timeline = ?DebugName::type_name::<Synced>(),
+                remote_timeline = ?DebugName::type_name::<Remote>(),
+                timeline_tick = sync_timeline.tick().0,
+                remote_tick = main_timeline.tick().0,
+                before = ?before_now,
+                after = ?sync_timeline.now(),
+                remote_estimate = ?remote_estimate,
+                relative_speed = sync_timeline.relative_speed(),
+                rtt_ms = ping_manager.rtt().as_secs_f64() * 1000.0,
+                jitter_ms = ping_manager.jitter().as_secs_f64() * 1000.0,
+                "timeline sync sampled"
+            );
         }
     }
 
-    /// Sync timeline T to timeline [`RemoteTimeline`](super::remote::RemoteTimeline) by either
-    /// - speeding up/slowing down the timeline T to match timeline Remote
-    /// - emitting a [`SyncEvent<T>`]
-    pub(crate) fn sync_timelines(
-        tick_duration: Res<TickDuration>,
-        mut commands: Commands,
-        mut query: Query<
-            (
-                Entity,
-                &mut Synced,
-                &Synced::Config,
-                &Remote,
-                &PingManager,
-                Has<IsSynced<Synced>>,
-            ),
-            (With<Connected>, Without<HostClient>),
-        >,
-    ) {
-        // TODO: return early if we haven't received any remote packets? (nothing to sync to)
-        query.iter_mut().for_each(
-            |(entity, mut sync_timeline, config, main_timeline, ping_manager, has_is_synced)| {
-                trace!(
-                    ?entity,
-                    ?has_is_synced,
-                    "In SyncTimelines from {:?} to {:?}",
-                    DebugName::type_name::<Synced>(),
-                    DebugName::type_name::<Remote>()
-                );
-                // return early if the remote timeline hasn't received any packets
-                if !main_timeline.received_packet() {
-                    trace!(
-                        target: "lightyear_debug::sync",
-                        kind = "sync_skipped_no_packet",
-                        schedule = "PostUpdate",
-                        sample_point = "PostUpdate",
-                        entity = ?entity,
-                        timeline = ?DebugName::type_name::<Synced>(),
-                        remote_timeline = ?DebugName::type_name::<Remote>(),
-                        timeline_tick = sync_timeline.tick().0,
-                        "sync skipped because remote timeline received no packet"
-                    );
-                    return;
-                }
-                if !has_is_synced && sync_timeline.is_synced() {
-                    debug!(
-                        "Timeline {:?} is synced to {:?}",
-                        DebugName::type_name::<Synced>(),
-                        DebugName::type_name::<Remote>()
-                    );
-                    commands
-                        .entity(entity)
-                        .insert(IsSynced::<Synced>::default());
-                    trace!(
-                        target: "lightyear_debug::sync",
-                        kind = "timeline_synced",
-                        schedule = "PostUpdate",
-                        sample_point = "PostUpdate",
-                        entity = ?entity,
-                        timeline = ?DebugName::type_name::<Synced>(),
-                        remote_timeline = ?DebugName::type_name::<Remote>(),
-                        timeline_tick = sync_timeline.tick().0,
-                        "timeline marked synced"
-                    );
-                }
-                let before_now = sync_timeline.now();
-                let remote_estimate = main_timeline.current_estimate();
-                if let Some(tick_delta) =
-                    sync_timeline.sync(main_timeline, config, ping_manager, tick_duration.0)
-                {
-                    trace!(
-                        target: "lightyear_debug::sync",
-                        kind = "sync_adjustment",
-                        schedule = "PostUpdate",
-                        sample_point = "PostUpdate",
-                        entity = ?entity,
-                        timeline = ?DebugName::type_name::<Synced>(),
-                        remote_timeline = ?DebugName::type_name::<Remote>(),
-                        timeline_tick = sync_timeline.tick().0,
-                        remote_tick = main_timeline.tick().0,
-                        before = ?before_now,
-                        after = ?sync_timeline.now(),
-                        remote_estimate = ?remote_estimate,
-                        tick_delta,
-                        relative_speed = sync_timeline.relative_speed(),
-                        rtt_ms = ping_manager.rtt().as_secs_f64() * 1000.0,
-                        jitter_ms = ping_manager.jitter().as_secs_f64() * 1000.0,
-                        "timeline sync emitted SyncEvent"
-                    );
-                    // if it's the driving pipeline, also update the LocalTimeline in `handle_sync_event`
-                    commands.trigger(SyncEvent::<Synced::Config>::new(entity, tick_delta));
-                } else {
-                    trace!(
-                        target: "lightyear_debug::sync",
-                        kind = "sync_sample",
-                        schedule = "PostUpdate",
-                        sample_point = "PostUpdate",
-                        entity = ?entity,
-                        timeline = ?DebugName::type_name::<Synced>(),
-                        remote_timeline = ?DebugName::type_name::<Remote>(),
-                        timeline_tick = sync_timeline.tick().0,
-                        remote_tick = main_timeline.tick().0,
-                        before = ?before_now,
-                        after = ?sync_timeline.now(),
-                        remote_estimate = ?remote_estimate,
-                        relative_speed = sync_timeline.relative_speed(),
-                        rtt_ms = ping_manager.rtt().as_secs_f64() * 1000.0,
-                        jitter_ms = ping_manager.jitter().as_secs_f64() * 1000.0,
-                        "timeline sync sampled"
-                    );
-                }
-            },
-        )
-    }
-
-    pub(crate) fn handle_sync_event(
+    /// Apply a driving timeline's whole-tick correction to [`LocalTimeline`].
+    fn handle_sync_event(
         trigger: On<SyncEvent<Synced::Config>>,
         mut local_timeline: ResMut<LocalTimeline>,
     ) {
@@ -440,8 +419,179 @@ impl<Synced: SyncedTimeline, Remote: SyncTargetTimeline, const DRIVING: bool>
     }
 }
 
-impl<Synced, Remote, const DRIVING: bool> Default
-    for SyncedTimelinePlugin<Synced, Remote, DRIVING>
+impl<Synced: SyncedTimeline, Remote: SyncTargetTimeline, const DRIVING: bool>
+    SyncedTimelinePlugin<Synced, Remote, DRIVING, ComponentTimelineStorage>
+{
+    /// Reset a link-held synchronized timeline when that link connects.
+    fn handle_connect(
+        trigger: On<Add, Connected>,
+        local_timeline: Res<LocalTimeline>,
+        mut query: Query<&mut Synced>,
+    ) {
+        if let Ok(mut timeline) = query.get_mut(trigger.entity) {
+            Self::reset_timeline(&mut timeline, &local_timeline);
+        }
+    }
+
+    /// Mark a host-client's link-held timeline as synchronized without a handshake.
+    fn handle_host_client(trigger: On<Add, HostClient>, mut commands: Commands) {
+        commands
+            .entity(trigger.entity)
+            .insert(IsSynced::<Synced>::default());
+    }
+
+    /// Remove the synchronization marker from a disconnected link.
+    fn handle_disconnect(trigger: On<Add, Disconnected>, mut commands: Commands) {
+        commands.entity(trigger.entity).remove::<IsSynced<Synced>>();
+    }
+
+    /// Copy local fixed-update phase into every link-held driving timeline.
+    fn sync_from_local_timeline(
+        local_timeline: Res<LocalTimeline>,
+        fixed_time: Res<Time<Fixed>>,
+        mut query: Query<&mut Synced>,
+    ) {
+        query.iter_mut().for_each(|mut synced| {
+            Self::sync_from_local(&mut synced, &local_timeline, &fixed_time)
+        });
+    }
+
+    /// Apply the single connected, synchronized link timeline's relative speed.
+    fn update_virtual_time(
+        mut virtual_time: ResMut<Time<Virtual>>,
+        query: Query<&Synced, (With<IsSynced<Synced>>, With<Connected>, Without<HostClient>)>,
+    ) {
+        if let Ok(timeline) = query.single() {
+            Self::apply_relative_speed(timeline, &mut virtual_time);
+        }
+    }
+
+    /// Synchronize each link-held timeline with the remote timeline on the same link.
+    fn sync_timelines(
+        tick_duration: Res<TickDuration>,
+        mut commands: Commands,
+        mut query: Query<
+            (
+                Entity,
+                &mut Synced,
+                &Synced::Config,
+                &Remote,
+                &PingManager,
+                Has<IsSynced<Synced>>,
+            ),
+            (With<Connected>, Without<HostClient>),
+        >,
+    ) {
+        query.iter_mut().for_each(
+            |(entity, mut synced, config, remote, ping_manager, is_synced)| {
+                Self::sync_timeline(
+                    entity,
+                    &mut synced,
+                    config,
+                    remote,
+                    ping_manager,
+                    is_synced,
+                    &tick_duration,
+                    &mut commands,
+                );
+            },
+        );
+    }
+}
+
+impl<Synced: SyncedTimeline, Remote: SyncTargetTimeline, const DRIVING: bool>
+    SyncedTimelinePlugin<Synced, Remote, DRIVING, ResourceTimelineStorage>
+where
+    Synced::Config: Resource,
+{
+    /// Reset the global synchronized timeline when its client link connects.
+    fn handle_connect(
+        trigger: On<Add, Connected>,
+        clients: Query<(), With<Client>>,
+        local_timeline: Res<LocalTimeline>,
+        mut timeline: Single<&mut Synced, With<IsResource>>,
+    ) {
+        if clients.get(trigger.entity).is_ok() {
+            Self::reset_timeline(&mut timeline, &local_timeline);
+        }
+    }
+
+    /// Mark the resource entity as synchronized for a host-client session.
+    fn handle_host_client(
+        trigger: On<Add, HostClient>,
+        clients: Query<(), With<Client>>,
+        timeline_entity: Single<Entity, (With<Synced>, With<IsResource>)>,
+        mut commands: Commands,
+    ) {
+        if clients.get(trigger.entity).is_ok() {
+            commands
+                .entity(*timeline_entity)
+                .insert(IsSynced::<Synced>::default());
+        }
+    }
+
+    /// Remove the synchronization marker from the resource entity when its client disconnects.
+    fn handle_disconnect(
+        trigger: On<Add, Disconnected>,
+        clients: Query<(), With<Client>>,
+        timeline_entity: Single<Entity, (With<Synced>, With<IsResource>)>,
+        mut commands: Commands,
+    ) {
+        if clients.get(trigger.entity).is_ok() {
+            commands
+                .entity(*timeline_entity)
+                .remove::<IsSynced<Synced>>();
+        }
+    }
+
+    /// Copy local fixed-update phase into the global driving timeline.
+    fn sync_from_local_timeline(
+        local_timeline: Res<LocalTimeline>,
+        fixed_time: Res<Time<Fixed>>,
+        mut timeline: Single<&mut Synced, With<IsResource>>,
+    ) {
+        Self::sync_from_local(&mut timeline, &local_timeline, &fixed_time);
+    }
+
+    /// Apply the synchronized resource timeline's relative speed to virtual time.
+    fn update_virtual_time(
+        timeline: Single<&Synced, (With<IsResource>, With<IsSynced<Synced>>)>,
+        mut virtual_time: ResMut<Time<Virtual>>,
+    ) {
+        Self::apply_relative_speed(&timeline, &mut virtual_time);
+    }
+
+    /// Synchronize the resource timeline with the single connected, non-host client link.
+    ///
+    /// P2P aggregation will provide a different remote-target policy while retaining the same
+    /// resource timeline and synchronization controller.
+    fn sync_timelines(
+        tick_duration: Res<TickDuration>,
+        config: Res<Synced::Config>,
+        timeline: Single<(Entity, &mut Synced, Has<IsSynced<Synced>>), With<IsResource>>,
+        remote: Single<
+            (&Remote, &PingManager),
+            (With<Client>, With<Connected>, Without<HostClient>),
+        >,
+        mut commands: Commands,
+    ) {
+        let (entity, mut synced, is_synced) = timeline.into_inner();
+        let (remote, ping_manager) = remote.into_inner();
+        Self::sync_timeline(
+            entity,
+            &mut synced,
+            &config,
+            remote,
+            ping_manager,
+            is_synced,
+            &tick_duration,
+            &mut commands,
+        );
+    }
+}
+
+impl<Synced, Remote, const DRIVING: bool, Storage> Default
+    for SyncedTimelinePlugin<Synced, Remote, DRIVING, Storage>
 {
     fn default() -> Self {
         Self {
@@ -451,7 +601,7 @@ impl<Synced, Remote, const DRIVING: bool> Default
 }
 
 impl<Synced: SyncedTimeline, Remote: SyncTargetTimeline, const DRIVING: bool> Plugin
-    for SyncedTimelinePlugin<Synced, Remote, DRIVING>
+    for SyncedTimelinePlugin<Synced, Remote, DRIVING, ComponentTimelineStorage>
 {
     fn build(&self, app: &mut App) {
         app.add_plugins(NetworkTimelinePlugin::<Synced>::default());
@@ -462,6 +612,33 @@ impl<Synced: SyncedTimeline, Remote: SyncTargetTimeline, const DRIVING: bool> Pl
         app.add_observer(Self::handle_host_client);
         app.add_observer(Self::handle_disconnect);
         // NOTE: we don't have to run this in PostUpdate, we could run this right after RunFixedMainLoop?
+        app.add_systems(PostUpdate, Self::sync_timelines.in_set(SyncSystems::Sync));
+        if DRIVING {
+            app.add_systems(
+                PostUpdate,
+                Self::sync_from_local_timeline
+                    .in_set(SyncSystems::Sync)
+                    .before(Self::sync_timelines),
+            );
+            app.add_systems(Last, Self::update_virtual_time);
+            app.add_observer(Self::handle_sync_event);
+        }
+    }
+}
+
+impl<Synced: SyncedTimeline + Resource + Default, Remote: SyncTargetTimeline, const DRIVING: bool>
+    Plugin for SyncedTimelinePlugin<Synced, Remote, DRIVING, ResourceTimelineStorage>
+where
+    Synced::Config: Resource + Default,
+{
+    fn build(&self, app: &mut App) {
+        app.add_plugins(NetworkTimelinePlugin::<Synced>::default());
+        app.init_resource::<Synced>();
+        app.init_resource::<Synced::Config>();
+
+        app.add_observer(Self::handle_connect);
+        app.add_observer(Self::handle_host_client);
+        app.add_observer(Self::handle_disconnect);
         app.add_systems(PostUpdate, Self::sync_timelines.in_set(SyncSystems::Sync));
         if DRIVING {
             app.add_systems(

--- a/crates/core/sync/src/timeline/sync.rs
+++ b/crates/core/sync/src/timeline/sync.rs
@@ -206,34 +206,22 @@ impl SyncContext {
     }
 }
 
-/// Stores each synchronized timeline on the link whose remote timeline it follows.
-///
-/// This is the default storage used by [`SyncedTimelinePlugin`], and is appropriate for
-/// per-link timelines such as an interpolation timeline.
-pub struct ComponentTimelineStorage;
-
-/// Stores one synchronized timeline as a Bevy resource.
-///
-/// The remote timeline and ping measurements remain on a single connected [`Client`] link. This
-/// storage is appropriate for application-global driving timelines such as the input timeline.
-pub struct ResourceTimelineStorage;
-
 /// Plugin to synchronize one timeline with a remote timeline.
 ///
-/// `Storage` determines whether the synchronized timeline and its configuration are components on
-/// the remote link or application-global resources. The const generic indicates whether the
-/// synchronized timeline drives [`Time<Virtual>`] and [`LocalTimeline`].
+/// `DRIVING` indicates whether the synchronized timeline drives [`Time<Virtual>`] and
+/// [`LocalTimeline`]. `RESOURCE` selects whether the synchronized timeline and its configuration
+/// are application-global resources or components on each remote link.
 pub struct SyncedTimelinePlugin<
     Synced,
     Remote,
     const DRIVING: bool = false,
-    Storage = ComponentTimelineStorage,
+    const RESOURCE: bool = false,
 > {
-    pub(crate) _marker: core::marker::PhantomData<(Synced, Remote, Storage)>,
+    pub(crate) _marker: core::marker::PhantomData<(Synced, Remote)>,
 }
 
-impl<Synced: SyncedTimeline, Remote: SyncTargetTimeline, const DRIVING: bool, Storage>
-    SyncedTimelinePlugin<Synced, Remote, DRIVING, Storage>
+impl<Synced: SyncedTimeline, Remote: SyncTargetTimeline, const DRIVING: bool, const RESOURCE: bool>
+    SyncedTimelinePlugin<Synced, Remote, DRIVING, RESOURCE>
 {
     /// Reset a timeline when its session starts and align a driving timeline with local time.
     fn reset_timeline(timeline: &mut Synced, local_timeline: &LocalTimeline) {
@@ -420,7 +408,7 @@ impl<Synced: SyncedTimeline, Remote: SyncTargetTimeline, const DRIVING: bool, St
 }
 
 impl<Synced: SyncedTimeline, Remote: SyncTargetTimeline, const DRIVING: bool>
-    SyncedTimelinePlugin<Synced, Remote, DRIVING, ComponentTimelineStorage>
+    SyncedTimelinePlugin<Synced, Remote, DRIVING, false>
 {
     /// Reset a link-held synchronized timeline when that link connects.
     fn handle_connect(
@@ -500,7 +488,7 @@ impl<Synced: SyncedTimeline, Remote: SyncTargetTimeline, const DRIVING: bool>
 }
 
 impl<Synced: SyncedTimeline, Remote: SyncTargetTimeline, const DRIVING: bool>
-    SyncedTimelinePlugin<Synced, Remote, DRIVING, ResourceTimelineStorage>
+    SyncedTimelinePlugin<Synced, Remote, DRIVING, true>
 where
     Synced::Config: Resource,
 {
@@ -590,8 +578,8 @@ where
     }
 }
 
-impl<Synced, Remote, const DRIVING: bool, Storage> Default
-    for SyncedTimelinePlugin<Synced, Remote, DRIVING, Storage>
+impl<Synced, Remote, const DRIVING: bool, const RESOURCE: bool> Default
+    for SyncedTimelinePlugin<Synced, Remote, DRIVING, RESOURCE>
 {
     fn default() -> Self {
         Self {
@@ -601,7 +589,7 @@ impl<Synced, Remote, const DRIVING: bool, Storage> Default
 }
 
 impl<Synced: SyncedTimeline, Remote: SyncTargetTimeline, const DRIVING: bool> Plugin
-    for SyncedTimelinePlugin<Synced, Remote, DRIVING, ComponentTimelineStorage>
+    for SyncedTimelinePlugin<Synced, Remote, DRIVING, false>
 {
     fn build(&self, app: &mut App) {
         app.add_plugins(NetworkTimelinePlugin::<Synced>::default());
@@ -627,7 +615,7 @@ impl<Synced: SyncedTimeline, Remote: SyncTargetTimeline, const DRIVING: bool> Pl
 }
 
 impl<Synced: SyncedTimeline + Resource + Default, Remote: SyncTargetTimeline, const DRIVING: bool>
-    Plugin for SyncedTimelinePlugin<Synced, Remote, DRIVING, ResourceTimelineStorage>
+    Plugin for SyncedTimelinePlugin<Synced, Remote, DRIVING, true>
 where
     Synced::Config: Resource + Default,
 {

--- a/crates/deterministic/deterministic_replication/src/checksum.rs
+++ b/crates/deterministic/deterministic_replication/src/checksum.rs
@@ -42,7 +42,7 @@ use lightyear_messages::receive::MessageReceiver;
 #[cfg(feature = "client")]
 use lightyear_prediction::manager::{LastConfirmedInput, StateRollbackMetadata};
 #[cfg(feature = "client")]
-use lightyear_sync::prelude::{InputTimeline, IsSynced};
+use lightyear_sync::prelude::InputTimeline;
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "server")]
 use tracing::error;
@@ -105,15 +105,16 @@ impl ChecksumSendPlugin {
     fn compute_and_send_checksum(
         mut world: ChecksumWorld<'_, '_, true>,
         local_timeline: Res<LocalTimeline>,
-        client: Single<
-            (&LastConfirmedInput, &mut MessageSender<ChecksumMessage>),
-            (With<Client>, With<IsSynced<InputTimeline>>),
-        >,
+        input_timeline: Res<InputTimeline>,
+        client: Single<(&LastConfirmedInput, &mut MessageSender<ChecksumMessage>), With<Client>>,
         #[cfg(feature = "replication")] catchup_manager: Option<
             Single<&CatchUpManager, With<Client>>,
         >,
         state_metadata: Res<StateRollbackMetadata>,
     ) {
+        if !input_timeline.is_synced() {
+            return;
+        }
         let mut checksum = 0u64;
         let current_tick = local_timeline.tick();
         let (last_confirmed_input, mut sender) = client.into_inner();
@@ -180,7 +181,7 @@ impl Plugin for ChecksumSendPlugin {
         }
 
         // we need the LastConfirmedInput to compute the checksums
-        app.register_required_components::<InputTimeline, LastConfirmedInput>();
+        app.register_required_components::<Client, LastConfirmedInput>();
 
         register_checksum_message(app);
     }

--- a/crates/deterministic/deterministic_replication/src/checksum.rs
+++ b/crates/deterministic/deterministic_replication/src/checksum.rs
@@ -42,7 +42,7 @@ use lightyear_messages::receive::MessageReceiver;
 #[cfg(feature = "client")]
 use lightyear_prediction::manager::{LastConfirmedInput, StateRollbackMetadata};
 #[cfg(feature = "client")]
-use lightyear_sync::prelude::InputTimeline;
+use lightyear_sync::prelude::SyncedInputTimeline;
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "server")]
 use tracing::error;
@@ -105,19 +105,17 @@ impl ChecksumSendPlugin {
     fn compute_and_send_checksum(
         mut world: ChecksumWorld<'_, '_, true>,
         local_timeline: Res<LocalTimeline>,
-        input_timeline: Res<InputTimeline>,
-        client: Single<(&LastConfirmedInput, &mut MessageSender<ChecksumMessage>), With<Client>>,
+        _input_timeline: SyncedInputTimeline,
+        last_confirmed_input: Res<LastConfirmedInput>,
+        sender: Single<&mut MessageSender<ChecksumMessage>, With<Client>>,
         #[cfg(feature = "replication")] catchup_manager: Option<
             Single<&CatchUpManager, With<Client>>,
         >,
         state_metadata: Res<StateRollbackMetadata>,
     ) {
-        if !input_timeline.is_synced() {
-            return;
-        }
         let mut checksum = 0u64;
         let current_tick = local_timeline.tick();
-        let (last_confirmed_input, mut sender) = client.into_inner();
+        let mut sender = sender.into_inner();
         let tick = last_confirmed_input.tick.get();
         // only compute the checksum when we have received remote inputs
         if tick > current_tick {
@@ -180,8 +178,8 @@ impl Plugin for ChecksumSendPlugin {
             app.add_plugins(DeterministicReplicationPlugin);
         }
 
-        // we need the LastConfirmedInput to compute the checksums
-        app.register_required_components::<Client, LastConfirmedInput>();
+        // We need the application-wide remote-input frontier to compute checksums.
+        app.init_resource::<LastConfirmedInput>();
 
         register_checksum_message(app);
     }

--- a/crates/deterministic/deterministic_replication/src/late_join/client.rs
+++ b/crates/deterministic/deterministic_replication/src/late_join/client.rs
@@ -18,7 +18,7 @@ use lightyear_prediction::prelude::{
 use lightyear_prediction::rollback::{CatchUpGated, DisableRollback};
 use lightyear_replication::metadata::MetadataChannel;
 use lightyear_replication::prelude::ReplicationSystems;
-use lightyear_sync::prelude::{InputTimeline, InputTimelineConfig, IsSynced};
+use lightyear_sync::prelude::{InputTimeline, InputTimelineConfig};
 use tracing::{debug, info, warn};
 
 use super::{CatchUpRequest, CatchUpSnapshotReady, CatchUpSystems};
@@ -142,21 +142,20 @@ fn catchup_snapshot_is_activating(manager: Option<Single<&CatchUpManager, With<C
 /// frame conservative is preferable to duplicating that input coverage logic.
 pub(crate) fn send_catchup_request(
     timeline: Res<LocalTimeline>,
+    input_timeline: Res<InputTimeline>,
     client: Single<
         (
             Entity,
             &mut CatchUpManager,
             &LastConfirmedInput,
             &mut MessageSender<CatchUpRequest>,
-            Has<IsSynced<InputTimeline>>,
         ),
         With<Client>,
     >,
     awaiting: Query<Entity, With<CatchUpGated>>,
 ) {
-    let (client_entity, mut manager, last_confirmed_input, mut sender, is_synced) =
-        client.into_inner();
-    if !is_synced {
+    let (client_entity, mut manager, last_confirmed_input, mut sender) = client.into_inner();
+    if !input_timeline.is_synced() {
         return;
     }
     if manager.completed {
@@ -260,13 +259,13 @@ fn on_receive_catchup_gated(
 /// fully receive (by checking ServerMutateTicks)
 pub(crate) fn trigger_snapshot_rollback(
     timeline: Res<LocalTimeline>,
+    input_config: Res<InputTimelineConfig>,
     manager: Single<
         (
             Entity,
             &mut CatchUpManager,
             &LastConfirmedInput,
             &PredictionManager,
-            &InputTimelineConfig,
         ),
         With<Client>,
     >,
@@ -274,7 +273,7 @@ pub(crate) fn trigger_snapshot_rollback(
     mut state_metadata: ResMut<StateRollbackMetadata>,
     mut commands: Commands,
 ) {
-    let (client_entity, mut manager, last_confirmed_input, prediction_manager, input_config) =
+    let (client_entity, mut manager, last_confirmed_input, prediction_manager) =
         manager.into_inner();
     if manager.completed {
         return;
@@ -295,7 +294,7 @@ pub(crate) fn trigger_snapshot_rollback(
     let max_rollback_ticks = i32::from(
         prediction_manager
             .rollback_policy
-            .effective_max_rollback_ticks(input_config),
+            .effective_max_rollback_ticks(&input_config),
     );
     if rollback_delta > max_rollback_ticks {
         warn!(

--- a/crates/deterministic/deterministic_replication/src/late_join/client.rs
+++ b/crates/deterministic/deterministic_replication/src/late_join/client.rs
@@ -18,7 +18,7 @@ use lightyear_prediction::prelude::{
 use lightyear_prediction::rollback::{CatchUpGated, DisableRollback};
 use lightyear_replication::metadata::MetadataChannel;
 use lightyear_replication::prelude::ReplicationSystems;
-use lightyear_sync::prelude::{InputTimeline, InputTimelineConfig};
+use lightyear_sync::prelude::{InputTimelineConfig, SyncedInputTimeline};
 use tracing::{debug, info, warn};
 
 use super::{CatchUpRequest, CatchUpSnapshotReady, CatchUpSystems};
@@ -142,22 +142,19 @@ fn catchup_snapshot_is_activating(manager: Option<Single<&CatchUpManager, With<C
 /// frame conservative is preferable to duplicating that input coverage logic.
 pub(crate) fn send_catchup_request(
     timeline: Res<LocalTimeline>,
-    input_timeline: Res<InputTimeline>,
+    _input_timeline: SyncedInputTimeline,
+    last_confirmed_input: Res<LastConfirmedInput>,
     client: Single<
         (
             Entity,
             &mut CatchUpManager,
-            &LastConfirmedInput,
             &mut MessageSender<CatchUpRequest>,
         ),
         With<Client>,
     >,
     awaiting: Query<Entity, With<CatchUpGated>>,
 ) {
-    let (client_entity, mut manager, last_confirmed_input, mut sender) = client.into_inner();
-    if !input_timeline.is_synced() {
-        return;
-    }
+    let (client_entity, mut manager, mut sender) = client.into_inner();
     if manager.completed {
         return;
     }
@@ -260,21 +257,13 @@ fn on_receive_catchup_gated(
 pub(crate) fn trigger_snapshot_rollback(
     timeline: Res<LocalTimeline>,
     input_config: Res<InputTimelineConfig>,
-    manager: Single<
-        (
-            Entity,
-            &mut CatchUpManager,
-            &LastConfirmedInput,
-            &PredictionManager,
-        ),
-        With<Client>,
-    >,
+    last_confirmed_input: Res<LastConfirmedInput>,
+    manager: Single<(Entity, &mut CatchUpManager, &PredictionManager), With<Client>>,
     server_mutate_ticks: Res<ServerMutateTicks>,
     mut state_metadata: ResMut<StateRollbackMetadata>,
     mut commands: Commands,
 ) {
-    let (client_entity, mut manager, last_confirmed_input, prediction_manager) =
-        manager.into_inner();
+    let (client_entity, mut manager, prediction_manager) = manager.into_inner();
     if manager.completed {
         return;
     }

--- a/crates/inputs/inputs/src/client.rs
+++ b/crates/inputs/inputs/src/client.rs
@@ -62,6 +62,7 @@ use bevy_ecs::prelude::*;
 use bevy_time::{Real, Time, Timer, TimerMode};
 use bevy_utils::prelude::DebugName;
 use lightyear_connection::host::HostClient;
+use lightyear_connection::network_topology::{NetworkTopology, NetworkingMetadata};
 use lightyear_core::prelude::*;
 use lightyear_core::tick::TickDuration;
 #[cfg(feature = "interpolation")]
@@ -77,8 +78,9 @@ use lightyear_messages::prelude::MessageSender;
 use lightyear_prediction::prelude::*;
 use lightyear_replication::prelude::{ControlledBy, PreSpawned};
 use lightyear_sync::plugin::SyncSystems;
+#[cfg(feature = "interpolation")]
 use lightyear_sync::prelude::client::IsSynced;
-use lightyear_sync::prelude::{InputTimeline, InputTimelineConfig};
+use lightyear_sync::prelude::{InputTimeline, InputTimelineConfig, InputTimelineShifted};
 use lightyear_transport::prelude::ChannelRegistry;
 #[allow(unused_imports)]
 use tracing::{debug, error, info, trace, warn};
@@ -121,6 +123,17 @@ pub enum InputSystems {
     CleanUp,
 }
 
+fn active_client_entity(metadata: &NetworkingMetadata) -> Option<Entity> {
+    match &metadata.mode {
+        NetworkTopology::Client(entity) => Some(*entity),
+        NetworkTopology::HostClient { client, .. } => Some(*client),
+        NetworkTopology::Undefined
+        | NetworkTopology::Server(_)
+        | NetworkTopology::P2P(_)
+        | NetworkTopology::Invalid(_) => None,
+    }
+}
+
 /// Client-side plugin that buffers local action state each tick and sends
 /// compressed input messages to the server.
 ///
@@ -155,6 +168,12 @@ impl<S: ActionStateSequence + MapEntities> Plugin for ClientInputPlugin<S> {
         app.init_resource::<SharedInputConfig>();
         app.insert_resource(self.config);
         app.init_resource::<MessageBuffer<S>>();
+        // These resources are normally installed and maintained by the connection/sync
+        // plugins. Initializing them here keeps this plugin composable in isolation.
+        app.init_resource::<NetworkingMetadata>();
+        app.init_resource::<InputTimeline>();
+        app.init_resource::<InputTimelineConfig>();
+
         // SETS
 
         // NOTE: this is subtle! We receive remote players messages after
@@ -279,14 +298,9 @@ fn buffer_action_state<S: ActionStateSequence>(
     // we buffer inputs even for the Host-Server so that
     // 1. the HostServer client can broadcast inputs to other clients
     // 2. the HostServer client can have input delay
-    input_timeline: Single<
-        (Entity, &InputTimeline),
-        (
-            With<Client>,
-            With<IsSynced<InputTimeline>>,
-            Without<Rollback>,
-        ),
-    >,
+    input_timeline: Res<InputTimeline>,
+    metadata: Res<NetworkingMetadata>,
+    clients: Query<Has<Rollback>, With<Client>>,
     mut action_state_query: Query<
         (
             Entity,
@@ -297,7 +311,15 @@ fn buffer_action_state<S: ActionStateSequence>(
         (With<S::Marker>, Allow<PredictionDisable>),
     >,
 ) {
-    let (client_entity, input_timeline) = input_timeline.into_inner();
+    if !input_timeline.is_synced() {
+        return;
+    }
+    let Some(client_entity) = active_client_entity(&metadata) else {
+        return;
+    };
+    if !matches!(clients.get(client_entity), Ok(false)) {
+        return;
+    }
     let current_tick = local_timeline.tick();
     let tick = current_tick + input_timeline.input_delay() as i32;
     for (entity, action_state, mut input_buffer, controlled_by) in action_state_query.iter_mut() {
@@ -340,10 +362,10 @@ fn get_action_state<S: ActionStateSequence>(
     local_timeline: Res<LocalTimeline>,
     // NOTE: we skip this for host-client because a similar system does the same thing
     //  in the server, and also clears the buffers
-    sender: Query<
-        (&InputTimeline, &InputTimelineConfig, Has<Rollback>),
-        (With<Client>, Without<HostClient>),
-    >,
+    input_timeline: Res<InputTimeline>,
+    input_timeline_config: Res<InputTimelineConfig>,
+    metadata: Res<NetworkingMetadata>,
+    clients: Query<(Has<Rollback>, Has<HostClient>), With<Client>>,
 
     // NOTE: we want to apply the Inputs for BOTH the local player and remote player
     // - local player: we need to get the input from the InputBuffer because of input delay
@@ -360,9 +382,18 @@ fn get_action_state<S: ActionStateSequence>(
         Allow<PredictionDisable>,
     >,
 ) {
-    let Ok((input_timeline, input_config, is_rollback)) = sender.single() else {
+    if !input_timeline.is_synced() {
+        return;
+    }
+    let Some(client_entity) = active_client_entity(&metadata) else {
         return;
     };
+    let Ok((is_rollback, is_host_client)) = clients.get(client_entity) else {
+        return;
+    };
+    if is_host_client {
+        return;
+    }
     let input_delay = input_timeline.input_delay() as i32;
     let tick = local_timeline.tick();
     if is_rollback && config.ignore_rollbacks {
@@ -422,7 +453,7 @@ fn get_action_state<S: ActionStateSequence>(
                 "restored action state from input buffer"
             );
         } else if !is_local && config.rebroadcast_inputs {
-            if input_config.is_lockstep() {
+            if input_timeline_config.is_lockstep() {
                 error!("We are in lockstep mode but didn't receive an input for tick {tick:?}!");
             }
             // we are here if:
@@ -463,10 +494,9 @@ fn get_action_state<S: ActionStateSequence>(
 /// (e.g. the delayed action state) because all inputs (i.e. diffs) are applied to the delayed action-state.
 fn get_delayed_action_state<S: ActionStateSequence>(
     timeline: Res<LocalTimeline>,
-    sender: Query<
-        (Entity, &InputTimeline, Has<Rollback>),
-        (With<Client>, With<IsSynced<InputTimeline>>),
-    >,
+    input_timeline: Res<InputTimeline>,
+    metadata: Res<NetworkingMetadata>,
+    clients: Query<Has<Rollback>, With<Client>>,
     mut action_state_query: Query<
         (
             Entity,
@@ -478,7 +508,13 @@ fn get_delayed_action_state<S: ActionStateSequence>(
         (With<S::Marker>, Allow<PredictionDisable>),
     >,
 ) {
-    let Ok((client_entity, input_timeline, is_rollback)) = sender.single() else {
+    if !input_timeline.is_synced() {
+        return;
+    }
+    let Some(client_entity) = active_client_entity(&metadata) else {
+        return;
+    };
+    let Ok(is_rollback) = clients.get(client_entity) else {
         return;
     };
     let input_delay_ticks = input_timeline.input_delay() as i32;
@@ -526,17 +562,28 @@ fn clean_buffers<S: ActionStateSequence>(
     timeline: Res<LocalTimeline>,
     // NOTE: we skip this for host-client because the get_action_state system on the server
     //  also clears the buffers
-    sender: Query<(), (With<Client>, With<InputTimeline>, Without<HostClient>)>,
-    prediction_manager: Option<Single<(&PredictionManager, &InputTimelineConfig), With<Client>>>,
+    metadata: Res<NetworkingMetadata>,
+    clients: Query<Has<HostClient>, With<Client>>,
+    prediction_manager: Option<Single<&PredictionManager, With<Client>>>,
+    input_config: Res<InputTimelineConfig>,
     mut input_buffer_query: Query<
         &mut InputBuffer<S::Snapshot, S::Action>,
         Allow<PredictionDisable>,
     >,
 ) {
-    if sender.single().is_err() {
+    let Some(client_entity) = active_client_entity(&metadata) else {
+        return;
+    };
+    if !matches!(clients.get(client_entity), Ok(false)) {
         return;
     }
-    let old_tick = timeline.tick() - input_history_depth(prediction_manager.as_deref().copied());
+    let old_tick = timeline.tick()
+        - input_history_depth(
+            prediction_manager
+                .as_deref()
+                .copied()
+                .map(|manager| (manager, input_config.as_ref())),
+        );
 
     // trace!(
     //     "popping all input buffers since old tick: {old_tick:?}",
@@ -590,17 +637,9 @@ fn prepare_input_message<S: ActionStateSequence>(
     tick_duration: Res<TickDuration>,
     timeline: Res<LocalTimeline>,
     input_config: Res<InputConfig<S::Action>>,
-    sender: Single<
-        (Entity, &InputTimeline, Has<HostClient>),
-        // the host-client doesn't need to send input messages since the ActionState is already on the entity
-        // unless we want to rebroadcast the HostClient inputs to other clients (in which
-        // case we prepare the input-message, which will be send_local to the server)
-        (
-            With<Client>,
-            With<IsSynced<InputTimeline>>,
-            Without<Rollback>,
-        ),
-    >,
+    input_timeline: Res<InputTimeline>,
+    metadata: Res<NetworkingMetadata>,
+    clients: Query<(Has<HostClient>, Has<Rollback>), With<Client>>,
     _channel_registry: Res<ChannelRegistry>,
     input_buffer_query: Query<
         (
@@ -614,6 +653,19 @@ fn prepare_input_message<S: ActionStateSequence>(
     real_time: Res<Time<Real>>,
     mut send_timer: Local<Option<Timer>>,
 ) {
+    if !input_timeline.is_synced() {
+        return;
+    }
+    let Some(client_entity) = active_client_entity(&metadata) else {
+        return;
+    };
+    let Ok((is_host_client, is_rollback)) = clients.get(client_entity) else {
+        return;
+    };
+    if is_rollback {
+        return;
+    }
+
     // Only prepare input every send-interval.
     if !input_config.send_interval.is_zero() {
         let timer = send_timer
@@ -624,7 +676,6 @@ fn prepare_input_message<S: ActionStateSequence>(
         }
     }
 
-    let (client_entity, input_timeline, is_host_client) = sender.into_inner();
     #[cfg(not(feature = "prediction"))]
     if is_host_client {
         // if there is not prediction, no need to rebroadcast inputs
@@ -751,18 +802,16 @@ fn receive_remote_player_input_messages<S: ActionStateSequence>(
     tick_duration: Res<TickDuration>,
     timeline: Res<LocalTimeline>,
     #[cfg(feature = "metrics")] mut input_metric_handles: ResMut<InputMetricHandles<S>>,
-    link: Single<
+    input_timeline: Res<InputTimeline>,
+    metadata: Res<NetworkingMetadata>,
+    mut links: Query<
         (
             &mut MessageReceiver<InputMessage<S>>,
             Option<&LastConfirmedInput>,
             &PredictionManager,
         ),
         // the host-client won't receive input messages from the Server
-        (
-            With<Client>,
-            With<IsSynced<InputTimeline>>,
-            Without<HostClient>,
-        ),
+        (With<Client>, Without<HostClient>),
     >,
     mut predicted_query: Query<
         Option<&mut InputBuffer<S::Snapshot, S::Action>>,
@@ -770,7 +819,16 @@ fn receive_remote_player_input_messages<S: ActionStateSequence>(
     >,
     prespawned: Query<(Entity, &PreSpawned)>,
 ) {
-    let (mut receiver, last_confirmed_input, prediction_manager) = link.into_inner();
+    if !input_timeline.is_synced() {
+        return;
+    }
+    let Some(client_entity) = active_client_entity(&metadata) else {
+        return;
+    };
+    let Ok((mut receiver, last_confirmed_input, prediction_manager)) = links.get_mut(client_entity)
+    else {
+        return;
+    };
     let tick = timeline.tick();
     let mut received_relevant_input = false;
     receiver.receive().for_each(|message| {
@@ -929,16 +987,24 @@ fn receive_remote_player_input_messages<S: ActionStateSequence>(
 /// (and not to tick 14) because we need to potentially re-apply inputs for ticks 11, 12, 13, 14.
 fn update_last_confirmed_input<S: ActionStateSequence>(
     timeline: Res<LocalTimeline>,
-    last_confirmed_input: Single<
-        (&mut LastConfirmedInput, &InputTimelineConfig),
-        (With<Client>, With<IsSynced<InputTimeline>>),
-    >,
+    input_timeline: Res<InputTimeline>,
+    input_config: Res<InputTimelineConfig>,
+    metadata: Res<NetworkingMetadata>,
+    mut last_confirmed_inputs: Query<&mut LastConfirmedInput, With<Client>>,
     predicted_query: Query<
         &InputBuffer<S::Snapshot, S::Action>,
         (Without<S::Marker>, Allow<PredictionDisable>),
     >,
 ) {
-    let (mut last_confirmed_input, input_config) = last_confirmed_input.into_inner();
+    if !input_timeline.is_synced() {
+        return;
+    }
+    let Some(client_entity) = active_client_entity(&metadata) else {
+        return;
+    };
+    let Ok(mut last_confirmed_input) = last_confirmed_inputs.get_mut(client_entity) else {
+        return;
+    };
     let tick = timeline.tick();
     // in lockstep mode, we don't need last confirmed input because we always have all inputs for a given tick.
     // we will just use the current tick as the last confirmed input tick
@@ -1060,21 +1126,24 @@ fn update_buffer_from_remote_player_message<S: ActionStateSequence>(
 /// Drain the messages from the buffer and send them to the server
 fn send_input_messages<S: ActionStateSequence>(
     input_config: Res<InputConfig<S::Action>>,
+    input_timeline: Res<InputTimeline>,
+    metadata: Res<NetworkingMetadata>,
     mut message_buffer: ResMut<MessageBuffer<S>>,
-    sender: Single<
-        (&mut MessageSender<InputMessage<S>>, Has<HostClient>),
-        (With<Client>, With<IsSynced<InputTimeline>>),
-    >,
-    #[cfg(feature = "interpolation")] interpolation_query: Single<
-        (&InputTimeline, &InterpolationTimeline),
-        (
-            With<Client>,
-            With<IsSynced<InterpolationTimeline>>,
-            With<IsSynced<InputTimeline>>,
-        ),
+    mut senders: Query<(&mut MessageSender<InputMessage<S>>, Has<HostClient>), With<Client>>,
+    #[cfg(feature = "interpolation")] interpolation_query: Query<
+        &InterpolationTimeline,
+        (With<Client>, With<IsSynced<InterpolationTimeline>>),
     >,
 ) {
-    let (mut sender, is_host_client) = sender.into_inner();
+    if !input_timeline.is_synced() {
+        return;
+    }
+    let Some(client_entity) = active_client_entity(&metadata) else {
+        return;
+    };
+    let Ok((mut sender, is_host_client)) = senders.get_mut(client_entity) else {
+        return;
+    };
 
     #[cfg(not(feature = "prediction"))]
     if is_host_client {
@@ -1105,7 +1174,9 @@ fn send_input_messages<S: ActionStateSequence>(
 
     #[cfg(feature = "interpolation")]
     let interpolation_delay = {
-        let (input_timeline, interpolation_timeline) = interpolation_query.into_inner();
+        let Ok(interpolation_timeline) = interpolation_query.get(client_entity) else {
+            return;
+        };
 
         // NOTE: this can be negative because of input-delay!
         let mut delay = input_timeline.now() - interpolation_timeline.now();
@@ -1136,9 +1207,9 @@ fn send_input_messages<S: ActionStateSequence>(
 
 /// In case the client tick changes suddenly, we also update the InputBuffer accordingly
 fn receive_tick_events<S: ActionStateSequence>(
-    trigger: On<SyncEvent<InputTimelineConfig>>,
+    trigger: On<InputTimelineShifted>,
+    metadata: Res<NetworkingMetadata>,
     mut message_buffer: ResMut<MessageBuffer<S>>,
-    clients: Query<(), With<Client>>,
     mut input_buffer_query: Query<
         (
             &mut InputBuffer<S::Snapshot, S::Action>,
@@ -1147,12 +1218,12 @@ fn receive_tick_events<S: ActionStateSequence>(
         Allow<PredictionDisable>,
     >,
 ) {
-    if clients.get(trigger.entity).is_err() {
+    let Some(client_entity) = active_client_entity(&metadata) else {
         return;
-    }
+    };
     let delta = trigger.tick_delta;
     for (mut input_buffer, controlled_by) in input_buffer_query.iter_mut() {
-        if controlled_by.is_some_and(|controlled_by| controlled_by.owner != trigger.entity) {
+        if controlled_by.is_some_and(|controlled_by| controlled_by.owner != client_entity) {
             continue;
         }
         if let Some(start_tick) = input_buffer.start_tick {

--- a/crates/inputs/inputs/src/client.rs
+++ b/crates/inputs/inputs/src/client.rs
@@ -62,7 +62,6 @@ use bevy_ecs::prelude::*;
 use bevy_time::{Real, Time, Timer, TimerMode};
 use bevy_utils::prelude::DebugName;
 use lightyear_connection::host::HostClient;
-use lightyear_connection::network_topology::{NetworkTopology, NetworkingMetadata};
 use lightyear_core::prelude::*;
 use lightyear_core::tick::TickDuration;
 #[cfg(feature = "interpolation")]
@@ -80,7 +79,7 @@ use lightyear_replication::prelude::{ControlledBy, PreSpawned};
 use lightyear_sync::plugin::SyncSystems;
 #[cfg(feature = "interpolation")]
 use lightyear_sync::prelude::client::IsSynced;
-use lightyear_sync::prelude::{InputTimeline, InputTimelineConfig, InputTimelineShifted};
+use lightyear_sync::prelude::{InputTimeline, InputTimelineConfig, SyncedInputTimeline};
 use lightyear_transport::prelude::ChannelRegistry;
 #[allow(unused_imports)]
 use tracing::{debug, error, info, trace, warn};
@@ -123,17 +122,6 @@ pub enum InputSystems {
     CleanUp,
 }
 
-fn active_client_entity(metadata: &NetworkingMetadata) -> Option<Entity> {
-    match &metadata.mode {
-        NetworkTopology::Client(entity) => Some(*entity),
-        NetworkTopology::HostClient { client, .. } => Some(*client),
-        NetworkTopology::Undefined
-        | NetworkTopology::Server(_)
-        | NetworkTopology::P2P(_)
-        | NetworkTopology::Invalid(_) => None,
-    }
-}
-
 /// Client-side plugin that buffers local action state each tick and sends
 /// compressed input messages to the server.
 ///
@@ -168,11 +156,13 @@ impl<S: ActionStateSequence + MapEntities> Plugin for ClientInputPlugin<S> {
         app.init_resource::<SharedInputConfig>();
         app.insert_resource(self.config);
         app.init_resource::<MessageBuffer<S>>();
-        // These resources are normally installed and maintained by the connection/sync
-        // plugins. Initializing them here keeps this plugin composable in isolation.
-        app.init_resource::<NetworkingMetadata>();
+        // Client input systems may be installed in a combined client/server app. Keep their
+        // global clock parameters available even when no client link is active; the
+        // SyncedInputTimeline parameter still gates systems that require synchronization.
         app.init_resource::<InputTimeline>();
         app.init_resource::<InputTimelineConfig>();
+        #[cfg(feature = "prediction")]
+        app.init_resource::<LastConfirmedInput>();
 
         // SETS
 
@@ -298,9 +288,8 @@ fn buffer_action_state<S: ActionStateSequence>(
     // we buffer inputs even for the Host-Server so that
     // 1. the HostServer client can broadcast inputs to other clients
     // 2. the HostServer client can have input delay
-    input_timeline: Res<InputTimeline>,
-    metadata: Res<NetworkingMetadata>,
-    clients: Query<Has<Rollback>, With<Client>>,
+    input_timeline: SyncedInputTimeline,
+    client_entity: Single<Entity, (With<Client>, Without<Rollback>)>,
     mut action_state_query: Query<
         (
             Entity,
@@ -311,15 +300,7 @@ fn buffer_action_state<S: ActionStateSequence>(
         (With<S::Marker>, Allow<PredictionDisable>),
     >,
 ) {
-    if !input_timeline.is_synced() {
-        return;
-    }
-    let Some(client_entity) = active_client_entity(&metadata) else {
-        return;
-    };
-    if !matches!(clients.get(client_entity), Ok(false)) {
-        return;
-    }
+    let client_entity = *client_entity;
     let current_tick = local_timeline.tick();
     let tick = current_tick + input_timeline.input_delay() as i32;
     for (entity, action_state, mut input_buffer, controlled_by) in action_state_query.iter_mut() {
@@ -364,8 +345,7 @@ fn get_action_state<S: ActionStateSequence>(
     //  in the server, and also clears the buffers
     input_timeline: Res<InputTimeline>,
     input_timeline_config: Res<InputTimelineConfig>,
-    metadata: Res<NetworkingMetadata>,
-    clients: Query<(Has<Rollback>, Has<HostClient>), With<Client>>,
+    client: Single<Has<Rollback>, (With<Client>, Without<HostClient>)>,
 
     // NOTE: we want to apply the Inputs for BOTH the local player and remote player
     // - local player: we need to get the input from the InputBuffer because of input delay
@@ -382,18 +362,7 @@ fn get_action_state<S: ActionStateSequence>(
         Allow<PredictionDisable>,
     >,
 ) {
-    if !input_timeline.is_synced() {
-        return;
-    }
-    let Some(client_entity) = active_client_entity(&metadata) else {
-        return;
-    };
-    let Ok((is_rollback, is_host_client)) = clients.get(client_entity) else {
-        return;
-    };
-    if is_host_client {
-        return;
-    }
+    let is_rollback = *client;
     let input_delay = input_timeline.input_delay() as i32;
     let tick = local_timeline.tick();
     if is_rollback && config.ignore_rollbacks {
@@ -494,9 +463,8 @@ fn get_action_state<S: ActionStateSequence>(
 /// (e.g. the delayed action state) because all inputs (i.e. diffs) are applied to the delayed action-state.
 fn get_delayed_action_state<S: ActionStateSequence>(
     timeline: Res<LocalTimeline>,
-    input_timeline: Res<InputTimeline>,
-    metadata: Res<NetworkingMetadata>,
-    clients: Query<Has<Rollback>, With<Client>>,
+    input_timeline: SyncedInputTimeline,
+    client: Single<(Entity, Has<Rollback>), With<Client>>,
     mut action_state_query: Query<
         (
             Entity,
@@ -508,15 +476,7 @@ fn get_delayed_action_state<S: ActionStateSequence>(
         (With<S::Marker>, Allow<PredictionDisable>),
     >,
 ) {
-    if !input_timeline.is_synced() {
-        return;
-    }
-    let Some(client_entity) = active_client_entity(&metadata) else {
-        return;
-    };
-    let Ok(is_rollback) = clients.get(client_entity) else {
-        return;
-    };
+    let (client_entity, is_rollback) = client.into_inner();
     let input_delay_ticks = input_timeline.input_delay() as i32;
     if is_rollback || input_delay_ticks == 0 {
         return;
@@ -562,8 +522,7 @@ fn clean_buffers<S: ActionStateSequence>(
     timeline: Res<LocalTimeline>,
     // NOTE: we skip this for host-client because the get_action_state system on the server
     //  also clears the buffers
-    metadata: Res<NetworkingMetadata>,
-    clients: Query<Has<HostClient>, With<Client>>,
+    _client: Single<(), (With<Client>, Without<HostClient>)>,
     prediction_manager: Option<Single<&PredictionManager, With<Client>>>,
     input_config: Res<InputTimelineConfig>,
     mut input_buffer_query: Query<
@@ -571,12 +530,6 @@ fn clean_buffers<S: ActionStateSequence>(
         Allow<PredictionDisable>,
     >,
 ) {
-    let Some(client_entity) = active_client_entity(&metadata) else {
-        return;
-    };
-    if !matches!(clients.get(client_entity), Ok(false)) {
-        return;
-    }
     let old_tick = timeline.tick()
         - input_history_depth(
             prediction_manager
@@ -637,9 +590,8 @@ fn prepare_input_message<S: ActionStateSequence>(
     tick_duration: Res<TickDuration>,
     timeline: Res<LocalTimeline>,
     input_config: Res<InputConfig<S::Action>>,
-    input_timeline: Res<InputTimeline>,
-    metadata: Res<NetworkingMetadata>,
-    clients: Query<(Has<HostClient>, Has<Rollback>), With<Client>>,
+    input_timeline: SyncedInputTimeline,
+    client: Single<(Entity, Has<HostClient>), (With<Client>, Without<Rollback>)>,
     _channel_registry: Res<ChannelRegistry>,
     input_buffer_query: Query<
         (
@@ -653,18 +605,7 @@ fn prepare_input_message<S: ActionStateSequence>(
     real_time: Res<Time<Real>>,
     mut send_timer: Local<Option<Timer>>,
 ) {
-    if !input_timeline.is_synced() {
-        return;
-    }
-    let Some(client_entity) = active_client_entity(&metadata) else {
-        return;
-    };
-    let Ok((is_host_client, is_rollback)) = clients.get(client_entity) else {
-        return;
-    };
-    if is_rollback {
-        return;
-    }
+    let (client_entity, is_host_client) = client.into_inner();
 
     // Only prepare input every send-interval.
     if !input_config.send_interval.is_zero() {
@@ -802,14 +743,10 @@ fn receive_remote_player_input_messages<S: ActionStateSequence>(
     tick_duration: Res<TickDuration>,
     timeline: Res<LocalTimeline>,
     #[cfg(feature = "metrics")] mut input_metric_handles: ResMut<InputMetricHandles<S>>,
-    input_timeline: Res<InputTimeline>,
-    metadata: Res<NetworkingMetadata>,
-    mut links: Query<
-        (
-            &mut MessageReceiver<InputMessage<S>>,
-            Option<&LastConfirmedInput>,
-            &PredictionManager,
-        ),
+    _input_timeline: SyncedInputTimeline,
+    last_confirmed_input: Res<LastConfirmedInput>,
+    link: Single<
+        (&mut MessageReceiver<InputMessage<S>>, &PredictionManager),
         // the host-client won't receive input messages from the Server
         (With<Client>, Without<HostClient>),
     >,
@@ -819,16 +756,7 @@ fn receive_remote_player_input_messages<S: ActionStateSequence>(
     >,
     prespawned: Query<(Entity, &PreSpawned)>,
 ) {
-    if !input_timeline.is_synced() {
-        return;
-    }
-    let Some(client_entity) = active_client_entity(&metadata) else {
-        return;
-    };
-    let Ok((mut receiver, last_confirmed_input, prediction_manager)) = links.get_mut(client_entity)
-    else {
-        return;
-    };
+    let (mut receiver, prediction_manager) = link.into_inner();
     let tick = timeline.tick();
     let mut received_relevant_input = false;
     receiver.receive().for_each(|message| {
@@ -970,9 +898,7 @@ fn receive_remote_player_input_messages<S: ActionStateSequence>(
         }
     });
 
-    if let Some(last_confirmed_input) = last_confirmed_input
-        && received_relevant_input
-    {
+    if received_relevant_input {
         last_confirmed_input
             .received_any_messages
             .store(true, bevy_platform::sync::atomic::Ordering::Relaxed);
@@ -987,24 +913,15 @@ fn receive_remote_player_input_messages<S: ActionStateSequence>(
 /// (and not to tick 14) because we need to potentially re-apply inputs for ticks 11, 12, 13, 14.
 fn update_last_confirmed_input<S: ActionStateSequence>(
     timeline: Res<LocalTimeline>,
-    input_timeline: Res<InputTimeline>,
+    _input_timeline: SyncedInputTimeline,
     input_config: Res<InputTimelineConfig>,
-    metadata: Res<NetworkingMetadata>,
-    mut last_confirmed_inputs: Query<&mut LastConfirmedInput, With<Client>>,
+    _client: Single<(), With<Client>>,
+    mut last_confirmed_input: ResMut<LastConfirmedInput>,
     predicted_query: Query<
         &InputBuffer<S::Snapshot, S::Action>,
         (Without<S::Marker>, Allow<PredictionDisable>),
     >,
 ) {
-    if !input_timeline.is_synced() {
-        return;
-    }
-    let Some(client_entity) = active_client_entity(&metadata) else {
-        return;
-    };
-    let Ok(mut last_confirmed_input) = last_confirmed_inputs.get_mut(client_entity) else {
-        return;
-    };
     let tick = timeline.tick();
     // in lockstep mode, we don't need last confirmed input because we always have all inputs for a given tick.
     // we will just use the current tick as the last confirmed input tick
@@ -1126,24 +1043,15 @@ fn update_buffer_from_remote_player_message<S: ActionStateSequence>(
 /// Drain the messages from the buffer and send them to the server
 fn send_input_messages<S: ActionStateSequence>(
     input_config: Res<InputConfig<S::Action>>,
-    input_timeline: Res<InputTimeline>,
-    metadata: Res<NetworkingMetadata>,
+    input_timeline: SyncedInputTimeline,
     mut message_buffer: ResMut<MessageBuffer<S>>,
-    mut senders: Query<(&mut MessageSender<InputMessage<S>>, Has<HostClient>), With<Client>>,
-    #[cfg(feature = "interpolation")] interpolation_query: Query<
+    sender: Single<(&mut MessageSender<InputMessage<S>>, Has<HostClient>), With<Client>>,
+    #[cfg(feature = "interpolation")] interpolation_timeline: Single<
         &InterpolationTimeline,
         (With<Client>, With<IsSynced<InterpolationTimeline>>),
     >,
 ) {
-    if !input_timeline.is_synced() {
-        return;
-    }
-    let Some(client_entity) = active_client_entity(&metadata) else {
-        return;
-    };
-    let Ok((mut sender, is_host_client)) = senders.get_mut(client_entity) else {
-        return;
-    };
+    let (mut sender, is_host_client) = sender.into_inner();
 
     #[cfg(not(feature = "prediction"))]
     if is_host_client {
@@ -1174,10 +1082,6 @@ fn send_input_messages<S: ActionStateSequence>(
 
     #[cfg(feature = "interpolation")]
     let interpolation_delay = {
-        let Ok(interpolation_timeline) = interpolation_query.get(client_entity) else {
-            return;
-        };
-
         // NOTE: this can be negative because of input-delay!
         let mut delay = input_timeline.now() - interpolation_timeline.now();
         if delay.is_negative() {
@@ -1207,8 +1111,8 @@ fn send_input_messages<S: ActionStateSequence>(
 
 /// In case the client tick changes suddenly, we also update the InputBuffer accordingly
 fn receive_tick_events<S: ActionStateSequence>(
-    trigger: On<InputTimelineShifted>,
-    metadata: Res<NetworkingMetadata>,
+    trigger: On<SyncEvent<InputTimelineConfig>>,
+    client_entity: Single<Entity, With<Client>>,
     mut message_buffer: ResMut<MessageBuffer<S>>,
     mut input_buffer_query: Query<
         (
@@ -1218,9 +1122,7 @@ fn receive_tick_events<S: ActionStateSequence>(
         Allow<PredictionDisable>,
     >,
 ) {
-    let Some(client_entity) = active_client_entity(&metadata) else {
-        return;
-    };
+    let client_entity = *client_entity;
     let delta = trigger.tick_delta;
     for (mut input_buffer, controlled_by) in input_buffer_query.iter_mut() {
         if controlled_by.is_some_and(|controlled_by| controlled_by.owner != client_entity) {

--- a/crates/replication/prediction/src/manager.rs
+++ b/crates/replication/prediction/src/manager.rs
@@ -101,7 +101,6 @@ impl RollbackPolicy {
 #[derive(Component, Debug, Reflect)]
 #[component(on_insert = PredictionManager::on_insert)]
 #[require(PreSpawnedReceiver)]
-#[require(LastConfirmedInput)]
 pub struct PredictionManager {
     /// Configuration for how rollbacks are triggered
     pub rollback_policy: RollbackPolicy,
@@ -119,8 +118,11 @@ pub struct PredictionManager {
     pub rollback: RwLock<RollbackState>,
 }
 
-/// Store the most recent confirmed input across all remote clients.
-#[derive(Component, Debug, Reflect)]
+/// Application-global frontier of confirmed input across all remote players.
+///
+/// This is a resource because the rollback decision combines every remote input stream in the
+/// application; it does not belong to any one network link.
+#[derive(Resource, Debug, Reflect)]
 pub struct LastConfirmedInput {
     /// Updated via [`AtomicTick::set_if_lower`] to track the minimum last-confirmed tick
     /// across all remote clients. Reset to a high value each frame by

--- a/crates/replication/prediction/src/manager.rs
+++ b/crates/replication/prediction/src/manager.rs
@@ -12,6 +12,7 @@ use bevy_ecs::world::DeferredWorld;
 use core::ops::{Deref, DerefMut};
 use lightyear_core::prelude::Tick;
 use lightyear_replication::prespawn::PreSpawnedReceiver;
+use lightyear_sync::prelude::InputTimelineConfig;
 use parking_lot::RwLock;
 
 #[derive(Resource)]

--- a/crates/replication/prediction/src/manager.rs
+++ b/crates/replication/prediction/src/manager.rs
@@ -12,13 +12,12 @@ use bevy_ecs::world::DeferredWorld;
 use core::ops::{Deref, DerefMut};
 use lightyear_core::prelude::Tick;
 use lightyear_replication::prespawn::PreSpawnedReceiver;
-use lightyear_sync::prelude::InputTimelineConfig;
 use parking_lot::RwLock;
 
 #[derive(Resource)]
 pub struct PredictionResource {
-    // entity that holds the InputTimeline
-    // We use this to avoid having to run a mutable query in component hook
+    // entity that holds the PredictionManager
+    // We use this to avoid having to run a mutable query in component hooks
     pub(crate) link_entity: Entity,
 }
 
@@ -101,7 +100,6 @@ impl RollbackPolicy {
 /// predicted entities, record prediction history, and perform rollback/reconciliation.
 #[derive(Component, Debug, Reflect)]
 #[component(on_insert = PredictionManager::on_insert)]
-#[require(InputTimelineConfig)]
 #[require(PreSpawnedReceiver)]
 #[require(LastConfirmedInput)]
 pub struct PredictionManager {

--- a/crates/replication/prediction/src/plugin.rs
+++ b/crates/replication/prediction/src/plugin.rs
@@ -5,7 +5,7 @@ use crate::correction::{
 };
 use crate::despawn::PredictionDisable;
 use crate::diagnostics::PredictionDiagnosticsPlugin;
-use crate::manager::PredictionManager;
+use crate::manager::{LastConfirmedInput, PredictionManager};
 use crate::predicted_history::{
     PredictionHistory, add_history_diff_receiver, add_prediction_history,
     apply_component_removal_predicted, handle_tick_event_history_diff_receiver,
@@ -24,7 +24,6 @@ use lightyear_connection::client::{Client, Connected};
 use lightyear_connection::host::HostClient;
 use lightyear_core::prelude::ConfirmedHistory;
 use lightyear_replication::prelude::ReplicationSystems;
-use lightyear_sync::prelude::InputTimeline;
 
 /// Plugin that installs client-side prediction systems.
 ///
@@ -183,7 +182,7 @@ impl Plugin for PredictionPlugin {
     fn build(&self, app: &mut App) {
         // RESOURCES
         app.init_resource::<PredictionRegistry>();
-        app.init_resource::<InputTimeline>();
+        app.init_resource::<LastConfirmedInput>();
 
         // Custom entity disabling
         let rollback_disable_id = app

--- a/crates/replication/prediction/src/plugin.rs
+++ b/crates/replication/prediction/src/plugin.rs
@@ -24,6 +24,7 @@ use lightyear_connection::client::{Client, Connected};
 use lightyear_connection::host::HostClient;
 use lightyear_core::prelude::ConfirmedHistory;
 use lightyear_replication::prelude::ReplicationSystems;
+use lightyear_sync::prelude::InputTimeline;
 
 /// Plugin that installs client-side prediction systems.
 ///
@@ -182,6 +183,7 @@ impl Plugin for PredictionPlugin {
     fn build(&self, app: &mut App) {
         // RESOURCES
         app.init_resource::<PredictionRegistry>();
+        app.init_resource::<InputTimeline>();
 
         // Custom entity disabling
         let rollback_disable_id = app

--- a/crates/replication/prediction/src/predicted_history.rs
+++ b/crates/replication/prediction/src/predicted_history.rs
@@ -93,18 +93,19 @@ impl<C> PredictionHistory<C> {
 ///
 /// This system only handles changes, removals are handled in `apply_component_removal`
 pub(crate) fn update_prediction_history<T: Component + Clone>(
-    manager: Single<(&PredictionManager, &InputTimelineConfig)>,
+    manager: Single<&PredictionManager>,
+    input_config: Res<InputTimelineConfig>,
     mut query: Query<(Entity, Ref<T>, &mut PredictionHistory<T>)>,
     timeline: Res<LocalTimeline>,
 ) {
     // tick for which we will record the history (either the current client tick or the current rollback tick)
     let tick = timeline.tick();
-    let (manager, input_config) = manager.into_inner();
+    let manager = manager.into_inner();
     let oldest_rollback_tick = tick
         - u32::from(
             manager
                 .rollback_policy
-                .effective_max_rollback_ticks(input_config),
+                .effective_max_rollback_ticks(&input_config),
         );
 
     // Update history if the predicted component changed, then prune it.
@@ -535,16 +536,14 @@ mod tests {
         let mut timeline = LocalTimeline::default();
         timeline.apply_delta(tick);
         app.insert_resource(timeline);
-        app.world_mut().spawn((
-            PredictionManager {
-                rollback_policy: RollbackPolicy {
-                    max_rollback_ticks,
-                    ..Default::default()
-                },
+        app.insert_resource(InputTimelineConfig::default().with_input_delay(input_delay_config));
+        app.world_mut().spawn(PredictionManager {
+            rollback_policy: RollbackPolicy {
+                max_rollback_ticks,
                 ..Default::default()
             },
-            InputTimelineConfig::default().with_input_delay(input_delay_config),
-        ));
+            ..Default::default()
+        });
         app.world_mut().flush();
         app
     }

--- a/crates/replication/prediction/src/predicted_history.rs
+++ b/crates/replication/prediction/src/predicted_history.rs
@@ -18,10 +18,10 @@ use core::ops::{Deref, DerefMut};
 use lightyear_core::history_buffer::{HistoryBuffer, HistoryState};
 use lightyear_core::prelude::{ConfirmedHistory, LocalTimeline};
 use lightyear_core::tick::Tick;
-use lightyear_core::timeline::Rollback;
+use lightyear_core::timeline::{Rollback, SyncEvent};
 use lightyear_replication::diff_history::HistoryDiffReceiver;
 use lightyear_replication::prelude::PreSpawned;
-use lightyear_sync::prelude::InputTimelineShifted;
+use lightyear_sync::prelude::InputTimelineConfig;
 #[allow(unused_imports)]
 use tracing::{debug, info, trace};
 
@@ -135,7 +135,7 @@ pub(crate) fn update_prediction_history<T: Component + Clone>(
 /// If there is a TickEvent and the client tick suddenly changes, we need
 /// to update the ticks in the history buffer.
 pub(crate) fn handle_tick_event_prediction_history<C: Component>(
-    trigger: On<InputTimelineShifted>,
+    trigger: On<SyncEvent<InputTimelineConfig>>,
     mut query: Query<&mut PredictionHistory<C>>,
 ) {
     for mut history in query.iter_mut() {
@@ -145,6 +145,7 @@ pub(crate) fn handle_tick_event_prediction_history<C: Component>(
             kind = "prediction_history_tick_delta",
             schedule = "PostUpdate",
             sample_point = "PostUpdate",
+            entity = ?trigger.entity,
             component = ?DebugName::type_name::<C>(),
             tick_delta = trigger.tick_delta,
             history_len = history.len(),
@@ -154,7 +155,7 @@ pub(crate) fn handle_tick_event_prediction_history<C: Component>(
 }
 
 pub(crate) fn handle_tick_event_history_diff_receiver<C: RepliconDiffable>(
-    trigger: On<InputTimelineShifted>,
+    trigger: On<SyncEvent<InputTimelineConfig>>,
     mut storage: ResMut<ReplicationStorage>,
 ) {
     for (entity, entity_storage) in storage.entities.iter_mut() {

--- a/crates/replication/prediction/src/predicted_history.rs
+++ b/crates/replication/prediction/src/predicted_history.rs
@@ -18,10 +18,10 @@ use core::ops::{Deref, DerefMut};
 use lightyear_core::history_buffer::{HistoryBuffer, HistoryState};
 use lightyear_core::prelude::{ConfirmedHistory, LocalTimeline};
 use lightyear_core::tick::Tick;
-use lightyear_core::timeline::{Rollback, SyncEvent};
+use lightyear_core::timeline::Rollback;
 use lightyear_replication::diff_history::HistoryDiffReceiver;
 use lightyear_replication::prelude::PreSpawned;
-use lightyear_sync::prelude::InputTimelineConfig;
+use lightyear_sync::prelude::InputTimelineShifted;
 #[allow(unused_imports)]
 use tracing::{debug, info, trace};
 
@@ -135,7 +135,7 @@ pub(crate) fn update_prediction_history<T: Component + Clone>(
 /// If there is a TickEvent and the client tick suddenly changes, we need
 /// to update the ticks in the history buffer.
 pub(crate) fn handle_tick_event_prediction_history<C: Component>(
-    trigger: On<SyncEvent<InputTimelineConfig>>,
+    trigger: On<InputTimelineShifted>,
     mut query: Query<&mut PredictionHistory<C>>,
 ) {
     for mut history in query.iter_mut() {
@@ -145,7 +145,6 @@ pub(crate) fn handle_tick_event_prediction_history<C: Component>(
             kind = "prediction_history_tick_delta",
             schedule = "PostUpdate",
             sample_point = "PostUpdate",
-            entity = ?trigger.entity,
             component = ?DebugName::type_name::<C>(),
             tick_delta = trigger.tick_delta,
             history_len = history.len(),
@@ -155,7 +154,7 @@ pub(crate) fn handle_tick_event_prediction_history<C: Component>(
 }
 
 pub(crate) fn handle_tick_event_history_diff_receiver<C: RepliconDiffable>(
-    trigger: On<SyncEvent<InputTimelineConfig>>,
+    trigger: On<InputTimelineShifted>,
     mut storage: ResMut<ReplicationStorage>,
 ) {
     for (entity, entity_storage) in storage.entities.iter_mut() {

--- a/crates/replication/prediction/src/rollback.rs
+++ b/crates/replication/prediction/src/rollback.rs
@@ -229,6 +229,7 @@ impl Plugin for RollbackPlugin {
             ParamBuilder,
             ParamBuilder,
             ParamBuilder,
+            ParamBuilder,
         )
             .build_state(app.world_mut())
             .build_system(check_rollback)

--- a/crates/replication/prediction/src/rollback.rs
+++ b/crates/replication/prediction/src/rollback.rs
@@ -67,7 +67,7 @@ use lightyear_replication::prelude::ConfirmHistory;
 use lightyear_replication::prespawn::PreSpawnedReceiver;
 use lightyear_replication::registry::ComponentRegistry;
 use lightyear_replication::{ReplicationSystems, checkpoint::ReplicationCheckpointMap};
-use lightyear_sync::prelude::{InputTimeline, InputTimelineConfig, IsSynced};
+use lightyear_sync::prelude::{InputTimeline, InputTimelineConfig};
 use lightyear_utils::adaptive_for_each_mut;
 #[cfg(feature = "metrics")]
 use lightyear_utils::timer_gauge;
@@ -227,6 +227,7 @@ impl Plugin for RollbackPlugin {
             ParamBuilder,
             ParamBuilder,
             ParamBuilder,
+            ParamBuilder,
         )
             .build_state(app.world_mut())
             .build_system(check_rollback)
@@ -358,6 +359,8 @@ fn check_rollback(
     // make sure to include disabled entities
     mut predicted_entities: Query<(&ConfirmHistory, FilteredEntityMut)>,
     timeline: Res<LocalTimeline>,
+    input_timeline: Res<InputTimeline>,
+    input_config: Res<InputTimelineConfig>,
     mut state_metadata: ResMut<StateRollbackMetadata>,
     checkpoints: Res<ReplicationCheckpointMap>,
     receiver_query: Single<
@@ -365,10 +368,9 @@ fn check_rollback(
             Entity,
             Option<&LastConfirmedInput>,
             &mut PredictionManager,
-            &InputTimelineConfig,
             &mut PreSpawnedReceiver,
         ),
-        (With<IsSynced<InputTimeline>>, Without<HostClient>),
+        (With<Client>, Without<HostClient>),
     >,
     component_registry: Res<ComponentRegistry>,
     prediction_registry: Res<PredictionRegistry>,
@@ -380,18 +382,16 @@ fn check_rollback(
     #[cfg(feature = "metrics")]
     let _timer = timer_gauge!("prediction/rollback/check");
 
-    let (
-        manager_entity,
-        last_confirmed_input,
-        mut prediction_manager,
-        input_config,
-        mut prespawned_receiver,
-    ) = receiver_query.into_inner();
+    if !input_timeline.is_synced() {
+        return;
+    }
+    let (manager_entity, last_confirmed_input, mut prediction_manager, mut prespawned_receiver) =
+        receiver_query.into_inner();
     let tick = timeline.tick();
     let received_state = state_metadata.received_messages_this_frame;
     let max_rollback_ticks = prediction_manager
         .rollback_policy
-        .effective_max_rollback_ticks(input_config);
+        .effective_max_rollback_ticks(&input_config);
 
     // The tick where ALL messages have been received (guaranteed complete information).
     // Explicit mismatch checks can exist before this is known, so don't return early.
@@ -831,8 +831,12 @@ fn check_rollback(
 ///
 /// This must run after the rollback check.
 pub fn reset_input_rollback_tracker(
-    client: Single<AnyOf<(&LastConfirmedInput, &PredictionManager)>, With<IsSynced<InputTimeline>>>,
+    input_timeline: Res<InputTimeline>,
+    client: Single<AnyOf<(&LastConfirmedInput, &PredictionManager)>, With<Client>>,
 ) {
+    if !input_timeline.is_synced() {
+        return;
+    }
     let (last_confirmed_input, prediction_manager) = client.into_inner();
 
     // Reset to u32::MAX so the next `set_if_lower` call always wins and we

--- a/crates/replication/prediction/src/rollback.rs
+++ b/crates/replication/prediction/src/rollback.rs
@@ -67,7 +67,7 @@ use lightyear_replication::prelude::ConfirmHistory;
 use lightyear_replication::prespawn::PreSpawnedReceiver;
 use lightyear_replication::registry::ComponentRegistry;
 use lightyear_replication::{ReplicationSystems, checkpoint::ReplicationCheckpointMap};
-use lightyear_sync::prelude::{InputTimeline, InputTimelineConfig};
+use lightyear_sync::prelude::{InputTimelineConfig, SyncedInputTimeline};
 use lightyear_utils::adaptive_for_each_mut;
 #[cfg(feature = "metrics")]
 use lightyear_utils::timer_gauge;
@@ -228,6 +228,7 @@ impl Plugin for RollbackPlugin {
             ParamBuilder,
             ParamBuilder,
             ParamBuilder,
+            ParamBuilder,
         )
             .build_state(app.world_mut())
             .build_system(check_rollback)
@@ -359,17 +360,13 @@ fn check_rollback(
     // make sure to include disabled entities
     mut predicted_entities: Query<(&ConfirmHistory, FilteredEntityMut)>,
     timeline: Res<LocalTimeline>,
-    input_timeline: Res<InputTimeline>,
+    _input_timeline: SyncedInputTimeline,
     input_config: Res<InputTimelineConfig>,
+    last_confirmed_input: Res<LastConfirmedInput>,
     mut state_metadata: ResMut<StateRollbackMetadata>,
     checkpoints: Res<ReplicationCheckpointMap>,
     receiver_query: Single<
-        (
-            Entity,
-            Option<&LastConfirmedInput>,
-            &mut PredictionManager,
-            &mut PreSpawnedReceiver,
-        ),
+        (Entity, &mut PredictionManager, &mut PreSpawnedReceiver),
         (With<Client>, Without<HostClient>),
     >,
     component_registry: Res<ComponentRegistry>,
@@ -382,10 +379,7 @@ fn check_rollback(
     #[cfg(feature = "metrics")]
     let _timer = timer_gauge!("prediction/rollback/check");
 
-    if !input_timeline.is_synced() {
-        return;
-    }
-    let (manager_entity, last_confirmed_input, mut prediction_manager, mut prespawned_receiver) =
+    let (manager_entity, mut prediction_manager, mut prespawned_receiver) =
         receiver_query.into_inner();
     let tick = timeline.tick();
     let received_state = state_metadata.received_messages_this_frame;
@@ -669,8 +663,7 @@ fn check_rollback(
             RollbackMode::Always => {
                 if prediction_manager.is_rollback() {
                     debug!("Rollback was triggered by state, skipping input rollback checks");
-                } else if let Some(last_confirmed_input) = last_confirmed_input
-                    && last_confirmed_input.received_input()
+                } else if last_confirmed_input.received_input()
                     && let Some(rollback_tick) = last_confirmed_input.get()
                 {
                     debug!(
@@ -831,26 +824,20 @@ fn check_rollback(
 ///
 /// This must run after the rollback check.
 pub fn reset_input_rollback_tracker(
-    input_timeline: Res<InputTimeline>,
-    client: Single<AnyOf<(&LastConfirmedInput, &PredictionManager)>, With<Client>>,
+    _input_timeline: SyncedInputTimeline,
+    last_confirmed_input: Res<LastConfirmedInput>,
+    prediction_manager: Option<Single<&PredictionManager, With<Client>>>,
 ) {
-    if !input_timeline.is_synced() {
-        return;
-    }
-    let (last_confirmed_input, prediction_manager) = client.into_inner();
-
     // Reset to u32::MAX so the next `set_if_lower` call always wins and we
     // compute the true minimum across all remote clients for this frame.
-    if let Some(last_confirmed_input) = last_confirmed_input {
-        last_confirmed_input
-            .tick
-            .0
-            .store(u32::MAX, bevy_platform::sync::atomic::Ordering::Relaxed);
-        last_confirmed_input
-            .received_any_messages
-            .store(false, bevy_platform::sync::atomic::Ordering::Relaxed);
-    }
-    if let Some(prediction_manager) = prediction_manager {
+    last_confirmed_input
+        .tick
+        .0
+        .store(u32::MAX, bevy_platform::sync::atomic::Ordering::Relaxed);
+    last_confirmed_input
+        .received_any_messages
+        .store(false, bevy_platform::sync::atomic::Ordering::Relaxed);
+    if let Some(prediction_manager) = prediction_manager.as_deref() {
         prediction_manager
             .earliest_mismatch_input
             .tick

--- a/crates/replication/replication/src/REPLICON_INTEGRATION.md
+++ b/crates/replication/replication/src/REPLICON_INTEGRATION.md
@@ -112,7 +112,7 @@ Rollback via `write_history` → `StateRollbackMetadata` → `check_rollback` is
 1. Add trace logging to `write_history` to confirm it's being called and `should_check` is true
 2. Check that `StateRollbackMetadata.should_rollback` is set after a server mutation
 3. Verify `ServerMutateTicks.last_tick()` advances when mutation messages arrive
-4. Check that the `check_rollback` system's `Single` query succeeds (entity has `PredictionManager + IsSynced<InputTimeline> + !HostClient`)
+4. Check that the global `InputTimeline` resource is synced and the `check_rollback` system's `Single` query succeeds (entity has `Client + PredictionManager + !HostClient`)
 
 **Ignored tests**: `test_rollback_time_resource`, `test_deterministic_predicted_skip_despawn`, `test_despawned_predicted_rollback`, `test_update_history` (also has tick timing issue)
 

--- a/crates/replication/replication/src/prespawn.rs
+++ b/crates/replication/replication/src/prespawn.rs
@@ -24,7 +24,9 @@ use lightyear_connection::client::Connected;
 use lightyear_connection::host::HostClient;
 use lightyear_core::prelude::{LocalTimeline, Tick};
 #[cfg(feature = "client")]
-use lightyear_sync::prelude::InputTimelineShifted;
+use lightyear_core::timeline::SyncEvent;
+#[cfg(feature = "client")]
+use lightyear_sync::prelude::InputTimelineConfig;
 #[allow(unused_imports)]
 use tracing::{debug, error, info, trace, warn};
 
@@ -452,7 +454,7 @@ impl PreSpawnedReceiver {
 
     #[cfg(feature = "client")]
     pub(crate) fn handle_tick_sync(
-        trigger: On<InputTimelineShifted>,
+        trigger: On<SyncEvent<InputTimelineConfig>>,
         mut manager: Single<&mut Self, With<Connected>>,
     ) {
         manager

--- a/crates/replication/replication/src/prespawn.rs
+++ b/crates/replication/replication/src/prespawn.rs
@@ -23,10 +23,10 @@ use core::hash::{Hash, Hasher};
 use lightyear_connection::client::Connected;
 use lightyear_connection::host::HostClient;
 use lightyear_core::prelude::{LocalTimeline, Tick};
+#[cfg(feature = "client")]
+use lightyear_sync::prelude::InputTimelineShifted;
 #[allow(unused_imports)]
 use tracing::{debug, error, info, trace, warn};
-#[cfg(feature = "client")]
-use {lightyear_core::prelude::SyncEvent, lightyear_sync::prelude::client::InputTimelineConfig};
 
 type EntityHashMap<K, V> = bevy_platform::collections::HashMap<K, V, EntityHash>;
 
@@ -452,7 +452,7 @@ impl PreSpawnedReceiver {
 
     #[cfg(feature = "client")]
     pub(crate) fn handle_tick_sync(
-        trigger: On<SyncEvent<InputTimelineConfig>>,
+        trigger: On<InputTimelineShifted>,
         mut manager: Single<&mut Self, With<Connected>>,
     ) {
         manager

--- a/crates/tests/src/client_server/base.rs
+++ b/crates/tests/src/client_server/base.rs
@@ -12,11 +12,17 @@ use test_log::test;
 /// - the various components we expect are present
 #[test]
 fn test_setup_client_server() {
-    let stepper = ClientServerStepper::from_config(StepperConfig::single());
+    let mut stepper = ClientServerStepper::from_config(StepperConfig::single());
 
     // Check that the various components we expect are present
     assert!(stepper.client(0).contains::<PingManager>());
-    assert!(stepper.client(0).contains::<InputTimeline>());
+    assert!(
+        stepper
+            .client_app()
+            .world()
+            .contains_resource::<InputTimeline>()
+    );
+    assert!(!stepper.client(0).contains::<InputTimeline>());
     assert!(stepper.client(0).contains::<RemoteTimeline>());
     assert!(stepper.client(0).contains::<InterpolationTimeline>());
     assert!(stepper.client(0).contains::<Transport>());

--- a/crates/tests/src/client_server/deterministic/stepper.rs
+++ b/crates/tests/src/client_server/deterministic/stepper.rs
@@ -119,6 +119,18 @@ impl DetStepper {
             client_id: client_id as u64,
         };
 
+        let mut sync = SyncConfig::default();
+        // 2-tick margin (vs the default 1.0) is needed because
+        // the stepper runs every client app then the server app
+        // sequentially inside one "frame", giving the network
+        // no real flush window. See `stepper::test_input_timeline_config`.
+        sync.jitter_margin = 2.0;
+        client_app.insert_resource(
+            InputTimelineConfig::default()
+                .with_input_delay(InputDelayConfig::fixed_input_delay(0))
+                .with_sync_config(sync),
+        );
+
         let client_entity = client_app
             .world_mut()
             .spawn((
@@ -136,17 +148,6 @@ impl DetStepper {
                         max_rollback_ticks: 100,
                     },
                     ..default()
-                },
-                {
-                    let mut sync = SyncConfig::default();
-                    // 2-tick margin (vs the default 1.0) is needed because
-                    // the stepper runs every client app then the server app
-                    // sequentially inside one "frame", giving the network
-                    // no real flush window. See `stepper::test_input_timeline_config`.
-                    sync.jitter_margin = 2.0;
-                    InputTimelineConfig::default()
-                        .with_input_delay(InputDelayConfig::fixed_input_delay(0))
-                        .with_sync_config(sync)
                 },
                 NetcodeClient::new(auth, NetcodeConfig::default()).unwrap(),
             ))
@@ -263,7 +264,10 @@ impl DetStepper {
         });
         for _ in 0..200 {
             if self.client(id).contains::<Connected>()
-                && self.client(id).contains::<IsSynced<InputTimeline>>()
+                && self.client_apps[id]
+                    .world()
+                    .resource::<InputTimeline>()
+                    .is_synced()
             {
                 info!("Client {} connected + synced", id);
                 return;
@@ -309,9 +313,12 @@ impl DetStepper {
 
     pub fn wait_for_sync(&mut self) {
         for _ in 0..100 {
-            if (0..self.client_entities.len())
-                .all(|id| self.client(id).contains::<IsSynced<InputTimeline>>())
-            {
+            if (0..self.client_entities.len()).all(|id| {
+                self.client_apps[id]
+                    .world()
+                    .resource::<InputTimeline>()
+                    .is_synced()
+            }) {
                 info!("All clients synced");
                 return;
             }

--- a/crates/tests/src/client_server/deterministic/stepper.rs
+++ b/crates/tests/src/client_server/deterministic/stepper.rs
@@ -6,6 +6,7 @@
 //! deterministic-replication surface area we want to exercise.
 
 use crate::client_server::deterministic::protocol::DetProtocolPlugin;
+use crate::stepper::input_timeline_is_synced;
 use avian2d::prelude::*;
 use bevy::MinimalPlugins;
 use bevy::app::PluginsState;
@@ -264,10 +265,7 @@ impl DetStepper {
         });
         for _ in 0..200 {
             if self.client(id).contains::<Connected>()
-                && self.client_apps[id]
-                    .world()
-                    .resource::<InputTimeline>()
-                    .is_synced()
+                && input_timeline_is_synced(self.client_apps[id].world())
             {
                 info!("Client {} connected + synced", id);
                 return;
@@ -313,12 +311,9 @@ impl DetStepper {
 
     pub fn wait_for_sync(&mut self) {
         for _ in 0..100 {
-            if (0..self.client_entities.len()).all(|id| {
-                self.client_apps[id]
-                    .world()
-                    .resource::<InputTimeline>()
-                    .is_synced()
-            }) {
+            if (0..self.client_entities.len())
+                .all(|id| input_timeline_is_synced(self.client_apps[id].world()))
+            {
                 info!("All clients synced");
                 return;
             }

--- a/crates/tests/src/client_server/input/bei.rs
+++ b/crates/tests/src/client_server/input/bei.rs
@@ -447,7 +447,7 @@ fn test_buffer_inputs_with_delay() {
     let mut config = StepperConfig::single();
     config.init = false;
     let mut stepper = ClientServerStepper::from_config(config);
-    stepper.client_mut(0).insert(
+    stepper.client_app().world_mut().insert_resource(
         InputTimelineConfig::default().with_input_delay(InputDelayConfig::fixed_input_delay(1)),
     );
     stepper.init();
@@ -622,7 +622,7 @@ fn test_buffer_vec2_inputs_with_delay_preserves_buffered_action_value_dimension(
     let mut config = StepperConfig::single();
     config.init = false;
     let mut stepper = ClientServerStepper::from_config(config);
-    stepper.client_mut(0).insert(
+    stepper.client_app().world_mut().insert_resource(
         InputTimelineConfig::default().with_input_delay(InputDelayConfig::fixed_input_delay(1)),
     );
     stepper.init();

--- a/crates/tests/src/client_server/input/leafwing.rs
+++ b/crates/tests/src/client_server/input/leafwing.rs
@@ -18,7 +18,7 @@ fn test_buffer_inputs_with_delay() {
     let mut config = StepperConfig::single();
     config.init = false;
     let mut stepper = ClientServerStepper::from_config(config);
-    stepper.client_mut(0).insert(
+    stepper.client_app().world_mut().insert_resource(
         InputTimelineConfig::default().with_input_delay(InputDelayConfig::fixed_input_delay(1)),
     );
     stepper.init();

--- a/crates/tests/src/client_server/input/native.rs
+++ b/crates/tests/src/client_server/input/native.rs
@@ -13,7 +13,6 @@ use lightyear_prediction::prelude::PredictionManager;
 use lightyear_replication::prelude::{PredictionTarget, Replicate};
 use lightyear_replication::prelude::{RoomAllocator, Rooms};
 use lightyear_sync::prelude::InputTimeline;
-use lightyear_sync::prelude::client::IsSynced;
 use test_log::test;
 use tracing::info;
 
@@ -22,12 +21,13 @@ use tracing::info;
 fn test_remote_client_replicated_input() {
     let mut stepper = ClientServerStepper::from_config(StepperConfig::single());
 
-    stepper
-        .client_app()
-        .world_mut()
-        .query::<&IsSynced<InputTimeline>>()
-        .single(stepper.client_app().world())
-        .unwrap();
+    assert!(
+        stepper
+            .client_app()
+            .world()
+            .resource::<InputTimeline>()
+            .is_synced()
+    );
 
     // SETUP
     // entity controlled by the remote client

--- a/crates/tests/src/client_server/input/native.rs
+++ b/crates/tests/src/client_server/input/native.rs
@@ -12,7 +12,6 @@ use lightyear_messages::MessageManager;
 use lightyear_prediction::prelude::PredictionManager;
 use lightyear_replication::prelude::{PredictionTarget, Replicate};
 use lightyear_replication::prelude::{RoomAllocator, Rooms};
-use lightyear_sync::prelude::InputTimeline;
 use test_log::test;
 use tracing::info;
 
@@ -21,13 +20,7 @@ use tracing::info;
 fn test_remote_client_replicated_input() {
     let mut stepper = ClientServerStepper::from_config(StepperConfig::single());
 
-    assert!(
-        stepper
-            .client_app()
-            .world()
-            .resource::<InputTimeline>()
-            .is_synced()
-    );
+    assert!(input_timeline_is_synced(stepper.client_app().world()));
 
     // SETUP
     // entity controlled by the remote client

--- a/crates/tests/src/client_server/prediction/prespawn.rs
+++ b/crates/tests/src/client_server/prediction/prespawn.rs
@@ -654,8 +654,9 @@ fn test_prespawn_local_despawn_match() {
     let mut sync_config = SyncConfig::default();
     sync_config.max_error_margin = 0.5;
     stepper
-        .client_mut(0)
-        .insert(InputTimelineConfig::default().with_sync_config(sync_config));
+        .client_app()
+        .world_mut()
+        .insert_resource(InputTimelineConfig::default().with_sync_config(sync_config));
     stepper
         .client_mut(0)
         .get_mut::<Link>()

--- a/crates/tests/src/client_server/prediction/rollback.rs
+++ b/crates/tests/src/client_server/prediction/rollback.rs
@@ -554,7 +554,8 @@ fn test_future_confirmed_insert_is_not_checked_by_unchanged_completed_tick() {
 
 #[test]
 fn test_input_timeline_sync_does_not_shift_confirmed_history() {
-    use lightyear_sync::prelude::InputTimelineShifted;
+    use lightyear_core::timeline::SyncEvent;
+    use lightyear_sync::prelude::{InputTimeline, InputTimelineConfig};
 
     let (mut stepper, predicted) = setup();
 
@@ -575,10 +576,21 @@ fn test_input_timeline_sync_does_not_shift_confirmed_history() {
         .entity_mut(predicted)
         .insert(prediction_history);
 
+    let timeline_component = stepper
+        .client_app()
+        .world()
+        .component_id::<InputTimeline>()
+        .unwrap();
+    let timeline_entity = stepper
+        .client_app()
+        .world()
+        .resource_entities()
+        .get(timeline_component)
+        .unwrap();
     stepper
         .client_app()
         .world_mut()
-        .trigger(InputTimelineShifted { tick_delta: 100 });
+        .trigger(SyncEvent::<InputTimelineConfig>::new(timeline_entity, 100));
 
     let world = stepper.client_app().world();
     let confirmed_history = world
@@ -1239,8 +1251,12 @@ fn setup_stepper_for_input_rollback(
     stepper.frame_step_server_first(1);
 
     // Check that in PostUpdate, the LastConfirmedInput is reset if no input messages were received
-    let client = stepper.client(0);
-    assert!(!client.get::<LastConfirmedInput>().unwrap().received_input());
+    assert!(
+        !stepper.client_apps[0]
+            .world()
+            .resource::<LastConfirmedInput>()
+            .received_input()
+    );
 
     // add input-markers on client 1/2 so that they can send remote input messages
     let client_entity_1 = stepper
@@ -1316,8 +1332,8 @@ fn test_input_rollback_always_mode() {
 
     let check_rollback_start =
         move |timeline: Res<LocalTimeline>,
-              manager: Single<(&LastConfirmedInput, &PredictionManager)>| {
-            let (last_confirmed_input, manager) = manager.into_inner();
+              last_confirmed_input: Res<LastConfirmedInput>,
+              manager: Single<&PredictionManager>| {
             let tick = timeline.tick();
             if tick == input_tick {
                 assert!(last_confirmed_input.received_input());
@@ -1346,10 +1362,9 @@ fn test_input_rollback_always_mode() {
 
     // after the rollback, the last_confirmed_input is reset
     assert_eq!(
-        stepper
-            .client(0)
-            .get::<LastConfirmedInput>()
-            .unwrap()
+        stepper.client_apps[0]
+            .world()
+            .resource::<LastConfirmedInput>()
             .tick
             .get(),
         input_tick
@@ -1378,7 +1393,10 @@ fn test_input_rollback_always_ignores_unset_last_confirmed_tick() {
             prediction_manager.rollback_policy.input = RollbackMode::Always;
             prediction_manager.rollback_policy.state = RollbackMode::Disabled;
         }
-        let last_confirmed_input = client.get::<LastConfirmedInput>().unwrap();
+        drop(client);
+        let last_confirmed_input = stepper.client_apps[0]
+            .world()
+            .resource::<LastConfirmedInput>();
         assert_eq!(last_confirmed_input.get(), None);
         last_confirmed_input
             .received_any_messages
@@ -1418,10 +1436,9 @@ fn test_last_confirmed_input_multiple_clients() {
     // after the rollback, the last_confirmed_input is updated. It's updated to `input_tick - 1` and not `input_tick`
     // because we didn't receive a new input message from client 1
     assert_eq!(
-        stepper
-            .client(0)
-            .get::<LastConfirmedInput>()
-            .unwrap()
+        stepper.client_apps[0]
+            .world()
+            .resource::<LastConfirmedInput>()
             .tick
             .get(),
         input_tick - 1

--- a/crates/tests/src/client_server/prediction/rollback.rs
+++ b/crates/tests/src/client_server/prediction/rollback.rs
@@ -554,7 +554,7 @@ fn test_future_confirmed_insert_is_not_checked_by_unchanged_completed_tick() {
 
 #[test]
 fn test_input_timeline_sync_does_not_shift_confirmed_history() {
-    use lightyear_sync::prelude::InputTimelineConfig;
+    use lightyear_sync::prelude::InputTimelineShifted;
 
     let (mut stepper, predicted) = setup();
 
@@ -578,7 +578,7 @@ fn test_input_timeline_sync_does_not_shift_confirmed_history() {
     stepper
         .client_app()
         .world_mut()
-        .trigger(lightyear_core::timeline::SyncEvent::<InputTimelineConfig>::new(predicted, 100));
+        .trigger(InputTimelineShifted { tick_delta: 100 });
 
     let world = stepper.client_app().world();
     let confirmed_history = world

--- a/crates/tests/src/client_server/replication.rs
+++ b/crates/tests/src/client_server/replication.rs
@@ -16,8 +16,8 @@ use lightyear_core::time::TickInstant;
 use lightyear_messages::MessageManager;
 use lightyear_replication::control::{ControlledBy, ControlledByRemote};
 use lightyear_replication::prelude::*;
-use lightyear_sync::prelude::InputTimeline;
 use lightyear_sync::prelude::IsSynced;
+use lightyear_sync::prelude::{InputTimelineConfig, SyncConfig};
 use test_log::test;
 use tracing::info;
 
@@ -592,8 +592,13 @@ fn test_late_join_client_gets_latest_state_for_existing_predicted_entity() {
 fn test_component_update_after_large_tick_jump() {
     for direction in active_replication_directions() {
         let mut stepper = ClientServerStepper::from_config(StepperConfig::single());
-        // remove InputTimeline otherwise it will try to resync
-        stepper.client_mut(0).remove::<InputTimeline>();
+        // Pause further input-timeline sync attempts while both sides are moved manually.
+        stepper.client_app().world_mut().insert_resource(
+            InputTimelineConfig::default().with_sync_config(SyncConfig {
+                handshake_pings: u8::MAX,
+                ..Default::default()
+            }),
+        );
 
         let source_entity =
             spawn_on_source(&mut stepper, direction, (direction.replicate(), CompA(1.0)));

--- a/crates/tests/src/host_server/base.rs
+++ b/crates/tests/src/host_server/base.rs
@@ -23,13 +23,7 @@ fn test_setup_host_server() {
     // Check that the various components we expect are present
     assert!(stepper.host_client().contains::<HostClient>());
     // The global input timeline follows LocalTimeline directly for a host client.
-    assert!(
-        stepper
-            .server_app
-            .world()
-            .resource::<InputTimeline>()
-            .is_synced()
-    );
+    assert!(input_timeline_is_synced(stepper.server_app.world()));
     assert!(!stepper.host_client().contains::<InputTimeline>());
     assert!(stepper.host_client().contains::<RemoteTimeline>());
     // TODO: update Interpolation to be disabled for host-clients!

--- a/crates/tests/src/host_server/base.rs
+++ b/crates/tests/src/host_server/base.rs
@@ -22,10 +22,15 @@ fn test_setup_host_server() {
 
     // Check that the various components we expect are present
     assert!(stepper.host_client().contains::<HostClient>());
-    // Input/Remote timeline are required by Client.
-    // TODO: update InputTimeline to match LocalTimeline and to not sync
-    assert!(stepper.host_client().contains::<InputTimeline>());
-    assert!(stepper.host_client().contains::<IsSynced<InputTimeline>>());
+    // The global input timeline follows LocalTimeline directly for a host client.
+    assert!(
+        stepper
+            .server_app
+            .world()
+            .resource::<InputTimeline>()
+            .is_synced()
+    );
+    assert!(!stepper.host_client().contains::<InputTimeline>());
     assert!(stepper.host_client().contains::<RemoteTimeline>());
     // TODO: update Interpolation to be disabled for host-clients!
     assert!(stepper.host_client().contains::<InterpolationTimeline>());

--- a/crates/tests/src/host_server/input/leafwing.rs
+++ b/crates/tests/src/host_server/input/leafwing.rs
@@ -19,7 +19,7 @@ use tracing::info;
 fn test_buffer_inputs_with_delay() {
     let mut stepper = ClientServerStepper::from_config(StepperConfig::host_server());
 
-    stepper.host_client_mut().insert(
+    stepper.server_app.world_mut().insert_resource(
         InputTimelineConfig::default().with_input_delay(InputDelayConfig::fixed_input_delay(1)),
     );
 

--- a/crates/tests/src/host_server/input/native.rs
+++ b/crates/tests/src/host_server/input/native.rs
@@ -6,7 +6,6 @@ use lightyear_connection::network_target::NetworkTarget;
 use lightyear_messages::MessageManager;
 use lightyear_replication::prelude::{PredictionTarget, Replicate};
 use lightyear_sync::prelude::InputTimeline;
-use lightyear_sync::prelude::client::IsSynced;
 use test_log::test;
 use tracing::info;
 
@@ -17,12 +16,13 @@ use tracing::info;
 fn test_remote_client_replicated_input() {
     let mut stepper = ClientServerStepper::from_config(StepperConfig::host_server());
 
-    stepper
-        .client_app()
-        .world_mut()
-        .query::<&IsSynced<InputTimeline>>()
-        .single(stepper.client_app().world())
-        .unwrap();
+    assert!(
+        stepper
+            .client_app()
+            .world()
+            .resource::<InputTimeline>()
+            .is_synced()
+    );
 
     // SETUP
     // entity controlled by the remote client
@@ -160,12 +160,13 @@ fn test_remote_client_predicted_input() {
 fn test_host_client_inputers_replicated_to_remote_client() {
     let mut stepper = ClientServerStepper::from_config(StepperConfig::host_server());
 
-    stepper
-        .server_app
-        .world_mut()
-        .query::<&IsSynced<InputTimeline>>()
-        .single(stepper.server_app.world())
-        .unwrap();
+    assert!(
+        stepper
+            .server_app
+            .world()
+            .resource::<InputTimeline>()
+            .is_synced()
+    );
 
     // SETUP
     // entity controlled by the host client

--- a/crates/tests/src/host_server/input/native.rs
+++ b/crates/tests/src/host_server/input/native.rs
@@ -5,7 +5,6 @@ use lightyear::prelude::input::native::ActionState;
 use lightyear_connection::network_target::NetworkTarget;
 use lightyear_messages::MessageManager;
 use lightyear_replication::prelude::{PredictionTarget, Replicate};
-use lightyear_sync::prelude::InputTimeline;
 use test_log::test;
 use tracing::info;
 
@@ -16,13 +15,7 @@ use tracing::info;
 fn test_remote_client_replicated_input() {
     let mut stepper = ClientServerStepper::from_config(StepperConfig::host_server());
 
-    assert!(
-        stepper
-            .client_app()
-            .world()
-            .resource::<InputTimeline>()
-            .is_synced()
-    );
+    assert!(input_timeline_is_synced(stepper.client_app().world()));
 
     // SETUP
     // entity controlled by the remote client
@@ -160,13 +153,7 @@ fn test_remote_client_predicted_input() {
 fn test_host_client_inputers_replicated_to_remote_client() {
     let mut stepper = ClientServerStepper::from_config(StepperConfig::host_server());
 
-    assert!(
-        stepper
-            .server_app
-            .world()
-            .resource::<InputTimeline>()
-            .is_synced()
-    );
+    assert!(input_timeline_is_synced(stepper.server_app.world()));
 
     // SETUP
     // entity controlled by the host client

--- a/crates/tests/src/stepper.rs
+++ b/crates/tests/src/stepper.rs
@@ -767,7 +767,10 @@ impl ClientServerStepper {
         let attempts = if self.io.uses_async_io() { 400 } else { 50 };
         for _ in 0..attempts {
             if (0..self.client_entities.len()).all(|client_id| {
-                self.client(client_id).contains::<IsSynced<InputTimeline>>()
+                self.client_apps[client_id]
+                    .world()
+                    .resource::<InputTimeline>()
+                    .is_synced()
                     && self
                         .client(client_id)
                         .contains::<IsSynced<InterpolationTimeline>>()

--- a/crates/tests/src/stepper.rs
+++ b/crates/tests/src/stepper.rs
@@ -60,6 +60,17 @@ fn unused_local_udp_addr() -> SocketAddr {
     socket.local_addr().unwrap()
 }
 
+/// Returns whether the global input timeline resource carries its synchronization marker.
+pub fn input_timeline_is_synced(world: &World) -> bool {
+    let Some(component_id) = world.component_id::<InputTimeline>() else {
+        return false;
+    };
+    let Some(entity) = world.resource_entities().get(component_id) else {
+        return false;
+    };
+    world.get::<IsSynced<InputTimeline>>(entity).is_some()
+}
+
 /// Stepper with:
 /// - n client in one 'client' App
 /// - 1 server in another App, with n ClientOf connected to each client
@@ -767,10 +778,7 @@ impl ClientServerStepper {
         let attempts = if self.io.uses_async_io() { 400 } else { 50 };
         for _ in 0..attempts {
             if (0..self.client_entities.len()).all(|client_id| {
-                self.client_apps[client_id]
-                    .world()
-                    .resource::<InputTimeline>()
-                    .is_synced()
+                input_timeline_is_synced(self.client_apps[client_id].world())
                     && self
                         .client(client_id)
                         .contains::<IsSynced<InterpolationTimeline>>()

--- a/crates/tests/src/timeline/sync_tests.rs
+++ b/crates/tests/src/timeline/sync_tests.rs
@@ -126,13 +126,13 @@ fn input_timeline_adjusts_speed_after_repeated_error() {
 #[test_log::test]
 fn input_delay_config_update_recomputes_public_delay() {
     let mut stepper = ClientServerStepper::from_config(StepperConfig::single());
-    stepper.client_mut(0).insert(
+    stepper.client_app().world_mut().insert_resource(
         InputTimelineConfig::default().with_input_delay(InputDelayConfig::fixed_input_delay(3)),
     );
 
     stepper.frame_step(1);
 
-    let input_timeline = stepper.client(0).get::<InputTimeline>().unwrap();
+    let input_timeline = stepper.client_app().world().resource::<InputTimeline>();
     assert_eq!(input_timeline.context.input_delay(), 3);
 }
 

--- a/demos/spaceships/src/main.rs
+++ b/demos/spaceships/src/main.rs
@@ -64,17 +64,10 @@ fn main() {
 
 #[cfg(feature = "client")]
 fn add_input_delay(app: &mut App) {
-    use lightyear::prelude::Client;
     use lightyear::prelude::client::InputDelayConfig;
 
-    let client = app
-        .world_mut()
-        .query_filtered::<Entity, With<Client>>()
-        .single(app.world_mut())
-        .unwrap();
-
     // set some input-delay since we are predicting all entities
-    app.world_mut().entity_mut(client).insert(
+    app.insert_resource(
         InputTimelineConfig::default().with_input_delay(InputDelayConfig::fixed_input_delay(10)),
     );
 }

--- a/demos/spaceships/src/shared.rs
+++ b/demos/spaceships/src/shared.rs
@@ -266,10 +266,10 @@ pub fn shared_player_firing(
     )>,
     mut commands: Commands,
     timeline: Res<LocalTimeline>,
-    synced_client: Query<(), (With<Client>, With<IsSynced<InputTimeline>>)>,
+    input_timeline: Option<Res<InputTimeline>>,
     server: Query<(), With<Server>>,
 ) {
-    let client_is_synced = !synced_client.is_empty();
+    let client_is_synced = input_timeline.is_some_and(|timeline| timeline.is_synced());
     let is_server = !server.is_empty();
     if q.is_empty() {
         return;

--- a/demos/spaceships/src/shared.rs
+++ b/demos/spaceships/src/shared.rs
@@ -266,10 +266,10 @@ pub fn shared_player_firing(
     )>,
     mut commands: Commands,
     timeline: Res<LocalTimeline>,
-    input_timeline: Option<Res<InputTimeline>>,
+    input_timeline: Option<SyncedInputTimeline>,
     server: Query<(), With<Server>>,
 ) {
-    let client_is_synced = input_timeline.is_some_and(|timeline| timeline.is_synced());
+    let client_is_synced = input_timeline.is_some();
     let is_server = !server.is_empty();
     if q.is_empty() {
         return;

--- a/examples/avian_2d/src/debug.rs
+++ b/examples/avian_2d/src/debug.rs
@@ -8,10 +8,7 @@ use lightyear::prelude::*;
 
 use crate::protocol::{BallMarker, PlayerActions, PlayerId};
 
-pub(crate) fn print_overstep(
-    time: Res<Time<Fixed>>,
-    timeline: Single<&InputTimeline, With<Client>>,
-) {
+pub(crate) fn print_overstep(time: Res<Time<Fixed>>, timeline: Res<InputTimeline>) {
     let input_overstep = timeline.overstep();
     let input_overstep_ms = input_overstep.to_f32() * (time.timestep().as_millis() as f32);
     let time_overstep = time.overstep();

--- a/examples/avian_2d/src/main.rs
+++ b/examples/avian_2d/src/main.rs
@@ -65,16 +65,9 @@ fn main() {
 
 #[cfg(feature = "client")]
 fn add_input_delay(app: &mut App) {
-    let client = app
-        .world_mut()
-        .query_filtered::<Entity, With<Client>>()
-        .single(app.world_mut())
-        .unwrap();
-
     // Optionally add input delay for the locally predicted player.
-    // app.world_mut()
-    //     .entity_mut(client)
-    //     .insert(InputTimeline(Timeline::from(
-    //         Input::default().with_input_delay(InputDelayConfig::fixed_input_delay(10)),
-    //     )));
+    // app.insert_resource(
+    //     InputTimelineConfig::default()
+    //         .with_input_delay(InputDelayConfig::fixed_input_delay(10)),
+    // );
 }

--- a/examples/avian_3d/src/main.rs
+++ b/examples/avian_3d/src/main.rs
@@ -4,7 +4,6 @@
 use bevy::prelude::*;
 use core::time::Duration;
 
-use lightyear::prelude::{Client, InputTimeline, Timeline};
 use lightyear_examples_common::cli::{Cli, Mode};
 use lightyear_examples_common::shared::FIXED_TIMESTEP_HZ;
 
@@ -65,14 +64,8 @@ fn main() {
 fn add_input_delay(app: &mut App) {
     use lightyear::prelude::client::{InputDelayConfig, InputTimelineConfig};
 
-    let client = app
-        .world_mut()
-        .query_filtered::<Entity, With<Client>>()
-        .single(app.world_mut())
-        .unwrap();
-
     // set some input-delay since we are predicting all entities
-    app.world_mut().entity_mut(client).insert(
+    app.insert_resource(
         InputTimelineConfig::default().with_input_delay(InputDelayConfig::fixed_input_delay(0)),
     );
 }

--- a/examples/bevy_enhanced_inputs/src/client.rs
+++ b/examples/bevy_enhanced_inputs/src/client.rs
@@ -41,13 +41,10 @@ fn configure_input_delay(mut commands: Commands) {
 /// observer is disabled.
 fn player_movement(
     trigger: On<Fire<Movement>>,
-    input_timeline: Res<InputTimeline>,
+    _input_timeline: SyncedInputTimeline,
     #[cfg(feature = "server")] host_server: Query<(), With<HostServer>>,
     mut position_query: Query<&mut PlayerPosition, With<Predicted>>,
 ) {
-    if !input_timeline.is_synced() {
-        return;
-    }
     #[cfg(feature = "server")]
     if !host_server.is_empty() {
         return;

--- a/examples/bevy_enhanced_inputs/src/client.rs
+++ b/examples/bevy_enhanced_inputs/src/client.rs
@@ -30,10 +30,10 @@ impl Plugin for ExampleClientPlugin {
     }
 }
 
-fn configure_input_delay(client: Single<Entity, With<Client>>, mut commands: Commands) {
-    commands
-        .entity(client.into_inner())
-        .insert(InputTimelineConfig::default().with_input_delay(InputDelayConfig::balanced()));
+fn configure_input_delay(mut commands: Commands) {
+    commands.insert_resource(
+        InputTimelineConfig::default().with_input_delay(InputDelayConfig::balanced()),
+    );
 }
 
 /// Applies local movement only to predicted entities owned by this client.
@@ -41,11 +41,11 @@ fn configure_input_delay(client: Single<Entity, With<Client>>, mut commands: Com
 /// observer is disabled.
 fn player_movement(
     trigger: On<Fire<Movement>>,
-    synced_client: Query<(), (With<Client>, With<IsSynced<InputTimeline>>)>,
+    input_timeline: Res<InputTimeline>,
     #[cfg(feature = "server")] host_server: Query<(), With<HostServer>>,
     mut position_query: Query<&mut PlayerPosition, With<Predicted>>,
 ) {
-    if synced_client.is_empty() {
+    if !input_timeline.is_synced() {
         return;
     }
     #[cfg(feature = "server")]

--- a/examples/deterministic_replication/src/automation.rs
+++ b/examples/deterministic_replication/src/automation.rs
@@ -155,7 +155,8 @@ mod client {
         random_state: Option<ResMut<RandomState>>,
         mode: Res<CatchUpMode>,
         timeline: Res<LocalTimeline>,
-        client: Option<Single<&LocalId, (With<Client>, With<IsSynced<InputTimeline>>)>>,
+        input_timeline: Res<InputTimeline>,
+        client: Option<Single<&LocalId, With<Client>>>,
         players: Query<(
             &PlayerId,
             Option<&LeafwingBuffer<PlayerActions>>,
@@ -169,7 +170,10 @@ mod client {
         if !input_rebroadcast_ready(
             &mode,
             timeline.tick(),
-            client.as_deref().copied(),
+            input_timeline
+                .is_synced()
+                .then(|| client.as_deref().copied())
+                .flatten(),
             &players,
             &settings,
         ) {
@@ -202,7 +206,8 @@ mod client {
         random_state: Option<Res<RandomState>>,
         mode: Res<CatchUpMode>,
         timeline: Res<LocalTimeline>,
-        client: Option<Single<&LocalId, (With<Client>, With<IsSynced<InputTimeline>>)>>,
+        input_timeline: Res<InputTimeline>,
+        client: Option<Single<&LocalId, With<Client>>>,
         players: Query<(
             &PlayerId,
             Option<&LeafwingBuffer<PlayerActions>>,
@@ -214,7 +219,10 @@ mod client {
         if !input_rebroadcast_ready(
             &mode,
             timeline.tick(),
-            client.as_deref().copied(),
+            input_timeline
+                .is_synced()
+                .then(|| client.as_deref().copied())
+                .flatten(),
             &players,
             &settings,
         ) {

--- a/examples/deterministic_replication/src/automation.rs
+++ b/examples/deterministic_replication/src/automation.rs
@@ -155,7 +155,7 @@ mod client {
         random_state: Option<ResMut<RandomState>>,
         mode: Res<CatchUpMode>,
         timeline: Res<LocalTimeline>,
-        input_timeline: Res<InputTimeline>,
+        input_timeline: Option<SyncedInputTimeline>,
         client: Option<Single<&LocalId, With<Client>>>,
         players: Query<(
             &PlayerId,
@@ -171,7 +171,7 @@ mod client {
             &mode,
             timeline.tick(),
             input_timeline
-                .is_synced()
+                .is_some()
                 .then(|| client.as_deref().copied())
                 .flatten(),
             &players,
@@ -206,7 +206,7 @@ mod client {
         random_state: Option<Res<RandomState>>,
         mode: Res<CatchUpMode>,
         timeline: Res<LocalTimeline>,
-        input_timeline: Res<InputTimeline>,
+        input_timeline: Option<SyncedInputTimeline>,
         client: Option<Single<&LocalId, With<Client>>>,
         players: Query<(
             &PlayerId,
@@ -220,7 +220,7 @@ mod client {
             &mode,
             timeline.tick(),
             input_timeline
-                .is_synced()
+                .is_some()
                 .then(|| client.as_deref().copied())
                 .flatten(),
             &players,

--- a/examples/deterministic_replication/src/client.rs
+++ b/examples/deterministic_replication/src/client.rs
@@ -33,12 +33,12 @@ struct InputMapAdded;
 /// sending input messages — without it, the client never broadcasts any
 /// input and the server can't rebroadcast it to other peers.
 fn add_input_map_after_sync(
-    input_timeline: Res<InputTimeline>,
+    _input_timeline: SyncedInputTimeline,
     client: Option<Single<&LocalId, With<Client>>>,
     mut commands: Commands,
     players: Query<(Entity, &PlayerId), (Without<InputMapAdded>, Without<InputMap<PlayerActions>>)>,
 ) {
-    let Some(client) = client.filter(|_| input_timeline.is_synced()) else {
+    let Some(client) = client else {
         return;
     };
     let local_id = client.into_inner();

--- a/examples/deterministic_replication/src/client.rs
+++ b/examples/deterministic_replication/src/client.rs
@@ -33,11 +33,12 @@ struct InputMapAdded;
 /// sending input messages — without it, the client never broadcasts any
 /// input and the server can't rebroadcast it to other peers.
 fn add_input_map_after_sync(
-    client: Option<Single<&LocalId, (With<Client>, With<IsSynced<InputTimeline>>)>>,
+    input_timeline: Res<InputTimeline>,
+    client: Option<Single<&LocalId, With<Client>>>,
     mut commands: Commands,
     players: Query<(Entity, &PlayerId), (Without<InputMapAdded>, Without<InputMap<PlayerActions>>)>,
 ) {
-    let Some(client) = client else {
+    let Some(client) = client.filter(|_| input_timeline.is_synced()) else {
         return;
     };
     let local_id = client.into_inner();

--- a/examples/deterministic_replication/src/main.rs
+++ b/examples/deterministic_replication/src/main.rs
@@ -89,15 +89,15 @@ fn add_input_delay(app: &mut App) {
                 max_rollback_ticks: 100,
             },
             ..default()
-        })
-        .insert(
-            InputTimelineConfig::default()
-                .with_sync_config(SyncConfig {
-                    jitter_margin: input_sync_margin_ticks(),
-                    ..default()
-                })
-                .with_input_delay(InputDelayConfig::fixed_input_delay(input_delay_ticks())),
-        );
+        });
+    app.insert_resource(
+        InputTimelineConfig::default()
+            .with_sync_config(SyncConfig {
+                jitter_margin: input_sync_margin_ticks(),
+                ..default()
+            })
+            .with_input_delay(InputDelayConfig::fixed_input_delay(input_delay_ticks())),
+    );
 }
 
 #[cfg(feature = "client")]

--- a/examples/fps/src/client.rs
+++ b/examples/fps/src/client.rs
@@ -63,10 +63,10 @@ fn strip_interpolated_bullet_local_physics(
 
 fn suppress_shoot_until_synced(
     host_server: Query<(), With<HostServer>>,
-    input_timeline: Res<InputTimeline>,
+    input_timeline: Option<SyncedInputTimeline>,
     mut action_state_query: Query<&mut ActionState<PlayerActions>, With<Predicted>>,
 ) {
-    if !host_server.is_empty() || input_timeline.is_synced() {
+    if !host_server.is_empty() || input_timeline.is_some() {
         return;
     }
     for mut action_state in &mut action_state_query {

--- a/examples/fps/src/client.rs
+++ b/examples/fps/src/client.rs
@@ -63,10 +63,10 @@ fn strip_interpolated_bullet_local_physics(
 
 fn suppress_shoot_until_synced(
     host_server: Query<(), With<HostServer>>,
-    synced_client: Query<(), (With<Client>, With<IsSynced<InputTimeline>>)>,
+    input_timeline: Res<InputTimeline>,
     mut action_state_query: Query<&mut ActionState<PlayerActions>, With<Predicted>>,
 ) {
-    if !host_server.is_empty() || !synced_client.is_empty() {
+    if !host_server.is_empty() || input_timeline.is_synced() {
         return;
     }
     for mut action_state in &mut action_state_query {

--- a/examples/fps/src/renderer.rs
+++ b/examples/fps/src/renderer.rs
@@ -7,8 +7,8 @@ use bevy::ecs::query::QueryFilter;
 use bevy::prelude::*;
 use lightyear::connection::host::HostServer;
 use lightyear::prelude::{
-    lightyear_debug_event, Client, DebugCategory, DebugSamplePoint, InputTimeline, Interpolated,
-    IsSynced, LocalTimeline, PreSpawned, Predicted, Replicate, Replicated, Server,
+    lightyear_debug_event, Client, DebugCategory, DebugSamplePoint, Interpolated, IsSynced,
+    LocalTimeline, PreSpawned, Predicted, Replicate, Replicated, Server,
 };
 #[cfg(feature = "client")]
 use lightyear::prelude::{

--- a/examples/fps/src/shared.rs
+++ b/examples/fps/src/shared.rs
@@ -118,7 +118,7 @@ fn player_movement(
     timeline: Res<LocalTimeline>,
     client: Query<(), With<Client>>,
     host_server: Query<(), With<HostServer>>,
-    input_timeline: Option<Res<InputTimeline>>,
+    input_timeline: Option<SyncedInputTimeline>,
     mut player_query: Query<
         (
             &mut Position,
@@ -132,7 +132,7 @@ fn player_movement(
 ) {
     let has_client = !client.is_empty();
     let is_host_server = !host_server.is_empty();
-    let client_is_synced = input_timeline.is_some_and(|timeline| timeline.is_synced());
+    let client_is_synced = input_timeline.is_some();
     for (position, rotation, action_state, player_id, is_predicted) in player_query.iter_mut() {
         if should_skip_client_side_entity(
             has_client,
@@ -167,7 +167,7 @@ pub(crate) fn shoot_bullet(
     timeline: Res<LocalTimeline>,
     client: Query<(), With<Client>>,
     host_server: Query<(), With<HostServer>>,
-    input_timeline: Option<Res<InputTimeline>>,
+    input_timeline: Option<SyncedInputTimeline>,
     mut query: Query<
         (
             &PlayerId,
@@ -185,7 +185,7 @@ pub(crate) fn shoot_bullet(
     let tick = timeline.tick();
     let has_client = !client.is_empty();
     let is_host_server = !host_server.is_empty();
-    let client_is_synced = input_timeline.is_some_and(|timeline| timeline.is_synced());
+    let client_is_synced = input_timeline.is_some();
     for (id, position, rotation, color, action, input_buffer, controlled_by, is_predicted) in
         query.iter_mut()
     {

--- a/examples/fps/src/shared.rs
+++ b/examples/fps/src/shared.rs
@@ -118,7 +118,7 @@ fn player_movement(
     timeline: Res<LocalTimeline>,
     client: Query<(), With<Client>>,
     host_server: Query<(), With<HostServer>>,
-    synced_client: Query<(), (With<Client>, With<IsSynced<InputTimeline>>)>,
+    input_timeline: Option<Res<InputTimeline>>,
     mut player_query: Query<
         (
             &mut Position,
@@ -132,7 +132,7 @@ fn player_movement(
 ) {
     let has_client = !client.is_empty();
     let is_host_server = !host_server.is_empty();
-    let client_is_synced = !synced_client.is_empty();
+    let client_is_synced = input_timeline.is_some_and(|timeline| timeline.is_synced());
     for (position, rotation, action_state, player_id, is_predicted) in player_query.iter_mut() {
         if should_skip_client_side_entity(
             has_client,
@@ -167,7 +167,7 @@ pub(crate) fn shoot_bullet(
     timeline: Res<LocalTimeline>,
     client: Query<(), With<Client>>,
     host_server: Query<(), With<HostServer>>,
-    synced_client: Query<(), (With<Client>, With<IsSynced<InputTimeline>>)>,
+    input_timeline: Option<Res<InputTimeline>>,
     mut query: Query<
         (
             &PlayerId,
@@ -185,7 +185,7 @@ pub(crate) fn shoot_bullet(
     let tick = timeline.tick();
     let has_client = !client.is_empty();
     let is_host_server = !host_server.is_empty();
-    let client_is_synced = !synced_client.is_empty();
+    let client_is_synced = input_timeline.is_some_and(|timeline| timeline.is_synced());
     for (id, position, rotation, color, action, input_buffer, controlled_by, is_predicted) in
         query.iter_mut()
     {

--- a/examples/lobby/src/renderer.rs
+++ b/examples/lobby/src/renderer.rs
@@ -37,12 +37,13 @@ struct VisualPlayerPosition {
 fn client_visuals_ready(
     client: &Query<(), With<Client>>,
     host_server: &Query<(), With<HostServer>>,
-    input_synced: &Query<(), (With<Client>, With<IsSynced<InputTimeline>>)>,
+    input_timeline: Option<&InputTimeline>,
     interpolation_synced: &Query<(), (With<Client>, With<IsSynced<InterpolationTimeline>>)>,
 ) -> bool {
     client.is_empty()
         || !host_server.is_empty()
-        || (!input_synced.is_empty() && !interpolation_synced.is_empty())
+        || (input_timeline.is_some_and(InputTimeline::is_synced)
+            && !interpolation_synced.is_empty())
 }
 
 fn ensure_player_visual_positions(
@@ -57,10 +58,15 @@ fn ensure_player_visual_positions(
     >,
     client: Query<(), With<Client>>,
     host_server: Query<(), With<HostServer>>,
-    input_synced: Query<(), (With<Client>, With<IsSynced<InputTimeline>>)>,
+    input_timeline: Option<Res<InputTimeline>>,
     interpolation_synced: Query<(), (With<Client>, With<IsSynced<InterpolationTimeline>>)>,
 ) {
-    if !client_visuals_ready(&client, &host_server, &input_synced, &interpolation_synced) {
+    if !client_visuals_ready(
+        &client,
+        &host_server,
+        input_timeline.as_deref(),
+        &interpolation_synced,
+    ) {
         return;
     }
     for (entity, position) in &players {

--- a/examples/lobby/src/renderer.rs
+++ b/examples/lobby/src/renderer.rs
@@ -6,8 +6,8 @@ use lightyear::connection::host::HostServer;
 use lightyear::interpolation::Interpolated;
 use lightyear::prediction::Predicted;
 use lightyear::prelude::{
-    lightyear_debug_event, Client, DebugCategory, DebugSamplePoint, InputTimeline,
-    InterpolationTimeline, IsSynced,
+    lightyear_debug_event, Client, DebugCategory, DebugSamplePoint, InterpolationTimeline,
+    IsSynced, SyncedInputTimeline,
 };
 
 #[derive(Clone)]
@@ -37,13 +37,12 @@ struct VisualPlayerPosition {
 fn client_visuals_ready(
     client: &Query<(), With<Client>>,
     host_server: &Query<(), With<HostServer>>,
-    input_timeline: Option<&InputTimeline>,
+    input_timeline_is_synced: bool,
     interpolation_synced: &Query<(), (With<Client>, With<IsSynced<InterpolationTimeline>>)>,
 ) -> bool {
     client.is_empty()
         || !host_server.is_empty()
-        || (input_timeline.is_some_and(InputTimeline::is_synced)
-            && !interpolation_synced.is_empty())
+        || (input_timeline_is_synced && !interpolation_synced.is_empty())
 }
 
 fn ensure_player_visual_positions(
@@ -58,13 +57,13 @@ fn ensure_player_visual_positions(
     >,
     client: Query<(), With<Client>>,
     host_server: Query<(), With<HostServer>>,
-    input_timeline: Option<Res<InputTimeline>>,
+    input_timeline: Option<SyncedInputTimeline>,
     interpolation_synced: Query<(), (With<Client>, With<IsSynced<InterpolationTimeline>>)>,
 ) {
     if !client_visuals_ready(
         &client,
         &host_server,
-        input_timeline.as_deref(),
+        input_timeline.is_some(),
         &interpolation_synced,
     ) {
         return;

--- a/examples/priority/src/client.rs
+++ b/examples/priority/src/client.rs
@@ -31,7 +31,7 @@ fn configure_input_delay(mut commands: Commands) {
 /// Applies local movement only to predicted entities owned by this client.
 fn player_movement(
     trigger: On<Fire<Movement>>,
-    input_timeline: Res<InputTimeline>,
+    _input_timeline: SyncedInputTimeline,
     _host_server: Query<(), With<HostServer>>,
     #[cfg(feature = "server")] server_actions: Query<
         (),
@@ -39,9 +39,6 @@ fn player_movement(
     >,
     mut position_query: Query<&mut Position, With<Predicted>>,
 ) {
-    if !input_timeline.is_synced() {
-        return;
-    }
     #[cfg(feature = "server")]
     if !_host_server.is_empty() && server_actions.contains(trigger.action) {
         return;

--- a/examples/priority/src/client.rs
+++ b/examples/priority/src/client.rs
@@ -22,16 +22,16 @@ impl Plugin for ExampleClientPlugin {
     }
 }
 
-fn configure_input_delay(client: Single<Entity, With<Client>>, mut commands: Commands) {
-    commands
-        .entity(client.into_inner())
-        .insert(InputTimelineConfig::default().with_input_delay(InputDelayConfig::balanced()));
+fn configure_input_delay(mut commands: Commands) {
+    commands.insert_resource(
+        InputTimelineConfig::default().with_input_delay(InputDelayConfig::balanced()),
+    );
 }
 
 /// Applies local movement only to predicted entities owned by this client.
 fn player_movement(
     trigger: On<Fire<Movement>>,
-    synced_client: Query<(), (With<Client>, With<IsSynced<InputTimeline>>)>,
+    input_timeline: Res<InputTimeline>,
     _host_server: Query<(), With<HostServer>>,
     #[cfg(feature = "server")] server_actions: Query<
         (),
@@ -39,7 +39,7 @@ fn player_movement(
     >,
     mut position_query: Query<&mut Position, With<Predicted>>,
 ) {
-    if synced_client.is_empty() {
+    if !input_timeline.is_synced() {
         return;
     }
     #[cfg(feature = "server")]

--- a/examples/projectiles/src/main.rs
+++ b/examples/projectiles/src/main.rs
@@ -84,8 +84,8 @@ fn update_client(app: &mut App) {
         .unwrap();
 
     // we need to add a ReplicationSender to the client entity to replicate the Action entities to the server
-    app.world_mut().entity_mut(client).insert((
-        ReplicationSender,
+    app.world_mut().entity_mut(client).insert(ReplicationSender);
+    app.insert_resource(
         InputTimelineConfig::default().with_input_delay(InputDelayConfig::balanced()),
-    ));
+    );
 }

--- a/examples/projectiles/src/server.rs
+++ b/examples/projectiles/src/server.rs
@@ -451,6 +451,11 @@ mod bot {
         };
         let conditioner = LinkConditionerConfig::average_condition().half();
 
+        app.insert_resource(
+            InputTimelineConfig::default()
+                .with_input_delay(InputDelayConfig::fixed_input_delay(BOT_INPUT_DELAY_TICKS)),
+        );
+
         app.world_mut().spawn((
             Client,
             BotClient,
@@ -464,8 +469,6 @@ mod bot {
             .unwrap(),
             crossbeam_client,
             PredictionManager::default(),
-            InputTimelineConfig::default()
-                .with_input_delay(InputDelayConfig::fixed_input_delay(BOT_INPUT_DELAY_TICKS)),
             Name::from("BotClient"),
         ));
         let server = server.into_inner();

--- a/examples/simple_box/src/client.rs
+++ b/examples/simple_box/src/client.rs
@@ -34,8 +34,8 @@ impl Plugin for ExampleClientPlugin {
     }
 }
 
-fn configure_input_delay(client: Single<Entity, With<Client>>, mut commands: Commands) {
-    commands.entity(client.into_inner()).insert(
+fn configure_input_delay(mut commands: Commands) {
+    commands.insert_resource(
         InputTimelineConfig::default().with_input_delay(InputDelayConfig::no_input_delay()),
     );
 }
@@ -92,11 +92,11 @@ fn buffer_input(
 ///
 /// If this example predicted remote entities, ownership would need to be checked before movement.
 fn player_movement(
-    synced_client: Query<(), (With<Client>, With<IsSynced<InputTimeline>>)>,
+    input_timeline: Res<InputTimeline>,
     // timeline: Single<&LocalTimeline>,
     mut position_query: Query<(&mut PlayerPosition, &ActionState<Inputs>), With<Predicted>>,
 ) {
-    if synced_client.is_empty() {
+    if !input_timeline.is_synced() {
         return;
     }
     // let tick = timeline.tick();

--- a/examples/simple_box/src/client.rs
+++ b/examples/simple_box/src/client.rs
@@ -92,13 +92,10 @@ fn buffer_input(
 ///
 /// If this example predicted remote entities, ownership would need to be checked before movement.
 fn player_movement(
-    input_timeline: Res<InputTimeline>,
+    _input_timeline: SyncedInputTimeline,
     // timeline: Single<&LocalTimeline>,
     mut position_query: Query<(&mut PlayerPosition, &ActionState<Inputs>), With<Predicted>>,
 ) {
-    if !input_timeline.is_synced() {
-        return;
-    }
     // let tick = timeline.tick();
     for (position, input) in position_query.iter_mut() {
         // trace!(?tick, ?position, ?input, "client");


### PR DESCRIPTION
Stacked on #1622.

## Summary

- make `InputTimeline` and `InputTimelineConfig` application-global resources
- keep `IsSynced<InputTimeline>` on the canonical Bevy resource entity and expose `SyncedInputTimeline` for ergonomic readiness-gated access
- generalize the existing `SyncedTimelinePlugin` over component and resource storage, sharing reset, sub-tick phase, sync adjustment, speed correction, marker, and event behavior
- preserve `SyncEvent<InputTimelineConfig>`; resource-backed sync events target the `InputTimeline` resource entity
- retain the original client/host-client query semantics while separating global input-clock state from per-Link senders and remote observations
- make `LastConfirmedInput` a resource because it is a global confirmed-input frontier; leave `PredictionManager` and the rest of rollback ownership for a later PR
- migrate input, prediction, deterministic-replication, tests, examples, and the spaceships demo

For conventional client/server operation, the resource sync adapter selects the single connected non-host Client Link's `RemoteTimeline` and `PingManager`. P2P objective aggregation and multi-Link input sending remain deferred to the later P2P/input-pipeline work.

## Why retain InputTimeline?

`LocalTimeline` only supplies the integer simulation tick. `InputTimeline` additionally stores the fractional/sub-tick phase used by synchronization, the sync-controller state and relative-speed correction that drive `Time<Virtual>`, the global input delay, and the input-versus-interpolation offset used for lag compensation. Removing it would recreate the same global driving-clock state under another name.
