### PR TITLE
refactor(serde): consolidate reader and writer implementations

### DIFF
--- a/crates/transport/serde/src/reader.rs
+++ b/crates/transport/serde/src/reader.rs
@@ -1,206 +1,100 @@
 use crate::SerializationError;
 use crate::varint::varint_parse_len;
+use alloc::vec::Vec;
 use bytes::Bytes;
 use no_std_io2::io::{Cursor, Error, Read, Result, Seek, SeekFrom};
 
-#[cfg(not(feature = "std"))]
-pub use no_std::Reader;
-#[cfg(feature = "std")]
-pub use std::Reader;
+#[derive(Clone)]
+pub struct Reader(Cursor<Bytes>);
 
-#[cfg(feature = "std")]
-pub(crate) mod std {
-    use super::*;
-
-    use alloc::vec::Vec;
-    use bytes::Buf;
-
-    #[derive(Clone)]
-    pub struct Reader(Cursor<Bytes>);
-
-    impl From<Bytes> for Reader {
-        fn from(value: Bytes) -> Self {
-            // TODO: check that this has no cost
-            Self(Cursor::new(value))
-        }
-    }
-
-    impl From<Vec<u8>> for Reader {
-        fn from(value: Vec<u8>) -> Self {
-            Self(Cursor::new(value.into()))
-        }
-    }
-
-    impl Seek for Reader {
-        fn seek(&mut self, pos: SeekFrom) -> Result<u64> {
-            self.0.seek(pos)
-        }
-    }
-
-    impl Read for Reader {
-        fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
-            self.0.read(buf)
-        }
-    }
-
-    impl AsRef<[u8]> for Reader {
-        fn as_ref(&self) -> &[u8] {
-            self.0.get_ref().as_ref()
-        }
-    }
-
-    impl Reader {
-        /// Returns the underlying RawData
-        pub fn consume(self) -> Bytes {
-            self.0.into_inner()
-        }
-
-        pub fn len(&self) -> usize {
-            self.0.get_ref().len()
-        }
-
-        pub fn is_empty(&self) -> bool {
-            self.len() == 0
-        }
-
-        /// Split of the next `len` bytes from the reader into a separate Bytes.
-        ///
-        /// This doesn't allocate and just increases some reference counts. O(1) cost.
-        pub fn split_len(&mut self, len: usize) -> Bytes {
-            let current_pos = self.0.position() as usize;
-            let new_pos = current_pos + len;
-            // slice off the subset into a separate Bytes
-            let bytes = self.0.get_ref().slice(current_pos..new_pos);
-            // increment the position
-            self.0.set_position(new_pos as u64);
-            bytes
-        }
-
-        /// Return the remaining length of the buffer as a separate Bytes.
-        ///
-        /// This doesn't allocate and just increases some reference counts. O(1) cost.
-        pub fn split(&mut self) -> Bytes {
-            let current_pos = self.0.position() as usize;
-            self.0.get_mut().split_off(current_pos)
-        }
-
-        pub fn has_remaining(&self) -> bool {
-            self.remaining() > 0
-        }
-
-        pub fn position(&self) -> u64 {
-            self.0.position()
-        }
-
-        pub fn set_position(&mut self, pos: u64) {
-            self.0.set_position(pos)
-        }
-
-        pub fn remaining(&self) -> usize {
-            self.0.remaining()
-        }
+#[inline(always)]
+fn saturating_sub_usize_u64(a: usize, b: u64) -> usize {
+    match usize::try_from(b) {
+        Ok(b) => a.saturating_sub(b),
+        Err(_) => 0,
     }
 }
 
-#[cfg(not(feature = "std"))]
-pub(crate) mod no_std {
-    use super::*;
-    use alloc::vec::Vec;
+impl From<Bytes> for Reader {
+    fn from(value: Bytes) -> Self {
+        // TODO: check that this has no cost
+        Self(Cursor::new(value))
+    }
+}
 
-    #[derive(Clone)]
-    pub struct Reader(Cursor<Bytes>);
+impl From<Vec<u8>> for Reader {
+    fn from(value: Vec<u8>) -> Self {
+        Self(Cursor::new(value.into()))
+    }
+}
 
-    #[inline(always)]
-    fn saturating_sub_usize_u64(a: usize, b: u64) -> usize {
-        use core::convert::TryFrom;
-        match usize::try_from(b) {
-            Ok(b) => a.saturating_sub(b),
-            Err(_) => 0,
-        }
+impl Seek for Reader {
+    fn seek(&mut self, pos: SeekFrom) -> Result<u64> {
+        self.0.seek(pos)
+    }
+}
+
+impl Read for Reader {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
+        self.0.read(buf)
+    }
+}
+
+impl AsRef<[u8]> for Reader {
+    fn as_ref(&self) -> &[u8] {
+        self.0.get_ref().as_ref()
+    }
+}
+
+impl Reader {
+    /// Returns the underlying RawData
+    pub fn consume(self) -> Bytes {
+        self.0.into_inner()
     }
 
-    impl From<Bytes> for Reader {
-        fn from(value: Bytes) -> Self {
-            // TODO: check that this has no cost
-            Self(Cursor::new(value))
-        }
+    pub fn len(&self) -> usize {
+        self.0.get_ref().len()
     }
 
-    impl From<Vec<u8>> for Reader {
-        fn from(value: Vec<u8>) -> Self {
-            Self(Cursor::new(value.into()))
-        }
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
     }
 
-    impl Seek for Reader {
-        fn seek(&mut self, pos: SeekFrom) -> Result<u64> {
-            self.0.seek(pos)
-        }
+    /// Split of the next `len` bytes from the reader into a separate Bytes.
+    ///
+    /// This doesn't allocate and just increases some reference counts. O(1) cost.
+    pub fn split_len(&mut self, len: usize) -> Bytes {
+        let current_pos = self.0.position() as usize;
+        let new_pos = current_pos + len;
+        // slice off the subset into a separate Bytes
+        let bytes = self.0.get_ref().slice(current_pos..new_pos);
+        // increment the position
+        self.0.set_position(new_pos as u64);
+        bytes
     }
 
-    impl Read for Reader {
-        fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
-            self.0.read(buf)
-        }
+    /// Return the remaining length of the buffer as a separate Bytes.
+    ///
+    /// This doesn't allocate and just increases some reference counts. O(1) cost.
+    pub fn split(&mut self) -> Bytes {
+        let current_pos = self.0.position() as usize;
+        self.0.get_mut().split_off(current_pos)
     }
 
-    impl AsRef<[u8]> for Reader {
-        fn as_ref(&self) -> &[u8] {
-            self.0.get_ref().as_ref()
-        }
+    pub fn has_remaining(&self) -> bool {
+        self.remaining() > 0
     }
 
-    impl Reader {
-        /// Returns the underlying RawData
-        pub fn consume(self) -> Bytes {
-            self.0.into_inner()
-        }
+    pub fn position(&self) -> u64 {
+        self.0.position()
+    }
 
-        pub fn len(&self) -> usize {
-            self.0.get_ref().len()
-        }
+    pub fn set_position(&mut self, pos: u64) {
+        self.0.set_position(pos)
+    }
 
-        pub fn is_empty(&self) -> bool {
-            self.len() == 0
-        }
-
-        /// Split of the next `len` bytes from the reader into a separate Bytes.
-        ///
-        /// This doesn't allocate and just increases some reference counts. O(1) cost.
-        pub fn split_len(&mut self, len: usize) -> Bytes {
-            let current_pos = self.0.position() as usize;
-            let new_pos = current_pos + len;
-            // slice off the subset into a separate Bytes
-            let bytes = self.0.get_ref().slice(current_pos..new_pos);
-            // increment the position
-            self.0.set_position(new_pos as u64);
-            bytes
-        }
-
-        /// Return the remaining length of the buffer as a separate Bytes.
-        ///
-        /// This doesn't allocate and just increases some reference counts. O(1) cost.
-        pub fn split(&mut self) -> Bytes {
-            let current_pos = self.0.position() as usize;
-            self.0.get_mut().split_off(current_pos)
-        }
-
-        pub fn has_remaining(&self) -> bool {
-            self.remaining() > 0
-        }
-
-        pub fn position(&self) -> u64 {
-            self.0.position()
-        }
-
-        pub fn set_position(&mut self, pos: u64) {
-            self.0.set_position(pos)
-        }
-
-        pub fn remaining(&self) -> usize {
-            // copied from the Buf implementation for std::io::Cursor in tokio::bytes
-            saturating_sub_usize_u64(self.len(), self.position())
-        }
+    pub fn remaining(&self) -> usize {
+        saturating_sub_usize_u64(self.len(), self.position())
     }
 }
 

--- a/crates/transport/serde/src/writer.rs
+++ b/crates/transport/serde/src/writer.rs
@@ -9,216 +9,110 @@
 use crate::SerializationError;
 use crate::varint::varint_len;
 use bytes::{BufMut, Bytes, BytesMut};
+use core::cmp;
 use no_std_io2::io;
 use no_std_io2::io::{Result, Write};
 
-#[cfg(not(feature = "std"))]
-pub use no_std::Writer;
-#[cfg(feature = "std")]
-pub use std::Writer;
+#[derive(Debug)]
+pub struct Writer(BytesMut);
 
-#[cfg(feature = "std")]
-pub(crate) mod std {
-    use super::*;
-
-    #[derive(Debug)]
-    pub struct Writer(bytes::buf::Writer<BytesMut>);
-
-    impl From<BytesMut> for Writer {
-        fn from(value: BytesMut) -> Self {
-            Self(value.writer())
-        }
-    }
-
-    impl Write for Writer {
-        fn write(&mut self, buf: &[u8]) -> Result<usize> {
-            self.0.write(buf)
-        }
-
-        fn flush(&mut self) -> Result<()> {
-            self.0.flush()
-        }
-    }
-
-    impl<const N: usize> From<[u8; N]> for Writer {
-        #[inline]
-        fn from(value: [u8; N]) -> Self {
-            BytesMut::from(Bytes::copy_from_slice(&value)).into()
-        }
-    }
-
-    impl AsMut<[u8]> for Writer {
-        fn as_mut(&mut self) -> &mut [u8] {
-            self.0.get_mut().as_mut()
-        }
-    }
-
-    impl Writer {
-        pub fn with_capacity(capacity: usize) -> Self {
-            let buf = BytesMut::with_capacity(capacity);
-            Self(buf.writer())
-        }
-
-        pub fn capacity(&self) -> usize {
-            self.0.get_ref().capacity()
-        }
-
-        pub fn len(&self) -> usize {
-            self.0.get_ref().len()
-        }
-
-        pub fn is_empty(&self) -> bool {
-            self.len() == 0
-        }
-
-        pub fn position(&self) -> usize {
-            self.len()
-        }
-
-        // TODO: how do reduce capacity over time?
-        /// Split the current bytes written as a separate [`Bytes`].
-        ///
-        /// Retains any additional capacity. O(1) operation.
-        pub fn split(&mut self) -> Bytes {
-            self.0.get_mut().split().freeze()
-        }
-
-        pub fn reserve(&mut self, additional: usize) {
-            self.0.get_mut().reserve(additional)
-        }
-
-        pub fn extend_from_slice(&mut self, extend: &[u8]) {
-            self.0.get_mut().extend_from_slice(extend)
-        }
-
-        /// Splits the buffer into two at the given index.
-        ///
-        /// Afterwards `self` contains elements `[at, len)`, and the returned `BytesMut`
-        /// contains elements `[0, at)`.
-        pub fn split_to(&mut self, at: usize) -> Bytes {
-            self.0.get_mut().split_to(at).freeze()
-        }
-
-        // TODO: normally there is no need to reset, because once all the messages that have been split
-        //  are dropped, the writer will move the current data to the front of the buffer to reuse memory
-        //  All the split bytes messages are dropped at Send for unreliable senders, but NOT for reliable
-        //  senders, think about what to do for that! Maybe do a clone there to drop the message?
-        /// Reset the writer but keeps the underlying allocation
-        pub fn reset(&mut self) {
-            self.0.get_mut().clear();
-        }
-
-        // by convention, to_* functions with non-Copy self types usually take a &self, but not here.
-        /// Consume the writer to get the RawData
-        #[allow(clippy::wrong_self_convention)]
-        pub fn to_bytes(self) -> Bytes {
-            self.0.into_inner().into()
-        }
-
-        // by convention, to_* functions with non-Copy self types usually take a &self, but not here.
-        /// Consume the writer to get the RawData
-        #[allow(clippy::wrong_self_convention)]
-        pub fn to_bytes_mut(self) -> BytesMut {
-            self.0.into_inner()
-        }
+impl From<BytesMut> for Writer {
+    fn from(value: BytesMut) -> Self {
+        Self(value)
     }
 }
-#[cfg(not(feature = "std"))]
-pub(crate) mod no_std {
-    use super::*;
-    use core::cmp;
-    #[derive(Debug)]
-    pub struct Writer(BytesMut);
 
-    impl From<BytesMut> for Writer {
-        fn from(value: BytesMut) -> Self {
-            Self(value)
-        }
+impl Write for Writer {
+    fn write(&mut self, src: &[u8]) -> Result<usize> {
+        let n = cmp::min(self.0.remaining_mut(), src.len());
+        self.0.put_slice(&src[..n]);
+        Ok(n)
     }
 
-    impl Write for Writer {
-        fn write(&mut self, src: &[u8]) -> Result<usize> {
-            let n = cmp::min(self.0.remaining_mut(), src.len());
-            self.0.put_slice(&src[..n]);
-            Ok(n)
-        }
+    fn flush(&mut self) -> Result<()> {
+        Ok(())
+    }
+}
 
-        fn flush(&mut self) -> Result<()> {
-            Ok(())
-        }
+impl<const N: usize> From<[u8; N]> for Writer {
+    #[inline]
+    fn from(value: [u8; N]) -> Self {
+        BytesMut::from(Bytes::copy_from_slice(&value)).into()
+    }
+}
+
+impl AsMut<[u8]> for Writer {
+    fn as_mut(&mut self) -> &mut [u8] {
+        self.0.as_mut()
+    }
+}
+
+impl Writer {
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self(BytesMut::with_capacity(capacity))
     }
 
-    impl<const N: usize> From<[u8; N]> for crate::writer::Writer {
-        #[inline]
-        fn from(value: [u8; N]) -> Self {
-            BytesMut::from(Bytes::copy_from_slice(&value)).into()
-        }
+    pub fn capacity(&self) -> usize {
+        self.0.capacity()
     }
 
-    impl AsMut<[u8]> for Writer {
-        fn as_mut(&mut self) -> &mut [u8] {
-            self.0.as_mut()
-        }
+    pub fn len(&self) -> usize {
+        self.0.len()
     }
 
-    impl Writer {
-        pub fn with_capacity(capacity: usize) -> Self {
-            let buf = BytesMut::with_capacity(capacity);
-            Self(buf)
-        }
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
 
-        pub fn capacity(&self) -> usize {
-            self.0.capacity()
-        }
+    pub fn position(&self) -> usize {
+        self.len()
+    }
 
-        pub fn len(&self) -> usize {
-            self.0.as_ref().len()
-        }
+    // TODO: how do reduce capacity over time?
+    /// Split the current bytes written as a separate [`Bytes`].
+    ///
+    /// Retains any additional capacity. O(1) operation.
+    pub fn split(&mut self) -> Bytes {
+        self.0.split().freeze()
+    }
 
-        pub fn is_empty(&self) -> bool {
-            self.len() == 0
-        }
+    pub fn reserve(&mut self, additional: usize) {
+        self.0.reserve(additional)
+    }
 
-        pub fn position(&self) -> usize {
-            self.len()
-        }
+    pub fn extend_from_slice(&mut self, extend: &[u8]) {
+        self.0.extend_from_slice(extend)
+    }
 
-        // TODO: how do reduce capacity over time?
-        /// Split the current bytes written as a separate [`Bytes`].
-        ///
-        /// Retains any additional capacity. O(1) operation.
-        pub fn split(&mut self) -> Bytes {
-            self.0.split().freeze()
-        }
+    /// Splits the buffer into two at the given index.
+    ///
+    /// Afterwards `self` contains elements `[at, len)`, and the returned `BytesMut`
+    /// contains elements `[0, at)`.
+    pub fn split_to(&mut self, at: usize) -> Bytes {
+        self.0.split_to(at).freeze()
+    }
 
-        pub fn reserve(&mut self, additional: usize) {
-            self.0.reserve(additional)
-        }
+    // TODO: normally there is no need to reset, because once all the messages that have been split
+    //  are dropped, the writer will move the current data to the front of the buffer to reuse memory
+    //  All the split bytes messages are dropped at Send for unreliable senders, but NOT for reliable
+    //  senders, think about what to do for that! Maybe do a clone there to drop the message?
+    /// Reset the writer but keeps the underlying allocation
+    pub fn reset(&mut self) {
+        self.0.clear();
+    }
 
-        pub fn extend_from_slice(&mut self, extend: &[u8]) {
-            self.0.extend_from_slice(extend)
-        }
+    // by convention, to_* functions with non-Copy self types usually take a &self, but not here.
+    /// Consume the writer to get the RawData
+    #[allow(clippy::wrong_self_convention)]
+    pub fn to_bytes(self) -> Bytes {
+        self.0.into()
+    }
 
-        // TODO: normally there is no need to reset, because once all the messages that have been split
-        //  are dropped, the writer will move the current data to the front of the buffer to reuse memory
-        //  All the split bytes messages are dropped at Send for unreliable senders, but NOT for reliable
-        //  senders, think about what to do for that! Maybe do a clone there to drop the message?
-        /// Reset the writer but keeps the underlying allocation
-        pub fn reset(&mut self) {
-            self.0.clear();
-        }
-
-        // by convention, to_* functions with non-Copy self types usually take a &self, but not here.
-        /// Consume the writer to get the RawData
-        #[allow(clippy::wrong_self_convention)]
-        pub fn to_bytes(self) -> Bytes {
-            self.0.into()
-        }
-
-        #[allow(clippy::wrong_self_convention)]
-        pub fn to_bytes_mut(self) -> BytesMut {
-            self.0
-        }
+    // by convention, to_* functions with non-Copy self types usually take a &self, but not here.
+    /// Consume the writer to get the RawData
+    #[allow(clippy::wrong_self_convention)]
+    pub fn to_bytes_mut(self) -> BytesMut {
+        self.0
     }
 }
 


### PR DESCRIPTION
Consolidates the feature-specific Reader and Writer types into shared implementations backed by Bytes and BytesMut.