### PR TITLE
refactor(serde): implement bytes Buf for Reader

### DIFF
--- a/crates/transport/serde/src/postcard_utils.rs
+++ b/crates/transport/serde/src/postcard_utils.rs
@@ -2,6 +2,7 @@
 
 use crate::reader::Reader;
 use crate::writer::Writer;
+use bytes::Buf;
 use postcard::ser_flavors::Flavor;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
@@ -39,18 +40,9 @@ impl Flavor for WriterFlavor<'_> {
 
 /// Deserializes from the unread part of a [`Reader`] and advances its cursor.
 pub(crate) fn from_reader<T: DeserializeOwned>(reader: &mut Reader) -> postcard::Result<T> {
-    let position = usize::try_from(reader.position())
-        .map_err(|_| postcard::Error::DeserializeUnexpectedEnd)?;
-    let (value, consumed) = {
-        let remaining = reader
-            .as_ref()
-            .get(position..)
-            .ok_or(postcard::Error::DeserializeUnexpectedEnd)?;
-        let initial_len = remaining.len();
-        let (value, remainder) = postcard::take_from_bytes(remaining)?;
-        (value, initial_len - remainder.len())
-    };
-    reader.set_position((position + consumed) as u64);
+    let initial_len = reader.remaining();
+    let (value, remainder) = postcard::take_from_bytes(reader.chunk())?;
+    reader.advance(initial_len - remainder.len());
     Ok(value)
 }
 

--- a/crates/transport/serde/src/reader.rs
+++ b/crates/transport/serde/src/reader.rs
@@ -1,7 +1,7 @@
 use crate::SerializationError;
 use crate::varint::varint_parse_len;
 use alloc::vec::Vec;
-use bytes::Bytes;
+use bytes::{Buf, Bytes};
 use no_std_io2::io::{Cursor, Error, ErrorKind, Read, Result, Seek, SeekFrom};
 
 #[derive(Clone)]
@@ -37,6 +37,27 @@ impl Seek for Reader {
 impl Read for Reader {
     fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
         self.0.read(buf)
+    }
+}
+
+impl Buf for Reader {
+    fn remaining(&self) -> usize {
+        Reader::remaining(self)
+    }
+
+    fn chunk(&self) -> &[u8] {
+        let Ok(position) = usize::try_from(self.position()) else {
+            return &[];
+        };
+        self.as_ref().get(position..).unwrap_or_default()
+    }
+
+    fn advance(&mut self, cnt: usize) {
+        assert!(
+            cnt <= Reader::remaining(self),
+            "cannot advance past the remaining bytes"
+        );
+        self.0.set_position(self.position() + cnt as u64);
     }
 }
 


### PR DESCRIPTION
Implements bytes::Buf for Reader and uses it to simplify Postcard deserialization and cursor advancement.