### PR TITLE
refactor(prediction): make rollback state global

### DIFF
--- a/book/src/concepts/advanced_replication/prespawning.md
+++ b/book/src/concepts/advanced_replication/prespawning.md
@@ -51,7 +51,7 @@ The various system-sets for prespawning are:
 
 - FixedUpdate schedule:
   - FixedUpdate::Main: prespawn the entity
-  - FixedUpdate::SetPreSpawnedHash: we store all new hashes and the spawn tick in the `PredictionManager` (not in the `PreSpawnedPlayerObject` component).
+  - FixedUpdate::SetPreSpawnedHash: we store all new hashes and the spawn tick in the link's `PreSpawnedReceiver` (not in the `PreSpawnedPlayerObject` component).
   - FixedUpdate::SpawnHistory: add a PredictionHistory for each component of the pre-spawned entity. We need this to:
     - not rollback immediately when we get the corresponding server entity
     - do rollbacks correctly for pre-spawned entities

--- a/book/src/tutorial/advanced_systems.md
+++ b/book/src/tutorial/advanced_systems.md
@@ -32,10 +32,10 @@ app.component::<PlayerPosition>().replicate()
     .predict();
 ```
 
-Then, enable the application's prediction pipeline. `ClientPlugins` installs the prediction systems, but the systems only run while the application has a `PredictionManager` resource. The shared example helpers enable it automatically; otherwise call `enable_prediction` during application setup:
+Then, enable the application's prediction pipeline. `ClientPlugins` installs the prediction systems, but the systems only run while the application has a `PredictionManager` resource. The shared example helpers enable it automatically; otherwise insert the resource during application setup:
 
 ```rust,ignore
-app.enable_prediction(PredictionManager::default());
+app.insert_resource(PredictionManager::default());
 ```
 
 Finally, choose which replicated entities should be predicted. If the sender knows which clients

--- a/book/src/tutorial/advanced_systems.md
+++ b/book/src/tutorial/advanced_systems.md
@@ -21,7 +21,7 @@ when we receive the actual state of the entity from the server. (if there is a m
 To do this in lightyear, you will need to change a few things:
 
 - enable prediction for the component in your protocol;
-- add a `PredictionManager` component to the local client entity;
+- enable the application's global prediction pipeline with a `PredictionManager` resource;
 - mark the entity as predicted, either with `PredictionTarget` on the send-side or by adding
   `Predicted` on the receive-side.
 
@@ -32,14 +32,10 @@ app.component::<PlayerPosition>().replicate()
     .predict();
 ```
 
-Then, make sure your client entity has a `PredictionManager`. `ClientPlugins` installs the prediction systems, but the systems only run for a connected client entity that has this component. The shared example helpers insert it in `ExampleClient`; if you spawn your own client entity, add it there:
+Then, enable the application's prediction pipeline. `ClientPlugins` installs the prediction systems, but the systems only run while the application has a `PredictionManager` resource. The shared example helpers enable it automatically; otherwise call `enable_prediction` during application setup:
 
 ```rust,ignore
-commands.spawn((
-    Client::default(),
-    PredictionManager::default(),
-    // Link, IO, connection components...
-));
+app.enable_prediction(PredictionManager::default());
 ```
 
 Finally, choose which replicated entities should be predicted. If the sender knows which clients

--- a/crates/core/core/src/timeline.rs
+++ b/crates/core/core/src/timeline.rs
@@ -8,9 +8,8 @@ use bevy_ecs::entity::Entity;
 use bevy_ecs::event::{EntityEvent, Event};
 use bevy_ecs::prelude::{On, Resource};
 use bevy_ecs::ptr::Ptr;
-use bevy_ecs::query::With;
 use bevy_ecs::schedule::SystemSet;
-use bevy_ecs::system::{Query, ResMut};
+use bevy_ecs::system::{Res, ResMut};
 use bevy_reflect::Reflect;
 use bevy_time::{Fixed, Time};
 use core::any::TypeId;
