### PR TITLE
fix(transport): disconnect links without ack progress

### DIFF
--- a/crates/transport/transport/src/channel/builder.rs
+++ b/crates/transport/transport/src/channel/builder.rs
@@ -36,6 +36,9 @@ use bevy_utils::prelude::DebugName;
 
 pub const DEFAULT_MESSAGE_PRIORITY: f32 = 1.0;
 
+/// Default time without packet acknowledgement progress before a transport is disconnected.
+pub const DEFAULT_PACKET_ACK_TIMEOUT: Duration = Duration::from_secs(10);
+
 /// Bounds reusable per-packet ACK lists retained by one transport.
 const MAX_RETAINED_PACKET_MESSAGE_ACK_LISTS: usize = 64;
 /// Avoid retaining an unusually large ACK list after a pathological packet.
@@ -214,6 +217,13 @@ pub struct Transport {
     /// Stable fragment payload size derived from the link's minimum MTU.
     fragment_size: usize,
     pub compression: CompressionConfig,
+    /// Maximum time ACK-eliciting packets may make no acknowledgement progress.
+    ///
+    /// The deadline starts when a data packet enters the link. An acknowledgement restarts it if
+    /// sent packets remain, or disarms it when all sent data is acknowledged. If it expires, the
+    /// entire transport is reset and the link is disconnected. Idle transports and ACK-only
+    /// packets do not start the deadline. Set this to [`Duration::MAX`] to disable the watchdog.
+    pub packet_ack_timeout: Duration,
 
     // TODO: do a HashMap<MessageId, PacketId> instead?
     // - when we receive a packet, go through all messages and check which ones match the packet? there shouldn't be too many
@@ -247,6 +257,7 @@ impl Transport {
             compression_scratch: CompressionScratch::default(),
             fragment_size: FRAGMENT_SIZE,
             compression: CompressionConfig::default(),
+            packet_ack_timeout: DEFAULT_PACKET_ACK_TIMEOUT,
             packet_message_acks: Default::default(),
             send_channel,
             recv_channel,
@@ -262,6 +273,16 @@ impl Transport {
 
     pub fn set_compression(&mut self, compression: CompressionConfig) {
         self.compression = compression;
+    }
+
+    pub fn with_packet_ack_timeout(mut self, timeout: Duration) -> Self {
+        self.packet_ack_timeout = timeout;
+        self
+    }
+
+    /// Updates the maximum interval without packet acknowledgement progress.
+    pub fn set_packet_ack_timeout(&mut self, timeout: Duration) {
+        self.packet_ack_timeout = timeout;
     }
 
     /// Number of packet payload buffers allocated because none was ready in the local pool.

--- a/crates/transport/transport/src/packet/header.rs
+++ b/crates/transport/transport/src/packet/header.rs
@@ -136,6 +136,11 @@ pub struct PacketHeaderManager {
     /// acknowledge them incidentally, but no response is guaranteed; tracking them would therefore
     /// misclassify an idle peer's ACK-only packets as lost.
     sent_packets_not_acked: IndexMap<PacketId, Duration, FixedHasher>,
+    /// Start of the current interval without acknowledgement progress.
+    ///
+    /// Unlike `sent_packets_not_acked`, this survives packet-level NACK classification so a
+    /// reliable retry under a new packet id cannot keep the connection alive forever.
+    ack_stall_started_at: Option<Duration>,
     stats_manager: PacketStatsManager,
     pub(crate) lost_packets: Vec<PacketId>,
     pub(crate) newly_acked_packets: IndexMap<PacketId, Duration, FixedHasher>,
@@ -171,6 +176,7 @@ impl PacketHeaderManager {
             next_packet_id: PacketId(0),
             stats_manager: PacketStatsManager::default(),
             sent_packets_not_acked: IndexMap::default(),
+            ack_stall_started_at: None,
             lost_packets: vec![],
             newly_acked_packets: IndexMap::default(),
             newly_acked_packet_scratch: vec![],
@@ -235,6 +241,9 @@ impl PacketHeaderManager {
                 self.record_newly_acked_packet(packet, real, time_sent);
             }
         }
+        if !self.newly_acked_packet_scratch.is_empty() {
+            self.ack_stall_started_at = (!self.sent_packets_not_acked.is_empty()).then_some(real);
+        }
         &self.newly_acked_packet_scratch
     }
 
@@ -289,6 +298,7 @@ impl PacketHeaderManager {
         );
         self.stats_manager.sent_ack_eliciting_packet();
         trace!(?self.next_packet_id, "Sent packet");
+        self.ack_stall_started_at.get_or_insert(real);
         self.sent_packets_not_acked.insert(packet_id, real);
         self.next_packet_id += 1;
         self.ack_pending = false;
@@ -313,6 +323,14 @@ impl PacketHeaderManager {
 
     pub(crate) fn has_pending_ack(&self) -> bool {
         self.ack_pending
+    }
+
+    /// Returns whether sent data has made no acknowledgement progress for `timeout`.
+    pub(crate) fn ack_timed_out(&self, real: Duration, timeout: Duration) -> bool {
+        timeout != Duration::MAX
+            && self
+                .ack_stall_started_at
+                .is_some_and(|started_at| real.saturating_sub(started_at) >= timeout)
     }
 }
 
@@ -528,6 +546,64 @@ mod tests {
     }
 
     #[test]
+    fn ack_watchdog_arms_only_for_ack_eliciting_packets() {
+        let timeout = Duration::from_secs(10);
+        let mut manager = PacketHeaderManager::new(1.5);
+
+        assert!(!manager.ack_timed_out(Duration::from_secs(100), timeout));
+
+        let ack_only = manager.preview_send_packet_header(PacketType::AckOnly, Tick(1));
+        manager.commit_send_ack_only(ack_only.packet_id);
+        assert!(!manager.ack_timed_out(Duration::from_secs(100), timeout));
+
+        let data = manager.preview_send_packet_header(PacketType::Data, Tick(2));
+        manager.commit_send_packet(data.packet_id, Duration::from_secs(100));
+        assert!(!manager.ack_timed_out(Duration::from_secs(109), timeout));
+        assert!(manager.ack_timed_out(Duration::from_secs(110), timeout));
+        assert!(!manager.ack_timed_out(Duration::MAX, Duration::MAX));
+    }
+
+    #[test]
+    fn acknowledgement_progress_restarts_watchdog() {
+        let timeout = Duration::from_secs(10);
+        let mut sender = PacketHeaderManager::new(1.5);
+        let mut receiver = PacketHeaderManager::new(1.5);
+
+        let first =
+            prepare_send_packet_header(&mut sender, PacketType::Data, Duration::ZERO, Tick(1));
+        prepare_send_packet_header(
+            &mut sender,
+            PacketType::Data,
+            Duration::from_secs(1),
+            Tick(2),
+        );
+        receiver.process_recv_packet_header(&first, Duration::from_secs(2));
+
+        let ack = receiver.preview_send_packet_header(PacketType::AckOnly, Tick(3));
+        receiver.commit_send_ack_only(ack.packet_id);
+        assert_eq!(
+            sender.process_recv_packet_header(&ack, Duration::from_secs(9)),
+            vec![(PacketId(0), Duration::from_secs(9))]
+        );
+
+        assert!(!sender.ack_timed_out(Duration::from_secs(18), timeout));
+        assert!(sender.ack_timed_out(Duration::from_secs(19), timeout));
+    }
+
+    #[test]
+    fn packet_loss_classification_does_not_disarm_ack_watchdog() {
+        let mut manager = PacketHeaderManager::new(1.5);
+        let data = manager.preview_send_packet_header(PacketType::Data, Tick(1));
+        manager.commit_send_packet(data.packet_id, Duration::ZERO);
+
+        manager.update(Duration::from_secs(4), &LinkStats::default());
+
+        assert!(manager.sent_packets_not_acked.is_empty());
+        assert_eq!(manager.lost_packets, vec![PacketId(0)]);
+        assert!(manager.ack_timed_out(Duration::from_secs(10), Duration::from_secs(10)));
+    }
+
+    #[test]
     fn packet_ack_produces_rtt_sample_from_latest_ack() {
         let mut sender = PacketHeaderManager::new(1.5);
         let mut receiver = PacketHeaderManager::new(1.5);
@@ -561,6 +637,7 @@ mod tests {
             sender.newly_acked_packets.get(&PacketId(0)),
             Some(&Duration::from_millis(50))
         );
+        assert!(!sender.ack_timed_out(Duration::from_secs(100), Duration::from_secs(10)));
     }
 
     #[test]

--- a/crates/transport/transport/src/plugin.rs
+++ b/crates/transport/transport/src/plugin.rs
@@ -23,7 +23,7 @@ use lightyear_connection::host::HostClient;
 use lightyear_connection::prelude::Disconnected;
 use lightyear_core::prelude::LocalTimeline;
 use lightyear_core::tick::Tick;
-use lightyear_link::{Link, LinkPlugin, LinkSystems, Linked};
+use lightyear_link::{Link, LinkPlugin, LinkSystems, Linked, Unlink};
 use lightyear_serde::reader::{ReadInteger, Reader};
 use lightyear_serde::{SerializationError, ToBytes};
 use lightyear_utils::adaptive_for_each_mut;
@@ -391,6 +391,31 @@ impl TransportPlugin {
                     Ok::<(), TransportError>(())
                 })
                 .ok();
+
+            let packet_ack_timeout = transport.packet_ack_timeout;
+            if transport
+                .packet_manager
+                .header_manager
+                .ack_timed_out(time.elapsed(), packet_ack_timeout)
+            {
+                error!(
+                    ?entity,
+                    ?packet_ack_timeout,
+                    "transport received no packet acknowledgement; unlinking connection"
+                );
+                let reason = alloc::format!(
+                    "Transport received no packet acknowledgement for {packet_ack_timeout:?}"
+                );
+                // Stop every channel, partial receive, retry, and queued payload immediately
+                // instead of waiting for the connection layer to observe Unlinked.
+                transport.reset(&channel_registry);
+                #[cfg(feature = "std")]
+                par_commands.command_scope(|mut commands| {
+                    commands.trigger(Unlink { entity, reason });
+                });
+                #[cfg(not(feature = "std"))]
+                commands.trigger(Unlink { entity, reason });
+            }
         });
     }
 
