### PR TITLE
feat(deterministic): add direct P2P input examples

### DIFF
--- a/crates/connection/connection/Cargo.toml
+++ b/crates/connection/connection/Cargo.toml
@@ -12,6 +12,7 @@ repository = "https://github.com/cBournhonesque/lightyear"
 default = []
 client = []
 server = []
+p2p = ["client"]
 
 [dependencies]
 # local crates

--- a/crates/connection/connection/Cargo.toml
+++ b/crates/connection/connection/Cargo.toml
@@ -12,7 +12,6 @@ repository = "https://github.com/cBournhonesque/lightyear"
 default = []
 client = []
 server = []
-p2p = ["client"]
 
 [dependencies]
 # local crates

--- a/crates/connection/connection/src/identity.rs
+++ b/crates/connection/connection/src/identity.rs
@@ -1,32 +1,33 @@
-use crate::client::Client;
-use crate::host::{HostClient, HostServer};
-use crate::server::{Started, Starting};
-use bevy_ecs::query::{Or, With, Without};
-use bevy_ecs::system::Query;
-use lightyear_link::server::Server;
+use crate::network_topology::NetworkingMetadata;
+use bevy_ecs::system::Res;
 
-/// Returns true if the peer is a client (host-server counts as a server)
-pub fn is_client(query: Query<(), (With<Client>, Without<HostClient>)>) -> bool {
-    !query.is_empty()
+/// Returns true for a connected conventional client topology.
+///
+/// Direct peers are reported by [`is_p2p`], not as conventional clients, even though every
+/// [`crate::p2p::P2P`] Link carries the internal [`crate::client::Client`] role marker.
+pub fn is_client(metadata: Res<NetworkingMetadata>) -> bool {
+    metadata.mode.is_client()
 }
 
-/// Returns true if the peer is starting or running a server.
-pub fn is_server(query: Query<(), (With<Server>, Or<(With<Starting>, With<Started>)>)>) -> bool {
-    !query.is_empty()
+/// Returns true for a started server, including the server side of a ready host-client topology.
+pub fn is_server(metadata: Res<NetworkingMetadata>) -> bool {
+    metadata.mode.is_server()
 }
 
-/// Returns true if the peer is starting or running a server without any client entities.
-pub fn is_headless_server(
-    server_query: Query<(), (With<Server>, Or<(With<Starting>, With<Started>)>)>,
-    client_query: Query<(), With<Client>>,
-) -> bool {
-    !server_query.is_empty() && client_query.is_empty()
+/// Returns true for a started server without a connected in-process client.
+pub fn is_headless_server(metadata: Res<NetworkingMetadata>) -> bool {
+    metadata.mode.is_headless_server()
 }
 
 /// Returns true if we are running in host-server mode, i.e. the server is acting as a client
 /// (in which case we can disable the networking/prediction/interpolation systems on the client)
 ///
-/// We are in host-server mode when a running server has been marked as a host server.
-pub fn is_host_server(query: Query<(), (With<Server>, With<Started>, With<HostServer>)>) -> bool {
-    !query.is_empty()
+/// We are in host-server mode when both sides form a ready cached host-client topology.
+pub fn is_host_server(metadata: Res<NetworkingMetadata>) -> bool {
+    metadata.mode.is_host_server()
+}
+
+/// Returns true when the cached topology contains direct P2P Links.
+pub fn is_p2p(metadata: Res<NetworkingMetadata>) -> bool {
+    metadata.mode.is_p2p()
 }

--- a/crates/connection/connection/src/lib.rs
+++ b/crates/connection/connection/src/lib.rs
@@ -60,11 +60,11 @@ pub enum ConnectionSystems {
 pub mod prelude {
     pub use crate::ConnectionSystems;
     pub use crate::direction::NetworkDirection;
+    pub use crate::identity::{is_client, is_p2p};
     pub use crate::network_target::NetworkTarget;
     pub use crate::network_topology::{
         NetworkTopology, NetworkTopologyError, NetworkTopologySystems, NetworkingMetadata,
     };
-
     // we also export these types at the top level for easier access
     pub use crate::client::{
         Client, ClientState, Connect, Connected, Connecting, ConnectionError, Disconnect,

--- a/crates/connection/connection/src/network_topology.rs
+++ b/crates/connection/connection/src/network_topology.rs
@@ -416,47 +416,6 @@ mod tests {
         &app.world().resource::<NetworkingMetadata>().mode
     }
 
-    fn role_predicates(topology: &NetworkTopology) -> (bool, bool, bool, bool, bool) {
-        (
-            topology.is_client(),
-            topology.is_server(),
-            topology.is_headless_server(),
-            topology.is_host_server(),
-            topology.is_p2p(),
-        )
-    }
-
-    #[test]
-    fn role_predicates_classify_the_cached_topology() {
-        let mut world = World::new();
-        let client = world.spawn_empty().id();
-        let server = world.spawn_empty().id();
-
-        assert_eq!(
-            role_predicates(&NetworkTopology::Undefined),
-            (false, false, false, false, false)
-        );
-        assert_eq!(
-            role_predicates(&NetworkTopology::Client(client)),
-            (true, false, false, false, false)
-        );
-        assert_eq!(
-            role_predicates(&NetworkTopology::Server(server)),
-            (false, true, true, false, false)
-        );
-        assert_eq!(
-            role_predicates(&NetworkTopology::HostClient { server, client }),
-            (false, true, false, true, false)
-        );
-        assert_eq!(
-            role_predicates(&NetworkTopology::P2P {
-                connected: SmallVec::new(),
-                declared_links: 1,
-            }),
-            (false, false, false, false, true)
-        );
-    }
-
     #[test]
     fn only_ready_client_and_server_entities_are_cached() {
         let mut app = test_app();

--- a/crates/connection/connection/src/network_topology.rs
+++ b/crates/connection/connection/src/network_topology.rs
@@ -41,6 +41,33 @@ pub enum NetworkTopology {
     Invalid(NetworkTopologyError),
 }
 
+impl NetworkTopology {
+    /// Returns true for a connected conventional client.
+    pub fn is_client(&self) -> bool {
+        matches!(self, Self::Client(_))
+    }
+
+    /// Returns true for a started server, including the server side of a host-client app.
+    pub fn is_server(&self) -> bool {
+        matches!(self, Self::Server(_) | Self::HostClient { .. })
+    }
+
+    /// Returns true for a started server without a connected in-process client.
+    pub fn is_headless_server(&self) -> bool {
+        matches!(self, Self::Server(_))
+    }
+
+    /// Returns true for a ready in-process host-client app.
+    pub fn is_host_server(&self) -> bool {
+        matches!(self, Self::HostClient { .. })
+    }
+
+    /// Returns true when direct P2P Links have been declared.
+    pub fn is_p2p(&self) -> bool {
+        matches!(self, Self::P2P { .. })
+    }
+}
+
 /// Cached metadata describing the networking configuration of this Bevy application.
 ///
 /// [`crate::ConnectionPlugin`] maintains this resource from role and lifecycle components. Users
@@ -387,6 +414,47 @@ mod tests {
 
     fn mode(app: &App) -> &NetworkTopology {
         &app.world().resource::<NetworkingMetadata>().mode
+    }
+
+    fn role_predicates(topology: &NetworkTopology) -> (bool, bool, bool, bool, bool) {
+        (
+            topology.is_client(),
+            topology.is_server(),
+            topology.is_headless_server(),
+            topology.is_host_server(),
+            topology.is_p2p(),
+        )
+    }
+
+    #[test]
+    fn role_predicates_classify_the_cached_topology() {
+        let mut world = World::new();
+        let client = world.spawn_empty().id();
+        let server = world.spawn_empty().id();
+
+        assert_eq!(
+            role_predicates(&NetworkTopology::Undefined),
+            (false, false, false, false, false)
+        );
+        assert_eq!(
+            role_predicates(&NetworkTopology::Client(client)),
+            (true, false, false, false, false)
+        );
+        assert_eq!(
+            role_predicates(&NetworkTopology::Server(server)),
+            (false, true, true, false, false)
+        );
+        assert_eq!(
+            role_predicates(&NetworkTopology::HostClient { server, client }),
+            (false, true, false, true, false)
+        );
+        assert_eq!(
+            role_predicates(&NetworkTopology::P2P {
+                connected: SmallVec::new(),
+                declared_links: 1,
+            }),
+            (false, false, false, false, true)
+        );
     }
 
     #[test]

--- a/crates/connection/raw_connection/src/client.rs
+++ b/crates/connection/raw_connection/src/client.rs
@@ -26,15 +26,17 @@ impl RawConnectionPlugin {
     /// For RawClients, Linked implies Connected
     fn on_linked(
         trigger: On<Add, Linked>,
-        query: Query<&LocalAddr, With<RawClient>>,
+        query: Query<(&LocalAddr, Option<&LocalId>, Option<&RemoteId>), With<RawClient>>,
         mut commands: Commands,
     ) {
-        if let Ok(local_addr) = query.get(trigger.entity) {
+        if let Ok((local_addr, local_id, remote_id)) = query.get(trigger.entity) {
             trace!("RawClient Linked! Adding Connected");
             commands.entity(trigger.entity).insert((
                 Connected,
-                LocalId(PeerId::Raw(local_addr.0)),
-                RemoteId(PeerId::Server),
+                local_id
+                    .copied()
+                    .unwrap_or(LocalId(PeerId::Raw(local_addr.0))),
+                remote_id.copied().unwrap_or(RemoteId(PeerId::Server)),
             ));
         }
     }
@@ -70,5 +72,35 @@ impl Plugin for RawConnectionPlugin {
         );
         app.add_observer(Self::on_linked);
         app.add_observer(Self::on_disconnect);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn raw_client_preserves_preconfigured_peer_ids() {
+        let mut app = App::new();
+        app.add_plugins(RawConnectionPlugin);
+        let local_id = LocalId(PeerId::Entity(1));
+        let remote_id = RemoteId(PeerId::Entity(2));
+        let entity = app
+            .world_mut()
+            .spawn((
+                RawClient,
+                LocalAddr("127.0.0.1:10001".parse().unwrap()),
+                local_id,
+                remote_id,
+            ))
+            .id();
+
+        app.world_mut().entity_mut(entity).insert(Linked);
+        app.world_mut().flush();
+
+        let entity = app.world().entity(entity);
+        assert!(entity.contains::<Connected>());
+        assert_eq!(entity.get::<LocalId>(), Some(&local_id));
+        assert_eq!(entity.get::<RemoteId>(), Some(&remote_id));
     }
 }

--- a/crates/core/lightyear/Cargo.toml
+++ b/crates/core/lightyear/Cargo.toml
@@ -94,9 +94,7 @@ deterministic = [
   "lightyear_avian3d?/deterministic",
 ]
 ## Enables transport-neutral peer-to-peer topology, synchronization, and input routing support.
-p2p = [
-  "client",
-]
+p2p = ["client"]
 ## Enables replicating entities between two peers
 replication = [
   "dep:lightyear_replication",

--- a/crates/core/lightyear/Cargo.toml
+++ b/crates/core/lightyear/Cargo.toml
@@ -96,13 +96,6 @@ deterministic = [
 ## Enables transport-neutral peer-to-peer topology, synchronization, and input routing support.
 p2p = [
   "client",
-  "lightyear_connection/p2p",
-  "lightyear_deterministic_replication?/p2p",
-  "lightyear_inputs?/p2p",
-  "lightyear_inputs_bei?/p2p",
-  "lightyear_inputs_leafwing?/p2p",
-  "lightyear_inputs_native?/p2p",
-  "lightyear_sync/p2p",
 ]
 ## Enables replicating entities between two peers
 replication = [

--- a/crates/core/lightyear/Cargo.toml
+++ b/crates/core/lightyear/Cargo.toml
@@ -93,6 +93,17 @@ deterministic = [
   "lightyear_avian2d?/deterministic",
   "lightyear_avian3d?/deterministic",
 ]
+## Enables transport-neutral peer-to-peer topology, synchronization, and input routing support.
+p2p = [
+  "client",
+  "lightyear_connection/p2p",
+  "lightyear_deterministic_replication?/p2p",
+  "lightyear_inputs?/p2p",
+  "lightyear_inputs_bei?/p2p",
+  "lightyear_inputs_leafwing?/p2p",
+  "lightyear_inputs_native?/p2p",
+  "lightyear_sync/p2p",
+]
 ## Enables replicating entities between two peers
 replication = [
   "dep:lightyear_replication",

--- a/crates/core/sync/Cargo.toml
+++ b/crates/core/sync/Cargo.toml
@@ -21,7 +21,6 @@ server = [
   "lightyear_messages/server",
   "lightyear_transport/server",
 ]
-p2p = ["client", "lightyear_connection/p2p"]
 
 [dependencies]
 lightyear_utils.workspace = true

--- a/crates/core/sync/Cargo.toml
+++ b/crates/core/sync/Cargo.toml
@@ -21,6 +21,7 @@ server = [
   "lightyear_messages/server",
   "lightyear_transport/server",
 ]
+p2p = ["client", "lightyear_connection/p2p"]
 
 [dependencies]
 lightyear_utils.workspace = true

--- a/crates/core/sync/src/ping/plugin.rs
+++ b/crates/core/sync/src/ping/plugin.rs
@@ -133,10 +133,23 @@ impl PingPlugin {
         )
     }
 
-    /// On connection, reset the PingManager.
-    pub(crate) fn handle_connect(trigger: On<Add, Connected>, mut query: Query<&mut PingManager>) {
+    /// On connection, reset the PingManager and restore its typed receivers.
+    ///
+    /// Disconnection cleanup removes typed receivers so stale messages cannot cross connection
+    /// epochs. They are normally recreated lazily by inbound traffic, but two symmetric raw P2P
+    /// clients would otherwise both wait for the other side to send the first ping. Restoring the
+    /// two protocol-internal receivers here lets either side initiate synchronization.
+    pub(crate) fn handle_connect(
+        trigger: On<Add, Connected>,
+        mut query: Query<&mut PingManager>,
+        mut commands: Commands,
+    ) {
         if let Ok(mut manager) = query.get_mut(trigger.entity) {
             manager.reset();
+            commands
+                .entity(trigger.entity)
+                .insert_if_new(MessageReceiver::<Ping>::default())
+                .insert_if_new(MessageReceiver::<Pong>::default());
         }
     }
 }
@@ -189,6 +202,7 @@ impl Plugin for PingPlugin {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use lightyear_core::id::{PeerId, RemoteId};
     use lightyear_transport::plugin::PacketAcked;
 
     #[test]
@@ -213,5 +227,26 @@ mod tests {
         assert_eq!(manager.pongs_recv, 0);
         assert_eq!(manager.latency_samples_recv(), 0);
         assert_eq!(manager.rtt(), Duration::ZERO);
+    }
+
+    #[test]
+    fn connecting_restores_ping_receivers() {
+        let mut app = App::new();
+        app.add_plugins(PingPlugin);
+
+        let entity = app
+            .world_mut()
+            .spawn((RemoteId(PeerId::Server), PingManager::default()))
+            .id();
+        app.world_mut()
+            .entity_mut(entity)
+            .remove::<(MessageReceiver<Ping>, MessageReceiver<Pong>)>();
+
+        app.world_mut().entity_mut(entity).insert(Connected);
+        app.world_mut().flush();
+
+        let entity = app.world().entity(entity);
+        assert!(entity.contains::<MessageReceiver<Ping>>());
+        assert!(entity.contains::<MessageReceiver<Pong>>());
     }
 }

--- a/crates/deterministic/deterministic_replication/Cargo.toml
+++ b/crates/deterministic/deterministic_replication/Cargo.toml
@@ -30,6 +30,12 @@ server = [
   "lightyear_sync/server",
   "lightyear_transport/server",
 ]
+p2p = [
+  "client",
+  "lightyear_connection/p2p",
+  "lightyear_inputs/p2p",
+  "lightyear_sync/p2p",
+]
 replication = []
 default = ["std", "client", "server"]
 

--- a/crates/deterministic/deterministic_replication/Cargo.toml
+++ b/crates/deterministic/deterministic_replication/Cargo.toml
@@ -30,12 +30,6 @@ server = [
   "lightyear_sync/server",
   "lightyear_transport/server",
 ]
-p2p = [
-  "client",
-  "lightyear_connection/p2p",
-  "lightyear_inputs/p2p",
-  "lightyear_sync/p2p",
-]
 replication = []
 default = ["std", "client", "server"]
 

--- a/crates/inputs/input_bei/Cargo.toml
+++ b/crates/inputs/input_bei/Cargo.toml
@@ -13,6 +13,7 @@ default = ["std"]
 std = ["lightyear_inputs/std"]
 client = ["lightyear_inputs/client"]
 server = ["lightyear_inputs/server"]
+p2p = ["client", "lightyear_connection/p2p", "lightyear_inputs/p2p"]
 
 [dependencies]
 lightyear_core.workspace = true

--- a/crates/inputs/input_bei/Cargo.toml
+++ b/crates/inputs/input_bei/Cargo.toml
@@ -13,7 +13,6 @@ default = ["std"]
 std = ["lightyear_inputs/std"]
 client = ["lightyear_inputs/client"]
 server = ["lightyear_inputs/server"]
-p2p = ["client", "lightyear_connection/p2p", "lightyear_inputs/p2p"]
 
 [dependencies]
 lightyear_core.workspace = true

--- a/crates/inputs/inputs/Cargo.toml
+++ b/crates/inputs/inputs/Cargo.toml
@@ -25,6 +25,7 @@ server = [
   "lightyear_link",
   "lightyear_transport/server",
 ]
+p2p = ["client", "lightyear_connection/p2p", "lightyear_sync/p2p"]
 metrics = ["dep:metrics", "std"]
 prediction = []
 interpolation = ["dep:lightyear_interpolation"]

--- a/crates/inputs/inputs/Cargo.toml
+++ b/crates/inputs/inputs/Cargo.toml
@@ -25,7 +25,6 @@ server = [
   "lightyear_link",
   "lightyear_transport/server",
 ]
-p2p = ["client", "lightyear_connection/p2p", "lightyear_sync/p2p"]
 metrics = ["dep:metrics", "std"]
 prediction = []
 interpolation = ["dep:lightyear_interpolation"]

--- a/crates/inputs/inputs/src/client.rs
+++ b/crates/inputs/inputs/src/client.rs
@@ -1482,7 +1482,7 @@ mod tests {
         let target = world.spawn_empty().id();
         let topology = NetworkTopology::P2P {
             connected: [link].into_iter().collect(),
-            declared: 1,
+            declared_links: 1,
         };
         let route = InputRoute::from_topology(&topology).unwrap();
         let prespawned = PreSpawned::new(0xCAFE);
@@ -1501,7 +1501,7 @@ mod tests {
         let target = world.spawn_empty().id();
         let topology = NetworkTopology::P2P {
             connected: [link].into_iter().collect(),
-            declared: 1,
+            declared_links: 1,
         };
         let route = InputRoute::from_topology(&topology).unwrap();
 

--- a/crates/inputs/inputs/src/client.rs
+++ b/crates/inputs/inputs/src/client.rs
@@ -207,7 +207,7 @@ impl<S: ActionStateSequence + MapEntities> Plugin for ClientInputPlugin<S> {
 
         // SYSTEMS
         #[cfg(feature = "prediction")]
-        if self.config.rebroadcast_inputs {
+        {
             // NOTE: we do NOT need to run this after RunFixedMainLoopSystems::BeforeFixedMainLoop to ensure that the
             //  local leafwing `states` have been switched to the `fixed_update` state (see
             //  https://github.com/Leafwing-Studios/leafwing-input-manager/blob/v0.16/src/plugin.rs#L170)
@@ -343,6 +343,11 @@ impl<'a> InputRoute<'a> {
     }
 
     #[inline]
+    fn requires_prespawned_targets(self) -> bool {
+        matches!(self, Self::P2P(_))
+    }
+
+    #[inline]
     fn accepts_local_target(self, controlled_by: Option<&ControlledBy>) -> bool {
         match self {
             Self::ClientServer { link, .. } => {
@@ -353,6 +358,37 @@ impl<'a> InputRoute<'a> {
             Self::P2P(_) => true,
         }
     }
+}
+
+/// Select the wire identity for one locally controlled input entity.
+///
+/// Conventional client/server links can use their replication-populated entity map. P2P has no
+/// authoritative replication stream to populate those per-Link maps, so every target must use a
+/// stable [`PreSpawned`] hash that the other peers can resolve in their own worlds.
+fn input_target(
+    route: InputRoute<'_>,
+    entity: Entity,
+    pre_spawned: Option<&PreSpawned>,
+) -> InputTarget {
+    if let Some(hash) = pre_spawned.and_then(|pre_spawned| pre_spawned.hash) {
+        debug!(?hash, ?entity, "Sending input for prespawned entity");
+        return InputTarget::PreSpawned(hash);
+    }
+    assert!(
+        !route.requires_prespawned_targets(),
+        "P2P input target {entity:?} must have a PreSpawned component with a resolved hash"
+    );
+    InputTarget::Entity(entity)
+}
+
+#[inline]
+fn matches_prespawned_target(
+    hash: u64,
+    p2p_link: Option<Entity>,
+    pre_spawned: &PreSpawned,
+) -> bool {
+    pre_spawned.hash.is_some_and(|candidate| candidate == hash)
+        && p2p_link.is_none_or(|link| pre_spawned.receiver == Some(link))
 }
 
 // equivalent to &ActionState<S::Action>
@@ -522,7 +558,7 @@ fn get_action_state<S: ActionStateSequence>(
                 input_buffer = %*input_buffer,
                 "restored action state from input buffer"
             );
-        } else if !is_local && config.rebroadcast_inputs {
+        } else if !is_local && (config.rebroadcast_inputs || matches!(route, InputRoute::P2P(_))) {
             if input_timeline_config.is_lockstep() {
                 error!("We are in lockstep mode but didn't receive an input for tick {tick:?}!");
             }
@@ -786,14 +822,7 @@ fn prepare_input_message<S: ActionStateSequence>(
             input_buffer
         );
 
-        let target = if let Some(prespawned) = pre_spawned
-            && let Some(hash) = prespawned.hash
-        {
-            debug!(?hash, ?entity, "Sending input for prespawned entity");
-            InputTarget::PreSpawned(hash)
-        } else {
-            InputTarget::Entity(entity)
-        };
+        let target = input_target(route, entity, pre_spawned);
 
         if let Some(state_sequence) = S::build_from_input_buffer(input_buffer, num_ticks, tick) {
             trace!(
@@ -859,6 +888,7 @@ fn receive_remote_player_input_messages<S: ActionStateSequence>(
     mut commands: Commands,
     tick_duration: Res<TickDuration>,
     timeline: Res<LocalTimeline>,
+    input_config: Res<InputConfig<S::Action>>,
     #[cfg(feature = "metrics")] mut input_metric_handles: ResMut<InputMetricHandles<S>>,
     _input_timeline: SyncedInputTimeline,
     metadata: Res<NetworkingMetadata>,
@@ -878,6 +908,11 @@ fn receive_remote_player_input_messages<S: ActionStateSequence>(
     if route.is_host_client() {
         return;
     }
+    // Conventional clients only receive other players' inputs when the server is configured to
+    // rebroadcast them. Direct P2P peers always exchange remote inputs with each other.
+    if matches!(route, InputRoute::ClientServer { .. }) && !input_config.rebroadcast_inputs {
+        return;
+    }
     let Some(prediction_manager) = prediction_manager else {
         return;
     };
@@ -891,6 +926,7 @@ fn receive_remote_player_input_messages<S: ActionStateSequence>(
                     &mut commands,
                     *tick_duration,
                     tick,
+                    None,
                     &prediction_manager,
                     &mut predicted_query,
                     &prespawned,
@@ -909,6 +945,7 @@ fn receive_remote_player_input_messages<S: ActionStateSequence>(
                     &mut commands,
                     *tick_duration,
                     tick,
+                    Some(*link),
                     &prediction_manager,
                     &mut predicted_query,
                     &prespawned,
@@ -932,6 +969,7 @@ fn receive_remote_player_input_messages_from_receiver<S: ActionStateSequence>(
     commands: &mut Commands,
     tick_duration: TickDuration,
     tick: Tick,
+    p2p_link: Option<Entity>,
     prediction_manager: &PredictionManager,
     predicted_query: &mut Query<
         Option<&mut InputBuffer<S::Snapshot, S::Action>>,
@@ -958,13 +996,19 @@ fn receive_remote_player_input_messages_from_receiver<S: ActionStateSequence>(
         );
         for target_data in message.inputs {
             let Some(entity) = (match target_data.target {
+                InputTarget::Entity(entity) if p2p_link.is_none() => Some(entity),
                 InputTarget::Entity(entity) => {
-                    Some(entity)
+                    error!(
+                        ?entity,
+                        end_tick = ?message.end_tick,
+                        "ignored P2P input target without a PreSpawned hash"
+                    );
+                    None
                 }
                 InputTarget::PreSpawned(hash) => {
-                    prespawned
-                        .iter()
-                        .find_map(|(e, p)| p.hash.is_some_and(|h| h == hash).then_some(e))
+                    prespawned.iter().find_map(|(entity, pre_spawned)| {
+                        matches_prespawned_target(hash, p2p_link, pre_spawned).then_some(entity)
+                    })
                 }
             }) else {
                 if message.rebroadcast {
@@ -972,6 +1016,12 @@ fn receive_remote_player_input_messages_from_receiver<S: ActionStateSequence>(
                         target = ?target_data.target,
                         end_tick = ?message.end_tick,
                         "ignored stale remote player input message for unmapped entity"
+                    );
+                } else if let Some(link) = p2p_link {
+                    warn!(
+                        ?link,
+                        target = ?target_data.target,
+                        "could not find a PreSpawned P2P input target owned by the sending Link"
                     );
                 } else {
                     warn!("Could not find entity in entity_map for remote player input message {:?}", target_data.target);
@@ -1091,6 +1141,7 @@ fn receive_remote_player_input_messages_from_receiver<S: ActionStateSequence>(
 fn update_last_confirmed_input<S: ActionStateSequence>(
     timeline: Res<LocalTimeline>,
     _input_timeline: SyncedInputTimeline,
+    action_config: Res<InputConfig<S::Action>>,
     input_config: Res<InputTimelineConfig>,
     metadata: Res<NetworkingMetadata>,
     mut last_confirmed_input: ResMut<LastConfirmedInput>,
@@ -1099,7 +1150,10 @@ fn update_last_confirmed_input<S: ActionStateSequence>(
         (Without<S::Marker>, Allow<PredictionDisable>),
     >,
 ) {
-    if InputRoute::from_topology(&metadata.mode).is_none() {
+    let Some(route) = InputRoute::from_topology(&metadata.mode) else {
+        return;
+    };
+    if matches!(route, InputRoute::ClientServer { .. }) && !action_config.rebroadcast_inputs {
         return;
     }
     let tick = timeline.tick();
@@ -1420,6 +1474,70 @@ mod tests {
         assert!(p2p_route.accepts_local_target(Some(&owned_by_client)));
         assert!(p2p_route.accepts_local_target(Some(&owned_by_other)));
     }
+
+    #[test]
+    fn p2p_input_targets_use_prespawned_hashes() {
+        let mut world = World::new();
+        let link = world.spawn_empty().id();
+        let target = world.spawn_empty().id();
+        let topology = NetworkTopology::P2P {
+            connected: [link].into_iter().collect(),
+            declared: 1,
+        };
+        let route = InputRoute::from_topology(&topology).unwrap();
+        let prespawned = PreSpawned::new(0xCAFE);
+
+        assert_eq!(
+            input_target(route, target, Some(&prespawned)),
+            InputTarget::PreSpawned(0xCAFE)
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "must have a PreSpawned component with a resolved hash")]
+    fn p2p_input_targets_reject_unmapped_entities() {
+        let mut world = World::new();
+        let link = world.spawn_empty().id();
+        let target = world.spawn_empty().id();
+        let topology = NetworkTopology::P2P {
+            connected: [link].into_iter().collect(),
+            declared: 1,
+        };
+        let route = InputRoute::from_topology(&topology).unwrap();
+
+        let _ = input_target(route, target, None);
+    }
+
+    #[test]
+    fn client_server_input_targets_still_allow_entities() {
+        let mut world = World::new();
+        let link = world.spawn_empty().id();
+        let target = world.spawn_empty().id();
+        let topology = NetworkTopology::Client(link);
+        let route = InputRoute::from_topology(&topology).unwrap();
+
+        assert_eq!(
+            input_target(route, target, None),
+            InputTarget::Entity(target)
+        );
+    }
+
+    #[test]
+    fn p2p_input_targets_are_scoped_to_the_sending_link() {
+        let mut world = World::new();
+        let owner = world.spawn_empty().id();
+        let other = world.spawn_empty().id();
+        let pre_spawned = PreSpawned::new(0xCAFE).for_receiver(owner);
+
+        assert!(matches_prespawned_target(0xCAFE, Some(owner), &pre_spawned));
+        assert!(!matches_prespawned_target(
+            0xCAFE,
+            Some(other),
+            &pre_spawned
+        ));
+        assert!(matches_prespawned_target(0xCAFE, None, &pre_spawned));
+    }
+
     #[test]
     fn input_history_depth_covers_prediction_rollback_window() {
         assert_eq!(input_history_depth(None), HISTORY_DEPTH);

--- a/crates/inputs/inputs/src/client.rs
+++ b/crates/inputs/inputs/src/client.rs
@@ -130,8 +130,8 @@ pub enum InputSystems {
 ///   them before it needs them.
 /// - **Redundancy**: each message includes the last N ticks of input to
 ///   recover from packet loss.
-/// - **Remote player prediction**: if `rebroadcast_inputs` is enabled,
-///   processes input messages received from the server for other players.
+/// - **Remote player prediction**: processes other players' inputs when a conventional server
+///   rebroadcasts them, or directly from every peer in a P2P topology.
 pub struct ClientInputPlugin<S: ActionStateSequence> {
     config: InputConfig<S::Action>,
 }
@@ -208,6 +208,9 @@ impl<S: ActionStateSequence + MapEntities> Plugin for ClientInputPlugin<S> {
         // SYSTEMS
         #[cfg(feature = "prediction")]
         {
+            // The topology is a runtime choice. Conventional clients still return immediately
+            // when rebroadcasting is disabled, while P2P peers must always drain direct remote
+            // input messages even though their client/server rebroadcast option is false.
             // NOTE: we do NOT need to run this after RunFixedMainLoopSystems::BeforeFixedMainLoop to ensure that the
             //  local leafwing `states` have been switched to the `fixed_update` state (see
             //  https://github.com/Leafwing-Studios/leafwing-input-manager/blob/v0.16/src/plugin.rs#L170)

--- a/crates/inputs/inputs/src/input_message.rs
+++ b/crates/inputs/inputs/src/input_message.rs
@@ -28,11 +28,18 @@ pub enum InputTarget {
     /// The input is for a predicted or confirmed entity.
     /// When sending from client to server, entity mapping is applied.
     /// (Also when rebroadcast from server to client)
+    ///
+    /// This target is not valid for direct P2P input because input-only P2P Links do not have a
+    /// replication stream that can populate their entity maps. Use [`InputTarget::PreSpawned`]
+    /// for P2P targets.
     Entity(Entity),
     /// The input is for a prespawned entity.
     /// We want the client to be able to send inputs for a prespawned entity before it gets matched with a server entity.
     /// To achieve this, the client sends the PreSpawned hash and the server will map it to the correct server entity.
     /// When rebroadcasting from server to other client, we rebroadcast it as a normal Entity?
+    ///
+    /// Direct P2P input also uses this stable hash because every peer has its own local ECS entity
+    /// and no authoritative replication stream exists to establish an entity map.
     PreSpawned(u64),
 }
 

--- a/crates/inputs/inputs_leafwing/Cargo.toml
+++ b/crates/inputs/inputs_leafwing/Cargo.toml
@@ -13,7 +13,6 @@ default = ["std"]
 std = []
 client = ["lightyear_inputs/client"]
 server = ["lightyear_inputs/server"]
-p2p = ["client", "lightyear_inputs/p2p", "lightyear_sync/p2p"]
 
 [dependencies]
 lightyear_inputs.workspace = true

--- a/crates/inputs/inputs_leafwing/Cargo.toml
+++ b/crates/inputs/inputs_leafwing/Cargo.toml
@@ -13,6 +13,7 @@ default = ["std"]
 std = []
 client = ["lightyear_inputs/client"]
 server = ["lightyear_inputs/server"]
+p2p = ["client", "lightyear_inputs/p2p", "lightyear_sync/p2p"]
 
 [dependencies]
 lightyear_inputs.workspace = true

--- a/crates/inputs/inputs_native/Cargo.toml
+++ b/crates/inputs/inputs_native/Cargo.toml
@@ -13,7 +13,6 @@ default = ["std"]
 std = ["lightyear_inputs/std"]
 client = ["lightyear_inputs/client"]
 server = ["lightyear_inputs/server"]
-p2p = ["client", "lightyear_inputs/p2p"]
 
 [dependencies]
 lightyear_core.workspace = true

--- a/crates/inputs/inputs_native/Cargo.toml
+++ b/crates/inputs/inputs_native/Cargo.toml
@@ -13,6 +13,7 @@ default = ["std"]
 std = ["lightyear_inputs/std"]
 client = ["lightyear_inputs/client"]
 server = ["lightyear_inputs/server"]
+p2p = ["client", "lightyear_inputs/p2p"]
 
 [dependencies]
 lightyear_core.workspace = true

--- a/crates/replication/interpolation/src/timeline.rs
+++ b/crates/replication/interpolation/src/timeline.rs
@@ -233,6 +233,12 @@ impl TimelinePlugin {
         if rollback.is_some() {
             return;
         }
+        // A deterministic prediction-window wait pauses `Time<Virtual>` so FixedUpdate cannot
+        // advance beyond the rollback window. Its delta is already zero in that state; avoid
+        // dividing by the zero relative speed while reconstructing the unscaled frame delta.
+        if time.relative_speed() == 0.0 {
+            return;
+        }
         let delta = time.delta();
         query.iter_mut().for_each(|mut t| {
             // make sure to account for the fact that Time<Virtual> is already updated from the Driving timeline
@@ -254,5 +260,46 @@ impl Plugin for TimelinePlugin {
             Self::advance_timeline.in_set(TimelineSystems::Advance),
         );
         app.add_observer(Self::receive_sender_metadata);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lightyear_core::id::{PeerId, RemoteId};
+
+    #[test]
+    fn paused_virtual_time_does_not_advance_interpolation_timeline() {
+        let mut app = App::new();
+        let mut virtual_time = Time::<Virtual>::default();
+        virtual_time.set_relative_speed(0.0);
+        app.insert_resource(virtual_time);
+        app.insert_resource(TickDuration(Duration::from_millis(16)));
+        app.add_systems(PreUpdate, TimelinePlugin::advance_timeline);
+
+        let entity = app
+            .world_mut()
+            .spawn((
+                InterpolationTimeline::default(),
+                RemoteId(PeerId::Server),
+                Connected,
+            ))
+            .id();
+        let before = app
+            .world()
+            .entity(entity)
+            .get::<InterpolationTimeline>()
+            .unwrap()
+            .now();
+
+        app.update();
+
+        let after = app
+            .world()
+            .entity(entity)
+            .get::<InterpolationTimeline>()
+            .unwrap()
+            .now();
+        assert_eq!(after, before);
     }
 }

--- a/crates/replication/replication/src/prespawn.rs
+++ b/crates/replication/replication/src/prespawn.rs
@@ -282,8 +282,11 @@ pub struct PreSpawned {
     pub user_salt: Option<u64>,
 
     // TODO: what if we want the Prespawned to only be for a given sender? or a subset of senders?
-    /// Receiver entity that is prespawning this entity.
-    /// If None, then we will use the entity that has a [`PreSpawnedReceiver`].
+    /// Receiver Link that owns this remote entity.
+    ///
+    /// Replication uses this to select a specific [`PreSpawnedReceiver`]. Direct P2P input uses
+    /// it to ensure that a stable input-target hash is accepted only from the Link for that peer.
+    /// If None, replication will use the entity that has a [`PreSpawnedReceiver`].
     pub receiver: Option<Entity>,
 }
 

--- a/demos/spaceships/Cargo.toml
+++ b/demos/spaceships/Cargo.toml
@@ -9,11 +9,17 @@ edition.workspace = true
 publish = false
 
 [features]
-default = ["client", "gui", "server", "netcode", "webtransport"]
+default = ["client", "gui", "server", "p2p", "netcode", "webtransport"]
 client = ["lightyear/client", "lightyear_examples_common/client"]
 gui = ["lightyear_examples_common/gui2d", "bevy/bevy_post_process"]
 server = ["lightyear/server", "lightyear_examples_common/server"]
 netcode = ["lightyear_examples_common/netcode"]
+p2p = [
+  "client",
+  "udp",
+  "lightyear/deterministic",
+  "lightyear_examples_common/p2p",
+]
 webtransport = ["lightyear_examples_common/webtransport"]
 udp = [
   "lightyear_examples_common/udp",
@@ -31,6 +37,7 @@ lightyear = { workspace = true, features = [
   "avian2d",
 ] }
 lightyear_frame_interpolation.workspace = true
+lightyear_deterministic_replication.workspace = true
 lightyear_examples_common = { workspace = true, features = [
   "structured-debug",
 ] }

--- a/demos/spaceships/Cargo.toml
+++ b/demos/spaceships/Cargo.toml
@@ -18,6 +18,7 @@ p2p = [
   "client",
   "udp",
   "lightyear/deterministic",
+  "lightyear/p2p",
   "lightyear_examples_common/p2p",
 ]
 webtransport = ["lightyear_examples_common/webtransport"]

--- a/demos/spaceships/README.md
+++ b/demos/spaceships/README.md
@@ -42,6 +42,14 @@ your client will rollback to position the bullet correctly.
 - Run the server without a gui: `cargo run --no-default-features --features=server`
 - Run the client and server in "HostClient" mode, where the server is also a client (there is only one App): `cargo run host-client`
 
+### P2P mode
+
+The demo can also run as a deterministic input-only game with no server. Start peer 0 with
+`cargo run --no-default-features --features=p2p -- --headless p2p --peer-id 0 --player-count 2`
+and peer 1 with the same command using `--peer-id 1`. Every peer predicts the complete physics
+world, spawns the same bullets from the shared input stream, and applies collision and score
+changes deterministically.
+
 You can control the behaviour of the example by changing the list of features. By default, all features are enabled (client, server, gui).
 For example you can run the server in headless mode (without gui) by running `cargo run --no-default-features --features=server`.
 You can modify the file `assets/settings.ron` to modify some networking settings.

--- a/demos/spaceships/src/client.rs
+++ b/demos/spaceships/src/client.rs
@@ -129,18 +129,22 @@ fn handle_controlled_player(
             return;
         }
         info!("Own player is now controlled, adding inputmap {entity:?} {player:?}");
-        commands.entity(entity).insert(InputMap::new([
-            (PlayerActions::Up, KeyCode::ArrowUp),
-            (PlayerActions::Down, KeyCode::ArrowDown),
-            (PlayerActions::Left, KeyCode::ArrowLeft),
-            (PlayerActions::Right, KeyCode::ArrowRight),
-            (PlayerActions::Up, KeyCode::KeyW),
-            (PlayerActions::Down, KeyCode::KeyS),
-            (PlayerActions::Left, KeyCode::KeyA),
-            (PlayerActions::Right, KeyCode::KeyD),
-            (PlayerActions::Fire, KeyCode::Space),
-        ]));
+        commands.entity(entity).insert(player_input_map());
     }
+}
+
+pub(crate) fn player_input_map() -> InputMap<PlayerActions> {
+    InputMap::new([
+        (PlayerActions::Up, KeyCode::ArrowUp),
+        (PlayerActions::Down, KeyCode::ArrowDown),
+        (PlayerActions::Left, KeyCode::ArrowLeft),
+        (PlayerActions::Right, KeyCode::ArrowRight),
+        (PlayerActions::Up, KeyCode::KeyW),
+        (PlayerActions::Down, KeyCode::KeyS),
+        (PlayerActions::Left, KeyCode::KeyA),
+        (PlayerActions::Right, KeyCode::KeyD),
+        (PlayerActions::Fire, KeyCode::Space),
+    ])
 }
 
 #[cfg(feature = "gui")]

--- a/demos/spaceships/src/main.rs
+++ b/demos/spaceships/src/main.rs
@@ -9,6 +9,8 @@ use lightyear_examples_common::shared::FIXED_TIMESTEP_HZ;
 
 #[cfg(feature = "client")]
 use crate::client::ExampleClientPlugin;
+#[cfg(feature = "p2p")]
+use crate::p2p::ExampleP2PPlugin;
 #[cfg(feature = "server")]
 use crate::server::ExampleServerPlugin;
 use crate::shared::SharedPlugin;
@@ -16,6 +18,8 @@ use crate::shared::SharedPlugin;
 mod automation;
 #[cfg(feature = "client")]
 mod client;
+#[cfg(feature = "p2p")]
+mod p2p;
 mod protocol;
 
 #[cfg(feature = "gui")]
@@ -38,10 +42,14 @@ fn main() {
     cli.spawn_connections(&mut app);
 
     match cli.mode {
-        #[cfg(feature = "client")]
+        #[cfg(all(feature = "client", any(not(feature = "p2p"), feature = "netcode")))]
         Some(Mode::Client { .. }) => {
             app.add_plugins(ExampleClientPlugin);
             add_input_delay(&mut app);
+        }
+        #[cfg(feature = "p2p")]
+        Some(Mode::P2P { .. }) => {
+            app.add_plugins((ExampleClientPlugin, ExampleP2PPlugin));
         }
         #[cfg(feature = "server")]
         Some(Mode::Server) => {

--- a/demos/spaceships/src/p2p.rs
+++ b/demos/spaceships/src/p2p.rs
@@ -1,0 +1,124 @@
+//! Deterministic input-only P2P setup for the spaceships demo.
+
+use core::f32::consts::TAU;
+
+use avian2d::prelude::*;
+use bevy::color::palettes::css;
+use bevy::prelude::*;
+use lightyear::prediction::rollback::DeterministicPredicted;
+use lightyear::prelude::input::client::InputSystems;
+use lightyear::prelude::input::leafwing::LeafwingBuffer;
+use lightyear::prelude::*;
+use lightyear_deterministic_replication::prelude::DeterministicReplicationPlugin;
+use lightyear_examples_common::p2p::{
+    GAMEPLAY_START_TICK, P2PGameplayStarted, P2PSettings, input_target_for_peer,
+};
+use lightyear_examples_common::shared::FIXED_TIMESTEP_HZ;
+use lightyear_frame_interpolation::FrameInterpolate;
+
+use crate::client::player_input_map;
+use crate::protocol::*;
+use crate::shared::color_from_id;
+
+const PLAYER_INPUT_HASH_BASE: u64 = 0x5350_4143_4500_0000;
+
+pub struct ExampleP2PPlugin;
+
+impl Plugin for ExampleP2PPlugin {
+    fn build(&self, app: &mut App) {
+        app.insert_resource(PredictionManager::default());
+        app.add_plugins(DeterministicReplicationPlugin);
+        app.add_systems(
+            FixedPreUpdate,
+            spawn_fixed_world.before(InputSystems::BufferClientInputs),
+        );
+        app.add_systems(
+            FixedPostUpdate,
+            update_scores.after(crate::shared::process_collisions),
+        );
+    }
+}
+
+fn spawn_fixed_world(
+    mut commands: Commands,
+    _synced: SyncedInputTimeline,
+    timeline: Res<LocalTimeline>,
+    started: Option<Res<P2PGameplayStarted>>,
+    settings: Res<P2PSettings>,
+    links: Query<(Entity, &RemoteId), With<P2P>>,
+) {
+    if started.is_some() || timeline.tick().0 < GAMEPLAY_START_TICK {
+        return;
+    }
+    commands.insert_resource(P2PGameplayStarted);
+
+    const NUM_BALLS: usize = 6;
+    for i in 0..NUM_BALLS {
+        let radius = 10.0 + i as f32 * 4.0;
+        let angle = i as f32 * (TAU / NUM_BALLS as f32);
+        let marker = BallMarker::new(radius);
+        commands.spawn((
+            Position(Vec2::new(125.0 * angle.cos(), 125.0 * angle.sin())),
+            ColorComponent(css::GOLD.into()),
+            marker.physics_bundle(),
+            marker,
+            DeterministicPredicted {
+                skip_despawn: true,
+                enable_rollback_after: 0,
+            },
+            FrameInterpolate,
+            Name::new("P2P Ball"),
+        ));
+    }
+
+    for peer_id in settings.peer_ids() {
+        let id = PeerId::Entity(u64::from(peer_id));
+        let angle = f32::from(peer_id) * (TAU / f32::from(settings.player_count));
+        let target = input_target_for_peer(
+            &settings,
+            &links,
+            peer_id,
+            PLAYER_INPUT_HASH_BASE | u64::from(peer_id),
+        );
+        let player = commands
+            .spawn((
+                Player::new(id, format!("Peer {peer_id}")),
+                Score(0),
+                Position(Vec2::new(200.0 * angle.cos(), 200.0 * angle.sin())),
+                PhysicsBundle::player_ship(),
+                Weapon::new((FIXED_TIMESTEP_HZ / 5.0) as u16),
+                ColorComponent(color_from_id(id)),
+                DeterministicPredicted {
+                    skip_despawn: true,
+                    enable_rollback_after: 0,
+                },
+                target,
+                LeafwingBuffer::<PlayerActions>::default(),
+                FrameInterpolate,
+                Name::new("P2P Player"),
+            ))
+            .id();
+        if peer_id == settings.local_peer_id {
+            commands.entity(player).insert(player_input_map());
+        }
+    }
+}
+
+fn update_scores(
+    mut events: MessageReader<BulletHitMessage>,
+    mut players: Query<(&Player, &mut Score)>,
+) {
+    for event in events.read() {
+        let Some(victim) = event.victim_client_id else {
+            continue;
+        };
+        for (player, mut score) in &mut players {
+            if player.client_id == victim {
+                score.0 -= 1;
+            }
+            if player.client_id == event.bullet_owner {
+                score.0 += 1;
+            }
+        }
+    }
+}

--- a/demos/spaceships/src/renderer.rs
+++ b/demos/spaceships/src/renderer.rs
@@ -76,7 +76,14 @@ fn add_frame_interpolation_components(
     // We use Position because it's added by avian later, and when it's added
     // we know that Predicted is already present on the entity
     trigger: On<Add, Position>,
-    q: Query<Entity, (Without<Wall>, With<Predicted>, Without<FrameInterpolate>)>,
+    q: Query<
+        Entity,
+        (
+            Without<Wall>,
+            Or<(With<Predicted>, With<DeterministicPredicted>)>,
+            Without<FrameInterpolate>,
+        ),
+    >,
     mut commands: Commands,
 ) {
     if !q.contains(trigger.entity) {
@@ -383,7 +390,10 @@ fn insert_bullet_mesh(
             Without<BulletVisualAttached>,
         ),
     >,
-    players: Query<(&Player, &Position, Option<&Rotation>), With<Predicted>>,
+    players: Query<
+        (&Player, &Position, Option<&Rotation>),
+        Or<(With<Predicted>, With<DeterministicPredicted>)>,
+    >,
     mut commands: Commands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<ColorMaterial>>,

--- a/demos/spaceships/src/shared.rs
+++ b/demos/spaceships/src/shared.rs
@@ -9,7 +9,7 @@ use crate::protocol::*;
 #[cfg(feature = "gui")]
 use crate::renderer::ExampleRendererPlugin;
 use avian2d::prelude::{forces::ForcesItem, *};
-use leafwing_input_manager::prelude::ActionState;
+use leafwing_input_manager::prelude::{ActionState, InputMap};
 use lightyear::avian2d::plugin::AvianReplicationMode;
 use lightyear::input::leafwing::prelude::LeafwingBuffer;
 use lightyear::prelude::*;
@@ -26,6 +26,13 @@ pub struct SharedPlugin {
 
 impl Plugin for SharedPlugin {
     fn build(&self, app: &mut App) {
+        #[cfg(feature = "p2p")]
+        let rollback_resources = app
+            .world()
+            .contains_resource::<lightyear_examples_common::p2p::P2PSettings>();
+        #[cfg(not(feature = "p2p"))]
+        let rollback_resources = false;
+
         app.add_plugins(ProtocolPlugin);
         app.init_resource::<BulletDebugRegistry>();
 
@@ -37,6 +44,11 @@ impl Plugin for SharedPlugin {
             replication_mode: AvianReplicationMode::Position {
                 sync_to_transform: false,
             },
+            // `ProtocolPlugin` owns the physics component registrations so it can use the
+            // demo's tighter rollback tolerances. Registering Avian's defaults as well would
+            // install the same prediction receive-marker functions twice.
+            register_physics_components: false,
+            rollback_resources,
             ..default()
         });
         app.add_plugins(
@@ -259,7 +271,9 @@ pub fn shared_player_firing(
         &mut Weapon,
         Option<&ConfirmedHistory<Weapon>>,
         Has<Controlled>,
+        Has<InputMap<PlayerActions>>,
         Has<Predicted>,
+        Has<DeterministicPredicted>,
         Has<Interpolated>,
         Option<&ControlledBy>,
         &Player,
@@ -267,6 +281,7 @@ pub fn shared_player_firing(
     mut commands: Commands,
     timeline: Res<LocalTimeline>,
     input_timeline: Option<SyncedInputTimeline>,
+    metadata: Res<NetworkingMetadata>,
     server: Query<(), With<Server>>,
 ) {
     let client_is_synced = input_timeline.is_some();
@@ -286,7 +301,9 @@ pub fn shared_player_firing(
         mut weapon,
         weapon_history,
         is_local,
+        has_input_map,
         is_predicted,
+        is_deterministic,
         is_interpolated,
         controlled_by,
         player,
@@ -296,9 +313,10 @@ pub fn shared_player_firing(
             if controlled_by.is_none() {
                 continue;
             }
-        } else if !client_is_synced || !is_predicted || is_interpolated {
+        } else if !client_is_synced || !(is_predicted || is_deterministic) || is_interpolated {
             continue;
         }
+        let is_local = is_local || has_input_map;
         // Firing runs in FixedUpdate. Using a level-trigger here is more robust than
         // relying on a frame-edge `just_pressed`, and the weapon cooldown already
         // guarantees we only spawn bullets at the intended rate.
@@ -362,6 +380,11 @@ pub fn shared_player_firing(
                 prespawned,
             ))
             .id();
+        if matches!(metadata.mode, NetworkTopology::P2P { .. }) {
+            commands
+                .entity(bullet_entity)
+                .insert(DeterministicPredicted::default());
+        }
         lightyear_debug_event!(
             DebugCategory::Prediction,
             DebugSamplePoint::FixedUpdate,
@@ -668,28 +691,31 @@ pub(crate) fn process_collisions(
         &Position,
         Has<PreSpawned>,
         Has<Predicted>,
+        Has<DeterministicPredicted>,
     )>,
     player_q: Query<&Player>,
     mut commands: Commands,
     timeline: Res<LocalTimeline>,
     server: Query<(), With<Server>>,
+    metadata: Res<NetworkingMetadata>,
     mut hit_ev_writer: MessageWriter<BulletHitMessage>,
 ) {
     let is_server = !server.is_empty();
+    let is_p2p = matches!(metadata.mode, NetworkTopology::P2P { .. });
     let tick = timeline.tick();
     // when A and B collide, it can be reported as one of:
     // * A collides with B
     // * B collides with A
     // which is why logic is duplicated twice here
     for contacts in collisions.iter() {
-        if let Ok((bullet, col, bullet_pos, is_prespawned, is_predicted)) =
+        if let Ok((bullet, col, bullet_pos, is_prespawned, is_predicted, is_deterministic)) =
             bullet_q.get(contacts.collider1)
         {
             // Keep unconfirmed client prespawns alive until the server entity can match them.
-            if !is_server && is_prespawned {
+            if !is_server && !is_p2p && is_prespawned {
                 continue;
             }
-            if !is_server && !is_predicted {
+            if !is_server && !(is_predicted || is_deterministic) {
                 info!(
                     ?tick,
                     bullet = ?contacts.collider1,
@@ -719,14 +745,14 @@ pub(crate) fn process_collisions(
             };
             hit_ev_writer.write(ev);
         }
-        if let Ok((bullet, col, bullet_pos, is_prespawned, is_predicted)) =
+        if let Ok((bullet, col, bullet_pos, is_prespawned, is_predicted, is_deterministic)) =
             bullet_q.get(contacts.collider2)
         {
             // Keep unconfirmed client prespawns alive until the server entity can match them.
-            if !is_server && is_prespawned {
+            if !is_server && !is_p2p && is_prespawned {
                 continue;
             }
-            if !is_server && !is_predicted {
+            if !is_server && !(is_predicted || is_deterministic) {
                 info!(
                     ?tick,
                     bullet = ?contacts.collider2,

--- a/examples/README.md
+++ b/examples/README.md
@@ -8,7 +8,7 @@ The top level `Cargo.toml` workspace defines the deps that examples can use and 
 ## Easy
 
 - `simple_setup`: minimal example that just shows how to create the lightyear client and server plugins
-- `simple_box`: example that showcases how to send inputs from client to server, and how to add client-prediction and interpolation
+- `simple_box`: example that showcases client/server prediction and interpolation, plus an optional deterministic input-only P2P mode
 - `bevy_enhanced_input`: example that shows how to integrate lightyear with the `bevy_enhanced_input` crate to handle inputs.
 
 ## Medium

--- a/examples/avian_2d/Cargo.toml
+++ b/examples/avian_2d/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 publish = false
 
 [features]
-default = ["client", "gui", "server", "netcode", "webtransport"]
+default = ["client", "gui", "server", "p2p", "netcode", "webtransport"]
 client = ["lightyear/client", "lightyear_examples_common/client"]
 gui = ["lightyear_examples_common/gui2d"]
 server = [
@@ -16,6 +16,12 @@ server = [
   "lightyear_examples_common/server",
 ]
 netcode = ["lightyear_examples_common/netcode"]
+p2p = [
+  "client",
+  "udp",
+  "lightyear/deterministic",
+  "lightyear_examples_common/p2p",
+]
 webtransport = ["lightyear_examples_common/webtransport"]
 udp = ["lightyear_examples_common/udp", "lightyear/std", "lightyear/udp"]
 
@@ -31,6 +37,7 @@ lightyear_examples_common = { workspace = true, features = [
   "structured-debug",
 ] }
 lightyear_frame_interpolation.workspace = true
+lightyear_deterministic_replication.workspace = true
 leafwing-input-manager.workspace = true
 avian2d = { workspace = true, features = [
   "2d",

--- a/examples/avian_2d/Cargo.toml
+++ b/examples/avian_2d/Cargo.toml
@@ -20,6 +20,7 @@ p2p = [
   "client",
   "udp",
   "lightyear/deterministic",
+  "lightyear/p2p",
   "lightyear_examples_common/p2p",
 ]
 webtransport = ["lightyear_examples_common/webtransport"]

--- a/examples/avian_2d/README.md
+++ b/examples/avian_2d/README.md
@@ -47,6 +47,14 @@ enabled.*
 - Run the server without a gui: `cargo run --no-default-features --features=server -- server`
 - Run the client and server in "HostClient" mode, where the client also acts as server (both are in the same App) : `cargo run -- host-client -c 0`
 
+### P2P mode
+
+The example can also run as a deterministic input-only game with no server. Start peer 0 with
+`cargo run --no-default-features --features=p2p -- --headless p2p --peer-id 0 --player-count 2`
+and peer 1 with the same command using `--peer-id 1`. Every peer creates the same physics world,
+predicts all players, and rolls back both entity and Avian simulation state when remote input is
+late.
+
 You can control the behaviour of the example by changing the list of features. By default, all features are enabled (client, server, gui).
 For example you can run the server in headless mode (without gui) by running `cargo run --no-default-features --features=server,webtransport,netcode`.
 

--- a/examples/avian_2d/src/client.rs
+++ b/examples/avian_2d/src/client.rs
@@ -69,7 +69,10 @@ fn player_movement(
             &mut LinearVelocity,
             &ActionState<PlayerActions>,
         ),
-        (With<Predicted>, With<PlayerId>),
+        (
+            Or<(With<Predicted>, With<DeterministicPredicted>)>,
+            With<PlayerId>,
+        ),
     >,
 ) {
     let tick = timeline.tick();
@@ -119,12 +122,16 @@ fn handle_controlled_spawn(
     if player_query.get(trigger.entity).is_err() {
         return;
     };
-    commands.entity(trigger.entity).insert(InputMap::new([
+    commands.entity(trigger.entity).insert(player_input_map());
+}
+
+pub(crate) fn player_input_map() -> InputMap<PlayerActions> {
+    InputMap::new([
         (PlayerActions::Up, KeyCode::KeyW),
         (PlayerActions::Down, KeyCode::KeyS),
         (PlayerActions::Left, KeyCode::KeyA),
         (PlayerActions::Right, KeyCode::KeyD),
-    ]));
+    ])
 }
 
 // Lower the saturation on interpolated entities so they are visually distinct.

--- a/examples/avian_2d/src/main.rs
+++ b/examples/avian_2d/src/main.rs
@@ -3,6 +3,8 @@
 #![allow(dead_code)]
 #[cfg(feature = "client")]
 use crate::client::ExampleClientPlugin;
+#[cfg(feature = "p2p")]
+use crate::p2p::ExampleP2PPlugin;
 #[cfg(feature = "server")]
 use crate::server::ExampleServerPlugin;
 use crate::shared::SharedPlugin;
@@ -16,6 +18,8 @@ mod automation;
 #[cfg(feature = "client")]
 mod client;
 mod debug;
+#[cfg(feature = "p2p")]
+mod p2p;
 mod protocol;
 
 #[cfg(feature = "gui")]
@@ -34,10 +38,14 @@ fn main() {
     cli.spawn_connections(&mut app);
 
     match cli.mode {
-        #[cfg(feature = "client")]
+        #[cfg(all(feature = "client", any(not(feature = "p2p"), feature = "netcode")))]
         Some(Mode::Client { .. }) => {
             app.add_plugins(ExampleClientPlugin);
             add_input_delay(&mut app);
+        }
+        #[cfg(feature = "p2p")]
+        Some(Mode::P2P { .. }) => {
+            app.add_plugins((ExampleClientPlugin, ExampleP2PPlugin));
         }
         #[cfg(feature = "server")]
         Some(Mode::Server) => {

--- a/examples/avian_2d/src/p2p.rs
+++ b/examples/avian_2d/src/p2p.rs
@@ -20,6 +20,9 @@ use crate::shared::color_from_id;
 
 const PLAYER_INPUT_HASH_BASE: u64 = 0x4156_3244_0000_0000;
 
+#[derive(Component)]
+struct PendingLocalInput(Tick);
+
 pub struct ExampleP2PPlugin;
 
 impl Plugin for ExampleP2PPlugin {
@@ -29,6 +32,10 @@ impl Plugin for ExampleP2PPlugin {
         app.add_systems(
             FixedPreUpdate,
             spawn_fixed_world.before(InputSystems::BufferClientInputs),
+        );
+        app.add_systems(
+            FixedPostUpdate,
+            enable_local_input.after(PredictionSystems::UpdateHistory),
         );
     }
 }
@@ -88,7 +95,26 @@ fn spawn_fixed_world(
             ))
             .id();
         if peer_id == settings.local_peer_id {
-            commands.entity(player).insert(player_input_map());
+            commands
+                .entity(player)
+                .insert(PendingLocalInput(timeline.tick()));
         }
+    }
+}
+
+/// Enable local input after the initial Avian rollback state has been recorded.
+fn enable_local_input(
+    mut commands: Commands,
+    timeline: Res<LocalTimeline>,
+    local_players: Query<(Entity, &PendingLocalInput)>,
+) {
+    for (entity, pending) in &local_players {
+        if timeline.tick() <= pending.0 {
+            continue;
+        }
+        commands
+            .entity(entity)
+            .insert(player_input_map())
+            .remove::<PendingLocalInput>();
     }
 }

--- a/examples/avian_2d/src/p2p.rs
+++ b/examples/avian_2d/src/p2p.rs
@@ -1,0 +1,94 @@
+//! Deterministic input-only P2P setup for the Avian 2D example.
+
+use avian2d::prelude::*;
+use bevy::color::palettes::css;
+use bevy::prelude::*;
+use leafwing_input_manager::prelude::ActionState;
+use lightyear::prediction::rollback::DeterministicPredicted;
+use lightyear::prelude::input::client::InputSystems;
+use lightyear::prelude::input::leafwing::LeafwingBuffer;
+use lightyear::prelude::*;
+use lightyear_deterministic_replication::prelude::DeterministicReplicationPlugin;
+use lightyear_examples_common::p2p::{
+    input_target_for_peer, P2PGameplayStarted, P2PSettings, GAMEPLAY_START_TICK,
+};
+use lightyear_frame_interpolation::FrameInterpolate;
+
+use crate::client::player_input_map;
+use crate::protocol::*;
+use crate::shared::color_from_id;
+
+const PLAYER_INPUT_HASH_BASE: u64 = 0x4156_3244_0000_0000;
+
+pub struct ExampleP2PPlugin;
+
+impl Plugin for ExampleP2PPlugin {
+    fn build(&self, app: &mut App) {
+        app.insert_resource(PredictionManager::default());
+        app.add_plugins(DeterministicReplicationPlugin);
+        app.add_systems(
+            FixedPreUpdate,
+            spawn_fixed_world.before(InputSystems::BufferClientInputs),
+        );
+    }
+}
+
+fn spawn_fixed_world(
+    mut commands: Commands,
+    _synced: SyncedInputTimeline,
+    timeline: Res<LocalTimeline>,
+    started: Option<Res<P2PGameplayStarted>>,
+    settings: Res<P2PSettings>,
+    links: Query<(Entity, &RemoteId), With<P2P>>,
+) {
+    if started.is_some() || timeline.tick().0 < GAMEPLAY_START_TICK {
+        return;
+    }
+    commands.insert_resource(P2PGameplayStarted);
+
+    commands.spawn((
+        Position::default(),
+        ColorComponent(css::AZURE.into()),
+        PhysicsBundle::ball(),
+        BallMarker,
+        DeterministicPredicted {
+            skip_despawn: true,
+            enable_rollback_after: 0,
+        },
+        FrameInterpolate,
+        Name::from("P2P Ball"),
+    ));
+
+    let spacing = 100.0;
+    let center = (f32::from(settings.player_count) - 1.0) * 0.5;
+    for peer_id in settings.peer_ids() {
+        let id = PeerId::Entity(u64::from(peer_id));
+        let target = input_target_for_peer(
+            &settings,
+            &links,
+            peer_id,
+            PLAYER_INPUT_HASH_BASE | u64::from(peer_id),
+        );
+        let player = commands
+            .spawn((
+                PlayerId(id),
+                Position::from(Vec2::new(-50.0, (f32::from(peer_id) - center) * spacing)),
+                Rotation::radians(0.15),
+                AngularVelocity(0.35),
+                ColorComponent(color_from_id(id)),
+                PhysicsBundle::player(),
+                DeterministicPredicted {
+                    skip_despawn: true,
+                    enable_rollback_after: 0,
+                },
+                target,
+                LeafwingBuffer::<PlayerActions>::default(),
+                FrameInterpolate,
+                Name::from("P2P Player"),
+            ))
+            .id();
+        if peer_id == settings.local_peer_id {
+            commands.entity(player).insert(player_input_map());
+        }
+    }
+}

--- a/examples/avian_2d/src/shared.rs
+++ b/examples/avian_2d/src/shared.rs
@@ -49,6 +49,13 @@ pub struct SharedPlugin;
 
 impl Plugin for SharedPlugin {
     fn build(&self, app: &mut App) {
+        #[cfg(feature = "p2p")]
+        let rollback_resources = app
+            .world()
+            .contains_resource::<lightyear_examples_common::p2p::P2PSettings>();
+        #[cfg(not(feature = "p2p"))]
+        let rollback_resources = false;
+
         app.add_plugins(ProtocolPlugin);
         app.add_observer(spawn_player_child_collider);
         // bundles
@@ -59,6 +66,7 @@ impl Plugin for SharedPlugin {
             replication_mode: AvianReplicationMode::Position {
                 sync_to_transform: false,
             },
+            rollback_resources,
             ..default()
         });
         app.add_plugins(

--- a/examples/avian_3d/Cargo.toml
+++ b/examples/avian_3d/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 publish = false
 
 [features]
-default = ["client", "gui", "server", "netcode", "webtransport"]
+default = ["client", "gui", "server", "p2p", "netcode", "webtransport"]
 client = ["lightyear/client", "lightyear_examples_common/client"]
 gui = ["lightyear_examples_common/gui3d"]
 server = [
@@ -16,6 +16,12 @@ server = [
   "lightyear_examples_common/server",
 ]
 netcode = ["lightyear_examples_common/netcode"]
+p2p = [
+  "client",
+  "udp",
+  "lightyear/deterministic",
+  "lightyear_examples_common/p2p",
+]
 webtransport = ["lightyear_examples_common/webtransport"]
 udp = ["lightyear_examples_common/udp", "lightyear/std", "lightyear/udp"]
 
@@ -28,6 +34,7 @@ lightyear = { workspace = true, features = [
   "avian3d",
 ] }
 lightyear_frame_interpolation.workspace = true
+lightyear_deterministic_replication.workspace = true
 lightyear_examples_common = { workspace = true, features = [
   "structured-debug",
 ] }

--- a/examples/avian_3d/Cargo.toml
+++ b/examples/avian_3d/Cargo.toml
@@ -20,6 +20,7 @@ p2p = [
   "client",
   "udp",
   "lightyear/deterministic",
+  "lightyear/p2p",
   "lightyear_examples_common/p2p",
 ]
 webtransport = ["lightyear_examples_common/webtransport"]

--- a/examples/avian_3d/README.md
+++ b/examples/avian_3d/README.md
@@ -27,6 +27,14 @@ https://github.com/user-attachments/assets/4e0eb373-2f46-4c48-8157-46e1e5085097
 - Run the server without a gui: `cargo run --no-default-features --features=server -- server`
 - Run the client and server in "HostClient" mode, where the client also acts as server (both are in the same App) : `cargo run -- host-client -c 0`
 
+### P2P mode
+
+The example can also run as a deterministic input-only game with no server. Start peer 0 with
+`cargo run --no-default-features --features=p2p -- --headless p2p --peer-id 0 --player-count 2`
+and peer 1 with the same command using `--peer-id 1`. Characters, the dynamic block, and
+projectiles are created and simulated by every peer, with Avian simulation state included in
+rollback.
+
 You can control the behaviour of the example by changing the list of features. By default, all features are enabled (client, server, gui).
 For example you can run the server in headless mode (without gui) by running `cargo run --no-default-features --features=server,webtransport,netcode`.
 

--- a/examples/avian_3d/src/client.rs
+++ b/examples/avian_3d/src/client.rs
@@ -34,7 +34,7 @@ fn handle_character_actions(
     spatial_query: SpatialQuery,
     mut query: Query<
         (Entity, &ComputedMass, &ActionState<CharacterAction>, Forces),
-        With<Predicted>,
+        Or<(With<Predicted>, With<DeterministicPredicted>)>,
     >,
     // In host-server mode, the server portion is already applying the
     // character actions and so we don't want to apply the character
@@ -84,13 +84,15 @@ fn handle_controlled_character(
         return;
     };
     info!("Adding InputMap to controlled character {entity:?}");
-    commands.entity(entity).insert(
-        InputMap::new([(CharacterAction::Jump, KeyCode::Space)])
-            .with(CharacterAction::Jump, GamepadButton::South)
-            .with(CharacterAction::Shoot, KeyCode::KeyQ)
-            .with_dual_axis(CharacterAction::Move, GamepadStick::LEFT)
-            .with_dual_axis(CharacterAction::Move, VirtualDPad::wasd()),
-    );
+    commands.entity(entity).insert(character_input_map());
+}
+
+pub(crate) fn character_input_map() -> InputMap<CharacterAction> {
+    InputMap::new([(CharacterAction::Jump, KeyCode::Space)])
+        .with(CharacterAction::Jump, GamepadButton::South)
+        .with(CharacterAction::Shoot, KeyCode::KeyQ)
+        .with_dual_axis(CharacterAction::Move, GamepadStick::LEFT)
+        .with_dual_axis(CharacterAction::Move, VirtualDPad::wasd())
 }
 
 /// Add physics to floors that are newly replicated. The query checks for

--- a/examples/avian_3d/src/main.rs
+++ b/examples/avian_3d/src/main.rs
@@ -9,6 +9,8 @@ use lightyear_examples_common::shared::FIXED_TIMESTEP_HZ;
 
 #[cfg(feature = "client")]
 use crate::client::ExampleClientPlugin;
+#[cfg(feature = "p2p")]
+use crate::p2p::ExampleP2PPlugin;
 #[cfg(feature = "server")]
 use crate::server::ExampleServerPlugin;
 use crate::shared::SharedPlugin;
@@ -16,6 +18,8 @@ mod automation;
 #[cfg(feature = "client")]
 mod client;
 mod debug;
+#[cfg(feature = "p2p")]
+mod p2p;
 mod protocol;
 #[cfg(feature = "gui")]
 mod renderer;
@@ -34,10 +38,14 @@ fn main() {
     cli.spawn_connections(&mut app);
 
     match cli.mode {
-        #[cfg(feature = "client")]
+        #[cfg(all(feature = "client", any(not(feature = "p2p"), feature = "netcode")))]
         Some(Mode::Client { .. }) => {
             app.add_plugins(ExampleClientPlugin);
             add_input_delay(&mut app);
+        }
+        #[cfg(feature = "p2p")]
+        Some(Mode::P2P { .. }) => {
+            app.add_plugins((ExampleClientPlugin, ExampleP2PPlugin));
         }
         #[cfg(feature = "server")]
         Some(Mode::Server) => {

--- a/examples/avian_3d/src/p2p.rs
+++ b/examples/avian_3d/src/p2p.rs
@@ -1,0 +1,137 @@
+//! Deterministic input-only P2P setup for the Avian 3D character example.
+
+use avian3d::prelude::*;
+use bevy::prelude::*;
+use leafwing_input_manager::prelude::ActionState;
+use lightyear::prediction::rollback::DeterministicPredicted;
+use lightyear::prelude::input::client::InputSystems;
+use lightyear::prelude::input::leafwing::LeafwingBuffer;
+use lightyear::prelude::*;
+use lightyear_deterministic_replication::prelude::DeterministicReplicationPlugin;
+use lightyear_examples_common::p2p::{
+    input_target_for_peer, P2PGameplayStarted, P2PSettings, GAMEPLAY_START_TICK,
+};
+
+use crate::client::character_input_map;
+use crate::protocol::*;
+use crate::shared::{
+    color_from_id, BlockPhysicsBundle, CharacterPhysicsBundle, FloorPhysicsBundle,
+    ProjectilePhysicsBundle,
+};
+
+const PLAYER_INPUT_HASH_BASE: u64 = 0x4156_3344_0000_0000;
+const PROJECTILE_LIFETIME_TICKS: i32 = 120;
+
+#[derive(Component)]
+struct DespawnAt(Tick);
+
+pub struct ExampleP2PPlugin;
+
+impl Plugin for ExampleP2PPlugin {
+    fn build(&self, app: &mut App) {
+        app.insert_resource(PredictionManager::default());
+        app.add_plugins(DeterministicReplicationPlugin);
+        app.add_systems(
+            FixedPreUpdate,
+            spawn_fixed_world.before(InputSystems::BufferClientInputs),
+        );
+        app.add_systems(FixedUpdate, (shoot, despawn_projectiles));
+    }
+}
+
+fn spawn_fixed_world(
+    mut commands: Commands,
+    _synced: SyncedInputTimeline,
+    timeline: Res<LocalTimeline>,
+    started: Option<Res<P2PGameplayStarted>>,
+    settings: Res<P2PSettings>,
+    links: Query<(Entity, &RemoteId), With<P2P>>,
+) {
+    if started.is_some() || timeline.tick().0 < GAMEPLAY_START_TICK {
+        return;
+    }
+    commands.insert_resource(P2PGameplayStarted);
+
+    commands.spawn((
+        Name::new("P2P Floor"),
+        FloorPhysicsBundle::default(),
+        FloorMarker,
+        Position::new(Vec3::ZERO),
+    ));
+    commands.spawn((
+        Name::new("P2P Block"),
+        BlockPhysicsBundle::default(),
+        BlockMarker,
+        Position::new(Vec3::new(1.0, 1.0, 0.0)),
+        DeterministicPredicted {
+            skip_despawn: true,
+            enable_rollback_after: 0,
+        },
+    ));
+
+    let spacing = 2.0;
+    let center = (f32::from(settings.player_count) - 1.0) * 0.5;
+    for peer_id in settings.peer_ids() {
+        let id = PeerId::Entity(u64::from(peer_id));
+        let target = input_target_for_peer(
+            &settings,
+            &links,
+            peer_id,
+            PLAYER_INPUT_HASH_BASE | u64::from(peer_id),
+        );
+        let character = commands
+            .spawn((
+                Name::new("P2P Character"),
+                Position(Vec3::new((f32::from(peer_id) - center) * spacing, 3.0, 0.0)),
+                CharacterPhysicsBundle::default(),
+                ColorComponent(color_from_id(id)),
+                CharacterMarker,
+                DeterministicPredicted {
+                    skip_despawn: true,
+                    enable_rollback_after: 0,
+                },
+                target,
+                LeafwingBuffer::<CharacterAction>::default(),
+            ))
+            .id();
+        if peer_id == settings.local_peer_id {
+            commands.entity(character).insert(character_input_map());
+        }
+    }
+}
+
+fn shoot(
+    mut commands: Commands,
+    timeline: Res<LocalTimeline>,
+    players: Query<(&ActionState<CharacterAction>, &Position), With<CharacterMarker>>,
+) {
+    let tick = timeline.tick();
+    for (action, position) in &players {
+        if !action.just_pressed(&CharacterAction::Shoot) {
+            continue;
+        }
+        commands.spawn((
+            Name::new("P2P Projectile"),
+            ProjectileMarker,
+            ProjectilePhysicsBundle::default(),
+            *position,
+            Rotation::default(),
+            LinearVelocity(Vec3::Z * 10.0),
+            DespawnAt(tick + PROJECTILE_LIFETIME_TICKS),
+            DeterministicPredicted::default(),
+        ));
+    }
+}
+
+fn despawn_projectiles(
+    mut commands: Commands,
+    timeline: Res<LocalTimeline>,
+    projectiles: Query<(Entity, &DespawnAt)>,
+) {
+    let tick = timeline.tick();
+    for (entity, despawn) in &projectiles {
+        if tick >= despawn.0 {
+            commands.entity(entity).prediction_despawn();
+        }
+    }
+}

--- a/examples/avian_3d/src/p2p.rs
+++ b/examples/avian_3d/src/p2p.rs
@@ -25,6 +25,10 @@ const PROJECTILE_LIFETIME_TICKS: i32 = 120;
 #[derive(Component)]
 struct DespawnAt(Tick);
 
+/// Marks the local character until its input map can be enabled after the first physics snapshot.
+#[derive(Component)]
+struct PendingLocalInput(Tick);
+
 pub struct ExampleP2PPlugin;
 
 impl Plugin for ExampleP2PPlugin {
@@ -34,6 +38,10 @@ impl Plugin for ExampleP2PPlugin {
         app.add_systems(
             FixedPreUpdate,
             spawn_fixed_world.before(InputSystems::BufferClientInputs),
+        );
+        app.add_systems(
+            FixedPostUpdate,
+            enable_local_input.after(PredictionSystems::UpdateHistory),
         );
         app.add_systems(FixedUpdate, (shoot, despawn_projectiles));
     }
@@ -95,8 +103,34 @@ fn spawn_fixed_world(
             ))
             .id();
         if peer_id == settings.local_peer_id {
-            commands.entity(character).insert(character_input_map());
+            commands
+                .entity(character)
+                .insert(PendingLocalInput(timeline.tick()));
         }
+    }
+}
+
+/// Enable input capture only after Avian and Lightyear have recorded the world's initial state.
+///
+/// The fixed world and its collider-tree proxies are created together at
+/// [`GAMEPLAY_START_TICK`]. Enabling input in the same tick would allow a late first input to roll
+/// back before the first complete physics snapshot, leaving live colliders paired with an empty
+/// restored collider tree. Waiting one complete warm-up tick makes the earliest possible input
+/// rollback target a world snapshot from after initialization. It also lets the per-collider
+/// rollback histories installed by Avian's observers record their initial proxy state.
+fn enable_local_input(
+    mut commands: Commands,
+    timeline: Res<LocalTimeline>,
+    local_characters: Query<(Entity, &PendingLocalInput)>,
+) {
+    for (entity, pending) in &local_characters {
+        if timeline.tick() <= pending.0 {
+            continue;
+        }
+        commands
+            .entity(entity)
+            .insert(character_input_map())
+            .remove::<PendingLocalInput>();
     }
 }
 

--- a/examples/avian_3d/src/renderer.rs
+++ b/examples/avian_3d/src/renderer.rs
@@ -73,7 +73,13 @@ fn add_visual_interpolation_components(
     // We use Position because it's added by avian later, and when it's added
     // we know that Predicted is already present on the entity
     trigger: On<Add, Position>,
-    query: Query<Entity, (With<Predicted>, Without<FloorMarker>)>,
+    query: Query<
+        Entity,
+        (
+            Or<(With<Predicted>, With<DeterministicPredicted>)>,
+            Without<FloorMarker>,
+        ),
+    >,
     clients: Query<(), With<Client>>,
     mut commands: Commands,
 ) {
@@ -93,7 +99,12 @@ fn add_character_cosmetics(
     character_query: Query<
         (Entity, &ColorComponent),
         (
-            Or<(Added<Predicted>, Added<Replicate>, Added<Interpolated>)>,
+            Or<(
+                Added<Predicted>,
+                Added<Replicate>,
+                Added<Interpolated>,
+                Added<DeterministicPredicted>,
+            )>,
             With<CharacterMarker>,
         ),
     >,
@@ -120,7 +131,11 @@ fn add_character_child_cosmetics(
         (),
         (
             With<CharacterMarker>,
-            Or<(With<Predicted>, With<Replicate>)>,
+            Or<(
+                With<Predicted>,
+                With<Replicate>,
+                With<DeterministicPredicted>,
+            )>,
         ),
     >,
     mut meshes: ResMut<Assets<Mesh>>,
@@ -140,22 +155,30 @@ fn add_character_child_cosmetics(
 fn add_projectile_cosmetics(
     mut commands: Commands,
     character_query: Query<
-        Entity,
+        (Entity, Has<RigidBody>),
         (
-            Or<(Added<Predicted>, Added<Replicate>)>,
+            Or<(
+                Added<Predicted>,
+                Added<Replicate>,
+                Added<DeterministicPredicted>,
+            )>,
             With<ProjectileMarker>,
         ),
     >,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
-    for entity in &character_query {
+    for (entity, has_physics) in &character_query {
         info!(?entity, "Adding cosmetics to projectile {:?}", entity);
         commands.entity(entity).insert((
             Mesh3d(meshes.add(Sphere::new(PROJECTILE_RADIUS))),
             MeshMaterial3d(materials.add(Color::from(MAGENTA))),
-            ProjectilePhysicsBundle::default(),
         ));
+        if !has_physics {
+            commands
+                .entity(entity)
+                .insert(ProjectilePhysicsBundle::default());
+        }
     }
 }
 
@@ -181,7 +204,17 @@ fn add_floor_cosmetics(
 /// see the predicted block and not the confirmed block.
 fn add_block_cosmetics(
     mut commands: Commands,
-    floor_query: Query<Entity, (Or<(Added<Predicted>, Added<Replicate>)>, With<BlockMarker>)>,
+    floor_query: Query<
+        Entity,
+        (
+            Or<(
+                Added<Predicted>,
+                Added<Replicate>,
+                Added<DeterministicPredicted>,
+            )>,
+            With<BlockMarker>,
+        ),
+    >,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {

--- a/examples/avian_3d/src/shared.rs
+++ b/examples/avian_3d/src/shared.rs
@@ -144,6 +144,13 @@ pub struct SharedPlugin;
 
 impl Plugin for SharedPlugin {
     fn build(&self, app: &mut App) {
+        #[cfg(feature = "p2p")]
+        let rollback_resources = app
+            .world()
+            .contains_resource::<lightyear_examples_common::p2p::P2PSettings>();
+        #[cfg(not(feature = "p2p"))]
+        let rollback_resources = false;
+
         app.add_plugins(ProtocolPlugin);
         app.add_observer(spawn_character_child_collider);
 
@@ -152,6 +159,7 @@ impl Plugin for SharedPlugin {
             replication_mode: AvianReplicationMode::Position {
                 sync_to_transform: false,
             },
+            rollback_resources,
             ..default()
         });
         app.add_plugins(

--- a/examples/bevy_enhanced_inputs/Cargo.toml
+++ b/examples/bevy_enhanced_inputs/Cargo.toml
@@ -12,11 +12,18 @@ license = "MIT OR Apache-2.0"
 publish = false
 
 [features]
-default = ["client", "gui", "server", "netcode", "webtransport"]
+default = ["client", "gui", "server", "p2p", "netcode", "webtransport"]
 client = ["lightyear/client", "lightyear_examples_common/client"]
 gui = ["lightyear_examples_common/gui2d"]
 server = ["lightyear/server", "lightyear_examples_common/server"]
 netcode = ["lightyear_examples_common/netcode"]
+p2p = [
+  "client",
+  "udp",
+  "lightyear/deterministic",
+  "lightyear/p2p",
+  "lightyear_examples_common/p2p",
+]
 webtransport = ["lightyear_examples_common/webtransport"]
 udp = [
   "lightyear_examples_common/udp",
@@ -34,6 +41,7 @@ lightyear = { "workspace" = true, features = [
   "input_bei",
 ] }
 bevy_enhanced_input.workspace = true
+lightyear_deterministic_replication.workspace = true
 lightyear_examples_common = { workspace = true, features = [
   "structured-debug",
 ] }

--- a/examples/bevy_enhanced_inputs/README.md
+++ b/examples/bevy_enhanced_inputs/README.md
@@ -16,6 +16,14 @@ https://github.com/cBournhonesque/lightyear/assets/8112632/7b57d48a-d8b0-4cdd-a1
 You can control the behaviour of the example by changing the list of features. By default, all features are enabled (client, server, gui).
 For example you can run the server in headless mode (without gui) by running `cargo run --no-default-features --features=server,webtransport,netcode`.
 
+### P2P mode
+
+The same movement example can run without a server. Every peer creates the fixed player roster and
+BEI action entities locally, then sends its action inputs directly to every other peer.
+
+- Peer 0: `cargo run --no-default-features --features=p2p -- --headless p2p --peer-id 0 --player-count 2`
+- Peer 1: `cargo run --no-default-features --features=p2p -- --headless p2p --peer-id 1 --player-count 2`
+
 ### Testing in wasm with webtransport
 
 NOTE: I am using the [bevy cli](https://github.com/TheBevyFlock/bevy_cli) to build and serve the wasm example.

--- a/examples/bevy_enhanced_inputs/src/client.rs
+++ b/examples/bevy_enhanced_inputs/src/client.rs
@@ -13,6 +13,7 @@ use bevy::prelude::*;
 #[cfg(feature = "server")]
 use lightyear::connection::host::HostServer;
 use lightyear::input::bei::prelude::{Action, ActionOf, Actions, Bindings, Cardinal, Fire};
+use lightyear::prediction::rollback::DeterministicPredicted;
 use lightyear::prelude::client::{InputDelayConfig, InputTimelineConfig};
 use lightyear::prelude::*;
 
@@ -43,7 +44,10 @@ fn player_movement(
     trigger: On<Fire<Movement>>,
     _input_timeline: SyncedInputTimeline,
     #[cfg(feature = "server")] host_server: Query<(), With<HostServer>>,
-    mut position_query: Query<&mut PlayerPosition, With<Predicted>>,
+    mut position_query: Query<
+        &mut PlayerPosition,
+        Or<(With<Predicted>, With<DeterministicPredicted>)>,
+    >,
 ) {
     #[cfg(feature = "server")]
     if !host_server.is_empty() {

--- a/examples/bevy_enhanced_inputs/src/debug.rs
+++ b/examples/bevy_enhanced_inputs/src/debug.rs
@@ -72,10 +72,18 @@ pub(crate) mod client {
 
     pub(crate) fn mark_debug_players(
         mut commands: Commands,
-        query: Query<(Entity, Has<Predicted>, Has<Interpolated>), Added<PlayerId>>,
+        query: Query<
+            (
+                Entity,
+                Has<Predicted>,
+                Has<Interpolated>,
+                Has<DeterministicPredicted>,
+            ),
+            Added<PlayerId>,
+        >,
     ) {
-        for (entity, predicted, interpolated) in &query {
-            if predicted || interpolated {
+        for (entity, predicted, interpolated, deterministic) in &query {
+            if predicted || interpolated || deterministic {
                 commands.entity(entity).insert(
                     LightyearDebug::component_at::<PlayerPosition>([DebugSamplePoint::Update])
                         .with_component_at::<PlayerId>([DebugSamplePoint::Update]),

--- a/examples/bevy_enhanced_inputs/src/lib.rs
+++ b/examples/bevy_enhanced_inputs/src/lib.rs
@@ -5,6 +5,9 @@ pub mod automation;
 #[cfg(feature = "client")]
 pub mod client;
 
+#[cfg(feature = "p2p")]
+pub mod p2p;
+
 pub mod debug;
 
 #[cfg(feature = "server")]

--- a/examples/bevy_enhanced_inputs/src/main.rs
+++ b/examples/bevy_enhanced_inputs/src/main.rs
@@ -13,6 +13,8 @@
 
 #[cfg(feature = "client")]
 use crate::client::ExampleClientPlugin;
+#[cfg(feature = "p2p")]
+use crate::p2p::ExampleP2PPlugin;
 #[cfg(feature = "server")]
 use crate::server::ExampleServerPlugin;
 use crate::shared::SharedPlugin;
@@ -26,6 +28,8 @@ use lightyear_examples_common::shared::{FIXED_TIMESTEP_HZ, SEND_INTERVAL};
 #[cfg(feature = "client")]
 mod client;
 mod debug;
+#[cfg(feature = "p2p")]
+mod p2p;
 mod protocol;
 #[cfg(feature = "gui")]
 mod renderer;
@@ -46,9 +50,14 @@ fn main() {
     cli.spawn_connections(&mut app);
 
     match cli.mode {
-        #[cfg(feature = "client")]
+        #[cfg(all(feature = "client", any(not(feature = "p2p"), feature = "netcode")))]
         Some(Mode::Client { .. }) => {
             app.add_plugins(ExampleClientPlugin);
+            add_input_delay(&mut app);
+        }
+        #[cfg(feature = "p2p")]
+        Some(Mode::P2P { .. }) => {
+            app.add_plugins((ExampleClientPlugin, ExampleP2PPlugin));
             add_input_delay(&mut app);
         }
         #[cfg(feature = "server")]

--- a/examples/bevy_enhanced_inputs/src/p2p.rs
+++ b/examples/bevy_enhanced_inputs/src/p2p.rs
@@ -1,0 +1,94 @@
+//! Direct P2P setup for the Bevy Enhanced Input example.
+//!
+//! Player contexts and their action entities are created locally in the same stable roster order
+//! on every peer. The action entity carries the stable input-wire identity because BEI input
+//! messages target actions rather than their player context.
+
+use crate::protocol::{Movement, Player, PlayerColor, PlayerId, PlayerPosition};
+use crate::shared;
+use bevy::prelude::*;
+use bevy_enhanced_input::context::ExternallyMocked;
+use lightyear::input::bei::prelude::{
+    Action, ActionOf, BEIBuffer, Bindings, Cardinal, InputMarker,
+};
+use lightyear::prediction::rollback::DeterministicPredicted;
+use lightyear::prelude::input::client::InputSystems;
+use lightyear::prelude::*;
+use lightyear_deterministic_replication::prelude::DeterministicReplicationPlugin;
+use lightyear_examples_common::p2p::{
+    input_target_for_peer, P2PGameplayStarted, P2PSettings, GAMEPLAY_START_TICK,
+};
+
+/// Namespace for stable BEI action hashes on the input wire.
+const MOVEMENT_INPUT_HASH_BASE: u64 = 0x4245_495F_4D4F_0000;
+
+pub struct ExampleP2PPlugin;
+
+impl Plugin for ExampleP2PPlugin {
+    fn build(&self, app: &mut App) {
+        app.insert_resource(PredictionManager::default());
+        app.add_plugins(DeterministicReplicationPlugin);
+        app.add_systems(
+            FixedPreUpdate,
+            spawn_fixed_roster.before(InputSystems::BufferClientInputs),
+        );
+    }
+}
+
+fn spawn_fixed_roster(
+    mut commands: Commands,
+    _synced: SyncedInputTimeline,
+    timeline: Res<LocalTimeline>,
+    started: Option<Res<P2PGameplayStarted>>,
+    settings: Res<P2PSettings>,
+    links: Query<(Entity, &RemoteId), With<P2P>>,
+) {
+    if started.is_some() || timeline.tick().0 < GAMEPLAY_START_TICK {
+        return;
+    }
+    commands.insert_resource(P2PGameplayStarted);
+
+    for peer_id in settings.peer_ids() {
+        let id = PeerId::Entity(u64::from(peer_id));
+        let player = commands
+            .spawn((
+                Player,
+                PlayerId(id),
+                PlayerPosition(shared::initial_player_position(id)),
+                PlayerColor(shared::color_from_id(id)),
+                DeterministicPredicted {
+                    skip_despawn: true,
+                    enable_rollback_after: 0,
+                },
+                Name::new(format!("P2P Player {peer_id}")),
+            ))
+            .id();
+        if peer_id == settings.local_peer_id {
+            commands.entity(player).insert(Controlled);
+        }
+
+        let input_target = input_target_for_peer(
+            &settings,
+            &links,
+            peer_id,
+            MOVEMENT_INPUT_HASH_BASE | u64::from(peer_id),
+        );
+        let action = commands
+            .spawn((
+                ActionOf::<Player>::new(player),
+                Action::<Movement>::new(),
+                BEIBuffer::<Player>::default(),
+                input_target,
+                Name::new(format!("P2P Movement {peer_id}")),
+            ))
+            .id();
+        if peer_id == settings.local_peer_id {
+            commands.entity(action).insert((
+                Bindings::spawn(Cardinal::wasd_keys()),
+                InputMarker::<Player>::default(),
+            ));
+        } else {
+            commands.entity(action).insert(ExternallyMocked);
+        }
+    }
+}

--- a/examples/bevy_enhanced_inputs/src/server.rs
+++ b/examples/bevy_enhanced_inputs/src/server.rs
@@ -54,17 +54,13 @@ pub(crate) fn handle_connected(
         return;
     };
     let client_id = client_id.0;
-    // Generate pseudo random color from client id.
-    let h = (((client_id.to_bits().wrapping_mul(30)) % 360) as f32) / 360.0;
-    let s = 0.8;
-    let l = 0.5;
-    let color = Color::hsl(h, s, l);
+    let color = shared::color_from_id(client_id);
     let player_entity = commands
         .spawn((
             // Add the context component on the server; it will be replicated to the client
             Player,
             PlayerId(client_id),
-            PlayerPosition(initial_player_position(client_id)),
+            PlayerPosition(shared::initial_player_position(client_id)),
             PlayerColor(color),
             // we replicate the Player entity to all clients that are connected to this server
             Replicate::to_clients(NetworkTarget::All),
@@ -81,11 +77,6 @@ pub(crate) fn handle_connected(
         player_entity, client_id
     );
     spawn_action_entities(&mut commands, player_entity);
-}
-
-fn initial_player_position(client_id: PeerId) -> Vec2 {
-    let slot = (client_id.to_bits() % 6) as f32;
-    Vec2::new((slot - 2.5) * 90.0, 0.0)
 }
 
 /// Spawn the BEI action entities for a player.

--- a/examples/bevy_enhanced_inputs/src/shared.rs
+++ b/examples/bevy_enhanced_inputs/src/shared.rs
@@ -4,6 +4,7 @@
 //! mispredictions/rollbacks.
 use crate::protocol::*;
 use bevy::prelude::*;
+use lightyear::prelude::PeerId;
 use lightyear_examples_common::shared::SharedSettings;
 
 pub struct SharedPlugin;
@@ -19,6 +20,16 @@ pub const SHARED_SETTINGS: SharedSettings = SharedSettings {
     protocol_id: 0,
     private_key: [0; 32],
 };
+
+pub(crate) fn initial_player_position(peer_id: PeerId) -> Vec2 {
+    let slot = (peer_id.to_bits() % 6) as f32;
+    Vec2::new((slot - 2.5) * 90.0, 0.0)
+}
+
+pub(crate) fn color_from_id(peer_id: PeerId) -> Color {
+    let h = (((peer_id.to_bits().wrapping_mul(30)) % 360) as f32) / 360.0;
+    Color::hsl(h, 0.8, 0.5)
+}
 
 // Applies movement input to a player position.
 pub(crate) fn shared_movement_behaviour(mut position: Mut<PlayerPosition>, input: Vec2) {

--- a/examples/common/Cargo.toml
+++ b/examples/common/Cargo.toml
@@ -15,6 +15,7 @@ exclude = ["/tests"]
 default = ["client", "server", "netcode", "webtransport"]
 client = ["lightyear/client"]
 server = ["lightyear/server"]
+p2p = ["client", "udp", "lightyear/raw_connection"]
 netcode = ["lightyear/netcode"]
 webtransport = [
   "lightyear/webtransport",

--- a/examples/common/Cargo.toml
+++ b/examples/common/Cargo.toml
@@ -15,7 +15,7 @@ exclude = ["/tests"]
 default = ["client", "server", "netcode", "webtransport"]
 client = ["lightyear/client"]
 server = ["lightyear/server"]
-p2p = ["client", "udp", "lightyear/raw_connection"]
+p2p = ["client", "udp", "lightyear/p2p", "lightyear/raw_connection"]
 netcode = ["lightyear/netcode"]
 webtransport = [
   "lightyear/webtransport",

--- a/examples/common/src/cli.rs
+++ b/examples/common/src/cli.rs
@@ -5,6 +5,11 @@
 
 use core::str::FromStr;
 use core::time::Duration;
+#[cfg(feature = "p2p")]
+use core::{
+    net::{Ipv4Addr, SocketAddr},
+    ops::Range,
+};
 
 use bevy::log::{Level, LogPlugin};
 use bevy::prelude::*;
@@ -14,7 +19,7 @@ use bevy::diagnostic::DiagnosticsPlugin;
 use bevy::state::app::StatesPlugin;
 use clap::{ArgAction, Parser, Subcommand};
 
-#[cfg(feature = "client")]
+#[cfg(all(feature = "client", any(not(feature = "p2p"), feature = "netcode")))]
 use crate::client::{ClientTransports, ExampleClient, connect};
 #[cfg(all(any(feature = "gui2d", feature = "gui3d"), feature = "client"))]
 use crate::client_renderer::ExampleClientRendererPlugin;
@@ -32,6 +37,33 @@ use {
     bevy::window::PresentMode,
     bevy::winit::{UpdateMode, WinitSettings},
 };
+
+#[cfg(feature = "p2p")]
+const MAX_P2P_PLAYERS: u8 = 4;
+#[cfg(feature = "p2p")]
+const DEFAULT_P2P_BASE_PORT: u16 = 6000;
+
+/// Fixed roster used by an example running in direct P2P mode.
+///
+/// The initial example transport assigns compact numeric peer identities. Iroh can replace the
+/// transport-specific identity construction later without changing the topology or game setup.
+#[cfg(feature = "p2p")]
+#[derive(Resource, Clone, Copy, Debug, PartialEq, Eq)]
+pub struct P2PSettings {
+    pub local_peer_id: u8,
+    pub player_count: u8,
+}
+
+#[cfg(feature = "p2p")]
+impl P2PSettings {
+    pub fn peer_ids(&self) -> Range<u8> {
+        0..self.player_count
+    }
+
+    pub fn local_id(&self) -> PeerId {
+        PeerId::Entity(u64::from(self.local_peer_id))
+    }
+}
 
 fn parse_bool_arg(value: &str) -> Result<bool, String> {
     if value.eq_ignore_ascii_case("true") {
@@ -64,7 +96,7 @@ pub struct Cli {
     pub mode: Option<Mode>,
 }
 
-#[cfg(feature = "client")]
+#[cfg(all(feature = "client", any(not(feature = "p2p"), feature = "netcode")))]
 fn default_client_transport() -> ClientTransports {
     ClientTransports::WebTransport
 }
@@ -81,12 +113,14 @@ impl Cli {
     /// Get the client id from the CLI
     pub fn client_id(&self) -> Option<u64> {
         match &self.mode {
-            #[cfg(feature = "client")]
+            #[cfg(all(feature = "client", any(not(feature = "p2p"), feature = "netcode")))]
             Some(Mode::Client { client_id }) => *client_id,
             #[cfg(all(feature = "client", feature = "server"))]
             Some(Mode::Separate { client_id }) => *client_id,
             #[cfg(all(feature = "client", feature = "server"))]
             Some(Mode::HostClient { client_id }) => *client_id,
+            #[cfg(feature = "p2p")]
+            Some(Mode::P2P { peer_id, .. }) => Some(u64::from(*peer_id)),
             _ => None,
         }
     }
@@ -106,10 +140,12 @@ impl Cli {
         // to ~60 FPS so that headless automation behaves closer to a
         // real windowed client. Dedicated servers stay unthrottled.
         let loop_wait = match mode {
-            #[cfg(feature = "client")]
+            #[cfg(all(feature = "client", any(not(feature = "p2p"), feature = "netcode")))]
             Some(Mode::Client { .. }) => {
                 Some(Duration::from_secs_f64(1.0 / HEADLESS_CLIENT_LOOP_HZ))
             }
+            #[cfg(feature = "p2p")]
+            Some(Mode::P2P { .. }) => Some(Duration::from_secs_f64(1.0 / HEADLESS_CLIENT_LOOP_HZ)),
             #[cfg(all(feature = "client", feature = "server"))]
             Some(Mode::HostClient { .. }) | Some(Mode::Separate { .. }) => {
                 Some(Duration::from_secs_f64(1.0 / HEADLESS_CLIENT_LOOP_HZ))
@@ -122,7 +158,7 @@ impl Cli {
     pub fn build_app(&self, tick_duration: Duration, add_inspector: bool) -> App {
         let mut app = Cli::create_app(add_inspector, self.mode.as_ref(), self.headless());
         match self.mode {
-            #[cfg(feature = "client")]
+            #[cfg(all(feature = "client", any(not(feature = "p2p"), feature = "netcode")))]
             Some(Mode::Client { client_id }) => {
                 #[cfg(feature = "steam")]
                 app.add_steam_resources(STEAM_APP_ID);
@@ -131,6 +167,26 @@ impl Cli {
                 if !self.headless() {
                     app.add_plugins(ExampleClientRendererPlugin::new(format!(
                         "Client {client_id:?}"
+                    )));
+                }
+                app
+            }
+            #[cfg(feature = "p2p")]
+            Some(Mode::P2P {
+                peer_id,
+                player_count,
+                ..
+            }) => {
+                validate_p2p_roster(peer_id, player_count);
+                app.add_plugins(lightyear::prelude::client::ClientPlugins { tick_duration });
+                app.insert_resource(P2PSettings {
+                    local_peer_id: peer_id,
+                    player_count,
+                });
+                #[cfg(any(feature = "gui2d", feature = "gui3d"))]
+                if !self.headless() {
+                    app.add_plugins(ExampleClientRendererPlugin::new(format!(
+                        "P2P Peer {peer_id}"
                     )));
                 }
                 app
@@ -178,7 +234,7 @@ impl Cli {
     pub fn spawn_connections(&self, app: &mut App) {
         let conditioner = LinkConditionerConfig::average_condition().half();
         match self.mode {
-            #[cfg(feature = "client")]
+            #[cfg(all(feature = "client", any(not(feature = "p2p"), feature = "netcode")))]
             Some(Mode::Client { client_id }) => {
                 let client = app
                     .world_mut()
@@ -197,6 +253,36 @@ impl Cli {
                     })
                     .id();
                 app.add_systems(Startup, connect);
+            }
+            #[cfg(feature = "p2p")]
+            Some(Mode::P2P {
+                peer_id,
+                player_count,
+                base_port,
+            }) => {
+                validate_p2p_roster(peer_id, player_count);
+                let local_id = PeerId::Entity(u64::from(peer_id));
+                for remote_peer_id in 0..player_count {
+                    if remote_peer_id == peer_id {
+                        continue;
+                    }
+                    let local_addr = p2p_addr(base_port, peer_id, remote_peer_id);
+                    let peer_addr = p2p_addr(base_port, remote_peer_id, peer_id);
+                    app.world_mut().spawn((
+                        P2P,
+                        RawClient,
+                        LocalId(local_id),
+                        RemoteId(PeerId::Entity(u64::from(remote_peer_id))),
+                        PingManager::default(),
+                        LocalAddr(local_addr),
+                        PeerAddr(peer_addr),
+                        UdpIo::default(),
+                        Link::default()
+                            .with_conditioner(Some(RecvLinkConditioner::new(conditioner.clone()))),
+                        Name::new(format!("P2P Link {peer_id} -> {remote_peer_id}")),
+                    ));
+                }
+                app.add_systems(Startup, connect_p2p);
             }
             #[cfg(feature = "server")]
             Some(Mode::Server) => {
@@ -256,11 +342,24 @@ impl Cli {
 
 #[derive(Subcommand, Debug)]
 pub enum Mode {
-    #[cfg(feature = "client")]
+    #[cfg(all(feature = "client", any(not(feature = "p2p"), feature = "netcode")))]
     /// Runs the app in client mode
     Client {
         #[arg(short, long, default_value = None)]
         client_id: Option<u64>,
+    },
+    #[cfg(feature = "p2p")]
+    /// Runs a fixed roster with one direct raw UDP Link to every other peer.
+    P2P {
+        /// Zero-based identity of this peer within the fixed roster.
+        #[arg(short, long)]
+        peer_id: u8,
+        /// Number of players in the fixed roster (2 through 4).
+        #[arg(short = 'n', long, default_value_t = 2)]
+        player_count: u8,
+        /// First UDP port reserved for the roster's directed peer Links.
+        #[arg(long, default_value_t = DEFAULT_P2P_BASE_PORT)]
+        base_port: u16,
     },
     #[cfg(feature = "server")]
     /// Runs the app in server mode
@@ -284,8 +383,14 @@ pub enum Mode {
 impl Mode {
     fn possible_options() -> &'static str {
         cfg_if::cfg_if! {
-            if #[cfg(all(feature = "client", feature = "server"))] {
+            if #[cfg(all(feature = "client", feature = "server", feature = "p2p"))] {
+                "client, server, separate, host-client, p2p"
+            } else if #[cfg(all(feature = "client", feature = "server"))] {
                 "client, server, separate, host-client"
+            } else if #[cfg(all(feature = "p2p", feature = "netcode"))] {
+                "client, p2p"
+            } else if #[cfg(feature = "p2p")] {
+                "p2p"
             } else if #[cfg(feature = "client")] {
                 "client"
             } else if #[cfg(feature = "server")] {
@@ -297,6 +402,34 @@ impl Mode {
     }
 }
 
+#[cfg(feature = "p2p")]
+fn validate_p2p_roster(peer_id: u8, player_count: u8) {
+    assert!(
+        (2..=MAX_P2P_PLAYERS).contains(&player_count),
+        "P2P player_count must be between 2 and {MAX_P2P_PLAYERS}"
+    );
+    assert!(
+        peer_id < player_count,
+        "P2P peer_id {peer_id} is outside the {player_count}-player roster"
+    );
+}
+
+#[cfg(feature = "p2p")]
+fn p2p_addr(base_port: u16, local_peer_id: u8, remote_peer_id: u8) -> SocketAddr {
+    let offset = u16::from(local_peer_id) * u16::from(MAX_P2P_PLAYERS) + u16::from(remote_peer_id);
+    let port = base_port
+        .checked_add(offset)
+        .expect("P2P base port plus roster offset must fit in u16");
+    SocketAddr::new(Ipv4Addr::LOCALHOST.into(), port)
+}
+
+#[cfg(feature = "p2p")]
+fn connect_p2p(mut commands: Commands, links: Query<Entity, With<P2P>>) {
+    for entity in &links {
+        commands.trigger(Connect { entity });
+    }
+}
+
 impl Default for Mode {
     fn default() -> Self {
         cfg_if::cfg_if! {
@@ -304,6 +437,12 @@ impl Default for Mode {
                 Mode::HostClient { client_id: None }
             } else if #[cfg(feature = "server")] {
                 Mode::Server
+            } else if #[cfg(feature = "p2p")] {
+                Mode::P2P {
+                    peer_id: 0,
+                    player_count: 2,
+                    base_port: DEFAULT_P2P_BASE_PORT,
+                }
             } else {
                 Mode::Client { client_id: None }
             }

--- a/examples/common/src/cli.rs
+++ b/examples/common/src/cli.rs
@@ -5,11 +5,6 @@
 
 use core::str::FromStr;
 use core::time::Duration;
-#[cfg(feature = "p2p")]
-use core::{
-    net::{Ipv4Addr, SocketAddr},
-    ops::Range,
-};
 
 use bevy::log::{Level, LogPlugin};
 use bevy::prelude::*;
@@ -23,6 +18,8 @@ use clap::{ArgAction, Parser, Subcommand};
 use crate::client::{ClientTransports, ExampleClient, connect};
 #[cfg(all(any(feature = "gui2d", feature = "gui3d"), feature = "client"))]
 use crate::client_renderer::ExampleClientRendererPlugin;
+#[cfg(feature = "p2p")]
+use crate::p2p::{self, DEFAULT_P2P_BASE_PORT};
 #[cfg(feature = "server")]
 use crate::server::{ExampleServer, ServerTransports, WebTransportCertificateSettings, start};
 #[cfg(all(any(feature = "gui2d", feature = "gui3d"), feature = "server"))]
@@ -37,33 +34,6 @@ use {
     bevy::window::PresentMode,
     bevy::winit::{UpdateMode, WinitSettings},
 };
-
-#[cfg(feature = "p2p")]
-const MAX_P2P_PLAYERS: u8 = 4;
-#[cfg(feature = "p2p")]
-const DEFAULT_P2P_BASE_PORT: u16 = 6000;
-
-/// Fixed roster used by an example running in direct P2P mode.
-///
-/// The initial example transport assigns compact numeric peer identities. Iroh can replace the
-/// transport-specific identity construction later without changing the topology or game setup.
-#[cfg(feature = "p2p")]
-#[derive(Resource, Clone, Copy, Debug, PartialEq, Eq)]
-pub struct P2PSettings {
-    pub local_peer_id: u8,
-    pub player_count: u8,
-}
-
-#[cfg(feature = "p2p")]
-impl P2PSettings {
-    pub fn peer_ids(&self) -> Range<u8> {
-        0..self.player_count
-    }
-
-    pub fn local_id(&self) -> PeerId {
-        PeerId::Entity(u64::from(self.local_peer_id))
-    }
-}
 
 fn parse_bool_arg(value: &str) -> Result<bool, String> {
     if value.eq_ignore_ascii_case("true") {
@@ -177,18 +147,13 @@ impl Cli {
                 player_count,
                 ..
             }) => {
-                validate_p2p_roster(peer_id, player_count);
-                app.add_plugins(lightyear::prelude::client::ClientPlugins { tick_duration });
-                app.insert_resource(P2PSettings {
-                    local_peer_id: peer_id,
+                p2p::configure_app(
+                    &mut app,
+                    tick_duration,
+                    self.headless(),
+                    peer_id,
                     player_count,
-                });
-                #[cfg(any(feature = "gui2d", feature = "gui3d"))]
-                if !self.headless() {
-                    app.add_plugins(ExampleClientRendererPlugin::new(format!(
-                        "P2P Peer {peer_id}"
-                    )));
-                }
+                );
                 app
             }
             #[cfg(feature = "server")]
@@ -260,29 +225,7 @@ impl Cli {
                 player_count,
                 base_port,
             }) => {
-                validate_p2p_roster(peer_id, player_count);
-                let local_id = PeerId::Entity(u64::from(peer_id));
-                for remote_peer_id in 0..player_count {
-                    if remote_peer_id == peer_id {
-                        continue;
-                    }
-                    let local_addr = p2p_addr(base_port, peer_id, remote_peer_id);
-                    let peer_addr = p2p_addr(base_port, remote_peer_id, peer_id);
-                    app.world_mut().spawn((
-                        P2P,
-                        RawClient,
-                        LocalId(local_id),
-                        RemoteId(PeerId::Entity(u64::from(remote_peer_id))),
-                        PingManager::default(),
-                        LocalAddr(local_addr),
-                        PeerAddr(peer_addr),
-                        UdpIo::default(),
-                        Link::default()
-                            .with_conditioner(Some(RecvLinkConditioner::new(conditioner.clone()))),
-                        Name::new(format!("P2P Link {peer_id} -> {remote_peer_id}")),
-                    ));
-                }
-                app.add_systems(Startup, connect_p2p);
+                p2p::spawn_connections(app, &conditioner, peer_id, player_count, base_port);
             }
             #[cfg(feature = "server")]
             Some(Mode::Server) => {
@@ -399,34 +342,6 @@ impl Mode {
                 "none"
             }
         }
-    }
-}
-
-#[cfg(feature = "p2p")]
-fn validate_p2p_roster(peer_id: u8, player_count: u8) {
-    assert!(
-        (2..=MAX_P2P_PLAYERS).contains(&player_count),
-        "P2P player_count must be between 2 and {MAX_P2P_PLAYERS}"
-    );
-    assert!(
-        peer_id < player_count,
-        "P2P peer_id {peer_id} is outside the {player_count}-player roster"
-    );
-}
-
-#[cfg(feature = "p2p")]
-fn p2p_addr(base_port: u16, local_peer_id: u8, remote_peer_id: u8) -> SocketAddr {
-    let offset = u16::from(local_peer_id) * u16::from(MAX_P2P_PLAYERS) + u16::from(remote_peer_id);
-    let port = base_port
-        .checked_add(offset)
-        .expect("P2P base port plus roster offset must fit in u16");
-    SocketAddr::new(Ipv4Addr::LOCALHOST.into(), port)
-}
-
-#[cfg(feature = "p2p")]
-fn connect_p2p(mut commands: Commands, links: Query<Entity, With<P2P>>) {
-    for entity in &links {
-        commands.trigger(Connect { entity });
     }
 }
 

--- a/examples/common/src/lib.rs
+++ b/examples/common/src/lib.rs
@@ -93,5 +93,7 @@ pub mod cli;
 // A direct P2P-only build needs ClientPlugins but not the conventional netcode client harness.
 #[cfg(all(feature = "client", any(not(feature = "p2p"), feature = "netcode")))]
 pub mod client;
+#[cfg(feature = "p2p")]
+pub mod p2p;
 #[cfg(feature = "server")]
 pub mod server;

--- a/examples/common/src/lib.rs
+++ b/examples/common/src/lib.rs
@@ -90,7 +90,8 @@ pub mod shared;
 
 pub mod automation;
 pub mod cli;
-#[cfg(feature = "client")]
+// A direct P2P-only build needs ClientPlugins but not the conventional netcode client harness.
+#[cfg(all(feature = "client", any(not(feature = "p2p"), feature = "netcode")))]
 pub mod client;
 #[cfg(feature = "server")]
 pub mod server;

--- a/examples/common/src/p2p.rs
+++ b/examples/common/src/p2p.rs
@@ -15,6 +15,17 @@ use crate::client_renderer::ExampleClientRendererPlugin;
 const MAX_P2P_PLAYERS: u8 = 4;
 pub(crate) const DEFAULT_P2P_BASE_PORT: u16 = 6000;
 
+/// Tick at which fixed-roster examples create their deterministic gameplay world.
+///
+/// Delaying creation gives every raw Link time to connect and lets the input timeline complete
+/// its one-time initial synchronization before any gameplay state is simulated. A future session
+/// handshake should replace this example convention with an agreed start epoch.
+pub const GAMEPLAY_START_TICK: u32 = 120;
+
+/// Marker inserted after an example has created its fixed deterministic P2P world.
+#[derive(Resource, Default)]
+pub struct P2PGameplayStarted;
+
 /// Fixed roster used by an example running in direct P2P mode.
 ///
 /// The initial example transport assigns compact numeric peer identities. Iroh can replace the
@@ -33,6 +44,30 @@ impl P2PSettings {
     pub fn local_id(&self) -> PeerId {
         PeerId::Entity(u64::from(self.local_peer_id))
     }
+}
+
+/// Build the stable input target shared by every peer for one roster member.
+///
+/// Remote targets are scoped to the Link that owns their input stream. The local target has no
+/// receiver because this app captures and originates its inputs.
+pub fn input_target_for_peer(
+    settings: &P2PSettings,
+    links: &Query<(Entity, &RemoteId), With<P2P>>,
+    peer_id: u8,
+    hash: u64,
+) -> PreSpawned {
+    let mut target = PreSpawned::new(hash);
+    if peer_id == settings.local_peer_id {
+        return target;
+    }
+
+    let remote_id = PeerId::Entity(u64::from(peer_id));
+    let owner_link = links
+        .iter()
+        .find_map(|(entity, id)| (id.0 == remote_id).then_some(entity))
+        .unwrap_or_else(|| panic!("missing P2P Link for roster peer {peer_id}"));
+    target = target.for_receiver(owner_link);
+    target
 }
 
 /// Add the client-side Lightyear plugins and roster state used by a direct P2P example.

--- a/examples/common/src/p2p.rs
+++ b/examples/common/src/p2p.rs
@@ -1,0 +1,116 @@
+//! Shared setup for examples running as a direct P2P mesh.
+
+use core::net::{Ipv4Addr, SocketAddr};
+use core::ops::Range;
+use core::time::Duration;
+
+use bevy::prelude::*;
+use lightyear::link::RecvLinkConditioner;
+use lightyear::prelude::client::{ClientPlugins, RawClient};
+use lightyear::prelude::*;
+
+#[cfg(any(feature = "gui2d", feature = "gui3d"))]
+use crate::client_renderer::ExampleClientRendererPlugin;
+
+const MAX_P2P_PLAYERS: u8 = 4;
+pub(crate) const DEFAULT_P2P_BASE_PORT: u16 = 6000;
+
+/// Fixed roster used by an example running in direct P2P mode.
+///
+/// The initial example transport assigns compact numeric peer identities. Iroh can replace the
+/// transport-specific identity construction later without changing the topology or game setup.
+#[derive(Resource, Clone, Copy, Debug, PartialEq, Eq)]
+pub struct P2PSettings {
+    pub local_peer_id: u8,
+    pub player_count: u8,
+}
+
+impl P2PSettings {
+    pub fn peer_ids(&self) -> Range<u8> {
+        0..self.player_count
+    }
+
+    pub fn local_id(&self) -> PeerId {
+        PeerId::Entity(u64::from(self.local_peer_id))
+    }
+}
+
+/// Add the client-side Lightyear plugins and roster state used by a direct P2P example.
+pub(crate) fn configure_app(
+    app: &mut App,
+    tick_duration: Duration,
+    _headless: bool,
+    peer_id: u8,
+    player_count: u8,
+) {
+    validate_roster(peer_id, player_count);
+    app.add_plugins(ClientPlugins { tick_duration });
+    app.insert_resource(P2PSettings {
+        local_peer_id: peer_id,
+        player_count,
+    });
+
+    #[cfg(any(feature = "gui2d", feature = "gui3d"))]
+    if !_headless {
+        app.add_plugins(ExampleClientRendererPlugin::new(format!(
+            "P2P Peer {peer_id}"
+        )));
+    }
+}
+
+/// Spawn one directed raw UDP Link for every other member of the fixed roster.
+pub(crate) fn spawn_connections(
+    app: &mut App,
+    conditioner: &LinkConditionerConfig,
+    peer_id: u8,
+    player_count: u8,
+    base_port: u16,
+) {
+    validate_roster(peer_id, player_count);
+    let local_id = PeerId::Entity(u64::from(peer_id));
+    for remote_peer_id in 0..player_count {
+        if remote_peer_id == peer_id {
+            continue;
+        }
+        let local_addr = peer_addr(base_port, peer_id, remote_peer_id);
+        let remote_addr = peer_addr(base_port, remote_peer_id, peer_id);
+        app.world_mut().spawn((
+            P2P,
+            RawClient,
+            LocalId(local_id),
+            RemoteId(PeerId::Entity(u64::from(remote_peer_id))),
+            PingManager::default(),
+            LocalAddr(local_addr),
+            PeerAddr(remote_addr),
+            UdpIo::default(),
+            Link::default().with_conditioner(Some(RecvLinkConditioner::new(conditioner.clone()))),
+            Name::new(format!("P2P Link {peer_id} -> {remote_peer_id}")),
+        ));
+    }
+    app.add_systems(Startup, connect);
+}
+
+fn validate_roster(peer_id: u8, player_count: u8) {
+    assert!(
+        (2..=MAX_P2P_PLAYERS).contains(&player_count),
+        "P2P player_count must be between 2 and {MAX_P2P_PLAYERS}"
+    );
+    assert!(
+        peer_id < player_count,
+        "P2P peer_id {peer_id} is outside the {player_count}-player roster"
+    );
+}
+
+fn peer_addr(base_port: u16, local_peer_id: u8, remote_peer_id: u8) -> SocketAddr {
+    let offset = u16::from(local_peer_id) * u16::from(MAX_P2P_PLAYERS) + u16::from(remote_peer_id);
+    let port = base_port
+        .checked_add(offset)
+        .expect("P2P base port plus roster offset must fit in u16");
+    SocketAddr::new(Ipv4Addr::LOCALHOST.into(), port)
+}
+
+fn connect(mut commands: Commands, links: Query<Entity, With<P2P>>) {
+    for entity in &links {
+        commands.trigger(Connect { entity });
+    }
+}

--- a/examples/deterministic_replication/Cargo.toml
+++ b/examples/deterministic_replication/Cargo.toml
@@ -6,7 +6,7 @@ edition.workspace = true
 publish = false
 
 [features]
-default = ["client", "gui", "server", "netcode", "webtransport"]
+default = ["client", "gui", "server", "p2p", "netcode", "webtransport"]
 client = ["lightyear/client", "lightyear_examples_common/client"]
 gui = ["lightyear_examples_common/gui2d"]
 server = [
@@ -16,6 +16,13 @@ server = [
   "lightyear_examples_common/server",
 ]
 netcode = ["lightyear_examples_common/netcode"]
+p2p = [
+  "client",
+  "udp",
+  "lightyear/deterministic",
+  "lightyear/p2p",
+  "lightyear_examples_common/p2p",
+]
 webtransport = ["lightyear_examples_common/webtransport"]
 udp = ["lightyear_examples_common/udp", "lightyear/std", "lightyear/udp"]
 

--- a/examples/deterministic_replication/README.md
+++ b/examples/deterministic_replication/README.md
@@ -20,6 +20,16 @@
 You can control the behaviour of the example by changing the list of features. By default, all features are enabled (client, server, gui).
 For example you can run the server in headless mode (without gui) by running `cargo run --no-default-features --features=server,webtransport,netcode`.
 
+### P2P mode
+
+The example can also run as a fixed deterministic P2P mesh. Every peer creates the same Avian
+world locally and exchanges only player inputs; there is no server or authoritative simulation.
+
+- Peer 0: `cargo run --no-default-features --features=p2p -- --headless p2p --peer-id 0 --player-count 2`
+- Peer 1: `cargo run --no-default-features --features=p2p -- --headless p2p --peer-id 1 --player-count 2`
+
+P2P mode uses input-only catch-up because there is no authoritative state source.
+
 ### Testing in wasm with webtransport
 
 NOTE: I am using the [bevy cli](https://github.com/TheBevyFlock/bevy_cli) to build and serve the wasm example.

--- a/examples/deterministic_replication/src/automation.rs
+++ b/examples/deterministic_replication/src/automation.rs
@@ -12,6 +12,8 @@ use lightyear::prelude::*;
 use lightyear_deterministic_replication::prelude::{CatchUpGated, CatchUpMode};
 #[cfg(feature = "client")]
 use lightyear_examples_common::automation::{HeadlessInputPlugin, env_string, sync_pressed_keys};
+#[cfg(all(feature = "client", feature = "p2p"))]
+use lightyear_examples_common::p2p::P2PSettings;
 
 #[cfg(feature = "client")]
 use crate::protocol::{PlayerActions, PlayerActivationTick, PlayerId};
@@ -156,7 +158,9 @@ mod client {
         mode: Res<CatchUpMode>,
         timeline: Res<LocalTimeline>,
         input_timeline: Option<SyncedInputTimeline>,
-        client: Option<Single<&LocalId, With<Client>>>,
+        metadata: Res<NetworkingMetadata>,
+        local_ids: Query<&LocalId>,
+        #[cfg(feature = "p2p")] p2p: Option<Res<P2PSettings>>,
         players: Query<(
             &PlayerId,
             Option<&LeafwingBuffer<PlayerActions>>,
@@ -172,7 +176,14 @@ mod client {
             timeline.tick(),
             input_timeline
                 .is_some()
-                .then(|| client.as_deref().copied())
+                .then(|| {
+                    local_peer_id(
+                        &metadata,
+                        &local_ids,
+                        #[cfg(feature = "p2p")]
+                        p2p.as_deref(),
+                    )
+                })
                 .flatten(),
             &players,
             &settings,
@@ -207,7 +218,9 @@ mod client {
         mode: Res<CatchUpMode>,
         timeline: Res<LocalTimeline>,
         input_timeline: Option<SyncedInputTimeline>,
-        client: Option<Single<&LocalId, With<Client>>>,
+        metadata: Res<NetworkingMetadata>,
+        local_ids: Query<&LocalId>,
+        #[cfg(feature = "p2p")] p2p: Option<Res<P2PSettings>>,
         players: Query<(
             &PlayerId,
             Option<&LeafwingBuffer<PlayerActions>>,
@@ -221,7 +234,14 @@ mod client {
             timeline.tick(),
             input_timeline
                 .is_some()
-                .then(|| client.as_deref().copied())
+                .then(|| {
+                    local_peer_id(
+                        &metadata,
+                        &local_ids,
+                        #[cfg(feature = "p2p")]
+                        p2p.as_deref(),
+                    )
+                })
                 .flatten(),
             &players,
             &settings,
@@ -256,7 +276,7 @@ mod client {
     fn input_rebroadcast_ready(
         mode: &CatchUpMode,
         local_tick: Tick,
-        client: Option<&LocalId>,
+        local_id: Option<PeerId>,
         players: &Query<(
             &PlayerId,
             Option<&LeafwingBuffer<PlayerActions>>,
@@ -265,14 +285,14 @@ mod client {
         )>,
         settings: &AutomationSettings,
     ) -> bool {
-        let Some(local_id) = client else {
+        let Some(local_id) = local_id else {
             return false;
         };
         let mut count = 0;
         let mut local_can_move = false;
         for (player_id, buffer, activation_tick, awaiting_catchup) in players.iter() {
             count += 1;
-            if player_id.0 == local_id.0 {
+            if player_id.0 == local_id {
                 if awaiting_catchup {
                     return false;
                 }
@@ -296,6 +316,23 @@ mod client {
             }
         }
         count >= settings.min_players_before_move && local_can_move
+    }
+
+    fn local_peer_id(
+        metadata: &NetworkingMetadata,
+        local_ids: &Query<&LocalId>,
+        #[cfg(feature = "p2p")] p2p: Option<&P2PSettings>,
+    ) -> Option<PeerId> {
+        #[cfg(feature = "p2p")]
+        if let Some(p2p) = p2p {
+            return Some(p2p.local_id());
+        }
+        match metadata.mode {
+            NetworkTopology::Client(link) | NetworkTopology::HostClient { client: link, .. } => {
+                local_ids.get(link).ok().map(|id| id.0)
+            }
+            _ => None,
+        }
     }
 
     fn release_all(action_state: &mut ActionState<PlayerActions>) {

--- a/examples/deterministic_replication/src/client.rs
+++ b/examples/deterministic_replication/src/client.rs
@@ -8,6 +8,8 @@ use crate::automation::AutomationClientPlugin;
 use crate::protocol::*;
 use crate::shared::color_from_id;
 use lightyear_deterministic_replication::prelude::CatchUpSnapshotReady;
+#[cfg(feature = "p2p")]
+use lightyear_examples_common::p2p::P2PSettings;
 
 pub struct ExampleClientPlugin;
 
@@ -34,16 +36,27 @@ struct InputMapAdded;
 /// input and the server can't rebroadcast it to other peers.
 fn add_input_map_after_sync(
     _input_timeline: SyncedInputTimeline,
-    client: Option<Single<&LocalId, With<Client>>>,
+    metadata: Res<NetworkingMetadata>,
+    local_ids: Query<&LocalId>,
+    #[cfg(feature = "p2p")] p2p: Option<Res<P2PSettings>>,
     mut commands: Commands,
     players: Query<(Entity, &PlayerId), (Without<InputMapAdded>, Without<InputMap<PlayerActions>>)>,
 ) {
-    let Some(client) = client else {
+    #[cfg(feature = "p2p")]
+    let p2p_id = p2p.as_deref().map(P2PSettings::local_id);
+    #[cfg(not(feature = "p2p"))]
+    let p2p_id = None;
+    let local_id = p2p_id.or_else(|| match metadata.mode {
+        NetworkTopology::Client(link) | NetworkTopology::HostClient { client: link, .. } => {
+            local_ids.get(link).ok().map(|id| id.0)
+        }
+        _ => None,
+    });
+    let Some(local_id) = local_id else {
         return;
     };
-    let local_id = client.into_inner();
     for (entity, player_id) in players.iter() {
-        if local_id.0 == player_id.0 {
+        if local_id == player_id.0 {
             info!("Client: adding InputMap to local player {:?}", player_id.0);
             commands.entity(entity).insert((
                 InputMap::new([

--- a/examples/deterministic_replication/src/main.rs
+++ b/examples/deterministic_replication/src/main.rs
@@ -1,5 +1,7 @@
 #[cfg(feature = "client")]
 use crate::client::ExampleClientPlugin;
+#[cfg(feature = "p2p")]
+use crate::p2p::ExampleP2PPlugin;
 #[cfg(feature = "server")]
 use crate::server::ExampleServerPlugin;
 use crate::shared::SharedPlugin;
@@ -23,6 +25,8 @@ mod automation;
 #[cfg(feature = "client")]
 mod client;
 mod debug;
+#[cfg(feature = "p2p")]
+mod p2p;
 mod protocol;
 
 #[cfg(feature = "gui")]
@@ -41,9 +45,15 @@ fn main() {
     cli.spawn_connections(&mut app);
 
     match cli.mode {
-        #[cfg(feature = "client")]
+        #[cfg(all(feature = "client", any(not(feature = "p2p"), feature = "netcode")))]
         Some(Mode::Client { .. }) => {
             app.add_plugins(ExampleClientPlugin);
+            enable_prediction(&mut app);
+            add_input_delay(&mut app);
+        }
+        #[cfg(feature = "p2p")]
+        Some(Mode::P2P { .. }) => {
+            app.add_plugins((ExampleClientPlugin, ExampleP2PPlugin));
             enable_prediction(&mut app);
             add_input_delay(&mut app);
         }

--- a/examples/deterministic_replication/src/p2p.rs
+++ b/examples/deterministic_replication/src/p2p.rs
@@ -1,0 +1,73 @@
+//! Direct P2P setup for the deterministic Avian simulation.
+//!
+//! Every peer creates the same fixed physics world and player roster locally. No entity state is
+//! replicated and no peer is authoritative; only tick-indexed player inputs cross the network.
+
+use crate::protocol::{PlayerActions, PlayerActivationTick, PlayerId};
+use crate::shared;
+use bevy::prelude::*;
+use leafwing_input_manager::prelude::ActionState;
+use lightyear::input::leafwing::prelude::LeafwingBuffer;
+use lightyear::prediction::rollback::DeterministicPredicted;
+use lightyear::prelude::input::client::InputSystems;
+use lightyear::prelude::*;
+use lightyear_deterministic_replication::prelude::CatchUpMode;
+use lightyear_examples_common::p2p::{
+    GAMEPLAY_START_TICK, P2PGameplayStarted, P2PSettings, input_target_for_peer,
+};
+
+/// Namespace for stable deterministic-replication player hashes on the input wire.
+const PLAYER_INPUT_HASH_BASE: u64 = 0x4445_5445_524D_0000;
+
+pub struct ExampleP2PPlugin;
+
+impl Plugin for ExampleP2PPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(
+            FixedPreUpdate,
+            spawn_fixed_world.before(InputSystems::BufferClientInputs),
+        );
+    }
+}
+
+/// Start the complete deterministic world in stable order once timeline synchronization finishes.
+fn spawn_fixed_world(
+    mut commands: Commands,
+    _synced: SyncedInputTimeline,
+    timeline: Res<LocalTimeline>,
+    mode: Res<CatchUpMode>,
+    started: Option<Res<P2PGameplayStarted>>,
+    settings: Res<P2PSettings>,
+    links: Query<(Entity, &RemoteId), With<P2P>>,
+) {
+    if started.is_some() || timeline.tick().0 < GAMEPLAY_START_TICK {
+        return;
+    }
+    commands.insert_resource(P2PGameplayStarted);
+
+    // P2P has no authoritative state source, so every peer starts from the same input-only world.
+    debug_assert_eq!(*mode, CatchUpMode::InputOnly);
+    shared::spawn_world(&mut commands, &mode, false, true);
+
+    for peer_id in settings.peer_ids() {
+        let id = PeerId::Entity(u64::from(peer_id));
+        let input_target = input_target_for_peer(
+            &settings,
+            &links,
+            peer_id,
+            PLAYER_INPUT_HASH_BASE | u64::from(peer_id),
+        );
+        commands.spawn((
+            PlayerId(id),
+            PlayerActivationTick(Tick(GAMEPLAY_START_TICK)),
+            shared::player_bundle(id),
+            DeterministicPredicted {
+                skip_despawn: true,
+                enable_rollback_after: 0,
+            },
+            input_target,
+            ActionState::<PlayerActions>::default(),
+            LeafwingBuffer::<PlayerActions>::default(),
+        ));
+    }
+}

--- a/examples/deterministic_replication/src/protocol.rs
+++ b/examples/deterministic_replication/src/protocol.rs
@@ -8,7 +8,10 @@ use leafwing_input_manager::prelude::*;
 use lightyear::input::config::InputConfig;
 use lightyear::prelude::input::leafwing;
 use lightyear::prelude::*;
+use lightyear_deterministic_replication::prelude::DeterministicReplicationPlugin;
 use lightyear_deterministic_replication::prelude::{AppCatchUpExt, CatchUpGated, ChecksumPlugin};
+#[cfg(feature = "p2p")]
+use lightyear_examples_common::p2p::P2PSettings;
 use serde::{Deserialize, Serialize};
 
 pub const BALL_SIZE: f32 = 15.0;
@@ -94,6 +97,11 @@ pub(crate) struct ProtocolPlugin;
 
 impl Plugin for ProtocolPlugin {
     fn build(&self, app: &mut App) {
+        #[cfg(feature = "p2p")]
+        let is_p2p = app.world().contains_resource::<P2PSettings>();
+        #[cfg(not(feature = "p2p"))]
+        let is_p2p = false;
+
         // inputs
         app.add_plugins(leafwing::InputPlugin::<PlayerActions> {
             config: InputConfig {
@@ -101,7 +109,13 @@ impl Plugin for ProtocolPlugin {
                 ..default()
             },
         });
-        app.add_plugins(ChecksumPlugin);
+        if is_p2p {
+            // The current checksum sender targets one conventional server Link. P2P checksums
+            // will be enabled once the deterministic protocol supports all-to-all validation.
+            app.add_plugins(DeterministicReplicationPlugin);
+        } else {
+            app.add_plugins(ChecksumPlugin);
+        }
 
         // Late-join catch-up: shared between client and server so it must
         // be registered before `cli.spawn_connections` adds the Client /
@@ -109,12 +123,14 @@ impl Plugin for ProtocolPlugin {
         // would fail because the archetype already exists). Registered in
         // ProtocolPlugin (loaded by SharedPlugin) so it runs before the
         // CLI spawns the networking entities.
-        app.add_plugins(lightyear_deterministic_replication::prelude::LateJoinCatchUpPlugin);
-        app.register_catchup_filter::<
-            (Position, Rotation, LinearVelocity, AngularVelocity),
-            leafwing::LeafwingSequence<PlayerActions>,
-        >();
-        register_avian_catchup_resources(app, false);
+        if !is_p2p {
+            app.add_plugins(lightyear_deterministic_replication::prelude::LateJoinCatchUpPlugin);
+            app.register_catchup_filter::<
+                (Position, Rotation, LinearVelocity, AngularVelocity),
+                leafwing::LeafwingSequence<PlayerActions>,
+            >();
+            register_avian_catchup_resources(app, false);
+        }
 
         // components
         app.component::<PlayerId>().replicate();

--- a/examples/deterministic_replication/src/shared.rs
+++ b/examples/deterministic_replication/src/shared.rs
@@ -8,6 +8,8 @@ use lightyear::prediction::rollback::{CatchUpGated, DeterministicPredicted};
 use lightyear::prelude::*;
 use lightyear_avian2d::plugin::AvianReplicationMode;
 use lightyear_deterministic_replication::prelude::CatchUpMode;
+#[cfg(feature = "p2p")]
+use lightyear_examples_common::p2p::P2PSettings;
 use lightyear_frame_interpolation::{FrameInterpolate, FrameInterpolationPlugin};
 
 const MAX_VELOCITY: f32 = 200.0;
@@ -22,9 +24,16 @@ pub struct SharedPlugin;
 impl Plugin for SharedPlugin {
     fn build(&self, app: &mut App) {
         app.add_plugins(ProtocolPlugin);
-        app.insert_resource(catch_up_mode_from_env());
+        let is_p2p = is_p2p(app);
+        app.insert_resource(if is_p2p {
+            CatchUpMode::InputOnly
+        } else {
+            catch_up_mode_from_env()
+        });
         // bundles
-        app.add_systems(Startup, init);
+        if !is_p2p {
+            app.add_systems(Startup, init);
+        }
 
         // Visual correction uses the same history and scheduling as frame
         // interpolation, so install it in shared code for both GUI and headless
@@ -64,6 +73,17 @@ impl Plugin for SharedPlugin {
         app.add_systems(FixedUpdate, player_movement);
 
         crate::debug::register_debug_systems(app);
+    }
+}
+
+fn is_p2p(app: &App) -> bool {
+    #[cfg(feature = "p2p")]
+    {
+        app.world().contains_resource::<P2PSettings>()
+    }
+    #[cfg(not(feature = "p2p"))]
+    {
+        false
     }
 }
 
@@ -115,7 +135,16 @@ pub(crate) fn init(
     let is_server = server.is_some();
     let is_client = client.is_some();
 
-    spawn_ball(&mut commands, &mode, is_server, is_client);
+    spawn_world(&mut commands, &mode, is_server, is_client);
+}
+
+pub(crate) fn spawn_world(
+    commands: &mut Commands,
+    mode: &CatchUpMode,
+    is_server: bool,
+    is_client: bool,
+) {
+    spawn_ball(commands, mode, is_server, is_client);
     commands.spawn(WallBundle::new(
         Vec2::new(-WALL_SIZE, -WALL_SIZE),
         Vec2::new(-WALL_SIZE, WALL_SIZE),

--- a/examples/fps/Cargo.toml
+++ b/examples/fps/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 publish = false
 
 [features]
-default = ["client", "gui", "server", "netcode", "webtransport"]
+default = ["client", "gui", "server", "p2p", "netcode", "webtransport"]
 client = ["lightyear/client", "lightyear_examples_common/client"]
 gui = ["lightyear_examples_common/gui2d"]
 server = [
@@ -16,6 +16,12 @@ server = [
   "lightyear_examples_common/server",
 ]
 netcode = ["lightyear_examples_common/netcode"]
+p2p = [
+  "client",
+  "udp",
+  "lightyear/deterministic",
+  "lightyear_examples_common/p2p",
+]
 webtransport = ["lightyear_examples_common/webtransport"]
 udp = ["lightyear_examples_common/udp", "lightyear/std", "lightyear/udp"]
 
@@ -39,6 +45,7 @@ lightyear_examples_common = { workspace = true, features = [
   "structured-debug",
 ] }
 lightyear_frame_interpolation.workspace = true
+lightyear_deterministic_replication.workspace = true
 lightyear_avian2d = { workspace = true, features = ["2d", "lag_compensation"] }
 
 leafwing-input-manager.workspace = true

--- a/examples/fps/Cargo.toml
+++ b/examples/fps/Cargo.toml
@@ -20,6 +20,7 @@ p2p = [
   "client",
   "udp",
   "lightyear/deterministic",
+  "lightyear/p2p",
   "lightyear_examples_common/p2p",
 ]
 webtransport = ["lightyear_examples_common/webtransport"]

--- a/examples/fps/README.md
+++ b/examples/fps/README.md
@@ -54,6 +54,14 @@ https://github.com/user-attachments/assets/17bc985d-f700-439d-ba48-4c69fbfd7885
 - Run the server without a gui: `cargo run --no-default-features --features=server -- server`
 - Run the client and server in "HostClient" mode, where the client also acts as server (both are in the same App) : `cargo run -- host-client -c 0`
 
+### P2P mode
+
+The example can also run as a deterministic input-only game with no server. Start peer 0 with
+`cargo run --no-default-features --features=p2p -- --headless p2p --peer-id 0 --player-count 2`
+and peer 1 with the same command using `--peer-id 1`. This mode simulates both targets and hit
+detection on every peer; the conventional mode remains the example of server-side lag
+compensation.
+
 You can control the behaviour of the example by changing the list of features. By default, all features are enabled (client, server, gui).
 For example you can run the server in headless mode (without gui) by running `cargo run --no-default-features --features=server,webtransport,netcode`.
 

--- a/examples/fps/src/automation.rs
+++ b/examples/fps/src/automation.rs
@@ -1,7 +1,7 @@
 use avian2d::prelude::Position;
 use bevy::prelude::*;
 use leafwing_input_manager::plugin::InputManagerSystem;
-use leafwing_input_manager::prelude::ActionState;
+use leafwing_input_manager::prelude::{ActionState, InputMap};
 use lightyear::input::client::InputSystems;
 use lightyear::prelude::*;
 use lightyear_examples_common::automation::{
@@ -129,7 +129,10 @@ mod client {
             (Entity, &Transform, Has<PredictedBot>, Has<InterpolatedBot>),
             Or<(With<PredictedBot>, With<InterpolatedBot>)>,
         >,
-        mut actions: Query<&mut ActionState<PlayerActions>, With<Predicted>>,
+        mut actions: Query<
+            &mut ActionState<PlayerActions>,
+            Or<(With<Predicted>, With<InputMap<PlayerActions>>)>,
+        >,
         mut previous_target: Local<Option<(Entity, AimTarget, Vec2)>>,
     ) {
         let target = bots.iter().find_map(

--- a/examples/fps/src/client.rs
+++ b/examples/fps/src/client.rs
@@ -64,7 +64,10 @@ fn strip_interpolated_bullet_local_physics(
 fn suppress_shoot_until_synced(
     host_server: Query<(), With<HostServer>>,
     input_timeline: Option<SyncedInputTimeline>,
-    mut action_state_query: Query<&mut ActionState<PlayerActions>, With<Predicted>>,
+    mut action_state_query: Query<
+        &mut ActionState<PlayerActions>,
+        Or<(With<Predicted>, With<InputMap<PlayerActions>>)>,
+    >,
 ) {
     if !host_server.is_empty() || input_timeline.is_some() {
         return;
@@ -78,7 +81,10 @@ fn suppress_shoot_until_synced(
 fn update_cursor_state_from_window(
     window: Option<Single<&Window>>,
     q_camera: Query<(&Camera, &GlobalTransform)>,
-    mut action_state_query: Query<&mut ActionState<PlayerActions>, With<Predicted>>,
+    mut action_state_query: Query<
+        &mut ActionState<PlayerActions>,
+        Or<(With<Predicted>, With<InputMap<PlayerActions>>)>,
+    >,
 ) {
     if automation_aim_target_enabled() {
         return;
@@ -144,13 +150,17 @@ pub(crate) fn handle_controlled_spawn(
     if player_query.get(entity).is_err() {
         return;
     };
-    commands.entity(entity).insert(InputMap::new([
+    commands.entity(entity).insert(player_input_map());
+}
+
+pub(crate) fn player_input_map() -> InputMap<PlayerActions> {
+    InputMap::new([
         (PlayerActions::Up, KeyCode::KeyW),
         (PlayerActions::Down, KeyCode::KeyS),
         (PlayerActions::Left, KeyCode::KeyA),
         (PlayerActions::Right, KeyCode::KeyD),
         (PlayerActions::Shoot, KeyCode::Space),
-    ]));
+    ])
 }
 
 pub(crate) fn handle_interpolated_spawn(

--- a/examples/fps/src/main.rs
+++ b/examples/fps/src/main.rs
@@ -9,6 +9,8 @@ use lightyear_examples_common::shared::FIXED_TIMESTEP_HZ;
 
 #[cfg(feature = "client")]
 use crate::client::ExampleClientPlugin;
+#[cfg(feature = "p2p")]
+use crate::p2p::ExampleP2PPlugin;
 #[cfg(feature = "server")]
 use crate::server::ExampleServerPlugin;
 use crate::shared::SharedPlugin;
@@ -17,6 +19,8 @@ mod automation;
 #[cfg(feature = "client")]
 mod client;
 mod debug;
+#[cfg(feature = "p2p")]
+mod p2p;
 mod protocol;
 
 #[cfg(feature = "gui")]
@@ -37,9 +41,13 @@ fn main() {
     cli.spawn_connections(&mut app);
 
     match cli.mode {
-        #[cfg(feature = "client")]
+        #[cfg(all(feature = "client", any(not(feature = "p2p"), feature = "netcode")))]
         Some(Mode::Client { .. }) => {
             app.add_plugins(ExampleClientPlugin);
+        }
+        #[cfg(feature = "p2p")]
+        Some(Mode::P2P { .. }) => {
+            app.add_plugins((ExampleClientPlugin, ExampleP2PPlugin));
         }
         #[cfg(feature = "server")]
         Some(Mode::Server) => {

--- a/examples/fps/src/p2p.rs
+++ b/examples/fps/src/p2p.rs
@@ -1,0 +1,141 @@
+//! Deterministic input-only P2P setup for the FPS example.
+//!
+//! Server-only lag compensation is intentionally absent. Both bots, every player, projectiles,
+//! scores, and hit prediction instead live in the same deterministic simulation on every peer.
+
+use avian2d::prelude::*;
+use bevy::prelude::*;
+use lightyear::prediction::rollback::DeterministicPredicted;
+use lightyear::prelude::input::client::InputSystems;
+use lightyear::prelude::input::leafwing::LeafwingBuffer;
+use lightyear::prelude::*;
+use lightyear_deterministic_replication::prelude::DeterministicReplicationPlugin;
+use lightyear_examples_common::p2p::{
+    input_target_for_peer, P2PGameplayStarted, P2PSettings, GAMEPLAY_START_TICK,
+};
+use lightyear_frame_interpolation::FrameInterpolate;
+
+use crate::client::player_input_map;
+use crate::protocol::*;
+use crate::shared::{color_from_id, BOT_RADIUS};
+
+const PLAYER_INPUT_HASH_BASE: u64 = 0x4650_5300_0000_0000;
+
+pub struct ExampleP2PPlugin;
+
+impl Plugin for ExampleP2PPlugin {
+    fn build(&self, app: &mut App) {
+        app.insert_resource(PredictionManager::default());
+        app.add_plugins(DeterministicReplicationPlugin);
+        app.add_systems(
+            FixedPreUpdate,
+            spawn_fixed_world.before(InputSystems::BufferClientInputs),
+        );
+
+        app.add_systems(
+            FixedPostUpdate,
+            compute_hits.after(PhysicsSystems::StepSimulation),
+        );
+    }
+}
+
+fn compute_hits(
+    mut commands: Commands,
+    spatial_query: SpatialQuery,
+    bullets: Query<(Entity, &PlayerId, &Position, &LinearVelocity), With<BulletMarker>>,
+    bots: Query<(), With<PredictedBot>>,
+    mut players: Query<(&mut Score, &PlayerId), With<PlayerMarker>>,
+) {
+    const COLLISION_DISTANCE: f32 = 4.0;
+    for (entity, shooter, position, velocity) in &bullets {
+        let Some(_hit) = spatial_query.cast_ray_predicate(
+            position.0,
+            Dir2::new_unchecked(velocity.0.normalize()),
+            COLLISION_DISTANCE,
+            false,
+            &SpatialQueryFilter::default(),
+            &|entity| bots.get(entity).is_ok(),
+        ) else {
+            continue;
+        };
+        if let Some((mut score, _)) = players.iter_mut().find(|(_, id)| id.0 == shooter.0) {
+            score.0 += 1;
+        }
+        commands.entity(entity).prediction_despawn();
+    }
+}
+
+fn spawn_fixed_world(
+    mut commands: Commands,
+    _synced: SyncedInputTimeline,
+    timeline: Res<LocalTimeline>,
+    started: Option<Res<P2PGameplayStarted>>,
+    settings: Res<P2PSettings>,
+    links: Query<(Entity, &RemoteId), With<P2P>>,
+) {
+    if started.is_some() || timeline.tick().0 < GAMEPLAY_START_TICK {
+        return;
+    }
+    commands.insert_resource(P2PGameplayStarted);
+
+    commands.spawn((
+        PredictedBot,
+        Name::new("P2P Predicted Bot"),
+        Position::from_xy(200.0, 10.0),
+        Rotation::default(),
+        RigidBody::Kinematic,
+        Collider::circle(BOT_RADIUS),
+        DeterministicPredicted {
+            skip_despawn: true,
+            enable_rollback_after: 0,
+        },
+        FrameInterpolate,
+    ));
+    commands.spawn((
+        InterpolatedBot,
+        Name::new("P2P Second Bot"),
+        Position::from_xy(-200.0, 10.0),
+        Rotation::default(),
+        RigidBody::Kinematic,
+        Collider::circle(BOT_RADIUS),
+        DeterministicPredicted {
+            skip_despawn: true,
+            enable_rollback_after: 0,
+        },
+        FrameInterpolate,
+    ));
+
+    let spacing = 100.0;
+    let center = (f32::from(settings.player_count) - 1.0) * 0.5;
+    for peer_id in settings.peer_ids() {
+        let id = PeerId::Entity(u64::from(peer_id));
+        let target = input_target_for_peer(
+            &settings,
+            &links,
+            peer_id,
+            PLAYER_INPUT_HASH_BASE | u64::from(peer_id),
+        );
+        let player = commands
+            .spawn((
+                Score(0),
+                PlayerId(id),
+                RigidBody::Kinematic,
+                Position::from_xy(0.0, (f32::from(peer_id) - center) * spacing),
+                Rotation::default(),
+                ColorComponent(color_from_id(id)),
+                PlayerMarker,
+                DeterministicPredicted {
+                    skip_despawn: true,
+                    enable_rollback_after: 0,
+                },
+                target,
+                LeafwingBuffer::<PlayerActions>::default(),
+                FrameInterpolate,
+                Name::new("P2P Player"),
+            ))
+            .id();
+        if peer_id == settings.local_peer_id {
+            commands.entity(player).insert(player_input_map());
+        }
+    }
+}

--- a/examples/fps/src/p2p.rs
+++ b/examples/fps/src/p2p.rs
@@ -21,6 +21,9 @@ use crate::shared::{color_from_id, BOT_RADIUS};
 
 const PLAYER_INPUT_HASH_BASE: u64 = 0x4650_5300_0000_0000;
 
+#[derive(Component)]
+struct PendingLocalInput(Tick);
+
 pub struct ExampleP2PPlugin;
 
 impl Plugin for ExampleP2PPlugin {
@@ -30,6 +33,10 @@ impl Plugin for ExampleP2PPlugin {
         app.add_systems(
             FixedPreUpdate,
             spawn_fixed_world.before(InputSystems::BufferClientInputs),
+        );
+        app.add_systems(
+            FixedPostUpdate,
+            enable_local_input.after(PredictionSystems::UpdateHistory),
         );
 
         app.add_systems(
@@ -135,7 +142,26 @@ fn spawn_fixed_world(
             ))
             .id();
         if peer_id == settings.local_peer_id {
-            commands.entity(player).insert(player_input_map());
+            commands
+                .entity(player)
+                .insert(PendingLocalInput(timeline.tick()));
         }
+    }
+}
+
+/// Enable local input after the initial Avian rollback state has been recorded.
+fn enable_local_input(
+    mut commands: Commands,
+    timeline: Res<LocalTimeline>,
+    local_players: Query<(Entity, &PendingLocalInput)>,
+) {
+    for (entity, pending) in &local_players {
+        if timeline.tick() <= pending.0 {
+            continue;
+        }
+        commands
+            .entity(entity)
+            .insert(player_input_map())
+            .remove::<PendingLocalInput>();
     }
 }

--- a/examples/fps/src/shared.rs
+++ b/examples/fps/src/shared.rs
@@ -15,12 +15,20 @@ pub const BOT_RADIUS: f32 = 15.0;
 pub(crate) const BOT_MOVE_SPEED: f32 = 1.0;
 const BULLET_MOVE_SPEED: f32 = 300.0;
 const MAP_LIMIT: f32 = 2000.0;
+const P2P_BULLET_LIFETIME_TICKS: i32 = 120;
 
 #[derive(Clone)]
 pub struct SharedPlugin;
 
 impl Plugin for SharedPlugin {
     fn build(&self, app: &mut App) {
+        #[cfg(feature = "p2p")]
+        let rollback_resources = app
+            .world()
+            .contains_resource::<lightyear_examples_common::p2p::P2PSettings>();
+        #[cfg(not(feature = "p2p"))]
+        let rollback_resources = false;
+
         app.add_plugins(ProtocolPlugin);
         crate::debug::register_debug_systems(app);
 
@@ -33,6 +41,7 @@ impl Plugin for SharedPlugin {
             },
             // This example keeps custom physics-component rules in its protocol.
             register_physics_components: false,
+            rollback_resources,
             ..default()
         });
 
@@ -41,7 +50,13 @@ impl Plugin for SharedPlugin {
         // Physics-based systems that can roll back must run in FixedUpdate.
         app.add_systems(
             FixedUpdate,
-            (predicted_bot_movement, player_movement, shoot_bullet).chain(),
+            (
+                predicted_bot_movement,
+                player_movement,
+                shoot_bullet,
+                despawn_p2p_bullets,
+            )
+                .chain(),
         );
         // both client and server need physics
         // (the client also needs the physics plugin to be able to compute predicted bullet hits)
@@ -126,18 +141,28 @@ fn player_movement(
             &ActionState<PlayerActions>,
             &PlayerId,
             Has<Predicted>,
+            Has<DeterministicPredicted>,
         ),
-        (Or<(With<Predicted>, With<Replicate>)>, With<PlayerMarker>),
+        (
+            Or<(
+                With<Predicted>,
+                With<Replicate>,
+                With<DeterministicPredicted>,
+            )>,
+            With<PlayerMarker>,
+        ),
     >,
 ) {
     let has_client = !client.is_empty();
     let is_host_server = !host_server.is_empty();
     let client_is_synced = input_timeline.is_some();
-    for (position, rotation, action_state, player_id, is_predicted) in player_query.iter_mut() {
+    for (position, rotation, action_state, player_id, is_predicted, is_deterministic) in
+        player_query.iter_mut()
+    {
         if should_skip_client_side_entity(
             has_client,
             is_host_server,
-            is_predicted,
+            is_predicted || is_deterministic,
             client_is_synced,
         ) {
             continue;
@@ -168,6 +193,7 @@ pub(crate) fn shoot_bullet(
     client: Query<(), With<Client>>,
     host_server: Query<(), With<HostServer>>,
     input_timeline: Option<SyncedInputTimeline>,
+    metadata: Res<NetworkingMetadata>,
     mut query: Query<
         (
             &PlayerId,
@@ -178,21 +204,39 @@ pub(crate) fn shoot_bullet(
             &LeafwingBuffer<PlayerActions>,
             Option<&ControlledBy>,
             Has<Predicted>,
+            Has<DeterministicPredicted>,
         ),
-        (Or<(With<Predicted>, With<Replicate>)>, With<PlayerMarker>),
+        (
+            Or<(
+                With<Predicted>,
+                With<Replicate>,
+                With<DeterministicPredicted>,
+            )>,
+            With<PlayerMarker>,
+        ),
     >,
 ) {
     let tick = timeline.tick();
     let has_client = !client.is_empty();
     let is_host_server = !host_server.is_empty();
     let client_is_synced = input_timeline.is_some();
-    for (id, position, rotation, color, action, input_buffer, controlled_by, is_predicted) in
-        query.iter_mut()
+    let is_p2p = matches!(metadata.mode, NetworkTopology::P2P { .. });
+    for (
+        id,
+        position,
+        rotation,
+        color,
+        action,
+        input_buffer,
+        controlled_by,
+        is_predicted,
+        is_deterministic,
+    ) in query.iter_mut()
     {
         if should_skip_client_side_entity(
             has_client,
             is_host_server,
-            is_predicted,
+            is_predicted || is_deterministic,
             client_is_synced,
         ) {
             continue;
@@ -238,6 +282,14 @@ pub(crate) fn shoot_bullet(
                         controlled_by,
                     ))
                     .id()
+            } else if is_p2p {
+                commands
+                    .spawn((
+                        bullet_bundle,
+                        PreSpawned::new(prespawn_hash),
+                        DeterministicPredicted::default(),
+                    ))
+                    .id()
             } else {
                 commands
                     .spawn((bullet_bundle, PreSpawned::new(prespawn_hash)))
@@ -245,9 +297,19 @@ pub(crate) fn shoot_bullet(
             };
             #[cfg(not(feature = "server"))]
             let bullet_entity = {
-                commands
-                    .spawn((bullet_bundle, PreSpawned::new(prespawn_hash)))
-                    .id()
+                if is_p2p {
+                    commands
+                        .spawn((
+                            bullet_bundle,
+                            PreSpawned::new(prespawn_hash),
+                            DeterministicPredicted::default(),
+                        ))
+                        .id()
+                } else {
+                    commands
+                        .spawn((bullet_bundle, PreSpawned::new(prespawn_hash)))
+                        .id()
+                }
             };
             lightyear_debug_event!(
                 DebugCategory::Prediction,
@@ -280,6 +342,20 @@ fn shoot_pressed_this_tick(input_buffer: &LeafwingBuffer<PlayerActions>, tick: T
         .get(tick - 1)
         .is_some_and(|snapshot| snapshot.0.pressed(&PlayerActions::Shoot));
     current_pressed && !previous_pressed
+}
+
+/// Despawn input-only P2P bullets on a deterministic tick boundary.
+fn despawn_p2p_bullets(
+    mut commands: Commands,
+    timeline: Res<LocalTimeline>,
+    bullets: Query<(Entity, &BulletMarker), With<DeterministicPredicted>>,
+) {
+    let tick = timeline.tick();
+    for (entity, bullet) in &bullets {
+        if tick - bullet.fire_tick >= P2P_BULLET_LIFETIME_TICKS {
+            commands.entity(entity).prediction_despawn();
+        }
+    }
 }
 
 #[derive(Component)]

--- a/examples/network_visibility/Cargo.toml
+++ b/examples/network_visibility/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT OR Apache-2.0"
 publish = false
 
 [features]
-default = ["client", "gui", "server", "netcode", "webtransport"]
+default = ["client", "gui", "server", "p2p", "netcode", "webtransport"]
 client = ["lightyear/client", "lightyear_examples_common/client"]
 gui = ["lightyear_examples_common/gui2d"]
 server = [
@@ -22,6 +22,12 @@ server = [
   "lightyear_examples_common/server",
 ]
 netcode = ["lightyear_examples_common/netcode"]
+p2p = [
+  "client",
+  "udp",
+  "lightyear/deterministic",
+  "lightyear_examples_common/p2p",
+]
 webtransport = ["lightyear_examples_common/webtransport"]
 udp = [
   "lightyear_examples_common/udp",
@@ -40,6 +46,7 @@ lightyear = { workspace = true, features = [
 lightyear_examples_common = { workspace = true, features = [
   "structured-debug",
 ] }
+lightyear_deterministic_replication.workspace = true
 
 serde.workspace = true
 bevy.workspace = true

--- a/examples/network_visibility/Cargo.toml
+++ b/examples/network_visibility/Cargo.toml
@@ -26,6 +26,7 @@ p2p = [
   "client",
   "udp",
   "lightyear/deterministic",
+  "lightyear/p2p",
   "lightyear_examples_common/p2p",
 ]
 webtransport = ["lightyear_examples_common/webtransport"]

--- a/examples/network_visibility/README.md
+++ b/examples/network_visibility/README.md
@@ -18,6 +18,14 @@ https://github.com/cBournhonesque/lightyear/assets/8112632/41a6d102-77a1-4a44-89
 - Run the server without a gui: `cargo run --no-default-features --features=server -- server`
 - Run the client and server in "HostClient" mode, where the client also acts as server (both are in the same App) : `cargo run -- host-client -c 0`
 
+### P2P mode
+
+The movement simulation can also run as a deterministic input-only game with no server. Start
+peer 0 with `cargo run --no-default-features --features=p2p -- --headless p2p --peer-id 0 --player-count 2`
+and peer 1 with the same command using `--peer-id 1`. Every peer creates the complete small scene
+locally. Interest management remains a feature of the conventional client/server mode because the
+P2P mode performs no entity replication.
+
 You can control the behaviour of the example by changing the list of features. By default, all features are enabled (client, server, gui).
 For example you can run the server in headless mode (without gui) by running `cargo run --no-default-features --features=server,webtransport,netcode`.
 

--- a/examples/network_visibility/src/client.rs
+++ b/examples/network_visibility/src/client.rs
@@ -53,8 +53,10 @@ pub(crate) fn buffer_input(
 }
 
 pub(crate) fn movement(
-    // TODO: maybe make prediction mode a separate component!!!
-    mut position_query: Query<(&mut Position, &ActionState<Inputs>), With<Predicted>>,
+    mut position_query: Query<
+        (&mut Position, &ActionState<Inputs>),
+        Or<(With<Predicted>, With<DeterministicPredicted>)>,
+    >,
 ) {
     for (position, input) in position_query.iter_mut() {
         shared_movement_behaviour(position, input);

--- a/examples/network_visibility/src/main.rs
+++ b/examples/network_visibility/src/main.rs
@@ -13,6 +13,8 @@
 
 #[cfg(feature = "client")]
 use crate::client::ExampleClientPlugin;
+#[cfg(feature = "p2p")]
+use crate::p2p::ExampleP2PPlugin;
 #[cfg(feature = "server")]
 use crate::server::ExampleServerPlugin;
 use crate::shared::SharedPlugin;
@@ -25,6 +27,8 @@ use lightyear_examples_common::shared::FIXED_TIMESTEP_HZ;
 #[cfg(feature = "client")]
 mod client;
 mod debug;
+#[cfg(feature = "p2p")]
+mod p2p;
 mod protocol;
 #[cfg(feature = "gui")]
 mod renderer;
@@ -45,9 +49,13 @@ fn main() {
     cli.spawn_connections(&mut app);
 
     match cli.mode {
-        #[cfg(feature = "client")]
+        #[cfg(all(feature = "client", any(not(feature = "p2p"), feature = "netcode")))]
         Some(Mode::Client { .. }) => {
             app.add_plugins(ExampleClientPlugin);
+        }
+        #[cfg(feature = "p2p")]
+        Some(Mode::P2P { .. }) => {
+            app.add_plugins((ExampleClientPlugin, ExampleP2PPlugin));
         }
         #[cfg(feature = "server")]
         Some(Mode::Server) => {

--- a/examples/network_visibility/src/p2p.rs
+++ b/examples/network_visibility/src/p2p.rs
@@ -1,44 +1,41 @@
-//! Direct P2P setup for the simple-box deterministic simulation.
+//! Input-only P2P setup for the network-visibility example.
 //!
-//! Unlike the conventional mode, no server spawns or replicates players. Every peer creates the
-//! same fixed roster locally and only exchanges tick-indexed inputs.
+//! Interest management remains a server-side replication demonstration in conventional mode. The
+//! P2P mode creates the complete small scene on every peer and exercises only deterministic player
+//! input exchange.
 
-use crate::protocol::{Inputs, PlayerBundle};
 use bevy::prelude::*;
 use lightyear::prediction::rollback::DeterministicPredicted;
 use lightyear::prelude::input::client::InputSystems;
 use lightyear::prelude::input::native::{ActionState, InputMarker};
 use lightyear::prelude::input::InputBuffer;
 use lightyear::prelude::*;
+use lightyear_deterministic_replication::prelude::DeterministicReplicationPlugin;
 use lightyear_examples_common::p2p::{
     input_target_for_peer, P2PGameplayStarted, P2PSettings, GAMEPLAY_START_TICK,
 };
 
-/// Namespace for stable simple-box player hashes on the input wire.
-const PLAYER_INPUT_HASH_BASE: u64 = 0x5349_4D50_4C45_0000;
+use crate::protocol::*;
+use crate::shared::color_from_id;
+
+const PLAYER_INPUT_HASH_BASE: u64 = 0x5649_5349_4200_0000;
+const GRID_SIZE: f32 = 200.0;
+const NUM_CIRCLES: i32 = 1;
 
 pub struct ExampleP2PPlugin;
 
 impl Plugin for ExampleP2PPlugin {
     fn build(&self, app: &mut App) {
         app.insert_resource(PredictionManager::default());
-        app.add_plugins(
-            lightyear_deterministic_replication::prelude::DeterministicReplicationPlugin,
-        );
+        app.add_plugins(DeterministicReplicationPlugin);
         app.add_systems(
             FixedPreUpdate,
-            spawn_fixed_roster.before(InputSystems::BufferClientInputs),
+            spawn_fixed_world.before(InputSystems::BufferClientInputs),
         );
-        crate::automation::add_p2p_debugging(app);
     }
 }
 
-/// Spawn one local deterministic copy of every player in stable roster order.
-///
-/// The local player receives [`InputMarker`], while remote players start with empty input buffers
-/// so prediction can begin before their first packet arrives. The explicit [`PreSpawned`] hash is
-/// the cross-world input identity; P2P deliberately does not depend on replication entity maps.
-fn spawn_fixed_roster(
+fn spawn_fixed_world(
     mut commands: Commands,
     _synced: SyncedInputTimeline,
     timeline: Res<LocalTimeline>,
@@ -51,30 +48,42 @@ fn spawn_fixed_roster(
     }
     commands.insert_resource(P2PGameplayStarted);
 
-    let spacing = 120.0;
-    let center = (f32::from(settings.player_count) - 1.0) * 0.5;
+    for x in -NUM_CIRCLES..NUM_CIRCLES {
+        for y in -NUM_CIRCLES..NUM_CIRCLES {
+            commands.spawn((
+                Position(Vec2::new(x as f32 * GRID_SIZE, y as f32 * GRID_SIZE)),
+                CircleMarker,
+            ));
+        }
+    }
 
+    let spacing = 100.0;
+    let center = (f32::from(settings.player_count) - 1.0) * 0.5;
     for peer_id in settings.peer_ids() {
         let id = PeerId::Entity(u64::from(peer_id));
-        let position = Vec2::new((f32::from(peer_id) - center) * spacing, 0.0);
-        let hash = PLAYER_INPUT_HASH_BASE | u64::from(peer_id);
-        let pre_spawned = input_target_for_peer(&settings, &links, peer_id, hash);
-
-        let entity = commands
+        let target = input_target_for_peer(
+            &settings,
+            &links,
+            peer_id,
+            PLAYER_INPUT_HASH_BASE | u64::from(peer_id),
+        );
+        let player = commands
             .spawn((
-                PlayerBundle::new(id, position),
+                PlayerId(id),
+                Position(Vec2::new((f32::from(peer_id) - center) * spacing, 0.0)),
+                PlayerColor(color_from_id(id)),
                 DeterministicPredicted {
                     skip_despawn: true,
                     enable_rollback_after: 0,
                 },
-                pre_spawned,
+                target,
                 ActionState::<Inputs>::default(),
                 InputBuffer::<ActionState<Inputs>, Inputs>::default(),
             ))
             .id();
         if peer_id == settings.local_peer_id {
             commands
-                .entity(entity)
+                .entity(player)
                 .insert(InputMarker::<Inputs>::default());
         }
     }

--- a/examples/replication_groups/Cargo.toml
+++ b/examples/replication_groups/Cargo.toml
@@ -13,7 +13,7 @@ publish = false
 
 
 [features]
-default = ["client", "gui", "server", "netcode", "webtransport"]
+default = ["client", "gui", "server", "p2p", "netcode", "webtransport"]
 client = ["lightyear/client", "lightyear_examples_common/client"]
 gui = ["lightyear_examples_common/gui2d"]
 server = [
@@ -23,6 +23,12 @@ server = [
   "lightyear_examples_common/server",
 ]
 netcode = ["lightyear_examples_common/netcode"]
+p2p = [
+  "client",
+  "udp",
+  "lightyear/deterministic",
+  "lightyear_examples_common/p2p",
+]
 webtransport = ["lightyear_examples_common/webtransport"]
 udp = [
   "lightyear_examples_common/udp",
@@ -39,6 +45,7 @@ lightyear = { "workspace" = true, features = [
   "input_native",
 ] }
 lightyear_frame_interpolation.workspace = true
+lightyear_deterministic_replication.workspace = true
 lightyear_examples_common = { workspace = true, features = [
   "structured-debug",
 ] }

--- a/examples/replication_groups/Cargo.toml
+++ b/examples/replication_groups/Cargo.toml
@@ -27,6 +27,7 @@ p2p = [
   "client",
   "udp",
   "lightyear/deterministic",
+  "lightyear/p2p",
   "lightyear_examples_common/p2p",
 ]
 webtransport = ["lightyear_examples_common/webtransport"]

--- a/examples/replication_groups/README.md
+++ b/examples/replication_groups/README.md
@@ -25,6 +25,14 @@ https://github.com/cBournhonesque/lightyear/assets/8112632/e7625286-a167-4f50-aa
 - Run the server without a gui: `cargo run --no-default-features --features=server -- server`
 - Run the client and server in "HostClient" mode, where the client also acts as server (both are in the same App) : `cargo run -- host-client -c 0`
 
+### P2P mode
+
+The snake simulation can also run as a deterministic input-only game with no server. Start peer 0
+with `cargo run --no-default-features --features=p2p -- --headless p2p --peer-id 0 --player-count 2`
+and peer 1 with the same command using `--peer-id 1`. Every peer creates the same heads and tails
+locally. Replication groups themselves remain a feature of the conventional client/server mode;
+the P2P mode performs no entity replication.
+
 You can control the behaviour of the example by changing the list of features. By default, all features are enabled (client, server, gui).
 For example you can run the server in headless mode (without gui) by running `cargo run --no-default-features --features=server,webtransport,netcode`.
 

--- a/examples/replication_groups/src/client.rs
+++ b/examples/replication_groups/src/client.rs
@@ -72,7 +72,10 @@ pub(crate) fn buffer_input(
 //
 // If this example predicted remote entities, ownership would need to be checked before movement.
 fn movement(
-    mut position_query: Query<(&mut PlayerPosition, &ActionState<Inputs>), With<Predicted>>,
+    mut position_query: Query<
+        (&mut PlayerPosition, &ActionState<Inputs>),
+        Or<(With<Predicted>, With<DeterministicPredicted>)>,
+    >,
 ) {
     for (position, input) in position_query.iter_mut() {
         shared_movement_behaviour(position, input);

--- a/examples/replication_groups/src/main.rs
+++ b/examples/replication_groups/src/main.rs
@@ -5,6 +5,8 @@
 
 #[cfg(feature = "client")]
 use crate::client::ExampleClientPlugin;
+#[cfg(feature = "p2p")]
+use crate::p2p::ExampleP2PPlugin;
 #[cfg(feature = "server")]
 use crate::server::ExampleServerPlugin;
 use crate::shared::SharedPlugin;
@@ -17,6 +19,8 @@ mod automation;
 #[cfg(feature = "client")]
 mod client;
 mod debug;
+#[cfg(feature = "p2p")]
+mod p2p;
 mod protocol;
 
 #[cfg(feature = "gui")]
@@ -36,9 +40,13 @@ fn main() {
     cli.spawn_connections(&mut app);
 
     match cli.mode {
-        #[cfg(feature = "client")]
+        #[cfg(all(feature = "client", any(not(feature = "p2p"), feature = "netcode")))]
         Some(Mode::Client { .. }) => {
             app.add_plugins(ExampleClientPlugin);
+        }
+        #[cfg(feature = "p2p")]
+        Some(Mode::P2P { .. }) => {
+            app.add_plugins((ExampleClientPlugin, ExampleP2PPlugin));
         }
         #[cfg(feature = "server")]
         Some(Mode::Server) => {

--- a/examples/replication_groups/src/p2p.rs
+++ b/examples/replication_groups/src/p2p.rs
@@ -3,6 +3,10 @@
 //! Replication groups remain demonstrated by the conventional server mode. In P2P mode every peer
 //! creates the same snake roster locally and exchanges only deterministic inputs.
 
+extern crate alloc;
+
+use crate::protocol::*;
+use alloc::collections::VecDeque;
 use bevy::prelude::*;
 use lightyear::prediction::rollback::DeterministicPredicted;
 use lightyear::prelude::input::client::InputSystems;
@@ -14,10 +18,6 @@ use lightyear_examples_common::p2p::{
     input_target_for_peer, P2PGameplayStarted, P2PSettings, GAMEPLAY_START_TICK,
 };
 use lightyear_frame_interpolation::FrameInterpolate;
-use std::collections::VecDeque;
-
-use crate::protocol::*;
-
 const PLAYER_INPUT_HASH_BASE: u64 = 0x4752_4F55_5000_0000;
 
 pub struct ExampleP2PPlugin;

--- a/examples/replication_groups/src/p2p.rs
+++ b/examples/replication_groups/src/p2p.rs
@@ -1,43 +1,38 @@
-//! Direct P2P setup for the simple-box deterministic simulation.
+//! Input-only P2P setup for the replication-groups example.
 //!
-//! Unlike the conventional mode, no server spawns or replicates players. Every peer creates the
-//! same fixed roster locally and only exchanges tick-indexed inputs.
+//! Replication groups remain demonstrated by the conventional server mode. In P2P mode every peer
+//! creates the same snake roster locally and exchanges only deterministic inputs.
 
-use crate::protocol::{Inputs, PlayerBundle};
 use bevy::prelude::*;
 use lightyear::prediction::rollback::DeterministicPredicted;
 use lightyear::prelude::input::client::InputSystems;
 use lightyear::prelude::input::native::{ActionState, InputMarker};
 use lightyear::prelude::input::InputBuffer;
 use lightyear::prelude::*;
+use lightyear_deterministic_replication::prelude::DeterministicReplicationPlugin;
 use lightyear_examples_common::p2p::{
     input_target_for_peer, P2PGameplayStarted, P2PSettings, GAMEPLAY_START_TICK,
 };
+use lightyear_frame_interpolation::FrameInterpolate;
+use std::collections::VecDeque;
 
-/// Namespace for stable simple-box player hashes on the input wire.
-const PLAYER_INPUT_HASH_BASE: u64 = 0x5349_4D50_4C45_0000;
+use crate::protocol::*;
+
+const PLAYER_INPUT_HASH_BASE: u64 = 0x4752_4F55_5000_0000;
 
 pub struct ExampleP2PPlugin;
 
 impl Plugin for ExampleP2PPlugin {
     fn build(&self, app: &mut App) {
         app.insert_resource(PredictionManager::default());
-        app.add_plugins(
-            lightyear_deterministic_replication::prelude::DeterministicReplicationPlugin,
-        );
+        app.add_plugins(DeterministicReplicationPlugin);
         app.add_systems(
             FixedPreUpdate,
             spawn_fixed_roster.before(InputSystems::BufferClientInputs),
         );
-        crate::automation::add_p2p_debugging(app);
     }
 }
 
-/// Spawn one local deterministic copy of every player in stable roster order.
-///
-/// The local player receives [`InputMarker`], while remote players start with empty input buffers
-/// so prediction can begin before their first packet arrives. The explicit [`PreSpawned`] hash is
-/// the cross-world input identity; P2P deliberately does not depend on replication entity maps.
 fn spawn_fixed_roster(
     mut commands: Commands,
     _synced: SyncedInputTimeline,
@@ -51,31 +46,53 @@ fn spawn_fixed_roster(
     }
     commands.insert_resource(P2PGameplayStarted);
 
-    let spacing = 120.0;
+    let spacing = 180.0;
     let center = (f32::from(settings.player_count) - 1.0) * 0.5;
-
     for peer_id in settings.peer_ids() {
         let id = PeerId::Entity(u64::from(peer_id));
         let position = Vec2::new((f32::from(peer_id) - center) * spacing, 0.0);
-        let hash = PLAYER_INPUT_HASH_BASE | u64::from(peer_id);
-        let pre_spawned = input_target_for_peer(&settings, &links, peer_id, hash);
-
-        let entity = commands
+        let color = Color::hsl((f32::from(peer_id) * 0.23) % 1.0, 0.8, 0.5);
+        let target = input_target_for_peer(
+            &settings,
+            &links,
+            peer_id,
+            PLAYER_INPUT_HASH_BASE | u64::from(peer_id),
+        );
+        let player = commands
             .spawn((
-                PlayerBundle::new(id, position),
+                PlayerId(id),
+                PlayerPosition(position),
+                PlayerColor(color),
                 DeterministicPredicted {
                     skip_despawn: true,
                     enable_rollback_after: 0,
                 },
-                pre_spawned,
+                target,
                 ActionState::<Inputs>::default(),
                 InputBuffer::<ActionState<Inputs>, Inputs>::default(),
+                FrameInterpolate,
+                Name::from("P2P Head"),
             ))
             .id();
         if peer_id == settings.local_peer_id {
             commands
-                .entity(entity)
+                .entity(player)
                 .insert(InputMarker::<Inputs>::default());
         }
+
+        let tail_length = 300.0;
+        let direction = Direction::Up;
+        let mut points = VecDeque::new();
+        points.push_front((direction.get_tail(position, tail_length), direction));
+        commands.spawn((
+            PlayerParent(player),
+            TailPoints(points),
+            TailLength(tail_length),
+            DeterministicPredicted {
+                skip_despawn: true,
+                enable_rollback_after: 0,
+            },
+            Name::from("P2P Tail"),
+        ));
     }
 }

--- a/examples/replication_groups/src/shared.rs
+++ b/examples/replication_groups/src/shared.rs
@@ -30,10 +30,21 @@ pub(crate) fn shared_movement_behaviour(mut position: Mut<PlayerPosition>, input
 // Updates predicted tail points when the head moves. Interpolated tails are updated during
 // interpolation, and confirmed tails are replicated from the server.
 pub(crate) fn shared_tail_behaviour(
-    player_position: Query<Ref<PlayerPosition>, Or<(With<Predicted>, With<Replicate>)>>,
+    player_position: Query<
+        Ref<PlayerPosition>,
+        Or<(
+            With<Predicted>,
+            With<Replicate>,
+            With<DeterministicPredicted>,
+        )>,
+    >,
     mut tails: Query<
         (&mut TailPoints, &PlayerParent, &TailLength),
-        Or<(With<Predicted>, With<ReplicateLike>)>,
+        Or<(
+            With<Predicted>,
+            With<ReplicateLike>,
+            With<DeterministicPredicted>,
+        )>,
     >,
 ) {
     for (mut points, parent, length) in tails.iter_mut() {

--- a/examples/simple_box/Cargo.toml
+++ b/examples/simple_box/Cargo.toml
@@ -26,6 +26,7 @@ p2p = [
   "client",
   "udp",
   "lightyear/deterministic",
+  "lightyear/p2p",
   "lightyear_examples_common/p2p",
 ]
 webtransport = ["lightyear_examples_common/webtransport"]

--- a/examples/simple_box/Cargo.toml
+++ b/examples/simple_box/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT OR Apache-2.0"
 publish = false
 
 [features]
-default = ["client", "gui", "server", "netcode", "webtransport"]
+default = ["client", "gui", "server", "p2p", "netcode", "webtransport"]
 client = ["lightyear/client", "lightyear_examples_common/client"]
 gui = ["lightyear_examples_common/gui2d"]
 server = [
@@ -22,6 +22,12 @@ server = [
   "lightyear_examples_common/server",
 ]
 netcode = ["lightyear_examples_common/netcode"]
+p2p = [
+  "client",
+  "udp",
+  "lightyear/deterministic",
+  "lightyear_examples_common/p2p",
+]
 webtransport = ["lightyear_examples_common/webtransport"]
 udp = ["lightyear_examples_common/udp", "lightyear/std", "lightyear/udp"]
 steam = ["lightyear_examples_common/steam"]
@@ -34,6 +40,7 @@ lightyear = { "workspace" = true, features = [
   "replication",
   "input_native",
 ] }
+lightyear_deterministic_replication.workspace = true
 lightyear_examples_common = { workspace = true, features = [
   "structured-debug",
 ] }

--- a/examples/simple_box/README.md
+++ b/examples/simple_box/README.md
@@ -26,15 +26,19 @@ simulation. Start one process for each member of the fixed roster:
 
 P2P mode currently uses direct raw UDP Links on localhost and supports two through four players.
 Every peer pre-spawns the same player roster with stable `PreSpawned` hashes, simulates every
-player locally, and sends only its own tick-indexed inputs to the other peers. The normal
-client/server and host-client modes remain available in the same example.
+player locally, and sends only its own tick-indexed inputs to the other peers. Each peer predicts
+missing remote inputs by repeating the latest known input, then rolls back and replays the complete
+deterministic world when corrected input arrives. The normal client/server and host-client modes
+remain available in the same example.
 
 You can control the behaviour of the example by changing the list of features. By default, all features are enabled (client, server, gui).
 For example you can run the server in headless mode (without gui) by running `cargo run --no-default-features --features=server,webtransport,netcode`.
 
-For automated headless verification, you can set `LIGHTYEAR_SIMPLE_BOX_AUTOMOVE=right` on one client and
-`LIGHTYEAR_SIMPLE_BOX_LOG_POSITIONS=1` on another client to confirm from logs that the interpolated remote player
-keeps receiving `PlayerPosition` updates.
+Run `just simple_box_p2p_smoke` for a two-process headless check that remote inputs cause rollback
+and both peers converge to identical player positions at the same tick.
+
+The smoke test leaves its normal and structured logs in the temporary directory printed on
+success or failure.
 
 ### Testing in wasm with webtransport
 

--- a/examples/simple_box/README.md
+++ b/examples/simple_box/README.md
@@ -18,6 +18,17 @@ https://github.com/cBournhonesque/lightyear/assets/8112632/7b57d48a-d8b0-4cdd-a1
 - Run a headless client without a gui: `cargo run --no-default-features --features=client,netcode,webtransport -- client -c 1`
 - Run the client and server in "HostClient" mode, where the client also acts as server (both are in the same App) : `cargo run -- host-client -c 0`
 
+The same example can run as a deterministic, input-only P2P game with no server or authoritative
+simulation. Start one process for each member of the fixed roster:
+
+- Peer 0: `cargo run --no-default-features --features=p2p -- --headless p2p --peer-id 0 --player-count 2`
+- Peer 1: `cargo run --no-default-features --features=p2p -- --headless p2p --peer-id 1 --player-count 2`
+
+P2P mode currently uses direct raw UDP Links on localhost and supports two through four players.
+Every peer pre-spawns the same player roster with stable `PreSpawned` hashes, simulates every
+player locally, and sends only its own tick-indexed inputs to the other peers. The normal
+client/server and host-client modes remain available in the same example.
+
 You can control the behaviour of the example by changing the list of features. By default, all features are enabled (client, server, gui).
 For example you can run the server in headless mode (without gui) by running `cargo run --no-default-features --features=server,webtransport,netcode`.
 

--- a/examples/simple_box/p2p_smoke.sh
+++ b/examples/simple_box/p2p_smoke.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+smoke_dir="$(mktemp -d "${TMPDIR:-/tmp}/lightyear-simple-box-p2p.XXXXXX")"
+peer_0_log="$smoke_dir/peer-0.log"
+peer_1_log="$smoke_dir/peer-1.log"
+peer_0_debug="$smoke_dir/peer-0.jsonl"
+peer_1_debug="$smoke_dir/peer-1.jsonl"
+peer_0_state="$smoke_dir/peer-0-state.json"
+peer_1_state="$smoke_dir/peer-1-state.json"
+
+exit_tick="${LIGHTYEAR_SIMPLE_BOX_SMOKE_EXIT_TICK:-420}"
+check_tick="${LIGHTYEAR_SIMPLE_BOX_SMOKE_CHECK_TICK:-380}"
+base_port="${LIGHTYEAR_SIMPLE_BOX_SMOKE_PORT:-$((30000 + $$ % 10000))}"
+
+if ((check_tick >= exit_tick)); then
+    echo "check tick must be earlier than exit tick" >&2
+    exit 1
+fi
+
+cargo build -p simple_box --no-default-features --features=p2p
+target_dir="$(cargo metadata --no-deps --format-version 1 | jq -r .target_directory)"
+binary="$target_dir/debug/simple_box"
+
+pids=()
+cleanup() {
+    for pid in "${pids[@]}"; do
+        kill "$pid" 2>/dev/null || true
+    done
+}
+trap cleanup EXIT INT TERM
+
+LIGHTYEAR_SIMPLE_BOX_AUTOMOVE=right \
+LIGHTYEAR_SIMPLE_BOX_EXIT_AFTER_TICK="$exit_tick" \
+LIGHTYEAR_DEBUG_FILE="$peer_0_debug" \
+RUST_LOG=info,lightyear_debug=trace \
+"$binary" --headless p2p --peer-id 0 --player-count 2 --base-port "$base_port" \
+    >"$peer_0_log" 2>&1 &
+pids+=("$!")
+
+LIGHTYEAR_SIMPLE_BOX_AUTOMOVE=none \
+LIGHTYEAR_SIMPLE_BOX_EXIT_AFTER_TICK="$exit_tick" \
+LIGHTYEAR_DEBUG_FILE="$peer_1_debug" \
+RUST_LOG=info,lightyear_debug=trace \
+"$binary" --headless p2p --peer-id 1 --player-count 2 --base-port "$base_port" \
+    >"$peer_1_log" 2>&1 &
+pids+=("$!")
+
+deadline=$((SECONDS + 20))
+while kill -0 "${pids[0]}" 2>/dev/null || kill -0 "${pids[1]}" 2>/dev/null; do
+    if ((SECONDS >= deadline)); then
+        echo "simple-box P2P smoke test timed out; logs: $smoke_dir" >&2
+        exit 1
+    fi
+    sleep 1
+done
+
+peer_0_status=0
+peer_1_status=0
+wait "${pids[0]}" || peer_0_status=$?
+wait "${pids[1]}" || peer_1_status=$?
+if ((peer_0_status != 0 || peer_1_status != 0)); then
+    echo "simple-box P2P peer failed; logs: $smoke_dir" >&2
+    exit 1
+fi
+
+if ! grep -q '"kind":"input_mismatch_rollback"' "$peer_1_debug"; then
+    echo "peer 1 did not roll back for peer 0 input; logs: $smoke_dir" >&2
+    exit 1
+fi
+
+extract_state() {
+    local source="$1"
+    local destination="$2"
+    # App exit can interrupt the final buffered debug record. Parse complete JSONL
+    # records individually so that an incomplete final line cannot hide the
+    # earlier rollback and state samples under test.
+    jq --null-input --raw-input --argjson tick "$check_tick" '
+        [
+            inputs
+            | fromjson?
+            | select(
+                .category == "component"
+                and .tick_id == $tick
+                and (
+                    (.component | endswith("PlayerId"))
+                    or (.component | endswith("PlayerPosition"))
+                )
+            )
+        ]
+        | group_by(.entity)
+        | map({
+            player: ([.[] | select(.component | endswith("PlayerId")) | .value] | last),
+            position: ([.[] | select(.component | endswith("PlayerPosition")) | .value] | last)
+        })
+        | map(select(.player != null and .position != null))
+        | sort_by(.player | tojson)
+    ' "$source" >"$destination"
+}
+
+extract_state "$peer_0_debug" "$peer_0_state"
+extract_state "$peer_1_debug" "$peer_1_state"
+
+if ! jq -e 'length == 2' "$peer_0_state" >/dev/null \
+    || ! jq -e 'length == 2' "$peer_1_state" >/dev/null; then
+    echo "did not capture both players at tick $check_tick; logs: $smoke_dir" >&2
+    exit 1
+fi
+if ! diff -u "$peer_0_state" "$peer_1_state"; then
+    echo "simple-box P2P peers diverged at tick $check_tick; logs: $smoke_dir" >&2
+    exit 1
+fi
+
+trap - EXIT INT TERM
+echo "simple-box P2P rollback and convergence passed at tick $check_tick"
+echo "logs: $smoke_dir"

--- a/examples/simple_box/src/automation.rs
+++ b/examples/simple_box/src/automation.rs
@@ -1,6 +1,10 @@
 use crate::protocol::Direction;
+#[cfg(feature = "p2p")]
+use crate::protocol::{PlayerId, PlayerPosition};
 use bevy::prelude::*;
 use lightyear::prelude::*;
+#[cfg(feature = "p2p")]
+use lightyear_examples_common::p2p::P2PSettings;
 
 #[cfg(feature = "client")]
 pub struct AutomationClientPlugin;
@@ -20,6 +24,51 @@ pub struct AutomationServerPlugin;
 impl Plugin for AutomationServerPlugin {
     fn build(&self, app: &mut App) {
         app.add_systems(Update, crate::debug::server::mark_debug_player_entities);
+    }
+}
+
+/// Install the opt-in diagnostics used by the headless P2P smoke test.
+#[cfg(feature = "p2p")]
+pub(crate) fn add_p2p_debugging(app: &mut App) {
+    if std::env::var_os("LIGHTYEAR_SIMPLE_BOX_LOG_POSITIONS").is_some() {
+        app.add_systems(Update, log_p2p_positions);
+    }
+}
+
+/// Periodically log P2P connection state and deterministic player positions.
+#[cfg(feature = "p2p")]
+fn log_p2p_positions(
+    time: Res<Time>,
+    timeline: Res<LocalTimeline>,
+    settings: Res<P2PSettings>,
+    links: Query<(&RemoteId, Has<Connected>, &PingManager), With<P2P>>,
+    synced_input_timeline: Query<(), (With<InputTimeline>, With<IsSynced<InputTimeline>>)>,
+    players: Query<(&PlayerId, &PlayerPosition)>,
+    mut timer: Local<Option<Timer>>,
+) {
+    let timer = timer.get_or_insert_with(|| Timer::from_seconds(1.0, TimerMode::Repeating));
+    timer.tick(time.delta());
+    if !timer.just_finished() {
+        return;
+    }
+    for (remote, connected, ping) in &links {
+        info!(
+            local_peer = settings.local_peer_id,
+            ?remote,
+            connected,
+            latency_samples = ping.latency_samples_recv(),
+            input_timeline_synced = !synced_input_timeline.is_empty(),
+            "P2P Link status"
+        );
+    }
+    for (player, position) in &players {
+        info!(
+            local_peer = settings.local_peer_id,
+            tick = timeline.tick().0,
+            ?player,
+            position = ?position.0,
+            "P2P player position"
+        );
     }
 }
 

--- a/examples/simple_box/src/automation.rs
+++ b/examples/simple_box/src/automation.rs
@@ -33,6 +33,29 @@ pub(crate) fn add_p2p_debugging(app: &mut App) {
     if std::env::var_os("LIGHTYEAR_SIMPLE_BOX_LOG_POSITIONS").is_some() {
         app.add_systems(Update, log_p2p_positions);
     }
+    if let Some(tick) = std::env::var("LIGHTYEAR_SIMPLE_BOX_EXIT_AFTER_TICK")
+        .ok()
+        .and_then(|value| value.parse::<u32>().ok())
+    {
+        app.insert_resource(ExitAfterTick(Tick(tick)));
+        app.add_systems(Update, exit_after_tick);
+    }
+}
+
+/// Optional deterministic endpoint for multi-process example automation.
+#[cfg(feature = "p2p")]
+#[derive(Resource)]
+struct ExitAfterTick(Tick);
+
+#[cfg(feature = "p2p")]
+fn exit_after_tick(
+    timeline: Res<LocalTimeline>,
+    exit_tick: Res<ExitAfterTick>,
+    mut exit: MessageWriter<AppExit>,
+) {
+    if timeline.tick() >= exit_tick.0 {
+        exit.write(AppExit::Success);
+    }
 }
 
 /// Periodically log P2P connection state and deterministic player positions.

--- a/examples/simple_box/src/client.rs
+++ b/examples/simple_box/src/client.rs
@@ -2,8 +2,8 @@
 //! The client will be responsible for:
 //! - connecting to the server at Startup
 //! - sending inputs to the server
-//! - applying inputs to the locally predicted player (for prediction to work, inputs have to be applied to both the
-//!   predicted entity and the server entity)
+//! - applying inputs to predicted entities. In client/server mode this is the locally controlled
+//!   player; in P2P mode every peer predicts the complete deterministic roster.
 
 use crate::automation::{self, AutomationClientPlugin};
 use crate::protocol::*;
@@ -91,9 +91,12 @@ fn buffer_input(
     }
 }
 
-/// Applies local movement only to predicted entities owned by this client.
+/// Apply movement to every entity simulated by this client.
 ///
-/// If this example predicted remote entities, ownership would need to be checked before movement.
+/// Conventional clients only have a [`Predicted`] copy of their locally controlled player. P2P
+/// peers instead give every roster member [`DeterministicPredicted`]: the local player uses captured
+/// input, while remote players repeat their latest known input and trigger rollback when corrected
+/// input arrives.
 fn player_movement(
     _input_timeline: SyncedInputTimeline,
     timeline: Res<LocalTimeline>,

--- a/examples/simple_box/src/client.rs
+++ b/examples/simple_box/src/client.rs
@@ -104,7 +104,7 @@ fn player_movement(
     >,
 ) {
     #[cfg(feature = "p2p")]
-    if p2p.is_some() && timeline.tick().0 < crate::p2p::GAMEPLAY_START_TICK {
+    if p2p.is_some() && timeline.tick().0 < lightyear_examples_common::p2p::GAMEPLAY_START_TICK {
         return;
     }
     for (position, input) in position_query.iter_mut() {

--- a/examples/simple_box/src/client.rs
+++ b/examples/simple_box/src/client.rs
@@ -15,7 +15,7 @@ use lightyear::prelude::client::{InputDelayConfig, InputTimelineConfig};
 use lightyear::prelude::input::native::*;
 use lightyear::prelude::*;
 #[cfg(feature = "p2p")]
-use lightyear_examples_common::cli::P2PSettings;
+use lightyear_examples_common::p2p::P2PSettings;
 
 pub struct ExampleClientPlugin;
 
@@ -37,20 +37,10 @@ impl Plugin for ExampleClientPlugin {
     }
 }
 
-fn configure_input_delay(
-    mut commands: Commands,
-    #[cfg(feature = "p2p")] p2p: Option<Res<P2PSettings>>,
-) {
-    #[cfg(feature = "p2p")]
-    let input_delay = if p2p.is_some() {
-        InputDelayConfig::fixed_input_delay(2)
-    } else {
-        InputDelayConfig::no_input_delay()
-    };
-    #[cfg(not(feature = "p2p"))]
-    let input_delay = InputDelayConfig::no_input_delay();
-
-    commands.insert_resource(InputTimelineConfig::default().with_input_delay(input_delay));
+fn configure_input_delay(mut commands: Commands) {
+    commands.insert_resource(
+        InputTimelineConfig::default().with_input_delay(InputDelayConfig::no_input_delay()),
+    );
 }
 
 /// System that reads from peripherals and adds inputs to the buffer

--- a/examples/simple_box/src/client.rs
+++ b/examples/simple_box/src/client.rs
@@ -9,10 +9,13 @@ use crate::automation::{self, AutomationClientPlugin};
 use crate::protocol::*;
 use crate::shared;
 use bevy::prelude::*;
+use lightyear::prediction::rollback::DeterministicPredicted;
 use lightyear::prelude::client::input::*;
 use lightyear::prelude::client::{InputDelayConfig, InputTimelineConfig};
 use lightyear::prelude::input::native::*;
 use lightyear::prelude::*;
+#[cfg(feature = "p2p")]
+use lightyear_examples_common::cli::P2PSettings;
 
 pub struct ExampleClientPlugin;
 
@@ -34,10 +37,20 @@ impl Plugin for ExampleClientPlugin {
     }
 }
 
-fn configure_input_delay(mut commands: Commands) {
-    commands.insert_resource(
-        InputTimelineConfig::default().with_input_delay(InputDelayConfig::no_input_delay()),
-    );
+fn configure_input_delay(
+    mut commands: Commands,
+    #[cfg(feature = "p2p")] p2p: Option<Res<P2PSettings>>,
+) {
+    #[cfg(feature = "p2p")]
+    let input_delay = if p2p.is_some() {
+        InputDelayConfig::fixed_input_delay(2)
+    } else {
+        InputDelayConfig::no_input_delay()
+    };
+    #[cfg(not(feature = "p2p"))]
+    let input_delay = InputDelayConfig::no_input_delay();
+
+    commands.insert_resource(InputTimelineConfig::default().with_input_delay(input_delay));
 }
 
 /// System that reads from peripherals and adds inputs to the buffer
@@ -93,10 +106,17 @@ fn buffer_input(
 /// If this example predicted remote entities, ownership would need to be checked before movement.
 fn player_movement(
     _input_timeline: SyncedInputTimeline,
-    // timeline: Single<&LocalTimeline>,
-    mut position_query: Query<(&mut PlayerPosition, &ActionState<Inputs>), With<Predicted>>,
+    timeline: Res<LocalTimeline>,
+    #[cfg(feature = "p2p")] p2p: Option<Res<P2PSettings>>,
+    mut position_query: Query<
+        (&mut PlayerPosition, &ActionState<Inputs>),
+        Or<(With<Predicted>, With<DeterministicPredicted>)>,
+    >,
 ) {
-    // let tick = timeline.tick();
+    #[cfg(feature = "p2p")]
+    if p2p.is_some() && timeline.tick().0 < crate::p2p::GAMEPLAY_START_TICK {
+        return;
+    }
     for (position, input) in position_query.iter_mut() {
         // trace!(?tick, ?position, ?input, "client");
         // Pass Mut<PlayerPosition> directly so change detection only fires when movement changes it.
@@ -105,7 +125,18 @@ fn player_movement(
 }
 
 /// System to receive messages on the client
-pub(crate) fn receive_message1(mut receiver: Single<&mut MessageReceiver<Message1>>) {
+pub(crate) fn receive_message1(
+    metadata: Res<NetworkingMetadata>,
+    mut receivers: Query<&mut MessageReceiver<Message1>>,
+) {
+    let link = match &metadata.mode {
+        NetworkTopology::Client(link) => *link,
+        NetworkTopology::HostClient { client, .. } => *client,
+        _ => return,
+    };
+    let Ok(mut receiver) = receivers.get_mut(link) else {
+        return;
+    };
     for message in receiver.receive() {
         info!("Received message: {:?}", message);
     }

--- a/examples/simple_box/src/debug.rs
+++ b/examples/simple_box/src/debug.rs
@@ -10,24 +10,39 @@ pub(crate) mod client {
 
     pub(crate) fn mark_debug_player_entities(
         mut commands: Commands,
-        query: Query<(Entity, Has<Predicted>, Has<Interpolated>), Added<PlayerId>>,
+        query: Query<
+            (
+                Entity,
+                Has<Predicted>,
+                Has<Interpolated>,
+                Has<DeterministicPredicted>,
+            ),
+            Added<PlayerId>,
+        >,
     ) {
-        for (entity, predicted, interpolated) in query.iter() {
-            if predicted || interpolated {
+        for (entity, predicted, interpolated, deterministic) in query.iter() {
+            if predicted || interpolated || deterministic {
                 let input_sample_points = [
                     DebugSamplePoint::FixedPreUpdate,
                     DebugSamplePoint::FixedUpdate,
                 ];
                 commands.entity(entity).insert(
-                    LightyearDebug::component_at::<PlayerPosition>([
+                    LightyearDebug::component_structured_at::<PlayerPosition>([
+                        DebugSamplePoint::FixedUpdate,
                         DebugSamplePoint::Update,
                         DebugSamplePoint::PostUpdate,
                     ])
+                    .with_component_structured_at::<PlayerId>([DebugSamplePoint::FixedUpdate])
                     .with_component_at::<Predicted>([
                         DebugSamplePoint::Update,
                         DebugSamplePoint::PostUpdate,
                     ])
                     .with_component_at::<Interpolated>([
+                        DebugSamplePoint::Update,
+                        DebugSamplePoint::PostUpdate,
+                    ])
+                    .with_component_at::<DeterministicPredicted>([
+                        DebugSamplePoint::FixedUpdate,
                         DebugSamplePoint::Update,
                         DebugSamplePoint::PostUpdate,
                     ])

--- a/examples/simple_box/src/lib.rs
+++ b/examples/simple_box/src/lib.rs
@@ -13,4 +13,7 @@ pub mod server;
 #[cfg(feature = "gui")]
 pub mod renderer;
 
+#[cfg(feature = "p2p")]
+pub mod p2p;
+
 pub mod shared;

--- a/examples/simple_box/src/main.rs
+++ b/examples/simple_box/src/main.rs
@@ -13,6 +13,8 @@
 
 #[cfg(feature = "client")]
 use crate::client::ExampleClientPlugin;
+#[cfg(feature = "p2p")]
+use crate::p2p::ExampleP2PPlugin;
 #[cfg(feature = "server")]
 use crate::server::ExampleServerPlugin;
 use crate::shared::SharedPlugin;
@@ -26,6 +28,8 @@ mod automation;
 #[cfg(feature = "client")]
 mod client;
 mod debug;
+#[cfg(feature = "p2p")]
+mod p2p;
 mod protocol;
 #[cfg(feature = "gui")]
 mod renderer;
@@ -46,9 +50,13 @@ fn main() {
     cli.spawn_connections(&mut app);
 
     match cli.mode {
-        #[cfg(feature = "client")]
+        #[cfg(all(feature = "client", any(not(feature = "p2p"), feature = "netcode")))]
         Some(Mode::Client { .. }) => {
             app.add_plugins(ExampleClientPlugin);
+        }
+        #[cfg(feature = "p2p")]
+        Some(Mode::P2P { .. }) => {
+            app.add_plugins((ExampleClientPlugin, ExampleP2PPlugin));
         }
         #[cfg(feature = "server")]
         Some(Mode::Server) => {

--- a/examples/simple_box/src/p2p.rs
+++ b/examples/simple_box/src/p2p.rs
@@ -3,13 +3,13 @@
 //! Unlike the conventional mode, no server spawns or replicates players. Every peer creates the
 //! same fixed roster locally and only exchanges tick-indexed inputs.
 
-use crate::protocol::{Inputs, PlayerBundle, PlayerId, PlayerPosition};
+use crate::protocol::{Inputs, PlayerBundle};
 use bevy::prelude::*;
 use lightyear::prediction::rollback::DeterministicPredicted;
 use lightyear::prelude::input::native::{ActionState, InputMarker};
 use lightyear::prelude::input::InputBuffer;
 use lightyear::prelude::*;
-use lightyear_examples_common::cli::P2PSettings;
+use lightyear_examples_common::p2p::P2PSettings;
 
 /// Namespace for stable simple-box player hashes on the input wire.
 const PLAYER_INPUT_HASH_BASE: u64 = 0x5349_4D50_4C45_0000;
@@ -30,9 +30,7 @@ impl Plugin for ExampleP2PPlugin {
             lightyear_deterministic_replication::prelude::DeterministicReplicationPlugin,
         );
         app.add_systems(Startup, spawn_fixed_roster);
-        if std::env::var_os("LIGHTYEAR_SIMPLE_BOX_LOG_POSITIONS").is_some() {
-            app.add_systems(Update, log_positions);
-        }
+        crate::automation::add_p2p_debugging(app);
     }
 }
 
@@ -79,41 +77,5 @@ fn spawn_fixed_roster(
                 .entity(entity)
                 .insert(InputMarker::<Inputs>::default());
         }
-    }
-}
-
-/// Periodic state dump used by the headless two-process smoke test.
-fn log_positions(
-    time: Res<Time>,
-    timeline: Res<LocalTimeline>,
-    settings: Res<P2PSettings>,
-    links: Query<(&RemoteId, Has<Connected>, &PingManager), With<P2P>>,
-    synced_input_timeline: Query<(), (With<InputTimeline>, With<IsSynced<InputTimeline>>)>,
-    players: Query<(&PlayerId, &PlayerPosition)>,
-    mut timer: Local<Option<Timer>>,
-) {
-    let timer = timer.get_or_insert_with(|| Timer::from_seconds(1.0, TimerMode::Repeating));
-    timer.tick(time.delta());
-    if !timer.just_finished() {
-        return;
-    }
-    for (remote, connected, ping) in &links {
-        info!(
-            local_peer = settings.local_peer_id,
-            ?remote,
-            connected,
-            latency_samples = ping.latency_samples_recv(),
-            input_timeline_synced = !synced_input_timeline.is_empty(),
-            "P2P Link status"
-        );
-    }
-    for (player, position) in &players {
-        info!(
-            local_peer = settings.local_peer_id,
-            tick = timeline.tick().0,
-            ?player,
-            position = ?position.0,
-            "P2P player position"
-        );
     }
 }

--- a/examples/simple_box/src/p2p.rs
+++ b/examples/simple_box/src/p2p.rs
@@ -1,0 +1,119 @@
+//! Direct P2P setup for the simple-box deterministic simulation.
+//!
+//! Unlike the conventional mode, no server spawns or replicates players. Every peer creates the
+//! same fixed roster locally and only exchanges tick-indexed inputs.
+
+use crate::protocol::{Inputs, PlayerBundle, PlayerId, PlayerPosition};
+use bevy::prelude::*;
+use lightyear::prediction::rollback::DeterministicPredicted;
+use lightyear::prelude::input::native::{ActionState, InputMarker};
+use lightyear::prelude::input::InputBuffer;
+use lightyear::prelude::*;
+use lightyear_examples_common::cli::P2PSettings;
+
+/// Namespace for stable simple-box player hashes on the input wire.
+const PLAYER_INPUT_HASH_BASE: u64 = 0x5349_4D50_4C45_0000;
+
+/// Tick at which the raw fixed-roster example begins applying buffered inputs.
+///
+/// This gives every peer time to complete initial timeline synchronization and exchange its first
+/// input window. The future session handshake will replace this local example convention with an
+/// agreed start epoch.
+pub(crate) const GAMEPLAY_START_TICK: u32 = 120;
+
+pub struct ExampleP2PPlugin;
+
+impl Plugin for ExampleP2PPlugin {
+    fn build(&self, app: &mut App) {
+        app.insert_resource(PredictionManager::default());
+        app.add_plugins(
+            lightyear_deterministic_replication::prelude::DeterministicReplicationPlugin,
+        );
+        app.add_systems(Startup, spawn_fixed_roster);
+        if std::env::var_os("LIGHTYEAR_SIMPLE_BOX_LOG_POSITIONS").is_some() {
+            app.add_systems(Update, log_positions);
+        }
+    }
+}
+
+/// Spawn one local deterministic copy of every player in stable roster order.
+///
+/// The local player receives [`InputMarker`], while remote players start with empty input buffers
+/// so prediction can begin before their first packet arrives. The explicit [`PreSpawned`] hash is
+/// the cross-world input identity; P2P deliberately does not depend on replication entity maps.
+fn spawn_fixed_roster(
+    mut commands: Commands,
+    settings: Res<P2PSettings>,
+    links: Query<(Entity, &RemoteId), With<P2P>>,
+) {
+    let spacing = 120.0;
+    let center = (f32::from(settings.player_count) - 1.0) * 0.5;
+
+    for peer_id in settings.peer_ids() {
+        let id = PeerId::Entity(u64::from(peer_id));
+        let position = Vec2::new((f32::from(peer_id) - center) * spacing, 0.0);
+        let hash = PLAYER_INPUT_HASH_BASE | u64::from(peer_id);
+        let mut pre_spawned = PreSpawned::new(hash);
+        if peer_id != settings.local_peer_id {
+            let owner_link = links
+                .iter()
+                .find_map(|(entity, remote_id)| (remote_id.0 == id).then_some(entity))
+                .unwrap_or_else(|| panic!("missing P2P Link for roster peer {peer_id}"));
+            pre_spawned = pre_spawned.for_receiver(owner_link);
+        }
+
+        let entity = commands
+            .spawn((
+                PlayerBundle::new(id, position),
+                DeterministicPredicted {
+                    skip_despawn: true,
+                    enable_rollback_after: 0,
+                },
+                pre_spawned,
+                ActionState::<Inputs>::default(),
+                InputBuffer::<ActionState<Inputs>, Inputs>::default(),
+            ))
+            .id();
+        if peer_id == settings.local_peer_id {
+            commands
+                .entity(entity)
+                .insert(InputMarker::<Inputs>::default());
+        }
+    }
+}
+
+/// Periodic state dump used by the headless two-process smoke test.
+fn log_positions(
+    time: Res<Time>,
+    timeline: Res<LocalTimeline>,
+    settings: Res<P2PSettings>,
+    links: Query<(&RemoteId, Has<Connected>, &PingManager), With<P2P>>,
+    synced_input_timeline: Query<(), (With<InputTimeline>, With<IsSynced<InputTimeline>>)>,
+    players: Query<(&PlayerId, &PlayerPosition)>,
+    mut timer: Local<Option<Timer>>,
+) {
+    let timer = timer.get_or_insert_with(|| Timer::from_seconds(1.0, TimerMode::Repeating));
+    timer.tick(time.delta());
+    if !timer.just_finished() {
+        return;
+    }
+    for (remote, connected, ping) in &links {
+        info!(
+            local_peer = settings.local_peer_id,
+            ?remote,
+            connected,
+            latency_samples = ping.latency_samples_recv(),
+            input_timeline_synced = !synced_input_timeline.is_empty(),
+            "P2P Link status"
+        );
+    }
+    for (player, position) in &players {
+        info!(
+            local_peer = settings.local_peer_id,
+            tick = timeline.tick().0,
+            ?player,
+            position = ?position.0,
+            "P2P player position"
+        );
+    }
+}

--- a/justfile
+++ b/justfile
@@ -54,7 +54,7 @@ _example_demo_p2p_non_avian_pkgs_filter := '.packages[] | select((.manifest_path
 #
 # Args:
 #   release=true|false   Defaults to false.
-#   headless=true|false  Defaults to true for features=server or p2p, false otherwise.
+#   headless=true|false  Defaults to true for features=server, false otherwise.
 #   features=server|client|both|p2p  Defaults to both.
 build_examples *args:
     #!/usr/bin/env bash
@@ -86,7 +86,7 @@ build_examples *args:
         esac
     done
     if [ -z "$headless" ]; then
-        if [ "$feature_mode" = server ] || [ "$feature_mode" = p2p ]; then
+        if [ "$feature_mode" = server ]; then
             headless=true
         else
             headless=false

--- a/justfile
+++ b/justfile
@@ -37,6 +37,10 @@ clippy_examples:
     cargo clippy -p simple_box --all-features -- -D warnings --no-deps
     # cargo clippy -p simple_setup --all-features -- -D warnings --no-deps
 
+# Run two conditioned simple-box peers and verify remote prediction rollback plus convergence.
+simple_box_p2p_smoke:
+    bash examples/simple_box/p2p_smoke.sh
+
 # jq filters shared by the example/demo build recipe.
 _example_demo_pkgs_filter := '.packages[] | select((.manifest_path | test("/(examples|demos)/")) and (.manifest_path | test("/examples/common/") | not) and (.manifest_path | test("/examples/launcher/") | not) and (.name != "simple_setup")) | .name'
 _example_demo_non_projectiles_pkgs_filter := '.packages[] | select((.manifest_path | test("/(examples|demos)/")) and (.manifest_path | test("/examples/common/") | not) and (.manifest_path | test("/examples/launcher/") | not) and (.name != "simple_setup") and (.name != "projectiles")) | .name'

--- a/justfile
+++ b/justfile
@@ -40,6 +40,7 @@ clippy_examples:
 # jq filters shared by the example/demo build recipe.
 _example_demo_pkgs_filter := '.packages[] | select((.manifest_path | test("/(examples|demos)/")) and (.manifest_path | test("/examples/common/") | not) and (.manifest_path | test("/examples/launcher/") | not) and (.name != "simple_setup")) | .name'
 _example_demo_non_projectiles_pkgs_filter := '.packages[] | select((.manifest_path | test("/(examples|demos)/")) and (.manifest_path | test("/examples/common/") | not) and (.manifest_path | test("/examples/launcher/") | not) and (.name != "simple_setup") and (.name != "projectiles")) | .name'
+_example_demo_p2p_non_avian_pkgs_filter := '.packages[] | select((.manifest_path | test("/(examples|demos)/")) and (.manifest_path | test("/examples/common/") | not) and (.features | has("p2p")) and (.name != "avian_2d") and (.name != "avian_3d")) | .name'
 # simple_setup is excluded from explicit feature builds because it has no client/server/gui feature gates.
 
 # Build all examples/demos.
@@ -49,15 +50,16 @@ _example_demo_non_projectiles_pkgs_filter := '.packages[] | select((.manifest_pa
 #   just build_examples features=server
 #   just build_examples features=client headless=true
 #   just build_examples release=true features=both
+#   just build_examples features=p2p
 #
 # Args:
 #   release=true|false   Defaults to false.
-#   headless=true|false  Defaults to true for features=server, false otherwise.
-#   features=server|client|both  Defaults to both.
+#   headless=true|false  Defaults to true for features=server or p2p, false otherwise.
+#   features=server|client|both|p2p  Defaults to both.
 build_examples *args:
     #!/usr/bin/env bash
     set -euo pipefail
-    usage='usage: just build_examples [release=true|false] [headless=true|false] [features=server|client|both]'
+    usage='usage: just build_examples [release=true|false] [headless=true|false] [features=server|client|both|p2p]'
     release=false
     headless=""
     feature_mode=both
@@ -69,7 +71,7 @@ build_examples *args:
             headless=true|headless=false)
                 headless="${arg#headless=}"
                 ;;
-            features=server|features=client|features=both)
+            features=server|features=client|features=both|features=p2p)
                 feature_mode="${arg#features=}"
                 ;;
             -h|--help|help)
@@ -84,7 +86,7 @@ build_examples *args:
         esac
     done
     if [ -z "$headless" ]; then
-        if [ "$feature_mode" = server ]; then
+        if [ "$feature_mode" = server ] || [ "$feature_mode" = p2p ]; then
             headless=true
         else
             headless=false
@@ -104,6 +106,7 @@ build_examples *args:
             both) target_dir="target/headless${release_suffix}" ;;
             client) target_dir="target/headless-client${release_suffix}" ;;
             server) target_dir="target/headless-server${release_suffix}" ;;
+            p2p) target_dir="target/headless-p2p${release_suffix}" ;;
         esac
     elif [ "$feature_mode" = server ]; then
         target_dir="target/server-only${release_suffix}"
@@ -116,19 +119,26 @@ build_examples *args:
         both:true) cargo_features="client,server,netcode,webtransport" ;;
         client:true) cargo_features="client,netcode,webtransport" ;;
         server:true) cargo_features="server,netcode,webtransport" ;;
+        p2p:true) cargo_features="p2p" ;;
         both:false) cargo_features="client,gui,server,netcode,webtransport" ;;
         client:false) cargo_features="client,gui,netcode,webtransport" ;;
         server:false) cargo_features="server,gui,netcode,webtransport" ;;
+        p2p:false) cargo_features="p2p,gui" ;;
     esac
 
-    if [ "$headless" = true ]; then
+    if [ "$feature_mode" = p2p ]; then
+        projectiles_features=""
+    elif [ "$headless" = true ]; then
         projectiles_features="client,server,netcode,webtransport"
     else
         projectiles_features="client,gui,server,netcode,webtransport"
     fi
 
     echo "Building examples: release=$release headless=$headless features=$feature_mode cargo_features=$cargo_features"
-    if [ "$projectiles_features" = "$cargo_features" ]; then
+    if [ "$feature_mode" = p2p ]; then
+        # Keep Avian 2D and 3D out of the same Cargo feature-unification graph.
+        pkgs_filter='{{ _example_demo_p2p_non_avian_pkgs_filter }}'
+    elif [ "$projectiles_features" = "$cargo_features" ]; then
         pkgs_filter='{{ _example_demo_pkgs_filter }}'
     else
         pkgs_filter='{{ _example_demo_non_projectiles_pkgs_filter }}'
@@ -138,7 +148,11 @@ build_examples *args:
         package_args+=(-p "$pkg")
     done < <(cargo metadata --no-deps --format-version 1 | jq -r "$pkgs_filter" | sort)
     "${cargo_build[@]}" --no-default-features --features="$cargo_features" "${package_args[@]}"
-    if [ "$projectiles_features" != "$cargo_features" ]; then
+    if [ "$feature_mode" = p2p ]; then
+        "${cargo_build[@]}" --no-default-features --features="$cargo_features" -p avian_2d
+        "${cargo_build[@]}" --no-default-features --features="$cargo_features" -p avian_3d
+    fi
+    if [ -n "$projectiles_features" ] && [ "$projectiles_features" != "$cargo_features" ]; then
         "${cargo_build[@]}" --no-default-features --features="$projectiles_features" -p projectiles
     fi
 
@@ -185,6 +199,7 @@ lightyear:
     # cargo clippy -p lightyear --no-default-features -- -D warnings --no-deps
     cargo clippy -p lightyear --no-default-features --features="std" -- -D warnings --no-deps
     cargo clippy -p lightyear --no-default-features --features="std client" -- -D warnings --no-deps
+    cargo clippy -p lightyear --no-default-features --features="std p2p" -- -D warnings --no-deps
     cargo clippy -p lightyear --no-default-features --features="std server" -- -D warnings --no-deps
     cargo clippy -p lightyear --no-default-features --features="std replication" -- -D warnings --no-deps
     cargo clippy -p lightyear --no-default-features --features="std prediction" -- -D warnings --no-deps
@@ -214,6 +229,7 @@ lightyear:
     # cargo clippy -p lightyear --tests --no-default-features -- -D warnings --no-deps
     cargo clippy -p lightyear --tests --no-default-features --features="std" -- -D warnings --no-deps
     cargo clippy -p lightyear --tests --no-default-features --features="std client" -- -D warnings --no-deps
+    cargo clippy -p lightyear --tests --no-default-features --features="std p2p" -- -D warnings --no-deps
     cargo clippy -p lightyear --tests --no-default-features --features="std server" -- -D warnings --no-deps
     cargo clippy -p lightyear --tests --no-default-features --features="std replication" -- -D warnings --no-deps
     cargo clippy -p lightyear --tests --no-default-features --features="std prediction" -- -D warnings --no-deps


### PR DESCRIPTION
## Summary

- make inputs handle P2P; because there is no replication-backed entity mapping, P2P input entities use stable `PreSpawned` identities
- add P2P mode to most examples


Stacked on #1630.
