### PR TITLE
feat(visibility): support retained scope lifetimes

### DIFF
--- a/crates/replication/replication/src/lib.rs
+++ b/crates/replication/replication/src/lib.rs
@@ -47,7 +47,11 @@
 //! ## Visibility
 //!
 //! [`VisibilityExt::gain_visibility`] and [`VisibilityExt::lose_visibility`]
-//! let you dynamically show or hide an entity for a specific client.
+//! let you dynamically show or hide an entity for a specific client. The default
+//! [`VisibilityExt::lose_visibility`] behavior despawns the remote entity. Use
+//! [`VisibilityExt::lose_visibility_retained`] to retain an entity the client has already seen, or
+//! [`VisibilityExt::lose_visibility_always_present`] to guarantee an initial remote entity even
+//! when it starts hidden. Both retaining policies pause updates while hidden.
 //! Visibility changes propagate through [`ReplicateLikeChildren`] so that
 //! hiding a parent also hides its replicated descendants.
 //!
@@ -85,6 +89,8 @@
 //! [`ReplicateLikeChildren`]: crate::hierarchy::ReplicateLikeChildren
 //! [`VisibilityExt::gain_visibility`]: crate::visibility::immediate::VisibilityExt::gain_visibility
 //! [`VisibilityExt::lose_visibility`]: crate::visibility::immediate::VisibilityExt::lose_visibility
+//! [`VisibilityExt::lose_visibility_retained`]: crate::visibility::immediate::VisibilityExt::lose_visibility_retained
+//! [`VisibilityExt::lose_visibility_always_present`]: crate::visibility::immediate::VisibilityExt::lose_visibility_always_present
 //! [`RoomPlugin`]: crate::visibility::room::RoomPlugin
 //! [`ControlledBy`]: crate::control::ControlledBy
 //! [`HasAuthority`]: crate::authority::HasAuthority

--- a/crates/replication/replication/src/send.rs
+++ b/crates/replication/replication/src/send.rs
@@ -41,7 +41,7 @@ use tracing::{error, trace, warn};
 use crate::ReplicationSystems;
 use crate::metadata::ReplicationMetadata;
 use crate::registry::ComponentRegistry;
-use crate::visibility::immediate::VisibilityBit;
+use crate::visibility::immediate::VisibilityBits;
 #[cfg(feature = "interpolation")]
 pub use interpolation::*;
 use lightyear_core::prelude::LocalTimeline;
