### PR TITLE
feat(deterministic): validate checksums across P2P peers

### DIFF
--- a/crates/core/lightyear/Cargo.toml
+++ b/crates/core/lightyear/Cargo.toml
@@ -95,7 +95,11 @@ deterministic = [
   "lightyear_avian3d?/deterministic",
 ]
 ## Enables peer-to-peer topology, synchronization, input routing, and deterministic sessions.
-p2p = ["client", "dep:lightyear_p2p"]
+p2p = [
+  "client",
+  "dep:lightyear_p2p",
+  "lightyear_deterministic_replication?/p2p",
+]
 ## Enables replicating entities between two peers
 replication = [
   "dep:lightyear_replication",

--- a/crates/deterministic/deterministic_replication/Cargo.toml
+++ b/crates/deterministic/deterministic_replication/Cargo.toml
@@ -22,6 +22,7 @@ client = [
   "lightyear_sync/client",
   "lightyear_transport/client",
 ]
+p2p = ["client"]
 server = [
   "lightyear_connection/server",
   "lightyear_inputs/server",

--- a/crates/deterministic/deterministic_replication/src/checksum.rs
+++ b/crates/deterministic/deterministic_replication/src/checksum.rs
@@ -1,6 +1,7 @@
 //! Utilities for computing checksums for data integrity verification.
 //!
-//! The clients will send checksums at regular intervals to the server, which will verify them against its own computed checksums.
+//! Conventional clients send checksums to the authoritative server. In direct P2P mode, every
+//! peer broadcasts and validates checksums against every other peer.
 //!
 //! Note: we don't have a good way to guarantee that we are iterating through entities in a stable order on both client and server.
 //! Because of this, we will compute an order-independent checksum by only hashing component data and then XOR-ing the results together.
@@ -10,26 +11,28 @@ use crate::archetypes::ChecksumWorld;
 use crate::late_join::CatchUpManager;
 use crate::plugin::DeterministicReplicationPlugin;
 use alloc::collections::BTreeMap;
+#[cfg(feature = "p2p")]
+use alloc::vec::Vec;
 #[cfg(feature = "server")]
 use bevy_app::FixedLast;
 use bevy_app::{App, Plugin, PostUpdate};
 use bevy_ecs::prelude::*;
 use core::hash::Hasher;
-#[cfg(feature = "client")]
+#[cfg(all(feature = "client", feature = "replication"))]
 use lightyear_connection::client::Client;
 #[cfg(feature = "server")]
 use lightyear_connection::client::Connected;
 use lightyear_connection::direction::NetworkDirection;
+#[cfg(feature = "client")]
+use lightyear_connection::network_topology::{NetworkTopology, NetworkingMetadata};
 #[cfg(feature = "server")]
 use lightyear_connection::server::Started;
-#[cfg(feature = "server")]
+#[cfg(any(feature = "p2p", feature = "server"))]
 use lightyear_core::id::RemoteId;
 use lightyear_core::prelude::LocalTimeline;
 use lightyear_core::tick::Tick;
 #[cfg(feature = "client")]
-use lightyear_inputs::InputChannel;
-#[cfg(feature = "client")]
-use lightyear_inputs::client::InputSystems;
+use lightyear_inputs::{InputChannel, client::InputSystems};
 #[cfg(feature = "server")]
 use lightyear_link::server::{LinkOf, Server};
 #[cfg(feature = "client")]
@@ -37,14 +40,14 @@ use lightyear_messages::plugin::MessageSystems;
 use lightyear_messages::prelude::AppMessageExt;
 #[cfg(feature = "client")]
 use lightyear_messages::prelude::MessageSender;
-#[cfg(feature = "server")]
+#[cfg(any(feature = "p2p", feature = "server"))]
 use lightyear_messages::receive::MessageReceiver;
 #[cfg(feature = "client")]
 use lightyear_prediction::manager::{LastConfirmedInput, StateRollbackMetadata};
 #[cfg(feature = "client")]
 use lightyear_sync::prelude::SyncedInputTimeline;
 use serde::{Deserialize, Serialize};
-#[cfg(feature = "server")]
+#[cfg(any(feature = "p2p", feature = "server"))]
 use tracing::error;
 use tracing::{debug, trace};
 
@@ -54,12 +57,86 @@ pub struct ChecksumHistory {
     history: BTreeMap<Tick, u64>,
 }
 
+const CHECKSUM_HISTORY_TICKS: u32 = 30;
+
+/// Local and remote P2P checksums waiting for their matching sample.
+///
+/// Peers do not necessarily advance [`LastConfirmedInput`] at the same time. A remote checksum can
+/// arrive before this peer has computed that tick, while a slower peer can report a tick after this
+/// peer has already computed and sent it. We retain both sides briefly so they can be compared once
+/// the same tick is available locally and remotely. An unchanged local or remote value is a no-op,
+/// so each checksum is compared only when it is first added or changes.
+#[cfg(feature = "p2p")]
+#[derive(Resource, Debug, Default)]
+struct PendingP2PChecksums {
+    by_tick: BTreeMap<Tick, PendingP2PChecksum>,
+}
+
+#[cfg(feature = "p2p")]
+#[derive(Debug, Default)]
+struct PendingP2PChecksum {
+    /// The checksum this peer computed and sent for this tick.
+    local: Option<u64>,
+    /// The latest checksum received from each remote peer for this tick.
+    remote: Vec<(lightyear_core::id::PeerId, u64)>,
+}
+
+#[cfg(feature = "p2p")]
+impl PendingP2PChecksums {
+    /// Store a new local value and immediately compare any remote values already waiting for it.
+    fn record_local(
+        &mut self,
+        tick: Tick,
+        checksum: u64,
+        mut compare: impl FnMut(lightyear_core::id::PeerId, Tick, u64, u64),
+    ) {
+        let pending = self.by_tick.entry(tick).or_default();
+        if pending.local == Some(checksum) {
+            return;
+        }
+        pending.local = Some(checksum);
+        pending.remote.iter().for_each(|&(peer, remote)| {
+            compare(peer, tick, checksum, remote);
+        });
+    }
+
+    /// Store a new remote value and immediately compare it if the local value is already present.
+    fn record_remote(
+        &mut self,
+        peer: lightyear_core::id::PeerId,
+        message: ChecksumMessage,
+        mut compare: impl FnMut(lightyear_core::id::PeerId, Tick, u64, u64),
+    ) {
+        let pending = self.by_tick.entry(message.tick).or_default();
+        if let Some((_, checksum)) = pending
+            .remote
+            .iter_mut()
+            .find(|(pending_peer, _)| *pending_peer == peer)
+        {
+            if *checksum == message.checksum {
+                return;
+            }
+            *checksum = message.checksum;
+        } else {
+            pending.remote.push((peer, message.checksum));
+        }
+        if let Some(local) = pending.local {
+            compare(peer, message.tick, local, message.checksum);
+        }
+    }
+
+    fn clean(&mut self, current_tick: Tick) {
+        let oldest_tick = current_tick - CHECKSUM_HISTORY_TICKS;
+        self.by_tick.retain(|tick, _| *tick >= oldest_tick);
+    }
+}
+
 /// Shared checksum protocol plugin.
 ///
 /// Add this from the shared protocol after `ClientPlugins` / `ServerPlugins`
 /// and before spawning networking entities. It installs the client send and/or
 /// server receive checksum plugins based on which Lightyear side plugins are
-/// present.
+/// present. In P2P mode it installs both plugins because every peer sends and receives.
 pub struct ChecksumPlugin;
 
 impl Plugin for ChecksumPlugin {
@@ -75,6 +152,13 @@ impl Plugin for ChecksumPlugin {
             app.add_plugins(ChecksumSendPlugin);
         }
 
+        #[cfg(feature = "p2p")]
+        if app.is_plugin_added::<lightyear_sync::client::ClientPlugin>()
+            && !app.is_plugin_added::<ChecksumReceivePlugin>()
+        {
+            app.add_plugins(ChecksumReceivePlugin);
+        }
+
         #[cfg(feature = "server")]
         if app.is_plugin_added::<lightyear_sync::server::ServerPlugin>()
             && !app.is_plugin_added::<ChecksumReceivePlugin>()
@@ -85,46 +169,72 @@ impl Plugin for ChecksumPlugin {
 }
 
 fn register_checksum_message(app: &mut App) {
+    // Sending reuses InputChannel, which is already bidirectional and unordered-unreliable.
+    let direction = if cfg!(feature = "p2p") {
+        NetworkDirection::Bidirectional
+    } else {
+        NetworkDirection::ClientToServer
+    };
     if !app.is_message_registered::<ChecksumMessage>() {
         app.register_message::<ChecksumMessage>()
-            .add_direction(NetworkDirection::ClientToServer);
+            .add_direction(direction);
     }
 }
 
-/// Plugin that can be added to clients to compute and send checksums for all deterministic entities with hashable components.
+/// Plugin that computes and sends checksums for deterministic entities with hashable components.
 ///
-/// The server will receive these checksums and verify them against its own computed checksums.
-/// If a checksum does not match, it indicates a desync between the client and server.
+/// Conventional clients send to their server. Direct P2P peers broadcast to every connected peer.
 #[cfg(feature = "client")]
 pub struct ChecksumSendPlugin;
 
 #[cfg(feature = "client")]
 impl ChecksumSendPlugin {
-    /// Compute a checksum over all deterministic entities' hashable
-    /// components at `LastConfirmedInput.tick` and send it to the server.
+    /// Compute and send the checksum at the complete confirmed-input frontier.
+    ///
+    /// This runs in `PostUpdate`, after both this frame's rollback replay and
+    /// [`InputSystems::UpdateRemoteInputTicks`], so the current [`LastConfirmedInput`] can be read
+    /// directly. In P2P mode the computed checksum is also retained for remote samples of the same
+    /// tick that can arrive later.
     fn compute_and_send_checksum(
         mut world: ChecksumWorld<'_, '_, true>,
         local_timeline: Res<LocalTimeline>,
         _input_timeline: SyncedInputTimeline,
+        metadata: Res<NetworkingMetadata>,
+        mut senders: Query<&mut MessageSender<ChecksumMessage>>,
         last_confirmed_input: Res<LastConfirmedInput>,
-        sender: Single<&mut MessageSender<ChecksumMessage>, With<Client>>,
-        #[cfg(feature = "replication")] catchup_manager: Option<
-            Single<&CatchUpManager, With<Client>>,
-        >,
+        #[cfg(feature = "p2p")] mut pending_checksums: ResMut<PendingP2PChecksums>,
+        #[cfg(feature = "replication")] catchup_managers: Query<&CatchUpManager, With<Client>>,
         state_metadata: Res<StateRollbackMetadata>,
     ) {
-        let mut checksum = 0u64;
         let current_tick = local_timeline.tick();
-        let mut sender = sender.into_inner();
-        let tick = last_confirmed_input.tick.get();
-        // only compute the checksum when we have received remote inputs
-        if tick > current_tick {
+        if !last_confirmed_input.received_for_all_clients {
             return;
         }
+        let Some(confirmed_tick) = last_confirmed_input.get() else {
+            return;
+        };
+        // only compute the checksum when we have received remote inputs
+        if confirmed_tick > current_tick {
+            return;
+        }
+        let conventional_link = match metadata.mode {
+            NetworkTopology::Client(link) | NetworkTopology::HostClient { client: link, .. } => {
+                Some(link)
+            }
+            #[cfg(feature = "p2p")]
+            NetworkTopology::P2P { ref connected, .. } if !connected.is_empty() => None,
+            NetworkTopology::Undefined
+            | NetworkTopology::Server(_)
+            | NetworkTopology::P2P { .. }
+            | NetworkTopology::Invalid(_) => return,
+        };
         #[cfg(feature = "replication")]
         // Skip while catch-up is running. The client is intentionally hashing
         // pre-catch-up state until the bundled snapshot has been replayed.
-        if catchup_manager.is_some_and(|manager| manager.suppresses_checksums()) {
+        if conventional_link
+            .and_then(|link| catchup_managers.get(link).ok())
+            .is_some_and(CatchUpManager::suppresses_checksums)
+        {
             return;
         }
         // Skip if a one-shot forced rollback is scheduled but not yet
@@ -136,33 +246,99 @@ impl ChecksumSendPlugin {
         }
 
         world.update_archetypes();
-        // SAFETY: world.update_archetypes() has been called
-        unsafe { world.iter_archetypes() }.for_each(|(archetype, checksum_archetype)| {
-            // TODO: guarantee stable entity iteration order across peers.
-            archetype.entities().iter().for_each(|entity| {
-                checksum_archetype.components.iter().for_each(|(component_id, storage_type)| {
-                    trace!("Adding component {:?} from entity {:?} to checksum for tick {:?}",
-                        component_id, entity.id(), tick);
+
+        if let Some(link) = conventional_link {
+            let checksum = compute_history_checksum(&mut world, confirmed_tick);
+            debug!(
+                ?current_tick,
+                "Computed checksum for LastConfirmedInput tick {:?}: {:016x}",
+                confirmed_tick,
+                checksum
+            );
+            if let Ok(mut sender) = senders.get_mut(link) {
+                sender.send::<InputChannel>(ChecksumMessage {
+                    tick: confirmed_tick,
+                    checksum,
+                });
+            }
+            return;
+        }
+
+        #[cfg(feature = "p2p")]
+        {
+            let NetworkTopology::P2P { connected, .. } = &metadata.mode else {
+                return;
+            };
+            let checksum = compute_history_checksum(&mut world, confirmed_tick);
+            pending_checksums.record_local(confirmed_tick, checksum, log_p2p_comparison);
+            pending_checksums.clean(confirmed_tick);
+            Self::send_p2p_checksum(&mut senders, connected, confirmed_tick, checksum);
+        }
+    }
+
+    #[cfg(feature = "p2p")]
+    fn send_p2p_checksum(
+        senders: &mut Query<&mut MessageSender<ChecksumMessage>>,
+        links: &[Entity],
+        tick: Tick,
+        checksum: u64,
+    ) {
+        debug!(
+            "Computed P2P checksum for tick {:?}: {:016x}",
+            tick, checksum
+        );
+        for &link in links {
+            if let Ok(mut sender) = senders.get_mut(link) {
+                sender.send::<InputChannel>(ChecksumMessage { tick, checksum });
+            }
+        }
+    }
+}
+
+#[cfg(feature = "client")]
+fn compute_history_checksum(world: &mut ChecksumWorld<'_, '_, true>, tick: Tick) -> u64 {
+    let mut checksum = 0u64;
+    // SAFETY: world.update_archetypes() has been called
+    unsafe { world.iter_archetypes() }.for_each(|(archetype, checksum_archetype)| {
+        // TODO: guarantee stable entity iteration order across peers.
+        archetype.entities().iter().for_each(|entity| {
+            checksum_archetype
+                .components
+                .iter()
+                .for_each(|(component_id, storage_type)| {
+                    trace!(
+                        "Adding component {:?} from entity {:?} to checksum for tick {:?}",
+                        component_id,
+                        entity.id(),
+                        tick
+                    );
                     // SAFETY: the way we constructed the archetypes guarantees that the component exists on the entity and we have unique write access
                     let history_ptr = unsafe {
-                        lightyear_utils::ecs::get_component_unchecked_mut(world.world, entity, archetype.table_id(), *storage_type, *component_id)
+                        lightyear_utils::ecs::get_component_unchecked_mut(
+                            world.world,
+                            entity,
+                            archetype.table_id(),
+                            *storage_type,
+                            *component_id,
+                        )
                     };
-                    let (hash_fn, pop_until_tick_and_hash_fn) = world.state.hash_fns.get(component_id).expect("Component in checksum archetype must have a hash function registered");
+                    let (hash_fn, pop_until_tick_and_hash_fn) =
+                        world.state.hash_fns.get(component_id).expect(
+                            "Component in checksum archetype must have a hash function registered",
+                        );
 
                     let mut hasher = seahash::SeaHasher::default();
-                    pop_until_tick_and_hash_fn.unwrap()(history_ptr, tick, &mut hasher, hash_fn.inner);
-                    let hash = hasher.finish();
-                    checksum ^= hash; // XOR the hashes together to get an order-independent checksum
+                    pop_until_tick_and_hash_fn.unwrap()(
+                        history_ptr,
+                        tick,
+                        &mut hasher,
+                        hash_fn.inner,
+                    );
+                    checksum ^= hasher.finish();
                 });
-            });
         });
-        debug!(
-            ?current_tick,
-            "Computed checksum for LastConfirmedInput tick {:?}: {:016x}", tick, checksum
-        );
-
-        sender.send::<InputChannel>(ChecksumMessage { tick, checksum });
-    }
+    });
+    checksum
 }
 
 #[derive(Serialize, Deserialize)]
@@ -180,6 +356,8 @@ impl Plugin for ChecksumSendPlugin {
 
         // We need the application-wide remote-input frontier to compute checksums.
         app.init_resource::<LastConfirmedInput>();
+        #[cfg(feature = "p2p")]
+        app.init_resource::<PendingP2PChecksums>();
 
         register_checksum_message(app);
     }
@@ -195,11 +373,54 @@ impl Plugin for ChecksumSendPlugin {
     }
 }
 
-/// Plugin that can be added to the server to receive and validate checksums sent by clients.
+/// Plugin that receives and validates checksums.
 ///
-/// The server needs to also run the simulation to be able to compute its own checksums for comparison.
-#[cfg(feature = "server")]
+/// An authoritative server compares clients against its simulation. In P2P mode each peer compares
+/// remote samples against its local confirmed prediction history.
+#[cfg(any(feature = "p2p", feature = "server"))]
 pub struct ChecksumReceivePlugin;
+
+#[cfg(feature = "p2p")]
+impl ChecksumReceivePlugin {
+    /// Drain checksum samples from every connected P2P Link.
+    fn receive_p2p_checksum_messages(
+        metadata: Res<NetworkingMetadata>,
+        mut messages: Query<(&mut MessageReceiver<ChecksumMessage>, &RemoteId)>,
+        mut pending_checksums: ResMut<PendingP2PChecksums>,
+    ) {
+        let NetworkTopology::P2P { connected, .. } = &metadata.mode else {
+            return;
+        };
+        for &link in connected {
+            let Ok((mut receiver, remote_id)) = messages.get_mut(link) else {
+                continue;
+            };
+            for message in receiver.receive() {
+                pending_checksums.record_remote(remote_id.0, message, log_p2p_comparison);
+            }
+        }
+    }
+}
+
+#[cfg(feature = "p2p")]
+fn log_p2p_comparison(peer: lightyear_core::id::PeerId, tick: Tick, expected: u64, actual: u64) {
+    if expected == actual {
+        debug!(
+            ?peer,
+            ?tick,
+            checksum = format_args!("{actual:016x}"),
+            "P2P checksum match"
+        );
+    } else {
+        error!(
+            ?peer,
+            ?tick,
+            expected = format_args!("{expected:016x}"),
+            actual = format_args!("{actual:016x}"),
+            "P2P checksum mismatch"
+        );
+    }
+}
 
 #[cfg(feature = "server")]
 impl ChecksumReceivePlugin {
@@ -285,32 +506,148 @@ impl ChecksumReceivePlugin {
     ) {
         let tick = timeline.tick();
         let mut history = history.into_inner();
-        // keep only the last 30 ticks of history
-        history.history.retain(|t, _| *t >= tick - 30);
+        history
+            .history
+            .retain(|t, _| *t >= tick - CHECKSUM_HISTORY_TICKS);
     }
 }
 
-#[cfg(feature = "server")]
+#[cfg(any(feature = "p2p", feature = "server"))]
 impl Plugin for ChecksumReceivePlugin {
     fn build(&self, app: &mut App) {
         if !app.is_plugin_added::<DeterministicReplicationPlugin>() {
             app.add_plugins(DeterministicReplicationPlugin);
         }
 
+        #[cfg(feature = "p2p")]
+        if app.is_plugin_added::<lightyear_sync::client::ClientPlugin>() {
+            app.init_resource::<LastConfirmedInput>();
+            app.init_resource::<PendingP2PChecksums>();
+        }
+
+        #[cfg(feature = "server")]
         // the server will check the checksum validity
-        app.register_required_components::<Server, ChecksumHistory>();
+        if app.is_plugin_added::<lightyear_sync::server::ServerPlugin>() {
+            app.register_required_components::<Server, ChecksumHistory>();
+        }
 
         register_checksum_message(app);
     }
 
     fn finish(&self, app: &mut App) {
-        app.add_systems(
-            PostUpdate,
-            (
-                ChecksumReceivePlugin::clean_history,
-                ChecksumReceivePlugin::receive_checksum_message,
-            ),
+        #[cfg(feature = "p2p")]
+        if app.is_plugin_added::<lightyear_sync::client::ClientPlugin>() {
+            app.add_systems(
+                PostUpdate,
+                ChecksumReceivePlugin::receive_p2p_checksum_messages.before(MessageSystems::Send),
+            );
+        }
+
+        #[cfg(feature = "server")]
+        if app.is_plugin_added::<lightyear_sync::server::ServerPlugin>() {
+            app.add_systems(
+                PostUpdate,
+                (
+                    ChecksumReceivePlugin::clean_history,
+                    ChecksumReceivePlugin::receive_checksum_message,
+                ),
+            );
+            app.add_systems(FixedLast, ChecksumReceivePlugin::compute_and_store_checksum);
+        }
+    }
+}
+
+#[cfg(all(test, feature = "p2p"))]
+mod tests {
+    use super::*;
+    use lightyear_core::id::PeerId;
+
+    fn peer(id: u64) -> PeerId {
+        PeerId::Entity(id)
+    }
+
+    #[test]
+    fn remote_checksum_waits_for_the_local_checksum() {
+        let mut pending = PendingP2PChecksums::default();
+        let mut comparisons = Vec::new();
+        pending.record_remote(
+            peer(1),
+            ChecksumMessage {
+                tick: Tick(12),
+                checksum: 0xCAFE,
+            },
+            |peer, tick, local, remote| {
+                comparisons.push((peer, tick, local, remote));
+            },
         );
-        app.add_systems(FixedLast, ChecksumReceivePlugin::compute_and_store_checksum);
+        assert!(comparisons.is_empty());
+
+        pending.record_local(Tick(12), 0xCAFE, |peer, tick, local, remote| {
+            comparisons.push((peer, tick, local, remote));
+        });
+        assert_eq!(comparisons, [(peer(1), Tick(12), 0xCAFE, 0xCAFE)]);
+
+        // Re-recording the same local value on the next frame does not compare it again.
+        pending.record_local(Tick(12), 0xCAFE, |peer, tick, local, remote| {
+            comparisons.push((peer, tick, local, remote));
+        });
+        assert_eq!(comparisons.len(), 1);
+    }
+
+    #[test]
+    fn local_checksum_waits_for_each_remote_peer() {
+        let mut pending = PendingP2PChecksums::default();
+        let mut comparisons = Vec::new();
+        pending.record_local(Tick(20), 7, |peer, tick, local, remote| {
+            comparisons.push((peer, tick, local, remote));
+        });
+        assert!(comparisons.is_empty());
+
+        for peer in [peer(1), peer(2), peer(3)] {
+            pending.record_remote(
+                peer,
+                ChecksumMessage {
+                    tick: Tick(20),
+                    checksum: 7,
+                },
+                |peer, tick, local, remote| {
+                    comparisons.push((peer, tick, local, remote));
+                },
+            );
+        }
+        assert_eq!(comparisons.len(), 3);
+
+        // A repeated value does not compare again.
+        pending.record_remote(
+            peer(2),
+            ChecksumMessage {
+                tick: Tick(20),
+                checksum: 7,
+            },
+            |peer, tick, local, remote| {
+                comparisons.push((peer, tick, local, remote));
+            },
+        );
+        assert_eq!(comparisons.len(), 3);
+        assert!(comparisons.contains(&(peer(1), Tick(20), 7, 7)));
+        assert!(comparisons.contains(&(peer(2), Tick(20), 7, 7)));
+        assert!(comparisons.contains(&(peer(3), Tick(20), 7, 7)));
+
+        // A changed value is a new checksum and compares once.
+        pending.record_remote(
+            peer(2),
+            ChecksumMessage {
+                tick: Tick(20),
+                checksum: 8,
+            },
+            |peer, tick, local, remote| {
+                comparisons.push((peer, tick, local, remote));
+            },
+        );
+        assert_eq!(comparisons.len(), 4);
+        assert_eq!(comparisons[3], (peer(2), Tick(20), 7, 8));
+
+        pending.clean(Tick(51));
+        assert!(pending.by_tick.is_empty());
     }
 }

--- a/crates/deterministic/deterministic_replication/src/lib.rs
+++ b/crates/deterministic/deterministic_replication/src/lib.rs
@@ -5,7 +5,7 @@
 //!   client/server checksum systems for whichever Lightyear side plugins are
 //!   present.
 //! - [`ChecksumSendPlugin`] / [`ChecksumReceivePlugin`] compute and verify
-//!   XOR checksums of prediction history across client and server.
+//!   XOR checksums of prediction history across client/server or all-to-all P2P topologies.
 //! - [`LateJoinCatchUpPlugin`] lets a client that connects mid-game request
 //!   a one-time snapshot of a remote entity's state so it can fast-forward
 //!   to the current tick via a forced rollback.
@@ -42,10 +42,12 @@ mod prediction_window;
 
 /// Commonly used items from the `lightyear_deterministic_replication` crate.
 pub mod prelude {
+    #[cfg(feature = "server")]
+    pub use crate::checksum::ChecksumHistory;
+    #[cfg(any(feature = "p2p", feature = "server"))]
+    pub use crate::checksum::ChecksumReceivePlugin;
     #[cfg(feature = "client")]
     pub use crate::checksum::ChecksumSendPlugin;
-    #[cfg(feature = "server")]
-    pub use crate::checksum::{ChecksumHistory, ChecksumReceivePlugin};
     pub use crate::checksum::{ChecksumMessage, ChecksumPlugin};
     #[cfg(feature = "replication")]
     pub use crate::late_join::{

--- a/crates/replication/replication/src/send.rs
+++ b/crates/replication/replication/src/send.rs
@@ -287,38 +287,41 @@ impl ReplicationTargetT for () {
             });
     }
 
-    fn on_discard(mut world: DeferredWorld, context: HookContext) {
-        let Ok(entity_ref) = world.get_entity(context.entity) else {
-            return;
-        };
-        let is_replacement = entity_ref.contains::<Replicate>();
-        let Some(visibility_bit) = world.get_resource::<ReplicateBit>().map(|bit| bit.0) else {
-            warn!(
-                entity = ?context.entity,
-                "Skipping replication target replacement because the visibility resource is missing"
-            );
-            return;
-        };
-        let unsafe_world = world.as_unsafe_world_cell();
-        if let Some(state) = unsafe { unsafe_world.world() }.get::<ReplicationState>(context.entity)
-        {
-            state.per_sender_state.keys().for_each(|sender_entity| {
-                if let Some(mut visibility) =
-                    unsafe { unsafe_world.world_mut() }.get_mut::<ClientVisibility>(*sender_entity)
-                {
-                    visibility.set(context.entity, visibility_bit, false);
-                }
-            });
-        }
-        if !is_replacement {
-            world.commands().queue(move |world: &mut World| {
-                let Ok(mut entity_mut) = world.get_entity_mut(context.entity) else {
-                    return;
-                };
-                entity_mut.remove::<Replicated>();
-            });
+    fn on_discard(_: DeferredWorld, _: HookContext) {}
+}
+
+/// Clear the replication visibility only when `Replicate` is replaced or removed.
+///
+/// A component hook cannot distinguish those operations from an entity despawn. Marking an entity
+/// hidden while it is being despawned makes Replicon suppress the actual despawn message.
+fn on_replicate_discard(
+    trigger: On<Discard, Replicate>,
+    replicate_bit: Res<ReplicateBit>,
+    states: Query<&ReplicationState>,
+    mut senders: Query<&mut ClientVisibility>,
+    mut commands: Commands,
+) {
+    if trigger.trigger().new_archetype.is_none() {
+        return;
+    }
+    let entity = trigger.entity;
+
+    if let Ok(state) = states.get(entity) {
+        for &sender_entity in state.per_sender_state.keys() {
+            if let Ok(mut visibility) = senders.get_mut(sender_entity) {
+                visibility.set(entity, replicate_bit.0, false);
+            }
         }
     }
+
+    commands.queue(move |world: &mut World| {
+        let Ok(mut entity_mut) = world.get_entity_mut(entity) else {
+            return;
+        };
+        if !entity_mut.contains::<Replicate>() {
+            entity_mut.remove::<Replicated>();
+        }
+    });
 }
 
 /// Entity-level visibility for [`Replicate`]
@@ -1096,6 +1099,7 @@ impl Plugin for SendPlugin {
         );
         #[cfg(feature = "server")]
         app.add_observer(emulate_replicate_on_host_client_added);
+        app.add_observer(on_replicate_discard);
 
         // make sure that any ordering relative to ReplicationSystems is also applied to ServerSystems
         app.configure_sets(

--- a/examples/deterministic_replication/src/protocol.rs
+++ b/examples/deterministic_replication/src/protocol.rs
@@ -8,7 +8,6 @@ use leafwing_input_manager::prelude::*;
 use lightyear::input::config::InputConfig;
 use lightyear::prelude::input::leafwing;
 use lightyear::prelude::*;
-use lightyear_deterministic_replication::prelude::DeterministicReplicationPlugin;
 use lightyear_deterministic_replication::prelude::{AppCatchUpExt, CatchUpGated, ChecksumPlugin};
 #[cfg(feature = "p2p")]
 use lightyear_examples_common::p2p::P2PSettings;
@@ -109,13 +108,7 @@ impl Plugin for ProtocolPlugin {
                 ..default()
             },
         });
-        if is_p2p {
-            // The current checksum sender targets one conventional server Link. P2P checksums
-            // will be enabled once the deterministic protocol supports all-to-all validation.
-            app.add_plugins(DeterministicReplicationPlugin);
-        } else {
-            app.add_plugins(ChecksumPlugin);
-        }
+        app.add_plugins(ChecksumPlugin);
 
         // Late-join catch-up: shared between client and server so it must
         // be registered before `cli.spawn_connections` adds the Client /


### PR DESCRIPTION
## Summary

- reuse the existing bidirectional, unordered-unreliable `InputChannel` for periodic checksum samples
- keep checksum computation/sending in `ChecksumSendPlugin` and P2P message draining in `ChecksumReceivePlugin`
- read the current complete `LastConfirmedInput` frontier directly; there is no extra checksum frontier state
- buffer local and remote P2P checksums by tick and compare only when a new value completes a pair
- gate all P2P-only checksum state and systems behind the deterministic crate `p2p` feature
- enable `ChecksumPlugin` in the deterministic-replication P2P example
- preserve replicated despawn messages after the visibility-lifetime API change currently on `main`

## How it works

`ChecksumSendPlugin` hashes the current complete `LastConfirmedInput` tick and sends it. Conventional clients target their server; P2P peers target every connected Link. Lost samples are intentionally not retransmitted. In P2P mode the sender also records the exact local checksum it sent.

`ChecksumReceivePlugin` drains incoming P2P samples and records the latest checksum for each peer and tick. The shared `PendingP2PChecksums` buffer performs matching at insertion time: `record_local` compares remote values already waiting for that tick, while `record_remote` compares immediately when the local value already exists. Recording an unchanged local or remote value is a no-op, so there is no per-frame checksum scan or repeated comparison system.

Peers do not necessarily advance `LastConfirmedInput` together. A faster peer can send tick 100 before this peer has computed tick 100, while a slower peer can send tick 98 after this peer has already advanced past it. `PendingP2PChecksums` therefore stores a `BTreeMap<Tick, PendingP2PChecksum>`, where each tick contains the local checksum this peer sent and the latest checksum received from each remote peer. Whichever side arrives first waits for the other. Entries older than 30 locally confirmed ticks are discarded.

P2P uses Lightyear client-role Links, so the deterministic `p2p` feature enables `client`; the Lightyear facade forwards that feature when deterministic replication is enabled.

## CI regression fix

Current `main` marks `Replicate` visibility as hidden from its component discard hook even when the whole entity is being despawned. With Replicon's new visibility lifetimes, that suppresses the real despawn message. Cleanup now runs from a discard observer, which can distinguish an entity despawn from replacing or removing `Replicate`; real despawns remain visible to Replicon's despawn collector, while target replacement behavior is unchanged.
