### PR TITLE
refactor(serde): clarify reader and writer APIs

### DIFF
--- a/crates/connection/connection/src/network_target.rs
+++ b/crates/connection/connection/src/network_target.rs
@@ -439,7 +439,7 @@ mod tests {
         let target = Target::AllExcept(vec![]);
         let mut writer = Writer::default();
         target.to_bytes(&mut writer).unwrap();
-        let mut reader = Reader::from(writer.to_bytes());
+        let mut reader = Reader::from(writer.into_bytes());
         let deserialized = Target::from_bytes(&mut reader).unwrap();
         assert_eq!(target, deserialized);
     }

--- a/crates/connection/netcode/src/client.rs
+++ b/crates/connection/netcode/src/client.rs
@@ -356,7 +356,7 @@ impl<Ctx> Client<Ctx> {
             self.token.protocol_id,
         )?;
         self.writer.extend_from_slice(&buf[..size]);
-        sender.push(self.writer.split());
+        sender.push(self.writer.take_written());
         self.last_send_time = self.time;
         self.sequence += 1;
         Ok(())
@@ -376,7 +376,7 @@ impl<Ctx> Client<Ctx> {
             self.token.protocol_id,
         )?;
         self.writer.extend_from_slice(&buf[..size]);
-        sender.push(self.writer.split());
+        sender.push(self.writer.take_written());
         self.last_send_time = self.time;
         self.sequence += 1;
         Ok(())
@@ -392,7 +392,7 @@ impl<Ctx> Client<Ctx> {
             self.token.protocol_id,
         )?;
         self.writer.extend_from_slice(&buf[..size]);
-        self.send_queue.push(self.writer.split());
+        self.send_queue.push(self.writer.take_written());
         self.last_send_time = self.time;
         self.sequence += 1;
         Ok(())

--- a/crates/connection/netcode/src/server.rs
+++ b/crates/connection/netcode/src/server.rs
@@ -537,7 +537,7 @@ impl<Ctx> Server<Ctx> {
         self.send_queue
             .entry(entity)
             .or_default()
-            .push(self.writer.split());
+            .push(self.writer.take_written());
         self.sequence += 1;
         Ok(())
     }
@@ -545,7 +545,7 @@ impl<Ctx> Server<Ctx> {
         let mut buf = [0u8; MAX_PKT_BUF_SIZE];
         let size = packet.write(&mut buf, self.sequence, &key, self.protocol_id)?;
         self.writer.extend_from_slice(&buf[..size]);
-        sender.push(self.writer.split());
+        sender.push(self.writer.take_written());
         self.sequence += 1;
         Ok(())
     }
