### PR TITLE
Reduce NetworkTarget allocation overhead

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,7 +130,7 @@ rand = "0.10"
 ringbuffer = "0.16"
 thiserror = "2.0.3"
 seahash = "4.1.0"
-smallvec = { version = "1", features = ["union", "const_generics"] }
+smallvec = { version = "1", features = ["union", "const_generics", "serde"] }
 variadics_please = "2.0.0"
 
 # no_std

--- a/crates/connection/connection/src/network_target.rs
+++ b/crates/connection/connection/src/network_target.rs
@@ -1,4 +1,4 @@
-use alloc::{vec, vec::Vec};
+use alloc::vec::Vec;
 use bevy_ecs::entity::{Entity, EntityHashSet};
 use bevy_platform::collections::{HashMap, HashSet};
 use bevy_reflect::Reflect;
@@ -8,15 +8,30 @@ use lightyear_serde::reader::{ReadInteger, Reader};
 use lightyear_serde::writer::WriteInteger;
 use lightyear_serde::{SerializationError, ToBytes};
 use serde::{Deserialize, Serialize};
-use smallvec::SmallVec;
+use smallvec::{SmallVec, smallvec};
+
+// Four covers the common small-server case without making every Target excessively large.
+const INLINE_TARGET_CAPACITY: usize = 4;
+
+/// Client IDs stored by the multi-client [`Target`] variants.
+///
+/// Up to four IDs live directly inside the target, which is the common case. Larger targets spill
+/// to the heap while keeping the same contiguous-list behavior.
+pub type TargetList<T> = SmallVec<[T; INLINE_TARGET_CAPACITY]>;
 
 pub type NetworkTarget = Target<PeerId>;
 pub type EntityTarget = Target<Entity>;
 
 /// Reusable storage for resolving a [`NetworkTarget`] to connected entities.
+///
+/// `targets` is the final set returned to the caller. `requested` is scratch storage used to map
+/// the peer IDs in a larger [`NetworkTarget::Only`] to entities before intersecting them with the
+/// server's connected-client list. Keeping both sets here lets repeated sends reuse their capacity.
 #[derive(Default)]
 pub struct NetworkTargetResolver {
+    /// Final connected recipients for the current resolution.
     targets: EntityHashSet,
+    /// Mapped `Only` recipients before filtering out entities not connected to this server.
     requested: EntityHashSet,
 }
 
