### PR TITLE
feat(serde): replace bincode with postcard

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,10 +137,7 @@ variadics_please = "2.0.0"
 no_std_io2 = { version = "0.9", features = ["alloc"] }
 
 # serialization
-bincode = { version = "2.0.1", default-features = false, features = [
-  "serde",
-  "alloc",
-] }
+postcard = { version = "1.1.3", default-features = false }
 bytes = { version = "1.8", default-features = false, features = ["serde"] }
 lz4_flex = { version = "0.13.1", default-features = false, features = [
   "safe-encode",

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Workspace crate sources live under `crates/`, grouped by role. Directory names d
     - WebSocket: available on both native and wasm!
     - Steam: use the SteamWorks SDK to send messages over the Steam network
 - Serialization
-    - *Lightyear* uses `bincode` as a default serializer, but you can provide your own serialization function
+    - *Lightyear* uses `postcard` as a default serializer, but you can provide your own serialization function
 - Message passing
     - *Lightyear* supports sending packets with different guarantees of ordering and reliability through the use of
       channels.

--- a/crates/transport/serde/Cargo.toml
+++ b/crates/transport/serde/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/cBournhonesque/lightyear"
 
 [features]
 default = ["std"]
-std = ["bincode/std", "bytes/std", "no_std_io2/std"]
+std = ["bytes/std", "no_std_io2/std"]
 
 [dependencies]
 # utils
@@ -20,7 +20,7 @@ tracing.workspace = true
 variadics_please.workspace = true
 
 # serde
-bincode.workspace = true
+postcard.workspace = true
 serde.workspace = true
 
 # bevy

--- a/crates/transport/serde/src/lib.rs
+++ b/crates/transport/serde/src/lib.rs
@@ -12,7 +12,7 @@
 #![no_std]
 
 extern crate alloc;
-#[cfg(feature = "std")]
+#[cfg(any(feature = "std", test))]
 extern crate std;
 
 use crate::reader::{ReadInteger, ReadVarInt, Reader};
@@ -25,6 +25,7 @@ use no_std_io2::io;
 
 /// Utilities for mapping entities during serialization and deserialization.
 pub mod entity_map;
+mod postcard_utils;
 /// Provides the [`Reader`] struct and traits for deserializing data from a byte stream.
 pub mod reader;
 /// Defines traits and structures for registering serializable types.
@@ -58,9 +59,7 @@ pub enum SerializationError {
     #[error("Subtraction overflow")]
     SubtractionOverflow,
     #[error(transparent)]
-    BincodeEncode(#[from] bincode::error::EncodeError),
-    #[error(transparent)]
-    BincodeDecode(#[from] bincode::error::DecodeError),
+    Postcard(#[from] postcard::Error),
 }
 
 /// Trait for types that can be serialized to and deserialized from a byte stream.

--- a/crates/transport/serde/src/postcard_utils.rs
+++ b/crates/transport/serde/src/postcard_utils.rs
@@ -1,0 +1,97 @@
+//! Postcard adapters for Lightyear's reusable byte buffers.
+
+use crate::reader::Reader;
+use crate::writer::Writer;
+use postcard::ser_flavors::Flavor;
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+
+/// Serializes directly into an existing [`Writer`] allocation.
+pub(crate) fn to_writer<T: Serialize + ?Sized>(
+    value: &T,
+    writer: &mut Writer,
+) -> postcard::Result<()> {
+    postcard::serialize_with_flavor(value, WriterFlavor(writer))
+}
+
+struct WriterFlavor<'a>(&'a mut Writer);
+
+impl Flavor for WriterFlavor<'_> {
+    type Output = ();
+
+    #[inline]
+    fn try_push(&mut self, data: u8) -> postcard::Result<()> {
+        self.0.extend_from_slice(&[data]);
+        Ok(())
+    }
+
+    #[inline]
+    fn try_extend(&mut self, data: &[u8]) -> postcard::Result<()> {
+        self.0.extend_from_slice(data);
+        Ok(())
+    }
+
+    #[inline]
+    fn finalize(self) -> postcard::Result<Self::Output> {
+        Ok(())
+    }
+}
+
+/// Deserializes from the unread part of a [`Reader`] and advances its cursor.
+pub(crate) fn from_reader<T: DeserializeOwned>(reader: &mut Reader) -> postcard::Result<T> {
+    let position = usize::try_from(reader.position())
+        .map_err(|_| postcard::Error::DeserializeUnexpectedEnd)?;
+    let (value, consumed) = {
+        let remaining = reader
+            .as_ref()
+            .get(position..)
+            .ok_or(postcard::Error::DeserializeUnexpectedEnd)?;
+        let initial_len = remaining.len();
+        let (value, remainder) = postcard::take_from_bytes(remaining)?;
+        (value, initial_len - remainder.len())
+    };
+    reader.set_position((position + consumed) as u64);
+    Ok(value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::string::String;
+    use alloc::vec;
+    use alloc::vec::Vec;
+    use serde::Deserialize;
+
+    #[derive(Debug, Deserialize, PartialEq, Serialize)]
+    struct Message {
+        sequence: u64,
+        text: String,
+        values: Vec<i16>,
+    }
+
+    #[test]
+    fn reuses_writer_and_advances_reader() {
+        let first = Message {
+            sequence: 1,
+            text: String::from("first"),
+            values: vec![-1, 2, 300],
+        };
+        let second = Message {
+            sequence: 2,
+            text: String::from("second"),
+            values: vec![4, 5, 6],
+        };
+        let mut writer = Writer::with_capacity(1);
+
+        to_writer(&first, &mut writer).unwrap();
+        let first_len = writer.len();
+        to_writer(&second, &mut writer).unwrap();
+
+        assert!(writer.len() > first_len);
+        let mut reader = Reader::from(writer.to_bytes());
+        assert_eq!(from_reader::<Message>(&mut reader).unwrap(), first);
+        assert_eq!(reader.position() as usize, first_len);
+        assert_eq!(from_reader::<Message>(&mut reader).unwrap(), second);
+        assert_eq!(reader.remaining(), 0);
+    }
+}

--- a/crates/transport/serde/src/reader.rs
+++ b/crates/transport/serde/src/reader.rs
@@ -106,7 +106,6 @@ pub(crate) mod std {
 pub(crate) mod no_std {
     use super::*;
     use alloc::vec::Vec;
-    use bincode::error::DecodeError;
 
     #[derive(Clone)]
     pub struct Reader(Cursor<Bytes>);
@@ -201,15 +200,6 @@ pub(crate) mod no_std {
         pub fn remaining(&self) -> usize {
             // copied from the Buf implementation for std::io::Cursor in tokio::bytes
             saturating_sub_usize_u64(self.len(), self.position())
-        }
-    }
-
-    /// We cannot decode into a Slice because the slice is not Extendable
-    impl bincode::de::read::Reader for Reader {
-        #[inline(always)]
-        fn read(&mut self, bytes: &mut [u8]) -> core::result::Result<(), DecodeError> {
-            self.read_exact(bytes)
-                .map_err(|_| DecodeError::Other("could not decode"))
         }
     }
 }

--- a/crates/transport/serde/src/registry.rs
+++ b/crates/transport/serde/src/registry.rs
@@ -1,4 +1,5 @@
 use crate::entity_map::{EntityMap, ReceiveEntityMap, SendEntityMap};
+use crate::postcard_utils;
 use crate::reader::Reader;
 use crate::writer::Writer;
 use crate::{SerializationError, ToBytes};
@@ -166,38 +167,18 @@ fn default_context_deserialize<C, M>(
     deserialize_fn(reader)
 }
 
-#[cfg(feature = "std")]
-/// Default serialize function using bincode
+/// Default serialize function using Postcard.
 fn default_serialize<M: Serialize>(
     message: &M,
     buffer: &mut Writer,
 ) -> Result<(), SerializationError> {
-    let _ = bincode::serde::encode_into_std_write(message, buffer, bincode::config::standard())?;
+    postcard_utils::to_writer(message, buffer)?;
     Ok(())
 }
 
-#[cfg(not(feature = "std"))]
-/// Default serialize function using bincode
-fn default_serialize<M: Serialize>(
-    message: &M,
-    buffer: &mut Writer,
-) -> Result<(), SerializationError> {
-    bincode::serde::encode_into_writer(message, buffer, bincode::config::standard())?;
-    Ok(())
-}
-
-#[cfg(feature = "std")]
-/// Default deserialize function using bincode
+/// Default deserialize function using Postcard.
 fn default_deserialize<M: DeserializeOwned>(buffer: &mut Reader) -> Result<M, SerializationError> {
-    let data = bincode::serde::decode_from_std_read(buffer, bincode::config::standard())?;
-    Ok(data)
-}
-
-#[cfg(not(feature = "std"))]
-/// Default deserialize function using bincode
-fn default_deserialize<M: DeserializeOwned>(buffer: &mut Reader) -> Result<M, SerializationError> {
-    let data = bincode::serde::decode_from_reader(buffer, bincode::config::standard())?;
-    Ok(data)
+    Ok(postcard_utils::from_reader(buffer)?)
 }
 
 fn erased_clone<M: Clone>(message: &M) -> M {

--- a/crates/transport/serde/src/writer.rs
+++ b/crates/transport/serde/src/writer.rs
@@ -126,7 +126,6 @@ pub(crate) mod std {
 #[cfg(not(feature = "std"))]
 pub(crate) mod no_std {
     use super::*;
-    use bincode::error::EncodeError;
     use core::cmp;
     #[derive(Debug)]
     pub struct Writer(BytesMut);
@@ -136,14 +135,6 @@ pub(crate) mod no_std {
             Self(value)
         }
     }
-
-    // impl bincode::Writer for Writer {
-    //     fn write_all(&mut self, buf: &[u8]) -> Result<(), EncodeError> {
-    //         let n = cmp::min(self.0.remaining_mut(), buf.len());
-    //         self.0.put_slice(&buf[..n]);
-    //         Ok(())
-    //     }
-    // }
 
     impl Write for Writer {
         fn write(&mut self, src: &[u8]) -> Result<usize> {
@@ -227,17 +218,6 @@ pub(crate) mod no_std {
         #[allow(clippy::wrong_self_convention)]
         pub fn to_bytes_mut(self) -> BytesMut {
             self.0
-        }
-    }
-
-    /// We need to provide our own implementation of bincode::enc::write::Writer.
-    /// We cannot use the SliceWriter because it supposes that the slice is immutable
-    impl bincode::enc::write::Writer for Writer {
-        #[inline(always)]
-        fn write(&mut self, bytes: &[u8]) -> core::result::Result<(), EncodeError> {
-            self.write_all(bytes)
-                .map_err(|_| EncodeError::Other("encode error"))?;
-            Ok(())
         }
     }
 }


### PR DESCRIPTION
Bincode is unmatained:
https://rustsec.org/advisories/RUSTSEC-2025-0141.html

Postcase has no-std support, and allows serializing into a buffer.