@@ -1109,7 +1109,7 @@ impl Plugin for SendPlugin {
 
         app.register_required_components::<Replicate, Replicated>();
         app.init_resource::<ReplicateBit>();
-        app.init_resource::<VisibilityBit>();
+        app.init_resource::<VisibilityBits>();
         #[cfg(feature = "prediction")]
         {
             app.register_required_components::<PredictionTarget, Predicted>();

--- a/crates/replication/replication/src/visibility/immediate.rs
+++ b/crates/replication/replication/src/visibility/immediate.rs
@@ -2,9 +2,40 @@
 
 # Network Visibility
 
-The **network visibility** is used to determine which entities are replicated to a client. The server will only replicate the entities that are relevant to a client. If the client stops being
-relevant, the server will despawn that entity for that client. This lets you save bandwidth by only sending the necessary data to each client.
+The **network visibility** is used to determine which entities are replicated to a client. The
+server will only replicate the entities that are relevant to a client. When an entity loses
+visibility, it can either be despawned on that client or retained without receiving updates.
+This lets you save bandwidth by only sending the necessary data to each client.
 
+Replicon supports three visibility scope lifetimes:
+
+| Scope lifetime | Hidden before first replication | Hidden after replication |
+| --- | --- | --- |
+| [`ScopeLifetime::WhileVisible`] | Not spawned | Despawned |
+| [`ScopeLifetime::AfterFirstVisibility`] | Not spawned | Retained without updates |
+| [`ScopeLifetime::AlwaysPresent`] | Spawned, but receives no further updates | Retained without updates |
+
+[`VisibilityExt::lose_visibility`] keeps its common despawning behavior. The two retaining
+lifetimes are exposed separately because they differ before the first replication:
+
+- [`VisibilityExt::lose_visibility_retained`] retains an entity only after the client has seen it.
+  This is useful for last-known-state views, stable client-side references, or avoiding repeated
+  spawn setup when an entity moves in and out of interest.
+- [`VisibilityExt::lose_visibility_always_present`] ensures that the entity is spawned even if it
+  is already hidden, then pauses further updates. This is useful for identity or hierarchy roots,
+  roster entries, objectives, and other placeholders that must exist before their live state is
+  relevant. It deliberately reveals the entity's existence and initial state, so it should not be
+  used when hidden entities must remain secret.
+
+The retaining policies pause mutations while hidden. The client keeps the last state it received,
+and is not automatically notified that the entity became hidden. Applications that need to mark
+the state as stale or suspend prediction should send or derive that state separately. Replicon also
+does not replay component removals that occur while a retaining scope is hidden, so retained
+entities should generally have a stable component layout or an application-level structural resync.
+
+Visibility only controls what happens when an entity becomes hidden. Actually despawning an
+authoritative entity still despawns every retained remote copy. To intentionally despawn only on
+the sender, remove [`Replicate`](crate::send::Replicate) before despawning the entity.
 
 Visibility is cached, so after you set an entity as `visible` for a client, it will remain relevant
 until you change the setting again.
@@ -23,9 +54,8 @@ world.lose_visibility(entity, client);
 */
 
 use bevy_app::prelude::*;
-use bevy_derive::Deref;
 use bevy_ecs::prelude::*;
-use bevy_replicon::prelude::ScopeLifetime;
+use bevy_replicon::prelude::{Replicated, ScopeLifetime};
 use bevy_replicon::server::visibility::client_visibility::ClientVisibility;
 use bevy_replicon::server::visibility::filters_mask::FilterBit;
 use bevy_replicon::server::visibility::registry::FilterRegistry;
@@ -36,21 +66,53 @@ use tracing::{info, trace};
 use crate::hierarchy::ReplicateLikeChildren;
 
 #[doc(hidden)]
-#[derive(Resource, Deref)]
-pub struct VisibilityBit(FilterBit);
+#[derive(Resource, Clone, Copy)]
+pub struct VisibilityBits {
+    while_visible: FilterBit,
+    after_first_visibility: FilterBit,
+    always_present: FilterBit,
+}
 
-impl FromWorld for VisibilityBit {
+impl VisibilityBits {
+    fn iter(self) -> impl Iterator<Item = FilterBit> {
+        [
+            self.while_visible,
+            self.after_first_visibility,
+            self.always_present,
+        ]
+        .into_iter()
+    }
+}
+
+impl FromWorld for VisibilityBits {
     fn from_world(world: &mut World) -> Self {
-        let bit = world.resource_scope(|world, mut filter_registry: Mut<FilterRegistry>| {
-            world.resource_scope(|world, mut registry: Mut<ReplicationRegistry>| {
-                filter_registry.register_scope::<Entity>(
-                    world,
-                    &mut registry,
-                    ScopeLifetime::WhileVisible,
-                )
-            })
-        });
-        Self(bit)
+        let (while_visible, after_first_visibility, always_present) =
+            world.resource_scope(|world, mut filter_registry: Mut<FilterRegistry>| {
+                world.resource_scope(|world, mut registry: Mut<ReplicationRegistry>| {
+                    (
+                        filter_registry.register_scope::<Entity>(
+                            world,
+                            &mut registry,
+                            ScopeLifetime::WhileVisible,
+                        ),
+                        filter_registry.register_scope::<Entity>(
+                            world,
+                            &mut registry,
+                            ScopeLifetime::AfterFirstVisibility,
+                        ),
+                        filter_registry.register_scope::<Entity>(
+                            world,
+                            &mut registry,
+                            ScopeLifetime::AlwaysPresent,
+                        ),
+                    )
+                })
+            });
+        Self {
+            while_visible,
+            after_first_visibility,
+            always_present,
+        }
     }
 }
 
@@ -72,6 +134,12 @@ impl FromWorld for VisibilityBit {
 /// // Hide an entity from a specific client
 /// commands.lose_visibility(server_entity, client_link_entity);
 ///
+/// // Pause updates, retaining the entity if this client has already seen it
+/// commands.lose_visibility_retained(server_entity, client_link_entity);
+///
+/// // Ensure the remote entity exists, but pause updates after its initial state
+/// commands.lose_visibility_always_present(server_entity, client_link_entity);
+///
 /// // Make it visible again
 /// commands.gain_visibility(server_entity, client_link_entity);
 /// ```
@@ -79,10 +147,31 @@ impl FromWorld for VisibilityBit {
 /// [`ReplicateLikeChildren`]: crate::hierarchy::ReplicateLikeChildren
 pub trait VisibilityExt {
     /// Make `entity` (and its replication-hierarchy descendants) visible to `sender`.
+    ///
+    /// This clears every manual visibility constraint. Other constraints such as replication,
+    /// prediction, interpolation, control, rooms, and user-defined visibility filters still apply.
     fn gain_visibility(&mut self, entity: Entity, sender: Entity);
 
-    /// Hide `entity` (and its replication-hierarchy descendants) from `sender`.
+    /// Hide `entity` (and its replication-hierarchy descendants) from `sender`, despawning the
+    /// remote entity if it was previously replicated.
     fn lose_visibility(&mut self, entity: Entity, sender: Entity);
+
+    /// Hide `entity` (and its replication-hierarchy descendants) from `sender` while retaining an
+    /// existing remote entity without updates.
+    ///
+    /// If the client has never received the entity, it remains absent until visibility is gained.
+    /// Despawning the authoritative entity still despawns its retained remote entity.
+    /// Remove [`Replicate`](crate::send::Replicate) first to intentionally suppress that despawn.
+    fn lose_visibility_retained(&mut self, entity: Entity, sender: Entity);
+
+    /// Hide `entity` (and its replication-hierarchy descendants) from updates while ensuring that
+    /// it is present on `sender`.
+    ///
+    /// If the client has never received the entity, its initial state is still replicated. Further
+    /// updates are paused until visibility is gained. Despawning the authoritative entity still
+    /// despawns its retained remote entity. Remove [`Replicate`](crate::send::Replicate) first to
+    /// intentionally suppress that despawn.
+    fn lose_visibility_always_present(&mut self, entity: Entity, sender: Entity);
 }
 
 impl VisibilityExt for Commands<'_, '_> {
@@ -97,34 +186,67 @@ impl VisibilityExt for Commands<'_, '_> {
             world.lose_visibility(entity, sender);
         });
     }
+
+    fn lose_visibility_retained(&mut self, entity: Entity, sender: Entity) {
+        self.queue(move |world: &mut World| {
+            world.lose_visibility_retained(entity, sender);
+        });
+    }
+
+    fn lose_visibility_always_present(&mut self, entity: Entity, sender: Entity) {
+        self.queue(move |world: &mut World| {
+            world.lose_visibility_always_present(entity, sender);
+        });
+    }
 }
 
 impl VisibilityExt for World {
     fn gain_visibility(&mut self, entity: Entity, sender: Entity) {
-        let bit = self.resource::<VisibilityBit>().0;
-        if let Some(mut vis) = self.get_mut::<ClientVisibility>(sender) {
-            vis.set(entity, bit, true);
-        }
-        set_replicate_like_children_visibility(self, entity, sender, bit, true);
+        let bits = *self.resource::<VisibilityBits>();
+        set_visibility(self, entity, sender, bits, None);
     }
 
     fn lose_visibility(&mut self, entity: Entity, sender: Entity) {
-        let bit = self.resource::<VisibilityBit>().0;
-        if let Some(mut vis) = self.get_mut::<ClientVisibility>(sender) {
-            vis.set(entity, bit, false);
-        }
-        set_replicate_like_children_visibility(self, entity, sender, bit, false);
+        let bits = *self.resource::<VisibilityBits>();
+        set_visibility(self, entity, sender, bits, Some(bits.while_visible));
+    }
+
+    fn lose_visibility_retained(&mut self, entity: Entity, sender: Entity) {
+        let bits = *self.resource::<VisibilityBits>();
+        set_visibility(
+            self,
+            entity,
+            sender,
+            bits,
+            Some(bits.after_first_visibility),
+        );
+    }
+
+    fn lose_visibility_always_present(&mut self, entity: Entity, sender: Entity) {
+        let bits = *self.resource::<VisibilityBits>();
+        set_visibility(self, entity, sender, bits, Some(bits.always_present));
     }
 }
 
-/// Recursively walk [`ReplicateLikeChildren`] and set the visibility bit for each descendant.
-fn set_replicate_like_children_visibility(
+/// Set one manual visibility state and recursively propagate it through [`ReplicateLikeChildren`].
+fn set_visibility(
     world: &mut World,
     entity: Entity,
     sender: Entity,
-    bit: FilterBit,
-    visible: bool,
+    bits: VisibilityBits,
+    hidden_bit: Option<FilterBit>,
 ) {
+    if let Some(mut visibility) = world.get_mut::<ClientVisibility>(sender) {
+        // The bits represent alternative states of one logical visibility filter. Clear every
+        // previous state before selecting the new one so a shorter lifetime cannot remain active.
+        for bit in bits.iter() {
+            visibility.set(entity, bit, true);
+        }
+        if let Some(bit) = hidden_bit {
+            visibility.set(entity, bit, false);
+        }
+    }
+
     let Some(children) = world.get::<ReplicateLikeChildren>(entity) else {
         return;
     };
@@ -132,10 +254,29 @@ fn set_replicate_like_children_visibility(
     // ReplicateLikeChildren is typically very small (1-3 entities).
     let child_entities: smallvec::SmallVec<[Entity; 8]> = children.iter().collect();
     for child in child_entities {
-        if let Some(mut vis) = world.get_mut::<ClientVisibility>(sender) {
-            vis.set(child, bit, visible);
-        }
-        set_replicate_like_children_visibility(world, child, sender, bit, visible);
+        set_visibility(world, child, sender, bits, hidden_bit);
+    }
+}
+
+/// Makes a real authoritative despawn override Lightyear's retaining visibility scopes.
+///
+/// Replicon normally suppresses an entity despawn while an `AfterFirstVisibility` or
+/// `AlwaysPresent` scope is hidden, because those scopes retain the remote entity when visibility
+/// is lost. That is surprising for an actual server-side despawn: visibility loss should retain the
+/// remote entity, but ending the authoritative entity's lifecycle should still remove it. Clearing
+/// Lightyear's retaining bits here lets Replicon send the authoritative despawn.
+///
+/// If the server intentionally wants to despawn its local entity without sending a despawn to the
+/// client, it should remove [`Replicate`](crate::send::Replicate) before despawning. Removing
+/// `Replicate` also removes [`Replicated`], so this observer will not run for that entity.
+fn clear_retained_visibility_on_despawn(
+    trigger: On<Despawn, Replicated>,
+    bits: Res<VisibilityBits>,
+    mut senders: Query<&mut ClientVisibility>,
+) {
+    for mut visibility in &mut senders {
+        visibility.set(trigger.entity, bits.after_first_visibility, true);
+        visibility.set(trigger.entity, bits.always_present, true);
     }
 }
 
@@ -145,6 +286,7 @@ pub struct NetworkVisibilityPlugin;
 
 impl Plugin for NetworkVisibilityPlugin {
     fn build(&self, app: &mut App) {
-        app.init_resource::<VisibilityBit>();
+        app.init_resource::<VisibilityBits>();
+        app.add_observer(clear_retained_visibility_on_despawn);
     }
 }

--- a/crates/tests/src/client_server/visibility.rs
+++ b/crates/tests/src/client_server/visibility.rs
@@ -122,6 +122,314 @@ fn test_despawn_lose_visibility() {
     );
 }
 
+#[test]
+fn test_retain_entity_on_lose_visibility() {
+    let mut stepper = ClientServerStepper::from_config(StepperConfig::single());
+
+    let server_entity = stepper
+        .server_app
+        .world_mut()
+        .spawn((Replicate::to_clients(NetworkTarget::All), CompSimple(1.0)))
+        .id();
+    let sender = stepper.client_of_entities[0];
+    stepper.frame_step(2);
+
+    let client_entity = stepper
+        .client(0)
+        .get::<MessageManager>()
+        .unwrap()
+        .entity_mapper
+        .get_local(server_entity)
+        .unwrap();
+    assert_eq!(
+        stepper.client_apps[0]
+            .world()
+            .get::<CompSimple>(client_entity),
+        Some(&CompSimple(1.0))
+    );
+
+    // Retain the existing remote entity but stop sending updates.
+    stepper
+        .server_app
+        .world_mut()
+        .commands()
+        .lose_visibility_retained(server_entity, sender);
+    stepper.frame_step(2);
+
+    assert_eq!(
+        stepper
+            .client(0)
+            .get::<MessageManager>()
+            .unwrap()
+            .entity_mapper
+            .get_local(server_entity),
+        Some(client_entity),
+        "retained visibility should preserve the remote entity mapping"
+    );
+
+    stepper
+        .server_app
+        .world_mut()
+        .entity_mut(server_entity)
+        .insert(CompSimple(2.0));
+    stepper.frame_step(2);
+    assert_eq!(
+        stepper.client_apps[0]
+            .world()
+            .get::<CompSimple>(client_entity),
+        Some(&CompSimple(1.0)),
+        "retained hidden entities should not receive mutations"
+    );
+
+    stepper
+        .server_app
+        .world_mut()
+        .gain_visibility(server_entity, sender);
+    stepper.frame_step(2);
+    assert_eq!(
+        stepper
+            .client(0)
+            .get::<MessageManager>()
+            .unwrap()
+            .entity_mapper
+            .get_local(server_entity),
+        Some(client_entity),
+        "gaining visibility should reuse the retained remote entity"
+    );
+    assert_eq!(
+        stepper.client_apps[0]
+            .world()
+            .get::<CompSimple>(client_entity),
+        Some(&CompSimple(2.0)),
+        "gaining visibility should send the latest component value"
+    );
+}
+
+#[test]
+fn test_retain_visibility_before_first_replication() {
+    let mut stepper = ClientServerStepper::from_config(StepperConfig::single());
+
+    let server_entity = stepper
+        .server_app
+        .world_mut()
+        .spawn(Replicate::to_clients(NetworkTarget::All))
+        .id();
+    let sender = stepper.client_of_entities[0];
+    stepper
+        .server_app
+        .world_mut()
+        .lose_visibility_retained(server_entity, sender);
+    stepper.frame_step(2);
+
+    assert!(
+        stepper
+            .client(0)
+            .get::<MessageManager>()
+            .unwrap()
+            .entity_mapper
+            .get_local(server_entity)
+            .is_none(),
+        "AfterFirstVisibility should not spawn an entity that was never visible"
+    );
+
+    stepper
+        .server_app
+        .world_mut()
+        .gain_visibility(server_entity, sender);
+    stepper.frame_step(2);
+    assert!(
+        stepper
+            .client(0)
+            .get::<MessageManager>()
+            .unwrap()
+            .entity_mapper
+            .get_local(server_entity)
+            .is_some(),
+        "the entity should spawn when it becomes visible for the first time"
+    );
+}
+
+#[test]
+fn test_always_present_visibility_before_first_replication() {
+    let mut stepper = ClientServerStepper::from_config(StepperConfig::single());
+
+    let server_entity = stepper
+        .server_app
+        .world_mut()
+        .spawn((Replicate::to_clients(NetworkTarget::All), CompSimple(1.0)))
+        .id();
+    let sender = stepper.client_of_entities[0];
+
+    // AlwaysPresent sends the initial state even when the entity starts hidden.
+    stepper
+        .server_app
+        .world_mut()
+        .commands()
+        .lose_visibility_always_present(server_entity, sender);
+    stepper.frame_step(2);
+
+    let client_entity = stepper
+        .client(0)
+        .get::<MessageManager>()
+        .unwrap()
+        .entity_mapper
+        .get_local(server_entity)
+        .expect("AlwaysPresent should spawn an entity that starts hidden");
+    assert_eq!(
+        stepper.client_apps[0]
+            .world()
+            .get::<CompSimple>(client_entity),
+        Some(&CompSimple(1.0))
+    );
+
+    stepper
+        .server_app
+        .world_mut()
+        .entity_mut(server_entity)
+        .insert(CompSimple(2.0));
+    stepper.frame_step(2);
+    assert_eq!(
+        stepper.client_apps[0]
+            .world()
+            .get::<CompSimple>(client_entity),
+        Some(&CompSimple(1.0)),
+        "AlwaysPresent entities should stop receiving updates while hidden"
+    );
+
+    stepper
+        .server_app
+        .world_mut()
+        .gain_visibility(server_entity, sender);
+    stepper.frame_step(2);
+    assert_eq!(
+        stepper
+            .client(0)
+            .get::<MessageManager>()
+            .unwrap()
+            .entity_mapper
+            .get_local(server_entity),
+        Some(client_entity),
+        "gaining visibility should reuse the always-present remote entity"
+    );
+    assert_eq!(
+        stepper.client_apps[0]
+            .world()
+            .get::<CompSimple>(client_entity),
+        Some(&CompSimple(2.0)),
+        "gaining visibility should send the latest component value"
+    );
+
+    // Visibility lifetime must not suppress a true authoritative despawn.
+    stepper
+        .server_app
+        .world_mut()
+        .commands()
+        .lose_visibility_always_present(server_entity, sender);
+    stepper.frame_step(2);
+    stepper.server_app.world_mut().despawn(server_entity);
+    stepper.frame_step(2);
+    assert!(
+        stepper.client_apps[0]
+            .world()
+            .get_entity(client_entity)
+            .is_err(),
+        "an authoritative despawn should override AlwaysPresent visibility"
+    );
+}
+
+#[test]
+fn test_true_despawn_reaches_retained_entity() {
+    let mut stepper = ClientServerStepper::from_config(StepperConfig::single());
+
+    let server_entity = stepper
+        .server_app
+        .world_mut()
+        .spawn(Replicate::to_clients(NetworkTarget::All))
+        .id();
+    let sender = stepper.client_of_entities[0];
+    stepper.frame_step(2);
+    let client_entity = stepper
+        .client(0)
+        .get::<MessageManager>()
+        .unwrap()
+        .entity_mapper
+        .get_local(server_entity)
+        .unwrap();
+
+    stepper
+        .server_app
+        .world_mut()
+        .lose_visibility_retained(server_entity, sender);
+    stepper.frame_step(2);
+    assert!(
+        stepper.client_apps[0]
+            .world()
+            .get_entity(client_entity)
+            .is_ok(),
+        "visibility loss should retain the remote entity"
+    );
+
+    stepper.server_app.world_mut().despawn(server_entity);
+    stepper.frame_step(2);
+    assert!(
+        stepper.client_apps[0]
+            .world()
+            .get_entity(client_entity)
+            .is_err(),
+        "an authoritative despawn should override retained visibility"
+    );
+    assert!(
+        stepper
+            .client(0)
+            .get::<MessageManager>()
+            .unwrap()
+            .entity_mapper
+            .get_local(server_entity)
+            .is_none()
+    );
+}
+
+#[test]
+fn test_remove_replicate_suppresses_despawn_of_retained_entity() {
+    let mut stepper = ClientServerStepper::from_config(StepperConfig::single());
+
+    let server_entity = stepper
+        .server_app
+        .world_mut()
+        .spawn(Replicate::to_clients(NetworkTarget::All))
+        .id();
+    let sender = stepper.client_of_entities[0];
+    stepper.frame_step(2);
+    let client_entity = stepper
+        .client(0)
+        .get::<MessageManager>()
+        .unwrap()
+        .entity_mapper
+        .get_local(server_entity)
+        .unwrap();
+
+    stepper
+        .server_app
+        .world_mut()
+        .lose_visibility_retained(server_entity, sender);
+    stepper.frame_step(2);
+
+    stepper
+        .server_app
+        .world_mut()
+        .entity_mut(server_entity)
+        .remove::<Replicate>();
+    stepper.server_app.world_mut().despawn(server_entity);
+    stepper.frame_step(2);
+    assert!(
+        stepper.client_apps[0]
+            .world()
+            .get_entity(client_entity)
+            .is_ok(),
+        "removing Replicate before despawning should keep the retained remote entity"
+    );
+}
+
 /// https://github.com/cBournhonesque/lightyear/issues/637
 /// Test that if an entity with NetworkVisibility is despawned, the DespawnMessage
 /// is only sent to clients that have visibility on it.

--- a/examples/network_visibility/README.md
+++ b/examples/network_visibility/README.md
@@ -7,6 +7,33 @@ we want to send only the data that is relevant to each client.
 
 In this example, we are going to replicate entities that are within a certain distance of the client.
 
+## Visibility lifetimes
+
+The client renders three kinds of circles so the lifetime policies can be compared directly:
+
+| Circle | Server policy | What the client observes |
+| --- | --- | --- |
+| Small green | `lose_visibility` / `WhileVisible` | Despawns outside the interest radius and respawns when it returns. |
+| Medium red | `lose_visibility_retained` / `AfterFirstVisibility` | Starts inside the interest radius. After you move away, it remains at its last received state while network updates are paused. |
+| Large blue | `lose_visibility_always_present` / `AlwaysPresent` | The server marks it hidden before its first replication, but the client still receives its initial state. Later updates remain paused while it is hidden. |
+
+The player starts at the origin. Move with WASD or the arrow keys; moving more than the interest
+radius away from the red circle demonstrates that it remains on the client while ordinary green
+circles disappear. The blue circle appears immediately even though the server never gains
+visibility for it.
+
+Retaining an entity is useful when destroying and rebuilding its client-side state would be costly,
+when other client entities need a stable reference to it, or when the UI should preserve a last
+known state after an entity leaves interest. `AlwaysPresent` is useful for identities, hierarchy
+roots, roster entries, objectives, or placeholders that must exist on every client even before
+their live state becomes relevant. Because `AlwaysPresent` reveals the entity's existence and
+initial state, it is not appropriate for information that must remain secret while hidden.
+
+Retained entities do not receive mutations while hidden, and the client is not automatically told
+that they became hidden. Games that need a stale/dormant indicator or need to suspend prediction
+should communicate that separately. A real server despawn still despawns retained client entities;
+remove `Replicate` before despawning when the client copy should intentionally survive.
+
 https://github.com/cBournhonesque/lightyear/assets/8112632/41a6d102-77a1-4a44-8974-1d208b4ef798
 
 ## Running an example

--- a/examples/network_visibility/src/main.rs
+++ b/examples/network_visibility/src/main.rs
@@ -1,4 +1,6 @@
-//! This example showcases how to use Lightyear with Bevy, to easily get replication along with prediction/interpolation working.
+//! This example showcases Lightyear interest management and its three visibility lifetimes:
+//! despawn while hidden, retain after first visibility, and always create the client entity even
+//! when it starts hidden.
 //!
 //! There is a lot of setup code, but it's mostly to have the examples work in all possible configurations of transport.
 //! (all transports are supported, as well as running the example in client-and-server or host-server mode)

--- a/examples/network_visibility/src/p2p.rs
+++ b/examples/network_visibility/src/p2p.rs
@@ -40,6 +40,7 @@ fn spawn_fixed_world(
             commands.spawn((
                 Position(Vec2::new(x as f32 * GRID_SIZE, y as f32 * GRID_SIZE)),
                 CircleMarker,
+                VisibilityPolicy::WhileVisible,
             ));
         }
     }

--- a/examples/network_visibility/src/protocol.rs
+++ b/examples/network_visibility/src/protocol.rs
@@ -28,6 +28,17 @@ pub struct PlayerColor(pub(crate) Color);
 // Marker component
 pub struct CircleMarker;
 
+/// Selects the visibility lifetime demonstrated by a circle.
+#[derive(Component, Deserialize, Serialize, Clone, Copy, Debug, PartialEq, Eq)]
+pub enum VisibilityPolicy {
+    /// Despawn the remote entity whenever it leaves the client's interest radius.
+    WhileVisible,
+    /// Keep a remote entity that the client has already seen, but pause its updates.
+    Retained,
+    /// Send the initial remote entity even while hidden, then pause its updates.
+    AlwaysPresent,
+}
+
 // Inputs
 
 #[derive(Serialize, Deserialize, Default, Debug, PartialEq, Eq, Clone, Reflect)]
@@ -64,5 +75,6 @@ impl Plugin for ProtocolPlugin {
             .add_linear_interpolation();
         app.component::<PlayerColor>().replicate();
         app.component::<CircleMarker>().replicate();
+        app.component::<VisibilityPolicy>().replicate();
     }
 }

--- a/examples/network_visibility/src/renderer.rs
+++ b/examples/network_visibility/src/renderer.rs
@@ -1,5 +1,5 @@
 use crate::protocol::*;
-use bevy::color::palettes::basic::GREEN;
+use bevy::color::palettes::basic::{BLUE, GREEN, RED};
 use bevy::prelude::*;
 
 #[derive(Clone)]
@@ -30,8 +30,16 @@ pub(crate) fn draw_boxes(mut gizmos: Gizmos, players: Query<(&Position, &PlayerC
 }
 
 /// System that draws circles
-pub(crate) fn draw_circles(mut gizmos: Gizmos, circles: Query<&Position, With<CircleMarker>>) {
-    for position in &circles {
-        gizmos.circle_2d(Isometry2d::from_translation(position.0), 1.0, GREEN);
+pub(crate) fn draw_circles(
+    mut gizmos: Gizmos,
+    circles: Query<(&Position, &VisibilityPolicy), With<CircleMarker>>,
+) {
+    for (position, policy) in &circles {
+        let (radius, color) = match policy {
+            VisibilityPolicy::WhileVisible => (5.0, GREEN),
+            VisibilityPolicy::Retained => (10.0, RED),
+            VisibilityPolicy::AlwaysPresent => (15.0, BLUE),
+        };
+        gizmos.circle_2d(Isometry2d::from_translation(position.0), radius, color);
     }
 }

--- a/examples/network_visibility/src/server.rs
+++ b/examples/network_visibility/src/server.rs
@@ -11,6 +11,8 @@ use lightyear_examples_common::shared::SEND_INTERVAL;
 const GRID_SIZE: f32 = 200.0;
 const NUM_CIRCLES: i32 = 1;
 const INTEREST_RADIUS: f32 = 150.0;
+const RETAINED_POSITION: Vec2 = Vec2::new(100.0, 0.0);
+const ALWAYS_PRESENT_POSITION: Vec2 = Vec2::new(250.0, 0.0);
 
 // Plugin for server-specific logic
 pub struct ExampleServerPlugin;
@@ -89,16 +91,35 @@ pub(crate) fn handle_connected(
 }
 
 pub(crate) fn init(mut commands: Commands) {
-    // spawn dots in a grid
+    // Green circles use the common WhileVisible policy and despawn outside the interest radius.
     for x in -NUM_CIRCLES..NUM_CIRCLES {
         for y in -NUM_CIRCLES..NUM_CIRCLES {
             commands.spawn((
                 Position(Vec2::new(x as f32 * GRID_SIZE, y as f32 * GRID_SIZE)),
                 CircleMarker,
+                VisibilityPolicy::WhileVisible,
                 Replicate::to_clients(NetworkTarget::All),
             ));
         }
     }
+
+    // This red circle starts inside the interest radius. After a client has seen it, moving away
+    // hides it on the server but retains its last received state on that client.
+    commands.spawn((
+        Position(RETAINED_POSITION),
+        CircleMarker,
+        VisibilityPolicy::Retained,
+        Replicate::to_clients(NetworkTarget::All),
+    ));
+
+    // This blue circle is marked hidden for every client before its first replication. The
+    // AlwaysPresent lifetime still sends its initial state, then pauses subsequent updates.
+    commands.spawn((
+        Position(ALWAYS_PRESENT_POSITION),
+        CircleMarker,
+        VisibilityPolicy::AlwaysPresent,
+        Replicate::to_clients(NetworkTarget::All),
+    ));
 }
 
 /// Here we perform more "immediate" interest management: we will make a circle visible to a client
@@ -106,7 +127,10 @@ pub(crate) fn init(mut commands: Commands) {
 pub(crate) fn interest_management(
     peer_metadata: Res<PeerMetadata>,
     player_query: Query<(&PlayerId, Ref<Position>), (Without<CircleMarker>, With<Replicate>)>,
-    circle_query: Query<(Entity, &Position), (With<CircleMarker>, With<Replicate>)>,
+    circle_query: Query<
+        (Entity, &Position, &VisibilityPolicy),
+        (With<CircleMarker>, With<Replicate>),
+    >,
     mut commands: Commands,
 ) {
     for (client_id, position) in player_query.iter() {
@@ -116,14 +140,25 @@ pub(crate) fn interest_management(
         };
         if position.is_changed() {
             // in real game, you would have a spatial index (kd-tree) to only find entities within a certain radius
-            for (circle, circle_position) in circle_query.iter() {
+            for (circle, circle_position, policy) in circle_query.iter() {
                 let distance = position.distance(**circle_position);
-                if distance < INTEREST_RADIUS {
-                    trace!("Gain visibility with {circle:?}");
-                    commands.gain_visibility(circle, *sender_entity);
-                } else {
-                    trace!("Lose visibility with {circle:?}");
-                    commands.lose_visibility(circle, *sender_entity);
+                match policy {
+                    VisibilityPolicy::AlwaysPresent => {
+                        trace!("Hide always-present {circle:?}");
+                        commands.lose_visibility_always_present(circle, *sender_entity);
+                    }
+                    VisibilityPolicy::WhileVisible if distance >= INTEREST_RADIUS => {
+                        trace!("Lose visibility with {circle:?}");
+                        commands.lose_visibility(circle, *sender_entity);
+                    }
+                    VisibilityPolicy::Retained if distance >= INTEREST_RADIUS => {
+                        trace!("Retain hidden {circle:?}");
+                        commands.lose_visibility_retained(circle, *sender_entity);
+                    }
+                    VisibilityPolicy::WhileVisible | VisibilityPolicy::Retained => {
+                        trace!("Gain visibility with {circle:?}");
+                        commands.gain_visibility(circle, *sender_entity);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Adds Lightyear visibility APIs for Replicon retained scope lifetimes.

- Keeps lose_visibility as the common despawning behavior.
- Adds lose_visibility_retained for AfterFirstVisibility.
- Adds lose_visibility_always_present for entities that must receive an initial state while hidden.