### PR TITLE
chore: simplify example build workflows

### DIFF
--- a/book/src/guides/remote_server.md
+++ b/book/src/guides/remote_server.md
@@ -33,7 +33,7 @@ On the server:
     only has 1 network card, or if you don't care which of the local ip addresses the socket binds to
   - Keep track of the port used for the server: S-P
 - You will need to keep track of the public ip address of your server: S-IP
-- Start the lightyear process on the server, for example with `cargo run --example interest_management -- server --headless`
+- Start the lightyear process on the server, for example with `cargo run --example interest_management -- server`
 
 On the client:
 - connect to the server by specifying the server public ip address and the server port:

--- a/demos/spaceships/README.md
+++ b/demos/spaceships/README.md
@@ -35,7 +35,7 @@ your client will rollback to position the bullet correctly.
 
 ## Running the example
 
-- Run the server with a gui: `cargo run server`
+- Run the server with a GUI: `cargo run -- --headless=false server`
 - Run client with id 1: `cargo run client -c 1`
 - Run client with id 2: `cargo run client -c 2`
 - Run the client and server in two separate bevy Apps: `cargo run` or `cargo run separate`
@@ -45,7 +45,7 @@ your client will rollback to position the bullet correctly.
 ### P2P mode
 
 The demo can also run as a deterministic input-only game with no server. Start peer 0 with
-`cargo run --no-default-features --features=p2p -- --headless p2p --peer-id 0 --player-count 2`
+`cargo run --no-default-features --features=p2p -- --headless=true p2p --peer-id 0 --player-count 2`
 and peer 1 with the same command using `--peer-id 1`. Every peer predicts the complete physics
 world, spawns the same bullets from the shared input stream, and applies collision and score
 changes deterministically.

--- a/demos/spaceships/src/main.rs
+++ b/demos/spaceships/src/main.rs
@@ -32,6 +32,7 @@ mod shared;
 
 fn main() {
     let cli = Cli::default();
+    let headless = cli.headless();
 
     let mut app = cli.build_app(Duration::from_secs_f64(1.0 / FIXED_TIMESTEP_HZ), true);
 
@@ -65,7 +66,9 @@ fn main() {
     }
 
     #[cfg(feature = "gui")]
-    app.add_plugins(renderer::ExampleRendererPlugin);
+    if !headless {
+        app.add_plugins(renderer::ExampleRendererPlugin);
+    }
 
     app.run();
 }

--- a/examples/README.md
+++ b/examples/README.md
@@ -36,15 +36,21 @@ The top level `Cargo.toml` workspace defines the deps that examples can use and 
 
 ## Running an example
 
-- Run the server with a gui: `cargo run -- server`
+- Run the server headlessly (the default): `cargo run -- server`
+- Run the server with a GUI: `cargo run -- --headless=false server`
 - Run client with id 1: `cargo run -- client -c 1`
 
 [//]: # (- Run the client and server in two separate bevy Apps: `cargo run` or `cargo run separate`)
-- Run the server without a gui: `cargo run --no-default-features --features=server -- server`
+- Build and run the server without GUI support: `cargo run --no-default-features --features=server -- server`
 - Run the client and server in "HostClient" mode, where the client also acts as server (both are in the same App) : `cargo run -- host-client -c 0`
 
 You can control the behaviour of the example by changing the list of features. By default, all features are enabled (client, server, gui).
 For example you can run the server in headless mode (without gui) by running `cargo run --no-default-features --features=server,webtransport,netcode`.
+
+To build all compatible examples, use `just build_examples features=client,server`. Add
+`headless=true` to omit the GUI from client/P2P builds, or `headless=false` to include it explicitly.
+Use `names=avian_3d` or a comma-separated list such as `names=avian_2d,avian_3d` to build only
+those example/demo packages.
 
 ### Testing in wasm with webtransport
 

--- a/examples/auth/README.md
+++ b/examples/auth/README.md
@@ -17,7 +17,7 @@ to the client. The client can then use the `ConnectToken` to start the `lightyea
 
 ## Running an example
 
-- Run the server with a gui: `cargo run -- server`
+- Run the server with a GUI: `cargo run -- --headless=false server`
 - Run client with id 1: `cargo run -- client -c 1`
 
 [//]: # (- Run the client and server in two separate bevy Apps: `cargo run` or `cargo run separate`)

--- a/examples/avian_2d/README.md
+++ b/examples/avian_2d/README.md
@@ -40,7 +40,7 @@ enabled.*
 
 ## Running an example
 
-- Run the server with a gui: `cargo run -- server`
+- Run the server with a GUI: `cargo run -- --headless=false server`
 - Run client with id 1: `cargo run -- client -c 1`
 
 [//]: # (- Run the client and server in two separate bevy Apps: `cargo run` or `cargo run separate`)
@@ -50,7 +50,7 @@ enabled.*
 ### P2P mode
 
 The example can also run as a deterministic input-only game with no server. Start peer 0 with
-`cargo run --no-default-features --features=p2p -- --headless p2p --peer-id 0 --player-count 2`
+`cargo run --no-default-features --features=p2p -- --headless=true p2p --peer-id 0 --player-count 2`
 and peer 1 with the same command using `--peer-id 1`. Every peer creates the same physics world,
 predicts all players, and rolls back both entity and Avian simulation state when remote input is
 late.

--- a/examples/avian_3d/README.md
+++ b/examples/avian_3d/README.md
@@ -20,7 +20,7 @@ https://github.com/user-attachments/assets/4e0eb373-2f46-4c48-8157-46e1e5085097
 
 ## Running an example
 
-- Run the server with a gui: `cargo run -- server`
+- Run the server with a GUI: `cargo run -- --headless=false server`
 - Run client with id 1: `cargo run -- client -c 1`
 
 [//]: # (- Run the client and server in two separate bevy Apps: `cargo run` or `cargo run separate`)
@@ -30,7 +30,7 @@ https://github.com/user-attachments/assets/4e0eb373-2f46-4c48-8157-46e1e5085097
 ### P2P mode
 
 The example can also run as a deterministic input-only game with no server. Start peer 0 with
-`cargo run --no-default-features --features=p2p -- --headless p2p --peer-id 0 --player-count 2`
+`cargo run --no-default-features --features=p2p -- --headless=true p2p --peer-id 0 --player-count 2`
 and peer 1 with the same command using `--peer-id 1`. Characters, the dynamic block, and
 projectiles are created and simulated by every peer, with Avian simulation state included in
 rollback.

--- a/examples/bevy_enhanced_inputs/README.md
+++ b/examples/bevy_enhanced_inputs/README.md
@@ -6,7 +6,7 @@ https://github.com/cBournhonesque/lightyear/assets/8112632/7b57d48a-d8b0-4cdd-a1
 
 ## Running an example
 
-- Run the server with a gui: `cargo run -- server`
+- Run the server with a GUI: `cargo run -- --headless=false server`
 - Run client with id 1: `cargo run -- client -c 1`
 
 [//]: # (- Run the client and server in two separate bevy Apps: `cargo run` or `cargo run separate`)
@@ -21,8 +21,8 @@ For example you can run the server in headless mode (without gui) by running `ca
 The same movement example can run without a server. Every peer creates the fixed player roster and
 BEI action entities locally, then sends its action inputs directly to every other peer.
 
-- Peer 0: `cargo run --no-default-features --features=p2p -- --headless p2p --peer-id 0 --player-count 2`
-- Peer 1: `cargo run --no-default-features --features=p2p -- --headless p2p --peer-id 1 --player-count 2`
+- Peer 0: `cargo run --no-default-features --features=p2p -- --headless=true p2p --peer-id 0 --player-count 2`
+- Peer 1: `cargo run --no-default-features --features=p2p -- --headless=true p2p --peer-id 1 --player-count 2`
 
 ### Testing in wasm with webtransport
 

--- a/examples/common/src/cli.rs
+++ b/examples/common/src/cli.rs
@@ -49,19 +49,20 @@ fn parse_bool_arg(value: &str) -> Result<bool, String> {
 #[derive(Parser, Debug)]
 #[command(version, about)]
 pub struct Cli {
-    /// Run without windowing/rendering plugins even when the example was built
-    /// with a GUI feature.
+    /// Override whether to run without windowing/rendering plugins.
+    ///
+    /// Dedicated servers are headless by default. Other modes use the GUI when
+    /// one was compiled. Pass `--headless=false` to show a dedicated server GUI.
     #[arg(
         long,
         global = true,
         action = ArgAction::Set,
-        default_value_t = false,
         default_missing_value = "true",
         num_args = 0..=1,
         require_equals = true,
         value_parser = parse_bool_arg
     )]
-    pub headless: bool,
+    pub headless: Option<bool>,
     #[command(subcommand)]
     pub mode: Option<Mode>,
 }
