### PR TITLE
fix(deps): Replace unmaintained bincode for STD

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,9 +137,8 @@ variadics_please = "2.0.0"
 no_std_io2 = { version = "0.9", features = ["alloc"] }
 
 # serialization
-bincode = { version = "2.0.1", default-features = false, features = [
+bitcode = { version = "0.6.9", default-features = false, features = [
   "serde",
-  "alloc",
 ] }
 bytes = { version = "1.8", default-features = false, features = ["serde"] }
 lz4_flex = { version = "0.13.1", default-features = false, features = [

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Workspace crate sources live under `crates/`, grouped by role. Directory names d
     - WebSocket: available on both native and wasm!
     - Steam: use the SteamWorks SDK to send messages over the Steam network
 - Serialization
-    - *Lightyear* uses `bincode` as a default serializer, but you can provide your own serialization function
+    - *Lightyear* uses `bitcode` as a default serializer, but you can provide your own serialization function
 - Message passing
     - *Lightyear* supports sending packets with different guarantees of ordering and reliability through the use of
       channels.

--- a/crates/core/core/src/time.rs
+++ b/crates/core/core/src/time.rs
@@ -717,20 +717,20 @@ mod tests {
     #[test]
     fn test_tickdelta_accessors() {
         let delta = TickDelta::lit("-32768");
-        assert_eq!(delta.is_positive(), false);
-        assert_eq!(delta.is_negative(), true);
+        assert!(!delta.is_positive());
+        assert!(delta.is_negative());
         assert_eq!(delta.tick_diff(), 32768);
         assert_eq!(delta.overstep().to_f32(), 0.0);
 
         let delta = TickDelta::lit("-32767.75");
-        assert_eq!(delta.is_positive(), false);
-        assert_eq!(delta.is_negative(), true);
+        assert!(!delta.is_positive());
+        assert!(delta.is_negative());
         assert_eq!(delta.tick_diff(), 32767);
         assert_eq!(delta.overstep().to_f32(), 0.75);
 
         let delta = TickDelta::lit("32767.75");
-        assert_eq!(delta.is_positive(), true);
-        assert_eq!(delta.is_negative(), false);
+        assert!(delta.is_positive());
+        assert!(!delta.is_negative());
         assert_eq!(delta.tick_diff(), 32767);
         assert_eq!(delta.overstep().to_f32(), 0.75);
     }

--- a/crates/inputs/input_bei/src/input_message.rs
+++ b/crates/inputs/input_bei/src/input_message.rs
@@ -488,10 +488,7 @@ mod tests {
 
         // Should be no mismatch since the action matches our prediction
         assert_eq!(earliest_mismatch, None);
-        assert_eq!(
-            input_buffer.get_raw(Tick(6)),
-            &Compressed::Input(snapshot.clone())
-        );
+        assert_eq!(input_buffer.get_raw(Tick(6)), &Compressed::Input(snapshot));
         snapshot.decay_tick(Duration::default());
         assert_eq!(input_buffer.get(Tick(7)), Some(&snapshot));
         assert_eq!(input_buffer.get_raw(Tick(8)), &Compressed::Absent);

--- a/crates/io/websocket/src/server.rs
+++ b/crates/io/websocket/src/server.rs
@@ -108,8 +108,11 @@ impl WebSocketServerPlugin {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use core::net::{Ipv4Addr, SocketAddr};
-    use std::{thread, time::Duration};
+    use core::{
+        net::{Ipv4Addr, SocketAddr},
+        time::Duration,
+    };
+    use std::thread;
 
     use lightyear_aeronet::AeronetLink;
     use lightyear_link::{LinkStart, Unlink, Unlinked};

--- a/crates/io/webtransport/src/server.rs
+++ b/crates/io/webtransport/src/server.rs
@@ -125,8 +125,11 @@ impl WebTransportServerPlugin {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use core::net::{Ipv4Addr, SocketAddr};
-    use std::{thread, time::Duration};
+    use core::{
+        net::{Ipv4Addr, SocketAddr},
+        time::Duration,
+    };
+    use std::thread;
 
     use lightyear_aeronet::AeronetLink;
     use lightyear_link::{LinkStart, Unlink, Unlinked};

--- a/crates/replication/replication/src/send.rs
+++ b/crates/replication/replication/src/send.rs
@@ -787,126 +787,6 @@ fn update_replication_tick(
     );
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use bevy_ecs::schedule::common_conditions::resource_changed;
-    use bevy_time::Time;
-    use core::time::Duration;
-
-    #[derive(Resource, Default)]
-    struct SendCount(usize);
-
-    fn count_sends(mut count: ResMut<SendCount>) {
-        count.0 += 1;
-    }
-
-    fn add_replication_tick_test_systems(app: &mut App) {
-        app.add_systems(
-            RunFixedMainLoop,
-            update_replication_tick.in_set(RunFixedMainLoopSystems::AfterFixedMainLoop),
-        );
-        app.add_systems(
-            PostUpdate,
-            count_sends.run_if(resource_changed::<ServerTick>),
-        );
-    }
-
-    fn clear_send_state(app: &mut App) {
-        app.world_mut().run_schedule(PostUpdate);
-        app.world_mut().resource_mut::<SendCount>().0 = 0;
-        app.world_mut().clear_trackers();
-    }
-
-    #[test]
-    fn unchanged_timeline_does_not_trigger_send() {
-        let mut app = App::new();
-        app.init_resource::<Time>();
-        app.insert_resource(LocalTimeline::default());
-        app.insert_resource(ReplicationMetadata::default());
-        app.init_resource::<ServerTick>();
-        app.init_resource::<SendCount>();
-        add_replication_tick_test_systems(&mut app);
-        clear_send_state(&mut app);
-
-        app.world_mut()
-            .resource_mut::<Time>()
-            .advance_by(Duration::from_millis(1));
-        app.world_mut().run_schedule(RunFixedMainLoop);
-        app.world_mut().run_schedule(PostUpdate);
-
-        assert_eq!(app.world().resource::<ServerTick>().get(), 0);
-        assert_eq!(app.world().resource::<SendCount>().0, 0);
-    }
-
-    #[test]
-    fn multiple_fixed_ticks_trigger_single_replication_tick_after_fixed_loop() {
-        let mut app = App::new();
-        app.init_resource::<Time>();
-        app.insert_resource(LocalTimeline::default());
-        app.insert_resource(ReplicationMetadata::default());
-        app.init_resource::<ServerTick>();
-        app.init_resource::<SendCount>();
-        add_replication_tick_test_systems(&mut app);
-        clear_send_state(&mut app);
-
-        app.world_mut()
-            .resource_mut::<LocalTimeline>()
-            .apply_delta(2);
-        app.world_mut()
-            .resource_mut::<Time>()
-            .advance_by(Duration::from_millis(1));
-        app.world_mut().run_schedule(RunFixedMainLoop);
-        app.world_mut().run_schedule(PostUpdate);
-
-        assert_eq!(app.world().resource::<ServerTick>().get(), 1);
-        assert_eq!(app.world().resource::<SendCount>().0, 1);
-    }
-
-    #[test]
-    fn elapsed_interval_on_no_fixed_frame_sends_on_next_fixed_frame() {
-        let mut app = App::new();
-        app.init_resource::<Time>();
-        app.insert_resource(LocalTimeline::default());
-        app.insert_resource(ReplicationMetadata::new(Duration::from_millis(10)));
-        app.init_resource::<ServerTick>();
-        app.init_resource::<SendCount>();
-        add_replication_tick_test_systems(&mut app);
-        clear_send_state(&mut app);
-
-        app.world_mut()
-            .resource_mut::<Time>()
-            .advance_by(Duration::from_millis(10));
-        app.world_mut().run_schedule(RunFixedMainLoop);
-        app.world_mut().run_schedule(PostUpdate);
-
-        assert_eq!(app.world().resource::<ServerTick>().get(), 0);
-        assert_eq!(app.world().resource::<SendCount>().0, 0);
-
-        app.world_mut().clear_trackers();
-        app.world_mut()
-            .resource_mut::<LocalTimeline>()
-            .apply_delta(1);
-        app.world_mut()
-            .resource_mut::<Time>()
-            .advance_by(Duration::from_millis(1));
-        app.world_mut().run_schedule(RunFixedMainLoop);
-        app.world_mut().run_schedule(PostUpdate);
-
-        assert_eq!(app.world().resource::<ServerTick>().get(), 1);
-        assert_eq!(app.world().resource::<SendCount>().0, 1);
-    }
-
-    #[test]
-    fn gain_authority_without_existing_entry() {
-        let mut state = ReplicationState::default();
-        let sender = Entity::from_raw_u32(0).unwrap();
-
-        state.gain_authority(sender);
-        assert!(state.has_authority(sender));
-    }
-}
-
 pub struct SendPlugin;
 
 /// When a client becomes a host client after replicated entities already exist, backfill the
@@ -1109,5 +989,125 @@ impl Plugin for SendPlugin {
             // Note: app.replicate::<Interpolated>() is called in SharedComponentRegistrationPlugin
             app.init_resource::<InterpolatedBit>();
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bevy_ecs::schedule::common_conditions::resource_changed;
+    use bevy_time::Time;
+    use core::time::Duration;
+
+    #[derive(Resource, Default)]
+    struct SendCount(usize);
+
+    fn count_sends(mut count: ResMut<SendCount>) {
+        count.0 += 1;
+    }
+
+    fn add_replication_tick_test_systems(app: &mut App) {
+        app.add_systems(
+            RunFixedMainLoop,
+            update_replication_tick.in_set(RunFixedMainLoopSystems::AfterFixedMainLoop),
+        );
+        app.add_systems(
+            PostUpdate,
+            count_sends.run_if(resource_changed::<ServerTick>),
+        );
+    }
+
+    fn clear_send_state(app: &mut App) {
+        app.world_mut().run_schedule(PostUpdate);
+        app.world_mut().resource_mut::<SendCount>().0 = 0;
+        app.world_mut().clear_trackers();
+    }
+
+    #[test]
+    fn unchanged_timeline_does_not_trigger_send() {
+        let mut app = App::new();
+        app.init_resource::<Time>();
+        app.insert_resource(LocalTimeline::default());
+        app.insert_resource(ReplicationMetadata::default());
+        app.init_resource::<ServerTick>();
+        app.init_resource::<SendCount>();
+        add_replication_tick_test_systems(&mut app);
+        clear_send_state(&mut app);
+
+        app.world_mut()
+            .resource_mut::<Time>()
+            .advance_by(Duration::from_millis(1));
+        app.world_mut().run_schedule(RunFixedMainLoop);
+        app.world_mut().run_schedule(PostUpdate);
+
+        assert_eq!(app.world().resource::<ServerTick>().get(), 0);
+        assert_eq!(app.world().resource::<SendCount>().0, 0);
+    }
+
+    #[test]
+    fn multiple_fixed_ticks_trigger_single_replication_tick_after_fixed_loop() {
+        let mut app = App::new();
+        app.init_resource::<Time>();
+        app.insert_resource(LocalTimeline::default());
+        app.insert_resource(ReplicationMetadata::default());
+        app.init_resource::<ServerTick>();
+        app.init_resource::<SendCount>();
+        add_replication_tick_test_systems(&mut app);
+        clear_send_state(&mut app);
+
+        app.world_mut()
+            .resource_mut::<LocalTimeline>()
+            .apply_delta(2);
+        app.world_mut()
+            .resource_mut::<Time>()
+            .advance_by(Duration::from_millis(1));
+        app.world_mut().run_schedule(RunFixedMainLoop);
+        app.world_mut().run_schedule(PostUpdate);
+
+        assert_eq!(app.world().resource::<ServerTick>().get(), 1);
+        assert_eq!(app.world().resource::<SendCount>().0, 1);
+    }
+
+    #[test]
+    fn elapsed_interval_on_no_fixed_frame_sends_on_next_fixed_frame() {
+        let mut app = App::new();
+        app.init_resource::<Time>();
+        app.insert_resource(LocalTimeline::default());
+        app.insert_resource(ReplicationMetadata::new(Duration::from_millis(10)));
+        app.init_resource::<ServerTick>();
+        app.init_resource::<SendCount>();
+        add_replication_tick_test_systems(&mut app);
+        clear_send_state(&mut app);
+
+        app.world_mut()
+            .resource_mut::<Time>()
+            .advance_by(Duration::from_millis(10));
+        app.world_mut().run_schedule(RunFixedMainLoop);
+        app.world_mut().run_schedule(PostUpdate);
+
+        assert_eq!(app.world().resource::<ServerTick>().get(), 0);
+        assert_eq!(app.world().resource::<SendCount>().0, 0);
+
+        app.world_mut().clear_trackers();
+        app.world_mut()
+            .resource_mut::<LocalTimeline>()
+            .apply_delta(1);
+        app.world_mut()
+            .resource_mut::<Time>()
+            .advance_by(Duration::from_millis(1));
+        app.world_mut().run_schedule(RunFixedMainLoop);
+        app.world_mut().run_schedule(PostUpdate);
+
+        assert_eq!(app.world().resource::<ServerTick>().get(), 1);
+        assert_eq!(app.world().resource::<SendCount>().0, 1);
+    }
+
+    #[test]
+    fn gain_authority_without_existing_entry() {
+        let mut state = ReplicationState::default();
+        let sender = Entity::from_raw_u32(0).unwrap();
+
+        state.gain_authority(sender);
+        assert!(state.has_authority(sender));
     }
 }

--- a/crates/transport/serde/Cargo.toml
+++ b/crates/transport/serde/Cargo.toml
@@ -10,7 +10,8 @@ repository = "https://github.com/cBournhonesque/lightyear"
 
 [features]
 default = ["std"]
-std = ["bincode/std", "bytes/std", "no_std_io2/std"]
+std = ["bitcode/std", "bytes/std", "no_std_io2/std"]
+no_std = ["dep:bincode"]
 
 [dependencies]
 # utils
@@ -20,8 +21,12 @@ tracing.workspace = true
 variadics_please.workspace = true
 
 # serde
-bincode.workspace = true
+bitcode.workspace = true
 serde.workspace = true
+bincode = { version = "2.0.1", default-features = false, optional = true, features = [
+  "serde",
+  "alloc",
+] }
 
 # bevy
 bevy_derive.workspace = true

--- a/crates/transport/serde/src/lib.rs
+++ b/crates/transport/serde/src/lib.rs
@@ -57,8 +57,13 @@ pub enum SerializationError {
     InvalidValue,
     #[error("Subtraction overflow")]
     SubtractionOverflow,
+    #[cfg(feature = "std")]
+    #[error(transparent)]
+    Bitcode(#[from] bitcode::Error),
+    #[cfg(not(feature = "std"))]
     #[error(transparent)]
     BincodeEncode(#[from] bincode::error::EncodeError),
+    #[cfg(not(feature = "std"))]
     #[error(transparent)]
     BincodeDecode(#[from] bincode::error::DecodeError),
 }

--- a/crates/transport/serde/src/registry.rs
+++ b/crates/transport/serde/src/registry.rs
@@ -167,12 +167,13 @@ fn default_context_deserialize<C, M>(
 }
 
 #[cfg(feature = "std")]
-/// Default serialize function using bincode
+/// Default serialize function using bitcode
 fn default_serialize<M: Serialize>(
     message: &M,
     buffer: &mut Writer,
 ) -> Result<(), SerializationError> {
-    let _ = bincode::serde::encode_into_std_write(message, buffer, bincode::config::standard())?;
+    let encoded = bitcode::serialize(message)?;
+    buffer.extend_from_slice(&encoded);
     Ok(())
 }
 
@@ -187,10 +188,10 @@ fn default_serialize<M: Serialize>(
 }
 
 #[cfg(feature = "std")]
-/// Default deserialize function using bincode
+/// Default deserialize function using bitcode
 fn default_deserialize<M: DeserializeOwned>(buffer: &mut Reader) -> Result<M, SerializationError> {
-    let data = bincode::serde::decode_from_std_read(buffer, bincode::config::standard())?;
-    Ok(data)
+    let encoded = buffer.split();
+    Ok(bitcode::deserialize(encoded.as_ref())?)
 }
 
 #[cfg(not(feature = "std"))]

--- a/demos/spaceships/src/shared.rs
+++ b/demos/spaceships/src/shared.rs
@@ -898,7 +898,7 @@ mod tests {
         let mut history = ConfirmedHistory::<Weapon>::default();
         history.insert(
             Tick(435),
-            Some(Weapon {
+            HistoryState::Updated(Weapon {
                 last_fire_tick: Tick(435),
                 cooldown: 12,
                 bullet_speed: 500.0,
@@ -921,7 +921,7 @@ mod tests {
         let mut history = ConfirmedHistory::<Weapon>::default();
         history.insert(
             Tick(383),
-            Some(Weapon {
+            HistoryState::Updated(Weapon {
                 last_fire_tick: Tick(383),
                 cooldown: 12,
                 bullet_speed: 500.0,

--- a/examples/lobby/src/server.rs
+++ b/examples/lobby/src/server.rs
@@ -10,7 +10,7 @@ use bevy::platform::collections::HashMap;
 use bevy::prelude::*;
 use core::time::Duration;
 
-use crate::automation::AutomationServerPlugin;
+// use crate::automation::AutomationServerPlugin;
 use crate::protocol::*;
 use crate::shared;
 use crate::shared::shared_movement_behaviour;
@@ -25,7 +25,7 @@ pub struct ExampleServerPlugin {
 
 impl Plugin for ExampleServerPlugin {
     fn build(&self, app: &mut App) {
-        app.add_plugins(AutomationServerPlugin);
+        // app.add_plugins(AutomationServerPlugin);
         // the server is using Rooms
         app.add_plugins(RoomPlugin);
         app.insert_resource(ReplicationMetadata::new(SEND_INTERVAL));


### PR DESCRIPTION
Library `bincode` is considered unmaintained with [RUSTSEC-2025-0141](https://rustsec.org/advisories/RUSTSEC-2025-0141.html)m while library `bitcode` is still maintained. 

Another reason for this PR is the [serialization benchmarks](https://github.com/djkoloski/rust_serialization_benchmark), that considers `bincode` a bit slower than `bitcode`, which has proven correct in my tests for the suggested change.
