### PR TITLE
feat(perf): adapt query iteration to entity count

### DIFF
--- a/crates/connection/netcode/src/client_plugin.rs
+++ b/crates/connection/netcode/src/client_plugin.rs
@@ -18,6 +18,7 @@ use lightyear_connection::host::HostClient;
 use lightyear_core::id::{LocalId, PeerId, RemoteId};
 use lightyear_link::{Link, LinkSystems, Linked};
 use lightyear_transport::plugin::TransportSystems;
+use lightyear_utils::adaptive_for_each_mut;
 use tracing::{debug, error, info};
 
 pub struct NetcodeClientPlugin;
@@ -107,7 +108,7 @@ impl NetcodeClientPlugin {
     fn send(
         mut query: Query<(&mut Link, &mut NetcodeClient), (With<Linked>, Without<HostClient>)>,
     ) {
-        query.par_iter_mut().for_each(|(mut link, mut client)| {
+        adaptive_for_each_mut!(query).for_each(|(mut link, mut client)| {
             // send user packets
             for _ in 0..link.send.len() {
                 if let Some(payload) = link.send.pop() {
@@ -146,9 +147,8 @@ impl NetcodeClientPlugin {
         parallel_commands: ParallelCommands,
     ) {
         let delta = real_time.delta();
-        query
-            .par_iter_mut()
-            .for_each(|(entity, mut link, mut client, connecting, disconnected)| {
+        adaptive_for_each_mut!(query).for_each(
+            |(entity, mut link, mut client, connecting, disconnected)| {
                 // #[cfg(feature = "test_utils")]
                 // trace!("CLIENT: length of each packet in receive: {:?}", link.recv.iter().map(|p| p.len()).collect::<Vec<_>>());
 
@@ -187,7 +187,8 @@ impl NetcodeClientPlugin {
                         });
                     }
                 }
-            })
+            },
+        )
     }
 
     fn connect(

--- a/crates/connection/netcode/src/server_plugin.rs
+++ b/crates/connection/netcode/src/server_plugin.rs
@@ -16,6 +16,7 @@ use lightyear_core::id::{LocalId, PeerId, RemoteId};
 use lightyear_link::prelude::{LinkOf, Server};
 use lightyear_link::{Link, LinkSystems, Unlink};
 use lightyear_transport::plugin::TransportSystems;
+use lightyear_utils::adaptive_for_each_mut;
 use tracing::{error, info, trace};
 
 pub struct NetcodeServerPlugin;
@@ -135,12 +136,11 @@ impl NetcodeServerPlugin {
         //  that the transports/links are all mutually exclusive...
         //  Maybe some unsafe Cloneble wrapper around the client_query?
         //  Or maybe store the clients into a Local<Vec<(&mut Transport, &mut Link)>>? so that we can iterate faster through them?
-        // we use Arc to tell the compiler that we know that the queries won't be used to access
-        // the same clients (because each Link is uniquely associated with a single server)
-        // This allow us to iterate in parallel over all servers
-        let client_query = Arc::new(client_query);
+        // Each Link is uniquely associated with one server, so parallel workers can safely share
+        // the query before taking their disjoint unsafe reborrows below.
+        let client_query = &client_query;
+        let server_query = adaptive_for_each_mut!(server_query);
         server_query
-            .par_iter_mut()
             // .iter_mut()
             .for_each(|(mut netcode_server, server)| {
                 // SAFETY: we know that each client is unique to a single server so we won't
@@ -223,13 +223,13 @@ impl NetcodeServerPlugin {
     ) {
         let delta = real_time.delta();
 
-        // we use Arc to tell the compiler that we know that the queries won't be used to access
-        // the same clients (because each Link is uniquely associated with a single server)
-        // This allow us to iterate in parallel over all servers
-        let link_query = Arc::new(link_query);
+        // Each Link is uniquely associated with one server, so parallel workers can safely share
+        // the query before taking their disjoint unsafe reborrows below.
+        let link_query = &link_query;
 
         // receive packets from the link and process them through the server
-        server_query.par_iter_mut().for_each(
+        let server_query = adaptive_for_each_mut!(server_query);
+        server_query.for_each(
             |(server_entity, mut netcode_server, mut server, stopping)| {
                 parallel_commands.command_scope(|mut c| {
                     // SAFETY: we know that each client is unique to a single server so we won't

--- a/crates/core/sync/src/ping/plugin.rs
+++ b/crates/core/sync/src/ping/plugin.rs
@@ -17,6 +17,7 @@ use lightyear_messages::prelude::AppMessageExt;
 use lightyear_messages::receive::MessageReceiver;
 use lightyear_messages::send::MessageSender;
 use lightyear_transport::prelude::{AppChannelExt, ChannelMode, ChannelSettings};
+use lightyear_utils::adaptive_for_each_mut;
 #[allow(unused_imports)]
 use tracing::{info, trace};
 
@@ -47,9 +48,8 @@ impl PingPlugin {
             (With<Connected>, Without<HostClient>),
         >,
     ) {
-        query
-            .par_iter_mut()
-            .for_each(|(mut link, mut m, mut ping_receiver, mut pong_receiver)| {
+        adaptive_for_each_mut!(query).for_each(
+            |(mut link, mut m, mut ping_receiver, mut pong_receiver)| {
                 // update
                 m.update(&real_time);
 
@@ -65,7 +65,8 @@ impl PingPlugin {
 
                 link.stats.rtt = m.rtt();
                 link.stats.jitter = m.jitter();
-            })
+            },
+        )
     }
 
     /// Send pings/pongs to the remote
@@ -90,9 +91,8 @@ impl PingPlugin {
         //     return
         // };
         // let frame_time = now - frame_start;
-        query
-            .par_iter_mut()
-            .for_each(|(entity, mut m, mut ping_sender, mut pong_sender)| {
+        adaptive_for_each_mut!(query).for_each(
+            |(entity, mut m, mut ping_sender, mut pong_sender)| {
                 // send the pings
                 if let Some(ping) = m.maybe_prepare_ping(now) {
                     trace!(
@@ -129,7 +129,8 @@ impl PingPlugin {
                         // pong.overstep = fixed_time.overstep_fraction();
                         pong_sender.send::<PingChannel>(pong);
                     });
-            })
+            },
+        )
     }
 
     /// On connection, reset the PingManager.

--- a/crates/core/utils/src/ecs.rs
+++ b/crates/core/utils/src/ecs.rs
@@ -3,8 +3,83 @@
 use bevy_ecs::archetype::ArchetypeEntity;
 use bevy_ecs::component::{ComponentId, StorageType};
 use bevy_ecs::ptr::{Ptr, PtrMut};
+use bevy_ecs::query::{IterQueryData, QueryFilter, QueryItem};
 use bevy_ecs::storage::TableId;
+use bevy_ecs::system::Query;
 use bevy_ecs::world::unsafe_world_cell::UnsafeWorldCell;
+
+/// Iterates a mutable query serially when it contains at most a small number of items, and in
+/// parallel otherwise.
+///
+/// The default serial threshold is one item:
+///
+/// ```ignore
+/// adaptive_for_each_mut!(query, |item| process(item));
+/// ```
+///
+/// An optional threshold keeps queries with at most that many items serial. Parallel iteration is
+/// used only when the query contains more items than the threshold:
+///
+/// ```ignore
+/// adaptive_for_each_mut!(query, 4, |item| process(item));
+/// ```
+///
+/// The adapter inspects only enough read-only query items to choose a mode, then performs the
+/// mutable iteration.
+#[macro_export]
+macro_rules! adaptive_for_each_mut {
+    ($query:expr, |$item:pat_param| $body:expr $(,)?) => {
+        $crate::ecs::AdaptiveQueryIterMut::new(&mut $query, 1).for_each(|$item| $body)
+    };
+    ($query:expr, $serial_threshold:expr, |$item:pat_param| $body:expr $(,)?) => {
+        $crate::ecs::AdaptiveQueryIterMut::new(&mut $query, $serial_threshold)
+            .for_each(|$item| $body)
+    };
+    // Adapter form for composing with an existing `.for_each` call.
+    ($query:expr $(,)?) => {
+        $crate::ecs::AdaptiveQueryIterMut::new(&mut $query, 1)
+    };
+}
+
+/// Mutable query adapter returned by [`adaptive_for_each_mut!`].
+///
+/// Call [`for_each`](Self::for_each) to select serial or parallel iteration based on the number of
+/// matching query items.
+#[doc(hidden)]
+pub struct AdaptiveQueryIterMut<'query, 'world, 'state, D, F>
+where
+    D: IterQueryData,
+    F: QueryFilter,
+{
+    query: &'query mut Query<'world, 'state, D, F>,
+    serial_threshold: usize,
+}
+
+impl<'query, 'world, 'state, D, F> AdaptiveQueryIterMut<'query, 'world, 'state, D, F>
+where
+    D: IterQueryData,
+    F: QueryFilter,
+{
+    #[doc(hidden)]
+    pub fn new(query: &'query mut Query<'world, 'state, D, F>, serial_threshold: usize) -> Self {
+        Self {
+            query,
+            serial_threshold,
+        }
+    }
+
+    /// Applies `func` to every matching item.
+    pub fn for_each<Func>(self, func: Func)
+    where
+        Func: for<'item> Fn(QueryItem<'item, 'state, D>) + Send + Sync + Clone,
+    {
+        if self.query.iter().nth(self.serial_threshold).is_some() {
+            self.query.par_iter_mut().for_each(func);
+        } else {
+            self.query.iter_mut().for_each(func);
+        }
+    }
+}
 
 /// Extracts a component as [`Ptr`] and its ticks from a table or sparse set, depending on its storage type.
 ///
@@ -63,5 +138,38 @@ pub unsafe fn get_component_unchecked<'w>(
             let sparse_set = storages.sparse_sets.get(component_id).unwrap_unchecked();
             sparse_set.get(entity.id()).unwrap_unchecked()
         },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bevy_ecs::prelude::*;
+
+    #[derive(Component)]
+    struct Value(u32);
+
+    #[test]
+    fn adaptive_iteration_supports_default_and_custom_thresholds() {
+        let mut world = World::new();
+        let first = world.spawn(Value(0)).id();
+        let mut query_state = world.query::<&mut Value>();
+
+        {
+            let mut query = query_state.query_mut(&mut world);
+            crate::adaptive_for_each_mut!(query, |mut value| value.0 += 1);
+        }
+
+        let second = world.spawn(Value(0)).id();
+        {
+            let mut query = query_state.query_mut(&mut world);
+            crate::adaptive_for_each_mut!(query, 2, |mut value| value.0 += 1);
+        }
+        {
+            let mut query = query_state.query_mut(&mut world);
+            crate::adaptive_for_each_mut!(query, |mut value| value.0 += 1);
+        }
+
+        assert_eq!(world.get::<Value>(first).unwrap().0, 3);
+        assert_eq!(world.get::<Value>(second).unwrap().0, 2);
     }
 }

--- a/crates/io/link/src/lib.rs
+++ b/crates/io/link/src/lib.rs
@@ -40,6 +40,7 @@ use bevy_ecs::world::DeferredWorld;
 use bytes::{Bytes, BytesMut};
 use core::time::Duration;
 use lightyear_core::time::Instant;
+use lightyear_utils::adaptive_for_each_mut;
 
 pub mod prelude {
     pub use crate::conditioner::{LinkConditionerConfig, LinkConditionerState};
@@ -453,7 +454,8 @@ impl LinkPlugin {
     /// simulated delivery time has elapsed. It is installed in
     /// [`LinkReceiveSystems::ApplyConditioner`] by [`LinkPlugin`].
     pub fn apply_link_conditioner(mut query: Query<&mut Link>) {
-        query.par_iter_mut().for_each(|mut link| {
+        let query = adaptive_for_each_mut!(query);
+        query.for_each(|mut link| {
             // enable split borrows
             let recv = &mut link.recv;
             if let Some(conditioner) = &mut recv.conditioner {

--- a/crates/io/udp/Cargo.toml
+++ b/crates/io/udp/Cargo.toml
@@ -17,6 +17,7 @@ test_utils = []
 [dependencies]
 lightyear_core.workspace = true
 lightyear_link.workspace = true
+lightyear_utils.workspace = true
 
 aeronet_io.workspace = true
 

--- a/crates/io/udp/src/lib.rs
+++ b/crates/io/udp/src/lib.rs
@@ -25,6 +25,7 @@ use lightyear_core::time::Instant;
 use lightyear_link::{
     Link, LinkPlugin, LinkReceiveSystems, LinkStart, LinkSystems, Linked, Linking, Unlink, Unlinked,
 };
+use lightyear_utils::adaptive_for_each_mut;
 use tracing::{error, info, trace};
 
 /// Server-side UDP socket support.
@@ -143,26 +144,24 @@ impl UdpPlugin {
     }
 
     fn send(mut query: Query<(&mut Link, &mut UdpIo, &PeerAddr), With<Linked>>) {
-        query
-            .par_iter_mut()
-            .for_each(|(mut link, mut udp_io, remote_addr)| {
-                link.send.drain().for_each(|payload| {
-                    // B/s
-                    #[cfg(feature = "metrics")]
-                    metrics::gauge!("udp/send").increment(payload.len() as f64);
-                    udp_io
-                        .socket
-                        .as_mut()
-                        .unwrap()
-                        .send_to(payload.as_ref(), remote_addr.0)
-                        .inspect_err(|e| error!("Error sending UDP packet: {}", e))
-                        .ok();
-                });
-            })
+        adaptive_for_each_mut!(query).for_each(|(mut link, mut udp_io, remote_addr)| {
+            link.send.drain().for_each(|payload| {
+                // B/s
+                #[cfg(feature = "metrics")]
+                metrics::gauge!("udp/send").increment(payload.len() as f64);
+                udp_io
+                    .socket
+                    .as_mut()
+                    .unwrap()
+                    .send_to(payload.as_ref(), remote_addr.0)
+                    .inspect_err(|e| error!("Error sending UDP packet: {}", e))
+                    .ok();
+            });
+        })
     }
 
     fn receive(mut query: Query<(&mut Link, &mut UdpIo), With<Linked>>) {
-        query.par_iter_mut().for_each(|(mut link, mut udp_io)| {
+        adaptive_for_each_mut!(query).for_each(|(mut link, mut udp_io)| {
             // enable split borrows
             let udp_io = &mut *udp_io;
             udp_io.recv_buffers.reclaim_pending();

--- a/crates/replication/prediction/src/rollback.rs
+++ b/crates/replication/prediction/src/rollback.rs
@@ -68,6 +68,7 @@ use lightyear_replication::prespawn::PreSpawnedReceiver;
 use lightyear_replication::registry::ComponentRegistry;
 use lightyear_replication::{ReplicationSystems, checkpoint::ReplicationCheckpointMap};
 use lightyear_sync::prelude::{InputTimeline, InputTimelineConfig, IsSynced};
+use lightyear_utils::adaptive_for_each_mut;
 #[cfg(feature = "metrics")]
 use lightyear_utils::timer_gauge;
 use serde::{Deserialize, Serialize};
@@ -582,7 +583,8 @@ fn check_rollback(
                             "Checking for state-based rollback at completed mutate tick"
                         );
 
-                        predicted_entities.par_iter_mut().for_each(
+                        let predicted_entities = adaptive_for_each_mut!(predicted_entities);
+                        predicted_entities.for_each(
                             |(confirm_history, mut entity_mut)| {
                             if prediction_manager.is_rollback() {
                                 return

--- a/crates/transport/messages/src/receive.rs
+++ b/crates/transport/messages/src/receive.rs
@@ -19,10 +19,10 @@ use lightyear_serde::entity_map::ReceiveEntityMap;
 use lightyear_serde::reader::Reader;
 use lightyear_transport::channel::ChannelKind;
 use lightyear_transport::prelude::Transport;
+use lightyear_utils::adaptive_for_each_mut;
 use lightyear_utils::collections::HashMap;
 use lightyear_utils::ready_buffer::ReadyBuffer;
 
-use alloc::sync::Arc;
 use bevy_ecs::lifecycle::HookContext;
 use bevy_utils::prelude::DebugName;
 use bytes::Bytes;
@@ -597,10 +597,11 @@ impl MessagePlugin {
         timeline_registry: Res<TimelineRegistry>,
         commands: ParallelCommands,
     ) {
-        // We use Arc to make the query Clone, since we know that we will only access MessageReceiver<M> components
-        // on potentially different entities in parallel (though the current loop isn't parallel)
-        let receiver_query = Arc::new(receiver_query);
-        transport_query.par_iter_mut().for_each(
+        // Each outer query item accesses receivers on a different entity, so workers can safely
+        // share the query before taking their disjoint unsafe reborrows below.
+        let receiver_query = &receiver_query;
+        let transport_query = adaptive_for_each_mut!(transport_query);
+        transport_query.for_each(
             |(
                 entity,
                 mut message_manager,

--- a/crates/transport/messages/src/send.rs
+++ b/crates/transport/messages/src/send.rs
@@ -3,7 +3,6 @@ use crate::plugin::{MAX_TIMELINE_LAG_TICKS, MessagePlugin};
 use crate::registry::MessageMetricHandles;
 use crate::registry::{MessageError, MessageKind, MessageRegistry};
 use crate::{Message, MessageManager, MessageNetId};
-use alloc::sync::Arc;
 use alloc::vec::Vec;
 use bevy_ecs::lifecycle::HookContext;
 use bevy_ecs::{
@@ -25,6 +24,7 @@ use lightyear_serde::registry::ErasedSerializeFns;
 use lightyear_serde::writer::Writer;
 use lightyear_transport::channel::{Channel, ChannelKind};
 use lightyear_transport::prelude::{ChannelRegistry, Transport};
+use lightyear_utils::adaptive_for_each_mut;
 #[allow(unused_imports)]
 use tracing::{error, info, trace};
 
@@ -283,12 +283,11 @@ impl MessagePlugin {
         message_sender_query: Query<FilteredEntityMut>,
         registry: Res<MessageRegistry>,
     ) {
-        // We use Arc to make the query Clone, since we know that we will only access MessageSender<M> components
-        // on different entities
-        let message_sender_query = Arc::new(message_sender_query);
-        transport_query
-            .par_iter_mut()
-            .for_each(|(entity, transport, mut message_manager)| {
+        // Each outer query item accesses senders on a different entity, so workers can safely
+        // share the query before taking their disjoint unsafe reborrows below.
+        let message_sender_query = &message_sender_query;
+        adaptive_for_each_mut!(transport_query).for_each(
+            |(entity, transport, mut message_manager)| {
                 // SAFETY: we know that this won't lead to violating the aliasing rule
                 let mut message_sender_query = unsafe { message_sender_query.reborrow_unsafe() };
 
@@ -371,7 +370,8 @@ impl MessagePlugin {
                     })
                     .inspect_err(|e| error!("error sending trigger: {e:?}"))
                     .ok();
-            })
+            },
+        )
     }
 
     /// For the host-client, we take messages to send from the [`MessageSender<M>`] components
@@ -391,83 +391,79 @@ impl MessagePlugin {
         channel_registry: Res<ChannelRegistry>,
         timeline_registry: Res<TimelineRegistry>,
     ) {
-        // We use Arc to make the query Clone, since we know that we will only access MessageSender<M>/MessageReceiver<M> components
-        // on different entities
+        // Each outer query item accesses components on a different entity, so workers can safely
+        // share the query before taking their disjoint unsafe reborrows below.
         let tick = timeline.tick();
-        let message_components_query = Arc::new(message_components_query);
-        manager_query
-            .par_iter_mut()
-            .for_each(|(entity, mut message_manager)| {
-                // SAFETY: we know that this won't lead to violating the aliasing rule
-                let mut message_sender_query =
-                    unsafe { message_components_query.reborrow_unsafe() };
-                let mut message_receiver_query =
-                    unsafe { message_components_query.reborrow_unsafe() };
+        let message_components_query = &message_components_query;
+        adaptive_for_each_mut!(manager_query).for_each(|(entity, mut message_manager)| {
+            // SAFETY: we know that this won't lead to violating the aliasing rule
+            let mut message_sender_query = unsafe { message_components_query.reborrow_unsafe() };
+            let mut message_receiver_query = unsafe { message_components_query.reborrow_unsafe() };
 
-                // TODO: allow sending from senders in parallel! The only issue is the mutable borrow of the entity mapper
-                // enable split borrows
-                let message_manager = &mut *message_manager;
-                message_manager
-                    .send_messages
-                    .iter()
-                    .try_for_each(|(message_kind, sender_id)| {
-                        let mut entity_mut = message_sender_query.get_mut(entity).unwrap();
-                        let message_sender = entity_mut
-                            .get_mut_by_id(*sender_id)
-                            .ok_or(MessageError::MissingComponent(*sender_id))?;
-                        let mut entity_mut = message_receiver_query.get_mut(entity).unwrap();
-                        let send_metadata = registry
-                            .send_metadata
-                            .get(message_kind)
-                            .ok_or(MessageError::UnrecognizedMessage(*message_kind))?;
-                        // SAFETY: we know the message_sender corresponds to the correct `MessageSender<M>` type
-                        unsafe {
-                            (send_metadata.send_local_message_fn)(
-                                message_sender,
-                                &mut entity_mut,
-                                &commands,
-                                tick,
-                                &registry,
-                                &channel_registry,
-                                &timeline_registry,
-                            )?;
-                        }
-                        Ok::<_, MessageError>(())
-                    })
-                    .inspect_err(|e| error!("error sending message on host-client: {e:?}"))
-                    .ok();
+            // TODO: allow sending from senders in parallel! The only issue is the mutable borrow of the entity mapper
+            // enable split borrows
+            let message_manager = &mut *message_manager;
+            message_manager
+                .send_messages
+                .iter()
+                .try_for_each(|(message_kind, sender_id)| {
+                    let mut entity_mut = message_sender_query.get_mut(entity).unwrap();
+                    let message_sender = entity_mut
+                        .get_mut_by_id(*sender_id)
+                        .ok_or(MessageError::MissingComponent(*sender_id))?;
+                    let mut entity_mut = message_receiver_query.get_mut(entity).unwrap();
+                    let send_metadata = registry
+                        .send_metadata
+                        .get(message_kind)
+                        .ok_or(MessageError::UnrecognizedMessage(*message_kind))?;
+                    // SAFETY: we know the message_sender corresponds to the correct `MessageSender<M>` type
+                    unsafe {
+                        (send_metadata.send_local_message_fn)(
+                            message_sender,
+                            &mut entity_mut,
+                            &commands,
+                            tick,
+                            &registry,
+                            &channel_registry,
+                            &timeline_registry,
+                        )?;
+                    }
+                    Ok::<_, MessageError>(())
+                })
+                .inspect_err(|e| error!("error sending message on host-client: {e:?}"))
+                .ok();
 
-                // TODO: allow sending from senders in parallel! The only issue is the mutable borrow of the entity mapper
-                // enable split borrows
-                message_manager
-                    .send_triggers
-                    .iter()
-                    .try_for_each(|(message_kind, sender_id)| {
-                        let mut entity_mut = message_sender_query.get_mut(entity).unwrap();
-                        let message_sender = entity_mut
-                            .get_mut_by_id(*sender_id)
-                            .ok_or(MessageError::MissingComponent(*sender_id))?;
-                        let send_metadata = registry
-                            .send_trigger_metadata
-                            .get(message_kind)
-                            .ok_or(MessageError::UnrecognizedMessage(*message_kind))?;
-                        let mut entity_mut = message_receiver_query.get_mut(entity).unwrap();
-                        // SAFETY: sender and receiver callbacks come from the registry for this event type.
-                        unsafe {
-                            (send_metadata.send_local_trigger_fn)(
-                                message_sender,
-                                &mut entity_mut,
-                                &commands,
-                                tick,
-                                &registry,
-                                &channel_registry,
-                                &timeline_registry,
-                            )?;
-                        }
-                        Ok::<_, MessageError>(())
-                    })
-                    .inspect_err(|e| error!("error sending trigger on host-client: {e:?}"))
-                    .ok();
-            })
+            // TODO: allow sending from senders in parallel! The only issue is the mutable borrow of the entity mapper
+            // enable split borrows
+            message_manager
+                .send_triggers
+                .iter()
+                .try_for_each(|(message_kind, sender_id)| {
+                    let mut entity_mut = message_sender_query.get_mut(entity).unwrap();
+                    let message_sender = entity_mut
+                        .get_mut_by_id(*sender_id)
+                        .ok_or(MessageError::MissingComponent(*sender_id))?;
+                    let send_metadata = registry
+                        .send_trigger_metadata
+                        .get(message_kind)
+                        .ok_or(MessageError::UnrecognizedMessage(*message_kind))?;
+                    let mut entity_mut = message_receiver_query.get_mut(entity).unwrap();
+                    // SAFETY: sender and receiver callbacks come from the registry for this event type.
+                    unsafe {
+                        (send_metadata.send_local_trigger_fn)(
+                            message_sender,
+                            &mut entity_mut,
+                            &commands,
+                            tick,
+                            &registry,
+                            &channel_registry,
+                            &timeline_registry,
+                        )?;
+                    }
+                    Ok::<_, MessageError>(())
+                })
+                .inspect_err(|e| error!("error sending trigger on host-client: {e:?}"))
+                .ok();
+        })
     }
 }

--- a/crates/transport/transport/src/plugin.rs
+++ b/crates/transport/transport/src/plugin.rs
@@ -26,6 +26,7 @@ use lightyear_core::tick::Tick;
 use lightyear_link::{Link, LinkPlugin, LinkSystems, Linked};
 use lightyear_serde::reader::{ReadInteger, Reader};
 use lightyear_serde::{SerializationError, ToBytes};
+use lightyear_utils::adaptive_for_each_mut;
 #[cfg(feature = "metrics")]
 use lightyear_utils::timer_gauge;
 #[allow(unused_imports)]
@@ -85,7 +86,7 @@ impl TransportPlugin {
         let _timer = timer_gauge!("transport/recv");
 
         #[cfg(feature = "std")]
-        let query = query.par_iter_mut();
+        let query = adaptive_for_each_mut!(query);
         #[cfg(not(feature = "std"))]
         let query = query.iter_mut();
 
@@ -403,7 +404,8 @@ impl TransportPlugin {
         #[cfg(feature = "metrics")]
         let _timer = timer_gauge!("transport/send");
         let tick = timeline.tick();
-        query.par_iter_mut().for_each(|(mut link, mut transport, host_client)| {
+        let query = adaptive_for_each_mut!(query);
+        query.for_each(|(mut link, mut transport, host_client)| {
             // allow split borrows
             let transport = &mut *transport;
             let mtu = link.mtu();


### PR DESCRIPTION
## Summary
- add `adaptive_for_each_mut!` with a configurable serial threshold (default: one item)
- use serial iteration for the common single-connection case and retain parallel iteration for larger queries
- replace per-run `Arc<Query>` wrappers with shared query references
- preserve the serial `Commands` path for no-std transport builds

## Validation
- `cargo fmt --all -- --check`
- targeted all-feature checks for link, UDP, netcode, transport, messages, sync, and prediction
- `cargo check -p lightyear_transport --no-default-features`
- targeted clippy with `-D warnings --no-deps`
- `cargo test -p lightyear_utils --all-features`
- `cargo test -p lightyear_tests --test allocation_regression --all-features -- --test-threads=1 --nocapture`