@@ -96,7 +97,13 @@ impl Cli {
     }
 
     pub fn headless(&self) -> bool {
-        self.headless || !cfg!(any(feature = "gui2d", feature = "gui3d"))
+        #[cfg(feature = "server")]
+        let dedicated_server = matches!(self.mode.as_ref(), Some(Mode::Server));
+        #[cfg(not(feature = "server"))]
+        let dedicated_server = false;
+
+        !cfg!(any(feature = "gui2d", feature = "gui3d"))
+            || self.headless.unwrap_or(dedicated_server)
     }
 
     pub fn create_app(add_inspector: bool, mode: Option<&Mode>, headless: bool) -> App {
@@ -390,7 +397,7 @@ pub fn cli() -> Cli {
         if #[cfg(target_family = "wasm")] {
             let client_id = rand::random::<u64>();
             Cli {
-                headless: false,
+                headless: None,
                 mode: Some(Mode::Client {
                     client_id: Some(client_id),
                 })

--- a/examples/delta_compression/README.md
+++ b/examples/delta_compression/README.md
@@ -14,7 +14,7 @@ remote trails slide smoothly between materialized diff states.
 
 ## Running an example
 
-- Run the server with a gui: `cargo run -- server`
+- Run the server with a GUI: `cargo run -- --headless=false server`
 - Run client with id 1: `cargo run -- client -c 1`
 
 [//]: # (- Run the client and server in two separate bevy Apps: `cargo run` or `cargo run separate`)

--- a/examples/deterministic_replication/README.md
+++ b/examples/deterministic_replication/README.md
@@ -10,7 +10,7 @@
 
 ## Running an example
 
-- Run the server with a gui: `cargo run -- server`
+- Run the server with a GUI: `cargo run -- --headless=false server`
 - Run client with id 1: `cargo run -- client -c 1`
 
 [//]: # (- Run the client and server in two separate bevy Apps: `cargo run` or `cargo run separate`)
@@ -25,8 +25,8 @@ For example you can run the server in headless mode (without gui) by running `ca
 The example can also run as a fixed deterministic P2P mesh. Every peer creates the same Avian
 world locally and exchanges only player inputs; there is no server or authoritative simulation.
 
-- Peer 0: `cargo run --no-default-features --features=p2p -- --headless p2p --peer-id 0 --player-count 2`
-- Peer 1: `cargo run --no-default-features --features=p2p -- --headless p2p --peer-id 1 --player-count 2`
+- Peer 0: `cargo run --no-default-features --features=p2p -- --headless=true p2p --peer-id 0 --player-count 2`
+- Peer 1: `cargo run --no-default-features --features=p2p -- --headless=true p2p --peer-id 1 --player-count 2`
 
 P2P mode uses input-only catch-up because there is no authoritative state source.
 

--- a/examples/fps/README.md
+++ b/examples/fps/README.md
@@ -47,7 +47,7 @@ https://github.com/user-attachments/assets/17bc985d-f700-439d-ba48-4c69fbfd7885
 
 ## Running an example
 
-- Run the server with a gui: `cargo run -- server`
+- Run the server with a GUI: `cargo run -- --headless=false server`
 - Run client with id 1: `cargo run -- client -c 1`
 
 [//]: # (- Run the client and server in two separate bevy Apps: `cargo run` or `cargo run separate`)
@@ -57,7 +57,7 @@ https://github.com/user-attachments/assets/17bc985d-f700-439d-ba48-4c69fbfd7885
 ### P2P mode
 
 The example can also run as a deterministic input-only game with no server. Start peer 0 with
-`cargo run --no-default-features --features=p2p -- --headless p2p --peer-id 0 --player-count 2`
+`cargo run --no-default-features --features=p2p -- --headless=true p2p --peer-id 0 --player-count 2`
 and peer 1 with the same command using `--peer-id 1`. This mode simulates both targets and hit
 detection on every peer; the conventional mode remains the example of server-side lag
 compensation.

--- a/examples/lobby/README.md
+++ b/examples/lobby/README.md
@@ -14,7 +14,7 @@ https://github.com/cBournhonesque/lightyear/assets/8112632/4ef661e6-b2e3-4b99-b1
 
 ## Running an example
 
-- Run the server with a gui: `cargo run -- server`
+- Run the server with a GUI: `cargo run -- --headless=false server`
 - Run client with id 1: `cargo run -- client -c 1`
 
 [//]: # (- Run the client and server in two separate bevy Apps: `cargo run` or `cargo run separate`)

--- a/examples/network_visibility/README.md
+++ b/examples/network_visibility/README.md
@@ -11,7 +11,7 @@ https://github.com/cBournhonesque/lightyear/assets/8112632/41a6d102-77a1-4a44-89
 
 ## Running an example
 
-- Run the server with a gui: `cargo run -- server`
+- Run the server with a GUI: `cargo run -- --headless=false server`
 - Run client with id 1: `cargo run -- client -c 1`
 
 [//]: # (- Run the client and server in two separate bevy Apps: `cargo run` or `cargo run separate`)
@@ -21,7 +21,7 @@ https://github.com/cBournhonesque/lightyear/assets/8112632/41a6d102-77a1-4a44-89
 ### P2P mode
 
 The movement simulation can also run as a deterministic input-only game with no server. Start
-peer 0 with `cargo run --no-default-features --features=p2p -- --headless p2p --peer-id 0 --player-count 2`
+peer 0 with `cargo run --no-default-features --features=p2p -- --headless=true p2p --peer-id 0 --player-count 2`
 and peer 1 with the same command using `--peer-id 1`. Every peer creates the complete small scene
 locally. Interest management remains a feature of the conventional client/server mode because the
 P2P mode performs no entity replication.

--- a/examples/priority/README.md
+++ b/examples/priority/README.md
@@ -17,7 +17,7 @@ https://github.com/cBournhonesque/lightyear/assets/8112632/0efcd974-b181-4910-93
 
 ## Running an example
 
-- Run the server with a gui: `cargo run -- server`
+- Run the server with a GUI: `cargo run -- --headless=false server`
 - Run client with id 1: `cargo run -- client -c 1`
 
 [//]: # (- Run the client and server in two separate bevy Apps: `cargo run` or `cargo run separate`)

--- a/examples/projectiles/README.md
+++ b/examples/projectiles/README.md
@@ -112,7 +112,7 @@ The example uses lightyear's room system to implement different replication stra
 
 ## Running an example
 
-- Run the server with a gui: `cargo run -- server`
+- Run the server with a GUI: `cargo run -- --headless=false server`
 - Run client with id 1: `cargo run -- client -c 1`
 
 [//]: # (- Run the client and server in two separate bevy Apps: `cargo run` or `cargo run separate`)
@@ -121,7 +121,6 @@ The example uses lightyear's room system to implement different replication stra
 
 You can control the behaviour of the example by changing the list of features. By default, all features are enabled (client, server, gui).
 For example you can run the server in headless mode without the fake bot by running `cargo run --no-default-features --features=server,webtransport,netcode`.
-When building all examples through `just`, `just build_examples features=server` builds the projectiles server with the extra `client` feature so the built-in fake bot is available.
 
 ### Testing in wasm with webtransport
 

--- a/examples/replication_groups/README.md
+++ b/examples/replication_groups/README.md
@@ -18,7 +18,7 @@ https://github.com/cBournhonesque/lightyear/assets/8112632/e7625286-a167-4f50-aa
 
 ## Running an example
 
-- Run the server with a gui: `cargo run -- server`
+- Run the server with a GUI: `cargo run -- --headless=false server`
 - Run client with id 1: `cargo run -- client -c 1`
 
 [//]: # (- Run the client and server in two separate bevy Apps: `cargo run` or `cargo run separate`)
@@ -28,7 +28,7 @@ https://github.com/cBournhonesque/lightyear/assets/8112632/e7625286-a167-4f50-aa
 ### P2P mode
 
 The snake simulation can also run as a deterministic input-only game with no server. Start peer 0
-with `cargo run --no-default-features --features=p2p -- --headless p2p --peer-id 0 --player-count 2`
+with `cargo run --no-default-features --features=p2p -- --headless=true p2p --peer-id 0 --player-count 2`
 and peer 1 with the same command using `--peer-id 1`. Every peer creates the same heads and tails
 locally. Replication groups themselves remain a feature of the conventional client/server mode;
 the P2P mode performs no entity replication.

--- a/examples/simple_box/README.md
+++ b/examples/simple_box/README.md
@@ -10,7 +10,7 @@ https://github.com/cBournhonesque/lightyear/assets/8112632/7b57d48a-d8b0-4cdd-a1
 
 ## Running an example
 
-- Run the server with a gui: `cargo run -- server`
+- Run the server with a GUI: `cargo run -- --headless=false server`
 - Run client with id 1: `cargo run -- client -c 1`
 
 [//]: # (- Run the client and server in two separate bevy Apps: `cargo run` or `cargo run separate`)
@@ -21,8 +21,8 @@ https://github.com/cBournhonesque/lightyear/assets/8112632/7b57d48a-d8b0-4cdd-a1
 The same example can run as a deterministic, input-only P2P game with no server or authoritative
 simulation. Start one process for each member of the fixed roster:
 
-- Peer 0: `cargo run --no-default-features --features=p2p -- --headless p2p --peer-id 0 --player-count 2`
-- Peer 1: `cargo run --no-default-features --features=p2p -- --headless p2p --peer-id 1 --player-count 2`
+- Peer 0: `cargo run --no-default-features --features=p2p -- --headless=true p2p --peer-id 0 --player-count 2`
+- Peer 1: `cargo run --no-default-features --features=p2p -- --headless=true p2p --peer-id 1 --player-count 2`
 
 P2P mode currently uses direct raw UDP Links on localhost and supports two through four players.
 Every peer pre-spawns the same player roster with stable `PreSpawned` hashes, simulates every

--- a/examples/simple_box/p2p_smoke.sh
+++ b/examples/simple_box/p2p_smoke.sh
@@ -37,7 +37,7 @@ LIGHTYEAR_SIMPLE_BOX_AUTOMOVE=right \
 LIGHTYEAR_SIMPLE_BOX_EXIT_AFTER_TICK="$exit_tick" \
 LIGHTYEAR_DEBUG_FILE="$peer_0_debug" \
 RUST_LOG=info,lightyear_debug=trace \
-"$binary" --headless p2p --peer-id 0 --player-count 2 --base-port "$base_port" \
+"$binary" --headless=true p2p --peer-id 0 --player-count 2 --base-port "$base_port" \
     >"$peer_0_log" 2>&1 &
 pids+=("$!")
 
@@ -45,7 +45,7 @@ LIGHTYEAR_SIMPLE_BOX_AUTOMOVE=none \
 LIGHTYEAR_SIMPLE_BOX_EXIT_AFTER_TICK="$exit_tick" \
 LIGHTYEAR_DEBUG_FILE="$peer_1_debug" \
 RUST_LOG=info,lightyear_debug=trace \
-"$binary" --headless p2p --peer-id 1 --player-count 2 --base-port "$base_port" \
+"$binary" --headless=true p2p --peer-id 1 --player-count 2 --base-port "$base_port" \
     >"$peer_1_log" 2>&1 &
 pids+=("$!")
 

--- a/examples/simple_setup/README.md
+++ b/examples/simple_setup/README.md
@@ -5,7 +5,8 @@ This minimal example shows how to create a bevy app with the lightyear client an
 
 ## Running an example
 
-- Run the server with a gui: `cargo run -- server`
+- Run the server headlessly (the default): `cargo run -- server`
+- Run the server with a GUI: `cargo run -- --headless=false server`
 - Run client with id 1: `cargo run -- client -c 1`
 
 [//]: # (- Run the client and server in two separate bevy Apps: `cargo run` or `cargo run separate`)

--- a/examples/simple_setup/src/automation.rs
+++ b/examples/simple_setup/src/automation.rs
@@ -14,6 +14,9 @@ pub struct ServerStartupConfig {
     pub auto_spawn: bool,
 }
 
+#[derive(Resource, Clone, Copy, Debug)]
+pub struct Headless(pub bool);
+
 impl Default for ServerStartupConfig {
     fn default() -> Self {
         Self { auto_spawn: true }
@@ -26,9 +29,11 @@ pub fn headless_enabled() -> bool {
         .unwrap_or(false)
 }
 
-pub fn build_base_app() -> App {
+pub fn build_base_app(headless: bool) -> App {
     let mut app = App::new();
-    if headless_enabled() {
+    let headless = headless || headless_enabled();
+    app.insert_resource(Headless(headless));
+    if headless {
         app.add_plugins((
             MinimalPlugins,
             LogPlugin {

--- a/examples/simple_setup/src/client.rs
+++ b/examples/simple_setup/src/client.rs
@@ -1,5 +1,5 @@
 //! The client plugin.
-use crate::automation::{headless_enabled, ClientStartupConfig};
+use crate::automation::{ClientStartupConfig, Headless};
 use crate::shared::*;
 use bevy::prelude::*;
 use core::net::Ipv4Addr;
@@ -20,8 +20,12 @@ impl Plugin for ExampleClientPlugin {
 }
 
 /// Spawn a client that connects to the server
-fn startup(mut commands: Commands, config: Res<ClientStartupConfig>) -> Result {
-    if !headless_enabled() {
+fn startup(
+    mut commands: Commands,
+    config: Res<ClientStartupConfig>,
+    headless: Res<Headless>,
+) -> Result {
+    if !headless.0 {
         commands.spawn(Camera2d);
     }
     let client = if let Some(server) = config.host_server {

--- a/examples/simple_setup/src/main.rs
+++ b/examples/simple_setup/src/main.rs
@@ -20,7 +20,7 @@ use crate::automation::ClientStartupConfig;
 use crate::automation::ServerStartupConfig;
 use crate::shared::{SharedPlugin, FIXED_TIMESTEP_HZ};
 use bevy::prelude::*;
-use clap::{Parser, Subcommand, ValueEnum};
+use clap::{ArgAction, Parser, Subcommand, ValueEnum};
 use core::time::Duration;
 #[cfg(feature = "server")]
 use lightyear::connection::server::Start;
@@ -45,8 +45,30 @@ use lightyear::prelude::*;
 #[derive(Parser, Debug)]
 #[command(version, about)]
 pub struct Cli {
+    /// Override headless mode. Dedicated servers are headless by default.
+    #[arg(
+        long,
+        global = true,
+        action = ArgAction::Set,
+        default_missing_value = "true",
+        num_args = 0..=1,
+        require_equals = true,
+        value_parser = clap::value_parser!(bool)
+    )]
+    pub headless: Option<bool>,
     #[command(subcommand)]
     pub mode: Mode,
+}
+
+impl Cli {
+    fn headless(&self) -> bool {
+        #[cfg(feature = "server")]
+        let dedicated_server = matches!(&self.mode, Mode::Server);
+        #[cfg(not(feature = "server"))]
+        let dedicated_server = false;
+
+        self.headless.unwrap_or(dedicated_server)
+    }
 }
 
 #[derive(Subcommand, Debug)]
@@ -64,7 +86,7 @@ pub enum Mode {
 
 fn main() {
     let cli = cli();
-    let mut app = automation::build_base_app();
+    let mut app = automation::build_base_app(cli.headless());
 
     match cli.mode {
         #[cfg(feature = "client")]
@@ -130,7 +152,10 @@ fn main() {
 fn cli() -> Cli {
     cfg_if::cfg_if! {
         if #[cfg(target_family = "wasm")] {
-            Cli { mode: Mode::Client }
+            Cli {
+                headless: None,
+                mode: Mode::Client,
+            }
         } else {
             Cli::parse()
         }

--- a/justfile
+++ b/justfile
@@ -1,4 +1,4 @@
-default: format taplo typos clippy clippy_examples test
+default: format taplo typos clippy test
 
 # Local CI
 format:
@@ -13,61 +13,51 @@ typos:
 doc:
     RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --document-private-items --keep-going --all-features --features="lightyear_avian2d/f32 lightyear_avian3d/f32"
 
-clippy: lightyear lightyear_aeronet lightyear_avian lightyear_connection lightyear_core \
-    lightyear_crossbeam lightyear_frame_interpolation lightyear_inputs lightyear_interpolation \
-    lightyear_link lightyear_messages lightyear_netcode lightyear_prediction lightyear_replication \
-    lightyear_serde lightyear_sync lightyear_tests lightyear_transport lightyear_udp lightyear_utils lightyear_webtransport
-    # You can't use `--all-features` because of conflict between `avian2d` and `avian3d`.
-    # cargo clippy --workspace --examples --tests --all-features -- -D warnings
-
-clippy_examples:
-    cargo clippy -p spaceships --all-features -- -D warnings --no-deps
-    cargo clippy -p auth --all-features -- -D warnings --no-deps
-    cargo clippy -p avian_3d --all-features -- -D warnings --no-deps
-    cargo clippy -p avian_2d --all-features -- -D warnings --no-deps
-    cargo clippy -p bevy_enhanced_inputs --all-features -- -D warnings --no-deps
-    cargo clippy -p lightyear_examples_common --all-features -- -D warnings --no-deps
-    # cargo clippy -p delta_compression --all-features -- -D warnings --no-deps
-    cargo clippy -p fps --all-features -- -D warnings --no-deps
-    cargo clippy -p launcher --all-features -- -D warnings --no-deps
-    cargo clippy -p lobby --all-features -- -D warnings --no-deps
-    cargo clippy -p network_visibility --all-features -- -D warnings --no-deps
-    cargo clippy -p priority --all-features -- -D warnings --no-deps
-    cargo clippy -p replication_groups --all-features -- -D warnings --no-deps
-    cargo clippy -p simple_box --all-features -- -D warnings --no-deps
-    # cargo clippy -p simple_setup --all-features -- -D warnings --no-deps
+# Keep local Clippy aligned with CI. The excluded GUI examples are linted in
+# separate feature graphs so Avian 2D and 3D are not unified.
+clippy:
+    cargo clippy --features=lightyear_core/not_mock,avian3d/f32 --workspace --exclude=compiletime --exclude=avian_3d --exclude=launcher --exclude=delta_compression --no-deps -- -D warnings -A clippy::needless_lifetimes
+    cargo clippy -p avian_3d --all-features --no-deps -- -D warnings
+    cargo clippy -p launcher --all-features --no-deps -- -D warnings
 
 # Run two conditioned simple-box peers and verify remote prediction rollback plus convergence.
 simple_box_p2p_smoke:
     bash examples/simple_box/p2p_smoke.sh
 
 # jq filters shared by the example/demo build recipe.
+[private]
 _example_demo_pkgs_filter := '.packages[] | select((.manifest_path | test("/(examples|demos)/")) and (.manifest_path | test("/examples/common/") | not) and (.manifest_path | test("/examples/launcher/") | not) and (.name != "simple_setup")) | .name'
-_example_demo_non_projectiles_pkgs_filter := '.packages[] | select((.manifest_path | test("/(examples|demos)/")) and (.manifest_path | test("/examples/common/") | not) and (.manifest_path | test("/examples/launcher/") | not) and (.name != "simple_setup") and (.name != "projectiles")) | .name'
-_example_demo_p2p_non_avian_pkgs_filter := '.packages[] | select((.manifest_path | test("/(examples|demos)/")) and (.manifest_path | test("/examples/common/") | not) and (.features | has("p2p")) and (.name != "avian_2d") and (.name != "avian_3d")) | .name'
-# simple_setup is excluded from explicit feature builds because it has no client/server/gui feature gates.
+[private]
+_example_demo_p2p_pkgs_filter := '.packages[] | select((.manifest_path | test("/(examples|demos)/")) and (.manifest_path | test("/examples/common/") | not) and (.features | has("p2p"))) | .name'
+# simple_setup is excluded from explicit feature builds because it has its own feature setup.
 
-# Build all examples/demos.
+# Build all examples/demos with the requested role features. Client/server add
+# the default netcode + WebTransport stack, and client/P2P add the GUI. When P2P
+# is requested, only examples that expose P2P are selected, and the Avian 2D/3D
+# examples are built separately to avoid feature unification.
 #
 # Usage:
 #   just build_examples
-#   just build_examples features=server
+#   just build_examples features=client,server
 #   just build_examples features=client headless=true
-#   just build_examples release=true features=both
-#   just build_examples features=p2p
+#   just build_examples names=avian_3d
+#   just build_examples names=avian_2d,avian_3d features=client headless=true
+#   just build_examples features=client,server,p2p
+#   just build_examples release=true features=server headless=false
 #
 # Args:
 #   release=true|false   Defaults to false.
-#   headless=true|false  Defaults to true for features=server, false otherwise.
-#   features=server|client|both|p2p  Defaults to both.
+#   headless=true|false  Removes/adds gui. Defaults based on the requested role.
+# names=NAME,... selects packages; features=FEATURE,... defaults to client,server.
 build_examples *args:
     #!/usr/bin/env bash
     set -euo pipefail
-    usage='usage: just build_examples [release=true|false] [headless=true|false] [features=server|client|both|p2p]'
+    usage='usage: just build_examples [release=true|false] [headless=true|false] [features=FEATURE,...] [names=NAME,...]'
     release=false
     headless=""
-    feature_mode=both
-    for arg in {{args}}; do
+    names=""
+    requested_features="client,server"
+    for arg in {{ args }}; do
         case "$arg" in
             release=true|release=false)
                 release="${arg#release=}"
@@ -75,8 +65,19 @@ build_examples *args:
             headless=true|headless=false)
                 headless="${arg#headless=}"
                 ;;
-            features=server|features=client|features=both|features=p2p)
-                feature_mode="${arg#features=}"
+            features=*)
+                requested_features="${arg#features=}"
+                if [ -z "$requested_features" ]; then
+                    echo "features must not be empty" >&2
+                    exit 2
+                fi
+                ;;
+            names=*)
+                names="${arg#names=}"
+                if [ -z "$names" ]; then
+                    echo "names must not be empty" >&2
+                    exit 2
+                fi
                 ;;
             -h|--help|help)
                 echo "$usage"
@@ -89,75 +90,112 @@ build_examples *args:
                 ;;
         esac
     done
-    if [ -z "$headless" ]; then
-        if [ "$feature_mode" = server ]; then
-            headless=true
-        else
-            headless=false
+
+    cargo_features="$requested_features"
+    has_feature() {
+        case ",$cargo_features," in
+            *,"$1",*) return 0 ;;
+            *) return 1 ;;
+        esac
+    }
+    add_feature() {
+        if ! has_feature "$1"; then
+            cargo_features="$cargo_features,$1"
         fi
+    }
+    remove_feature() {
+        local padded_features=",$cargo_features,"
+        padded_features="${padded_features//,$1,/,}"
+        cargo_features="${padded_features#,}"
+        cargo_features="${cargo_features%,}"
+    }
+    if has_feature client || has_feature server; then
+        add_feature netcode
+        add_feature webtransport
+    fi
+    if [ "$headless" = true ]; then
+        remove_feature gui
+    elif [ "$headless" = false ]; then
+        add_feature gui
+    elif has_feature client || has_feature p2p; then
+        add_feature gui
     fi
 
     cargo_build=(cargo build -j 1)
-    release_suffix=""
     if [ "$release" = true ]; then
         cargo_build+=(--release)
-        release_suffix="-release"
     fi
 
-    target_dir=""
-    if [ "$headless" = true ]; then
-        case "$feature_mode" in
-            both) target_dir="target/headless${release_suffix}" ;;
-            client) target_dir="target/headless-client${release_suffix}" ;;
-            server) target_dir="target/headless-server${release_suffix}" ;;
-            p2p) target_dir="target/headless-p2p${release_suffix}" ;;
-        esac
-    elif [ "$feature_mode" = server ]; then
-        target_dir="target/server-only${release_suffix}"
-    fi
-    if [ -n "$target_dir" ]; then
-        cargo_build+=(--target-dir "$target_dir")
-    fi
-
-    case "$feature_mode:$headless" in
-        both:true) cargo_features="client,server,netcode,webtransport" ;;
-        client:true) cargo_features="client,netcode,webtransport" ;;
-        server:true) cargo_features="server,netcode,webtransport" ;;
-        p2p:true) cargo_features="p2p" ;;
-        both:false) cargo_features="client,gui,server,netcode,webtransport" ;;
-        client:false) cargo_features="client,gui,netcode,webtransport" ;;
-        server:false) cargo_features="server,gui,netcode,webtransport" ;;
-        p2p:false) cargo_features="p2p,gui" ;;
+    p2p=false
+    case ",$cargo_features," in
+        *,p2p,*) p2p=true ;;
     esac
 
-    if [ "$feature_mode" = p2p ]; then
-        projectiles_features=""
-    elif [ "$headless" = true ]; then
-        projectiles_features="client,server,netcode,webtransport"
+    workspace_metadata="$(cargo metadata --no-deps --format-version 1)"
+    selected_packages=()
+    if [ -n "$names" ]; then
+        IFS=',' read -r -a requested_names <<< "$names"
+        IFS=',' read -r -a resolved_features <<< "$cargo_features"
+        for pkg in "${requested_names[@]}"; do
+            if [ -z "$pkg" ]; then
+                echo "names must not contain an empty package name" >&2
+                exit 2
+            fi
+            if ! jq -e --arg pkg "$pkg" '
+                any(.packages[];
+                    .name == $pkg
+                    and (.manifest_path | test("/(examples|demos)/"))
+                    and (.manifest_path | test("/examples/common/") | not)
+                )
+            ' <<< "$workspace_metadata" >/dev/null; then
+                echo "unknown example/demo package: $pkg" >&2
+                exit 2
+            fi
+            for feature in "${resolved_features[@]}"; do
+                if ! jq -e --arg pkg "$pkg" --arg feature "$feature" '
+                    any(.packages[]; .name == $pkg and (.features | has($feature)))
+                ' <<< "$workspace_metadata" >/dev/null; then
+                    echo "example/demo package '$pkg' does not support feature '$feature'" >&2
+                    exit 2
+                fi
+            done
+            selected_packages+=("$pkg")
+        done
     else
-        projectiles_features="client,gui,server,netcode,webtransport"
+        if [ "$p2p" = true ]; then
+            pkgs_filter='{{ _example_demo_p2p_pkgs_filter }}'
+        else
+            pkgs_filter='{{ _example_demo_pkgs_filter }}'
+        fi
+        while IFS= read -r pkg; do
+            selected_packages+=("$pkg")
+        done < <(jq -r "$pkgs_filter" <<< "$workspace_metadata" | sort)
     fi
 
-    echo "Building examples: release=$release headless=$headless features=$feature_mode cargo_features=$cargo_features"
-    if [ "$feature_mode" = p2p ]; then
-        # Keep Avian 2D and 3D out of the same Cargo feature-unification graph.
-        pkgs_filter='{{ _example_demo_p2p_non_avian_pkgs_filter }}'
-    elif [ "$projectiles_features" = "$cargo_features" ]; then
-        pkgs_filter='{{ _example_demo_pkgs_filter }}'
-    else
-        pkgs_filter='{{ _example_demo_non_projectiles_pkgs_filter }}'
-    fi
+    echo "Building examples: release=$release headless=${headless:-auto} requested=$requested_features features=$cargo_features"
+    echo "Selected packages: ${selected_packages[*]}"
     package_args=()
-    while IFS= read -r pkg; do
-        package_args+=(-p "$pkg")
-    done < <(cargo metadata --no-deps --format-version 1 | jq -r "$pkgs_filter" | sort)
-    "${cargo_build[@]}" --no-default-features --features="$cargo_features" "${package_args[@]}"
-    if [ "$feature_mode" = p2p ]; then
-        "${cargo_build[@]}" --no-default-features --features="$cargo_features" -p avian_2d
-        "${cargo_build[@]}" --no-default-features --features="$cargo_features" -p avian_3d
+    non_avian_count=0
+    build_avian_2d=false
+    build_avian_3d=false
+    for pkg in "${selected_packages[@]}"; do
+        if [ "$p2p" = true ] && [ "$pkg" = avian_2d ]; then
+            build_avian_2d=true
+        elif [ "$p2p" = true ] && [ "$pkg" = avian_3d ]; then
+            build_avian_3d=true
+        else
+            package_args+=(-p "$pkg")
+            non_avian_count=$((non_avian_count + 1))
+        fi
+    done
+    if [ "$non_avian_count" -gt 0 ]; then
+        "${cargo_build[@]}" --no-default-features --features="$cargo_features" "${package_args[@]}"
     fi
-    if [ -n "$projectiles_features" ] && [ "$projectiles_features" != "$cargo_features" ]; then
-        "${cargo_build[@]}" --no-default-features --features="$projectiles_features" -p projectiles
+    if [ "$build_avian_2d" = true ]; then
+        "${cargo_build[@]}" --no-default-features --features="$cargo_features" -p avian_2d
+    fi
+    if [ "$build_avian_3d" = true ]; then
+        "${cargo_build[@]}" --no-default-features --features="$cargo_features" -p avian_3d
     fi
 
 test:
@@ -197,359 +235,6 @@ test:
     # Limit to 1 test thread to prevent mocked GlobalTime from going crazy
     cargo test -p lightyear_tests --all-features -- --test-threads=1
 
-# Clippy
-lightyear:
-    # `lightyear_avian` only works on `std`
-    # cargo clippy -p lightyear --no-default-features -- -D warnings --no-deps
-    cargo clippy -p lightyear --no-default-features --features="std" -- -D warnings --no-deps
-    cargo clippy -p lightyear --no-default-features --features="std client" -- -D warnings --no-deps
-    cargo clippy -p lightyear --no-default-features --features="std p2p" -- -D warnings --no-deps
-    cargo clippy -p lightyear --no-default-features --features="std server" -- -D warnings --no-deps
-    cargo clippy -p lightyear --no-default-features --features="std replication" -- -D warnings --no-deps
-    cargo clippy -p lightyear --no-default-features --features="std prediction" -- -D warnings --no-deps
-    cargo clippy -p lightyear --no-default-features --features="std interpolation" -- -D warnings --no-deps
-    cargo clippy -p lightyear --no-default-features --features="std trace" -- -D warnings --no-deps
-    cargo clippy -p lightyear --no-default-features --features="metrics" -- -D warnings --no-deps
-    cargo clippy -p lightyear --no-default-features --features="std netcode" -- -D warnings --no-deps
-    cargo clippy -p lightyear --no-default-features --features="webtransport" -- -D warnings --no-deps
-    cargo clippy -p lightyear --no-default-features --features="std webtransport_self_signed" -- -D warnings --no-deps
-    cargo clippy -p lightyear --no-default-features --features="std webtransport_dangerous_configuration" -- -D warnings --no-deps
-    cargo clippy -p lightyear --no-default-features --features="std input_native" -- -D warnings --no-deps
-    cargo clippy -p lightyear --no-default-features --features="std leafwing" -- -D warnings --no-deps
-    cargo clippy -p lightyear --no-default-features --features="std input_bei" -- -D warnings --no-deps
-    cargo clippy -p lightyear --no-default-features --features="avian2d lightyear_avian2d/f32" -- -D warnings --no-deps
-    cargo clippy -p lightyear --no-default-features --features="avian3d lightyear_avian3d/f32" -- -D warnings --no-deps
-    cargo clippy -p lightyear --no-default-features --features="udp" -- -D warnings --no-deps
-    cargo clippy -p lightyear --no-default-features --features="websocket" -- -D warnings --no-deps
-    cargo clippy -p lightyear --no-default-features --features="std crossbeam" -- -D warnings --no-deps
-    cargo clippy -p lightyear --no-default-features --features="steam" -- -D warnings --no-deps
-    # You can't use `--all-features` because of conflict between `avian2d` and `avian3d`
-    cargo clippy -p lightyear --no-default-features --features="std client server replication \
-    interpolation trace metrics netcode webtransport webtransport_self_signed webtransport_dangerous_configuration \
-    input_native leafwing input_bei avian2d lightyear_avian2d/f32 udp websocket crossbeam steam" -- -D warnings --no-deps
-    cargo clippy -p lightyear --no-default-features --features="std client server replication \
-    interpolation trace metrics netcode webtransport webtransport_self_signed webtransport_dangerous_configuration \
-    input_native leafwing input_bei avian3d lightyear_avian3d/f32 udp websocket crossbeam steam" -- -D warnings --no-deps
-    # cargo clippy -p lightyear --tests --no-default-features -- -D warnings --no-deps
-    cargo clippy -p lightyear --tests --no-default-features --features="std" -- -D warnings --no-deps
-    cargo clippy -p lightyear --tests --no-default-features --features="std client" -- -D warnings --no-deps
-    cargo clippy -p lightyear --tests --no-default-features --features="std p2p" -- -D warnings --no-deps
-    cargo clippy -p lightyear --tests --no-default-features --features="std server" -- -D warnings --no-deps
-    cargo clippy -p lightyear --tests --no-default-features --features="std replication" -- -D warnings --no-deps
-    cargo clippy -p lightyear --tests --no-default-features --features="std prediction" -- -D warnings --no-deps
-    cargo clippy -p lightyear --tests --no-default-features --features="std interpolation" -- -D warnings --no-deps
-    cargo clippy -p lightyear --tests --no-default-features --features="std trace" -- -D warnings --no-deps
-    cargo clippy -p lightyear --tests --no-default-features --features="metrics" -- -D warnings --no-deps
-    cargo clippy -p lightyear --tests --no-default-features --features="std netcode" -- -D warnings --no-deps
-    cargo clippy -p lightyear --tests --no-default-features --features="webtransport" -- -D warnings --no-deps
-    cargo clippy -p lightyear --tests --no-default-features --features="std webtransport_self_signed" -- -D warnings --no-deps
-    cargo clippy -p lightyear --tests --no-default-features --features="std webtransport_dangerous_configuration" -- -D warnings --no-deps
-    cargo clippy -p lightyear --tests --no-default-features --features="std input_native" -- -D warnings --no-deps
-    cargo clippy -p lightyear --tests --no-default-features --features="std leafwing" -- -D warnings --no-deps
-    cargo clippy -p lightyear --tests --no-default-features --features="std input_bei" -- -D warnings --no-deps
-    cargo clippy -p lightyear --tests --no-default-features --features="avian2d lightyear_avian2d/f32" -- -D warnings --no-deps
-    cargo clippy -p lightyear --tests --no-default-features --features="avian3d lightyear_avian3d/f32" -- -D warnings --no-deps
-    cargo clippy -p lightyear --tests --no-default-features --features="udp" -- -D warnings --no-deps
-    cargo clippy -p lightyear --tests --no-default-features --features="websocket" -- -D warnings --no-deps
-    cargo clippy -p lightyear --tests --no-default-features --features="std crossbeam" -- -D warnings --no-deps
-    cargo clippy -p lightyear --tests --no-default-features --features="steam" -- -D warnings --no-deps
-    # You can't use `--all-features` because of conflict between `avian2d` and `avian3d`
-    cargo clippy -p lightyear --tests --no-default-features --features="std client server replication \
-    interpolation trace metrics netcode webtransport webtransport_self_signed webtransport_dangerous_configuration \
-    input_native leafwing input_bei avian2d lightyear_avian2d/f32 udp websocket crossbeam steam" -- -D warnings --no-deps
-    cargo clippy -p lightyear --tests --no-default-features --features="std client server replication \
-    interpolation trace metrics netcode webtransport webtransport_self_signed webtransport_dangerous_configuration \
-    input_native leafwing input_bei avian3d lightyear_avian3d/f32 udp websocket crossbeam steam" -- -D warnings --no-deps
-
-lightyear_aeronet:
-    cargo clippy -p lightyear_aeronet --no-default-features -- -D warnings --no-deps
-    cargo clippy -p lightyear_aeronet --no-default-features --features="test_utils" -- -D warnings --no-deps
-    cargo clippy -p lightyear_aeronet --all-features -- -D warnings --no-deps
-    cargo clippy -p lightyear_aeronet --tests --no-default-features -- -D warnings --no-deps
-    cargo clippy -p lightyear_aeronet --tests --no-default-features --features="test_utils" -- -D warnings --no-deps
-    cargo clippy -p lightyear_aeronet --tests --all-features -- -D warnings --no-deps
-
-lightyear_avian:
-    # `lightyear_avian` only works on `std`
-    # `2d` and `3d` are mutually exclusive
-    # `lag_compensation` requires either `2d` or `3d`
-    cargo clippy -p lightyear_avian --no-default-features -- -D warnings --no-deps
-    cargo clippy -p lightyear_avian --no-default-features --features="std 2d" -- -D warnings --no-deps
-    cargo clippy -p lightyear_avian --no-default-features --features="std 3d" -- -D warnings --no-deps
-    cargo clippy -p lightyear_avian --no-default-features --features="std 2d lag_compensation" -- -D warnings --no-deps
-    cargo clippy -p lightyear_avian --no-default-features --features="std 3d lag_compensation" -- -D warnings --no-deps
-    # cargo clippy -p lightyear_avian --tests --no-default-features -- -D warnings --no-deps
-    cargo clippy -p lightyear_avian --tests --no-default-features --features="std 2d" -- -D warnings --no-deps
-    cargo clippy -p lightyear_avian --tests --no-default-features --features="std 3d" -- -D warnings --no-deps
-    cargo clippy -p lightyear_avian --tests --no-default-features --features="std 2d lag_compensation" -- -D warnings --no-deps
-    cargo clippy -p lightyear_avian --tests --no-default-features --features="std 3d lag_compensation" -- -D warnings --no-deps
-
-lightyear_connection:
-    cargo clippy -p lightyear_connection --no-default-features -- -D warnings --no-deps
-    cargo clippy -p lightyear_connection --no-default-features --features="client" -- -D warnings --no-deps
-    cargo clippy -p lightyear_connection --no-default-features --features="server" -- -D warnings --no-deps
-    cargo clippy -p lightyear_connection --all-features -- -D warnings --no-deps
-    cargo clippy -p lightyear_connection --tests --no-default-features -- -D warnings --no-deps
-    cargo clippy -p lightyear_connection --tests --no-default-features --features="client" -- -D warnings --no-deps
-    cargo clippy -p lightyear_connection --tests --no-default-features --features="server" -- -D warnings --no-deps
-    cargo clippy -p lightyear_connection --tests --all-features -- -D warnings --no-deps
-
-lightyear_core:
-    cargo clippy -p lightyear_core --no-default-features -- -D warnings --no-deps
-    cargo clippy -p lightyear_core --no-default-features --features="prediction" -- -D warnings --no-deps
-    cargo clippy -p lightyear_core --no-default-features --features="interpolation" -- -D warnings --no-deps
-    cargo clippy -p lightyear_core --no-default-features --features="test_utils" -- -D warnings --no-deps
-    cargo clippy -p lightyear_core --no-default-features --features="not_mock" -- -D warnings --no-deps
-    cargo clippy -p lightyear_core --all-features -- -D warnings --no-deps
-    cargo clippy -p lightyear_core --tests --no-default-features -- -D warnings --no-deps
-    cargo clippy -p lightyear_core --tests --no-default-features --features="prediction" -- -D warnings --no-deps
-    cargo clippy -p lightyear_core --tests --no-default-features --features="interpolation" -- -D warnings --no-deps
-    cargo clippy -p lightyear_core --tests --no-default-features --features="test_utils" -- -D warnings --no-deps
-    cargo clippy -p lightyear_core --tests --no-default-features --features="not_mock" -- -D warnings --no-deps
-    cargo clippy -p lightyear_core --tests --all-features -- -D warnings --no-deps
-
-lightyear_crossbeam:
-    cargo clippy -p lightyear_crossbeam --no-default-features -- -D warnings --no-deps
-    cargo clippy -p lightyear_crossbeam --all-features -- -D warnings --no-deps
-    cargo clippy -p lightyear_crossbeam --tests --no-default-features -- -D warnings --no-deps
-    cargo clippy -p lightyear_crossbeam --tests --all-features -- -D warnings --no-deps
-
-lightyear_frame_interpolation:
-    # `lightyear_frame_interpolation` only works with `std`
-    # cargo clippy -p lightyear_frame_interpolation --no-default-features -- -D warnings --no-deps
-    cargo clippy -p lightyear_frame_interpolation --no-default-features --features="std" -- -D warnings --no-deps
-    cargo clippy -p lightyear_frame_interpolation --all-features -- -D warnings --no-deps
-    # cargo clippy -p lightyear_frame_interpolation --tests --no-default-features -- -D warnings --no-deps
-    # cargo clippy -p lightyear_frame_interpolation --tests --no-default-features --features="std" -- -D warnings --no-deps
-    # cargo clippy -p lightyear_frame_interpolation --tests --all-features -- -D warnings --no-deps
-
-lightyear_inputs:
-    # `lightyear_inputs` only works with `std`
-    # cargo clippy -p lightyear_inputs --no-default-features -- -D warnings --no-deps
-    cargo clippy -p lightyear_inputs --no-default-features --features="std" -- -D warnings --no-deps
-    cargo clippy -p lightyear_inputs --no-default-features --features="std client" -- -D warnings --no-deps
-    cargo clippy -p lightyear_inputs --no-default-features --features="std server" -- -D warnings --no-deps
-    cargo clippy -p lightyear_inputs --no-default-features --features="metrics" -- -D warnings --no-deps
-    cargo clippy -p lightyear_inputs --no-default-features --features="std interpolation" -- -D warnings --no-deps
-    cargo clippy -p lightyear_inputs --no-default-features --features="std interpolation client" -- -D warnings --no-deps
-    cargo clippy -p lightyear_inputs --no-default-features --features="std interpolation server" -- -D warnings --no-deps
-    cargo clippy -p lightyear_inputs --all-features -- -D warnings --no-deps
-    # # cargo clippy -p lightyear_inputs --tests --no-default-features -- -D warnings --no-deps
-    cargo clippy -p lightyear_inputs --tests --no-default-features --features="std" -- -D warnings --no-deps
-    cargo clippy -p lightyear_inputs --tests --no-default-features --features="std client" -- -D warnings --no-deps
-    cargo clippy -p lightyear_inputs --tests --no-default-features --features="std server" -- -D warnings --no-deps
-    cargo clippy -p lightyear_inputs --tests --no-default-features --features="metrics" -- -D warnings --no-deps
-    cargo clippy -p lightyear_inputs --tests --no-default-features --features="std interpolation" -- -D warnings --no-deps
-    cargo clippy -p lightyear_inputs --tests --no-default-features --features="std interpolation client" -- -D warnings --no-deps
-    cargo clippy -p lightyear_inputs --tests --no-default-features --features="std interpolation server" -- -D warnings --no-deps
-    cargo clippy -p lightyear_inputs --tests --all-features -- -D warnings --no-deps
-
-lightyear_inputs_bei:
-    # `lightyear_inputs_bei` only works with `std`
-    # cargo clippy -p lightyear_inputs_bei --no-default-features -- -D warnings --no-deps
-    cargo clippy -p lightyear_inputs_bei --no-default-features --features="std" -- -D warnings --no-deps
-    cargo clippy -p lightyear_inputs_bei --no-default-features --features="std client" -- -D warnings --no-deps
-    cargo clippy -p lightyear_inputs_bei --no-default-features --features="std server" -- -D warnings --no-deps
-    cargo clippy -p lightyear_inputs_bei --all-features -- -D warnings --no-deps
-    # cargo clippy -p lightyear_inputs_bei --tests --no-default-features -- -D warnings --no-deps
-    cargo clippy -p lightyear_inputs_bei --tests --no-default-features --features="std" -- -D warnings --no-deps
-    cargo clippy -p lightyear_inputs_bei --tests --no-default-features --features="std client" -- -D warnings --no-deps
-    cargo clippy -p lightyear_inputs_bei --tests --no-default-features --features="std server" -- -D warnings --no-deps
-    cargo clippy -p lightyear_inputs_bei --tests --all-features -- -D warnings --no-deps
-
-lightyear_inputs_leafwing:
-    # `lightyear_inputs_leafwing` only works with `std`
-    cargo clippy -p lightyear_inputs_leafwing --no-default-features -- -D warnings --no-deps
-    cargo clippy -p lightyear_inputs_leafwing --no-default-features --features="std" -- -D warnings --no-deps
-    cargo clippy -p lightyear_inputs_leafwing --no-default-features --features="client" -- -D warnings --no-deps
-    cargo clippy -p lightyear_inputs_leafwing --no-default-features --features="server" -- -D warnings --no-deps
-    cargo clippy -p lightyear_inputs_leafwing --no-default-features --features="std client" -- -D warnings --no-deps
-    cargo clippy -p lightyear_inputs_leafwing --no-default-features --features="std server" -- -D warnings --no-deps
-    cargo clippy -p lightyear_inputs_leafwing --all-features -- -D warnings --no-deps
-    cargo clippy -p lightyear_inputs_leafwing --tests --no-default-features -- -D warnings --no-deps
-    cargo clippy -p lightyear_inputs_leafwing --tests --no-default-features --features="std" -- -D warnings --no-deps
-    cargo clippy -p lightyear_inputs_leafwing --tests --no-default-features --features="client" -- -D warnings --no-deps
-    cargo clippy -p lightyear_inputs_leafwing --tests --no-default-features --features="server" -- -D warnings --no-deps
-    cargo clippy -p lightyear_inputs_leafwing --tests --no-default-features --features="std client" -- -D warnings --no-deps
-    cargo clippy -p lightyear_inputs_leafwing --tests --no-default-features --features="std server" -- -D warnings --no-deps
-    cargo clippy -p lightyear_inputs_leafwing --tests --all-features -- -D warnings --no-deps
-
-lightyear_inputs_native:
-    # `lightyear_inputs_native` only works with `std`
-    # cargo clippy -p lightyear_inputs_native --no-default-features -- -D warnings --no-deps
-    cargo clippy -p lightyear_inputs_native --no-default-features --features="std" -- -D warnings --no-deps
-    cargo clippy -p lightyear_inputs_native --no-default-features --features="std client" -- -D warnings --no-deps
-    cargo clippy -p lightyear_inputs_native --no-default-features --features="std server" -- -D warnings --no-deps
-    cargo clippy -p lightyear_inputs_native --all-features -- -D warnings --no-deps
-    # cargo clippy -p lightyear_inputs_native --tests --no-default-features -- -D warnings --no-deps
-    cargo clippy -p lightyear_inputs_native --tests --no-default-features --features="std" -- -D warnings --no-deps
-    cargo clippy -p lightyear_inputs_native --tests --no-default-features --features="std client" -- -D warnings --no-deps
-    cargo clippy -p lightyear_inputs_native --tests --no-default-features --features="std server" -- -D warnings --no-deps
-    cargo clippy -p lightyear_inputs_native --tests --all-features -- -D warnings --no-deps
-
-lightyear_interpolation:
-    # `lightyear_interpolation` only works with `std`
-    # cargo clippy -p lightyear_interpolation --no-default-features -- -D warnings --no-deps
-    cargo clippy -p lightyear_interpolation --no-default-features --features="std" -- -D warnings --no-deps
-    cargo clippy -p lightyear_interpolation --no-default-features --features="metrics" -- -D warnings --no-deps
-    cargo clippy -p lightyear_interpolation --all-features -- -D warnings --no-deps
-    # cargo clippy -p lightyear_interpolation --tests --no-default-features -- -D warnings --no-deps
-    cargo clippy -p lightyear_interpolation --tests --no-default-features --features="std" -- -D warnings --no-deps
-    cargo clippy -p lightyear_interpolation --tests --no-default-features --features="metrics" -- -D warnings --no-deps
-    cargo clippy -p lightyear_interpolation --tests --all-features -- -D warnings --no-deps
-
-lightyear_link:
-    cargo clippy -p lightyear_link --no-default-features -- -D warnings --no-deps
-    cargo clippy -p lightyear_link --no-default-features --features="test_utils" -- -D warnings --no-deps
-    cargo clippy -p lightyear_link --all-features -- -D warnings --no-deps
-    cargo clippy -p lightyear_link --tests --no-default-features -- -D warnings --no-deps
-    cargo clippy -p lightyear_link --tests --no-default-features --features="test_utils" -- -D warnings --no-deps
-    cargo clippy -p lightyear_link --tests --all-features -- -D warnings --no-deps
-
-lightyear_messages:
-    # `lightyear_messages` only works in `std`
-    # cargo clippy -p lightyear_messages --no-default-features -- -D warnings --no-deps
-    cargo clippy -p lightyear_messages --no-default-features --features="std client" -- -D warnings --no-deps
-    cargo clippy -p lightyear_messages --no-default-features --features="std server" -- -D warnings --no-deps
-    cargo clippy -p lightyear_messages --no-default-features --features="std test_utils" -- -D warnings --no-deps
-    cargo clippy -p lightyear_messages --all-features -- -D warnings --no-deps
-    # cargo clippy -p lightyear_messages --tests --no-default-features -- -D warnings --no-deps
-    cargo clippy -p lightyear_messages --tests --no-default-features --features="std client" -- -D warnings --no-deps
-    cargo clippy -p lightyear_messages --tests --no-default-features --features="std server" -- -D warnings --no-deps
-    cargo clippy -p lightyear_messages --tests --no-default-features --features="std test_utils" -- -D warnings --no-deps
-    cargo clippy -p lightyear_messages --tests --all-features -- -D warnings --no-deps
-
-lightyear_netcode:
-    # `lightyear_netcode` only works in `std`
-    # `trace` only affects `server`
-    # cargo clippy -p lightyear_netcode --no-default-features -- -D warnings --no-deps
-    cargo clippy -p lightyear_netcode --no-default-features --features="std client" -- -D warnings --no-deps
-    cargo clippy -p lightyear_netcode --no-default-features --features="std server" -- -D warnings --no-deps
-    cargo clippy -p lightyear_netcode --no-default-features --features="std server trace" -- -D warnings --no-deps
-    cargo clippy -p lightyear_netcode --all-features -- -D warnings --no-deps
-    # cargo clippy -p lightyear_netcode --tests --no-default-features -- -D warnings --no-deps
-    cargo clippy -p lightyear_netcode --tests --no-default-features --features="std client" -- -D warnings --no-deps
-    cargo clippy -p lightyear_netcode --tests --no-default-features --features="std server" -- -D warnings --no-deps
-    cargo clippy -p lightyear_netcode --tests --no-default-features --features="std server trace" -- -D warnings --no-deps
-    cargo clippy -p lightyear_netcode --tests --all-features -- -D warnings --no-deps
-
-lightyear_prediction:
-    # `lightyear_prediction` only works in `std`
-    # cargo clippy -p lightyear_prediction --no-default-features -- -D warnings --no-deps
-    cargo clippy -p lightyear_prediction --no-default-features --features="std server" -- -D warnings --no-deps
-    cargo clippy -p lightyear_prediction --no-default-features --features="metrics" -- -D warnings --no-deps
-    cargo clippy -p lightyear_prediction --all-features -- -D warnings --no-deps
-    # cargo clippy -p lightyear_prediction --tests --no-default-features -- -D warnings --no-deps
-    # cargo clippy -p lightyear_prediction --tests --no-default-features --features="std server" -- -D warnings --no-deps
-    # cargo clippy -p lightyear_prediction --tests --no-default-features --features="metrics" -- -D warnings --no-deps
-    # cargo clippy -p lightyear_prediction --tests --all-features -- -D warnings --no-deps
-
-lightyear_replication:
-    # `lightyear_replication` only works in `std`
-    # cargo clippy -p lightyear_replication --no-default-features -- -D warnings --no-deps
-    cargo clippy -p lightyear_replication --no-default-features --features="std client" -- -D warnings --no-deps
-    cargo clippy -p lightyear_replication --no-default-features --features="std server" -- -D warnings --no-deps
-    cargo clippy -p lightyear_replication --no-default-features --features="std prediction" -- -D warnings --no-deps
-    cargo clippy -p lightyear_replication --no-default-features --features="std interpolation" -- -D warnings --no-deps
-    cargo clippy -p lightyear_replication --no-default-features --features="std trace" -- -D warnings --no-deps
-    cargo clippy -p lightyear_replication --no-default-features --features="metrics" -- -D warnings --no-deps
-    cargo clippy -p lightyear_replication --no-default-features --features="std test_utils" -- -D warnings --no-deps
-    cargo clippy -p lightyear_replication --all-features -- -D warnings --no-deps
-    # cargo clippy -p lightyear_replication --tests --no-default-features -- -D warnings --no-deps
-    cargo clippy -p lightyear_replication --tests --no-default-features --features="std client" -- -D warnings --no-deps
-    cargo clippy -p lightyear_replication --tests --no-default-features --features="std server" -- -D warnings --no-deps
-    cargo clippy -p lightyear_replication --tests --no-default-features --features="std prediction" -- -D warnings --no-deps
-    cargo clippy -p lightyear_replication --tests --no-default-features --features="std interpolation" -- -D warnings --no-deps
-    cargo clippy -p lightyear_replication --tests --no-default-features --features="std trace" -- -D warnings --no-deps
-    cargo clippy -p lightyear_replication --tests --no-default-features --features="metrics" -- -D warnings --no-deps
-    cargo clippy -p lightyear_replication --tests --no-default-features --features="std test_utils" -- -D warnings --no-deps
-    cargo clippy -p lightyear_replication --tests --all-features -- -D warnings --no-deps
-
-lightyear_serde:
-    cargo clippy -p lightyear_serde --no-default-features -- -D warnings --no-deps
-    cargo clippy -p lightyear_serde --no-default-features --features="std" -- -D warnings --no-deps
-    cargo clippy -p lightyear_serde --all-features -- -D warnings --no-deps
-    cargo clippy -p lightyear_serde --tests --no-default-features -- -D warnings --no-deps
-    cargo clippy -p lightyear_serde --tests --no-default-features --features="std" -- -D warnings --no-deps
-    cargo clippy -p lightyear_serde --tests --all-features -- -D warnings --no-deps
-
-lightyear_steam:
-    cargo clippy -p lightyear_steam --no-default-features -- -D warnings --no-deps
-    cargo clippy -p lightyear_steam --no-default-features --features="std" -- -D warnings --no-deps
-    cargo clippy -p lightyear_steam --no-default-features --features="client" -- -D warnings --no-deps
-    cargo clippy -p lightyear_steam --no-default-features --features="server" -- -D warnings --no-deps
-    cargo clippy -p lightyear_steam --all-features -- -D warnings --no-deps
-    cargo clippy -p lightyear_steam --tests --no-default-features -- -D warnings --no-deps
-    cargo clippy -p lightyear_steam --tests --no-default-features --features="std" -- -D warnings --no-deps
-    cargo clippy -p lightyear_steam --tests --no-default-features --features="client" -- -D warnings --no-deps
-    cargo clippy -p lightyear_steam --tests --no-default-features --features="server" -- -D warnings --no-deps
-    cargo clippy -p lightyear_steam --tests --all-features -- -D warnings --no-deps
-
-lightyear_sync:
-    # `lightyear_sync` only works in `std`
-    # cargo clippy -p lightyear_sync --no-default-features -- -D warnings --no-deps
-    cargo clippy -p lightyear_sync --no-default-features --features="std" -- -D warnings --no-deps
-    cargo clippy -p lightyear_sync --no-default-features --features="std client" -- -D warnings --no-deps
-    cargo clippy -p lightyear_sync --no-default-features --features="std server" -- -D warnings --no-deps
-    cargo clippy -p lightyear_sync --all-features -- -D warnings --no-deps
-    # cargo clippy -p lightyear_sync --tests --no-default-features -- -D warnings --no-deps
-    cargo clippy -p lightyear_sync --tests --no-default-features --features="std" -- -D warnings --no-deps
-    cargo clippy -p lightyear_sync --tests --no-default-features --features="std client" -- -D warnings --no-deps
-    cargo clippy -p lightyear_sync --tests --no-default-features --features="std server" -- -D warnings --no-deps
-    cargo clippy -p lightyear_sync --tests --all-features -- -D warnings --no-deps
-
-lightyear_tests:
-    # `lightyear_tests` only works in `std`
-    # cargo clippy -p lightyear_tests --no-default-features -- -D warnings --no-deps
-    cargo clippy -p lightyear_tests --no-default-features --features="std" -- -D warnings --no-deps
-
-lightyear_transport:
-    # `lightyear_transport` only works in `std`
-    # cargo clippy -p lightyear_transport --no-default-features -- -D warnings --no-deps
-    cargo clippy -p lightyear_transport --no-default-features --features="std" -- -D warnings --no-deps
-    cargo clippy -p lightyear_transport --no-default-features --features="std client" -- -D warnings --no-deps
-    cargo clippy -p lightyear_transport --no-default-features --features="std server" -- -D warnings --no-deps
-    cargo clippy -p lightyear_transport --no-default-features --features="metrics" -- -D warnings --no-deps
-    cargo clippy -p lightyear_transport --no-default-features --features="std trace" -- -D warnings --no-deps
-    cargo clippy -p lightyear_transport --no-default-features --features="std test_utils" -- -D warnings --no-deps
-    cargo clippy -p lightyear_transport --all-features -- -D warnings --no-deps
-    # cargo clippy -p lightyear_transport --tests --no-default-features -- -D warnings --no-deps
-    cargo clippy -p lightyear_transport --tests --no-default-features --features="std" -- -D warnings --no-deps
-    cargo clippy -p lightyear_transport --tests --no-default-features --features="std client" -- -D warnings --no-deps
-    cargo clippy -p lightyear_transport --tests --no-default-features --features="std server" -- -D warnings --no-deps
-    cargo clippy -p lightyear_transport --tests --no-default-features --features="metrics" -- -D warnings --no-deps
-    cargo clippy -p lightyear_transport --tests --no-default-features --features="std trace" -- -D warnings --no-deps
-    cargo clippy -p lightyear_transport --tests --no-default-features --features="std test_utils" -- -D warnings --no-deps
-    cargo clippy -p lightyear_transport --tests --all-features -- -D warnings --no-deps
-
-lightyear_udp:
-    cargo clippy -p lightyear_udp --no-default-features -- -D warnings --no-deps
-    cargo clippy -p lightyear_udp --no-default-features --features="server" -- -D warnings --no-deps
-    cargo clippy -p lightyear_udp --all-features -- -D warnings --no-deps
-    cargo clippy -p lightyear_udp --tests --no-default-features -- -D warnings --no-deps
-    cargo clippy -p lightyear_udp --tests --no-default-features --features="server" -- -D warnings --no-deps
-    cargo clippy -p lightyear_udp --tests --all-features -- -D warnings --no-deps
-
-lightyear_utils:
-    cargo clippy -p lightyear_utils --no-default-features -- -D warnings --no-deps
-    cargo clippy -p lightyear_utils --all-features -- -D warnings --no-deps
-    cargo clippy -p lightyear_utils --tests --no-default-features -- -D warnings --no-deps
-    cargo clippy -p lightyear_utils --tests --all-features -- -D warnings --no-deps
-
-lightyear_webtransport:
-    cargo clippy -p lightyear_webtransport --no-default-features -- -D warnings --no-deps
-    cargo clippy -p lightyear_webtransport --no-default-features --features="client" -- -D warnings --no-deps
-    cargo clippy -p lightyear_webtransport --no-default-features --features="server" -- -D warnings --no-deps
-    cargo clippy -p lightyear_webtransport --no-default-features --features="self-signed" -- -D warnings --no-deps
-    cargo clippy -p lightyear_webtransport --no-default-features --features="dangerous-configuration" -- -D warnings --no-deps
-    cargo clippy -p lightyear_webtransport --all-features -- -D warnings --no-deps
-    cargo clippy -p lightyear_webtransport --tests --no-default-features -- -D warnings --no-deps
-    cargo clippy -p lightyear_webtransport --tests --no-default-features --features="client" -- -D warnings --no-deps
-    cargo clippy -p lightyear_webtransport --tests --no-default-features --features="server" -- -D warnings --no-deps
-    cargo clippy -p lightyear_webtransport --tests --no-default-features --features="self-signed" -- -D warnings --no-deps
-    cargo clippy -p lightyear_webtransport --tests --no-default-features --features="dangerous-configuration" -- -D warnings --no-deps
-    cargo clippy -p lightyear_webtransport --tests --all-features -- -D warnings --no-deps
-
 add_avian_symlinks:
     #!/usr/bin/env bash
     set -euo pipefail
@@ -588,7 +273,7 @@ release_dryrun version:
     trap cleanup EXIT
     trap 'exit 130' INT
     trap 'exit 143' TERM
-    cargo release --no-publish --no-tag --no-push --workspace --config .release.toml "{{version}}"
+    cargo release --no-publish --no-tag --no-push --workspace --config .release.toml "{{ version }}"
     just add_avian_symlinks
     pkgs=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.publish != []) | "-p " + .name' | tr "\n" " ")
     cargo package --allow-dirty -j 4 $pkgs
@@ -604,7 +289,7 @@ release version:
     trap cleanup EXIT
     trap 'exit 130' INT
     trap 'exit 143' TERM
-    cargo release --execute --no-publish --no-tag --no-push --workspace --config .release.toml "{{version}}"
+    cargo release --execute --no-publish --no-tag --no-push --workspace --config .release.toml "{{ version }}"
     just add_avian_symlinks
     pkgs=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.publish != []) | "-p " + .name' | tr "\n" " ")
     cargo publish --allow-dirty -j 4 $pkgs


### PR DESCRIPTION
## Summary

- allow selecting example/demo package names and feature sets in the build recipe
- support build-time GUI opt-in/out while adding the usual networking defaults
- run dedicated servers headlessly unless explicitly overridden
- replace the exhaustive local Clippy feature matrix with concise CI-aligned checks