### PR TITLE
fix(prediction): prune prediction history

### DIFF
--- a/crates/core/sync/src/timeline/input.rs
+++ b/crates/core/sync/src/timeline/input.rs
@@ -47,6 +47,11 @@ impl InputTimelineConfig {
         self.input_delay_config.is_lockstep()
     }
 
+    /// Maximum number of ticks the local simulation is allowed to predict ahead.
+    pub fn maximum_predicted_ticks(&self) -> u16 {
+        self.input_delay_config.maximum_predicted_ticks
+    }
+
     /// Update the input delay based on the current RTT and tick duration
     /// when there is a SyncEvent
     pub(crate) fn recompute_input_delay_on_sync(

--- a/crates/deterministic/deterministic_replication/src/late_join/client.rs
+++ b/crates/deterministic/deterministic_replication/src/late_join/client.rs
@@ -18,7 +18,7 @@ use lightyear_prediction::prelude::{
 use lightyear_prediction::rollback::{CatchUpGated, DisableRollback};
 use lightyear_replication::metadata::MetadataChannel;
 use lightyear_replication::prelude::ReplicationSystems;
-use lightyear_sync::prelude::{InputTimeline, IsSynced};
+use lightyear_sync::prelude::{InputTimeline, InputTimelineConfig, IsSynced};
 use tracing::{debug, info, warn};
 
 use super::{CatchUpRequest, CatchUpSnapshotReady, CatchUpSystems};
@@ -266,6 +266,7 @@ pub(crate) fn trigger_snapshot_rollback(
             &mut CatchUpManager,
             &LastConfirmedInput,
             &PredictionManager,
+            &InputTimelineConfig,
         ),
         With<Client>,
     >,
@@ -273,7 +274,7 @@ pub(crate) fn trigger_snapshot_rollback(
     mut state_metadata: ResMut<StateRollbackMetadata>,
     mut commands: Commands,
 ) {
-    let (client_entity, mut manager, last_confirmed_input, prediction_manager) =
+    let (client_entity, mut manager, last_confirmed_input, prediction_manager, input_config) =
         manager.into_inner();
     if manager.completed {
         return;
@@ -291,7 +292,11 @@ pub(crate) fn trigger_snapshot_rollback(
     if rollback_delta < 0 {
         return;
     }
-    let max_rollback_ticks = i32::from(prediction_manager.rollback_policy.max_rollback_ticks);
+    let max_rollback_ticks = i32::from(
+        prediction_manager
+            .rollback_policy
+            .effective_max_rollback_ticks(input_config),
+    );
     if rollback_delta > max_rollback_ticks {
         warn!(
             ?client_entity,

--- a/crates/inputs/inputs/src/client.rs
+++ b/crates/inputs/inputs/src/client.rs
@@ -532,7 +532,7 @@ fn clean_buffers<S: ActionStateSequence>(
     // NOTE: we skip this for host-client because the get_action_state system on the server
     //  also clears the buffers
     sender: Query<(), (With<Client>, With<InputTimeline>, Without<HostClient>)>,
-    prediction_manager: Option<Single<&PredictionManager, With<Client>>>,
+    prediction_manager: Option<Single<(&PredictionManager, &InputTimelineConfig), With<Client>>>,
     mut input_buffer_query: Query<
         &mut InputBuffer<S::Snapshot, S::Action>,
         Allow<PredictionDisable>,
@@ -552,9 +552,17 @@ fn clean_buffers<S: ActionStateSequence>(
     }
 }
 
-fn input_history_depth(prediction_manager: Option<&PredictionManager>) -> u32 {
+fn input_history_depth(
+    prediction_manager: Option<(&PredictionManager, &InputTimelineConfig)>,
+) -> u32 {
     prediction_manager
-        .map(|manager| u32::from(manager.rollback_policy.max_rollback_ticks) + 1)
+        .map(|(manager, input_config)| {
+            u32::from(
+                manager
+                    .rollback_policy
+                    .effective_max_rollback_ticks(input_config),
+            ) + 1
+        })
         .unwrap_or(0)
         .max(HISTORY_DEPTH)
 }
@@ -1177,6 +1185,8 @@ mod tests {
     fn input_history_depth_covers_prediction_rollback_window() {
         assert_eq!(input_history_depth(None), HISTORY_DEPTH);
 
+        let input_config = InputTimelineConfig::default();
+
         let mut manager = PredictionManager {
             rollback_policy: RollbackPolicy {
                 max_rollback_ticks: 100,
@@ -1184,9 +1194,12 @@ mod tests {
             },
             ..Default::default()
         };
-        assert_eq!(input_history_depth(Some(&manager)), 101);
+        assert_eq!(input_history_depth(Some((&manager, &input_config))), 101);
 
         manager.rollback_policy.max_rollback_ticks = 5;
-        assert_eq!(input_history_depth(Some(&manager)), HISTORY_DEPTH);
+        assert_eq!(
+            input_history_depth(Some((&manager, &input_config))),
+            HISTORY_DEPTH
+        );
     }
 }

--- a/crates/replication/prediction/src/manager.rs
+++ b/crates/replication/prediction/src/manager.rs
@@ -52,8 +52,10 @@ pub enum RollbackMode {
 pub struct RollbackPolicy {
     pub state: RollbackMode,
     pub input: RollbackMode,
-    /// Maximum number of ticks we can rollback to. If we receive some packets that would make us rollback more than
-    /// this number of ticks, we just do nothing.
+    /// Upper bound on the number of ticks we can roll back.
+    ///
+    /// A non-zero [`InputTimelineConfig::maximum_predicted_ticks`] can lower the effective bound.
+    /// Rollback requests beyond the effective bound are ignored.
     pub max_rollback_ticks: u16,
 }
 
@@ -62,12 +64,26 @@ impl Default for RollbackPolicy {
         Self {
             state: RollbackMode::Check,
             input: RollbackMode::Check,
-            max_rollback_ticks: 100,
+            max_rollback_ticks: 20,
         }
     }
 }
 
 impl RollbackPolicy {
+    /// Maximum rollback depth after applying the input timeline's prediction limit.
+    ///
+    /// A non-zero `maximum_predicted_ticks` bounds how far ahead the local simulation can be, so
+    /// rollback state older than that cannot be needed. Zero denotes lockstep and does not cap
+    /// explicit or forced state rollbacks.
+    pub fn effective_max_rollback_ticks(&self, input_config: &InputTimelineConfig) -> u16 {
+        let maximum_predicted_ticks = input_config.maximum_predicted_ticks();
+        if maximum_predicted_ticks == 0 {
+            self.max_rollback_ticks
+        } else {
+            self.max_rollback_ticks.min(maximum_predicted_ticks)
+        }
+    }
+
     /// Returns true if we don't need to store a prediction history.
     ///
     /// PredictionHistory is not needed if we always rollback on new states
@@ -343,6 +359,24 @@ impl StateRollbackMetadata {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use lightyear_sync::timeline::input::InputDelayConfig;
+
+    #[test]
+    fn effective_max_rollback_ticks_respects_prediction_limit() {
+        let mut policy = RollbackPolicy::default();
+        assert_eq!(policy.max_rollback_ticks, 20);
+
+        let balanced =
+            InputTimelineConfig::default().with_input_delay(InputDelayConfig::balanced());
+        assert_eq!(policy.effective_max_rollback_ticks(&balanced), 7);
+
+        policy.max_rollback_ticks = 5;
+        assert_eq!(policy.effective_max_rollback_ticks(&balanced), 5);
+
+        let lockstep =
+            InputTimelineConfig::default().with_input_delay(InputDelayConfig::no_prediction());
+        assert_eq!(policy.effective_max_rollback_ticks(&lockstep), 5);
+    }
 
     #[test]
     fn last_confirmed_input_default_starts_unset() {

--- a/crates/replication/prediction/src/predicted_history.rs
+++ b/crates/replication/prediction/src/predicted_history.rs
@@ -5,7 +5,7 @@
 //! 2. Rollback to a past local state and replay the simulation
 
 use crate::rollback::{CatchUpGated, DeterministicPredicted};
-use crate::{Predicted, SyncComponent};
+use crate::{Predicted, SyncComponent, manager::PredictionManager};
 use bevy_ecs::component::Mutable;
 use bevy_ecs::prelude::*;
 use bevy_reflect::Reflect;
@@ -92,13 +92,21 @@ impl<C> PredictionHistory<C> {
 ///
 /// This system only handles changes, removals are handled in `apply_component_removal`
 pub(crate) fn update_prediction_history<T: Component + Clone>(
+    manager: Single<(&PredictionManager, &InputTimelineConfig)>,
     mut query: Query<(Entity, Ref<T>, &mut PredictionHistory<T>)>,
     timeline: Res<LocalTimeline>,
 ) {
     // tick for which we will record the history (either the current client tick or the current rollback tick)
     let tick = timeline.tick();
+    let (manager, input_config) = manager.into_inner();
+    let oldest_rollback_tick = tick
+        - u32::from(
+            manager
+                .rollback_policy
+                .effective_max_rollback_ticks(input_config),
+        );
 
-    // update history if the predicted component changed
+    // Update history if the predicted component changed, then prune it.
     for (entity, component, mut history) in query.iter_mut() {
         // change detection works even when running the schedule for rollback
         if component.is_changed() {
@@ -119,6 +127,7 @@ pub(crate) fn update_prediction_history<T: Component + Clone>(
                 "recorded predicted component history"
             );
         }
+        history.clear_until_tick(oldest_rollback_tick);
     }
 }
 
@@ -465,12 +474,13 @@ pub(crate) fn snap_to_confirmed_during_rollback<
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::manager::StateRollbackMetadata;
+    use crate::manager::{RollbackPolicy, StateRollbackMetadata};
     use bevy_app::{App, Update};
     use bevy_replicon::shared::replication::diff::diff_index::DiffIndex;
+    use lightyear_sync::timeline::input::InputDelayConfig;
     use serde::{Deserialize, Serialize};
 
-    #[derive(Clone, PartialEq, Debug)]
+    #[derive(Component, Clone, PartialEq, Debug)]
     struct TestValue(f32);
 
     #[derive(Component, Clone, Debug, Deserialize, PartialEq, Serialize)]
@@ -506,6 +516,54 @@ mod tests {
         let has_tick_9 = history.buffer().iter().any(|(t, _)| *t == Tick(9));
         assert!(!has_tick_5);
         assert!(!has_tick_9);
+    }
+
+    fn prediction_history_test_app(
+        max_rollback_ticks: u16,
+        input_delay_config: InputDelayConfig,
+        tick: i32,
+    ) -> App {
+        let mut app = App::new();
+        let mut timeline = LocalTimeline::default();
+        timeline.apply_delta(tick);
+        app.insert_resource(timeline);
+        app.world_mut().spawn((
+            PredictionManager {
+                rollback_policy: RollbackPolicy {
+                    max_rollback_ticks,
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            InputTimelineConfig::default().with_input_delay(input_delay_config),
+        ));
+        app.world_mut().flush();
+        app
+    }
+
+    #[test]
+    fn prediction_history_is_pruned_to_effective_rollback_horizon() {
+        let mut app = prediction_history_test_app(20, InputDelayConfig::balanced(), 100);
+        app.add_systems(Update, update_prediction_history::<TestValue>);
+
+        let mut history = PredictionHistory::default();
+        for tick in [90, 95, 100] {
+            history.add_predicted(Tick(tick), Some(TestValue(tick as f32)));
+        }
+        let entity = app.world_mut().spawn((TestValue(100.0), history)).id();
+
+        app.update();
+
+        let history = app
+            .world()
+            .get::<PredictionHistory<TestValue>>(entity)
+            .unwrap();
+        assert_eq!(history.oldest().unwrap().0, Tick(93));
+        assert_eq!(
+            history.get(Tick(93)),
+            Some(&TestValue(90.0)),
+            "balanced input delay should cap the 20-tick policy at 7 ticks"
+        );
     }
 
     #[test]

--- a/crates/replication/prediction/src/rollback.rs
+++ b/crates/replication/prediction/src/rollback.rs
@@ -67,7 +67,7 @@ use lightyear_replication::prelude::ConfirmHistory;
 use lightyear_replication::prespawn::PreSpawnedReceiver;
 use lightyear_replication::registry::ComponentRegistry;
 use lightyear_replication::{ReplicationSystems, checkpoint::ReplicationCheckpointMap};
-use lightyear_sync::prelude::{InputTimeline, IsSynced};
+use lightyear_sync::prelude::{InputTimeline, InputTimelineConfig, IsSynced};
 #[cfg(feature = "metrics")]
 use lightyear_utils::metrics::TimerGauge;
 use serde::{Deserialize, Serialize};
@@ -364,6 +364,7 @@ fn check_rollback(
             Entity,
             Option<&LastConfirmedInput>,
             &mut PredictionManager,
+            &InputTimelineConfig,
             &mut PreSpawnedReceiver,
         ),
         (With<IsSynced<InputTimeline>>, Without<HostClient>),
@@ -378,10 +379,18 @@ fn check_rollback(
     #[cfg(feature = "metrics")]
     let _timer = TimerGauge::new("prediction/rollback/check");
 
-    let (manager_entity, last_confirmed_input, mut prediction_manager, mut prespawned_receiver) =
-        receiver_query.into_inner();
+    let (
+        manager_entity,
+        last_confirmed_input,
+        mut prediction_manager,
+        input_config,
+        mut prespawned_receiver,
+    ) = receiver_query.into_inner();
     let tick = timeline.tick();
     let received_state = state_metadata.received_messages_this_frame;
+    let max_rollback_ticks = prediction_manager
+        .rollback_policy
+        .effective_max_rollback_ticks(input_config);
 
     // The tick where ALL messages have been received (guaranteed complete information).
     // Explicit mismatch checks can exist before this is known, so don't return early.
@@ -392,7 +401,6 @@ fn check_rollback(
                             prediction_manager: &PredictionManager,
                             commands: &mut Commands,
                             rollback: Rollback| {
-        let max_rollback_ticks = prediction_manager.rollback_policy.max_rollback_ticks;
         let delta = tick - rollback_tick;
         if delta < 0 || delta > max_rollback_ticks as i32 {
             warn!(


### PR DESCRIPTION
Currently we prune the PredictionHistory on rollback, but we could have very rare rollbacks in which case the PredictionHistory grows indefinitely.

This PR:
- prunes the prediction history every tick
- is much more strict on what the `max_rollback_ticks` can be