### PR TITLE
Simplify priority example with ReplicatePriority

### DIFF
--- a/crates/replication/replication/src/lib.rs
+++ b/crates/replication/replication/src/lib.rs
@@ -126,7 +126,7 @@ pub mod prelude {
     pub use bevy_replicon::prelude::Remote;
     pub use bevy_replicon::prelude::Remote as Replicated;
     #[cfg(feature = "server")]
-    pub use bevy_replicon::server::PriorityMap;
+    pub use bevy_replicon::server::{PriorityMap, ReplicatePriority};
 
     pub use crate::ReplicationSystems;
     pub use crate::authority::{AuthorityBroker, GiveAuthority, HasAuthority, RequestAuthority};

--- a/examples/priority/README.md
+++ b/examples/priority/README.md
@@ -6,10 +6,9 @@ quota.
 
 To not starve lower priority entities, their priority is accumulated over time, so that they can eventually be sent.
 
-In this example, rows have static priority marker components. The server writes Replicon's `PriorityMap`
-for each connected client: the center row is low priority, the next rows are medium priority, and the
-outer rows are high priority. `PriorityMap` only affects component mutations, so initial spawns are still
-sent immediately.
+In this example, the server assigns Replicon's `ReplicatePriority` to each prop: the center row is low
+priority, the next rows are medium priority, and the outer rows are high priority. Replication priority
+only affects component mutations, so initial spawns are still sent immediately.
 
 You can find more information in
 the [book](https://github.com/cBournhonesque/lightyear/blob/main/book/src/concepts/advanced_replication/bandwidth_management.md)

--- a/examples/priority/src/protocol.rs
+++ b/examples/priority/src/protocol.rs
@@ -32,15 +32,6 @@ pub enum Shape {
     Square,
 }
 
-#[derive(Component, Deserialize, Serialize, Clone, Copy, Debug, PartialEq)]
-pub struct LowPriority;
-
-#[derive(Component, Deserialize, Serialize, Clone, Copy, Debug, PartialEq)]
-pub struct MediumPriority;
-
-#[derive(Component, Deserialize, Serialize, Clone, Copy, Debug, PartialEq)]
-pub struct HighPriority;
-
 // Channels
 
 pub struct Channel1;
@@ -76,10 +67,6 @@ impl Plugin for ProtocolPlugin {
             .add_linear_interpolation();
 
         app.component::<PlayerColor>().replicate();
-
-        app.component::<LowPriority>().replicate_once();
-        app.component::<MediumPriority>().replicate_once();
-        app.component::<HighPriority>().replicate_once();
 
         app.component::<Shape>().replicate();
     }

--- a/examples/priority/src/server.rs
+++ b/examples/priority/src/server.rs
@@ -27,10 +27,6 @@ impl Plugin for ExampleServerPlugin {
         app.add_observer(handle_connected);
         app.add_observer(movement);
         app.add_systems(Update, (tick_timers, update_props).chain());
-        app.add_systems(
-            PostUpdate,
-            update_priority_maps.before(ReplicationSystems::Send),
-        );
     }
 }
 
@@ -51,23 +47,18 @@ pub(crate) fn setup(mut commands: Commands) {
     for x in -GRID_RADIUS..=GRID_RADIUS {
         for y in -GRID_RADIUS..=GRID_RADIUS {
             let position = Position(Vec2::new(x as f32 * GRID_SIZE, y as f32 * GRID_SIZE));
-            let mut entity = commands.spawn((
+            let priority = match y.abs() {
+                0 => LOW_PROP_PRIORITY,
+                1 => MEDIUM_PROP_PRIORITY,
+                _ => HIGH_PROP_PRIORITY,
+            };
+            commands.spawn((
                 position,
                 Shape::Circle,
                 ShapeChangeTimer(Timer::from_seconds(2.0, TimerMode::Repeating)),
+                ReplicatePriority(priority),
                 Replicate::to_clients(NetworkTarget::All),
             ));
-            match y.abs() {
-                0 => {
-                    entity.insert(LowPriority);
-                }
-                1 => {
-                    entity.insert(MediumPriority);
-                }
-                _ => {
-                    entity.insert(HighPriority);
-                }
-            }
         }
     }
 }
@@ -172,34 +163,6 @@ pub(crate) fn update_props(mut props: Query<(&mut Shape, &ShapeChangeTimer)>) {
             } else if shape.deref() == &Shape::Square {
                 *shape = Shape::Circle;
             }
-        }
-    }
-}
-
-fn update_priority_maps(
-    props: Query<
-        (
-            Entity,
-            Has<HighPriority>,
-            Has<MediumPriority>,
-            Has<LowPriority>,
-        ),
-        With<Shape>,
-    >,
-    mut clients: Query<&mut PriorityMap, With<ClientOf>>,
-) {
-    for mut priority_map in &mut clients {
-        for (entity, high_priority, medium_priority, low_priority) in &props {
-            let priority = if high_priority {
-                HIGH_PROP_PRIORITY
-            } else if medium_priority {
-                MEDIUM_PROP_PRIORITY
-            } else if low_priority {
-                LOW_PROP_PRIORITY
-            } else {
-                continue;
-            };
-            priority_map.insert(entity, priority);
         }
     }
 }


### PR DESCRIPTION
Replicon now provides a global `ReplicatePriority` component in simgine/bevy_replicon#725, so the priority example no longer needs to populate identical per-client `PriorityMap`s.

## Summary

- assign `ReplicatePriority` directly when spawning props
- remove the priority marker components and per-client update system
- re-export `ReplicatePriority` through the Lightyear replication prelude
- update the example documentation