### PR TITLE
refactor(replication): simplify PreSpawned logic

### DIFF
--- a/crates/inputs/inputs/src/server.rs
+++ b/crates/inputs/inputs/src/server.rs
@@ -462,8 +462,8 @@ fn receive_input_message<S: ActionStateSequence>(
                     },
                     InputTarget::PreSpawned(hash) => {
                         debug!(?hash, "Received input for prespawned entity");
-                        // We cannot match using the PreSpawnedReceiver since it only stores hashes for entities
-                        // with no Replicate component, so resolve the input target against server-side input entities.
+                        // PreSpawnedReceiver only stores lifecycle ticks and entities, so resolve
+                        // the hash against server-side input entities.
                         prespawned
                             .iter()
                             .filter_map(|(e, p)| p.hash.is_some_and(|h| h == hash).then_some(e)).next()

--- a/crates/replication/prediction/src/plugin.rs
+++ b/crates/replication/prediction/src/plugin.rs
@@ -22,7 +22,8 @@ use bevy_ecs::prelude::*;
 use bevy_replicon::shared::replication::diff::Diffable as RepliconDiffable;
 use lightyear_connection::network_topology::{NetworkTopology, NetworkingMetadata};
 use lightyear_core::prelude::{ConfirmedHistory, is_in_rollback};
-use lightyear_replication::prelude::{ReplicationReceiver, ReplicationSystems};
+use lightyear_replication::prelude::ReplicationSystems;
+#[cfg(test)]
 use lightyear_replication::prespawn::PreSpawnedReceiver;
 
 /// Plugin that installs client-side prediction systems.
@@ -201,10 +202,6 @@ impl Plugin for PredictionPlugin {
             app.init_resource::<LastConfirmedInput>();
         }
 
-        // State rollback keeps prespawn matching state on the authoritative receiver Link. This
-        // remains Link-scoped even though the rollback decision and manager are application-global.
-        app.register_required_components::<ReplicationReceiver, PreSpawnedReceiver>();
-
         // Custom entity disabling
         let rollback_disable_id = app
             .world_mut()
@@ -311,14 +308,11 @@ mod tests {
     }
 
     #[test]
-    fn prespawn_state_is_required_by_replication_receiver() {
+    fn prespawn_state_is_application_global() {
         let mut app = App::new();
         app.add_plugins(PredictionPlugin);
 
-        let receiver = app.world_mut().spawn(ReplicationReceiver).id();
-        app.world_mut().flush();
-
-        assert!(app.world().get::<PreSpawnedReceiver>(receiver).is_some());
+        assert!(app.world().contains_resource::<PreSpawnedReceiver>());
     }
 
     #[derive(Resource, Default)]

--- a/crates/replication/prediction/src/rollback.rs
+++ b/crates/replication/prediction/src/rollback.rs
@@ -123,6 +123,7 @@ impl Plugin for RollbackPlugin {
         // rollback decision system to operate on remote inputs.
         app.init_resource::<ComponentRegistry>();
         app.init_resource::<ReplicationCheckpointMap>();
+        app.init_resource::<PreSpawnedReceiver>();
 
         // SETS
         app.configure_sets(
@@ -360,7 +361,7 @@ fn check_rollback(
     mut prediction_manager: ResMut<PredictionManager>,
     mut state_metadata: ResMut<StateRollbackMetadata>,
     checkpoints: Res<ReplicationCheckpointMap>,
-    mut prespawned_receivers: Query<&mut PreSpawnedReceiver>,
+    mut prespawned_receiver: ResMut<PreSpawnedReceiver>,
     component_registry: Res<ComponentRegistry>,
     prediction_registry: Res<PredictionRegistry>,
     awaiting_catchup: Query<(), (With<CatchUpGated>, With<ConfirmHistory>)>,
@@ -727,19 +728,17 @@ fn check_rollback(
             })
             .collect::<Vec<_>>();
         // If the prespawned entity didn't exist at the rollback tick, despawn it
-        if let Ok(mut prespawned_receiver) = prespawned_receivers.single_mut() {
-            prespawned_receiver.despawn_prespawned_after_with(
-                rollback_tick + 1,
-                |entity| {
-                    protected_prespawn_entities.contains(&entity)
-                        || (forced_rollback_requested
-                            && deterministic_predicted
-                                .get(entity)
-                                .is_ok_and(|predicted| predicted.skip_despawn))
-                },
-                &mut commands,
-            );
-        }
+        prespawned_receiver.despawn_prespawned_after_with(
+            rollback_tick + 1,
+            |entity| {
+                protected_prespawn_entities.contains(&entity)
+                    || (forced_rollback_requested
+                        && deterministic_predicted
+                            .get(entity)
+                            .is_ok_and(|predicted| predicted.skip_despawn))
+            },
+            &mut commands,
+        );
 
         // If the deterministic predicted entity didn't exist at the rollback tick, despawn it
         // We can drain everything because:

--- a/crates/replication/replication/src/REPLICON_INTEGRATION.md
+++ b/crates/replication/replication/src/REPLICON_INTEGRATION.md
@@ -82,20 +82,16 @@ This branch (`cb/lightyear-replicon`) replaces lightyear's custom replication in
 
 ## Next Steps
 
-### Priority 1: Prespawn Matching Integration
+### Resolved: Prespawn Matching Integration
 
-**Affects**: 5 prespawn tests + 1 history test
-
-The `PreSpawnedReceiver::matches()` method exists but is never called. In the old lightyear, prespawn matching happened during the custom receive path. With replicon, we need a new integration point.
-
-**Problem**: When a server entity with `PreSpawned` is replicated to the client, replicon creates a NEW entity. But the client already has a pre-spawned entity with the same hash. The entity map needs to point to the existing pre-spawned entity instead.
-
-**Possible approaches**:
-- **Modify replicon**: Add a `PrePopulatedEntityMappings` resource or entity-resolver callback that replicon checks before spawning new entities in `apply_changes`. Requires knowing the server entity → hash mapping before message processing.
-- **Post-processing**: After replicon creates the entity, detect `(Added<ConfirmHistory>, PreSpawned)` entities, match by hash, transfer components to the pre-spawned entity, update entity maps, despawn the replicon entity. Complex because transferring all components generically is hard in bevy.
-- **Custom `write_fn` for `PreSpawned`**: Use replicon's `replicate_with` to provide a custom deserialize function that does the matching during component application. The `WriteCtx` has access to `entity_map` but not to redirect which entity receives components.
-
-**Ignored tests**: `test_compute_hash`, `test_multiple_prespawn`, `test_prespawn_success`, `test_prespawn_local_despawn_match`, `test_prespawn_local_despawn_no_match`, `test_history_added_when_prespawned_added`
+Prespawn matching is handled by Replicon's `Signature`. Adding `PreSpawned`
+inserts the corresponding signature on both peers, and Replicon maps the
+server entity directly to the existing local entity before applying component
+updates. `PreSpawnedReceiver` only retains Lightyear-specific lifecycle data
+needed for timeout cleanup, timeline synchronization, and rollback. It is a
+world-global resource, matching the global `LocalTimeline` and Replicon
+`SignatureMap`. `PreSpawned::for_client` forwards sender-side client scoping to
+`Signature::for_client`; it scopes the mapping message, not entity visibility.
 
 ### Priority 2: Rollback Detection
 

--- a/crates/replication/replication/src/lib.rs
+++ b/crates/replication/replication/src/lib.rs
@@ -68,6 +68,10 @@
 //! [`PreSpawned`] allows both client and server to spawn the same entity
 //! independently, then match them via a deterministic hash. This enables
 //! zero-latency predicted spawns (e.g. bullets, projectiles).
+//! Sender-side [`PreSpawned::for_client`] scopes the matching signature to one
+//! remote client without changing the entity's replication visibility.
+//! Rollback and timeout bookkeeping lives in the world-global
+//! [`prespawn::PreSpawnedReceiver`] resource.
 //!
 //! [`Replicate`]: crate::send::Replicate
 //! [`ReplicationTarget<()>`]: crate::send::ReplicationTarget

--- a/crates/replication/replication/src/prespawn.rs
+++ b/crates/replication/replication/src/prespawn.rs
@@ -6,12 +6,12 @@ use crate::prelude::InterpolationTarget;
 #[cfg(feature = "prediction")]
 use crate::prelude::PredictionTarget;
 use crate::prelude::Replicate;
+use crate::receive::ReplicationReceiver;
 use crate::registry::{ComponentKind, ComponentRegistry};
 use alloc::vec::Vec;
 use bevy_app::{App, Plugin, PostUpdate};
 use bevy_ecs::archetype::Archetype;
 use bevy_ecs::component::Components;
-use bevy_ecs::entity::EntityHash;
 use bevy_ecs::lifecycle::HookContext;
 use bevy_ecs::prelude::*;
 use bevy_ecs::world::DeferredWorld;
@@ -20,53 +20,15 @@ use bevy_replicon::client::confirm_history::ConfirmHistory;
 use bevy_replicon::prelude::Signature;
 use core::any::TypeId;
 use core::hash::{Hash, Hasher};
-use lightyear_connection::client::Connected;
+use lightyear_connection::client::{Client, Connected};
 use lightyear_connection::host::HostClient;
+use lightyear_connection::p2p::P2P;
 use lightyear_core::prelude::{LocalTimeline, Tick};
 #[cfg(feature = "client")]
 use lightyear_core::timeline::SyncEvent;
 #[cfg(feature = "client")]
 use lightyear_sync::prelude::InputTimelineConfig;
-#[allow(unused_imports)]
-use tracing::{debug, error, info, trace, warn};
-
-type EntityHashMap<K, V> = bevy_platform::collections::HashMap<K, V, EntityHash>;
-
-#[derive(Resource, Default)]
-struct ActivePreSpawnedSignatures {
-    by_hash: bevy_platform::collections::HashMap<u64, Entity>,
-    by_entity: EntityHashMap<Entity, u64>,
-}
-
-impl ActivePreSpawnedSignatures {
-    fn insert(&mut self, entity: Entity, hash: u64) -> Result<(), Entity> {
-        if self.by_entity.get(&entity).is_some_and(|h| *h == hash) {
-            return Ok(());
-        }
-        if let Some(existing_entity) = self.by_hash.get(&hash).copied()
-            && existing_entity != entity
-        {
-            return Err(existing_entity);
-        }
-
-        self.by_hash.insert(hash, entity);
-        self.by_entity.insert(entity, hash);
-        Ok(())
-    }
-
-    fn remove(&mut self, entity: Entity) {
-        let Some(hash) = self.by_entity.remove(&entity) else {
-            return;
-        };
-        if self
-            .by_hash
-            .get(&hash)
-            .is_some_and(|candidate| *candidate == entity)
-        {
-            self.by_hash.remove(&hash);
-        }
-    }
-}
+use tracing::debug;
 
 /// PreSpawning allows you to replicate an entity to the remote, but instead of creating a new
 /// entity in the remote world, you match an existing pre-spawned entity.
@@ -88,10 +50,9 @@ pub enum PreSpawnedSystems {
 
 impl Plugin for PreSpawnedPlugin {
     fn build(&self, app: &mut App) {
-        app.init_resource::<ActivePreSpawnedSignatures>();
+        app.init_resource::<PreSpawnedReceiver>();
         app.configure_sets(PostUpdate, PreSpawnedSystems::CleanUp);
         app.add_observer(Self::register_prespawn);
-        app.add_observer(Self::cleanup_removed_prespawn_signature);
         app.add_observer(Self::cleanup_matched_prespawn);
         app.add_observer(PreSpawnedReceiver::cleanup_removed_prespawn);
         app.add_observer(PreSpawnedReceiver::cleanup_despawned_prespawn);
@@ -105,8 +66,8 @@ impl Plugin for PreSpawnedPlugin {
 }
 
 impl PreSpawnedPlugin {
-    /// For all newly added prespawns, register their active matching hash and
-    /// insert a Replicon Signature so incoming replicated entities can be
+    /// For all newly added prespawns, register receiver-side lifecycle state
+    /// and insert a Replicon Signature so incoming replicated entities can be
     /// matched to the local entity.
     fn register_prespawn(
         trigger: On<Add, PreSpawned>,
@@ -117,8 +78,17 @@ impl PreSpawnedPlugin {
             // ConfirmHistory as a new local matching candidate.
             Without<ConfirmHistory>,
         >,
-        mut active_signatures: ResMut<ActivePreSpawnedSignatures>,
-        mut manager_query: Query<&mut PreSpawnedReceiver, (With<Connected>, Without<HostClient>)>,
+        connected_receivers: Query<
+            (),
+            (
+                With<Client>,
+                With<Connected>,
+                With<ReplicationReceiver>,
+                Without<HostClient>,
+                Without<P2P>,
+            ),
+        >,
+        mut receiver: ResMut<PreSpawnedReceiver>,
         mut commands: Commands,
     ) {
         let entity = trigger.entity;
@@ -132,67 +102,45 @@ impl PreSpawnedPlugin {
             .hash
             .expect("prespawn hash should have been calculated by a hook");
 
-        if let Err(existing_entity) = active_signatures.insert(entity, hash) {
-            error!(
-                ?hash,
-                ?existing_entity,
-                duplicate_entity = ?entity,
-                "Duplicate active PreSpawned hash; keeping the existing matching candidate and ignoring the duplicate"
-            );
-            return;
+        // Only conventional receiver-side prespawns need timeout and rollback
+        // bookkeeping. PreSpawnedPlugin also runs in authoritative server worlds,
+        // where tracking these entities would incorrectly expire them after the
+        // client timeout. Direct P2P uses PreSpawned as a permanent stable input
+        // identity and has no authoritative entity stream to match against.
+        if !connected_receivers.is_empty() {
+            receiver.register_unmatched_entity(tick, entity);
         }
 
-        let receiver = match prespawn.receiver {
-            None => manager_query.single_mut().ok(),
-            Some(receiver) => manager_query.get_mut(receiver).ok(),
-        };
-
-        if let Some(mut receiver) = receiver
-            && let Err(existing_entity) = receiver.register_unmatched_entity(tick, hash, entity)
-        {
-            active_signatures.remove(entity);
-            error!(
-                ?hash,
-                ?existing_entity,
-                duplicate_entity = ?entity,
-                "Duplicate active PreSpawned receiver hash; keeping the existing matching candidate and ignoring the duplicate"
-            );
-            return;
+        let mut signature = Signature::from(hash);
+        if let Some(client) = prespawn.client {
+            signature = signature.for_client(client);
         }
-
-        commands.entity(entity).insert(Signature::from(hash));
+        commands.entity(entity).insert(signature);
     }
 
     /// Cleanup the client prespawned entities for which we couldn't find a mapped server entity
     pub(crate) fn pre_spawned_player_object_cleanup(
         mut commands: Commands,
         local_timeline: Res<LocalTimeline>,
-        manager_query: Option<Single<&mut PreSpawnedReceiver>>,
+        mut receiver: ResMut<PreSpawnedReceiver>,
     ) {
-        let Some(manager_query) = manager_query else {
-            return;
-        };
         let tick = local_timeline.tick();
-        let mut manager = manager_query.into_inner();
-        let manager = &mut *manager;
 
         // TODO: choose a past tick based on the replication frequency received.
         let past_tick = tick - 50;
         // remove all the prespawned entities that have not been matched with a server entity
-        let split_idx = manager
-            .prespawn_tick_to_hash
-            .partition_point(|(t, _, _)| *t < past_tick);
-        let expired = manager
-            .prespawn_tick_to_hash
+        let split_idx = receiver
+            .unmatched_prespawn_spawn_tick_to_entities
+            .partition_point(|(spawn_tick, _)| *spawn_tick < past_tick);
+        let expired = receiver
+            .unmatched_prespawn_spawn_tick_to_entities
             .drain(..split_idx)
             .collect::<Vec<_>>();
-        for (_, hash, entity) in expired {
-            manager.remove_unmatched_entity(hash, entity);
+        for (_, entity) in expired {
             if let Ok(mut entity_commands) = commands.get_entity(entity) {
                 debug!(
                     ?tick,
                     ?entity,
-                    ?hash,
                     "Cleaning up prespawned player object up to past tick: {:?}",
                     past_tick
                 );
@@ -201,39 +149,26 @@ impl PreSpawnedPlugin {
         }
     }
 
-    fn cleanup_removed_prespawn_signature(
-        trigger: On<Remove, PreSpawned>,
-        mut active_signatures: ResMut<ActivePreSpawnedSignatures>,
-    ) {
-        active_signatures.remove(trigger.entity);
-    }
-
     /// When a prespawned entity is matched with a server entity (ConfirmHistory added),
-    /// clean up the PreSpawnedReceiver tracking.
+    /// update the PreSpawnedReceiver resource.
     fn cleanup_matched_prespawn(
         trigger: On<Add, ConfirmHistory>,
-        query: Query<&PreSpawned>,
-        mut active_signatures: ResMut<ActivePreSpawnedSignatures>,
-        mut receiver_query: Query<&mut PreSpawnedReceiver, (With<Connected>, Without<HostClient>)>,
+        query: Query<(), With<PreSpawned>>,
+        mut receiver: ResMut<PreSpawnedReceiver>,
     ) {
         let entity = trigger.entity;
-        if let Ok(prespawn) = query.get(entity) {
-            active_signatures.remove(entity);
-            if let Some(hash) = prespawn.hash
-                && let Ok(mut receiver) = receiver_query.single_mut()
-            {
-                receiver.remove_unmatched_entity(hash, entity);
-                if let Some(index) = receiver.prespawn_tick_to_hash.iter().position(
-                    |(_, candidate_hash, candidate)| {
-                        *candidate_hash == hash && *candidate == entity
-                    },
-                ) {
-                    let (spawn_tick, _, _) = receiver.prespawn_tick_to_hash.remove(index);
-                    receiver
-                        .matched_prespawn_spawn_tick_to_entities
-                        .push((spawn_tick, entity));
-                }
-            }
+        if query.get(entity).is_ok()
+            && let Some(index) = receiver
+                .unmatched_prespawn_spawn_tick_to_entities
+                .iter()
+                .position(|(_, candidate)| *candidate == entity)
+        {
+            let (spawn_tick, _) = receiver
+                .unmatched_prespawn_spawn_tick_to_entities
+                .remove(index);
+            receiver
+                .matched_prespawn_spawn_tick_to_entities
+                .push((spawn_tick, entity));
             // Keep Signature attached for the rest of the entity lifetime.
             // Replicon removes SignatureMap during receive_replication, so
             // removing Signature during or shortly after the match can miss the
@@ -270,7 +205,6 @@ impl PreSpawnedPlugin {
 #[component(on_add = PreSpawned::on_add)]
 #[reflect(Component, Default)]
 pub struct PreSpawned {
-    // TODO: be able to specify for which receiver this pre-spawned entity is?
     /// The hash that will identify the spawned entity
     /// By default, if the hash is not set, it will be generated from the entity's archetype (list of components) and spawn tick
     /// Otherwise you can manually set it to a value that will be the same on both the client and server
@@ -281,12 +215,17 @@ pub struct PreSpawned {
     /// distinguish between bullets spawned on the same tick, but by different players.
     pub user_salt: Option<u64>,
 
-    // TODO: what if we want the Prespawned to only be for a given sender? or a subset of senders?
-    /// Receiver Link that owns this remote entity.
+    /// Optional client entity that should receive this entity's signature mapping.
     ///
-    /// Replication uses this to select a specific [`PreSpawnedReceiver`]. Direct P2P input uses
-    /// it to ensure that a stable input-target hash is accepted only from the Link for that peer.
-    /// If None, replication will use the entity that has a [`PreSpawnedReceiver`].
+    /// This is primarily sender-side configuration. It scopes only Replicon's
+    /// signature mapping; replication visibility is still controlled separately.
+    pub client: Option<Entity>,
+
+    /// Receiver link that owns this remote entity's P2P input stream.
+    ///
+    /// Direct P2P input uses this to accept a stable input-target hash only
+    /// from the link for that peer. This does not select lifecycle state;
+    /// [`PreSpawnedReceiver`] is application-global.
     pub receiver: Option<Entity>,
 }
 
@@ -296,6 +235,7 @@ impl PreSpawned {
         Self {
             hash: Some(hash),
             user_salt: None,
+            client: None,
             receiver: None,
         }
     }
@@ -304,36 +244,42 @@ impl PreSpawned {
         Self {
             hash: None,
             user_salt: Some(salt),
+            client: None,
             receiver: None,
         }
     }
 
-    pub fn for_receiver(self, entity: Entity) -> Self {
-        Self {
-            hash: self.hash,
-            user_salt: self.user_salt,
-            receiver: Some(entity),
-        }
+    /// Associates the signature mapping with a specific client.
+    ///
+    /// The `client` must be the sender-side client link entity known to Replicon.
+    /// Other clients can still receive the entity according to its replication
+    /// visibility, but they won't receive this prespawn mapping.
+    #[must_use]
+    pub fn for_client(mut self, client: Entity) -> Self {
+        self.client = Some(client);
+        self
+    }
+
+    /// Associates this stable input target with its receiving P2P link.
+    #[must_use]
+    pub fn for_receiver(mut self, receiver: Entity) -> Self {
+        self.receiver = Some(receiver);
+        self
     }
 }
 
-/// Component that can be inserted on an entity that has a [`ReplicationReceiver`](crate::receive::ReplicationReceiver)
-/// so that it can match replicated entities that have a PreSpawned hash with locally prespawned entities.
-#[derive(Component, Debug, Default)]
+/// Global lifecycle state for locally prespawned entities.
+///
+/// Tracks locally prespawned entities for timeout cleanup, timeline synchronization, and rollback.
+/// Entity matching itself is handled by Replicon's [`Signature`].
+#[derive(Resource, Debug, Default)]
 pub struct PreSpawnedReceiver {
     #[doc(hidden)]
-    /// Map from the hash of a PrespawnedPlayerObject to the corresponding active local entity.
-    /// Duplicate active hashes are a serious user error; if one is detected we
-    /// keep the first entity as the matching candidate and ignore the duplicate.
+    /// Stores the spawn tick of each unmatched local prespawned entity.
+    /// If the local timeline advances far enough without a match, the entity is despawned.
     ///
-    /// Also stores the tick at which the entities was spawned.
-    /// If the interpolation_tick reaches that tick and there is till no match, we should despawn the entity
-    pub prespawn_hash_to_entity: EntityHashMap<u64, Entity>,
-    #[doc(hidden)]
-    // TODO(perf): prespawned entities are added in order or tick, so we can use a Vec!
-    /// Store the spawn tick of the entity, as well as the corresponding hash
     /// Sorted in ascending order of Tick.
-    pub prespawn_tick_to_hash: Vec<(Tick, u64, Entity)>,
+    pub unmatched_prespawn_spawn_tick_to_entities: Vec<(Tick, Entity)>,
     #[doc(hidden)]
     /// Store matched prespawned entities so rollback can despawn entities that
     /// were spawned after the rollback tick even after Replicon has matched
@@ -342,70 +288,15 @@ pub struct PreSpawnedReceiver {
 }
 
 impl PreSpawnedReceiver {
-    fn register_unmatched_entity(
-        &mut self,
-        tick: Tick,
-        hash: u64,
-        entity: Entity,
-    ) -> Result<(), Entity> {
-        if let Some(existing_entity) = self.prespawn_hash_to_entity.get(&hash).copied()
-            && existing_entity != entity
-        {
-            return Err(existing_entity);
-        }
-        self.prespawn_hash_to_entity.insert(hash, entity);
+    fn register_unmatched_entity(&mut self, tick: Tick, entity: Entity) {
         if !self
-            .prespawn_tick_to_hash
+            .unmatched_prespawn_spawn_tick_to_entities
             .iter()
-            .any(|(_, candidate_hash, candidate)| *candidate_hash == hash && *candidate == entity)
+            .any(|(_, candidate)| *candidate == entity)
         {
-            self.prespawn_tick_to_hash.push((tick, hash, entity));
+            self.unmatched_prespawn_spawn_tick_to_entities
+                .push((tick, entity));
         }
-        Ok(())
-    }
-
-    fn remove_unmatched_entity(&mut self, hash: u64, entity: Entity) {
-        if self
-            .prespawn_hash_to_entity
-            .get(&hash)
-            .is_some_and(|candidate| *candidate == entity)
-        {
-            self.prespawn_hash_to_entity.remove(&hash);
-        }
-    }
-
-    /// Returns the PreSpawned entity on the receiver World that corresponds to the hash
-    /// received from the remote sender
-    pub(crate) fn matches(&mut self, hash: u64, entity: Entity) -> Option<Entity> {
-        let Some(prespawned_entity) = self.prespawn_hash_to_entity.remove(&hash) else {
-            #[cfg(feature = "metrics")]
-            {
-                metrics::counter!("prespawn::no_match").increment(1);
-            }
-            debug!(
-                ?hash,
-                "Received a PreSpawned entity {entity:?} from the remote with a hash that does not match any prespawned entity"
-            );
-            return None;
-        };
-        #[cfg(feature = "metrics")]
-        {
-            metrics::counter!("prespawn::match::found").increment(1);
-        }
-        debug!(
-            "found a client pre-spawned entity {prespawned_entity:?} for remote entity {entity:?} and hash {hash:?}!",
-        );
-        Some(prespawned_entity)
-    }
-
-    /// Despawn all local PreSpawned entities spawned at a tick >= Tick.
-    ///
-    /// This includes already matched entities, because rollback replay must be
-    /// able to recreate entities spawned after the rollback tick instead of
-    /// leaving the previous matched instance live.
-    #[doc(hidden)]
-    pub fn despawn_prespawned_after(&mut self, tick: Tick, commands: &mut Commands) {
-        self.despawn_prespawned_after_with(tick, |_| false, commands);
     }
 
     /// Despawn all local PreSpawned entities spawned at a tick >= Tick,
@@ -423,10 +314,10 @@ impl PreSpawnedReceiver {
         commands: &mut Commands,
     ) {
         let mut entities_to_despawn = Vec::new();
-        self.prespawn_tick_to_hash
-            .retain(|(spawn_tick, hash, entity)| {
+        self.unmatched_prespawn_spawn_tick_to_entities
+            .retain(|(spawn_tick, entity)| {
                 if *spawn_tick >= tick && !should_keep(*entity) {
-                    entities_to_despawn.push((*entity, Some(*hash)));
+                    entities_to_despawn.push(*entity);
                     false
                 } else {
                     true
@@ -435,16 +326,13 @@ impl PreSpawnedReceiver {
         self.matched_prespawn_spawn_tick_to_entities
             .retain(|(spawn_tick, entity)| {
                 if *spawn_tick >= tick && !should_keep(*entity) {
-                    entities_to_despawn.push((*entity, None));
+                    entities_to_despawn.push(*entity);
                     false
                 } else {
                     true
                 }
             });
-        for (entity, hash) in entities_to_despawn {
-            if let Some(hash) = hash {
-                self.remove_unmatched_entity(hash, entity);
-            }
+        for entity in entities_to_despawn {
             debug!(
                 ?entity,
                 "deleting pre-spawned entity because it was created after the rollback tick"
@@ -458,13 +346,13 @@ impl PreSpawnedReceiver {
     #[cfg(feature = "client")]
     pub(crate) fn handle_tick_sync(
         trigger: On<SyncEvent<InputTimelineConfig>>,
-        mut manager: Single<&mut Self, With<Connected>>,
+        mut receiver: ResMut<Self>,
     ) {
-        manager
-            .prespawn_tick_to_hash
+        receiver
+            .unmatched_prespawn_spawn_tick_to_entities
             .iter_mut()
-            .for_each(|(tick, _, _)| *tick = *tick + trigger.tick_delta);
-        manager
+            .for_each(|(tick, _)| *tick = *tick + trigger.tick_delta);
+        receiver
             .matched_prespawn_spawn_tick_to_entities
             .iter_mut()
             .for_each(|(tick, _)| *tick = *tick + trigger.tick_delta);
@@ -472,34 +360,26 @@ impl PreSpawnedReceiver {
 
     fn cleanup_removed_prespawn(
         trigger: On<Remove, PreSpawned>,
-        mut manager_query: Query<&mut PreSpawnedReceiver, (With<Connected>, Without<HostClient>)>,
+        mut receiver: ResMut<PreSpawnedReceiver>,
     ) {
         let entity = trigger.entity;
-        let Ok(mut manager) = manager_query.single_mut() else {
-            return;
-        };
-        manager.cleanup_unmatched_entity(entity);
+        receiver.cleanup_unmatched_entity(entity);
     }
 
     fn cleanup_despawned_prespawn(
         trigger: On<Despawn, (Signature, PreSpawned)>,
-        mut manager_query: Query<&mut PreSpawnedReceiver, (With<Connected>, Without<HostClient>)>,
+        mut receiver: ResMut<PreSpawnedReceiver>,
     ) {
         let entity = trigger.entity;
-        let Ok(mut manager) = manager_query.single_mut() else {
-            return;
-        };
-        manager.cleanup_unmatched_entity(entity);
-        manager
+        receiver.cleanup_unmatched_entity(entity);
+        receiver
             .matched_prespawn_spawn_tick_to_entities
             .retain(|(_, candidate)| *candidate != entity);
     }
 
     fn cleanup_unmatched_entity(&mut self, entity: Entity) {
-        self.prespawn_hash_to_entity
-            .retain(|_, candidate| *candidate != entity);
-        self.prespawn_tick_to_hash
-            .retain(|(_, _, candidate)| *candidate != entity);
+        self.unmatched_prespawn_spawn_tick_to_entities
+            .retain(|(_, candidate)| *candidate != entity);
     }
 }
 
@@ -609,4 +489,59 @@ pub(crate) fn compute_default_hash(
     }
 
     hasher.finish()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lightyear_core::id::{PeerId, RemoteId};
+
+    fn test_app() -> App {
+        let mut app = App::new();
+        app.init_resource::<LocalTimeline>();
+        app.init_resource::<ComponentRegistry>();
+        app.add_plugins(PreSpawnedPlugin);
+        app
+    }
+
+    #[test]
+    fn conventional_client_prespawns_are_lifecycle_tracked() {
+        let mut app = test_app();
+        app.world_mut().spawn((
+            Client,
+            RemoteId(PeerId::Server),
+            Connected,
+            ReplicationReceiver,
+        ));
+        let prespawned = app.world_mut().spawn(PreSpawned::new(1)).id();
+        app.update();
+
+        assert_eq!(
+            app.world()
+                .resource::<PreSpawnedReceiver>()
+                .unmatched_prespawn_spawn_tick_to_entities,
+            [(Tick::default(), prespawned)]
+        );
+    }
+
+    #[test]
+    fn p2p_stable_input_targets_are_not_lifecycle_tracked() {
+        let mut app = test_app();
+        app.world_mut().spawn((
+            P2P,
+            RemoteId(PeerId::Local(1)),
+            Connected,
+            ReplicationReceiver,
+        ));
+        let prespawned = app.world_mut().spawn(PreSpawned::new(1)).id();
+        app.update();
+
+        assert!(app.world().get::<Signature>(prespawned).is_some());
+        assert!(
+            app.world()
+                .resource::<PreSpawnedReceiver>()
+                .unmatched_prespawn_spawn_tick_to_entities
+                .is_empty()
+        );
+    }
 }

--- a/crates/tests/src/client_server/deterministic/input_only.rs
+++ b/crates/tests/src/client_server/deterministic/input_only.rs
@@ -16,7 +16,7 @@ use crate::client_server::deterministic::protocol::{
     DetPlayerId, DetProtocolPlugin, Player,
 };
 use crate::client_server::deterministic::stepper::{
-    DetStepper, spawn_local_action_on_client, spawn_player_on_server,
+    DetStepper, configure_local_action_on_client, spawn_player_on_server,
 };
 use approx::assert_relative_eq;
 use avian2d::collision::contact_types::ContactGraph;
@@ -452,9 +452,8 @@ fn test_input_only_two_clients() {
         );
     }
 
-    // On each client, spawn the matching local action entity (PreSpawned).
+    // On each client, attach local input to its replicated server-owned action.
     for client_id in 0..2 {
-        let peer = PeerId::Netcode(client_id as u64);
         let server_player = match client_id {
             0 => server_player_a,
             1 => server_player_b,
@@ -467,7 +466,7 @@ fn test_input_only_two_clients() {
             .entity_mapper
             .get_local(server_player)
             .expect("client should have received its own player by now");
-        spawn_local_action_on_client(stepper.client_app(client_id), local_player, peer);
+        configure_local_action_on_client(stepper.client_app(client_id), local_player);
     }
 
     // Warmup (50 ticks of zero input) + random-input exchange phase.
@@ -597,7 +596,6 @@ fn test_input_only_islands_many_colliders_small_box() {
     stepper.frame_step(15);
 
     for client_id in 0..2 {
-        let peer = PeerId::Netcode(client_id as u64);
         let server_player = match client_id {
             0 => server_player_a,
             1 => server_player_b,
@@ -610,7 +608,7 @@ fn test_input_only_islands_many_colliders_small_box() {
             .entity_mapper
             .get_local(server_player)
             .expect("client should have received its own player by now");
-        spawn_local_action_on_client(stepper.client_app(client_id), local_player, peer);
+        configure_local_action_on_client(stepper.client_app(client_id), local_player);
     }
 
     stepper.frame_step(200);

--- a/crates/tests/src/client_server/deterministic/protocol.rs
+++ b/crates/tests/src/client_server/deterministic/protocol.rs
@@ -458,13 +458,5 @@ fn add_frame_interpolation(
     }
 }
 
-/// Deterministic hash for a client's action entity (so client + server
-/// can independently spawn matching PreSpawned pairs).
-pub fn action_prespawn_hash(peer: PeerId) -> u64 {
-    peer.to_bits()
-        .wrapping_mul(6364136223846793005)
-        .wrapping_add(0xDEAD_BEEF)
-}
-
 /// Re-export BEIBuffer for tests that need to check readiness.
 pub type DetBuffer = BEIBuffer<Player>;

--- a/crates/tests/src/client_server/deterministic/state_based_catchup.rs
+++ b/crates/tests/src/client_server/deterministic/state_based_catchup.rs
@@ -17,7 +17,7 @@ use crate::client_server::deterministic::protocol::{
     DetWallMarker, Player,
 };
 use crate::client_server::deterministic::stepper::{
-    DetStepper, spawn_local_action_on_client, spawn_player_on_server,
+    DetStepper, configure_local_action_on_client, local_movement_action, spawn_player_on_server,
 };
 use approx::assert_relative_eq;
 use avian2d::prelude::*;
@@ -603,34 +603,26 @@ fn motion_sample_at(world: &World, subject: MotionSubject, tick: Tick) -> Motion
         })
 }
 
-fn wait_for_client_mapping(
+fn configure_local_action_after_mapping(
     stepper: &mut DetStepper,
     client_id: usize,
-    server_entity: Entity,
-) -> Entity {
+    server_player: Entity,
+) {
     for _ in 0..120 {
-        if let Some(local) = stepper
+        if let Some(local_player) = stepper
             .client(client_id)
             .get::<MessageManager>()
             .unwrap()
             .entity_mapper
-            .get_local(server_entity)
+            .get_local(server_player)
+            && local_movement_action(&stepper.client_apps[client_id], local_player).is_some()
         {
-            return local;
+            configure_local_action_on_client(stepper.client_app(client_id), local_player);
+            return;
         }
         stepper.frame_step(1);
     }
-    panic!("client {client_id} did not receive server entity {server_entity:?}");
-}
-
-fn spawn_local_action_after_mapping(
-    stepper: &mut DetStepper,
-    client_id: usize,
-    server_player: Entity,
-    peer: PeerId,
-) {
-    let local_player = wait_for_client_mapping(stepper, client_id, server_player);
-    spawn_local_action_on_client(stepper.client_app(client_id), local_player, peer);
+    panic!("client {client_id} did not receive the action for player {server_player:?}");
 }
 
 fn despawn_server_player_and_action(stepper: &mut DetStepper, player: Entity) {
@@ -1306,10 +1298,8 @@ fn test_state_based_catchup_two_clients() {
     // `DetPlayerId` + `Player` component.
     stepper.frame_step(15);
 
-    // On each client, find the local player entity and spawn the matching
-    // local action entity (`PreSpawned` same hash as on server).
+    // On each client, attach local input to its replicated server-owned action.
     for client_id in 0..2 {
-        let peer = PeerId::Netcode(client_id as u64);
         let server_player = match client_id {
             0 => server_player_a,
             1 => server_player_b,
@@ -1322,7 +1312,7 @@ fn test_state_based_catchup_two_clients() {
             .entity_mapper
             .get_local(server_player)
             .expect("client should have received its own player by now");
-        spawn_local_action_on_client(stepper.client_app(client_id), local_player, peer);
+        configure_local_action_on_client(stepper.client_app(client_id), local_player);
     }
 
     // Let catch-up + forced rollback + sustained random motion happen.
@@ -1415,7 +1405,7 @@ fn test_state_based_catchup_late_join_after_movement() {
     let peer_b = PeerId::Netcode(1);
     let server_player_a =
         spawn_player_on_server(&mut stepper.server_app, peer_a, Vec2::new(-20.0, 0.0), true);
-    spawn_local_action_after_mapping(&mut stepper, 0, server_player_a, peer_a);
+    configure_local_action_after_mapping(&mut stepper, 0, server_player_a);
 
     // Client 0 moves and collides with the deterministic ball/walls before
     // client 1 exists.
@@ -1424,7 +1414,7 @@ fn test_state_based_catchup_late_join_after_movement() {
     stepper.connect_single(1);
     let server_player_b =
         spawn_player_on_server(&mut stepper.server_app, peer_b, Vec2::new(20.0, 0.0), true);
-    spawn_local_action_after_mapping(&mut stepper, 1, server_player_b, peer_b);
+    configure_local_action_after_mapping(&mut stepper, 1, server_player_b);
 
     // Let client 1 receive the state snapshot, activate physics, roll back,
     // and replay from the catch-up tick while both clients keep sending input.
@@ -1459,7 +1449,7 @@ fn test_state_based_catchup_late_join_while_first_client_holds_input() {
     let peer_b = PeerId::Netcode(1);
     let server_player_a =
         spawn_player_on_server(&mut stepper.server_app, peer_a, Vec2::new(-20.0, 0.0), true);
-    spawn_local_action_after_mapping(&mut stepper, 0, server_player_a, peer_a);
+    configure_local_action_after_mapping(&mut stepper, 0, server_player_a);
 
     // Client 0 is holding right before client 1 joins, and keeps holding it
     // through the catch-up snapshot and forced rollback.
@@ -1468,7 +1458,7 @@ fn test_state_based_catchup_late_join_while_first_client_holds_input() {
     stepper.connect_single(1);
     let server_player_b =
         spawn_player_on_server(&mut stepper.server_app, peer_b, Vec2::new(20.0, 0.0), true);
-    spawn_local_action_after_mapping(&mut stepper, 1, server_player_b, peer_b);
+    configure_local_action_after_mapping(&mut stepper, 1, server_player_b);
 
     stepper.frame_step(220);
 
@@ -1501,7 +1491,7 @@ fn test_state_based_catchup_late_join_reconnect_after_movement() {
     let peer_b = PeerId::Netcode(1);
     let server_player_a =
         spawn_player_on_server(&mut stepper.server_app, peer_a, Vec2::new(-20.0, 0.0), true);
-    spawn_local_action_after_mapping(&mut stepper, 0, server_player_a, peer_a);
+    configure_local_action_after_mapping(&mut stepper, 0, server_player_a);
 
     // Client 0 moves and collides before the second client appears.
     stepper.frame_step(140);
@@ -1509,7 +1499,7 @@ fn test_state_based_catchup_late_join_reconnect_after_movement() {
     stepper.connect_single(1);
     let server_player_b =
         spawn_player_on_server(&mut stepper.server_app, peer_b, Vec2::new(20.0, 0.0), true);
-    spawn_local_action_after_mapping(&mut stepper, 1, server_player_b, peer_b);
+    configure_local_action_after_mapping(&mut stepper, 1, server_player_b);
 
     // Continue with both clients driving random inputs, then disconnect
     // client 1 and remove its server-owned deterministic entities.
@@ -1529,7 +1519,7 @@ fn test_state_based_catchup_late_join_reconnect_after_movement() {
     stepper.connect_single(reconnected);
     let server_player_b_reconnect =
         spawn_player_on_server(&mut stepper.server_app, peer_b, Vec2::new(20.0, 0.0), true);
-    spawn_local_action_after_mapping(&mut stepper, reconnected, server_player_b_reconnect, peer_b);
+    configure_local_action_after_mapping(&mut stepper, reconnected, server_player_b_reconnect);
 
     stepper.frame_step(220);
     assert_clean_stepper_player_entities(&mut stepper, &[peer_a, peer_b]);
@@ -1565,8 +1555,8 @@ fn test_state_based_catchup_reconnect_after_all_clients_disconnect() {
         spawn_player_on_server(&mut stepper.server_app, peer_a, Vec2::new(-20.0, 0.0), true);
     let server_player_b =
         spawn_player_on_server(&mut stepper.server_app, peer_b, Vec2::new(20.0, 0.0), true);
-    spawn_local_action_after_mapping(&mut stepper, 0, server_player_a, peer_a);
-    spawn_local_action_after_mapping(&mut stepper, 1, server_player_b, peer_b);
+    configure_local_action_after_mapping(&mut stepper, 0, server_player_a);
+    configure_local_action_after_mapping(&mut stepper, 1, server_player_b);
 
     stepper.frame_step(200);
     assert_clean_stepper_player_entities(&mut stepper, &[peer_a, peer_b]);
@@ -1593,12 +1583,7 @@ fn test_state_based_catchup_reconnect_after_all_clients_disconnect() {
 
     let server_player_a_reconnect =
         spawn_player_on_server(&mut stepper.server_app, peer_a, Vec2::new(-20.0, 0.0), true);
-    spawn_local_action_after_mapping(
-        &mut stepper,
-        reconnected_a,
-        server_player_a_reconnect,
-        peer_a,
-    );
+    configure_local_action_after_mapping(&mut stepper, reconnected_a, server_player_a_reconnect);
     stepper.frame_step(120);
     assert_clean_stepper_player_entities(&mut stepper, &[peer_a]);
     assert_clean_stepper_ball_entities(&mut stepper);
@@ -1610,12 +1595,7 @@ fn test_state_based_catchup_reconnect_after_all_clients_disconnect() {
     stepper.connect_single(reconnected_b);
     let server_player_b_reconnect =
         spawn_player_on_server(&mut stepper.server_app, peer_b, Vec2::new(20.0, 0.0), true);
-    spawn_local_action_after_mapping(
-        &mut stepper,
-        reconnected_b,
-        server_player_b_reconnect,
-        peer_b,
-    );
+    configure_local_action_after_mapping(&mut stepper, reconnected_b, server_player_b_reconnect);
 
     stepper.frame_step(220);
     assert_clean_stepper_player_entities(&mut stepper, &[peer_a, peer_b]);

--- a/crates/tests/src/client_server/deterministic/stepper.rs
+++ b/crates/tests/src/client_server/deterministic/stepper.rs
@@ -342,8 +342,7 @@ impl DetStepper {
     }
 }
 
-/// Spawn the player entity + BEI action entity for the given client on
-/// the server.
+/// Spawn the player entity and its server-owned BEI action entity.
 ///
 /// When `gated` is `true`, the player's physics components are hidden until
 /// the client requests a bundled catch-up snapshot (matching
@@ -351,8 +350,6 @@ impl DetStepper {
 /// for `CatchUpMode::InputOnly` tests where clients rely on `replicate_once`
 /// at spawn time to receive the initial state.
 ///
-/// The action entity is spawned with `PreSpawned::new(hash)` so that the
-/// client can spawn a local matching action entity with the same hash.
 pub fn spawn_player_on_server(
     server_app: &mut App,
     peer_id: PeerId,
@@ -361,12 +358,10 @@ pub fn spawn_player_on_server(
 ) -> Entity {
     use crate::client_server::deterministic::protocol::{
         DetMovement, DetPhysicsBundle, DetPlayerActivationTick, DetPlayerId, Player,
-        action_prespawn_hash,
     };
     use bevy_enhanced_input::prelude::{Action, ActionOf};
     use lightyear_prediction::rollback::CatchUpGated;
     use lightyear_prediction::rollback::DeterministicPredicted;
-    use lightyear_replication::prelude::PreSpawned;
 
     let mut entity = server_app.world_mut().spawn((
         Replicate::to_clients(NetworkTarget::All),
@@ -389,74 +384,57 @@ pub fn spawn_player_on_server(
     }
     let player_entity = entity.id();
 
-    // Spawn the action entity on the server. Replicate it to every client
-    // EXCEPT the owning peer — the owning client spawns a matching PreSpawned
-    // action entity locally via `spawn_local_action_on_client`.
-    //
-    // Why AllExcept instead of All: replicon's PreSpawned signature matching
-    // only fires when the server's entity-mapping message arrives AT OR AFTER
-    // the client has registered its local prespawn in `SignatureMap`. In this
-    // test, the stepper lets replication settle (`frame_step(15)`) before
-    // calling `spawn_local_action_on_client`, so if the server action were
-    // replicated to the owning client it would have already been materialized
-    // as a new (non-prespawn) entity and the later-arriving local prespawn
-    // would never merge with it. The owning client would then have TWO action
-    // entities (replicated + prespawn) for the same (Player, Action) pair,
-    // causing `apply_movement` to fire twice per tick and desynchronize the
-    // simulation (most visibly as a checksum divergence the moment remote
-    // inputs start arriving). Sending the server action only to the non-
-    // owning clients keeps each client with exactly one action entity per
-    // player. See `examples/bevy_enhanced_inputs` for the alternative pattern
-    // where the prespawn is spawned immediately on `Connected` to stay ahead
-    // of replication.
-    let hash = action_prespawn_hash(peer_id);
+    // Match the BEI example: the server owns the action and replicates it with
+    // the same targets and entity mappings as its player context. The owning
+    // client attaches its local-only ActionMock after receiving this entity.
     server_app.world_mut().spawn((
         ActionOf::<Player>::new(player_entity),
         Action::<DetMovement>::new(),
-        PreSpawned::new(hash),
-        Replicate::to_clients(NetworkTarget::AllExceptSingle(peer_id)),
+        ReplicateLike {
+            root: player_entity,
+        },
     ));
 
     player_entity
 }
 
-/// Spawn the local action entity on the given client, matching the server
-/// via `PreSpawned` hash, and insert `InputMarker::<Player>` on the
-/// player (context) entity so BEI knows this is the locally-owned
-/// context. Called once the client has received its own
-/// `DetPlayerId` entity.
-pub fn spawn_local_action_on_client(
+/// Returns the server-owned movement action replicated with this player.
+pub fn local_movement_action(client_app: &App, client_player_entity: Entity) -> Option<Entity> {
+    use crate::client_server::deterministic::protocol::{DetMovement, Player};
+    use bevy_enhanced_input::prelude::{Action, Actions};
+
+    let world = client_app.world();
+    world
+        .get::<Actions<Player>>(client_player_entity)?
+        .iter()
+        .find(|action| world.get::<Action<DetMovement>>(*action).is_some())
+}
+
+/// Attach local input state to the server-owned action replicated for this
+/// player, matching the action topology in `examples/bevy_enhanced_inputs`.
+pub fn configure_local_action_on_client(
     client_app: &mut App,
     client_player_entity: Entity,
-    peer_id: PeerId,
 ) -> Entity {
-    use crate::client_server::deterministic::protocol::{
-        DetBuffer, DetMovement, Player, action_prespawn_hash,
-    };
-    use bevy_enhanced_input::prelude::{Action, ActionOf};
+    use crate::client_server::deterministic::protocol::Player;
+    use bevy_enhanced_input::context::ExternallyMocked;
+    use bevy_enhanced_input::prelude::ActionMock;
     use lightyear::prelude::input::bei::InputMarker;
-    use lightyear_replication::prelude::PreSpawned;
 
-    // InputMarker goes on the context entity (player), not the action entity.
-    client_app
-        .world_mut()
+    let action_entity = local_movement_action(client_app, client_player_entity)
+        .expect("the server-owned movement action should be replicated with its player");
+
+    let world = client_app.world_mut();
+    world
         .entity_mut(client_player_entity)
         .insert(InputMarker::<Player>::default());
-
-    let hash = action_prespawn_hash(peer_id);
-    // Seed with a disabled `ActionMock` so tests can later write into it
-    // without dealing with inserting the component. `enabled=false` means
-    // BEI ignores it until a system flips it on.
-    use bevy_enhanced_input::prelude::ActionMock;
-    client_app
-        .world_mut()
-        .spawn((
-            ActionOf::<Player>::new(client_player_entity),
-            Action::<DetMovement>::new(),
-            DetBuffer::default(),
-            PreSpawned::new(hash).for_receiver(client_player_entity),
-            ActionMock::default(),
-            InputMarker::<Player>::default(),
-        ))
-        .id()
+    // These tests deterministically simulate every player on every client, so
+    // they do not use ControlledBy to select one predicted player. Explicitly
+    // unmock only this client's action, then seed the mock that its drive
+    // system updates each tick.
+    world
+        .entity_mut(action_entity)
+        .remove::<ExternallyMocked>()
+        .insert((ActionMock::default(), InputMarker::<Player>::default()));
+    action_entity
 }

--- a/crates/tests/src/client_server/prediction/prespawn.rs
+++ b/crates/tests/src/client_server/prediction/prespawn.rs
@@ -45,28 +45,33 @@ fn test_compute_hash() {
     stepper.frame_step(1);
 
     let current_tick = stepper.client_tick(0);
-    let prediction_manager = stepper.client(0).get::<PreSpawnedReceiver>().unwrap();
-    tracing::info!(?prediction_manager
-            .prespawn_hash_to_entity, "hi");
-    assert_eq!(prediction_manager.prespawn_hash_to_entity.len(), 2);
-    let expected_hash = prediction_manager
-        .prespawn_tick_to_hash
-        .last()
-        .expect("prespawn hash should be registered")
-        .1;
+    let hash_1 = stepper
+        .client_app()
+        .world()
+        .get::<PreSpawned>(entity_1)
+        .unwrap()
+        .hash
+        .unwrap();
+    let hash_2 = stepper
+        .client_app()
+        .world()
+        .get::<PreSpawned>(entity_2)
+        .unwrap()
+        .hash
+        .unwrap();
+    assert_ne!(hash_1, hash_2);
+
+    let receiver = stepper
+        .client_app()
+        .world()
+        .resource::<PreSpawnedReceiver>();
+    assert_eq!(receiver.unmatched_prespawn_spawn_tick_to_entities.len(), 2);
     assert_eq!(
-        prediction_manager
-            .prespawn_hash_to_entity
-            .get(&expected_hash)
-            .copied(),
-        Some(entity_2)
-    );
-    assert_eq!(
-        prediction_manager.prespawn_tick_to_hash.last(),
+        receiver.unmatched_prespawn_spawn_tick_to_entities.last(),
         // NOTE: in this test we have to add + 1 here because the `register_prespawn` observer
         //  runs outside of the FixedUpdate schedule so the entity is registered with the previous tick
         //  in a real situation the entity would be spawned inside FixedUpdate so the hash would be correct
-        Some(&(current_tick - 1, expected_hash, entity_2))
+        Some(&(current_tick - 1, entity_2))
     );
 
     // check that a PredictionHistory got added to the entity
@@ -82,9 +87,8 @@ fn test_compute_hash() {
     );
 }
 
-/// Duplicate active prespawn hashes are a serious user error. Keep the first
-/// matching candidate so Replicon never sees two local entities with the same
-/// Signature.
+/// Duplicate active prespawn hashes are a serious user error. Replicon's
+/// SignatureMap keeps the first matching candidate.
 #[test]
 fn test_duplicate_prespawn_hash_keeps_first_candidate() {
     let mut stepper = ClientServerStepper::from_config(StepperConfig::single());
@@ -145,16 +149,63 @@ fn test_duplicate_prespawn_hash_keeps_first_candidate() {
             .is_none(),
         "the duplicate prespawn candidate should be ignored"
     );
-    assert_eq!(
+}
+
+/// A sender-scoped prespawn mapping must only claim the matching local entity
+/// on the selected client. Other clients still receive the replicated entity,
+/// but Replicon should spawn it normally even if they have the same signature.
+#[test]
+fn test_prespawn_signature_for_client() {
+    let mut stepper = ClientServerStepper::from_config(StepperConfig::with_netcode_clients(2));
+
+    let client_0_prespawn = stepper.client_apps[0]
+        .world_mut()
+        .spawn((PreSpawned::new(1), CompFull(1.0)))
+        .id();
+    let client_1_prespawn = stepper.client_apps[1]
+        .world_mut()
+        .spawn((PreSpawned::new(1), CompFull(1.0)))
+        .id();
+
+    let client_0_link = stepper.client_of_entities[0];
+    let server_prespawn = stepper
+        .server_app
+        .world_mut()
+        .spawn((
+            PreSpawned::new(1).for_client(client_0_link),
+            CompFull(1.0),
+            Replicate::to_clients(NetworkTarget::All),
+            PredictionTarget::to_clients(NetworkTarget::All),
+        ))
+        .id();
+
+    stepper.frame_step(2);
+
+    let client_0_mapped = stepper
+        .client(0)
+        .get::<MessageManager>()
+        .unwrap()
+        .entity_mapper
+        .get_local(server_prespawn)
+        .unwrap();
+    let client_1_mapped = stepper
+        .client(1)
+        .get::<MessageManager>()
+        .unwrap()
+        .entity_mapper
+        .get_local(server_prespawn)
+        .unwrap();
+
+    assert_eq!(client_0_mapped, client_0_prespawn);
+    assert_ne!(client_1_mapped, client_1_prespawn);
+    assert!(
         stepper
-            .client(0)
-            .get::<PreSpawnedReceiver>()
-            .unwrap()
-            .prespawn_hash_to_entity
-            .get(&1)
-            .copied(),
-        None,
-        "the active prespawn hash should be removed after the match"
+            .server_app
+            .world()
+            .resource::<PreSpawnedReceiver>()
+            .unmatched_prespawn_spawn_tick_to_entities
+            .is_empty(),
+        "authoritative sender prespawns should not enter the receiver timeout ledger"
     );
 }
 
@@ -329,9 +380,9 @@ fn test_matched_prespawn_despawned_on_rollback_before_spawn_tick() {
     );
     assert!(
         stepper
-            .client(0)
-            .get::<PreSpawnedReceiver>()
-            .unwrap()
+            .client_app()
+            .world()
+            .resource::<PreSpawnedReceiver>()
             .matched_prespawn_spawn_tick_to_entities
             .iter()
             .any(|(tick, entity)| *tick == spawn_tick && *entity == client_prespawn),

--- a/crates/tests/src/client_server/prediction/rollback.rs
+++ b/crates/tests/src/client_server/prediction/rollback.rs
@@ -1314,23 +1314,16 @@ fn setup_stepper_for_input_rollback(
     )
 }
 
-/// Test that input-only prediction rolls back without any replication state on its client Link.
+/// Test that input-only prediction rolls back with application-global prespawn state.
 #[test]
-fn test_input_rollback_always_mode_without_replication_receiver() {
+fn test_input_rollback_always_mode_with_global_prespawn_state() {
     let (mut stepper, _, _, client_entity, _) =
         setup_stepper_for_input_rollback(RollbackMode::Always);
 
-    let client_link = stepper.client(0).id();
-    stepper.client_apps[0]
-        .world_mut()
-        .entity_mut(client_link)
-        .remove::<ReplicationReceiver>()
-        .remove::<PreSpawnedReceiver>();
     assert!(
         stepper.client_apps[0]
             .world()
-            .get::<PreSpawnedReceiver>(client_link)
-            .is_none()
+            .contains_resource::<PreSpawnedReceiver>()
     );
 
     // build a steady state where have already received an input


### PR DESCRIPTION
## Summary

- delegates pre-spawn entity matching and duplicate-signature handling to Replicon’s global `SignatureMap`;
- removes Lightyear’s duplicate `ActivePreSpawnedSignatures` and `prespawn_hash_to_entity` indexes;
- converts `PreSpawnedReceiver` from a component on a receiver/manager entity into an application-global resource;
- keeps only Lightyear-specific lifecycle data for timeout cleanup, timeline synchronization, and rollback;
- adds `PreSpawned::for_client` for sender-side per-client signature mapping;
- preserves `PreSpawned::for_receiver` as the separate direct-P2P input-ownership scope added on `main`;
- removes the public receiver-lifecycle opt-out and migrates deterministic BEI actions to the normal server-owned `ReplicateLike` flow used by the example.

## Why

`PreSpawned` previously maintained three overlapping hash indexes:

- Lightyear’s `ActivePreSpawnedSignatures`;
- `PreSpawnedReceiver::prespawn_hash_to_entity`;
- Replicon’s `SignatureMap`.

Replicon is the component that ultimately selects a local entity for an incoming authoritative entity. Keeping two additional Lightyear maps duplicated collision policy and created state that could diverge from the actual matcher. This PR makes Replicon the single source of truth for matching.

The remaining Lightyear state is lifecycle bookkeeping rather than matching state. It is application-global because `LocalTimeline`, rollback state, and Replicon’s receiving-side signature map are application-global on current `main`.

## Matching behavior

Adding `PreSpawned` still derives or accepts the Lightyear pre-spawn hash and installs `Signature::from(hash)`. Replicon then:

1. registers the local candidate;
2. keeps its existing candidate selection behavior when duplicate active signatures exist;
3. maps an incoming authoritative entity directly onto the selected local entity;
4. falls back to a normal replicated spawn when no local signature matches.

Lightyear no longer performs a second lookup or stores a parallel hash-to-entity map. `Signature` stays attached after a successful match so Replicon’s removal hook can clean its map when the entity is eventually despawned.

## Global lifecycle and rollback state

`PreSpawnedReceiver` is now a resource with two ordered ledgers:

- unmatched entities, used for timeout cleanup when no authoritative entity arrives;
- matched entities with their original local spawn ticks, used to remove entities that did not exist at a rollback tick.

The resource is updated when a prespawn matches, loses `PreSpawned`, despawns, or when the input timeline is resynchronized. Rollback accesses this resource directly and preserves the existing `DeterministicPredicted { skip_despawn: true }` protection.

Authoritative sender worlds do not enroll their prespawns in receiver timeout tracking. Conventional connected client receivers do.

There is intentionally no public `without_lifecycle_tracking` escape hatch. A conventional receiver-side `PreSpawned` entity is a local spawn awaiting an authoritative match and therefore participates in the standard timeout and rollback lifecycle. Code that only needs matching, without predicted-spawn lifecycle, should use Replicon’s `Signature` directly.

## Two independent scopes

`PreSpawned::for_client(client)` and `PreSpawned::for_receiver(receiver)` have different meanings:

- `for_client` is sender-side and forwards to `Signature::for_client`; it selects which client receives the signature mapping. It does not control replication visibility.
- `for_receiver` is used by direct P2P input. It records which receiving P2P link owns a stable input target so another peer cannot submit input for that target. It does not select a lifecycle resource or affect Replicon matching.

Current direct-P2P examples use `PreSpawned` as a permanent stable roster/input identity, not as a local entity waiting for an authoritative replication stream. Because there is nothing authoritative to match, direct-P2P links are excluded from the unmatched-authority timeout ledger. This prevents their stable roster entities from being deleted after 50 ticks while retaining their signatures and input ownership checks.

Replication visibility remains independently controlled by `Replicate`, visibility APIs, and prediction/interpolation targets.

## Prediction behavior

This PR does not remove the prediction semantics currently attached to `PreSpawned`:

- prediction history can begin before the authoritative match;
- the first authoritative value is routed into confirmed history instead of overwriting the live predicted value;
- prediction-aware local despawn behavior remains intact;
- rollback can remove both unmatched and already matched entities created after the rollback point.

Those responsibilities are independent of signature matching and can be split into prediction-owned state in a later change.

## BEI action entities

BEI action entities do not need `PreSpawned` merely because they carry input. The `bevy_enhanced_inputs` example already uses a simpler topology:

1. the server spawns the action with `ActionOf`, `Action`, and `ReplicateLike { root: player }`;
2. Replicon creates and maps the action on clients;
3. the owning client adds local bindings or a test input mock to the received action.

The deterministic input and late-join tests now follow that topology. This removes their custom action prespawn hash, `AllExcept` replication workaround, duplicate client-local action, and lifecycle-tracking exception while continuing to exercise input rebroadcast and rollback catch-up.

## Follow-up direction

The remaining `PreSpawned` API still combines identity, automatic hashing, input addressing, prediction marking, timeout cleanup, and rollback bookkeeping. A follow-up can separate these concerns into:

- Replicon `Signature` for entity matching;
- an explicit `SpawnId` for pre-mapping and P2P input identity;
- prediction-owned spawn lifecycle/rollback tracking;
- explicit `Predicted` semantics for locally simulated spawns.
