### PR TITLE
chore(deps): use released bevy_replicon 0.42

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -238,9 +238,8 @@ bevy_enhanced_input = { version = "0.26", default-features = false, features = [
 leafwing-input-manager = { version = "0.21", default-features = false, features = [
   "keyboard",
 ] }
-
 # replication
-bevy_replicon = { git = "https://github.com/simgine/bevy_replicon", branch = "master", default-features = false, features = [
+bevy_replicon = { version = "0.42", default-features = false, features = [
   "client",
   "server",
 ] }

--- a/crates/replication/replication/src/prespawn.rs
+++ b/crates/replication/replication/src/prespawn.rs
@@ -109,7 +109,7 @@ impl PreSpawnedPlugin {
             receiver.register_unmatched_entity(tick, entity);
         }
 
-        let mut signature = Signature::from(hash);
+        let mut signature = Signature::from_hash(hash);
         if let Some(client) = prespawn.client {
             signature = signature.for_client(client);
         }


### PR DESCRIPTION
## Summary

- replace the bevy_replicon master dependency with the crates.io 0.42 release
- construct prespawn signatures from their precomputed hashes to avoid hashing them a second time