### PR TITLE
Use enums for unlink and disconnect reasons

### DIFF
--- a/crates/connection/connection/src/client.rs
+++ b/crates/connection/connection/src/client.rs
@@ -227,7 +227,6 @@ impl Plugin for ConnectionPlugin {
 mod tests {
     use super::*;
     use crate::client_of::ClientOf;
-    use alloc::string::ToString;
     use bevy_ecs::world::World;
 
     #[test]
@@ -255,31 +254,6 @@ mod tests {
         let state = query.get(&world, connected_client_of).unwrap();
         assert!(state.is_connected());
         assert!(!state.is_disconnected());
-    }
-
-    #[test]
-    fn disconnected_reason_display_includes_optional_context() {
-        assert_eq!(DisconnectedReason::Unknown.to_string(), "Unknown");
-        assert_eq!(
-            DisconnectedReason::LinkFailed(UnlinkReason::ServerStopped).to_string(),
-            "Link failed: Server stopped"
-        );
-        assert_eq!(
-            DisconnectedReason::UserRequested(None).to_string(),
-            "User requested"
-        );
-        assert_eq!(
-            DisconnectedReason::UserRequested(Some(String::from("switching servers"))).to_string(),
-            "User requested: switching servers"
-        );
-        assert_eq!(
-            DisconnectedReason::ByPeer(None).to_string(),
-            "Disconnected by peer"
-        );
-        assert_eq!(
-            DisconnectedReason::TransportError(String::from("timed out")).to_string(),
-            "Transport error: timed out"
-        );
     }
 
     #[test]

--- a/crates/connection/connection/src/client.rs
+++ b/crates/connection/connection/src/client.rs
@@ -1,4 +1,4 @@
-use alloc::{format, string::String};
+use alloc::string::String;
 use bevy_app::{App, Plugin};
 use bevy_ecs::lifecycle::HookContext;
 use bevy_ecs::prelude::*;
@@ -8,7 +8,7 @@ use bevy_platform::collections::HashMap;
 use bevy_reflect::Reflect;
 use lightyear_core::id::{PeerId, RemoteId};
 use lightyear_link::LinkStart;
-use lightyear_link::prelude::{Server, Unlinked};
+use lightyear_link::prelude::{Server, UnlinkReason, Unlinked};
 #[allow(unused_imports)]
 use tracing::{info, trace};
 
@@ -82,10 +82,41 @@ impl Connecting {
     }
 }
 
+/// Why a [`Disconnected`] component was inserted on a connection entity.
+#[derive(Default, Debug, Clone, PartialEq, Eq, Reflect)]
+pub enum DisconnectedReason {
+    /// The connection has not been attempted yet, or no more specific reason is available.
+    #[default]
+    Unknown,
+    /// The underlying link was closed or failed.
+    LinkFailed(UnlinkReason),
+    /// The local user requested the disconnect, optionally with additional context.
+    UserRequested(Option<String>),
+    /// The remote peer disconnected, optionally with a reason.
+    ByPeer(Option<String>),
+    /// The connection transport or protocol encountered an error.
+    TransportError(String),
+}
+
+impl core::fmt::Display for DisconnectedReason {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Unknown => f.write_str("Unknown"),
+            Self::LinkFailed(reason) => write!(f, "Link failed: {reason}"),
+            Self::UserRequested(Some(reason)) => write!(f, "User requested: {reason}"),
+            Self::UserRequested(None) => f.write_str("User requested"),
+            Self::ByPeer(Some(reason)) => write!(f, "Disconnected by peer: {reason}"),
+            Self::ByPeer(None) => f.write_str("Disconnected by peer"),
+            Self::TransportError(reason) => write!(f, "Transport error: {reason}"),
+        }
+    }
+}
+
 #[derive(Component, Default, Debug, Reflect)]
 #[component(on_add = Disconnected::on_add)]
 pub struct Disconnected {
-    pub reason: Option<String>,
+    /// Structured reason for the disconnection.
+    pub reason: DisconnectedReason,
 }
 
 impl Disconnected {
@@ -178,7 +209,7 @@ impl ConnectionPlugin {
                 unlinked.reason
             );
             commands.entity(trigger.entity).insert(Disconnected {
-                reason: Some(format!("Link failed: {:?}", unlinked.reason)),
+                reason: DisconnectedReason::LinkFailed(unlinked.reason.clone()),
             });
         }
     }