@@ -564,7 +564,7 @@ impl<Ctx> Server<Ctx> {
         let mut buf = [0u8; MAX_PKT_BUF_SIZE];
         let size = packet.write(&mut buf, conn.sequence, &conn.send_key, self.protocol_id)?;
         self.writer.extend_from_slice(&buf[..size]);
-        sender.push(self.writer.split());
+        sender.push(self.writer.take_written());
 
         conn.last_access_time = self.time;
         conn.last_send_time = self.time;
@@ -593,7 +593,7 @@ impl<Ctx> Server<Ctx> {
             self.protocol_id,
         )?;
         self.writer.extend_from_slice(&buf[..size]);
-        sender.push(self.writer.split());
+        sender.push(self.writer.take_written());
 
         conn.last_access_time = self.time;
         conn.last_send_time = self.time;
@@ -619,7 +619,7 @@ impl<Ctx> Server<Ctx> {
         self.send_queue
             .entry(entity)
             .or_default()
-            .push(self.writer.split());
+            .push(self.writer.take_written());
 
         conn.last_access_time = self.time;
         conn.last_send_time = self.time;

--- a/crates/transport/messages/src/multi.rs
+++ b/crates/transport/messages/src/multi.rs
@@ -46,7 +46,7 @@ impl<'w, 's, F: QueryFilter> MultiMessageSender<'w, 's, F> {
                 &mut self.writer,
                 &mut SendEntityMap::default(),
             )?;
-            let bytes = self.writer.split();
+            let bytes = self.writer.take_written();
             let bytes_len = bytes.len();
             self.query
                 .iter_many_unique_mut(senders)
@@ -65,7 +65,7 @@ impl<'w, 's, F: QueryFilter> MultiMessageSender<'w, 's, F> {
                         // TODO: ideally we could do entity mapping without Mut!!!
                         &mut manager.entity_mapper.local_to_remote,
                     )?;
-                    let bytes = self.writer.split();
+                    let bytes = self.writer.take_written();
                     #[cfg(feature = "metrics")]
                     metric_handles.record_send::<M>(bytes.len());
                     transport.send_with_priority::<C>(bytes, priority)?;

--- a/crates/transport/messages/src/registry.rs
+++ b/crates/transport/messages/src/registry.rs
@@ -544,7 +544,7 @@ mod tests {
         registry
             .serialize(&message, &mut writer, &mut SendEntityMap::default())
             .unwrap();
-        let data = writer.to_bytes();
+        let data = writer.into_bytes();
 
         let mut reader = Reader::from(data);
         let read = registry
@@ -566,7 +566,7 @@ mod tests {
         registry
             .serialize(&message, &mut writer, &mut SendEntityMap::default())
             .unwrap();
-        let data = writer.to_bytes();
+        let data = writer.into_bytes();
 
         let mut reader = Reader::from(data);
         let read = registry
@@ -602,7 +602,7 @@ mod tests {
         registry
             .serialize(&message, &mut writer, &mut entity_map)
             .unwrap();
-        let data = writer.to_bytes();
+        let data = writer.into_bytes();
 
         let mut reader = Reader::from(data);
         let read = registry

--- a/crates/transport/messages/src/send.rs
+++ b/crates/transport/messages/src/send.rs
@@ -144,7 +144,7 @@ impl<M: Message> MessageSender<M> {
                         entity_map,
                     )?
                 };
-                let bytes = sender.writer.split();
+                let bytes = sender.writer.take_written();
                 #[cfg(feature = "metrics")]
                 metric_handles.record_send::<M>(bytes.len());
                 trace!(

--- a/crates/transport/messages/src/send_trigger.rs
+++ b/crates/transport/messages/src/send_trigger.rs
@@ -74,7 +74,7 @@ impl<M: Event> EventSender<M> {
                     entity_map,
                 )?
             };
-            let bytes = sender.writer.split();
+            let bytes = sender.writer.take_written();
             trace!(
                 "Sending message of type {:?} with net_id {net_id:?} on channel {:?}",
                 DebugName::type_name::<M>(),

--- a/crates/transport/serde/src/entity_map.rs
+++ b/crates/transport/serde/src/entity_map.rs
@@ -342,7 +342,7 @@ mod tests {
         e.to_bytes(&mut writer).unwrap();
         // entities of the first generation only serialize the row
         assert_eq!(writer.len(), 1);
-        let mut reader = Reader::from(writer.split());
+        let mut reader = Reader::from(writer.take_written());
         let serde_e = Entity::from_bytes(&mut reader).unwrap();
         assert_eq!(e, serde_e);
     }
@@ -358,7 +358,7 @@ mod tests {
         e.to_bytes(&mut writer).unwrap();
         // both the row and generation are serialized
         assert_eq!(writer.len(), 2);
-        let mut reader = Reader::from(writer.split());
+        let mut reader = Reader::from(writer.take_written());
         let serde_e = Entity::from_bytes(&mut reader).unwrap();
         assert_eq!(e, serde_e);
     }
@@ -374,7 +374,7 @@ mod tests {
         entity_mapped.to_bytes(&mut writer).unwrap();
         // even with entity mapping, it only takes 1 bytes (since the `is_mapped` information is included in the row)
         assert_eq!(writer.len(), 1);
-        let mut reader = Reader::from(writer.split());
+        let mut reader = Reader::from(writer.take_written());
         let serde_e = Entity::from_bytes(&mut reader).unwrap();
         assert_eq!(entity_mapped, serde_e);
     }
@@ -392,7 +392,7 @@ mod tests {
         let mut writer = Writer::with_capacity(100);
         entity_mapped.to_bytes(&mut writer).unwrap();
         assert_eq!(writer.len(), 2);
-        let mut reader = Reader::from(writer.split());
+        let mut reader = Reader::from(writer.take_written());
         let serde_e = Entity::from_bytes(&mut reader).unwrap();
         assert_eq!(entity_mapped, serde_e);
     }

--- a/crates/transport/serde/src/lib.rs
+++ b/crates/transport/serde/src/lib.rs
@@ -274,7 +274,7 @@ mod tests {
         let mut writer = Writer::with_capacity(5);
         a.to_bytes(&mut writer).unwrap();
 
-        let mut reader = Reader::from(writer.to_bytes());
+        let mut reader = Reader::from(writer.into_bytes());
         let read = Bytes::from_bytes(&mut reader).unwrap();
         assert_eq!(a, read);
     }
@@ -285,7 +285,7 @@ mod tests {
         writer.write_varint(10).unwrap();
         writer.extend_from_slice(&[7]);
 
-        let mut reader = Reader::from(writer.to_bytes());
+        let mut reader = Reader::from(writer.into_bytes());
         assert!(Bytes::from_bytes(&mut reader).is_err());
     }
 
@@ -297,7 +297,7 @@ mod tests {
         let b: Vec<u8> = vec![];
         b.to_bytes(&mut writer).unwrap();
 
-        let mut reader = Reader::from(writer.to_bytes());
+        let mut reader = Reader::from(writer.into_bytes());
         let a_read = Vec::<u8>::from_bytes(&mut reader).unwrap();
         let b_read = Vec::<u8>::from_bytes(&mut reader).unwrap();
         assert_eq!(a, a_read);
@@ -312,7 +312,7 @@ mod tests {
         let mut writer = Writer::with_capacity(5);
         a.to_bytes(&mut writer).unwrap();
 
-        let mut reader = Reader::from(writer.to_bytes());
+        let mut reader = Reader::from(writer.into_bytes());
         let read = HashMap::<u8, u8>::from_bytes(&mut reader).unwrap();
         assert_eq!(a, read);
     }
@@ -327,7 +327,7 @@ mod tests {
         b.to_bytes(&mut writer).unwrap();
         c.to_bytes(&mut writer).unwrap();
 
-        let mut reader = Reader::from(writer.to_bytes());
+        let mut reader = Reader::from(writer.into_bytes());
         let read_a = Entity::from_bytes(&mut reader).unwrap();
         let read_b = Entity::from_bytes(&mut reader).unwrap();
         let read_c = Entity::from_bytes(&mut reader).unwrap();

--- a/crates/transport/serde/src/postcard_utils.rs
+++ b/crates/transport/serde/src/postcard_utils.rs
@@ -80,7 +80,7 @@ mod tests {
         to_writer(&second, &mut writer).unwrap();
 
         assert!(writer.len() > first_len);
-        let mut reader = Reader::from(writer.to_bytes());
+        let mut reader = Reader::from(writer.into_bytes());
         assert_eq!(from_reader::<Message>(&mut reader).unwrap(), first);
         assert_eq!(reader.position() as usize, first_len);
         assert_eq!(from_reader::<Message>(&mut reader).unwrap(), second);

--- a/crates/transport/serde/src/reader.rs
+++ b/crates/transport/serde/src/reader.rs
@@ -68,8 +68,10 @@ impl AsRef<[u8]> for Reader {
 }
 
 impl Reader {
-    /// Returns the underlying RawData
-    pub fn consume(self) -> Bytes {
+    /// Consumes the reader and returns its entire underlying buffer.
+    ///
+    /// This includes bytes before the current cursor position.
+    pub fn into_bytes(self) -> Bytes {
         self.0.into_inner()
     }
 
@@ -102,9 +104,17 @@ impl Reader {
     /// Return the remaining length of the buffer as a separate Bytes.
     ///
     /// This doesn't allocate and just increases some reference counts. O(1) cost.
-    pub fn split(&mut self) -> Bytes {
+    pub fn take_remaining(&mut self) -> Bytes {
         let current_pos = self.0.position() as usize;
         self.0.get_mut().split_off(current_pos)
+    }
+
+    /// Returns the unread portion of the underlying buffer.
+    pub fn remaining_slice(&self) -> &[u8] {
+        let Ok(position) = usize::try_from(self.position()) else {
+            return &[];
+        };
+        self.as_ref().get(position..).unwrap_or_default()
     }
 
     pub fn has_remaining(&self) -> bool {

--- a/crates/transport/serde/src/writer.rs
+++ b/crates/transport/serde/src/writer.rs
@@ -35,6 +35,10 @@ impl Write for Writer {
 }
 
 impl<const N: usize> From<[u8; N]> for Writer {
+    /// Creates a writer containing all `N` bytes from `value`.
+    ///
+    /// In particular, `Writer::from([0; N])` has length `N`; it is not an empty
+    /// writer with capacity `N`. Use [`Writer::with_capacity`] for that.
     #[inline]
     fn from(value: [u8; N]) -> Self {
         BytesMut::from(Bytes::copy_from_slice(&value)).into()
@@ -72,7 +76,7 @@ impl Writer {
     /// Split the current bytes written as a separate [`Bytes`].
     ///
     /// Retains any additional capacity. O(1) operation.
-    pub fn split(&mut self) -> Bytes {
+    pub fn take_written(&mut self) -> Bytes {
         self.0.split().freeze()
     }
 
@@ -101,17 +105,13 @@ impl Writer {
         self.0.clear();
     }
 
-    // by convention, to_* functions with non-Copy self types usually take a &self, but not here.
-    /// Consume the writer to get the RawData
-    #[allow(clippy::wrong_self_convention)]
-    pub fn to_bytes(self) -> Bytes {
+    /// Consumes the writer and returns its written bytes as immutable storage.
+    pub fn into_bytes(self) -> Bytes {
         self.0.into()
     }
 
-    // by convention, to_* functions with non-Copy self types usually take a &self, but not here.
-    /// Consume the writer to get the RawData
-    #[allow(clippy::wrong_self_convention)]
-    pub fn to_bytes_mut(self) -> BytesMut {
+    /// Consumes the writer and returns its mutable byte storage.
+    pub fn into_bytes_mut(self) -> BytesMut {
         self.0
     }
 }

--- a/crates/transport/transport/src/channel/builder.rs
+++ b/crates/transport/transport/src/channel/builder.rs
@@ -739,7 +739,7 @@ mod tests {
         let tick = header.tick;
         let mut packet_type = header.get_packet_type();
         if packet_type.is_compressed() {
-            let compressed_payload = cursor.split();
+            let compressed_payload = cursor.take_remaining();
             let decompressed_payload =
                 decompress_payload(compressed_payload.as_ref(), compression)?;
             cursor = Reader::from(decompressed_payload);

--- a/crates/transport/transport/src/plugin.rs
+++ b/crates/transport/transport/src/plugin.rs
@@ -229,7 +229,7 @@ impl TransportPlugin {
 
                     let mut packet_type = header.get_packet_type();
                     if packet_type.is_compressed() {
-                        let compressed_payload = cursor.split();
+                        let compressed_payload = cursor.take_remaining();
                         let decompressed_payload =
                             decompress_payload(compressed_payload.as_ref(), transport.compression)?;
                         cursor = Reader::from(decompressed_payload);


### PR DESCRIPTION
Renames consuming and buffer-taking methods to reflect ownership and adds an explicit view of unread Reader bytes.