### PR TITLE
feat(perf): reuse receive buffer allocations

### DIFF
--- a/crates/connection/netcode/src/client.rs
+++ b/crates/connection/netcode/src/client.rs
@@ -6,9 +6,7 @@ use super::{
     ClientId, MAX_PACKET_SIZE, MAX_PKT_BUF_SIZE, PACKET_SEND_RATE_SEC,
     bytes::Bytes,
     error::{Error, Result},
-    packet::{
-        DisconnectPacket, KeepAlivePacket, Packet, PayloadPacket, RequestPacket, ResponsePacket,
-    },
+    packet::{DisconnectPacket, KeepAlivePacket, Packet, RequestPacket, ResponsePacket},
     replay::ReplayProtection,
     token::{ChallengeToken, ConnectToken},
     utils,
@@ -364,6 +362,26 @@ impl<Ctx> Client<Ctx> {
         Ok(())
     }
 
+    fn send_payload_packet(
+        &mut self,
+        payload: &SendPayload,
+        sender: &mut LinkSender,
+    ) -> Result<()> {
+        let mut buf = [0u8; MAX_PKT_BUF_SIZE];
+        let size = Packet::write_payload(
+            payload,
+            &mut buf,
+            self.sequence,
+            &self.token.client_to_server_key,
+            self.token.protocol_id,
+        )?;
+        self.writer.extend_from_slice(&buf[..size]);
+        sender.push(self.writer.split());
+        self.last_send_time = self.time;
+        self.sequence += 1;
+        Ok(())
+    }
+
     /// We buffer netcode packets (non-user-payload packets) instead of storing them in the link
     fn send_netcode_packet(&mut self, packet: Packet) -> Result<()> {
         let mut buf = [0u8; MAX_PKT_BUF_SIZE];
@@ -422,7 +440,7 @@ impl<Ctx> Client<Ctx> {
             (Packet::Payload(pkt), ClientState::Connected) => {
                 // trace!(?pkt.buf, "client received payload packet from server");
                 // TODO: control the size of the packet queue?
-                Some(pkt.buf)
+                Some(pkt.into_recv())
             }
             (Packet::Disconnect(_), ClientState::Connected) => {
                 debug!("client received disconnect packet from server");
@@ -592,7 +610,7 @@ impl<Ctx> Client<Ctx> {
         if buf.len() > MAX_PACKET_SIZE {
             return Err(Error::SizeMismatch(MAX_PACKET_SIZE, buf.len()));
         }
-        self.send_packet(PayloadPacket::create(buf), sender)?;
+        self.send_payload_packet(&buf, sender)?;
         Ok(())
     }
     /// Disconnects the client from the server.

--- a/crates/connection/netcode/src/packet.rs
+++ b/crates/connection/netcode/src/packet.rs
@@ -1,5 +1,4 @@
 use alloc::{borrow::ToOwned, boxed::Box, string::String, vec};
-use bytes::BytesMut;
 use core::mem::size_of;
 #[cfg(not(feature = "std"))]
 use no_std_io2::{
@@ -18,7 +17,7 @@ use super::{
     token::{ChallengeToken, ConnectTokenPrivate},
 };
 use chacha20poly1305::XNonce;
-use lightyear_link::{RecvPayload, SendPayload};
+use lightyear_link::RecvPayload;
 use lightyear_serde::reader::{ReadInteger, Reader};
 use lightyear_serde::writer::WriteInteger;
 use lightyear_serde::{SerializationError, ToBytes};
@@ -359,13 +358,18 @@ impl Bytes for KeepAlivePacket {
     }
 }
 
+/// An application payload parsed from an inbound Netcode packet.
+///
+/// Outbound application payloads are written directly by [`Packet::write_payload`] instead of
+/// constructing this receive-side representation.
 pub struct PayloadPacket {
-    pub buf: SendPayload,
+    buf: RecvPayload,
 }
 
 impl PayloadPacket {
-    pub fn create(buf: SendPayload) -> Packet {
-        Packet::Payload(PayloadPacket { buf })
+    /// Consumes the parsed packet and returns its mutable application payload.
+    pub fn into_recv(self) -> RecvPayload {
+        self.buf
     }
 }
 
@@ -434,8 +438,8 @@ impl Packet {
             Packet::Disconnect(_) => Packet::DISCONNECT,
         }
     }
-    fn set_prefix(&self, sequence: u64) -> u8 {
-        sequence_len(sequence) << 4 | self.kind()
+    fn prefix(kind: PacketKind, sequence: u64) -> u8 {
+        sequence_len(sequence) << 4 | kind
     }
     fn aead(
         protocol_id: u64,
@@ -461,33 +465,77 @@ impl Packet {
         packet_key: &Key,
         protocol_id: u64,
     ) -> Result<usize, NetcodeError> {
-        let len = out.len();
-        let mut cursor = io::Cursor::new(&mut out[..]);
         if let Packet::Request(pkt) = self {
+            let mut cursor = io::Cursor::new(&mut out[..]);
             cursor.write_u8(Packet::REQUEST)?;
             pkt.write_to(&mut cursor)?;
             return Ok(cursor.position() as usize);
         }
-        cursor.write_u8(self.set_prefix(sequence))?;
-        cursor.write_sequence(sequence)?;
-        let encryption_start = cursor.position() as usize;
-        match self {
-            Packet::Denied(pkt) => pkt.write_to(&mut cursor)?,
-            Packet::Challenge(pkt) => pkt.write_to(&mut cursor)?,
-            Packet::Response(pkt) => pkt.write_to(&mut cursor)?,
-            Packet::KeepAlive(pkt) => pkt.write_to(&mut cursor)?,
-            Packet::Disconnect(pkt) => pkt.write_to(&mut cursor)?,
-            Packet::Payload(PayloadPacket { buf }) => cursor.write_all(buf)?,
-            _ => unreachable!(), // Packet::Request variant is handled above
-        }
-        if cursor.position() as usize > len - MAC_BYTES {
-            return Err(Error::TooLarge.into());
-        }
-        let encryption_end = cursor.position() as usize + MAC_BYTES;
+
+        Self::write_encrypted(
+            out,
+            self.kind(),
+            sequence,
+            packet_key,
+            protocol_id,
+            |cursor| {
+                match self {
+                    Packet::Denied(pkt) => pkt.write_to(cursor)?,
+                    Packet::Challenge(pkt) => pkt.write_to(cursor)?,
+                    Packet::Response(pkt) => pkt.write_to(cursor)?,
+                    Packet::KeepAlive(pkt) => pkt.write_to(cursor)?,
+                    Packet::Disconnect(pkt) => pkt.write_to(cursor)?,
+                    Packet::Payload(pkt) => cursor.write_all(&pkt.buf)?,
+                    Packet::Request(_) => unreachable!("request packets are written above"),
+                }
+                Ok(())
+            },
+        )
+    }
+
+    /// Writes and encrypts an outbound application payload without constructing a parsed packet.
+    pub fn write_payload(
+        payload: &[u8],
+        out: &mut [u8],
+        sequence: u64,
+        packet_key: &Key,
+        protocol_id: u64,
+    ) -> Result<usize, NetcodeError> {
+        Self::write_encrypted(
+            out,
+            Self::PAYLOAD,
+            sequence,
+            packet_key,
+            protocol_id,
+            |cursor| cursor.write_all(payload),
+        )
+    }
+
+    fn write_encrypted(
+        out: &mut [u8],
+        kind: PacketKind,
+        sequence: u64,
+        packet_key: &Key,
+        protocol_id: u64,
+        write_body: impl FnOnce(&mut io::Cursor<&mut [u8]>) -> io::Result<()>,
+    ) -> Result<usize, NetcodeError> {
+        let len = out.len();
+        let prefix = Self::prefix(kind, sequence);
+        let (encryption_start, encryption_end) = {
+            let mut cursor = io::Cursor::new(&mut out[..]);
+            cursor.write_u8(prefix)?;
+            cursor.write_sequence(sequence)?;
+            let encryption_start = cursor.position() as usize;
+            write_body(&mut cursor)?;
+            if cursor.position() as usize > len - MAC_BYTES {
+                return Err(Error::TooLarge.into());
+            }
+            (encryption_start, cursor.position() as usize + MAC_BYTES)
+        };
 
         crypto::chacha_encrypt(
             &mut out[encryption_start..encryption_end],
-            Some(&Packet::aead(protocol_id, self.set_prefix(sequence))?),
+            Some(&Packet::aead(protocol_id, prefix)?),
             sequence,
             packet_key,
         )?;
@@ -538,9 +586,12 @@ impl Packet {
 
         let decryption_start = cursor.position() as usize;
 
-        // suffix starts at `decryption_start`
-        // this should not make a copy since we should only have one owner of the bytes
-        let mut suffix = BytesMut::from(cursor.into_inner().split_off(decryption_start));
+        let mut encrypted_packet = cursor.into_inner();
+        let mut suffix = encrypted_packet.split_off(decryption_start);
+        // The cleartext prefix has already been parsed into `prefix_byte` and `sequence`, so no
+        // later stage needs to retain it. Dropping this disjoint `BytesMut` view also lets the IO
+        // buffer pool recover the entire allocation as soon as the decrypted suffix is consumed.
+        drop(encrypted_packet);
         crypto::chacha_decrypt(
             suffix.as_mut(),
             Some(&Packet::aead(protocol_id, prefix_byte)?),
@@ -548,8 +599,7 @@ impl Packet {
             &key,
         )?;
 
-        // remove the last
-        let mut cursor = io::Cursor::new(suffix.freeze());
+        let mut cursor = io::Cursor::new(suffix);
 
         if let Some(replay_protection) = replay_protection
             && pkt_kind >= Packet::KEEP_ALIVE
@@ -585,6 +635,7 @@ mod tests {
 
     use alloc::vec::Vec;
     use chacha20poly1305::{AeadCore, XChaCha20Poly1305, aead::OsRng};
+    use lightyear_link::recv_payload_from_bytes;
     use lightyear_serde::writer::Writer;
     use std::dbg;
 
@@ -652,7 +703,7 @@ mod tests {
         dbg!(size);
 
         let packet = Packet::read(
-            buf.split_to(size),
+            recv_payload_from_bytes(buf.split_to(size)),
             protocol_id,
             0,
             private_key,
@@ -701,7 +752,7 @@ mod tests {
             .unwrap();
 
         let packet = Packet::read(
-            buf.split_to(size),
+            recv_payload_from_bytes(buf.split_to(size)),
             protocol_id,
             0,
             packet_key,
@@ -733,7 +784,7 @@ mod tests {
             .unwrap();
 
         let packet = Packet::read(
-            buf.split_to(size),
+            recv_payload_from_bytes(buf.split_to(size)),
             protocol_id,
             0,
             packet_key,
@@ -764,7 +815,7 @@ mod tests {
             .unwrap();
 
         let packet = Packet::read(
-            buf.split_to(size),
+            recv_payload_from_bytes(buf.split_to(size)),
             protocol_id,
             0,
             packet_key,
@@ -797,7 +848,7 @@ mod tests {
             .unwrap();
 
         let packet = Packet::read(
-            buf.split_to(size),
+            recv_payload_from_bytes(buf.split_to(size)),
             protocol_id,
             0,
             packet_key,
@@ -827,7 +878,7 @@ mod tests {
             .write(buf.as_mut(), sequence, &packet_key, protocol_id)
             .unwrap();
 
-        let received = buf.split_to(size);
+        let received = recv_payload_from_bytes(buf.split_to(size));
         let packet = Packet::read(
             received,
             protocol_id,
@@ -851,15 +902,21 @@ mod tests {
         let mut replay_protection = ReplayProtection::new();
 
         let payload = bytes::Bytes::from(vec![0u8; 100]);
-        let packet = Packet::Payload(PayloadPacket { buf: payload });
 
         let mut writer = Writer::from([0; MAX_PACKET_SIZE]);
-        let size = packet
-            .write(writer.as_mut(), sequence, &packet_key, protocol_id)
-            .unwrap();
+        let size = Packet::write_payload(
+            &payload,
+            writer.as_mut(),
+            sequence,
+            &packet_key,
+            protocol_id,
+        )
+        .unwrap();
 
+        let received = recv_payload_from_bytes(writer.split_to(size));
+        let received_range = received.as_ptr_range();
         let packet = Packet::read(
-            writer.split_to(size),
+            received,
             protocol_id,
             0,
             packet_key,
@@ -868,10 +925,12 @@ mod tests {
         )
         .unwrap();
 
-        let Packet::Payload(data_pkt) = packet else {
+        let Packet::Payload(PayloadPacket { buf: payload }) = packet else {
             panic!("wrong packet type");
         };
 
-        assert_eq!(data_pkt.buf.len(), 100);
+        assert_eq!(payload.len(), 100);
+        assert!(payload.as_ptr() >= received_range.start);
+        assert!(payload.as_ptr_range().end <= received_range.end);
     }
 }

--- a/crates/connection/netcode/src/server.rs
+++ b/crates/connection/netcode/src/server.rs
@@ -11,8 +11,8 @@ use super::{
     crypto::{self, Key},
     error::{Error, Result},
     packet::{
-        ChallengePacket, DeniedPacket, DisconnectPacket, KeepAlivePacket, Packet, PayloadPacket,
-        RequestPacket, ResponsePacket,
+        ChallengePacket, DeniedPacket, DisconnectPacket, KeepAlivePacket, Packet, RequestPacket,
+        ResponsePacket,
     },
     replay::ReplayProtection,
     token::{ChallengeToken, ConnectToken, ConnectTokenBuilder, ConnectTokenPrivate},
@@ -514,7 +514,7 @@ impl<Ctx> Server<Ctx> {
                     self.conn_cache.find_by_entity(&entity).map(|c| c.client_id)
                 {
                     self.touch_client(client_id);
-                    Ok(Some(packet.buf))
+                    Ok(Some(packet.into_recv()))
                 } else {
                     Ok(None)
                 }
@@ -563,6 +563,35 @@ impl<Ctx> Server<Ctx> {
 
         let mut buf = [0u8; MAX_PKT_BUF_SIZE];
         let size = packet.write(&mut buf, conn.sequence, &conn.send_key, self.protocol_id)?;
+        self.writer.extend_from_slice(&buf[..size]);
+        sender.push(self.writer.split());
+
+        conn.last_access_time = self.time;
+        conn.last_send_time = self.time;
+        conn.sequence += 1;
+        Ok(())
+    }
+
+    fn send_payload_to_client(
+        &mut self,
+        payload: &SendPayload,
+        id: ClientId,
+        sender: &mut LinkSender,
+    ) -> Result<()> {
+        let conn = &mut self
+            .conn_cache
+            .clients
+            .get_mut(&id)
+            .ok_or(Error::ClientNotFound(id::PeerId::Netcode(id)))?;
+
+        let mut buf = [0u8; MAX_PKT_BUF_SIZE];
+        let size = Packet::write_payload(
+            payload,
+            &mut buf,
+            conn.sequence,
+            &conn.send_key,
+            self.protocol_id,
+        )?;
         self.writer.extend_from_slice(&buf[..size]);
         sender.push(self.writer.split());
 
@@ -924,8 +953,7 @@ impl<Ctx> Server<Ctx> {
             // send a keep-alive packet to the client to confirm the connection
             self.send_to_client(KeepAlivePacket::create(client_id), client_id, sender)?;
         }
-        let packet = PayloadPacket::create(buf);
-        self.send_to_client(packet, client_id, sender)
+        self.send_payload_to_client(&buf, client_id, sender)
     }
 
     /// Sends a packet to all connected clients.

--- a/crates/core/core/Cargo.toml
+++ b/crates/core/core/Cargo.toml
@@ -19,6 +19,7 @@ lightyear_utils.workspace = true
 lightyear_serde.workspace = true
 
 # utils
+bytes.workspace = true
 chrono.workspace = true
 fixed.workspace = true
 tracing.workspace = true

--- a/crates/core/core/src/buffer_pool.rs
+++ b/crates/core/core/src/buffer_pool.rs
@@ -1,0 +1,220 @@
+//! Bounded recycling for split [`BytesMut`] allocations.
+
+use alloc::vec::Vec;
+use bytes::BytesMut;
+
+/// A bounded pool of fixed-capacity [`BytesMut`] allocations.
+///
+/// The pool supports zero-copy ownership handoffs through
+/// [`split_for_handoff`](Self::split_for_handoff). That operation returns the initialized prefix
+/// and retains the empty sibling tail. Both views share one allocation, so the tail remains
+/// pending until every handed-off view has been dropped and [`BytesMut::try_reclaim`] can recover
+/// the complete allocation.
+///
+/// Ready and pending buffers are kept separate so [`take`](Self::take) is O(1). Call
+/// [`reclaim_pending`](Self::reclaim_pending) once at the start of a processing pass instead of
+/// probing every pending allocation for every buffer request.
+///
+/// The returned prefix remains a [`BytesMut`]. Callers that need immutable shared views can freeze
+/// it after the handoff; callers that need in-place mutation can keep it mutable.
+#[derive(Debug)]
+pub struct BufferPool {
+    buffer_capacity: usize,
+    max_retained: usize,
+    ready: Vec<BytesMut>,
+    pending: Vec<BytesMut>,
+    misses: usize,
+}
+
+impl BufferPool {
+    /// Creates an empty pool for allocations with exactly `buffer_capacity` visible capacity.
+    ///
+    /// At most `max_retained` allocations are held across the ready and pending partitions.
+    pub const fn new(buffer_capacity: usize, max_retained: usize) -> Self {
+        Self {
+            buffer_capacity,
+            max_retained,
+            ready: Vec::new(),
+            pending: Vec::new(),
+            misses: 0,
+        }
+    }
+
+    /// Allocates up to `count` immediately writable buffers without recording pool misses.
+    ///
+    /// This is intended for setup-time preallocation. Existing retained buffers count toward both
+    /// `count` and the pool's retention bound.
+    pub fn preallocate(&mut self, count: usize) {
+        let target = count.min(self.max_retained);
+        while self.retained_len() < target {
+            self.ready
+                .push(BytesMut::with_capacity(self.buffer_capacity));
+        }
+    }
+
+    /// Returns an empty writable buffer with at least the configured capacity.
+    ///
+    /// A miss allocates a new buffer. That allocation can later enter the pool through
+    /// [`recycle`](Self::recycle) or [`split_for_handoff`](Self::split_for_handoff).
+    pub fn take(&mut self) -> BytesMut {
+        if let Some(mut buffer) = self.ready.pop() {
+            debug_assert!(buffer.capacity() >= self.buffer_capacity);
+            buffer.clear();
+            return buffer;
+        }
+        self.misses += 1;
+        BytesMut::with_capacity(self.buffer_capacity)
+    }
+
+    /// Updates the required capacity, dropping all retained allocations when it changes.
+    ///
+    /// Existing allocations cannot safely be reclassified because the pool intentionally retains
+    /// only allocations whose complete visible capacity matched the previous value exactly.
+    pub fn set_buffer_capacity(&mut self, buffer_capacity: usize) {
+        if self.buffer_capacity != buffer_capacity {
+            self.buffer_capacity = buffer_capacity;
+            self.ready.clear();
+            self.pending.clear();
+        }
+    }
+
+    /// Promotes pending tails whose handed-off siblings have all been dropped.
+    pub fn reclaim_pending(&mut self) {
+        let mut index = 0;
+        while index < self.pending.len() {
+            if self.pending[index].try_reclaim(self.buffer_capacity) {
+                let buffer = self.pending.swap_remove(index);
+                self.ready.push(buffer);
+            } else {
+                index += 1;
+            }
+        }
+    }
+
+    /// Recycles a complete buffer that has not crossed an ownership boundary.
+    ///
+    /// Buffers whose visible capacity differs from the configured capacity are dropped. This keeps
+    /// unexpectedly enlarged allocations from weakening the pool's memory bound.
+    pub fn recycle(&mut self, mut buffer: BytesMut) {
+        buffer.clear();
+        if buffer.capacity() != self.buffer_capacity {
+            return;
+        }
+        self.enqueue(buffer);
+    }
+
+    /// Splits a buffer for zero-copy handoff and retains its empty sibling tail when eligible.
+    ///
+    /// Eligibility is checked before splitting because the tail's visible capacity does not reveal
+    /// the complete allocation size. The returned prefix is mutable; callers may subsequently call
+    /// [`BytesMut::freeze`] without copying.
+    pub fn split_for_handoff(&mut self, mut buffer: BytesMut) -> BytesMut {
+        let retain_tail = buffer.capacity() == self.buffer_capacity;
+        let payload = buffer.split();
+        if retain_tail {
+            self.enqueue(buffer);
+        }
+        payload
+    }
+
+    /// Returns how many calls to [`take`](Self::take) allocated because no ready buffer existed.
+    pub const fn misses(&self) -> usize {
+        self.misses
+    }
+
+    fn enqueue(&mut self, mut buffer: BytesMut) {
+        if self.retained_len() >= self.max_retained {
+            return;
+        }
+        if buffer.try_reclaim(self.buffer_capacity) {
+            self.ready.push(buffer);
+        } else {
+            self.pending.push(buffer);
+        }
+    }
+
+    fn retained_len(&self) -> usize {
+        self.ready.len() + self.pending.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const CAPACITY: usize = 128;
+
+    #[test]
+    fn split_tail_becomes_ready_after_mutable_payload_drop() {
+        let mut pool = BufferPool::new(CAPACITY, 4);
+        let mut buffer = pool.take();
+        buffer.extend_from_slice(b"payload");
+
+        let payload = pool.split_for_handoff(buffer);
+        assert!(pool.ready.is_empty());
+        assert_eq!(pool.pending.len(), 1);
+
+        pool.reclaim_pending();
+        assert!(pool.ready.is_empty());
+
+        drop(payload);
+        pool.reclaim_pending();
+        assert_eq!(pool.ready.len(), 1);
+        assert!(pool.pending.is_empty());
+    }
+
+    #[test]
+    fn split_tail_becomes_ready_after_frozen_payload_drop() {
+        let mut pool = BufferPool::new(CAPACITY, 4);
+        let mut buffer = pool.take();
+        buffer.extend_from_slice(b"payload");
+
+        let payload = pool.split_for_handoff(buffer).freeze();
+        assert_eq!(pool.pending.len(), 1);
+
+        drop(payload);
+        pool.reclaim_pending();
+        assert_eq!(pool.ready.len(), 1);
+        assert!(pool.pending.is_empty());
+    }
+
+    #[test]
+    fn oversized_complete_buffer_is_not_retained() {
+        let mut pool = BufferPool::new(CAPACITY, 4);
+        pool.recycle(BytesMut::with_capacity(CAPACITY * 2));
+
+        assert_eq!(pool.retained_len(), 0);
+        let misses = pool.misses();
+        let _ = pool.take();
+        assert_eq!(pool.misses(), misses + 1);
+    }
+
+    #[test]
+    fn preallocation_and_retention_are_bounded() {
+        let mut pool = BufferPool::new(CAPACITY, 2);
+        pool.preallocate(usize::MAX);
+        assert_eq!(pool.ready.len(), 2);
+        assert_eq!(pool.misses(), 0);
+
+        let first = pool.take();
+        let second = pool.take();
+        let third = pool.take();
+        assert_eq!(pool.misses(), 1);
+
+        pool.recycle(first);
+        pool.recycle(second);
+        pool.recycle(third);
+        assert_eq!(pool.retained_len(), 2);
+    }
+
+    #[test]
+    fn changing_capacity_drops_retained_buffers() {
+        let mut pool = BufferPool::new(CAPACITY, 2);
+        pool.preallocate(1);
+
+        pool.set_buffer_capacity(CAPACITY * 2);
+
+        assert_eq!(pool.retained_len(), 0);
+        assert_eq!(pool.take().capacity(), CAPACITY * 2);
+    }
+}

--- a/crates/core/core/src/lib.rs
+++ b/crates/core/core/src/lib.rs
@@ -14,6 +14,9 @@ extern crate core;
 #[cfg(test)]
 extern crate std;
 
+/// Bounded recycling for split mutable byte-buffer allocations.
+pub mod buffer_pool;
+
 /// Defines the `Tick` type and related systems for managing discrete time steps.
 pub mod tick;
 

--- a/crates/io/aeronet/src/lib.rs
+++ b/crates/io/aeronet/src/lib.rs
@@ -28,6 +28,7 @@ use bevy_ecs::relationship::Relationship;
 use bevy_reflect::Reflect;
 use lightyear_link::{
     Link, LinkPlugin, LinkReceiveSystems, LinkSystems, Linked, Linking, Unlink, Unlinked,
+    recv_payload_from_bytes,
 };
 use tracing::trace;
 
@@ -193,10 +194,13 @@ impl AeronetPlugin {
                 trace!("Received {:?} packets", session.recv.len());
                 session.recv.drain(..).for_each(|recv| {
                     #[cfg(feature = "test_utils")]
-                    link.recv
-                        .push(recv.payload, lightyear_core::time::Instant::now());
+                    link.recv.push(
+                        recv_payload_from_bytes(recv.payload),
+                        lightyear_core::time::Instant::now(),
+                    );
                     #[cfg(not(feature = "test_utils"))]
-                    link.recv.push(recv.payload, recv.recv_at);
+                    link.recv
+                        .push(recv_payload_from_bytes(recv.payload), recv.recv_at);
                 });
             }
         });

--- a/crates/io/crossbeam/src/lib.rs
+++ b/crates/io/crossbeam/src/lib.rs
@@ -52,6 +52,7 @@ use crossbeam_channel::{Receiver, Sender, TryRecvError, TrySendError};
 use lightyear_core::time::Instant;
 use lightyear_link::{
     Link, LinkPlugin, LinkReceiveSystems, LinkStart, LinkSystems, Linked, Unlink,
+    recv_payload_from_bytes,
 };
 use tracing::{error, trace};
 
@@ -191,7 +192,8 @@ impl CrossbeamPlugin {
                 match crossbeam_io.receiver.try_recv() {
                     Ok(data) => {
                         trace!("recv data: {data:?}");
-                        link.recv.push(data, Instant::now())
+                        link.recv
+                            .push(recv_payload_from_bytes(data), Instant::now())
                     }
                     Err(TryRecvError::Empty) => break,
                     Err(TryRecvError::Disconnected) => {

--- a/crates/io/link/src/lib.rs
+++ b/crates/io/link/src/lib.rs
@@ -4,8 +4,8 @@
 //! systems and concrete IO backends. Protocol, connection, replication, and message systems
 //! read from and write to [`Link`] buffers; transport crates such as `lightyear_udp`,
 //! `lightyear_webtransport`, `lightyear_websocket`, `lightyear_steam`, and
-//! `lightyear_crossbeam` are responsible for moving those [`bytes::Bytes`] payloads across an
-//! actual network or in-process channel.
+//! `lightyear_crossbeam` are responsible for moving byte payloads across an actual network or
+//! in-process channel.
 //!
 //! The crate deliberately keeps the IO abstraction narrow:
 //! - [`RecvPayload`] and [`SendPayload`] are opaque byte payloads.
@@ -37,7 +37,7 @@ use bevy_app::{App, Plugin, PostUpdate, PreUpdate};
 use bevy_ecs::lifecycle::HookContext;
 use bevy_ecs::prelude::*;
 use bevy_ecs::world::DeferredWorld;
-use bytes::Bytes;
+use bytes::{Bytes, BytesMut};
 use core::time::Duration;
 use lightyear_core::time::Instant;
 
@@ -54,12 +54,13 @@ pub mod prelude {
     }
 }
 
-/// Opaque byte payload received from a transport.
+/// Mutable byte payload received from a transport.
 ///
 /// A transport pushes this payload into [`LinkReceiver`] after decoding any transport-specific
-/// envelope. Higher-level Lightyear systems then interpret the bytes as messages, replication
-/// data, connection packets, or other protocol frames.
-pub type RecvPayload = Bytes;
+/// envelope. Keeping receive payloads mutable lets connection layers decrypt in place without
+/// first trying to recover mutable ownership from an immutable [`Bytes`] handle. Higher-level
+/// Lightyear systems can freeze the payload once they need cheap immutable subslices.
+pub type RecvPayload = BytesMut;
 
 /// Opaque byte payload queued for a transport to send.
 ///
@@ -67,6 +68,19 @@ pub type RecvPayload = Bytes;
 /// A transport drains [`LinkSender`] in [`LinkSystems::Send`] and writes the bytes to its concrete
 /// IO backend.
 pub type SendPayload = Bytes;
+
+/// Converts an immutable transport payload into Lightyear's mutable receive payload.
+///
+/// Some IO APIs, including Aeronet and Crossbeam, expose received packets as [`Bytes`]. This
+/// conversion reuses the allocation when that handle is uniquely owned and copies only when the
+/// IO backend or sender still holds another reference. IO backends that already receive into a
+/// [`BytesMut`] should push it directly instead of calling this function.
+pub fn recv_payload_from_bytes(payload: Bytes) -> RecvPayload {
+    match payload.try_into_mut() {
+        Ok(payload) => payload,
+        Err(payload) => BytesMut::from(payload),
+    }
+}
 
 /// Current lifecycle state of a [`Link`].
 ///
@@ -212,7 +226,7 @@ impl LinkReceiver {
 
     /// Iterates over the currently available received payloads without consuming them.
     #[cfg(feature = "test_utils")]
-    pub fn iter(&self) -> impl Iterator<Item = &SendPayload> {
+    pub fn iter(&self) -> impl Iterator<Item = &RecvPayload> {
         self.buffer.iter()
     }
 }
@@ -485,6 +499,28 @@ impl Plugin for LinkPlugin {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn immutable_receive_payload_reuses_unique_allocation() {
+        let bytes = Bytes::from(alloc::vec![1, 2, 3]);
+        let allocation = bytes.as_ptr();
+
+        let payload = recv_payload_from_bytes(bytes);
+
+        assert_eq!(payload.as_ptr(), allocation);
+    }
+
+    #[test]
+    fn immutable_receive_payload_copies_shared_allocation() {
+        let bytes = Bytes::from(alloc::vec![1, 2, 3]);
+        let shared = bytes.clone();
+        let allocation = bytes.as_ptr();
+
+        let payload = recv_payload_from_bytes(bytes);
+
+        assert_ne!(payload.as_ptr(), allocation);
+        assert_eq!(payload.as_ref(), shared.as_ref());
+    }
 
     #[test]
     fn explicit_link_mtu_does_not_change_link_owned_latency_stats() {

--- a/crates/io/udp/Cargo.toml
+++ b/crates/io/udp/Cargo.toml
@@ -12,6 +12,7 @@ repository = "https://github.com/cBournhonesque/lightyear"
 default = []
 server = ["bevy_platform"]
 metrics = ["dep:metrics"]
+test_utils = []
 
 [dependencies]
 lightyear_core.workspace = true

--- a/crates/io/udp/src/lib.rs
+++ b/crates/io/udp/src/lib.rs
@@ -19,7 +19,8 @@ use std::net::UdpSocket;
 use aeronet_io::connection::{LocalAddr, PeerAddr};
 use bevy_app::prelude::*;
 use bevy_ecs::prelude::*;
-use bytes::{BufMut, BytesMut};
+use bytes::BufMut;
+use lightyear_core::buffer_pool::BufferPool;
 use lightyear_core::time::Instant;
 use lightyear_link::{
     Link, LinkPlugin, LinkReceiveSystems, LinkStart, LinkSystems, Linked, Linking, Unlink, Unlinked,
@@ -52,6 +53,15 @@ pub mod prelude {
 /// <https://gafferongames.com/post/packet_fragmentation_and_reassembly/>.
 pub(crate) const MTU: usize = 1472;
 
+const MAX_RETAINED_RECV_BUFFERS: usize = 64;
+
+/// Creates the per-socket receive pool with one buffer allocated during setup.
+fn recv_buffer_pool() -> BufferPool {
+    let mut pool = BufferPool::new(MTU, MAX_RETAINED_RECV_BUFFERS);
+    pool.preallocate(1);
+    pool
+}
+
 /// Single-peer UDP socket transport component.
 ///
 /// Insert this on the entity that owns the Lightyear [`Link`] for a UDP peer. A [`LocalAddr`] must
@@ -65,15 +75,23 @@ pub(crate) const MTU: usize = 1472;
 // TODO: add LocalAddr using Construct
 pub struct UdpIo {
     socket: Option<UdpSocket>,
-    buffer: BytesMut,
+    recv_buffers: BufferPool,
 }
 
 impl Default for UdpIo {
     fn default() -> Self {
-        UdpIo {
+        Self {
             socket: None,
-            buffer: BytesMut::with_capacity(MTU),
+            recv_buffers: recv_buffer_pool(),
         }
+    }
+}
+
+impl UdpIo {
+    /// Returns receive-buffer pool misses for allocation regression tests.
+    #[cfg(feature = "test_utils")]
+    pub fn recv_buffer_pool_misses(&self) -> usize {
+        self.recv_buffers.misses()
     }
 }
 
@@ -147,29 +165,21 @@ impl UdpPlugin {
         query.par_iter_mut().for_each(|(mut link, mut udp_io)| {
             // enable split borrows
             let udp_io = &mut *udp_io;
+            udp_io.recv_buffers.reclaim_pending();
             loop {
-                // TODO: this might cause Copy-on-Writes and re-allocations if we receive more than MTU bytes
-                //  in one frame. Solutions:
-                // 1. use a bump allocator to temporarily store the messages before deserializing them
-                // 2. track how often we need to reclaim memory, or track how many bytes we receive each frame,
-                //    and increase the size of the buffer accordingly according to the average/median of the last
-                //    few seconds
-
-                // reserve additional space in the buffer
-                // this tries to reclaim space at the start of the buffer if possible
-                udp_io.buffer.reserve(MTU);
+                let mut buffer = udp_io.recv_buffers.take();
 
                 // Check how much actual uninitialized space we have at the end
-                let capacity = udp_io.buffer.capacity();
-                let current_len = udp_io.buffer.len();
+                let capacity = buffer.capacity();
+                let current_len = buffer.len();
                 assert_eq!(current_len, 0);
                 let available_uninit = capacity - current_len;
                 let max_recv_len = core::cmp::min(available_uninit, MTU);
 
                 // We get a raw pointer to the start of the uninitialized region.
-                // SAFETY: we know we have enough space to receive the data because we just reserved it
+                // SAFETY: `take` returns a buffer with at least `MTU` bytes of writable capacity.
                 let buf_slice: &mut [u8] = unsafe {
-                    let ptr = udp_io.buffer.as_mut_ptr().add(current_len);
+                    let ptr = buffer.as_mut_ptr().add(current_len);
                     core::slice::from_raw_parts_mut(ptr, max_recv_len)
                 };
                 match udp_io.socket.as_mut().unwrap().recv_from(buf_slice) {
@@ -177,17 +187,24 @@ impl UdpPlugin {
                         // Mark the received bytes as initialized
                         // SAFETY: we know that the buffer is large enough to hold the received data.
                         unsafe {
-                            udp_io.buffer.advance_mut(recv_len);
+                            buffer.advance_mut(recv_len);
                         }
-                        let payload = udp_io.buffer.split_to(recv_len);
-                        link.recv.push(payload.freeze(), Instant::now());
+                        let payload = udp_io.recv_buffers.split_for_handoff(buffer);
+                        link.recv.push(payload, Instant::now());
                     }
-                    Err(ref e) if e.kind() == ErrorKind::WouldBlock => return,
+                    Err(ref e) if e.kind() == ErrorKind::WouldBlock => {
+                        udp_io.recv_buffers.recycle(buffer);
+                        return;
+                    }
                     // Windows-specific: when the remote end rejects a UDP packet, the OS
                     // raises WSAECONNRESET (10054) on the next recv. This is harmless for
                     // a connectionless UDP socket — just skip to the next receive attempt.
-                    Err(ref e) if e.kind() == ErrorKind::ConnectionReset => continue,
+                    Err(ref e) if e.kind() == ErrorKind::ConnectionReset => {
+                        udp_io.recv_buffers.recycle(buffer);
+                        continue;
+                    }
                     Err(e) => {
+                        udp_io.recv_buffers.recycle(buffer);
                         error!("Error receiving UDP packet: {}", e);
                         return;
                     }
@@ -209,5 +226,31 @@ impl Plugin for UdpPlugin {
             Self::receive.in_set(LinkReceiveSystems::BufferToLink),
         );
         app.add_systems(PostUpdate, Self::send.in_set(LinkSystems::Send));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn receive_buffer_pool_reclaims_a_published_datagram_after_drop() {
+        let mut pool = recv_buffer_pool();
+        let mut buffer = pool.take();
+        buffer.extend_from_slice(b"datagram");
+
+        let payload = pool.split_for_handoff(buffer);
+        let misses = pool.misses();
+
+        pool.reclaim_pending();
+        let in_flight_fallback = pool.take();
+        assert_eq!(pool.misses(), misses + 1);
+        pool.recycle(in_flight_fallback);
+
+        drop(payload);
+        pool.reclaim_pending();
+        let misses = pool.misses();
+        assert!(pool.take().capacity() >= MTU);
+        assert_eq!(pool.misses(), misses);
     }
 }

--- a/crates/io/udp/src/server.rs
+++ b/crates/io/udp/src/server.rs
@@ -19,8 +19,9 @@ use tracing::{debug, error, info};
 use crate::UdpError;
 use aeronet_io::connection::{LocalAddr, PeerAddr};
 use bevy_platform::collections::{HashMap, hash_map::Entry};
-use bytes::{BufMut, BytesMut};
+use bytes::BufMut;
 use core::net::SocketAddr;
+use lightyear_core::buffer_pool::BufferPool;
 use lightyear_core::time::Instant;
 use lightyear_link::prelude::{LinkOf, Server};
 use lightyear_link::{Link, LinkPlugin, LinkStart, LinkSystems, Linked, Linking, Unlink, Unlinked};
@@ -43,7 +44,7 @@ pub(crate) const MTU: usize = 1472;
 #[require(Server)]
 pub struct ServerUdpIo {
     socket: Option<std::net::UdpSocket>,
-    buffer: BytesMut,
+    recv_buffers: BufferPool,
     connected_addresses: HashMap<SocketAddr, LinkOfStatus>,
 }
 
@@ -70,9 +71,17 @@ impl Default for ServerUdpIo {
     fn default() -> Self {
         ServerUdpIo {
             socket: None,
-            buffer: BytesMut::with_capacity(MTU),
+            recv_buffers: crate::recv_buffer_pool(),
             connected_addresses: HashMap::with_capacity(1),
         }
+    }
+}
+
+impl ServerUdpIo {
+    /// Returns receive-buffer pool misses for allocation regression tests.
+    #[cfg(feature = "test_utils")]
+    pub fn recv_buffer_pool_misses(&self) -> usize {
+        self.recv_buffers.misses()
     }
 }
 
@@ -162,22 +171,21 @@ impl ServerUdpPlugin {
 
                 // enable split borrows
                 let server_udp_io = &mut *server_udp_io;
+                server_udp_io.recv_buffers.reclaim_pending();
 
                 loop {
-                    // reserve additional space in the buffer
-                    // this tries to reclaim space at the start of the buffer if possible
-                    server_udp_io.buffer.reserve(crate::MTU);
+                    let mut buffer = server_udp_io.recv_buffers.take();
                     // Check how much actual uninitialized space we have at the end
-                    let capacity = server_udp_io.buffer.capacity();
-                    let current_len = server_udp_io.buffer.len();
+                    let capacity = buffer.capacity();
+                    let current_len = buffer.len();
                     assert_eq!(current_len, 0);
                     let available_uninit = capacity - current_len;
                     let max_recv_len = core::cmp::min(available_uninit, crate::MTU);
 
                     // We get a raw pointer to the start of the uninitialized region.
-                    // SAFETY: we know we have enough space to receive the data because we just reserved it
+                    // SAFETY: `take` returns a buffer with at least `MTU` bytes of writable capacity.
                     let buf_slice: &mut [u8] = unsafe {
-                        let ptr = server_udp_io.buffer.as_mut_ptr().add(current_len);
+                        let ptr = buffer.as_mut_ptr().add(current_len);
                         core::slice::from_raw_parts_mut(ptr, max_recv_len)
                     };
                     match server_udp_io.socket.as_mut().unwrap().recv_from(buf_slice) {
@@ -185,9 +193,9 @@ impl ServerUdpPlugin {
                             // Mark the received bytes as initialized
                             // SAFETY: we know that the buffer is large enough to hold the received data.
                             unsafe {
-                                server_udp_io.buffer.advance_mut(recv_len);
+                                buffer.advance_mut(recv_len);
                             }
-                            let payload = server_udp_io.buffer.split_to(recv_len).freeze();
+                            let payload = server_udp_io.recv_buffers.split_for_handoff(buffer);
                             match server_udp_io.connected_addresses.entry(address) {
                                 Entry::Occupied(mut entry) => {
                                     match *entry.get_mut() {
@@ -254,12 +262,19 @@ impl ServerUdpPlugin {
                                 }
                             };
                         }
-                        Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => break,
+                        Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                            server_udp_io.recv_buffers.recycle(buffer);
+                            break;
+                        }
                         // Windows-specific: when a UDP client disconnects, the OS sends an
                         // ICMP "port unreachable" back, which surfaces as ConnectionReset on
                         // the next recv. This is harmless — just skip to the next packet.
-                        Err(ref e) if e.kind() == std::io::ErrorKind::ConnectionReset => continue,
+                        Err(ref e) if e.kind() == std::io::ErrorKind::ConnectionReset => {
+                            server_udp_io.recv_buffers.recycle(buffer);
+                            continue;
+                        }
                         Err(e) => {
+                            server_udp_io.recv_buffers.recycle(buffer);
                             error!("Error receiving UDP packet: {}", e);
                             break;
                         }

--- a/crates/tests/Cargo.toml
+++ b/crates/tests/Cargo.toml
@@ -20,6 +20,7 @@ std = [
   "lightyear_serde/std",
   "lightyear_sync/std",
   "lightyear_transport/std",
+  "dep:lightyear_udp",
 ]
 test_utils = [
   "lightyear_core/test_utils",
@@ -27,9 +28,15 @@ test_utils = [
   "lightyear_replication/test_utils",
   "lightyear_crossbeam/test_utils",
   "lightyear_aeronet/test_utils",
+  "lightyear_udp?/test_utils",
 ]
 steam = ["lightyear/steam"]
-
+webtransport = [
+  "std",
+  "lightyear/webtransport",
+  "lightyear/webtransport_self_signed",
+  "lightyear/webtransport_dangerous_configuration",
+]
 
 [dependencies]
 lightyear = { workspace = true, features = [
@@ -67,6 +74,7 @@ lightyear_inputs_leafwing.workspace = true
 lightyear_avian2d = { workspace = true, features = ["deterministic", "2d"] }
 lightyear_link.workspace = true
 lightyear_aeronet.workspace = true
+lightyear_udp = { workspace = true, features = ["server"], optional = true }
 
 bevy_replicon.workspace = true
 

--- a/crates/tests/src/client_server/base.rs
+++ b/crates/tests/src/client_server/base.rs
@@ -1,6 +1,8 @@
 use crate::protocol::StringMessage;
 use crate::stepper::*;
 use lightyear::prelude::client::*;
+#[cfg(all(feature = "webtransport", not(target_family = "wasm")))]
+use lightyear::prelude::server::WebTransportServerIo;
 use lightyear::prelude::*;
 use lightyear_connection::server::{Started, Stop, Stopped};
 use lightyear_crossbeam::CrossbeamIo;
@@ -55,6 +57,36 @@ fn test_setup_client_server() {
     assert!(stepper.client_of(0).contains::<RemoteId>());
 }
 
+/// Exercises the same stepper and connection stack as the other client/server tests, but with a
+/// real local WebTransport session. The OS-selected port makes this safe to run alongside other
+/// tests without maintaining a separate WebTransport harness.
+#[cfg(all(feature = "webtransport", not(target_family = "wasm")))]
+#[test]
+fn test_setup_netcode_webtransport_client_server() {
+    let stepper =
+        ClientServerStepper::from_config(StepperConfig::single().with_io(IoType::WebTransport));
+
+    assert_ne!(stepper.server_addr.port(), 0);
+    assert_eq!(
+        stepper.server().get::<LocalAddr>().unwrap().0,
+        stepper.server_addr
+    );
+    assert_eq!(
+        stepper.client(0).get::<PeerAddr>().unwrap().0,
+        stepper.server_addr
+    );
+    assert!(stepper.server().contains::<WebTransportServerIo>());
+    assert!(stepper.client(0).contains::<WebTransportClientIo>());
+    assert!(stepper.client(0).contains::<Connected>());
+    assert!(stepper.client_of(0).contains::<Connected>());
+    assert!(stepper.client(0).contains::<IsSynced<InputTimeline>>());
+    assert!(
+        stepper
+            .client(0)
+            .contains::<IsSynced<InterpolationTimeline>>()
+    );
+}
+
 #[test]
 fn test_stop_netcode_server_unlinks_transport() {
     let mut stepper = ClientServerStepper::from_config(StepperConfig::single());
@@ -75,7 +107,7 @@ fn test_stop_netcode_server_unlinks_transport() {
 /// Check that the client/server setup is correct when the connection type is Raw instead of Netcode
 #[test]
 fn test_setup_raw_client_server() {
-    let stepper = ClientServerStepper::from_config(StepperConfig::from_link_types(
+    let stepper = ClientServerStepper::from_config(StepperConfig::from_connection_types(
         vec![ClientType::Raw],
         ServerType::Raw,
     ));

--- a/crates/tests/src/host_server/input/bei.rs
+++ b/crates/tests/src/host_server/input/bei.rs
@@ -17,7 +17,7 @@ const TEST_HASH: u64 = 42;
 /// while a host client is present in the topology.
 #[test]
 fn test_rebroadcast() {
-    let mut stepper = ClientServerStepper::from_config(StepperConfig::from_link_types(
+    let mut stepper = ClientServerStepper::from_config(StepperConfig::from_connection_types(
         vec![ClientType::Host, ClientType::Netcode, ClientType::Netcode],
         ServerType::Netcode,
     ));

--- a/crates/tests/src/host_server/replication.rs
+++ b/crates/tests/src/host_server/replication.rs
@@ -15,7 +15,8 @@ use lightyear_replication::send::ReplicatedFrom;
 use test_log::test;
 
 fn host_only_stepper_before_host_connect() -> ClientServerStepper {
-    let mut config = StepperConfig::from_link_types(vec![ClientType::Host], ServerType::Netcode);
+    let mut config =
+        StepperConfig::from_connection_types(vec![ClientType::Host], ServerType::Netcode);
     config.init = false;
     let mut stepper = ClientServerStepper::from_config(config);
     stepper.server_app.finish();

--- a/crates/tests/src/multi_server/steam.rs
+++ b/crates/tests/src/multi_server/steam.rs
@@ -33,7 +33,7 @@ fn add_steam_server_io(stepper: &mut ClientServerStepper) {
 #[ignore]
 fn test_steam_server_with_netcode_server() {
     // the server will have both SteamServerIo and NetcodeServerIo
-    let mut stepper = ClientServerStepper::from_config(StepperConfig::from_link_types(
+    let mut stepper = ClientServerStepper::from_config(StepperConfig::from_connection_types(
         vec![ClientType::Steam, ClientType::Netcode],
         ServerType::Netcode,
     ));

--- a/crates/tests/src/stepper.rs
+++ b/crates/tests/src/stepper.rs
@@ -12,12 +12,17 @@ use core::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
 use core::time::Duration;
 use lightyear::avian2d::plugin::AvianReplicationMode;
 use lightyear::prelude::{client::*, server::*, *};
+use lightyear_connection::host::HostClient;
 #[cfg(feature = "test_utils")]
 use lightyear_core::test::TestHelper;
 use lightyear_netcode::client_plugin::NetcodeConfig;
 use lightyear_raw_connection::client::RawClient;
 use lightyear_raw_connection::server::RawServer;
 use lightyear_replication::receive::ReplicationReceiver;
+#[cfg(feature = "std")]
+use lightyear_udp::server::{ServerUdpIo, ServerUdpPlugin};
+#[cfg(feature = "std")]
+use lightyear_udp::{UdpIo, UdpPlugin};
 
 pub const SERVER_PORT: u16 = 56789;
 pub const SERVER_ADDR: SocketAddr =
@@ -27,12 +32,42 @@ pub const STEAM_APP_ID: u32 = 480; // Steamworks App ID for Spacewar, used for t
 
 pub const TICK_DURATION: Duration = Duration::from_millis(10);
 
+/// Adds the per-peer components needed by the shared test protocol to links created by any IO.
+fn configure_server_link(
+    trigger: On<Add, LinkOf>,
+    clients: Query<(), With<Client>>,
+    mut commands: Commands,
+) {
+    // A host client also has `LinkOf`, but it is a local Client relationship rather than a remote
+    // server peer. Host-specific systems configure it separately.
+    if clients.contains(trigger.entity) {
+        return;
+    }
+    commands.entity(trigger.entity).insert((
+        PingManager::new(PingConfig {
+            ping_interval: Duration::default(),
+        }),
+        ReplicationSender,
+        ReplicationReceiver,
+        #[cfg(feature = "test_utils")]
+        TestHelper::default(),
+    ));
+}
+
+#[cfg(feature = "std")]
+fn unused_local_udp_addr() -> SocketAddr {
+    let socket = std::net::UdpSocket::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+    socket.local_addr().unwrap()
+}
+
 /// Stepper with:
 /// - n client in one 'client' App
 /// - 1 server in another App, with n ClientOf connected to each client
 ///
-/// Connected via crossbeam channels, and using Netcode for connection if `raw_server` is false
-/// We create two separate apps to make it easy to order the client and server updates.
+/// The IO backend and connection layer are configured independently: for example, the same
+/// Netcode scenario can run over deterministic in-process Crossbeam channels, real loopback UDP
+/// sockets, or a local WebTransport session. We create separate apps to make client/server update
+/// ordering explicit.
 pub struct ClientServerStepper {
     pub client_apps: Vec<App>,
     pub server_app: App,
@@ -44,9 +79,50 @@ pub struct ClientServerStepper {
     pub tick_duration: Duration,
     pub current_time: bevy::platform::time::Instant,
     pub avian_mode: AvianReplicationMode,
+    pub io: IoType,
+    pub server_addr: SocketAddr,
+    server_started: bool,
 }
 
-/// Type of client to add
+/// IO backend used between the stepper's client and server applications.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum IoType {
+    /// In-process channels. This is the default because it is deterministic and supports `no_std`.
+    #[default]
+    Crossbeam,
+    /// Real non-blocking loopback UDP sockets.
+    #[cfg(feature = "std")]
+    Udp,
+    /// A real local WebTransport session using a self-signed certificate.
+    #[cfg(all(feature = "webtransport", not(target_family = "wasm")))]
+    WebTransport,
+}
+
+impl IoType {
+    /// Whether the server must bind before remote clients can be configured.
+    fn requires_bound_server_addr(self) -> bool {
+        match self {
+            Self::Crossbeam => false,
+            #[cfg(feature = "std")]
+            Self::Udp => false,
+            #[cfg(all(feature = "webtransport", not(target_family = "wasm")))]
+            Self::WebTransport => true,
+        }
+    }
+
+    /// Whether progress depends on giving an asynchronous IO task real wall-clock time.
+    fn uses_async_io(self) -> bool {
+        match self {
+            Self::Crossbeam => false,
+            #[cfg(feature = "std")]
+            Self::Udp => false,
+            #[cfg(all(feature = "webtransport", not(target_family = "wasm")))]
+            Self::WebTransport => true,
+        }
+    }
+}
+
+/// Connection layer used by a stepper client.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ClientType {
     Host,
@@ -56,7 +132,7 @@ pub enum ClientType {
     Steam,
 }
 
-/// Type of server to use
+/// Connection layer used by the stepper server.
 pub enum ServerType {
     Raw,
     Netcode,
@@ -74,6 +150,8 @@ pub struct StepperConfig {
     pub server_registry: Option<MetricsRegistry>,
     pub client_registry: Option<MetricsRegistry>,
     pub avian_mode: AvianReplicationMode,
+    /// IO backend, independent from the raw/netcode connection layer.
+    pub io: IoType,
 }
 
 impl StepperConfig {
@@ -88,6 +166,7 @@ impl StepperConfig {
             server_registry: None,
             client_registry: None,
             avian_mode: AvianReplicationMode::default(),
+            io: IoType::Crossbeam,
         }
     }
 
@@ -102,6 +181,7 @@ impl StepperConfig {
             server_registry: None,
             client_registry: None,
             avian_mode: AvianReplicationMode::default(),
+            io: IoType::Crossbeam,
         }
     }
 
@@ -115,10 +195,12 @@ impl StepperConfig {
             server_registry: None,
             client_registry: None,
             avian_mode: AvianReplicationMode::default(),
+            io: IoType::Crossbeam,
         }
     }
 
-    pub fn from_link_types(clients: Vec<ClientType>, server: ServerType) -> Self {
+    /// Configures client and server connection layers, leaving IO at its default.
+    pub fn from_connection_types(clients: Vec<ClientType>, server: ServerType) -> Self {
         Self {
             frame_duration: TICK_DURATION,
             tick_duration: TICK_DURATION,
@@ -128,7 +210,20 @@ impl StepperConfig {
             server_registry: None,
             client_registry: None,
             avian_mode: AvianReplicationMode::default(),
+            io: IoType::Crossbeam,
         }
+    }
+
+    /// Backwards-compatible alias for [`Self::from_connection_types`].
+    #[deprecated(note = "use `from_connection_types`; these select connection layers, not IO")]
+    pub fn from_link_types(clients: Vec<ClientType>, server: ServerType) -> Self {
+        Self::from_connection_types(clients, server)
+    }
+
+    /// Selects the IO backend without changing the configured connection layer.
+    pub fn with_io(mut self, io: IoType) -> Self {
+        self.io = io;
+        self
     }
 }
 
@@ -140,9 +235,37 @@ impl ClientServerStepper {
             config.server,
             config.avian_mode,
             config.server_registry.clone(),
+            config.io,
         );
-        for client_type in config.clients {
-            stepper.new_client(client_type, config.client_registry.clone());
+
+        if stepper.io.requires_bound_server_addr() {
+            assert!(
+                config.init,
+                "WebTransport steppers must be initialized so the port-zero server can bind before clients are configured"
+            );
+
+            // Host clients add client plugins to the server app, so install those before the app
+            // is finalized and started. Remote clients need the actual port selected by the OS.
+            for client_type in config
+                .clients
+                .iter()
+                .copied()
+                .filter(|client_type| *client_type == ClientType::Host)
+            {
+                stepper.new_client(client_type, config.client_registry.clone());
+            }
+            stepper.initialize_server();
+            for client_type in config
+                .clients
+                .into_iter()
+                .filter(|client_type| *client_type != ClientType::Host)
+            {
+                stepper.new_client(client_type, config.client_registry.clone());
+            }
+        } else {
+            for client_type in config.clients {
+                stepper.new_client(client_type, config.client_registry.clone());
+            }
         }
         if config.init {
             stepper.init();
@@ -158,7 +281,15 @@ impl ClientServerStepper {
         server_type: ServerType,
         avian_mode: AvianReplicationMode,
         metrics_registry: Option<MetricsRegistry>,
+        io: IoType,
     ) -> Self {
+        let server_addr = match io {
+            IoType::Crossbeam => SERVER_ADDR,
+            #[cfg(feature = "std")]
+            IoType::Udp => unused_local_udp_addr(),
+            #[cfg(all(feature = "webtransport", not(target_family = "wasm")))]
+            IoType::WebTransport => SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 0),
+        };
         let mut server_app = App::new();
         // NOTE: we add LogPlugin so that tracing works
         server_app.add_plugins((
@@ -175,6 +306,11 @@ impl ClientServerStepper {
             server_app.add_steam_resources(STEAM_APP_ID);
         }
         server_app.add_plugins((server::ServerPlugins { tick_duration }, RoomPlugin));
+        #[cfg(feature = "std")]
+        if io == IoType::Udp {
+            server_app.add_plugins(ServerUdpPlugin);
+        }
+        server_app.add_observer(configure_server_link);
         // ProtocolPlugin needs to be added AFTER InputPlugin
         server_app.add_plugins(ProtocolPlugin { avian_mode });
         let mut server = server_app.world_mut().spawn_empty();
@@ -198,6 +334,20 @@ impl ClientServerStepper {
                 });
             }
         }
+        #[cfg(feature = "std")]
+        if io == IoType::Udp {
+            server.insert((LocalAddr(server_addr), ServerUdpIo::default()));
+        }
+        #[cfg(all(feature = "webtransport", not(target_family = "wasm")))]
+        if io == IoType::WebTransport {
+            server.insert((
+                LocalAddr(server_addr),
+                WebTransportServerIo {
+                    certificate: Identity::self_signed(["localhost", "127.0.0.1", "::1"])
+                        .expect("test WebTransport identity should be valid"),
+                },
+            ));
+        }
         let server_entity = server.id();
         Self {
             client_apps: vec![],
@@ -210,6 +360,9 @@ impl ClientServerStepper {
             tick_duration,
             current_time: bevy::platform::time::Instant::now(),
             avian_mode,
+            io,
+            server_addr,
+            server_started: false,
         }
     }
 
@@ -236,6 +389,10 @@ impl ClientServerStepper {
         client_app.add_plugins(client::ClientPlugins {
             tick_duration: self.tick_duration,
         });
+        #[cfg(feature = "std")]
+        if self.io == IoType::Udp {
+            client_app.add_plugins(UdpPlugin);
+        }
         // ProtocolPlugin needs to be added AFTER ClientPlugins, InputPlugin, because we need the PredictionRegistry to exist
         client_app.add_plugins(ProtocolPlugin {
             avian_mode: self.avian_mode,
@@ -243,10 +400,9 @@ impl ClientServerStepper {
         client_app.finish();
         client_app.cleanup();
         let client_id = self.client_entities.len();
-        let (crossbeam_client, crossbeam_server) = lightyear_crossbeam::CrossbeamIo::new_pair();
 
         let auth = Authentication::Manual {
-            server_addr: SERVER_ADDR,
+            server_addr: self.server_addr,
             protocol_id: Default::default(),
             private_key: Default::default(),
             client_id: client_id as u64,
@@ -283,11 +439,63 @@ impl ClientServerStepper {
             }),
             ReplicationSender,
             ReplicationReceiver,
-            crossbeam_client,
             #[cfg(feature = "test_utils")]
             TestHelper::default(),
             PredictionManager::default(),
         ));
+        match self.io {
+            IoType::Crossbeam => {
+                let (crossbeam_client, crossbeam_server) =
+                    lightyear_crossbeam::CrossbeamIo::new_pair();
+                client.insert(crossbeam_client);
+                self.client_of_entities.push(
+                    self.server_app
+                        .world_mut()
+                        .spawn((
+                            LinkOf {
+                                server: self.server_entity,
+                            },
+                            Link::default(),
+                            PeerAddr(SocketAddr::new(
+                                core::net::IpAddr::V4(Ipv4Addr::LOCALHOST),
+                                client_id as u16,
+                            )),
+                            // Crossbeam has no listening server that creates this link.
+                            Linked,
+                            crossbeam_server,
+                        ))
+                        .id(),
+                );
+            }
+            #[cfg(feature = "std")]
+            IoType::Udp => {
+                client.insert((
+                    LocalAddr(SocketAddr::new(
+                        core::net::IpAddr::V4(Ipv4Addr::LOCALHOST),
+                        0,
+                    )),
+                    PeerAddr(self.server_addr),
+                    UdpIo::default(),
+                ));
+                // ServerUdpIo creates the corresponding LinkOf after the first datagram arrives.
+                self.client_of_entities.push(Entity::PLACEHOLDER);
+            }
+            #[cfg(all(feature = "webtransport", not(target_family = "wasm")))]
+            IoType::WebTransport => {
+                client.insert((
+                    PeerAddr(self.server_addr),
+                    WebTransportClientIo {
+                        // This native-only test mode enables Lightyear's explicitly dangerous
+                        // no-certificate-validation feature for the ephemeral self-signed identity.
+                        certificate_digest: String::new(),
+                        target: None,
+                    },
+                ));
+                // The listening WebTransport server creates the corresponding LinkOf after the
+                // session is accepted.
+                self.client_of_entities.push(Entity::PLACEHOLDER);
+            }
+        }
         match client_type {
             ClientType::Host => unreachable!(),
             ClientType::Raw => {
@@ -305,34 +513,6 @@ impl ClientServerStepper {
             }
         }
         self.client_entities.push(client.id());
-        self.client_of_entities.push(
-            self.server_app
-                .world_mut()
-                .spawn((
-                    LinkOf {
-                        server: self.server_entity,
-                    },
-                    // Send pings every frame, so that the Acks are sent every frame
-                    PingManager::new(PingConfig {
-                        ping_interval: Duration::default(),
-                    }),
-                    // TODO: we want the ReplicationSender/Receiver to be added automatically when ClientOf is created, but with configs pre-specified by the server
-                    ReplicationSender,
-                    ReplicationReceiver,
-                    // we will act like each client has a different port
-                    Link::default(),
-                    PeerAddr(SocketAddr::new(
-                        core::net::IpAddr::V4(Ipv4Addr::LOCALHOST),
-                        client_id as u16,
-                    )),
-                    // For Crossbeam we need to mark the IO as Linked, as there is no ServerLink to do that for us
-                    Linked,
-                    crossbeam_server,
-                    #[cfg(feature = "test_utils")]
-                    TestHelper::default(),
-                ))
-                .id(),
-        );
         self.client_apps.push(client_app);
         client_id
     }
@@ -368,6 +548,7 @@ impl ClientServerStepper {
             server_type,
             AvianReplicationMode::default(),
             None,
+            IoType::Crossbeam,
         )
     }
 
@@ -419,16 +600,51 @@ impl ClientServerStepper {
     }
 
     pub fn client_of(&self, id: usize) -> EntityRef<'_> {
+        assert_ne!(self.client_of_entities[id], Entity::PLACEHOLDER);
         self.server_app.world().entity(self.client_of_entities[id])
     }
 
     pub fn client_of_mut(&mut self, id: usize) -> EntityWorldMut<'_> {
+        assert_ne!(self.client_of_entities[id], Entity::PLACEHOLDER);
         self.server_app
             .world_mut()
             .entity_mut(self.client_of_entities[id])
     }
 
     pub fn init(&mut self) {
+        self.initialize_server();
+
+        let now = self.current_time;
+        for i in 0..self.client_entities.len() {
+            self.client_apps[i]
+                .world_mut()
+                .get_resource_mut::<Time<Real>>()
+                .unwrap()
+                .update_with_instant(now);
+            self.client_apps[i].world_mut().trigger(Connect {
+                entity: self.client_entities[i],
+            });
+        }
+        if let Some(host) = self.host_client_entity {
+            self.server_app
+                .world_mut()
+                .trigger(Connect { entity: host });
+        }
+
+        self.wait_for_connection();
+        self.wait_for_sync();
+    }
+
+    /// Finalizes and starts the server once.
+    ///
+    /// WebTransport binds to port zero, so it is started before remote clients are constructed.
+    /// Once Aeronet publishes the selected local address, that address is used by both the IO
+    /// component and Netcode authentication on each client.
+    fn initialize_server(&mut self) {
+        if self.server_started {
+            return;
+        }
+
         if matches!(
             self.server_app.plugins_state(),
             PluginsState::Ready | PluginsState::Adding
@@ -451,42 +667,105 @@ impl ClientServerStepper {
         // For HostServer, the server needs to be started before the client,
         // so make sure it is started
         self.server_app.world_mut().flush();
-        for i in 0..self.client_entities.len() {
-            self.client_apps[i]
-                .world_mut()
-                .get_resource_mut::<Time<Real>>()
-                .unwrap()
-                .update_with_instant(now);
-            self.client_apps[i].world_mut().trigger(Connect {
-                entity: self.client_entities[i],
-            });
-        }
-        if let Some(host) = self.host_client_entity {
-            self.server_app
-                .world_mut()
-                .trigger(Connect { entity: host });
-        }
+        self.server_started = true;
 
-        self.wait_for_connection();
-        self.wait_for_sync();
+        #[cfg(all(feature = "webtransport", not(target_family = "wasm")))]
+        if self.io == IoType::WebTransport {
+            self.wait_for_webtransport_server_addr();
+        }
+    }
+
+    /// Waits for the port-zero WebTransport listener to report the address selected by the OS.
+    #[cfg(all(feature = "webtransport", not(target_family = "wasm")))]
+    fn wait_for_webtransport_server_addr(&mut self) {
+        for _ in 0..400 {
+            if let Some(addr) = self
+                .server()
+                .get::<LocalAddr>()
+                .map(|local_addr| local_addr.0)
+                .filter(|addr| addr.port() != 0)
+            {
+                self.server_addr = addr;
+                return;
+            }
+            self.tick_step(1);
+            self.wait_for_async_io();
+        }
+        panic!("WebTransport server did not bind within two seconds");
     }
 
     /// Frame step until all clients are connected
     pub fn wait_for_connection(&mut self) {
-        for _ in 0..50 {
+        let attempts = if self.io.uses_async_io() { 400 } else { 50 };
+        for _ in 0..attempts {
+            self.refresh_client_of_entities();
             if (0..self.client_entities.len())
                 .all(|client_id| self.client(client_id).contains::<Connected>())
+                && self
+                    .client_of_entities
+                    .iter()
+                    .all(|entity| *entity != Entity::PLACEHOLDER)
             {
                 info!("Clients are all connected");
                 break;
             }
             self.tick_step(1);
+            self.wait_for_async_io();
+        }
+    }
+
+    /// Resolves server-side links that listening IO backends create after receiving a packet.
+    fn refresh_client_of_entities(&mut self) {
+        if self
+            .client_of_entities
+            .iter()
+            .all(|entity| *entity != Entity::PLACEHOLDER)
+        {
+            return;
+        }
+
+        let server_entity = self.server_entity;
+        let links = {
+            let world = self.server_app.world_mut();
+            let mut query = world.query_filtered::<
+                (Entity, &LinkOf, Option<&RemoteId>),
+                (With<Connected>, Without<HostClient>),
+            >();
+            query
+                .iter(world)
+                .filter(|(_, link_of, _)| link_of.server == server_entity)
+                .map(|(entity, _, remote_id)| (entity, remote_id.map(|id| id.0)))
+                .collect::<Vec<_>>()
+        };
+
+        for (entity, remote_id) in &links {
+            if let Some(PeerId::Netcode(client_id)) = remote_id
+                && let Some(slot) = self.client_of_entities.get_mut((*client_id) as usize)
+            {
+                *slot = *entity;
+            }
+        }
+
+        // Raw connections do not carry the stepper's numeric client id. Fill any remaining slots
+        // deterministically; this is exact for the common one-client listening-IO case.
+        for (entity, _) in links {
+            if self.client_of_entities.contains(&entity) {
+                continue;
+            }
+            if let Some(slot) = self
+                .client_of_entities
+                .iter_mut()
+                .find(|slot| **slot == Entity::PLACEHOLDER)
+            {
+                *slot = entity;
+            }
         }
     }
 
     // Advance the world until the client is synced
     pub fn wait_for_sync(&mut self) {
-        for _ in 0..50 {
+        let attempts = if self.io.uses_async_io() { 400 } else { 50 };
+        for _ in 0..attempts {
             if (0..self.client_entities.len()).all(|client_id| {
                 self.client(client_id).contains::<IsSynced<InputTimeline>>()
                     && self
@@ -497,6 +776,15 @@ impl ClientServerStepper {
                 break;
             }
             self.tick_step(1);
+            self.wait_for_async_io();
+        }
+    }
+
+    /// Lets background IO tasks progress when simulated test time advances without sleeping.
+    fn wait_for_async_io(&self) {
+        #[cfg(all(feature = "webtransport", not(target_family = "wasm")))]
+        if self.io == IoType::WebTransport {
+            std::thread::sleep(Duration::from_millis(5));
         }
     }
 
@@ -539,6 +827,7 @@ impl ClientServerStepper {
                     error_span!("client", ?i).in_scope(|| client_app.update());
                 });
             error_span!("server").in_scope(|| self.server_app.update());
+            self.refresh_client_of_entities();
         }
     }
 
@@ -561,6 +850,7 @@ impl ClientServerStepper {
                 .for_each(|(i, client_app)| {
                     error_span!("client", ?i).in_scope(|| client_app.update());
                 });
+            self.refresh_client_of_entities();
         }
     }
 
@@ -582,6 +872,7 @@ impl ClientServerStepper {
                     error_span!("client", ?i).in_scope(|| client_app.update());
                 });
             error_span!("server").in_scope(|| self.server_app.update());
+            self.refresh_client_of_entities();
         }
     }
 }

--- a/crates/tests/tests/allocation_regression.rs
+++ b/crates/tests/tests/allocation_regression.rs
@@ -10,7 +10,11 @@ use lightyear::prelude::{
 use lightyear_messages::MessageManager;
 use lightyear_prediction::predicted_history::PredictionHistory;
 use lightyear_tests::protocol::{Channel1, CompFull, StringMessage};
-use lightyear_tests::stepper::{ClientServerStepper, ClientType, ServerType, StepperConfig};
+use lightyear_tests::stepper::{
+    ClientServerStepper, ClientType, IoType, ServerType, StepperConfig,
+};
+use lightyear_udp::UdpIo;
+use lightyear_udp::server::ServerUdpIo;
 use stats_alloc::{INSTRUMENTED_SYSTEM, Region, Stats, StatsAlloc};
 
 #[global_allocator]
@@ -78,7 +82,7 @@ fn steady_state_networking_work_stays_within_allocation_budget() {
 #[test]
 fn packet_payload_pool_has_no_misses_after_warmup_through_crossbeam_io() {
     let _guard = ALLOCATION_TEST_LOCK.lock().unwrap();
-    let mut stepper = ClientServerStepper::from_config(StepperConfig::from_link_types(
+    let mut stepper = ClientServerStepper::from_config(StepperConfig::from_connection_types(
         vec![ClientType::Raw],
         ServerType::Raw,
     ));
@@ -110,6 +114,54 @@ fn packet_payload_pool_has_no_misses_after_warmup_through_crossbeam_io() {
         misses_before,
         "the real Transport -> Link -> Crossbeam IO path allocated a packet payload after warmup",
     );
+}
+
+#[test]
+fn udp_receive_payload_pool_has_no_misses_after_warmup() {
+    let _guard = ALLOCATION_TEST_LOCK.lock().unwrap();
+    let mut stepper =
+        ClientServerStepper::from_config(StepperConfig::single().with_io(IoType::Udp));
+    stepper.server_app.init_resource::<ReceivedMessageCount>();
+    stepper
+        .server_app
+        .add_systems(Update, count_received_messages);
+    stepper.client_app().init_resource::<ReceivedMessageCount>();
+    stepper
+        .client_app()
+        .add_systems(Update, count_received_messages);
+    use_single_threaded_schedules(&mut stepper);
+
+    for _ in 0..WARMUP_FRAMES {
+        run_bidirectional_message_cycle(&mut stepper);
+    }
+    let misses_before = udp_receive_pool_misses(&stepper);
+    assert!(
+        misses_before > 0,
+        "warmup should exercise UDP receive-buffer allocation instrumentation",
+    );
+
+    for _ in 0..MEASURED_FRAMES {
+        run_bidirectional_message_cycle(&mut stepper);
+    }
+
+    assert_eq!(
+        udp_receive_pool_misses(&stepper),
+        misses_before,
+        "the real Transport -> Netcode -> Link -> UDP path allocated a receive buffer after warmup",
+    );
+}
+
+fn udp_receive_pool_misses(stepper: &ClientServerStepper) -> usize {
+    stepper
+        .client(0)
+        .get::<UdpIo>()
+        .expect("UDP client should have UdpIo")
+        .recv_buffer_pool_misses()
+        + stepper
+            .server()
+            .get::<ServerUdpIo>()
+            .expect("UDP server should have ServerUdpIo")
+            .recv_buffer_pool_misses()
 }
 
 fn packet_payload_pool_misses(stepper: &ClientServerStepper) -> usize {
@@ -180,7 +232,19 @@ fn run_bidirectional_message_cycle(stepper: &mut ClientServerStepper) {
         .get_mut::<MessageSender<StringMessage>>()
         .expect("server-side message sender should exist")
         .send::<Channel1>(StringMessage(String::new()));
-    stepper.frame_step_server_first(1);
+    for _ in 0..100 {
+        stepper.frame_step_server_first(1);
+        if stepper
+            .client_app()
+            .world()
+            .resource::<ReceivedMessageCount>()
+            .0
+            == client_received_before + 1
+        {
+            break;
+        }
+        std::thread::yield_now();
+    }
     assert_eq!(
         stepper
             .client_app()
@@ -200,7 +264,19 @@ fn run_bidirectional_message_cycle(stepper: &mut ClientServerStepper) {
         .get_mut::<MessageSender<StringMessage>>()
         .expect("client-side message sender should exist")
         .send::<Channel1>(StringMessage(String::new()));
-    stepper.frame_step(1);
+    for _ in 0..100 {
+        stepper.frame_step(1);
+        if stepper
+            .server_app
+            .world()
+            .resource::<ReceivedMessageCount>()
+            .0
+            == server_received_before + 1
+        {
+            break;
+        }
+        std::thread::yield_now();
+    }
     assert_eq!(
         stepper
             .server_app

--- a/crates/transport/messages/src/plugin.rs
+++ b/crates/transport/messages/src/plugin.rs
@@ -340,7 +340,7 @@ mod tests {
     use lightyear_core::prelude::{LocalTimeline, NetworkTimeline, Tick, TimelineKind};
     use lightyear_core::time::{Overstep, TickDelta, TickInstant};
     use lightyear_core::timeline::TimelineConfig;
-    use lightyear_link::{Link, Linked};
+    use lightyear_link::{Link, Linked, recv_payload_from_bytes};
     use lightyear_transport::channel::ChannelKind;
     use lightyear_transport::plugin::TestChannel;
     use lightyear_transport::plugin::TestTransportPlugin;
@@ -438,7 +438,7 @@ mod tests {
         let mut entity_mut = app.world_mut().entity_mut(entity);
         let mut link = entity_mut.get_mut::<Link>().unwrap();
         let payload = link.send.pop().expect("expected one outgoing payload");
-        link.recv.push_raw(payload);
+        link.recv.push_raw(recv_payload_from_bytes(payload));
     }
 
     // TODO: should we do a test without the Link?
@@ -489,7 +489,7 @@ mod tests {
 
         // transfer that payload to the recv side of the link
         let payload = link.send.pop().unwrap();
-        link.recv.push_raw(payload);
+        link.recv.push_raw(recv_payload_from_bytes(payload));
 
         app.world_mut().run_schedule(PreUpdate);
 

--- a/crates/transport/transport/src/packet/packet_builder.rs
+++ b/crates/transport/transport/src/packet/packet_builder.rs
@@ -11,7 +11,7 @@ use crate::packet::packet::{HEADER_BYTES, MessageMetadata, Packet, SendCommit};
 use crate::packet::packet_type::PacketType;
 use alloc::vec::Vec;
 use bytes::{Bytes, BytesMut};
-use lightyear_core::tick::Tick;
+use lightyear_core::{buffer_pool::BufferPool, tick::Tick};
 use lightyear_link::{DEFAULT_MTU, SendPayload};
 use lightyear_serde::{SerializationError, ToBytes};
 use no_std_io2::io::{self, Write};
@@ -80,69 +80,34 @@ struct SingleBatchState {
 #[derive(Debug)]
 pub(crate) struct PacketBuilder {
     pub(crate) header_manager: PacketHeaderManager,
-    buffer_pool: BufferPool,
+    buffer_pool: PacketBufferPool,
     compression_output: Vec<u8>,
 }
 
-/// Reusable packet-builder buffers, partitioned by whether they are currently writable.
+/// Reusable packet-builder storage.
 ///
-/// A successful send splits a mutable packet buffer into an immutable [`Bytes`] prefix for
-/// `Link`/IO and an empty [`BytesMut`] tail retained here. Both handles share one allocation. The
-/// tail cannot recover the prefix's capacity until every immutable clone has been dropped.
-///
-/// Keeping two lists makes the packet-building hot path cheap:
-///
-/// - `ready_payloads` contains buffers already known to have the full configured capacity, so
-///   [`take_payload`](Self::take_payload) is an O(1) pop with no ownership probe.
-/// - `pending_payloads` contains only shared tails that failed [`BytesMut::try_reclaim`]. They are
-///   scanned once at the start of a transport send pass, rather than repeatedly scanning and
-///   retrying every retained buffer whenever another packet is built in the same pass.
-///
-/// The pending scan is still linear in the number of in-flight payloads, but it is bounded by
-/// [`MAX_RETAINED_PACKET_PAYLOADS`] and never visits buffers already known to be ready.
+/// Payload allocation recycling is delegated to the shared [`BufferPool`]. This wrapper also
+/// retains packet-specific message metadata lists.
 #[derive(Debug)]
-pub(crate) struct BufferPool {
-    payload_capacity: usize,
-    /// Writable buffers with at least `payload_capacity` immediately available.
-    ready_payloads: Vec<BytesMut>,
-    /// Split tails waiting for all immutable `Bytes` views of their allocation to be dropped.
-    pending_payloads: Vec<BytesMut>,
+pub(crate) struct PacketBufferPool {
+    payloads: BufferPool,
     message_metadata: Vec<Vec<MessageMetadata>>,
-    #[cfg(feature = "test_utils")]
-    payload_pool_misses: usize,
 }
 
-impl BufferPool {
+impl PacketBufferPool {
     pub(crate) fn new(payload_capacity: usize) -> Self {
         Self {
-            payload_capacity,
-            ready_payloads: Vec::new(),
-            pending_payloads: Vec::new(),
+            payloads: BufferPool::new(payload_capacity, MAX_RETAINED_PACKET_PAYLOADS),
             message_metadata: Vec::new(),
-            #[cfg(feature = "test_utils")]
-            payload_pool_misses: 0,
         }
     }
 
     pub(crate) fn take_payload(&mut self) -> BytesMut {
-        if let Some(mut payload) = self.ready_payloads.pop() {
-            debug_assert!(payload.capacity() >= self.payload_capacity);
-            payload.clear();
-            return payload;
-        }
-        #[cfg(feature = "test_utils")]
-        {
-            self.payload_pool_misses += 1;
-        }
-        BytesMut::with_capacity(self.payload_capacity)
+        self.payloads.take()
     }
 
     fn set_payload_capacity(&mut self, payload_capacity: usize) {
-        if self.payload_capacity != payload_capacity {
-            self.payload_capacity = payload_capacity;
-            self.ready_payloads.clear();
-            self.pending_payloads.clear();
-        }
+        self.payloads.set_buffer_capacity(payload_capacity);
     }
 
     /// Promotes split tails whose immutable views have all been dropped to the ready list.
@@ -151,15 +116,7 @@ impl BufferPool {
     /// restore the sibling's capacity. It only makes `try_reclaim` capable of recovering the full
     /// allocation. This sweep performs that explicit recovery once per transport send pass.
     fn reclaim_pending_payloads(&mut self) {
-        let mut index = 0;
-        while index < self.pending_payloads.len() {
-            if self.pending_payloads[index].try_reclaim(self.payload_capacity) {
-                let payload = self.pending_payloads.swap_remove(index);
-                self.ready_payloads.push(payload);
-            } else {
-                index += 1;
-            }
-        }
+        self.payloads.reclaim_pending();
     }
 
     pub(crate) fn take_message_metadata(&mut self) -> Vec<MessageMetadata> {
@@ -177,49 +134,8 @@ impl BufferPool {
         let Packet {
             payload, messages, ..
         } = packet;
-        self.recycle_unsplit_payload(payload);
+        self.payloads.recycle(payload);
         self.recycle_message_metadata(messages);
-    }
-
-    /// Recycles a complete buffer from a packet that never crossed the `Link` ownership boundary.
-    ///
-    /// Its current capacity still describes the complete writable allocation, so it is safe to
-    /// apply the MTU-sized retention policy here. A buffer can legitimately have grown beyond the
-    /// MTU even though no oversized packet is sent: candidate serialization writes speculatively
-    /// and then truncates when the candidate does not fit, while compression-aware packing may
-    /// intentionally build an uncompressed payload larger than the MTU before compressing it.
-    /// `truncate` reduces the length but does not shrink the allocation, so this is not a valid
-    /// debug assertion. Oversized allocations are simply not retained by the pool.
-    fn recycle_unsplit_payload(&mut self, mut payload: BytesMut) {
-        payload.clear();
-        if payload.capacity() != self.payload_capacity {
-            return;
-        }
-        self.enqueue_retained_payload(payload);
-    }
-
-    /// Recycles the empty mutable tail left by a successful send-side split.
-    ///
-    /// Unlike [`Self::recycle_unsplit_payload`], `payload.capacity()` no longer describes the
-    /// complete allocation: splitting an `N`-byte packet from an MTU-sized buffer leaves this tail
-    /// with only `MTU - N` visible capacity. The full capacity was therefore checked before the
-    /// split in [`PacketBuilder::take_send_payload`]. Here `try_reclaim` decides whether the tail
-    /// is immediately writable or must wait in `pending_payloads` for Link/IO to drop its `Bytes`.
-    fn recycle_split_payload_tail(&mut self, mut payload: BytesMut) {
-        payload.clear();
-        self.enqueue_retained_payload(payload);
-    }
-
-    /// Places an eligible payload in the ready or pending partition.
-    fn enqueue_retained_payload(&mut self, mut payload: BytesMut) {
-        if self.ready_payloads.len() + self.pending_payloads.len() >= MAX_RETAINED_PACKET_PAYLOADS {
-            return;
-        }
-        if payload.try_reclaim(self.payload_capacity) {
-            self.ready_payloads.push(payload);
-        } else {
-            self.pending_payloads.push(payload);
-        }
     }
 
     pub(crate) fn recycle_message_metadata(&mut self, mut messages: Vec<MessageMetadata>) {
@@ -230,9 +146,8 @@ impl BufferPool {
         }
     }
 
-    #[cfg(feature = "test_utils")]
     fn payload_pool_misses(&self) -> usize {
-        self.payload_pool_misses
+        self.payloads.misses()
     }
 }
 
@@ -246,7 +161,7 @@ impl PacketBuilder {
     pub fn new(nack_rtt_multiple: f32) -> Self {
         Self {
             header_manager: PacketHeaderManager::new(nack_rtt_multiple),
-            buffer_pool: BufferPool::new(DEFAULT_MTU),
+            buffer_pool: PacketBufferPool::new(DEFAULT_MTU),
             compression_output: Vec::new(),
         }
     }
@@ -280,25 +195,18 @@ impl PacketBuilder {
     /// 1. Check the complete buffer's capacity before splitting. After the split, the tail exposes
     ///    only its remaining portion and cannot reveal whether the original allocation was larger
     ///    than the MTU.
-    /// 2. [`BytesMut::split`] moves the initialized prefix into another `BytesMut` and leaves
-    ///    `packet.payload` as an empty tail with `original_capacity - packet_len` capacity.
+    /// 2. [`BufferPool::split_for_handoff`] moves the initialized prefix into another
+    ///    [`BytesMut`] and retains the empty sibling tail internally.
     /// 3. Freezing the prefix produces the ordinary [`SendPayload`] (`Bytes`) expected by Link and
     ///    every IO backend, without copying the packet bytes.
-    /// 4. Move the tail into the pool. It usually enters `pending_payloads` because the returned
-    ///    `Bytes` still shares the allocation. Dropping the final `Bytes` clone merely makes the
-    ///    tail reclaimable; the next [`Self::begin_send`] sweep explicitly restores its capacity.
+    /// 4. The retained tail is normally pending because the returned [`Bytes`] still shares its
+    ///    allocation. Dropping the final `Bytes` clone merely makes the tail reclaimable; the next
+    ///    [`Self::begin_send`] sweep explicitly restores its capacity.
     pub(crate) fn take_send_payload(&mut self, packet: &mut Packet) -> SendPayload {
-        // `BytesMut::capacity` reports only the capacity visible to the current handle. Capture it
-        // while this handle still spans the complete writable allocation; after splitting, an
-        // oversized allocation can leave an MTU-sized tail and become indistinguishable from a
-        // normal pooled buffer.
-        let retain_tail = packet.payload.capacity() == self.buffer_pool.payload_capacity;
-        let payload = packet.payload.split().freeze();
-        let tail = core::mem::take(&mut packet.payload);
-        if retain_tail {
-            self.buffer_pool.recycle_split_payload_tail(tail);
-        }
-        payload
+        self.buffer_pool
+            .payloads
+            .split_for_handoff(core::mem::take(&mut packet.payload))
+            .freeze()
     }
 
     /// Build a header-only acknowledgement packet.
@@ -817,7 +725,7 @@ mod tests {
 
     #[test]
     fn buffer_pool_reuses_message_metadata_up_to_retained_capacity() {
-        let mut pool = BufferPool::new(DEFAULT_MTU);
+        let mut pool = PacketBufferPool::new(DEFAULT_MTU);
 
         pool.recycle_message_metadata(Vec::with_capacity(MAX_RETAINED_MESSAGE_METADATA_CAPACITY));
         assert_eq!(
@@ -828,7 +736,7 @@ mod tests {
 
     #[test]
     fn buffer_pool_drops_oversized_message_metadata() {
-        let mut pool = BufferPool::new(DEFAULT_MTU);
+        let mut pool = PacketBufferPool::new(DEFAULT_MTU);
 
         pool.recycle_message_metadata(Vec::with_capacity(
             MAX_RETAINED_MESSAGE_METADATA_CAPACITY + 1,
@@ -837,61 +745,16 @@ mod tests {
     }
 
     #[test]
-    fn buffer_pool_reclaims_split_payload_after_bytes_drop() {
-        let mut pool = BufferPool::new(DEFAULT_MTU);
-        let mut payload = pool.take_payload();
-        payload.extend_from_slice(b"packet");
-        let bytes = payload.split().freeze();
-
-        pool.recycle_split_payload_tail(payload);
-        assert!(pool.ready_payloads.is_empty());
-        assert_eq!(pool.pending_payloads.len(), 1);
-
-        pool.reclaim_pending_payloads();
-        assert!(pool.ready_payloads.is_empty());
-        assert_eq!(pool.pending_payloads.len(), 1);
-
-        drop(bytes);
-        pool.reclaim_pending_payloads();
-        assert_eq!(pool.ready_payloads.len(), 1);
-        assert!(pool.pending_payloads.is_empty());
-        assert!(pool.take_payload().capacity() >= DEFAULT_MTU);
-    }
-
-    #[test]
-    fn buffer_pool_reclaims_multiple_outstanding_payloads() {
-        let mut pool = BufferPool::new(DEFAULT_MTU);
-        let bytes = (0..3)
-            .map(|value| {
-                let mut payload = pool.take_payload();
-                payload.extend_from_slice(&[value]);
-                let bytes = payload.split().freeze();
-                pool.recycle_split_payload_tail(payload);
-                bytes
-            })
-            .collect::<Vec<_>>();
-
-        assert!(pool.ready_payloads.is_empty());
-        assert_eq!(pool.pending_payloads.len(), 3);
-        pool.reclaim_pending_payloads();
-        assert_eq!(pool.pending_payloads.len(), 3);
-
-        drop(bytes);
-        pool.reclaim_pending_payloads();
-        assert_eq!(pool.ready_payloads.len(), 3);
-        assert!(pool.pending_payloads.is_empty());
-    }
-
-    #[test]
     fn buffer_pool_does_not_retain_payloads_that_grew_past_the_mtu() {
-        let mut pool = BufferPool::new(DEFAULT_MTU);
+        let mut pool = PacketBufferPool::new(DEFAULT_MTU);
         let mut payload = pool.take_payload();
         payload.extend_from_slice(&alloc::vec![0; DEFAULT_MTU + 1]);
 
-        pool.recycle_unsplit_payload(payload);
+        pool.payloads.recycle(payload);
 
-        assert!(pool.ready_payloads.is_empty());
-        assert!(pool.pending_payloads.is_empty());
+        let misses = pool.payload_pool_misses();
+        let _ = pool.take_payload();
+        assert_eq!(pool.payload_pool_misses(), misses + 1);
     }
 
     #[test]
@@ -910,8 +773,9 @@ mod tests {
 
         assert_eq!(bytes.len(), DEFAULT_MTU);
         assert_eq!(packet.payload.capacity(), 0);
-        assert!(builder.buffer_pool.ready_payloads.is_empty());
-        assert!(builder.buffer_pool.pending_payloads.is_empty());
+        let misses = builder.buffer_pool.payload_pool_misses();
+        let _ = builder.buffer_pool.take_payload();
+        assert_eq!(builder.buffer_pool.payload_pool_misses(), misses + 1);
     }
 
     #[test]

--- a/crates/transport/transport/src/plugin.rs
+++ b/crates/transport/transport/src/plugin.rs
@@ -167,7 +167,9 @@ impl TransportPlugin {
                     #[cfg(feature = "metrics")]
                     metrics::gauge!("transport/recv_bytes").increment(packet_len as f64);
 
-                    let mut cursor = Reader::from(packet);
+                    // Connection layers are the last receive stage that needs in-place mutation.
+                    // Freeze here so transport parsing can retain cheap immutable subslices.
+                    let mut cursor = Reader::from(packet.freeze());
 
                     // Parse the packet
                     let header = PacketHeader::from_bytes(&mut cursor)?;
@@ -787,11 +789,9 @@ mod tests {
         let entity = world
             .spawn((Link::default(), Linked, Transport::default()))
             .id();
-        world
-            .get_mut::<Link>(entity)
-            .unwrap()
-            .recv
-            .push_raw(Bytes::from(data_packet));
+        world.get_mut::<Link>(entity).unwrap().recv.push_raw(
+            lightyear_link::recv_payload_from_bytes(Bytes::from(data_packet)),
+        );
 
         world
             .run_system_once(TransportPlugin::buffer_receive)
@@ -815,7 +815,7 @@ mod tests {
             .get_mut::<Link>(entity)
             .unwrap()
             .recv
-            .push_raw(ack_packet);
+            .push_raw(lightyear_link::recv_payload_from_bytes(ack_packet));
         world
             .run_system_once(TransportPlugin::buffer_receive)
             .unwrap();
@@ -864,9 +864,10 @@ mod tests {
 
         {
             let mut link = world.get_mut::<Link>(entity).unwrap();
-            packets
-                .into_iter()
-                .for_each(|packet| link.recv.push_raw(packet));
+            packets.into_iter().for_each(|packet| {
+                link.recv
+                    .push_raw(lightyear_link::recv_payload_from_bytes(packet));
+            });
         }
         world
             .run_system_once(TransportPlugin::buffer_receive)


### PR DESCRIPTION
## Summary

- introduce lightyear_core::buffer_pool::BufferPool, a bounded ready/pending pool that recycles split BytesMut allocations for both Transport packet payloads and UDP receive buffers
- change Link RecvPayload to BytesMut so Netcode can split and decrypt received packets in place without reallocating; immutable Aeronet and Crossbeam inputs reuse uniquely owned allocations and retain a copy fallback for shared inputs
- separate connection-layer selection from IO selection in ClientServerStepper and support real loopback UDP and native WebTransport with an ephemeral port, self-signed identity, and test-only insecure client configuration

