### PR TITLE
feat(replication): add receiver-side persistence

### DIFF
--- a/crates/replication/replication/src/client.rs
+++ b/crates/replication/replication/src/client.rs
@@ -17,6 +17,7 @@ use crate::ReplicationSystems;
 use crate::channels::RepliconChannelMap;
 use crate::checkpoint::ReplicationCheckpointMap;
 use crate::prelude::Replicated;
+use crate::receive::{Persistent, ReplicationReceiver};
 use crate::send::Replicate;
 use lightyear_messages::plugin::MessageSystems;
 use tracing::debug;
@@ -175,16 +176,23 @@ fn send_client_packets(
     }
 }
 
-/// Despawn all replicated entities when the client disconnects.
+/// Despawn non-persistent replicated entities when the client disconnects.
 ///
 /// This matches the old `ReplicationReceivePlugin::handle_disconnection` behavior:
 /// all entities that were spawned from replication are despawned on disconnect.
 /// In the Replicon flow, received entities have `Remote`, which Lightyear exposes
-/// as its receiver-side `Replicated` marker.
+/// as its receiver-side `Replicated` marker. A [`Persistent`] marker on either a
+/// received entity or the [`ReplicationReceiver`] keeps the applicable entities alive.
 fn despawn_replicated_on_disconnect(
     mut commands: Commands,
-    replicated: Query<Entity, (With<Replicated>, Without<Replicate>)>,
+    persistent_receivers: Query<(), (With<ReplicationReceiver>, With<Persistent>)>,
+    replicated: Query<Entity, (With<Replicated>, Without<Replicate>, Without<Persistent>)>,
 ) {
+    if !persistent_receivers.is_empty() {
+        debug!("Keeping replicated entities because the replication receiver is persistent");
+        return;
+    }
+
     for entity in replicated.iter() {
         debug!("Despawning replicated entity {:?} on disconnect", entity);
         commands.entity(entity).try_despawn();

--- a/crates/replication/replication/src/client.rs
+++ b/crates/replication/replication/src/client.rs
@@ -68,16 +68,9 @@ impl Plugin for RepliconClientPlugin {
                 .after(ServerSystems::Receive),
         );
 
-        // Despawn all replicated entities when the client disconnects.
-        // bevy_replicon's reset only clears the entity map; lightyear must
-        // clean up the actual entities.
-        app.add_systems(
-            OnExit(ClientState::Connected),
-            (
-                clear_checkpoint_map_on_disconnect,
-                despawn_replicated_on_disconnect.after(ClientSystems::Reset),
-            ),
-        );
+        // bevy_replicon's reset only clears the entity map; lightyear must clean up the actual
+        // entities when their receiver disconnects or is removed.
+        app.add_observer(on_replication_disconnect);
 
         app.configure_sets(
             PreUpdate,
@@ -96,7 +89,22 @@ impl Plugin for RepliconClientPlugin {
 fn sync_checkpoint_last_confirmed_tick(
     server_mutate_ticks: Res<ServerMutateTicks>,
     mut checkpoints: ResMut<ReplicationCheckpointMap>,
+    connected_receivers: Query<
+        (),
+        (
+            With<Connected>,
+            With<Client>,
+            With<ReplicationReceiver>,
+            Without<HostClient>,
+        ),
+    >,
 ) {
+    // Receiver cleanup clears the checkpoint map before Replicon's state transition resets its
+    // mutate ticks. Do not compare those two resources during that short transition window.
+    if connected_receivers.is_empty() {
+        return;
+    }
+
     let Some(replicon_tick) = server_mutate_ticks.last_confirmed_tick() else {
         return;
     };
@@ -115,19 +123,23 @@ fn sync_checkpoint_last_confirmed_tick(
     }
 }
 
-fn clear_checkpoint_map_on_disconnect(mut checkpoints: ResMut<ReplicationCheckpointMap>) {
-    checkpoints.clear();
-}
-
 /// Sync replicon's `ClientState` with lightyear lifecycle.
 ///
-/// Sets `Connected` only for real remote clients.
+/// Sets `Connected` only for real remote clients that can receive replication.
 ///
 /// Host-clients intentionally keep Replicon's `ClientState` disconnected so the app behaves like
 /// a listen server: replication receive stays disabled and host-local client behavior is emulated
 /// directly in the shared world instead.
 fn sync_client_state(
-    connected: Query<(), (With<Connected>, With<Client>, Without<HostClient>)>,
+    connected: Query<
+        (),
+        (
+            With<Connected>,
+            With<Client>,
+            With<ReplicationReceiver>,
+            Without<HostClient>,
+        ),
+    >,
     state: Res<State<ClientState>>,
     mut next_state: ResMut<NextState<ClientState>>,
 ) {
@@ -145,7 +157,7 @@ fn sync_client_state(
 fn receive_client_packets(
     channel_map: Res<RepliconChannelMap>,
     mut client_messages: ResMut<ClientMessages>,
-    mut transports: Query<&mut Transport, With<Client>>,
+    mut transports: Query<&mut Transport, (With<Client>, With<ReplicationReceiver>)>,
 ) {
     for mut transport in transports.iter_mut() {
         for (idx, &(_, channel_id)) in channel_map.server_channels.iter().enumerate() {
@@ -164,7 +176,7 @@ fn receive_client_packets(
 fn send_client_packets(
     channel_map: Res<RepliconChannelMap>,
     mut client_messages: ResMut<ClientMessages>,
-    mut transports: Query<&mut Transport, With<Client>>,
+    mut transports: Query<&mut Transport, (With<Client>, With<ReplicationReceiver>)>,
 ) {
     for (channel_idx, message) in client_messages.drain_sent() {
         let (channel_kind, _) = channel_map.client_channels[channel_idx];
@@ -176,19 +188,37 @@ fn send_client_packets(
     }
 }
 
-/// Despawn non-persistent replicated entities when the client disconnects.
+/// Cleans up receiver-side replication state when a receiver disconnects or is removed.
 ///
-/// This matches the old `ReplicationReceivePlugin::handle_disconnection` behavior:
-/// all entities that were spawned from replication are despawned on disconnect.
-/// In the Replicon flow, received entities have `Remote`, which Lightyear exposes
-/// as its receiver-side `Replicated` marker. A [`Persistent`] marker on either a
-/// received entity or the [`ReplicationReceiver`] keeps the applicable entities alive.
-fn despawn_replicated_on_disconnect(
+/// Watching `Remove` for both [`Connected`] and [`ReplicationReceiver`] handles disconnection,
+/// explicit receiver removal, and receiver entity despawn with a single observer. Lifecycle
+/// `Remove` observers run before the components disappear, so receiver-local [`Persistent`] can
+/// still be read here.
+fn on_replication_disconnect(
+    trigger: On<Remove, (Connected, ReplicationReceiver)>,
     mut commands: Commands,
-    persistent_receivers: Query<(), (With<ReplicationReceiver>, With<Persistent>)>,
+    receivers: Query<
+        Has<Persistent>,
+        (
+            With<Connected>,
+            With<Client>,
+            With<ReplicationReceiver>,
+            Without<HostClient>,
+        ),
+    >,
     replicated: Query<Entity, (With<Replicated>, Without<Replicate>, Without<Persistent>)>,
+    mut checkpoints: ResMut<ReplicationCheckpointMap>,
 ) {
-    if !persistent_receivers.is_empty() {
+    // The tuple observer runs when either component is removed. Only clean up a connection that
+    // had both components immediately before this removal, and do not clean up twice if its
+    // receiver entity is later despawned.
+    let Ok(receiver_is_persistent) = receivers.get(trigger.entity) else {
+        return;
+    };
+
+    checkpoints.clear();
+
+    if receiver_is_persistent {
         debug!("Keeping replicated entities because the replication receiver is persistent");
         return;
     }

--- a/crates/replication/replication/src/control.rs
+++ b/crates/replication/replication/src/control.rs
@@ -47,8 +47,8 @@ pub struct ControlledByRemote(Vec<Entity>);
 /// The receiver will add a [`Controlled`] marker component upon receiving the entity.
 ///
 /// When the link is disconnected, the sender will optionally (based on the [`Lifetime`] value)
-/// despawn the entity. If you want to persist an entity on the receiver side even after the link is disconnected,
-/// see [`Lifetime::Persistent`].
+/// despawn the entity. To keep a received entity alive when its connection ends, use
+/// [`Persistent`](crate::receive::Persistent) on the receiver side instead.
 #[derive(Component, Clone, Copy, PartialEq, Debug, Reflect)]
 #[require(ControlledSend)]
 #[reflect(Component)]
@@ -167,9 +167,9 @@ fn emulate_controlled_on_add(
 #[derive(Clone, Copy, Debug, Default, PartialEq, Reflect)]
 pub enum Lifetime {
     #[default]
-    /// When the client that controls the entity disconnects, the entity is despawned
+    /// When the client that controls the entity disconnects, the entity is despawned on the sender.
     SessionBased,
-    /// The entity is not despawned even if the controlling client disconnects
+    /// The entity is not despawned on the sender when the controlling client disconnects.
     Persistent,
 }
 

--- a/crates/replication/replication/src/lib.rs
+++ b/crates/replication/replication/src/lib.rs
@@ -137,7 +137,7 @@ pub mod prelude {
     pub use crate::hierarchy::{DisableReplicateHierarchy, ReplicateLike};
     pub use crate::metadata::{ReplicationMetadata, SenderMetadata};
     pub use crate::prespawn::PreSpawned;
-    pub use crate::receive::ReplicationReceiver;
+    pub use crate::receive::{Persistent, ReplicationReceiver};
     pub use crate::send::{Replicate, ReplicatedFrom, ReplicationSender, ReplicationState};
 
     pub use crate::registry::ComponentRegistry;

--- a/crates/replication/replication/src/receive.rs
+++ b/crates/replication/replication/src/receive.rs
@@ -22,10 +22,14 @@ pub use bevy_replicon::prelude::Remote as Replicated;
 /// entities). For normal server-to-client replication, only
 /// [`ReplicationSender`](crate::send::ReplicationSender) is required on the
 /// server side.
+///
+/// Removing this component ends the receiver's current replication epoch and cleans up received
+/// entities unless they are marked [`Persistent`].
 #[derive(Component, Default)]
 pub struct ReplicationReceiver;
 
-/// Prevents receiver-side entities from being despawned when the connection ends.
+/// Prevents receiver-side entities from being despawned when the connection ends or their
+/// [`ReplicationReceiver`] is removed.
 ///
 /// Add this marker to a received [`Replicated`] entity to preserve only that entity, or add it to
 /// the entity holding [`ReplicationReceiver`] to preserve every entity received through the

--- a/crates/replication/replication/src/receive.rs
+++ b/crates/replication/replication/src/receive.rs
@@ -1,6 +1,7 @@
 use crate::ReplicationSystems;
 use bevy_app::prelude::*;
 use bevy_ecs::prelude::*;
+use bevy_reflect::Reflect;
 use bevy_replicon::client::ClientSystems;
 // TODO: add special rules so that entities with Predicted/Interpolation apply components differently
 
@@ -23,6 +24,18 @@ pub use bevy_replicon::prelude::Remote as Replicated;
 /// server side.
 #[derive(Component, Default)]
 pub struct ReplicationReceiver;
+
+/// Prevents receiver-side entities from being despawned when the connection ends.
+///
+/// Add this marker to a received [`Replicated`] entity to preserve only that entity, or add it to
+/// the entity holding [`ReplicationReceiver`] to preserve every entity received through the
+/// receiver.
+///
+/// This only affects disconnect cleanup. A despawn explicitly replicated by the sender will still
+/// despawn the entity.
+#[derive(Component, Clone, Copy, Debug, Default, PartialEq, Eq, Reflect)]
+#[reflect(Component)]
+pub struct Persistent;
 
 pub struct ReceivePlugin;
 impl Plugin for ReceivePlugin {

--- a/crates/tests/src/client_server/replication.rs
+++ b/crates/tests/src/client_server/replication.rs
@@ -102,6 +102,28 @@ fn spawn_on_source<B: Bundle>(
     with_source_world(stepper, direction, |world| world.spawn(bundle).id())
 }
 
+fn disconnect_client_in_place(stepper: &mut ClientServerStepper, client_id: usize) {
+    use lightyear_connection::client::Disconnect;
+
+    let client_entity = stepper.client_entities[client_id];
+    stepper.client_apps[client_id]
+        .world_mut()
+        .trigger(Disconnect {
+            entity: client_entity,
+        });
+
+    let client_of_entity = stepper.client_of_entities[client_id];
+    stepper
+        .server_app
+        .world_mut()
+        .entity_mut(client_of_entity)
+        .insert(Disconnected {
+            reason: DisconnectedReason::Unknown,
+        });
+    stepper.client_apps[client_id].world_mut().flush();
+    stepper.server_app.world_mut().flush();
+}
+
 #[test]
 fn test_spawn() {
     for direction in active_replication_directions() {
@@ -1214,6 +1236,36 @@ fn test_controlled_entity_despawned_on_server_when_client_disconnects() {
     );
 }
 
+/// `Lifetime::Persistent` keeps a controlled entity alive on the sender when its controller
+/// disconnects.
+#[test]
+fn test_controlled_entity_with_persistent_lifetime_survives_client_disconnect() {
+    let mut stepper = ClientServerStepper::from_config(StepperConfig::with_netcode_clients(2));
+
+    let client_of_1 = stepper.client_of(1).id();
+    let server_entity = stepper
+        .server_app
+        .world_mut()
+        .spawn((
+            Replicate::to_clients(NetworkTarget::All),
+            ControlledBy {
+                owner: client_of_1,
+                lifetime: Lifetime::Persistent,
+            },
+        ))
+        .id();
+    stepper.frame_step(2);
+
+    // Disconnect and remove client 1's link entity.
+    stepper.disconnect_client();
+    stepper.frame_step(2);
+
+    assert!(
+        stepper.server_app.world().get_entity(server_entity).is_ok(),
+        "Entity with persistent lifetime should remain on the sender"
+    );
+}
+
 /// When a client disconnects, all replicated entities on that client should be despawned.
 #[test]
 fn test_replicated_entities_despawned_on_client_when_client_disconnects() {
@@ -1264,7 +1316,6 @@ fn test_replicated_entities_despawned_on_client_when_client_disconnects() {
 /// Instead, we manually trigger the disconnect on the client side and keep running it.
 #[test]
 fn test_all_replicated_despawned_on_disconnecting_client() {
-    use lightyear_connection::client::Disconnect;
     let mut stepper = ClientServerStepper::from_config(StepperConfig::with_netcode_clients(2));
 
     // server spawns an entity replicated to all clients
@@ -1292,20 +1343,7 @@ fn test_all_replicated_despawned_on_disconnecting_client() {
     );
 
     // Manually trigger disconnect on client 1 without removing it from the stepper
-    let client_1_entity = stepper.client_entities[1];
-    stepper.client_apps[1].world_mut().trigger(Disconnect {
-        entity: client_1_entity,
-    });
-    // Also insert Disconnected on the server side for client_of 1
-    let client_of_1 = stepper.client_of_entities[1];
-    stepper
-        .server_app
-        .world_mut()
-        .entity_mut(client_of_1)
-        .insert(Disconnected {
-            reason: DisconnectedReason::Unknown,
-        });
-    stepper.server_app.world_mut().flush();
+    disconnect_client_in_place(&mut stepper, 1);
 
     // Run a few frames to let the state transition happen
     // We need to update client 1 manually since frame_step updates all clients
@@ -1318,6 +1356,169 @@ fn test_all_replicated_despawned_on_disconnecting_client() {
             .get_entity(client_entity_on_1)
             .is_err(),
         "Replicated entity should be despawned on client 1 after disconnect"
+    );
+}
+
+/// A `Persistent` marker on a received entity exempts only that entity from disconnect cleanup.
+#[test]
+fn test_persistent_replicated_entity_survives_client_disconnect() {
+    let mut stepper = ClientServerStepper::from_config(StepperConfig::with_netcode_clients(2));
+
+    let persistent_server_entity = stepper
+        .server_app
+        .world_mut()
+        .spawn((Replicate::to_clients(NetworkTarget::All),))
+        .id();
+    let session_server_entity = stepper
+        .server_app
+        .world_mut()
+        .spawn((Replicate::to_clients(NetworkTarget::All),))
+        .id();
+    stepper.frame_step(2);
+
+    let persistent_client_entity = stepper
+        .client(1)
+        .get::<MessageManager>()
+        .unwrap()
+        .entity_mapper
+        .get_local(persistent_server_entity)
+        .expect("persistent entity should be replicated to client 1");
+    let session_client_entity = stepper
+        .client(1)
+        .get::<MessageManager>()
+        .unwrap()
+        .entity_mapper
+        .get_local(session_server_entity)
+        .expect("session entity should be replicated to client 1");
+    stepper.client_apps[1]
+        .world_mut()
+        .entity_mut(persistent_client_entity)
+        .insert(Persistent);
+
+    disconnect_client_in_place(&mut stepper, 1);
+    stepper.frame_step(3);
+
+    assert!(
+        stepper.client_apps[1]
+            .world()
+            .get_entity(persistent_client_entity)
+            .is_ok(),
+        "Persistent replicated entity should survive disconnect"
+    );
+    assert!(
+        stepper.client_apps[1]
+            .world()
+            .get_entity(session_client_entity)
+            .is_err(),
+        "Non-persistent replicated entity should be despawned on disconnect"
+    );
+}
+
+/// A `Persistent` marker on the receiver exempts all received entities from disconnect cleanup.
+#[test]
+fn test_persistent_replication_receiver_preserves_entities_on_disconnect() {
+    let mut stepper = ClientServerStepper::from_config(StepperConfig::with_netcode_clients(2));
+
+    let server_entity = stepper
+        .server_app
+        .world_mut()
+        .spawn((Replicate::to_clients(NetworkTarget::All),))
+        .id();
+    stepper.frame_step(2);
+
+    let client_entity = stepper
+        .client(1)
+        .get::<MessageManager>()
+        .unwrap()
+        .entity_mapper
+        .get_local(server_entity)
+        .expect("entity should be replicated to client 1");
+    let receiver = stepper.client_entities[1];
+    stepper.client_apps[1]
+        .world_mut()
+        .entity_mut(receiver)
+        .insert(Persistent);
+
+    disconnect_client_in_place(&mut stepper, 1);
+    stepper.frame_step(3);
+
+    assert!(
+        stepper.client_apps[1]
+            .world()
+            .get_entity(client_entity)
+            .is_ok(),
+        "Persistent receiver should preserve its replicated entities"
+    );
+}
+
+/// `Persistent` only controls disconnect cleanup; sender-replicated despawns still apply.
+#[test]
+fn test_persistent_replicated_entity_honors_remote_despawn() {
+    let mut stepper = ClientServerStepper::from_config(StepperConfig::single());
+
+    let server_entity = stepper
+        .server_app
+        .world_mut()
+        .spawn((Replicate::to_clients(NetworkTarget::All),))
+        .id();
+    stepper.frame_step(2);
+    let client_entity = stepper
+        .client(0)
+        .get::<MessageManager>()
+        .unwrap()
+        .entity_mapper
+        .get_local(server_entity)
+        .expect("entity should be replicated to the client");
+    stepper.client_apps[0]
+        .world_mut()
+        .entity_mut(client_entity)
+        .insert(Persistent);
+
+    stepper.server_app.world_mut().despawn(server_entity);
+    stepper.frame_step(2);
+
+    assert!(
+        stepper.client_apps[0]
+            .world()
+            .get_entity(client_entity)
+            .is_err(),
+        "An explicitly replicated despawn should still despawn a persistent entity"
+    );
+}
+
+/// Removing Replicon's sender marker before despawning keeps the despawn local to the sender.
+#[test]
+fn test_sender_can_despawn_without_replicating_despawn() {
+    let mut stepper = ClientServerStepper::from_config(StepperConfig::single());
+
+    let server_entity = stepper
+        .server_app
+        .world_mut()
+        .spawn((Replicate::to_clients(NetworkTarget::All),))
+        .id();
+    stepper.frame_step(2);
+    let client_entity = stepper
+        .client(0)
+        .get::<MessageManager>()
+        .unwrap()
+        .entity_mapper
+        .get_local(server_entity)
+        .expect("entity should be replicated to the client");
+
+    stepper
+        .server_app
+        .world_mut()
+        .entity_mut(server_entity)
+        .remove::<RepliconReplicated>();
+    stepper.server_app.world_mut().despawn(server_entity);
+    stepper.frame_step(2);
+
+    assert!(
+        stepper.client_apps[0]
+            .world()
+            .get_entity(client_entity)
+            .is_ok(),
+        "Removing Replicated before despawning should suppress the remote despawn"
     );
 }
 

--- a/crates/tests/src/client_server/replication.rs
+++ b/crates/tests/src/client_server/replication.rs
@@ -5,7 +5,7 @@ use crate::protocol::{
 };
 use crate::stepper::*;
 use bevy::prelude::{Bundle, Entity, Name, With, World};
-use bevy_replicon::prelude::Replicated as RepliconReplicated;
+use bevy_replicon::prelude::{Replicated as RepliconReplicated, RepliconTick};
 use lightyear::prelude::{ConfirmedHistory, InterpolationTimeline};
 use lightyear_connection::client::{Disconnected, DisconnectedReason};
 use lightyear_connection::network_target::NetworkTarget;
@@ -1448,6 +1448,133 @@ fn test_persistent_replication_receiver_preserves_entities_on_disconnect() {
             .get_entity(client_entity)
             .is_ok(),
         "Persistent receiver should preserve its replicated entities"
+    );
+}
+
+/// Removing `ReplicationReceiver` performs the same cleanup as disconnecting its link.
+#[test]
+fn test_removing_replication_receiver_cleans_up_replication_state() {
+    let mut stepper = ClientServerStepper::from_config(StepperConfig::single());
+
+    let persistent_server_entity = stepper
+        .server_app
+        .world_mut()
+        .spawn((Replicate::to_clients(NetworkTarget::All),))
+        .id();
+    let session_server_entity = stepper
+        .server_app
+        .world_mut()
+        .spawn((Replicate::to_clients(NetworkTarget::All),))
+        .id();
+    stepper.frame_step(2);
+
+    let persistent_client_entity = stepper
+        .client(0)
+        .get::<MessageManager>()
+        .unwrap()
+        .entity_mapper
+        .get_local(persistent_server_entity)
+        .expect("persistent entity should be replicated to the client");
+    let session_client_entity = stepper
+        .client(0)
+        .get::<MessageManager>()
+        .unwrap()
+        .entity_mapper
+        .get_local(session_server_entity)
+        .expect("session entity should be replicated to the client");
+    let checkpoint = RepliconTick::new(123);
+    let receiver = stepper.client_entities[0];
+    {
+        let world = stepper.client_apps[0].world_mut();
+        world
+            .entity_mut(persistent_client_entity)
+            .insert(Persistent);
+        world
+            .resource_mut::<ReplicationCheckpointMap>()
+            .record(checkpoint, Tick(456));
+        world.entity_mut(receiver).remove::<ReplicationReceiver>();
+        world.flush();
+    }
+
+    assert!(
+        stepper.client_apps[0]
+            .world()
+            .get_entity(persistent_client_entity)
+            .is_ok(),
+        "Persistent replicated entity should survive receiver removal"
+    );
+    assert!(
+        stepper.client_apps[0]
+            .world()
+            .get_entity(session_client_entity)
+            .is_err(),
+        "Non-persistent replicated entity should be despawned on receiver removal"
+    );
+    assert_eq!(
+        stepper.client_apps[0]
+            .world()
+            .resource::<ReplicationCheckpointMap>()
+            .get(checkpoint),
+        None,
+        "Receiver removal should clear the checkpoint map"
+    );
+
+    stepper.frame_step(2);
+    assert_eq!(
+        stepper.client_apps[0]
+            .world()
+            .resource::<bevy::prelude::State<bevy_replicon::prelude::ClientState>>()
+            .get(),
+        &bevy_replicon::prelude::ClientState::Disconnected,
+        "Removing ReplicationReceiver should reset Replicon's client state"
+    );
+}
+
+/// Receiver persistence remains observable while the receiver entity itself is being despawned.
+#[test]
+fn test_despawning_persistent_replication_receiver_preserves_entities() {
+    let mut stepper = ClientServerStepper::from_config(StepperConfig::single());
+
+    let server_entity = stepper
+        .server_app
+        .world_mut()
+        .spawn((Replicate::to_clients(NetworkTarget::All),))
+        .id();
+    stepper.frame_step(2);
+
+    let client_entity = stepper
+        .client(0)
+        .get::<MessageManager>()
+        .unwrap()
+        .entity_mapper
+        .get_local(server_entity)
+        .expect("entity should be replicated to the client");
+    let checkpoint = RepliconTick::new(123);
+    let receiver = stepper.client_entities[0];
+    {
+        let world = stepper.client_apps[0].world_mut();
+        world
+            .resource_mut::<ReplicationCheckpointMap>()
+            .record(checkpoint, Tick(456));
+        world.entity_mut(receiver).insert(Persistent);
+        world.despawn(receiver);
+        world.flush();
+    }
+
+    assert!(
+        stepper.client_apps[0]
+            .world()
+            .get_entity(client_entity)
+            .is_ok(),
+        "Persistent receiver should preserve entities while it is despawned"
+    );
+    assert_eq!(
+        stepper.client_apps[0]
+            .world()
+            .resource::<ReplicationCheckpointMap>()
+            .get(checkpoint),
+        None,
+        "Receiver despawn should clear the checkpoint map"
     );
 }
 


### PR DESCRIPTION
## Summary

- add a receiver-local Persistent marker for individual replicated entities or entire ReplicationReceiver links
Persistent entities are not despawned when the receiver disconnects.
If Persistent is present on the receiver, no entities are despawned on disconnect.

Closes #1264