@@ -705,16 +730,27 @@ mod tests {
     use alloc::{vec, vec::Vec};
 
     use super::*;
-    use crate::channel::builder::{ChannelMode, ChannelSettings};
+    use crate::channel::builder::{ChannelMode, ChannelSettings, ReliableSettings};
     use crate::channel::registry::ChannelKind;
     use crate::packet::header::PacketHeaderManager;
     use crate::packet::packet::PacketId;
     use crate::packet::priority_manager::PriorityConfig;
     use bevy_ecs::system::RunSystemOnce;
+    use lightyear_connection::client::{Connected, ConnectionPlugin, Disconnected};
+    use lightyear_core::id::{PeerId, RemoteId};
+    use lightyear_link::Unlinked;
 
     struct RetryChannel;
     struct DiscardChannel;
     struct SmallMtuChannel;
+    struct AckTimeoutChannel;
+
+    #[derive(Resource, Default)]
+    struct UnlinkRequests(Vec<Entity>);
+
+    fn record_unlink(trigger: On<Unlink>, mut requests: ResMut<UnlinkRequests>) {
+        requests.0.push(trigger.entity);
+    }
 
     fn spawn_transport<C: crate::channel::Channel>(
         world: &mut World,
@@ -780,6 +816,70 @@ mod tests {
         );
         assert_eq!(
             pending_candidates::<DiscardChannel>(&mut world, discard_entity),
+            0
+        );
+    }
+
+    #[test]
+    fn packet_ack_timeout_unlinks_and_resets_transport() {
+        let settings = ChannelSettings {
+            mode: ChannelMode::UnorderedReliable(ReliableSettings::default()),
+            ..ChannelSettings::default()
+        };
+        let mut registry = ChannelRegistry::default();
+        let (channel_kind, channel_id) = registry.add_channel::<AckTimeoutChannel>(settings);
+        let mut transport = Transport::default().with_packet_ack_timeout(Duration::from_secs(10));
+        transport.add_channel_send::<AckTimeoutChannel>(settings, channel_id);
+        transport.add_channel_receive::<AckTimeoutChannel>(settings, channel_id);
+
+        let mut app = App::new();
+        app.insert_resource(registry);
+        app.init_resource::<Time<Real>>();
+        app.init_resource::<LocalTimeline>();
+        app.init_resource::<UnlinkRequests>();
+        app.add_plugins((LinkPlugin, ConnectionPlugin));
+        app.add_observer(record_unlink);
+        let entity = app
+            .world_mut()
+            .spawn((
+                Link::default(),
+                Linked,
+                transport,
+                RemoteId(PeerId::Server),
+                Connected,
+            ))
+            .id();
+        app.world()
+            .get::<Transport>(entity)
+            .unwrap()
+            .send_erased(channel_kind, Bytes::from_static(b"reliable"), 1.0)
+            .unwrap();
+
+        app.world_mut()
+            .run_system_once(TransportPlugin::buffer_send)
+            .unwrap();
+        assert_eq!(app.world().resource::<UnlinkRequests>().0.len(), 0);
+
+        app.world_mut()
+            .resource_mut::<Time<Real>>()
+            .advance_by(Duration::from_secs(10));
+        app.world_mut()
+            .run_system_once(TransportPlugin::buffer_receive)
+            .unwrap();
+
+        let requests = &app.world().resource::<UnlinkRequests>().0;
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0], entity);
+        assert!(
+            app.world()
+                .get::<Unlinked>(entity)
+                .unwrap()
+                .reason
+                .contains("no packet acknowledgement")
+        );
+        assert!(app.world().get::<Disconnected>(entity).is_some());
+        assert_eq!(
+            pending_candidates::<AckTimeoutChannel>(app.world_mut(), entity),
             0
         );
     }


### PR DESCRIPTION
## Summary

- replace per-channel reliable-message and fragment deadlines with one transport-wide ACK-progress watchdog
- arm the watchdog only after an ACK-eliciting packet enters the link; ACK-only traffic and idle links do not start it
- restart the deadline on ACK progress and disconnect after 10 seconds without progress by resetting the full transport and triggering an unlink
- expose the timeout on `Transport::packet_ack_timeout`; `Duration::MAX` disables it

## Validation

- `cargo test -p lightyear_transport --all-features`
- `cargo clippy -p lightyear_transport --all-features -- -D warnings --no-deps`
- no-default, client-only, and server-only transport checks
- facade check with the 2D feature set

Fixes #167