@@ -29,6 +44,8 @@ impl NetworkTargetResolver {
         clients: &[Entity],
         mapping: &HashMap<PeerId, Entity>,
     ) -> &EntityHashSet {
+        // Clearing preserves the allocated tables, so steady-state sends only rewrite their
+        // contents. Both sets must be cleared because a resolver is reused across target shapes.
         self.targets.clear();
         self.requested.clear();
 
@@ -41,6 +58,8 @@ impl NetworkTargetResolver {
                 }
             }
             NetworkTarget::AllExcept(peer_ids) => {
+                // Starting from all connected clients and removing exclusions writes the final
+                // answer directly, so this branch does not need the `requested` scratch set.
                 self.targets.extend(clients.iter().copied());
                 for peer_id in peer_ids {
                     if let Some(entity) = mapping.get(peer_id) {
@@ -56,11 +75,15 @@ impl NetworkTargetResolver {
                 }
             }
             NetworkTarget::Only(peer_ids) => {
-                if clients.len() <= 4 && peer_ids.len() <= 4 {
+                // For the common small-server case, mapping into an inline list and scanning it is
+                // cheaper than hashing and cannot allocate.
+                if clients.len() <= INLINE_TARGET_CAPACITY
+                    && peer_ids.len() <= INLINE_TARGET_CAPACITY
+                {
                     let requested = peer_ids
                         .iter()
                         .filter_map(|peer_id| mapping.get(peer_id).copied())
-                        .collect::<SmallVec<[Entity; 4]>>();
+                        .collect::<SmallVec<[Entity; INLINE_TARGET_CAPACITY]>>();
                     self.targets.extend(
                         clients
                             .iter()
@@ -69,6 +92,8 @@ impl NetworkTargetResolver {
                     );
                     return &self.targets;
                 }
+                // For larger lists, hash the mapped request once and scan connected clients once.
+                // This avoids the O(clients * requested) nested membership scan.
                 self.requested
                     .extend(peer_ids.iter().filter_map(|peer_id| mapping.get(peer_id)));
                 self.targets.extend(
@@ -106,7 +131,7 @@ impl NetworkTarget {
                 let entity_ids = client_ids
                     .iter()
                     .map(|p| *mapping.get(p).unwrap_or(&Entity::PLACEHOLDER))
-                    .collect::<SmallVec<[Entity; 4]>>();
+                    .collect::<SmallVec<[Entity; INLINE_TARGET_CAPACITY]>>();
                 clients
                     .into_iter()
                     .filter(|e| !entity_ids.contains(e))
@@ -122,7 +147,7 @@ impl NetworkTarget {
                 let entity_ids = client_ids
                     .iter()
                     .map(|p| *mapping.get(p).unwrap_or(&Entity::PLACEHOLDER))
-                    .collect::<SmallVec<[Entity; 4]>>();
+                    .collect::<SmallVec<[Entity; INLINE_TARGET_CAPACITY]>>();
                 clients
                     .into_iter()
                     .filter(|e| entity_ids.contains(e))
@@ -141,13 +166,12 @@ pub enum Target<T> {
     None,
     /// Message sent to all clients except one
     AllExceptSingle(T),
-    // TODO: use small vec
     /// Message sent to all clients except for these
-    AllExcept(Vec<T>),
+    AllExcept(TargetList<T>),
     /// Message sent to all clients
     All,
     /// Message sent to only these
-    Only(Vec<T>),
+    Only(TargetList<T>),
     /// Message sent to only this one client
     Single(T),
 }
@@ -199,9 +223,9 @@ impl ToBytes for Target<PeerId> {
         match buffer.read_u8()? {
             0 => Ok(Target::None),
             1 => Ok(Target::AllExceptSingle(PeerId::from_bytes(buffer)?)),
-            2 => Ok(Target::AllExcept(Vec::<PeerId>::from_bytes(buffer)?)),
+            2 => Ok(Target::AllExcept(TargetList::<PeerId>::from_bytes(buffer)?)),
             3 => Ok(Target::All),
-            4 => Ok(Target::Only(Vec::<PeerId>::from_bytes(buffer)?)),
+            4 => Ok(Target::Only(TargetList::<PeerId>::from_bytes(buffer)?)),
             5 => Ok(Target::Single(PeerId::from_bytes(buffer)?)),
             _ => Err(SerializationError::InvalidPacketType),
         }
@@ -235,7 +259,7 @@ impl<T> FromIterator<T> for Target<T> {
         let Some(second) = iter.next() else {
             return Target::Single(first);
         };
-        let mut clients = Vec::with_capacity(iter.size_hint().0.saturating_add(2));
+        let mut clients = TargetList::with_capacity(iter.size_hint().0.saturating_add(2));
         clients.extend([first, second]);
         clients.extend(iter);
         Target::Only(clients)
@@ -243,7 +267,13 @@ impl<T> FromIterator<T> for Target<T> {
 }
 
 impl<T> From<Vec<T>> for Target<T> {
-    fn from(mut value: Vec<T>) -> Self {
+    fn from(value: Vec<T>) -> Self {
+        Target::from(TargetList::from_vec(value))
+    }
+}
+
+impl<T> From<TargetList<T>> for Target<T> {
+    fn from(mut value: TargetList<T>) -> Self {
         match value.len() {
             0 => Target::None,
             1 => Target::Single(value.pop().unwrap()),
@@ -252,6 +282,13 @@ impl<T> From<Vec<T>> for Target<T> {
     }
 }
 
+// The algebra has three performance tiers:
+// 1. Resolve All/None identities before touching target lists.
+// 2. Scan inline lists directly when either side has at most four IDs.
+// 3. Build one pre-sized membership set for larger list/list operations.
+//
+// This keeps common cases allocation-free without returning to the quadratic behavior of scanning
+// every large list against every other large list.
 impl<T: Eq + Hash + Copy> Target<T> {
     /// Returns true if the target is empty
     pub fn is_empty(&self) -> bool {
@@ -298,7 +335,7 @@ impl<T: Eq + Hash + Copy> Target<T> {
             }
             Target::Single(existing) => {
                 if *existing != client_id {
-                    let mut included = Vec::with_capacity(capacity);
+                    let mut included = TargetList::with_capacity(capacity);
                     included.extend([*existing, client_id]);
                     *self = Target::Only(included);
                 }
@@ -316,7 +353,8 @@ impl<T: Eq + Hash + Copy> Target<T> {
         let Some(second) = iter.next() else {
             return Target::Single(first);
         };
-        let mut client_ids = Vec::with_capacity(iter.size_hint().1.unwrap_or(0).saturating_add(2));
+        let mut client_ids =
+            TargetList::with_capacity(iter.size_hint().1.unwrap_or(0).saturating_add(2));
         client_ids.extend([first, second]);
         client_ids.extend(iter);
         Self::deduplicate(&mut client_ids);
@@ -333,7 +371,7 @@ impl<T: Eq + Hash + Copy> Target<T> {
         }
     }
 
-    fn all_except_from_vec(mut client_ids: Vec<T>) -> Self {
+    fn all_except_from_list(mut client_ids: TargetList<T>) -> Self {
         match client_ids.len() {
             0 => Target::All,
             1 => Target::AllExceptSingle(client_ids.pop().unwrap()),
@@ -382,8 +420,8 @@ impl<T: Eq + Hash + Copy> Target<T> {
     }
 
     /// Stable deduplication with an allocation-free path for the common small-client case.
-    fn deduplicate(client_ids: &mut Vec<T>) {
-        if client_ids.len() > 4 {
+    fn deduplicate(client_ids: &mut TargetList<T>) {
+        if client_ids.len() > INLINE_TARGET_CAPACITY {
             let mut seen = HashSet::with_capacity(client_ids.len());
             client_ids.retain(|client_id| seen.insert(*client_id));
             return;
@@ -399,8 +437,9 @@ impl<T: Eq + Hash + Copy> Target<T> {
     }
 
     /// Appends IDs while preserving order and uniqueness.
-    fn append_unique(client_ids: &mut Vec<T>, extra: &[T]) {
-        if client_ids.len() <= 4 || extra.len() <= 4 {
+    fn append_unique(client_ids: &mut TargetList<T>, extra: &[T]) {
+        if client_ids.len() <= INLINE_TARGET_CAPACITY || extra.len() <= INLINE_TARGET_CAPACITY {
+            // A few contiguous comparisons are cheaper than constructing a hash table.
             for client_id in extra {
                 if !client_ids.contains(client_id) {
                     client_ids.push(*client_id);
@@ -409,6 +448,7 @@ impl<T: Eq + Hash + Copy> Target<T> {
             return;
         }
 
+        // Seed one set from the existing IDs, then use it for both deduplication and membership.
         let mut seen = HashSet::with_capacity(client_ids.len().saturating_add(extra.len()));
         client_ids.retain(|client_id| seen.insert(*client_id));
         client_ids.reserve(extra.len());
@@ -420,12 +460,13 @@ impl<T: Eq + Hash + Copy> Target<T> {
     }
 
     /// Retains either the IDs present in `other` or those absent from it.
-    fn retain_membership(client_ids: &mut Vec<T>, other: &[T], keep_present: bool) {
-        if client_ids.len() <= 4 || other.len() <= 4 {
+    fn retain_membership(client_ids: &mut TargetList<T>, other: &[T], keep_present: bool) {
+        if client_ids.len() <= INLINE_TARGET_CAPACITY || other.len() <= INLINE_TARGET_CAPACITY {
             client_ids.retain(|client_id| other.contains(client_id) == keep_present);
             return;
         }
 
+        // One lookup table changes the large-list path from O(left * right) to O(left + right).
         if keep_present {
             let mut remaining = HashSet::with_capacity(other.len());
             remaining.extend(other.iter().copied());
@@ -440,13 +481,13 @@ impl<T: Eq + Hash + Copy> Target<T> {
 
     /// Builds an inclusive target containing the unique IDs in `left` but not in `right`.
     fn only_difference(left: &[T], right: &[T]) -> Self {
-        if left.len() <= 4 || right.len() <= 4 {
+        if left.len() <= INLINE_TARGET_CAPACITY || right.len() <= INLINE_TARGET_CAPACITY {
             return Self::only_unique(left.iter().copied().filter(|id| !right.contains(id)));
         }
 
         let mut excluded_or_seen = HashSet::with_capacity(left.len().saturating_add(right.len()));
         excluded_or_seen.extend(right.iter().copied());
-        let mut result = Vec::with_capacity(left.len());
+        let mut result = TargetList::with_capacity(left.len());
         result.extend(
             left.iter()
                 .copied()
@@ -466,6 +507,7 @@ impl<T: Eq + Hash + Copy> Target<T> {
 
     /// Compute the intersection of this target with another one (A ∩ B)
     pub(crate) fn intersection(&mut self, target: &Target<T>) {
+        // Handle algebraic identities before inspecting lists or allocating.
         if matches!(self, Target::None) || matches!(target, Target::All) {
             return;
         }
@@ -563,6 +605,7 @@ impl<T: Eq + Hash + Copy> Target<T> {
 
     /// Compute the union of this target with another one (A U B)
     pub(crate) fn union(&mut self, target: &Target<T>) {
+        // Handle algebraic identities before inspecting lists or allocating.
         if matches!(self, Target::All) || matches!(target, Target::None) {
             return;
         }
@@ -656,7 +699,7 @@ impl<T: Eq + Hash + Copy> Target<T> {
                 }
                 Target::Single(target_client_id) => {
                     if existing_client_id != target_client_id {
-                        *self = Target::Only(vec![*existing_client_id, *target_client_id]);
+                        *self = Target::Only(smallvec![*existing_client_id, *target_client_id]);
                     }
                 }
             },
@@ -669,6 +712,8 @@ impl<T: Eq + Hash + Copy> Target<T> {
 
     /// Compute the inverse of this target (¬A)
     pub(crate) fn inverse(&mut self) {
+        // Inversion only changes the meaning of the owned list, so move it between variants rather
+        // than cloning, deduplicating, or allocating.
         *self = match core::mem::take(self) {
             Target::All => Target::None,
             Target::AllExceptSingle(client_id) => Target::Single(client_id),
@@ -681,6 +726,7 @@ impl<T: Eq + Hash + Copy> Target<T> {
 
     /// Compute the difference of this target with another one (A - B)
     pub(crate) fn exclude(&mut self, target: &Target<T>) {
+        // Handle algebraic identities before inspecting lists or allocating.
         if matches!(self, Target::None) || matches!(target, Target::None) {
             return;
         }
@@ -696,7 +742,7 @@ impl<T: Eq + Hash + Copy> Target<T> {
                     Target::AllExceptSingle(client_id) => Target::Single(*client_id),
                     Target::AllExcept(client_ids) => Target::from(client_ids.clone()),
                     Target::All => Target::None,
-                    Target::Only(client_ids) => Self::all_except_from_vec(client_ids.clone()),
+                    Target::Only(client_ids) => Self::all_except_from_list(client_ids.clone()),
                     Target::Single(client_id) => Target::AllExceptSingle(*client_id),
                 };
             }
@@ -779,16 +825,22 @@ impl<T: Eq + Hash + Copy> Target<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::vec;
     use lightyear_serde::writer::Writer;
 
     #[test]
     fn test_serde() {
-        let target = Target::AllExcept(vec![]);
-        let mut writer = Writer::default();
-        target.to_bytes(&mut writer).unwrap();
-        let mut reader = Reader::from(writer.into_bytes());
-        let deserialized = Target::from_bytes(&mut reader).unwrap();
-        assert_eq!(target, deserialized);
+        let targets = [
+            Target::AllExcept(smallvec![]),
+            Target::Only((0..=INLINE_TARGET_CAPACITY as u64).map(peer).collect()),
+        ];
+        for target in targets {
+            let mut writer = Writer::default();
+            target.to_bytes(&mut writer).unwrap();
+            let mut reader = Reader::from(writer.into_bytes());
+            let deserialized = Target::from_bytes(&mut reader).unwrap();
+            assert_eq!(target, deserialized);
+        }
     }
 
     fn peer(id: u64) -> PeerId {
@@ -813,7 +865,7 @@ mod tests {
         assert_entities(resolver.resolve(&Target::All, &clients, &mapping), &clients);
         assert_entities(
             resolver.resolve(
-                &Target::Only(vec![peer(1), peer(2), peer(3)]),
+                &Target::Only(smallvec![peer(1), peer(2), peer(3)]),
                 &clients,
                 &mapping,
             ),
@@ -821,7 +873,7 @@ mod tests {
         );
         assert_entities(
             resolver.resolve(
-                &Target::AllExcept(vec![peer(1), peer(2)]),
+                &Target::AllExcept(smallvec![peer(1), peer(2)]),
                 &clients,
                 &mapping,
             ),
@@ -836,14 +888,17 @@ mod tests {
             ("all", Target::All),
             ("single", Target::Single(peer(0))),
             ("all-except-single", Target::AllExceptSingle(peer(0))),
-            ("only-many", Target::Only(vec![peer(0), peer(1)])),
-            ("all-except-many", Target::AllExcept(vec![peer(0), peer(1)])),
-            ("only-empty", Target::Only(vec![])),
-            ("all-except-empty", Target::AllExcept(vec![])),
-            ("only-duplicate", Target::Only(vec![peer(0), peer(0)])),
+            ("only-many", Target::Only(smallvec![peer(0), peer(1)])),
+            (
+                "all-except-many",
+                Target::AllExcept(smallvec![peer(0), peer(1)]),
+            ),
+            ("only-empty", Target::Only(smallvec![])),
+            ("all-except-empty", Target::AllExcept(smallvec![])),
+            ("only-duplicate", Target::Only(smallvec![peer(0), peer(0)])),
             (
                 "all-except-duplicate",
-                Target::AllExcept(vec![peer(0), peer(0)]),
+                Target::AllExcept(smallvec![peer(0), peer(0)]),
             ),
         ]
     }
@@ -911,21 +966,24 @@ mod tests {
 
         let mut target = Target::Single(peer(0));
         target.extend([peer(0), peer(1), peer(1)]);
-        assert_eq!(target, Target::Only(vec![peer(0), peer(1)]));
+        assert_eq!(target, Target::Only(smallvec![peer(0), peer(1)]));
     }
 
     #[test]
-    fn operations_reuse_left_hand_vec_capacity() {
-        assert_reuses_left_hand_vec(Target::intersection, Target::Only(vec![peer(0), peer(2)]));
-        assert_reuses_left_hand_vec(Target::union, Target::Single(peer(3)));
-        assert_reuses_left_hand_vec(Target::exclude, Target::Single(peer(1)));
+    fn operations_reuse_left_hand_list_capacity() {
+        assert_reuses_left_hand_list(
+            Target::intersection,
+            Target::Only(smallvec![peer(0), peer(2)]),
+        );
+        assert_reuses_left_hand_list(Target::union, Target::Single(peer(3)));
+        assert_reuses_left_hand_list(Target::exclude, Target::Single(peer(1)));
     }
 
-    fn assert_reuses_left_hand_vec(
+    fn assert_reuses_left_hand_list(
         operation: fn(&mut NetworkTarget, &NetworkTarget),
         right: NetworkTarget,
     ) {
-        let mut client_ids = Vec::with_capacity(8);
+        let mut client_ids = TargetList::with_capacity(8);
         client_ids.extend([peer(0), peer(1), peer(2)]);
         let pointer = client_ids.as_ptr();
         let capacity = client_ids.capacity();
@@ -938,5 +996,18 @@ mod tests {
         };
         assert_eq!(client_ids.as_ptr(), pointer);
         assert_eq!(client_ids.capacity(), capacity);
+    }
+
+    #[test]
+    fn target_list_stores_four_clients_inline() {
+        let inline = (0..INLINE_TARGET_CAPACITY as u64)
+            .map(peer)
+            .collect::<TargetList<_>>();
+        assert!(!inline.spilled());
+
+        let spilled = (0..=INLINE_TARGET_CAPACITY as u64)
+            .map(peer)
+            .collect::<TargetList<_>>();
+        assert!(spilled.spilled());
     }
 }

--- a/crates/connection/connection/src/network_target.rs
+++ b/crates/connection/connection/src/network_target.rs
@@ -1,19 +1,13 @@
 use alloc::{vec, vec::Vec};
 use bevy_ecs::entity::Entity;
-use bevy_platform::{
-    collections::{HashMap, HashSet},
-    hash::FixedHasher,
-};
+use bevy_platform::collections::HashMap;
 use bevy_reflect::Reflect;
-use core::hash::Hash;
 use lightyear_core::id::PeerId;
 use lightyear_serde::reader::{ReadInteger, Reader};
 use lightyear_serde::writer::WriteInteger;
 use lightyear_serde::{SerializationError, ToBytes};
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
-
-type HS<K> = HashSet<K, FixedHasher>;
 
 pub type NetworkTarget = Target<PeerId>;
 pub type EntityTarget = Target<Entity>;
@@ -141,16 +135,37 @@ impl ToBytes for Target<PeerId> {
     }
 }
 
-impl<T: PartialEq + Eq + Hash + Clone + Copy> Extend<T> for Target<T> {
+impl<T: PartialEq + Copy> Extend<T> for Target<T> {
     fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
-        self.union(&iter.into_iter().collect::<Target<T>>());
+        self.normalize();
+        let iter = iter.into_iter();
+        let existing_len = match self {
+            Target::Single(_) => 1,
+            Target::Only(client_ids) => client_ids.len(),
+            _ => 0,
+        };
+        let capacity = existing_len.saturating_add(iter.size_hint().0).max(2);
+        if let Target::Only(client_ids) = self {
+            client_ids.reserve(capacity.saturating_sub(client_ids.len()));
+        }
+        iter.for_each(|id| self.insert(id, capacity));
+        self.normalize();
     }
 }
 
 impl<T> FromIterator<T> for Target<T> {
     fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
-        let clients: Vec<T> = iter.into_iter().collect();
-        Target::from(clients)
+        let mut iter = iter.into_iter();
+        let Some(first) = iter.next() else {
+            return Target::None;
+        };
+        let Some(second) = iter.next() else {
+            return Target::Single(first);
+        };
+        let mut clients = Vec::with_capacity(iter.size_hint().0.saturating_add(2));
+        clients.extend([first, second]);
+        clients.extend(iter);
+        Target::Only(clients)
     }
 }
 
@@ -164,7 +179,7 @@ impl<T> From<Vec<T>> for Target<T> {
     }
 }
 
-impl<T: PartialEq + Eq + Hash + Clone + Copy> Target<T> {
+impl<T: PartialEq + Copy> Target<T> {
     /// Returns true if the target is empty
     pub fn is_empty(&self) -> bool {
         match self {
@@ -175,12 +190,10 @@ impl<T: PartialEq + Eq + Hash + Clone + Copy> Target<T> {
     }
 
     pub fn from_exclude(client_ids: impl IntoIterator<Item = T>) -> Self {
-        let mut client_ids = client_ids.into_iter().collect::<Vec<_>>();
-        match client_ids.len() {
-            0 => Target::All,
-            1 => Target::AllExceptSingle(client_ids.pop().unwrap()),
-            _ => Target::AllExcept(client_ids),
-        }
+        let mut target = Target::None;
+        target.extend(client_ids);
+        target.inverse();
+        target
     }
 
     /// Return true if we should replicate to the specified client
@@ -195,41 +208,168 @@ impl<T: PartialEq + Eq + Hash + Clone + Copy> Target<T> {
         }
     }
 
+    /// Inserts one client into this target without allocating an intermediate collection.
+    fn insert(&mut self, client_id: T, capacity: usize) {
+        match self {
+            Target::All => {}
+            Target::AllExceptSingle(excluded) => {
+                if *excluded == client_id {
+                    *self = Target::All;
+                }
+            }
+            Target::AllExcept(excluded) => excluded.retain(|id| id != &client_id),
+            Target::Only(included) => {
+                if !included.contains(&client_id) {
+                    included.push(client_id);
+                }
+            }
+            Target::Single(existing) => {
+                if *existing != client_id {
+                    let mut included = Vec::with_capacity(capacity);
+                    included.extend([*existing, client_id]);
+                    *self = Target::Only(included);
+                }
+            }
+            Target::None => *self = Target::Single(client_id),
+        }
+    }
+
+    /// Builds an inclusive target while avoiding a heap allocation for zero or one unique item.
+    fn only_unique(client_ids: impl IntoIterator<Item = T>) -> Self {
+        let iter = client_ids.into_iter();
+        // Internal callers derive this iterator from an existing target list, so its upper bound
+        // lets a multi-ID result allocate its final storage once without allocating for zero or
+        // one result.
+        let capacity = iter.size_hint().1.unwrap_or(2).max(2);
+        let mut first = None;
+        let mut many: Option<Vec<T>> = None;
+
+        for client_id in iter {
+            if let Some(client_ids) = many.as_mut() {
+                if !client_ids.contains(&client_id) {
+                    client_ids.push(client_id);
+                }
+            } else if let Some(first_client_id) = first {
+                if first_client_id != client_id {
+                    let mut client_ids = Vec::with_capacity(capacity);
+                    client_ids.extend([first_client_id, client_id]);
+                    many = Some(client_ids);
+                }
+            } else {
+                first = Some(client_id);
+            }
+        }
+
+        match many {
+            Some(client_ids) => Target::Only(client_ids),
+            None => first.map_or(Target::None, Target::Single),
+        }
+    }
+
+    /// Builds an exclusive target while avoiding a heap allocation for zero or one unique item.
+    fn all_except_unique(client_ids: impl IntoIterator<Item = T>) -> Self {
+        match Self::only_unique(client_ids) {
+            Target::None => Target::All,
+            Target::Single(client_id) => Target::AllExceptSingle(client_id),
+            Target::Only(client_ids) => Target::AllExcept(client_ids),
+            _ => unreachable!("only_unique only constructs inclusive targets"),
+        }
+    }
+
+    /// Restores the compact canonical representation and removes duplicate IDs in place.
+    fn normalize(&mut self) {
+        *self = match core::mem::take(self) {
+            Target::Only(mut client_ids) => {
+                Self::deduplicate(&mut client_ids);
+                match client_ids.len() {
+                    0 => Target::None,
+                    1 => Target::Single(client_ids.pop().unwrap()),
+                    _ => Target::Only(client_ids),
+                }
+            }
+            Target::AllExcept(mut client_ids) => {
+                Self::deduplicate(&mut client_ids);
+                match client_ids.len() {
+                    0 => Target::All,
+                    1 => Target::AllExceptSingle(client_ids.pop().unwrap()),
+                    _ => Target::AllExcept(client_ids),
+                }
+            }
+            target => target,
+        };
+    }
+
+    /// Stable in-place deduplication for the usually-small target lists.
+    fn deduplicate(client_ids: &mut Vec<T>) {
+        let mut index = 1;
+        while index < client_ids.len() {
+            if client_ids[..index].contains(&client_ids[index]) {
+                client_ids.remove(index);
+            } else {
+                index += 1;
+            }
+        }
+    }
+
     /// Compute the intersection of this target with another one (A ∩ B)
     pub(crate) fn intersection(&mut self, target: &Target<T>) {
+        self.normalize();
         match self {
             Target::All => {
                 *self = target.clone();
             }
-            // TODO: write the implementation by hand as an optimization!
             Target::AllExceptSingle(existing_client_id) => {
-                let mut a = Target::AllExcept(vec![*existing_client_id]);
-                a.intersection(target);
-                *self = a;
+                let existing_client_id = *existing_client_id;
+                *self = match target {
+                    Target::None => Target::None,
+                    Target::AllExceptSingle(target_client_id) => {
+                        Self::all_except_unique([existing_client_id, *target_client_id])
+                    }
+                    Target::AllExcept(target_client_ids) => Self::all_except_unique(
+                        core::iter::once(existing_client_id)
+                            .chain(target_client_ids.iter().copied()),
+                    ),
+                    Target::All => Target::AllExceptSingle(existing_client_id),
+                    Target::Only(target_client_ids) => Self::only_unique(
+                        target_client_ids
+                            .iter()
+                            .copied()
+                            .filter(|id| id != &existing_client_id),
+                    ),
+                    Target::Single(target_client_id) => {
+                        if existing_client_id == *target_client_id {
+                            Target::None
+                        } else {
+                            Target::Single(*target_client_id)
+                        }
+                    }
+                };
             }
             Target::AllExcept(existing_client_ids) => match target {
                 Target::None => {
                     *self = Target::None;
                 }
                 Target::AllExceptSingle(target_client_id) => {
-                    let mut new_excluded_ids = HS::from_iter(existing_client_ids.clone());
-                    new_excluded_ids.insert(*target_client_id);
-                    *existing_client_ids = Vec::from_iter(new_excluded_ids);
+                    if !existing_client_ids.contains(target_client_id) {
+                        existing_client_ids.push(*target_client_id);
+                    }
                 }
                 Target::AllExcept(target_client_ids) => {
-                    let mut new_excluded_ids = HS::from_iter(existing_client_ids.clone());
-                    target_client_ids.iter().for_each(|id| {
-                        new_excluded_ids.insert(*id);
+                    target_client_ids.iter().copied().for_each(|id| {
+                        if !existing_client_ids.contains(&id) {
+                            existing_client_ids.push(id);
+                        }
                     });
-                    *existing_client_ids = Vec::from_iter(new_excluded_ids);
                 }
                 Target::All => {}
                 Target::Only(target_client_ids) => {
-                    let mut new_included_ids = HS::from_iter(target_client_ids.clone());
-                    existing_client_ids.iter_mut().for_each(|id| {
-                        new_included_ids.remove(id);
-                    });
-                    *self = Target::Only(Vec::from_iter(new_included_ids));
+                    let included = Self::only_unique(
+                        target_client_ids
+                            .iter()
+                            .copied()
+                            .filter(|id| !existing_client_ids.contains(id)),
+                    );
+                    *self = included;
                 }
                 Target::Single(target_client_id) => {
                     if existing_client_ids.contains(target_client_id) {
@@ -244,30 +384,17 @@ impl<T: PartialEq + Eq + Hash + Clone + Copy> Target<T> {
                     *self = Target::None;
                 }
                 Target::AllExceptSingle(target_client_id) => {
-                    let mut new_included_ids = HS::from_iter(existing_client_ids.clone());
-                    new_included_ids.remove(target_client_id);
-                    *self = Target::from(Vec::from_iter(new_included_ids));
+                    existing_client_ids.retain(|id| id != target_client_id);
                 }
                 Target::AllExcept(target_client_ids) => {
-                    let mut new_included_ids = HS::from_iter(existing_client_ids.clone());
-                    target_client_ids.iter().for_each(|id| {
-                        new_included_ids.remove(id);
-                    });
-                    *self = Target::from(Vec::from_iter(new_included_ids));
+                    existing_client_ids.retain(|id| !target_client_ids.contains(id));
                 }
                 Target::All => {}
                 Target::Single(target_client_id) => {
-                    if existing_client_ids.contains(target_client_id) {
-                        *self = Target::Single(*target_client_id);
-                    } else {
-                        *self = Target::None;
-                    }
+                    existing_client_ids.retain(|id| id == target_client_id);
                 }
                 Target::Only(target_client_ids) => {
-                    let new_included_ids = HS::from_iter(existing_client_ids.clone());
-                    let target_included_ids = HS::from_iter(target_client_ids.clone());
-                    let intersection = new_included_ids.intersection(&target_included_ids).cloned();
-                    *self = Target::from(intersection.collect::<Vec<_>>());
+                    existing_client_ids.retain(|id| target_client_ids.contains(id));
                 }
             },
             Target::Single(existing_client_id) => {
@@ -277,10 +404,12 @@ impl<T: PartialEq + Eq + Hash + Clone + Copy> Target<T> {
             }
             Target::None => {}
         }
+        self.normalize();
     }
 
     /// Compute the union of this target with another one (A U B)
     pub(crate) fn union(&mut self, target: &Target<T>) {
+        self.normalize();
         match self {
             Target::All => {}
             Target::AllExceptSingle(existing_client_id) => {
@@ -298,23 +427,13 @@ impl<T: PartialEq + Eq + Hash + Clone + Copy> Target<T> {
                     }
                 }
                 Target::AllExcept(target_client_ids) => {
-                    let new_excluded_ids = HS::from_iter(existing_client_ids.clone());
-                    let target_excluded_ids = HS::from_iter(target_client_ids.clone());
-                    let intersection = new_excluded_ids
-                        .intersection(&target_excluded_ids)
-                        .copied()
-                        .collect();
-                    *existing_client_ids = intersection;
+                    existing_client_ids.retain(|id| target_client_ids.contains(id));
                 }
                 Target::All => {
                     *self = Target::All;
                 }
                 Target::Only(target_client_ids) => {
-                    let mut new_excluded_ids = HS::from_iter(existing_client_ids.clone());
-                    target_client_ids.iter().for_each(|id| {
-                        new_excluded_ids.remove(id);
-                    });
-                    *self = Target::from_exclude(new_excluded_ids)
+                    existing_client_ids.retain(|id| !target_client_ids.contains(id));
                 }
                 Target::Single(target_client_id) => {
                     existing_client_ids.retain(|id| id != target_client_id);
@@ -330,23 +449,13 @@ impl<T: PartialEq + Eq + Hash + Clone + Copy> Target<T> {
                     }
                 }
                 Target::AllExcept(target_client_ids) => {
-                    let mut target_excluded_ids = HS::from_iter(target_client_ids.clone());
-                    existing_client_ids.iter().for_each(|id| {
-                        target_excluded_ids.remove(id);
-                    });
-                    match target_excluded_ids.len() {
-                        0 => {
-                            *self = Target::All;
-                        }
-                        1 => {
-                            *self = Target::AllExceptSingle(
-                                *target_excluded_ids.iter().next().unwrap(),
-                            );
-                        }
-                        _ => {
-                            *self = Target::AllExcept(Vec::from_iter(target_excluded_ids));
-                        }
-                    }
+                    let excluded = Self::all_except_unique(
+                        target_client_ids
+                            .iter()
+                            .copied()
+                            .filter(|id| !existing_client_ids.contains(id)),
+                    );
+                    *self = excluded;
                 }
                 Target::All => {
                     *self = Target::All;
@@ -357,10 +466,11 @@ impl<T: PartialEq + Eq + Hash + Clone + Copy> Target<T> {
                     }
                 }
                 Target::Only(target_client_ids) => {
-                    let new_included_ids = HS::from_iter(existing_client_ids.clone());
-                    let target_included_ids = HS::from_iter(target_client_ids.clone());
-                    let union = new_included_ids.union(&target_included_ids);
-                    *existing_client_ids = union.into_iter().copied().collect::<Vec<_>>();
+                    target_client_ids.iter().copied().for_each(|id| {
+                        if !existing_client_ids.contains(&id) {
+                            existing_client_ids.push(id);
+                        }
+                    });
                 }
             },
             Target::Single(existing_client_id) => match target {
@@ -373,17 +483,21 @@ impl<T: PartialEq + Eq + Hash + Clone + Copy> Target<T> {
                     }
                 }
                 Target::AllExcept(target_client_ids) => {
-                    let mut new_excluded = target_client_ids.clone();
-                    new_excluded.retain(|id| id != existing_client_id);
-                    *self = Target::from_exclude(new_excluded);
+                    *self = Self::all_except_unique(
+                        target_client_ids
+                            .iter()
+                            .copied()
+                            .filter(|id| id != existing_client_id),
+                    );
                 }
                 Target::All => {
                     *self = Target::All;
                 }
                 Target::Only(target_client_ids) => {
-                    let mut new_targets = HS::from_iter(target_client_ids.clone());
-                    new_targets.insert(*existing_client_id);
-                    *self = Target::from(Vec::from_iter(new_targets));
+                    *self = Self::only_unique(
+                        core::iter::once(*existing_client_id)
+                            .chain(target_client_ids.iter().copied()),
+                    );
                 }
                 Target::Single(target_client_id) => {
                     if existing_client_id != target_client_id {
@@ -395,37 +509,106 @@ impl<T: PartialEq + Eq + Hash + Clone + Copy> Target<T> {
                 *self = target.clone();
             }
         }
+        self.normalize();
     }
 
     /// Compute the inverse of this target (¬A)
     pub(crate) fn inverse(&mut self) {
-        match self {
-            Target::All => {
-                *self = Target::None;
-            }
-            Target::AllExceptSingle(client_id) => {
-                *self = Target::Single(*client_id);
-            }
-            Target::AllExcept(client_ids) => {
-                *self = Target::Only(client_ids.clone());
-            }
-            Target::Only(client_ids) => {
-                *self = Target::AllExcept(client_ids.clone());
-            }
-            Target::Single(client_id) => {
-                *self = Target::AllExceptSingle(*client_id);
-            }
-            Target::None => {
-                *self = Target::All;
-            }
-        }
+        self.normalize();
+        *self = match core::mem::take(self) {
+            Target::All => Target::None,
+            Target::AllExceptSingle(client_id) => Target::Single(client_id),
+            Target::AllExcept(client_ids) => Target::Only(client_ids),
+            Target::Only(client_ids) => Target::AllExcept(client_ids),
+            Target::Single(client_id) => Target::AllExceptSingle(client_id),
+            Target::None => Target::All,
+        };
     }
 
     /// Compute the difference of this target with another one (A - B)
     pub(crate) fn exclude(&mut self, target: &Target<T>) {
-        let mut target = target.clone();
-        target.inverse();
-        self.intersection(&target);
+        self.normalize();
+        match self {
+            Target::All => {
+                *self = match target {
+                    Target::None => Target::All,
+                    Target::AllExceptSingle(client_id) => Target::Single(*client_id),
+                    Target::AllExcept(client_ids) => Self::only_unique(client_ids.iter().copied()),
+                    Target::All => Target::None,
+                    Target::Only(client_ids) => Self::all_except_unique(client_ids.iter().copied()),
+                    Target::Single(client_id) => Target::AllExceptSingle(*client_id),
+                };
+            }
+            Target::AllExceptSingle(existing_client_id) => {
+                let existing_client_id = *existing_client_id;
+                *self = match target {
+                    Target::None => Target::AllExceptSingle(existing_client_id),
+                    Target::AllExceptSingle(target_client_id) => {
+                        if existing_client_id == *target_client_id {
+                            Target::None
+                        } else {
+                            Target::Single(*target_client_id)
+                        }
+                    }
+                    Target::AllExcept(target_client_ids) => Self::only_unique(
+                        target_client_ids
+                            .iter()
+                            .copied()
+                            .filter(|id| id != &existing_client_id),
+                    ),
+                    Target::All => Target::None,
+                    Target::Only(target_client_ids) => Self::all_except_unique(
+                        core::iter::once(existing_client_id)
+                            .chain(target_client_ids.iter().copied()),
+                    ),
+                    Target::Single(target_client_id) => {
+                        Self::all_except_unique([existing_client_id, *target_client_id])
+                    }
+                };
+            }
+            Target::AllExcept(existing_client_ids) => match target {
+                Target::None => {}
+                Target::AllExceptSingle(target_client_id) => {
+                    if existing_client_ids.contains(target_client_id) {
+                        *self = Target::None;
+                    } else {
+                        *self = Target::Single(*target_client_id);
+                    }
+                }
+                Target::AllExcept(target_client_ids) => {
+                    let included = Self::only_unique(
+                        target_client_ids
+                            .iter()
+                            .copied()
+                            .filter(|id| !existing_client_ids.contains(id)),
+                    );
+                    *self = included;
+                }
+                Target::All => *self = Target::None,
+                Target::Only(target_client_ids) => {
+                    target_client_ids.iter().copied().for_each(|id| {
+                        if !existing_client_ids.contains(&id) {
+                            existing_client_ids.push(id);
+                        }
+                    });
+                }
+                Target::Single(target_client_id) => {
+                    if !existing_client_ids.contains(target_client_id) {
+                        existing_client_ids.push(*target_client_id);
+                    }
+                }
+            },
+            Target::Only(existing_client_ids) => {
+                existing_client_ids.retain(|id| !target.targets(id));
+            }
+            Target::Single(existing_client_id) => {
+                if target.targets(existing_client_id) {
+                    *self = Target::None;
+                }
+            }
+            Target::None => {}
+        }
+        self.normalize();
     }
 }
 
@@ -444,106 +627,131 @@ mod tests {
         assert_eq!(target, deserialized);
     }
 
-    #[test]
-    fn test_exclude() {
-        let client_0 = PeerId::Netcode(0);
-        let client_1 = PeerId::Netcode(1);
-        let client_2 = PeerId::Netcode(2);
-        let mut target = Target::All;
-        assert!(target.targets(&client_0));
-        target.exclude(&Target::Only(vec![client_1, client_2]));
-        assert_eq!(target, Target::AllExcept(vec![client_1, client_2]));
+    fn peer(id: u64) -> PeerId {
+        PeerId::Netcode(id)
+    }
 
-        target = Target::AllExcept(vec![client_0]);
-        assert!(!target.targets(&client_0));
-        assert!(target.targets(&client_1));
-        target.exclude(&Target::Only(vec![client_0, client_1]));
-        assert!(matches!(target, Target::AllExcept(_)));
+    fn target_cases() -> Vec<(&'static str, NetworkTarget)> {
+        vec![
+            ("none", Target::None),
+            ("all", Target::All),
+            ("single", Target::Single(peer(0))),
+            ("all-except-single", Target::AllExceptSingle(peer(0))),
+            ("only-many", Target::Only(vec![peer(0), peer(1)])),
+            ("all-except-many", Target::AllExcept(vec![peer(0), peer(1)])),
+            ("only-empty", Target::Only(vec![])),
+            ("all-except-empty", Target::AllExcept(vec![])),
+            ("only-duplicate", Target::Only(vec![peer(0), peer(0)])),
+            (
+                "all-except-duplicate",
+                Target::AllExcept(vec![peer(0), peer(0)]),
+            ),
+        ]
+    }
 
-        if let Target::AllExcept(ids) = target {
-            assert!(ids.contains(&client_0));
-            assert!(ids.contains(&client_1));
+    fn assert_canonical(target: &NetworkTarget) {
+        if let Target::Only(client_ids) | Target::AllExcept(client_ids) = target {
+            assert!(client_ids.len() >= 2, "non-canonical target: {target:?}");
+            for (index, client_id) in client_ids.iter().enumerate() {
+                assert!(
+                    !client_ids[..index].contains(client_id),
+                    "duplicate client in target: {target:?}"
+                );
+            }
         }
+    }
 
-        target = Target::Only(vec![client_0]);
-        assert!(target.targets(&client_0));
-        assert!(!target.targets(&client_1));
-        target.exclude(&Target::Single(client_1));
-        assert_eq!(target, Target::Single(client_0));
-        target.exclude(&Target::Only(vec![client_0, client_2]));
-        assert_eq!(target, Target::None);
+    fn assert_binary_operation(
+        name: &str,
+        operation: fn(&mut NetworkTarget, &NetworkTarget),
+        expected: fn(bool, bool) -> bool,
+    ) {
+        let cases = target_cases();
+        let clients = [peer(0), peer(1), peer(2), peer(3)];
 
-        target = Target::None;
-        assert!(!target.targets(&client_0));
-        target.exclude(&Target::Single(client_1));
-        assert_eq!(target, Target::None);
+        for (left_name, left) in &cases {
+            for (right_name, right) in &cases {
+                let mut actual = left.clone();
+                operation(&mut actual, right);
+
+                for client in clients {
+                    assert_eq!(
+                        actual.targets(&client),
+                        expected(left.targets(&client), right.targets(&client)),
+                        "{name} failed for {left_name} and {right_name} at {client:?}: {actual:?}"
+                    );
+                }
+                assert_canonical(&actual);
+            }
+        }
     }
 
     #[test]
-    fn test_intersection() {
-        let client_0 = PeerId::Netcode(0);
-        let client_1 = PeerId::Netcode(1);
-        let client_2 = PeerId::Netcode(2);
-        let mut target = Target::All;
-        target.intersection(&Target::AllExcept(vec![client_1, client_2]));
-        assert_eq!(target, Target::AllExcept(vec![client_1, client_2]));
-
-        target = Target::AllExcept(vec![client_0]);
-        target.intersection(&Target::AllExcept(vec![client_0, client_1]));
-        assert!(matches!(target, Target::AllExcept(_)));
-
-        if let Target::AllExcept(ids) = target {
-            assert!(ids.contains(&client_0));
-            assert!(ids.contains(&client_1));
-        }
-
-        target = Target::AllExcept(vec![client_0, client_1]);
-        target.intersection(&Target::Only(vec![client_0, client_2]));
-        assert_eq!(target, Target::Only(vec![client_2]));
-
-        target = Target::Only(vec![client_0, client_1]);
-        target.intersection(&Target::Only(vec![client_0, client_2]));
-        assert_eq!(target, Target::Single(client_0));
-
-        target = Target::Only(vec![client_0, client_1]);
-        target.intersection(&Target::AllExcept(vec![client_0, client_2]));
-        assert_eq!(target, Target::Single(client_1));
-
-        target = Target::None;
-        target.intersection(&Target::AllExcept(vec![client_0, client_2]));
-        assert_eq!(target, Target::None);
+    fn set_operations_match_membership() {
+        assert_binary_operation("intersection", Target::intersection, |left, right| {
+            left && right
+        });
+        assert_binary_operation("union", Target::union, |left, right| left || right);
+        assert_binary_operation("exclude", Target::exclude, |left, right| left && !right);
     }
 
     #[test]
-    fn test_union() {
-        let client_0 = PeerId::Netcode(0);
-        let client_1 = PeerId::Netcode(1);
-        let client_2 = PeerId::Netcode(2);
-        let mut target = Target::All;
-        target.union(&Target::AllExcept(vec![client_1, client_2]));
-        assert_eq!(target, Target::All);
+    fn inverse_matches_membership() {
+        let clients = [peer(0), peer(1), peer(2), peer(3)];
+        for (name, target) in target_cases() {
+            let mut actual = target.clone();
+            actual.inverse();
+            for client in clients {
+                assert_eq!(
+                    actual.targets(&client),
+                    !target.targets(&client),
+                    "inverse failed for {name} at {client:?}: {actual:?}"
+                );
+            }
+            assert_canonical(&actual);
+        }
+    }
 
-        target = Target::AllExcept(vec![client_0]);
-        target.union(&Target::Only(vec![client_0, client_1]));
-        assert_eq!(target, Target::All);
+    #[test]
+    fn builders_use_compact_variants() {
+        assert_eq!(core::iter::empty().collect::<NetworkTarget>(), Target::None);
+        assert_eq!(
+            [peer(0)].into_iter().collect::<NetworkTarget>(),
+            Target::Single(peer(0))
+        );
+        assert_eq!(
+            NetworkTarget::from_exclude([peer(0), peer(0)]),
+            Target::AllExceptSingle(peer(0))
+        );
 
-        target = Target::AllExcept(vec![client_0, client_1]);
-        target.union(&Target::Only(vec![client_0, client_2]));
-        assert_eq!(target, Target::AllExceptSingle(client_1));
+        let mut target = Target::Single(peer(0));
+        target.extend([peer(0), peer(1), peer(1)]);
+        assert_eq!(target, Target::Only(vec![peer(0), peer(1)]));
+    }
 
-        target = Target::Only(vec![client_0, client_1]);
-        target.union(&Target::Only(vec![client_0, client_2]));
-        assert!(matches!(target, Target::Only(_)));
-        assert!(target.targets(&client_0));
-        assert!(target.targets(&client_1));
-        assert!(target.targets(&client_2));
+    #[test]
+    fn operations_reuse_left_hand_vec_capacity() {
+        assert_reuses_left_hand_vec(Target::intersection, Target::Only(vec![peer(0), peer(2)]));
+        assert_reuses_left_hand_vec(Target::union, Target::Single(peer(3)));
+        assert_reuses_left_hand_vec(Target::exclude, Target::Single(peer(1)));
+    }
 
-        target = Target::Only(vec![client_0, client_1]);
-        target.union(&Target::AllExcept(vec![client_0, client_2]));
-        assert_eq!(target, Target::AllExceptSingle(client_2));
+    fn assert_reuses_left_hand_vec(
+        operation: fn(&mut NetworkTarget, &NetworkTarget),
+        right: NetworkTarget,
+    ) {
+        let mut client_ids = Vec::with_capacity(8);
+        client_ids.extend([peer(0), peer(1), peer(2)]);
+        let pointer = client_ids.as_ptr();
+        let capacity = client_ids.capacity();
+        let mut target = Target::Only(client_ids);
 
-        target = Target::None;
-        target.union(&Target::AllExcept(vec![client_0, client_2]));
-        assert_eq!(target, Target::AllExcept(vec![client_0, client_2]));
+        operation(&mut target, &right);
+
+        let Target::Only(client_ids) = target else {
+            panic!("expected a multi-client inclusive target");
+        };
+        assert_eq!(client_ids.as_ptr(), pointer);
+        assert_eq!(client_ids.capacity(), capacity);
     }
 }

--- a/crates/connection/connection/src/network_target.rs
+++ b/crates/connection/connection/src/network_target.rs
@@ -1,7 +1,8 @@
 use alloc::{vec, vec::Vec};
-use bevy_ecs::entity::Entity;
-use bevy_platform::collections::HashMap;
+use bevy_ecs::entity::{Entity, EntityHashSet};
+use bevy_platform::collections::{HashMap, HashSet};
 use bevy_reflect::Reflect;
+use core::hash::Hash;
 use lightyear_core::id::PeerId;
 use lightyear_serde::reader::{ReadInteger, Reader};
 use lightyear_serde::writer::WriteInteger;
@@ -11,6 +12,78 @@ use smallvec::SmallVec;
 
 pub type NetworkTarget = Target<PeerId>;
 pub type EntityTarget = Target<Entity>;
+
+/// Reusable storage for resolving a [`NetworkTarget`] to connected entities.
+#[derive(Default)]
+pub struct NetworkTargetResolver {
+    targets: EntityHashSet,
+    requested: EntityHashSet,
+}
+
+impl NetworkTargetResolver {
+    /// Resolves `target` against the connected `clients` without allocating after the sets have
+    /// grown to the required capacity.
+    pub fn resolve(
+        &mut self,
+        target: &NetworkTarget,
+        clients: &[Entity],
+        mapping: &HashMap<PeerId, Entity>,
+    ) -> &EntityHashSet {
+        self.targets.clear();
+        self.requested.clear();
+
+        match target {
+            NetworkTarget::All => self.targets.extend(clients.iter().copied()),
+            NetworkTarget::AllExceptSingle(peer_id) => {
+                self.targets.extend(clients.iter().copied());
+                if let Some(entity) = mapping.get(peer_id) {
+                    self.targets.remove(entity);
+                }
+            }
+            NetworkTarget::AllExcept(peer_ids) => {
+                self.targets.extend(clients.iter().copied());
+                for peer_id in peer_ids {
+                    if let Some(entity) = mapping.get(peer_id) {
+                        self.targets.remove(entity);
+                    }
+                }
+            }
+            NetworkTarget::Single(peer_id) => {
+                if let Some(entity) = mapping.get(peer_id)
+                    && clients.contains(entity)
+                {
+                    self.targets.insert(*entity);
+                }
+            }
+            NetworkTarget::Only(peer_ids) => {
+                if clients.len() <= 4 && peer_ids.len() <= 4 {
+                    let requested = peer_ids
+                        .iter()
+                        .filter_map(|peer_id| mapping.get(peer_id).copied())
+                        .collect::<SmallVec<[Entity; 4]>>();
+                    self.targets.extend(
+                        clients
+                            .iter()
+                            .filter(|entity| requested.contains(entity))
+                            .copied(),
+                    );
+                    return &self.targets;
+                }
+                self.requested
+                    .extend(peer_ids.iter().filter_map(|peer_id| mapping.get(peer_id)));
+                self.targets.extend(
+                    clients
+                        .iter()
+                        .filter(|entity| self.requested.contains(*entity))
+                        .copied(),
+                );
+            }
+            NetworkTarget::None => {}
+        }
+
+        &self.targets
+    }
+}
 
 impl NetworkTarget {
     /// Calls func on each client entity that matches the provided `target`
@@ -135,7 +208,7 @@ impl ToBytes for Target<PeerId> {
     }
 }
 
-impl<T: PartialEq + Copy> Extend<T> for Target<T> {
+impl<T: Eq + Hash + Copy> Extend<T> for Target<T> {
     fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
         self.normalize();
         let iter = iter.into_iter();
@@ -179,7 +252,7 @@ impl<T> From<Vec<T>> for Target<T> {
     }
 }
 
-impl<T: PartialEq + Copy> Target<T> {
+impl<T: Eq + Hash + Copy> Target<T> {
     /// Returns true if the target is empty
     pub fn is_empty(&self) -> bool {
         match self {
@@ -236,34 +309,18 @@ impl<T: PartialEq + Copy> Target<T> {
 
     /// Builds an inclusive target while avoiding a heap allocation for zero or one unique item.
     fn only_unique(client_ids: impl IntoIterator<Item = T>) -> Self {
-        let iter = client_ids.into_iter();
-        // Internal callers derive this iterator from an existing target list, so its upper bound
-        // lets a multi-ID result allocate its final storage once without allocating for zero or
-        // one result.
-        let capacity = iter.size_hint().1.unwrap_or(2).max(2);
-        let mut first = None;
-        let mut many: Option<Vec<T>> = None;
-
-        for client_id in iter {
-            if let Some(client_ids) = many.as_mut() {
-                if !client_ids.contains(&client_id) {
-                    client_ids.push(client_id);
-                }
-            } else if let Some(first_client_id) = first {
-                if first_client_id != client_id {
-                    let mut client_ids = Vec::with_capacity(capacity);
-                    client_ids.extend([first_client_id, client_id]);
-                    many = Some(client_ids);
-                }
-            } else {
-                first = Some(client_id);
-            }
-        }
-
-        match many {
-            Some(client_ids) => Target::Only(client_ids),
-            None => first.map_or(Target::None, Target::Single),
-        }
+        let mut iter = client_ids.into_iter();
+        let Some(first) = iter.next() else {
+            return Target::None;
+        };
+        let Some(second) = iter.next() else {
+            return Target::Single(first);
+        };
+        let mut client_ids = Vec::with_capacity(iter.size_hint().1.unwrap_or(0).saturating_add(2));
+        client_ids.extend([first, second]);
+        client_ids.extend(iter);
+        Self::deduplicate(&mut client_ids);
+        Target::from(client_ids)
     }
 
     /// Builds an exclusive target while avoiding a heap allocation for zero or one unique item.
@@ -273,6 +330,14 @@ impl<T: PartialEq + Copy> Target<T> {
             Target::Single(client_id) => Target::AllExceptSingle(client_id),
             Target::Only(client_ids) => Target::AllExcept(client_ids),
             _ => unreachable!("only_unique only constructs inclusive targets"),
+        }
+    }
+
+    fn all_except_from_vec(mut client_ids: Vec<T>) -> Self {
+        match client_ids.len() {
+            0 => Target::All,
+            1 => Target::AllExceptSingle(client_ids.pop().unwrap()),
+            _ => Target::AllExcept(client_ids),
         }
     }
 
@@ -299,8 +364,30 @@ impl<T: PartialEq + Copy> Target<T> {
         };
     }
 
-    /// Stable in-place deduplication for the usually-small target lists.
+    /// Restores the zero/one/many representation without scanning a list for duplicates.
+    fn compact(&mut self) {
+        *self = match core::mem::take(self) {
+            Target::Only(mut client_ids) => match client_ids.len() {
+                0 => Target::None,
+                1 => Target::Single(client_ids.pop().unwrap()),
+                _ => Target::Only(client_ids),
+            },
+            Target::AllExcept(mut client_ids) => match client_ids.len() {
+                0 => Target::All,
+                1 => Target::AllExceptSingle(client_ids.pop().unwrap()),
+                _ => Target::AllExcept(client_ids),
+            },
+            target => target,
+        };
+    }
+
+    /// Stable deduplication with an allocation-free path for the common small-client case.
     fn deduplicate(client_ids: &mut Vec<T>) {
+        if client_ids.len() > 4 {
+            let mut seen = HashSet::with_capacity(client_ids.len());
+            client_ids.retain(|client_id| seen.insert(*client_id));
+            return;
+        }
         let mut index = 1;
         while index < client_ids.len() {
             if client_ids[..index].contains(&client_ids[index]) {
@@ -311,9 +398,86 @@ impl<T: PartialEq + Copy> Target<T> {
         }
     }
 
+    /// Appends IDs while preserving order and uniqueness.
+    fn append_unique(client_ids: &mut Vec<T>, extra: &[T]) {
+        if client_ids.len() <= 4 || extra.len() <= 4 {
+            for client_id in extra {
+                if !client_ids.contains(client_id) {
+                    client_ids.push(*client_id);
+                }
+            }
+            return;
+        }
+
+        let mut seen = HashSet::with_capacity(client_ids.len().saturating_add(extra.len()));
+        client_ids.retain(|client_id| seen.insert(*client_id));
+        client_ids.reserve(extra.len());
+        for client_id in extra {
+            if seen.insert(*client_id) {
+                client_ids.push(*client_id);
+            }
+        }
+    }
+
+    /// Retains either the IDs present in `other` or those absent from it.
+    fn retain_membership(client_ids: &mut Vec<T>, other: &[T], keep_present: bool) {
+        if client_ids.len() <= 4 || other.len() <= 4 {
+            client_ids.retain(|client_id| other.contains(client_id) == keep_present);
+            return;
+        }
+
+        if keep_present {
+            let mut remaining = HashSet::with_capacity(other.len());
+            remaining.extend(other.iter().copied());
+            client_ids.retain(|client_id| remaining.remove(client_id));
+        } else {
+            let mut excluded_or_seen =
+                HashSet::with_capacity(client_ids.len().saturating_add(other.len()));
+            excluded_or_seen.extend(other.iter().copied());
+            client_ids.retain(|client_id| excluded_or_seen.insert(*client_id));
+        }
+    }
+
+    /// Builds an inclusive target containing the unique IDs in `left` but not in `right`.
+    fn only_difference(left: &[T], right: &[T]) -> Self {
+        if left.len() <= 4 || right.len() <= 4 {
+            return Self::only_unique(left.iter().copied().filter(|id| !right.contains(id)));
+        }
+
+        let mut excluded_or_seen = HashSet::with_capacity(left.len().saturating_add(right.len()));
+        excluded_or_seen.extend(right.iter().copied());
+        let mut result = Vec::with_capacity(left.len());
+        result.extend(
+            left.iter()
+                .copied()
+                .filter(|client_id| excluded_or_seen.insert(*client_id)),
+        );
+        Target::from(result)
+    }
+
+    fn all_except_difference(left: &[T], right: &[T]) -> Self {
+        match Self::only_difference(left, right) {
+            Target::None => Target::All,
+            Target::Single(client_id) => Target::AllExceptSingle(client_id),
+            Target::Only(client_ids) => Target::AllExcept(client_ids),
+            _ => unreachable!("only_difference only constructs inclusive targets"),
+        }
+    }
+
     /// Compute the intersection of this target with another one (A ∩ B)
     pub(crate) fn intersection(&mut self, target: &Target<T>) {
-        self.normalize();
+        if matches!(self, Target::None) || matches!(target, Target::All) {
+            return;
+        }
+        if matches!(target, Target::None) {
+            *self = Target::None;
+            return;
+        }
+        if matches!(self, Target::All) {
+            *self = target.clone();
+            return;
+        }
+
         match self {
             Target::All => {
                 *self = target.clone();
@@ -355,21 +519,11 @@ impl<T: PartialEq + Copy> Target<T> {
                     }
                 }
                 Target::AllExcept(target_client_ids) => {
-                    target_client_ids.iter().copied().for_each(|id| {
-                        if !existing_client_ids.contains(&id) {
-                            existing_client_ids.push(id);
-                        }
-                    });
+                    Self::append_unique(existing_client_ids, target_client_ids);
                 }
                 Target::All => {}
                 Target::Only(target_client_ids) => {
-                    let included = Self::only_unique(
-                        target_client_ids
-                            .iter()
-                            .copied()
-                            .filter(|id| !existing_client_ids.contains(id)),
-                    );
-                    *self = included;
+                    *self = Self::only_difference(target_client_ids, existing_client_ids);
                 }
                 Target::Single(target_client_id) => {
                     if existing_client_ids.contains(target_client_id) {
@@ -387,14 +541,14 @@ impl<T: PartialEq + Copy> Target<T> {
                     existing_client_ids.retain(|id| id != target_client_id);
                 }
                 Target::AllExcept(target_client_ids) => {
-                    existing_client_ids.retain(|id| !target_client_ids.contains(id));
+                    Self::retain_membership(existing_client_ids, target_client_ids, false);
                 }
                 Target::All => {}
                 Target::Single(target_client_id) => {
                     existing_client_ids.retain(|id| id == target_client_id);
                 }
                 Target::Only(target_client_ids) => {
-                    existing_client_ids.retain(|id| target_client_ids.contains(id));
+                    Self::retain_membership(existing_client_ids, target_client_ids, true);
                 }
             },
             Target::Single(existing_client_id) => {
@@ -404,12 +558,23 @@ impl<T: PartialEq + Copy> Target<T> {
             }
             Target::None => {}
         }
-        self.normalize();
+        self.compact();
     }
 
     /// Compute the union of this target with another one (A U B)
     pub(crate) fn union(&mut self, target: &Target<T>) {
-        self.normalize();
+        if matches!(self, Target::All) || matches!(target, Target::None) {
+            return;
+        }
+        if matches!(target, Target::All) {
+            *self = Target::All;
+            return;
+        }
+        if matches!(self, Target::None) {
+            *self = target.clone();
+            return;
+        }
+
         match self {
             Target::All => {}
             Target::AllExceptSingle(existing_client_id) => {
@@ -427,13 +592,13 @@ impl<T: PartialEq + Copy> Target<T> {
                     }
                 }
                 Target::AllExcept(target_client_ids) => {
-                    existing_client_ids.retain(|id| target_client_ids.contains(id));
+                    Self::retain_membership(existing_client_ids, target_client_ids, true);
                 }
                 Target::All => {
                     *self = Target::All;
                 }
                 Target::Only(target_client_ids) => {
-                    existing_client_ids.retain(|id| !target_client_ids.contains(id));
+                    Self::retain_membership(existing_client_ids, target_client_ids, false);
                 }
                 Target::Single(target_client_id) => {
                     existing_client_ids.retain(|id| id != target_client_id);
@@ -449,13 +614,7 @@ impl<T: PartialEq + Copy> Target<T> {
                     }
                 }
                 Target::AllExcept(target_client_ids) => {
-                    let excluded = Self::all_except_unique(
-                        target_client_ids
-                            .iter()
-                            .copied()
-                            .filter(|id| !existing_client_ids.contains(id)),
-                    );
-                    *self = excluded;
+                    *self = Self::all_except_difference(target_client_ids, existing_client_ids);
                 }
                 Target::All => {
                     *self = Target::All;
@@ -466,11 +625,7 @@ impl<T: PartialEq + Copy> Target<T> {
                     }
                 }
                 Target::Only(target_client_ids) => {
-                    target_client_ids.iter().copied().for_each(|id| {
-                        if !existing_client_ids.contains(&id) {
-                            existing_client_ids.push(id);
-                        }
-                    });
+                    Self::append_unique(existing_client_ids, target_client_ids);
                 }
             },
             Target::Single(existing_client_id) => match target {
@@ -509,12 +664,11 @@ impl<T: PartialEq + Copy> Target<T> {
                 *self = target.clone();
             }
         }
-        self.normalize();
+        self.compact();
     }
 
     /// Compute the inverse of this target (¬A)
     pub(crate) fn inverse(&mut self) {
-        self.normalize();
         *self = match core::mem::take(self) {
             Target::All => Target::None,
             Target::AllExceptSingle(client_id) => Target::Single(client_id),
@@ -527,15 +681,22 @@ impl<T: PartialEq + Copy> Target<T> {
 
     /// Compute the difference of this target with another one (A - B)
     pub(crate) fn exclude(&mut self, target: &Target<T>) {
-        self.normalize();
+        if matches!(self, Target::None) || matches!(target, Target::None) {
+            return;
+        }
+        if matches!(target, Target::All) {
+            *self = Target::None;
+            return;
+        }
+
         match self {
             Target::All => {
                 *self = match target {
                     Target::None => Target::All,
                     Target::AllExceptSingle(client_id) => Target::Single(*client_id),
-                    Target::AllExcept(client_ids) => Self::only_unique(client_ids.iter().copied()),
+                    Target::AllExcept(client_ids) => Target::from(client_ids.clone()),
                     Target::All => Target::None,
-                    Target::Only(client_ids) => Self::all_except_unique(client_ids.iter().copied()),
+                    Target::Only(client_ids) => Self::all_except_from_vec(client_ids.clone()),
                     Target::Single(client_id) => Target::AllExceptSingle(*client_id),
                 };
             }
@@ -576,21 +737,11 @@ impl<T: PartialEq + Copy> Target<T> {
                     }
                 }
                 Target::AllExcept(target_client_ids) => {
-                    let included = Self::only_unique(
-                        target_client_ids
-                            .iter()
-                            .copied()
-                            .filter(|id| !existing_client_ids.contains(id)),
-                    );
-                    *self = included;
+                    *self = Self::only_difference(target_client_ids, existing_client_ids);
                 }
                 Target::All => *self = Target::None,
                 Target::Only(target_client_ids) => {
-                    target_client_ids.iter().copied().for_each(|id| {
-                        if !existing_client_ids.contains(&id) {
-                            existing_client_ids.push(id);
-                        }
-                    });
+                    Self::append_unique(existing_client_ids, target_client_ids);
                 }
                 Target::Single(target_client_id) => {
                     if !existing_client_ids.contains(target_client_id) {
@@ -598,9 +749,22 @@ impl<T: PartialEq + Copy> Target<T> {
                     }
                 }
             },
-            Target::Only(existing_client_ids) => {
-                existing_client_ids.retain(|id| !target.targets(id));
-            }
+            Target::Only(existing_client_ids) => match target {
+                Target::None => {}
+                Target::AllExceptSingle(target_client_id) => {
+                    existing_client_ids.retain(|id| id == target_client_id);
+                }
+                Target::AllExcept(target_client_ids) => {
+                    Self::retain_membership(existing_client_ids, target_client_ids, true);
+                }
+                Target::All => *self = Target::None,
+                Target::Only(target_client_ids) => {
+                    Self::retain_membership(existing_client_ids, target_client_ids, false);
+                }
+                Target::Single(target_client_id) => {
+                    existing_client_ids.retain(|id| id != target_client_id);
+                }
+            },
             Target::Single(existing_client_id) => {
                 if target.targets(existing_client_id) {
                     *self = Target::None;
@@ -608,7 +772,7 @@ impl<T: PartialEq + Copy> Target<T> {
             }
             Target::None => {}
         }
-        self.normalize();
+        self.compact();
     }
 }
 
@@ -631,6 +795,41 @@ mod tests {
         PeerId::Netcode(id)
     }
 
+    fn assert_entities(actual: &EntityHashSet, expected: &[Entity]) {
+        assert_eq!(actual.len(), expected.len());
+        assert!(expected.iter().all(|entity| actual.contains(entity)));
+    }
+
+    #[test]
+    fn resolver_reuses_storage_and_filters_to_connected_clients() {
+        let clients = [Entity::from_bits(1), Entity::from_bits(2)];
+        let mapping = HashMap::from_iter([
+            (peer(0), clients[0]),
+            (peer(1), clients[1]),
+            (peer(2), Entity::from_bits(3)),
+        ]);
+        let mut resolver = NetworkTargetResolver::default();
+
+        assert_entities(resolver.resolve(&Target::All, &clients, &mapping), &clients);
+        assert_entities(
+            resolver.resolve(
+                &Target::Only(vec![peer(1), peer(2), peer(3)]),
+                &clients,
+                &mapping,
+            ),
+            &[clients[1]],
+        );
+        assert_entities(
+            resolver.resolve(
+                &Target::AllExcept(vec![peer(1), peer(2)]),
+                &clients,
+                &mapping,
+            ),
+            &[clients[0]],
+        );
+        assert_entities(resolver.resolve(&Target::None, &clients, &mapping), &[]);
+    }
+
     fn target_cases() -> Vec<(&'static str, NetworkTarget)> {
         vec![
             ("none", Target::None),
@@ -647,18 +846,6 @@ mod tests {
                 Target::AllExcept(vec![peer(0), peer(0)]),
             ),
         ]
-    }
-
-    fn assert_canonical(target: &NetworkTarget) {
-        if let Target::Only(client_ids) | Target::AllExcept(client_ids) = target {
-            assert!(client_ids.len() >= 2, "non-canonical target: {target:?}");
-            for (index, client_id) in client_ids.iter().enumerate() {
-                assert!(
-                    !client_ids[..index].contains(client_id),
-                    "duplicate client in target: {target:?}"
-                );
-            }
-        }
     }
 
     fn assert_binary_operation(
@@ -681,7 +868,6 @@ mod tests {
                         "{name} failed for {left_name} and {right_name} at {client:?}: {actual:?}"
                     );
                 }
-                assert_canonical(&actual);
             }
         }
     }
@@ -708,7 +894,6 @@ mod tests {
                     "inverse failed for {name} at {client:?}: {actual:?}"
                 );
             }
-            assert_canonical(&actual);
         }
     }
 

--- a/crates/tests/src/client_server/messages.rs
+++ b/crates/tests/src/client_server/messages.rs
@@ -260,11 +260,20 @@ fn test_send_multi_messages_with_target() {
     info!("Sending messages from server to client");
     let send_message = StringMessage("World".to_string());
     let message = send_message.clone();
+    let client_0_id = stepper.client_of(0).get::<RemoteId>().unwrap().0;
     let system_id = stepper.server_app.register_system(
-        move |mut sender: ServerMultiMessageSender, server: Single<&Server>| {
+        move |mut sender: ServerMultiMessageSender,
+              server: Single<&Server>,
+              mut sent_all: Local<bool>| {
+            let target = if *sent_all {
+                NetworkTarget::Single(client_0_id)
+            } else {
+                NetworkTarget::All
+            };
             sender
-                .send::<_, Channel1>(&message, server.into_inner(), &NetworkTarget::All)
+                .send::<_, Channel1>(&message, server.into_inner(), &target)
                 .ok();
+            *sent_all = true;
         },
     );
     stepper.server_app.world_mut().run_system(system_id);
@@ -285,5 +294,37 @@ fn test_send_multi_messages_with_target() {
         &received_messages
             .0
             .contains(&(stepper.client_entities[1], send_message.clone()))
+    );
+
+    stepper.client_apps[0]
+        .world_mut()
+        .resource_mut::<Buffer<StringMessage>>()
+        .0
+        .clear();
+    stepper.client_apps[1]
+        .world_mut()
+        .resource_mut::<Buffer<StringMessage>>()
+        .0
+        .clear();
+
+    // Run the same system again with a narrower target. The reusable target set must not retain
+    // the second client from the previous broadcast.
+    stepper.server_app.world_mut().run_system(system_id);
+    stepper.frame_step(2);
+
+    let received_messages = stepper.client_apps[0]
+        .world()
+        .resource::<Buffer<StringMessage>>();
+    assert!(
+        received_messages
+            .0
+            .contains(&(stepper.client_entities[0], send_message))
+    );
+    assert!(
+        stepper.client_apps[1]
+            .world()
+            .resource::<Buffer<StringMessage>>()
+            .0
+            .is_empty()
     );
 }

--- a/crates/transport/messages/src/server.rs
+++ b/crates/transport/messages/src/server.rs
@@ -5,7 +5,7 @@ use crate::registry::MessageRegistration;
 use crate::send::Priority;
 use crate::send_trigger::EventSender;
 use crate::trigger::TriggerRegistration;
-use bevy_ecs::entity::{EntityHashSet, EntitySet};
+use bevy_ecs::entity::EntitySet;
 use bevy_ecs::query::QueryFilter;
 use bevy_ecs::{
     error::Result,
@@ -16,7 +16,7 @@ use bevy_ecs::{
 use lightyear_connection::client::PeerMetadata;
 use lightyear_connection::client_of::ClientOf;
 use lightyear_connection::direction::NetworkDirection;
-use lightyear_connection::network_target::NetworkTarget;
+use lightyear_connection::network_target::{NetworkTarget, NetworkTargetResolver};
 use lightyear_link::prelude::Server;
 use lightyear_transport::channel::Channel;
 
@@ -29,7 +29,7 @@ use lightyear_transport::channel::Channel;
 pub struct ServerMultiMessageSender<'w, 's, F: QueryFilter + 'static = ()> {
     sender: MultiMessageSender<'w, 's, F>,
     metadata: Res<'w, PeerMetadata>,
-    targets: Local<'s, EntityHashSet>,
+    resolver: Local<'s, NetworkTargetResolver>,
 }
 
 impl<'w, 's, F: QueryFilter> ServerMultiMessageSender<'w, 's, F> {
@@ -53,18 +53,15 @@ impl<'w, 's, F: QueryFilter> ServerMultiMessageSender<'w, 's, F> {
         target: &NetworkTarget,
         priority: Priority,
     ) -> Result {
-        // Resolve the NetworkTarget to concrete entities, then delegate to
-        // MultiMessageSender which handles per-client entity mapping correctly.
-        self.targets.clear();
-        target.apply_targets(
-            server.collection().iter().copied(),
+        // Resolve the NetworkTarget to concrete entities, then delegate to MultiMessageSender,
+        // which handles per-client entity mapping correctly.
+        let targets = self.resolver.resolve(
+            target,
+            server.collection().as_slice(),
             &self.metadata.mapping,
-            &mut |entity| {
-                self.targets.insert(entity);
-            },
         );
         self.sender
-            .send_with_priority::<M, C>(message, &*self.targets, priority)
+            .send_with_priority::<M, C>(message, targets, priority)
     }
 
     /// Send a message to a set of  [`ClientOf`]s entities associated with the provided [`Server`]

--- a/crates/transport/messages/src/server.rs
+++ b/crates/transport/messages/src/server.rs
@@ -5,13 +5,13 @@ use crate::registry::MessageRegistration;
 use crate::send::Priority;
 use crate::send_trigger::EventSender;
 use crate::trigger::TriggerRegistration;
-use bevy_ecs::entity::EntitySet;
+use bevy_ecs::entity::{EntityHashSet, EntitySet};
 use bevy_ecs::query::QueryFilter;
 use bevy_ecs::{
     error::Result,
     event::Event,
     relationship::RelationshipTarget,
-    system::{Res, SystemParam},
+    system::{Local, Res, SystemParam},
 };
 use lightyear_connection::client::PeerMetadata;
 use lightyear_connection::client_of::ClientOf;
@@ -29,6 +29,7 @@ use lightyear_transport::channel::Channel;
 pub struct ServerMultiMessageSender<'w, 's, F: QueryFilter + 'static = ()> {
     sender: MultiMessageSender<'w, 's, F>,
     metadata: Res<'w, PeerMetadata>,
+    targets: Local<'s, EntityHashSet>,
 }
 
 impl<'w, 's, F: QueryFilter> ServerMultiMessageSender<'w, 's, F> {
@@ -54,16 +55,16 @@ impl<'w, 's, F: QueryFilter> ServerMultiMessageSender<'w, 's, F> {
     ) -> Result {
         // Resolve the NetworkTarget to concrete entities, then delegate to
         // MultiMessageSender which handles per-client entity mapping correctly.
-        let mut targets = bevy_ecs::entity::EntityHashSet::default();
+        self.targets.clear();
         target.apply_targets(
             server.collection().iter().copied(),
             &self.metadata.mapping,
             &mut |entity| {
-                targets.insert(entity);
+                self.targets.insert(entity);
             },
         );
         self.sender
-            .send_with_priority::<M, C>(message, &targets, priority)
+            .send_with_priority::<M, C>(message, &*self.targets, priority)
     }
 
     /// Send a message to a set of  [`ClientOf`]s entities associated with the provided [`Server`]

--- a/crates/transport/serde/Cargo.toml
+++ b/crates/transport/serde/Cargo.toml
@@ -15,6 +15,7 @@ std = ["bytes/std", "no_std_io2/std"]
 [dependencies]
 # utils
 bytes.workspace = true
+smallvec.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 variadics_please.workspace = true

--- a/crates/transport/serde/src/lib.rs
+++ b/crates/transport/serde/src/lib.rs
@@ -22,6 +22,7 @@ use bevy_platform::collections::HashMap;
 use bytes::Bytes;
 use core::hash::{BuildHasher, Hash};
 use no_std_io2::io;
+use smallvec::{Array, SmallVec};
 
 /// Utilities for mapping entities during serialization and deserialization.
 pub mod entity_map;
@@ -226,6 +227,36 @@ impl<M: ToBytes> ToBytes for Vec<M> {
     }
 }
 
+impl<A> ToBytes for SmallVec<A>
+where
+    A: Array,
+    A::Item: ToBytes,
+{
+    // Match Vec's framing exactly so changing an in-memory collection to SmallVec does not change
+    // the wire format.
+    fn bytes_len(&self) -> usize {
+        varint_len(self.len() as u64) + self.iter().map(ToBytes::bytes_len).sum::<usize>()
+    }
+
+    fn to_bytes(&self, buffer: &mut impl WriteInteger) -> Result<(), SerializationError> {
+        buffer.write_varint(self.len() as u64)?;
+        self.iter().try_for_each(|item| item.to_bytes(buffer))?;
+        Ok(())
+    }
+
+    fn from_bytes(buffer: &mut Reader) -> Result<Self, SerializationError>
+    where
+        Self: Sized,
+    {
+        let len = buffer.read_varint()? as usize;
+        let mut values = SmallVec::with_capacity(len);
+        for _ in 0..len {
+            values.push(A::Item::from_bytes(buffer)?);
+        }
+        Ok(values)
+    }
+}
+
 impl<K: ToBytes + Eq + Hash, V: ToBytes, S: Default + BuildHasher> ToBytes for HashMap<K, V, S> {
     fn bytes_len(&self) -> usize {
         varint_len(self.len() as u64)
@@ -302,6 +333,23 @@ mod tests {
         let b_read = Vec::<u8>::from_bytes(&mut reader).unwrap();
         assert_eq!(a, a_read);
         assert_eq!(b, b_read);
+    }
+
+    #[test]
+    fn smallvec_uses_vec_wire_format() {
+        let vec = (0..6_u8).collect::<Vec<_>>();
+        let small = SmallVec::<[u8; 4]>::from_vec(vec.clone());
+
+        let mut vec_writer = Writer::default();
+        vec.to_bytes(&mut vec_writer).unwrap();
+        let mut small_writer = Writer::default();
+        small.to_bytes(&mut small_writer).unwrap();
+        let vec_bytes = vec_writer.into_bytes();
+        let small_bytes = small_writer.into_bytes();
+        assert_eq!(vec_bytes, small_bytes);
+
+        let mut reader = Reader::from(small_bytes);
+        assert_eq!(SmallVec::<[u8; 4]>::from_bytes(&mut reader).unwrap(), small);
     }
 
     #[test]

--- a/examples/lobby/src/server.rs
+++ b/examples/lobby/src/server.rs
@@ -306,7 +306,7 @@ mod lobby {
                             host: lobby.host,
                         },
                         server,
-                        &NetworkTarget::Only(lobby.players.clone()),
+                        &NetworkTarget::Only(lobby.players.clone().into()),
                     )?;
                 }
             }


### PR DESCRIPTION
## Summary

- add constant-time fast paths for the `All` and `None` algebra cases
- store up to four `Only`/`AllExcept` IDs inline with `SmallVec<[T; 4]>`, while preserving the existing wire format
- use contiguous linear scans when either target list has at most four entries, and one pre-sized membership set for larger list/list operations
- keep union, intersection, inverse, and exclusion while preserving their membership semantics for canonical and non-canonical inputs
- resolve server message targets through reusable output and scratch sets, with an inline lookup path for up to four connected clients
- document the distinction between the resolver's requested-recipient scratch set and its final connected targets
- cover target algebra exhaustively and verify reused recipient storage is cleared between sends

Closes #893

## Validation

Benchmarked the exact base commit, the first PR implementation, and the revised implementation in release mode on an Apple M3 Pro with rustc 1.97.0 and Divan 0.1.21. Each result is the median of 100 samples; algebra inputs are cloned outside the measured body. List/list cases use half-overlapping `Only` targets.

| Case | Base | First implementation | Revised |
|---|---:|---:|---:|
| union, 4 clients | 285 ns | 109 ns | 56 ns |
| intersection, 4 clients | 230 ns | 50 ns | 30 ns |
| exclude, 4 clients | 187 ns | 52 ns | 31 ns |
| union, 100 clients | 2.37 us | 30.2 us | 1.17 us |
| intersection, 100 clients | 2.21 us | 14.0 us | 0.89 us |
| exclude, 100 clients | 1.53 us | 14.0 us | 0.85 us |
| `None` union `Only(100)` | 89 ns | 7.71 us | 125 ns |
| `All` intersection `Only(100)` | 84 ns | 5.79 us | 126 ns |
| `All` exclude `Only(100)` | 208 ns | 15.7 us | 149 ns |

At 100 clients, the original implementation performed five allocations in the measured list/list algebra cases. The revision uses one pre-sized temporary set; the small intersection and exclusion paths allocate no temporary storage.

Resolving a reused `Only(100)` recipient set dropped from 4.02 us and one temporary allocation to 0.87 us with no steady-state allocation.

Targeted checks:

- `cargo test -p lightyear_connection --all-features`
- `cargo test -p lightyear_messages --all-features`
- `cargo test -p lightyear_serde --all-features tests::smallvec_uses_vec_wire_format -- --exact`
- `cargo test -p lightyear_tests --all-features test_send_multi_messages_with_target -- --test-threads=1`
- `cargo check -p lobby --all-features`
- `cargo clippy -p lightyear_connection --all-features -- -D warnings --no-deps`
- `cargo clippy -p lightyear_messages --all-features -- -D warnings --no-deps`
- `cargo clippy -p lightyear_serde --all-features -- -D warnings --no-deps`
