### PR TITLE
fix(perf): reuse packet bookkeeping allocations

### DIFF
--- a/crates/connection/netcode/src/server.rs
+++ b/crates/connection/netcode/src/server.rs
@@ -115,6 +115,9 @@ struct ConnectionCache {
     // the main difference being that `Connection` includes the encryption mapping as well.
     clients: HashMap<ClientId, Connection>,
 
+    /// Reusable snapshot for loops that mutate `clients` while visiting its IDs.
+    client_ids_scratch: Vec<ClientId>,
+
     // map from client entity to client id
     client_id_map: HashMap<Entity, ClientId>,
 
@@ -129,6 +132,7 @@ impl ConnectionCache {
     fn new(server_time: f64) -> Self {
         Self {
             clients: HashMap::default(),
+            client_ids_scratch: Vec::new(),
             client_id_map: HashMap::default(),
             replay_protection: HashMap::default(),
             time: server_time,
@@ -185,8 +189,15 @@ impl ConnectionCache {
         self.clients.remove(&client_id);
     }
 
-    fn ids(&self) -> Vec<ClientId> {
-        self.clients.keys().cloned().collect()
+    fn take_client_ids(&mut self) -> Vec<ClientId> {
+        let mut client_ids = core::mem::take(&mut self.client_ids_scratch);
+        client_ids.clear();
+        client_ids.extend(self.clients.keys().copied());
+        client_ids
+    }
+
+    fn recycle_client_ids(&mut self, client_ids: Vec<ClientId>) {
+        self.client_ids_scratch = client_ids;
     }
 
     fn find_by_entity(&self, entity: &Entity) -> Option<&Connection> {
@@ -777,7 +788,8 @@ impl<Ctx> Server<Ctx> {
         Ok(())
     }
     fn check_for_timeouts(&mut self) {
-        for id in self.conn_cache.ids() {
+        let client_ids = self.conn_cache.take_client_ids();
+        for &id in &client_ids {
             let Some(client) = self.conn_cache.clients.get_mut(&id) else {
                 continue;
             };
@@ -793,6 +805,7 @@ impl<Ctx> Server<Ctx> {
                 self.conn_cache.remove(id);
             }
         }
+        self.conn_cache.recycle_client_ids(client_ids);
     }
 
     // fn send_keepalives(&mut self, sender: &mut LinkSender) -> Result<()> {
@@ -960,15 +973,21 @@ impl<Ctx> Server<Ctx> {
     ///
     /// The provided buffer must be smaller than [`MAX_PACKET_SIZE`].
     pub fn send_all(&mut self, buf: SendPayload, sender: &mut LinkSender) -> Result<()> {
-        for id in self.conn_cache.ids() {
+        let client_ids = self.conn_cache.take_client_ids();
+        let mut result = Ok(());
+        for &id in &client_ids {
             match self.send(buf.clone(), id, sender) {
                 Ok(_) | Err(Error::ClientNotConnected(_)) | Err(Error::ClientNotFound(_)) => {
                     continue;
                 }
-                Err(e) => return Err(e),
+                Err(e) => {
+                    result = Err(e);
+                    break;
+                }
             }
         }
-        Ok(())
+        self.conn_cache.recycle_client_ids(client_ids);
+        result
     }
 
     /// Creates a connect token builder for a given client ID.
@@ -1050,17 +1069,23 @@ impl<Ctx> Server<Ctx> {
     /// Disconnects all clients.
     pub fn disconnect_all(&mut self, sender: &mut LinkSender) -> Result<()> {
         debug!("Server preparing to disconnect all clients");
-        for id in self.conn_cache.ids() {
+        let client_ids = self.conn_cache.take_client_ids();
+        let mut result = Ok(());
+        for &id in &client_ids {
             let Some(conn) = self.conn_cache.clients.get_mut(&id) else {
                 warn!("Could not disconnect client {id:?} because the connection was not found");
                 continue;
             };
             if conn.is_connected() {
                 debug!("Server preparing to disconnect client {id:?}");
-                self.disconnect(id, sender)?;
+                if let Err(error) = self.disconnect(id, sender) {
+                    result = Err(error);
+                    break;
+                }
             }
         }
-        Ok(())
+        self.conn_cache.recycle_client_ids(client_ids);
+        result
     }
 
     pub fn connected_client_ids(&self) -> impl Iterator<Item = ClientId> + '_ {

--- a/crates/transport/transport/src/channel/builder.rs
+++ b/crates/transport/transport/src/channel/builder.rs
@@ -36,6 +36,54 @@ use bevy_utils::prelude::DebugName;
 
 pub const DEFAULT_MESSAGE_PRIORITY: f32 = 1.0;
 
+/// Bounds reusable per-packet ACK lists retained by one transport.
+const MAX_RETAINED_PACKET_MESSAGE_ACK_LISTS: usize = 64;
+/// Avoid retaining an unusually large ACK list after a pathological packet.
+const MAX_RETAINED_PACKET_MESSAGE_ACK_CAPACITY: usize = 256;
+
+type PacketMessageAcks = Vec<(ChannelKind, MessageAck)>;
+
+/// Tracks message ACKs by packet while recycling removed value allocations.
+///
+/// The map itself retains its buckets after removal, but removing a `Vec` value would otherwise
+/// free that value's allocation and force a later tracked packet to allocate it again.
+#[derive(Debug, Default)]
+pub(crate) struct PacketMessageAckTracker {
+    tracked: HashMap<PacketId, PacketMessageAcks>,
+    ready: Vec<PacketMessageAcks>,
+}
+
+impl PacketMessageAckTracker {
+    pub(crate) fn track(
+        &mut self,
+        packet_id: PacketId,
+        channel_kind: ChannelKind,
+        message_ack: MessageAck,
+    ) {
+        if let Some(message_acks) = self.tracked.get_mut(&packet_id) {
+            message_acks.push((channel_kind, message_ack));
+            return;
+        }
+        let mut message_acks = self.ready.pop().unwrap_or_default();
+        message_acks.push((channel_kind, message_ack));
+        self.tracked.insert(packet_id, message_acks);
+    }
+
+    pub(crate) fn take(&mut self, packet_id: &PacketId) -> Option<PacketMessageAcks> {
+        self.tracked.remove(packet_id)
+    }
+
+    pub(crate) fn recycle(&mut self, mut message_acks: PacketMessageAcks) {
+        if self.ready.len() >= MAX_RETAINED_PACKET_MESSAGE_ACK_LISTS
+            || message_acks.capacity() > MAX_RETAINED_PACKET_MESSAGE_ACK_CAPACITY
+        {
+            return;
+        }
+        message_acks.clear();
+        self.ready.push(message_acks);
+    }
+}
+
 /// [`ChannelSettings`] are used to specify how the [`Channel`] behaves (reliability, ordering, direction)
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ChannelSettings {
@@ -175,7 +223,7 @@ pub struct Transport {
     /// reliable senders can stop trying to send a message that has already been received
     ///
     /// Every packet is either acked or nacked, so this shouldn't grow indefinitely
-    pub(crate) packet_to_message_map: HashMap<PacketId, Vec<(ChannelKind, MessageAck)>>,
+    pub(crate) packet_message_acks: PacketMessageAckTracker,
     /// mpsc channel sender/receiver to allow users to write bytes to the same channel in parallel
     pub send_channel: Sender<(ChannelKind, Bytes, f32)>,
     pub recv_channel: Receiver<(ChannelKind, Bytes, f32)>,
@@ -199,7 +247,7 @@ impl Transport {
             compression_scratch: CompressionScratch::default(),
             fragment_size: FRAGMENT_SIZE,
             compression: CompressionConfig::default(),
-            packet_to_message_map: Default::default(),
+            packet_message_acks: Default::default(),
             send_channel,
             recv_channel,
             send: vec![],
@@ -475,7 +523,7 @@ impl Transport {
         self.bandwidth_limiter = BandwidthLimiter::new(priority_config);
         self.packet_manager = Default::default();
         self.compression_scratch = Default::default();
-        self.packet_to_message_map = Default::default();
+        self.packet_message_acks = Default::default();
         let (send_channel, recv_channel) = crossbeam_channel::unbounded();
         self.send_channel = send_channel;
         self.recv_channel = recv_channel;

--- a/crates/transport/transport/src/packet/header.rs
+++ b/crates/transport/transport/src/packet/header.rs
@@ -139,6 +139,13 @@ pub struct PacketHeaderManager {
     stats_manager: PacketStatsManager,
     pub(crate) lost_packets: Vec<PacketId>,
     pub(crate) newly_acked_packets: IndexMap<PacketId, Duration, FixedHasher>,
+    /// Per-received-packet ACK results exposed to the transport event pipeline.
+    ///
+    /// This is separate from `newly_acked_packets`, which accumulates ACKs until channel
+    /// bookkeeping runs at the end of the receive pass. Clearing this scratch before each packet
+    /// keeps its allocation available while preserving the per-packet ordering of `PacketAcked`
+    /// and `PacketReceived` events.
+    newly_acked_packet_scratch: Vec<(PacketId, Duration)>,
 
     // keep track of the packets that were received (last packet received and the
     // `ACK_BITFIELD_SIZE` packets before that)
@@ -166,6 +173,7 @@ impl PacketHeaderManager {
             sent_packets_not_acked: IndexMap::default(),
             lost_packets: vec![],
             newly_acked_packets: IndexMap::default(),
+            newly_acked_packet_scratch: vec![],
             recv_buffer: ReceiveBuffer::new(),
             ack_pending: false,
             nack_rtt_multiple,
@@ -197,13 +205,16 @@ impl PacketHeaderManager {
 
     /// Process the header of a received packet (update ack metadata)
     ///
-    /// Returns the list of packets that have been newly acked by the remote
+    /// Returns the packets newly acknowledged by this header.
+    ///
+    /// The returned slice borrows manager-owned scratch storage. Its allocation is retained and
+    /// reused by the next call instead of creating a new `Vec` for every received packet.
     pub(crate) fn process_recv_packet_header(
         &mut self,
         header: &PacketHeader,
         real: Duration,
-    ) -> Vec<(PacketId, Duration)> {
-        let mut newly_acked_packets = vec![];
+    ) -> &[(PacketId, Duration)] {
+        self.newly_acked_packet_scratch.clear();
         // update the receive buffer
         self.stats_manager.received_packet();
         self.recv_buffer.recv_packet(header.packet_id);
@@ -214,30 +225,24 @@ impl PacketHeaderManager {
         if let Some((packet, time_sent)) =
             self.update_sent_packets_not_acked(&header.last_ack_packet_id)
         {
-            self.record_newly_acked_packet(packet, real, time_sent, &mut newly_acked_packets);
+            self.record_newly_acked_packet(packet, real, time_sent);
         }
         for i in 1..=ACK_BITFIELD_SIZE {
             let packet_id = PacketId(header.last_ack_packet_id.wrapping_sub(i as u32));
             if header.get_bitfield_bit(i - 1)
                 && let Some((packet, time_sent)) = self.update_sent_packets_not_acked(&packet_id)
             {
-                self.record_newly_acked_packet(packet, real, time_sent, &mut newly_acked_packets);
+                self.record_newly_acked_packet(packet, real, time_sent);
             }
         }
-        newly_acked_packets
+        &self.newly_acked_packet_scratch
     }
 
-    fn record_newly_acked_packet(
-        &mut self,
-        packet: PacketId,
-        real: Duration,
-        time_sent: Duration,
-        newly_acked_packets: &mut Vec<(PacketId, Duration)>,
-    ) {
+    fn record_newly_acked_packet(&mut self, packet: PacketId, real: Duration, time_sent: Duration) {
         self.stats_manager.sent_packet_acked();
         let rtt_sample = real.saturating_sub(time_sent);
         self.newly_acked_packets.insert(packet, rtt_sample);
-        newly_acked_packets.push((packet, rtt_sample));
+        self.newly_acked_packet_scratch.push((packet, rtt_sample));
     }
 
     /// Update the list of sent packets that have not been acked yet

--- a/crates/transport/transport/src/plugin.rs
+++ b/crates/transport/transport/src/plugin.rs
@@ -108,6 +108,8 @@ impl TransportPlugin {
                 .packet_manager
                 .header_manager
                 .update(time.elapsed(), &link.stats);
+            let packet_message_acks = &mut transport.packet_message_acks;
+            let senders = &mut transport.senders;
             transport
                 .packet_manager
                 .header_manager
@@ -138,23 +140,27 @@ impl TransportPlugin {
                         entity,
                         packet_id: lost_packet.0,
                     });
-                    if let Some(message_map) = transport.packet_to_message_map.remove(&lost_packet)
-                    {
-                        for (channel_kind, message_ack) in message_map {
-                            let channel_send = transport
-                                .senders
-                                .get_mut(&channel_kind)
-                                .ok_or(PacketError::ChannelNotFound)?;
-                            // TODO: batch the messages?
-                            trace!(
-                                ?lost_packet,
-                                ?channel_kind,
-                                "message lost: {:?}",
-                                message_ack.message_id
-                            );
-                            channel_send.message_nacks.push(message_ack.message_id);
-                            channel_send.receive_nack(&message_ack);
-                        }
+                    if let Some(mut message_acks) = packet_message_acks.take(&lost_packet) {
+                        let result =
+                            message_acks
+                                .drain(..)
+                                .try_for_each(|(channel_kind, message_ack)| {
+                                    let channel_send = senders
+                                        .get_mut(&channel_kind)
+                                        .ok_or(PacketError::ChannelNotFound)?;
+                                    // TODO: batch the messages?
+                                    trace!(
+                                        ?lost_packet,
+                                        ?channel_kind,
+                                        "message lost: {:?}",
+                                        message_ack.message_id
+                                    );
+                                    channel_send.message_nacks.push(message_ack.message_id);
+                                    channel_send.receive_nack(&message_ack);
+                                    Ok::<(), TransportError>(())
+                                });
+                        packet_message_acks.recycle(message_acks);
+                        result?;
                     }
                     Ok::<(), TransportError>(())
                 })
@@ -341,6 +347,8 @@ impl TransportPlugin {
                 .ok();
 
             // Update the list of messages that have been acked
+            let packet_message_acks = &mut transport.packet_message_acks;
+            let senders = &mut transport.senders;
             transport
                 .packet_manager
                 .header_manager
@@ -358,23 +366,26 @@ impl TransportPlugin {
                         rtt_sample_ms = rtt_sample.as_secs_f64() * 1000.0,
                         "transport packet acked"
                     );
-                    if let Some(message_acks) =
-                        transport.packet_to_message_map.remove(&acked_packet)
-                    {
-                        for (channel_kind, message_ack) in message_acks {
-                            let channel_send = transport
-                                .senders
-                                .get_mut(&channel_kind)
-                                .ok_or(PacketError::ChannelNotFound)?;
-                            if channel_send.receive_ack(&message_ack) {
-                                trace!(
-                                    "Acked message: channel={:?},message_ack={:?}",
-                                    channel_send.name(),
-                                    message_ack
-                                );
-                                channel_send.message_acks.push(message_ack.message_id);
-                            }
-                        }
+                    if let Some(mut message_acks) = packet_message_acks.take(&acked_packet) {
+                        let result =
+                            message_acks
+                                .drain(..)
+                                .try_for_each(|(channel_kind, message_ack)| {
+                                    let channel_send = senders
+                                        .get_mut(&channel_kind)
+                                        .ok_or(PacketError::ChannelNotFound)?;
+                                    if channel_send.receive_ack(&message_ack) {
+                                        trace!(
+                                            "Acked message: channel={:?},message_ack={:?}",
+                                            channel_send.name(),
+                                            message_ack
+                                        );
+                                        channel_send.message_acks.push(message_ack.message_id);
+                                    }
+                                    Ok::<(), TransportError>(())
+                                });
+                        packet_message_acks.recycle(message_acks);
+                        result?;
                     }
                     Ok::<(), TransportError>(())
                 })
@@ -560,18 +571,15 @@ impl TransportPlugin {
                             metadata.channel, metadata, packet.packet_id
                         );
 
-                        transport
-                            .packet_to_message_map
-                            .entry(packet.packet_id)
-                            .or_default()
-                            .push((
-                                commit.channel_kind,
-                                MessageAck {
-                                    message_id,
-                                    fragment_id: metadata.fragment_index,
-                                },
-                            ));
-                        trace!(?transport.packet_to_message_map, "packet to message");
+                        transport.packet_message_acks.track(
+                            packet.packet_id,
+                            commit.channel_kind,
+                            MessageAck {
+                                message_id,
+                                fragment_id: metadata.fragment_index,
+                            },
+                        );
+                        trace!(?transport.packet_message_acks, "packet to message");
                     }
                 }
                 transport


### PR DESCRIPTION
## Summary

- retain per-packet ACK result scratch in `PacketHeaderManager` and return a borrowed slice
- snapshot connection `HashMap` keys into reusable scratch storage before mutation-heavy server passes instead of collecting a new `Vec` each time
- recycle the `Vec` values removed from packet-to-message ACK tracking with a bounded per-Transport pool