@@ -349,10 +348,11 @@ impl<T: TimelineConfig> Clone for SyncEvent<T> {
 
 impl<T: TimelineConfig> Copy for SyncEvent<T> {}
 
-/// Marker component inserted on the Link if we are currently in rollback
+/// Application-global marker resource inserted while the simulation is being rolled back.
 ///
-/// This is in `lightyear_core` to avoid circular dependencies. Many other plugins behave differently during rollback
-#[derive(Component, Debug, Clone, Copy)]
+/// This is in `lightyear_core` to avoid circular dependencies. Many other plugins behave
+/// differently during rollback.
+#[derive(Resource, Debug, Clone, Copy)]
 pub enum Rollback {
     /// The rollback is initiated because we have received new Confirmed state from the server
     /// that doesn't match our prediction history.
@@ -364,6 +364,6 @@ pub enum Rollback {
 }
 
 /// Run condition to check if we are in rollback
-pub fn is_in_rollback(client: Query<(), With<Rollback>>) -> bool {
-    client.single().is_ok()
+pub fn is_in_rollback(rollback: Option<Res<Rollback>>) -> bool {
+    rollback.is_some()
 }

--- a/crates/core/sync/src/timeline/remote.rs
+++ b/crates/core/sync/src/timeline/remote.rs
@@ -252,8 +252,12 @@ pub(crate) fn update_remote_timeline(
 pub(crate) fn advance_remote_timeline(
     fixed_time: Res<Time<Real>>,
     tick_duration: Res<TickDuration>,
-    mut query: Query<&mut RemoteTimeline, (With<Linked>, Without<Rollback>)>,
+    rollback: Option<Res<Rollback>>,
+    mut query: Query<&mut RemoteTimeline, With<Linked>>,
 ) {
+    if rollback.is_some() {
+        return;
+    }
     let delta = fixed_time.delta();
     query.iter_mut().for_each(|mut t| {
         t.apply_duration(delta, tick_duration.0);

--- a/crates/deterministic/deterministic_replication/src/late_join/client.rs
+++ b/crates/deterministic/deterministic_replication/src/late_join/client.rs
@@ -258,12 +258,13 @@ pub(crate) fn trigger_snapshot_rollback(
     timeline: Res<LocalTimeline>,
     input_config: Res<InputTimelineConfig>,
     last_confirmed_input: Res<LastConfirmedInput>,
-    manager: Single<(Entity, &mut CatchUpManager, &PredictionManager), With<Client>>,
+    manager: Single<(Entity, &mut CatchUpManager), With<Client>>,
+    prediction_manager: Res<PredictionManager>,
     server_mutate_ticks: Res<ServerMutateTicks>,
     mut state_metadata: ResMut<StateRollbackMetadata>,
     mut commands: Commands,
 ) {
-    let (client_entity, mut manager, prediction_manager) = manager.into_inner();
+    let (client_entity, mut manager) = manager.into_inner();
     if manager.completed {
         return;
     }
@@ -324,12 +325,10 @@ pub(crate) fn trigger_snapshot_rollback(
 /// This is so that when CatchUpSnapshotReady is observed, the CatchUpGated components are already restored
 /// to their snapshot state.
 fn trigger_catch_up_snapshot_activation(
-    client: Query<(&Rollback, &CatchUpManager), With<Client>>,
+    rollback: Res<Rollback>,
+    manager: Single<&CatchUpManager, With<Client>>,
     mut commands: Commands,
 ) {
-    let Ok((rollback, manager)) = client.single() else {
-        return;
-    };
     if manager.completed || !matches!(*rollback, Rollback::FromState) {
         return;
     }
@@ -344,13 +343,11 @@ fn trigger_catch_up_snapshot_activation(
 }
 
 fn finish_catch_up_snapshot_activation(
-    mut client: Query<(&mut CatchUpManager, &mut PredictionManager), With<Client>>,
+    mut manager: Single<&mut CatchUpManager, With<Client>>,
+    mut prediction_manager: ResMut<PredictionManager>,
     gated: Query<Entity, With<CatchUpGated>>,
     mut commands: Commands,
 ) {
-    let Ok((mut manager, mut prediction_manager)) = client.single_mut() else {
-        return;
-    };
     if manager.completed || manager.activating_snapshot.is_none() {
         return;
     }

--- a/crates/inputs/inputs/src/client.rs
+++ b/crates/inputs/inputs/src/client.rs
@@ -324,19 +324,6 @@ impl<'a> InputRoute<'a> {
             Self::P2P(_) => true,
         }
     }
-
-    #[inline]
-    fn any_link(self, mut predicate: impl FnMut(Entity) -> bool) -> bool {
-        match self {
-            Self::ClientServer { link, .. } => predicate(link),
-            Self::P2P(links) => links.iter().copied().any(predicate),
-        }
-    }
-}
-
-#[inline]
-fn route_is_in_rollback(route: InputRoute<'_>, rollbacks: &Query<(), With<Rollback>>) -> bool {
-    route.any_link(|link| rollbacks.contains(link))
 }
 
 // equivalent to &ActionState<S::Action>
@@ -360,7 +347,7 @@ fn buffer_action_state<S: ActionStateSequence>(
     // 2. the HostServer client can have input delay
     input_timeline: SyncedInputTimeline,
     metadata: Res<NetworkingMetadata>,
-    rollbacks: Query<(), With<Rollback>>,
+    rollback: Option<Res<Rollback>>,
     mut action_state_query: Query<
         (
             Entity,
@@ -374,7 +361,7 @@ fn buffer_action_state<S: ActionStateSequence>(
     let Some(route) = InputRoute::from_topology(&metadata.mode) else {
         return;
     };
-    if route_is_in_rollback(route, &rollbacks) {
+    if rollback.is_some() {
         return;
     }
     let current_tick = local_timeline.tick();
@@ -422,7 +409,7 @@ fn get_action_state<S: ActionStateSequence>(
     input_timeline: Res<InputTimeline>,
     input_timeline_config: Res<InputTimelineConfig>,
     metadata: Res<NetworkingMetadata>,
-    rollbacks: Query<(), With<Rollback>>,
+    rollback: Option<Res<Rollback>>,
 
     // NOTE: we want to apply the Inputs for BOTH the local player and remote player
     // - local player: we need to get the input from the InputBuffer because of input delay
@@ -447,7 +434,7 @@ fn get_action_state<S: ActionStateSequence>(
     if route.is_host_client() {
         return;
     }
-    let is_rollback = route_is_in_rollback(route, &rollbacks);
+    let is_rollback = rollback.is_some();
     let input_delay = input_timeline.input_delay() as i32;
     let tick = local_timeline.tick();
     if is_rollback && config.ignore_rollbacks {
@@ -550,7 +537,7 @@ fn get_delayed_action_state<S: ActionStateSequence>(
     timeline: Res<LocalTimeline>,
     input_timeline: SyncedInputTimeline,
     metadata: Res<NetworkingMetadata>,
-    rollbacks: Query<(), With<Rollback>>,
+    rollback: Option<Res<Rollback>>,
     mut action_state_query: Query<
         (
             Entity,
@@ -565,7 +552,7 @@ fn get_delayed_action_state<S: ActionStateSequence>(
     let Some(route) = InputRoute::from_topology(&metadata.mode) else {
         return;
     };
-    let is_rollback = route_is_in_rollback(route, &rollbacks);
+    let is_rollback = rollback.is_some();
     let input_delay_ticks = input_timeline.input_delay() as i32;
     if is_rollback || input_delay_ticks == 0 {
         return;
@@ -612,7 +599,7 @@ fn clean_buffers<S: ActionStateSequence>(
     // NOTE: we skip this for host-client because the get_action_state system on the server
     //  also clears the buffers
     metadata: Res<NetworkingMetadata>,
-    prediction_managers: Query<&PredictionManager>,
+    prediction_manager: Option<Res<PredictionManager>>,
     input_config: Res<InputTimelineConfig>,
     mut input_buffer_query: Query<
         &mut InputBuffer<S::Snapshot, S::Action>,
@@ -625,8 +612,12 @@ fn clean_buffers<S: ActionStateSequence>(
     if route.is_host_client() {
         return;
     }
-    let old_tick =
-        timeline.tick() - input_history_depth_for_route(route, &prediction_managers, &input_config);
+    let old_tick = timeline.tick()
+        - input_history_depth(
+            prediction_manager
+                .as_deref()
+                .map(|manager| (manager, input_config.as_ref())),
+        );
 
     // trace!(
     //     "popping all input buffers since old tick: {old_tick:?}",
@@ -650,30 +641,6 @@ fn input_history_depth(
         })
         .unwrap_or(0)
         .max(HISTORY_DEPTH)
-}
-
-fn input_history_depth_for_route(
-    route: InputRoute<'_>,
-    prediction_managers: &Query<&PredictionManager>,
-    input_config: &InputTimelineConfig,
-) -> u32 {
-    let mut history_depth = HISTORY_DEPTH;
-    match route {
-        InputRoute::ClientServer { link, .. } => {
-            if let Ok(manager) = prediction_managers.get(link) {
-                history_depth = input_history_depth(Some((manager, input_config)));
-            }
-        }
-        InputRoute::P2P(links) => {
-            for link in links {
-                if let Ok(manager) = prediction_managers.get(*link) {
-                    history_depth =
-                        history_depth.max(input_history_depth(Some((manager, input_config))));
-                }
-            }
-        }
-    }
-    history_depth
 }
 
 // TODO: is this actually necessary? The sync happens in PostUpdate,
@@ -706,7 +673,7 @@ fn prepare_input_message<S: ActionStateSequence>(
     input_config: Res<InputConfig<S::Action>>,
     input_timeline: SyncedInputTimeline,
     metadata: Res<NetworkingMetadata>,
-    rollbacks: Query<(), With<Rollback>>,
+    rollback: Option<Res<Rollback>>,
     _channel_registry: Res<ChannelRegistry>,
     input_buffer_query: Query<
         (
@@ -723,7 +690,7 @@ fn prepare_input_message<S: ActionStateSequence>(
     let Some(route) = InputRoute::from_topology(&metadata.mode) else {
         return;
     };
-    if route_is_in_rollback(route, &rollbacks) {
+    if rollback.is_some() {
         return;
     }
     let is_host_client = route.is_host_client();
@@ -867,8 +834,8 @@ fn receive_remote_player_input_messages<S: ActionStateSequence>(
     _input_timeline: SyncedInputTimeline,
     metadata: Res<NetworkingMetadata>,
     last_confirmed_input: Res<LastConfirmedInput>,
+    prediction_manager: Option<Res<PredictionManager>>,
     mut receivers: Query<&mut MessageReceiver<InputMessage<S>>>,
-    prediction_managers: Query<&PredictionManager>,
     mut predicted_query: Query<
         Option<&mut InputBuffer<S::Snapshot, S::Action>>,
         (Without<S::Marker>, Allow<PredictionDisable>),
@@ -882,10 +849,7 @@ fn receive_remote_player_input_messages<S: ActionStateSequence>(
     if route.is_host_client() {
         return;
     }
-    let Some(prediction_manager_link) = prediction_manager_link(route, &prediction_managers) else {
-        return;
-    };
-    let Ok(prediction_manager) = prediction_managers.get(prediction_manager_link) else {
+    let Some(prediction_manager) = prediction_manager else {
         return;
     };
     let tick = timeline.tick();
@@ -898,7 +862,7 @@ fn receive_remote_player_input_messages<S: ActionStateSequence>(
                     &mut commands,
                     *tick_duration,
                     tick,
-                    prediction_manager,
+                    &prediction_manager,
                     &mut predicted_query,
                     &prespawned,
                     #[cfg(feature = "metrics")]
@@ -916,7 +880,7 @@ fn receive_remote_player_input_messages<S: ActionStateSequence>(
                     &mut commands,
                     *tick_duration,
                     tick,
-                    prediction_manager,
+                    &prediction_manager,
                     &mut predicted_query,
                     &prespawned,
                     #[cfg(feature = "metrics")]
@@ -930,28 +894,6 @@ fn receive_remote_player_input_messages<S: ActionStateSequence>(
         last_confirmed_input
             .received_any_messages
             .store(true, bevy_platform::sync::atomic::Ordering::Relaxed);
-    }
-}
-
-/// Return the sole prediction-manager Link selected by the cached route.
-///
-/// P2P temporarily keeps `PredictionManager` on one Link until it becomes a resource in PR 4. If
-/// zero or multiple routed Links contain a manager, input receive remains inactive rather than
-/// associating rollback state with an arbitrary peer.
-fn prediction_manager_link(
-    route: InputRoute<'_>,
-    prediction_managers: &Query<&PredictionManager>,
-) -> Option<Entity> {
-    match route {
-        InputRoute::ClientServer { link, .. } => prediction_managers.contains(link).then_some(link),
-        InputRoute::P2P(links) => {
-            let mut matches = links
-                .iter()
-                .copied()
-                .filter(|link| prediction_managers.contains(*link));
-            let first = matches.next()?;
-            matches.next().is_none().then_some(first)
-        }
     }
 }
 

--- a/crates/replication/interpolation/src/timeline.rs
+++ b/crates/replication/interpolation/src/timeline.rs
@@ -221,8 +221,12 @@ impl TimelinePlugin {
         time: Res<Time<Virtual>>,
         tick_duration: Res<TickDuration>,
         // make sure to not update the timelines during Rollback
-        mut query: Query<&mut InterpolationTimeline, (With<Connected>, Without<Rollback>)>,
+        rollback: Option<Res<Rollback>>,
+        mut query: Query<&mut InterpolationTimeline, With<Connected>>,
     ) {
+        if rollback.is_some() {
+            return;
+        }
         let delta = time.delta();
         query.iter_mut().for_each(|mut t| {
             // make sure to account for the fact that Time<Virtual> is already updated from the Driving timeline

--- a/crates/replication/prediction/src/correction.rs
+++ b/crates/replication/prediction/src/correction.rs
@@ -780,7 +780,7 @@ pub(crate) fn add_visual_correction<
 >(
     time: Res<Time<Virtual>>,
     prediction: Res<PredictionRegistry>,
-    manager: Single<&PredictionManager>,
+    manager: Res<PredictionManager>,
     mut query: Query<(Entity, &mut C, &mut VisualCorrection<D>)>,
     mut commands: Commands,
 ) {
@@ -1014,7 +1014,7 @@ mod tests {
         app.init_resource::<PredictionRegistry>();
         app.insert_resource(Time::<Virtual>::default());
         app.component::<CorrectionA>().predict().add_correction();
-        app.world_mut().spawn(PredictionManager::default());
+        app.insert_resource(PredictionManager::default());
         let entity = app
             .world_mut()
             .spawn((
@@ -1193,8 +1193,8 @@ mod tests {
 
         let prediction_manager = PredictionManager::default();
         prediction_manager.set_rollback_tick(PREVIOUS_TICK);
-        app.world_mut()
-            .spawn((prediction_manager, Rollback::FromInputs));
+        app.insert_resource(prediction_manager);
+        app.insert_resource(Rollback::FromInputs);
 
         app.component::<CorrectionA>().predict();
         app.finish();

--- a/crates/replication/prediction/src/despawn.rs
+++ b/crates/replication/prediction/src/despawn.rs
@@ -1,10 +1,9 @@
 use crate::Predicted;
-use crate::manager::PredictionResource;
+use crate::manager::PredictionManager;
 use crate::prelude::DeterministicPredicted;
 use bevy_ecs::error::ignore;
 use bevy_ecs::prelude::*;
 use bevy_reflect::Reflect;
-use lightyear_connection::host::HostClient;
 use lightyear_replication::prelude::PreSpawned;
 #[allow(unused_imports)]
 use tracing::{debug, error, info};
@@ -36,10 +35,9 @@ impl Command for PredictionDespawnCommand {
     type Out = ();
 
     fn apply(self, world: &mut World) -> Self::Out {
-        // if we are the server (or host-client), there is no rollback so we can despawn the entity immediately
-        if world
-            .get_resource::<PredictionResource>()
-            .is_none_or(|r| world.entity(r.link_entity).contains::<HostClient>())
+        // Without the application-global prediction manager there is no rollback, so the entity
+        // can be despawned immediately.
+        if !world.contains_resource::<PredictionManager>()
             && let Ok(e) = world.get_entity_mut(self.entity)
         {
             e.despawn();
@@ -73,10 +71,7 @@ impl PredictionDespawnCommandsExt for EntityCommands<'_> {
         self.queue_handled(
             move |entity_mut: EntityWorldMut| {
                 let world = entity_mut.world();
-                if world
-                    .get_resource::<PredictionResource>()
-                    .is_some_and(|r| !world.entity(r.link_entity).contains::<HostClient>())
-                {
+                if world.contains_resource::<PredictionManager>() {
                     PredictionDespawnCommand { entity }.apply(entity_mut.into_world_mut());
                 } else {
                     // if we are the server (or host server), just despawn the entity

--- a/crates/replication/prediction/src/lib.rs
+++ b/crates/replication/prediction/src/lib.rs
@@ -29,7 +29,7 @@ pub mod prelude {
     pub use crate::manager::{
         LastConfirmedInput, PredictionManager, RollbackMode, RollbackPolicy, StateRollbackMetadata,
     };
-    pub use crate::plugin::{PredictionPlugin, PredictionSystems};
+    pub use crate::plugin::{PredictionAppExt, PredictionPlugin, PredictionSystems};
     pub use crate::predicted_history::PredictionHistory;
     pub use crate::registry::{
         LocalRollbackComponentRegistration, PredictedComponentRegistration,

--- a/crates/replication/prediction/src/lib.rs
+++ b/crates/replication/prediction/src/lib.rs
@@ -29,7 +29,7 @@ pub mod prelude {
     pub use crate::manager::{
         LastConfirmedInput, PredictionManager, RollbackMode, RollbackPolicy, StateRollbackMetadata,
     };
-    pub use crate::plugin::{PredictionAppExt, PredictionPlugin, PredictionSystems};
+    pub use crate::plugin::{PredictionPlugin, PredictionSystems};
     pub use crate::predicted_history::PredictionHistory;
     pub use crate::registry::{
         LocalRollbackComponentRegistration, PredictedComponentRegistration,

--- a/crates/replication/prediction/src/manager.rs
+++ b/crates/replication/prediction/src/manager.rs
@@ -7,20 +7,10 @@ use crate::correction::CorrectionPolicy;
 use crate::rollback::RollbackState;
 use alloc::vec::Vec;
 use bevy_ecs::entity::EntityHash;
-use bevy_ecs::lifecycle::HookContext;
-use bevy_ecs::world::DeferredWorld;
 use core::ops::{Deref, DerefMut};
 use lightyear_core::prelude::Tick;
-use lightyear_replication::prespawn::PreSpawnedReceiver;
 use lightyear_sync::prelude::InputTimelineConfig;
 use parking_lot::RwLock;
-
-#[derive(Resource)]
-pub struct PredictionResource {
-    // entity that holds the PredictionManager
-    // We use this to avoid having to run a mutable query in component hooks
-    pub(crate) link_entity: Entity,
-}
 
 type EntityHashMap<K, V> = bevy_platform::collections::HashMap<K, V, EntityHash>;
 
@@ -93,15 +83,14 @@ impl RollbackPolicy {
     }
 }
 
-/// Component that enables prediction and rollback for a local client.
+/// Application-global state that enables prediction and rollback.
 ///
 /// [`PredictionPlugin`](crate::prelude::PredictionPlugin) installs the prediction systems, but
-/// those systems only run for a connected, non-host [`Client`](lightyear_connection::client::Client)
-/// entity that also has `PredictionManager`. Add this to your client entity when it should create
-/// predicted entities, record prediction history, and perform rollback/reconciliation.
-#[derive(Component, Debug, Reflect)]
-#[component(on_insert = PredictionManager::on_insert)]
-#[require(PreSpawnedReceiver)]
+/// those systems only run when this resource is present and the cached network topology is a
+/// conventional client or P2P session. Insert one manager into the application when it should
+/// create predicted entities, record prediction history, and perform one global
+/// rollback/reconciliation pipeline.
+#[derive(Resource, Debug, Reflect)]
 pub struct PredictionManager {
     /// Configuration for how rollbacks are triggered
     pub rollback_policy: RollbackPolicy,
@@ -508,17 +497,6 @@ impl Default for PredictionManager {
             deterministic_despawn: Vec::default(),
             rollback: RwLock::new(RollbackState::Default),
         }
-    }
-}
-
-impl PredictionManager {
-    fn on_insert(mut deferred: DeferredWorld, context: HookContext) {
-        let entity = context.entity;
-        deferred.commands().queue(move |world: &mut World| {
-            world.insert_resource(PredictionResource {
-                link_entity: entity,
-            });
-        })
     }
 }
 

--- a/crates/replication/prediction/src/plugin.rs
+++ b/crates/replication/prediction/src/plugin.rs
@@ -20,18 +20,34 @@ use bevy_ecs::component::Mutable;
 use bevy_ecs::entity_disabling::DefaultQueryFilters;
 use bevy_ecs::prelude::*;
 use bevy_replicon::shared::replication::diff::Diffable as RepliconDiffable;
-use lightyear_connection::client::{Client, Connected};
-use lightyear_connection::host::HostClient;
-use lightyear_core::prelude::ConfirmedHistory;
-use lightyear_replication::prelude::ReplicationSystems;
+#[cfg(feature = "metrics")]
+use bevy_utils::prelude::DebugName;
+use lightyear_connection::network_topology::{NetworkTopology, NetworkingMetadata};
+use lightyear_core::prelude::{ConfirmedHistory, is_in_rollback};
+use lightyear_replication::prelude::{ReplicationReceiver, ReplicationSystems};
+use lightyear_replication::prespawn::PreSpawnedReceiver;
 
 /// Plugin that installs client-side prediction systems.
 ///
-/// The systems run for connected, non-host client entities with a
-/// [`PredictionManager`] component. Add `PredictionManager` to the local client
-/// entity to opt that client into prediction and rollback.
+/// The systems run when the application contains a [`PredictionManager`] resource and its cached
+/// network topology is a conventional client or P2P session. Use
+/// [`PredictionAppExt::enable_prediction`] to opt the application into one global prediction and
+/// rollback pipeline. Host-client and server topologies remain authoritative and do not run it.
 #[derive(Default)]
 pub struct PredictionPlugin;
+
+/// Application extension for enabling the global prediction pipeline.
+pub trait PredictionAppExt {
+    /// Enable prediction and rollback with the provided application-global manager.
+    fn enable_prediction(&mut self, manager: PredictionManager) -> &mut Self;
+}
+
+impl PredictionAppExt for App {
+    fn enable_prediction(&mut self, manager: PredictionManager) -> &mut Self {
+        self.init_resource::<LastConfirmedInput>()
+            .insert_resource(manager)
+    }
+}
 
 #[deprecated(note = "Use PredictionSystems instead")]
 pub type PredictionSet = PredictionSystems;
@@ -58,19 +74,19 @@ pub enum PredictionSystems {
     All,
 }
 
-pub(crate) type PredictionFilter = (
-    With<PredictionManager>,
-    With<Client>,
-    With<Connected>,
-    Without<HostClient>,
-);
-
 // NOTE: we need to run the prediction systems even if we're not synced, because we want
 //  our HistoryBuffer to contain values for components/resources that were updated before syncing
 //  is done.
-/// Returns true if the client is not a HostClient and is Connected
-pub(crate) fn should_run(query: Query<(), PredictionFilter>) -> bool {
-    query.single().is_ok()
+/// Returns true if this application opted into prediction and has a supported remote topology.
+pub(crate) fn should_run(
+    manager: Option<Res<PredictionManager>>,
+    metadata: Res<NetworkingMetadata>,
+) -> bool {
+    manager.is_some()
+        && matches!(
+            metadata.mode,
+            NetworkTopology::Client(_) | NetworkTopology::P2P(_)
+        )
 }
 
 /// Enable rollbacking a component even if the component is not networked
@@ -184,6 +200,10 @@ impl Plugin for PredictionPlugin {
         app.init_resource::<PredictionRegistry>();
         app.init_resource::<LastConfirmedInput>();
 
+        // State rollback keeps prespawn matching state on the authoritative receiver Link. This
+        // remains Link-scoped even though the rollback decision and manager are application-global.
+        app.register_required_components::<ReplicationReceiver, PreSpawnedReceiver>();
+
         // Custom entity disabling
         let rollback_disable_id = app
             .world_mut()
@@ -215,7 +235,9 @@ impl Plugin for PredictionPlugin {
         // - During rollback, snap components to confirmed values if we have them
         app.configure_sets(
             FixedPreUpdate,
-            PredictionSystems::SnapToConfirmed.in_set(PredictionSystems::All),
+            PredictionSystems::SnapToConfirmed
+                .in_set(PredictionSystems::All)
+                .run_if(is_in_rollback),
         );
         app.configure_sets(FixedPreUpdate, PredictionSystems::All.run_if(should_run));
 
@@ -242,5 +264,68 @@ impl Plugin for PredictionPlugin {
 
         // PLUGINS
         app.add_plugins((PredictionDiagnosticsPlugin::default(), RollbackPlugin));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bevy_ecs::system::RunSystemOnce;
+
+    #[test]
+    fn enable_prediction_inserts_one_global_manager() {
+        let mut app = App::new();
+        let manager = PredictionManager {
+            rollback_policy: crate::manager::RollbackPolicy {
+                max_rollback_ticks: 17,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        app.enable_prediction(manager);
+
+        assert_eq!(
+            app.world()
+                .resource::<PredictionManager>()
+                .rollback_policy
+                .max_rollback_ticks,
+            17
+        );
+        assert!(app.world().contains_resource::<LastConfirmedInput>());
+    }
+
+    #[test]
+    fn prespawn_state_is_required_by_replication_receiver() {
+        let mut app = App::new();
+        app.add_plugins(PredictionPlugin);
+
+        let receiver = app.world_mut().spawn(ReplicationReceiver).id();
+        app.world_mut().flush();
+
+        assert!(app.world().get::<PreSpawnedReceiver>(receiver).is_some());
+    }
+
+    #[test]
+    fn prediction_pipeline_excludes_authoritative_topologies() {
+        let mut app = App::new();
+        app.init_resource::<NetworkingMetadata>();
+        app.enable_prediction(PredictionManager::default());
+        let client = app.world_mut().spawn_empty().id();
+        let server = app.world_mut().spawn_empty().id();
+
+        app.world_mut().resource_mut::<NetworkingMetadata>().mode = NetworkTopology::Client(client);
+        assert!(app.world_mut().run_system_once(should_run).unwrap());
+
+        app.world_mut().resource_mut::<NetworkingMetadata>().mode =
+            NetworkTopology::P2P(Default::default());
+        assert!(app.world_mut().run_system_once(should_run).unwrap());
+
+        app.world_mut().resource_mut::<NetworkingMetadata>().mode =
+            NetworkTopology::HostClient { server, client };
+        assert!(!app.world_mut().run_system_once(should_run).unwrap());
+
+        app.world_mut().resource_mut::<NetworkingMetadata>().mode = NetworkTopology::Server(server);
+        assert!(!app.world_mut().run_system_once(should_run).unwrap());
     }
 }

--- a/crates/replication/prediction/src/plugin.rs
+++ b/crates/replication/prediction/src/plugin.rs
@@ -362,7 +362,7 @@ mod tests {
 
         app.world_mut().resource_mut::<NetworkingMetadata>().mode = NetworkTopology::P2P {
             connected: Default::default(),
-            declared: 1,
+            declared_links: 1,
         };
         assert!(app.world_mut().run_system_once(should_run).unwrap());
 

--- a/crates/replication/prediction/src/plugin.rs
+++ b/crates/replication/prediction/src/plugin.rs
@@ -20,8 +20,6 @@ use bevy_ecs::component::Mutable;
 use bevy_ecs::entity_disabling::DefaultQueryFilters;
 use bevy_ecs::prelude::*;
 use bevy_replicon::shared::replication::diff::Diffable as RepliconDiffable;
-#[cfg(feature = "metrics")]
-use bevy_utils::prelude::DebugName;
 use lightyear_connection::network_topology::{NetworkTopology, NetworkingMetadata};
 use lightyear_core::prelude::{ConfirmedHistory, is_in_rollback};
 use lightyear_replication::prelude::{ReplicationReceiver, ReplicationSystems};

--- a/crates/replication/prediction/src/plugin.rs
+++ b/crates/replication/prediction/src/plugin.rs
@@ -83,7 +83,7 @@ pub(crate) fn should_run(
     manager.is_some()
         && matches!(
             metadata.mode,
-            NetworkTopology::Client(_) | NetworkTopology::P2P(_)
+            NetworkTopology::Client(_) | NetworkTopology::P2P { .. }
         )
 }
 
@@ -362,8 +362,10 @@ mod tests {
         app.world_mut().resource_mut::<NetworkingMetadata>().mode = NetworkTopology::Client(client);
         assert!(app.world_mut().run_system_once(should_run).unwrap());
 
-        app.world_mut().resource_mut::<NetworkingMetadata>().mode =
-            NetworkTopology::P2P(Default::default());
+        app.world_mut().resource_mut::<NetworkingMetadata>().mode = NetworkTopology::P2P {
+            connected: Default::default(),
+            declared: 1,
+        };
         assert!(app.world_mut().run_system_once(should_run).unwrap());
 
         app.world_mut().resource_mut::<NetworkingMetadata>().mode =

--- a/crates/replication/prediction/src/plugin.rs
+++ b/crates/replication/prediction/src/plugin.rs
@@ -30,23 +30,21 @@ use lightyear_replication::prespawn::PreSpawnedReceiver;
 /// Plugin that installs client-side prediction systems.
 ///
 /// The systems run when the application contains a [`PredictionManager`] resource and its cached
-/// network topology is a conventional client or P2P session. Use
-/// [`PredictionAppExt::enable_prediction`] to opt the application into one global prediction and
-/// rollback pipeline. Host-client and server topologies remain authoritative and do not run it.
+/// network topology is a conventional client or P2P session. Insert a [`PredictionManager`]
+/// resource to opt the application into one global prediction and rollback pipeline. Host-client
+/// and server topologies remain authoritative and do not run it.
 #[derive(Default)]
 pub struct PredictionPlugin;
 
-/// Application extension for enabling the global prediction pipeline.
-pub trait PredictionAppExt {
-    /// Enable prediction and rollback with the provided application-global manager.
-    fn enable_prediction(&mut self, manager: PredictionManager) -> &mut Self;
-}
-
-impl PredictionAppExt for App {
-    fn enable_prediction(&mut self, manager: PredictionManager) -> &mut Self {
-        self.init_resource::<LastConfirmedInput>()
-            .insert_resource(manager)
-    }
+/// Initialize resources required by the global prediction pipeline.
+///
+/// `LastConfirmedInput` is deliberately not removed with `PredictionManager`: it also represents
+/// useful global input state for deterministic simulations that do not enable prediction.
+fn initialize_prediction_resources(
+    _trigger: On<Insert, PredictionManager>,
+    mut commands: Commands,
+) {
+    commands.init_resource::<LastConfirmedInput>();
 }
 
 #[deprecated(note = "Use PredictionSystems instead")]
@@ -198,7 +196,12 @@ impl Plugin for PredictionPlugin {
     fn build(&self, app: &mut App) {
         // RESOURCES
         app.init_resource::<PredictionRegistry>();
-        app.init_resource::<LastConfirmedInput>();
+        app.add_observer(initialize_prediction_resources);
+        // Observers are not retroactive, so also handle applications that inserted their manager
+        // before adding this plugin.
+        if app.world().contains_resource::<PredictionManager>() {
+            app.init_resource::<LastConfirmedInput>();
+        }
 
         // State rollback keeps prespawn matching state on the authoritative receiver Link. This
         // remains Link-scoped even though the rollback decision and manager are application-global.
@@ -271,10 +274,12 @@ impl Plugin for PredictionPlugin {
 mod tests {
     use super::*;
     use bevy_ecs::system::RunSystemOnce;
+    use lightyear_core::timeline::Rollback;
 
     #[test]
-    fn enable_prediction_inserts_one_global_manager() {
+    fn prediction_manager_initializes_global_input_frontier() {
         let mut app = App::new();
+        app.add_plugins(PredictionPlugin);
         let manager = PredictionManager {
             rollback_policy: crate::manager::RollbackPolicy {
                 max_rollback_ticks: 17,
@@ -283,7 +288,9 @@ mod tests {
             ..Default::default()
         };
 
-        app.enable_prediction(manager);
+        assert!(!app.world().contains_resource::<LastConfirmedInput>());
+        app.insert_resource(manager);
+        app.world_mut().flush();
 
         assert_eq!(
             app.world()
@@ -292,6 +299,16 @@ mod tests {
                 .max_rollback_ticks,
             17
         );
+        assert!(app.world().contains_resource::<LastConfirmedInput>());
+    }
+
+    #[test]
+    fn prediction_manager_inserted_before_plugin_initializes_global_input_frontier() {
+        let mut app = App::new();
+        app.insert_resource(PredictionManager::default());
+
+        app.add_plugins(PredictionPlugin);
+
         assert!(app.world().contains_resource::<LastConfirmedInput>());
     }
 
@@ -306,11 +323,39 @@ mod tests {
         assert!(app.world().get::<PreSpawnedReceiver>(receiver).is_some());
     }
 
+    #[derive(Resource, Default)]
+    struct SnapRuns(u32);
+
+    fn count_snap_runs(mut runs: ResMut<SnapRuns>) {
+        runs.0 += 1;
+    }
+
+    #[test]
+    fn snap_to_confirmed_set_only_runs_during_rollback() {
+        let mut app = App::new();
+        app.add_plugins(PredictionPlugin);
+        app.insert_resource(PredictionManager::default());
+        app.init_resource::<SnapRuns>();
+        let client = app.world_mut().spawn_empty().id();
+        app.world_mut().resource_mut::<NetworkingMetadata>().mode = NetworkTopology::Client(client);
+        app.add_systems(
+            FixedPreUpdate,
+            count_snap_runs.in_set(PredictionSystems::SnapToConfirmed),
+        );
+
+        app.world_mut().run_schedule(FixedPreUpdate);
+        assert_eq!(app.world().resource::<SnapRuns>().0, 0);
+
+        app.insert_resource(Rollback::FromInputs);
+        app.world_mut().run_schedule(FixedPreUpdate);
+        assert_eq!(app.world().resource::<SnapRuns>().0, 1);
+    }
+
     #[test]
     fn prediction_pipeline_excludes_authoritative_topologies() {
         let mut app = App::new();
         app.init_resource::<NetworkingMetadata>();
-        app.enable_prediction(PredictionManager::default());
+        app.insert_resource(PredictionManager::default());
         let client = app.world_mut().spawn_empty().id();
         let server = app.world_mut().spawn_empty().id();
 

--- a/crates/replication/prediction/src/predicted_history.rs
+++ b/crates/replication/prediction/src/predicted_history.rs
@@ -397,6 +397,11 @@ pub(crate) fn add_history_diff_receiver<C: SyncComponent + RepliconDiffable>(
 
 /// During rollback re-simulation, check if we have a confirmed value for this tick.
 /// If so, snap the component to the confirmed value instead of using the predicted value.
+///
+/// [`PredictionSystems::SnapToConfirmed`](crate::plugin::PredictionSystems::SnapToConfirmed) gates
+/// this system with [`is_in_rollback`](lightyear_core::timeline::is_in_rollback), so the global
+/// [`Rollback`](lightyear_core::timeline::Rollback) resource does not need to be fetched by every
+/// monomorphized component system.
 pub(crate) fn snap_to_confirmed_during_rollback<
     C: Component<Mutability = Mutable> + Clone + PartialEq + Debug,
 >(

--- a/crates/replication/prediction/src/predicted_history.rs
+++ b/crates/replication/prediction/src/predicted_history.rs
@@ -93,14 +93,13 @@ impl<C> PredictionHistory<C> {
 ///
 /// This system only handles changes, removals are handled in `apply_component_removal`
 pub(crate) fn update_prediction_history<T: Component + Clone>(
-    manager: Single<&PredictionManager>,
+    manager: Res<PredictionManager>,
     input_config: Res<InputTimelineConfig>,
     mut query: Query<(Entity, Ref<T>, &mut PredictionHistory<T>)>,
     timeline: Res<LocalTimeline>,
 ) {
     // tick for which we will record the history (either the current client tick or the current rollback tick)
     let tick = timeline.tick();
-    let manager = manager.into_inner();
     let oldest_rollback_tick = tick
         - u32::from(
             manager
@@ -539,15 +538,14 @@ mod tests {
         let mut timeline = LocalTimeline::default();
         timeline.apply_delta(tick);
         app.insert_resource(timeline);
-        app.insert_resource(InputTimelineConfig::default().with_input_delay(input_delay_config));
-        app.world_mut().spawn(PredictionManager {
+        app.insert_resource(PredictionManager {
             rollback_policy: RollbackPolicy {
                 max_rollback_ticks,
                 ..Default::default()
             },
             ..Default::default()
         });
-        app.world_mut().flush();
+        app.insert_resource(InputTimelineConfig::default().with_input_delay(input_delay_config));
         app
     }
 

--- a/crates/replication/prediction/src/predicted_history.rs
+++ b/crates/replication/prediction/src/predicted_history.rs
@@ -18,7 +18,7 @@ use core::ops::{Deref, DerefMut};
 use lightyear_core::history_buffer::{HistoryBuffer, HistoryState};
 use lightyear_core::prelude::{ConfirmedHistory, LocalTimeline};
 use lightyear_core::tick::Tick;
-use lightyear_core::timeline::{Rollback, SyncEvent};
+use lightyear_core::timeline::SyncEvent;
 use lightyear_replication::diff_history::HistoryDiffReceiver;
 use lightyear_replication::prelude::PreSpawned;
 use lightyear_sync::prelude::InputTimelineConfig;
@@ -402,8 +402,6 @@ pub(crate) fn snap_to_confirmed_during_rollback<
 >(
     mut commands: Commands,
     timeline: Res<LocalTimeline>,
-    // Only run during rollback
-    rollback: Single<&Rollback>,
     mut query: Query<(Entity, Option<&mut C>, &ConfirmedHistory<C>), With<Predicted>>,
 ) {
     let tick = timeline.tick();

--- a/crates/replication/prediction/src/registry.rs
+++ b/crates/replication/prediction/src/registry.rs
@@ -1,4 +1,4 @@
-use crate::manager::{PredictionResource, RollbackMode, StateRollbackMetadata};
+use crate::manager::{RollbackMode, StateRollbackMetadata};
 use crate::plugin::{add_non_networked_rollback_systems, add_prediction_systems};
 use crate::predicted_history::PredictionHistory;
 use crate::prelude::PredictionManager;
@@ -1407,9 +1407,8 @@ fn add_resolved_confirmed_to_history<C: SyncComponent>(
         let state_metadata =
             world.resource::<StateRollbackMetadata>() as *const StateRollbackMetadata;
         let current_tick = world.resource::<LocalTimeline>().tick();
-        let prediction_link = world.resource::<PredictionResource>().link_entity;
         let should_check = world
-            .get::<PredictionManager>(prediction_link)
+            .get_resource::<PredictionManager>()
             .is_some_and(|m| matches!(m.rollback_policy.state, RollbackMode::Check));
         (unsafe { &*registry }, should_check, current_tick, unsafe {
             &*state_metadata
@@ -1446,9 +1445,8 @@ fn remove_history<C: SyncComponent>(ctx: &mut RemoveCtx, entity: &mut DeferredEn
         let state_metadata =
             world.resource::<StateRollbackMetadata>() as *const StateRollbackMetadata;
         let current_tick = world.resource::<LocalTimeline>().tick();
-        let prediction_link = world.resource::<PredictionResource>().link_entity;
         let should_check = world
-            .get::<PredictionManager>(prediction_link)
+            .get_resource::<PredictionManager>()
             .is_some_and(|m| matches!(m.rollback_policy.state, RollbackMode::Check));
         // SAFETY: registry lives in the World and won't be moved/dropped during this function
         (
@@ -1665,7 +1663,7 @@ mod tests {
         app.add_plugins((StatesPlugin, RepliconPlugins, PredictionPlugin));
         app.insert_resource(LocalTimeline::default());
         app.insert_resource(ReplicationCheckpointMap::default());
-        app.world_mut().spawn(PredictionManager::default());
+        app.insert_resource(PredictionManager::default());
         app.world_mut().flush();
         app.component::<TestDiffComponent>()
             .replicate_diff()

--- a/crates/replication/prediction/src/registry.rs
+++ b/crates/replication/prediction/src/registry.rs
@@ -1505,6 +1505,7 @@ mod tests {
     use lightyear_interpolation::prelude::{InterpolationRegistrationExt, InterpolationRegistry};
     use lightyear_replication::checkpoint::ReplicationCheckpointMap;
     use lightyear_replication::prelude::AppComponentExt;
+    use lightyear_sync::prelude::InputTimelineConfig;
     use serde::{Deserialize, Serialize};
 
     #[derive(Clone, PartialEq, Debug)]
@@ -1531,6 +1532,8 @@ mod tests {
             },
         ));
         app.init_resource::<PredictionRegistry>();
+        app.init_resource::<PredictionManager>();
+        app.init_resource::<InputTimelineConfig>();
         app
     }
 

--- a/crates/replication/prediction/src/rollback.rs
+++ b/crates/replication/prediction/src/rollback.rs
@@ -36,9 +36,7 @@ use super::predicted_history::PredictionHistory;
 use crate::correction::PreviousVisual;
 use crate::despawn::PredictionDisable;
 use crate::diagnostics::PredictionMetrics;
-use crate::manager::{
-    LastConfirmedInput, PredictionManager, PredictionResource, RollbackMode, StateRollbackMetadata,
-};
+use crate::manager::{LastConfirmedInput, PredictionManager, RollbackMode, StateRollbackMetadata};
 use crate::plugin::PredictionSystems;
 use crate::registry::PredictionRegistry;
 use alloc::vec::Vec;
@@ -56,8 +54,7 @@ use bevy_replicon::shared::backend::channels::ServerChannel;
 use bevy_time::{Fixed, Time};
 use bevy_utils::prelude::DebugName;
 use core::fmt::Debug;
-use lightyear_connection::client::{Client, Connected};
-use lightyear_connection::host::HostClient;
+use lightyear_connection::network_topology::NetworkingMetadata;
 use lightyear_core::history_buffer::HistoryState;
 use lightyear_core::prelude::{ConfirmedHistory, LocalTimeline};
 use lightyear_core::tick::Tick;
@@ -99,7 +96,7 @@ pub enum RollbackSystems {
     Rollback,
     /// Logic that returns right after the rollback is done:
     /// - Setting the VisualCorrection
-    /// - Removing the Rollback component
+    /// - Removing the [`Rollback`] resource
     EndRollback,
 
     // PostUpdate
@@ -116,7 +113,16 @@ struct NoRollbackCheckTargets;
 impl Plugin for RollbackPlugin {
     fn build(&self, app: &mut App) {
         // RESOURCES
+        // `PredictionPlugin` can also be installed directly in small or test applications without
+        // the full Lightyear plugin group. Keep the cached topology available to the common
+        // rollback pipeline in those applications too.
+        app.init_resource::<NetworkingMetadata>();
         app.init_resource::<StateRollbackMetadata>();
+        // Input-only prediction does not install the replication backend. Empty registries and
+        // checkpoint state keep the state-reconciliation branch dormant while allowing the common
+        // rollback decision system to operate on remote inputs.
+        app.init_resource::<ComponentRegistry>();
+        app.init_resource::<ReplicationCheckpointMap>();
 
         // SETS
         app.configure_sets(
@@ -144,7 +150,7 @@ impl Plugin for RollbackPlugin {
         app.add_systems(
             PreUpdate,
             (
-                reset_state_rollback_metadata_if_disconnected.before(RollbackSystems::Check),
+                reset_state_rollback_metadata_on_topology_change.before(RollbackSystems::Check),
                 check_received_replication_messages
                     .after(ClientSystems::ReceivePackets)
                     .before(ClientSystems::Receive),
@@ -283,14 +289,7 @@ impl DeterministicPredicted {
         // TODO: avoid fetching DeterministicPredicted twice when we can convert DeferredWorld to UnsafeWorldCell (0.17.3)
         let deterministic_predicted = *world.get::<DeterministicPredicted>(context.entity).unwrap();
         let tick = world.resource::<LocalTimeline>().tick();
-        let Some(prediction_manager_entity) = world
-            .get_resource::<PredictionResource>()
-            .map(|r| r.link_entity)
-        else {
-            return;
-        };
-        let Some(mut manager) = world.get_mut::<PredictionManager>(prediction_manager_entity)
-        else {
+        let Some(mut manager) = world.get_resource_mut::<PredictionManager>() else {
             return;
         };
         if !deterministic_predicted.skip_despawn {
@@ -317,33 +316,26 @@ pub struct DisabledDuringRollback;
 /// Set a flag if we received any replication message this frame.
 /// Also reset the per-frame state.
 fn check_received_replication_messages(
-    client_messages: Res<ClientMessages>,
+    client_messages: Option<Res<ClientMessages>>,
     mut metadata: ResMut<StateRollbackMetadata>,
 ) {
     // Reset per-frame state
     metadata.reset_frame_state();
 
     // Check if we received any replication messages
-    if client_messages.received_count(ServerChannel::Updates) > 0
-        || client_messages.received_count(ServerChannel::Mutations) > 0
-    {
+    if client_messages.is_some_and(|messages| {
+        messages.received_count(ServerChannel::Updates) > 0
+            || messages.received_count(ServerChannel::Mutations) > 0
+    }) {
         metadata.received_messages_this_frame = true;
     }
 }
 
-fn reset_state_rollback_metadata_if_disconnected(
-    query: Query<
-        (),
-        (
-            With<PredictionManager>,
-            With<Client>,
-            With<Connected>,
-            Without<HostClient>,
-        ),
-    >,
+fn reset_state_rollback_metadata_on_topology_change(
+    networking: Res<NetworkingMetadata>,
     mut metadata: ResMut<StateRollbackMetadata>,
 ) {
-    if query.single().is_err() {
+    if networking.is_changed() {
         metadata.reset_connection_state();
     }
 }
@@ -364,12 +356,10 @@ fn check_rollback(
     _input_timeline: SyncedInputTimeline,
     input_config: Res<InputTimelineConfig>,
     last_confirmed_input: Res<LastConfirmedInput>,
+    mut prediction_manager: ResMut<PredictionManager>,
     mut state_metadata: ResMut<StateRollbackMetadata>,
     checkpoints: Res<ReplicationCheckpointMap>,
-    receiver_query: Single<
-        (Entity, &mut PredictionManager, &mut PreSpawnedReceiver),
-        (With<Client>, Without<HostClient>),
-    >,
+    mut prespawned_receivers: Query<&mut PreSpawnedReceiver>,
     component_registry: Res<ComponentRegistry>,
     prediction_registry: Res<PredictionRegistry>,
     awaiting_catchup: Query<(), (With<CatchUpGated>, With<ConfirmHistory>)>,
@@ -380,8 +370,6 @@ fn check_rollback(
     #[cfg(feature = "metrics")]
     let _timer = timer_gauge!("prediction/rollback/check");
 
-    let (manager_entity, mut prediction_manager, mut prespawned_receiver) =
-        receiver_query.into_inner();
     let tick = timeline.tick();
     let received_state = state_metadata.received_messages_this_frame;
     let max_rollback_ticks = prediction_manager
@@ -409,7 +397,6 @@ fn check_rollback(
                 kind = "rollback_rejected",
                 schedule = "PreUpdate",
                 sample_point = "PreUpdate",
-                entity = ?manager_entity,
                 local_tick = tick.0,
                 rollback_tick = rollback_tick.0,
                 rollback_delta = delta,
@@ -421,13 +408,12 @@ fn check_rollback(
             return;
         }
         prediction_manager.set_rollback_tick(rollback_tick);
-        commands.entity(manager_entity).insert(rollback);
+        commands.insert_resource(rollback);
         trace!(
             target: "lightyear_debug::prediction",
             kind = "rollback_requested",
             schedule = "PreUpdate",
             sample_point = "PreUpdate",
-            entity = ?manager_entity,
             local_tick = tick.0,
             rollback_tick = rollback_tick.0,
             rollback_delta = delta,
@@ -740,17 +726,19 @@ fn check_rollback(
             })
             .collect::<Vec<_>>();
         // If the prespawned entity didn't exist at the rollback tick, despawn it
-        prespawned_receiver.despawn_prespawned_after_with(
-            rollback_tick + 1,
-            |entity| {
-                protected_prespawn_entities.contains(&entity)
-                    || (forced_rollback_requested
-                        && deterministic_predicted
-                            .get(entity)
-                            .is_ok_and(|predicted| predicted.skip_despawn))
-            },
-            &mut commands,
-        );
+        if let Ok(mut prespawned_receiver) = prespawned_receivers.single_mut() {
+            prespawned_receiver.despawn_prespawned_after_with(
+                rollback_tick + 1,
+                |entity| {
+                    protected_prespawn_entities.contains(&entity)
+                        || (forced_rollback_requested
+                            && deterministic_predicted
+                                .get(entity)
+                                .is_ok_and(|predicted| predicted.skip_despawn))
+                },
+                &mut commands,
+            );
+        }
 
         // If the deterministic predicted entity didn't exist at the rollback tick, despawn it
         // We can drain everything because:
@@ -827,7 +815,7 @@ fn check_rollback(
 pub fn reset_input_rollback_tracker(
     _input_timeline: SyncedInputTimeline,
     last_confirmed_input: Res<LastConfirmedInput>,
-    prediction_manager: Option<Single<&PredictionManager, With<Client>>>,
+    prediction_manager: Option<Res<PredictionManager>>,
 ) {
     // Reset to u32::MAX so the next `set_if_lower` call always wins and we
     // compute the true minimum across all remote clients for this frame.
@@ -838,7 +826,7 @@ pub fn reset_input_rollback_tracker(
     last_confirmed_input
         .received_any_messages
         .store(false, bevy_platform::sync::atomic::Ordering::Relaxed);
-    if let Some(prediction_manager) = prediction_manager.as_deref() {
+    if let Some(prediction_manager) = prediction_manager {
         prediction_manager
             .earliest_mismatch_input
             .tick
@@ -891,10 +879,10 @@ pub(crate) fn prepare_rollback<C: Component<Mutability = Mutable> + Clone>(
         ),
         Without<DisableRollback>,
     >,
-    manager_query: Single<(&PredictionManager, &Rollback)>,
+    manager: Res<PredictionManager>,
+    rollback: Res<Rollback>,
 ) {
     let kind = DebugName::type_name::<C>();
-    let (manager, rollback) = manager_query.into_inner();
     let current_tick = timeline.tick();
     let _span = trace_span!("prepare_rollback", tick = ?current_tick, kind = ?kind).entered();
     let rollback_tick = manager.get_rollback_start_tick().unwrap();
@@ -905,7 +893,7 @@ pub(crate) fn prepare_rollback<C: Component<Mutability = Mutable> + Clone>(
     for (entity, predicted_component, mut predicted_history, confirmed_history) in
         predicted_query.iter_mut()
     {
-        let is_state_rollback = matches!(rollback, Rollback::FromState);
+        let is_state_rollback = matches!(*rollback, Rollback::FromState);
         let is_completed_state_rollback =
             is_state_rollback && server_confirmed_tick == Some(rollback_tick);
         let is_forced_state_rollback = is_state_rollback && !is_completed_state_rollback;
@@ -1068,9 +1056,7 @@ pub(crate) fn run_rollback(world: &mut World) {
     let local_timeline = world.resource_mut::<LocalTimeline>();
     let current_tick = local_timeline.tick();
     let rollback_start_tick = world
-        .query::<&PredictionManager>()
-        .single(world)
-        .unwrap()
+        .resource::<PredictionManager>()
         .get_rollback_start_tick()
         .expect("we should be in rollback");
 
@@ -1187,22 +1173,22 @@ pub(crate) fn run_rollback(world: &mut World) {
 }
 
 pub(crate) fn end_rollback(
-    prediction_manager: Single<(Entity, &PredictionManager), With<Rollback>>,
+    prediction_manager: Res<PredictionManager>,
+    rollback: Res<Rollback>,
     mut commands: Commands,
 ) {
-    let (entity, prediction_manager) = prediction_manager.into_inner();
     let rollback_tick = prediction_manager.get_rollback_start_tick();
     trace!(
         target: "lightyear_debug::prediction",
         kind = "rollback_end",
         schedule = "PreUpdate",
         sample_point = "PreUpdate",
-        entity = ?entity,
+        rollback = ?*rollback,
         rollback_tick = ?rollback_tick,
         "ending rollback"
     );
     prediction_manager.set_non_rollback();
-    commands.entity(entity).remove::<Rollback>();
+    commands.remove_resource::<Rollback>();
 }
 
 #[cfg(feature = "metrics")]
@@ -1253,12 +1239,10 @@ mod tests {
         world.init_resource::<PredictionRegistry>();
         world.init_resource::<ReplicationCheckpointMap>();
 
-        let manager = world
-            .spawn((PredictionManager::default(), Rollback::FromState))
-            .id();
+        world.insert_resource(PredictionManager::default());
+        world.insert_resource(Rollback::FromState);
         world
-            .get_mut::<PredictionManager>(manager)
-            .unwrap()
+            .resource::<PredictionManager>()
             .set_rollback_tick(rollback_tick);
 
         let mut history = PredictionHistory::<TestComponent>::default();

--- a/crates/replication/prediction/src/rollback.rs
+++ b/crates/replication/prediction/src/rollback.rs
@@ -1273,9 +1273,8 @@ mod tests {
         world.init_resource::<PredictionRegistry>();
         world.init_resource::<ReplicationCheckpointMap>();
 
-        let manager = world
-            .spawn((PredictionManager::default(), Rollback::FromInputs))
-            .id();
+        world.insert_resource(PredictionManager::default());
+        world.insert_resource(Rollback::FromInputs);
 
         let mut history = PredictionHistory::<TestComponent>::default();
         for tick in [8, 10, 12, 15] {
@@ -1287,8 +1286,7 @@ mod tests {
         // strictly newer entries are discarded, and the component restores
         // to the floor sample at the target.
         world
-            .get_mut::<PredictionManager>(manager)
-            .unwrap()
+            .resource::<PredictionManager>()
             .set_rollback_tick(Tick(12));
         world
             .run_system_once(prepare_rollback::<TestComponent>)
@@ -1317,8 +1315,7 @@ mod tests {
         // Second, DEEPER rollback to tick 8: restores from the preserved
         // per-tick sample, not from the live post-first-rollback value.
         world
-            .get_mut::<PredictionManager>(manager)
-            .unwrap()
+            .resource::<PredictionManager>()
             .set_rollback_tick(Tick(8));
         world
             .run_system_once(prepare_rollback::<TestComponent>)

--- a/crates/replication/prediction/src/rollback.rs
+++ b/crates/replication/prediction/src/rollback.rs
@@ -236,6 +236,7 @@ impl Plugin for RollbackPlugin {
             ParamBuilder,
             ParamBuilder,
             ParamBuilder,
+            ParamBuilder,
         )
             .build_state(app.world_mut())
             .build_system(check_rollback)

--- a/crates/replication/replication/src/REPLICON_INTEGRATION.md
+++ b/crates/replication/replication/src/REPLICON_INTEGRATION.md
@@ -104,7 +104,7 @@ The `PreSpawnedReceiver::matches()` method exists but is never called. In the ol
 Rollback via `write_history` → `StateRollbackMetadata` → `check_rollback` is not triggering. Possible causes:
 
 - `PredictionManager.rollback_policy.state` may not be `RollbackMode::Check` — verify it's set correctly during test setup
-- `PredictionResource.link_entity` may point to the wrong entity
+- the application may not contain the global `PredictionManager` resource
 - `ServerMutateTicks.last_tick()` may not be advancing (replicon may not be calling `confirm()` in the test stepper's transport path)
 - `check_received_replication_messages` uses `ClientMessages.received_count()` which may not reflect messages received through the lightyear transport bridge
 
@@ -112,7 +112,7 @@ Rollback via `write_history` → `StateRollbackMetadata` → `check_rollback` is
 1. Add trace logging to `write_history` to confirm it's being called and `should_check` is true
 2. Check that `StateRollbackMetadata.should_rollback` is set after a server mutation
 3. Verify `ServerMutateTicks.last_tick()` advances when mutation messages arrive
-4. Check that the global `InputTimeline` resource is synced and the `check_rollback` system's `Single` query succeeds (entity has `Client + PredictionManager + !HostClient`)
+4. Check that the global `InputTimeline` resource is synced and the application contains its global `PredictionManager`
 
 **Ignored tests**: `test_rollback_time_resource`, `test_deterministic_predicted_skip_despawn`, `test_despawned_predicted_rollback`, `test_update_history` (also has tick timing issue)
 

--- a/crates/tests/src/client_server/deterministic/state_based_catchup.rs
+++ b/crates/tests/src/client_server/deterministic/state_based_catchup.rs
@@ -371,8 +371,8 @@ fn sample_pre_physics_state(
     players: Query<(Entity, &DetPlayerId)>,
     balls: Query<Entity, With<DetBallMarker>>,
     walls: Query<Entity, With<DetWallMarker>>,
-    rollback_markers: Query<&Rollback>,
-    prediction_managers: Query<&PredictionManager>,
+    rollback: Option<Res<Rollback>>,
+    prediction_manager: Option<Res<PredictionManager>>,
 ) {
     sample_physics_state(
         SampleStage::PrePhysics,
@@ -385,8 +385,8 @@ fn sample_pre_physics_state(
         players,
         balls,
         walls,
-        rollback_markers,
-        prediction_managers,
+        rollback,
+        prediction_manager,
     );
 }
 
@@ -403,8 +403,8 @@ fn sample_post_physics_state(
     players: Query<(Entity, &DetPlayerId)>,
     balls: Query<Entity, With<DetBallMarker>>,
     walls: Query<Entity, With<DetWallMarker>>,
-    rollback_markers: Query<&Rollback>,
-    prediction_managers: Query<&PredictionManager>,
+    rollback: Option<Res<Rollback>>,
+    prediction_manager: Option<Res<PredictionManager>>,
 ) {
     sample_physics_state(
         SampleStage::PostPhysics,
@@ -417,8 +417,8 @@ fn sample_post_physics_state(
         players,
         balls,
         walls,
-        rollback_markers,
-        prediction_managers,
+        rollback,
+        prediction_manager,
     );
 }
 
@@ -437,14 +437,13 @@ fn sample_physics_state(
     players: Query<(Entity, &DetPlayerId)>,
     balls: Query<Entity, With<DetBallMarker>>,
     walls: Query<Entity, With<DetWallMarker>>,
-    rollback_markers: Query<&Rollback>,
-    prediction_managers: Query<&PredictionManager>,
+    rollback: Option<Res<Rollback>>,
+    prediction_manager: Option<Res<PredictionManager>>,
 ) {
     let tick = timeline.tick();
-    let rollback = rollback_markers.iter().next().copied();
-    let rollback_start = prediction_managers
-        .iter()
-        .next()
+    let rollback = rollback.as_deref().copied();
+    let rollback_start = prediction_manager
+        .as_deref()
         .and_then(PredictionManager::get_rollback_start_tick);
     for (id, position, velocity) in &player_motion {
         motion_samples.0.push(StageMotionSample {
@@ -531,16 +530,15 @@ fn sample_positions(
     >,
     action_players: Query<(Entity, &DetPlayerId)>,
     action_buffers: Query<(&ActionOf<Player>, &DetBuffer)>,
-    rollback_markers: Query<&Rollback>,
-    prediction_managers: Query<&PredictionManager>,
+    rollback: Option<Res<Rollback>>,
+    prediction_manager: Option<Res<PredictionManager>>,
 ) {
     use bevy::ecs::relationship::Relationship;
 
     let tick = timeline.tick().0;
-    let rollback = rollback_markers.iter().next().copied();
-    let rollback_start = prediction_managers
-        .iter()
-        .next()
+    let rollback = rollback.as_deref().copied();
+    let rollback_start = prediction_manager
+        .as_deref()
         .and_then(PredictionManager::get_rollback_start_tick);
     execution_samples.0.push(ExecutionSample {
         tick: Tick(tick),

--- a/crates/tests/src/client_server/deterministic/stepper.rs
+++ b/crates/tests/src/client_server/deterministic/stepper.rs
@@ -131,6 +131,14 @@ impl DetStepper {
                 .with_input_delay(InputDelayConfig::fixed_input_delay(0))
                 .with_sync_config(sync),
         );
+        client_app.insert_resource(PredictionManager {
+            rollback_policy: RollbackPolicy {
+                state: RollbackMode::Disabled,
+                input: RollbackMode::Check,
+                max_rollback_ticks: 100,
+            },
+            ..default()
+        });
 
         let client_entity = client_app
             .world_mut()
@@ -142,14 +150,6 @@ impl DetStepper {
                 ReplicationSender,
                 ReplicationReceiver,
                 crossbeam_client,
-                PredictionManager {
-                    rollback_policy: RollbackPolicy {
-                        state: RollbackMode::Disabled,
-                        input: RollbackMode::Check,
-                        max_rollback_ticks: 100,
-                    },
-                    ..default()
-                },
                 NetcodeClient::new(auth, NetcodeConfig::default()).unwrap(),
             ))
             .id();

--- a/crates/tests/src/client_server/diff.rs
+++ b/crates/tests/src/client_server/diff.rs
@@ -181,7 +181,7 @@ fn setup_prediction_receive_app() -> (App, bevy_replicon::shared::replication::r
     ));
     app.insert_resource(lightyear_core::prelude::LocalTimeline::default());
     app.insert_resource(ReplicationCheckpointMap::default());
-    app.world_mut().spawn(PredictionManager::default());
+    app.insert_resource(PredictionManager::default());
     app.world_mut().flush();
     app.component::<CompRepliconDiff>()
         .replicate_diff()

--- a/crates/tests/src/client_server/input/native.rs
+++ b/crates/tests/src/client_server/input/native.rs
@@ -276,7 +276,7 @@ fn test_input_broadcasting_prediction() {
     // check that during rollbacks, we fetch the input value from the input buffer even for remote inputs
     let check_input =
         move |timeline: Res<LocalTimeline>,
-              c: Single<(), With<Rollback>>,
+              _rollback: Res<Rollback>,
               q: Single<&ActionState<MyInput>, Without<InputMarker<MyInput>>>| {
             let tick = timeline.tick();
             info!(
@@ -307,11 +307,10 @@ fn test_input_broadcasting_prediction() {
 
     // trigger rollback for client 1
     let rollback_tick = client1_tick - 1;
-    stepper.client_mut(1).insert(Rollback::FromInputs);
-    stepper
-        .client_mut(1)
-        .get_mut::<PredictionManager>()
-        .unwrap()
+    stepper.client_apps[1].insert_resource(Rollback::FromInputs);
+    stepper.client_apps[1]
+        .world()
+        .resource::<PredictionManager>()
         .set_rollback_tick(rollback_tick);
     stepper.client_apps[1].update();
 }

--- a/crates/tests/src/client_server/prediction/mod.rs
+++ b/crates/tests/src/client_server/prediction/mod.rs
@@ -86,10 +86,10 @@ pub(crate) fn trigger_rollback_check_without_completed_tick(
 }
 
 pub(crate) fn trigger_state_rollback(stepper: &mut ClientServerStepper, tick: Tick) {
-    stepper.client_mut(0).insert(Rollback::FromState);
+    stepper.client_app().insert_resource(Rollback::FromState);
     stepper
-        .client_mut(0)
-        .get_mut::<PredictionManager>()
-        .unwrap()
+        .client_app()
+        .world()
+        .resource::<PredictionManager>()
         .set_rollback_tick(tick);
 }

--- a/crates/tests/src/client_server/prediction/rollback.rs
+++ b/crates/tests/src/client_server/prediction/rollback.rs
@@ -22,6 +22,7 @@ use lightyear_prediction::manager::{LastConfirmedInput, RollbackMode, StateRollb
 use lightyear_prediction::prelude::*;
 use lightyear_prediction::rollback::{DeterministicPredicted, reset_input_rollback_tracker};
 use lightyear_replication::prelude::*;
+use lightyear_replication::prespawn::PreSpawnedReceiver;
 use test_log::test;
 
 fn setup() -> (ClientServerStepper, Entity) {
@@ -69,7 +70,7 @@ fn record_completed_mutate_tick(world: &mut World, replicon_tick: RepliconTick, 
 struct ObservedRollbackStart(Option<Tick>);
 
 fn record_rollback_start(
-    manager: Single<&PredictionManager>,
+    manager: Res<PredictionManager>,
     mut observed: ResMut<ObservedRollbackStart>,
 ) {
     if observed.0.is_none() {
@@ -897,10 +898,7 @@ fn test_missing_confirm_history_checkpoint_mapping_does_not_request_rollback() {
     #[derive(Resource, Default)]
     struct RollbackObserved(bool);
 
-    fn record_rollback(
-        manager: Single<&PredictionManager>,
-        mut observed: ResMut<RollbackObserved>,
-    ) {
+    fn record_rollback(manager: Res<PredictionManager>, mut observed: ResMut<RollbackObserved>) {
         observed.0 |= manager.get_rollback_start_tick().is_some();
     }
 
@@ -1164,10 +1162,10 @@ fn test_rollback_time_resource() {
     fn track_time(
         time: Res<Time>,
         mut time_tracker: ResMut<TimeTracker>,
-        rollback: Single<&PredictionManager>,
+        manager: Res<PredictionManager>,
     ) {
         time_tracker.snapshots.push(TimeSnapshot {
-            is_rollback: rollback.is_rollback(),
+            is_rollback: manager.is_rollback(),
             delta: time.delta(),
             elapsed: time.elapsed(),
         });
@@ -1229,8 +1227,9 @@ fn setup_stepper_for_input_rollback(
 ) -> (ClientServerStepper, Entity, Entity, Entity, Entity) {
     let mut stepper = ClientServerStepper::from_config(StepperConfig::with_netcode_clients(3));
 
-    let mut client_mut = stepper.client_mut(0);
-    let mut prediction_manager = client_mut.get_mut::<PredictionManager>().unwrap();
+    let mut prediction_manager = stepper.client_apps[0]
+        .world_mut()
+        .resource_mut::<PredictionManager>();
     prediction_manager.rollback_policy.input = mode;
     prediction_manager.rollback_policy.state = RollbackMode::Disabled;
 
@@ -1315,11 +1314,24 @@ fn setup_stepper_for_input_rollback(
     )
 }
 
-/// Test that we rollback from the last confirmed input when RollbackMode::Always for inputs
+/// Test that input-only prediction rolls back without any replication state on its client Link.
 #[test]
-fn test_input_rollback_always_mode() {
+fn test_input_rollback_always_mode_without_replication_receiver() {
     let (mut stepper, _, _, client_entity, _) =
         setup_stepper_for_input_rollback(RollbackMode::Always);
+
+    let client_link = stepper.client(0).id();
+    stepper.client_apps[0]
+        .world_mut()
+        .entity_mut(client_link)
+        .remove::<ReplicationReceiver>()
+        .remove::<PreSpawnedReceiver>();
+    assert!(
+        stepper.client_apps[0]
+            .world()
+            .get::<PreSpawnedReceiver>(client_link)
+            .is_none()
+    );
 
     // build a steady state where have already received an input
     stepper.frame_step(2);
@@ -1333,7 +1345,7 @@ fn test_input_rollback_always_mode() {
     let check_rollback_start =
         move |timeline: Res<LocalTimeline>,
               last_confirmed_input: Res<LastConfirmedInput>,
-              manager: Single<&PredictionManager>| {
+              manager: Res<PredictionManager>| {
             let tick = timeline.tick();
             if tick == input_tick {
                 assert!(last_confirmed_input.received_input());
@@ -1387,13 +1399,13 @@ fn test_input_rollback_always_mode() {
 fn test_input_rollback_always_ignores_unset_last_confirmed_tick() {
     let mut stepper = ClientServerStepper::from_config(StepperConfig::single());
     {
-        let mut client = stepper.client_mut(0);
         {
-            let mut prediction_manager = client.get_mut::<PredictionManager>().unwrap();
+            let mut prediction_manager = stepper.client_apps[0]
+                .world_mut()
+                .resource_mut::<PredictionManager>();
             prediction_manager.rollback_policy.input = RollbackMode::Always;
             prediction_manager.rollback_policy.state = RollbackMode::Disabled;
         }
-        drop(client);
         let last_confirmed_input = stepper.client_apps[0]
             .world()
             .resource::<LastConfirmedInput>();
@@ -1465,8 +1477,7 @@ fn test_input_rollback_check_mode_earliest_mismatch() {
     let input_tick = stepper.client_tick(1);
 
     let check_rollback_start =
-        move |timeline: Res<LocalTimeline>, manager: Single<&PredictionManager>| {
-            let manager = manager.into_inner();
+        move |timeline: Res<LocalTimeline>, manager: Res<PredictionManager>| {
             let tick = timeline.tick();
             if tick == input_tick {
                 assert!(manager.earliest_mismatch_input.has_mismatches());
@@ -1501,8 +1512,7 @@ fn test_no_rollback_without_input_mismatches() {
     let input_tick = stepper.client_tick(1);
 
     let check_rollback_start =
-        move |timeline: Res<LocalTimeline>, manager: Single<&PredictionManager>| {
-            let manager = manager.into_inner();
+        move |timeline: Res<LocalTimeline>, manager: Res<PredictionManager>| {
             let tick = timeline.tick();
             if tick == input_tick {
                 assert!(!manager.earliest_mismatch_input.has_mismatches());

--- a/crates/tests/src/stepper.rs
+++ b/crates/tests/src/stepper.rs
@@ -442,6 +442,7 @@ impl ClientServerStepper {
             );
             return 0;
         }
+        client_app.insert_resource(PredictionManager::default());
         let mut client = client_app.world_mut().spawn((
             Client,
             // Send pings every frame, so that the Acks are sent every frame
@@ -452,7 +453,6 @@ impl ClientServerStepper {
             ReplicationReceiver,
             #[cfg(feature = "test_utils")]
             TestHelper::default(),
-            PredictionManager::default(),
         ));
         match self.io {
             IoType::Crossbeam => {

--- a/examples/common/src/client.rs
+++ b/examples/common/src/client.rs
@@ -45,15 +45,16 @@ impl ExampleClient {
     fn on_add(mut world: DeferredWorld, context: HookContext) {
         let entity = context.entity;
         world.commands().queue(move |world: &mut World| -> Result {
+            world.insert_resource(PredictionManager::default());
             let mut entity_mut = world.entity_mut(entity);
             let settings = entity_mut.take::<ExampleClient>().unwrap();
             let client_addr = SocketAddr::new(Ipv4Addr::UNSPECIFIED.into(), settings.client_port);
             entity_mut.insert((
                 Client,
+                ReplicationReceiver,
                 Link::default().with_conditioner(settings.conditioner.clone()),
                 LocalAddr(client_addr),
                 PeerAddr(settings.server_addr),
-                PredictionManager::default(),
                 Name::from("Client"),
             ));
 

--- a/examples/deterministic_replication/src/main.rs
+++ b/examples/deterministic_replication/src/main.rs
@@ -44,6 +44,7 @@ fn main() {
         #[cfg(feature = "client")]
         Some(Mode::Client { .. }) => {
             app.add_plugins(ExampleClientPlugin);
+            enable_prediction(&mut app);
             add_input_delay(&mut app);
         }
         #[cfg(feature = "server")]
@@ -70,26 +71,27 @@ fn main() {
 }
 
 #[cfg(feature = "client")]
-fn add_input_delay(app: &mut App) {
-    use lightyear::prelude::client::{InputDelayConfig, InputTimelineConfig};
-    use lightyear::prelude::{Client, PredictionManager, RollbackMode, RollbackPolicy, SyncConfig};
-    let client = app
-        .world_mut()
-        .query_filtered::<Entity, With<Client>>()
-        .single(app.world_mut())
-        .unwrap();
+fn enable_prediction(app: &mut App) {
+    use lightyear::prelude::{PredictionAppExt, PredictionManager, RollbackMode, RollbackPolicy};
 
-    // set some input-delay since we are predicting all entities
-    app.world_mut()
-        .entity_mut(client)
-        .insert(PredictionManager {
-            rollback_policy: RollbackPolicy {
-                state: RollbackMode::Disabled,
-                input: RollbackMode::Check,
-                max_rollback_ticks: 100,
-            },
-            ..default()
-        });
+    app.enable_prediction(PredictionManager {
+        rollback_policy: RollbackPolicy {
+            state: RollbackMode::Disabled,
+            input: RollbackMode::Check,
+            max_rollback_ticks: 100,
+        },
+        ..default()
+    });
+}
+
+#[cfg(feature = "client")]
+fn add_input_delay(app: &mut App) {
+    use lightyear::prelude::SyncConfig;
+    use lightyear::prelude::client::{InputDelayConfig, InputTimelineConfig};
+
+    // Set some input delay since a remote client predicts all deterministic entities. The
+    // host-client uses the same delayed input timeline but does not enable rollback for its
+    // authoritative in-process simulation.
     app.insert_resource(
         InputTimelineConfig::default()
             .with_sync_config(SyncConfig {

--- a/examples/deterministic_replication/src/main.rs
+++ b/examples/deterministic_replication/src/main.rs
@@ -72,9 +72,9 @@ fn main() {
 
 #[cfg(feature = "client")]
 fn enable_prediction(app: &mut App) {
-    use lightyear::prelude::{PredictionAppExt, PredictionManager, RollbackMode, RollbackPolicy};
+    use lightyear::prelude::{PredictionManager, RollbackMode, RollbackPolicy};
 
-    app.enable_prediction(PredictionManager {
+    app.insert_resource(PredictionManager {
         rollback_policy: RollbackPolicy {
             state: RollbackMode::Disabled,
             input: RollbackMode::Check,

--- a/examples/fps/src/debug.rs
+++ b/examples/fps/src/debug.rs
@@ -213,10 +213,10 @@ fn track_bullet_lifecycle_added(
         ),
         Added<BulletMarker>,
     >,
-    rollback: Query<(), With<Rollback>>,
+    rollback: Option<Res<Rollback>>,
 ) {
     let tick = timeline.tick();
-    let in_rollback = !rollback.is_empty();
+    let in_rollback = rollback.is_some();
     for (
         entity,
         marker,
@@ -258,10 +258,10 @@ fn track_bullet_lifecycle_removed(
     timeline: Res<LocalTimeline>,
     mut registry: ResMut<BulletDebugRegistry>,
     mut removed: RemovedComponents<BulletMarker>,
-    rollback: Query<(), With<Rollback>>,
+    rollback: Option<Res<Rollback>>,
 ) {
     let tick = timeline.tick();
-    let in_rollback = !rollback.is_empty();
+    let in_rollback = rollback.is_some();
     for entity in removed.read() {
         let marker = registry.bullets.remove(&entity);
         lightyear_debug_event!(
@@ -298,7 +298,7 @@ fn detect_duplicate_bullets(
         ),
         With<BulletMarker>,
     >,
-    rollback: Query<(), With<Rollback>>,
+    rollback: Option<Res<Rollback>>,
 ) {
     #[derive(Debug)]
     struct BulletDuplicateState {
@@ -314,7 +314,7 @@ fn detect_duplicate_bullets(
     }
 
     let tick = timeline.tick();
-    let in_rollback = !rollback.is_empty();
+    let in_rollback = rollback.is_some();
     let mut groups: HashMap<u64, Vec<BulletDuplicateState>> = HashMap::new();
     for (
         entity,

--- a/examples/projectiles/src/server.rs
+++ b/examples/projectiles/src/server.rs
@@ -455,6 +455,7 @@ mod bot {
             InputTimelineConfig::default()
                 .with_input_delay(InputDelayConfig::fixed_input_delay(BOT_INPUT_DELAY_TICKS)),
         );
+        app.enable_prediction(PredictionManager::default());
 
         app.world_mut().spawn((
             Client,
@@ -468,7 +469,6 @@ mod bot {
             )
             .unwrap(),
             crossbeam_client,
-            PredictionManager::default(),
             Name::from("BotClient"),
         ));
         let server = server.into_inner();

--- a/examples/projectiles/src/server.rs
+++ b/examples/projectiles/src/server.rs
@@ -455,7 +455,7 @@ mod bot {
             InputTimelineConfig::default()
                 .with_input_delay(InputDelayConfig::fixed_input_delay(BOT_INPUT_DELAY_TICKS)),
         );
-        app.enable_prediction(PredictionManager::default());
+        app.insert_resource(PredictionManager::default());
 
         app.world_mut().spawn((
             Client,

--- a/examples/projectiles/src/shared.rs
+++ b/examples/projectiles/src/shared.rs
@@ -269,7 +269,7 @@ pub(crate) fn shoot_weapon(
         ),
         With<ClientContext>,
     >,
-    rollback: Query<(), With<Rollback>>,
+    rollback: Option<Res<Rollback>>,
 ) {
     let tick = timeline.tick();
     let tick_duration = tick_duration.0;
@@ -302,7 +302,7 @@ pub(crate) fn shoot_weapon(
 
         weapon.last_fire_tick = Some(tick);
 
-        let in_rollback = rollback.single().is_ok();
+        let in_rollback = rollback.is_some();
         if !is_server
             && in_rollback
             && replication_mode != &GameReplicationMode::OnlyInputsReplicated


### PR DESCRIPTION
Stacked on #1627.

## Summary

- make `PredictionManager` and active `Rollback` application-global resources
- remove `PredictionResource` and all manager/rollback Link selection queries
- opt into prediction by inserting `PredictionManager`; an observer initializes `LastConfirmedInput`, with plugin-order backfill
- gate the single prediction pipeline through cached `Client` or `P2P` topology
- keep `PreSpawnedReceiver` Link-local by requiring it from `ReplicationReceiver`
- let shared rollback machinery run input-only without replication messages, receivers, or prespawn state
- complete global resource access in prediction-history pruning and rollback test setup
- retain current `main` RollbackPolicy behavior and effective prediction-window bound

## Validation

- `cargo test -p lightyear_prediction --all-features`
- rollback integration tests for Always, Check, missing replication receiver, and multi-client confirmed input
- targeted all-feature clippy across prediction and its dependent stack