@@ -196,6 +227,7 @@ impl Plugin for ConnectionPlugin {
 mod tests {
     use super::*;
     use crate::client_of::ClientOf;
+    use alloc::string::ToString;
     use bevy_ecs::world::World;
 
     #[test]
@@ -223,5 +255,49 @@ mod tests {
         let state = query.get(&world, connected_client_of).unwrap();
         assert!(state.is_connected());
         assert!(!state.is_disconnected());
+    }
+
+    #[test]
+    fn disconnected_reason_display_includes_optional_context() {
+        assert_eq!(DisconnectedReason::Unknown.to_string(), "Unknown");
+        assert_eq!(
+            DisconnectedReason::LinkFailed(UnlinkReason::ServerStopped).to_string(),
+            "Link failed: Server stopped"
+        );
+        assert_eq!(
+            DisconnectedReason::UserRequested(None).to_string(),
+            "User requested"
+        );
+        assert_eq!(
+            DisconnectedReason::UserRequested(Some(String::from("switching servers"))).to_string(),
+            "User requested: switching servers"
+        );
+        assert_eq!(
+            DisconnectedReason::ByPeer(None).to_string(),
+            "Disconnected by peer"
+        );
+        assert_eq!(
+            DisconnectedReason::TransportError(String::from("timed out")).to_string(),
+            "Transport error: timed out"
+        );
+    }
+
+    #[test]
+    fn link_failure_preserves_structured_reason() {
+        let mut app = App::new();
+        app.add_plugins(ConnectionPlugin);
+        let entity = app
+            .world_mut()
+            .spawn(Unlinked {
+                reason: UnlinkReason::ByPeer(String::from("server shutdown")),
+            })
+            .id();
+
+        app.update();
+
+        assert_eq!(
+            app.world().get::<Disconnected>(entity).unwrap().reason,
+            DisconnectedReason::LinkFailed(UnlinkReason::ByPeer(String::from("server shutdown")))
+        );
     }
 }

--- a/crates/connection/connection/src/host.rs
+++ b/crates/connection/connection/src/host.rs
@@ -5,13 +5,11 @@
 //! - is a ClientOf of a Server
 //! - the Server is started
 
-#[cfg(feature = "server")]
-use alloc::string::ToString;
 use alloc::vec::Vec;
 
 #[cfg(feature = "server")]
 use crate::{
-    client::{Client, Connect, Connected, Disconnect, Disconnected},
+    client::{Client, Connect, Connected, Disconnect, Disconnected, DisconnectedReason},
     client_of::ClientOf,
     server::Started,
 };
@@ -96,7 +94,7 @@ impl HostPlugin {
                 .entity(trigger.entity)
                 .remove::<HostClient>()
                 .insert(Disconnected {
-                    reason: Some("Client trigger".to_string()),
+                    reason: DisconnectedReason::UserRequested(None),
                 });
             commands.entity(link_of.server).remove::<HostServer>();
         }

--- a/crates/connection/connection/src/lib.rs
+++ b/crates/connection/connection/src/lib.rs
@@ -68,7 +68,7 @@ pub mod prelude {
     // we also export these types at the top level for easier access
     pub use crate::client::{
         Client, ClientState, Connect, Connected, Connecting, ConnectionError, Disconnect,
-        Disconnected, PeerMetadata,
+        Disconnected, DisconnectedReason, PeerMetadata,
     };
     pub use crate::p2p::P2P;
 
@@ -76,7 +76,7 @@ pub mod prelude {
     pub mod client {
         pub use crate::client::{
             Client, ClientState, Connect, Connected, Connecting, ConnectionError, Disconnect,
-            Disconnected,
+            Disconnected, DisconnectedReason,
         };
     }
 

--- a/crates/connection/connection/src/network_topology.rs
+++ b/crates/connection/connection/src/network_topology.rs
@@ -361,6 +361,7 @@ fn infer_standard_topology(client: Option<ReadyClient>, server: Option<Entity>) 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::client::DisconnectedReason;
     use crate::client::PeerMetadata;
     use alloc::vec::Vec;
     use bevy_ecs::change_detection::DetectChanges;
@@ -403,7 +404,7 @@ mod tests {
         assert_eq!(mode(&app), &NetworkTopology::Client(client));
 
         app.world_mut().entity_mut(client).insert(Disconnected {
-            reason: Some("test".into()),
+            reason: DisconnectedReason::UserRequested(Some("test".into())),
         });
         app.update();
         assert_eq!(mode(&app), &NetworkTopology::Undefined);
@@ -483,7 +484,7 @@ mod tests {
         );
 
         app.world_mut().entity_mut(first).insert(Disconnected {
-            reason: Some("test".into()),
+            reason: DisconnectedReason::UserRequested(Some("test".into())),
         });
         app.update();
         assert_eq!(

--- a/crates/connection/connection/src/server.rs
+++ b/crates/connection/connection/src/server.rs
@@ -1,4 +1,4 @@
-use crate::client::{Disconnected, Disconnecting, PeerMetadata};
+use crate::client::{Disconnected, DisconnectedReason, Disconnecting, PeerMetadata};
 use crate::client_of::ClientOf;
 use bevy_app::{App, Last, Plugin};
 use bevy_ecs::lifecycle::HookContext;
@@ -149,7 +149,9 @@ impl ConnectionPlugin {
             // Set to Disconnected before despawning to trigger observers
             commands
                 .entity(entity)
-                .insert(Disconnected { reason: None })
+                .insert(Disconnected {
+                    reason: DisconnectedReason::UserRequested(None),
+                })
                 .despawn();
         }
     }

--- a/crates/connection/netcode/src/client_plugin.rs
+++ b/crates/connection/netcode/src/client_plugin.rs
@@ -1,4 +1,4 @@
-use alloc::{format, string::ToString};
+use alloc::format;
 
 use crate::Error;
 use crate::auth::Authentication;
@@ -12,7 +12,7 @@ use bevy_reflect::Reflect;
 use bevy_time::{Real, Time};
 use lightyear_connection::ConnectionSystems;
 use lightyear_connection::client::{
-    Connect, Connected, Connecting, ConnectionPlugin, Disconnect, Disconnected,
+    Connect, Connected, Connecting, ConnectionPlugin, Disconnect, Disconnected, DisconnectedReason,
 };
 use lightyear_connection::host::HostClient;
 use lightyear_core::id::{LocalId, PeerId, RemoteId};
@@ -182,7 +182,10 @@ impl NetcodeClientPlugin {
                         info!("Client {} disconnected. State: {state:?}", client.id());
                         parallel_commands.command_scope(|mut commands| {
                             commands.entity(entity).insert(Disconnected {
-                                reason: Some(format!("Client disconnected: {state:?}")),
+                                reason: match state {
+                                    ClientState::Disconnected => DisconnectedReason::ByPeer(None),
+                                    _ => DisconnectedReason::TransportError(format!("{state:?}")),
+                                },
                             });
                         });
                     }
@@ -211,7 +214,7 @@ impl NetcodeClientPlugin {
         if let Ok(mut client) = query.get_mut(trigger.entity) {
             client.inner.disconnect()?;
             commands.entity(trigger.entity).insert(Disconnected {
-                reason: Some("Client trigger".to_string()),
+                reason: DisconnectedReason::UserRequested(None),
             });
         }
         Ok(())

--- a/crates/connection/netcode/src/server_plugin.rs
+++ b/crates/connection/netcode/src/server_plugin.rs
@@ -1,12 +1,12 @@
 use crate::{ClientId, Key, PRIVATE_KEY_BYTES, ServerConfig, USER_DATA_BYTES};
-use alloc::{string::String, sync::Arc, vec::Vec};
+use alloc::{sync::Arc, vec::Vec};
 use bevy_app::{App, Plugin, PostUpdate, PreUpdate};
 use bevy_ecs::prelude::*;
 use bevy_ecs::{
     entity::UniqueEntitySlice, relationship::RelationshipTarget, system::ParallelCommands,
 };
 use bevy_time::{Real, Time};
-use lightyear_connection::client::{Connected, Disconnected, Disconnecting};
+use lightyear_connection::client::{Connected, Disconnected, DisconnectedReason, Disconnecting};
 use lightyear_connection::client_of::SkipNetcode;
 use lightyear_connection::host::HostClient;
 use lightyear_connection::prelude::{server::*, *};
@@ -14,7 +14,7 @@ use lightyear_connection::server::Stopping;
 use lightyear_connection::shared::ConnectionRequestHandler;
 use lightyear_core::id::{LocalId, PeerId, RemoteId};
 use lightyear_link::prelude::{LinkOf, Server};
-use lightyear_link::{Link, LinkSystems, Unlink};
+use lightyear_link::{Link, LinkSystems, Unlink, UnlinkReason};
 use lightyear_transport::plugin::TransportSystems;
 use lightyear_utils::adaptive_for_each_mut;
 use tracing::{error, info, trace};
@@ -307,14 +307,16 @@ impl NetcodeServerPlugin {
                             );
                             // first disconnect to trigger observers
                             c.entity(entity)
-                                .try_insert(Disconnected { reason: None })
+                                .try_insert(Disconnected {
+                                    reason: DisconnectedReason::ByPeer(None),
+                                })
                                 .despawn();
                         });
                     if stopping {
                         // after we sent disconnection packets, we can stop the server transport
                         c.trigger(Unlink {
                             entity: server_entity,
-                            reason: String::from("Server stopped"),
+                            reason: UnlinkReason::ServerStopped,
                         });
                         c.entity(server_entity).insert(Stopped);
                     }

--- a/crates/connection/raw_connection/src/client.rs
+++ b/crates/connection/raw_connection/src/client.rs
@@ -1,11 +1,10 @@
 use aeronet_io::connection::LocalAddr;
-use alloc::string::ToString;
 use bevy_app::{App, Plugin, PostUpdate, PreUpdate};
 use bevy_ecs::prelude::*;
 use lightyear_connection::client::ConnectionPlugin;
 use lightyear_connection::prelude::client::*;
 use lightyear_core::id::{LocalId, PeerId, RemoteId};
-use lightyear_link::{Link, LinkSystems, Linked, Unlink};
+use lightyear_link::{Link, LinkSystems, Linked, Unlink, UnlinkReason};
 use lightyear_transport::plugin::TransportSystems;
 #[allow(unused_imports)]
 use tracing::{info, trace};
@@ -49,7 +48,7 @@ impl RawConnectionPlugin {
             trace!("RawClient Disconnect! Triggering Unlink");
             commands.trigger(Unlink {
                 entity: trigger.entity,
-                reason: "Client requested".to_string(),
+                reason: UnlinkReason::UserRequested(None),
             });
         }
     }

--- a/crates/connection/raw_connection/src/server.rs
+++ b/crates/connection/raw_connection/src/server.rs
@@ -1,5 +1,4 @@
 use aeronet_io::connection::PeerAddr;
-use alloc::string::ToString;
 use bevy_app::{App, Plugin, PostUpdate, PreUpdate};
 use bevy_ecs::entity::UniqueEntitySlice;
 use bevy_ecs::prelude::*;
@@ -71,7 +70,7 @@ impl RawConnectionPlugin {
             trace!("RawClient Stop! Disconnecting all LinkOfs and triggering Unlink");
             commands.trigger(Unlink {
                 entity: trigger.entity,
-                reason: "Server stopped".to_string(),
+                reason: UnlinkReason::ServerStopped,
             });
             commands.entity(trigger.entity).insert(Stopping);
             // SAFETY: we know that the list of client entities are unique because it is a Relationship

--- a/crates/connection/steam/src/client.rs
+++ b/crates/connection/steam/src/client.rs
@@ -4,7 +4,6 @@ use aeronet_steam::{
     SessionConfig, SteamworksClient,
     client::{ConnectTarget, SteamNetClientPlugin},
 };
-use alloc::string::ToString;
 use bevy_app::{App, Plugin};
 use bevy_ecs::lifecycle::HookContext;
 use bevy_ecs::prelude::*;
@@ -12,7 +11,7 @@ use bevy_ecs::world::DeferredWorld;
 use lightyear_aeronet::{AeronetLinkOf, AeronetPlugin};
 use lightyear_connection::client::{Connected, Disconnect};
 use lightyear_core::id::{LocalId, PeerId, RemoteId};
-use lightyear_link::{Link, LinkStart, Linked, Linking, Unlink};
+use lightyear_link::{Link, LinkStart, Linked, Linking, Unlink, UnlinkReason};
 use tracing::trace;
 
 pub struct SteamClientPlugin;
@@ -118,7 +117,7 @@ impl SteamClientPlugin {
         if query.get(trigger.entity).is_ok() {
             commands.trigger(Unlink {
                 entity: trigger.entity,
-                reason: "User requested disconnect".to_string(),
+                reason: UnlinkReason::UserRequested(None),
             });
         }
     }

--- a/crates/connection/steam/src/server.rs
+++ b/crates/connection/steam/src/server.rs
@@ -4,19 +4,19 @@ use aeronet_steam::SessionConfig;
 use aeronet_steam::server::{
     ListenTarget, SessionRequest, SessionResponse, SteamNetServer, SteamNetServerClient,
 };
-use alloc::format;
+use alloc::{format, string::ToString};
 use bevy_app::{App, Plugin};
 use bevy_ecs::prelude::*;
 use bevy_ecs::relationship::RelationshipTarget;
 use lightyear_aeronet::server::ServerAeronetPlugin;
 use lightyear_aeronet::{AeronetLink, AeronetLinkOf, AeronetPlugin};
-use lightyear_connection::client::{Connected, Disconnected};
+use lightyear_connection::client::{Connected, Disconnected, DisconnectedReason};
 use lightyear_connection::client_of::{ClientOf, SkipNetcode};
 use lightyear_connection::server::{Start, Started, Stop};
 use lightyear_core::id::{PeerId, RemoteId};
 use lightyear_link::prelude::LinkOf;
 use lightyear_link::server::Server;
-use lightyear_link::{Link, LinkStart, Linked, Linking};
+use lightyear_link::{Link, LinkStart, Linked, Linking, UnlinkReason};
 use tracing::{info, trace};
 
 /// Enables starting a Steam server
@@ -210,12 +210,23 @@ impl SteamServerPlugin {
                 trigger,
                 link_of_entity.id()
             );
+            let unlink_reason = match &trigger.reason {
+                aeronet_io::connection::DisconnectReason::ByUser(reason) => {
+                    UnlinkReason::UserRequested((!reason.is_empty()).then(|| reason.to_string()))
+                }
+                aeronet_io::connection::DisconnectReason::ByPeer(reason) => {
+                    UnlinkReason::ByPeer(reason.to_string())
+                }
+                aeronet_io::connection::DisconnectReason::ByError(error) => {
+                    UnlinkReason::TransportError(format!("{error:?}"))
+                }
+            };
             link_of_entity
                 // to avoid warnings if we delete the Aeronet entity before the deletion trigger can run by aeronet
                 // Can remove if https://github.com/aecsocket/aeronet/pull/49 is merged
                 .remove::<AeronetLink>()
                 .insert(Disconnected {
-                    reason: Some(format!("Aeronet link disconnected: {trigger:?}")),
+                    reason: DisconnectedReason::LinkFailed(unlink_reason),
                 })
                 .try_despawn();
         }

--- a/crates/io/aeronet/src/lib.rs
+++ b/crates/io/aeronet/src/lib.rs
@@ -21,14 +21,14 @@ pub mod server;
 use aeronet_io::connection::{Disconnect, DisconnectReason, Disconnected, LocalAddr, PeerAddr};
 use aeronet_io::server::{Close, Server};
 use aeronet_io::{IoSystems, Session, SessionEndpoint};
-use alloc::format;
+use alloc::{format, string::ToString};
 use bevy_app::prelude::*;
 use bevy_ecs::prelude::*;
 use bevy_ecs::relationship::Relationship;
 use bevy_reflect::Reflect;
 use lightyear_link::{
-    Link, LinkPlugin, LinkReceiveSystems, LinkSystems, Linked, Linking, Unlink, Unlinked,
-    recv_payload_from_bytes,
+    Link, LinkPlugin, LinkReceiveSystems, LinkSystems, Linked, Linking, Unlink, UnlinkReason,
+    Unlinked, recv_payload_from_bytes,
 };
 use tracing::trace;
 
@@ -144,14 +144,10 @@ impl AeronetPlugin {
         {
             let reason = match &trigger.reason {
                 DisconnectReason::ByUser(reason) => {
-                    format!("Disconnected by user: {reason}")
+                    UnlinkReason::UserRequested((!reason.is_empty()).then(|| reason.to_string()))
                 }
-                DisconnectReason::ByPeer(reason) => {
-                    format!("Disconnected by remote: {reason}")
-                }
-                DisconnectReason::ByError(err) => {
-                    format!("Disconnected due to error: {err:?}")
-                }
+                DisconnectReason::ByPeer(reason) => UnlinkReason::ByPeer(reason.to_string()),
+                DisconnectReason::ByError(err) => UnlinkReason::TransportError(format!("{err:?}")),
             };
             trace!(
                 "Disconnected (reason: {reason:?}) triggered added on AeronetLink {:?}. Adding Unlinked on Link entity {:?}",
@@ -172,7 +168,7 @@ impl AeronetPlugin {
             // get the aeronet session entity
             && let Ok(is_server) = aeronet_query.get(aeronet_link.0)
         {
-            let reason = core::mem::take(&mut trigger.reason);
+            let reason = core::mem::take(&mut trigger.reason).to_string();
             trace!(
                 "Unlink triggered on Link entity {:?} (reason: {reason:?}). Closing/Disconnecting AeronetLink entity {:?}",
                 trigger.entity, aeronet_link.0

--- a/crates/io/aeronet/src/server.rs
+++ b/crates/io/aeronet/src/server.rs
@@ -7,14 +7,14 @@
 //! [`Server`](lightyear_link::server::Server). This module observes Aeronet open/close events and
 //! keeps the Lightyear lifecycle markers in sync.
 
-use alloc::format;
+use alloc::{format, string::ToString};
 use bevy_app::{App, Plugin};
 use bevy_ecs::prelude::*;
 
 use crate::AeronetLinkOf;
 use aeronet_io::server::{CloseReason, Closed, Server, ServerEndpoint};
 use lightyear_link::server::ServerLinkPlugin;
-use lightyear_link::{Linked, Linking, Unlinked};
+use lightyear_link::{Linked, Linking, UnlinkReason, Unlinked};
 use tracing::trace;
 
 /// Plugin that mirrors Aeronet server endpoint state into Lightyear server link state.
@@ -63,11 +63,9 @@ impl ServerAeronetPlugin {
             );
             let reason = match &trigger.reason {
                 CloseReason::ByUser(reason) => {
-                    format!("Closed by user: {reason}")
+                    UnlinkReason::UserRequested((!reason.is_empty()).then(|| reason.to_string()))
                 }
-                CloseReason::ByError(err) => {
-                    format!("Closed due to error: {err:?}")
-                }
+                CloseReason::ByError(err) => UnlinkReason::TransportError(format!("{err:?}")),
             };
             c.insert(Unlinked { reason });
         }

--- a/crates/io/crossbeam/src/lib.rs
+++ b/crates/io/crossbeam/src/lib.rs
@@ -42,7 +42,7 @@
 extern crate alloc;
 
 use aeronet_io::connection::{LocalAddr, PeerAddr};
-use alloc::string::ToString;
+use alloc::string::String;
 use bevy_app::{App, Plugin, PostUpdate, PreUpdate};
 use bevy_ecs::prelude::*;
 use bevy_ecs::query::QueryData;
@@ -51,7 +51,7 @@ use core::net::{Ipv4Addr, SocketAddr};
 use crossbeam_channel::{Receiver, Sender, TryRecvError, TrySendError};
 use lightyear_core::time::Instant;
 use lightyear_link::{
-    Link, LinkPlugin, LinkReceiveSystems, LinkStart, LinkSystems, Linked, Unlink,
+    Link, LinkPlugin, LinkReceiveSystems, LinkStart, LinkSystems, Linked, Unlink, UnlinkReason,
     recv_payload_from_bytes,
 };
 use tracing::{error, trace};
@@ -163,7 +163,9 @@ impl CrossbeamPlugin {
                         let _ = io.link.send.drain();
                         commands.trigger(Unlink {
                             entity,
-                            reason: "Crossbeam channel disconnected".to_string(),
+                            reason: UnlinkReason::TransportError(String::from(
+                                "Crossbeam channel disconnected",
+                            )),
                         });
                         break;
                     }
@@ -202,7 +204,9 @@ impl CrossbeamPlugin {
                         );
                         commands.trigger(Unlink {
                             entity,
-                            reason: "Crossbeam channel disconnected".to_string(),
+                            reason: UnlinkReason::TransportError(String::from(
+                                "Crossbeam channel disconnected",
+                            )),
                         });
                         break;
                     }

--- a/crates/io/link/src/lib.rs
+++ b/crates/io/link/src/lib.rs
@@ -531,7 +531,6 @@ impl Plugin for LinkPlugin {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloc::string::ToString;
 
     #[test]
     fn immutable_receive_payload_reuses_unique_allocation() {
@@ -553,28 +552,6 @@ mod tests {
 
         assert_ne!(payload.as_ptr(), allocation);
         assert_eq!(payload.as_ref(), shared.as_ref());
-    }
-
-    #[test]
-    fn unlink_reason_display_includes_optional_context() {
-        assert_eq!(UnlinkReason::Initial.to_string(), "Not connected");
-        assert_eq!(
-            UnlinkReason::UserRequested(None).to_string(),
-            "User requested"
-        );
-        assert_eq!(
-            UnlinkReason::UserRequested(Some(String::from("switching servers"))).to_string(),
-            "User requested: switching servers"
-        );
-        assert_eq!(UnlinkReason::ServerStopped.to_string(), "Server stopped");
-        assert_eq!(
-            UnlinkReason::ByPeer(String::from("going away")).to_string(),
-            "Disconnected by peer: going away"
-        );
-        assert_eq!(
-            UnlinkReason::TransportError(String::from("socket closed")).to_string(),
-            "Transport error: socket closed"
-        );
     }
 
     #[test]

--- a/crates/io/link/src/lib.rs
+++ b/crates/io/link/src/lib.rs
@@ -37,6 +37,7 @@ use bevy_app::{App, Plugin, PostUpdate, PreUpdate};
 use bevy_ecs::lifecycle::HookContext;
 use bevy_ecs::prelude::*;
 use bevy_ecs::world::DeferredWorld;
+use bevy_reflect::Reflect;
 use bytes::{Bytes, BytesMut};
 use core::time::Duration;
 use lightyear_core::time::Instant;
@@ -47,7 +48,7 @@ pub mod prelude {
     pub use crate::server::{LinkOf, Server};
     pub use crate::{
         DEFAULT_MTU, Link, LinkMtu, LinkStart, LinkStats, LinkSystems, Linked, Linking,
-        MtuTooSmall, RecvLinkConditioner, Unlink, Unlinked,
+        MtuTooSmall, RecvLinkConditioner, Unlink, UnlinkReason, Unlinked,
     };
 
     pub mod server {
@@ -352,6 +353,35 @@ pub struct LinkStart {
     pub entity: Entity,
 }
 
+/// Why a [`Link`] was unlinked via [`Unlink`] or [`Unlinked`].
+#[derive(Default, Debug, Clone, PartialEq, Eq, Reflect)]
+pub enum UnlinkReason {
+    /// The link has not yet been established.
+    #[default]
+    Initial,
+    /// The local user requested the unlink, optionally with additional context.
+    UserRequested(Option<String>),
+    /// The server stopped and closed its links.
+    ServerStopped,
+    /// The remote peer closed the link and supplied a reason.
+    ByPeer(String),
+    /// The transport encountered an error and can no longer communicate with the peer.
+    TransportError(String),
+}
+
+impl core::fmt::Display for UnlinkReason {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Initial => f.write_str("Not connected"),
+            Self::UserRequested(Some(reason)) => write!(f, "User requested: {reason}"),
+            Self::UserRequested(None) => f.write_str("User requested"),
+            Self::ServerStopped => f.write_str("Server stopped"),
+            Self::ByPeer(reason) => write!(f, "Disconnected by peer: {reason}"),
+            Self::TransportError(reason) => write!(f, "Transport error: {reason}"),
+        }
+    }
+}
+
 /// Entity event requesting that a transport terminate a [`Link`].
 ///
 /// [`LinkPlugin`] observes this event and inserts [`Unlinked`] with the provided reason. Concrete
@@ -361,8 +391,8 @@ pub struct Unlink {
     /// Entity that owns the [`Link`] to terminate.
     #[event_target]
     pub entity: Entity,
-    /// Human-readable reason propagated to [`Unlinked::reason`].
-    pub reason: String,
+    /// Structured reason propagated to [`Unlinked::reason`].
+    pub reason: UnlinkReason,
 }
 
 /// Marker component for a link whose transport connection is being established.
@@ -414,13 +444,13 @@ impl Linked {
 /// Marker component for a link that is not connected.
 ///
 /// Inserting this component updates [`Link::state`] to [`LinkState::Unlinked`] and removes
-/// [`Linked`] and [`Linking`]. The optional [`reason`](Self::reason) is intended for diagnostics
-/// and for transports that need to surface disconnect causes to application code.
+/// [`Linked`] and [`Linking`]. The [`reason`](Self::reason) is intended for diagnostics and for
+/// transports that need to surface disconnect causes to application code.
 #[derive(Component, Default, Debug)]
 #[component(on_insert = Unlinked::on_insert)]
 pub struct Unlinked {
-    /// Human-readable disconnect or initial-state reason.
-    pub reason: String,
+    /// Structured disconnect or initial-state reason.
+    pub reason: UnlinkReason,
 }
 
 impl Unlinked {
@@ -501,6 +531,7 @@ impl Plugin for LinkPlugin {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::string::ToString;
 
     #[test]
     fn immutable_receive_payload_reuses_unique_allocation() {
@@ -522,6 +553,28 @@ mod tests {
 
         assert_ne!(payload.as_ptr(), allocation);
         assert_eq!(payload.as_ref(), shared.as_ref());
+    }
+
+    #[test]
+    fn unlink_reason_display_includes_optional_context() {
+        assert_eq!(UnlinkReason::Initial.to_string(), "Not connected");
+        assert_eq!(
+            UnlinkReason::UserRequested(None).to_string(),
+            "User requested"
+        );
+        assert_eq!(
+            UnlinkReason::UserRequested(Some(String::from("switching servers"))).to_string(),
+            "User requested: switching servers"
+        );
+        assert_eq!(UnlinkReason::ServerStopped.to_string(), "Server stopped");
+        assert_eq!(
+            UnlinkReason::ByPeer(String::from("going away")).to_string(),
+            "Disconnected by peer: going away"
+        );
+        assert_eq!(
+            UnlinkReason::TransportError(String::from("socket closed")).to_string(),
+            "Transport error: socket closed"
+        );
     }
 
     #[test]

--- a/crates/io/link/src/server.rs
+++ b/crates/io/link/src/server.rs
@@ -5,8 +5,10 @@
 //! each child link entity to point back to the server. Transport crates can use this to keep the
 //! server endpoint independent from the concrete links used for each connected peer.
 
-use crate::{Link, LinkPlugin, Linked, Linking, RecvLinkConditioner, Unlink, Unlinked};
-use alloc::{format, string::String, vec::Vec};
+use crate::{
+    Link, LinkPlugin, Linked, Linking, RecvLinkConditioner, Unlink, UnlinkReason, Unlinked,
+};
+use alloc::{format, vec::Vec};
 use bevy_app::{App, Plugin};
 use bevy_ecs::lifecycle::HookContext;
 use bevy_ecs::prelude::*;
@@ -60,7 +62,7 @@ impl Server {
         {
             trace!("Inserting Unlinked because Server was added");
             world.commands().entity(context.entity).insert(Unlinked {
-                reason: String::new(),
+                reason: UnlinkReason::Initial,
             });
         };
     }
@@ -271,7 +273,7 @@ mod tests {
             .id();
 
         app.world_mut().entity_mut(server).insert(Unlinked {
-            reason: alloc::string::String::from("server stopped"),
+            reason: UnlinkReason::ServerStopped,
         });
         app.update();
 

--- a/crates/io/websocket/src/server.rs
+++ b/crates/io/websocket/src/server.rs
@@ -112,7 +112,7 @@ mod tests {
     use std::{thread, time::Duration};
 
     use lightyear_aeronet::AeronetLink;
-    use lightyear_link::{LinkStart, Unlink, Unlinked};
+    use lightyear_link::{LinkStart, Unlink, UnlinkReason, Unlinked};
 
     fn server_config(addr: SocketAddr) -> ServerConfig {
         ServerConfig::builder()
@@ -158,7 +158,7 @@ mod tests {
 
         app.world_mut().trigger(Unlink {
             entity: server,
-            reason: "test shutdown".to_string(),
+            reason: UnlinkReason::UserRequested(Some("test shutdown".to_string())),
         });
         run_app_until(&mut app, |world| {
             world.get::<Unlinked>(server).is_some() && world.get::<AeronetLink>(server).is_none()

--- a/crates/io/webtransport/src/server.rs
+++ b/crates/io/webtransport/src/server.rs
@@ -129,7 +129,7 @@ mod tests {
     use std::{thread, time::Duration};
 
     use lightyear_aeronet::AeronetLink;
-    use lightyear_link::{LinkStart, Unlink, Unlinked};
+    use lightyear_link::{LinkStart, Unlink, UnlinkReason, Unlinked};
 
     fn spawn_server(app: &mut App, addr: SocketAddr) -> Entity {
         let entity = app
@@ -169,7 +169,7 @@ mod tests {
 
         app.world_mut().trigger(Unlink {
             entity: server,
-            reason: "test shutdown".to_string(),
+            reason: UnlinkReason::UserRequested(Some("test shutdown".to_string())),
         });
         run_app_until(&mut app, |world| {
             world.get::<Unlinked>(server).is_some() && world.get::<AeronetLink>(server).is_none()

--- a/crates/tests/src/client_server/connection.rs
+++ b/crates/tests/src/client_server/connection.rs
@@ -28,7 +28,7 @@ mod disconnection_log_tests {
     use bevy::ecs::schedule::{Schedules, SingleThreadedExecutor};
     use core::sync::atomic::{AtomicUsize, Ordering};
     use lightyear_connection::server::Stop;
-    use lightyear_link::Unlinked;
+    use lightyear_link::{UnlinkReason, Unlinked};
     use tracing::{Event, Level, Subscriber};
     use tracing_subscriber::layer::Context;
     use tracing_subscriber::{Layer, prelude::*};
@@ -135,7 +135,9 @@ mod disconnection_log_tests {
                 .world_mut()
                 .entity_mut(server_client)
                 .insert(Unlinked {
-                    reason: "WebTransport connection timed out".to_string(),
+                    reason: UnlinkReason::TransportError(
+                        "WebTransport connection timed out".to_string(),
+                    ),
                 });
 
             // Netcode's default client timeout is three seconds. Simulated stepper time lets us

--- a/crates/tests/src/client_server/replication.rs
+++ b/crates/tests/src/client_server/replication.rs
@@ -7,6 +7,7 @@ use crate::stepper::*;
 use bevy::prelude::{Bundle, Entity, Name, With, World};
 use bevy_replicon::prelude::Replicated as RepliconReplicated;
 use lightyear::prelude::{ConfirmedHistory, InterpolationTimeline};
+use lightyear_connection::client::{Disconnected, DisconnectedReason};
 use lightyear_connection::network_target::NetworkTarget;
 use lightyear_core::interpolation::Interpolated;
 use lightyear_core::prediction::Predicted;
@@ -1301,8 +1302,8 @@ fn test_all_replicated_despawned_on_disconnecting_client() {
         .server_app
         .world_mut()
         .entity_mut(client_of_1)
-        .insert(lightyear_connection::client::Disconnected {
-            reason: lightyear_connection::client::DisconnectedReason::Unknown,
+        .insert(Disconnected {
+            reason: DisconnectedReason::Unknown,
         });
     stepper.server_app.world_mut().flush();
 

--- a/crates/tests/src/client_server/replication.rs
+++ b/crates/tests/src/client_server/replication.rs
@@ -1301,7 +1301,9 @@ fn test_all_replicated_despawned_on_disconnecting_client() {
         .server_app
         .world_mut()
         .entity_mut(client_of_1)
-        .insert(lightyear_connection::client::Disconnected { reason: None });
+        .insert(lightyear_connection::client::Disconnected {
+            reason: lightyear_connection::client::DisconnectedReason::Unknown,
+        });
     stepper.server_app.world_mut().flush();
 
     // Run a few frames to let the state transition happen

--- a/crates/tests/src/stepper.rs
+++ b/crates/tests/src/stepper.rs
@@ -531,7 +531,9 @@ impl ClientServerStepper {
         self.server_app
             .world_mut()
             .entity_mut(server_entity)
-            .insert(Disconnected { reason: None });
+            .insert(Disconnected {
+                reason: DisconnectedReason::Unknown,
+            });
         client_app.world_mut().flush();
         self.server_app.world_mut().flush();
         client_app.world_mut().despawn(client_entity);

--- a/examples/common/src/client_renderer.rs
+++ b/examples/common/src/client_renderer.rs
@@ -169,9 +169,8 @@ pub(crate) fn handle_disconnection(
         "Disconnected ({})",
         disconnected
             .get(trigger.entity)
-            .map(|d| d.1.reason.as_ref())
-            .unwrap_or(None)
-            .unwrap_or(&"Unknown".to_string())
+            .map(|(_, disconnected)| disconnected.reason.to_string())
+            .unwrap_or_else(|_| "Unknown".to_string())
     )));
     for entity in debug_text.iter() {
         commands.entity(entity).despawn();

--- a/examples/lobby/src/client.rs
+++ b/examples/lobby/src/client.rs
@@ -453,7 +453,9 @@ mod lobby {
                     // First remove the previous link
                     commands.trigger(Unlink {
                         entity: local_client,
-                        reason: "Client becoming Host".to_string(),
+                        reason: UnlinkReason::UserRequested(Some(
+                            "Client becoming Host".to_string(),
+                        )),
                     });
 
                     // Convert the existing remote client into an in-process host-client by
@@ -478,7 +480,9 @@ mod lobby {
                     // First unlink from the dedicated server
                     commands.trigger(Unlink {
                         entity: local_client,
-                        reason: "Connecting to host-client".to_string(),
+                        reason: UnlinkReason::UserRequested(Some(
+                            "Connecting to host-client".to_string(),
+                        )),
                     });
 
                     let host_addr =


### PR DESCRIPTION
Closes #1376

Reimplements #1485 against the current crate layout and incorporates its review feedback.

## Summary

- replace string unlink and disconnect reasons with `UnlinkReason` and `DisconnectedReason`
- keep optional context for user-requested disconnects and use explicit initial/unknown variants instead of `Option`
- preserve structured causes across Aeronet, Netcode, Steam, Crossbeam, examples, and test helpers