### PR TITLE
Merge the completed P2P stacked PRs into main

### DIFF
--- a/book/src/concepts/advanced_replication/prespawning.md
+++ b/book/src/concepts/advanced_replication/prespawning.md
@@ -51,7 +51,7 @@ The various system-sets for prespawning are:
 
 - FixedUpdate schedule:
   - FixedUpdate::Main: prespawn the entity
-  - FixedUpdate::SetPreSpawnedHash: we store all new hashes and the spawn tick in the `PredictionManager` (not in the `PreSpawnedPlayerObject` component).
+  - FixedUpdate::SetPreSpawnedHash: we store all new hashes and the spawn tick in the link's `PreSpawnedReceiver` (not in the `PreSpawnedPlayerObject` component).
   - FixedUpdate::SpawnHistory: add a PredictionHistory for each component of the pre-spawned entity. We need this to:
     - not rollback immediately when we get the corresponding server entity
     - do rollbacks correctly for pre-spawned entities

--- a/book/src/tutorial/advanced_systems.md
+++ b/book/src/tutorial/advanced_systems.md
@@ -21,7 +21,7 @@ when we receive the actual state of the entity from the server. (if there is a m
 To do this in lightyear, you will need to change a few things:
 
 - enable prediction for the component in your protocol;
-- add a `PredictionManager` component to the local client entity;
+- enable the application's global prediction pipeline with a `PredictionManager` resource;
 - mark the entity as predicted, either with `PredictionTarget` on the send-side or by adding
   `Predicted` on the receive-side.
 
@@ -32,14 +32,10 @@ app.component::<PlayerPosition>().replicate()
     .predict();
 ```
 
-Then, make sure your client entity has a `PredictionManager`. `ClientPlugins` installs the prediction systems, but the systems only run for a connected client entity that has this component. The shared example helpers insert it in `ExampleClient`; if you spawn your own client entity, add it there:
+Then, enable the application's prediction pipeline. `ClientPlugins` installs the prediction systems, but the systems only run while the application has a `PredictionManager` resource. The shared example helpers enable it automatically; otherwise insert the resource during application setup:
 
 ```rust,ignore
-commands.spawn((
-    Client::default(),
-    PredictionManager::default(),
-    // Link, IO, connection components...
-));
+app.insert_resource(PredictionManager::default());
 ```
 
 Finally, choose which replicated entities should be predicted. If the sender knows which clients

--- a/crates/connection/connection/src/identity.rs
+++ b/crates/connection/connection/src/identity.rs
@@ -1,32 +1,33 @@
-use crate::client::Client;
-use crate::host::{HostClient, HostServer};
-use crate::server::{Started, Starting};
-use bevy_ecs::query::{Or, With, Without};
-use bevy_ecs::system::Query;
-use lightyear_link::server::Server;
+use crate::network_topology::NetworkingMetadata;
+use bevy_ecs::system::Res;
 
-/// Returns true if the peer is a client (host-server counts as a server)
-pub fn is_client(query: Query<(), (With<Client>, Without<HostClient>)>) -> bool {
-    !query.is_empty()
+/// Returns true for a connected conventional client topology.
+///
+/// Direct peers are reported by [`is_p2p`], not as conventional clients, even though every
+/// [`crate::p2p::P2P`] Link carries the internal [`crate::client::Client`] role marker.
+pub fn is_client(metadata: Res<NetworkingMetadata>) -> bool {
+    metadata.mode.is_client()
 }
 
-/// Returns true if the peer is starting or running a server.
-pub fn is_server(query: Query<(), (With<Server>, Or<(With<Starting>, With<Started>)>)>) -> bool {
-    !query.is_empty()
+/// Returns true for a started server, including the server side of a ready host-client topology.
+pub fn is_server(metadata: Res<NetworkingMetadata>) -> bool {
+    metadata.mode.is_server()
 }
 
-/// Returns true if the peer is starting or running a server without any client entities.
-pub fn is_headless_server(
-    server_query: Query<(), (With<Server>, Or<(With<Starting>, With<Started>)>)>,
-    client_query: Query<(), With<Client>>,
-) -> bool {
-    !server_query.is_empty() && client_query.is_empty()
+/// Returns true for a started server without a connected in-process client.
+pub fn is_headless_server(metadata: Res<NetworkingMetadata>) -> bool {
+    metadata.mode.is_headless_server()
 }
 
 /// Returns true if we are running in host-server mode, i.e. the server is acting as a client
 /// (in which case we can disable the networking/prediction/interpolation systems on the client)
 ///
-/// We are in host-server mode when a running server has been marked as a host server.
-pub fn is_host_server(query: Query<(), (With<Server>, With<Started>, With<HostServer>)>) -> bool {
-    !query.is_empty()
+/// We are in host-server mode when both sides form a ready cached host-client topology.
+pub fn is_host_server(metadata: Res<NetworkingMetadata>) -> bool {
+    metadata.mode.is_host_server()
+}
+
+/// Returns true when the cached topology contains direct P2P Links.
+pub fn is_p2p(metadata: Res<NetworkingMetadata>) -> bool {
+    metadata.mode.is_p2p()
 }

--- a/crates/connection/connection/src/lib.rs
+++ b/crates/connection/connection/src/lib.rs
@@ -60,11 +60,11 @@ pub enum ConnectionSystems {
 pub mod prelude {
     pub use crate::ConnectionSystems;
     pub use crate::direction::NetworkDirection;
+    pub use crate::identity::{is_client, is_p2p};
     pub use crate::network_target::NetworkTarget;
     pub use crate::network_topology::{
         NetworkTopology, NetworkTopologyError, NetworkTopologySystems, NetworkingMetadata,
     };
-
     // we also export these types at the top level for easier access
     pub use crate::client::{
         Client, ClientState, Connect, Connected, Connecting, ConnectionError, Disconnect,

--- a/crates/connection/connection/src/network_topology.rs
+++ b/crates/connection/connection/src/network_topology.rs
@@ -41,6 +41,33 @@ pub enum NetworkTopology {
     Invalid(NetworkTopologyError),
 }
 
+impl NetworkTopology {
+    /// Returns true for a connected conventional client.
+    pub fn is_client(&self) -> bool {
+        matches!(self, Self::Client(_))
+    }
+
+    /// Returns true for a started server, including the server side of a host-client app.
+    pub fn is_server(&self) -> bool {
+        matches!(self, Self::Server(_) | Self::HostClient { .. })
+    }
+
+    /// Returns true for a started server without a connected in-process client.
+    pub fn is_headless_server(&self) -> bool {
+        matches!(self, Self::Server(_))
+    }
+
+    /// Returns true for a ready in-process host-client app.
+    pub fn is_host_server(&self) -> bool {
+        matches!(self, Self::HostClient { .. })
+    }
+
+    /// Returns true when direct P2P Links have been declared.
+    pub fn is_p2p(&self) -> bool {
+        matches!(self, Self::P2P { .. })
+    }
+}
+
 /// Cached metadata describing the networking configuration of this Bevy application.
 ///
 /// [`crate::ConnectionPlugin`] maintains this resource from role and lifecycle components. Users

--- a/crates/connection/raw_connection/src/client.rs
+++ b/crates/connection/raw_connection/src/client.rs
@@ -25,15 +25,17 @@ impl RawConnectionPlugin {
     /// For RawClients, Linked implies Connected
     fn on_linked(
         trigger: On<Add, Linked>,
-        query: Query<&LocalAddr, With<RawClient>>,
+        query: Query<(&LocalAddr, Option<&LocalId>, Option<&RemoteId>), With<RawClient>>,
         mut commands: Commands,
     ) {
-        if let Ok(local_addr) = query.get(trigger.entity) {
+        if let Ok((local_addr, local_id, remote_id)) = query.get(trigger.entity) {
             trace!("RawClient Linked! Adding Connected");
             commands.entity(trigger.entity).insert((
                 Connected,
-                LocalId(PeerId::Raw(local_addr.0)),
-                RemoteId(PeerId::Server),
+                local_id
+                    .copied()
+                    .unwrap_or(LocalId(PeerId::Raw(local_addr.0))),
+                remote_id.copied().unwrap_or(RemoteId(PeerId::Server)),
             ));
         }
     }
@@ -69,5 +71,35 @@ impl Plugin for RawConnectionPlugin {
         );
         app.add_observer(Self::on_linked);
         app.add_observer(Self::on_disconnect);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn raw_client_preserves_preconfigured_peer_ids() {
+        let mut app = App::new();
+        app.add_plugins(RawConnectionPlugin);
+        let local_id = LocalId(PeerId::Entity(1));
+        let remote_id = RemoteId(PeerId::Entity(2));
+        let entity = app
+            .world_mut()
+            .spawn((
+                RawClient,
+                LocalAddr("127.0.0.1:10001".parse().unwrap()),
+                local_id,
+                remote_id,
+            ))
+            .id();
+
+        app.world_mut().entity_mut(entity).insert(Linked);
+        app.world_mut().flush();
+
+        let entity = app.world().entity(entity);
+        assert!(entity.contains::<Connected>());
+        assert_eq!(entity.get::<LocalId>(), Some(&local_id));
+        assert_eq!(entity.get::<RemoteId>(), Some(&remote_id));
     }
 }

--- a/crates/core/core/src/timeline.rs
+++ b/crates/core/core/src/timeline.rs
@@ -8,9 +8,8 @@ use bevy_ecs::entity::Entity;
 use bevy_ecs::event::{EntityEvent, Event};
 use bevy_ecs::prelude::{On, Resource};
 use bevy_ecs::ptr::Ptr;
-use bevy_ecs::query::With;
 use bevy_ecs::schedule::SystemSet;
-use bevy_ecs::system::{Query, ResMut};
+use bevy_ecs::system::{Res, ResMut};
 use bevy_reflect::Reflect;
 use bevy_time::{Fixed, Time};
 use core::any::TypeId;
@@ -349,10 +348,11 @@ impl<T: TimelineConfig> Clone for SyncEvent<T> {
 
 impl<T: TimelineConfig> Copy for SyncEvent<T> {}
 
-/// Marker component inserted on the Link if we are currently in rollback
+/// Application-global marker resource inserted while the simulation is being rolled back.
 ///
-/// This is in `lightyear_core` to avoid circular dependencies. Many other plugins behave differently during rollback
-#[derive(Component, Debug, Clone, Copy)]
+/// This is in `lightyear_core` to avoid circular dependencies. Many other plugins behave
+/// differently during rollback.
+#[derive(Resource, Debug, Clone, Copy)]
 pub enum Rollback {
     /// The rollback is initiated because we have received new Confirmed state from the server
     /// that doesn't match our prediction history.
@@ -364,6 +364,6 @@ pub enum Rollback {
 }
 
 /// Run condition to check if we are in rollback
-pub fn is_in_rollback(client: Query<(), With<Rollback>>) -> bool {
-    client.single().is_ok()
+pub fn is_in_rollback(rollback: Option<Res<Rollback>>) -> bool {
+    rollback.is_some()
 }

--- a/crates/core/lightyear/Cargo.toml
+++ b/crates/core/lightyear/Cargo.toml
@@ -93,6 +93,8 @@ deterministic = [
   "lightyear_avian2d?/deterministic",
   "lightyear_avian3d?/deterministic",
 ]
+## Enables transport-neutral peer-to-peer topology, synchronization, and input routing support.
+p2p = ["client"]
 ## Enables replicating entities between two peers
 replication = [
   "dep:lightyear_replication",

--- a/crates/core/sync/src/client.rs
+++ b/crates/core/sync/src/client.rs
@@ -1,9 +1,8 @@
 /*! Handles syncing the time between the client and the server
 */
 use crate::plugin::TimelineSyncPlugin;
-use crate::prelude::InputTimeline;
 use crate::prelude::client::RemoteTimeline;
-use crate::timeline::input::InputTimelineConfig;
+use crate::timeline::input::{InputTimeline, InputTimelineConfig};
 use crate::timeline::remote;
 use crate::timeline::sync::SyncedTimelinePlugin;
 use bevy_app::prelude::*;
@@ -48,14 +47,21 @@ impl Plugin for ClientPlugin {
             app.add_plugins(TimelineSyncPlugin);
         }
 
-        app.register_required_components::<Client, InputTimelineConfig>();
         app.register_required_components::<Client, RemoteTimeline>();
 
+        // The application has one driving input clock even when it has several network links.
+        app.add_plugins(SyncedTimelinePlugin::<
+            InputTimeline,
+            RemoteTimeline,
+            true,
+            true,
+        >::default());
+
+        // Register these after the resource-backed timeline plugin initializes its default
+        // configuration. `ClientPlugin` can be built before `CorePlugins` installs TickDuration,
+        // while every runtime configuration update, connection, and sync event happens after it.
         app.add_observer(InputTimelineConfig::recompute_input_delay_on_sync);
         app.add_observer(InputTimelineConfig::recompute_input_delay_on_config_update);
-
-        // the client will use the Input timeline as the driving timeline
-        app.add_plugins(SyncedTimelinePlugin::<InputTimeline, RemoteTimeline, true>::default());
 
         // remote timeline
         app.add_plugins(NetworkTimelinePlugin::<RemoteTimeline>::default());
@@ -74,6 +80,7 @@ mod tests {
     use super::*;
     use bevy_time::{TimePlugin, TimeUpdateStrategy};
     use core::time::Duration;
+    use lightyear_connection::network_topology::NetworkingMetadata;
     use lightyear_core::plugin::CorePlugins;
     use lightyear_core::time::TickInstant;
     use lightyear_link::prelude::Linked;
@@ -86,6 +93,7 @@ mod tests {
             .insert_resource(TimeUpdateStrategy::ManualDuration(Duration::from_millis(
                 10,
             )));
+        app.init_resource::<NetworkingMetadata>();
         app.add_plugins((
             TimePlugin,
             CorePlugins {

--- a/crates/core/sync/src/lib.rs
+++ b/crates/core/sync/src/lib.rs
@@ -37,19 +37,25 @@ pub mod prelude {
     pub use crate::ping::manager::{PingConfig, PingManager};
     pub use crate::ping::message::{Ping, Pong};
     pub use crate::plugin::{SyncSystems, TimelineSyncPlugin};
-    pub use crate::timeline::sync::{IsSynced, SyncConfig, SyncedTimelinePlugin};
+    pub use crate::timeline::sync::{
+        IsSynced, P2PTimelineDiverged, SyncConfig, SyncedTimelinePlugin,
+    };
     pub use crate::timeline::{
         DrivingTimeline,
-        input::{InputTimeline, InputTimelineConfig, SyncedInputTimeline},
+        input::{
+            InputTimeline, InputTimelineConfig, PREDICTION_WINDOW_HYSTERESIS_TICKS,
+            PredictionWindowWait, SyncedInputTimeline,
+        },
     };
 
     #[cfg(feature = "client")]
     pub mod client {
         pub use crate::timeline::input::{
-            InputDelayConfig, InputTimeline, InputTimelineConfig, SyncedInputTimeline,
+            InputDelayConfig, InputTimeline, InputTimelineConfig,
+            PREDICTION_WINDOW_HYSTERESIS_TICKS, PredictionWindowWait, SyncedInputTimeline,
         };
         pub use crate::timeline::remote::{RemoteEstimate, RemoteTimeline};
-        pub use crate::timeline::sync::IsSynced;
+        pub use crate::timeline::sync::{IsSynced, P2PTimelineDiverged};
     }
 
     #[cfg(feature = "server")]

--- a/crates/core/sync/src/lib.rs
+++ b/crates/core/sync/src/lib.rs
@@ -37,15 +37,17 @@ pub mod prelude {
     pub use crate::ping::manager::{PingConfig, PingManager};
     pub use crate::ping::message::{Ping, Pong};
     pub use crate::plugin::{SyncSystems, TimelineSyncPlugin};
-    pub use crate::timeline::sync::{IsSynced, SyncConfig};
+    pub use crate::timeline::sync::{IsSynced, SyncConfig, SyncedTimelinePlugin};
     pub use crate::timeline::{
         DrivingTimeline,
-        input::{InputTimeline, InputTimelineConfig},
+        input::{InputTimeline, InputTimelineConfig, SyncedInputTimeline},
     };
 
     #[cfg(feature = "client")]
     pub mod client {
-        pub use crate::timeline::input::{InputDelayConfig, InputTimeline, InputTimelineConfig};
+        pub use crate::timeline::input::{
+            InputDelayConfig, InputTimeline, InputTimelineConfig, SyncedInputTimeline,
+        };
         pub use crate::timeline::remote::{RemoteEstimate, RemoteTimeline};
         pub use crate::timeline::sync::IsSynced;
     }

--- a/crates/core/sync/src/ping/plugin.rs
+++ b/crates/core/sync/src/ping/plugin.rs
@@ -133,10 +133,23 @@ impl PingPlugin {
         )
     }
 
-    /// On connection, reset the PingManager.
-    pub(crate) fn handle_connect(trigger: On<Add, Connected>, mut query: Query<&mut PingManager>) {
+    /// On connection, reset the PingManager and restore its typed receivers.
+    ///
+    /// Disconnection cleanup removes typed receivers so stale messages cannot cross connection
+    /// epochs. They are normally recreated lazily by inbound traffic, but two symmetric raw P2P
+    /// clients would otherwise both wait for the other side to send the first ping. Restoring the
+    /// two protocol-internal receivers here lets either side initiate synchronization.
+    pub(crate) fn handle_connect(
+        trigger: On<Add, Connected>,
+        mut query: Query<&mut PingManager>,
+        mut commands: Commands,
+    ) {
         if let Ok(mut manager) = query.get_mut(trigger.entity) {
             manager.reset();
+            commands
+                .entity(trigger.entity)
+                .insert_if_new(MessageReceiver::<Ping>::default())
+                .insert_if_new(MessageReceiver::<Pong>::default());
         }
     }
 }
@@ -189,6 +202,7 @@ impl Plugin for PingPlugin {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use lightyear_core::id::{PeerId, RemoteId};
     use lightyear_transport::plugin::PacketAcked;
 
     #[test]
@@ -213,5 +227,26 @@ mod tests {
         assert_eq!(manager.pongs_recv, 0);
         assert_eq!(manager.latency_samples_recv(), 0);
         assert_eq!(manager.rtt(), Duration::ZERO);
+    }
+
+    #[test]
+    fn connecting_restores_ping_receivers() {
+        let mut app = App::new();
+        app.add_plugins(PingPlugin);
+
+        let entity = app
+            .world_mut()
+            .spawn((RemoteId(PeerId::Server), PingManager::default()))
+            .id();
+        app.world_mut()
+            .entity_mut(entity)
+            .remove::<(MessageReceiver<Ping>, MessageReceiver<Pong>)>();
+
+        app.world_mut().entity_mut(entity).insert(Connected);
+        app.world_mut().flush();
+
+        let entity = app.world().entity(entity);
+        assert!(entity.contains::<MessageReceiver<Ping>>());
+        assert!(entity.contains::<MessageReceiver<Pong>>());
     }
 }

--- a/crates/core/sync/src/timeline/input.rs
+++ b/crates/core/sync/src/timeline/input.rs
@@ -1,12 +1,17 @@
 use crate::ping::manager::PingManager;
 use crate::timeline::sync::{
-    SyncAdjustment, SyncConfig, SyncContext, SyncTargetTimeline, SyncedTimeline,
+    IsSynced, SyncAdjustment, SyncConfig, SyncContext, SyncTargetTimeline, SyncedTimeline,
 };
 
 use bevy_derive::{Deref, DerefMut};
+use bevy_ecs::change_detection::Tick as ChangeTick;
 use bevy_ecs::prelude::*;
+use bevy_ecs::query::FilteredAccessSet;
+use bevy_ecs::system::{ReadOnlySystemParam, SystemMeta, SystemParam, SystemParamValidationError};
+use bevy_ecs::world::unsafe_world_cell::UnsafeWorldCell;
 use bevy_reflect::Reflect;
-use core::time::Duration;
+use core::{marker::PhantomData, time::Duration};
+use lightyear_connection::network_topology::{NetworkTopology, NetworkingMetadata};
 use lightyear_core::tick::{Tick, TickDuration};
 use lightyear_core::time::{TickDelta, TickInstant};
 use lightyear_core::timeline::{NetworkTimeline, SyncEvent, Timeline, TimelineConfig};
@@ -15,8 +20,7 @@ use tracing::trace;
 
 /// Timeline that is used to make sure that Inputs from this peer will arrive on time
 /// on the remote peer
-#[derive(Debug, Component, Reflect)]
-#[require(InputTimeline)]
+#[derive(Debug, Resource, Reflect)]
 pub struct InputTimelineConfig {
     pub(crate) sync: SyncConfig,
     pub(crate) input_delay_config: InputDelayConfig,
@@ -46,65 +50,62 @@ impl InputTimelineConfig {
     pub fn is_lockstep(&self) -> bool {
         self.input_delay_config.is_lockstep()
     }
-
     /// Maximum number of ticks the local simulation is allowed to predict ahead.
     pub fn maximum_predicted_ticks(&self) -> u16 {
         self.input_delay_config.maximum_predicted_ticks
     }
 
-    /// Update the input delay based on the current RTT and tick duration
-    /// when there is a SyncEvent
+    /// Recompute input delay after the global input timeline snaps by whole ticks.
+    ///
+    /// The [`SyncEvent`] targets the input timeline's resource entity. Link statistics remain on
+    /// the topology-selected client Links and are deliberately selected independently of that
+    /// entity.
     pub(crate) fn recompute_input_delay_on_sync(
-        trigger: On<SyncEvent<InputTimelineConfig>>,
+        _trigger: On<SyncEvent<InputTimelineConfig>>,
         tick_duration: Res<TickDuration>,
-        mut query: Query<(&Link, &mut InputTimeline, &InputTimelineConfig)>,
+        metadata: Res<NetworkingMetadata>,
+        links: Query<&Link>,
+        config: Res<InputTimelineConfig>,
+        mut timeline: ResMut<InputTimeline>,
     ) {
-        if let Ok((link, mut timeline, config)) = query.get_mut(trigger.entity) {
-            let before = timeline.input_delay_ticks;
-            timeline.input_delay_ticks = config.input_delay_config.input_delay_ticks(
-                link.stats,
-                &config.sync,
-                tick_duration.0,
-            );
-            trace!(
-                "Recomputing input delay on sync event! Input delay ticks: {}",
-                timeline.input_delay_ticks
-            );
-            trace!(
-                target: "lightyear_debug::sync",
-                kind = "input_delay_recomputed_on_sync",
-                schedule = "PreUpdate",
-                sample_point = "PreUpdate",
-                entity = ?trigger.entity,
-                tick_delta = trigger.tick_delta,
-                input_delay_ticks_before = before,
-                input_delay_ticks_after = timeline.input_delay_ticks,
-                rtt_ms = link.stats.rtt.as_secs_f64() * 1000.0,
-                "sync event: recomputed input delay"
-            );
+        let before = timeline.input_delay();
+        if !timeline.recompute_input_delay(&config, &metadata.mode, &links, tick_duration.0) {
+            return;
         }
+        trace!(
+            target: "lightyear_debug::sync",
+            kind = "input_delay_recomputed_on_sync",
+            schedule = "PostUpdate",
+            sample_point = "PostUpdate",
+            input_delay_ticks_before = before,
+            input_delay_ticks_after = timeline.input_delay(),
+            topology = ?metadata.mode,
+            "sync event: recomputed global input delay"
+        );
     }
 
-    // TODO: we want to limit this when only the config updates, not the timeline itself!
-    //  disabling this for now
-    /// Update the input delay based on the current RTT and tick duration
-    /// when the InputDelayConfig is updated
+    /// Recompute input delay when the global configuration resource is inserted or replaced.
     pub(crate) fn recompute_input_delay_on_config_update(
-        trigger: On<Insert, InputTimelineConfig>,
+        _trigger: On<Insert, InputTimelineConfig>,
         tick_duration: Res<TickDuration>,
-        mut query: Query<(&Link, &mut InputTimeline, &InputTimelineConfig)>,
+        metadata: Res<NetworkingMetadata>,
+        links: Query<&Link>,
+        config: Res<InputTimelineConfig>,
+        mut timeline: ResMut<InputTimeline>,
     ) {
-        if let Ok((link, mut timeline, config)) = query.get_mut(trigger.entity) {
-            timeline.input_delay_ticks = config.input_delay_config.input_delay_ticks(
-                link.stats,
-                &config.sync,
-                tick_duration.0,
-            );
-            trace!(
-                "Recomputing input delay on config update! Input delay ticks: {}. Config: {:?}",
-                timeline.input_delay_ticks, config.input_delay_config
-            );
+        if !timeline.recompute_input_delay(&config, &metadata.mode, &links, tick_duration.0) {
+            // Configuration is commonly installed before a Client or HostClient connects. The
+            // configured minimum is topology-independent; the first SyncEvent will replace it
+            // with the latency-aware aggregate once the relevant Links are ready.
+            timeline.context.input_delay_ticks =
+                config.input_delay_config.minimum_input_delay_ticks;
         }
+        trace!(
+            input_delay_ticks = timeline.input_delay(),
+            config = ?config.input_delay_config,
+            topology = ?metadata.mode,
+            "recomputed global input delay after config update"
+        );
     }
 }
 
@@ -264,16 +265,163 @@ impl InputDelayConfig {
     }
 }
 
-/// Timeline that is used to keep track of when the client should buffer inputs.
+/// Application-global timeline used to decide which tick should receive locally buffered input.
 ///
-/// This timeline is synced with the server timeline, and is the main driving timeline:
+/// This timeline is synced with a remote target timeline, and is the main driving timeline:
 /// any speed adjustments applied to this timeline will also be applied to the `Time<Virtual>` timeline.
 /// (and will therefore affect how fast the FixedUpdate loop runs, and how ticks are incremented)
 ///
 /// This timeline is updated in PostUpdate; it CANNOT be used to get accurate `tick` in PreUpdate or Update;
 /// use `LocalTimeline` instead.
-#[derive(Component, Deref, DerefMut, Default, Debug, Reflect)]
+#[derive(Resource, Deref, DerefMut, Default, Debug, Reflect)]
 pub struct InputTimeline(pub Timeline<InputTimelineConfig>);
+
+/// Read-only access to the global [`InputTimeline`] after it has synchronized.
+///
+/// Systems using this parameter are skipped until [`IsSynced<InputTimeline>`] has been inserted on
+/// the resource entity. The timeline itself uses [`Res`]'s cached resource lookup; readiness is
+/// then checked directly on that entity instead of scanning for a unique matching component.
+pub struct SyncedInputTimeline<'w, 's> {
+    timeline: Res<'w, InputTimeline>,
+    marker: PhantomData<&'s ()>,
+}
+
+impl core::ops::Deref for SyncedInputTimeline<'_, '_> {
+    type Target = InputTimeline;
+
+    fn deref(&self) -> &Self::Target {
+        &self.timeline
+    }
+}
+
+type InputTimelineMarkerQuery<'w, 's> = Query<'w, 's, (), With<IsSynced<InputTimeline>>>;
+
+// SAFETY: Both delegated parameters are read-only. `Res<InputTimeline>` registers the timeline
+// resource access, while the marker query registers access to `IsSynced<InputTimeline>` before
+// `get_param` uses it to inspect the resource entity.
+unsafe impl SystemParam for SyncedInputTimeline<'_, '_> {
+    type State = (
+        <Res<'static, InputTimeline> as SystemParam>::State,
+        <InputTimelineMarkerQuery<'static, 'static> as SystemParam>::State,
+    );
+    type Item<'world, 'state> = SyncedInputTimeline<'world, 'state>;
+
+    fn init_state(world: &mut World) -> Self::State {
+        (
+            <Res<'static, InputTimeline> as SystemParam>::init_state(world),
+            <InputTimelineMarkerQuery<'static, 'static> as SystemParam>::init_state(world),
+        )
+    }
+
+    fn init_access(
+        state: &Self::State,
+        system_meta: &mut SystemMeta,
+        component_access_set: &mut FilteredAccessSet,
+        world: &mut World,
+    ) {
+        <Res<'static, InputTimeline> as SystemParam>::init_access(
+            &state.0,
+            system_meta,
+            component_access_set,
+            world,
+        );
+        <InputTimelineMarkerQuery<'static, 'static> as SystemParam>::init_access(
+            &state.1,
+            system_meta,
+            component_access_set,
+            world,
+        );
+    }
+
+    #[inline]
+    unsafe fn get_param<'world, 'state>(
+        state: &'state mut Self::State,
+        system_meta: &SystemMeta,
+        world: UnsafeWorldCell<'world>,
+        change_tick: ChangeTick,
+    ) -> Result<Self::Item<'world, 'state>, SystemParamValidationError> {
+        // SAFETY: `init_access` delegated to `Res<InputTimeline>`, and the caller guarantees that
+        // this is the same World used by `init_state`.
+        let timeline = unsafe {
+            <Res<'static, InputTimeline> as SystemParam>::get_param(
+                &mut state.0,
+                system_meta,
+                world,
+                change_tick,
+            )
+        }?;
+        // SAFETY: The resource cache is metadata read through a read-only World cell. `state.0` is
+        // the cached ComponentId registered by `Res<InputTimeline>`.
+        let resource_entity = unsafe { world.resource_entities() }
+            .get(state.0)
+            .ok_or_else(|| {
+                SystemParamValidationError::invalid::<Self>(
+                    "InputTimeline resource entity does not exist",
+                )
+            })?;
+        // SAFETY: `init_access` delegated to the read-only marker query, and the caller guarantees
+        // that this is the same World used by `init_state`.
+        let marker_query = unsafe {
+            <InputTimelineMarkerQuery<'static, 'static> as SystemParam>::get_param(
+                &mut state.1,
+                system_meta,
+                world,
+                change_tick,
+            )
+        }?;
+        if marker_query.get(resource_entity).is_err() {
+            return Err(SystemParamValidationError::skipped::<Self>(
+                "InputTimeline is not synchronized",
+            ));
+        }
+        Ok(SyncedInputTimeline {
+            timeline,
+            marker: PhantomData,
+        })
+    }
+}
+
+// SAFETY: `SyncedInputTimeline` only delegates to read-only system parameters.
+unsafe impl ReadOnlySystemParam for SyncedInputTimeline<'_, '_> {}
+
+impl InputTimeline {
+    /// Recompute the global input delay from the Links selected by the current topology.
+    ///
+    /// Conventional modes use their sole client Link. P2P uses the maximum required delay across
+    /// all connected peer Links so that one tick-indexed local input stream is safe for every peer.
+    /// Returns `false` when the topology has no complete set of ready Link statistics.
+    pub(crate) fn recompute_input_delay(
+        &mut self,
+        config: &InputTimelineConfig,
+        topology: &NetworkTopology,
+        links: &Query<&Link>,
+        tick_duration: Duration,
+    ) -> bool {
+        let delay_for = |entity| {
+            links.get(entity).ok().map(|link| {
+                config
+                    .input_delay_config
+                    .input_delay_ticks(link.stats, &config.sync, tick_duration)
+            })
+        };
+        let input_delay_ticks = match topology {
+            NetworkTopology::Client(entity) => delay_for(*entity),
+            NetworkTopology::HostClient { client, .. } => delay_for(*client),
+            NetworkTopology::P2P { connected, .. } if !connected.is_empty() => connected
+                .iter()
+                .try_fold(0, |maximum, entity| Some(maximum.max(delay_for(*entity)?))),
+            NetworkTopology::Undefined
+            | NetworkTopology::Server(_)
+            | NetworkTopology::P2P { .. }
+            | NetworkTopology::Invalid(_) => None,
+        };
+        let Some(input_delay_ticks) = input_delay_ticks else {
+            return false;
+        };
+        self.context.input_delay_ticks = input_delay_ticks;
+        true
+    }
+}
 
 impl TimelineConfig for InputTimelineConfig {
     type Context = InputContext;
@@ -416,6 +564,7 @@ impl SyncedTimeline for InputTimeline {
 mod tests {
     use super::*;
     use crate::timeline::remote::RemoteTimeline;
+    use bevy_app::{App, Update};
     use bevy_utils::default;
     use lightyear_core::timeline::NetworkTimeline;
 
@@ -425,6 +574,38 @@ mod tests {
             error < 0.001,
             "expected {expected:?}, got {actual:?}, error {error}"
         );
+    }
+
+    #[derive(Resource, Default)]
+    struct SyncedParamRuns(u8);
+
+    #[test]
+    fn synced_input_timeline_checks_the_resource_entity_marker() {
+        fn require_synced_timeline(
+            _timeline: SyncedInputTimeline,
+            mut runs: ResMut<SyncedParamRuns>,
+        ) {
+            runs.0 += 1;
+        }
+
+        let mut app = App::new();
+        app.init_resource::<InputTimeline>();
+        app.init_resource::<SyncedParamRuns>();
+        app.add_systems(Update, require_synced_timeline);
+
+        // A marker on an arbitrary entity must not make the resource available as synchronized.
+        app.world_mut().spawn(IsSynced::<InputTimeline>::default());
+        app.update();
+        assert_eq!(app.world().resource::<SyncedParamRuns>().0, 0);
+
+        let timeline_id = app.world().component_id::<InputTimeline>().unwrap();
+        let timeline_entity = app.world().resource_entities().get(timeline_id).unwrap();
+        app.world_mut()
+            .entity_mut(timeline_entity)
+            .insert(IsSynced::<InputTimeline>::default());
+
+        app.update();
+        assert_eq!(app.world().resource::<SyncedParamRuns>().0, 1);
     }
 
     #[test]
@@ -532,6 +713,52 @@ mod tests {
              PreUpdate and advancing in FixedFirst, so the packet must contain \
              input for at least {required_input_tick:?} (= remote + 1).",
         );
+    }
+
+    #[test]
+    fn p2p_input_delay_uses_maximum_across_links() {
+        let mut app = App::new();
+        let mut fast_link = Link::default();
+        fast_link.stats.rtt = Duration::from_millis(10);
+        let fast = app.world_mut().spawn(fast_link).id();
+        let mut slow_link = Link::default();
+        slow_link.stats.rtt = Duration::from_millis(50);
+        let slow = app.world_mut().spawn(slow_link).id();
+
+        let mut metadata = NetworkingMetadata::default();
+        metadata.mode = NetworkTopology::P2P {
+            connected: [fast, slow].into_iter().collect(),
+            declared_links: 2,
+        };
+        app.insert_resource(metadata);
+        app.insert_resource(TickDuration(Duration::from_millis(10)));
+        let mut config =
+            InputTimelineConfig::default().with_input_delay(InputDelayConfig::balanced());
+        config.sync.jitter_multiple = 0;
+        config.sync.jitter_margin = 0.0;
+        app.insert_resource(config);
+        app.init_resource::<InputTimeline>();
+        app.add_systems(
+            Update,
+            |mut timeline: ResMut<InputTimeline>,
+             config: Res<InputTimelineConfig>,
+             metadata: Res<NetworkingMetadata>,
+             links: Query<&Link>,
+             tick_duration: Res<TickDuration>| {
+                assert!(timeline.recompute_input_delay(
+                    &config,
+                    &metadata.mode,
+                    &links,
+                    tick_duration.0,
+                ));
+            },
+        );
+
+        app.update();
+
+        // The 10ms Link needs one delayed tick, while the 50ms Link reaches the balanced
+        // configuration's three-tick pre-prediction cap. The global delay must satisfy both.
+        assert_eq!(app.world().resource::<InputTimeline>().input_delay(), 3);
     }
 
     #[test]

--- a/crates/core/sync/src/timeline/input.rs
+++ b/crates/core/sync/src/timeline/input.rs
@@ -50,7 +50,8 @@ impl InputTimelineConfig {
     pub fn is_lockstep(&self) -> bool {
         self.input_delay_config.is_lockstep()
     }
-    /// Maximum number of ticks the local simulation is allowed to predict ahead.
+    /// Maximum number of ticks the local simulation may predict beyond confirmed remote input.
+    #[inline]
     pub fn maximum_predicted_ticks(&self) -> u16 {
         self.input_delay_config.maximum_predicted_ticks
     }
@@ -106,6 +107,122 @@ impl InputTimelineConfig {
             topology = ?metadata.mode,
             "recomputed global input delay after config update"
         );
+    }
+}
+
+/// Number of confirmed-input ticks that must be recovered before a prediction-window wait ends.
+///
+/// Waiting at the exact prediction limit and immediately resuming after one newly confirmed tick
+/// would alternate between running and waiting every fixed tick. Requiring two ticks of headroom
+/// lets the simulation make useful progress after it resumes.
+pub const PREDICTION_WINDOW_HYSTERESIS_TICKS: u16 = 2;
+
+/// Application-global signal that stops deterministic simulation at its safe prediction limit.
+///
+/// Deterministic replication updates this resource from the minimum confirmed-input frontier
+/// across all remote players and registered input types. The driving timeline synchronization
+/// system reads it when applying its speed to `Time<Virtual>`: while waiting, virtual time receives
+/// an effective relative speed of zero, but the timeline's phase-controller speed is preserved.
+///
+/// This signal is deliberately specific to confirmed-input availability. P2P phase lead continues
+/// to use the normal timeline slowdown controller and does not request a hard wait.
+#[derive(Resource, Debug, Clone, Copy, Reflect)]
+pub struct PredictionWindowWait {
+    waiting: bool,
+    origin_tick: Option<Tick>,
+    current_tick: Tick,
+    confirmed_tick: Option<Tick>,
+    prediction_depth: i32,
+    maximum_predicted_ticks: u16,
+}
+
+impl Default for PredictionWindowWait {
+    fn default() -> Self {
+        Self {
+            waiting: false,
+            origin_tick: None,
+            current_tick: Tick(0),
+            confirmed_tick: None,
+            prediction_depth: 0,
+            maximum_predicted_ticks: 0,
+        }
+    }
+}
+
+impl PredictionWindowWait {
+    /// Returns whether deterministic simulation must currently wait for remote input.
+    #[inline]
+    pub fn is_waiting(&self) -> bool {
+        self.waiting
+    }
+
+    /// Current local lead over the global confirmed-input frontier, in ticks.
+    ///
+    /// This can be negative when input delay has provided confirmed remote input for future ticks.
+    #[inline]
+    pub fn prediction_depth(&self) -> i32 {
+        self.prediction_depth
+    }
+
+    /// Latest global confirmed-input frontier used by the wait decision.
+    #[inline]
+    pub fn confirmed_tick(&self) -> Option<Tick> {
+        self.confirmed_tick
+    }
+
+    /// Effective prediction limit used by the wait decision.
+    #[inline]
+    pub fn maximum_predicted_ticks(&self) -> u16 {
+        self.maximum_predicted_ticks
+    }
+
+    /// Clear all state when there is no active deterministic input session.
+    pub fn reset(&mut self) {
+        *self = Self::default();
+    }
+
+    /// Update the wait decision from the current and globally confirmed input ticks.
+    ///
+    /// `maximum_predicted_ticks` must already account for the rollback-history bound. The method
+    /// starts waiting when another fixed tick would exceed that bound, and resumes only after
+    /// [`PREDICTION_WINDOW_HYSTERESIS_TICKS`] ticks of headroom have been recovered.
+    ///
+    /// Before any remote input exists, the first observed local tick becomes the session origin.
+    /// One initial fixed tick is allowed so the fixed input pipeline can capture and send its first
+    /// sample even for a zero-sized prediction window.
+    ///
+    /// Returns `true` when the waiting state changed.
+    pub fn update(
+        &mut self,
+        current_tick: Tick,
+        confirmed_tick: Option<Tick>,
+        maximum_predicted_ticks: u16,
+    ) -> bool {
+        let origin_tick = *self.origin_tick.get_or_insert(current_tick);
+        let frontier = confirmed_tick.unwrap_or(origin_tick);
+        let prediction_depth = current_tick - frontier;
+        let maximum = i32::from(maximum_predicted_ticks);
+        // A window smaller than the preferred hysteresis cannot require future input beyond the
+        // current tick: if every peer waited there, no one could capture that future input. Fall
+        // back to resuming at zero prediction depth for those small windows.
+        let resume_at =
+            i32::from(maximum_predicted_ticks.saturating_sub(PREDICTION_WINDOW_HYSTERESIS_TICKS));
+
+        let waiting = if confirmed_tick.is_none() && current_tick == origin_tick {
+            false
+        } else if self.waiting {
+            prediction_depth > resume_at
+        } else {
+            prediction_depth >= maximum
+        };
+        let changed = waiting != self.waiting;
+
+        self.waiting = waiting;
+        self.current_tick = current_tick;
+        self.confirmed_tick = confirmed_tick;
+        self.prediction_depth = prediction_depth;
+        self.maximum_predicted_ticks = maximum_predicted_ticks;
+        changed
     }
 }
 
@@ -508,7 +625,7 @@ impl SyncedTimeline for InputTimeline {
         let adjustment = if !self.is_synced {
             SyncAdjustment::Resync
         } else {
-            self.sync.speed_adjustment(&config.sync, error_ticks)
+            self.speed_adjustment(config, error_ticks)
         };
         trace!(
             ?now,
@@ -524,19 +641,25 @@ impl SyncedTimeline for InputTimeline {
             SyncAdjustment::Resync => {
                 return Some(self.resync(objective));
             }
-            SyncAdjustment::SpeedAdjust(ratio) => {
-                self.set_relative_speed(ratio);
-            }
-            SyncAdjustment::DoNothing => {
-                // within acceptable margins, gradually return to normal speed (1.0)
-                let current = self.relative_speed();
-                if (current - 1.0).abs() > 0.001 {
-                    let new_speed = current + (1.0 - current) * 0.1;
-                    self.set_relative_speed(new_speed);
-                }
-            }
+            SyncAdjustment::SpeedAdjust(_) | SyncAdjustment::DoNothing => {}
         }
         None
+    }
+
+    fn speed_adjustment(&mut self, config: &Self::Config, offset: f32) -> SyncAdjustment {
+        let adjustment = self.sync.speed_adjustment(&config.sync, offset);
+        match adjustment {
+            SyncAdjustment::SpeedAdjust(ratio) => self.set_relative_speed(ratio),
+            SyncAdjustment::DoNothing => {
+                // Within acceptable margins, gradually return to normal speed.
+                let current = self.relative_speed();
+                if (current - 1.0).abs() > 0.001 {
+                    self.set_relative_speed(current + (1.0 - current) * 0.1);
+                }
+            }
+            SyncAdjustment::Resync => {}
+        }
+        adjustment
     }
 
     fn is_synced(&self) -> bool {
@@ -553,6 +676,7 @@ impl SyncedTimeline for InputTimeline {
 
     fn reset(&mut self) {
         trace!("Resetting InputTimeline");
+        self.sync = SyncContext::default();
         self.is_synced = false;
         self.relative_speed = 1.0;
         self.now = Default::default();
@@ -578,6 +702,44 @@ mod tests {
 
     #[derive(Resource, Default)]
     struct SyncedParamRuns(u8);
+
+    #[test]
+    fn prediction_window_wait_uses_hysteresis() {
+        let mut wait = PredictionWindowWait::default();
+
+        assert!(!wait.update(Tick(100), None, 4));
+        assert!(!wait.is_waiting());
+        assert_eq!(wait.prediction_depth(), 0);
+
+        assert!(wait.update(Tick(104), None, 4));
+        assert!(wait.is_waiting());
+        assert_eq!(wait.prediction_depth(), 4);
+
+        // One newly confirmed tick is not enough to resume and immediately hit the limit again.
+        assert!(!wait.update(Tick(104), Some(Tick(101)), 4));
+        assert!(wait.is_waiting());
+
+        // Two ticks of recovered headroom release the wait.
+        assert!(wait.update(Tick(104), Some(Tick(102)), 4));
+        assert!(!wait.is_waiting());
+        assert_eq!(wait.prediction_depth(), 2);
+    }
+
+    #[test]
+    fn zero_prediction_window_can_bootstrap_then_wait_for_future_input() {
+        let mut wait = PredictionWindowWait::default();
+
+        // The first fixed tick is allowed to capture and send the initial local input sample.
+        assert!(!wait.update(Tick(20), None, 0));
+        assert!(wait.update(Tick(21), None, 0));
+        assert!(wait.is_waiting());
+
+        // A zero-sized window cannot require future input beyond the current tick, or every peer
+        // could wait forever. Confirming the current tick releases this degenerate case.
+        assert!(wait.update(Tick(21), Some(Tick(21)), 0));
+        assert!(!wait.is_waiting());
+        assert_eq!(wait.prediction_depth(), 0);
+    }
 
     #[test]
     fn synced_input_timeline_checks_the_resource_entity_marker() {

--- a/crates/core/sync/src/timeline/remote.rs
+++ b/crates/core/sync/src/timeline/remote.rs
@@ -252,8 +252,12 @@ pub(crate) fn update_remote_timeline(
 pub(crate) fn advance_remote_timeline(
     fixed_time: Res<Time<Real>>,
     tick_duration: Res<TickDuration>,
-    mut query: Query<&mut RemoteTimeline, (With<Linked>, Without<Rollback>)>,
+    rollback: Option<Res<Rollback>>,
+    mut query: Query<&mut RemoteTimeline, With<Linked>>,
 ) {
+    if rollback.is_some() {
+        return;
+    }
     let delta = fixed_time.delta();
     query.iter_mut().for_each(|mut t| {
         t.apply_duration(delta, tick_duration.0);

--- a/crates/core/sync/src/timeline/remote.rs
+++ b/crates/core/sync/src/timeline/remote.rs
@@ -278,6 +278,10 @@ impl SyncTargetTimeline for RemoteTimeline {
         self.now + self.offset
     }
 
+    fn is_initialized(&self) -> bool {
+        self.last_received_tick.is_some()
+    }
+
     fn received_packet(&self) -> bool {
         self.received_packet
     }

--- a/crates/core/sync/src/timeline/sync.rs
+++ b/crates/core/sync/src/timeline/sync.rs
@@ -2,12 +2,15 @@ use crate::ping::manager::PingManager;
 use crate::plugin::SyncSystems;
 use bevy_app::{App, Last, Plugin, PostUpdate};
 use bevy_ecs::prelude::*;
+use bevy_ecs::resource::IsResource;
 use bevy_reflect::Reflect;
 use bevy_time::{Fixed, Time, Virtual};
 use bevy_utils::prelude::DebugName;
 use core::time::Duration;
-use lightyear_connection::client::{Connected, Disconnected};
+use lightyear_connection::client::{Client, Connected, Disconnected};
 use lightyear_connection::host::HostClient;
+use lightyear_connection::network_topology::{NetworkTopology, NetworkingMetadata};
+use lightyear_connection::p2p::P2P;
 use lightyear_core::prelude::{LocalTimeline, NetworkTimelinePlugin};
 use lightyear_core::tick::TickDuration;
 use lightyear_core::time::{Overstep, TickInstant};
@@ -205,217 +208,183 @@ impl SyncContext {
     }
 }
 
-/// Plugin to sync the Synced timeline to the Remote timeline
+/// Plugin to synchronize one timeline with a remote timeline.
 ///
-/// The const generic is used to indicate if the timeline is driving/updating the [`Time<Virtual>`] and [`LocalTimeline`].
-pub struct SyncedTimelinePlugin<Synced, Remote, const DRIVING: bool = false> {
+/// `DRIVING` indicates whether the synchronized timeline drives [`Time<Virtual>`] and
+/// [`LocalTimeline`]. `RESOURCE` selects whether the synchronized timeline and its configuration
+/// are application-global resources or components on each remote link.
+pub struct SyncedTimelinePlugin<
+    Synced,
+    Remote,
+    const DRIVING: bool = false,
+    const RESOURCE: bool = false,
+> {
     pub(crate) _marker: core::marker::PhantomData<(Synced, Remote)>,
 }
 
-impl<Synced: SyncedTimeline, Remote: SyncTargetTimeline, const DRIVING: bool>
-    SyncedTimelinePlugin<Synced, Remote, DRIVING>
+impl<Synced: SyncedTimeline, Remote: SyncTargetTimeline, const DRIVING: bool, const RESOURCE: bool>
+    SyncedTimelinePlugin<Synced, Remote, DRIVING, RESOURCE>
 {
-    /// On connection, reset the Synced timeline.
-    pub(crate) fn handle_connect(
-        trigger: On<Add, Connected>,
-        local_timeline: Res<LocalTimeline>,
-        mut query: Query<&mut Synced>,
-    ) {
-        let local_tick = local_timeline.tick();
-        if let Ok(mut timeline) = query.get_mut(trigger.entity) {
-            timeline.reset();
-            if DRIVING {
-                trace!("Set Driving timeline tick to LocalTimeline");
-                let delta = local_tick - timeline.tick();
-                timeline.apply_delta(delta.into());
-            }
+    /// Reset a timeline when its session starts and align a driving timeline with local time.
+    fn reset_timeline(timeline: &mut Synced, local_timeline: &LocalTimeline) {
+        timeline.reset();
+        if DRIVING {
+            trace!("Set Driving timeline tick to LocalTimeline");
+            let delta = local_timeline.tick() - timeline.tick();
+            timeline.apply_delta(delta.into());
         }
     }
 
-    /// For HostClient, we directly set IsSynced on connection (since there is no messages exchanged) and the
-    /// Synced timeline is always the same as the Remote timeline
-    pub(crate) fn handle_host_client(trigger: On<Add, HostClient>, mut commands: Commands) {
-        commands
-            .entity(trigger.entity)
-            .insert(IsSynced::<Synced>::default());
-    }
-
-    /// On disconnection, remove IsSynced.
-    pub(crate) fn handle_disconnect(trigger: On<Add, Disconnected>, mut commands: Commands) {
-        commands.entity(trigger.entity).remove::<IsSynced<Synced>>();
-    }
-
-    /// Synchronize the driving timeline's phase with the local simulation phase
-    /// derived from [`LocalTimeline`] and [`Time<Fixed>`].
-    ///
-    /// This runs once per frame before `sync_timelines` for driving timelines.
-    pub(crate) fn sync_from_local_timeline(
-        local_timeline: Res<LocalTimeline>,
-        fixed_time: Res<Time<Fixed>>,
-        mut query: Query<&mut Synced>,
+    /// Copy the application's current fixed-update phase into a driving timeline.
+    fn sync_from_local(
+        synced: &mut Synced,
+        local_timeline: &LocalTimeline,
+        fixed_time: &Time<Fixed>,
     ) {
         let local_tick = local_timeline.tick();
         let overstep = fixed_time.overstep_fraction();
-        query.iter_mut().for_each(|mut synced| {
-            // Desired phase: LocalTimeline.tick + Time<Fixed> overstep.
-            synced.set_now(TickInstant::from_tick_and_overstep(
-                local_tick,
-                Overstep::from_f32(overstep),
-            ));
-            trace!(
-                target: "lightyear_debug::timeline",
-                kind = "sync_from_local_timeline",
-                schedule = "PostUpdate",
-                sample_point = "PostUpdate",
-                timeline = ?DebugName::type_name::<Synced>(),
-                local_tick = local_tick.0,
-                timeline_tick = synced.tick().0,
-                overstep,
-                "driving timeline synced from LocalTimeline"
-            );
-        });
+        synced.set_now(TickInstant::from_tick_and_overstep(
+            local_tick,
+            Overstep::from_f32(overstep),
+        ));
+        trace!(
+            target: "lightyear_debug::timeline",
+            kind = "sync_from_local_timeline",
+            schedule = "PostUpdate",
+            sample_point = "PostUpdate",
+            timeline = ?DebugName::type_name::<Synced>(),
+            local_tick = local_tick.0,
+            timeline_tick = synced.tick().0,
+            overstep,
+            "driving timeline synced from LocalTimeline"
+        );
     }
 
-    pub(crate) fn update_virtual_time(
-        mut virtual_time: ResMut<Time<Virtual>>,
-        query: Query<&Synced, (With<IsSynced<Synced>>, With<Connected>, Without<HostClient>)>,
+    /// Apply a synchronized timeline's speed correction to Bevy virtual time.
+    fn apply_relative_speed(timeline: &Synced, virtual_time: &mut Time<Virtual>) {
+        trace!(
+            "Timeline {} sets the virtual time relative speed to {}",
+            DebugName::type_name::<Synced>(),
+            timeline.relative_speed()
+        );
+        trace!(
+            target: "lightyear_debug::sync",
+            kind = "relative_speed",
+            schedule = "Last",
+            sample_point = "Last",
+            timeline = ?DebugName::type_name::<Synced>(),
+            tick = timeline.tick().0,
+            relative_speed = timeline.relative_speed(),
+            "timeline relative speed applied to Virtual time"
+        );
+        // TODO: be able to apply the speed_ratio on top of any speed ratio already applied by the user.
+        virtual_time.set_relative_speed(timeline.relative_speed());
+    }
+
+    /// Synchronize one timeline and emit a [`SyncEvent`] if it snaps by whole ticks.
+    fn sync_timeline(
+        entity: Entity,
+        sync_timeline: &mut Synced,
+        config: &Synced::Config,
+        main_timeline: &Remote,
+        ping_manager: &PingManager,
+        has_is_synced: bool,
+        tick_duration: &TickDuration,
+        commands: &mut Commands,
     ) {
-        if let Ok(timeline) = query.single() {
-            trace!(
-                "Timeline {} sets the virtual time relative speed to {}",
-                DebugName::type_name::<Synced>(),
-                timeline.relative_speed()
-            );
+        trace!(
+            ?entity,
+            ?has_is_synced,
+            "In SyncTimelines from {:?} to {:?}",
+            DebugName::type_name::<Synced>(),
+            DebugName::type_name::<Remote>()
+        );
+        // return early if the remote timeline hasn't received any packets
+        if !main_timeline.received_packet() {
             trace!(
                 target: "lightyear_debug::sync",
-                kind = "relative_speed",
-                schedule = "Last",
-                sample_point = "Last",
+                kind = "sync_skipped_no_packet",
+                schedule = "PostUpdate",
+                sample_point = "PostUpdate",
+                entity = ?entity,
                 timeline = ?DebugName::type_name::<Synced>(),
-                tick = timeline.tick().0,
-                relative_speed = timeline.relative_speed(),
-                "timeline relative speed applied to Virtual time"
+                remote_timeline = ?DebugName::type_name::<Remote>(),
+                timeline_tick = sync_timeline.tick().0,
+                "sync skipped because remote timeline received no packet"
             );
-            // TODO: be able to apply the speed_ratio on top of any speed ratio already applied by the user.
-            virtual_time.set_relative_speed(timeline.relative_speed());
+            return;
+        }
+        if !has_is_synced && sync_timeline.is_synced() {
+            debug!(
+                "Timeline {:?} is synced to {:?}",
+                DebugName::type_name::<Synced>(),
+                DebugName::type_name::<Remote>()
+            );
+            commands
+                .entity(entity)
+                .insert(IsSynced::<Synced>::default());
+            trace!(
+                target: "lightyear_debug::sync",
+                kind = "timeline_synced",
+                schedule = "PostUpdate",
+                sample_point = "PostUpdate",
+                entity = ?entity,
+                timeline = ?DebugName::type_name::<Synced>(),
+                remote_timeline = ?DebugName::type_name::<Remote>(),
+                timeline_tick = sync_timeline.tick().0,
+                "timeline marked synced"
+            );
+        }
+        let before_now = sync_timeline.now();
+        let remote_estimate = main_timeline.current_estimate();
+        if let Some(tick_delta) =
+            sync_timeline.sync(main_timeline, config, ping_manager, tick_duration.0)
+        {
+            trace!(
+                target: "lightyear_debug::sync",
+                kind = "sync_adjustment",
+                schedule = "PostUpdate",
+                sample_point = "PostUpdate",
+                entity = ?entity,
+                timeline = ?DebugName::type_name::<Synced>(),
+                remote_timeline = ?DebugName::type_name::<Remote>(),
+                timeline_tick = sync_timeline.tick().0,
+                remote_tick = main_timeline.tick().0,
+                before = ?before_now,
+                after = ?sync_timeline.now(),
+                remote_estimate = ?remote_estimate,
+                tick_delta,
+                relative_speed = sync_timeline.relative_speed(),
+                rtt_ms = ping_manager.rtt().as_secs_f64() * 1000.0,
+                jitter_ms = ping_manager.jitter().as_secs_f64() * 1000.0,
+                "timeline sync emitted SyncEvent"
+            );
+            // if it's the driving pipeline, also update the LocalTimeline in `handle_sync_event`
+            commands.trigger(SyncEvent::<Synced::Config>::new(entity, tick_delta));
+        } else {
+            trace!(
+                target: "lightyear_debug::sync",
+                kind = "sync_sample",
+                schedule = "PostUpdate",
+                sample_point = "PostUpdate",
+                entity = ?entity,
+                timeline = ?DebugName::type_name::<Synced>(),
+                remote_timeline = ?DebugName::type_name::<Remote>(),
+                timeline_tick = sync_timeline.tick().0,
+                remote_tick = main_timeline.tick().0,
+                before = ?before_now,
+                after = ?sync_timeline.now(),
+                remote_estimate = ?remote_estimate,
+                relative_speed = sync_timeline.relative_speed(),
+                rtt_ms = ping_manager.rtt().as_secs_f64() * 1000.0,
+                jitter_ms = ping_manager.jitter().as_secs_f64() * 1000.0,
+                "timeline sync sampled"
+            );
         }
     }
 
-    /// Sync timeline T to timeline [`RemoteTimeline`](super::remote::RemoteTimeline) by either
-    /// - speeding up/slowing down the timeline T to match timeline Remote
-    /// - emitting a [`SyncEvent<T>`]
-    pub(crate) fn sync_timelines(
-        tick_duration: Res<TickDuration>,
-        mut commands: Commands,
-        mut query: Query<
-            (
-                Entity,
-                &mut Synced,
-                &Synced::Config,
-                &Remote,
-                &PingManager,
-                Has<IsSynced<Synced>>,
-            ),
-            (With<Connected>, Without<HostClient>),
-        >,
-    ) {
-        // TODO: return early if we haven't received any remote packets? (nothing to sync to)
-        query.iter_mut().for_each(
-            |(entity, mut sync_timeline, config, main_timeline, ping_manager, has_is_synced)| {
-                trace!(
-                    ?entity,
-                    ?has_is_synced,
-                    "In SyncTimelines from {:?} to {:?}",
-                    DebugName::type_name::<Synced>(),
-                    DebugName::type_name::<Remote>()
-                );
-                // return early if the remote timeline hasn't received any packets
-                if !main_timeline.received_packet() {
-                    trace!(
-                        target: "lightyear_debug::sync",
-                        kind = "sync_skipped_no_packet",
-                        schedule = "PostUpdate",
-                        sample_point = "PostUpdate",
-                        entity = ?entity,
-                        timeline = ?DebugName::type_name::<Synced>(),
-                        remote_timeline = ?DebugName::type_name::<Remote>(),
-                        timeline_tick = sync_timeline.tick().0,
-                        "sync skipped because remote timeline received no packet"
-                    );
-                    return;
-                }
-                if !has_is_synced && sync_timeline.is_synced() {
-                    debug!(
-                        "Timeline {:?} is synced to {:?}",
-                        DebugName::type_name::<Synced>(),
-                        DebugName::type_name::<Remote>()
-                    );
-                    commands
-                        .entity(entity)
-                        .insert(IsSynced::<Synced>::default());
-                    trace!(
-                        target: "lightyear_debug::sync",
-                        kind = "timeline_synced",
-                        schedule = "PostUpdate",
-                        sample_point = "PostUpdate",
-                        entity = ?entity,
-                        timeline = ?DebugName::type_name::<Synced>(),
-                        remote_timeline = ?DebugName::type_name::<Remote>(),
-                        timeline_tick = sync_timeline.tick().0,
-                        "timeline marked synced"
-                    );
-                }
-                let before_now = sync_timeline.now();
-                let remote_estimate = main_timeline.current_estimate();
-                if let Some(tick_delta) =
-                    sync_timeline.sync(main_timeline, config, ping_manager, tick_duration.0)
-                {
-                    trace!(
-                        target: "lightyear_debug::sync",
-                        kind = "sync_adjustment",
-                        schedule = "PostUpdate",
-                        sample_point = "PostUpdate",
-                        entity = ?entity,
-                        timeline = ?DebugName::type_name::<Synced>(),
-                        remote_timeline = ?DebugName::type_name::<Remote>(),
-                        timeline_tick = sync_timeline.tick().0,
-                        remote_tick = main_timeline.tick().0,
-                        before = ?before_now,
-                        after = ?sync_timeline.now(),
-                        remote_estimate = ?remote_estimate,
-                        tick_delta,
-                        relative_speed = sync_timeline.relative_speed(),
-                        rtt_ms = ping_manager.rtt().as_secs_f64() * 1000.0,
-                        jitter_ms = ping_manager.jitter().as_secs_f64() * 1000.0,
-                        "timeline sync emitted SyncEvent"
-                    );
-                    // if it's the driving pipeline, also update the LocalTimeline in `handle_sync_event`
-                    commands.trigger(SyncEvent::<Synced::Config>::new(entity, tick_delta));
-                } else {
-                    trace!(
-                        target: "lightyear_debug::sync",
-                        kind = "sync_sample",
-                        schedule = "PostUpdate",
-                        sample_point = "PostUpdate",
-                        entity = ?entity,
-                        timeline = ?DebugName::type_name::<Synced>(),
-                        remote_timeline = ?DebugName::type_name::<Remote>(),
-                        timeline_tick = sync_timeline.tick().0,
-                        remote_tick = main_timeline.tick().0,
-                        before = ?before_now,
-                        after = ?sync_timeline.now(),
-                        remote_estimate = ?remote_estimate,
-                        relative_speed = sync_timeline.relative_speed(),
-                        rtt_ms = ping_manager.rtt().as_secs_f64() * 1000.0,
-                        jitter_ms = ping_manager.jitter().as_secs_f64() * 1000.0,
-                        "timeline sync sampled"
-                    );
-                }
-            },
-        )
-    }
-
-    pub(crate) fn handle_sync_event(
+    /// Apply a driving timeline's whole-tick correction to [`LocalTimeline`].
+    fn handle_sync_event(
         trigger: On<SyncEvent<Synced::Config>>,
         mut local_timeline: ResMut<LocalTimeline>,
     ) {
@@ -440,8 +409,185 @@ impl<Synced: SyncedTimeline, Remote: SyncTargetTimeline, const DRIVING: bool>
     }
 }
 
-impl<Synced, Remote, const DRIVING: bool> Default
-    for SyncedTimelinePlugin<Synced, Remote, DRIVING>
+impl<Synced: SyncedTimeline, Remote: SyncTargetTimeline, const DRIVING: bool>
+    SyncedTimelinePlugin<Synced, Remote, DRIVING, false>
+{
+    /// Reset a link-held synchronized timeline when that link connects.
+    fn handle_connect(
+        trigger: On<Add, Connected>,
+        local_timeline: Res<LocalTimeline>,
+        mut query: Query<&mut Synced>,
+    ) {
+        if let Ok(mut timeline) = query.get_mut(trigger.entity) {
+            Self::reset_timeline(&mut timeline, &local_timeline);
+        }
+    }
+
+    /// Mark a host-client's link-held timeline as synchronized without a handshake.
+    fn handle_host_client(trigger: On<Add, HostClient>, mut commands: Commands) {
+        commands
+            .entity(trigger.entity)
+            .insert(IsSynced::<Synced>::default());
+    }
+
+    /// Remove the synchronization marker from a disconnected link.
+    fn handle_disconnect(trigger: On<Add, Disconnected>, mut commands: Commands) {
+        commands.entity(trigger.entity).remove::<IsSynced<Synced>>();
+    }
+
+    /// Copy local fixed-update phase into every link-held driving timeline.
+    fn sync_from_local_timeline(
+        local_timeline: Res<LocalTimeline>,
+        fixed_time: Res<Time<Fixed>>,
+        mut query: Query<&mut Synced>,
+    ) {
+        query.iter_mut().for_each(|mut synced| {
+            Self::sync_from_local(&mut synced, &local_timeline, &fixed_time)
+        });
+    }
+
+    /// Apply the single connected, synchronized link timeline's relative speed.
+    fn update_virtual_time(
+        mut virtual_time: ResMut<Time<Virtual>>,
+        query: Query<&Synced, (With<IsSynced<Synced>>, With<Connected>, Without<HostClient>)>,
+    ) {
+        if let Ok(timeline) = query.single() {
+            Self::apply_relative_speed(timeline, &mut virtual_time);
+        }
+    }
+
+    /// Synchronize each link-held timeline with the remote timeline on the same link.
+    fn sync_timelines(
+        tick_duration: Res<TickDuration>,
+        mut commands: Commands,
+        mut query: Query<
+            (
+                Entity,
+                &mut Synced,
+                &Synced::Config,
+                &Remote,
+                &PingManager,
+                Has<IsSynced<Synced>>,
+            ),
+            (With<Connected>, Without<HostClient>),
+        >,
+    ) {
+        query.iter_mut().for_each(
+            |(entity, mut synced, config, remote, ping_manager, is_synced)| {
+                Self::sync_timeline(
+                    entity,
+                    &mut synced,
+                    config,
+                    remote,
+                    ping_manager,
+                    is_synced,
+                    &tick_duration,
+                    &mut commands,
+                );
+            },
+        );
+    }
+}
+
+impl<Synced: SyncedTimeline, Remote: SyncTargetTimeline, const DRIVING: bool>
+    SyncedTimelinePlugin<Synced, Remote, DRIVING, true>
+where
+    Synced::Config: Resource,
+{
+    /// Reset the global synchronized timeline when its client link connects.
+    fn handle_connect(
+        trigger: On<Add, Connected>,
+        clients: Query<(), (With<Client>, Without<P2P>)>,
+        local_timeline: Res<LocalTimeline>,
+        mut timeline: Single<&mut Synced, With<IsResource>>,
+    ) {
+        if clients.get(trigger.entity).is_ok() {
+            Self::reset_timeline(&mut timeline, &local_timeline);
+        }
+    }
+
+    /// Mark the resource entity as synchronized for a host-client session.
+    fn handle_host_client(
+        trigger: On<Add, HostClient>,
+        clients: Query<(), (With<Client>, Without<P2P>)>,
+        timeline_entity: Single<Entity, (With<Synced>, With<IsResource>)>,
+        mut commands: Commands,
+    ) {
+        if clients.get(trigger.entity).is_ok() {
+            commands
+                .entity(*timeline_entity)
+                .insert(IsSynced::<Synced>::default());
+        }
+    }
+
+    /// Remove the synchronization marker from the resource entity when its client disconnects.
+    fn handle_disconnect(
+        trigger: On<Add, Disconnected>,
+        clients: Query<(), (With<Client>, Without<P2P>)>,
+        timeline_entity: Single<Entity, (With<Synced>, With<IsResource>)>,
+        mut commands: Commands,
+    ) {
+        if clients.get(trigger.entity).is_ok() {
+            commands
+                .entity(*timeline_entity)
+                .remove::<IsSynced<Synced>>();
+        }
+    }
+
+    /// Copy local fixed-update phase into the global driving timeline.
+    fn sync_from_local_timeline(
+        local_timeline: Res<LocalTimeline>,
+        fixed_time: Res<Time<Fixed>>,
+        mut timeline: Single<&mut Synced, With<IsResource>>,
+    ) {
+        Self::sync_from_local(&mut timeline, &local_timeline, &fixed_time);
+    }
+
+    /// Apply the synchronized resource timeline's relative speed to virtual time.
+    fn update_virtual_time(
+        timeline: Single<&Synced, (With<IsResource>, With<IsSynced<Synced>>)>,
+        mut virtual_time: ResMut<Time<Virtual>>,
+    ) {
+        Self::apply_relative_speed(&timeline, &mut virtual_time);
+    }
+
+    /// Synchronize the resource timeline with the conventional Client Link cached by the topology.
+    ///
+    /// P2P aggregation will provide a different remote-target policy while retaining the same
+    /// resource timeline and synchronization controller.
+    fn sync_timelines(
+        tick_duration: Res<TickDuration>,
+        metadata: Res<NetworkingMetadata>,
+        config: Res<Synced::Config>,
+        timeline: Single<(Entity, &mut Synced, Has<IsSynced<Synced>>), With<IsResource>>,
+        remotes: Query<
+            (&Remote, &PingManager),
+            (With<Client>, With<Connected>, Without<HostClient>),
+        >,
+        mut commands: Commands,
+    ) {
+        let NetworkTopology::Client(client) = &metadata.mode else {
+            return;
+        };
+        let Ok((remote, ping_manager)) = remotes.get(*client) else {
+            return;
+        };
+        let (entity, mut synced, is_synced) = timeline.into_inner();
+        Self::sync_timeline(
+            entity,
+            &mut synced,
+            &config,
+            remote,
+            ping_manager,
+            is_synced,
+            &tick_duration,
+            &mut commands,
+        );
+    }
+}
+
+impl<Synced, Remote, const DRIVING: bool, const RESOURCE: bool> Default
+    for SyncedTimelinePlugin<Synced, Remote, DRIVING, RESOURCE>
 {
     fn default() -> Self {
         Self {
@@ -451,7 +597,7 @@ impl<Synced, Remote, const DRIVING: bool> Default
 }
 
 impl<Synced: SyncedTimeline, Remote: SyncTargetTimeline, const DRIVING: bool> Plugin
-    for SyncedTimelinePlugin<Synced, Remote, DRIVING>
+    for SyncedTimelinePlugin<Synced, Remote, DRIVING, false>
 {
     fn build(&self, app: &mut App) {
         app.add_plugins(NetworkTimelinePlugin::<Synced>::default());
@@ -462,6 +608,33 @@ impl<Synced: SyncedTimeline, Remote: SyncTargetTimeline, const DRIVING: bool> Pl
         app.add_observer(Self::handle_host_client);
         app.add_observer(Self::handle_disconnect);
         // NOTE: we don't have to run this in PostUpdate, we could run this right after RunFixedMainLoop?
+        app.add_systems(PostUpdate, Self::sync_timelines.in_set(SyncSystems::Sync));
+        if DRIVING {
+            app.add_systems(
+                PostUpdate,
+                Self::sync_from_local_timeline
+                    .in_set(SyncSystems::Sync)
+                    .before(Self::sync_timelines),
+            );
+            app.add_systems(Last, Self::update_virtual_time);
+            app.add_observer(Self::handle_sync_event);
+        }
+    }
+}
+
+impl<Synced: SyncedTimeline + Resource + Default, Remote: SyncTargetTimeline, const DRIVING: bool>
+    Plugin for SyncedTimelinePlugin<Synced, Remote, DRIVING, true>
+where
+    Synced::Config: Resource + Default,
+{
+    fn build(&self, app: &mut App) {
+        app.add_plugins(NetworkTimelinePlugin::<Synced>::default());
+        app.init_resource::<Synced>();
+        app.init_resource::<Synced::Config>();
+
+        app.add_observer(Self::handle_connect);
+        app.add_observer(Self::handle_host_client);
+        app.add_observer(Self::handle_disconnect);
         app.add_systems(PostUpdate, Self::sync_timelines.in_set(SyncSystems::Sync));
         if DRIVING {
             app.add_systems(

--- a/crates/core/sync/src/timeline/sync.rs
+++ b/crates/core/sync/src/timeline/sync.rs
@@ -1,5 +1,6 @@
 use crate::ping::manager::PingManager;
 use crate::plugin::SyncSystems;
+use crate::timeline::input::PredictionWindowWait;
 use bevy_app::{App, Last, Plugin, PostUpdate};
 use bevy_ecs::prelude::*;
 use bevy_ecs::resource::IsResource;
@@ -16,7 +17,7 @@ use lightyear_core::tick::TickDuration;
 use lightyear_core::time::{Overstep, TickInstant};
 use lightyear_core::timeline::{NetworkTimeline, SyncEvent};
 #[allow(unused_imports)]
-use tracing::{debug, info, trace};
+use tracing::{debug, error, info, trace};
 
 /// Marker component to indicate that the timeline has been synced
 #[derive(Component, Debug)]
@@ -30,6 +31,22 @@ impl<T> Default for IsSynced<T> {
             marker: core::marker::PhantomData,
         }
     }
+}
+
+/// Triggered when a running P2P timeline is too far ahead to correct with bounded pacing.
+///
+/// A running deterministic peer cannot safely emit a local [`SyncEvent`], because other peers
+/// would retain inputs under the old tick labels. The P2P session owner should treat this event as
+/// fatal and abort the session, unless it implements a coordinated all-peer resynchronization
+/// protocol.
+#[derive(EntityEvent, Debug, Clone, Copy)]
+pub struct P2PTimelineDiverged {
+    /// Resource entity holding the application-global driving timeline.
+    pub entity: Entity,
+    /// P2P Link whose remote estimate produced the worst local lead.
+    pub limiting_link: Entity,
+    /// Local lead over the limiting Link, measured in fractional ticks.
+    pub lead: f32,
 }
 
 /// Timeline that is synced to another timeline
@@ -61,6 +78,14 @@ pub trait SyncedTimeline: NetworkTimeline {
         tick_duration: Duration,
     ) -> Option<i32>;
 
+    /// Apply the common speed controller for an error measured in fractional ticks.
+    ///
+    /// Implementations apply speed changes and recovery toward `1.0`. A
+    /// [`SyncAdjustment::Resync`] result is left to the synchronization policy: conventional
+    /// client/server synchronization may snap, while a running P2P session must abort or perform
+    /// a coordinated recovery instead.
+    fn speed_adjustment(&mut self, config: &Self::Config, offset: f32) -> SyncAdjustment;
+
     fn is_synced(&self) -> bool;
 
     /// Returns the speed of your timeline relative to your system clock as an `f32`.
@@ -76,6 +101,11 @@ pub trait SyncedTimeline: NetworkTimeline {
 
 pub trait SyncTargetTimeline: NetworkTimeline + Default {
     fn current_estimate(&self) -> TickInstant;
+
+    /// Returns true after this timeline has received enough information to estimate remote time.
+    fn is_initialized(&self) -> bool {
+        true
+    }
 
     /// Returns true if the SyncTimelines are allowed to use this timeline as a sync target this frame
     fn received_packet(&self) -> bool;
@@ -279,6 +309,16 @@ impl<Synced: SyncedTimeline, Remote: SyncTargetTimeline, const DRIVING: bool, co
         );
         // TODO: be able to apply the speed_ratio on top of any speed ratio already applied by the user.
         virtual_time.set_relative_speed(timeline.relative_speed());
+    }
+
+    /// Reset controller history without changing the driving timeline's current phase.
+    fn reset_controller(sync_timeline: &mut Synced, relative_speed: f32) {
+        let now = sync_timeline.now();
+        sync_timeline.reset();
+        // `sync_from_local_timeline` already copied the current application phase this frame.
+        // Preserve it while clearing controller state so diagnostics never observe a spurious zero.
+        sync_timeline.set_now(now);
+        sync_timeline.set_relative_speed(relative_speed);
     }
 
     /// Synchronize one timeline and emit a [`SyncEvent`] if it snaps by whole ticks.
@@ -543,18 +583,53 @@ where
         Self::sync_from_local(&mut timeline, &local_timeline, &fixed_time);
     }
 
-    /// Apply the synchronized resource timeline's relative speed to virtual time.
+    /// Apply the resource timeline's relative speed to virtual time.
+    ///
+    /// P2P always owns virtual time, but runs at normal speed when no usable phase estimate exists.
+    /// Other topologies run at normal speed until their resource timeline is synchronized.
     fn update_virtual_time(
-        timeline: Single<&Synced, (With<IsResource>, With<IsSynced<Synced>>)>,
+        metadata: Res<NetworkingMetadata>,
+        prediction_window_wait: Res<PredictionWindowWait>,
+        timeline: Single<(&Synced, Has<IsSynced<Synced>>), With<IsResource>>,
         mut virtual_time: ResMut<Time<Virtual>>,
     ) {
-        Self::apply_relative_speed(&timeline, &mut virtual_time);
+        let (timeline, is_synced) = timeline.into_inner();
+        match metadata.mode {
+            NetworkTopology::Client(_) | NetworkTopology::P2P { .. }
+                if is_synced && prediction_window_wait.is_waiting() =>
+            {
+                // Keep the phase controller's desired speed on the timeline while preventing the
+                // next FixedMain run. Network receive and timeline observation continue in the
+                // variable schedules, so confirmed input can advance and release the wait.
+                virtual_time.set_relative_speed(0.0);
+                trace!(
+                    target: "lightyear_debug::sync",
+                    kind = "prediction_window_wait",
+                    schedule = "Last",
+                    sample_point = "Last",
+                    prediction_depth = prediction_window_wait.prediction_depth(),
+                    maximum_predicted_ticks = prediction_window_wait.maximum_predicted_ticks(),
+                    confirmed_tick = ?prediction_window_wait.confirmed_tick(),
+                    desired_relative_speed = timeline.relative_speed(),
+                    "paused virtual time at the deterministic prediction-window limit"
+                );
+            }
+            NetworkTopology::P2P { .. } => {
+                Self::apply_relative_speed(timeline, &mut virtual_time);
+            }
+            NetworkTopology::Client(_) | NetworkTopology::HostClient { .. } if is_synced => {
+                Self::apply_relative_speed(timeline, &mut virtual_time);
+            }
+            _ => virtual_time.set_relative_speed(1.0),
+        }
     }
 
-    /// Synchronize the resource timeline with the conventional Client Link cached by the topology.
+    /// Synchronize the resource timeline from the objective selected by the cached topology.
     ///
-    /// P2P aggregation will provide a different remote-target policy while retaining the same
-    /// resource timeline and synchronization controller.
+    /// Conventional client/server mode uses one remote Link and may snap by whole ticks. P2P mode
+    /// reads the already-smoothed estimate on every currently connected P2P Link, selects the
+    /// largest local lead, and feeds that aggregate error into the common speed controller once.
+    /// Fixed-roster agreement and gameplay start readiness belong to the P2P session layer.
     fn sync_timelines(
         tick_duration: Res<TickDuration>,
         metadata: Res<NetworkingMetadata>,
@@ -566,23 +641,167 @@ where
         >,
         mut commands: Commands,
     ) {
-        let NetworkTopology::Client(client) = &metadata.mode else {
-            return;
-        };
-        let Ok((remote, ping_manager)) = remotes.get(*client) else {
-            return;
-        };
-        let (entity, mut synced, is_synced) = timeline.into_inner();
-        Self::sync_timeline(
-            entity,
-            &mut synced,
-            &config,
-            remote,
-            ping_manager,
-            is_synced,
-            &tick_duration,
-            &mut commands,
-        );
+        let (entity, mut synced, mut is_synced) = timeline.into_inner();
+
+        // NetworkingMetadata only reports changed when its public topology changes. Resetting here
+        // prevents controller history from leaking between Link sets. A running P2P timeline keeps
+        // its readiness marker: an existing deterministic session must never locally relabel ticks
+        // merely because a peer connected or disconnected. A fresh app remains unready until the
+        // initial P2P alignment below completes.
+        if metadata.is_changed() {
+            Self::reset_controller(&mut synced, 1.0);
+            let preserve_running_p2p =
+                is_synced && matches!(&metadata.mode, NetworkTopology::P2P { .. });
+            if is_synced && !preserve_running_p2p {
+                commands.entity(entity).remove::<IsSynced<Synced>>();
+            }
+            is_synced = preserve_running_p2p;
+        }
+
+        match &metadata.mode {
+            NetworkTopology::Client(client) => {
+                let Ok((remote, ping_manager)) = remotes.get(*client) else {
+                    return;
+                };
+                Self::sync_timeline(
+                    entity,
+                    &mut synced,
+                    &config,
+                    remote,
+                    ping_manager,
+                    is_synced,
+                    &tick_duration,
+                    &mut commands,
+                );
+            }
+            NetworkTopology::P2P {
+                connected,
+                declared_links,
+            } if DRIVING => {
+                // P2P Links can be declared before their connection handshake completes. Waiting
+                // for all declared Links lets a lobby establish its fixed roster up front without
+                // allowing the first connection to start input capture prematurely.
+                let all_declared_links_connected =
+                    is_synced || connected.len() == usize::from(*declared_links);
+                let mut all_initialized = !connected.is_empty() && all_declared_links_connected;
+                let mut sampled_any = false;
+                let mut limiting = None;
+                for &link_entity in connected {
+                    let Ok((remote, _ping_manager)) = remotes.get(link_entity) else {
+                        all_initialized = false;
+                        trace!(
+                            target: "lightyear_debug::sync",
+                            kind = "p2p_sync_missing_link_state",
+                            schedule = "PostUpdate",
+                            sample_point = "PostUpdate",
+                            ?link_entity,
+                            "ignoring P2P Link without sync state"
+                        );
+                        continue;
+                    };
+                    if !remote.is_initialized() {
+                        all_initialized = false;
+                        continue;
+                    }
+                    sampled_any |= remote.received_packet();
+                    // Unlike client/server, P2P has no single asymmetric `sync_objective`: each
+                    // initialized remote estimate is an execution-phase target. Taking the maximum
+                    // of `local - remote` finds the Link furthest behind this app (the worst local
+                    // lead), matching GGRS's maximum frame-advantage policy. Only that aggregate is
+                    // passed to the shared controller, so the app slows toward its slowest peer.
+                    let remote_estimate = remote.current_estimate();
+                    let lead = (synced.now() - remote_estimate).to_f32();
+                    if limiting.is_none_or(|(_, worst, _)| lead > worst) {
+                        limiting = Some((link_entity, lead, remote_estimate));
+                    }
+                }
+
+                // Before the timeline becomes ready, no input-capture system using
+                // `SyncedInputTimeline` can run. It is therefore safe to align the local tick labels
+                // once. Including the local phase in the minimum makes every starting peer converge
+                // toward the slowest observed execution phase instead of swapping clocks.
+                if !is_synced {
+                    if !all_initialized || !sampled_any {
+                        return;
+                    }
+                    let Some((limiting_link, worst_lead, remote_estimate)) = limiting else {
+                        return;
+                    };
+                    let objective = if worst_lead > 0.0 {
+                        remote_estimate
+                    } else {
+                        synced.now()
+                    };
+                    let tick_delta = synced.resync(objective);
+                    synced.set_relative_speed(1.0);
+                    commands.trigger(SyncEvent::<Synced::Config>::new(entity, tick_delta));
+                    commands
+                        .entity(entity)
+                        .insert(IsSynced::<Synced>::default());
+                    trace!(
+                        target: "lightyear_debug::sync",
+                        kind = "p2p_initial_sync",
+                        schedule = "PostUpdate",
+                        sample_point = "PostUpdate",
+                        ?limiting_link,
+                        worst_lead,
+                        ?objective,
+                        tick_delta,
+                        "initial P2P timeline aligned before input capture became ready"
+                    );
+                    return;
+                }
+
+                // Match conventional synchronization: controller hysteresis advances on network
+                // observations, not once per render frame using the same estimates.
+                if !sampled_any {
+                    return;
+                }
+                let Some((limiting_link, worst_lead, _)) = limiting else {
+                    return;
+                };
+                let adjustment = synced.speed_adjustment(&config, worst_lead.max(0.0));
+                if matches!(adjustment, SyncAdjustment::Resync) {
+                    synced.set_relative_speed(1.0);
+                    commands.trigger(P2PTimelineDiverged {
+                        entity,
+                        limiting_link,
+                        lead: worst_lead,
+                    });
+                    error!(
+                        ?limiting_link,
+                        worst_lead,
+                        "running P2P timeline diverged beyond bounded pacing; abort the session"
+                    );
+                    trace!(
+                        target: "lightyear_debug::sync",
+                        kind = "p2p_sync_phase_gap",
+                        schedule = "PostUpdate",
+                        sample_point = "PostUpdate",
+                        ?limiting_link,
+                        worst_lead,
+                        "running P2P phase gap requires session abort or coordinated recovery"
+                    );
+                    return;
+                }
+                trace!(
+                    target: "lightyear_debug::sync",
+                    kind = "p2p_sync_aggregate",
+                    schedule = "PostUpdate",
+                    sample_point = "PostUpdate",
+                    ?limiting_link,
+                    worst_lead,
+                    relative_speed = synced.relative_speed(),
+                    "applied one aggregate P2P pacing decision"
+                );
+            }
+            NetworkTopology::HostClient { .. } if !is_synced => {
+                commands
+                    .entity(entity)
+                    .insert(IsSynced::<Synced>::default());
+            }
+            _ => {}
+        }
     }
 }
 
@@ -604,6 +823,9 @@ impl<Synced: SyncedTimeline, Remote: SyncTargetTimeline, const DRIVING: bool> Pl
 
         app.register_required_components::<Synced, PingManager>();
         app.register_required_components::<Synced, Remote>();
+        if DRIVING {
+            app.init_resource::<PredictionWindowWait>();
+        }
         app.add_observer(Self::handle_connect);
         app.add_observer(Self::handle_host_client);
         app.add_observer(Self::handle_disconnect);
@@ -631,6 +853,9 @@ where
         app.add_plugins(NetworkTimelinePlugin::<Synced>::default());
         app.init_resource::<Synced>();
         app.init_resource::<Synced::Config>();
+        if DRIVING {
+            app.init_resource::<PredictionWindowWait>();
+        }
 
         app.add_observer(Self::handle_connect);
         app.add_observer(Self::handle_host_client);
@@ -646,5 +871,447 @@ where
             app.add_systems(Last, Self::update_virtual_time);
             app.add_observer(Self::handle_sync_event);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::timeline::input::{InputTimeline, InputTimelineConfig};
+    use alloc::vec::Vec;
+    use bevy_app::{FixedUpdate, PostUpdate};
+    use bevy_time::TimeUpdateStrategy;
+    use lightyear_core::id::{PeerId, RemoteId};
+    use lightyear_core::plugin::CorePlugins;
+    use lightyear_core::tick::Tick;
+    use lightyear_core::time::TickDelta;
+    use lightyear_core::timeline::TimelineConfig;
+
+    #[derive(Component, Default)]
+    struct TestRemoteConfig;
+
+    #[derive(Component, Default)]
+    struct TestRemote {
+        now: TickInstant,
+        estimate: TickInstant,
+        initialized: bool,
+        received_packet: bool,
+    }
+
+    #[derive(Resource, Default)]
+    struct RecordedDivergences(Vec<P2PTimelineDiverged>);
+
+    fn record_divergence(
+        trigger: On<P2PTimelineDiverged>,
+        mut divergences: ResMut<RecordedDivergences>,
+    ) {
+        divergences.0.push(*trigger);
+    }
+
+    #[derive(Resource, Default)]
+    struct FixedRuns(u32);
+
+    #[test]
+    fn prediction_window_wait_stops_bevy_fixed_schedules() {
+        fn count_fixed_runs(mut runs: ResMut<FixedRuns>) {
+            runs.0 += 1;
+        }
+
+        let tick_duration = Duration::from_millis(10);
+        let mut app = App::new();
+        app.add_plugins((
+            CorePlugins { tick_duration },
+            SyncedTimelinePlugin::<InputTimeline, TestRemote, true, true>::default(),
+        ));
+        app.insert_resource(TimeUpdateStrategy::ManualDuration(tick_duration));
+        app.init_resource::<NetworkingMetadata>();
+        app.init_resource::<FixedRuns>();
+        app.add_systems(FixedUpdate, count_fixed_runs);
+        let timeline_id = app.world().component_id::<InputTimeline>().unwrap();
+        let timeline_entity = app.world().resource_entities().get(timeline_id).unwrap();
+        app.world_mut()
+            .entity_mut(timeline_entity)
+            .insert(IsSynced::<InputTimeline>::default());
+        app.world_mut().resource_mut::<NetworkingMetadata>().mode = NetworkTopology::P2P {
+            connected: Default::default(),
+            declared_links: 1,
+        };
+        {
+            let mut wait = app.world_mut().resource_mut::<PredictionWindowWait>();
+            wait.update(Tick(0), None, 1);
+            wait.update(Tick(1), None, 1);
+        }
+
+        // The signal is applied in Last, after this frame's fixed loop has already run.
+        app.update();
+        let before_wait = app.world().resource::<FixedRuns>().0;
+        assert_eq!(
+            app.world().resource::<Time<Virtual>>().relative_speed(),
+            0.0
+        );
+
+        app.update();
+        assert_eq!(app.world().resource::<FixedRuns>().0, before_wait);
+
+        // Releasing the signal similarly takes effect for the following application frame.
+        app.world_mut()
+            .resource_mut::<PredictionWindowWait>()
+            .update(Tick(1), Some(Tick(1)), 1);
+        app.update();
+        assert_eq!(app.world().resource::<FixedRuns>().0, before_wait);
+        app.update();
+        assert!(app.world().resource::<FixedRuns>().0 > before_wait);
+    }
+
+    impl TimelineConfig for TestRemoteConfig {
+        type Context = ();
+        type Timeline = TestRemote;
+    }
+
+    impl NetworkTimeline for TestRemote {
+        type Config = TestRemoteConfig;
+
+        fn now(&self) -> TickInstant {
+            self.now
+        }
+
+        fn tick(&self) -> Tick {
+            self.now.tick()
+        }
+
+        fn overstep(&self) -> Overstep {
+            self.now.overstep()
+        }
+
+        fn set_now(&mut self, now: TickInstant) {
+            self.now = now;
+        }
+
+        fn apply_delta(&mut self, delta: TickDelta) {
+            self.now = self.now + delta;
+        }
+    }
+
+    impl SyncTargetTimeline for TestRemote {
+        fn current_estimate(&self) -> TickInstant {
+            self.estimate
+        }
+
+        fn is_initialized(&self) -> bool {
+            self.initialized
+        }
+
+        fn received_packet(&self) -> bool {
+            self.received_packet
+        }
+    }
+
+    #[test]
+    fn resource_pipeline_initializes_then_paces_from_the_worst_p2p_lead() {
+        let mut app = App::new();
+        app.add_plugins((
+            CorePlugins {
+                tick_duration: Duration::from_millis(10),
+            },
+            SyncedTimelinePlugin::<InputTimeline, TestRemote, true, true>::default(),
+        ));
+        app.init_resource::<NetworkingMetadata>();
+        app.init_resource::<RecordedDivergences>();
+        app.add_observer(record_divergence);
+        app.update();
+
+        app.insert_resource(InputTimelineConfig::default().with_sync_config(SyncConfig {
+            handshake_pings: 0,
+            error_margin: 2.0,
+            max_error_margin: 10.0,
+            consecutive_errors_threshold: 1,
+            ..Default::default()
+        }));
+        app.world_mut()
+            .resource_mut::<LocalTimeline>()
+            .apply_delta(100);
+        let local_now = TickInstant::from(app.world().resource::<LocalTimeline>().tick());
+
+        let mut links = Vec::new();
+        // The middle Link has the slowest observed execution phase. Declare the final Link without
+        // connecting it first to verify that the first connection cannot start input capture while
+        // a member of the fixed roster is still joining.
+        for (peer, lead) in [(1, 1), (2, 4), (3, 0)] {
+            let estimate = local_now - TickDelta::from_i32(lead);
+            let entity = app
+                .world_mut()
+                .spawn((
+                    P2P,
+                    RemoteId(PeerId::Local(peer)),
+                    TestRemote {
+                        now: estimate,
+                        estimate,
+                        initialized: peer != 3,
+                        received_packet: true,
+                    },
+                    PingManager::default(),
+                ))
+                .id();
+            if peer != 3 {
+                app.world_mut().entity_mut(entity).insert(Connected);
+            }
+            links.push(entity);
+        }
+        app.world_mut().resource_mut::<NetworkingMetadata>().mode = NetworkTopology::P2P {
+            connected: links[..2].iter().copied().collect(),
+            declared_links: 3,
+        };
+
+        app.world_mut().run_schedule(PostUpdate);
+
+        let timeline_id = app.world().component_id::<InputTimeline>().unwrap();
+        let timeline_entity = app.world().resource_entities().get(timeline_id).unwrap();
+        assert_eq!(
+            app.world().resource::<LocalTimeline>().tick(),
+            local_now.tick()
+        );
+        assert_eq!(app.world().resource::<InputTimeline>().now(), local_now);
+        assert_eq!(
+            app.world().resource::<InputTimeline>().relative_speed(),
+            1.0
+        );
+        assert!(
+            app.world()
+                .get::<IsSynced<InputTimeline>>(timeline_entity)
+                .is_none(),
+            "input capture must remain gated until every declared P2P Link is connected"
+        );
+
+        // Connecting the final Link is still not enough until its remote timeline has initialized.
+        app.world_mut().entity_mut(links[2]).insert(Connected);
+        app.world_mut().resource_mut::<NetworkingMetadata>().mode = NetworkTopology::P2P {
+            connected: links.iter().copied().collect(),
+            declared_links: 3,
+        };
+        app.world_mut().run_schedule(PostUpdate);
+        assert!(
+            app.world()
+                .get::<IsSynced<InputTimeline>>(timeline_entity)
+                .is_none()
+        );
+
+        // Once every current Link has initialized, align both driving timelines to the slowest
+        // observed phase and only then expose the synchronized input timeline.
+        app.world_mut()
+            .entity_mut(links[2])
+            .get_mut::<TestRemote>()
+            .unwrap()
+            .initialized = true;
+        app.world_mut().run_schedule(PostUpdate);
+
+        let initial_objective = local_now - TickDelta::from_i32(4);
+        assert_eq!(
+            app.world().resource::<LocalTimeline>().tick(),
+            initial_objective.tick()
+        );
+        assert_eq!(
+            app.world().resource::<InputTimeline>().now(),
+            initial_objective
+        );
+        assert_eq!(
+            app.world().resource::<InputTimeline>().relative_speed(),
+            1.0
+        );
+        assert!(
+            app.world()
+                .get::<IsSynced<InputTimeline>>(timeline_entity)
+                .is_some(),
+            "the normal readiness marker is inserted only after initial P2P alignment"
+        );
+
+        // After readiness, only the middle Link exceeds the controller deadband. A correct
+        // maximum aggregate must therefore slow the app, independent of the controller's exact
+        // speed formula.
+        for (&link, lead) in links.iter().zip([1, 4, 0]) {
+            let mut link = app.world_mut().entity_mut(link);
+            let mut remote = link.get_mut::<TestRemote>().unwrap();
+            remote.estimate = initial_objective - TickDelta::from_i32(lead);
+            remote.received_packet = true;
+        }
+        app.world_mut().run_schedule(PostUpdate);
+
+        let slowed_speed = app.world().resource::<InputTimeline>().relative_speed();
+        assert!(
+            slowed_speed < 1.0,
+            "the maximum four-tick lead must cross the two-tick deadband"
+        );
+        assert_eq!(
+            app.world().resource::<LocalTimeline>().tick(),
+            initial_objective.tick()
+        );
+        assert!(
+            app.world()
+                .get::<IsSynced<InputTimeline>>(timeline_entity)
+                .is_some()
+        );
+
+        // Prediction-window exhaustion is a hard wait layered over the phase controller. It
+        // pauses virtual time without overwriting the slowdown that should be restored on resume.
+        {
+            let mut wait = app.world_mut().resource_mut::<PredictionWindowWait>();
+            wait.update(Tick(0), None, 4);
+            wait.update(Tick(4), None, 4);
+        }
+        app.world_mut().run_schedule(Last);
+        assert_eq!(
+            app.world().resource::<Time<Virtual>>().relative_speed(),
+            0.0
+        );
+        assert_eq!(
+            app.world().resource::<InputTimeline>().relative_speed(),
+            slowed_speed,
+            "hard waiting must preserve the phase controller's desired speed"
+        );
+
+        {
+            let mut wait = app.world_mut().resource_mut::<PredictionWindowWait>();
+            wait.update(Tick(4), Some(Tick(2)), 4);
+        }
+        app.world_mut().run_schedule(Last);
+        assert_eq!(
+            app.world().resource::<Time<Virtual>>().relative_speed(),
+            slowed_speed,
+            "recovering two confirmed ticks must resume at the phase-controller speed"
+        );
+
+        // Render frames without a new network observation must preserve both the controller state
+        // and its current correction. Recovery is driven by later fresh observations.
+        {
+            let world = app.world_mut();
+            let mut query = world.query::<&mut TestRemote>();
+            query
+                .iter_mut(world)
+                .for_each(|mut remote| remote.received_packet = false);
+        }
+        app.world_mut().run_schedule(PostUpdate);
+        assert_eq!(
+            app.world().resource::<InputTimeline>().relative_speed(),
+            slowed_speed,
+            "a frame without a fresh observation must not alter P2P pacing"
+        );
+
+        // Exclude the four-tick Link and provide a fresh observation on the remaining Links. Their
+        // maximum lead is one tick, inside the deadband, so the controller begins recovering.
+        app.world_mut()
+            .entity_mut(links[1])
+            .get_mut::<TestRemote>()
+            .unwrap()
+            .initialized = false;
+        {
+            let world = app.world_mut();
+            let mut query = world.query::<&mut TestRemote>();
+            query
+                .iter_mut(world)
+                .for_each(|mut remote| remote.received_packet = true);
+        }
+        app.world_mut().run_schedule(PostUpdate);
+
+        let timeline = app.world().resource::<InputTimeline>();
+        assert_eq!(timeline.now(), initial_objective);
+        let recovering_speed = timeline.relative_speed();
+        assert!(
+            recovering_speed > slowed_speed && recovering_speed <= 1.0,
+            "excluding the only lead outside the deadband must start speed recovery"
+        );
+        assert!(
+            app.world()
+                .get::<IsSynced<InputTimeline>>(timeline_entity)
+                .is_some()
+        );
+
+        // Losing every usable estimate without a topology change is still not a new observation;
+        // keep the last correction until timing resumes or the topology itself changes.
+        {
+            let world = app.world_mut();
+            let mut query = world.query::<&mut TestRemote>();
+            query.iter_mut(world).for_each(|mut remote| {
+                remote.initialized = false;
+                remote.received_packet = false;
+            });
+        }
+        app.world_mut().run_schedule(PostUpdate);
+        assert_eq!(
+            app.world().resource::<InputTimeline>().relative_speed(),
+            recovering_speed,
+            "missing observations must preserve controller hysteresis"
+        );
+        assert!(
+            app.world()
+                .get::<IsSynced<InputTimeline>>(timeline_entity)
+                .is_some()
+        );
+
+        // Once input capture is active, a resync-sized gap is unsafe to apply locally. Report the
+        // limiting Link to the session owner and leave all tick labels unchanged.
+        {
+            let mut link = app.world_mut().entity_mut(links[0]);
+            let mut remote = link.get_mut::<TestRemote>().unwrap();
+            remote.initialized = true;
+            remote.received_packet = true;
+            remote.estimate = initial_objective - TickDelta::from_i32(20);
+        }
+        app.world_mut().run_schedule(PostUpdate);
+        assert_eq!(
+            app.world().resource::<InputTimeline>().relative_speed(),
+            1.0
+        );
+        assert_eq!(
+            app.world().resource::<LocalTimeline>().tick(),
+            initial_objective.tick(),
+            "a running P2P session must not relabel local ticks"
+        );
+        assert!(
+            app.world()
+                .get::<IsSynced<InputTimeline>>(timeline_entity)
+                .is_some()
+        );
+        let divergences = &app.world().resource::<RecordedDivergences>().0;
+        assert_eq!(divergences.len(), 1);
+        assert_eq!(divergences[0].entity, timeline_entity);
+        assert_eq!(divergences[0].limiting_link, links[0]);
+        assert_eq!(divergences[0].lead, 20.0);
+
+        // A P2P roster change resets controller history but cannot revoke readiness or resynchronize
+        // a running deterministic world. An empty connected set keeps application time advancing
+        // normally; the session owner is responsible for treating peer loss as fatal if required.
+        app.world_mut().resource_mut::<NetworkingMetadata>().mode = NetworkTopology::P2P {
+            connected: Default::default(),
+            declared_links: 3,
+        };
+        app.world_mut().run_schedule(PostUpdate);
+
+        let timeline = app.world().resource::<InputTimeline>();
+        assert_eq!(timeline.now(), initial_objective);
+        assert_eq!(timeline.relative_speed(), 1.0);
+        assert!(
+            app.world()
+                .get::<IsSynced<InputTimeline>>(timeline_entity)
+                .is_some()
+        );
+
+        app.world_mut().run_schedule(Last);
+        assert_eq!(
+            app.world().resource::<Time<Virtual>>().relative_speed(),
+            1.0
+        );
+
+        app.world_mut().resource_mut::<NetworkingMetadata>().mode = NetworkTopology::Undefined;
+        app.world_mut().run_schedule(PostUpdate);
+        app.world_mut().run_schedule(Last);
+        assert!(
+            app.world()
+                .get::<IsSynced<InputTimeline>>(timeline_entity)
+                .is_none()
+        );
+        assert_eq!(
+            app.world().resource::<Time<Virtual>>().relative_speed(),
+            1.0,
+            "leaving P2P topology must restore normal application time"
+        );
     }
 }

--- a/crates/deterministic/deterministic_replication/src/checksum.rs
+++ b/crates/deterministic/deterministic_replication/src/checksum.rs
@@ -42,7 +42,7 @@ use lightyear_messages::receive::MessageReceiver;
 #[cfg(feature = "client")]
 use lightyear_prediction::manager::{LastConfirmedInput, StateRollbackMetadata};
 #[cfg(feature = "client")]
-use lightyear_sync::prelude::{InputTimeline, IsSynced};
+use lightyear_sync::prelude::SyncedInputTimeline;
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "server")]
 use tracing::error;
@@ -105,10 +105,9 @@ impl ChecksumSendPlugin {
     fn compute_and_send_checksum(
         mut world: ChecksumWorld<'_, '_, true>,
         local_timeline: Res<LocalTimeline>,
-        client: Single<
-            (&LastConfirmedInput, &mut MessageSender<ChecksumMessage>),
-            (With<Client>, With<IsSynced<InputTimeline>>),
-        >,
+        _input_timeline: SyncedInputTimeline,
+        last_confirmed_input: Res<LastConfirmedInput>,
+        sender: Single<&mut MessageSender<ChecksumMessage>, With<Client>>,
         #[cfg(feature = "replication")] catchup_manager: Option<
             Single<&CatchUpManager, With<Client>>,
         >,
@@ -116,7 +115,7 @@ impl ChecksumSendPlugin {
     ) {
         let mut checksum = 0u64;
         let current_tick = local_timeline.tick();
-        let (last_confirmed_input, mut sender) = client.into_inner();
+        let mut sender = sender.into_inner();
         let tick = last_confirmed_input.tick.get();
         // only compute the checksum when we have received remote inputs
         if tick > current_tick {
@@ -179,8 +178,8 @@ impl Plugin for ChecksumSendPlugin {
             app.add_plugins(DeterministicReplicationPlugin);
         }
 
-        // we need the LastConfirmedInput to compute the checksums
-        app.register_required_components::<InputTimeline, LastConfirmedInput>();
+        // We need the application-wide remote-input frontier to compute checksums.
+        app.init_resource::<LastConfirmedInput>();
 
         register_checksum_message(app);
     }

--- a/crates/deterministic/deterministic_replication/src/late_join/client.rs
+++ b/crates/deterministic/deterministic_replication/src/late_join/client.rs
@@ -18,7 +18,7 @@ use lightyear_prediction::prelude::{
 use lightyear_prediction::rollback::{CatchUpGated, DisableRollback};
 use lightyear_replication::metadata::MetadataChannel;
 use lightyear_replication::prelude::ReplicationSystems;
-use lightyear_sync::prelude::{InputTimeline, InputTimelineConfig, IsSynced};
+use lightyear_sync::prelude::{InputTimelineConfig, SyncedInputTimeline};
 use tracing::{debug, info, warn};
 
 use super::{CatchUpRequest, CatchUpSnapshotReady, CatchUpSystems};
@@ -142,23 +142,19 @@ fn catchup_snapshot_is_activating(manager: Option<Single<&CatchUpManager, With<C
 /// frame conservative is preferable to duplicating that input coverage logic.
 pub(crate) fn send_catchup_request(
     timeline: Res<LocalTimeline>,
+    _input_timeline: SyncedInputTimeline,
+    last_confirmed_input: Res<LastConfirmedInput>,
     client: Single<
         (
             Entity,
             &mut CatchUpManager,
-            &LastConfirmedInput,
             &mut MessageSender<CatchUpRequest>,
-            Has<IsSynced<InputTimeline>>,
         ),
         With<Client>,
     >,
     awaiting: Query<Entity, With<CatchUpGated>>,
 ) {
-    let (client_entity, mut manager, last_confirmed_input, mut sender, is_synced) =
-        client.into_inner();
-    if !is_synced {
-        return;
-    }
+    let (client_entity, mut manager, mut sender) = client.into_inner();
     if manager.completed {
         return;
     }
@@ -260,22 +256,14 @@ fn on_receive_catchup_gated(
 /// fully receive (by checking ServerMutateTicks)
 pub(crate) fn trigger_snapshot_rollback(
     timeline: Res<LocalTimeline>,
-    manager: Single<
-        (
-            Entity,
-            &mut CatchUpManager,
-            &LastConfirmedInput,
-            &PredictionManager,
-            &InputTimelineConfig,
-        ),
-        With<Client>,
-    >,
+    input_config: Res<InputTimelineConfig>,
+    last_confirmed_input: Res<LastConfirmedInput>,
+    manager: Single<(Entity, &mut CatchUpManager, &PredictionManager), With<Client>>,
     server_mutate_ticks: Res<ServerMutateTicks>,
     mut state_metadata: ResMut<StateRollbackMetadata>,
     mut commands: Commands,
 ) {
-    let (client_entity, mut manager, last_confirmed_input, prediction_manager, input_config) =
-        manager.into_inner();
+    let (client_entity, mut manager, prediction_manager) = manager.into_inner();
     if manager.completed {
         return;
     }
@@ -295,7 +283,7 @@ pub(crate) fn trigger_snapshot_rollback(
     let max_rollback_ticks = i32::from(
         prediction_manager
             .rollback_policy
-            .effective_max_rollback_ticks(input_config),
+            .effective_max_rollback_ticks(&input_config),
     );
     if rollback_delta > max_rollback_ticks {
         warn!(

--- a/crates/deterministic/deterministic_replication/src/late_join/client.rs
+++ b/crates/deterministic/deterministic_replication/src/late_join/client.rs
@@ -258,12 +258,13 @@ pub(crate) fn trigger_snapshot_rollback(
     timeline: Res<LocalTimeline>,
     input_config: Res<InputTimelineConfig>,
     last_confirmed_input: Res<LastConfirmedInput>,
-    manager: Single<(Entity, &mut CatchUpManager, &PredictionManager), With<Client>>,
+    manager: Single<(Entity, &mut CatchUpManager), With<Client>>,
+    prediction_manager: Res<PredictionManager>,
     server_mutate_ticks: Res<ServerMutateTicks>,
     mut state_metadata: ResMut<StateRollbackMetadata>,
     mut commands: Commands,
 ) {
-    let (client_entity, mut manager, prediction_manager) = manager.into_inner();
+    let (client_entity, mut manager) = manager.into_inner();
     if manager.completed {
         return;
     }
@@ -324,12 +325,10 @@ pub(crate) fn trigger_snapshot_rollback(
 /// This is so that when CatchUpSnapshotReady is observed, the CatchUpGated components are already restored
 /// to their snapshot state.
 fn trigger_catch_up_snapshot_activation(
-    client: Query<(&Rollback, &CatchUpManager), With<Client>>,
+    rollback: Res<Rollback>,
+    manager: Single<&CatchUpManager, With<Client>>,
     mut commands: Commands,
 ) {
-    let Ok((rollback, manager)) = client.single() else {
-        return;
-    };
     if manager.completed || !matches!(*rollback, Rollback::FromState) {
         return;
     }
@@ -344,13 +343,11 @@ fn trigger_catch_up_snapshot_activation(
 }
 
 fn finish_catch_up_snapshot_activation(
-    mut client: Query<(&mut CatchUpManager, &mut PredictionManager), With<Client>>,
+    mut manager: Single<&mut CatchUpManager, With<Client>>,
+    mut prediction_manager: ResMut<PredictionManager>,
     gated: Query<Entity, With<CatchUpGated>>,
     mut commands: Commands,
 ) {
-    let Ok((mut manager, mut prediction_manager)) = client.single_mut() else {
-        return;
-    };
     if manager.completed || manager.activating_snapshot.is_none() {
         return;
     }

--- a/crates/deterministic/deterministic_replication/src/lib.rs
+++ b/crates/deterministic/deterministic_replication/src/lib.rs
@@ -37,6 +37,8 @@ pub mod late_join;
 /// Configuration mode for catch-up (state-based vs input-only).
 pub mod mode;
 mod plugin;
+#[cfg(feature = "client")]
+mod prediction_window;
 
 /// Commonly used items from the `lightyear_deterministic_replication` crate.
 pub mod prelude {

--- a/crates/deterministic/deterministic_replication/src/plugin.rs
+++ b/crates/deterministic/deterministic_replication/src/plugin.rs
@@ -1,4 +1,6 @@
 use crate::Deterministic;
+#[cfg(feature = "client")]
+use crate::prediction_window::PredictionWindowWaitPlugin;
 use bevy_app::{App, Plugin};
 use lightyear_prediction::rollback::DeterministicPredicted;
 
@@ -17,5 +19,7 @@ pub struct DeterministicReplicationPlugin;
 impl Plugin for DeterministicReplicationPlugin {
     fn build(&self, app: &mut App) {
         app.register_required_components::<DeterministicPredicted, Deterministic>();
+        #[cfg(feature = "client")]
+        app.add_plugins(PredictionWindowWaitPlugin);
     }
 }

--- a/crates/deterministic/deterministic_replication/src/prediction_window.rs
+++ b/crates/deterministic/deterministic_replication/src/prediction_window.rs
@@ -1,0 +1,184 @@
+use bevy_app::{App, Plugin, PostUpdate};
+use bevy_ecs::prelude::*;
+use lightyear_connection::network_topology::{NetworkTopology, NetworkingMetadata};
+use lightyear_core::timeline::LocalTimeline;
+use lightyear_inputs::client::InputSystems;
+use lightyear_prediction::prelude::{LastConfirmedInput, PredictionManager};
+use lightyear_sync::plugin::SyncSystems;
+use lightyear_sync::prelude::{InputTimelineConfig, PredictionWindowWait, SyncedInputTimeline};
+use tracing::{info, trace};
+
+/// Installs the application-global deterministic prediction-window controller.
+pub(crate) struct PredictionWindowWaitPlugin;
+
+impl Plugin for PredictionWindowWaitPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<PredictionWindowWait>();
+        app.init_resource::<LastConfirmedInput>();
+        app.add_systems(
+            PostUpdate,
+            update_prediction_window_wait
+                .after(InputSystems::UpdateRemoteInputTicks)
+                .after(SyncSystems::Sync),
+        );
+    }
+}
+
+/// Stop deterministic fixed simulation before its next tick would exceed the rollback-safe input
+/// window.
+///
+/// [`LastConfirmedInput`] is the minimum across every remote input buffer and every registered
+/// input type. A missing stream anchors the controller to the session's first observed tick until
+/// input arrives. An application with no remote input streams does not wait.
+fn update_prediction_window_wait(
+    timeline: Res<LocalTimeline>,
+    _input_timeline: SyncedInputTimeline,
+    metadata: Res<NetworkingMetadata>,
+    input_config: Res<InputTimelineConfig>,
+    prediction_manager: Option<Res<PredictionManager>>,
+    last_confirmed_input: Res<LastConfirmedInput>,
+    mut wait: ResMut<PredictionWindowWait>,
+) {
+    if metadata.is_changed() {
+        wait.reset();
+    }
+
+    let active_topology = match &metadata.mode {
+        NetworkTopology::Client(_) => true,
+        NetworkTopology::P2P { connected, .. } => !connected.is_empty(),
+        NetworkTopology::Undefined
+        | NetworkTopology::Server(_)
+        | NetworkTopology::HostClient { .. }
+        | NetworkTopology::Invalid(_) => false,
+    };
+    let Some(prediction_manager) = prediction_manager.filter(|_| active_topology) else {
+        wait.reset();
+        return;
+    };
+
+    let current_frontier = last_confirmed_input.get();
+    if current_frontier.is_none() && last_confirmed_input.received_for_all_clients {
+        // An empty aggregate means this deterministic simulation has no remote input streams. A
+        // stream that exists but has not received its first sample sets this flag to false.
+        wait.reset();
+        return;
+    }
+
+    let configured_maximum = input_config.maximum_predicted_ticks();
+    let effective_maximum = if configured_maximum == 0 {
+        // `effective_max_rollback_ticks` intentionally leaves forced state rollback enabled in
+        // lockstep mode. The input prediction window itself is still zero.
+        0
+    } else {
+        prediction_manager
+            .rollback_policy
+            .effective_max_rollback_ticks(&input_config)
+    };
+    let confirmed_tick = last_confirmed_input
+        .received_for_all_clients
+        .then_some(current_frontier)
+        .flatten();
+    let changed = wait.update(timeline.tick(), confirmed_tick, effective_maximum);
+
+    if changed {
+        info!(
+            waiting = wait.is_waiting(),
+            current_tick = timeline.tick().0,
+            confirmed_tick = ?wait.confirmed_tick(),
+            prediction_depth = wait.prediction_depth(),
+            maximum_predicted_ticks = wait.maximum_predicted_ticks(),
+            "deterministic prediction-window wait state changed"
+        );
+    }
+    trace!(
+        target: "lightyear_debug::input",
+        kind = "prediction_window",
+        schedule = "PostUpdate",
+        sample_point = "PostUpdate",
+        waiting = wait.is_waiting(),
+        current_tick = timeline.tick().0,
+        confirmed_tick = ?wait.confirmed_tick(),
+        prediction_depth = wait.prediction_depth(),
+        maximum_predicted_ticks = wait.maximum_predicted_ticks(),
+        "updated deterministic prediction-window wait signal"
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lightyear_core::prelude::Tick;
+    use lightyear_sync::prelude::{InputTimeline, IsSynced};
+
+    fn wait_app(topology: NetworkTopology) -> App {
+        let mut app = App::new();
+        app.init_resource::<LocalTimeline>();
+        app.init_resource::<InputTimeline>();
+        app.init_resource::<InputTimelineConfig>();
+        app.init_resource::<NetworkingMetadata>();
+        app.init_resource::<LastConfirmedInput>();
+        app.init_resource::<PredictionWindowWait>();
+        app.insert_resource(PredictionManager {
+            rollback_policy: lightyear_prediction::prelude::RollbackPolicy {
+                max_rollback_ticks: 4,
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+        app.add_systems(PostUpdate, update_prediction_window_wait);
+
+        let timeline_id = app.world().component_id::<InputTimeline>().unwrap();
+        let timeline_entity = app.world().resource_entities().get(timeline_id).unwrap();
+        app.world_mut()
+            .entity_mut(timeline_entity)
+            .insert(IsSynced::<InputTimeline>::default());
+        app.world_mut().resource_mut::<NetworkingMetadata>().mode = topology;
+        app
+    }
+
+    #[test]
+    fn wait_uses_effective_rollback_depth_for_client_and_p2p() {
+        for p2p in [false, true] {
+            let mut topology_world = World::new();
+            let link = topology_world.spawn_empty().id();
+            let topology = if p2p {
+                NetworkTopology::P2P {
+                    connected: [link].into_iter().collect(),
+                    declared_links: 1,
+                }
+            } else {
+                NetworkTopology::Client(link)
+            };
+            let mut app = wait_app(topology);
+            app.world_mut()
+                .resource_mut::<LocalTimeline>()
+                .apply_delta(104);
+            {
+                let mut confirmed = app.world_mut().resource_mut::<LastConfirmedInput>();
+                confirmed.tick.set_if_lower(Tick(100));
+                confirmed.received_for_all_clients = true;
+            }
+
+            app.world_mut().run_schedule(PostUpdate);
+            let wait = app.world().resource::<PredictionWindowWait>();
+            assert!(wait.is_waiting());
+            assert_eq!(wait.maximum_predicted_ticks(), 4);
+        }
+    }
+
+    #[test]
+    fn deterministic_session_without_remote_input_streams_does_not_wait() {
+        let mut topology_world = World::new();
+        let link = topology_world.spawn_empty().id();
+        let mut app = wait_app(NetworkTopology::Client(link));
+        app.world_mut()
+            .resource_mut::<LocalTimeline>()
+            .apply_delta(100);
+        app.world_mut()
+            .resource_mut::<LastConfirmedInput>()
+            .received_for_all_clients = true;
+
+        app.world_mut().run_schedule(PostUpdate);
+        assert!(!app.world().resource::<PredictionWindowWait>().is_waiting());
+    }
+}

--- a/crates/inputs/input_bei/src/setup.rs
+++ b/crates/inputs/input_bei/src/setup.rs
@@ -13,14 +13,15 @@ use bevy_replicon::shared::replication::registry::ctx::{SerializeCtx, WriteCtx};
 use lightyear_replication::prelude::ControlledBy;
 #[cfg(feature = "client")]
 use {
-    bevy_enhanced_input::context::ExternallyMocked, lightyear_connection::client::Client,
+    bevy_enhanced_input::context::ExternallyMocked,
+    lightyear_connection::network_topology::{NetworkTopology, NetworkingMetadata},
     lightyear_replication::prelude::Controlled,
 };
 
 use bevy_enhanced_input::prelude::*;
 #[cfg(any(feature = "client", feature = "server"))]
 use bevy_utils::prelude::DebugName;
-#[cfg(any(feature = "client", feature = "server"))]
+#[cfg(feature = "server")]
 use lightyear_connection::host::HostClient;
 #[cfg(all(feature = "client", feature = "server"))]
 use lightyear_connection::host::HostServer;
@@ -169,13 +170,13 @@ impl InputRegistryPlugin {
     #[cfg(feature = "client")]
     pub(crate) fn on_rebroadcast_action_received<C: Component>(
         trigger: On<Add, ActionOf<C>>,
-        clients: Query<(), (With<Client>, Without<HostClient>)>,
+        metadata: Res<NetworkingMetadata>,
         actions: Query<(&ActionOf<C>, Has<ExternallyMocked>, Has<Bindings>), With<Remote>>,
         contexts: Query<(), With<C>>,
         controlled: Query<(), With<Controlled>>,
         mut commands: Commands,
     ) {
-        if clients.is_empty() {
+        if !receives_remote_inputs(&metadata.mode) {
             return;
         }
         let entity = trigger.entity;
@@ -197,12 +198,12 @@ impl InputRegistryPlugin {
     #[cfg(feature = "client")]
     pub(crate) fn on_rebroadcast_context_received<C: Component>(
         trigger: On<Add, C>,
-        clients: Query<(), (With<Client>, Without<HostClient>)>,
+        metadata: Res<NetworkingMetadata>,
         contexts: Query<(&Actions<C>, Has<Controlled>), With<C>>,
         actions: Query<(&ActionOf<C>, Has<ExternallyMocked>, Has<Bindings>), With<Remote>>,
         mut commands: Commands,
     ) {
-        if clients.is_empty() {
+        if !receives_remote_inputs(&metadata.mode) {
             return;
         }
         let Ok((context_actions, has_controlled)) = contexts.get(trigger.entity) else {
@@ -221,12 +222,12 @@ impl InputRegistryPlugin {
     #[cfg(feature = "client")]
     pub(crate) fn on_rebroadcast_context_controlled<C: Component>(
         trigger: On<Add, Controlled>,
-        clients: Query<(), (With<Client>, Without<HostClient>)>,
+        metadata: Res<NetworkingMetadata>,
         contexts: Query<(&Actions<C>, Has<Controlled>), With<C>>,
         actions: Query<(&ActionOf<C>, Has<ExternallyMocked>, Has<Bindings>), With<Remote>>,
         mut commands: Commands,
     ) {
-        if clients.is_empty() {
+        if !receives_remote_inputs(&metadata.mode) {
             return;
         }
         let Ok((context_actions, has_controlled)) = contexts.get(trigger.entity) else {
@@ -238,6 +239,18 @@ impl InputRegistryPlugin {
             &actions,
             &mut commands,
         );
+    }
+}
+
+#[cfg(feature = "client")]
+fn receives_remote_inputs(topology: &NetworkTopology) -> bool {
+    match topology {
+        NetworkTopology::Client(_) => true,
+        NetworkTopology::P2P { connected, .. } => !connected.is_empty(),
+        NetworkTopology::Undefined
+        | NetworkTopology::Server(_)
+        | NetworkTopology::HostClient { .. }
+        | NetworkTopology::Invalid(_) => false,
     }
 }
 
@@ -344,7 +357,6 @@ impl InputRegistryExt for &mut App {
 #[cfg(all(test, feature = "client"))]
 mod tests {
     use super::*;
-    use lightyear_connection::client::Client;
     use lightyear_replication::prelude::Controlled;
 
     #[derive(Component)]
@@ -355,7 +367,10 @@ mod tests {
         app.add_observer(InputRegistryPlugin::on_rebroadcast_action_received::<TestContext>);
         app.add_observer(InputRegistryPlugin::on_rebroadcast_context_received::<TestContext>);
         app.add_observer(InputRegistryPlugin::on_rebroadcast_context_controlled::<TestContext>);
-        app.world_mut().spawn(Client);
+        let client = app.world_mut().spawn_empty().id();
+        let mut metadata = NetworkingMetadata::default();
+        metadata.mode = NetworkTopology::Client(client);
+        app.insert_resource(metadata);
         app
     }
 

--- a/crates/inputs/inputs/src/client.rs
+++ b/crates/inputs/inputs/src/client.rs
@@ -130,8 +130,8 @@ pub enum InputSystems {
 ///   them before it needs them.
 /// - **Redundancy**: each message includes the last N ticks of input to
 ///   recover from packet loss.
-/// - **Remote player prediction**: if `rebroadcast_inputs` is enabled,
-///   processes input messages received from the server for other players.
+/// - **Remote player prediction**: processes other players' inputs when a conventional server
+///   rebroadcasts them, or directly from every peer in a P2P topology.
 pub struct ClientInputPlugin<S: ActionStateSequence> {
     config: InputConfig<S::Action>,
 }
@@ -207,7 +207,10 @@ impl<S: ActionStateSequence + MapEntities> Plugin for ClientInputPlugin<S> {
 
         // SYSTEMS
         #[cfg(feature = "prediction")]
-        if self.config.rebroadcast_inputs {
+        {
+            // The topology is a runtime choice. Conventional clients still return immediately
+            // when rebroadcasting is disabled, while P2P peers must always drain direct remote
+            // input messages even though their client/server rebroadcast option is false.
             // NOTE: we do NOT need to run this after RunFixedMainLoopSystems::BeforeFixedMainLoop to ensure that the
             //  local leafwing `states` have been switched to the `fixed_update` state (see
             //  https://github.com/Leafwing-Studios/leafwing-input-manager/blob/v0.16/src/plugin.rs#L170)
@@ -343,6 +346,11 @@ impl<'a> InputRoute<'a> {
     }
 
     #[inline]
+    fn requires_prespawned_targets(self) -> bool {
+        matches!(self, Self::P2P(_))
+    }
+
+    #[inline]
     fn accepts_local_target(self, controlled_by: Option<&ControlledBy>) -> bool {
         match self {
             Self::ClientServer { link, .. } => {
@@ -353,6 +361,37 @@ impl<'a> InputRoute<'a> {
             Self::P2P(_) => true,
         }
     }
+}
+
+/// Select the wire identity for one locally controlled input entity.
+///
+/// Conventional client/server links can use their replication-populated entity map. P2P has no
+/// authoritative replication stream to populate those per-Link maps, so every target must use a
+/// stable [`PreSpawned`] hash that the other peers can resolve in their own worlds.
+fn input_target(
+    route: InputRoute<'_>,
+    entity: Entity,
+    pre_spawned: Option<&PreSpawned>,
+) -> InputTarget {
+    if let Some(hash) = pre_spawned.and_then(|pre_spawned| pre_spawned.hash) {
+        debug!(?hash, ?entity, "Sending input for prespawned entity");
+        return InputTarget::PreSpawned(hash);
+    }
+    assert!(
+        !route.requires_prespawned_targets(),
+        "P2P input target {entity:?} must have a PreSpawned component with a resolved hash"
+    );
+    InputTarget::Entity(entity)
+}
+
+#[inline]
+fn matches_prespawned_target(
+    hash: u64,
+    p2p_link: Option<Entity>,
+    pre_spawned: &PreSpawned,
+) -> bool {
+    pre_spawned.hash.is_some_and(|candidate| candidate == hash)
+        && p2p_link.is_none_or(|link| pre_spawned.receiver == Some(link))
 }
 
 // equivalent to &ActionState<S::Action>
@@ -522,7 +561,7 @@ fn get_action_state<S: ActionStateSequence>(
                 input_buffer = %*input_buffer,
                 "restored action state from input buffer"
             );
-        } else if !is_local && config.rebroadcast_inputs {
+        } else if !is_local && (config.rebroadcast_inputs || matches!(route, InputRoute::P2P(_))) {
             if input_timeline_config.is_lockstep() {
                 error!("We are in lockstep mode but didn't receive an input for tick {tick:?}!");
             }
@@ -786,14 +825,7 @@ fn prepare_input_message<S: ActionStateSequence>(
             input_buffer
         );
 
-        let target = if let Some(prespawned) = pre_spawned
-            && let Some(hash) = prespawned.hash
-        {
-            debug!(?hash, ?entity, "Sending input for prespawned entity");
-            InputTarget::PreSpawned(hash)
-        } else {
-            InputTarget::Entity(entity)
-        };
+        let target = input_target(route, entity, pre_spawned);
 
         if let Some(state_sequence) = S::build_from_input_buffer(input_buffer, num_ticks, tick) {
             trace!(
@@ -859,6 +891,7 @@ fn receive_remote_player_input_messages<S: ActionStateSequence>(
     mut commands: Commands,
     tick_duration: Res<TickDuration>,
     timeline: Res<LocalTimeline>,
+    input_config: Res<InputConfig<S::Action>>,
     #[cfg(feature = "metrics")] mut input_metric_handles: ResMut<InputMetricHandles<S>>,
     _input_timeline: SyncedInputTimeline,
     metadata: Res<NetworkingMetadata>,
@@ -878,6 +911,11 @@ fn receive_remote_player_input_messages<S: ActionStateSequence>(
     if route.is_host_client() {
         return;
     }
+    // Conventional clients only receive other players' inputs when the server is configured to
+    // rebroadcast them. Direct P2P peers always exchange remote inputs with each other.
+    if matches!(route, InputRoute::ClientServer { .. }) && !input_config.rebroadcast_inputs {
+        return;
+    }
     let Some(prediction_manager) = prediction_manager else {
         return;
     };
@@ -891,6 +929,7 @@ fn receive_remote_player_input_messages<S: ActionStateSequence>(
                     &mut commands,
                     *tick_duration,
                     tick,
+                    None,
                     &prediction_manager,
                     &mut predicted_query,
                     &prespawned,
@@ -909,6 +948,7 @@ fn receive_remote_player_input_messages<S: ActionStateSequence>(
                     &mut commands,
                     *tick_duration,
                     tick,
+                    Some(*link),
                     &prediction_manager,
                     &mut predicted_query,
                     &prespawned,
@@ -932,6 +972,7 @@ fn receive_remote_player_input_messages_from_receiver<S: ActionStateSequence>(
     commands: &mut Commands,
     tick_duration: TickDuration,
     tick: Tick,
+    p2p_link: Option<Entity>,
     prediction_manager: &PredictionManager,
     predicted_query: &mut Query<
         Option<&mut InputBuffer<S::Snapshot, S::Action>>,
@@ -958,13 +999,19 @@ fn receive_remote_player_input_messages_from_receiver<S: ActionStateSequence>(
         );
         for target_data in message.inputs {
             let Some(entity) = (match target_data.target {
+                InputTarget::Entity(entity) if p2p_link.is_none() => Some(entity),
                 InputTarget::Entity(entity) => {
-                    Some(entity)
+                    error!(
+                        ?entity,
+                        end_tick = ?message.end_tick,
+                        "ignored P2P input target without a PreSpawned hash"
+                    );
+                    None
                 }
                 InputTarget::PreSpawned(hash) => {
-                    prespawned
-                        .iter()
-                        .find_map(|(e, p)| p.hash.is_some_and(|h| h == hash).then_some(e))
+                    prespawned.iter().find_map(|(entity, pre_spawned)| {
+                        matches_prespawned_target(hash, p2p_link, pre_spawned).then_some(entity)
+                    })
                 }
             }) else {
                 if message.rebroadcast {
@@ -972,6 +1019,12 @@ fn receive_remote_player_input_messages_from_receiver<S: ActionStateSequence>(
                         target = ?target_data.target,
                         end_tick = ?message.end_tick,
                         "ignored stale remote player input message for unmapped entity"
+                    );
+                } else if let Some(link) = p2p_link {
+                    warn!(
+                        ?link,
+                        target = ?target_data.target,
+                        "could not find a PreSpawned P2P input target owned by the sending Link"
                     );
                 } else {
                     warn!("Could not find entity in entity_map for remote player input message {:?}", target_data.target);
@@ -1091,6 +1144,7 @@ fn receive_remote_player_input_messages_from_receiver<S: ActionStateSequence>(
 fn update_last_confirmed_input<S: ActionStateSequence>(
     timeline: Res<LocalTimeline>,
     _input_timeline: SyncedInputTimeline,
+    action_config: Res<InputConfig<S::Action>>,
     input_config: Res<InputTimelineConfig>,
     metadata: Res<NetworkingMetadata>,
     mut last_confirmed_input: ResMut<LastConfirmedInput>,
@@ -1099,7 +1153,10 @@ fn update_last_confirmed_input<S: ActionStateSequence>(
         (Without<S::Marker>, Allow<PredictionDisable>),
     >,
 ) {
-    if InputRoute::from_topology(&metadata.mode).is_none() {
+    let Some(route) = InputRoute::from_topology(&metadata.mode) else {
+        return;
+    };
+    if matches!(route, InputRoute::ClientServer { .. }) && !action_config.rebroadcast_inputs {
         return;
     }
     let tick = timeline.tick();
@@ -1420,6 +1477,70 @@ mod tests {
         assert!(p2p_route.accepts_local_target(Some(&owned_by_client)));
         assert!(p2p_route.accepts_local_target(Some(&owned_by_other)));
     }
+
+    #[test]
+    fn p2p_input_targets_use_prespawned_hashes() {
+        let mut world = World::new();
+        let link = world.spawn_empty().id();
+        let target = world.spawn_empty().id();
+        let topology = NetworkTopology::P2P {
+            connected: [link].into_iter().collect(),
+            declared_links: 1,
+        };
+        let route = InputRoute::from_topology(&topology).unwrap();
+        let prespawned = PreSpawned::new(0xCAFE);
+
+        assert_eq!(
+            input_target(route, target, Some(&prespawned)),
+            InputTarget::PreSpawned(0xCAFE)
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "must have a PreSpawned component with a resolved hash")]
+    fn p2p_input_targets_reject_unmapped_entities() {
+        let mut world = World::new();
+        let link = world.spawn_empty().id();
+        let target = world.spawn_empty().id();
+        let topology = NetworkTopology::P2P {
+            connected: [link].into_iter().collect(),
+            declared_links: 1,
+        };
+        let route = InputRoute::from_topology(&topology).unwrap();
+
+        let _ = input_target(route, target, None);
+    }
+
+    #[test]
+    fn client_server_input_targets_still_allow_entities() {
+        let mut world = World::new();
+        let link = world.spawn_empty().id();
+        let target = world.spawn_empty().id();
+        let topology = NetworkTopology::Client(link);
+        let route = InputRoute::from_topology(&topology).unwrap();
+
+        assert_eq!(
+            input_target(route, target, None),
+            InputTarget::Entity(target)
+        );
+    }
+
+    #[test]
+    fn p2p_input_targets_are_scoped_to_the_sending_link() {
+        let mut world = World::new();
+        let owner = world.spawn_empty().id();
+        let other = world.spawn_empty().id();
+        let pre_spawned = PreSpawned::new(0xCAFE).for_receiver(owner);
+
+        assert!(matches_prespawned_target(0xCAFE, Some(owner), &pre_spawned));
+        assert!(!matches_prespawned_target(
+            0xCAFE,
+            Some(other),
+            &pre_spawned
+        ));
+        assert!(matches_prespawned_target(0xCAFE, None, &pre_spawned));
+    }
+
     #[test]
     fn input_history_depth_covers_prediction_rollback_window() {
         assert_eq!(input_history_depth(None), HISTORY_DEPTH);

--- a/crates/inputs/inputs/src/client.rs
+++ b/crates/inputs/inputs/src/client.rs
@@ -77,8 +77,9 @@ use lightyear_messages::prelude::MessageSender;
 use lightyear_prediction::prelude::*;
 use lightyear_replication::prelude::{ControlledBy, PreSpawned};
 use lightyear_sync::plugin::SyncSystems;
+#[cfg(feature = "interpolation")]
 use lightyear_sync::prelude::client::IsSynced;
-use lightyear_sync::prelude::{InputTimeline, InputTimelineConfig};
+use lightyear_sync::prelude::{InputTimeline, InputTimelineConfig, SyncedInputTimeline};
 use lightyear_transport::prelude::ChannelRegistry;
 #[allow(unused_imports)]
 use tracing::{debug, error, info, trace, warn};
@@ -155,6 +156,14 @@ impl<S: ActionStateSequence + MapEntities> Plugin for ClientInputPlugin<S> {
         app.init_resource::<SharedInputConfig>();
         app.insert_resource(self.config);
         app.init_resource::<MessageBuffer<S>>();
+        // Client input systems may be installed in a combined client/server app. Keep their
+        // global clock parameters available even when no client link is active; the
+        // SyncedInputTimeline parameter still gates systems that require synchronization.
+        app.init_resource::<InputTimeline>();
+        app.init_resource::<InputTimelineConfig>();
+        #[cfg(feature = "prediction")]
+        app.init_resource::<LastConfirmedInput>();
+
         // SETS
 
         // NOTE: this is subtle! We receive remote players messages after
@@ -279,14 +288,8 @@ fn buffer_action_state<S: ActionStateSequence>(
     // we buffer inputs even for the Host-Server so that
     // 1. the HostServer client can broadcast inputs to other clients
     // 2. the HostServer client can have input delay
-    input_timeline: Single<
-        (Entity, &InputTimeline),
-        (
-            With<Client>,
-            With<IsSynced<InputTimeline>>,
-            Without<Rollback>,
-        ),
-    >,
+    input_timeline: SyncedInputTimeline,
+    client_entity: Single<Entity, (With<Client>, Without<Rollback>)>,
     mut action_state_query: Query<
         (
             Entity,
@@ -297,7 +300,7 @@ fn buffer_action_state<S: ActionStateSequence>(
         (With<S::Marker>, Allow<PredictionDisable>),
     >,
 ) {
-    let (client_entity, input_timeline) = input_timeline.into_inner();
+    let client_entity = *client_entity;
     let current_tick = local_timeline.tick();
     let tick = current_tick + input_timeline.input_delay() as i32;
     for (entity, action_state, mut input_buffer, controlled_by) in action_state_query.iter_mut() {
@@ -340,10 +343,9 @@ fn get_action_state<S: ActionStateSequence>(
     local_timeline: Res<LocalTimeline>,
     // NOTE: we skip this for host-client because a similar system does the same thing
     //  in the server, and also clears the buffers
-    sender: Query<
-        (&InputTimeline, &InputTimelineConfig, Has<Rollback>),
-        (With<Client>, Without<HostClient>),
-    >,
+    input_timeline: Res<InputTimeline>,
+    input_timeline_config: Res<InputTimelineConfig>,
+    client: Single<Has<Rollback>, (With<Client>, Without<HostClient>)>,
 
     // NOTE: we want to apply the Inputs for BOTH the local player and remote player
     // - local player: we need to get the input from the InputBuffer because of input delay
@@ -360,9 +362,7 @@ fn get_action_state<S: ActionStateSequence>(
         Allow<PredictionDisable>,
     >,
 ) {
-    let Ok((input_timeline, input_config, is_rollback)) = sender.single() else {
-        return;
-    };
+    let is_rollback = *client;
     let input_delay = input_timeline.input_delay() as i32;
     let tick = local_timeline.tick();
     if is_rollback && config.ignore_rollbacks {
@@ -422,7 +422,7 @@ fn get_action_state<S: ActionStateSequence>(
                 "restored action state from input buffer"
             );
         } else if !is_local && config.rebroadcast_inputs {
-            if input_config.is_lockstep() {
+            if input_timeline_config.is_lockstep() {
                 error!("We are in lockstep mode but didn't receive an input for tick {tick:?}!");
             }
             // we are here if:
@@ -463,10 +463,8 @@ fn get_action_state<S: ActionStateSequence>(
 /// (e.g. the delayed action state) because all inputs (i.e. diffs) are applied to the delayed action-state.
 fn get_delayed_action_state<S: ActionStateSequence>(
     timeline: Res<LocalTimeline>,
-    sender: Query<
-        (Entity, &InputTimeline, Has<Rollback>),
-        (With<Client>, With<IsSynced<InputTimeline>>),
-    >,
+    input_timeline: SyncedInputTimeline,
+    client: Single<(Entity, Has<Rollback>), With<Client>>,
     mut action_state_query: Query<
         (
             Entity,
@@ -478,9 +476,7 @@ fn get_delayed_action_state<S: ActionStateSequence>(
         (With<S::Marker>, Allow<PredictionDisable>),
     >,
 ) {
-    let Ok((client_entity, input_timeline, is_rollback)) = sender.single() else {
-        return;
-    };
+    let (client_entity, is_rollback) = client.into_inner();
     let input_delay_ticks = input_timeline.input_delay() as i32;
     if is_rollback || input_delay_ticks == 0 {
         return;
@@ -526,17 +522,21 @@ fn clean_buffers<S: ActionStateSequence>(
     timeline: Res<LocalTimeline>,
     // NOTE: we skip this for host-client because the get_action_state system on the server
     //  also clears the buffers
-    sender: Query<(), (With<Client>, With<InputTimeline>, Without<HostClient>)>,
-    prediction_manager: Option<Single<(&PredictionManager, &InputTimelineConfig), With<Client>>>,
+    _client: Single<(), (With<Client>, Without<HostClient>)>,
+    prediction_manager: Option<Single<&PredictionManager, With<Client>>>,
+    input_config: Res<InputTimelineConfig>,
     mut input_buffer_query: Query<
         &mut InputBuffer<S::Snapshot, S::Action>,
         Allow<PredictionDisable>,
     >,
 ) {
-    if sender.single().is_err() {
-        return;
-    }
-    let old_tick = timeline.tick() - input_history_depth(prediction_manager.as_deref().copied());
+    let old_tick = timeline.tick()
+        - input_history_depth(
+            prediction_manager
+                .as_deref()
+                .copied()
+                .map(|manager| (manager, input_config.as_ref())),
+        );
 
     // trace!(
     //     "popping all input buffers since old tick: {old_tick:?}",
@@ -590,17 +590,8 @@ fn prepare_input_message<S: ActionStateSequence>(
     tick_duration: Res<TickDuration>,
     timeline: Res<LocalTimeline>,
     input_config: Res<InputConfig<S::Action>>,
-    sender: Single<
-        (Entity, &InputTimeline, Has<HostClient>),
-        // the host-client doesn't need to send input messages since the ActionState is already on the entity
-        // unless we want to rebroadcast the HostClient inputs to other clients (in which
-        // case we prepare the input-message, which will be send_local to the server)
-        (
-            With<Client>,
-            With<IsSynced<InputTimeline>>,
-            Without<Rollback>,
-        ),
-    >,
+    input_timeline: SyncedInputTimeline,
+    client: Single<(Entity, Has<HostClient>), (With<Client>, Without<Rollback>)>,
     _channel_registry: Res<ChannelRegistry>,
     input_buffer_query: Query<
         (
@@ -614,6 +605,8 @@ fn prepare_input_message<S: ActionStateSequence>(
     real_time: Res<Time<Real>>,
     mut send_timer: Local<Option<Timer>>,
 ) {
+    let (client_entity, is_host_client) = client.into_inner();
+
     // Only prepare input every send-interval.
     if !input_config.send_interval.is_zero() {
         let timer = send_timer
@@ -624,7 +617,6 @@ fn prepare_input_message<S: ActionStateSequence>(
         }
     }
 
-    let (client_entity, input_timeline, is_host_client) = sender.into_inner();
     #[cfg(not(feature = "prediction"))]
     if is_host_client {
         // if there is not prediction, no need to rebroadcast inputs
@@ -751,18 +743,12 @@ fn receive_remote_player_input_messages<S: ActionStateSequence>(
     tick_duration: Res<TickDuration>,
     timeline: Res<LocalTimeline>,
     #[cfg(feature = "metrics")] mut input_metric_handles: ResMut<InputMetricHandles<S>>,
+    _input_timeline: SyncedInputTimeline,
+    last_confirmed_input: Res<LastConfirmedInput>,
     link: Single<
-        (
-            &mut MessageReceiver<InputMessage<S>>,
-            Option<&LastConfirmedInput>,
-            &PredictionManager,
-        ),
+        (&mut MessageReceiver<InputMessage<S>>, &PredictionManager),
         // the host-client won't receive input messages from the Server
-        (
-            With<Client>,
-            With<IsSynced<InputTimeline>>,
-            Without<HostClient>,
-        ),
+        (With<Client>, Without<HostClient>),
     >,
     mut predicted_query: Query<
         Option<&mut InputBuffer<S::Snapshot, S::Action>>,
@@ -770,7 +756,7 @@ fn receive_remote_player_input_messages<S: ActionStateSequence>(
     >,
     prespawned: Query<(Entity, &PreSpawned)>,
 ) {
-    let (mut receiver, last_confirmed_input, prediction_manager) = link.into_inner();
+    let (mut receiver, prediction_manager) = link.into_inner();
     let tick = timeline.tick();
     let mut received_relevant_input = false;
     receiver.receive().for_each(|message| {
@@ -912,9 +898,7 @@ fn receive_remote_player_input_messages<S: ActionStateSequence>(
         }
     });
 
-    if let Some(last_confirmed_input) = last_confirmed_input
-        && received_relevant_input
-    {
+    if received_relevant_input {
         last_confirmed_input
             .received_any_messages
             .store(true, bevy_platform::sync::atomic::Ordering::Relaxed);
@@ -929,16 +913,15 @@ fn receive_remote_player_input_messages<S: ActionStateSequence>(
 /// (and not to tick 14) because we need to potentially re-apply inputs for ticks 11, 12, 13, 14.
 fn update_last_confirmed_input<S: ActionStateSequence>(
     timeline: Res<LocalTimeline>,
-    last_confirmed_input: Single<
-        (&mut LastConfirmedInput, &InputTimelineConfig),
-        (With<Client>, With<IsSynced<InputTimeline>>),
-    >,
+    _input_timeline: SyncedInputTimeline,
+    input_config: Res<InputTimelineConfig>,
+    _client: Single<(), With<Client>>,
+    mut last_confirmed_input: ResMut<LastConfirmedInput>,
     predicted_query: Query<
         &InputBuffer<S::Snapshot, S::Action>,
         (Without<S::Marker>, Allow<PredictionDisable>),
     >,
 ) {
-    let (mut last_confirmed_input, input_config) = last_confirmed_input.into_inner();
     let tick = timeline.tick();
     // in lockstep mode, we don't need last confirmed input because we always have all inputs for a given tick.
     // we will just use the current tick as the last confirmed input tick
@@ -1060,18 +1043,12 @@ fn update_buffer_from_remote_player_message<S: ActionStateSequence>(
 /// Drain the messages from the buffer and send them to the server
 fn send_input_messages<S: ActionStateSequence>(
     input_config: Res<InputConfig<S::Action>>,
+    input_timeline: SyncedInputTimeline,
     mut message_buffer: ResMut<MessageBuffer<S>>,
-    sender: Single<
-        (&mut MessageSender<InputMessage<S>>, Has<HostClient>),
-        (With<Client>, With<IsSynced<InputTimeline>>),
-    >,
-    #[cfg(feature = "interpolation")] interpolation_query: Single<
-        (&InputTimeline, &InterpolationTimeline),
-        (
-            With<Client>,
-            With<IsSynced<InterpolationTimeline>>,
-            With<IsSynced<InputTimeline>>,
-        ),
+    sender: Single<(&mut MessageSender<InputMessage<S>>, Has<HostClient>), With<Client>>,
+    #[cfg(feature = "interpolation")] interpolation_timeline: Single<
+        &InterpolationTimeline,
+        (With<Client>, With<IsSynced<InterpolationTimeline>>),
     >,
 ) {
     let (mut sender, is_host_client) = sender.into_inner();
@@ -1105,8 +1082,6 @@ fn send_input_messages<S: ActionStateSequence>(
 
     #[cfg(feature = "interpolation")]
     let interpolation_delay = {
-        let (input_timeline, interpolation_timeline) = interpolation_query.into_inner();
-
         // NOTE: this can be negative because of input-delay!
         let mut delay = input_timeline.now() - interpolation_timeline.now();
         if delay.is_negative() {
@@ -1137,8 +1112,8 @@ fn send_input_messages<S: ActionStateSequence>(
 /// In case the client tick changes suddenly, we also update the InputBuffer accordingly
 fn receive_tick_events<S: ActionStateSequence>(
     trigger: On<SyncEvent<InputTimelineConfig>>,
+    client_entity: Single<Entity, With<Client>>,
     mut message_buffer: ResMut<MessageBuffer<S>>,
-    clients: Query<(), With<Client>>,
     mut input_buffer_query: Query<
         (
             &mut InputBuffer<S::Snapshot, S::Action>,
@@ -1147,12 +1122,10 @@ fn receive_tick_events<S: ActionStateSequence>(
         Allow<PredictionDisable>,
     >,
 ) {
-    if clients.get(trigger.entity).is_err() {
-        return;
-    }
+    let client_entity = *client_entity;
     let delta = trigger.tick_delta;
     for (mut input_buffer, controlled_by) in input_buffer_query.iter_mut() {
-        if controlled_by.is_some_and(|controlled_by| controlled_by.owner != trigger.entity) {
+        if controlled_by.is_some_and(|controlled_by| controlled_by.owner != client_entity) {
             continue;
         }
         if let Some(start_tick) = input_buffer.start_tick {

--- a/crates/inputs/inputs/src/client.rs
+++ b/crates/inputs/inputs/src/client.rs
@@ -162,7 +162,11 @@ impl<S: ActionStateSequence + MapEntities> Plugin for ClientInputPlugin<S> {
         app.init_resource::<InputTimeline>();
         app.init_resource::<InputTimelineConfig>();
         #[cfg(feature = "prediction")]
-        app.init_resource::<LastConfirmedInput>();
+        {
+            if !app.is_plugin_added::<LastConfirmedInputPlugin>() {
+                app.add_plugins(LastConfirmedInputPlugin);
+            }
+        }
 
         // SETS
 
@@ -267,6 +271,31 @@ impl<S: ActionStateSequence + MapEntities> Plugin for ClientInputPlugin<S> {
         // if the client tick is updated because of a desync, update the ticks in the input buffers
         app.add_observer(receive_tick_events::<S>);
     }
+}
+
+/// Installs application-global confirmed-input frontier bookkeeping.
+///
+/// A client application can register several input types. Installing this non-generic plugin once
+/// ensures their contributions are finalized only after every input type has updated the shared
+/// [`LastConfirmedInput`] resource.
+#[cfg(feature = "prediction")]
+struct LastConfirmedInputPlugin;
+
+#[cfg(feature = "prediction")]
+impl Plugin for LastConfirmedInputPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<LastConfirmedInput>();
+        app.add_systems(
+            PostUpdate,
+            finalize_last_confirmed_input.after(InputSystems::UpdateRemoteInputTicks),
+        );
+    }
+}
+
+#[cfg(feature = "prediction")]
+/// Preserve the completed aggregate for next frame's rollback decision.
+fn finalize_last_confirmed_input(mut last_confirmed_input: ResMut<LastConfirmedInput>) {
+    last_confirmed_input.finalize_frame();
 }
 
 /// Cached input routing derived from [`NetworkingMetadata`].
@@ -1074,9 +1103,10 @@ fn update_last_confirmed_input<S: ActionStateSequence>(
         return;
     }
     let tick = timeline.tick();
-    // in lockstep mode, we don't need last confirmed input because we always have all inputs for a given tick.
-    // we will just use the current tick as the last confirmed input tick
-    if input_config.is_lockstep() {
+    // Preserve the conventional lockstep behavior: input delay guarantees that the sole remote
+    // endpoint has supplied the current tick. P2P must inspect the actual global frontier because
+    // one slow peer can still be missing while the others are ready.
+    if input_config.is_lockstep() && !matches!(metadata.mode, NetworkTopology::P2P { .. }) {
         last_confirmed_input.tick.set_if_lower(tick);
         return;
     }
@@ -1084,16 +1114,19 @@ fn update_last_confirmed_input<S: ActionStateSequence>(
 
     // find the earliest last_confirmed_tick for each client
     // The tracker was reset to a high tick, so the first real tick always becomes the minimum.
-    last_confirmed_input.received_for_all_clients = true;
+    let mut received_for_all_clients = true;
     predicted_query.iter().for_each(|buffer| {
         // if we received any messages, we update the LastConfirmedInput
         // (this is used to determine the last confirmed tick for each client)
         if let Some(end_tick) = buffer.last_remote_tick {
             last_confirmed_input.tick.set_if_lower(end_tick);
         } else {
-            last_confirmed_input.received_for_all_clients = false;
+            received_for_all_clients = false;
         }
     });
+    // Several generic input plugins contribute sequentially in the same set. The tracker is reset
+    // to true once in PreUpdate, so AND-ing preserves a missing stream reported by any input type.
+    last_confirmed_input.received_for_all_clients &= received_for_all_clients;
     trace!(
         target: "lightyear_debug::input",
         kind = "last_confirmed_input",

--- a/crates/inputs/inputs/src/client.rs
+++ b/crates/inputs/inputs/src/client.rs
@@ -324,19 +324,6 @@ impl<'a> InputRoute<'a> {
             Self::P2P(_) => true,
         }
     }
-
-    #[inline]
-    fn any_link(self, mut predicate: impl FnMut(Entity) -> bool) -> bool {
-        match self {
-            Self::ClientServer { link, .. } => predicate(link),
-            Self::P2P(links) => links.iter().copied().any(predicate),
-        }
-    }
-}
-
-#[inline]
-fn route_is_in_rollback(route: InputRoute<'_>, rollbacks: &Query<(), With<Rollback>>) -> bool {
-    route.any_link(|link| rollbacks.contains(link))
 }
 
 // equivalent to &ActionState<S::Action>
@@ -360,7 +347,7 @@ fn buffer_action_state<S: ActionStateSequence>(
     // 2. the HostServer client can have input delay
     input_timeline: SyncedInputTimeline,
     metadata: Res<NetworkingMetadata>,
-    rollbacks: Query<(), With<Rollback>>,
+    rollback: Option<Res<Rollback>>,
     mut action_state_query: Query<
         (
             Entity,
@@ -374,7 +361,7 @@ fn buffer_action_state<S: ActionStateSequence>(
     let Some(route) = InputRoute::from_topology(&metadata.mode) else {
         return;
     };
-    if route_is_in_rollback(route, &rollbacks) {
+    if rollback.is_some() {
         return;
     }
     let current_tick = local_timeline.tick();
@@ -422,7 +409,7 @@ fn get_action_state<S: ActionStateSequence>(
     input_timeline: Res<InputTimeline>,
     input_timeline_config: Res<InputTimelineConfig>,
     metadata: Res<NetworkingMetadata>,
-    rollbacks: Query<(), With<Rollback>>,
+    rollback: Option<Res<Rollback>>,
 
     // NOTE: we want to apply the Inputs for BOTH the local player and remote player
     // - local player: we need to get the input from the InputBuffer because of input delay
@@ -447,7 +434,7 @@ fn get_action_state<S: ActionStateSequence>(
     if route.is_host_client() {
         return;
     }
-    let is_rollback = route_is_in_rollback(route, &rollbacks);
+    let is_rollback = rollback.is_some();
     let input_delay = input_timeline.input_delay() as i32;
     let tick = local_timeline.tick();
     if is_rollback && config.ignore_rollbacks {
@@ -550,7 +537,7 @@ fn get_delayed_action_state<S: ActionStateSequence>(
     timeline: Res<LocalTimeline>,
     input_timeline: SyncedInputTimeline,
     metadata: Res<NetworkingMetadata>,
-    rollbacks: Query<(), With<Rollback>>,
+    rollback: Option<Res<Rollback>>,
     mut action_state_query: Query<
         (
             Entity,
@@ -565,7 +552,7 @@ fn get_delayed_action_state<S: ActionStateSequence>(
     let Some(route) = InputRoute::from_topology(&metadata.mode) else {
         return;
     };
-    let is_rollback = route_is_in_rollback(route, &rollbacks);
+    let is_rollback = rollback.is_some();
     let input_delay_ticks = input_timeline.input_delay() as i32;
     if is_rollback || input_delay_ticks == 0 {
         return;
@@ -612,7 +599,7 @@ fn clean_buffers<S: ActionStateSequence>(
     // NOTE: we skip this for host-client because the get_action_state system on the server
     //  also clears the buffers
     metadata: Res<NetworkingMetadata>,
-    prediction_managers: Query<&PredictionManager>,
+    prediction_manager: Option<Res<PredictionManager>>,
     input_config: Res<InputTimelineConfig>,
     mut input_buffer_query: Query<
         &mut InputBuffer<S::Snapshot, S::Action>,
@@ -625,8 +612,12 @@ fn clean_buffers<S: ActionStateSequence>(
     if route.is_host_client() {
         return;
     }
-    let old_tick =
-        timeline.tick() - input_history_depth_for_route(route, &prediction_managers, &input_config);
+    let old_tick = timeline.tick()
+        - input_history_depth(
+            prediction_manager
+                .as_deref()
+                .map(|manager| (manager, input_config.as_ref())),
+        );
 
     // trace!(
     //     "popping all input buffers since old tick: {old_tick:?}",
@@ -650,30 +641,6 @@ fn input_history_depth(
         })
         .unwrap_or(0)
         .max(HISTORY_DEPTH)
-}
-
-fn input_history_depth_for_route(
-    route: InputRoute<'_>,
-    prediction_managers: &Query<&PredictionManager>,
-    input_config: &InputTimelineConfig,
-) -> u32 {
-    let mut history_depth = HISTORY_DEPTH;
-    match route {
-        InputRoute::ClientServer { link, .. } => {
-            if let Ok(manager) = prediction_managers.get(link) {
-                history_depth = input_history_depth(Some((manager, input_config)));
-            }
-        }
-        InputRoute::P2P(links) => {
-            for link in links {
-                if let Ok(manager) = prediction_managers.get(*link) {
-                    history_depth =
-                        history_depth.max(input_history_depth(Some((manager, input_config))));
-                }
-            }
-        }
-    }
-    history_depth
 }
 
 // TODO: is this actually necessary? The sync happens in PostUpdate,
@@ -706,7 +673,7 @@ fn prepare_input_message<S: ActionStateSequence>(
     input_config: Res<InputConfig<S::Action>>,
     input_timeline: SyncedInputTimeline,
     metadata: Res<NetworkingMetadata>,
-    rollbacks: Query<(), With<Rollback>>,
+    rollback: Option<Res<Rollback>>,
     _channel_registry: Res<ChannelRegistry>,
     input_buffer_query: Query<
         (
@@ -723,7 +690,7 @@ fn prepare_input_message<S: ActionStateSequence>(
     let Some(route) = InputRoute::from_topology(&metadata.mode) else {
         return;
     };
-    if route_is_in_rollback(route, &rollbacks) {
+    if rollback.is_some() {
         return;
     }
     let is_host_client = route.is_host_client();
@@ -867,8 +834,8 @@ fn receive_remote_player_input_messages<S: ActionStateSequence>(
     _input_timeline: SyncedInputTimeline,
     metadata: Res<NetworkingMetadata>,
     last_confirmed_input: Res<LastConfirmedInput>,
+    prediction_manager: Option<Res<PredictionManager>>,
     mut receivers: Query<&mut MessageReceiver<InputMessage<S>>>,
-    prediction_managers: Query<&PredictionManager>,
     mut predicted_query: Query<
         Option<&mut InputBuffer<S::Snapshot, S::Action>>,
         (Without<S::Marker>, Allow<PredictionDisable>),
@@ -882,10 +849,7 @@ fn receive_remote_player_input_messages<S: ActionStateSequence>(
     if route.is_host_client() {
         return;
     }
-    let Some(prediction_manager_link) = prediction_manager_link(route, &prediction_managers) else {
-        return;
-    };
-    let Ok(prediction_manager) = prediction_managers.get(prediction_manager_link) else {
+    let Some(prediction_manager) = prediction_manager else {
         return;
     };
     let tick = timeline.tick();
@@ -898,7 +862,7 @@ fn receive_remote_player_input_messages<S: ActionStateSequence>(
                     &mut commands,
                     *tick_duration,
                     tick,
-                    prediction_manager,
+                    &prediction_manager,
                     &mut predicted_query,
                     &prespawned,
                     #[cfg(feature = "metrics")]
@@ -916,7 +880,7 @@ fn receive_remote_player_input_messages<S: ActionStateSequence>(
                     &mut commands,
                     *tick_duration,
                     tick,
-                    prediction_manager,
+                    &prediction_manager,
                     &mut predicted_query,
                     &prespawned,
                     #[cfg(feature = "metrics")]
@@ -930,28 +894,6 @@ fn receive_remote_player_input_messages<S: ActionStateSequence>(
         last_confirmed_input
             .received_any_messages
             .store(true, bevy_platform::sync::atomic::Ordering::Relaxed);
-    }
-}
-
-/// Return the sole prediction-manager Link selected by the cached route.
-///
-/// P2P temporarily keeps `PredictionManager` on one Link until it becomes a resource in PR 4. If
-/// zero or multiple routed Links contain a manager, input receive remains inactive rather than
-/// associating rollback state with an arbitrary peer.
-fn prediction_manager_link(
-    route: InputRoute<'_>,
-    prediction_managers: &Query<&PredictionManager>,
-) -> Option<Entity> {
-    match route {
-        InputRoute::ClientServer { link, .. } => prediction_managers.contains(link).then_some(link),
-        InputRoute::P2P(links) => {
-            let mut matches = links
-                .iter()
-                .copied()
-                .filter(|link| prediction_managers.contains(*link));
-            let first = matches.next()?;
-            matches.next().is_none().then_some(first)
-        }
     }
 }
 

--- a/crates/inputs/inputs/src/client.rs
+++ b/crates/inputs/inputs/src/client.rs
@@ -57,19 +57,19 @@ use alloc::{vec, vec::Vec};
 use bevy_app::{
     App, FixedPostUpdate, FixedPreUpdate, Plugin, PostUpdate, PreUpdate, RunFixedMainLoopSystems,
 };
-use bevy_ecs::entity::MapEntities;
+use bevy_ecs::entity::{MapEntities, UniqueEntitySlice};
 use bevy_ecs::prelude::*;
 use bevy_time::{Real, Time, Timer, TimerMode};
 use bevy_utils::prelude::DebugName;
-use lightyear_connection::host::HostClient;
+use lightyear_connection::network_topology::{NetworkTopology, NetworkingMetadata};
 use lightyear_core::prelude::*;
 use lightyear_core::tick::TickDuration;
 #[cfg(feature = "interpolation")]
 use lightyear_core::time::TickDelta;
 
-use lightyear_connection::client::Client;
 #[cfg(feature = "interpolation")]
 use lightyear_interpolation::prelude::*;
+use lightyear_messages::multi::MultiMessageSender;
 use lightyear_messages::plugin::MessageSystems;
 #[cfg(feature = "prediction")]
 use lightyear_messages::prelude::MessageReceiver;
@@ -269,6 +269,76 @@ impl<S: ActionStateSequence + MapEntities> Plugin for ClientInputPlugin<S> {
     }
 }
 
+/// Cached input routing derived from [`NetworkingMetadata`].
+///
+/// Client/server and host-client modes retain their single Link as the local ownership
+/// identity. P2P mode borrows the already-cached connected Link slice and treats `S::Marker` as
+/// the local-input identity because each Link represents a remote peer.
+#[derive(Clone, Copy, Debug)]
+enum InputRoute<'a> {
+    ClientServer { link: Entity, host_client: bool },
+    P2P(&'a [Entity]),
+}
+
+impl<'a> InputRoute<'a> {
+    #[inline]
+    fn from_topology(topology: &'a NetworkTopology) -> Option<Self> {
+        match topology {
+            NetworkTopology::Client(link) => Some(Self::ClientServer {
+                link: *link,
+                host_client: false,
+            }),
+            NetworkTopology::HostClient { client, .. } => Some(Self::ClientServer {
+                link: *client,
+                host_client: true,
+            }),
+            NetworkTopology::P2P { connected, .. } if !connected.is_empty() => {
+                Some(Self::P2P(connected.as_slice()))
+            }
+            NetworkTopology::Undefined
+            | NetworkTopology::Server(_)
+            | NetworkTopology::P2P { .. }
+            | NetworkTopology::Invalid(_) => None,
+        }
+    }
+
+    #[inline]
+    fn is_host_client(self) -> bool {
+        matches!(
+            self,
+            Self::ClientServer {
+                host_client: true,
+                ..
+            }
+        )
+    }
+
+    #[inline]
+    fn accepts_local_target(self, controlled_by: Option<&ControlledBy>) -> bool {
+        match self {
+            Self::ClientServer { link, .. } => {
+                !controlled_by.is_some_and(|controlled_by| controlled_by.owner != link)
+            }
+            // `S::Marker` is the local-capture marker in P2P. `ControlledBy` describes a
+            // replication sender and therefore cannot identify this app among remote peer Links.
+            Self::P2P(_) => true,
+        }
+    }
+
+    #[inline]
+    fn any_link(self, mut predicate: impl FnMut(Entity) -> bool) -> bool {
+        match self {
+            Self::ClientServer { link, .. } => predicate(link),
+            Self::P2P(links) => links.iter().copied().any(predicate),
+        }
+    }
+}
+
+#[inline]
+fn route_is_in_rollback(route: InputRoute<'_>, rollbacks: &Query<(), With<Rollback>>) -> bool {
+    route.any_link(|link| rollbacks.contains(link))
+}
+
 // equivalent to &ActionState<S::Action>
 
 /// Write the value of the ActionState in the InputBuffer.
@@ -289,7 +359,8 @@ fn buffer_action_state<S: ActionStateSequence>(
     // 1. the HostServer client can broadcast inputs to other clients
     // 2. the HostServer client can have input delay
     input_timeline: SyncedInputTimeline,
-    client_entity: Single<Entity, (With<Client>, Without<Rollback>)>,
+    metadata: Res<NetworkingMetadata>,
+    rollbacks: Query<(), With<Rollback>>,
     mut action_state_query: Query<
         (
             Entity,
@@ -300,11 +371,16 @@ fn buffer_action_state<S: ActionStateSequence>(
         (With<S::Marker>, Allow<PredictionDisable>),
     >,
 ) {
-    let client_entity = *client_entity;
+    let Some(route) = InputRoute::from_topology(&metadata.mode) else {
+        return;
+    };
+    if route_is_in_rollback(route, &rollbacks) {
+        return;
+    }
     let current_tick = local_timeline.tick();
     let tick = current_tick + input_timeline.input_delay() as i32;
     for (entity, action_state, mut input_buffer, controlled_by) in action_state_query.iter_mut() {
-        if controlled_by.is_some_and(|controlled_by| controlled_by.owner != client_entity) {
+        if !route.accepts_local_target(controlled_by) {
             continue;
         }
         input_buffer.set(tick, S::to_snapshot(action_state));
@@ -345,7 +421,8 @@ fn get_action_state<S: ActionStateSequence>(
     //  in the server, and also clears the buffers
     input_timeline: Res<InputTimeline>,
     input_timeline_config: Res<InputTimelineConfig>,
-    client: Single<Has<Rollback>, (With<Client>, Without<HostClient>)>,
+    metadata: Res<NetworkingMetadata>,
+    rollbacks: Query<(), With<Rollback>>,
 
     // NOTE: we want to apply the Inputs for BOTH the local player and remote player
     // - local player: we need to get the input from the InputBuffer because of input delay
@@ -362,7 +439,15 @@ fn get_action_state<S: ActionStateSequence>(
         Allow<PredictionDisable>,
     >,
 ) {
-    let is_rollback = *client;
+    let Some(route) = InputRoute::from_topology(&metadata.mode) else {
+        return;
+    };
+    // A host-client shares its authoritative input application with the server-side input
+    // pipeline, so the client system must retain its existing exclusion.
+    if route.is_host_client() {
+        return;
+    }
+    let is_rollback = route_is_in_rollback(route, &rollbacks);
     let input_delay = input_timeline.input_delay() as i32;
     let tick = local_timeline.tick();
     if is_rollback && config.ignore_rollbacks {
@@ -464,7 +549,8 @@ fn get_action_state<S: ActionStateSequence>(
 fn get_delayed_action_state<S: ActionStateSequence>(
     timeline: Res<LocalTimeline>,
     input_timeline: SyncedInputTimeline,
-    client: Single<(Entity, Has<Rollback>), With<Client>>,
+    metadata: Res<NetworkingMetadata>,
+    rollbacks: Query<(), With<Rollback>>,
     mut action_state_query: Query<
         (
             Entity,
@@ -476,7 +562,10 @@ fn get_delayed_action_state<S: ActionStateSequence>(
         (With<S::Marker>, Allow<PredictionDisable>),
     >,
 ) {
-    let (client_entity, is_rollback) = client.into_inner();
+    let Some(route) = InputRoute::from_topology(&metadata.mode) else {
+        return;
+    };
+    let is_rollback = route_is_in_rollback(route, &rollbacks);
     let input_delay_ticks = input_timeline.input_delay() as i32;
     if is_rollback || input_delay_ticks == 0 {
         return;
@@ -484,7 +573,7 @@ fn get_delayed_action_state<S: ActionStateSequence>(
     let tick = timeline.tick();
     let delayed_tick = tick + input_delay_ticks;
     for (entity, action_state, input_buffer, controlled_by) in action_state_query.iter_mut() {
-        if controlled_by.is_some_and(|controlled_by| controlled_by.owner != client_entity) {
+        if !route.accepts_local_target(controlled_by) {
             continue;
         }
         // TODO: lots of clone + is complicated. Shouldn't we just have a DelayedActionState component + resource?
@@ -522,21 +611,22 @@ fn clean_buffers<S: ActionStateSequence>(
     timeline: Res<LocalTimeline>,
     // NOTE: we skip this for host-client because the get_action_state system on the server
     //  also clears the buffers
-    _client: Single<(), (With<Client>, Without<HostClient>)>,
-    prediction_manager: Option<Single<&PredictionManager, With<Client>>>,
+    metadata: Res<NetworkingMetadata>,
+    prediction_managers: Query<&PredictionManager>,
     input_config: Res<InputTimelineConfig>,
     mut input_buffer_query: Query<
         &mut InputBuffer<S::Snapshot, S::Action>,
         Allow<PredictionDisable>,
     >,
 ) {
-    let old_tick = timeline.tick()
-        - input_history_depth(
-            prediction_manager
-                .as_deref()
-                .copied()
-                .map(|manager| (manager, input_config.as_ref())),
-        );
+    let Some(route) = InputRoute::from_topology(&metadata.mode) else {
+        return;
+    };
+    if route.is_host_client() {
+        return;
+    }
+    let old_tick =
+        timeline.tick() - input_history_depth_for_route(route, &prediction_managers, &input_config);
 
     // trace!(
     //     "popping all input buffers since old tick: {old_tick:?}",
@@ -560,6 +650,30 @@ fn input_history_depth(
         })
         .unwrap_or(0)
         .max(HISTORY_DEPTH)
+}
+
+fn input_history_depth_for_route(
+    route: InputRoute<'_>,
+    prediction_managers: &Query<&PredictionManager>,
+    input_config: &InputTimelineConfig,
+) -> u32 {
+    let mut history_depth = HISTORY_DEPTH;
+    match route {
+        InputRoute::ClientServer { link, .. } => {
+            if let Ok(manager) = prediction_managers.get(link) {
+                history_depth = input_history_depth(Some((manager, input_config)));
+            }
+        }
+        InputRoute::P2P(links) => {
+            for link in links {
+                if let Ok(manager) = prediction_managers.get(*link) {
+                    history_depth =
+                        history_depth.max(input_history_depth(Some((manager, input_config))));
+                }
+            }
+        }
+    }
+    history_depth
 }
 
 // TODO: is this actually necessary? The sync happens in PostUpdate,
@@ -591,7 +705,8 @@ fn prepare_input_message<S: ActionStateSequence>(
     timeline: Res<LocalTimeline>,
     input_config: Res<InputConfig<S::Action>>,
     input_timeline: SyncedInputTimeline,
-    client: Single<(Entity, Has<HostClient>), (With<Client>, Without<Rollback>)>,
+    metadata: Res<NetworkingMetadata>,
+    rollbacks: Query<(), With<Rollback>>,
     _channel_registry: Res<ChannelRegistry>,
     input_buffer_query: Query<
         (
@@ -605,7 +720,13 @@ fn prepare_input_message<S: ActionStateSequence>(
     real_time: Res<Time<Real>>,
     mut send_timer: Local<Option<Timer>>,
 ) {
-    let (client_entity, is_host_client) = client.into_inner();
+    let Some(route) = InputRoute::from_topology(&metadata.mode) else {
+        return;
+    };
+    if route_is_in_rollback(route, &rollbacks) {
+        return;
+    }
+    let is_host_client = route.is_host_client();
 
     // Only prepare input every send-interval.
     if !input_config.send_interval.is_zero() {
@@ -659,7 +780,7 @@ fn prepare_input_message<S: ActionStateSequence>(
     num_ticks *= input_config.packet_redundancy as u32;
     let mut message = InputMessage::<S>::new(tick);
     for (entity, input_buffer, pre_spawned, controlled_by) in input_buffer_query.iter() {
-        if controlled_by.is_some_and(|controlled_by| controlled_by.owner != client_entity) {
+        if !route.accepts_local_target(controlled_by) {
             continue;
         }
         trace!(
@@ -744,20 +865,110 @@ fn receive_remote_player_input_messages<S: ActionStateSequence>(
     timeline: Res<LocalTimeline>,
     #[cfg(feature = "metrics")] mut input_metric_handles: ResMut<InputMetricHandles<S>>,
     _input_timeline: SyncedInputTimeline,
+    metadata: Res<NetworkingMetadata>,
     last_confirmed_input: Res<LastConfirmedInput>,
-    link: Single<
-        (&mut MessageReceiver<InputMessage<S>>, &PredictionManager),
-        // the host-client won't receive input messages from the Server
-        (With<Client>, Without<HostClient>),
-    >,
+    mut receivers: Query<&mut MessageReceiver<InputMessage<S>>>,
+    prediction_managers: Query<&PredictionManager>,
     mut predicted_query: Query<
         Option<&mut InputBuffer<S::Snapshot, S::Action>>,
         (Without<S::Marker>, Allow<PredictionDisable>),
     >,
     prespawned: Query<(Entity, &PreSpawned)>,
 ) {
-    let (mut receiver, prediction_manager) = link.into_inner();
+    let Some(route) = InputRoute::from_topology(&metadata.mode) else {
+        return;
+    };
+    // The host-client receives authoritative input directly through the server-side pipeline.
+    if route.is_host_client() {
+        return;
+    }
+    let Some(prediction_manager_link) = prediction_manager_link(route, &prediction_managers) else {
+        return;
+    };
+    let Ok(prediction_manager) = prediction_managers.get(prediction_manager_link) else {
+        return;
+    };
     let tick = timeline.tick();
+    let mut received_relevant_input = false;
+    match route {
+        InputRoute::ClientServer { link, .. } => {
+            if let Ok(mut receiver) = receivers.get_mut(link) {
+                received_relevant_input |= receive_remote_player_input_messages_from_receiver::<S>(
+                    &mut receiver,
+                    &mut commands,
+                    *tick_duration,
+                    tick,
+                    prediction_manager,
+                    &mut predicted_query,
+                    &prespawned,
+                    #[cfg(feature = "metrics")]
+                    &mut input_metric_handles,
+                );
+            }
+        }
+        InputRoute::P2P(links) => {
+            for link in links {
+                let Ok(mut receiver) = receivers.get_mut(*link) else {
+                    continue;
+                };
+                received_relevant_input |= receive_remote_player_input_messages_from_receiver::<S>(
+                    &mut receiver,
+                    &mut commands,
+                    *tick_duration,
+                    tick,
+                    prediction_manager,
+                    &mut predicted_query,
+                    &prespawned,
+                    #[cfg(feature = "metrics")]
+                    &mut input_metric_handles,
+                );
+            }
+        }
+    }
+
+    if received_relevant_input {
+        last_confirmed_input
+            .received_any_messages
+            .store(true, bevy_platform::sync::atomic::Ordering::Relaxed);
+    }
+}
+
+/// Return the sole prediction-manager Link selected by the cached route.
+///
+/// P2P temporarily keeps `PredictionManager` on one Link until it becomes a resource in PR 4. If
+/// zero or multiple routed Links contain a manager, input receive remains inactive rather than
+/// associating rollback state with an arbitrary peer.
+fn prediction_manager_link(
+    route: InputRoute<'_>,
+    prediction_managers: &Query<&PredictionManager>,
+) -> Option<Entity> {
+    match route {
+        InputRoute::ClientServer { link, .. } => prediction_managers.contains(link).then_some(link),
+        InputRoute::P2P(links) => {
+            let mut matches = links
+                .iter()
+                .copied()
+                .filter(|link| prediction_managers.contains(*link));
+            let first = matches.next()?;
+            matches.next().is_none().then_some(first)
+        }
+    }
+}
+
+#[cfg(feature = "prediction")]
+fn receive_remote_player_input_messages_from_receiver<S: ActionStateSequence>(
+    receiver: &mut MessageReceiver<InputMessage<S>>,
+    commands: &mut Commands,
+    tick_duration: TickDuration,
+    tick: Tick,
+    prediction_manager: &PredictionManager,
+    predicted_query: &mut Query<
+        Option<&mut InputBuffer<S::Snapshot, S::Action>>,
+        (Without<S::Marker>, Allow<PredictionDisable>),
+    >,
+    prespawned: &Query<(Entity, &PreSpawned)>,
+    #[cfg(feature = "metrics")] input_metric_handles: &mut InputMetricHandles<S>,
+) -> bool {
     let mut received_relevant_input = false;
     receiver.receive().for_each(|message| {
         trace!(?message.end_tick, ?message, "received remote input message for action: {:?}", DebugName::type_name::<S::Action>());
@@ -864,9 +1075,9 @@ fn receive_remote_player_input_messages<S: ActionStateSequence>(
                     message.end_tick,
                     entity,
                     prediction_manager,
-                    *tick_duration,
+                    tick_duration,
                     #[cfg(feature = "metrics")]
-                    &input_metric_handles,
+                    &*input_metric_handles,
                 );
             } else {
                 // add the ActionState and InputBuffer if they are missing
@@ -879,9 +1090,9 @@ fn receive_remote_player_input_messages<S: ActionStateSequence>(
                     message.end_tick,
                     entity,
                     prediction_manager,
-                    *tick_duration,
+                    tick_duration,
                     #[cfg(feature = "metrics")]
-                    &input_metric_handles,
+                    &*input_metric_handles,
                 );
                 // Initialize ActionState from the latest buffered input rather
                 // than from base_value(). When the remote player's end_tick is
@@ -897,12 +1108,7 @@ fn receive_remote_player_input_messages<S: ActionStateSequence>(
             };
         }
     });
-
-    if received_relevant_input {
-        last_confirmed_input
-            .received_any_messages
-            .store(true, bevy_platform::sync::atomic::Ordering::Relaxed);
-    }
+    received_relevant_input
 }
 
 #[cfg(feature = "prediction")]
@@ -915,13 +1121,16 @@ fn update_last_confirmed_input<S: ActionStateSequence>(
     timeline: Res<LocalTimeline>,
     _input_timeline: SyncedInputTimeline,
     input_config: Res<InputTimelineConfig>,
-    _client: Single<(), With<Client>>,
+    metadata: Res<NetworkingMetadata>,
     mut last_confirmed_input: ResMut<LastConfirmedInput>,
     predicted_query: Query<
         &InputBuffer<S::Snapshot, S::Action>,
         (Without<S::Marker>, Allow<PredictionDisable>),
     >,
 ) {
+    if InputRoute::from_topology(&metadata.mode).is_none() {
+        return;
+    }
     let tick = timeline.tick();
     // in lockstep mode, we don't need last confirmed input because we always have all inputs for a given tick.
     // we will just use the current tick as the last confirmed input tick
@@ -1041,17 +1250,31 @@ fn update_buffer_from_remote_player_message<S: ActionStateSequence>(
 }
 
 /// Drain the messages from the buffer and send them to the server
+#[cfg_attr(
+    not(feature = "interpolation"),
+    expect(
+        unused_mut,
+        reason = "InputMessage is mutated only when interpolation is enabled"
+    )
+)]
 fn send_input_messages<S: ActionStateSequence>(
     input_config: Res<InputConfig<S::Action>>,
     input_timeline: SyncedInputTimeline,
+    metadata: Res<NetworkingMetadata>,
     mut message_buffer: ResMut<MessageBuffer<S>>,
-    sender: Single<(&mut MessageSender<InputMessage<S>>, Has<HostClient>), With<Client>>,
-    #[cfg(feature = "interpolation")] interpolation_timeline: Single<
+    mut senders: Query<&mut MessageSender<InputMessage<S>>>,
+    mut multi_sender: MultiMessageSender,
+    #[cfg(feature = "interpolation")] interpolation_timelines: Query<
         &InterpolationTimeline,
-        (With<Client>, With<IsSynced<InterpolationTimeline>>),
+        With<IsSynced<InterpolationTimeline>>,
     >,
 ) {
-    let (mut sender, is_host_client) = sender.into_inner();
+    // An inactive topology retains the buffered messages, matching the old `Single<Client>`
+    // parameter's skip-on-no-match behavior across disconnect/reconnect boundaries.
+    let Some(route) = InputRoute::from_topology(&metadata.mode) else {
+        return;
+    };
+    let is_host_client = route.is_host_client();
 
     #[cfg(not(feature = "prediction"))]
     if is_host_client {
@@ -1081,63 +1304,97 @@ fn send_input_messages<S: ActionStateSequence>(
     );
 
     #[cfg(feature = "interpolation")]
-    let interpolation_delay = {
-        // NOTE: this can be negative because of input-delay!
-        let mut delay = input_timeline.now() - interpolation_timeline.now();
-        if delay.is_negative() {
-            delay = TickDelta::from(Tick(0));
+    let interpolation_delay = match route {
+        InputRoute::ClientServer { link, .. } => {
+            let Ok(interpolation_timeline) = interpolation_timelines.get(link) else {
+                return;
+            };
+            // NOTE: this can be negative because of input-delay!
+            let mut delay = input_timeline.now() - interpolation_timeline.now();
+            if delay.is_negative() {
+                delay = TickDelta::from(Tick(0));
+            }
+            Some(InterpolationDelay {
+                delay: delay.into(),
+            })
         }
-        InterpolationDelay {
-            delay: delay.into(),
-        }
+        // Input-only P2P has no interpolation timeline or server lag-compensation target.
+        InputRoute::P2P(_) => None,
     };
 
-    #[cfg_attr(
-        not(feature = "interpolation"),
-        expect(unused_mut, reason = "Used by expression behind feature flag")
-    )]
-    for mut message in message_buffer.0.drain(..) {
-        // if lag compensation is enabled, we send the current delay to the server
-        // (this runs here because the delay is only correct after the SyncSet has run)
-        // TODO: or should we actually use the interpolation_delay BEFORE SyncSet
-        //  because the user is reacting to stuff from the previous frame?
-        #[cfg(feature = "interpolation")]
-        if input_config.lag_compensation {
-            message.interpolation_delay = Some(interpolation_delay);
+    match route {
+        InputRoute::ClientServer { link, .. } => {
+            let Ok(mut sender) = senders.get_mut(link) else {
+                return;
+            };
+            for mut message in message_buffer.0.drain(..) {
+                // if lag compensation is enabled, we send the current delay to the server
+                // (this runs here because the delay is only correct after the SyncSet has run)
+                // TODO: or should we actually use the interpolation_delay BEFORE SyncSet
+                //  because the user is reacting to stuff from the previous frame?
+                #[cfg(feature = "interpolation")]
+                if input_config.lag_compensation {
+                    message.interpolation_delay = interpolation_delay;
+                }
+                sender.send::<InputChannel>(message);
+            }
         }
-        sender.send::<InputChannel>(message);
+        InputRoute::P2P(links) => {
+            let Some(links) = unique_p2p_links(links) else {
+                error!("cached P2P Link entities must be unique");
+                message_buffer.0.clear();
+                return;
+            };
+            for mut message in message_buffer.0.drain(..) {
+                #[cfg(feature = "interpolation")]
+                if input_config.lag_compensation {
+                    message.interpolation_delay = interpolation_delay;
+                }
+                if let Err(error) =
+                    multi_sender.send::<InputMessage<S>, InputChannel>(&message, links)
+                {
+                    error!(%error, "failed to send input message to P2P Links");
+                }
+            }
+        }
     }
+}
+
+/// View the cached P2P Link slice as Bevy's allocation-free entity-set type.
+///
+/// `NetworkingMetadata` builds this slice from distinct query entities. The explicit check keeps
+/// this conversion sound even if user code mutates the public cached metadata.
+fn unique_p2p_links(links: &[Entity]) -> Option<&UniqueEntitySlice> {
+    let has_duplicates = links
+        .iter()
+        .enumerate()
+        .any(|(index, link)| links[index + 1..].contains(link));
+    if has_duplicates {
+        return None;
+    }
+    // SAFETY: the pairwise check above proves that every Entity in the slice is unique.
+    Some(unsafe { UniqueEntitySlice::from_slice_unchecked(links) })
 }
 
 /// In case the client tick changes suddenly, we also update the InputBuffer accordingly
 fn receive_tick_events<S: ActionStateSequence>(
     trigger: On<SyncEvent<InputTimelineConfig>>,
-    client_entity: Single<Entity, With<Client>>,
     mut message_buffer: ResMut<MessageBuffer<S>>,
     mut input_buffer_query: Query<
-        (
-            &mut InputBuffer<S::Snapshot, S::Action>,
-            Option<&ControlledBy>,
-        ),
+        &mut InputBuffer<S::Snapshot, S::Action>,
         Allow<PredictionDisable>,
     >,
 ) {
-    let client_entity = *client_entity;
     let delta = trigger.tick_delta;
-    for (mut input_buffer, controlled_by) in input_buffer_query.iter_mut() {
-        if controlled_by.is_some_and(|controlled_by| controlled_by.owner != client_entity) {
-            continue;
-        }
-        if let Some(start_tick) = input_buffer.start_tick {
-            input_buffer.start_tick = Some(start_tick + delta);
+    for mut input_buffer in input_buffer_query.iter_mut() {
+        let had_start_tick = input_buffer.start_tick.is_some();
+        shift_input_buffer_ticks(&mut input_buffer, delta);
+        if had_start_tick {
             debug!(
                 "Receive tick snap event {:?}. Updating input buffer start_tick to {:?}!",
                 trigger.event(),
                 input_buffer.start_tick
             );
-        }
-        if let Some(last_remote_tick) = input_buffer.last_remote_tick {
-            input_buffer.last_remote_tick = Some(last_remote_tick + delta);
         }
     }
     for message in message_buffer.0.iter_mut() {
@@ -1145,10 +1402,49 @@ fn receive_tick_events<S: ActionStateSequence>(
     }
 }
 
+fn shift_input_buffer_ticks<S, A>(input_buffer: &mut InputBuffer<S, A>, delta: i32) {
+    if let Some(start_tick) = input_buffer.start_tick {
+        input_buffer.start_tick = Some(start_tick + delta);
+    }
+    if let Some(last_remote_tick) = input_buffer.last_remote_tick {
+        input_buffer.last_remote_tick = Some(last_remote_tick + delta);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use lightyear_replication::prelude::Lifetime;
 
+    #[test]
+    fn input_route_uses_link_ownership_only_for_client_server() {
+        let mut world = World::new();
+        let client = world.spawn_empty().id();
+        let other = world.spawn_empty().id();
+        let owned_by_client = ControlledBy {
+            owner: client,
+            lifetime: Lifetime::SessionBased,
+        };
+        let owned_by_other = ControlledBy {
+            owner: other,
+            lifetime: Lifetime::SessionBased,
+        };
+
+        let client_server = NetworkTopology::Client(client);
+        let client_server_route = InputRoute::from_topology(&client_server).unwrap();
+        assert!(client_server_route.accepts_local_target(None));
+        assert!(client_server_route.accepts_local_target(Some(&owned_by_client)));
+        assert!(!client_server_route.accepts_local_target(Some(&owned_by_other)));
+
+        let p2p = NetworkTopology::P2P {
+            connected: [client, other].into_iter().collect(),
+            declared_links: 2,
+        };
+        let p2p_route = InputRoute::from_topology(&p2p).unwrap();
+        assert!(p2p_route.accepts_local_target(None));
+        assert!(p2p_route.accepts_local_target(Some(&owned_by_client)));
+        assert!(p2p_route.accepts_local_target(Some(&owned_by_other)));
+    }
     #[test]
     fn input_history_depth_covers_prediction_rollback_window() {
         assert_eq!(input_history_depth(None), HISTORY_DEPTH);

--- a/crates/inputs/inputs/src/input_message.rs
+++ b/crates/inputs/inputs/src/input_message.rs
@@ -28,11 +28,18 @@ pub enum InputTarget {
     /// The input is for a predicted or confirmed entity.
     /// When sending from client to server, entity mapping is applied.
     /// (Also when rebroadcast from server to client)
+    ///
+    /// This target is not valid for direct P2P input because input-only P2P Links do not have a
+    /// replication stream that can populate their entity maps. Use [`InputTarget::PreSpawned`]
+    /// for P2P targets.
     Entity(Entity),
     /// The input is for a prespawned entity.
     /// We want the client to be able to send inputs for a prespawned entity before it gets matched with a server entity.
     /// To achieve this, the client sends the PreSpawned hash and the server will map it to the correct server entity.
     /// When rebroadcasting from server to other client, we rebroadcast it as a normal Entity?
+    ///
+    /// Direct P2P input also uses this stable hash because every peer has its own local ECS entity
+    /// and no authoritative replication stream exists to establish an entity map.
     PreSpawned(u64),
 }
 

--- a/crates/replication/interpolation/src/timeline.rs
+++ b/crates/replication/interpolation/src/timeline.rs
@@ -233,6 +233,12 @@ impl TimelinePlugin {
         if rollback.is_some() {
             return;
         }
+        // A deterministic prediction-window wait pauses `Time<Virtual>` so FixedUpdate cannot
+        // advance beyond the rollback window. Its delta is already zero in that state; avoid
+        // dividing by the zero relative speed while reconstructing the unscaled frame delta.
+        if time.relative_speed() == 0.0 {
+            return;
+        }
         let delta = time.delta();
         query.iter_mut().for_each(|mut t| {
             // make sure to account for the fact that Time<Virtual> is already updated from the Driving timeline
@@ -254,5 +260,46 @@ impl Plugin for TimelinePlugin {
             Self::advance_timeline.in_set(TimelineSystems::Advance),
         );
         app.add_observer(Self::receive_sender_metadata);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lightyear_core::id::{PeerId, RemoteId};
+
+    #[test]
+    fn paused_virtual_time_does_not_advance_interpolation_timeline() {
+        let mut app = App::new();
+        let mut virtual_time = Time::<Virtual>::default();
+        virtual_time.set_relative_speed(0.0);
+        app.insert_resource(virtual_time);
+        app.insert_resource(TickDuration(Duration::from_millis(16)));
+        app.add_systems(PreUpdate, TimelinePlugin::advance_timeline);
+
+        let entity = app
+            .world_mut()
+            .spawn((
+                InterpolationTimeline::default(),
+                RemoteId(PeerId::Server),
+                Connected,
+            ))
+            .id();
+        let before = app
+            .world()
+            .entity(entity)
+            .get::<InterpolationTimeline>()
+            .unwrap()
+            .now();
+
+        app.update();
+
+        let after = app
+            .world()
+            .entity(entity)
+            .get::<InterpolationTimeline>()
+            .unwrap()
+            .now();
+        assert_eq!(after, before);
     }
 }

--- a/crates/replication/interpolation/src/timeline.rs
+++ b/crates/replication/interpolation/src/timeline.rs
@@ -146,7 +146,7 @@ impl SyncedTimeline for InterpolationTimeline {
         let adjustment = if !self.is_synced {
             SyncAdjustment::Resync
         } else {
-            self.sync.speed_adjustment(&config.sync, error_ticks)
+            self.speed_adjustment(config, error_ticks)
         };
         trace!(
             ?now,
@@ -162,19 +162,25 @@ impl SyncedTimeline for InterpolationTimeline {
             SyncAdjustment::Resync => {
                 return Some(self.resync(objective));
             }
-            SyncAdjustment::SpeedAdjust(ratio) => {
-                self.set_relative_speed(ratio);
-            }
-            SyncAdjustment::DoNothing => {
-                // within acceptable margins, gradually return to normal speed (1.0)
-                let current = self.relative_speed();
-                if (current - 1.0).abs() > 0.001 {
-                    let new_speed = current + (1.0 - current) * 0.1;
-                    self.set_relative_speed(new_speed);
-                }
-            }
+            SyncAdjustment::SpeedAdjust(_) | SyncAdjustment::DoNothing => {}
         }
         None
+    }
+
+    fn speed_adjustment(&mut self, config: &Self::Config, offset: f32) -> SyncAdjustment {
+        let adjustment = self.sync.speed_adjustment(&config.sync, offset);
+        match adjustment {
+            SyncAdjustment::SpeedAdjust(ratio) => self.set_relative_speed(ratio),
+            SyncAdjustment::DoNothing => {
+                // Within acceptable margins, gradually return to normal speed.
+                let current = self.relative_speed();
+                if (current - 1.0).abs() > 0.001 {
+                    self.set_relative_speed(current + (1.0 - current) * 0.1);
+                }
+            }
+            SyncAdjustment::Resync => {}
+        }
+        adjustment
     }
 
     fn is_synced(&self) -> bool {

--- a/crates/replication/interpolation/src/timeline.rs
+++ b/crates/replication/interpolation/src/timeline.rs
@@ -221,8 +221,12 @@ impl TimelinePlugin {
         time: Res<Time<Virtual>>,
         tick_duration: Res<TickDuration>,
         // make sure to not update the timelines during Rollback
-        mut query: Query<&mut InterpolationTimeline, (With<Connected>, Without<Rollback>)>,
+        rollback: Option<Res<Rollback>>,
+        mut query: Query<&mut InterpolationTimeline, With<Connected>>,
     ) {
+        if rollback.is_some() {
+            return;
+        }
         let delta = time.delta();
         query.iter_mut().for_each(|mut t| {
             // make sure to account for the fact that Time<Virtual> is already updated from the Driving timeline

--- a/crates/replication/prediction/src/correction.rs
+++ b/crates/replication/prediction/src/correction.rs
@@ -780,7 +780,7 @@ pub(crate) fn add_visual_correction<
 >(
     time: Res<Time<Virtual>>,
     prediction: Res<PredictionRegistry>,
-    manager: Single<&PredictionManager>,
+    manager: Res<PredictionManager>,
     mut query: Query<(Entity, &mut C, &mut VisualCorrection<D>)>,
     mut commands: Commands,
 ) {
@@ -1014,7 +1014,7 @@ mod tests {
         app.init_resource::<PredictionRegistry>();
         app.insert_resource(Time::<Virtual>::default());
         app.component::<CorrectionA>().predict().add_correction();
-        app.world_mut().spawn(PredictionManager::default());
+        app.insert_resource(PredictionManager::default());
         let entity = app
             .world_mut()
             .spawn((
@@ -1193,8 +1193,8 @@ mod tests {
 
         let prediction_manager = PredictionManager::default();
         prediction_manager.set_rollback_tick(PREVIOUS_TICK);
-        app.world_mut()
-            .spawn((prediction_manager, Rollback::FromInputs));
+        app.insert_resource(prediction_manager);
+        app.insert_resource(Rollback::FromInputs);
 
         app.component::<CorrectionA>().predict();
         app.finish();

--- a/crates/replication/prediction/src/despawn.rs
+++ b/crates/replication/prediction/src/despawn.rs
@@ -1,10 +1,9 @@
 use crate::Predicted;
-use crate::manager::PredictionResource;
+use crate::manager::PredictionManager;
 use crate::prelude::DeterministicPredicted;
 use bevy_ecs::error::ignore;
 use bevy_ecs::prelude::*;
 use bevy_reflect::Reflect;
-use lightyear_connection::host::HostClient;
 use lightyear_replication::prelude::PreSpawned;
 #[allow(unused_imports)]
 use tracing::{debug, error, info};
@@ -36,10 +35,9 @@ impl Command for PredictionDespawnCommand {
     type Out = ();
 
     fn apply(self, world: &mut World) -> Self::Out {
-        // if we are the server (or host-client), there is no rollback so we can despawn the entity immediately
-        if world
-            .get_resource::<PredictionResource>()
-            .is_none_or(|r| world.entity(r.link_entity).contains::<HostClient>())
+        // Without the application-global prediction manager there is no rollback, so the entity
+        // can be despawned immediately.
+        if !world.contains_resource::<PredictionManager>()
             && let Ok(e) = world.get_entity_mut(self.entity)
         {
             e.despawn();
@@ -73,10 +71,7 @@ impl PredictionDespawnCommandsExt for EntityCommands<'_> {
         self.queue_handled(
             move |entity_mut: EntityWorldMut| {
                 let world = entity_mut.world();
-                if world
-                    .get_resource::<PredictionResource>()
-                    .is_some_and(|r| !world.entity(r.link_entity).contains::<HostClient>())
-                {
+                if world.contains_resource::<PredictionManager>() {
                     PredictionDespawnCommand { entity }.apply(entity_mut.into_world_mut());
                 } else {
                     // if we are the server (or host server), just despawn the entity

--- a/crates/replication/prediction/src/manager.rs
+++ b/crates/replication/prediction/src/manager.rs
@@ -7,20 +7,10 @@ use crate::correction::CorrectionPolicy;
 use crate::rollback::RollbackState;
 use alloc::vec::Vec;
 use bevy_ecs::entity::EntityHash;
-use bevy_ecs::lifecycle::HookContext;
-use bevy_ecs::world::DeferredWorld;
 use core::ops::{Deref, DerefMut};
 use lightyear_core::prelude::Tick;
-use lightyear_replication::prespawn::PreSpawnedReceiver;
 use lightyear_sync::prelude::InputTimelineConfig;
 use parking_lot::RwLock;
-
-#[derive(Resource)]
-pub struct PredictionResource {
-    // entity that holds the PredictionManager
-    // We use this to avoid having to run a mutable query in component hooks
-    pub(crate) link_entity: Entity,
-}
 
 type EntityHashMap<K, V> = bevy_platform::collections::HashMap<K, V, EntityHash>;
 
@@ -93,15 +83,14 @@ impl RollbackPolicy {
     }
 }
 
-/// Component that enables prediction and rollback for a local client.
+/// Application-global state that enables prediction and rollback.
 ///
 /// [`PredictionPlugin`](crate::prelude::PredictionPlugin) installs the prediction systems, but
-/// those systems only run for a connected, non-host [`Client`](lightyear_connection::client::Client)
-/// entity that also has `PredictionManager`. Add this to your client entity when it should create
-/// predicted entities, record prediction history, and perform rollback/reconciliation.
-#[derive(Component, Debug, Reflect)]
-#[component(on_insert = PredictionManager::on_insert)]
-#[require(PreSpawnedReceiver)]
+/// those systems only run when this resource is present and the cached network topology is a
+/// conventional client or P2P session. Insert one manager into the application when it should
+/// create predicted entities, record prediction history, and perform one global
+/// rollback/reconciliation pipeline.
+#[derive(Resource, Debug, Reflect)]
 pub struct PredictionManager {
     /// Configuration for how rollbacks are triggered
     pub rollback_policy: RollbackPolicy,
@@ -508,17 +497,6 @@ impl Default for PredictionManager {
             deterministic_despawn: Vec::default(),
             rollback: RwLock::new(RollbackState::Default),
         }
-    }
-}
-
-impl PredictionManager {
-    fn on_insert(mut deferred: DeferredWorld, context: HookContext) {
-        let entity = context.entity;
-        deferred.commands().queue(move |world: &mut World| {
-            world.insert_resource(PredictionResource {
-                link_entity: entity,
-            });
-        })
     }
 }
 

--- a/crates/replication/prediction/src/manager.rs
+++ b/crates/replication/prediction/src/manager.rs
@@ -17,8 +17,8 @@ use parking_lot::RwLock;
 
 #[derive(Resource)]
 pub struct PredictionResource {
-    // entity that holds the InputTimeline
-    // We use this to avoid having to run a mutable query in component hook
+    // entity that holds the PredictionManager
+    // We use this to avoid having to run a mutable query in component hooks
     pub(crate) link_entity: Entity,
 }
 
@@ -101,9 +101,7 @@ impl RollbackPolicy {
 /// predicted entities, record prediction history, and perform rollback/reconciliation.
 #[derive(Component, Debug, Reflect)]
 #[component(on_insert = PredictionManager::on_insert)]
-#[require(InputTimelineConfig)]
 #[require(PreSpawnedReceiver)]
-#[require(LastConfirmedInput)]
 pub struct PredictionManager {
     /// Configuration for how rollbacks are triggered
     pub rollback_policy: RollbackPolicy,
@@ -121,8 +119,11 @@ pub struct PredictionManager {
     pub rollback: RwLock<RollbackState>,
 }
 
-/// Store the most recent confirmed input across all remote clients.
-#[derive(Component, Debug, Reflect)]
+/// Application-global frontier of confirmed input across all remote players.
+///
+/// This is a resource because the rollback decision combines every remote input stream in the
+/// application; it does not belong to any one network link.
+#[derive(Resource, Debug, Reflect)]
 pub struct LastConfirmedInput {
     /// Updated via [`AtomicTick::set_if_lower`] to track the minimum last-confirmed tick
     /// across all remote clients. Reset to a high value each frame by

--- a/crates/replication/prediction/src/manager.rs
+++ b/crates/replication/prediction/src/manager.rs
@@ -114,15 +114,20 @@ pub struct PredictionManager {
 /// application; it does not belong to any one network link.
 #[derive(Resource, Debug, Reflect)]
 pub struct LastConfirmedInput {
-    /// Updated via [`AtomicTick::set_if_lower`] to track the minimum last-confirmed tick
-    /// across all remote clients. Reset to a high value each frame by
+    /// Current frame's aggregate, updated via [`AtomicTick::set_if_lower`] to track the minimum
+    /// last-confirmed tick across all remote clients. Reset to a high value each frame by
     /// [`reset_input_rollback_tracker`] so the minimum is computed correctly.
     ///
     /// [`AtomicTick::set_if_lower`]: lightyear_core::tick::AtomicTick::set_if_lower
     /// [`reset_input_rollback_tracker`]: crate::rollback::reset_input_rollback_tracker
     pub tick: lightyear_core::tick::AtomicTick,
+    /// Completed aggregate from the previous frame.
+    ///
+    /// Rollback uses this explicitly so inputs received in the current frame are replayed from the
+    /// frontier that was known before those inputs arrived.
+    pub previous_frame_tick: Tick,
     pub received_any_messages: bevy_platform::sync::atomic::AtomicBool,
-    /// Set to true if we have received inputs from all remote clients.
+    /// Set to true if the current aggregate contains inputs from all remote clients.
     pub received_for_all_clients: bool,
 }
 
@@ -130,6 +135,7 @@ impl Default for LastConfirmedInput {
     fn default() -> Self {
         Self {
             tick: lightyear_core::tick::AtomicTick::new_max(),
+            previous_frame_tick: Tick(u32::MAX),
             received_any_messages: bevy_platform::sync::atomic::AtomicBool::new(false),
             received_for_all_clients: false,
         }
@@ -149,6 +155,19 @@ impl LastConfirmedInput {
             tick if tick == Tick(u32::MAX) => None,
             tick => Some(tick),
         }
+    }
+
+    /// Return the confirmed-input frontier completed during the previous frame.
+    pub fn previous_frame(&self) -> Option<Tick> {
+        match self.previous_frame_tick {
+            tick if tick == Tick(u32::MAX) => None,
+            tick => Some(tick),
+        }
+    }
+
+    /// Preserve the current aggregate for systems that must consume the previous frame's view.
+    pub fn finalize_frame(&mut self) {
+        self.previous_frame_tick = self.tick.get();
     }
 }
 
@@ -370,11 +389,17 @@ mod tests {
 
     #[test]
     fn last_confirmed_input_default_starts_unset() {
-        let last_confirmed_input = LastConfirmedInput::default();
+        let mut last_confirmed_input = LastConfirmedInput::default();
 
         assert_eq!(last_confirmed_input.tick.get(), Tick(u32::MAX));
         assert_eq!(last_confirmed_input.get(), None);
+        assert_eq!(last_confirmed_input.previous_frame(), None);
         assert!(!last_confirmed_input.received_input());
+
+        last_confirmed_input.tick.set_if_lower(Tick(12));
+        last_confirmed_input.received_for_all_clients = true;
+        last_confirmed_input.finalize_frame();
+        assert_eq!(last_confirmed_input.previous_frame(), Some(Tick(12)));
     }
 
     #[test]

--- a/crates/replication/prediction/src/plugin.rs
+++ b/crates/replication/prediction/src/plugin.rs
@@ -5,7 +5,7 @@ use crate::correction::{
 };
 use crate::despawn::PredictionDisable;
 use crate::diagnostics::PredictionDiagnosticsPlugin;
-use crate::manager::PredictionManager;
+use crate::manager::{LastConfirmedInput, PredictionManager};
 use crate::predicted_history::{
     PredictionHistory, add_history_diff_receiver, add_prediction_history,
     apply_component_removal_predicted, handle_tick_event_history_diff_receiver,
@@ -182,6 +182,7 @@ impl Plugin for PredictionPlugin {
     fn build(&self, app: &mut App) {
         // RESOURCES
         app.init_resource::<PredictionRegistry>();
+        app.init_resource::<LastConfirmedInput>();
 
         // Custom entity disabling
         let rollback_disable_id = app

--- a/crates/replication/prediction/src/plugin.rs
+++ b/crates/replication/prediction/src/plugin.rs
@@ -20,18 +20,30 @@ use bevy_ecs::component::Mutable;
 use bevy_ecs::entity_disabling::DefaultQueryFilters;
 use bevy_ecs::prelude::*;
 use bevy_replicon::shared::replication::diff::Diffable as RepliconDiffable;
-use lightyear_connection::client::{Client, Connected};
-use lightyear_connection::host::HostClient;
-use lightyear_core::prelude::ConfirmedHistory;
-use lightyear_replication::prelude::ReplicationSystems;
+use lightyear_connection::network_topology::{NetworkTopology, NetworkingMetadata};
+use lightyear_core::prelude::{ConfirmedHistory, is_in_rollback};
+use lightyear_replication::prelude::{ReplicationReceiver, ReplicationSystems};
+use lightyear_replication::prespawn::PreSpawnedReceiver;
 
 /// Plugin that installs client-side prediction systems.
 ///
-/// The systems run for connected, non-host client entities with a
-/// [`PredictionManager`] component. Add `PredictionManager` to the local client
-/// entity to opt that client into prediction and rollback.
+/// The systems run when the application contains a [`PredictionManager`] resource and its cached
+/// network topology is a conventional client or P2P session. Insert a [`PredictionManager`]
+/// resource to opt the application into one global prediction and rollback pipeline. Host-client
+/// and server topologies remain authoritative and do not run it.
 #[derive(Default)]
 pub struct PredictionPlugin;
+
+/// Initialize resources required by the global prediction pipeline.
+///
+/// `LastConfirmedInput` is deliberately not removed with `PredictionManager`: it also represents
+/// useful global input state for deterministic simulations that do not enable prediction.
+fn initialize_prediction_resources(
+    _trigger: On<Insert, PredictionManager>,
+    mut commands: Commands,
+) {
+    commands.init_resource::<LastConfirmedInput>();
+}
 
 #[deprecated(note = "Use PredictionSystems instead")]
 pub type PredictionSet = PredictionSystems;
@@ -58,19 +70,19 @@ pub enum PredictionSystems {
     All,
 }
 
-pub(crate) type PredictionFilter = (
-    With<PredictionManager>,
-    With<Client>,
-    With<Connected>,
-    Without<HostClient>,
-);
-
 // NOTE: we need to run the prediction systems even if we're not synced, because we want
 //  our HistoryBuffer to contain values for components/resources that were updated before syncing
 //  is done.
-/// Returns true if the client is not a HostClient and is Connected
-pub(crate) fn should_run(query: Query<(), PredictionFilter>) -> bool {
-    query.single().is_ok()
+/// Returns true if this application opted into prediction and has a supported remote topology.
+pub(crate) fn should_run(
+    manager: Option<Res<PredictionManager>>,
+    metadata: Res<NetworkingMetadata>,
+) -> bool {
+    manager.is_some()
+        && matches!(
+            metadata.mode,
+            NetworkTopology::Client(_) | NetworkTopology::P2P { .. }
+        )
 }
 
 /// Enable rollbacking a component even if the component is not networked
@@ -182,7 +194,16 @@ impl Plugin for PredictionPlugin {
     fn build(&self, app: &mut App) {
         // RESOURCES
         app.init_resource::<PredictionRegistry>();
-        app.init_resource::<LastConfirmedInput>();
+        app.add_observer(initialize_prediction_resources);
+        // Observers are not retroactive, so also handle applications that inserted their manager
+        // before adding this plugin.
+        if app.world().contains_resource::<PredictionManager>() {
+            app.init_resource::<LastConfirmedInput>();
+        }
+
+        // State rollback keeps prespawn matching state on the authoritative receiver Link. This
+        // remains Link-scoped even though the rollback decision and manager are application-global.
+        app.register_required_components::<ReplicationReceiver, PreSpawnedReceiver>();
 
         // Custom entity disabling
         let rollback_disable_id = app
@@ -215,7 +236,9 @@ impl Plugin for PredictionPlugin {
         // - During rollback, snap components to confirmed values if we have them
         app.configure_sets(
             FixedPreUpdate,
-            PredictionSystems::SnapToConfirmed.in_set(PredictionSystems::All),
+            PredictionSystems::SnapToConfirmed
+                .in_set(PredictionSystems::All)
+                .run_if(is_in_rollback),
         );
         app.configure_sets(FixedPreUpdate, PredictionSystems::All.run_if(should_run));
 
@@ -242,5 +265,112 @@ impl Plugin for PredictionPlugin {
 
         // PLUGINS
         app.add_plugins((PredictionDiagnosticsPlugin::default(), RollbackPlugin));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bevy_ecs::system::RunSystemOnce;
+    use lightyear_core::timeline::Rollback;
+
+    #[test]
+    fn prediction_manager_initializes_global_input_frontier() {
+        let mut app = App::new();
+        app.add_plugins(PredictionPlugin);
+        let manager = PredictionManager {
+            rollback_policy: crate::manager::RollbackPolicy {
+                max_rollback_ticks: 17,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        assert!(!app.world().contains_resource::<LastConfirmedInput>());
+        app.insert_resource(manager);
+        app.world_mut().flush();
+
+        assert_eq!(
+            app.world()
+                .resource::<PredictionManager>()
+                .rollback_policy
+                .max_rollback_ticks,
+            17
+        );
+        assert!(app.world().contains_resource::<LastConfirmedInput>());
+    }
+
+    #[test]
+    fn prediction_manager_inserted_before_plugin_initializes_global_input_frontier() {
+        let mut app = App::new();
+        app.insert_resource(PredictionManager::default());
+
+        app.add_plugins(PredictionPlugin);
+
+        assert!(app.world().contains_resource::<LastConfirmedInput>());
+    }
+
+    #[test]
+    fn prespawn_state_is_required_by_replication_receiver() {
+        let mut app = App::new();
+        app.add_plugins(PredictionPlugin);
+
+        let receiver = app.world_mut().spawn(ReplicationReceiver).id();
+        app.world_mut().flush();
+
+        assert!(app.world().get::<PreSpawnedReceiver>(receiver).is_some());
+    }
+
+    #[derive(Resource, Default)]
+    struct SnapRuns(u32);
+
+    fn count_snap_runs(mut runs: ResMut<SnapRuns>) {
+        runs.0 += 1;
+    }
+
+    #[test]
+    fn snap_to_confirmed_set_only_runs_during_rollback() {
+        let mut app = App::new();
+        app.add_plugins(PredictionPlugin);
+        app.insert_resource(PredictionManager::default());
+        app.init_resource::<SnapRuns>();
+        let client = app.world_mut().spawn_empty().id();
+        app.world_mut().resource_mut::<NetworkingMetadata>().mode = NetworkTopology::Client(client);
+        app.add_systems(
+            FixedPreUpdate,
+            count_snap_runs.in_set(PredictionSystems::SnapToConfirmed),
+        );
+
+        app.world_mut().run_schedule(FixedPreUpdate);
+        assert_eq!(app.world().resource::<SnapRuns>().0, 0);
+
+        app.insert_resource(Rollback::FromInputs);
+        app.world_mut().run_schedule(FixedPreUpdate);
+        assert_eq!(app.world().resource::<SnapRuns>().0, 1);
+    }
+
+    #[test]
+    fn prediction_pipeline_excludes_authoritative_topologies() {
+        let mut app = App::new();
+        app.init_resource::<NetworkingMetadata>();
+        app.insert_resource(PredictionManager::default());
+        let client = app.world_mut().spawn_empty().id();
+        let server = app.world_mut().spawn_empty().id();
+
+        app.world_mut().resource_mut::<NetworkingMetadata>().mode = NetworkTopology::Client(client);
+        assert!(app.world_mut().run_system_once(should_run).unwrap());
+
+        app.world_mut().resource_mut::<NetworkingMetadata>().mode = NetworkTopology::P2P {
+            connected: Default::default(),
+            declared_links: 1,
+        };
+        assert!(app.world_mut().run_system_once(should_run).unwrap());
+
+        app.world_mut().resource_mut::<NetworkingMetadata>().mode =
+            NetworkTopology::HostClient { server, client };
+        assert!(!app.world_mut().run_system_once(should_run).unwrap());
+
+        app.world_mut().resource_mut::<NetworkingMetadata>().mode = NetworkTopology::Server(server);
+        assert!(!app.world_mut().run_system_once(should_run).unwrap());
     }
 }

--- a/crates/replication/prediction/src/predicted_history.rs
+++ b/crates/replication/prediction/src/predicted_history.rs
@@ -93,18 +93,19 @@ impl<C> PredictionHistory<C> {
 ///
 /// This system only handles changes, removals are handled in `apply_component_removal`
 pub(crate) fn update_prediction_history<T: Component + Clone>(
-    manager: Single<(&PredictionManager, &InputTimelineConfig)>,
+    manager: Single<&PredictionManager>,
+    input_config: Res<InputTimelineConfig>,
     mut query: Query<(Entity, Ref<T>, &mut PredictionHistory<T>)>,
     timeline: Res<LocalTimeline>,
 ) {
     // tick for which we will record the history (either the current client tick or the current rollback tick)
     let tick = timeline.tick();
-    let (manager, input_config) = manager.into_inner();
+    let manager = manager.into_inner();
     let oldest_rollback_tick = tick
         - u32::from(
             manager
                 .rollback_policy
-                .effective_max_rollback_ticks(input_config),
+                .effective_max_rollback_ticks(&input_config),
         );
 
     // Update history if the predicted component changed, then prune it.
@@ -535,16 +536,14 @@ mod tests {
         let mut timeline = LocalTimeline::default();
         timeline.apply_delta(tick);
         app.insert_resource(timeline);
-        app.world_mut().spawn((
-            PredictionManager {
-                rollback_policy: RollbackPolicy {
-                    max_rollback_ticks,
-                    ..Default::default()
-                },
+        app.insert_resource(InputTimelineConfig::default().with_input_delay(input_delay_config));
+        app.world_mut().spawn(PredictionManager {
+            rollback_policy: RollbackPolicy {
+                max_rollback_ticks,
                 ..Default::default()
             },
-            InputTimelineConfig::default().with_input_delay(input_delay_config),
-        ));
+            ..Default::default()
+        });
         app.world_mut().flush();
         app
     }

--- a/crates/replication/prediction/src/predicted_history.rs
+++ b/crates/replication/prediction/src/predicted_history.rs
@@ -18,7 +18,7 @@ use core::ops::{Deref, DerefMut};
 use lightyear_core::history_buffer::{HistoryBuffer, HistoryState};
 use lightyear_core::prelude::{ConfirmedHistory, LocalTimeline};
 use lightyear_core::tick::Tick;
-use lightyear_core::timeline::{Rollback, SyncEvent};
+use lightyear_core::timeline::SyncEvent;
 use lightyear_replication::diff_history::HistoryDiffReceiver;
 use lightyear_replication::prelude::PreSpawned;
 use lightyear_sync::prelude::InputTimelineConfig;
@@ -93,14 +93,13 @@ impl<C> PredictionHistory<C> {
 ///
 /// This system only handles changes, removals are handled in `apply_component_removal`
 pub(crate) fn update_prediction_history<T: Component + Clone>(
-    manager: Single<&PredictionManager>,
+    manager: Res<PredictionManager>,
     input_config: Res<InputTimelineConfig>,
     mut query: Query<(Entity, Ref<T>, &mut PredictionHistory<T>)>,
     timeline: Res<LocalTimeline>,
 ) {
     // tick for which we will record the history (either the current client tick or the current rollback tick)
     let tick = timeline.tick();
-    let manager = manager.into_inner();
     let oldest_rollback_tick = tick
         - u32::from(
             manager
@@ -397,13 +396,16 @@ pub(crate) fn add_history_diff_receiver<C: SyncComponent + RepliconDiffable>(
 
 /// During rollback re-simulation, check if we have a confirmed value for this tick.
 /// If so, snap the component to the confirmed value instead of using the predicted value.
+///
+/// [`PredictionSystems::SnapToConfirmed`](crate::plugin::PredictionSystems::SnapToConfirmed) gates
+/// this system with [`is_in_rollback`](lightyear_core::timeline::is_in_rollback), so the global
+/// [`Rollback`](lightyear_core::timeline::Rollback) resource does not need to be fetched by every
+/// monomorphized component system.
 pub(crate) fn snap_to_confirmed_during_rollback<
     C: Component<Mutability = Mutable> + Clone + PartialEq + Debug,
 >(
     mut commands: Commands,
     timeline: Res<LocalTimeline>,
-    // Only run during rollback
-    rollback: Single<&Rollback>,
     mut query: Query<(Entity, Option<&mut C>, &ConfirmedHistory<C>), With<Predicted>>,
 ) {
     let tick = timeline.tick();
@@ -536,15 +538,14 @@ mod tests {
         let mut timeline = LocalTimeline::default();
         timeline.apply_delta(tick);
         app.insert_resource(timeline);
-        app.insert_resource(InputTimelineConfig::default().with_input_delay(input_delay_config));
-        app.world_mut().spawn(PredictionManager {
+        app.insert_resource(PredictionManager {
             rollback_policy: RollbackPolicy {
                 max_rollback_ticks,
                 ..Default::default()
             },
             ..Default::default()
         });
-        app.world_mut().flush();
+        app.insert_resource(InputTimelineConfig::default().with_input_delay(input_delay_config));
         app
     }
 

--- a/crates/replication/prediction/src/registry.rs
+++ b/crates/replication/prediction/src/registry.rs
@@ -1,4 +1,4 @@
-use crate::manager::{PredictionResource, RollbackMode, StateRollbackMetadata};
+use crate::manager::{RollbackMode, StateRollbackMetadata};
 use crate::plugin::{add_non_networked_rollback_systems, add_prediction_systems};
 use crate::predicted_history::PredictionHistory;
 use crate::prelude::PredictionManager;
@@ -1407,9 +1407,8 @@ fn add_resolved_confirmed_to_history<C: SyncComponent>(
         let state_metadata =
             world.resource::<StateRollbackMetadata>() as *const StateRollbackMetadata;
         let current_tick = world.resource::<LocalTimeline>().tick();
-        let prediction_link = world.resource::<PredictionResource>().link_entity;
         let should_check = world
-            .get::<PredictionManager>(prediction_link)
+            .get_resource::<PredictionManager>()
             .is_some_and(|m| matches!(m.rollback_policy.state, RollbackMode::Check));
         (unsafe { &*registry }, should_check, current_tick, unsafe {
             &*state_metadata
@@ -1446,9 +1445,8 @@ fn remove_history<C: SyncComponent>(ctx: &mut RemoveCtx, entity: &mut DeferredEn
         let state_metadata =
             world.resource::<StateRollbackMetadata>() as *const StateRollbackMetadata;
         let current_tick = world.resource::<LocalTimeline>().tick();
-        let prediction_link = world.resource::<PredictionResource>().link_entity;
         let should_check = world
-            .get::<PredictionManager>(prediction_link)
+            .get_resource::<PredictionManager>()
             .is_some_and(|m| matches!(m.rollback_policy.state, RollbackMode::Check));
         // SAFETY: registry lives in the World and won't be moved/dropped during this function
         (
@@ -1534,6 +1532,8 @@ mod tests {
             },
         ));
         app.init_resource::<PredictionRegistry>();
+        app.init_resource::<PredictionManager>();
+        app.init_resource::<InputTimelineConfig>();
         app
     }
 
@@ -1666,7 +1666,7 @@ mod tests {
         app.add_plugins((StatesPlugin, RepliconPlugins, PredictionPlugin));
         app.insert_resource(LocalTimeline::default());
         app.insert_resource(ReplicationCheckpointMap::default());
-        app.world_mut().spawn(PredictionManager::default());
+        app.insert_resource(PredictionManager::default());
         app.world_mut().flush();
         app.component::<TestDiffComponent>()
             .replicate_diff()

--- a/crates/replication/prediction/src/rollback.rs
+++ b/crates/replication/prediction/src/rollback.rs
@@ -652,7 +652,7 @@ fn check_rollback(
                 if prediction_manager.is_rollback() {
                     debug!("Rollback was triggered by state, skipping input rollback checks");
                 } else if last_confirmed_input.received_input()
-                    && let Some(rollback_tick) = last_confirmed_input.get()
+                    && let Some(rollback_tick) = last_confirmed_input.previous_frame()
                 {
                     debug!(
                         ?last_confirmed_input,
@@ -815,7 +815,7 @@ fn check_rollback(
 /// This must run after the rollback check.
 pub fn reset_input_rollback_tracker(
     _input_timeline: SyncedInputTimeline,
-    last_confirmed_input: Res<LastConfirmedInput>,
+    mut last_confirmed_input: ResMut<LastConfirmedInput>,
     prediction_manager: Option<Res<PredictionManager>>,
 ) {
     // Reset to u32::MAX so the next `set_if_lower` call always wins and we
@@ -827,6 +827,9 @@ pub fn reset_input_rollback_tracker(
     last_confirmed_input
         .received_any_messages
         .store(false, bevy_platform::sync::atomic::Ordering::Relaxed);
+    // Each generic input plugin ANDs its own readiness into this value in PostUpdate. Resetting
+    // once here makes the result independent of input-plugin execution order.
+    last_confirmed_input.received_for_all_clients = true;
     if let Some(prediction_manager) = prediction_manager {
         prediction_manager
             .earliest_mismatch_input

--- a/crates/replication/prediction/src/rollback.rs
+++ b/crates/replication/prediction/src/rollback.rs
@@ -67,7 +67,7 @@ use lightyear_replication::prelude::ConfirmHistory;
 use lightyear_replication::prespawn::PreSpawnedReceiver;
 use lightyear_replication::registry::ComponentRegistry;
 use lightyear_replication::{ReplicationSystems, checkpoint::ReplicationCheckpointMap};
-use lightyear_sync::prelude::{InputTimeline, InputTimelineConfig, IsSynced};
+use lightyear_sync::prelude::{InputTimelineConfig, SyncedInputTimeline};
 use lightyear_utils::adaptive_for_each_mut;
 #[cfg(feature = "metrics")]
 use lightyear_utils::timer_gauge;
@@ -227,6 +227,9 @@ impl Plugin for RollbackPlugin {
             ParamBuilder,
             ParamBuilder,
             ParamBuilder,
+            ParamBuilder,
+            ParamBuilder,
+            ParamBuilder,
         )
             .build_state(app.world_mut())
             .build_system(check_rollback)
@@ -358,17 +361,14 @@ fn check_rollback(
     // make sure to include disabled entities
     mut predicted_entities: Query<(&ConfirmHistory, FilteredEntityMut)>,
     timeline: Res<LocalTimeline>,
+    _input_timeline: SyncedInputTimeline,
+    input_config: Res<InputTimelineConfig>,
+    last_confirmed_input: Res<LastConfirmedInput>,
     mut state_metadata: ResMut<StateRollbackMetadata>,
     checkpoints: Res<ReplicationCheckpointMap>,
     receiver_query: Single<
-        (
-            Entity,
-            Option<&LastConfirmedInput>,
-            &mut PredictionManager,
-            &InputTimelineConfig,
-            &mut PreSpawnedReceiver,
-        ),
-        (With<IsSynced<InputTimeline>>, Without<HostClient>),
+        (Entity, &mut PredictionManager, &mut PreSpawnedReceiver),
+        (With<Client>, Without<HostClient>),
     >,
     component_registry: Res<ComponentRegistry>,
     prediction_registry: Res<PredictionRegistry>,
@@ -380,18 +380,13 @@ fn check_rollback(
     #[cfg(feature = "metrics")]
     let _timer = timer_gauge!("prediction/rollback/check");
 
-    let (
-        manager_entity,
-        last_confirmed_input,
-        mut prediction_manager,
-        input_config,
-        mut prespawned_receiver,
-    ) = receiver_query.into_inner();
+    let (manager_entity, mut prediction_manager, mut prespawned_receiver) =
+        receiver_query.into_inner();
     let tick = timeline.tick();
     let received_state = state_metadata.received_messages_this_frame;
     let max_rollback_ticks = prediction_manager
         .rollback_policy
-        .effective_max_rollback_ticks(input_config);
+        .effective_max_rollback_ticks(&input_config);
 
     // The tick where ALL messages have been received (guaranteed complete information).
     // Explicit mismatch checks can exist before this is known, so don't return early.
@@ -669,8 +664,7 @@ fn check_rollback(
             RollbackMode::Always => {
                 if prediction_manager.is_rollback() {
                     debug!("Rollback was triggered by state, skipping input rollback checks");
-                } else if let Some(last_confirmed_input) = last_confirmed_input
-                    && last_confirmed_input.received_input()
+                } else if last_confirmed_input.received_input()
                     && let Some(rollback_tick) = last_confirmed_input.get()
                 {
                     debug!(
@@ -831,22 +825,20 @@ fn check_rollback(
 ///
 /// This must run after the rollback check.
 pub fn reset_input_rollback_tracker(
-    client: Single<AnyOf<(&LastConfirmedInput, &PredictionManager)>, With<IsSynced<InputTimeline>>>,
+    _input_timeline: SyncedInputTimeline,
+    last_confirmed_input: Res<LastConfirmedInput>,
+    prediction_manager: Option<Single<&PredictionManager, With<Client>>>,
 ) {
-    let (last_confirmed_input, prediction_manager) = client.into_inner();
-
     // Reset to u32::MAX so the next `set_if_lower` call always wins and we
     // compute the true minimum across all remote clients for this frame.
-    if let Some(last_confirmed_input) = last_confirmed_input {
-        last_confirmed_input
-            .tick
-            .0
-            .store(u32::MAX, bevy_platform::sync::atomic::Ordering::Relaxed);
-        last_confirmed_input
-            .received_any_messages
-            .store(false, bevy_platform::sync::atomic::Ordering::Relaxed);
-    }
-    if let Some(prediction_manager) = prediction_manager {
+    last_confirmed_input
+        .tick
+        .0
+        .store(u32::MAX, bevy_platform::sync::atomic::Ordering::Relaxed);
+    last_confirmed_input
+        .received_any_messages
+        .store(false, bevy_platform::sync::atomic::Ordering::Relaxed);
+    if let Some(prediction_manager) = prediction_manager.as_deref() {
         prediction_manager
             .earliest_mismatch_input
             .tick

--- a/crates/replication/prediction/src/rollback.rs
+++ b/crates/replication/prediction/src/rollback.rs
@@ -36,9 +36,7 @@ use super::predicted_history::PredictionHistory;
 use crate::correction::PreviousVisual;
 use crate::despawn::PredictionDisable;
 use crate::diagnostics::PredictionMetrics;
-use crate::manager::{
-    LastConfirmedInput, PredictionManager, PredictionResource, RollbackMode, StateRollbackMetadata,
-};
+use crate::manager::{LastConfirmedInput, PredictionManager, RollbackMode, StateRollbackMetadata};
 use crate::plugin::PredictionSystems;
 use crate::registry::PredictionRegistry;
 use alloc::vec::Vec;
@@ -56,8 +54,7 @@ use bevy_replicon::shared::backend::channels::ServerChannel;
 use bevy_time::{Fixed, Time};
 use bevy_utils::prelude::DebugName;
 use core::fmt::Debug;
-use lightyear_connection::client::{Client, Connected};
-use lightyear_connection::host::HostClient;
+use lightyear_connection::network_topology::NetworkingMetadata;
 use lightyear_core::history_buffer::HistoryState;
 use lightyear_core::prelude::{ConfirmedHistory, LocalTimeline};
 use lightyear_core::tick::Tick;
@@ -99,7 +96,7 @@ pub enum RollbackSystems {
     Rollback,
     /// Logic that returns right after the rollback is done:
     /// - Setting the VisualCorrection
-    /// - Removing the Rollback component
+    /// - Removing the [`Rollback`] resource
     EndRollback,
 
     // PostUpdate
@@ -116,7 +113,16 @@ struct NoRollbackCheckTargets;
 impl Plugin for RollbackPlugin {
     fn build(&self, app: &mut App) {
         // RESOURCES
+        // `PredictionPlugin` can also be installed directly in small or test applications without
+        // the full Lightyear plugin group. Keep the cached topology available to the common
+        // rollback pipeline in those applications too.
+        app.init_resource::<NetworkingMetadata>();
         app.init_resource::<StateRollbackMetadata>();
+        // Input-only prediction does not install the replication backend. Empty registries and
+        // checkpoint state keep the state-reconciliation branch dormant while allowing the common
+        // rollback decision system to operate on remote inputs.
+        app.init_resource::<ComponentRegistry>();
+        app.init_resource::<ReplicationCheckpointMap>();
 
         // SETS
         app.configure_sets(
@@ -144,7 +150,7 @@ impl Plugin for RollbackPlugin {
         app.add_systems(
             PreUpdate,
             (
-                reset_state_rollback_metadata_if_disconnected.before(RollbackSystems::Check),
+                reset_state_rollback_metadata_on_topology_change.before(RollbackSystems::Check),
                 check_received_replication_messages
                     .after(ClientSystems::ReceivePackets)
                     .before(ClientSystems::Receive),
@@ -230,6 +236,7 @@ impl Plugin for RollbackPlugin {
             ParamBuilder,
             ParamBuilder,
             ParamBuilder,
+            ParamBuilder,
         )
             .build_state(app.world_mut())
             .build_system(check_rollback)
@@ -283,14 +290,7 @@ impl DeterministicPredicted {
         // TODO: avoid fetching DeterministicPredicted twice when we can convert DeferredWorld to UnsafeWorldCell (0.17.3)
         let deterministic_predicted = *world.get::<DeterministicPredicted>(context.entity).unwrap();
         let tick = world.resource::<LocalTimeline>().tick();
-        let Some(prediction_manager_entity) = world
-            .get_resource::<PredictionResource>()
-            .map(|r| r.link_entity)
-        else {
-            return;
-        };
-        let Some(mut manager) = world.get_mut::<PredictionManager>(prediction_manager_entity)
-        else {
+        let Some(mut manager) = world.get_resource_mut::<PredictionManager>() else {
             return;
         };
         if !deterministic_predicted.skip_despawn {
@@ -317,33 +317,26 @@ pub struct DisabledDuringRollback;
 /// Set a flag if we received any replication message this frame.
 /// Also reset the per-frame state.
 fn check_received_replication_messages(
-    client_messages: Res<ClientMessages>,
+    client_messages: Option<Res<ClientMessages>>,
     mut metadata: ResMut<StateRollbackMetadata>,
 ) {
     // Reset per-frame state
     metadata.reset_frame_state();
 
     // Check if we received any replication messages
-    if client_messages.received_count(ServerChannel::Updates) > 0
-        || client_messages.received_count(ServerChannel::Mutations) > 0
-    {
+    if client_messages.is_some_and(|messages| {
+        messages.received_count(ServerChannel::Updates) > 0
+            || messages.received_count(ServerChannel::Mutations) > 0
+    }) {
         metadata.received_messages_this_frame = true;
     }
 }
 
-fn reset_state_rollback_metadata_if_disconnected(
-    query: Query<
-        (),
-        (
-            With<PredictionManager>,
-            With<Client>,
-            With<Connected>,
-            Without<HostClient>,
-        ),
-    >,
+fn reset_state_rollback_metadata_on_topology_change(
+    networking: Res<NetworkingMetadata>,
     mut metadata: ResMut<StateRollbackMetadata>,
 ) {
-    if query.single().is_err() {
+    if networking.is_changed() {
         metadata.reset_connection_state();
     }
 }
@@ -364,12 +357,10 @@ fn check_rollback(
     _input_timeline: SyncedInputTimeline,
     input_config: Res<InputTimelineConfig>,
     last_confirmed_input: Res<LastConfirmedInput>,
+    mut prediction_manager: ResMut<PredictionManager>,
     mut state_metadata: ResMut<StateRollbackMetadata>,
     checkpoints: Res<ReplicationCheckpointMap>,
-    receiver_query: Single<
-        (Entity, &mut PredictionManager, &mut PreSpawnedReceiver),
-        (With<Client>, Without<HostClient>),
-    >,
+    mut prespawned_receivers: Query<&mut PreSpawnedReceiver>,
     component_registry: Res<ComponentRegistry>,
     prediction_registry: Res<PredictionRegistry>,
     awaiting_catchup: Query<(), (With<CatchUpGated>, With<ConfirmHistory>)>,
@@ -380,8 +371,6 @@ fn check_rollback(
     #[cfg(feature = "metrics")]
     let _timer = timer_gauge!("prediction/rollback/check");
 
-    let (manager_entity, mut prediction_manager, mut prespawned_receiver) =
-        receiver_query.into_inner();
     let tick = timeline.tick();
     let received_state = state_metadata.received_messages_this_frame;
     let max_rollback_ticks = prediction_manager
@@ -409,7 +398,6 @@ fn check_rollback(
                 kind = "rollback_rejected",
                 schedule = "PreUpdate",
                 sample_point = "PreUpdate",
-                entity = ?manager_entity,
                 local_tick = tick.0,
                 rollback_tick = rollback_tick.0,
                 rollback_delta = delta,
@@ -421,13 +409,12 @@ fn check_rollback(
             return;
         }
         prediction_manager.set_rollback_tick(rollback_tick);
-        commands.entity(manager_entity).insert(rollback);
+        commands.insert_resource(rollback);
         trace!(
             target: "lightyear_debug::prediction",
             kind = "rollback_requested",
             schedule = "PreUpdate",
             sample_point = "PreUpdate",
-            entity = ?manager_entity,
             local_tick = tick.0,
             rollback_tick = rollback_tick.0,
             rollback_delta = delta,
@@ -740,17 +727,19 @@ fn check_rollback(
             })
             .collect::<Vec<_>>();
         // If the prespawned entity didn't exist at the rollback tick, despawn it
-        prespawned_receiver.despawn_prespawned_after_with(
-            rollback_tick + 1,
-            |entity| {
-                protected_prespawn_entities.contains(&entity)
-                    || (forced_rollback_requested
-                        && deterministic_predicted
-                            .get(entity)
-                            .is_ok_and(|predicted| predicted.skip_despawn))
-            },
-            &mut commands,
-        );
+        if let Ok(mut prespawned_receiver) = prespawned_receivers.single_mut() {
+            prespawned_receiver.despawn_prespawned_after_with(
+                rollback_tick + 1,
+                |entity| {
+                    protected_prespawn_entities.contains(&entity)
+                        || (forced_rollback_requested
+                            && deterministic_predicted
+                                .get(entity)
+                                .is_ok_and(|predicted| predicted.skip_despawn))
+                },
+                &mut commands,
+            );
+        }
 
         // If the deterministic predicted entity didn't exist at the rollback tick, despawn it
         // We can drain everything because:
@@ -827,7 +816,7 @@ fn check_rollback(
 pub fn reset_input_rollback_tracker(
     _input_timeline: SyncedInputTimeline,
     last_confirmed_input: Res<LastConfirmedInput>,
-    prediction_manager: Option<Single<&PredictionManager, With<Client>>>,
+    prediction_manager: Option<Res<PredictionManager>>,
 ) {
     // Reset to u32::MAX so the next `set_if_lower` call always wins and we
     // compute the true minimum across all remote clients for this frame.
@@ -838,7 +827,7 @@ pub fn reset_input_rollback_tracker(
     last_confirmed_input
         .received_any_messages
         .store(false, bevy_platform::sync::atomic::Ordering::Relaxed);
-    if let Some(prediction_manager) = prediction_manager.as_deref() {
+    if let Some(prediction_manager) = prediction_manager {
         prediction_manager
             .earliest_mismatch_input
             .tick
@@ -891,10 +880,10 @@ pub(crate) fn prepare_rollback<C: Component<Mutability = Mutable> + Clone>(
         ),
         Without<DisableRollback>,
     >,
-    manager_query: Single<(&PredictionManager, &Rollback)>,
+    manager: Res<PredictionManager>,
+    rollback: Res<Rollback>,
 ) {
     let kind = DebugName::type_name::<C>();
-    let (manager, rollback) = manager_query.into_inner();
     let current_tick = timeline.tick();
     let _span = trace_span!("prepare_rollback", tick = ?current_tick, kind = ?kind).entered();
     let rollback_tick = manager.get_rollback_start_tick().unwrap();
@@ -905,7 +894,7 @@ pub(crate) fn prepare_rollback<C: Component<Mutability = Mutable> + Clone>(
     for (entity, predicted_component, mut predicted_history, confirmed_history) in
         predicted_query.iter_mut()
     {
-        let is_state_rollback = matches!(rollback, Rollback::FromState);
+        let is_state_rollback = matches!(*rollback, Rollback::FromState);
         let is_completed_state_rollback =
             is_state_rollback && server_confirmed_tick == Some(rollback_tick);
         let is_forced_state_rollback = is_state_rollback && !is_completed_state_rollback;
@@ -1068,9 +1057,7 @@ pub(crate) fn run_rollback(world: &mut World) {
     let local_timeline = world.resource_mut::<LocalTimeline>();
     let current_tick = local_timeline.tick();
     let rollback_start_tick = world
-        .query::<&PredictionManager>()
-        .single(world)
-        .unwrap()
+        .resource::<PredictionManager>()
         .get_rollback_start_tick()
         .expect("we should be in rollback");
 
@@ -1187,22 +1174,22 @@ pub(crate) fn run_rollback(world: &mut World) {
 }
 
 pub(crate) fn end_rollback(
-    prediction_manager: Single<(Entity, &PredictionManager), With<Rollback>>,
+    prediction_manager: Res<PredictionManager>,
+    rollback: Res<Rollback>,
     mut commands: Commands,
 ) {
-    let (entity, prediction_manager) = prediction_manager.into_inner();
     let rollback_tick = prediction_manager.get_rollback_start_tick();
     trace!(
         target: "lightyear_debug::prediction",
         kind = "rollback_end",
         schedule = "PreUpdate",
         sample_point = "PreUpdate",
-        entity = ?entity,
+        rollback = ?*rollback,
         rollback_tick = ?rollback_tick,
         "ending rollback"
     );
     prediction_manager.set_non_rollback();
-    commands.entity(entity).remove::<Rollback>();
+    commands.remove_resource::<Rollback>();
 }
 
 #[cfg(feature = "metrics")]
@@ -1253,12 +1240,10 @@ mod tests {
         world.init_resource::<PredictionRegistry>();
         world.init_resource::<ReplicationCheckpointMap>();
 
-        let manager = world
-            .spawn((PredictionManager::default(), Rollback::FromState))
-            .id();
+        world.insert_resource(PredictionManager::default());
+        world.insert_resource(Rollback::FromState);
         world
-            .get_mut::<PredictionManager>(manager)
-            .unwrap()
+            .resource::<PredictionManager>()
             .set_rollback_tick(rollback_tick);
 
         let mut history = PredictionHistory::<TestComponent>::default();
@@ -1288,9 +1273,8 @@ mod tests {
         world.init_resource::<PredictionRegistry>();
         world.init_resource::<ReplicationCheckpointMap>();
 
-        let manager = world
-            .spawn((PredictionManager::default(), Rollback::FromInputs))
-            .id();
+        world.insert_resource(PredictionManager::default());
+        world.insert_resource(Rollback::FromInputs);
 
         let mut history = PredictionHistory::<TestComponent>::default();
         for tick in [8, 10, 12, 15] {
@@ -1302,8 +1286,7 @@ mod tests {
         // strictly newer entries are discarded, and the component restores
         // to the floor sample at the target.
         world
-            .get_mut::<PredictionManager>(manager)
-            .unwrap()
+            .resource::<PredictionManager>()
             .set_rollback_tick(Tick(12));
         world
             .run_system_once(prepare_rollback::<TestComponent>)
@@ -1332,8 +1315,7 @@ mod tests {
         // Second, DEEPER rollback to tick 8: restores from the preserved
         // per-tick sample, not from the live post-first-rollback value.
         world
-            .get_mut::<PredictionManager>(manager)
-            .unwrap()
+            .resource::<PredictionManager>()
             .set_rollback_tick(Tick(8));
         world
             .run_system_once(prepare_rollback::<TestComponent>)

--- a/crates/replication/replication/src/REPLICON_INTEGRATION.md
+++ b/crates/replication/replication/src/REPLICON_INTEGRATION.md
@@ -104,7 +104,7 @@ The `PreSpawnedReceiver::matches()` method exists but is never called. In the ol
 Rollback via `write_history` → `StateRollbackMetadata` → `check_rollback` is not triggering. Possible causes:
 
 - `PredictionManager.rollback_policy.state` may not be `RollbackMode::Check` — verify it's set correctly during test setup
-- `PredictionResource.link_entity` may point to the wrong entity
+- the application may not contain the global `PredictionManager` resource
 - `ServerMutateTicks.last_tick()` may not be advancing (replicon may not be calling `confirm()` in the test stepper's transport path)
 - `check_received_replication_messages` uses `ClientMessages.received_count()` which may not reflect messages received through the lightyear transport bridge
 
@@ -112,7 +112,7 @@ Rollback via `write_history` → `StateRollbackMetadata` → `check_rollback` is
 1. Add trace logging to `write_history` to confirm it's being called and `should_check` is true
 2. Check that `StateRollbackMetadata.should_rollback` is set after a server mutation
 3. Verify `ServerMutateTicks.last_tick()` advances when mutation messages arrive
-4. Check that the global `InputTimeline` resource is synced and the `check_rollback` system's `Single` query succeeds (entity has `Client + PredictionManager + !HostClient`)
+4. Check that the global `InputTimeline` resource is synced and the application contains its global `PredictionManager`
 
 **Ignored tests**: `test_rollback_time_resource`, `test_deterministic_predicted_skip_despawn`, `test_despawned_predicted_rollback`, `test_update_history` (also has tick timing issue)
 

--- a/crates/replication/replication/src/REPLICON_INTEGRATION.md
+++ b/crates/replication/replication/src/REPLICON_INTEGRATION.md
@@ -112,7 +112,7 @@ Rollback via `write_history` → `StateRollbackMetadata` → `check_rollback` is
 1. Add trace logging to `write_history` to confirm it's being called and `should_check` is true
 2. Check that `StateRollbackMetadata.should_rollback` is set after a server mutation
 3. Verify `ServerMutateTicks.last_tick()` advances when mutation messages arrive
-4. Check that the `check_rollback` system's `Single` query succeeds (entity has `PredictionManager + IsSynced<InputTimeline> + !HostClient`)
+4. Check that the global `InputTimeline` resource is synced and the `check_rollback` system's `Single` query succeeds (entity has `Client + PredictionManager + !HostClient`)
 
 **Ignored tests**: `test_rollback_time_resource`, `test_deterministic_predicted_skip_despawn`, `test_despawned_predicted_rollback`, `test_update_history` (also has tick timing issue)
 

--- a/crates/replication/replication/src/control.rs
+++ b/crates/replication/replication/src/control.rs
@@ -5,7 +5,7 @@ use bevy_derive::Deref;
 use bevy_ecs::prelude::*;
 use bevy_reflect::Reflect;
 use bevy_replicon::bytes::Bytes;
-use bevy_replicon::prelude::{RuleFns, SingleComponent};
+use bevy_replicon::prelude::{RuleFns, ScopeLifetime, SingleComponent};
 use bevy_replicon::server::visibility::client_visibility::ClientVisibility;
 use bevy_replicon::server::visibility::filters_mask::FilterBit;
 use bevy_replicon::server::visibility::registry::FilterRegistry;
@@ -181,8 +181,11 @@ impl FromWorld for ControlBit {
     fn from_world(world: &mut World) -> Self {
         let bit = world.resource_scope(|world, mut filter_registry: Mut<FilterRegistry>| {
             world.resource_scope(|world, mut registry: Mut<ReplicationRegistry>| {
-                filter_registry
-                    .register_scope::<SingleComponent<ControlledSend>>(world, &mut registry)
+                filter_registry.register_scope::<SingleComponent<ControlledSend>>(
+                    world,
+                    &mut registry,
+                    ScopeLifetime::WhileVisible,
+                )
             })
         });
         Self(bit)

--- a/crates/replication/replication/src/prespawn.rs
+++ b/crates/replication/replication/src/prespawn.rs
@@ -282,8 +282,11 @@ pub struct PreSpawned {
     pub user_salt: Option<u64>,
 
     // TODO: what if we want the Prespawned to only be for a given sender? or a subset of senders?
-    /// Receiver entity that is prespawning this entity.
-    /// If None, then we will use the entity that has a [`PreSpawnedReceiver`].
+    /// Receiver Link that owns this remote entity.
+    ///
+    /// Replication uses this to select a specific [`PreSpawnedReceiver`]. Direct P2P input uses
+    /// it to ensure that a stable input-target hash is accepted only from the Link for that peer.
+    /// If None, replication will use the entity that has a [`PreSpawnedReceiver`].
     pub receiver: Option<Entity>,
 }
 

--- a/crates/replication/replication/src/prespawn.rs
+++ b/crates/replication/replication/src/prespawn.rs
@@ -23,10 +23,12 @@ use core::hash::{Hash, Hasher};
 use lightyear_connection::client::Connected;
 use lightyear_connection::host::HostClient;
 use lightyear_core::prelude::{LocalTimeline, Tick};
+#[cfg(feature = "client")]
+use lightyear_core::timeline::SyncEvent;
+#[cfg(feature = "client")]
+use lightyear_sync::prelude::InputTimelineConfig;
 #[allow(unused_imports)]
 use tracing::{debug, error, info, trace, warn};
-#[cfg(feature = "client")]
-use {lightyear_core::prelude::SyncEvent, lightyear_sync::prelude::client::InputTimelineConfig};
 
 type EntityHashMap<K, V> = bevy_platform::collections::HashMap<K, V, EntityHash>;
 

--- a/crates/replication/replication/src/send.rs
+++ b/crates/replication/replication/src/send.rs
@@ -19,7 +19,7 @@ use bevy_ecs::world::DeferredWorld;
 use bevy_reflect::Reflect;
 #[allow(unused_imports)]
 use bevy_replicon::prelude::{
-    AppRuleExt, FilterScope, Replicated, SingleComponent, VisibilityFilter,
+    AppRuleExt, FilterScope, Replicated, ScopeLifetime, SingleComponent, VisibilityFilter,
 };
 use bevy_replicon::server::ServerSystems;
 use bevy_replicon::server::server_tick::ServerTick;
@@ -330,7 +330,11 @@ impl FromWorld for ReplicateBit {
     fn from_world(world: &mut World) -> Self {
         let bit = world.resource_scope(|world, mut filter_registry: Mut<FilterRegistry>| {
             world.resource_scope(|world, mut registry: Mut<ReplicationRegistry>| {
-                filter_registry.register_scope::<Entity>(world, &mut registry)
+                filter_registry.register_scope::<Entity>(
+                    world,
+                    &mut registry,
+                    ScopeLifetime::WhileVisible,
+                )
             })
         });
         Self(bit)
@@ -410,8 +414,11 @@ mod prediction {
         fn from_world(world: &mut World) -> Self {
             let bit = world.resource_scope(|world, mut filter_registry: Mut<FilterRegistry>| {
                 world.resource_scope(|world, mut registry: Mut<ReplicationRegistry>| {
-                    filter_registry
-                        .register_scope::<SingleComponent<Predicted>>(world, &mut registry)
+                    filter_registry.register_scope::<SingleComponent<Predicted>>(
+                        world,
+                        &mut registry,
+                        ScopeLifetime::WhileVisible,
+                    )
                 })
             });
             Self(bit)
@@ -481,8 +488,11 @@ mod interpolation {
         fn from_world(world: &mut World) -> Self {
             let bit = world.resource_scope(|world, mut filter_registry: Mut<FilterRegistry>| {
                 world.resource_scope(|world, mut registry: Mut<ReplicationRegistry>| {
-                    filter_registry
-                        .register_scope::<SingleComponent<Interpolated>>(world, &mut registry)
+                    filter_registry.register_scope::<SingleComponent<Interpolated>>(
+                        world,
+                        &mut registry,
+                        ScopeLifetime::WhileVisible,
+                    )
                 })
             });
             Self(bit)

--- a/crates/replication/replication/src/visibility/immediate.rs
+++ b/crates/replication/replication/src/visibility/immediate.rs
@@ -25,6 +25,7 @@ world.lose_visibility(entity, client);
 use bevy_app::prelude::*;
 use bevy_derive::Deref;
 use bevy_ecs::prelude::*;
+use bevy_replicon::prelude::ScopeLifetime;
 use bevy_replicon::server::visibility::client_visibility::ClientVisibility;
 use bevy_replicon::server::visibility::filters_mask::FilterBit;
 use bevy_replicon::server::visibility::registry::FilterRegistry;
@@ -42,7 +43,11 @@ impl FromWorld for VisibilityBit {
     fn from_world(world: &mut World) -> Self {
         let bit = world.resource_scope(|world, mut filter_registry: Mut<FilterRegistry>| {
             world.resource_scope(|world, mut registry: Mut<ReplicationRegistry>| {
-                filter_registry.register_scope::<Entity>(world, &mut registry)
+                filter_registry.register_scope::<Entity>(
+                    world,
+                    &mut registry,
+                    ScopeLifetime::WhileVisible,
+                )
             })
         });
         Self(bit)

--- a/crates/tests/src/client_server/base.rs
+++ b/crates/tests/src/client_server/base.rs
@@ -12,11 +12,17 @@ use test_log::test;
 /// - the various components we expect are present
 #[test]
 fn test_setup_client_server() {
-    let stepper = ClientServerStepper::from_config(StepperConfig::single());
+    let mut stepper = ClientServerStepper::from_config(StepperConfig::single());
 
     // Check that the various components we expect are present
     assert!(stepper.client(0).contains::<PingManager>());
-    assert!(stepper.client(0).contains::<InputTimeline>());
+    assert!(
+        stepper
+            .client_app()
+            .world()
+            .contains_resource::<InputTimeline>()
+    );
+    assert!(!stepper.client(0).contains::<InputTimeline>());
     assert!(stepper.client(0).contains::<RemoteTimeline>());
     assert!(stepper.client(0).contains::<InterpolationTimeline>());
     assert!(stepper.client(0).contains::<Transport>());

--- a/crates/tests/src/client_server/deterministic/state_based_catchup.rs
+++ b/crates/tests/src/client_server/deterministic/state_based_catchup.rs
@@ -371,8 +371,8 @@ fn sample_pre_physics_state(
     players: Query<(Entity, &DetPlayerId)>,
     balls: Query<Entity, With<DetBallMarker>>,
     walls: Query<Entity, With<DetWallMarker>>,
-    rollback_markers: Query<&Rollback>,
-    prediction_managers: Query<&PredictionManager>,
+    rollback: Option<Res<Rollback>>,
+    prediction_manager: Option<Res<PredictionManager>>,
 ) {
     sample_physics_state(
         SampleStage::PrePhysics,
@@ -385,8 +385,8 @@ fn sample_pre_physics_state(
         players,
         balls,
         walls,
-        rollback_markers,
-        prediction_managers,
+        rollback,
+        prediction_manager,
     );
 }
 
@@ -403,8 +403,8 @@ fn sample_post_physics_state(
     players: Query<(Entity, &DetPlayerId)>,
     balls: Query<Entity, With<DetBallMarker>>,
     walls: Query<Entity, With<DetWallMarker>>,
-    rollback_markers: Query<&Rollback>,
-    prediction_managers: Query<&PredictionManager>,
+    rollback: Option<Res<Rollback>>,
+    prediction_manager: Option<Res<PredictionManager>>,
 ) {
     sample_physics_state(
         SampleStage::PostPhysics,
@@ -417,8 +417,8 @@ fn sample_post_physics_state(
         players,
         balls,
         walls,
-        rollback_markers,
-        prediction_managers,
+        rollback,
+        prediction_manager,
     );
 }
 
@@ -437,14 +437,13 @@ fn sample_physics_state(
     players: Query<(Entity, &DetPlayerId)>,
     balls: Query<Entity, With<DetBallMarker>>,
     walls: Query<Entity, With<DetWallMarker>>,
-    rollback_markers: Query<&Rollback>,
-    prediction_managers: Query<&PredictionManager>,
+    rollback: Option<Res<Rollback>>,
+    prediction_manager: Option<Res<PredictionManager>>,
 ) {
     let tick = timeline.tick();
-    let rollback = rollback_markers.iter().next().copied();
-    let rollback_start = prediction_managers
-        .iter()
-        .next()
+    let rollback = rollback.as_deref().copied();
+    let rollback_start = prediction_manager
+        .as_deref()
         .and_then(PredictionManager::get_rollback_start_tick);
     for (id, position, velocity) in &player_motion {
         motion_samples.0.push(StageMotionSample {
@@ -531,16 +530,15 @@ fn sample_positions(
     >,
     action_players: Query<(Entity, &DetPlayerId)>,
     action_buffers: Query<(&ActionOf<Player>, &DetBuffer)>,
-    rollback_markers: Query<&Rollback>,
-    prediction_managers: Query<&PredictionManager>,
+    rollback: Option<Res<Rollback>>,
+    prediction_manager: Option<Res<PredictionManager>>,
 ) {
     use bevy::ecs::relationship::Relationship;
 
     let tick = timeline.tick().0;
-    let rollback = rollback_markers.iter().next().copied();
-    let rollback_start = prediction_managers
-        .iter()
-        .next()
+    let rollback = rollback.as_deref().copied();
+    let rollback_start = prediction_manager
+        .as_deref()
         .and_then(PredictionManager::get_rollback_start_tick);
     execution_samples.0.push(ExecutionSample {
         tick: Tick(tick),

--- a/crates/tests/src/client_server/deterministic/stepper.rs
+++ b/crates/tests/src/client_server/deterministic/stepper.rs
@@ -6,6 +6,7 @@
 //! deterministic-replication surface area we want to exercise.
 
 use crate::client_server::deterministic::protocol::DetProtocolPlugin;
+use crate::stepper::input_timeline_is_synced;
 use avian2d::prelude::*;
 use bevy::MinimalPlugins;
 use bevy::app::PluginsState;
@@ -119,6 +120,18 @@ impl DetStepper {
             client_id: client_id as u64,
         };
 
+        let mut sync = SyncConfig::default();
+        // 2-tick margin (vs the default 1.0) is needed because
+        // the stepper runs every client app then the server app
+        // sequentially inside one "frame", giving the network
+        // no real flush window. See `stepper::test_input_timeline_config`.
+        sync.jitter_margin = 2.0;
+        client_app.insert_resource(
+            InputTimelineConfig::default()
+                .with_input_delay(InputDelayConfig::fixed_input_delay(0))
+                .with_sync_config(sync),
+        );
+
         let client_entity = client_app
             .world_mut()
             .spawn((
@@ -136,17 +149,6 @@ impl DetStepper {
                         max_rollback_ticks: 100,
                     },
                     ..default()
-                },
-                {
-                    let mut sync = SyncConfig::default();
-                    // 2-tick margin (vs the default 1.0) is needed because
-                    // the stepper runs every client app then the server app
-                    // sequentially inside one "frame", giving the network
-                    // no real flush window. See `stepper::test_input_timeline_config`.
-                    sync.jitter_margin = 2.0;
-                    InputTimelineConfig::default()
-                        .with_input_delay(InputDelayConfig::fixed_input_delay(0))
-                        .with_sync_config(sync)
                 },
                 NetcodeClient::new(auth, NetcodeConfig::default()).unwrap(),
             ))
@@ -263,7 +265,7 @@ impl DetStepper {
         });
         for _ in 0..200 {
             if self.client(id).contains::<Connected>()
-                && self.client(id).contains::<IsSynced<InputTimeline>>()
+                && input_timeline_is_synced(self.client_apps[id].world())
             {
                 info!("Client {} connected + synced", id);
                 return;
@@ -310,7 +312,7 @@ impl DetStepper {
     pub fn wait_for_sync(&mut self) {
         for _ in 0..100 {
             if (0..self.client_entities.len())
-                .all(|id| self.client(id).contains::<IsSynced<InputTimeline>>())
+                .all(|id| input_timeline_is_synced(self.client_apps[id].world()))
             {
                 info!("All clients synced");
                 return;

--- a/crates/tests/src/client_server/deterministic/stepper.rs
+++ b/crates/tests/src/client_server/deterministic/stepper.rs
@@ -131,6 +131,14 @@ impl DetStepper {
                 .with_input_delay(InputDelayConfig::fixed_input_delay(0))
                 .with_sync_config(sync),
         );
+        client_app.insert_resource(PredictionManager {
+            rollback_policy: RollbackPolicy {
+                state: RollbackMode::Disabled,
+                input: RollbackMode::Check,
+                max_rollback_ticks: 100,
+            },
+            ..default()
+        });
 
         let client_entity = client_app
             .world_mut()
@@ -142,14 +150,6 @@ impl DetStepper {
                 ReplicationSender,
                 ReplicationReceiver,
                 crossbeam_client,
-                PredictionManager {
-                    rollback_policy: RollbackPolicy {
-                        state: RollbackMode::Disabled,
-                        input: RollbackMode::Check,
-                        max_rollback_ticks: 100,
-                    },
-                    ..default()
-                },
                 NetcodeClient::new(auth, NetcodeConfig::default()).unwrap(),
             ))
             .id();

--- a/crates/tests/src/client_server/diff.rs
+++ b/crates/tests/src/client_server/diff.rs
@@ -181,7 +181,7 @@ fn setup_prediction_receive_app() -> (App, bevy_replicon::shared::replication::r
     ));
     app.insert_resource(lightyear_core::prelude::LocalTimeline::default());
     app.insert_resource(ReplicationCheckpointMap::default());
-    app.world_mut().spawn(PredictionManager::default());
+    app.insert_resource(PredictionManager::default());
     app.world_mut().flush();
     app.component::<CompRepliconDiff>()
         .replicate_diff()

--- a/crates/tests/src/client_server/input/bei.rs
+++ b/crates/tests/src/client_server/input/bei.rs
@@ -447,7 +447,7 @@ fn test_buffer_inputs_with_delay() {
     let mut config = StepperConfig::single();
     config.init = false;
     let mut stepper = ClientServerStepper::from_config(config);
-    stepper.client_mut(0).insert(
+    stepper.client_app().world_mut().insert_resource(
         InputTimelineConfig::default().with_input_delay(InputDelayConfig::fixed_input_delay(1)),
     );
     stepper.init();
@@ -622,7 +622,7 @@ fn test_buffer_vec2_inputs_with_delay_preserves_buffered_action_value_dimension(
     let mut config = StepperConfig::single();
     config.init = false;
     let mut stepper = ClientServerStepper::from_config(config);
-    stepper.client_mut(0).insert(
+    stepper.client_app().world_mut().insert_resource(
         InputTimelineConfig::default().with_input_delay(InputDelayConfig::fixed_input_delay(1)),
     );
     stepper.init();

--- a/crates/tests/src/client_server/input/leafwing.rs
+++ b/crates/tests/src/client_server/input/leafwing.rs
@@ -18,7 +18,7 @@ fn test_buffer_inputs_with_delay() {
     let mut config = StepperConfig::single();
     config.init = false;
     let mut stepper = ClientServerStepper::from_config(config);
-    stepper.client_mut(0).insert(
+    stepper.client_app().world_mut().insert_resource(
         InputTimelineConfig::default().with_input_delay(InputDelayConfig::fixed_input_delay(1)),
     );
     stepper.init();

--- a/crates/tests/src/client_server/input/native.rs
+++ b/crates/tests/src/client_server/input/native.rs
@@ -12,8 +12,6 @@ use lightyear_messages::MessageManager;
 use lightyear_prediction::prelude::PredictionManager;
 use lightyear_replication::prelude::{PredictionTarget, Replicate};
 use lightyear_replication::prelude::{RoomAllocator, Rooms};
-use lightyear_sync::prelude::InputTimeline;
-use lightyear_sync::prelude::client::IsSynced;
 use test_log::test;
 use tracing::info;
 
@@ -22,12 +20,7 @@ use tracing::info;
 fn test_remote_client_replicated_input() {
     let mut stepper = ClientServerStepper::from_config(StepperConfig::single());
 
-    stepper
-        .client_app()
-        .world_mut()
-        .query::<&IsSynced<InputTimeline>>()
-        .single(stepper.client_app().world())
-        .unwrap();
+    assert!(input_timeline_is_synced(stepper.client_app().world()));
 
     // SETUP
     // entity controlled by the remote client

--- a/crates/tests/src/client_server/input/native.rs
+++ b/crates/tests/src/client_server/input/native.rs
@@ -276,7 +276,7 @@ fn test_input_broadcasting_prediction() {
     // check that during rollbacks, we fetch the input value from the input buffer even for remote inputs
     let check_input =
         move |timeline: Res<LocalTimeline>,
-              c: Single<(), With<Rollback>>,
+              _rollback: Res<Rollback>,
               q: Single<&ActionState<MyInput>, Without<InputMarker<MyInput>>>| {
             let tick = timeline.tick();
             info!(
@@ -307,11 +307,10 @@ fn test_input_broadcasting_prediction() {
 
     // trigger rollback for client 1
     let rollback_tick = client1_tick - 1;
-    stepper.client_mut(1).insert(Rollback::FromInputs);
-    stepper
-        .client_mut(1)
-        .get_mut::<PredictionManager>()
-        .unwrap()
+    stepper.client_apps[1].insert_resource(Rollback::FromInputs);
+    stepper.client_apps[1]
+        .world()
+        .resource::<PredictionManager>()
         .set_rollback_tick(rollback_tick);
     stepper.client_apps[1].update();
 }

--- a/crates/tests/src/client_server/prediction/mod.rs
+++ b/crates/tests/src/client_server/prediction/mod.rs
@@ -86,10 +86,10 @@ pub(crate) fn trigger_rollback_check_without_completed_tick(
 }
 
 pub(crate) fn trigger_state_rollback(stepper: &mut ClientServerStepper, tick: Tick) {
-    stepper.client_mut(0).insert(Rollback::FromState);
+    stepper.client_app().insert_resource(Rollback::FromState);
     stepper
-        .client_mut(0)
-        .get_mut::<PredictionManager>()
-        .unwrap()
+        .client_app()
+        .world()
+        .resource::<PredictionManager>()
         .set_rollback_tick(tick);
 }

--- a/crates/tests/src/client_server/prediction/prespawn.rs
+++ b/crates/tests/src/client_server/prediction/prespawn.rs
@@ -654,8 +654,9 @@ fn test_prespawn_local_despawn_match() {
     let mut sync_config = SyncConfig::default();
     sync_config.max_error_margin = 0.5;
     stepper
-        .client_mut(0)
-        .insert(InputTimelineConfig::default().with_sync_config(sync_config));
+        .client_app()
+        .world_mut()
+        .insert_resource(InputTimelineConfig::default().with_sync_config(sync_config));
     stepper
         .client_mut(0)
         .get_mut::<Link>()

--- a/crates/tests/src/client_server/prediction/rollback.rs
+++ b/crates/tests/src/client_server/prediction/rollback.rs
@@ -22,6 +22,7 @@ use lightyear_prediction::manager::{LastConfirmedInput, RollbackMode, StateRollb
 use lightyear_prediction::prelude::*;
 use lightyear_prediction::rollback::{DeterministicPredicted, reset_input_rollback_tracker};
 use lightyear_replication::prelude::*;
+use lightyear_replication::prespawn::PreSpawnedReceiver;
 use test_log::test;
 
 fn setup() -> (ClientServerStepper, Entity) {
@@ -69,7 +70,7 @@ fn record_completed_mutate_tick(world: &mut World, replicon_tick: RepliconTick, 
 struct ObservedRollbackStart(Option<Tick>);
 
 fn record_rollback_start(
-    manager: Single<&PredictionManager>,
+    manager: Res<PredictionManager>,
     mut observed: ResMut<ObservedRollbackStart>,
 ) {
     if observed.0.is_none() {
@@ -897,10 +898,7 @@ fn test_missing_confirm_history_checkpoint_mapping_does_not_request_rollback() {
     #[derive(Resource, Default)]
     struct RollbackObserved(bool);
 
-    fn record_rollback(
-        manager: Single<&PredictionManager>,
-        mut observed: ResMut<RollbackObserved>,
-    ) {
+    fn record_rollback(manager: Res<PredictionManager>, mut observed: ResMut<RollbackObserved>) {
         observed.0 |= manager.get_rollback_start_tick().is_some();
     }
 
@@ -1164,10 +1162,10 @@ fn test_rollback_time_resource() {
     fn track_time(
         time: Res<Time>,
         mut time_tracker: ResMut<TimeTracker>,
-        rollback: Single<&PredictionManager>,
+        manager: Res<PredictionManager>,
     ) {
         time_tracker.snapshots.push(TimeSnapshot {
-            is_rollback: rollback.is_rollback(),
+            is_rollback: manager.is_rollback(),
             delta: time.delta(),
             elapsed: time.elapsed(),
         });
@@ -1229,8 +1227,9 @@ fn setup_stepper_for_input_rollback(
 ) -> (ClientServerStepper, Entity, Entity, Entity, Entity) {
     let mut stepper = ClientServerStepper::from_config(StepperConfig::with_netcode_clients(3));
 
-    let mut client_mut = stepper.client_mut(0);
-    let mut prediction_manager = client_mut.get_mut::<PredictionManager>().unwrap();
+    let mut prediction_manager = stepper.client_apps[0]
+        .world_mut()
+        .resource_mut::<PredictionManager>();
     prediction_manager.rollback_policy.input = mode;
     prediction_manager.rollback_policy.state = RollbackMode::Disabled;
 
@@ -1315,11 +1314,24 @@ fn setup_stepper_for_input_rollback(
     )
 }
 
-/// Test that we rollback from the last confirmed input when RollbackMode::Always for inputs
+/// Test that input-only prediction rolls back without any replication state on its client Link.
 #[test]
-fn test_input_rollback_always_mode() {
+fn test_input_rollback_always_mode_without_replication_receiver() {
     let (mut stepper, _, _, client_entity, _) =
         setup_stepper_for_input_rollback(RollbackMode::Always);
+
+    let client_link = stepper.client(0).id();
+    stepper.client_apps[0]
+        .world_mut()
+        .entity_mut(client_link)
+        .remove::<ReplicationReceiver>()
+        .remove::<PreSpawnedReceiver>();
+    assert!(
+        stepper.client_apps[0]
+            .world()
+            .get::<PreSpawnedReceiver>(client_link)
+            .is_none()
+    );
 
     // build a steady state where have already received an input
     stepper.frame_step(2);
@@ -1333,7 +1345,7 @@ fn test_input_rollback_always_mode() {
     let check_rollback_start =
         move |timeline: Res<LocalTimeline>,
               last_confirmed_input: Res<LastConfirmedInput>,
-              manager: Single<&PredictionManager>| {
+              manager: Res<PredictionManager>| {
             let tick = timeline.tick();
             if tick == input_tick {
                 assert!(last_confirmed_input.received_input());
@@ -1387,13 +1399,13 @@ fn test_input_rollback_always_mode() {
 fn test_input_rollback_always_ignores_unset_last_confirmed_tick() {
     let mut stepper = ClientServerStepper::from_config(StepperConfig::single());
     {
-        let mut client = stepper.client_mut(0);
         {
-            let mut prediction_manager = client.get_mut::<PredictionManager>().unwrap();
+            let mut prediction_manager = stepper.client_apps[0]
+                .world_mut()
+                .resource_mut::<PredictionManager>();
             prediction_manager.rollback_policy.input = RollbackMode::Always;
             prediction_manager.rollback_policy.state = RollbackMode::Disabled;
         }
-        drop(client);
         let last_confirmed_input = stepper.client_apps[0]
             .world()
             .resource::<LastConfirmedInput>();
@@ -1465,8 +1477,7 @@ fn test_input_rollback_check_mode_earliest_mismatch() {
     let input_tick = stepper.client_tick(1);
 
     let check_rollback_start =
-        move |timeline: Res<LocalTimeline>, manager: Single<&PredictionManager>| {
-            let manager = manager.into_inner();
+        move |timeline: Res<LocalTimeline>, manager: Res<PredictionManager>| {
             let tick = timeline.tick();
             if tick == input_tick {
                 assert!(manager.earliest_mismatch_input.has_mismatches());
@@ -1501,8 +1512,7 @@ fn test_no_rollback_without_input_mismatches() {
     let input_tick = stepper.client_tick(1);
 
     let check_rollback_start =
-        move |timeline: Res<LocalTimeline>, manager: Single<&PredictionManager>| {
-            let manager = manager.into_inner();
+        move |timeline: Res<LocalTimeline>, manager: Res<PredictionManager>| {
             let tick = timeline.tick();
             if tick == input_tick {
                 assert!(!manager.earliest_mismatch_input.has_mismatches());

--- a/crates/tests/src/client_server/prediction/rollback.rs
+++ b/crates/tests/src/client_server/prediction/rollback.rs
@@ -554,7 +554,8 @@ fn test_future_confirmed_insert_is_not_checked_by_unchanged_completed_tick() {
 
 #[test]
 fn test_input_timeline_sync_does_not_shift_confirmed_history() {
-    use lightyear_sync::prelude::InputTimelineConfig;
+    use lightyear_core::timeline::SyncEvent;
+    use lightyear_sync::prelude::{InputTimeline, InputTimelineConfig};
 
     let (mut stepper, predicted) = setup();
 
@@ -575,10 +576,21 @@ fn test_input_timeline_sync_does_not_shift_confirmed_history() {
         .entity_mut(predicted)
         .insert(prediction_history);
 
+    let timeline_component = stepper
+        .client_app()
+        .world()
+        .component_id::<InputTimeline>()
+        .unwrap();
+    let timeline_entity = stepper
+        .client_app()
+        .world()
+        .resource_entities()
+        .get(timeline_component)
+        .unwrap();
     stepper
         .client_app()
         .world_mut()
-        .trigger(lightyear_core::timeline::SyncEvent::<InputTimelineConfig>::new(predicted, 100));
+        .trigger(SyncEvent::<InputTimelineConfig>::new(timeline_entity, 100));
 
     let world = stepper.client_app().world();
     let confirmed_history = world
@@ -1239,8 +1251,12 @@ fn setup_stepper_for_input_rollback(
     stepper.frame_step_server_first(1);
 
     // Check that in PostUpdate, the LastConfirmedInput is reset if no input messages were received
-    let client = stepper.client(0);
-    assert!(!client.get::<LastConfirmedInput>().unwrap().received_input());
+    assert!(
+        !stepper.client_apps[0]
+            .world()
+            .resource::<LastConfirmedInput>()
+            .received_input()
+    );
 
     // add input-markers on client 1/2 so that they can send remote input messages
     let client_entity_1 = stepper
@@ -1316,8 +1332,8 @@ fn test_input_rollback_always_mode() {
 
     let check_rollback_start =
         move |timeline: Res<LocalTimeline>,
-              manager: Single<(&LastConfirmedInput, &PredictionManager)>| {
-            let (last_confirmed_input, manager) = manager.into_inner();
+              last_confirmed_input: Res<LastConfirmedInput>,
+              manager: Single<&PredictionManager>| {
             let tick = timeline.tick();
             if tick == input_tick {
                 assert!(last_confirmed_input.received_input());
@@ -1346,10 +1362,9 @@ fn test_input_rollback_always_mode() {
 
     // after the rollback, the last_confirmed_input is reset
     assert_eq!(
-        stepper
-            .client(0)
-            .get::<LastConfirmedInput>()
-            .unwrap()
+        stepper.client_apps[0]
+            .world()
+            .resource::<LastConfirmedInput>()
             .tick
             .get(),
         input_tick
@@ -1378,7 +1393,10 @@ fn test_input_rollback_always_ignores_unset_last_confirmed_tick() {
             prediction_manager.rollback_policy.input = RollbackMode::Always;
             prediction_manager.rollback_policy.state = RollbackMode::Disabled;
         }
-        let last_confirmed_input = client.get::<LastConfirmedInput>().unwrap();
+        drop(client);
+        let last_confirmed_input = stepper.client_apps[0]
+            .world()
+            .resource::<LastConfirmedInput>();
         assert_eq!(last_confirmed_input.get(), None);
         last_confirmed_input
             .received_any_messages
@@ -1418,10 +1436,9 @@ fn test_last_confirmed_input_multiple_clients() {
     // after the rollback, the last_confirmed_input is updated. It's updated to `input_tick - 1` and not `input_tick`
     // because we didn't receive a new input message from client 1
     assert_eq!(
-        stepper
-            .client(0)
-            .get::<LastConfirmedInput>()
-            .unwrap()
+        stepper.client_apps[0]
+            .world()
+            .resource::<LastConfirmedInput>()
             .tick
             .get(),
         input_tick - 1

--- a/crates/tests/src/client_server/replication.rs
+++ b/crates/tests/src/client_server/replication.rs
@@ -17,8 +17,8 @@ use lightyear_core::time::TickInstant;
 use lightyear_messages::MessageManager;
 use lightyear_replication::control::{ControlledBy, ControlledByRemote};
 use lightyear_replication::prelude::*;
-use lightyear_sync::prelude::InputTimeline;
 use lightyear_sync::prelude::IsSynced;
+use lightyear_sync::prelude::{InputTimelineConfig, SyncConfig};
 use test_log::test;
 use tracing::info;
 
@@ -615,8 +615,13 @@ fn test_late_join_client_gets_latest_state_for_existing_predicted_entity() {
 fn test_component_update_after_large_tick_jump() {
     for direction in active_replication_directions() {
         let mut stepper = ClientServerStepper::from_config(StepperConfig::single());
-        // remove InputTimeline otherwise it will try to resync
-        stepper.client_mut(0).remove::<InputTimeline>();
+        // Pause further input-timeline sync attempts while both sides are moved manually.
+        stepper.client_app().world_mut().insert_resource(
+            InputTimelineConfig::default().with_sync_config(SyncConfig {
+                handshake_pings: u8::MAX,
+                ..Default::default()
+            }),
+        );
 
         let source_entity =
             spawn_on_source(&mut stepper, direction, (direction.replicate(), CompA(1.0)));

--- a/crates/tests/src/host_server/base.rs
+++ b/crates/tests/src/host_server/base.rs
@@ -23,10 +23,9 @@ fn test_setup_host_server() {
 
     // Check that the various components we expect are present
     assert!(stepper.host_client().contains::<HostClient>());
-    // Input/Remote timeline are required by Client.
-    // TODO: update InputTimeline to match LocalTimeline and to not sync
-    assert!(stepper.host_client().contains::<InputTimeline>());
-    assert!(stepper.host_client().contains::<IsSynced<InputTimeline>>());
+    // The global input timeline follows LocalTimeline directly for a host client.
+    assert!(input_timeline_is_synced(stepper.server_app.world()));
+    assert!(!stepper.host_client().contains::<InputTimeline>());
     assert!(stepper.host_client().contains::<RemoteTimeline>());
     // TODO: update Interpolation to be disabled for host-clients!
     assert!(stepper.host_client().contains::<InterpolationTimeline>());

--- a/crates/tests/src/host_server/input/leafwing.rs
+++ b/crates/tests/src/host_server/input/leafwing.rs
@@ -19,7 +19,7 @@ use tracing::info;
 fn test_buffer_inputs_with_delay() {
     let mut stepper = ClientServerStepper::from_config(StepperConfig::host_server());
 
-    stepper.host_client_mut().insert(
+    stepper.server_app.world_mut().insert_resource(
         InputTimelineConfig::default().with_input_delay(InputDelayConfig::fixed_input_delay(1)),
     );
 

--- a/crates/tests/src/host_server/input/native.rs
+++ b/crates/tests/src/host_server/input/native.rs
@@ -5,8 +5,6 @@ use lightyear::prelude::input::native::ActionState;
 use lightyear_connection::network_target::NetworkTarget;
 use lightyear_messages::MessageManager;
 use lightyear_replication::prelude::{PredictionTarget, Replicate};
-use lightyear_sync::prelude::InputTimeline;
-use lightyear_sync::prelude::client::IsSynced;
 use test_log::test;
 use tracing::info;
 
@@ -17,12 +15,7 @@ use tracing::info;
 fn test_remote_client_replicated_input() {
     let mut stepper = ClientServerStepper::from_config(StepperConfig::host_server());
 
-    stepper
-        .client_app()
-        .world_mut()
-        .query::<&IsSynced<InputTimeline>>()
-        .single(stepper.client_app().world())
-        .unwrap();
+    assert!(input_timeline_is_synced(stepper.client_app().world()));
 
     // SETUP
     // entity controlled by the remote client
@@ -160,12 +153,7 @@ fn test_remote_client_predicted_input() {
 fn test_host_client_inputers_replicated_to_remote_client() {
     let mut stepper = ClientServerStepper::from_config(StepperConfig::host_server());
 
-    stepper
-        .server_app
-        .world_mut()
-        .query::<&IsSynced<InputTimeline>>()
-        .single(stepper.server_app.world())
-        .unwrap();
+    assert!(input_timeline_is_synced(stepper.server_app.world()));
 
     // SETUP
     // entity controlled by the host client

--- a/crates/tests/src/stepper.rs
+++ b/crates/tests/src/stepper.rs
@@ -60,6 +60,17 @@ fn unused_local_udp_addr() -> SocketAddr {
     socket.local_addr().unwrap()
 }
 
+/// Returns whether the global input timeline resource carries its synchronization marker.
+pub fn input_timeline_is_synced(world: &World) -> bool {
+    let Some(component_id) = world.component_id::<InputTimeline>() else {
+        return false;
+    };
+    let Some(entity) = world.resource_entities().get(component_id) else {
+        return false;
+    };
+    world.get::<IsSynced<InputTimeline>>(entity).is_some()
+}
+
 /// Stepper with:
 /// - n client in one 'client' App
 /// - 1 server in another App, with n ClientOf connected to each client
@@ -769,7 +780,7 @@ impl ClientServerStepper {
         let attempts = if self.io.uses_async_io() { 400 } else { 50 };
         for _ in 0..attempts {
             if (0..self.client_entities.len()).all(|client_id| {
-                self.client(client_id).contains::<IsSynced<InputTimeline>>()
+                input_timeline_is_synced(self.client_apps[client_id].world())
                     && self
                         .client(client_id)
                         .contains::<IsSynced<InterpolationTimeline>>()

--- a/crates/tests/src/stepper.rs
+++ b/crates/tests/src/stepper.rs
@@ -442,6 +442,7 @@ impl ClientServerStepper {
             );
             return 0;
         }
+        client_app.insert_resource(PredictionManager::default());
         let mut client = client_app.world_mut().spawn((
             Client,
             // Send pings every frame, so that the Acks are sent every frame
@@ -452,7 +453,6 @@ impl ClientServerStepper {
             ReplicationReceiver,
             #[cfg(feature = "test_utils")]
             TestHelper::default(),
-            PredictionManager::default(),
         ));
         match self.io {
             IoType::Crossbeam => {

--- a/crates/tests/src/timeline/sync_tests.rs
+++ b/crates/tests/src/timeline/sync_tests.rs
@@ -126,13 +126,13 @@ fn input_timeline_adjusts_speed_after_repeated_error() {
 #[test_log::test]
 fn input_delay_config_update_recomputes_public_delay() {
     let mut stepper = ClientServerStepper::from_config(StepperConfig::single());
-    stepper.client_mut(0).insert(
+    stepper.client_app().world_mut().insert_resource(
         InputTimelineConfig::default().with_input_delay(InputDelayConfig::fixed_input_delay(3)),
     );
 
     stepper.frame_step(1);
 
-    let input_timeline = stepper.client(0).get::<InputTimeline>().unwrap();
+    let input_timeline = stepper.client_app().world().resource::<InputTimeline>();
     assert_eq!(input_timeline.context.input_delay(), 3);
 }
 

--- a/demos/spaceships/Cargo.toml
+++ b/demos/spaceships/Cargo.toml
@@ -9,11 +9,18 @@ edition.workspace = true
 publish = false
 
 [features]
-default = ["client", "gui", "server", "netcode", "webtransport"]
+default = ["client", "gui", "server", "p2p", "netcode", "webtransport"]
 client = ["lightyear/client", "lightyear_examples_common/client"]
 gui = ["lightyear_examples_common/gui2d", "bevy/bevy_post_process"]
 server = ["lightyear/server", "lightyear_examples_common/server"]
 netcode = ["lightyear_examples_common/netcode"]
+p2p = [
+  "client",
+  "udp",
+  "lightyear/deterministic",
+  "lightyear/p2p",
+  "lightyear_examples_common/p2p",
+]
 webtransport = ["lightyear_examples_common/webtransport"]
 udp = [
   "lightyear_examples_common/udp",
@@ -31,6 +38,7 @@ lightyear = { workspace = true, features = [
   "avian2d",
 ] }
 lightyear_frame_interpolation.workspace = true
+lightyear_deterministic_replication.workspace = true
 lightyear_examples_common = { workspace = true, features = [
   "structured-debug",
 ] }

--- a/demos/spaceships/README.md
+++ b/demos/spaceships/README.md
@@ -42,6 +42,14 @@ your client will rollback to position the bullet correctly.
 - Run the server without a gui: `cargo run --no-default-features --features=server`
 - Run the client and server in "HostClient" mode, where the server is also a client (there is only one App): `cargo run host-client`
 
+### P2P mode
+
+The demo can also run as a deterministic input-only game with no server. Start peer 0 with
+`cargo run --no-default-features --features=p2p -- --headless p2p --peer-id 0 --player-count 2`
+and peer 1 with the same command using `--peer-id 1`. Every peer predicts the complete physics
+world, spawns the same bullets from the shared input stream, and applies collision and score
+changes deterministically.
+
 You can control the behaviour of the example by changing the list of features. By default, all features are enabled (client, server, gui).
 For example you can run the server in headless mode (without gui) by running `cargo run --no-default-features --features=server`.
 You can modify the file `assets/settings.ron` to modify some networking settings.

--- a/demos/spaceships/src/client.rs
+++ b/demos/spaceships/src/client.rs
@@ -129,18 +129,22 @@ fn handle_controlled_player(
             return;
         }
         info!("Own player is now controlled, adding inputmap {entity:?} {player:?}");
-        commands.entity(entity).insert(InputMap::new([
-            (PlayerActions::Up, KeyCode::ArrowUp),
-            (PlayerActions::Down, KeyCode::ArrowDown),
-            (PlayerActions::Left, KeyCode::ArrowLeft),
-            (PlayerActions::Right, KeyCode::ArrowRight),
-            (PlayerActions::Up, KeyCode::KeyW),
-            (PlayerActions::Down, KeyCode::KeyS),
-            (PlayerActions::Left, KeyCode::KeyA),
-            (PlayerActions::Right, KeyCode::KeyD),
-            (PlayerActions::Fire, KeyCode::Space),
-        ]));
+        commands.entity(entity).insert(player_input_map());
     }
+}
+
+pub(crate) fn player_input_map() -> InputMap<PlayerActions> {
+    InputMap::new([
+        (PlayerActions::Up, KeyCode::ArrowUp),
+        (PlayerActions::Down, KeyCode::ArrowDown),
+        (PlayerActions::Left, KeyCode::ArrowLeft),
+        (PlayerActions::Right, KeyCode::ArrowRight),
+        (PlayerActions::Up, KeyCode::KeyW),
+        (PlayerActions::Down, KeyCode::KeyS),
+        (PlayerActions::Left, KeyCode::KeyA),
+        (PlayerActions::Right, KeyCode::KeyD),
+        (PlayerActions::Fire, KeyCode::Space),
+    ])
 }
 
 #[cfg(feature = "gui")]

--- a/demos/spaceships/src/main.rs
+++ b/demos/spaceships/src/main.rs
@@ -64,17 +64,10 @@ fn main() {
 
 #[cfg(feature = "client")]
 fn add_input_delay(app: &mut App) {
-    use lightyear::prelude::Client;
     use lightyear::prelude::client::InputDelayConfig;
 
-    let client = app
-        .world_mut()
-        .query_filtered::<Entity, With<Client>>()
-        .single(app.world_mut())
-        .unwrap();
-
     // set some input-delay since we are predicting all entities
-    app.world_mut().entity_mut(client).insert(
+    app.insert_resource(
         InputTimelineConfig::default().with_input_delay(InputDelayConfig::fixed_input_delay(10)),
     );
 }

--- a/demos/spaceships/src/main.rs
+++ b/demos/spaceships/src/main.rs
@@ -9,6 +9,8 @@ use lightyear_examples_common::shared::FIXED_TIMESTEP_HZ;
 
 #[cfg(feature = "client")]
 use crate::client::ExampleClientPlugin;
+#[cfg(feature = "p2p")]
+use crate::p2p::ExampleP2PPlugin;
 #[cfg(feature = "server")]
 use crate::server::ExampleServerPlugin;
 use crate::shared::SharedPlugin;
@@ -16,6 +18,8 @@ use crate::shared::SharedPlugin;
 mod automation;
 #[cfg(feature = "client")]
 mod client;
+#[cfg(feature = "p2p")]
+mod p2p;
 mod protocol;
 
 #[cfg(feature = "gui")]
@@ -38,10 +42,14 @@ fn main() {
     cli.spawn_connections(&mut app);
 
     match cli.mode {
-        #[cfg(feature = "client")]
+        #[cfg(all(feature = "client", any(not(feature = "p2p"), feature = "netcode")))]
         Some(Mode::Client { .. }) => {
             app.add_plugins(ExampleClientPlugin);
             add_input_delay(&mut app);
+        }
+        #[cfg(feature = "p2p")]
+        Some(Mode::P2P { .. }) => {
+            app.add_plugins((ExampleClientPlugin, ExampleP2PPlugin));
         }
         #[cfg(feature = "server")]
         Some(Mode::Server) => {

--- a/demos/spaceships/src/p2p.rs
+++ b/demos/spaceships/src/p2p.rs
@@ -1,0 +1,124 @@
+//! Deterministic input-only P2P setup for the spaceships demo.
+
+use core::f32::consts::TAU;
+
+use avian2d::prelude::*;
+use bevy::color::palettes::css;
+use bevy::prelude::*;
+use lightyear::prediction::rollback::DeterministicPredicted;
+use lightyear::prelude::input::client::InputSystems;
+use lightyear::prelude::input::leafwing::LeafwingBuffer;
+use lightyear::prelude::*;
+use lightyear_deterministic_replication::prelude::DeterministicReplicationPlugin;
+use lightyear_examples_common::p2p::{
+    GAMEPLAY_START_TICK, P2PGameplayStarted, P2PSettings, input_target_for_peer,
+};
+use lightyear_examples_common::shared::FIXED_TIMESTEP_HZ;
+use lightyear_frame_interpolation::FrameInterpolate;
+
+use crate::client::player_input_map;
+use crate::protocol::*;
+use crate::shared::color_from_id;
+
+const PLAYER_INPUT_HASH_BASE: u64 = 0x5350_4143_4500_0000;
+
+pub struct ExampleP2PPlugin;
+
+impl Plugin for ExampleP2PPlugin {
+    fn build(&self, app: &mut App) {
+        app.insert_resource(PredictionManager::default());
+        app.add_plugins(DeterministicReplicationPlugin);
+        app.add_systems(
+            FixedPreUpdate,
+            spawn_fixed_world.before(InputSystems::BufferClientInputs),
+        );
+        app.add_systems(
+            FixedPostUpdate,
+            update_scores.after(crate::shared::process_collisions),
+        );
+    }
+}
+
+fn spawn_fixed_world(
+    mut commands: Commands,
+    _synced: SyncedInputTimeline,
+    timeline: Res<LocalTimeline>,
+    started: Option<Res<P2PGameplayStarted>>,
+    settings: Res<P2PSettings>,
+    links: Query<(Entity, &RemoteId), With<P2P>>,
+) {
+    if started.is_some() || timeline.tick().0 < GAMEPLAY_START_TICK {
+        return;
+    }
+    commands.insert_resource(P2PGameplayStarted);
+
+    const NUM_BALLS: usize = 6;
+    for i in 0..NUM_BALLS {
+        let radius = 10.0 + i as f32 * 4.0;
+        let angle = i as f32 * (TAU / NUM_BALLS as f32);
+        let marker = BallMarker::new(radius);
+        commands.spawn((
+            Position(Vec2::new(125.0 * angle.cos(), 125.0 * angle.sin())),
+            ColorComponent(css::GOLD.into()),
+            marker.physics_bundle(),
+            marker,
+            DeterministicPredicted {
+                skip_despawn: true,
+                enable_rollback_after: 0,
+            },
+            FrameInterpolate,
+            Name::new("P2P Ball"),
+        ));
+    }
+
+    for peer_id in settings.peer_ids() {
+        let id = PeerId::Entity(u64::from(peer_id));
+        let angle = f32::from(peer_id) * (TAU / f32::from(settings.player_count));
+        let target = input_target_for_peer(
+            &settings,
+            &links,
+            peer_id,
+            PLAYER_INPUT_HASH_BASE | u64::from(peer_id),
+        );
+        let player = commands
+            .spawn((
+                Player::new(id, format!("Peer {peer_id}")),
+                Score(0),
+                Position(Vec2::new(200.0 * angle.cos(), 200.0 * angle.sin())),
+                PhysicsBundle::player_ship(),
+                Weapon::new((FIXED_TIMESTEP_HZ / 5.0) as u16),
+                ColorComponent(color_from_id(id)),
+                DeterministicPredicted {
+                    skip_despawn: true,
+                    enable_rollback_after: 0,
+                },
+                target,
+                LeafwingBuffer::<PlayerActions>::default(),
+                FrameInterpolate,
+                Name::new("P2P Player"),
+            ))
+            .id();
+        if peer_id == settings.local_peer_id {
+            commands.entity(player).insert(player_input_map());
+        }
+    }
+}
+
+fn update_scores(
+    mut events: MessageReader<BulletHitMessage>,
+    mut players: Query<(&Player, &mut Score)>,
+) {
+    for event in events.read() {
+        let Some(victim) = event.victim_client_id else {
+            continue;
+        };
+        for (player, mut score) in &mut players {
+            if player.client_id == victim {
+                score.0 -= 1;
+            }
+            if player.client_id == event.bullet_owner {
+                score.0 += 1;
+            }
+        }
+    }
+}

--- a/demos/spaceships/src/renderer.rs
+++ b/demos/spaceships/src/renderer.rs
@@ -76,7 +76,14 @@ fn add_frame_interpolation_components(
     // We use Position because it's added by avian later, and when it's added
     // we know that Predicted is already present on the entity
     trigger: On<Add, Position>,
-    q: Query<Entity, (Without<Wall>, With<Predicted>, Without<FrameInterpolate>)>,
+    q: Query<
+        Entity,
+        (
+            Without<Wall>,
+            Or<(With<Predicted>, With<DeterministicPredicted>)>,
+            Without<FrameInterpolate>,
+        ),
+    >,
     mut commands: Commands,
 ) {
     if !q.contains(trigger.entity) {
@@ -383,7 +390,10 @@ fn insert_bullet_mesh(
             Without<BulletVisualAttached>,
         ),
     >,
-    players: Query<(&Player, &Position, Option<&Rotation>), With<Predicted>>,
+    players: Query<
+        (&Player, &Position, Option<&Rotation>),
+        Or<(With<Predicted>, With<DeterministicPredicted>)>,
+    >,
     mut commands: Commands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<ColorMaterial>>,

--- a/demos/spaceships/src/shared.rs
+++ b/demos/spaceships/src/shared.rs
@@ -9,7 +9,7 @@ use crate::protocol::*;
 #[cfg(feature = "gui")]
 use crate::renderer::ExampleRendererPlugin;
 use avian2d::prelude::{forces::ForcesItem, *};
-use leafwing_input_manager::prelude::ActionState;
+use leafwing_input_manager::prelude::{ActionState, InputMap};
 use lightyear::avian2d::plugin::AvianReplicationMode;
 use lightyear::input::leafwing::prelude::LeafwingBuffer;
 use lightyear::prelude::*;
@@ -26,6 +26,13 @@ pub struct SharedPlugin {
 
 impl Plugin for SharedPlugin {
     fn build(&self, app: &mut App) {
+        #[cfg(feature = "p2p")]
+        let rollback_resources = app
+            .world()
+            .contains_resource::<lightyear_examples_common::p2p::P2PSettings>();
+        #[cfg(not(feature = "p2p"))]
+        let rollback_resources = false;
+
         app.add_plugins(ProtocolPlugin);
         app.init_resource::<BulletDebugRegistry>();
 
@@ -37,6 +44,11 @@ impl Plugin for SharedPlugin {
             replication_mode: AvianReplicationMode::Position {
                 sync_to_transform: false,
             },
+            // `ProtocolPlugin` owns the physics component registrations so it can use the
+            // demo's tighter rollback tolerances. Registering Avian's defaults as well would
+            // install the same prediction receive-marker functions twice.
+            register_physics_components: false,
+            rollback_resources,
             ..default()
         });
         app.add_plugins(
@@ -259,7 +271,9 @@ pub fn shared_player_firing(
         &mut Weapon,
         Option<&ConfirmedHistory<Weapon>>,
         Has<Controlled>,
+        Has<InputMap<PlayerActions>>,
         Has<Predicted>,
+        Has<DeterministicPredicted>,
         Has<Interpolated>,
         Option<&ControlledBy>,
         &Player,
@@ -267,6 +281,7 @@ pub fn shared_player_firing(
     mut commands: Commands,
     timeline: Res<LocalTimeline>,
     input_timeline: Option<SyncedInputTimeline>,
+    metadata: Res<NetworkingMetadata>,
     server: Query<(), With<Server>>,
 ) {
     let client_is_synced = input_timeline.is_some();
@@ -286,7 +301,9 @@ pub fn shared_player_firing(
         mut weapon,
         weapon_history,
         is_local,
+        has_input_map,
         is_predicted,
+        is_deterministic,
         is_interpolated,
         controlled_by,
         player,
@@ -296,9 +313,10 @@ pub fn shared_player_firing(
             if controlled_by.is_none() {
                 continue;
             }
-        } else if !client_is_synced || !is_predicted || is_interpolated {
+        } else if !client_is_synced || !(is_predicted || is_deterministic) || is_interpolated {
             continue;
         }
+        let is_local = is_local || has_input_map;
         // Firing runs in FixedUpdate. Using a level-trigger here is more robust than
         // relying on a frame-edge `just_pressed`, and the weapon cooldown already
         // guarantees we only spawn bullets at the intended rate.
@@ -362,6 +380,11 @@ pub fn shared_player_firing(
                 prespawned,
             ))
             .id();
+        if matches!(metadata.mode, NetworkTopology::P2P { .. }) {
+            commands
+                .entity(bullet_entity)
+                .insert(DeterministicPredicted::default());
+        }
         lightyear_debug_event!(
             DebugCategory::Prediction,
             DebugSamplePoint::FixedUpdate,
@@ -668,28 +691,31 @@ pub(crate) fn process_collisions(
         &Position,
         Has<PreSpawned>,
         Has<Predicted>,
+        Has<DeterministicPredicted>,
     )>,
     player_q: Query<&Player>,
     mut commands: Commands,
     timeline: Res<LocalTimeline>,
     server: Query<(), With<Server>>,
+    metadata: Res<NetworkingMetadata>,
     mut hit_ev_writer: MessageWriter<BulletHitMessage>,
 ) {
     let is_server = !server.is_empty();
+    let is_p2p = matches!(metadata.mode, NetworkTopology::P2P { .. });
     let tick = timeline.tick();
     // when A and B collide, it can be reported as one of:
     // * A collides with B
     // * B collides with A
     // which is why logic is duplicated twice here
     for contacts in collisions.iter() {
-        if let Ok((bullet, col, bullet_pos, is_prespawned, is_predicted)) =
+        if let Ok((bullet, col, bullet_pos, is_prespawned, is_predicted, is_deterministic)) =
             bullet_q.get(contacts.collider1)
         {
             // Keep unconfirmed client prespawns alive until the server entity can match them.
-            if !is_server && is_prespawned {
+            if !is_server && !is_p2p && is_prespawned {
                 continue;
             }
-            if !is_server && !is_predicted {
+            if !is_server && !(is_predicted || is_deterministic) {
                 info!(
                     ?tick,
                     bullet = ?contacts.collider1,
@@ -719,14 +745,14 @@ pub(crate) fn process_collisions(
             };
             hit_ev_writer.write(ev);
         }
-        if let Ok((bullet, col, bullet_pos, is_prespawned, is_predicted)) =
+        if let Ok((bullet, col, bullet_pos, is_prespawned, is_predicted, is_deterministic)) =
             bullet_q.get(contacts.collider2)
         {
             // Keep unconfirmed client prespawns alive until the server entity can match them.
-            if !is_server && is_prespawned {
+            if !is_server && !is_p2p && is_prespawned {
                 continue;
             }
-            if !is_server && !is_predicted {
+            if !is_server && !(is_predicted || is_deterministic) {
                 info!(
                     ?tick,
                     bullet = ?contacts.collider2,

--- a/demos/spaceships/src/shared.rs
+++ b/demos/spaceships/src/shared.rs
@@ -266,10 +266,10 @@ pub fn shared_player_firing(
     )>,
     mut commands: Commands,
     timeline: Res<LocalTimeline>,
-    synced_client: Query<(), (With<Client>, With<IsSynced<InputTimeline>>)>,
+    input_timeline: Option<SyncedInputTimeline>,
     server: Query<(), With<Server>>,
 ) {
-    let client_is_synced = !synced_client.is_empty();
+    let client_is_synced = input_timeline.is_some();
     let is_server = !server.is_empty();
     if q.is_empty() {
         return;

--- a/examples/README.md
+++ b/examples/README.md
@@ -8,7 +8,7 @@ The top level `Cargo.toml` workspace defines the deps that examples can use and 
 ## Easy
 
 - `simple_setup`: minimal example that just shows how to create the lightyear client and server plugins
-- `simple_box`: example that showcases how to send inputs from client to server, and how to add client-prediction and interpolation
+- `simple_box`: example that showcases client/server prediction and interpolation, plus an optional deterministic input-only P2P mode
 - `bevy_enhanced_input`: example that shows how to integrate lightyear with the `bevy_enhanced_input` crate to handle inputs.
 
 ## Medium

--- a/examples/avian_2d/Cargo.toml
+++ b/examples/avian_2d/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 publish = false
 
 [features]
-default = ["client", "gui", "server", "netcode", "webtransport"]
+default = ["client", "gui", "server", "p2p", "netcode", "webtransport"]
 client = ["lightyear/client", "lightyear_examples_common/client"]
 gui = ["lightyear_examples_common/gui2d"]
 server = [
@@ -16,6 +16,13 @@ server = [
   "lightyear_examples_common/server",
 ]
 netcode = ["lightyear_examples_common/netcode"]
+p2p = [
+  "client",
+  "udp",
+  "lightyear/deterministic",
+  "lightyear/p2p",
+  "lightyear_examples_common/p2p",
+]
 webtransport = ["lightyear_examples_common/webtransport"]
 udp = ["lightyear_examples_common/udp", "lightyear/std", "lightyear/udp"]
 
@@ -31,6 +38,7 @@ lightyear_examples_common = { workspace = true, features = [
   "structured-debug",
 ] }
 lightyear_frame_interpolation.workspace = true
+lightyear_deterministic_replication.workspace = true
 leafwing-input-manager.workspace = true
 avian2d = { workspace = true, features = [
   "2d",

--- a/examples/avian_2d/README.md
+++ b/examples/avian_2d/README.md
@@ -47,6 +47,14 @@ enabled.*
 - Run the server without a gui: `cargo run --no-default-features --features=server -- server`
 - Run the client and server in "HostClient" mode, where the client also acts as server (both are in the same App) : `cargo run -- host-client -c 0`
 
+### P2P mode
+
+The example can also run as a deterministic input-only game with no server. Start peer 0 with
+`cargo run --no-default-features --features=p2p -- --headless p2p --peer-id 0 --player-count 2`
+and peer 1 with the same command using `--peer-id 1`. Every peer creates the same physics world,
+predicts all players, and rolls back both entity and Avian simulation state when remote input is
+late.
+
 You can control the behaviour of the example by changing the list of features. By default, all features are enabled (client, server, gui).
 For example you can run the server in headless mode (without gui) by running `cargo run --no-default-features --features=server,webtransport,netcode`.
 

--- a/examples/avian_2d/src/client.rs
+++ b/examples/avian_2d/src/client.rs
@@ -69,7 +69,10 @@ fn player_movement(
             &mut LinearVelocity,
             &ActionState<PlayerActions>,
         ),
-        (With<Predicted>, With<PlayerId>),
+        (
+            Or<(With<Predicted>, With<DeterministicPredicted>)>,
+            With<PlayerId>,
+        ),
     >,
 ) {
     let tick = timeline.tick();
@@ -119,12 +122,16 @@ fn handle_controlled_spawn(
     if player_query.get(trigger.entity).is_err() {
         return;
     };
-    commands.entity(trigger.entity).insert(InputMap::new([
+    commands.entity(trigger.entity).insert(player_input_map());
+}
+
+pub(crate) fn player_input_map() -> InputMap<PlayerActions> {
+    InputMap::new([
         (PlayerActions::Up, KeyCode::KeyW),
         (PlayerActions::Down, KeyCode::KeyS),
         (PlayerActions::Left, KeyCode::KeyA),
         (PlayerActions::Right, KeyCode::KeyD),
-    ]));
+    ])
 }
 
 // Lower the saturation on interpolated entities so they are visually distinct.

--- a/examples/avian_2d/src/debug.rs
+++ b/examples/avian_2d/src/debug.rs
@@ -8,10 +8,7 @@ use lightyear::prelude::*;
 
 use crate::protocol::{BallMarker, PlayerActions, PlayerId};
 
-pub(crate) fn print_overstep(
-    time: Res<Time<Fixed>>,
-    timeline: Single<&InputTimeline, With<Client>>,
-) {
+pub(crate) fn print_overstep(time: Res<Time<Fixed>>, timeline: Res<InputTimeline>) {
     let input_overstep = timeline.overstep();
     let input_overstep_ms = input_overstep.to_f32() * (time.timestep().as_millis() as f32);
     let time_overstep = time.overstep();

--- a/examples/avian_2d/src/main.rs
+++ b/examples/avian_2d/src/main.rs
@@ -3,6 +3,8 @@
 #![allow(dead_code)]
 #[cfg(feature = "client")]
 use crate::client::ExampleClientPlugin;
+#[cfg(feature = "p2p")]
+use crate::p2p::ExampleP2PPlugin;
 #[cfg(feature = "server")]
 use crate::server::ExampleServerPlugin;
 use crate::shared::SharedPlugin;
@@ -16,6 +18,8 @@ mod automation;
 #[cfg(feature = "client")]
 mod client;
 mod debug;
+#[cfg(feature = "p2p")]
+mod p2p;
 mod protocol;
 
 #[cfg(feature = "gui")]
@@ -34,10 +38,14 @@ fn main() {
     cli.spawn_connections(&mut app);
 
     match cli.mode {
-        #[cfg(feature = "client")]
+        #[cfg(all(feature = "client", any(not(feature = "p2p"), feature = "netcode")))]
         Some(Mode::Client { .. }) => {
             app.add_plugins(ExampleClientPlugin);
             add_input_delay(&mut app);
+        }
+        #[cfg(feature = "p2p")]
+        Some(Mode::P2P { .. }) => {
+            app.add_plugins((ExampleClientPlugin, ExampleP2PPlugin));
         }
         #[cfg(feature = "server")]
         Some(Mode::Server) => {

--- a/examples/avian_2d/src/main.rs
+++ b/examples/avian_2d/src/main.rs
@@ -65,16 +65,9 @@ fn main() {
 
 #[cfg(feature = "client")]
 fn add_input_delay(app: &mut App) {
-    let client = app
-        .world_mut()
-        .query_filtered::<Entity, With<Client>>()
-        .single(app.world_mut())
-        .unwrap();
-
     // Optionally add input delay for the locally predicted player.
-    // app.world_mut()
-    //     .entity_mut(client)
-    //     .insert(InputTimeline(Timeline::from(
-    //         Input::default().with_input_delay(InputDelayConfig::fixed_input_delay(10)),
-    //     )));
+    // app.insert_resource(
+    //     InputTimelineConfig::default()
+    //         .with_input_delay(InputDelayConfig::fixed_input_delay(10)),
+    // );
 }

--- a/examples/avian_2d/src/p2p.rs
+++ b/examples/avian_2d/src/p2p.rs
@@ -1,0 +1,120 @@
+//! Deterministic input-only P2P setup for the Avian 2D example.
+
+use avian2d::prelude::*;
+use bevy::color::palettes::css;
+use bevy::prelude::*;
+use leafwing_input_manager::prelude::ActionState;
+use lightyear::prediction::rollback::DeterministicPredicted;
+use lightyear::prelude::input::client::InputSystems;
+use lightyear::prelude::input::leafwing::LeafwingBuffer;
+use lightyear::prelude::*;
+use lightyear_deterministic_replication::prelude::DeterministicReplicationPlugin;
+use lightyear_examples_common::p2p::{
+    input_target_for_peer, P2PGameplayStarted, P2PSettings, GAMEPLAY_START_TICK,
+};
+use lightyear_frame_interpolation::FrameInterpolate;
+
+use crate::client::player_input_map;
+use crate::protocol::*;
+use crate::shared::color_from_id;
+
+const PLAYER_INPUT_HASH_BASE: u64 = 0x4156_3244_0000_0000;
+
+#[derive(Component)]
+struct PendingLocalInput(Tick);
+
+pub struct ExampleP2PPlugin;
+
+impl Plugin for ExampleP2PPlugin {
+    fn build(&self, app: &mut App) {
+        app.insert_resource(PredictionManager::default());
+        app.add_plugins(DeterministicReplicationPlugin);
+        app.add_systems(
+            FixedPreUpdate,
+            spawn_fixed_world.before(InputSystems::BufferClientInputs),
+        );
+        app.add_systems(
+            FixedPostUpdate,
+            enable_local_input.after(PredictionSystems::UpdateHistory),
+        );
+    }
+}
+
+fn spawn_fixed_world(
+    mut commands: Commands,
+    _synced: SyncedInputTimeline,
+    timeline: Res<LocalTimeline>,
+    started: Option<Res<P2PGameplayStarted>>,
+    settings: Res<P2PSettings>,
+    links: Query<(Entity, &RemoteId), With<P2P>>,
+) {
+    if started.is_some() || timeline.tick().0 < GAMEPLAY_START_TICK {
+        return;
+    }
+    commands.insert_resource(P2PGameplayStarted);
+
+    commands.spawn((
+        Position::default(),
+        ColorComponent(css::AZURE.into()),
+        PhysicsBundle::ball(),
+        BallMarker,
+        DeterministicPredicted {
+            skip_despawn: true,
+            enable_rollback_after: 0,
+        },
+        FrameInterpolate,
+        Name::from("P2P Ball"),
+    ));
+
+    let spacing = 100.0;
+    let center = (f32::from(settings.player_count) - 1.0) * 0.5;
+    for peer_id in settings.peer_ids() {
+        let id = PeerId::Entity(u64::from(peer_id));
+        let target = input_target_for_peer(
+            &settings,
+            &links,
+            peer_id,
+            PLAYER_INPUT_HASH_BASE | u64::from(peer_id),
+        );
+        let player = commands
+            .spawn((
+                PlayerId(id),
+                Position::from(Vec2::new(-50.0, (f32::from(peer_id) - center) * spacing)),
+                Rotation::radians(0.15),
+                AngularVelocity(0.35),
+                ColorComponent(color_from_id(id)),
+                PhysicsBundle::player(),
+                DeterministicPredicted {
+                    skip_despawn: true,
+                    enable_rollback_after: 0,
+                },
+                target,
+                LeafwingBuffer::<PlayerActions>::default(),
+                FrameInterpolate,
+                Name::from("P2P Player"),
+            ))
+            .id();
+        if peer_id == settings.local_peer_id {
+            commands
+                .entity(player)
+                .insert(PendingLocalInput(timeline.tick()));
+        }
+    }
+}
+
+/// Enable local input after the initial Avian rollback state has been recorded.
+fn enable_local_input(
+    mut commands: Commands,
+    timeline: Res<LocalTimeline>,
+    local_players: Query<(Entity, &PendingLocalInput)>,
+) {
+    for (entity, pending) in &local_players {
+        if timeline.tick() <= pending.0 {
+            continue;
+        }
+        commands
+            .entity(entity)
+            .insert(player_input_map())
+            .remove::<PendingLocalInput>();
+    }
+}

--- a/examples/avian_2d/src/shared.rs
+++ b/examples/avian_2d/src/shared.rs
@@ -49,6 +49,13 @@ pub struct SharedPlugin;
 
 impl Plugin for SharedPlugin {
     fn build(&self, app: &mut App) {
+        #[cfg(feature = "p2p")]
+        let rollback_resources = app
+            .world()
+            .contains_resource::<lightyear_examples_common::p2p::P2PSettings>();
+        #[cfg(not(feature = "p2p"))]
+        let rollback_resources = false;
+
         app.add_plugins(ProtocolPlugin);
         app.add_observer(spawn_player_child_collider);
         // bundles
@@ -59,6 +66,7 @@ impl Plugin for SharedPlugin {
             replication_mode: AvianReplicationMode::Position {
                 sync_to_transform: false,
             },
+            rollback_resources,
             ..default()
         });
         app.add_plugins(

--- a/examples/avian_3d/Cargo.toml
+++ b/examples/avian_3d/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 publish = false
 
 [features]
-default = ["client", "gui", "server", "netcode", "webtransport"]
+default = ["client", "gui", "server", "p2p", "netcode", "webtransport"]
 client = ["lightyear/client", "lightyear_examples_common/client"]
 gui = ["lightyear_examples_common/gui3d"]
 server = [
@@ -16,6 +16,13 @@ server = [
   "lightyear_examples_common/server",
 ]
 netcode = ["lightyear_examples_common/netcode"]
+p2p = [
+  "client",
+  "udp",
+  "lightyear/deterministic",
+  "lightyear/p2p",
+  "lightyear_examples_common/p2p",
+]
 webtransport = ["lightyear_examples_common/webtransport"]
 udp = ["lightyear_examples_common/udp", "lightyear/std", "lightyear/udp"]
 
@@ -28,6 +35,7 @@ lightyear = { workspace = true, features = [
   "avian3d",
 ] }
 lightyear_frame_interpolation.workspace = true
+lightyear_deterministic_replication.workspace = true
 lightyear_examples_common = { workspace = true, features = [
   "structured-debug",
 ] }

--- a/examples/avian_3d/README.md
+++ b/examples/avian_3d/README.md
@@ -27,6 +27,14 @@ https://github.com/user-attachments/assets/4e0eb373-2f46-4c48-8157-46e1e5085097
 - Run the server without a gui: `cargo run --no-default-features --features=server -- server`
 - Run the client and server in "HostClient" mode, where the client also acts as server (both are in the same App) : `cargo run -- host-client -c 0`
 
+### P2P mode
+
+The example can also run as a deterministic input-only game with no server. Start peer 0 with
+`cargo run --no-default-features --features=p2p -- --headless p2p --peer-id 0 --player-count 2`
+and peer 1 with the same command using `--peer-id 1`. Characters, the dynamic block, and
+projectiles are created and simulated by every peer, with Avian simulation state included in
+rollback.
+
 You can control the behaviour of the example by changing the list of features. By default, all features are enabled (client, server, gui).
 For example you can run the server in headless mode (without gui) by running `cargo run --no-default-features --features=server,webtransport,netcode`.
 

--- a/examples/avian_3d/src/client.rs
+++ b/examples/avian_3d/src/client.rs
@@ -34,7 +34,7 @@ fn handle_character_actions(
     spatial_query: SpatialQuery,
     mut query: Query<
         (Entity, &ComputedMass, &ActionState<CharacterAction>, Forces),
-        With<Predicted>,
+        Or<(With<Predicted>, With<DeterministicPredicted>)>,
     >,
     // In host-server mode, the server portion is already applying the
     // character actions and so we don't want to apply the character
@@ -84,13 +84,15 @@ fn handle_controlled_character(
         return;
     };
     info!("Adding InputMap to controlled character {entity:?}");
-    commands.entity(entity).insert(
-        InputMap::new([(CharacterAction::Jump, KeyCode::Space)])
-            .with(CharacterAction::Jump, GamepadButton::South)
-            .with(CharacterAction::Shoot, KeyCode::KeyQ)
-            .with_dual_axis(CharacterAction::Move, GamepadStick::LEFT)
-            .with_dual_axis(CharacterAction::Move, VirtualDPad::wasd()),
-    );
+    commands.entity(entity).insert(character_input_map());
+}
+
+pub(crate) fn character_input_map() -> InputMap<CharacterAction> {
+    InputMap::new([(CharacterAction::Jump, KeyCode::Space)])
+        .with(CharacterAction::Jump, GamepadButton::South)
+        .with(CharacterAction::Shoot, KeyCode::KeyQ)
+        .with_dual_axis(CharacterAction::Move, GamepadStick::LEFT)
+        .with_dual_axis(CharacterAction::Move, VirtualDPad::wasd())
 }
 
 /// Add physics to floors that are newly replicated. The query checks for

--- a/examples/avian_3d/src/main.rs
+++ b/examples/avian_3d/src/main.rs
@@ -9,6 +9,8 @@ use lightyear_examples_common::shared::FIXED_TIMESTEP_HZ;
 
 #[cfg(feature = "client")]
 use crate::client::ExampleClientPlugin;
+#[cfg(feature = "p2p")]
+use crate::p2p::ExampleP2PPlugin;
 #[cfg(feature = "server")]
 use crate::server::ExampleServerPlugin;
 use crate::shared::SharedPlugin;
@@ -16,6 +18,8 @@ mod automation;
 #[cfg(feature = "client")]
 mod client;
 mod debug;
+#[cfg(feature = "p2p")]
+mod p2p;
 mod protocol;
 #[cfg(feature = "gui")]
 mod renderer;
@@ -34,10 +38,14 @@ fn main() {
     cli.spawn_connections(&mut app);
 
     match cli.mode {
-        #[cfg(feature = "client")]
+        #[cfg(all(feature = "client", any(not(feature = "p2p"), feature = "netcode")))]
         Some(Mode::Client { .. }) => {
             app.add_plugins(ExampleClientPlugin);
             add_input_delay(&mut app);
+        }
+        #[cfg(feature = "p2p")]
+        Some(Mode::P2P { .. }) => {
+            app.add_plugins((ExampleClientPlugin, ExampleP2PPlugin));
         }
         #[cfg(feature = "server")]
         Some(Mode::Server) => {

--- a/examples/avian_3d/src/main.rs
+++ b/examples/avian_3d/src/main.rs
@@ -4,7 +4,6 @@
 use bevy::prelude::*;
 use core::time::Duration;
 
-use lightyear::prelude::{Client, InputTimeline, Timeline};
 use lightyear_examples_common::cli::{Cli, Mode};
 use lightyear_examples_common::shared::FIXED_TIMESTEP_HZ;
 
@@ -65,14 +64,8 @@ fn main() {
 fn add_input_delay(app: &mut App) {
     use lightyear::prelude::client::{InputDelayConfig, InputTimelineConfig};
 
-    let client = app
-        .world_mut()
-        .query_filtered::<Entity, With<Client>>()
-        .single(app.world_mut())
-        .unwrap();
-
     // set some input-delay since we are predicting all entities
-    app.world_mut().entity_mut(client).insert(
+    app.insert_resource(
         InputTimelineConfig::default().with_input_delay(InputDelayConfig::fixed_input_delay(0)),
     );
 }

--- a/examples/avian_3d/src/p2p.rs
+++ b/examples/avian_3d/src/p2p.rs
@@ -1,0 +1,171 @@
+//! Deterministic input-only P2P setup for the Avian 3D character example.
+
+use avian3d::prelude::*;
+use bevy::prelude::*;
+use leafwing_input_manager::prelude::ActionState;
+use lightyear::prediction::rollback::DeterministicPredicted;
+use lightyear::prelude::input::client::InputSystems;
+use lightyear::prelude::input::leafwing::LeafwingBuffer;
+use lightyear::prelude::*;
+use lightyear_deterministic_replication::prelude::DeterministicReplicationPlugin;
+use lightyear_examples_common::p2p::{
+    input_target_for_peer, P2PGameplayStarted, P2PSettings, GAMEPLAY_START_TICK,
+};
+
+use crate::client::character_input_map;
+use crate::protocol::*;
+use crate::shared::{
+    color_from_id, BlockPhysicsBundle, CharacterPhysicsBundle, FloorPhysicsBundle,
+    ProjectilePhysicsBundle,
+};
+
+const PLAYER_INPUT_HASH_BASE: u64 = 0x4156_3344_0000_0000;
+const PROJECTILE_LIFETIME_TICKS: i32 = 120;
+
+#[derive(Component)]
+struct DespawnAt(Tick);
+
+/// Marks the local character until its input map can be enabled after the first physics snapshot.
+#[derive(Component)]
+struct PendingLocalInput(Tick);
+
+pub struct ExampleP2PPlugin;
+
+impl Plugin for ExampleP2PPlugin {
+    fn build(&self, app: &mut App) {
+        app.insert_resource(PredictionManager::default());
+        app.add_plugins(DeterministicReplicationPlugin);
+        app.add_systems(
+            FixedPreUpdate,
+            spawn_fixed_world.before(InputSystems::BufferClientInputs),
+        );
+        app.add_systems(
+            FixedPostUpdate,
+            enable_local_input.after(PredictionSystems::UpdateHistory),
+        );
+        app.add_systems(FixedUpdate, (shoot, despawn_projectiles));
+    }
+}
+
+fn spawn_fixed_world(
+    mut commands: Commands,
+    _synced: SyncedInputTimeline,
+    timeline: Res<LocalTimeline>,
+    started: Option<Res<P2PGameplayStarted>>,
+    settings: Res<P2PSettings>,
+    links: Query<(Entity, &RemoteId), With<P2P>>,
+) {
+    if started.is_some() || timeline.tick().0 < GAMEPLAY_START_TICK {
+        return;
+    }
+    commands.insert_resource(P2PGameplayStarted);
+
+    commands.spawn((
+        Name::new("P2P Floor"),
+        FloorPhysicsBundle::default(),
+        FloorMarker,
+        Position::new(Vec3::ZERO),
+    ));
+    commands.spawn((
+        Name::new("P2P Block"),
+        BlockPhysicsBundle::default(),
+        BlockMarker,
+        Position::new(Vec3::new(1.0, 1.0, 0.0)),
+        DeterministicPredicted {
+            skip_despawn: true,
+            enable_rollback_after: 0,
+        },
+    ));
+
+    let spacing = 2.0;
+    let center = (f32::from(settings.player_count) - 1.0) * 0.5;
+    for peer_id in settings.peer_ids() {
+        let id = PeerId::Entity(u64::from(peer_id));
+        let target = input_target_for_peer(
+            &settings,
+            &links,
+            peer_id,
+            PLAYER_INPUT_HASH_BASE | u64::from(peer_id),
+        );
+        let character = commands
+            .spawn((
+                Name::new("P2P Character"),
+                Position(Vec3::new((f32::from(peer_id) - center) * spacing, 3.0, 0.0)),
+                CharacterPhysicsBundle::default(),
+                ColorComponent(color_from_id(id)),
+                CharacterMarker,
+                DeterministicPredicted {
+                    skip_despawn: true,
+                    enable_rollback_after: 0,
+                },
+                target,
+                LeafwingBuffer::<CharacterAction>::default(),
+            ))
+            .id();
+        if peer_id == settings.local_peer_id {
+            commands
+                .entity(character)
+                .insert(PendingLocalInput(timeline.tick()));
+        }
+    }
+}
+
+/// Enable input capture only after Avian and Lightyear have recorded the world's initial state.
+///
+/// The fixed world and its collider-tree proxies are created together at
+/// [`GAMEPLAY_START_TICK`]. Enabling input in the same tick would allow a late first input to roll
+/// back before the first complete physics snapshot, leaving live colliders paired with an empty
+/// restored collider tree. Waiting one complete warm-up tick makes the earliest possible input
+/// rollback target a world snapshot from after initialization. It also lets the per-collider
+/// rollback histories installed by Avian's observers record their initial proxy state.
+fn enable_local_input(
+    mut commands: Commands,
+    timeline: Res<LocalTimeline>,
+    local_characters: Query<(Entity, &PendingLocalInput)>,
+) {
+    for (entity, pending) in &local_characters {
+        if timeline.tick() <= pending.0 {
+            continue;
+        }
+        commands
+            .entity(entity)
+            .insert(character_input_map())
+            .remove::<PendingLocalInput>();
+    }
+}
+
+fn shoot(
+    mut commands: Commands,
+    timeline: Res<LocalTimeline>,
+    players: Query<(&ActionState<CharacterAction>, &Position), With<CharacterMarker>>,
+) {
+    let tick = timeline.tick();
+    for (action, position) in &players {
+        if !action.just_pressed(&CharacterAction::Shoot) {
+            continue;
+        }
+        commands.spawn((
+            Name::new("P2P Projectile"),
+            ProjectileMarker,
+            ProjectilePhysicsBundle::default(),
+            *position,
+            Rotation::default(),
+            LinearVelocity(Vec3::Z * 10.0),
+            DespawnAt(tick + PROJECTILE_LIFETIME_TICKS),
+            DeterministicPredicted::default(),
+        ));
+    }
+}
+
+fn despawn_projectiles(
+    mut commands: Commands,
+    timeline: Res<LocalTimeline>,
+    projectiles: Query<(Entity, &DespawnAt)>,
+) {
+    let tick = timeline.tick();
+    for (entity, despawn) in &projectiles {
+        if tick >= despawn.0 {
+            commands.entity(entity).prediction_despawn();
+        }
+    }
+}

--- a/examples/avian_3d/src/renderer.rs
+++ b/examples/avian_3d/src/renderer.rs
@@ -73,7 +73,13 @@ fn add_visual_interpolation_components(
     // We use Position because it's added by avian later, and when it's added
     // we know that Predicted is already present on the entity
     trigger: On<Add, Position>,
-    query: Query<Entity, (With<Predicted>, Without<FloorMarker>)>,
+    query: Query<
+        Entity,
+        (
+            Or<(With<Predicted>, With<DeterministicPredicted>)>,
+            Without<FloorMarker>,
+        ),
+    >,
     clients: Query<(), With<Client>>,
     mut commands: Commands,
 ) {
@@ -93,7 +99,12 @@ fn add_character_cosmetics(
     character_query: Query<
         (Entity, &ColorComponent),
         (
-            Or<(Added<Predicted>, Added<Replicate>, Added<Interpolated>)>,
+            Or<(
+                Added<Predicted>,
+                Added<Replicate>,
+                Added<Interpolated>,
+                Added<DeterministicPredicted>,
+            )>,
             With<CharacterMarker>,
         ),
     >,
@@ -120,7 +131,11 @@ fn add_character_child_cosmetics(
         (),
         (
             With<CharacterMarker>,
-            Or<(With<Predicted>, With<Replicate>)>,
+            Or<(
+                With<Predicted>,
+                With<Replicate>,
+                With<DeterministicPredicted>,
+            )>,
         ),
     >,
     mut meshes: ResMut<Assets<Mesh>>,
@@ -140,22 +155,30 @@ fn add_character_child_cosmetics(
 fn add_projectile_cosmetics(
     mut commands: Commands,
     character_query: Query<
-        Entity,
+        (Entity, Has<RigidBody>),
         (
-            Or<(Added<Predicted>, Added<Replicate>)>,
+            Or<(
+                Added<Predicted>,
+                Added<Replicate>,
+                Added<DeterministicPredicted>,
+            )>,
             With<ProjectileMarker>,
         ),
     >,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
-    for entity in &character_query {
+    for (entity, has_physics) in &character_query {
         info!(?entity, "Adding cosmetics to projectile {:?}", entity);
         commands.entity(entity).insert((
             Mesh3d(meshes.add(Sphere::new(PROJECTILE_RADIUS))),
             MeshMaterial3d(materials.add(Color::from(MAGENTA))),
-            ProjectilePhysicsBundle::default(),
         ));
+        if !has_physics {
+            commands
+                .entity(entity)
+                .insert(ProjectilePhysicsBundle::default());
+        }
     }
 }
 
@@ -181,7 +204,17 @@ fn add_floor_cosmetics(
 /// see the predicted block and not the confirmed block.
 fn add_block_cosmetics(
     mut commands: Commands,
-    floor_query: Query<Entity, (Or<(Added<Predicted>, Added<Replicate>)>, With<BlockMarker>)>,
+    floor_query: Query<
+        Entity,
+        (
+            Or<(
+                Added<Predicted>,
+                Added<Replicate>,
+                Added<DeterministicPredicted>,
+            )>,
+            With<BlockMarker>,
+        ),
+    >,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {

--- a/examples/avian_3d/src/shared.rs
+++ b/examples/avian_3d/src/shared.rs
@@ -144,6 +144,13 @@ pub struct SharedPlugin;
 
 impl Plugin for SharedPlugin {
     fn build(&self, app: &mut App) {
+        #[cfg(feature = "p2p")]
+        let rollback_resources = app
+            .world()
+            .contains_resource::<lightyear_examples_common::p2p::P2PSettings>();
+        #[cfg(not(feature = "p2p"))]
+        let rollback_resources = false;
+
         app.add_plugins(ProtocolPlugin);
         app.add_observer(spawn_character_child_collider);
 
@@ -152,6 +159,7 @@ impl Plugin for SharedPlugin {
             replication_mode: AvianReplicationMode::Position {
                 sync_to_transform: false,
             },
+            rollback_resources,
             ..default()
         });
         app.add_plugins(

--- a/examples/bevy_enhanced_inputs/Cargo.toml
+++ b/examples/bevy_enhanced_inputs/Cargo.toml
@@ -12,11 +12,18 @@ license = "MIT OR Apache-2.0"
 publish = false
 
 [features]
-default = ["client", "gui", "server", "netcode", "webtransport"]
+default = ["client", "gui", "server", "p2p", "netcode", "webtransport"]
 client = ["lightyear/client", "lightyear_examples_common/client"]
 gui = ["lightyear_examples_common/gui2d"]
 server = ["lightyear/server", "lightyear_examples_common/server"]
 netcode = ["lightyear_examples_common/netcode"]
+p2p = [
+  "client",
+  "udp",
+  "lightyear/deterministic",
+  "lightyear/p2p",
+  "lightyear_examples_common/p2p",
+]
 webtransport = ["lightyear_examples_common/webtransport"]
 udp = [
   "lightyear_examples_common/udp",
@@ -34,6 +41,7 @@ lightyear = { "workspace" = true, features = [
   "input_bei",
 ] }
 bevy_enhanced_input.workspace = true
+lightyear_deterministic_replication.workspace = true
 lightyear_examples_common = { workspace = true, features = [
   "structured-debug",
 ] }

--- a/examples/bevy_enhanced_inputs/README.md
+++ b/examples/bevy_enhanced_inputs/README.md
@@ -16,6 +16,14 @@ https://github.com/cBournhonesque/lightyear/assets/8112632/7b57d48a-d8b0-4cdd-a1
 You can control the behaviour of the example by changing the list of features. By default, all features are enabled (client, server, gui).
 For example you can run the server in headless mode (without gui) by running `cargo run --no-default-features --features=server,webtransport,netcode`.
 
+### P2P mode
+
+The same movement example can run without a server. Every peer creates the fixed player roster and
+BEI action entities locally, then sends its action inputs directly to every other peer.
+
+- Peer 0: `cargo run --no-default-features --features=p2p -- --headless p2p --peer-id 0 --player-count 2`
+- Peer 1: `cargo run --no-default-features --features=p2p -- --headless p2p --peer-id 1 --player-count 2`
+
 ### Testing in wasm with webtransport
 
 NOTE: I am using the [bevy cli](https://github.com/TheBevyFlock/bevy_cli) to build and serve the wasm example.

--- a/examples/bevy_enhanced_inputs/src/client.rs
+++ b/examples/bevy_enhanced_inputs/src/client.rs
@@ -30,10 +30,10 @@ impl Plugin for ExampleClientPlugin {
     }
 }
 
-fn configure_input_delay(client: Single<Entity, With<Client>>, mut commands: Commands) {
-    commands
-        .entity(client.into_inner())
-        .insert(InputTimelineConfig::default().with_input_delay(InputDelayConfig::balanced()));
+fn configure_input_delay(mut commands: Commands) {
+    commands.insert_resource(
+        InputTimelineConfig::default().with_input_delay(InputDelayConfig::balanced()),
+    );
 }
 
 /// Applies local movement only to predicted entities owned by this client.
@@ -41,13 +41,10 @@ fn configure_input_delay(client: Single<Entity, With<Client>>, mut commands: Com
 /// observer is disabled.
 fn player_movement(
     trigger: On<Fire<Movement>>,
-    synced_client: Query<(), (With<Client>, With<IsSynced<InputTimeline>>)>,
+    _input_timeline: SyncedInputTimeline,
     #[cfg(feature = "server")] host_server: Query<(), With<HostServer>>,
     mut position_query: Query<&mut PlayerPosition, With<Predicted>>,
 ) {
-    if synced_client.is_empty() {
-        return;
-    }
     #[cfg(feature = "server")]
     if !host_server.is_empty() {
         return;

--- a/examples/bevy_enhanced_inputs/src/client.rs
+++ b/examples/bevy_enhanced_inputs/src/client.rs
@@ -13,6 +13,7 @@ use bevy::prelude::*;
 #[cfg(feature = "server")]
 use lightyear::connection::host::HostServer;
 use lightyear::input::bei::prelude::{Action, ActionOf, Actions, Bindings, Cardinal, Fire};
+use lightyear::prediction::rollback::DeterministicPredicted;
 use lightyear::prelude::client::{InputDelayConfig, InputTimelineConfig};
 use lightyear::prelude::*;
 
@@ -43,7 +44,10 @@ fn player_movement(
     trigger: On<Fire<Movement>>,
     _input_timeline: SyncedInputTimeline,
     #[cfg(feature = "server")] host_server: Query<(), With<HostServer>>,
-    mut position_query: Query<&mut PlayerPosition, With<Predicted>>,
+    mut position_query: Query<
+        &mut PlayerPosition,
+        Or<(With<Predicted>, With<DeterministicPredicted>)>,
+    >,
 ) {
     #[cfg(feature = "server")]
     if !host_server.is_empty() {

--- a/examples/bevy_enhanced_inputs/src/debug.rs
+++ b/examples/bevy_enhanced_inputs/src/debug.rs
@@ -72,10 +72,18 @@ pub(crate) mod client {
 
     pub(crate) fn mark_debug_players(
         mut commands: Commands,
-        query: Query<(Entity, Has<Predicted>, Has<Interpolated>), Added<PlayerId>>,
+        query: Query<
+            (
+                Entity,
+                Has<Predicted>,
+                Has<Interpolated>,
+                Has<DeterministicPredicted>,
+            ),
+            Added<PlayerId>,
+        >,
     ) {
-        for (entity, predicted, interpolated) in &query {
-            if predicted || interpolated {
+        for (entity, predicted, interpolated, deterministic) in &query {
+            if predicted || interpolated || deterministic {
                 commands.entity(entity).insert(
                     LightyearDebug::component_at::<PlayerPosition>([DebugSamplePoint::Update])
                         .with_component_at::<PlayerId>([DebugSamplePoint::Update]),

--- a/examples/bevy_enhanced_inputs/src/lib.rs
+++ b/examples/bevy_enhanced_inputs/src/lib.rs
@@ -5,6 +5,9 @@ pub mod automation;
 #[cfg(feature = "client")]
 pub mod client;
 
+#[cfg(feature = "p2p")]
+pub mod p2p;
+
 pub mod debug;
 
 #[cfg(feature = "server")]

--- a/examples/bevy_enhanced_inputs/src/main.rs
+++ b/examples/bevy_enhanced_inputs/src/main.rs
@@ -13,6 +13,8 @@
 
 #[cfg(feature = "client")]
 use crate::client::ExampleClientPlugin;
+#[cfg(feature = "p2p")]
+use crate::p2p::ExampleP2PPlugin;
 #[cfg(feature = "server")]
 use crate::server::ExampleServerPlugin;
 use crate::shared::SharedPlugin;
@@ -26,6 +28,8 @@ use lightyear_examples_common::shared::{FIXED_TIMESTEP_HZ, SEND_INTERVAL};
 #[cfg(feature = "client")]
 mod client;
 mod debug;
+#[cfg(feature = "p2p")]
+mod p2p;
 mod protocol;
 #[cfg(feature = "gui")]
 mod renderer;
@@ -46,9 +50,14 @@ fn main() {
     cli.spawn_connections(&mut app);
 
     match cli.mode {
-        #[cfg(feature = "client")]
+        #[cfg(all(feature = "client", any(not(feature = "p2p"), feature = "netcode")))]
         Some(Mode::Client { .. }) => {
             app.add_plugins(ExampleClientPlugin);
+            add_input_delay(&mut app);
+        }
+        #[cfg(feature = "p2p")]
+        Some(Mode::P2P { .. }) => {
+            app.add_plugins((ExampleClientPlugin, ExampleP2PPlugin));
             add_input_delay(&mut app);
         }
         #[cfg(feature = "server")]

--- a/examples/bevy_enhanced_inputs/src/p2p.rs
+++ b/examples/bevy_enhanced_inputs/src/p2p.rs
@@ -1,0 +1,94 @@
+//! Direct P2P setup for the Bevy Enhanced Input example.
+//!
+//! Player contexts and their action entities are created locally in the same stable roster order
+//! on every peer. The action entity carries the stable input-wire identity because BEI input
+//! messages target actions rather than their player context.
+
+use crate::protocol::{Movement, Player, PlayerColor, PlayerId, PlayerPosition};
+use crate::shared;
+use bevy::prelude::*;
+use bevy_enhanced_input::context::ExternallyMocked;
+use lightyear::input::bei::prelude::{
+    Action, ActionOf, BEIBuffer, Bindings, Cardinal, InputMarker,
+};
+use lightyear::prediction::rollback::DeterministicPredicted;
+use lightyear::prelude::input::client::InputSystems;
+use lightyear::prelude::*;
+use lightyear_deterministic_replication::prelude::DeterministicReplicationPlugin;
+use lightyear_examples_common::p2p::{
+    input_target_for_peer, P2PGameplayStarted, P2PSettings, GAMEPLAY_START_TICK,
+};
+
+/// Namespace for stable BEI action hashes on the input wire.
+const MOVEMENT_INPUT_HASH_BASE: u64 = 0x4245_495F_4D4F_0000;
+
+pub struct ExampleP2PPlugin;
+
+impl Plugin for ExampleP2PPlugin {
+    fn build(&self, app: &mut App) {
+        app.insert_resource(PredictionManager::default());
+        app.add_plugins(DeterministicReplicationPlugin);
+        app.add_systems(
+            FixedPreUpdate,
+            spawn_fixed_roster.before(InputSystems::BufferClientInputs),
+        );
+    }
+}
+
+fn spawn_fixed_roster(
+    mut commands: Commands,
+    _synced: SyncedInputTimeline,
+    timeline: Res<LocalTimeline>,
+    started: Option<Res<P2PGameplayStarted>>,
+    settings: Res<P2PSettings>,
+    links: Query<(Entity, &RemoteId), With<P2P>>,
+) {
+    if started.is_some() || timeline.tick().0 < GAMEPLAY_START_TICK {
+        return;
+    }
+    commands.insert_resource(P2PGameplayStarted);
+
+    for peer_id in settings.peer_ids() {
+        let id = PeerId::Entity(u64::from(peer_id));
+        let player = commands
+            .spawn((
+                Player,
+                PlayerId(id),
+                PlayerPosition(shared::initial_player_position(id)),
+                PlayerColor(shared::color_from_id(id)),
+                DeterministicPredicted {
+                    skip_despawn: true,
+                    enable_rollback_after: 0,
+                },
+                Name::new(format!("P2P Player {peer_id}")),
+            ))
+            .id();
+        if peer_id == settings.local_peer_id {
+            commands.entity(player).insert(Controlled);
+        }
+
+        let input_target = input_target_for_peer(
+            &settings,
+            &links,
+            peer_id,
+            MOVEMENT_INPUT_HASH_BASE | u64::from(peer_id),
+        );
+        let action = commands
+            .spawn((
+                ActionOf::<Player>::new(player),
+                Action::<Movement>::new(),
+                BEIBuffer::<Player>::default(),
+                input_target,
+                Name::new(format!("P2P Movement {peer_id}")),
+            ))
+            .id();
+        if peer_id == settings.local_peer_id {
+            commands.entity(action).insert((
+                Bindings::spawn(Cardinal::wasd_keys()),
+                InputMarker::<Player>::default(),
+            ));
+        } else {
+            commands.entity(action).insert(ExternallyMocked);
+        }
+    }
+}

--- a/examples/bevy_enhanced_inputs/src/server.rs
+++ b/examples/bevy_enhanced_inputs/src/server.rs
@@ -54,17 +54,13 @@ pub(crate) fn handle_connected(
         return;
     };
     let client_id = client_id.0;
-    // Generate pseudo random color from client id.
-    let h = (((client_id.to_bits().wrapping_mul(30)) % 360) as f32) / 360.0;
-    let s = 0.8;
-    let l = 0.5;
-    let color = Color::hsl(h, s, l);
+    let color = shared::color_from_id(client_id);
     let player_entity = commands
         .spawn((
             // Add the context component on the server; it will be replicated to the client
             Player,
             PlayerId(client_id),
-            PlayerPosition(initial_player_position(client_id)),
+            PlayerPosition(shared::initial_player_position(client_id)),
             PlayerColor(color),
             // we replicate the Player entity to all clients that are connected to this server
             Replicate::to_clients(NetworkTarget::All),
@@ -81,11 +77,6 @@ pub(crate) fn handle_connected(
         player_entity, client_id
     );
     spawn_action_entities(&mut commands, player_entity);
-}
-
-fn initial_player_position(client_id: PeerId) -> Vec2 {
-    let slot = (client_id.to_bits() % 6) as f32;
-    Vec2::new((slot - 2.5) * 90.0, 0.0)
 }
 
 /// Spawn the BEI action entities for a player.

--- a/examples/bevy_enhanced_inputs/src/shared.rs
+++ b/examples/bevy_enhanced_inputs/src/shared.rs
@@ -4,6 +4,7 @@
 //! mispredictions/rollbacks.
 use crate::protocol::*;
 use bevy::prelude::*;
+use lightyear::prelude::PeerId;
 use lightyear_examples_common::shared::SharedSettings;
 
 pub struct SharedPlugin;
@@ -19,6 +20,16 @@ pub const SHARED_SETTINGS: SharedSettings = SharedSettings {
     protocol_id: 0,
     private_key: [0; 32],
 };
+
+pub(crate) fn initial_player_position(peer_id: PeerId) -> Vec2 {
+    let slot = (peer_id.to_bits() % 6) as f32;
+    Vec2::new((slot - 2.5) * 90.0, 0.0)
+}
+
+pub(crate) fn color_from_id(peer_id: PeerId) -> Color {
+    let h = (((peer_id.to_bits().wrapping_mul(30)) % 360) as f32) / 360.0;
+    Color::hsl(h, 0.8, 0.5)
+}
 
 // Applies movement input to a player position.
 pub(crate) fn shared_movement_behaviour(mut position: Mut<PlayerPosition>, input: Vec2) {

--- a/examples/common/Cargo.toml
+++ b/examples/common/Cargo.toml
@@ -15,6 +15,7 @@ exclude = ["/tests"]
 default = ["client", "server", "netcode", "webtransport"]
 client = ["lightyear/client"]
 server = ["lightyear/server"]
+p2p = ["client", "udp", "lightyear/p2p", "lightyear/raw_connection"]
 netcode = ["lightyear/netcode"]
 webtransport = [
   "lightyear/webtransport",

--- a/examples/common/src/cli.rs
+++ b/examples/common/src/cli.rs
@@ -14,10 +14,12 @@ use bevy::diagnostic::DiagnosticsPlugin;
 use bevy::state::app::StatesPlugin;
 use clap::{ArgAction, Parser, Subcommand};
 
-#[cfg(feature = "client")]
+#[cfg(all(feature = "client", any(not(feature = "p2p"), feature = "netcode")))]
 use crate::client::{ClientTransports, ExampleClient, connect};
 #[cfg(all(any(feature = "gui2d", feature = "gui3d"), feature = "client"))]
 use crate::client_renderer::ExampleClientRendererPlugin;
+#[cfg(feature = "p2p")]
+use crate::p2p::{self, DEFAULT_P2P_BASE_PORT};
 #[cfg(feature = "server")]
 use crate::server::{ExampleServer, ServerTransports, WebTransportCertificateSettings, start};
 #[cfg(all(any(feature = "gui2d", feature = "gui3d"), feature = "server"))]
@@ -64,7 +66,7 @@ pub struct Cli {
     pub mode: Option<Mode>,
 }
 
-#[cfg(feature = "client")]
+#[cfg(all(feature = "client", any(not(feature = "p2p"), feature = "netcode")))]
 fn default_client_transport() -> ClientTransports {
     ClientTransports::WebTransport
 }
@@ -81,12 +83,14 @@ impl Cli {
     /// Get the client id from the CLI
     pub fn client_id(&self) -> Option<u64> {
         match &self.mode {
-            #[cfg(feature = "client")]
+            #[cfg(all(feature = "client", any(not(feature = "p2p"), feature = "netcode")))]
             Some(Mode::Client { client_id }) => *client_id,
             #[cfg(all(feature = "client", feature = "server"))]
             Some(Mode::Separate { client_id }) => *client_id,
             #[cfg(all(feature = "client", feature = "server"))]
             Some(Mode::HostClient { client_id }) => *client_id,
+            #[cfg(feature = "p2p")]
+            Some(Mode::P2P { peer_id, .. }) => Some(u64::from(*peer_id)),
             _ => None,
         }
     }
@@ -106,10 +110,12 @@ impl Cli {
         // to ~60 FPS so that headless automation behaves closer to a
         // real windowed client. Dedicated servers stay unthrottled.
         let loop_wait = match mode {
-            #[cfg(feature = "client")]
+            #[cfg(all(feature = "client", any(not(feature = "p2p"), feature = "netcode")))]
             Some(Mode::Client { .. }) => {
                 Some(Duration::from_secs_f64(1.0 / HEADLESS_CLIENT_LOOP_HZ))
             }
+            #[cfg(feature = "p2p")]
+            Some(Mode::P2P { .. }) => Some(Duration::from_secs_f64(1.0 / HEADLESS_CLIENT_LOOP_HZ)),
             #[cfg(all(feature = "client", feature = "server"))]
             Some(Mode::HostClient { .. }) | Some(Mode::Separate { .. }) => {
                 Some(Duration::from_secs_f64(1.0 / HEADLESS_CLIENT_LOOP_HZ))
@@ -122,7 +128,7 @@ impl Cli {
     pub fn build_app(&self, tick_duration: Duration, add_inspector: bool) -> App {
         let mut app = Cli::create_app(add_inspector, self.mode.as_ref(), self.headless());
         match self.mode {
-            #[cfg(feature = "client")]
+            #[cfg(all(feature = "client", any(not(feature = "p2p"), feature = "netcode")))]
             Some(Mode::Client { client_id }) => {
                 #[cfg(feature = "steam")]
                 app.add_steam_resources(STEAM_APP_ID);
@@ -133,6 +139,21 @@ impl Cli {
                         "Client {client_id:?}"
                     )));
                 }
+                app
+            }
+            #[cfg(feature = "p2p")]
+            Some(Mode::P2P {
+                peer_id,
+                player_count,
+                ..
+            }) => {
+                p2p::configure_app(
+                    &mut app,
+                    tick_duration,
+                    self.headless(),
+                    peer_id,
+                    player_count,
+                );
                 app
             }
             #[cfg(feature = "server")]
@@ -178,7 +199,7 @@ impl Cli {
     pub fn spawn_connections(&self, app: &mut App) {
         let conditioner = LinkConditionerConfig::average_condition().half();
         match self.mode {
-            #[cfg(feature = "client")]
+            #[cfg(all(feature = "client", any(not(feature = "p2p"), feature = "netcode")))]
             Some(Mode::Client { client_id }) => {
                 let client = app
                     .world_mut()
@@ -197,6 +218,14 @@ impl Cli {
                     })
                     .id();
                 app.add_systems(Startup, connect);
+            }
+            #[cfg(feature = "p2p")]
+            Some(Mode::P2P {
+                peer_id,
+                player_count,
+                base_port,
+            }) => {
+                p2p::spawn_connections(app, &conditioner, peer_id, player_count, base_port);
             }
             #[cfg(feature = "server")]
             Some(Mode::Server) => {
@@ -256,11 +285,24 @@ impl Cli {
 
 #[derive(Subcommand, Debug)]
 pub enum Mode {
-    #[cfg(feature = "client")]
+    #[cfg(all(feature = "client", any(not(feature = "p2p"), feature = "netcode")))]
     /// Runs the app in client mode
     Client {
         #[arg(short, long, default_value = None)]
         client_id: Option<u64>,
+    },
+    #[cfg(feature = "p2p")]
+    /// Runs a fixed roster with one direct raw UDP Link to every other peer.
+    P2P {
+        /// Zero-based identity of this peer within the fixed roster.
+        #[arg(short, long)]
+        peer_id: u8,
+        /// Number of players in the fixed roster (2 through 4).
+        #[arg(short = 'n', long, default_value_t = 2)]
+        player_count: u8,
+        /// First UDP port reserved for the roster's directed peer Links.
+        #[arg(long, default_value_t = DEFAULT_P2P_BASE_PORT)]
+        base_port: u16,
     },
     #[cfg(feature = "server")]
     /// Runs the app in server mode
@@ -284,8 +326,14 @@ pub enum Mode {
 impl Mode {
     fn possible_options() -> &'static str {
         cfg_if::cfg_if! {
-            if #[cfg(all(feature = "client", feature = "server"))] {
+            if #[cfg(all(feature = "client", feature = "server", feature = "p2p"))] {
+                "client, server, separate, host-client, p2p"
+            } else if #[cfg(all(feature = "client", feature = "server"))] {
                 "client, server, separate, host-client"
+            } else if #[cfg(all(feature = "p2p", feature = "netcode"))] {
+                "client, p2p"
+            } else if #[cfg(feature = "p2p")] {
+                "p2p"
             } else if #[cfg(feature = "client")] {
                 "client"
             } else if #[cfg(feature = "server")] {
@@ -304,6 +352,12 @@ impl Default for Mode {
                 Mode::HostClient { client_id: None }
             } else if #[cfg(feature = "server")] {
                 Mode::Server
+            } else if #[cfg(feature = "p2p")] {
+                Mode::P2P {
+                    peer_id: 0,
+                    player_count: 2,
+                    base_port: DEFAULT_P2P_BASE_PORT,
+                }
             } else {
                 Mode::Client { client_id: None }
             }

--- a/examples/common/src/client.rs
+++ b/examples/common/src/client.rs
@@ -45,15 +45,16 @@ impl ExampleClient {
     fn on_add(mut world: DeferredWorld, context: HookContext) {
         let entity = context.entity;
         world.commands().queue(move |world: &mut World| -> Result {
+            world.insert_resource(PredictionManager::default());
             let mut entity_mut = world.entity_mut(entity);
             let settings = entity_mut.take::<ExampleClient>().unwrap();
             let client_addr = SocketAddr::new(Ipv4Addr::UNSPECIFIED.into(), settings.client_port);
             entity_mut.insert((
                 Client,
+                ReplicationReceiver,
                 Link::default().with_conditioner(settings.conditioner.clone()),
                 LocalAddr(client_addr),
                 PeerAddr(settings.server_addr),
-                PredictionManager::default(),
                 Name::from("Client"),
             ));
 

--- a/examples/common/src/lib.rs
+++ b/examples/common/src/lib.rs
@@ -90,7 +90,10 @@ pub mod shared;
 
 pub mod automation;
 pub mod cli;
-#[cfg(feature = "client")]
+// A direct P2P-only build needs ClientPlugins but not the conventional netcode client harness.
+#[cfg(all(feature = "client", any(not(feature = "p2p"), feature = "netcode")))]
 pub mod client;
+#[cfg(feature = "p2p")]
+pub mod p2p;
 #[cfg(feature = "server")]
 pub mod server;

--- a/examples/common/src/p2p.rs
+++ b/examples/common/src/p2p.rs
@@ -1,0 +1,151 @@
+//! Shared setup for examples running as a direct P2P mesh.
+
+use core::net::{Ipv4Addr, SocketAddr};
+use core::ops::Range;
+use core::time::Duration;
+
+use bevy::prelude::*;
+use lightyear::link::RecvLinkConditioner;
+use lightyear::prelude::client::{ClientPlugins, RawClient};
+use lightyear::prelude::*;
+
+#[cfg(any(feature = "gui2d", feature = "gui3d"))]
+use crate::client_renderer::ExampleClientRendererPlugin;
+
+const MAX_P2P_PLAYERS: u8 = 4;
+pub(crate) const DEFAULT_P2P_BASE_PORT: u16 = 6000;
+
+/// Tick at which fixed-roster examples create their deterministic gameplay world.
+///
+/// Delaying creation gives every raw Link time to connect and lets the input timeline complete
+/// its one-time initial synchronization before any gameplay state is simulated. A future session
+/// handshake should replace this example convention with an agreed start epoch.
+pub const GAMEPLAY_START_TICK: u32 = 120;
+
+/// Marker inserted after an example has created its fixed deterministic P2P world.
+#[derive(Resource, Default)]
+pub struct P2PGameplayStarted;
+
+/// Fixed roster used by an example running in direct P2P mode.
+///
+/// The initial example transport assigns compact numeric peer identities. Iroh can replace the
+/// transport-specific identity construction later without changing the topology or game setup.
+#[derive(Resource, Clone, Copy, Debug, PartialEq, Eq)]
+pub struct P2PSettings {
+    pub local_peer_id: u8,
+    pub player_count: u8,
+}
+
+impl P2PSettings {
+    pub fn peer_ids(&self) -> Range<u8> {
+        0..self.player_count
+    }
+
+    pub fn local_id(&self) -> PeerId {
+        PeerId::Entity(u64::from(self.local_peer_id))
+    }
+}
+
+/// Build the stable input target shared by every peer for one roster member.
+///
+/// Remote targets are scoped to the Link that owns their input stream. The local target has no
+/// receiver because this app captures and originates its inputs.
+pub fn input_target_for_peer(
+    settings: &P2PSettings,
+    links: &Query<(Entity, &RemoteId), With<P2P>>,
+    peer_id: u8,
+    hash: u64,
+) -> PreSpawned {
+    let mut target = PreSpawned::new(hash);
+    if peer_id == settings.local_peer_id {
+        return target;
+    }
+
+    let remote_id = PeerId::Entity(u64::from(peer_id));
+    let owner_link = links
+        .iter()
+        .find_map(|(entity, id)| (id.0 == remote_id).then_some(entity))
+        .unwrap_or_else(|| panic!("missing P2P Link for roster peer {peer_id}"));
+    target = target.for_receiver(owner_link);
+    target
+}
+
+/// Add the client-side Lightyear plugins and roster state used by a direct P2P example.
+pub(crate) fn configure_app(
+    app: &mut App,
+    tick_duration: Duration,
+    _headless: bool,
+    peer_id: u8,
+    player_count: u8,
+) {
+    validate_roster(peer_id, player_count);
+    app.add_plugins(ClientPlugins { tick_duration });
+    app.insert_resource(P2PSettings {
+        local_peer_id: peer_id,
+        player_count,
+    });
+
+    #[cfg(any(feature = "gui2d", feature = "gui3d"))]
+    if !_headless {
+        app.add_plugins(ExampleClientRendererPlugin::new(format!(
+            "P2P Peer {peer_id}"
+        )));
+    }
+}
+
+/// Spawn one directed raw UDP Link for every other member of the fixed roster.
+pub(crate) fn spawn_connections(
+    app: &mut App,
+    conditioner: &LinkConditionerConfig,
+    peer_id: u8,
+    player_count: u8,
+    base_port: u16,
+) {
+    validate_roster(peer_id, player_count);
+    let local_id = PeerId::Entity(u64::from(peer_id));
+    for remote_peer_id in 0..player_count {
+        if remote_peer_id == peer_id {
+            continue;
+        }
+        let local_addr = peer_addr(base_port, peer_id, remote_peer_id);
+        let remote_addr = peer_addr(base_port, remote_peer_id, peer_id);
+        app.world_mut().spawn((
+            P2P,
+            RawClient,
+            LocalId(local_id),
+            RemoteId(PeerId::Entity(u64::from(remote_peer_id))),
+            PingManager::default(),
+            LocalAddr(local_addr),
+            PeerAddr(remote_addr),
+            UdpIo::default(),
+            Link::default().with_conditioner(Some(RecvLinkConditioner::new(conditioner.clone()))),
+            Name::new(format!("P2P Link {peer_id} -> {remote_peer_id}")),
+        ));
+    }
+    app.add_systems(Startup, connect);
+}
+
+fn validate_roster(peer_id: u8, player_count: u8) {
+    assert!(
+        (2..=MAX_P2P_PLAYERS).contains(&player_count),
+        "P2P player_count must be between 2 and {MAX_P2P_PLAYERS}"
+    );
+    assert!(
+        peer_id < player_count,
+        "P2P peer_id {peer_id} is outside the {player_count}-player roster"
+    );
+}
+
+fn peer_addr(base_port: u16, local_peer_id: u8, remote_peer_id: u8) -> SocketAddr {
+    let offset = u16::from(local_peer_id) * u16::from(MAX_P2P_PLAYERS) + u16::from(remote_peer_id);
+    let port = base_port
+        .checked_add(offset)
+        .expect("P2P base port plus roster offset must fit in u16");
+    SocketAddr::new(Ipv4Addr::LOCALHOST.into(), port)
+}
+
+fn connect(mut commands: Commands, links: Query<Entity, With<P2P>>) {
+    for entity in &links {
+        commands.trigger(Connect { entity });
+    }
+}

--- a/examples/deterministic_replication/Cargo.toml
+++ b/examples/deterministic_replication/Cargo.toml
@@ -6,7 +6,7 @@ edition.workspace = true
 publish = false
 
 [features]
-default = ["client", "gui", "server", "netcode", "webtransport"]
+default = ["client", "gui", "server", "p2p", "netcode", "webtransport"]
 client = ["lightyear/client", "lightyear_examples_common/client"]
 gui = ["lightyear_examples_common/gui2d"]
 server = [
@@ -16,6 +16,13 @@ server = [
   "lightyear_examples_common/server",
 ]
 netcode = ["lightyear_examples_common/netcode"]
+p2p = [
+  "client",
+  "udp",
+  "lightyear/deterministic",
+  "lightyear/p2p",
+  "lightyear_examples_common/p2p",
+]
 webtransport = ["lightyear_examples_common/webtransport"]
 udp = ["lightyear_examples_common/udp", "lightyear/std", "lightyear/udp"]
 

--- a/examples/deterministic_replication/README.md
+++ b/examples/deterministic_replication/README.md
@@ -20,6 +20,16 @@
 You can control the behaviour of the example by changing the list of features. By default, all features are enabled (client, server, gui).
 For example you can run the server in headless mode (without gui) by running `cargo run --no-default-features --features=server,webtransport,netcode`.
 
+### P2P mode
+
+The example can also run as a fixed deterministic P2P mesh. Every peer creates the same Avian
+world locally and exchanges only player inputs; there is no server or authoritative simulation.
+
+- Peer 0: `cargo run --no-default-features --features=p2p -- --headless p2p --peer-id 0 --player-count 2`
+- Peer 1: `cargo run --no-default-features --features=p2p -- --headless p2p --peer-id 1 --player-count 2`
+
+P2P mode uses input-only catch-up because there is no authoritative state source.
+
 ### Testing in wasm with webtransport
 
 NOTE: I am using the [bevy cli](https://github.com/TheBevyFlock/bevy_cli) to build and serve the wasm example.

--- a/examples/deterministic_replication/src/automation.rs
+++ b/examples/deterministic_replication/src/automation.rs
@@ -12,6 +12,8 @@ use lightyear::prelude::*;
 use lightyear_deterministic_replication::prelude::{CatchUpGated, CatchUpMode};
 #[cfg(feature = "client")]
 use lightyear_examples_common::automation::{HeadlessInputPlugin, env_string, sync_pressed_keys};
+#[cfg(all(feature = "client", feature = "p2p"))]
+use lightyear_examples_common::p2p::P2PSettings;
 
 #[cfg(feature = "client")]
 use crate::protocol::{PlayerActions, PlayerActivationTick, PlayerId};
@@ -156,7 +158,9 @@ mod client {
         mode: Res<CatchUpMode>,
         timeline: Res<LocalTimeline>,
         input_timeline: Option<SyncedInputTimeline>,
-        client: Option<Single<&LocalId, With<Client>>>,
+        metadata: Res<NetworkingMetadata>,
+        local_ids: Query<&LocalId>,
+        #[cfg(feature = "p2p")] p2p: Option<Res<P2PSettings>>,
         players: Query<(
             &PlayerId,
             Option<&LeafwingBuffer<PlayerActions>>,
@@ -172,7 +176,14 @@ mod client {
             timeline.tick(),
             input_timeline
                 .is_some()
-                .then(|| client.as_deref().copied())
+                .then(|| {
+                    local_peer_id(
+                        &metadata,
+                        &local_ids,
+                        #[cfg(feature = "p2p")]
+                        p2p.as_deref(),
+                    )
+                })
                 .flatten(),
             &players,
             &settings,
@@ -207,7 +218,9 @@ mod client {
         mode: Res<CatchUpMode>,
         timeline: Res<LocalTimeline>,
         input_timeline: Option<SyncedInputTimeline>,
-        client: Option<Single<&LocalId, With<Client>>>,
+        metadata: Res<NetworkingMetadata>,
+        local_ids: Query<&LocalId>,
+        #[cfg(feature = "p2p")] p2p: Option<Res<P2PSettings>>,
         players: Query<(
             &PlayerId,
             Option<&LeafwingBuffer<PlayerActions>>,
@@ -221,7 +234,14 @@ mod client {
             timeline.tick(),
             input_timeline
                 .is_some()
-                .then(|| client.as_deref().copied())
+                .then(|| {
+                    local_peer_id(
+                        &metadata,
+                        &local_ids,
+                        #[cfg(feature = "p2p")]
+                        p2p.as_deref(),
+                    )
+                })
                 .flatten(),
             &players,
             &settings,
@@ -256,7 +276,7 @@ mod client {
     fn input_rebroadcast_ready(
         mode: &CatchUpMode,
         local_tick: Tick,
-        client: Option<&LocalId>,
+        local_id: Option<PeerId>,
         players: &Query<(
             &PlayerId,
             Option<&LeafwingBuffer<PlayerActions>>,
@@ -265,14 +285,14 @@ mod client {
         )>,
         settings: &AutomationSettings,
     ) -> bool {
-        let Some(local_id) = client else {
+        let Some(local_id) = local_id else {
             return false;
         };
         let mut count = 0;
         let mut local_can_move = false;
         for (player_id, buffer, activation_tick, awaiting_catchup) in players.iter() {
             count += 1;
-            if player_id.0 == local_id.0 {
+            if player_id.0 == local_id {
                 if awaiting_catchup {
                     return false;
                 }
@@ -296,6 +316,23 @@ mod client {
             }
         }
         count >= settings.min_players_before_move && local_can_move
+    }
+
+    fn local_peer_id(
+        metadata: &NetworkingMetadata,
+        local_ids: &Query<&LocalId>,
+        #[cfg(feature = "p2p")] p2p: Option<&P2PSettings>,
+    ) -> Option<PeerId> {
+        #[cfg(feature = "p2p")]
+        if let Some(p2p) = p2p {
+            return Some(p2p.local_id());
+        }
+        match metadata.mode {
+            NetworkTopology::Client(link) | NetworkTopology::HostClient { client: link, .. } => {
+                local_ids.get(link).ok().map(|id| id.0)
+            }
+            _ => None,
+        }
     }
 
     fn release_all(action_state: &mut ActionState<PlayerActions>) {

--- a/examples/deterministic_replication/src/automation.rs
+++ b/examples/deterministic_replication/src/automation.rs
@@ -155,7 +155,8 @@ mod client {
         random_state: Option<ResMut<RandomState>>,
         mode: Res<CatchUpMode>,
         timeline: Res<LocalTimeline>,
-        client: Option<Single<&LocalId, (With<Client>, With<IsSynced<InputTimeline>>)>>,
+        input_timeline: Option<SyncedInputTimeline>,
+        client: Option<Single<&LocalId, With<Client>>>,
         players: Query<(
             &PlayerId,
             Option<&LeafwingBuffer<PlayerActions>>,
@@ -169,7 +170,10 @@ mod client {
         if !input_rebroadcast_ready(
             &mode,
             timeline.tick(),
-            client.as_deref().copied(),
+            input_timeline
+                .is_some()
+                .then(|| client.as_deref().copied())
+                .flatten(),
             &players,
             &settings,
         ) {
@@ -202,7 +206,8 @@ mod client {
         random_state: Option<Res<RandomState>>,
         mode: Res<CatchUpMode>,
         timeline: Res<LocalTimeline>,
-        client: Option<Single<&LocalId, (With<Client>, With<IsSynced<InputTimeline>>)>>,
+        input_timeline: Option<SyncedInputTimeline>,
+        client: Option<Single<&LocalId, With<Client>>>,
         players: Query<(
             &PlayerId,
             Option<&LeafwingBuffer<PlayerActions>>,
@@ -214,7 +219,10 @@ mod client {
         if !input_rebroadcast_ready(
             &mode,
             timeline.tick(),
-            client.as_deref().copied(),
+            input_timeline
+                .is_some()
+                .then(|| client.as_deref().copied())
+                .flatten(),
             &players,
             &settings,
         ) {

--- a/examples/deterministic_replication/src/client.rs
+++ b/examples/deterministic_replication/src/client.rs
@@ -8,6 +8,8 @@ use crate::automation::AutomationClientPlugin;
 use crate::protocol::*;
 use crate::shared::color_from_id;
 use lightyear_deterministic_replication::prelude::CatchUpSnapshotReady;
+#[cfg(feature = "p2p")]
+use lightyear_examples_common::p2p::P2PSettings;
 
 pub struct ExampleClientPlugin;
 
@@ -34,16 +36,27 @@ struct InputMapAdded;
 /// input and the server can't rebroadcast it to other peers.
 fn add_input_map_after_sync(
     _input_timeline: SyncedInputTimeline,
-    client: Option<Single<&LocalId, With<Client>>>,
+    metadata: Res<NetworkingMetadata>,
+    local_ids: Query<&LocalId>,
+    #[cfg(feature = "p2p")] p2p: Option<Res<P2PSettings>>,
     mut commands: Commands,
     players: Query<(Entity, &PlayerId), (Without<InputMapAdded>, Without<InputMap<PlayerActions>>)>,
 ) {
-    let Some(client) = client else {
+    #[cfg(feature = "p2p")]
+    let p2p_id = p2p.as_deref().map(P2PSettings::local_id);
+    #[cfg(not(feature = "p2p"))]
+    let p2p_id = None;
+    let local_id = p2p_id.or_else(|| match metadata.mode {
+        NetworkTopology::Client(link) | NetworkTopology::HostClient { client: link, .. } => {
+            local_ids.get(link).ok().map(|id| id.0)
+        }
+        _ => None,
+    });
+    let Some(local_id) = local_id else {
         return;
     };
-    let local_id = client.into_inner();
     for (entity, player_id) in players.iter() {
-        if local_id.0 == player_id.0 {
+        if local_id == player_id.0 {
             info!("Client: adding InputMap to local player {:?}", player_id.0);
             commands.entity(entity).insert((
                 InputMap::new([

--- a/examples/deterministic_replication/src/client.rs
+++ b/examples/deterministic_replication/src/client.rs
@@ -33,7 +33,8 @@ struct InputMapAdded;
 /// sending input messages — without it, the client never broadcasts any
 /// input and the server can't rebroadcast it to other peers.
 fn add_input_map_after_sync(
-    client: Option<Single<&LocalId, (With<Client>, With<IsSynced<InputTimeline>>)>>,
+    _input_timeline: SyncedInputTimeline,
+    client: Option<Single<&LocalId, With<Client>>>,
     mut commands: Commands,
     players: Query<(Entity, &PlayerId), (Without<InputMapAdded>, Without<InputMap<PlayerActions>>)>,
 ) {

--- a/examples/deterministic_replication/src/main.rs
+++ b/examples/deterministic_replication/src/main.rs
@@ -1,5 +1,7 @@
 #[cfg(feature = "client")]
 use crate::client::ExampleClientPlugin;
+#[cfg(feature = "p2p")]
+use crate::p2p::ExampleP2PPlugin;
 #[cfg(feature = "server")]
 use crate::server::ExampleServerPlugin;
 use crate::shared::SharedPlugin;
@@ -23,6 +25,8 @@ mod automation;
 #[cfg(feature = "client")]
 mod client;
 mod debug;
+#[cfg(feature = "p2p")]
+mod p2p;
 mod protocol;
 
 #[cfg(feature = "gui")]
@@ -41,9 +45,15 @@ fn main() {
     cli.spawn_connections(&mut app);
 
     match cli.mode {
-        #[cfg(feature = "client")]
+        #[cfg(all(feature = "client", any(not(feature = "p2p"), feature = "netcode")))]
         Some(Mode::Client { .. }) => {
             app.add_plugins(ExampleClientPlugin);
+            enable_prediction(&mut app);
+            add_input_delay(&mut app);
+        }
+        #[cfg(feature = "p2p")]
+        Some(Mode::P2P { .. }) => {
+            app.add_plugins((ExampleClientPlugin, ExampleP2PPlugin));
             enable_prediction(&mut app);
             add_input_delay(&mut app);
         }

--- a/examples/deterministic_replication/src/main.rs
+++ b/examples/deterministic_replication/src/main.rs
@@ -44,6 +44,7 @@ fn main() {
         #[cfg(feature = "client")]
         Some(Mode::Client { .. }) => {
             app.add_plugins(ExampleClientPlugin);
+            enable_prediction(&mut app);
             add_input_delay(&mut app);
         }
         #[cfg(feature = "server")]
@@ -70,26 +71,27 @@ fn main() {
 }
 
 #[cfg(feature = "client")]
-fn add_input_delay(app: &mut App) {
-    use lightyear::prelude::client::{InputDelayConfig, InputTimelineConfig};
-    use lightyear::prelude::{Client, PredictionManager, RollbackMode, RollbackPolicy, SyncConfig};
-    let client = app
-        .world_mut()
-        .query_filtered::<Entity, With<Client>>()
-        .single(app.world_mut())
-        .unwrap();
+fn enable_prediction(app: &mut App) {
+    use lightyear::prelude::{PredictionManager, RollbackMode, RollbackPolicy};
 
-    // set some input-delay since we are predicting all entities
-    app.world_mut()
-        .entity_mut(client)
-        .insert(PredictionManager {
-            rollback_policy: RollbackPolicy {
-                state: RollbackMode::Disabled,
-                input: RollbackMode::Check,
-                max_rollback_ticks: 100,
-            },
-            ..default()
-        });
+    app.insert_resource(PredictionManager {
+        rollback_policy: RollbackPolicy {
+            state: RollbackMode::Disabled,
+            input: RollbackMode::Check,
+            max_rollback_ticks: 100,
+        },
+        ..default()
+    });
+}
+
+#[cfg(feature = "client")]
+fn add_input_delay(app: &mut App) {
+    use lightyear::prelude::SyncConfig;
+    use lightyear::prelude::client::{InputDelayConfig, InputTimelineConfig};
+
+    // Set some input delay since a remote client predicts all deterministic entities. The
+    // host-client uses the same delayed input timeline but does not enable rollback for its
+    // authoritative in-process simulation.
     app.insert_resource(
         InputTimelineConfig::default()
             .with_sync_config(SyncConfig {

--- a/examples/deterministic_replication/src/main.rs
+++ b/examples/deterministic_replication/src/main.rs
@@ -89,15 +89,15 @@ fn add_input_delay(app: &mut App) {
                 max_rollback_ticks: 100,
             },
             ..default()
-        })
-        .insert(
-            InputTimelineConfig::default()
-                .with_sync_config(SyncConfig {
-                    jitter_margin: input_sync_margin_ticks(),
-                    ..default()
-                })
-                .with_input_delay(InputDelayConfig::fixed_input_delay(input_delay_ticks())),
-        );
+        });
+    app.insert_resource(
+        InputTimelineConfig::default()
+            .with_sync_config(SyncConfig {
+                jitter_margin: input_sync_margin_ticks(),
+                ..default()
+            })
+            .with_input_delay(InputDelayConfig::fixed_input_delay(input_delay_ticks())),
+    );
 }
 
 #[cfg(feature = "client")]

--- a/examples/deterministic_replication/src/p2p.rs
+++ b/examples/deterministic_replication/src/p2p.rs
@@ -1,0 +1,73 @@
+//! Direct P2P setup for the deterministic Avian simulation.
+//!
+//! Every peer creates the same fixed physics world and player roster locally. No entity state is
+//! replicated and no peer is authoritative; only tick-indexed player inputs cross the network.
+
+use crate::protocol::{PlayerActions, PlayerActivationTick, PlayerId};
+use crate::shared;
+use bevy::prelude::*;
+use leafwing_input_manager::prelude::ActionState;
+use lightyear::input::leafwing::prelude::LeafwingBuffer;
+use lightyear::prediction::rollback::DeterministicPredicted;
+use lightyear::prelude::input::client::InputSystems;
+use lightyear::prelude::*;
+use lightyear_deterministic_replication::prelude::CatchUpMode;
+use lightyear_examples_common::p2p::{
+    GAMEPLAY_START_TICK, P2PGameplayStarted, P2PSettings, input_target_for_peer,
+};
+
+/// Namespace for stable deterministic-replication player hashes on the input wire.
+const PLAYER_INPUT_HASH_BASE: u64 = 0x4445_5445_524D_0000;
+
+pub struct ExampleP2PPlugin;
+
+impl Plugin for ExampleP2PPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(
+            FixedPreUpdate,
+            spawn_fixed_world.before(InputSystems::BufferClientInputs),
+        );
+    }
+}
+
+/// Start the complete deterministic world in stable order once timeline synchronization finishes.
+fn spawn_fixed_world(
+    mut commands: Commands,
+    _synced: SyncedInputTimeline,
+    timeline: Res<LocalTimeline>,
+    mode: Res<CatchUpMode>,
+    started: Option<Res<P2PGameplayStarted>>,
+    settings: Res<P2PSettings>,
+    links: Query<(Entity, &RemoteId), With<P2P>>,
+) {
+    if started.is_some() || timeline.tick().0 < GAMEPLAY_START_TICK {
+        return;
+    }
+    commands.insert_resource(P2PGameplayStarted);
+
+    // P2P has no authoritative state source, so every peer starts from the same input-only world.
+    debug_assert_eq!(*mode, CatchUpMode::InputOnly);
+    shared::spawn_world(&mut commands, &mode, false, true);
+
+    for peer_id in settings.peer_ids() {
+        let id = PeerId::Entity(u64::from(peer_id));
+        let input_target = input_target_for_peer(
+            &settings,
+            &links,
+            peer_id,
+            PLAYER_INPUT_HASH_BASE | u64::from(peer_id),
+        );
+        commands.spawn((
+            PlayerId(id),
+            PlayerActivationTick(Tick(GAMEPLAY_START_TICK)),
+            shared::player_bundle(id),
+            DeterministicPredicted {
+                skip_despawn: true,
+                enable_rollback_after: 0,
+            },
+            input_target,
+            ActionState::<PlayerActions>::default(),
+            LeafwingBuffer::<PlayerActions>::default(),
+        ));
+    }
+}

--- a/examples/deterministic_replication/src/protocol.rs
+++ b/examples/deterministic_replication/src/protocol.rs
@@ -8,7 +8,10 @@ use leafwing_input_manager::prelude::*;
 use lightyear::input::config::InputConfig;
 use lightyear::prelude::input::leafwing;
 use lightyear::prelude::*;
+use lightyear_deterministic_replication::prelude::DeterministicReplicationPlugin;
 use lightyear_deterministic_replication::prelude::{AppCatchUpExt, CatchUpGated, ChecksumPlugin};
+#[cfg(feature = "p2p")]
+use lightyear_examples_common::p2p::P2PSettings;
 use serde::{Deserialize, Serialize};
 
 pub const BALL_SIZE: f32 = 15.0;
@@ -94,6 +97,11 @@ pub(crate) struct ProtocolPlugin;
 
 impl Plugin for ProtocolPlugin {
     fn build(&self, app: &mut App) {
+        #[cfg(feature = "p2p")]
+        let is_p2p = app.world().contains_resource::<P2PSettings>();
+        #[cfg(not(feature = "p2p"))]
+        let is_p2p = false;
+
         // inputs
         app.add_plugins(leafwing::InputPlugin::<PlayerActions> {
             config: InputConfig {
@@ -101,7 +109,13 @@ impl Plugin for ProtocolPlugin {
                 ..default()
             },
         });
-        app.add_plugins(ChecksumPlugin);
+        if is_p2p {
+            // The current checksum sender targets one conventional server Link. P2P checksums
+            // will be enabled once the deterministic protocol supports all-to-all validation.
+            app.add_plugins(DeterministicReplicationPlugin);
+        } else {
+            app.add_plugins(ChecksumPlugin);
+        }
 
         // Late-join catch-up: shared between client and server so it must
         // be registered before `cli.spawn_connections` adds the Client /
@@ -109,12 +123,14 @@ impl Plugin for ProtocolPlugin {
         // would fail because the archetype already exists). Registered in
         // ProtocolPlugin (loaded by SharedPlugin) so it runs before the
         // CLI spawns the networking entities.
-        app.add_plugins(lightyear_deterministic_replication::prelude::LateJoinCatchUpPlugin);
-        app.register_catchup_filter::<
-            (Position, Rotation, LinearVelocity, AngularVelocity),
-            leafwing::LeafwingSequence<PlayerActions>,
-        >();
-        register_avian_catchup_resources(app, false);
+        if !is_p2p {
+            app.add_plugins(lightyear_deterministic_replication::prelude::LateJoinCatchUpPlugin);
+            app.register_catchup_filter::<
+                (Position, Rotation, LinearVelocity, AngularVelocity),
+                leafwing::LeafwingSequence<PlayerActions>,
+            >();
+            register_avian_catchup_resources(app, false);
+        }
 
         // components
         app.component::<PlayerId>().replicate();

--- a/examples/deterministic_replication/src/shared.rs
+++ b/examples/deterministic_replication/src/shared.rs
@@ -8,6 +8,8 @@ use lightyear::prediction::rollback::{CatchUpGated, DeterministicPredicted};
 use lightyear::prelude::*;
 use lightyear_avian2d::plugin::AvianReplicationMode;
 use lightyear_deterministic_replication::prelude::CatchUpMode;
+#[cfg(feature = "p2p")]
+use lightyear_examples_common::p2p::P2PSettings;
 use lightyear_frame_interpolation::{FrameInterpolate, FrameInterpolationPlugin};
 
 const MAX_VELOCITY: f32 = 200.0;
@@ -22,9 +24,16 @@ pub struct SharedPlugin;
 impl Plugin for SharedPlugin {
     fn build(&self, app: &mut App) {
         app.add_plugins(ProtocolPlugin);
-        app.insert_resource(catch_up_mode_from_env());
+        let is_p2p = is_p2p(app);
+        app.insert_resource(if is_p2p {
+            CatchUpMode::InputOnly
+        } else {
+            catch_up_mode_from_env()
+        });
         // bundles
-        app.add_systems(Startup, init);
+        if !is_p2p {
+            app.add_systems(Startup, init);
+        }
 
         // Visual correction uses the same history and scheduling as frame
         // interpolation, so install it in shared code for both GUI and headless
@@ -64,6 +73,17 @@ impl Plugin for SharedPlugin {
         app.add_systems(FixedUpdate, player_movement);
 
         crate::debug::register_debug_systems(app);
+    }
+}
+
+fn is_p2p(app: &App) -> bool {
+    #[cfg(feature = "p2p")]
+    {
+        app.world().contains_resource::<P2PSettings>()
+    }
+    #[cfg(not(feature = "p2p"))]
+    {
+        false
     }
 }
 
@@ -115,7 +135,16 @@ pub(crate) fn init(
     let is_server = server.is_some();
     let is_client = client.is_some();
 
-    spawn_ball(&mut commands, &mode, is_server, is_client);
+    spawn_world(&mut commands, &mode, is_server, is_client);
+}
+
+pub(crate) fn spawn_world(
+    commands: &mut Commands,
+    mode: &CatchUpMode,
+    is_server: bool,
+    is_client: bool,
+) {
+    spawn_ball(commands, mode, is_server, is_client);
     commands.spawn(WallBundle::new(
         Vec2::new(-WALL_SIZE, -WALL_SIZE),
         Vec2::new(-WALL_SIZE, WALL_SIZE),

--- a/examples/fps/Cargo.toml
+++ b/examples/fps/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 publish = false
 
 [features]
-default = ["client", "gui", "server", "netcode", "webtransport"]
+default = ["client", "gui", "server", "p2p", "netcode", "webtransport"]
 client = ["lightyear/client", "lightyear_examples_common/client"]
 gui = ["lightyear_examples_common/gui2d"]
 server = [
@@ -16,6 +16,13 @@ server = [
   "lightyear_examples_common/server",
 ]
 netcode = ["lightyear_examples_common/netcode"]
+p2p = [
+  "client",
+  "udp",
+  "lightyear/deterministic",
+  "lightyear/p2p",
+  "lightyear_examples_common/p2p",
+]
 webtransport = ["lightyear_examples_common/webtransport"]
 udp = ["lightyear_examples_common/udp", "lightyear/std", "lightyear/udp"]
 
@@ -39,6 +46,7 @@ lightyear_examples_common = { workspace = true, features = [
   "structured-debug",
 ] }
 lightyear_frame_interpolation.workspace = true
+lightyear_deterministic_replication.workspace = true
 lightyear_avian2d = { workspace = true, features = ["2d", "lag_compensation"] }
 
 leafwing-input-manager.workspace = true

--- a/examples/fps/README.md
+++ b/examples/fps/README.md
@@ -54,6 +54,14 @@ https://github.com/user-attachments/assets/17bc985d-f700-439d-ba48-4c69fbfd7885
 - Run the server without a gui: `cargo run --no-default-features --features=server -- server`
 - Run the client and server in "HostClient" mode, where the client also acts as server (both are in the same App) : `cargo run -- host-client -c 0`
 
+### P2P mode
+
+The example can also run as a deterministic input-only game with no server. Start peer 0 with
+`cargo run --no-default-features --features=p2p -- --headless p2p --peer-id 0 --player-count 2`
+and peer 1 with the same command using `--peer-id 1`. This mode simulates both targets and hit
+detection on every peer; the conventional mode remains the example of server-side lag
+compensation.
+
 You can control the behaviour of the example by changing the list of features. By default, all features are enabled (client, server, gui).
 For example you can run the server in headless mode (without gui) by running `cargo run --no-default-features --features=server,webtransport,netcode`.
 

--- a/examples/fps/src/automation.rs
+++ b/examples/fps/src/automation.rs
@@ -1,7 +1,7 @@
 use avian2d::prelude::Position;
 use bevy::prelude::*;
 use leafwing_input_manager::plugin::InputManagerSystem;
-use leafwing_input_manager::prelude::ActionState;
+use leafwing_input_manager::prelude::{ActionState, InputMap};
 use lightyear::input::client::InputSystems;
 use lightyear::prelude::*;
 use lightyear_examples_common::automation::{
@@ -129,7 +129,10 @@ mod client {
             (Entity, &Transform, Has<PredictedBot>, Has<InterpolatedBot>),
             Or<(With<PredictedBot>, With<InterpolatedBot>)>,
         >,
-        mut actions: Query<&mut ActionState<PlayerActions>, With<Predicted>>,
+        mut actions: Query<
+            &mut ActionState<PlayerActions>,
+            Or<(With<Predicted>, With<InputMap<PlayerActions>>)>,
+        >,
         mut previous_target: Local<Option<(Entity, AimTarget, Vec2)>>,
     ) {
         let target = bots.iter().find_map(

--- a/examples/fps/src/client.rs
+++ b/examples/fps/src/client.rs
@@ -64,7 +64,10 @@ fn strip_interpolated_bullet_local_physics(
 fn suppress_shoot_until_synced(
     host_server: Query<(), With<HostServer>>,
     input_timeline: Option<SyncedInputTimeline>,
-    mut action_state_query: Query<&mut ActionState<PlayerActions>, With<Predicted>>,
+    mut action_state_query: Query<
+        &mut ActionState<PlayerActions>,
+        Or<(With<Predicted>, With<InputMap<PlayerActions>>)>,
+    >,
 ) {
     if !host_server.is_empty() || input_timeline.is_some() {
         return;
@@ -78,7 +81,10 @@ fn suppress_shoot_until_synced(
 fn update_cursor_state_from_window(
     window: Option<Single<&Window>>,
     q_camera: Query<(&Camera, &GlobalTransform)>,
-    mut action_state_query: Query<&mut ActionState<PlayerActions>, With<Predicted>>,
+    mut action_state_query: Query<
+        &mut ActionState<PlayerActions>,
+        Or<(With<Predicted>, With<InputMap<PlayerActions>>)>,
+    >,
 ) {
     if automation_aim_target_enabled() {
         return;
@@ -144,13 +150,17 @@ pub(crate) fn handle_controlled_spawn(
     if player_query.get(entity).is_err() {
         return;
     };
-    commands.entity(entity).insert(InputMap::new([
+    commands.entity(entity).insert(player_input_map());
+}
+
+pub(crate) fn player_input_map() -> InputMap<PlayerActions> {
+    InputMap::new([
         (PlayerActions::Up, KeyCode::KeyW),
         (PlayerActions::Down, KeyCode::KeyS),
         (PlayerActions::Left, KeyCode::KeyA),
         (PlayerActions::Right, KeyCode::KeyD),
         (PlayerActions::Shoot, KeyCode::Space),
-    ]));
+    ])
 }
 
 pub(crate) fn handle_interpolated_spawn(

--- a/examples/fps/src/client.rs
+++ b/examples/fps/src/client.rs
@@ -63,10 +63,10 @@ fn strip_interpolated_bullet_local_physics(
 
 fn suppress_shoot_until_synced(
     host_server: Query<(), With<HostServer>>,
-    synced_client: Query<(), (With<Client>, With<IsSynced<InputTimeline>>)>,
+    input_timeline: Option<SyncedInputTimeline>,
     mut action_state_query: Query<&mut ActionState<PlayerActions>, With<Predicted>>,
 ) {
-    if !host_server.is_empty() || !synced_client.is_empty() {
+    if !host_server.is_empty() || input_timeline.is_some() {
         return;
     }
     for mut action_state in &mut action_state_query {

--- a/examples/fps/src/debug.rs
+++ b/examples/fps/src/debug.rs
@@ -213,10 +213,10 @@ fn track_bullet_lifecycle_added(
         ),
         Added<BulletMarker>,
     >,
-    rollback: Query<(), With<Rollback>>,
+    rollback: Option<Res<Rollback>>,
 ) {
     let tick = timeline.tick();
-    let in_rollback = !rollback.is_empty();
+    let in_rollback = rollback.is_some();
     for (
         entity,
         marker,
@@ -258,10 +258,10 @@ fn track_bullet_lifecycle_removed(
     timeline: Res<LocalTimeline>,
     mut registry: ResMut<BulletDebugRegistry>,
     mut removed: RemovedComponents<BulletMarker>,
-    rollback: Query<(), With<Rollback>>,
+    rollback: Option<Res<Rollback>>,
 ) {
     let tick = timeline.tick();
-    let in_rollback = !rollback.is_empty();
+    let in_rollback = rollback.is_some();
     for entity in removed.read() {
         let marker = registry.bullets.remove(&entity);
         lightyear_debug_event!(
@@ -298,7 +298,7 @@ fn detect_duplicate_bullets(
         ),
         With<BulletMarker>,
     >,
-    rollback: Query<(), With<Rollback>>,
+    rollback: Option<Res<Rollback>>,
 ) {
     #[derive(Debug)]
     struct BulletDuplicateState {
@@ -314,7 +314,7 @@ fn detect_duplicate_bullets(
     }
 
     let tick = timeline.tick();
-    let in_rollback = !rollback.is_empty();
+    let in_rollback = rollback.is_some();
     let mut groups: HashMap<u64, Vec<BulletDuplicateState>> = HashMap::new();
     for (
         entity,

--- a/examples/fps/src/main.rs
+++ b/examples/fps/src/main.rs
@@ -9,6 +9,8 @@ use lightyear_examples_common::shared::FIXED_TIMESTEP_HZ;
 
 #[cfg(feature = "client")]
 use crate::client::ExampleClientPlugin;
+#[cfg(feature = "p2p")]
+use crate::p2p::ExampleP2PPlugin;
 #[cfg(feature = "server")]
 use crate::server::ExampleServerPlugin;
 use crate::shared::SharedPlugin;
@@ -17,6 +19,8 @@ mod automation;
 #[cfg(feature = "client")]
 mod client;
 mod debug;
+#[cfg(feature = "p2p")]
+mod p2p;
 mod protocol;
 
 #[cfg(feature = "gui")]
@@ -37,9 +41,13 @@ fn main() {
     cli.spawn_connections(&mut app);
 
     match cli.mode {
-        #[cfg(feature = "client")]
+        #[cfg(all(feature = "client", any(not(feature = "p2p"), feature = "netcode")))]
         Some(Mode::Client { .. }) => {
             app.add_plugins(ExampleClientPlugin);
+        }
+        #[cfg(feature = "p2p")]
+        Some(Mode::P2P { .. }) => {
+            app.add_plugins((ExampleClientPlugin, ExampleP2PPlugin));
         }
         #[cfg(feature = "server")]
         Some(Mode::Server) => {

--- a/examples/fps/src/p2p.rs
+++ b/examples/fps/src/p2p.rs
@@ -1,0 +1,167 @@
+//! Deterministic input-only P2P setup for the FPS example.
+//!
+//! Server-only lag compensation is intentionally absent. Both bots, every player, projectiles,
+//! scores, and hit prediction instead live in the same deterministic simulation on every peer.
+
+use avian2d::prelude::*;
+use bevy::prelude::*;
+use lightyear::prediction::rollback::DeterministicPredicted;
+use lightyear::prelude::input::client::InputSystems;
+use lightyear::prelude::input::leafwing::LeafwingBuffer;
+use lightyear::prelude::*;
+use lightyear_deterministic_replication::prelude::DeterministicReplicationPlugin;
+use lightyear_examples_common::p2p::{
+    input_target_for_peer, P2PGameplayStarted, P2PSettings, GAMEPLAY_START_TICK,
+};
+use lightyear_frame_interpolation::FrameInterpolate;
+
+use crate::client::player_input_map;
+use crate::protocol::*;
+use crate::shared::{color_from_id, BOT_RADIUS};
+
+const PLAYER_INPUT_HASH_BASE: u64 = 0x4650_5300_0000_0000;
+
+#[derive(Component)]
+struct PendingLocalInput(Tick);
+
+pub struct ExampleP2PPlugin;
+
+impl Plugin for ExampleP2PPlugin {
+    fn build(&self, app: &mut App) {
+        app.insert_resource(PredictionManager::default());
+        app.add_plugins(DeterministicReplicationPlugin);
+        app.add_systems(
+            FixedPreUpdate,
+            spawn_fixed_world.before(InputSystems::BufferClientInputs),
+        );
+        app.add_systems(
+            FixedPostUpdate,
+            enable_local_input.after(PredictionSystems::UpdateHistory),
+        );
+
+        app.add_systems(
+            FixedPostUpdate,
+            compute_hits.after(PhysicsSystems::StepSimulation),
+        );
+    }
+}
+
+fn compute_hits(
+    mut commands: Commands,
+    spatial_query: SpatialQuery,
+    bullets: Query<(Entity, &PlayerId, &Position, &LinearVelocity), With<BulletMarker>>,
+    bots: Query<(), With<PredictedBot>>,
+    mut players: Query<(&mut Score, &PlayerId), With<PlayerMarker>>,
+) {
+    const COLLISION_DISTANCE: f32 = 4.0;
+    for (entity, shooter, position, velocity) in &bullets {
+        let Some(_hit) = spatial_query.cast_ray_predicate(
+            position.0,
+            Dir2::new_unchecked(velocity.0.normalize()),
+            COLLISION_DISTANCE,
+            false,
+            &SpatialQueryFilter::default(),
+            &|entity| bots.get(entity).is_ok(),
+        ) else {
+            continue;
+        };
+        if let Some((mut score, _)) = players.iter_mut().find(|(_, id)| id.0 == shooter.0) {
+            score.0 += 1;
+        }
+        commands.entity(entity).prediction_despawn();
+    }
+}
+
+fn spawn_fixed_world(
+    mut commands: Commands,
+    _synced: SyncedInputTimeline,
+    timeline: Res<LocalTimeline>,
+    started: Option<Res<P2PGameplayStarted>>,
+    settings: Res<P2PSettings>,
+    links: Query<(Entity, &RemoteId), With<P2P>>,
+) {
+    if started.is_some() || timeline.tick().0 < GAMEPLAY_START_TICK {
+        return;
+    }
+    commands.insert_resource(P2PGameplayStarted);
+
+    commands.spawn((
+        PredictedBot,
+        Name::new("P2P Predicted Bot"),
+        Position::from_xy(200.0, 10.0),
+        Rotation::default(),
+        RigidBody::Kinematic,
+        Collider::circle(BOT_RADIUS),
+        DeterministicPredicted {
+            skip_despawn: true,
+            enable_rollback_after: 0,
+        },
+        FrameInterpolate,
+    ));
+    commands.spawn((
+        InterpolatedBot,
+        Name::new("P2P Second Bot"),
+        Position::from_xy(-200.0, 10.0),
+        Rotation::default(),
+        RigidBody::Kinematic,
+        Collider::circle(BOT_RADIUS),
+        DeterministicPredicted {
+            skip_despawn: true,
+            enable_rollback_after: 0,
+        },
+        FrameInterpolate,
+    ));
+
+    let spacing = 100.0;
+    let center = (f32::from(settings.player_count) - 1.0) * 0.5;
+    for peer_id in settings.peer_ids() {
+        let id = PeerId::Entity(u64::from(peer_id));
+        let target = input_target_for_peer(
+            &settings,
+            &links,
+            peer_id,
+            PLAYER_INPUT_HASH_BASE | u64::from(peer_id),
+        );
+        let player = commands
+            .spawn((
+                Score(0),
+                PlayerId(id),
+                RigidBody::Kinematic,
+                Position::from_xy(0.0, (f32::from(peer_id) - center) * spacing),
+                Rotation::default(),
+                ColorComponent(color_from_id(id)),
+                PlayerMarker,
+                DeterministicPredicted {
+                    skip_despawn: true,
+                    enable_rollback_after: 0,
+                },
+                target,
+                LeafwingBuffer::<PlayerActions>::default(),
+                FrameInterpolate,
+                Name::new("P2P Player"),
+            ))
+            .id();
+        if peer_id == settings.local_peer_id {
+            commands
+                .entity(player)
+                .insert(PendingLocalInput(timeline.tick()));
+        }
+    }
+}
+
+/// Enable local input after the initial Avian rollback state has been recorded.
+fn enable_local_input(
+    mut commands: Commands,
+    timeline: Res<LocalTimeline>,
+    local_players: Query<(Entity, &PendingLocalInput)>,
+) {
+    for (entity, pending) in &local_players {
+        if timeline.tick() <= pending.0 {
+            continue;
+        }
+        commands
+            .entity(entity)
+            .insert(player_input_map())
+            .remove::<PendingLocalInput>();
+    }
+}

--- a/examples/fps/src/renderer.rs
+++ b/examples/fps/src/renderer.rs
@@ -7,8 +7,8 @@ use bevy::ecs::query::QueryFilter;
 use bevy::prelude::*;
 use lightyear::connection::host::HostServer;
 use lightyear::prelude::{
-    lightyear_debug_event, Client, DebugCategory, DebugSamplePoint, InputTimeline, Interpolated,
-    IsSynced, LocalTimeline, PreSpawned, Predicted, Replicate, Replicated, Server,
+    lightyear_debug_event, Client, DebugCategory, DebugSamplePoint, Interpolated, IsSynced,
+    LocalTimeline, PreSpawned, Predicted, Replicate, Replicated, Server,
 };
 #[cfg(feature = "client")]
 use lightyear::prelude::{

--- a/examples/fps/src/shared.rs
+++ b/examples/fps/src/shared.rs
@@ -118,7 +118,7 @@ fn player_movement(
     timeline: Res<LocalTimeline>,
     client: Query<(), With<Client>>,
     host_server: Query<(), With<HostServer>>,
-    synced_client: Query<(), (With<Client>, With<IsSynced<InputTimeline>>)>,
+    input_timeline: Option<SyncedInputTimeline>,
     mut player_query: Query<
         (
             &mut Position,
@@ -132,7 +132,7 @@ fn player_movement(
 ) {
     let has_client = !client.is_empty();
     let is_host_server = !host_server.is_empty();
-    let client_is_synced = !synced_client.is_empty();
+    let client_is_synced = input_timeline.is_some();
     for (position, rotation, action_state, player_id, is_predicted) in player_query.iter_mut() {
         if should_skip_client_side_entity(
             has_client,
@@ -167,7 +167,7 @@ pub(crate) fn shoot_bullet(
     timeline: Res<LocalTimeline>,
     client: Query<(), With<Client>>,
     host_server: Query<(), With<HostServer>>,
-    synced_client: Query<(), (With<Client>, With<IsSynced<InputTimeline>>)>,
+    input_timeline: Option<SyncedInputTimeline>,
     mut query: Query<
         (
             &PlayerId,
@@ -185,7 +185,7 @@ pub(crate) fn shoot_bullet(
     let tick = timeline.tick();
     let has_client = !client.is_empty();
     let is_host_server = !host_server.is_empty();
-    let client_is_synced = !synced_client.is_empty();
+    let client_is_synced = input_timeline.is_some();
     for (id, position, rotation, color, action, input_buffer, controlled_by, is_predicted) in
         query.iter_mut()
     {

--- a/examples/fps/src/shared.rs
+++ b/examples/fps/src/shared.rs
@@ -15,12 +15,20 @@ pub const BOT_RADIUS: f32 = 15.0;
 pub(crate) const BOT_MOVE_SPEED: f32 = 1.0;
 const BULLET_MOVE_SPEED: f32 = 300.0;
 const MAP_LIMIT: f32 = 2000.0;
+const P2P_BULLET_LIFETIME_TICKS: i32 = 120;
 
 #[derive(Clone)]
 pub struct SharedPlugin;
 
 impl Plugin for SharedPlugin {
     fn build(&self, app: &mut App) {
+        #[cfg(feature = "p2p")]
+        let rollback_resources = app
+            .world()
+            .contains_resource::<lightyear_examples_common::p2p::P2PSettings>();
+        #[cfg(not(feature = "p2p"))]
+        let rollback_resources = false;
+
         app.add_plugins(ProtocolPlugin);
         crate::debug::register_debug_systems(app);
 
@@ -33,6 +41,7 @@ impl Plugin for SharedPlugin {
             },
             // This example keeps custom physics-component rules in its protocol.
             register_physics_components: false,
+            rollback_resources,
             ..default()
         });
 
@@ -41,7 +50,13 @@ impl Plugin for SharedPlugin {
         // Physics-based systems that can roll back must run in FixedUpdate.
         app.add_systems(
             FixedUpdate,
-            (predicted_bot_movement, player_movement, shoot_bullet).chain(),
+            (
+                predicted_bot_movement,
+                player_movement,
+                shoot_bullet,
+                despawn_p2p_bullets,
+            )
+                .chain(),
         );
         // both client and server need physics
         // (the client also needs the physics plugin to be able to compute predicted bullet hits)
@@ -126,18 +141,28 @@ fn player_movement(
             &ActionState<PlayerActions>,
             &PlayerId,
             Has<Predicted>,
+            Has<DeterministicPredicted>,
         ),
-        (Or<(With<Predicted>, With<Replicate>)>, With<PlayerMarker>),
+        (
+            Or<(
+                With<Predicted>,
+                With<Replicate>,
+                With<DeterministicPredicted>,
+            )>,
+            With<PlayerMarker>,
+        ),
     >,
 ) {
     let has_client = !client.is_empty();
     let is_host_server = !host_server.is_empty();
     let client_is_synced = input_timeline.is_some();
-    for (position, rotation, action_state, player_id, is_predicted) in player_query.iter_mut() {
+    for (position, rotation, action_state, player_id, is_predicted, is_deterministic) in
+        player_query.iter_mut()
+    {
         if should_skip_client_side_entity(
             has_client,
             is_host_server,
-            is_predicted,
+            is_predicted || is_deterministic,
             client_is_synced,
         ) {
             continue;
@@ -168,6 +193,7 @@ pub(crate) fn shoot_bullet(
     client: Query<(), With<Client>>,
     host_server: Query<(), With<HostServer>>,
     input_timeline: Option<SyncedInputTimeline>,
+    metadata: Res<NetworkingMetadata>,
     mut query: Query<
         (
             &PlayerId,
@@ -178,21 +204,39 @@ pub(crate) fn shoot_bullet(
             &LeafwingBuffer<PlayerActions>,
             Option<&ControlledBy>,
             Has<Predicted>,
+            Has<DeterministicPredicted>,
         ),
-        (Or<(With<Predicted>, With<Replicate>)>, With<PlayerMarker>),
+        (
+            Or<(
+                With<Predicted>,
+                With<Replicate>,
+                With<DeterministicPredicted>,
+            )>,
+            With<PlayerMarker>,
+        ),
     >,
 ) {
     let tick = timeline.tick();
     let has_client = !client.is_empty();
     let is_host_server = !host_server.is_empty();
     let client_is_synced = input_timeline.is_some();
-    for (id, position, rotation, color, action, input_buffer, controlled_by, is_predicted) in
-        query.iter_mut()
+    let is_p2p = matches!(metadata.mode, NetworkTopology::P2P { .. });
+    for (
+        id,
+        position,
+        rotation,
+        color,
+        action,
+        input_buffer,
+        controlled_by,
+        is_predicted,
+        is_deterministic,
+    ) in query.iter_mut()
     {
         if should_skip_client_side_entity(
             has_client,
             is_host_server,
-            is_predicted,
+            is_predicted || is_deterministic,
             client_is_synced,
         ) {
             continue;
@@ -238,6 +282,14 @@ pub(crate) fn shoot_bullet(
                         controlled_by,
                     ))
                     .id()
+            } else if is_p2p {
+                commands
+                    .spawn((
+                        bullet_bundle,
+                        PreSpawned::new(prespawn_hash),
+                        DeterministicPredicted::default(),
+                    ))
+                    .id()
             } else {
                 commands
                     .spawn((bullet_bundle, PreSpawned::new(prespawn_hash)))
@@ -245,9 +297,19 @@ pub(crate) fn shoot_bullet(
             };
             #[cfg(not(feature = "server"))]
             let bullet_entity = {
-                commands
-                    .spawn((bullet_bundle, PreSpawned::new(prespawn_hash)))
-                    .id()
+                if is_p2p {
+                    commands
+                        .spawn((
+                            bullet_bundle,
+                            PreSpawned::new(prespawn_hash),
+                            DeterministicPredicted::default(),
+                        ))
+                        .id()
+                } else {
+                    commands
+                        .spawn((bullet_bundle, PreSpawned::new(prespawn_hash)))
+                        .id()
+                }
             };
             lightyear_debug_event!(
                 DebugCategory::Prediction,
@@ -280,6 +342,20 @@ fn shoot_pressed_this_tick(input_buffer: &LeafwingBuffer<PlayerActions>, tick: T
         .get(tick - 1)
         .is_some_and(|snapshot| snapshot.0.pressed(&PlayerActions::Shoot));
     current_pressed && !previous_pressed
+}
+
+/// Despawn input-only P2P bullets on a deterministic tick boundary.
+fn despawn_p2p_bullets(
+    mut commands: Commands,
+    timeline: Res<LocalTimeline>,
+    bullets: Query<(Entity, &BulletMarker), With<DeterministicPredicted>>,
+) {
+    let tick = timeline.tick();
+    for (entity, bullet) in &bullets {
+        if tick - bullet.fire_tick >= P2P_BULLET_LIFETIME_TICKS {
+            commands.entity(entity).prediction_despawn();
+        }
+    }
 }
 
 #[derive(Component)]

--- a/examples/lobby/src/renderer.rs
+++ b/examples/lobby/src/renderer.rs
@@ -6,8 +6,8 @@ use lightyear::connection::host::HostServer;
 use lightyear::interpolation::Interpolated;
 use lightyear::prediction::Predicted;
 use lightyear::prelude::{
-    lightyear_debug_event, Client, DebugCategory, DebugSamplePoint, InputTimeline,
-    InterpolationTimeline, IsSynced,
+    lightyear_debug_event, Client, DebugCategory, DebugSamplePoint, InterpolationTimeline,
+    IsSynced, SyncedInputTimeline,
 };
 
 #[derive(Clone)]
@@ -37,12 +37,12 @@ struct VisualPlayerPosition {
 fn client_visuals_ready(
     client: &Query<(), With<Client>>,
     host_server: &Query<(), With<HostServer>>,
-    input_synced: &Query<(), (With<Client>, With<IsSynced<InputTimeline>>)>,
+    input_timeline_is_synced: bool,
     interpolation_synced: &Query<(), (With<Client>, With<IsSynced<InterpolationTimeline>>)>,
 ) -> bool {
     client.is_empty()
         || !host_server.is_empty()
-        || (!input_synced.is_empty() && !interpolation_synced.is_empty())
+        || (input_timeline_is_synced && !interpolation_synced.is_empty())
 }
 
 fn ensure_player_visual_positions(
@@ -57,10 +57,15 @@ fn ensure_player_visual_positions(
     >,
     client: Query<(), With<Client>>,
     host_server: Query<(), With<HostServer>>,
-    input_synced: Query<(), (With<Client>, With<IsSynced<InputTimeline>>)>,
+    input_timeline: Option<SyncedInputTimeline>,
     interpolation_synced: Query<(), (With<Client>, With<IsSynced<InterpolationTimeline>>)>,
 ) {
-    if !client_visuals_ready(&client, &host_server, &input_synced, &interpolation_synced) {
+    if !client_visuals_ready(
+        &client,
+        &host_server,
+        input_timeline.is_some(),
+        &interpolation_synced,
+    ) {
         return;
     }
     for (entity, position) in &players {

--- a/examples/network_visibility/Cargo.toml
+++ b/examples/network_visibility/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT OR Apache-2.0"
 publish = false
 
 [features]
-default = ["client", "gui", "server", "netcode", "webtransport"]
+default = ["client", "gui", "server", "p2p", "netcode", "webtransport"]
 client = ["lightyear/client", "lightyear_examples_common/client"]
 gui = ["lightyear_examples_common/gui2d"]
 server = [
@@ -22,6 +22,13 @@ server = [
   "lightyear_examples_common/server",
 ]
 netcode = ["lightyear_examples_common/netcode"]
+p2p = [
+  "client",
+  "udp",
+  "lightyear/deterministic",
+  "lightyear/p2p",
+  "lightyear_examples_common/p2p",
+]
 webtransport = ["lightyear_examples_common/webtransport"]
 udp = [
   "lightyear_examples_common/udp",
@@ -40,6 +47,7 @@ lightyear = { workspace = true, features = [
 lightyear_examples_common = { workspace = true, features = [
   "structured-debug",
 ] }
+lightyear_deterministic_replication.workspace = true
 
 serde.workspace = true
 bevy.workspace = true

--- a/examples/network_visibility/README.md
+++ b/examples/network_visibility/README.md
@@ -18,6 +18,14 @@ https://github.com/cBournhonesque/lightyear/assets/8112632/41a6d102-77a1-4a44-89
 - Run the server without a gui: `cargo run --no-default-features --features=server -- server`
 - Run the client and server in "HostClient" mode, where the client also acts as server (both are in the same App) : `cargo run -- host-client -c 0`
 
+### P2P mode
+
+The movement simulation can also run as a deterministic input-only game with no server. Start
+peer 0 with `cargo run --no-default-features --features=p2p -- --headless p2p --peer-id 0 --player-count 2`
+and peer 1 with the same command using `--peer-id 1`. Every peer creates the complete small scene
+locally. Interest management remains a feature of the conventional client/server mode because the
+P2P mode performs no entity replication.
+
 You can control the behaviour of the example by changing the list of features. By default, all features are enabled (client, server, gui).
 For example you can run the server in headless mode (without gui) by running `cargo run --no-default-features --features=server,webtransport,netcode`.
 

--- a/examples/network_visibility/src/client.rs
+++ b/examples/network_visibility/src/client.rs
@@ -53,8 +53,10 @@ pub(crate) fn buffer_input(
 }
 
 pub(crate) fn movement(
-    // TODO: maybe make prediction mode a separate component!!!
-    mut position_query: Query<(&mut Position, &ActionState<Inputs>), With<Predicted>>,
+    mut position_query: Query<
+        (&mut Position, &ActionState<Inputs>),
+        Or<(With<Predicted>, With<DeterministicPredicted>)>,
+    >,
 ) {
     for (position, input) in position_query.iter_mut() {
         shared_movement_behaviour(position, input);

--- a/examples/network_visibility/src/main.rs
+++ b/examples/network_visibility/src/main.rs
@@ -13,6 +13,8 @@
 
 #[cfg(feature = "client")]
 use crate::client::ExampleClientPlugin;
+#[cfg(feature = "p2p")]
+use crate::p2p::ExampleP2PPlugin;
 #[cfg(feature = "server")]
 use crate::server::ExampleServerPlugin;
 use crate::shared::SharedPlugin;
@@ -25,6 +27,8 @@ use lightyear_examples_common::shared::FIXED_TIMESTEP_HZ;
 #[cfg(feature = "client")]
 mod client;
 mod debug;
+#[cfg(feature = "p2p")]
+mod p2p;
 mod protocol;
 #[cfg(feature = "gui")]
 mod renderer;
@@ -45,9 +49,13 @@ fn main() {
     cli.spawn_connections(&mut app);
 
     match cli.mode {
-        #[cfg(feature = "client")]
+        #[cfg(all(feature = "client", any(not(feature = "p2p"), feature = "netcode")))]
         Some(Mode::Client { .. }) => {
             app.add_plugins(ExampleClientPlugin);
+        }
+        #[cfg(feature = "p2p")]
+        Some(Mode::P2P { .. }) => {
+            app.add_plugins((ExampleClientPlugin, ExampleP2PPlugin));
         }
         #[cfg(feature = "server")]
         Some(Mode::Server) => {

--- a/examples/network_visibility/src/p2p.rs
+++ b/examples/network_visibility/src/p2p.rs
@@ -1,0 +1,90 @@
+//! Input-only P2P setup for the network-visibility example.
+//!
+//! Interest management remains a server-side replication demonstration in conventional mode. The
+//! P2P mode creates the complete small scene on every peer and exercises only deterministic player
+//! input exchange.
+
+use bevy::prelude::*;
+use lightyear::prediction::rollback::DeterministicPredicted;
+use lightyear::prelude::input::client::InputSystems;
+use lightyear::prelude::input::native::{ActionState, InputMarker};
+use lightyear::prelude::input::InputBuffer;
+use lightyear::prelude::*;
+use lightyear_deterministic_replication::prelude::DeterministicReplicationPlugin;
+use lightyear_examples_common::p2p::{
+    input_target_for_peer, P2PGameplayStarted, P2PSettings, GAMEPLAY_START_TICK,
+};
+
+use crate::protocol::*;
+use crate::shared::color_from_id;
+
+const PLAYER_INPUT_HASH_BASE: u64 = 0x5649_5349_4200_0000;
+const GRID_SIZE: f32 = 200.0;
+const NUM_CIRCLES: i32 = 1;
+
+pub struct ExampleP2PPlugin;
+
+impl Plugin for ExampleP2PPlugin {
+    fn build(&self, app: &mut App) {
+        app.insert_resource(PredictionManager::default());
+        app.add_plugins(DeterministicReplicationPlugin);
+        app.add_systems(
+            FixedPreUpdate,
+            spawn_fixed_world.before(InputSystems::BufferClientInputs),
+        );
+    }
+}
+
+fn spawn_fixed_world(
+    mut commands: Commands,
+    _synced: SyncedInputTimeline,
+    timeline: Res<LocalTimeline>,
+    started: Option<Res<P2PGameplayStarted>>,
+    settings: Res<P2PSettings>,
+    links: Query<(Entity, &RemoteId), With<P2P>>,
+) {
+    if started.is_some() || timeline.tick().0 < GAMEPLAY_START_TICK {
+        return;
+    }
+    commands.insert_resource(P2PGameplayStarted);
+
+    for x in -NUM_CIRCLES..NUM_CIRCLES {
+        for y in -NUM_CIRCLES..NUM_CIRCLES {
+            commands.spawn((
+                Position(Vec2::new(x as f32 * GRID_SIZE, y as f32 * GRID_SIZE)),
+                CircleMarker,
+            ));
+        }
+    }
+
+    let spacing = 100.0;
+    let center = (f32::from(settings.player_count) - 1.0) * 0.5;
+    for peer_id in settings.peer_ids() {
+        let id = PeerId::Entity(u64::from(peer_id));
+        let target = input_target_for_peer(
+            &settings,
+            &links,
+            peer_id,
+            PLAYER_INPUT_HASH_BASE | u64::from(peer_id),
+        );
+        let player = commands
+            .spawn((
+                PlayerId(id),
+                Position(Vec2::new((f32::from(peer_id) - center) * spacing, 0.0)),
+                PlayerColor(color_from_id(id)),
+                DeterministicPredicted {
+                    skip_despawn: true,
+                    enable_rollback_after: 0,
+                },
+                target,
+                ActionState::<Inputs>::default(),
+                InputBuffer::<ActionState<Inputs>, Inputs>::default(),
+            ))
+            .id();
+        if peer_id == settings.local_peer_id {
+            commands
+                .entity(player)
+                .insert(InputMarker::<Inputs>::default());
+        }
+    }
+}

--- a/examples/priority/src/client.rs
+++ b/examples/priority/src/client.rs
@@ -22,16 +22,16 @@ impl Plugin for ExampleClientPlugin {
     }
 }
 
-fn configure_input_delay(client: Single<Entity, With<Client>>, mut commands: Commands) {
-    commands
-        .entity(client.into_inner())
-        .insert(InputTimelineConfig::default().with_input_delay(InputDelayConfig::balanced()));
+fn configure_input_delay(mut commands: Commands) {
+    commands.insert_resource(
+        InputTimelineConfig::default().with_input_delay(InputDelayConfig::balanced()),
+    );
 }
 
 /// Applies local movement only to predicted entities owned by this client.
 fn player_movement(
     trigger: On<Fire<Movement>>,
-    synced_client: Query<(), (With<Client>, With<IsSynced<InputTimeline>>)>,
+    _input_timeline: SyncedInputTimeline,
     _host_server: Query<(), With<HostServer>>,
     #[cfg(feature = "server")] server_actions: Query<
         (),
@@ -39,9 +39,6 @@ fn player_movement(
     >,
     mut position_query: Query<&mut Position, With<Predicted>>,
 ) {
-    if synced_client.is_empty() {
-        return;
-    }
     #[cfg(feature = "server")]
     if !_host_server.is_empty() && server_actions.contains(trigger.action) {
         return;

--- a/examples/projectiles/src/main.rs
+++ b/examples/projectiles/src/main.rs
@@ -84,8 +84,8 @@ fn update_client(app: &mut App) {
         .unwrap();
 
     // we need to add a ReplicationSender to the client entity to replicate the Action entities to the server
-    app.world_mut().entity_mut(client).insert((
-        ReplicationSender,
+    app.world_mut().entity_mut(client).insert(ReplicationSender);
+    app.insert_resource(
         InputTimelineConfig::default().with_input_delay(InputDelayConfig::balanced()),
-    ));
+    );
 }

--- a/examples/projectiles/src/server.rs
+++ b/examples/projectiles/src/server.rs
@@ -455,6 +455,7 @@ mod bot {
             InputTimelineConfig::default()
                 .with_input_delay(InputDelayConfig::fixed_input_delay(BOT_INPUT_DELAY_TICKS)),
         );
+        app.insert_resource(PredictionManager::default());
 
         app.world_mut().spawn((
             Client,
@@ -468,7 +469,6 @@ mod bot {
             )
             .unwrap(),
             crossbeam_client,
-            PredictionManager::default(),
             Name::from("BotClient"),
         ));
         let server = server.into_inner();

--- a/examples/projectiles/src/server.rs
+++ b/examples/projectiles/src/server.rs
@@ -451,6 +451,11 @@ mod bot {
         };
         let conditioner = LinkConditionerConfig::average_condition().half();
 
+        app.insert_resource(
+            InputTimelineConfig::default()
+                .with_input_delay(InputDelayConfig::fixed_input_delay(BOT_INPUT_DELAY_TICKS)),
+        );
+
         app.world_mut().spawn((
             Client,
             BotClient,
@@ -464,8 +469,6 @@ mod bot {
             .unwrap(),
             crossbeam_client,
             PredictionManager::default(),
-            InputTimelineConfig::default()
-                .with_input_delay(InputDelayConfig::fixed_input_delay(BOT_INPUT_DELAY_TICKS)),
             Name::from("BotClient"),
         ));
         let server = server.into_inner();

--- a/examples/projectiles/src/shared.rs
+++ b/examples/projectiles/src/shared.rs
@@ -269,7 +269,7 @@ pub(crate) fn shoot_weapon(
         ),
         With<ClientContext>,
     >,
-    rollback: Query<(), With<Rollback>>,
+    rollback: Option<Res<Rollback>>,
 ) {
     let tick = timeline.tick();
     let tick_duration = tick_duration.0;
@@ -302,7 +302,7 @@ pub(crate) fn shoot_weapon(
 
         weapon.last_fire_tick = Some(tick);
 
-        let in_rollback = rollback.single().is_ok();
+        let in_rollback = rollback.is_some();
         if !is_server
             && in_rollback
             && replication_mode != &GameReplicationMode::OnlyInputsReplicated

--- a/examples/replication_groups/Cargo.toml
+++ b/examples/replication_groups/Cargo.toml
@@ -13,7 +13,7 @@ publish = false
 
 
 [features]
-default = ["client", "gui", "server", "netcode", "webtransport"]
+default = ["client", "gui", "server", "p2p", "netcode", "webtransport"]
 client = ["lightyear/client", "lightyear_examples_common/client"]
 gui = ["lightyear_examples_common/gui2d"]
 server = [
@@ -23,6 +23,13 @@ server = [
   "lightyear_examples_common/server",
 ]
 netcode = ["lightyear_examples_common/netcode"]
+p2p = [
+  "client",
+  "udp",
+  "lightyear/deterministic",
+  "lightyear/p2p",
+  "lightyear_examples_common/p2p",
+]
 webtransport = ["lightyear_examples_common/webtransport"]
 udp = [
   "lightyear_examples_common/udp",
@@ -39,6 +46,7 @@ lightyear = { "workspace" = true, features = [
   "input_native",
 ] }
 lightyear_frame_interpolation.workspace = true
+lightyear_deterministic_replication.workspace = true
 lightyear_examples_common = { workspace = true, features = [
   "structured-debug",
 ] }

--- a/examples/replication_groups/README.md
+++ b/examples/replication_groups/README.md
@@ -25,6 +25,14 @@ https://github.com/cBournhonesque/lightyear/assets/8112632/e7625286-a167-4f50-aa
 - Run the server without a gui: `cargo run --no-default-features --features=server -- server`
 - Run the client and server in "HostClient" mode, where the client also acts as server (both are in the same App) : `cargo run -- host-client -c 0`
 
+### P2P mode
+
+The snake simulation can also run as a deterministic input-only game with no server. Start peer 0
+with `cargo run --no-default-features --features=p2p -- --headless p2p --peer-id 0 --player-count 2`
+and peer 1 with the same command using `--peer-id 1`. Every peer creates the same heads and tails
+locally. Replication groups themselves remain a feature of the conventional client/server mode;
+the P2P mode performs no entity replication.
+
 You can control the behaviour of the example by changing the list of features. By default, all features are enabled (client, server, gui).
 For example you can run the server in headless mode (without gui) by running `cargo run --no-default-features --features=server,webtransport,netcode`.
 

--- a/examples/replication_groups/src/client.rs
+++ b/examples/replication_groups/src/client.rs
@@ -72,7 +72,10 @@ pub(crate) fn buffer_input(
 //
 // If this example predicted remote entities, ownership would need to be checked before movement.
 fn movement(
-    mut position_query: Query<(&mut PlayerPosition, &ActionState<Inputs>), With<Predicted>>,
+    mut position_query: Query<
+        (&mut PlayerPosition, &ActionState<Inputs>),
+        Or<(With<Predicted>, With<DeterministicPredicted>)>,
+    >,
 ) {
     for (position, input) in position_query.iter_mut() {
         shared_movement_behaviour(position, input);

--- a/examples/replication_groups/src/main.rs
+++ b/examples/replication_groups/src/main.rs
@@ -5,6 +5,8 @@
 
 #[cfg(feature = "client")]
 use crate::client::ExampleClientPlugin;
+#[cfg(feature = "p2p")]
+use crate::p2p::ExampleP2PPlugin;
 #[cfg(feature = "server")]
 use crate::server::ExampleServerPlugin;
 use crate::shared::SharedPlugin;
@@ -17,6 +19,8 @@ mod automation;
 #[cfg(feature = "client")]
 mod client;
 mod debug;
+#[cfg(feature = "p2p")]
+mod p2p;
 mod protocol;
 
 #[cfg(feature = "gui")]
@@ -36,9 +40,13 @@ fn main() {
     cli.spawn_connections(&mut app);
 
     match cli.mode {
-        #[cfg(feature = "client")]
+        #[cfg(all(feature = "client", any(not(feature = "p2p"), feature = "netcode")))]
         Some(Mode::Client { .. }) => {
             app.add_plugins(ExampleClientPlugin);
+        }
+        #[cfg(feature = "p2p")]
+        Some(Mode::P2P { .. }) => {
+            app.add_plugins((ExampleClientPlugin, ExampleP2PPlugin));
         }
         #[cfg(feature = "server")]
         Some(Mode::Server) => {

--- a/examples/replication_groups/src/p2p.rs
+++ b/examples/replication_groups/src/p2p.rs
@@ -1,0 +1,98 @@
+//! Input-only P2P setup for the replication-groups example.
+//!
+//! Replication groups remain demonstrated by the conventional server mode. In P2P mode every peer
+//! creates the same snake roster locally and exchanges only deterministic inputs.
+
+extern crate alloc;
+
+use crate::protocol::*;
+use alloc::collections::VecDeque;
+use bevy::prelude::*;
+use lightyear::prediction::rollback::DeterministicPredicted;
+use lightyear::prelude::input::client::InputSystems;
+use lightyear::prelude::input::native::{ActionState, InputMarker};
+use lightyear::prelude::input::InputBuffer;
+use lightyear::prelude::*;
+use lightyear_deterministic_replication::prelude::DeterministicReplicationPlugin;
+use lightyear_examples_common::p2p::{
+    input_target_for_peer, P2PGameplayStarted, P2PSettings, GAMEPLAY_START_TICK,
+};
+use lightyear_frame_interpolation::FrameInterpolate;
+const PLAYER_INPUT_HASH_BASE: u64 = 0x4752_4F55_5000_0000;
+
+pub struct ExampleP2PPlugin;
+
+impl Plugin for ExampleP2PPlugin {
+    fn build(&self, app: &mut App) {
+        app.insert_resource(PredictionManager::default());
+        app.add_plugins(DeterministicReplicationPlugin);
+        app.add_systems(
+            FixedPreUpdate,
+            spawn_fixed_roster.before(InputSystems::BufferClientInputs),
+        );
+    }
+}
+
+fn spawn_fixed_roster(
+    mut commands: Commands,
+    _synced: SyncedInputTimeline,
+    timeline: Res<LocalTimeline>,
+    started: Option<Res<P2PGameplayStarted>>,
+    settings: Res<P2PSettings>,
+    links: Query<(Entity, &RemoteId), With<P2P>>,
+) {
+    if started.is_some() || timeline.tick().0 < GAMEPLAY_START_TICK {
+        return;
+    }
+    commands.insert_resource(P2PGameplayStarted);
+
+    let spacing = 180.0;
+    let center = (f32::from(settings.player_count) - 1.0) * 0.5;
+    for peer_id in settings.peer_ids() {
+        let id = PeerId::Entity(u64::from(peer_id));
+        let position = Vec2::new((f32::from(peer_id) - center) * spacing, 0.0);
+        let color = Color::hsl((f32::from(peer_id) * 0.23) % 1.0, 0.8, 0.5);
+        let target = input_target_for_peer(
+            &settings,
+            &links,
+            peer_id,
+            PLAYER_INPUT_HASH_BASE | u64::from(peer_id),
+        );
+        let player = commands
+            .spawn((
+                PlayerId(id),
+                PlayerPosition(position),
+                PlayerColor(color),
+                DeterministicPredicted {
+                    skip_despawn: true,
+                    enable_rollback_after: 0,
+                },
+                target,
+                ActionState::<Inputs>::default(),
+                InputBuffer::<ActionState<Inputs>, Inputs>::default(),
+                FrameInterpolate,
+                Name::from("P2P Head"),
+            ))
+            .id();
+        if peer_id == settings.local_peer_id {
+            commands
+                .entity(player)
+                .insert(InputMarker::<Inputs>::default());
+        }
+
+        let tail_length = 300.0;
+        let direction = Direction::Up;
+        let mut points = VecDeque::new();
+        points.push_front((direction.get_tail(position, tail_length), direction));
+        commands.spawn((
+            PlayerParent(player),
+            TailPoints(points),
+            TailLength(tail_length),
+            DeterministicPredicted {
+                skip_despawn: true,
+                enable_rollback_after: 0,
+            },
+            Name::from("P2P Tail"),
+        ));
+    }
+}

--- a/examples/replication_groups/src/shared.rs
+++ b/examples/replication_groups/src/shared.rs
@@ -30,10 +30,21 @@ pub(crate) fn shared_movement_behaviour(mut position: Mut<PlayerPosition>, input
 // Updates predicted tail points when the head moves. Interpolated tails are updated during
 // interpolation, and confirmed tails are replicated from the server.
 pub(crate) fn shared_tail_behaviour(
-    player_position: Query<Ref<PlayerPosition>, Or<(With<Predicted>, With<Replicate>)>>,
+    player_position: Query<
+        Ref<PlayerPosition>,
+        Or<(
+            With<Predicted>,
+            With<Replicate>,
+            With<DeterministicPredicted>,
+        )>,
+    >,
     mut tails: Query<
         (&mut TailPoints, &PlayerParent, &TailLength),
-        Or<(With<Predicted>, With<ReplicateLike>)>,
+        Or<(
+            With<Predicted>,
+            With<ReplicateLike>,
+            With<DeterministicPredicted>,
+        )>,
     >,
 ) {
     for (mut points, parent, length) in tails.iter_mut() {

--- a/examples/simple_box/Cargo.toml
+++ b/examples/simple_box/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT OR Apache-2.0"
 publish = false
 
 [features]
-default = ["client", "gui", "server", "netcode", "webtransport"]
+default = ["client", "gui", "server", "p2p", "netcode", "webtransport"]
 client = ["lightyear/client", "lightyear_examples_common/client"]
 gui = ["lightyear_examples_common/gui2d"]
 server = [
@@ -22,6 +22,13 @@ server = [
   "lightyear_examples_common/server",
 ]
 netcode = ["lightyear_examples_common/netcode"]
+p2p = [
+  "client",
+  "udp",
+  "lightyear/deterministic",
+  "lightyear/p2p",
+  "lightyear_examples_common/p2p",
+]
 webtransport = ["lightyear_examples_common/webtransport"]
 udp = ["lightyear_examples_common/udp", "lightyear/std", "lightyear/udp"]
 steam = ["lightyear_examples_common/steam"]
@@ -34,6 +41,7 @@ lightyear = { "workspace" = true, features = [
   "replication",
   "input_native",
 ] }
+lightyear_deterministic_replication.workspace = true
 lightyear_examples_common = { workspace = true, features = [
   "structured-debug",
 ] }

--- a/examples/simple_box/README.md
+++ b/examples/simple_box/README.md
@@ -18,12 +18,27 @@ https://github.com/cBournhonesque/lightyear/assets/8112632/7b57d48a-d8b0-4cdd-a1
 - Run a headless client without a gui: `cargo run --no-default-features --features=client,netcode,webtransport -- client -c 1`
 - Run the client and server in "HostClient" mode, where the client also acts as server (both are in the same App) : `cargo run -- host-client -c 0`
 
+The same example can run as a deterministic, input-only P2P game with no server or authoritative
+simulation. Start one process for each member of the fixed roster:
+
+- Peer 0: `cargo run --no-default-features --features=p2p -- --headless p2p --peer-id 0 --player-count 2`
+- Peer 1: `cargo run --no-default-features --features=p2p -- --headless p2p --peer-id 1 --player-count 2`
+
+P2P mode currently uses direct raw UDP Links on localhost and supports two through four players.
+Every peer pre-spawns the same player roster with stable `PreSpawned` hashes, simulates every
+player locally, and sends only its own tick-indexed inputs to the other peers. Each peer predicts
+missing remote inputs by repeating the latest known input, then rolls back and replays the complete
+deterministic world when corrected input arrives. The normal client/server and host-client modes
+remain available in the same example.
+
 You can control the behaviour of the example by changing the list of features. By default, all features are enabled (client, server, gui).
 For example you can run the server in headless mode (without gui) by running `cargo run --no-default-features --features=server,webtransport,netcode`.
 
-For automated headless verification, you can set `LIGHTYEAR_SIMPLE_BOX_AUTOMOVE=right` on one client and
-`LIGHTYEAR_SIMPLE_BOX_LOG_POSITIONS=1` on another client to confirm from logs that the interpolated remote player
-keeps receiving `PlayerPosition` updates.
+Run `just simple_box_p2p_smoke` for a two-process headless check that remote inputs cause rollback
+and both peers converge to identical player positions at the same tick.
+
+The smoke test leaves its normal and structured logs in the temporary directory printed on
+success or failure.
 
 ### Testing in wasm with webtransport
 

--- a/examples/simple_box/p2p_smoke.sh
+++ b/examples/simple_box/p2p_smoke.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+smoke_dir="$(mktemp -d "${TMPDIR:-/tmp}/lightyear-simple-box-p2p.XXXXXX")"
+peer_0_log="$smoke_dir/peer-0.log"
+peer_1_log="$smoke_dir/peer-1.log"
+peer_0_debug="$smoke_dir/peer-0.jsonl"
+peer_1_debug="$smoke_dir/peer-1.jsonl"
+peer_0_state="$smoke_dir/peer-0-state.json"
+peer_1_state="$smoke_dir/peer-1-state.json"
+
+exit_tick="${LIGHTYEAR_SIMPLE_BOX_SMOKE_EXIT_TICK:-420}"
+check_tick="${LIGHTYEAR_SIMPLE_BOX_SMOKE_CHECK_TICK:-380}"
+base_port="${LIGHTYEAR_SIMPLE_BOX_SMOKE_PORT:-$((30000 + $$ % 10000))}"
+
+if ((check_tick >= exit_tick)); then
+    echo "check tick must be earlier than exit tick" >&2
+    exit 1
+fi
+
+cargo build -p simple_box --no-default-features --features=p2p
+target_dir="$(cargo metadata --no-deps --format-version 1 | jq -r .target_directory)"
+binary="$target_dir/debug/simple_box"
+
+pids=()
+cleanup() {
+    for pid in "${pids[@]}"; do
+        kill "$pid" 2>/dev/null || true
+    done
+}
+trap cleanup EXIT INT TERM
+
+LIGHTYEAR_SIMPLE_BOX_AUTOMOVE=right \
+LIGHTYEAR_SIMPLE_BOX_EXIT_AFTER_TICK="$exit_tick" \
+LIGHTYEAR_DEBUG_FILE="$peer_0_debug" \
+RUST_LOG=info,lightyear_debug=trace \
+"$binary" --headless p2p --peer-id 0 --player-count 2 --base-port "$base_port" \
+    >"$peer_0_log" 2>&1 &
+pids+=("$!")
+
+LIGHTYEAR_SIMPLE_BOX_AUTOMOVE=none \
+LIGHTYEAR_SIMPLE_BOX_EXIT_AFTER_TICK="$exit_tick" \
+LIGHTYEAR_DEBUG_FILE="$peer_1_debug" \
+RUST_LOG=info,lightyear_debug=trace \
+"$binary" --headless p2p --peer-id 1 --player-count 2 --base-port "$base_port" \
+    >"$peer_1_log" 2>&1 &
+pids+=("$!")
+
+deadline=$((SECONDS + 20))
+while kill -0 "${pids[0]}" 2>/dev/null || kill -0 "${pids[1]}" 2>/dev/null; do
+    if ((SECONDS >= deadline)); then
+        echo "simple-box P2P smoke test timed out; logs: $smoke_dir" >&2
+        exit 1
+    fi
+    sleep 1
+done
+
+peer_0_status=0
+peer_1_status=0
+wait "${pids[0]}" || peer_0_status=$?
+wait "${pids[1]}" || peer_1_status=$?
+if ((peer_0_status != 0 || peer_1_status != 0)); then
+    echo "simple-box P2P peer failed; logs: $smoke_dir" >&2
+    exit 1
+fi
+
+if ! grep -q '"kind":"input_mismatch_rollback"' "$peer_1_debug"; then
+    echo "peer 1 did not roll back for peer 0 input; logs: $smoke_dir" >&2
+    exit 1
+fi
+
+extract_state() {
+    local source="$1"
+    local destination="$2"
+    # App exit can interrupt the final buffered debug record. Parse complete JSONL
+    # records individually so that an incomplete final line cannot hide the
+    # earlier rollback and state samples under test.
+    jq --null-input --raw-input --argjson tick "$check_tick" '
+        [
+            inputs
+            | fromjson?
+            | select(
+                .category == "component"
+                and .tick_id == $tick
+                and (
+                    (.component | endswith("PlayerId"))
+                    or (.component | endswith("PlayerPosition"))
+                )
+            )
+        ]
+        | group_by(.entity)
+        | map({
+            player: ([.[] | select(.component | endswith("PlayerId")) | .value] | last),
+            position: ([.[] | select(.component | endswith("PlayerPosition")) | .value] | last)
+        })
+        | map(select(.player != null and .position != null))
+        | sort_by(.player | tojson)
+    ' "$source" >"$destination"
+}
+
+extract_state "$peer_0_debug" "$peer_0_state"
+extract_state "$peer_1_debug" "$peer_1_state"
+
+if ! jq -e 'length == 2' "$peer_0_state" >/dev/null \
+    || ! jq -e 'length == 2' "$peer_1_state" >/dev/null; then
+    echo "did not capture both players at tick $check_tick; logs: $smoke_dir" >&2
+    exit 1
+fi
+if ! diff -u "$peer_0_state" "$peer_1_state"; then
+    echo "simple-box P2P peers diverged at tick $check_tick; logs: $smoke_dir" >&2
+    exit 1
+fi
+
+trap - EXIT INT TERM
+echo "simple-box P2P rollback and convergence passed at tick $check_tick"
+echo "logs: $smoke_dir"

--- a/examples/simple_box/src/automation.rs
+++ b/examples/simple_box/src/automation.rs
@@ -1,6 +1,10 @@
 use crate::protocol::Direction;
+#[cfg(feature = "p2p")]
+use crate::protocol::{PlayerId, PlayerPosition};
 use bevy::prelude::*;
 use lightyear::prelude::*;
+#[cfg(feature = "p2p")]
+use lightyear_examples_common::p2p::P2PSettings;
 
 #[cfg(feature = "client")]
 pub struct AutomationClientPlugin;
@@ -20,6 +24,74 @@ pub struct AutomationServerPlugin;
 impl Plugin for AutomationServerPlugin {
     fn build(&self, app: &mut App) {
         app.add_systems(Update, crate::debug::server::mark_debug_player_entities);
+    }
+}
+
+/// Install the opt-in diagnostics used by the headless P2P smoke test.
+#[cfg(feature = "p2p")]
+pub(crate) fn add_p2p_debugging(app: &mut App) {
+    if std::env::var_os("LIGHTYEAR_SIMPLE_BOX_LOG_POSITIONS").is_some() {
+        app.add_systems(Update, log_p2p_positions);
+    }
+    if let Some(tick) = std::env::var("LIGHTYEAR_SIMPLE_BOX_EXIT_AFTER_TICK")
+        .ok()
+        .and_then(|value| value.parse::<u32>().ok())
+    {
+        app.insert_resource(ExitAfterTick(Tick(tick)));
+        app.add_systems(Update, exit_after_tick);
+    }
+}
+
+/// Optional deterministic endpoint for multi-process example automation.
+#[cfg(feature = "p2p")]
+#[derive(Resource)]
+struct ExitAfterTick(Tick);
+
+#[cfg(feature = "p2p")]
+fn exit_after_tick(
+    timeline: Res<LocalTimeline>,
+    exit_tick: Res<ExitAfterTick>,
+    mut exit: MessageWriter<AppExit>,
+) {
+    if timeline.tick() >= exit_tick.0 {
+        exit.write(AppExit::Success);
+    }
+}
+
+/// Periodically log P2P connection state and deterministic player positions.
+#[cfg(feature = "p2p")]
+fn log_p2p_positions(
+    time: Res<Time>,
+    timeline: Res<LocalTimeline>,
+    settings: Res<P2PSettings>,
+    links: Query<(&RemoteId, Has<Connected>, &PingManager), With<P2P>>,
+    synced_input_timeline: Query<(), (With<InputTimeline>, With<IsSynced<InputTimeline>>)>,
+    players: Query<(&PlayerId, &PlayerPosition)>,
+    mut timer: Local<Option<Timer>>,
+) {
+    let timer = timer.get_or_insert_with(|| Timer::from_seconds(1.0, TimerMode::Repeating));
+    timer.tick(time.delta());
+    if !timer.just_finished() {
+        return;
+    }
+    for (remote, connected, ping) in &links {
+        info!(
+            local_peer = settings.local_peer_id,
+            ?remote,
+            connected,
+            latency_samples = ping.latency_samples_recv(),
+            input_timeline_synced = !synced_input_timeline.is_empty(),
+            "P2P Link status"
+        );
+    }
+    for (player, position) in &players {
+        info!(
+            local_peer = settings.local_peer_id,
+            tick = timeline.tick().0,
+            ?player,
+            position = ?position.0,
+            "P2P player position"
+        );
     }
 }
 

--- a/examples/simple_box/src/client.rs
+++ b/examples/simple_box/src/client.rs
@@ -2,17 +2,20 @@
 //! The client will be responsible for:
 //! - connecting to the server at Startup
 //! - sending inputs to the server
-//! - applying inputs to the locally predicted player (for prediction to work, inputs have to be applied to both the
-//!   predicted entity and the server entity)
+//! - applying inputs to predicted entities. In client/server mode this is the locally controlled
+//!   player; in P2P mode every peer predicts the complete deterministic roster.
 
 use crate::automation::{self, AutomationClientPlugin};
 use crate::protocol::*;
 use crate::shared;
 use bevy::prelude::*;
+use lightyear::prediction::rollback::DeterministicPredicted;
 use lightyear::prelude::client::input::*;
 use lightyear::prelude::client::{InputDelayConfig, InputTimelineConfig};
 use lightyear::prelude::input::native::*;
 use lightyear::prelude::*;
+#[cfg(feature = "p2p")]
+use lightyear_examples_common::p2p::P2PSettings;
 
 pub struct ExampleClientPlugin;
 
@@ -88,15 +91,25 @@ fn buffer_input(
     }
 }
 
-/// Applies local movement only to predicted entities owned by this client.
+/// Apply movement to every entity simulated by this client.
 ///
-/// If this example predicted remote entities, ownership would need to be checked before movement.
+/// Conventional clients only have a [`Predicted`] copy of their locally controlled player. P2P
+/// peers instead give every roster member [`DeterministicPredicted`]: the local player uses captured
+/// input, while remote players repeat their latest known input and trigger rollback when corrected
+/// input arrives.
 fn player_movement(
     _input_timeline: SyncedInputTimeline,
-    // timeline: Single<&LocalTimeline>,
-    mut position_query: Query<(&mut PlayerPosition, &ActionState<Inputs>), With<Predicted>>,
+    timeline: Res<LocalTimeline>,
+    #[cfg(feature = "p2p")] p2p: Option<Res<P2PSettings>>,
+    mut position_query: Query<
+        (&mut PlayerPosition, &ActionState<Inputs>),
+        Or<(With<Predicted>, With<DeterministicPredicted>)>,
+    >,
 ) {
-    // let tick = timeline.tick();
+    #[cfg(feature = "p2p")]
+    if p2p.is_some() && timeline.tick().0 < lightyear_examples_common::p2p::GAMEPLAY_START_TICK {
+        return;
+    }
     for (position, input) in position_query.iter_mut() {
         // trace!(?tick, ?position, ?input, "client");
         // Pass Mut<PlayerPosition> directly so change detection only fires when movement changes it.
@@ -105,7 +118,18 @@ fn player_movement(
 }
 
 /// System to receive messages on the client
-pub(crate) fn receive_message1(mut receiver: Single<&mut MessageReceiver<Message1>>) {
+pub(crate) fn receive_message1(
+    metadata: Res<NetworkingMetadata>,
+    mut receivers: Query<&mut MessageReceiver<Message1>>,
+) {
+    let link = match &metadata.mode {
+        NetworkTopology::Client(link) => *link,
+        NetworkTopology::HostClient { client, .. } => *client,
+        _ => return,
+    };
+    let Ok(mut receiver) = receivers.get_mut(link) else {
+        return;
+    };
     for message in receiver.receive() {
         info!("Received message: {:?}", message);
     }

--- a/examples/simple_box/src/client.rs
+++ b/examples/simple_box/src/client.rs
@@ -34,8 +34,8 @@ impl Plugin for ExampleClientPlugin {
     }
 }
 
-fn configure_input_delay(client: Single<Entity, With<Client>>, mut commands: Commands) {
-    commands.entity(client.into_inner()).insert(
+fn configure_input_delay(mut commands: Commands) {
+    commands.insert_resource(
         InputTimelineConfig::default().with_input_delay(InputDelayConfig::no_input_delay()),
     );
 }
@@ -92,13 +92,10 @@ fn buffer_input(
 ///
 /// If this example predicted remote entities, ownership would need to be checked before movement.
 fn player_movement(
-    synced_client: Query<(), (With<Client>, With<IsSynced<InputTimeline>>)>,
+    _input_timeline: SyncedInputTimeline,
     // timeline: Single<&LocalTimeline>,
     mut position_query: Query<(&mut PlayerPosition, &ActionState<Inputs>), With<Predicted>>,
 ) {
-    if synced_client.is_empty() {
-        return;
-    }
     // let tick = timeline.tick();
     for (position, input) in position_query.iter_mut() {
         // trace!(?tick, ?position, ?input, "client");

--- a/examples/simple_box/src/debug.rs
+++ b/examples/simple_box/src/debug.rs
@@ -10,24 +10,39 @@ pub(crate) mod client {
 
     pub(crate) fn mark_debug_player_entities(
         mut commands: Commands,
-        query: Query<(Entity, Has<Predicted>, Has<Interpolated>), Added<PlayerId>>,
+        query: Query<
+            (
+                Entity,
+                Has<Predicted>,
+                Has<Interpolated>,
+                Has<DeterministicPredicted>,
+            ),
+            Added<PlayerId>,
+        >,
     ) {
-        for (entity, predicted, interpolated) in query.iter() {
-            if predicted || interpolated {
+        for (entity, predicted, interpolated, deterministic) in query.iter() {
+            if predicted || interpolated || deterministic {
                 let input_sample_points = [
                     DebugSamplePoint::FixedPreUpdate,
                     DebugSamplePoint::FixedUpdate,
                 ];
                 commands.entity(entity).insert(
-                    LightyearDebug::component_at::<PlayerPosition>([
+                    LightyearDebug::component_structured_at::<PlayerPosition>([
+                        DebugSamplePoint::FixedUpdate,
                         DebugSamplePoint::Update,
                         DebugSamplePoint::PostUpdate,
                     ])
+                    .with_component_structured_at::<PlayerId>([DebugSamplePoint::FixedUpdate])
                     .with_component_at::<Predicted>([
                         DebugSamplePoint::Update,
                         DebugSamplePoint::PostUpdate,
                     ])
                     .with_component_at::<Interpolated>([
+                        DebugSamplePoint::Update,
+                        DebugSamplePoint::PostUpdate,
+                    ])
+                    .with_component_at::<DeterministicPredicted>([
+                        DebugSamplePoint::FixedUpdate,
                         DebugSamplePoint::Update,
                         DebugSamplePoint::PostUpdate,
                     ])

--- a/examples/simple_box/src/lib.rs
+++ b/examples/simple_box/src/lib.rs
@@ -13,4 +13,7 @@ pub mod server;
 #[cfg(feature = "gui")]
 pub mod renderer;
 
+#[cfg(feature = "p2p")]
+pub mod p2p;
+
 pub mod shared;

--- a/examples/simple_box/src/main.rs
+++ b/examples/simple_box/src/main.rs
@@ -13,6 +13,8 @@
 
 #[cfg(feature = "client")]
 use crate::client::ExampleClientPlugin;
+#[cfg(feature = "p2p")]
+use crate::p2p::ExampleP2PPlugin;
 #[cfg(feature = "server")]
 use crate::server::ExampleServerPlugin;
 use crate::shared::SharedPlugin;
@@ -26,6 +28,8 @@ mod automation;
 #[cfg(feature = "client")]
 mod client;
 mod debug;
+#[cfg(feature = "p2p")]
+mod p2p;
 mod protocol;
 #[cfg(feature = "gui")]
 mod renderer;
@@ -46,9 +50,13 @@ fn main() {
     cli.spawn_connections(&mut app);
 
     match cli.mode {
-        #[cfg(feature = "client")]
+        #[cfg(all(feature = "client", any(not(feature = "p2p"), feature = "netcode")))]
         Some(Mode::Client { .. }) => {
             app.add_plugins(ExampleClientPlugin);
+        }
+        #[cfg(feature = "p2p")]
+        Some(Mode::P2P { .. }) => {
+            app.add_plugins((ExampleClientPlugin, ExampleP2PPlugin));
         }
         #[cfg(feature = "server")]
         Some(Mode::Server) => {

--- a/examples/simple_box/src/p2p.rs
+++ b/examples/simple_box/src/p2p.rs
@@ -1,0 +1,81 @@
+//! Direct P2P setup for the simple-box deterministic simulation.
+//!
+//! Unlike the conventional mode, no server spawns or replicates players. Every peer creates the
+//! same fixed roster locally and only exchanges tick-indexed inputs.
+
+use crate::protocol::{Inputs, PlayerBundle};
+use bevy::prelude::*;
+use lightyear::prediction::rollback::DeterministicPredicted;
+use lightyear::prelude::input::client::InputSystems;
+use lightyear::prelude::input::native::{ActionState, InputMarker};
+use lightyear::prelude::input::InputBuffer;
+use lightyear::prelude::*;
+use lightyear_examples_common::p2p::{
+    input_target_for_peer, P2PGameplayStarted, P2PSettings, GAMEPLAY_START_TICK,
+};
+
+/// Namespace for stable simple-box player hashes on the input wire.
+const PLAYER_INPUT_HASH_BASE: u64 = 0x5349_4D50_4C45_0000;
+
+pub struct ExampleP2PPlugin;
+
+impl Plugin for ExampleP2PPlugin {
+    fn build(&self, app: &mut App) {
+        app.insert_resource(PredictionManager::default());
+        app.add_plugins(
+            lightyear_deterministic_replication::prelude::DeterministicReplicationPlugin,
+        );
+        app.add_systems(
+            FixedPreUpdate,
+            spawn_fixed_roster.before(InputSystems::BufferClientInputs),
+        );
+        crate::automation::add_p2p_debugging(app);
+    }
+}
+
+/// Spawn one local deterministic copy of every player in stable roster order.
+///
+/// The local player receives [`InputMarker`], while remote players start with empty input buffers
+/// so prediction can begin before their first packet arrives. The explicit [`PreSpawned`] hash is
+/// the cross-world input identity; P2P deliberately does not depend on replication entity maps.
+fn spawn_fixed_roster(
+    mut commands: Commands,
+    _synced: SyncedInputTimeline,
+    timeline: Res<LocalTimeline>,
+    started: Option<Res<P2PGameplayStarted>>,
+    settings: Res<P2PSettings>,
+    links: Query<(Entity, &RemoteId), With<P2P>>,
+) {
+    if started.is_some() || timeline.tick().0 < GAMEPLAY_START_TICK {
+        return;
+    }
+    commands.insert_resource(P2PGameplayStarted);
+
+    let spacing = 120.0;
+    let center = (f32::from(settings.player_count) - 1.0) * 0.5;
+
+    for peer_id in settings.peer_ids() {
+        let id = PeerId::Entity(u64::from(peer_id));
+        let position = Vec2::new((f32::from(peer_id) - center) * spacing, 0.0);
+        let hash = PLAYER_INPUT_HASH_BASE | u64::from(peer_id);
+        let pre_spawned = input_target_for_peer(&settings, &links, peer_id, hash);
+
+        let entity = commands
+            .spawn((
+                PlayerBundle::new(id, position),
+                DeterministicPredicted {
+                    skip_despawn: true,
+                    enable_rollback_after: 0,
+                },
+                pre_spawned,
+                ActionState::<Inputs>::default(),
+                InputBuffer::<ActionState<Inputs>, Inputs>::default(),
+            ))
+            .id();
+        if peer_id == settings.local_peer_id {
+            commands
+                .entity(entity)
+                .insert(InputMarker::<Inputs>::default());
+        }
+    }
+}

--- a/justfile
+++ b/justfile
@@ -37,9 +37,14 @@ clippy_examples:
     cargo clippy -p simple_box --all-features -- -D warnings --no-deps
     # cargo clippy -p simple_setup --all-features -- -D warnings --no-deps
 
+# Run two conditioned simple-box peers and verify remote prediction rollback plus convergence.
+simple_box_p2p_smoke:
+    bash examples/simple_box/p2p_smoke.sh
+
 # jq filters shared by the example/demo build recipe.
 _example_demo_pkgs_filter := '.packages[] | select((.manifest_path | test("/(examples|demos)/")) and (.manifest_path | test("/examples/common/") | not) and (.manifest_path | test("/examples/launcher/") | not) and (.name != "simple_setup")) | .name'
 _example_demo_non_projectiles_pkgs_filter := '.packages[] | select((.manifest_path | test("/(examples|demos)/")) and (.manifest_path | test("/examples/common/") | not) and (.manifest_path | test("/examples/launcher/") | not) and (.name != "simple_setup") and (.name != "projectiles")) | .name'
+_example_demo_p2p_non_avian_pkgs_filter := '.packages[] | select((.manifest_path | test("/(examples|demos)/")) and (.manifest_path | test("/examples/common/") | not) and (.features | has("p2p")) and (.name != "avian_2d") and (.name != "avian_3d")) | .name'
 # simple_setup is excluded from explicit feature builds because it has no client/server/gui feature gates.
 
 # Build all examples/demos.
@@ -49,15 +54,16 @@ _example_demo_non_projectiles_pkgs_filter := '.packages[] | select((.manifest_pa
 #   just build_examples features=server
 #   just build_examples features=client headless=true
 #   just build_examples release=true features=both
+#   just build_examples features=p2p
 #
 # Args:
 #   release=true|false   Defaults to false.
 #   headless=true|false  Defaults to true for features=server, false otherwise.
-#   features=server|client|both  Defaults to both.
+#   features=server|client|both|p2p  Defaults to both.
 build_examples *args:
     #!/usr/bin/env bash
     set -euo pipefail
-    usage='usage: just build_examples [release=true|false] [headless=true|false] [features=server|client|both]'
+    usage='usage: just build_examples [release=true|false] [headless=true|false] [features=server|client|both|p2p]'
     release=false
     headless=""
     feature_mode=both
@@ -69,7 +75,7 @@ build_examples *args:
             headless=true|headless=false)
                 headless="${arg#headless=}"
                 ;;
-            features=server|features=client|features=both)
+            features=server|features=client|features=both|features=p2p)
                 feature_mode="${arg#features=}"
                 ;;
             -h|--help|help)
@@ -104,6 +110,7 @@ build_examples *args:
             both) target_dir="target/headless${release_suffix}" ;;
             client) target_dir="target/headless-client${release_suffix}" ;;
             server) target_dir="target/headless-server${release_suffix}" ;;
+            p2p) target_dir="target/headless-p2p${release_suffix}" ;;
         esac
     elif [ "$feature_mode" = server ]; then
         target_dir="target/server-only${release_suffix}"
@@ -116,19 +123,26 @@ build_examples *args:
         both:true) cargo_features="client,server,netcode,webtransport" ;;
         client:true) cargo_features="client,netcode,webtransport" ;;
         server:true) cargo_features="server,netcode,webtransport" ;;
+        p2p:true) cargo_features="p2p" ;;
         both:false) cargo_features="client,gui,server,netcode,webtransport" ;;
         client:false) cargo_features="client,gui,netcode,webtransport" ;;
         server:false) cargo_features="server,gui,netcode,webtransport" ;;
+        p2p:false) cargo_features="p2p,gui" ;;
     esac
 
-    if [ "$headless" = true ]; then
+    if [ "$feature_mode" = p2p ]; then
+        projectiles_features=""
+    elif [ "$headless" = true ]; then
         projectiles_features="client,server,netcode,webtransport"
     else
         projectiles_features="client,gui,server,netcode,webtransport"
     fi
 
     echo "Building examples: release=$release headless=$headless features=$feature_mode cargo_features=$cargo_features"
-    if [ "$projectiles_features" = "$cargo_features" ]; then
+    if [ "$feature_mode" = p2p ]; then
+        # Keep Avian 2D and 3D out of the same Cargo feature-unification graph.
+        pkgs_filter='{{ _example_demo_p2p_non_avian_pkgs_filter }}'
+    elif [ "$projectiles_features" = "$cargo_features" ]; then
         pkgs_filter='{{ _example_demo_pkgs_filter }}'
     else
         pkgs_filter='{{ _example_demo_non_projectiles_pkgs_filter }}'
@@ -138,7 +152,11 @@ build_examples *args:
         package_args+=(-p "$pkg")
     done < <(cargo metadata --no-deps --format-version 1 | jq -r "$pkgs_filter" | sort)
     "${cargo_build[@]}" --no-default-features --features="$cargo_features" "${package_args[@]}"
-    if [ "$projectiles_features" != "$cargo_features" ]; then
+    if [ "$feature_mode" = p2p ]; then
+        "${cargo_build[@]}" --no-default-features --features="$cargo_features" -p avian_2d
+        "${cargo_build[@]}" --no-default-features --features="$cargo_features" -p avian_3d
+    fi
+    if [ -n "$projectiles_features" ] && [ "$projectiles_features" != "$cargo_features" ]; then
         "${cargo_build[@]}" --no-default-features --features="$projectiles_features" -p projectiles
     fi
 
@@ -185,6 +203,7 @@ lightyear:
     # cargo clippy -p lightyear --no-default-features -- -D warnings --no-deps
     cargo clippy -p lightyear --no-default-features --features="std" -- -D warnings --no-deps
     cargo clippy -p lightyear --no-default-features --features="std client" -- -D warnings --no-deps
+    cargo clippy -p lightyear --no-default-features --features="std p2p" -- -D warnings --no-deps
     cargo clippy -p lightyear --no-default-features --features="std server" -- -D warnings --no-deps
     cargo clippy -p lightyear --no-default-features --features="std replication" -- -D warnings --no-deps
     cargo clippy -p lightyear --no-default-features --features="std prediction" -- -D warnings --no-deps
@@ -214,6 +233,7 @@ lightyear:
     # cargo clippy -p lightyear --tests --no-default-features -- -D warnings --no-deps
     cargo clippy -p lightyear --tests --no-default-features --features="std" -- -D warnings --no-deps
     cargo clippy -p lightyear --tests --no-default-features --features="std client" -- -D warnings --no-deps
+    cargo clippy -p lightyear --tests --no-default-features --features="std p2p" -- -D warnings --no-deps
     cargo clippy -p lightyear --tests --no-default-features --features="std server" -- -D warnings --no-deps
     cargo clippy -p lightyear --tests --no-default-features --features="std replication" -- -D warnings --no-deps
     cargo clippy -p lightyear --tests --no-default-features --features="std prediction" -- -D warnings --no-deps


### PR DESCRIPTION
This replays the completed P2P stack onto `main` in dependency order:

- #1624 — make the input timeline application-global
- #1627 — route inputs through the cached network topology
- #1628 — make prediction rollback state global
- #1630 — aggregate P2P timeline pacing
- #1647 — add direct P2P input examples

It intentionally excludes the still-open descendant PRs #1651 and #1659.

The final compatibility commit supplies `ScopeLifetime::WhileVisible` to the current `bevy_replicon` API, preserving the previous visibility behavior.