### PR TITLE
feat(sync): aggregate P2P timeline pacing

### DIFF
--- a/crates/core/sync/src/lib.rs
+++ b/crates/core/sync/src/lib.rs
@@ -42,13 +42,17 @@ pub mod prelude {
     };
     pub use crate::timeline::{
         DrivingTimeline,
-        input::{InputTimeline, InputTimelineConfig, SyncedInputTimeline},
+        input::{
+            InputTimeline, InputTimelineConfig, PREDICTION_WINDOW_HYSTERESIS_TICKS,
+            PredictionWindowWait, SyncedInputTimeline,
+        },
     };
 
     #[cfg(feature = "client")]
     pub mod client {
         pub use crate::timeline::input::{
-            InputDelayConfig, InputTimeline, InputTimelineConfig, SyncedInputTimeline,
+            InputDelayConfig, InputTimeline, InputTimelineConfig,
+            PREDICTION_WINDOW_HYSTERESIS_TICKS, PredictionWindowWait, SyncedInputTimeline,
         };
         pub use crate::timeline::remote::{RemoteEstimate, RemoteTimeline};
         pub use crate::timeline::sync::{IsSynced, P2PTimelineDiverged};

--- a/crates/core/sync/src/lib.rs
+++ b/crates/core/sync/src/lib.rs
@@ -37,7 +37,9 @@ pub mod prelude {
     pub use crate::ping::manager::{PingConfig, PingManager};
     pub use crate::ping::message::{Ping, Pong};
     pub use crate::plugin::{SyncSystems, TimelineSyncPlugin};
-    pub use crate::timeline::sync::{IsSynced, SyncConfig, SyncedTimelinePlugin};
+    pub use crate::timeline::sync::{
+        IsSynced, P2PTimelineDiverged, SyncConfig, SyncedTimelinePlugin,
+    };
     pub use crate::timeline::{
         DrivingTimeline,
         input::{InputTimeline, InputTimelineConfig, SyncedInputTimeline},
@@ -49,7 +51,7 @@ pub mod prelude {
             InputDelayConfig, InputTimeline, InputTimelineConfig, SyncedInputTimeline,
         };
         pub use crate::timeline::remote::{RemoteEstimate, RemoteTimeline};
-        pub use crate::timeline::sync::IsSynced;
+        pub use crate::timeline::sync::{IsSynced, P2PTimelineDiverged};
     }
 
     #[cfg(feature = "server")]

--- a/crates/core/sync/src/timeline/input.rs
+++ b/crates/core/sync/src/timeline/input.rs
@@ -508,7 +508,7 @@ impl SyncedTimeline for InputTimeline {
         let adjustment = if !self.is_synced {
             SyncAdjustment::Resync
         } else {
-            self.sync.speed_adjustment(&config.sync, error_ticks)
+            self.speed_adjustment(config, error_ticks)
         };
         trace!(
             ?now,
@@ -524,19 +524,25 @@ impl SyncedTimeline for InputTimeline {
             SyncAdjustment::Resync => {
                 return Some(self.resync(objective));
             }
-            SyncAdjustment::SpeedAdjust(ratio) => {
-                self.set_relative_speed(ratio);
-            }
-            SyncAdjustment::DoNothing => {
-                // within acceptable margins, gradually return to normal speed (1.0)
-                let current = self.relative_speed();
-                if (current - 1.0).abs() > 0.001 {
-                    let new_speed = current + (1.0 - current) * 0.1;
-                    self.set_relative_speed(new_speed);
-                }
-            }
+            SyncAdjustment::SpeedAdjust(_) | SyncAdjustment::DoNothing => {}
         }
         None
+    }
+
+    fn speed_adjustment(&mut self, config: &Self::Config, offset: f32) -> SyncAdjustment {
+        let adjustment = self.sync.speed_adjustment(&config.sync, offset);
+        match adjustment {
+            SyncAdjustment::SpeedAdjust(ratio) => self.set_relative_speed(ratio),
+            SyncAdjustment::DoNothing => {
+                // Within acceptable margins, gradually return to normal speed.
+                let current = self.relative_speed();
+                if (current - 1.0).abs() > 0.001 {
+                    self.set_relative_speed(current + (1.0 - current) * 0.1);
+                }
+            }
+            SyncAdjustment::Resync => {}
+        }
+        adjustment
     }
 
     fn is_synced(&self) -> bool {
@@ -553,6 +559,7 @@ impl SyncedTimeline for InputTimeline {
 
     fn reset(&mut self) {
         trace!("Resetting InputTimeline");
+        self.sync = SyncContext::default();
         self.is_synced = false;
         self.relative_speed = 1.0;
         self.now = Default::default();

--- a/crates/core/sync/src/timeline/input.rs
+++ b/crates/core/sync/src/timeline/input.rs
@@ -50,7 +50,8 @@ impl InputTimelineConfig {
     pub fn is_lockstep(&self) -> bool {
         self.input_delay_config.is_lockstep()
     }
-    /// Maximum number of ticks the local simulation is allowed to predict ahead.
+    /// Maximum number of ticks the local simulation may predict beyond confirmed remote input.
+    #[inline]
     pub fn maximum_predicted_ticks(&self) -> u16 {
         self.input_delay_config.maximum_predicted_ticks
     }
@@ -106,6 +107,122 @@ impl InputTimelineConfig {
             topology = ?metadata.mode,
             "recomputed global input delay after config update"
         );
+    }
+}
+
+/// Number of confirmed-input ticks that must be recovered before a prediction-window wait ends.
+///
+/// Waiting at the exact prediction limit and immediately resuming after one newly confirmed tick
+/// would alternate between running and waiting every fixed tick. Requiring two ticks of headroom
+/// lets the simulation make useful progress after it resumes.
+pub const PREDICTION_WINDOW_HYSTERESIS_TICKS: u16 = 2;
+
+/// Application-global signal that stops deterministic simulation at its safe prediction limit.
+///
+/// Deterministic replication updates this resource from the minimum confirmed-input frontier
+/// across all remote players and registered input types. The driving timeline synchronization
+/// system reads it when applying its speed to `Time<Virtual>`: while waiting, virtual time receives
+/// an effective relative speed of zero, but the timeline's phase-controller speed is preserved.
+///
+/// This signal is deliberately specific to confirmed-input availability. P2P phase lead continues
+/// to use the normal timeline slowdown controller and does not request a hard wait.
+#[derive(Resource, Debug, Clone, Copy, Reflect)]
+pub struct PredictionWindowWait {
+    waiting: bool,
+    origin_tick: Option<Tick>,
+    current_tick: Tick,
+    confirmed_tick: Option<Tick>,
+    prediction_depth: i32,
+    maximum_predicted_ticks: u16,
+}
+
+impl Default for PredictionWindowWait {
+    fn default() -> Self {
+        Self {
+            waiting: false,
+            origin_tick: None,
+            current_tick: Tick(0),
+            confirmed_tick: None,
+            prediction_depth: 0,
+            maximum_predicted_ticks: 0,
+        }
+    }
+}
+
+impl PredictionWindowWait {
+    /// Returns whether deterministic simulation must currently wait for remote input.
+    #[inline]
+    pub fn is_waiting(&self) -> bool {
+        self.waiting
+    }
+
+    /// Current local lead over the global confirmed-input frontier, in ticks.
+    ///
+    /// This can be negative when input delay has provided confirmed remote input for future ticks.
+    #[inline]
+    pub fn prediction_depth(&self) -> i32 {
+        self.prediction_depth
+    }
+
+    /// Latest global confirmed-input frontier used by the wait decision.
+    #[inline]
+    pub fn confirmed_tick(&self) -> Option<Tick> {
+        self.confirmed_tick
+    }
+
+    /// Effective prediction limit used by the wait decision.
+    #[inline]
+    pub fn maximum_predicted_ticks(&self) -> u16 {
+        self.maximum_predicted_ticks
+    }
+
+    /// Clear all state when there is no active deterministic input session.
+    pub fn reset(&mut self) {
+        *self = Self::default();
+    }
+
+    /// Update the wait decision from the current and globally confirmed input ticks.
+    ///
+    /// `maximum_predicted_ticks` must already account for the rollback-history bound. The method
+    /// starts waiting when another fixed tick would exceed that bound, and resumes only after
+    /// [`PREDICTION_WINDOW_HYSTERESIS_TICKS`] ticks of headroom have been recovered.
+    ///
+    /// Before any remote input exists, the first observed local tick becomes the session origin.
+    /// One initial fixed tick is allowed so the fixed input pipeline can capture and send its first
+    /// sample even for a zero-sized prediction window.
+    ///
+    /// Returns `true` when the waiting state changed.
+    pub fn update(
+        &mut self,
+        current_tick: Tick,
+        confirmed_tick: Option<Tick>,
+        maximum_predicted_ticks: u16,
+    ) -> bool {
+        let origin_tick = *self.origin_tick.get_or_insert(current_tick);
+        let frontier = confirmed_tick.unwrap_or(origin_tick);
+        let prediction_depth = current_tick - frontier;
+        let maximum = i32::from(maximum_predicted_ticks);
+        // A window smaller than the preferred hysteresis cannot require future input beyond the
+        // current tick: if every peer waited there, no one could capture that future input. Fall
+        // back to resuming at zero prediction depth for those small windows.
+        let resume_at =
+            i32::from(maximum_predicted_ticks.saturating_sub(PREDICTION_WINDOW_HYSTERESIS_TICKS));
+
+        let waiting = if confirmed_tick.is_none() && current_tick == origin_tick {
+            false
+        } else if self.waiting {
+            prediction_depth > resume_at
+        } else {
+            prediction_depth >= maximum
+        };
+        let changed = waiting != self.waiting;
+
+        self.waiting = waiting;
+        self.current_tick = current_tick;
+        self.confirmed_tick = confirmed_tick;
+        self.prediction_depth = prediction_depth;
+        self.maximum_predicted_ticks = maximum_predicted_ticks;
+        changed
     }
 }
 
@@ -585,6 +702,44 @@ mod tests {
 
     #[derive(Resource, Default)]
     struct SyncedParamRuns(u8);
+
+    #[test]
+    fn prediction_window_wait_uses_hysteresis() {
+        let mut wait = PredictionWindowWait::default();
+
+        assert!(!wait.update(Tick(100), None, 4));
+        assert!(!wait.is_waiting());
+        assert_eq!(wait.prediction_depth(), 0);
+
+        assert!(wait.update(Tick(104), None, 4));
+        assert!(wait.is_waiting());
+        assert_eq!(wait.prediction_depth(), 4);
+
+        // One newly confirmed tick is not enough to resume and immediately hit the limit again.
+        assert!(!wait.update(Tick(104), Some(Tick(101)), 4));
+        assert!(wait.is_waiting());
+
+        // Two ticks of recovered headroom release the wait.
+        assert!(wait.update(Tick(104), Some(Tick(102)), 4));
+        assert!(!wait.is_waiting());
+        assert_eq!(wait.prediction_depth(), 2);
+    }
+
+    #[test]
+    fn zero_prediction_window_can_bootstrap_then_wait_for_future_input() {
+        let mut wait = PredictionWindowWait::default();
+
+        // The first fixed tick is allowed to capture and send the initial local input sample.
+        assert!(!wait.update(Tick(20), None, 0));
+        assert!(wait.update(Tick(21), None, 0));
+        assert!(wait.is_waiting());
+
+        // A zero-sized window cannot require future input beyond the current tick, or every peer
+        // could wait forever. Confirming the current tick releases this degenerate case.
+        assert!(wait.update(Tick(21), Some(Tick(21)), 0));
+        assert!(!wait.is_waiting());
+        assert_eq!(wait.prediction_depth(), 0);
+    }
 
     #[test]
     fn synced_input_timeline_checks_the_resource_entity_marker() {

--- a/crates/core/sync/src/timeline/remote.rs
+++ b/crates/core/sync/src/timeline/remote.rs
@@ -278,6 +278,10 @@ impl SyncTargetTimeline for RemoteTimeline {
         self.now + self.offset
     }
 
+    fn is_initialized(&self) -> bool {
+        self.last_received_tick.is_some()
+    }
+
     fn received_packet(&self) -> bool {
         self.received_packet
     }

--- a/crates/core/sync/src/timeline/sync.rs
+++ b/crates/core/sync/src/timeline/sync.rs
@@ -1,5 +1,6 @@
 use crate::ping::manager::PingManager;
 use crate::plugin::SyncSystems;
+use crate::timeline::input::PredictionWindowWait;
 use bevy_app::{App, Last, Plugin, PostUpdate};
 use bevy_ecs::prelude::*;
 use bevy_ecs::resource::IsResource;
@@ -588,12 +589,32 @@ where
     /// Other topologies run at normal speed until their resource timeline is synchronized.
     fn update_virtual_time(
         metadata: Res<NetworkingMetadata>,
+        prediction_window_wait: Res<PredictionWindowWait>,
         timeline: Single<(&Synced, Has<IsSynced<Synced>>), With<IsResource>>,
         mut virtual_time: ResMut<Time<Virtual>>,
     ) {
         let (timeline, is_synced) = timeline.into_inner();
         match metadata.mode {
-            NetworkTopology::P2P(_) => {
+            NetworkTopology::Client(_) | NetworkTopology::P2P { .. }
+                if is_synced && prediction_window_wait.is_waiting() =>
+            {
+                // Keep the phase controller's desired speed on the timeline while preventing the
+                // next FixedMain run. Network receive and timeline observation continue in the
+                // variable schedules, so confirmed input can advance and release the wait.
+                virtual_time.set_relative_speed(0.0);
+                trace!(
+                    target: "lightyear_debug::sync",
+                    kind = "prediction_window_wait",
+                    schedule = "Last",
+                    sample_point = "Last",
+                    prediction_depth = prediction_window_wait.prediction_depth(),
+                    maximum_predicted_ticks = prediction_window_wait.maximum_predicted_ticks(),
+                    confirmed_tick = ?prediction_window_wait.confirmed_tick(),
+                    desired_relative_speed = timeline.relative_speed(),
+                    "paused virtual time at the deterministic prediction-window limit"
+                );
+            }
+            NetworkTopology::P2P { .. } => {
                 Self::apply_relative_speed(timeline, &mut virtual_time);
             }
             NetworkTopology::Client(_) | NetworkTopology::HostClient { .. } if is_synced => {
@@ -618,7 +639,6 @@ where
             (&Remote, &PingManager),
             (With<Client>, With<Connected>, Without<HostClient>),
         >,
-        declared_p2p_links: Query<(), (With<P2P>, With<Client>, Without<HostClient>)>,
         mut commands: Commands,
     ) {
         let (entity, mut synced, mut is_synced) = timeline.into_inner();
@@ -631,7 +651,7 @@ where
         if metadata.is_changed() {
             Self::reset_controller(&mut synced, 1.0);
             let preserve_running_p2p =
-                is_synced && matches!(&metadata.mode, NetworkTopology::P2P(_));
+                is_synced && matches!(&metadata.mode, NetworkTopology::P2P { .. });
             if is_synced && !preserve_running_p2p {
                 commands.entity(entity).remove::<IsSynced<Synced>>();
             }
@@ -654,16 +674,19 @@ where
                     &mut commands,
                 );
             }
-            NetworkTopology::P2P(links) if DRIVING => {
+            NetworkTopology::P2P {
+                connected,
+                declared,
+            } if DRIVING => {
                 // P2P Links can be declared before their connection handshake completes. Waiting
                 // for all declared Links lets a lobby establish its fixed roster up front without
                 // allowing the first connection to start input capture prematurely.
                 let all_declared_links_connected =
-                    is_synced || links.len() == declared_p2p_links.iter().count();
-                let mut all_initialized = !links.is_empty() && all_declared_links_connected;
+                    is_synced || connected.len() == usize::from(*declared);
+                let mut all_initialized = !connected.is_empty() && all_declared_links_connected;
                 let mut sampled_any = false;
                 let mut limiting = None;
-                for &link_entity in links {
+                for &link_entity in connected {
                     let Ok((remote, _ping_manager)) = remotes.get(link_entity) else {
                         all_initialized = false;
                         trace!(
@@ -800,6 +823,9 @@ impl<Synced: SyncedTimeline, Remote: SyncTargetTimeline, const DRIVING: bool> Pl
 
         app.register_required_components::<Synced, PingManager>();
         app.register_required_components::<Synced, Remote>();
+        if DRIVING {
+            app.init_resource::<PredictionWindowWait>();
+        }
         app.add_observer(Self::handle_connect);
         app.add_observer(Self::handle_host_client);
         app.add_observer(Self::handle_disconnect);
@@ -827,6 +853,9 @@ where
         app.add_plugins(NetworkTimelinePlugin::<Synced>::default());
         app.init_resource::<Synced>();
         app.init_resource::<Synced::Config>();
+        if DRIVING {
+            app.init_resource::<PredictionWindowWait>();
+        }
 
         app.add_observer(Self::handle_connect);
         app.add_observer(Self::handle_host_client);
@@ -850,7 +879,8 @@ mod tests {
     use super::*;
     use crate::timeline::input::{InputTimeline, InputTimelineConfig};
     use alloc::vec::Vec;
-    use bevy_app::PostUpdate;
+    use bevy_app::{FixedUpdate, PostUpdate};
+    use bevy_time::TimeUpdateStrategy;
     use lightyear_core::id::{PeerId, RemoteId};
     use lightyear_core::plugin::CorePlugins;
     use lightyear_core::tick::Tick;
@@ -876,6 +906,61 @@ mod tests {
         mut divergences: ResMut<RecordedDivergences>,
     ) {
         divergences.0.push(*trigger);
+    }
+
+    #[derive(Resource, Default)]
+    struct FixedRuns(u32);
+
+    #[test]
+    fn prediction_window_wait_stops_bevy_fixed_schedules() {
+        fn count_fixed_runs(mut runs: ResMut<FixedRuns>) {
+            runs.0 += 1;
+        }
+
+        let tick_duration = Duration::from_millis(10);
+        let mut app = App::new();
+        app.add_plugins((
+            CorePlugins { tick_duration },
+            SyncedTimelinePlugin::<InputTimeline, TestRemote, true, true>::default(),
+        ));
+        app.insert_resource(TimeUpdateStrategy::ManualDuration(tick_duration));
+        app.init_resource::<NetworkingMetadata>();
+        app.init_resource::<FixedRuns>();
+        app.add_systems(FixedUpdate, count_fixed_runs);
+        let timeline_id = app.world().component_id::<InputTimeline>().unwrap();
+        let timeline_entity = app.world().resource_entities().get(timeline_id).unwrap();
+        app.world_mut()
+            .entity_mut(timeline_entity)
+            .insert(IsSynced::<InputTimeline>::default());
+        app.world_mut().resource_mut::<NetworkingMetadata>().mode = NetworkTopology::P2P {
+            connected: Default::default(),
+            declared: 1,
+        };
+        {
+            let mut wait = app.world_mut().resource_mut::<PredictionWindowWait>();
+            wait.update(Tick(0), None, 1);
+            wait.update(Tick(1), None, 1);
+        }
+
+        // The signal is applied in Last, after this frame's fixed loop has already run.
+        app.update();
+        let before_wait = app.world().resource::<FixedRuns>().0;
+        assert_eq!(
+            app.world().resource::<Time<Virtual>>().relative_speed(),
+            0.0
+        );
+
+        app.update();
+        assert_eq!(app.world().resource::<FixedRuns>().0, before_wait);
+
+        // Releasing the signal similarly takes effect for the following application frame.
+        app.world_mut()
+            .resource_mut::<PredictionWindowWait>()
+            .update(Tick(1), Some(Tick(1)), 1);
+        app.update();
+        assert_eq!(app.world().resource::<FixedRuns>().0, before_wait);
+        app.update();
+        assert!(app.world().resource::<FixedRuns>().0 > before_wait);
     }
 
     impl TimelineConfig for TestRemoteConfig {
@@ -972,8 +1057,10 @@ mod tests {
             }
             links.push(entity);
         }
-        app.world_mut().resource_mut::<NetworkingMetadata>().mode =
-            NetworkTopology::P2P(links[..2].iter().copied().collect());
+        app.world_mut().resource_mut::<NetworkingMetadata>().mode = NetworkTopology::P2P {
+            connected: links[..2].iter().copied().collect(),
+            declared: 3,
+        };
 
         app.world_mut().run_schedule(PostUpdate);
 
@@ -997,8 +1084,10 @@ mod tests {
 
         // Connecting the final Link is still not enough until its remote timeline has initialized.
         app.world_mut().entity_mut(links[2]).insert(Connected);
-        app.world_mut().resource_mut::<NetworkingMetadata>().mode =
-            NetworkTopology::P2P(links.iter().copied().collect());
+        app.world_mut().resource_mut::<NetworkingMetadata>().mode = NetworkTopology::P2P {
+            connected: links.iter().copied().collect(),
+            declared: 3,
+        };
         app.world_mut().run_schedule(PostUpdate);
         assert!(
             app.world()
@@ -1059,6 +1148,35 @@ mod tests {
             app.world()
                 .get::<IsSynced<InputTimeline>>(timeline_entity)
                 .is_some()
+        );
+
+        // Prediction-window exhaustion is a hard wait layered over the phase controller. It
+        // pauses virtual time without overwriting the slowdown that should be restored on resume.
+        {
+            let mut wait = app.world_mut().resource_mut::<PredictionWindowWait>();
+            wait.update(Tick(0), None, 4);
+            wait.update(Tick(4), None, 4);
+        }
+        app.world_mut().run_schedule(Last);
+        assert_eq!(
+            app.world().resource::<Time<Virtual>>().relative_speed(),
+            0.0
+        );
+        assert_eq!(
+            app.world().resource::<InputTimeline>().relative_speed(),
+            slowed_speed,
+            "hard waiting must preserve the phase controller's desired speed"
+        );
+
+        {
+            let mut wait = app.world_mut().resource_mut::<PredictionWindowWait>();
+            wait.update(Tick(4), Some(Tick(2)), 4);
+        }
+        app.world_mut().run_schedule(Last);
+        assert_eq!(
+            app.world().resource::<Time<Virtual>>().relative_speed(),
+            slowed_speed,
+            "recovering two confirmed ticks must resume at the phase-controller speed"
         );
 
         // Render frames without a new network observation must preserve both the controller state
@@ -1161,8 +1279,10 @@ mod tests {
         // A P2P roster change resets controller history but cannot revoke readiness or resynchronize
         // a running deterministic world. An empty connected set keeps application time advancing
         // normally; the session owner is responsible for treating peer loss as fatal if required.
-        app.world_mut().resource_mut::<NetworkingMetadata>().mode =
-            NetworkTopology::P2P(Default::default());
+        app.world_mut().resource_mut::<NetworkingMetadata>().mode = NetworkTopology::P2P {
+            connected: Default::default(),
+            declared: 3,
+        };
         app.world_mut().run_schedule(PostUpdate);
 
         let timeline = app.world().resource::<InputTimeline>();

--- a/crates/core/sync/src/timeline/sync.rs
+++ b/crates/core/sync/src/timeline/sync.rs
@@ -16,7 +16,7 @@ use lightyear_core::tick::TickDuration;
 use lightyear_core::time::{Overstep, TickInstant};
 use lightyear_core::timeline::{NetworkTimeline, SyncEvent};
 #[allow(unused_imports)]
-use tracing::{debug, info, trace};
+use tracing::{debug, error, info, trace};
 
 /// Marker component to indicate that the timeline has been synced
 #[derive(Component, Debug)]
@@ -30,6 +30,22 @@ impl<T> Default for IsSynced<T> {
             marker: core::marker::PhantomData,
         }
     }
+}
+
+/// Triggered when a running P2P timeline is too far ahead to correct with bounded pacing.
+///
+/// A running deterministic peer cannot safely emit a local [`SyncEvent`], because other peers
+/// would retain inputs under the old tick labels. The P2P session owner should treat this event as
+/// fatal and abort the session, unless it implements a coordinated all-peer resynchronization
+/// protocol.
+#[derive(EntityEvent, Debug, Clone, Copy)]
+pub struct P2PTimelineDiverged {
+    /// Resource entity holding the application-global driving timeline.
+    pub entity: Entity,
+    /// P2P Link whose remote estimate produced the worst local lead.
+    pub limiting_link: Entity,
+    /// Local lead over the limiting Link, measured in fractional ticks.
+    pub lead: f32,
 }
 
 /// Timeline that is synced to another timeline
@@ -61,6 +77,14 @@ pub trait SyncedTimeline: NetworkTimeline {
         tick_duration: Duration,
     ) -> Option<i32>;
 
+    /// Apply the common speed controller for an error measured in fractional ticks.
+    ///
+    /// Implementations apply speed changes and recovery toward `1.0`. A
+    /// [`SyncAdjustment::Resync`] result is left to the synchronization policy: conventional
+    /// client/server synchronization may snap, while a running P2P session must abort or perform
+    /// a coordinated recovery instead.
+    fn speed_adjustment(&mut self, config: &Self::Config, offset: f32) -> SyncAdjustment;
+
     fn is_synced(&self) -> bool;
 
     /// Returns the speed of your timeline relative to your system clock as an `f32`.
@@ -76,6 +100,11 @@ pub trait SyncedTimeline: NetworkTimeline {
 
 pub trait SyncTargetTimeline: NetworkTimeline + Default {
     fn current_estimate(&self) -> TickInstant;
+
+    /// Returns true after this timeline has received enough information to estimate remote time.
+    fn is_initialized(&self) -> bool {
+        true
+    }
 
     /// Returns true if the SyncTimelines are allowed to use this timeline as a sync target this frame
     fn received_packet(&self) -> bool;
@@ -279,6 +308,16 @@ impl<Synced: SyncedTimeline, Remote: SyncTargetTimeline, const DRIVING: bool, co
         );
         // TODO: be able to apply the speed_ratio on top of any speed ratio already applied by the user.
         virtual_time.set_relative_speed(timeline.relative_speed());
+    }
+
+    /// Reset controller history without changing the driving timeline's current phase.
+    fn reset_controller(sync_timeline: &mut Synced, relative_speed: f32) {
+        let now = sync_timeline.now();
+        sync_timeline.reset();
+        // `sync_from_local_timeline` already copied the current application phase this frame.
+        // Preserve it while clearing controller state so diagnostics never observe a spurious zero.
+        sync_timeline.set_now(now);
+        sync_timeline.set_relative_speed(relative_speed);
     }
 
     /// Synchronize one timeline and emit a [`SyncEvent`] if it snaps by whole ticks.
@@ -543,18 +582,33 @@ where
         Self::sync_from_local(&mut timeline, &local_timeline, &fixed_time);
     }
 
-    /// Apply the synchronized resource timeline's relative speed to virtual time.
+    /// Apply the resource timeline's relative speed to virtual time.
+    ///
+    /// P2P always owns virtual time, but runs at normal speed when no usable phase estimate exists.
+    /// Other topologies run at normal speed until their resource timeline is synchronized.
     fn update_virtual_time(
-        timeline: Single<&Synced, (With<IsResource>, With<IsSynced<Synced>>)>,
+        metadata: Res<NetworkingMetadata>,
+        timeline: Single<(&Synced, Has<IsSynced<Synced>>), With<IsResource>>,
         mut virtual_time: ResMut<Time<Virtual>>,
     ) {
-        Self::apply_relative_speed(&timeline, &mut virtual_time);
+        let (timeline, is_synced) = timeline.into_inner();
+        match metadata.mode {
+            NetworkTopology::P2P(_) => {
+                Self::apply_relative_speed(timeline, &mut virtual_time);
+            }
+            NetworkTopology::Client(_) | NetworkTopology::HostClient { .. } if is_synced => {
+                Self::apply_relative_speed(timeline, &mut virtual_time);
+            }
+            _ => virtual_time.set_relative_speed(1.0),
+        }
     }
 
-    /// Synchronize the resource timeline with the conventional Client Link cached by the topology.
+    /// Synchronize the resource timeline from the objective selected by the cached topology.
     ///
-    /// P2P aggregation will provide a different remote-target policy while retaining the same
-    /// resource timeline and synchronization controller.
+    /// Conventional client/server mode uses one remote Link and may snap by whole ticks. P2P mode
+    /// reads the already-smoothed estimate on every currently connected P2P Link, selects the
+    /// largest local lead, and feeds that aggregate error into the common speed controller once.
+    /// Fixed-roster agreement and gameplay start readiness belong to the P2P session layer.
     fn sync_timelines(
         tick_duration: Res<TickDuration>,
         metadata: Res<NetworkingMetadata>,
@@ -564,25 +618,167 @@ where
             (&Remote, &PingManager),
             (With<Client>, With<Connected>, Without<HostClient>),
         >,
+        declared_p2p_links: Query<(), (With<P2P>, With<Client>, Without<HostClient>)>,
         mut commands: Commands,
     ) {
-        let NetworkTopology::Client(client) = &metadata.mode else {
-            return;
-        };
-        let Ok((remote, ping_manager)) = remotes.get(*client) else {
-            return;
-        };
-        let (entity, mut synced, is_synced) = timeline.into_inner();
-        Self::sync_timeline(
-            entity,
-            &mut synced,
-            &config,
-            remote,
-            ping_manager,
-            is_synced,
-            &tick_duration,
-            &mut commands,
-        );
+        let (entity, mut synced, mut is_synced) = timeline.into_inner();
+
+        // NetworkingMetadata only reports changed when its public topology changes. Resetting here
+        // prevents controller history from leaking between Link sets. A running P2P timeline keeps
+        // its readiness marker: an existing deterministic session must never locally relabel ticks
+        // merely because a peer connected or disconnected. A fresh app remains unready until the
+        // initial P2P alignment below completes.
+        if metadata.is_changed() {
+            Self::reset_controller(&mut synced, 1.0);
+            let preserve_running_p2p =
+                is_synced && matches!(&metadata.mode, NetworkTopology::P2P(_));
+            if is_synced && !preserve_running_p2p {
+                commands.entity(entity).remove::<IsSynced<Synced>>();
+            }
+            is_synced = preserve_running_p2p;
+        }
+
+        match &metadata.mode {
+            NetworkTopology::Client(client) => {
+                let Ok((remote, ping_manager)) = remotes.get(*client) else {
+                    return;
+                };
+                Self::sync_timeline(
+                    entity,
+                    &mut synced,
+                    &config,
+                    remote,
+                    ping_manager,
+                    is_synced,
+                    &tick_duration,
+                    &mut commands,
+                );
+            }
+            NetworkTopology::P2P(links) if DRIVING => {
+                // P2P Links can be declared before their connection handshake completes. Waiting
+                // for all declared Links lets a lobby establish its fixed roster up front without
+                // allowing the first connection to start input capture prematurely.
+                let all_declared_links_connected =
+                    is_synced || links.len() == declared_p2p_links.iter().count();
+                let mut all_initialized = !links.is_empty() && all_declared_links_connected;
+                let mut sampled_any = false;
+                let mut limiting = None;
+                for &link_entity in links {
+                    let Ok((remote, _ping_manager)) = remotes.get(link_entity) else {
+                        all_initialized = false;
+                        trace!(
+                            target: "lightyear_debug::sync",
+                            kind = "p2p_sync_missing_link_state",
+                            schedule = "PostUpdate",
+                            sample_point = "PostUpdate",
+                            ?link_entity,
+                            "ignoring P2P Link without sync state"
+                        );
+                        continue;
+                    };
+                    if !remote.is_initialized() {
+                        all_initialized = false;
+                        continue;
+                    }
+                    sampled_any |= remote.received_packet();
+                    // Unlike client/server, P2P has no single asymmetric `sync_objective`: each
+                    // initialized remote estimate is an execution-phase target. Taking the maximum
+                    // of `local - remote` finds the Link furthest behind this app (the worst local
+                    // lead), matching GGRS's maximum frame-advantage policy. Only that aggregate is
+                    // passed to the shared controller, so the app slows toward its slowest peer.
+                    let remote_estimate = remote.current_estimate();
+                    let lead = (synced.now() - remote_estimate).to_f32();
+                    if limiting.is_none_or(|(_, worst, _)| lead > worst) {
+                        limiting = Some((link_entity, lead, remote_estimate));
+                    }
+                }
+
+                // Before the timeline becomes ready, no input-capture system using
+                // `SyncedInputTimeline` can run. It is therefore safe to align the local tick labels
+                // once. Including the local phase in the minimum makes every starting peer converge
+                // toward the slowest observed execution phase instead of swapping clocks.
+                if !is_synced {
+                    if !all_initialized || !sampled_any {
+                        return;
+                    }
+                    let Some((limiting_link, worst_lead, remote_estimate)) = limiting else {
+                        return;
+                    };
+                    let objective = if worst_lead > 0.0 {
+                        remote_estimate
+                    } else {
+                        synced.now()
+                    };
+                    let tick_delta = synced.resync(objective);
+                    synced.set_relative_speed(1.0);
+                    commands.trigger(SyncEvent::<Synced::Config>::new(entity, tick_delta));
+                    commands
+                        .entity(entity)
+                        .insert(IsSynced::<Synced>::default());
+                    trace!(
+                        target: "lightyear_debug::sync",
+                        kind = "p2p_initial_sync",
+                        schedule = "PostUpdate",
+                        sample_point = "PostUpdate",
+                        ?limiting_link,
+                        worst_lead,
+                        ?objective,
+                        tick_delta,
+                        "initial P2P timeline aligned before input capture became ready"
+                    );
+                    return;
+                }
+
+                // Match conventional synchronization: controller hysteresis advances on network
+                // observations, not once per render frame using the same estimates.
+                if !sampled_any {
+                    return;
+                }
+                let Some((limiting_link, worst_lead, _)) = limiting else {
+                    return;
+                };
+                let adjustment = synced.speed_adjustment(&config, worst_lead.max(0.0));
+                if matches!(adjustment, SyncAdjustment::Resync) {
+                    synced.set_relative_speed(1.0);
+                    commands.trigger(P2PTimelineDiverged {
+                        entity,
+                        limiting_link,
+                        lead: worst_lead,
+                    });
+                    error!(
+                        ?limiting_link,
+                        worst_lead,
+                        "running P2P timeline diverged beyond bounded pacing; abort the session"
+                    );
+                    trace!(
+                        target: "lightyear_debug::sync",
+                        kind = "p2p_sync_phase_gap",
+                        schedule = "PostUpdate",
+                        sample_point = "PostUpdate",
+                        ?limiting_link,
+                        worst_lead,
+                        "running P2P phase gap requires session abort or coordinated recovery"
+                    );
+                    return;
+                }
+                trace!(
+                    target: "lightyear_debug::sync",
+                    kind = "p2p_sync_aggregate",
+                    schedule = "PostUpdate",
+                    sample_point = "PostUpdate",
+                    ?limiting_link,
+                    worst_lead,
+                    relative_speed = synced.relative_speed(),
+                    "applied one aggregate P2P pacing decision"
+                );
+            }
+            NetworkTopology::HostClient { .. } if !is_synced => {
+                commands
+                    .entity(entity)
+                    .insert(IsSynced::<Synced>::default());
+            }
+            _ => {}
+        }
     }
 }
 
@@ -646,5 +842,356 @@ where
             app.add_systems(Last, Self::update_virtual_time);
             app.add_observer(Self::handle_sync_event);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::timeline::input::{InputTimeline, InputTimelineConfig};
+    use alloc::vec::Vec;
+    use bevy_app::PostUpdate;
+    use lightyear_core::id::{PeerId, RemoteId};
+    use lightyear_core::plugin::CorePlugins;
+    use lightyear_core::tick::Tick;
+    use lightyear_core::time::TickDelta;
+    use lightyear_core::timeline::TimelineConfig;
+
+    #[derive(Component, Default)]
+    struct TestRemoteConfig;
+
+    #[derive(Component, Default)]
+    struct TestRemote {
+        now: TickInstant,
+        estimate: TickInstant,
+        initialized: bool,
+        received_packet: bool,
+    }
+
+    #[derive(Resource, Default)]
+    struct RecordedDivergences(Vec<P2PTimelineDiverged>);
+
+    fn record_divergence(
+        trigger: On<P2PTimelineDiverged>,
+        mut divergences: ResMut<RecordedDivergences>,
+    ) {
+        divergences.0.push(*trigger);
+    }
+
+    impl TimelineConfig for TestRemoteConfig {
+        type Context = ();
+        type Timeline = TestRemote;
+    }
+
+    impl NetworkTimeline for TestRemote {
+        type Config = TestRemoteConfig;
+
+        fn now(&self) -> TickInstant {
+            self.now
+        }
+
+        fn tick(&self) -> Tick {
+            self.now.tick()
+        }
+
+        fn overstep(&self) -> Overstep {
+            self.now.overstep()
+        }
+
+        fn set_now(&mut self, now: TickInstant) {
+            self.now = now;
+        }
+
+        fn apply_delta(&mut self, delta: TickDelta) {
+            self.now = self.now + delta;
+        }
+    }
+
+    impl SyncTargetTimeline for TestRemote {
+        fn current_estimate(&self) -> TickInstant {
+            self.estimate
+        }
+
+        fn is_initialized(&self) -> bool {
+            self.initialized
+        }
+
+        fn received_packet(&self) -> bool {
+            self.received_packet
+        }
+    }
+
+    #[test]
+    fn resource_pipeline_initializes_then_paces_from_the_worst_p2p_lead() {
+        let mut app = App::new();
+        app.add_plugins((
+            CorePlugins {
+                tick_duration: Duration::from_millis(10),
+            },
+            SyncedTimelinePlugin::<InputTimeline, TestRemote, true, true>::default(),
+        ));
+        app.init_resource::<NetworkingMetadata>();
+        app.init_resource::<RecordedDivergences>();
+        app.add_observer(record_divergence);
+        app.update();
+
+        app.insert_resource(InputTimelineConfig::default().with_sync_config(SyncConfig {
+            handshake_pings: 0,
+            error_margin: 2.0,
+            max_error_margin: 10.0,
+            consecutive_errors_threshold: 1,
+            ..Default::default()
+        }));
+        app.world_mut()
+            .resource_mut::<LocalTimeline>()
+            .apply_delta(100);
+        let local_now = TickInstant::from(app.world().resource::<LocalTimeline>().tick());
+
+        let mut links = Vec::new();
+        // The middle Link has the slowest observed execution phase. Declare the final Link without
+        // connecting it first to verify that the first connection cannot start input capture while
+        // a member of the fixed roster is still joining.
+        for (peer, lead) in [(1, 1), (2, 4), (3, 0)] {
+            let estimate = local_now - TickDelta::from_i32(lead);
+            let entity = app
+                .world_mut()
+                .spawn((
+                    P2P,
+                    RemoteId(PeerId::Local(peer)),
+                    TestRemote {
+                        now: estimate,
+                        estimate,
+                        initialized: peer != 3,
+                        received_packet: true,
+                    },
+                    PingManager::default(),
+                ))
+                .id();
+            if peer != 3 {
+                app.world_mut().entity_mut(entity).insert(Connected);
+            }
+            links.push(entity);
+        }
+        app.world_mut().resource_mut::<NetworkingMetadata>().mode =
+            NetworkTopology::P2P(links[..2].iter().copied().collect());
+
+        app.world_mut().run_schedule(PostUpdate);
+
+        let timeline_id = app.world().component_id::<InputTimeline>().unwrap();
+        let timeline_entity = app.world().resource_entities().get(timeline_id).unwrap();
+        assert_eq!(
+            app.world().resource::<LocalTimeline>().tick(),
+            local_now.tick()
+        );
+        assert_eq!(app.world().resource::<InputTimeline>().now(), local_now);
+        assert_eq!(
+            app.world().resource::<InputTimeline>().relative_speed(),
+            1.0
+        );
+        assert!(
+            app.world()
+                .get::<IsSynced<InputTimeline>>(timeline_entity)
+                .is_none(),
+            "input capture must remain gated until every declared P2P Link is connected"
+        );
+
+        // Connecting the final Link is still not enough until its remote timeline has initialized.
+        app.world_mut().entity_mut(links[2]).insert(Connected);
+        app.world_mut().resource_mut::<NetworkingMetadata>().mode =
+            NetworkTopology::P2P(links.iter().copied().collect());
+        app.world_mut().run_schedule(PostUpdate);
+        assert!(
+            app.world()
+                .get::<IsSynced<InputTimeline>>(timeline_entity)
+                .is_none()
+        );
+
+        // Once every current Link has initialized, align both driving timelines to the slowest
+        // observed phase and only then expose the synchronized input timeline.
+        app.world_mut()
+            .entity_mut(links[2])
+            .get_mut::<TestRemote>()
+            .unwrap()
+            .initialized = true;
+        app.world_mut().run_schedule(PostUpdate);
+
+        let initial_objective = local_now - TickDelta::from_i32(4);
+        assert_eq!(
+            app.world().resource::<LocalTimeline>().tick(),
+            initial_objective.tick()
+        );
+        assert_eq!(
+            app.world().resource::<InputTimeline>().now(),
+            initial_objective
+        );
+        assert_eq!(
+            app.world().resource::<InputTimeline>().relative_speed(),
+            1.0
+        );
+        assert!(
+            app.world()
+                .get::<IsSynced<InputTimeline>>(timeline_entity)
+                .is_some(),
+            "the normal readiness marker is inserted only after initial P2P alignment"
+        );
+
+        // After readiness, only the middle Link exceeds the controller deadband. A correct
+        // maximum aggregate must therefore slow the app, independent of the controller's exact
+        // speed formula.
+        for (&link, lead) in links.iter().zip([1, 4, 0]) {
+            let mut link = app.world_mut().entity_mut(link);
+            let mut remote = link.get_mut::<TestRemote>().unwrap();
+            remote.estimate = initial_objective - TickDelta::from_i32(lead);
+            remote.received_packet = true;
+        }
+        app.world_mut().run_schedule(PostUpdate);
+
+        let slowed_speed = app.world().resource::<InputTimeline>().relative_speed();
+        assert!(
+            slowed_speed < 1.0,
+            "the maximum four-tick lead must cross the two-tick deadband"
+        );
+        assert_eq!(
+            app.world().resource::<LocalTimeline>().tick(),
+            initial_objective.tick()
+        );
+        assert!(
+            app.world()
+                .get::<IsSynced<InputTimeline>>(timeline_entity)
+                .is_some()
+        );
+
+        // Render frames without a new network observation must preserve both the controller state
+        // and its current correction. Recovery is driven by later fresh observations.
+        {
+            let world = app.world_mut();
+            let mut query = world.query::<&mut TestRemote>();
+            query
+                .iter_mut(world)
+                .for_each(|mut remote| remote.received_packet = false);
+        }
+        app.world_mut().run_schedule(PostUpdate);
+        assert_eq!(
+            app.world().resource::<InputTimeline>().relative_speed(),
+            slowed_speed,
+            "a frame without a fresh observation must not alter P2P pacing"
+        );
+
+        // Exclude the four-tick Link and provide a fresh observation on the remaining Links. Their
+        // maximum lead is one tick, inside the deadband, so the controller begins recovering.
+        app.world_mut()
+            .entity_mut(links[1])
+            .get_mut::<TestRemote>()
+            .unwrap()
+            .initialized = false;
+        {
+            let world = app.world_mut();
+            let mut query = world.query::<&mut TestRemote>();
+            query
+                .iter_mut(world)
+                .for_each(|mut remote| remote.received_packet = true);
+        }
+        app.world_mut().run_schedule(PostUpdate);
+
+        let timeline = app.world().resource::<InputTimeline>();
+        assert_eq!(timeline.now(), initial_objective);
+        let recovering_speed = timeline.relative_speed();
+        assert!(
+            recovering_speed > slowed_speed && recovering_speed <= 1.0,
+            "excluding the only lead outside the deadband must start speed recovery"
+        );
+        assert!(
+            app.world()
+                .get::<IsSynced<InputTimeline>>(timeline_entity)
+                .is_some()
+        );
+
+        // Losing every usable estimate without a topology change is still not a new observation;
+        // keep the last correction until timing resumes or the topology itself changes.
+        {
+            let world = app.world_mut();
+            let mut query = world.query::<&mut TestRemote>();
+            query.iter_mut(world).for_each(|mut remote| {
+                remote.initialized = false;
+                remote.received_packet = false;
+            });
+        }
+        app.world_mut().run_schedule(PostUpdate);
+        assert_eq!(
+            app.world().resource::<InputTimeline>().relative_speed(),
+            recovering_speed,
+            "missing observations must preserve controller hysteresis"
+        );
+        assert!(
+            app.world()
+                .get::<IsSynced<InputTimeline>>(timeline_entity)
+                .is_some()
+        );
+
+        // Once input capture is active, a resync-sized gap is unsafe to apply locally. Report the
+        // limiting Link to the session owner and leave all tick labels unchanged.
+        {
+            let mut link = app.world_mut().entity_mut(links[0]);
+            let mut remote = link.get_mut::<TestRemote>().unwrap();
+            remote.initialized = true;
+            remote.received_packet = true;
+            remote.estimate = initial_objective - TickDelta::from_i32(20);
+        }
+        app.world_mut().run_schedule(PostUpdate);
+        assert_eq!(
+            app.world().resource::<InputTimeline>().relative_speed(),
+            1.0
+        );
+        assert_eq!(
+            app.world().resource::<LocalTimeline>().tick(),
+            initial_objective.tick(),
+            "a running P2P session must not relabel local ticks"
+        );
+        assert!(
+            app.world()
+                .get::<IsSynced<InputTimeline>>(timeline_entity)
+                .is_some()
+        );
+        let divergences = &app.world().resource::<RecordedDivergences>().0;
+        assert_eq!(divergences.len(), 1);
+        assert_eq!(divergences[0].entity, timeline_entity);
+        assert_eq!(divergences[0].limiting_link, links[0]);
+        assert_eq!(divergences[0].lead, 20.0);
+
+        // A P2P roster change resets controller history but cannot revoke readiness or resynchronize
+        // a running deterministic world. An empty connected set keeps application time advancing
+        // normally; the session owner is responsible for treating peer loss as fatal if required.
+        app.world_mut().resource_mut::<NetworkingMetadata>().mode =
+            NetworkTopology::P2P(Default::default());
+        app.world_mut().run_schedule(PostUpdate);
+
+        let timeline = app.world().resource::<InputTimeline>();
+        assert_eq!(timeline.now(), initial_objective);
+        assert_eq!(timeline.relative_speed(), 1.0);
+        assert!(
+            app.world()
+                .get::<IsSynced<InputTimeline>>(timeline_entity)
+                .is_some()
+        );
+
+        app.world_mut().run_schedule(Last);
+        assert_eq!(
+            app.world().resource::<Time<Virtual>>().relative_speed(),
+            1.0
+        );
+
+        app.world_mut().resource_mut::<NetworkingMetadata>().mode = NetworkTopology::Undefined;
+        app.world_mut().run_schedule(PostUpdate);
+        app.world_mut().run_schedule(Last);
+        assert!(
+            app.world()
+                .get::<IsSynced<InputTimeline>>(timeline_entity)
+                .is_none()
+        );
+        assert_eq!(
+            app.world().resource::<Time<Virtual>>().relative_speed(),
+            1.0,
+            "leaving P2P topology must restore normal application time"
+        );
     }
 }

--- a/crates/core/sync/src/timeline/sync.rs
+++ b/crates/core/sync/src/timeline/sync.rs
@@ -676,13 +676,13 @@ where
             }
             NetworkTopology::P2P {
                 connected,
-                declared,
+                declared_links,
             } if DRIVING => {
                 // P2P Links can be declared before their connection handshake completes. Waiting
                 // for all declared Links lets a lobby establish its fixed roster up front without
                 // allowing the first connection to start input capture prematurely.
                 let all_declared_links_connected =
-                    is_synced || connected.len() == usize::from(*declared);
+                    is_synced || connected.len() == usize::from(*declared_links);
                 let mut all_initialized = !connected.is_empty() && all_declared_links_connected;
                 let mut sampled_any = false;
                 let mut limiting = None;
@@ -934,7 +934,7 @@ mod tests {
             .insert(IsSynced::<InputTimeline>::default());
         app.world_mut().resource_mut::<NetworkingMetadata>().mode = NetworkTopology::P2P {
             connected: Default::default(),
-            declared: 1,
+            declared_links: 1,
         };
         {
             let mut wait = app.world_mut().resource_mut::<PredictionWindowWait>();
@@ -1059,7 +1059,7 @@ mod tests {
         }
         app.world_mut().resource_mut::<NetworkingMetadata>().mode = NetworkTopology::P2P {
             connected: links[..2].iter().copied().collect(),
-            declared: 3,
+            declared_links: 3,
         };
 
         app.world_mut().run_schedule(PostUpdate);
@@ -1086,7 +1086,7 @@ mod tests {
         app.world_mut().entity_mut(links[2]).insert(Connected);
         app.world_mut().resource_mut::<NetworkingMetadata>().mode = NetworkTopology::P2P {
             connected: links.iter().copied().collect(),
-            declared: 3,
+            declared_links: 3,
         };
         app.world_mut().run_schedule(PostUpdate);
         assert!(
@@ -1281,7 +1281,7 @@ mod tests {
         // normally; the session owner is responsible for treating peer loss as fatal if required.
         app.world_mut().resource_mut::<NetworkingMetadata>().mode = NetworkTopology::P2P {
             connected: Default::default(),
-            declared: 3,
+            declared_links: 3,
         };
         app.world_mut().run_schedule(PostUpdate);
 

--- a/crates/deterministic/deterministic_replication/src/lib.rs
+++ b/crates/deterministic/deterministic_replication/src/lib.rs
@@ -37,6 +37,8 @@ pub mod late_join;
 /// Configuration mode for catch-up (state-based vs input-only).
 pub mod mode;
 mod plugin;
+#[cfg(feature = "client")]
+mod prediction_window;
 
 /// Commonly used items from the `lightyear_deterministic_replication` crate.
 pub mod prelude {

--- a/crates/deterministic/deterministic_replication/src/plugin.rs
+++ b/crates/deterministic/deterministic_replication/src/plugin.rs
@@ -1,4 +1,6 @@
 use crate::Deterministic;
+#[cfg(feature = "client")]
+use crate::prediction_window::PredictionWindowWaitPlugin;
 use bevy_app::{App, Plugin};
 use lightyear_prediction::rollback::DeterministicPredicted;
 
@@ -17,5 +19,7 @@ pub struct DeterministicReplicationPlugin;
 impl Plugin for DeterministicReplicationPlugin {
     fn build(&self, app: &mut App) {
         app.register_required_components::<DeterministicPredicted, Deterministic>();
+        #[cfg(feature = "client")]
+        app.add_plugins(PredictionWindowWaitPlugin);
     }
 }

--- a/crates/deterministic/deterministic_replication/src/prediction_window.rs
+++ b/crates/deterministic/deterministic_replication/src/prediction_window.rs
@@ -1,0 +1,184 @@
+use bevy_app::{App, Plugin, PostUpdate};
+use bevy_ecs::prelude::*;
+use lightyear_connection::network_topology::{NetworkTopology, NetworkingMetadata};
+use lightyear_core::timeline::LocalTimeline;
+use lightyear_inputs::client::InputSystems;
+use lightyear_prediction::prelude::{LastConfirmedInput, PredictionManager};
+use lightyear_sync::plugin::SyncSystems;
+use lightyear_sync::prelude::{InputTimelineConfig, PredictionWindowWait, SyncedInputTimeline};
+use tracing::{info, trace};
+
+/// Installs the application-global deterministic prediction-window controller.
+pub(crate) struct PredictionWindowWaitPlugin;
+
+impl Plugin for PredictionWindowWaitPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<PredictionWindowWait>();
+        app.init_resource::<LastConfirmedInput>();
+        app.add_systems(
+            PostUpdate,
+            update_prediction_window_wait
+                .after(InputSystems::UpdateRemoteInputTicks)
+                .after(SyncSystems::Sync),
+        );
+    }
+}
+
+/// Stop deterministic fixed simulation before its next tick would exceed the rollback-safe input
+/// window.
+///
+/// [`LastConfirmedInput`] is the minimum across every remote input buffer and every registered
+/// input type. A missing stream anchors the controller to the session's first observed tick until
+/// input arrives. An application with no remote input streams does not wait.
+fn update_prediction_window_wait(
+    timeline: Res<LocalTimeline>,
+    _input_timeline: SyncedInputTimeline,
+    metadata: Res<NetworkingMetadata>,
+    input_config: Res<InputTimelineConfig>,
+    prediction_manager: Option<Res<PredictionManager>>,
+    last_confirmed_input: Res<LastConfirmedInput>,
+    mut wait: ResMut<PredictionWindowWait>,
+) {
+    if metadata.is_changed() {
+        wait.reset();
+    }
+
+    let active_topology = match &metadata.mode {
+        NetworkTopology::Client(_) => true,
+        NetworkTopology::P2P { connected, .. } => !connected.is_empty(),
+        NetworkTopology::Undefined
+        | NetworkTopology::Server(_)
+        | NetworkTopology::HostClient { .. }
+        | NetworkTopology::Invalid(_) => false,
+    };
+    let Some(prediction_manager) = prediction_manager.filter(|_| active_topology) else {
+        wait.reset();
+        return;
+    };
+
+    let current_frontier = last_confirmed_input.get();
+    if current_frontier.is_none() && last_confirmed_input.received_for_all_clients {
+        // An empty aggregate means this deterministic simulation has no remote input streams. A
+        // stream that exists but has not received its first sample sets this flag to false.
+        wait.reset();
+        return;
+    }
+
+    let configured_maximum = input_config.maximum_predicted_ticks();
+    let effective_maximum = if configured_maximum == 0 {
+        // `effective_max_rollback_ticks` intentionally leaves forced state rollback enabled in
+        // lockstep mode. The input prediction window itself is still zero.
+        0
+    } else {
+        prediction_manager
+            .rollback_policy
+            .effective_max_rollback_ticks(&input_config)
+    };
+    let confirmed_tick = last_confirmed_input
+        .received_for_all_clients
+        .then_some(current_frontier)
+        .flatten();
+    let changed = wait.update(timeline.tick(), confirmed_tick, effective_maximum);
+
+    if changed {
+        info!(
+            waiting = wait.is_waiting(),
+            current_tick = timeline.tick().0,
+            confirmed_tick = ?wait.confirmed_tick(),
+            prediction_depth = wait.prediction_depth(),
+            maximum_predicted_ticks = wait.maximum_predicted_ticks(),
+            "deterministic prediction-window wait state changed"
+        );
+    }
+    trace!(
+        target: "lightyear_debug::input",
+        kind = "prediction_window",
+        schedule = "PostUpdate",
+        sample_point = "PostUpdate",
+        waiting = wait.is_waiting(),
+        current_tick = timeline.tick().0,
+        confirmed_tick = ?wait.confirmed_tick(),
+        prediction_depth = wait.prediction_depth(),
+        maximum_predicted_ticks = wait.maximum_predicted_ticks(),
+        "updated deterministic prediction-window wait signal"
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lightyear_core::prelude::Tick;
+    use lightyear_sync::prelude::{InputTimeline, IsSynced};
+
+    fn wait_app(topology: NetworkTopology) -> App {
+        let mut app = App::new();
+        app.init_resource::<LocalTimeline>();
+        app.init_resource::<InputTimeline>();
+        app.init_resource::<InputTimelineConfig>();
+        app.init_resource::<NetworkingMetadata>();
+        app.init_resource::<LastConfirmedInput>();
+        app.init_resource::<PredictionWindowWait>();
+        app.insert_resource(PredictionManager {
+            rollback_policy: lightyear_prediction::prelude::RollbackPolicy {
+                max_rollback_ticks: 4,
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+        app.add_systems(PostUpdate, update_prediction_window_wait);
+
+        let timeline_id = app.world().component_id::<InputTimeline>().unwrap();
+        let timeline_entity = app.world().resource_entities().get(timeline_id).unwrap();
+        app.world_mut()
+            .entity_mut(timeline_entity)
+            .insert(IsSynced::<InputTimeline>::default());
+        app.world_mut().resource_mut::<NetworkingMetadata>().mode = topology;
+        app
+    }
+
+    #[test]
+    fn wait_uses_effective_rollback_depth_for_client_and_p2p() {
+        for p2p in [false, true] {
+            let mut topology_world = World::new();
+            let link = topology_world.spawn_empty().id();
+            let topology = if p2p {
+                NetworkTopology::P2P {
+                    connected: [link].into_iter().collect(),
+                    declared: 1,
+                }
+            } else {
+                NetworkTopology::Client(link)
+            };
+            let mut app = wait_app(topology);
+            app.world_mut()
+                .resource_mut::<LocalTimeline>()
+                .apply_delta(104);
+            {
+                let mut confirmed = app.world_mut().resource_mut::<LastConfirmedInput>();
+                confirmed.tick.set_if_lower(Tick(100));
+                confirmed.received_for_all_clients = true;
+            }
+
+            app.world_mut().run_schedule(PostUpdate);
+            let wait = app.world().resource::<PredictionWindowWait>();
+            assert!(wait.is_waiting());
+            assert_eq!(wait.maximum_predicted_ticks(), 4);
+        }
+    }
+
+    #[test]
+    fn deterministic_session_without_remote_input_streams_does_not_wait() {
+        let mut topology_world = World::new();
+        let link = topology_world.spawn_empty().id();
+        let mut app = wait_app(NetworkTopology::Client(link));
+        app.world_mut()
+            .resource_mut::<LocalTimeline>()
+            .apply_delta(100);
+        app.world_mut()
+            .resource_mut::<LastConfirmedInput>()
+            .received_for_all_clients = true;
+
+        app.world_mut().run_schedule(PostUpdate);
+        assert!(!app.world().resource::<PredictionWindowWait>().is_waiting());
+    }
+}

--- a/crates/deterministic/deterministic_replication/src/prediction_window.rs
+++ b/crates/deterministic/deterministic_replication/src/prediction_window.rs
@@ -144,7 +144,7 @@ mod tests {
             let topology = if p2p {
                 NetworkTopology::P2P {
                     connected: [link].into_iter().collect(),
-                    declared: 1,
+                    declared_links: 1,
                 }
             } else {
                 NetworkTopology::Client(link)

--- a/crates/inputs/inputs/src/client.rs
+++ b/crates/inputs/inputs/src/client.rs
@@ -162,7 +162,11 @@ impl<S: ActionStateSequence + MapEntities> Plugin for ClientInputPlugin<S> {
         app.init_resource::<InputTimeline>();
         app.init_resource::<InputTimelineConfig>();
         #[cfg(feature = "prediction")]
-        app.init_resource::<LastConfirmedInput>();
+        {
+            if !app.is_plugin_added::<LastConfirmedInputPlugin>() {
+                app.add_plugins(LastConfirmedInputPlugin);
+            }
+        }
 
         // SETS
 
@@ -267,6 +271,31 @@ impl<S: ActionStateSequence + MapEntities> Plugin for ClientInputPlugin<S> {
         // if the client tick is updated because of a desync, update the ticks in the input buffers
         app.add_observer(receive_tick_events::<S>);
     }
+}
+
+/// Installs application-global confirmed-input frontier bookkeeping.
+///
+/// A client application can register several input types. Installing this non-generic plugin once
+/// ensures their contributions are finalized only after every input type has updated the shared
+/// [`LastConfirmedInput`] resource.
+#[cfg(feature = "prediction")]
+struct LastConfirmedInputPlugin;
+
+#[cfg(feature = "prediction")]
+impl Plugin for LastConfirmedInputPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<LastConfirmedInput>();
+        app.add_systems(
+            PostUpdate,
+            finalize_last_confirmed_input.after(InputSystems::UpdateRemoteInputTicks),
+        );
+    }
+}
+
+#[cfg(feature = "prediction")]
+/// Preserve the completed aggregate for next frame's rollback decision.
+fn finalize_last_confirmed_input(mut last_confirmed_input: ResMut<LastConfirmedInput>) {
+    last_confirmed_input.finalize_frame();
 }
 
 /// Cached input routing derived from [`NetworkingMetadata`].
@@ -1074,9 +1103,10 @@ fn update_last_confirmed_input<S: ActionStateSequence>(
         return;
     }
     let tick = timeline.tick();
-    // in lockstep mode, we don't need last confirmed input because we always have all inputs for a given tick.
-    // we will just use the current tick as the last confirmed input tick
-    if input_config.is_lockstep() {
+    // Preserve the conventional lockstep behavior: input delay guarantees that the sole remote
+    // endpoint has supplied the current tick. P2P must inspect the actual global frontier because
+    // one slow peer can still be missing while the others are ready.
+    if input_config.is_lockstep() && !matches!(metadata.mode, NetworkTopology::P2P { .. }) {
         last_confirmed_input.tick.set_if_lower(tick);
         return;
     }
@@ -1084,16 +1114,19 @@ fn update_last_confirmed_input<S: ActionStateSequence>(
 
     // find the earliest last_confirmed_tick for each client
     // The tracker was reset to a high tick, so the first real tick always becomes the minimum.
-    last_confirmed_input.received_for_all_clients = true;
+    let mut received_for_all_clients = true;
     predicted_query.iter().for_each(|buffer| {
         // if we received any messages, we update the LastConfirmedInput
         // (this is used to determine the last confirmed tick for each client)
         if let Some(end_tick) = buffer.last_remote_tick {
             last_confirmed_input.tick.set_if_lower(end_tick);
         } else {
-            last_confirmed_input.received_for_all_clients = false;
+            received_for_all_clients = false;
         }
     });
+    // Several generic input plugins contribute sequentially in the same set. The tracker is reset
+    // to true once in PreUpdate, so AND-ing preserves a missing stream reported by any input type.
+    last_confirmed_input.received_for_all_clients &= received_for_all_clients;
     trace!(
         target: "lightyear_debug::input",
         kind = "last_confirmed_input",

--- a/crates/replication/interpolation/src/timeline.rs
+++ b/crates/replication/interpolation/src/timeline.rs
@@ -146,7 +146,7 @@ impl SyncedTimeline for InterpolationTimeline {
         let adjustment = if !self.is_synced {
             SyncAdjustment::Resync
         } else {
-            self.sync.speed_adjustment(&config.sync, error_ticks)
+            self.speed_adjustment(config, error_ticks)
         };
         trace!(
             ?now,
@@ -162,19 +162,25 @@ impl SyncedTimeline for InterpolationTimeline {
             SyncAdjustment::Resync => {
                 return Some(self.resync(objective));
             }
-            SyncAdjustment::SpeedAdjust(ratio) => {
-                self.set_relative_speed(ratio);
-            }
-            SyncAdjustment::DoNothing => {
-                // within acceptable margins, gradually return to normal speed (1.0)
-                let current = self.relative_speed();
-                if (current - 1.0).abs() > 0.001 {
-                    let new_speed = current + (1.0 - current) * 0.1;
-                    self.set_relative_speed(new_speed);
-                }
-            }
+            SyncAdjustment::SpeedAdjust(_) | SyncAdjustment::DoNothing => {}
         }
         None
+    }
+
+    fn speed_adjustment(&mut self, config: &Self::Config, offset: f32) -> SyncAdjustment {
+        let adjustment = self.sync.speed_adjustment(&config.sync, offset);
+        match adjustment {
+            SyncAdjustment::SpeedAdjust(ratio) => self.set_relative_speed(ratio),
+            SyncAdjustment::DoNothing => {
+                // Within acceptable margins, gradually return to normal speed.
+                let current = self.relative_speed();
+                if (current - 1.0).abs() > 0.001 {
+                    self.set_relative_speed(current + (1.0 - current) * 0.1);
+                }
+            }
+            SyncAdjustment::Resync => {}
+        }
+        adjustment
     }
 
     fn is_synced(&self) -> bool {

--- a/crates/replication/prediction/src/manager.rs
+++ b/crates/replication/prediction/src/manager.rs
@@ -114,15 +114,20 @@ pub struct PredictionManager {
 /// application; it does not belong to any one network link.
 #[derive(Resource, Debug, Reflect)]
 pub struct LastConfirmedInput {
-    /// Updated via [`AtomicTick::set_if_lower`] to track the minimum last-confirmed tick
-    /// across all remote clients. Reset to a high value each frame by
+    /// Current frame's aggregate, updated via [`AtomicTick::set_if_lower`] to track the minimum
+    /// last-confirmed tick across all remote clients. Reset to a high value each frame by
     /// [`reset_input_rollback_tracker`] so the minimum is computed correctly.
     ///
     /// [`AtomicTick::set_if_lower`]: lightyear_core::tick::AtomicTick::set_if_lower
     /// [`reset_input_rollback_tracker`]: crate::rollback::reset_input_rollback_tracker
     pub tick: lightyear_core::tick::AtomicTick,
+    /// Completed aggregate from the previous frame.
+    ///
+    /// Rollback uses this explicitly so inputs received in the current frame are replayed from the
+    /// frontier that was known before those inputs arrived.
+    pub previous_frame_tick: Tick,
     pub received_any_messages: bevy_platform::sync::atomic::AtomicBool,
-    /// Set to true if we have received inputs from all remote clients.
+    /// Set to true if the current aggregate contains inputs from all remote clients.
     pub received_for_all_clients: bool,
 }
 
@@ -130,6 +135,7 @@ impl Default for LastConfirmedInput {
     fn default() -> Self {
         Self {
             tick: lightyear_core::tick::AtomicTick::new_max(),
+            previous_frame_tick: Tick(u32::MAX),
             received_any_messages: bevy_platform::sync::atomic::AtomicBool::new(false),
             received_for_all_clients: false,
         }
@@ -149,6 +155,19 @@ impl LastConfirmedInput {
             tick if tick == Tick(u32::MAX) => None,
             tick => Some(tick),
         }
+    }
+
+    /// Return the confirmed-input frontier completed during the previous frame.
+    pub fn previous_frame(&self) -> Option<Tick> {
+        match self.previous_frame_tick {
+            tick if tick == Tick(u32::MAX) => None,
+            tick => Some(tick),
+        }
+    }
+
+    /// Preserve the current aggregate for systems that must consume the previous frame's view.
+    pub fn finalize_frame(&mut self) {
+        self.previous_frame_tick = self.tick.get();
     }
 }
 
@@ -370,11 +389,17 @@ mod tests {
 
     #[test]
     fn last_confirmed_input_default_starts_unset() {
-        let last_confirmed_input = LastConfirmedInput::default();
+        let mut last_confirmed_input = LastConfirmedInput::default();
 
         assert_eq!(last_confirmed_input.tick.get(), Tick(u32::MAX));
         assert_eq!(last_confirmed_input.get(), None);
+        assert_eq!(last_confirmed_input.previous_frame(), None);
         assert!(!last_confirmed_input.received_input());
+
+        last_confirmed_input.tick.set_if_lower(Tick(12));
+        last_confirmed_input.received_for_all_clients = true;
+        last_confirmed_input.finalize_frame();
+        assert_eq!(last_confirmed_input.previous_frame(), Some(Tick(12)));
     }
 
     #[test]

--- a/crates/replication/prediction/src/rollback.rs
+++ b/crates/replication/prediction/src/rollback.rs
@@ -652,7 +652,7 @@ fn check_rollback(
                 if prediction_manager.is_rollback() {
                     debug!("Rollback was triggered by state, skipping input rollback checks");
                 } else if last_confirmed_input.received_input()
-                    && let Some(rollback_tick) = last_confirmed_input.get()
+                    && let Some(rollback_tick) = last_confirmed_input.previous_frame()
                 {
                     debug!(
                         ?last_confirmed_input,
@@ -815,7 +815,7 @@ fn check_rollback(
 /// This must run after the rollback check.
 pub fn reset_input_rollback_tracker(
     _input_timeline: SyncedInputTimeline,
-    last_confirmed_input: Res<LastConfirmedInput>,
+    mut last_confirmed_input: ResMut<LastConfirmedInput>,
     prediction_manager: Option<Res<PredictionManager>>,
 ) {
     // Reset to u32::MAX so the next `set_if_lower` call always wins and we
@@ -827,6 +827,9 @@ pub fn reset_input_rollback_tracker(
     last_confirmed_input
         .received_any_messages
         .store(false, bevy_platform::sync::atomic::Ordering::Relaxed);
+    // Each generic input plugin ANDs its own readiness into this value in PostUpdate. Resetting
+    // once here makes the result independent of input-plugin execution order.
+    last_confirmed_input.received_for_all_clients = true;
     if let Some(prediction_manager) = prediction_manager {
         prediction_manager
             .earliest_mismatch_input


### PR DESCRIPTION
Stacked on #1628.

## Summary

- extend the resource-backed `SyncedTimelinePlugin` with runtime P2P aggregation over cached `NetworkTopology`
- gate initial readiness on `connected.len() == declared_links`, initialized remote timelines, and a fresh observation; no secondary declared-Link query is required
- perform one safe pre-input `SyncEvent<InputTimelineConfig>` alignment, then pace from the worst positive local lead across initialized peers
- preserve controller hysteresis without fresh observations and emit `P2PTimelineDiverged` instead of locally relabeling ticks after gameplay starts
- add an application-global `PredictionWindowWait`; deterministic replication produces it for both conventional deterministic clients and P2P peers, while sync applies the virtual-time pause
- retain `InputBuffer::last_remote_tick` semantics and explicitly store the previous-frame frontier in `LastConfirmedInput` for rollback
- add no `P2PSyncConfig`, generic input config, `P2PSession`, or duplicate P2P sync plugin/state

## Hard wait policy

For local tick `T`, confirmed frontier `C`, and effective rollback-safe limit `M`, enter waiting at `T - C >= M`. Resume after up to two ticks of recovered headroom. `Time<Virtual>` runs at speed zero while waiting, so fixed schedules stop and variable networking schedules continue. P2P phase lead remains a soft slowdown.

The wait is not a packet-contiguity proof. Reliable delivery or ACK/resend remains follow-up work for permanent gaps.

## Validation

- `cargo test -p lightyear_sync --all-features`
- `cargo test -p lightyear_inputs --all-features`
- `cargo test -p lightyear_prediction --all-features`
- `cargo test -p lightyear_deterministic_replication --all-features`
- allocation-regression budget test
- all-feature Clippy with warnings denied for connection, sync, inputs, prediction, and deterministic replication