### PR TITLE
fix(prediction): bound P2P input rollbacks to session start

### DIFF
--- a/crates/connection/p2p/src/session.rs
+++ b/crates/connection/p2p/src/session.rs
@@ -351,13 +351,13 @@ pub struct P2PStop {
     pub unlink: bool,
 }
 
-/// Triggered at the agreed tick, immediately before the fixed simulation schedule.
+/// Triggered immediately before the fixed simulation advances to the agreed tick.
 ///
 /// Applications can observe this to create the shared deterministic world in the same order on
-/// every peer.
+/// every peer. Prediction treats the start tick as the oldest valid input rollback snapshot.
 #[derive(Event, Debug, Clone, Copy, PartialEq, Eq)]
 pub struct P2PStarted {
-    /// Common tick at which deterministic play begins.
+    /// Common simulation start tick and earliest permitted input rollback target.
     pub start_tick: Tick,
 }
 

--- a/crates/core/lightyear/Cargo.toml
+++ b/crates/core/lightyear/Cargo.toml
@@ -99,6 +99,7 @@ p2p = [
   "client",
   "dep:lightyear_p2p",
   "lightyear_deterministic_replication?/p2p",
+  "lightyear_prediction?/p2p",
 ]
 ## Enables replicating entities between two peers
 replication = [

--- a/crates/deterministic/deterministic_replication/Cargo.toml
+++ b/crates/deterministic/deterministic_replication/Cargo.toml
@@ -22,7 +22,7 @@ client = [
   "lightyear_sync/client",
   "lightyear_transport/client",
 ]
-p2p = ["client"]
+p2p = ["client", "lightyear_prediction/p2p"]
 server = [
   "lightyear_connection/server",
   "lightyear_inputs/server",

--- a/crates/deterministic/deterministic_replication/src/checksum.rs
+++ b/crates/deterministic/deterministic_replication/src/checksum.rs
@@ -29,6 +29,7 @@ use lightyear_connection::network_topology::{NetworkTopology, NetworkingMetadata
 use lightyear_connection::server::Started;
 #[cfg(any(feature = "p2p", feature = "server"))]
 use lightyear_core::id::RemoteId;
+#[cfg(feature = "server")]
 use lightyear_core::prelude::LocalTimeline;
 use lightyear_core::tick::Tick;
 #[cfg(feature = "client")]

--- a/crates/replication/prediction/Cargo.toml
+++ b/crates/replication/prediction/Cargo.toml
@@ -10,8 +10,9 @@ repository = "https://github.com/cBournhonesque/lightyear"
 
 [features]
 default = ["std"]
-std = ["lightyear_replication/std", "bevy_math/std"]
+std = ["lightyear_p2p?/std", "lightyear_replication/std", "bevy_math/std"]
 deterministic = []
+p2p = ["dep:lightyear_p2p"]
 server = ["dep:lightyear_messages"]
 metrics = ["dep:metrics", "lightyear_utils/metrics", "std"]
 
@@ -27,6 +28,7 @@ lightyear_sync.workspace = true
 lightyear_messages = { workspace = true, optional = true }
 lightyear_frame_interpolation.workspace = true
 lightyear_interpolation.workspace = true
+lightyear_p2p = { workspace = true, optional = true }
 
 # replication
 bevy_replicon.workspace = true

--- a/crates/replication/prediction/src/manager.rs
+++ b/crates/replication/prediction/src/manager.rs
@@ -99,6 +99,13 @@ pub struct PredictionManager {
     /// For input-based rollback: tracks earliest mismatch across remote clients
     pub earliest_mismatch_input: EarliestMismatchedInput,
 
+    /// Earliest tick that an input rollback may restore.
+    ///
+    /// A deterministic P2P session sets this to its agreed start tick so stale inputs cannot
+    /// restore prediction history from before the session's initial world snapshot.
+    #[doc(hidden)]
+    pub input_rollback_floor: Option<Tick>,
+
     #[doc(hidden)]
     pub deterministic_despawn: Vec<(Tick, Entity)>,
     #[doc(hidden)]
@@ -518,6 +525,7 @@ impl Default for PredictionManager {
             rollback_policy: RollbackPolicy::default(),
             correction_policy: CorrectionPolicy::default(),
             earliest_mismatch_input: EarliestMismatchedInput::default(),
+            input_rollback_floor: None,
             deterministic_skip_despawn: Vec::default(),
             deterministic_despawn: Vec::default(),
             rollback: RwLock::new(RollbackState::Default),
@@ -530,6 +538,12 @@ unsafe impl Send for PredictionManager {}
 unsafe impl Sync for PredictionManager {}
 
 impl PredictionManager {
+    /// Returns whether restoring `rollback_tick` stays within the active session's input history.
+    pub(crate) fn input_rollback_is_allowed(&self, rollback_tick: Tick) -> bool {
+        self.input_rollback_floor
+            .is_none_or(|floor| rollback_tick >= floor)
+    }
+
     /// Returns true if we are currently in a rollback state
     pub fn is_rollback(&self) -> bool {
         match *self.rollback.read().deref() {

--- a/crates/replication/prediction/src/rollback.rs
+++ b/crates/replication/prediction/src/rollback.rs
@@ -60,6 +60,8 @@ use lightyear_core::prelude::{ConfirmedHistory, LocalTimeline};
 use lightyear_core::tick::Tick;
 use lightyear_core::timeline::{Rollback, is_in_rollback};
 use lightyear_frame_interpolation::FrameInterpolationSystems;
+#[cfg(feature = "p2p")]
+use lightyear_p2p::prelude::{P2PStarted, P2PStopped};
 use lightyear_replication::prelude::ConfirmHistory;
 use lightyear_replication::prespawn::PreSpawnedReceiver;
 use lightyear_replication::registry::ComponentRegistry;
@@ -105,6 +107,11 @@ pub enum RollbackSystems {
     VisualCorrection,
 }
 
+/// Installs prediction rollback detection, restoration, and replay.
+///
+/// With the `p2p` feature, the plugin also tracks the active session's start tick and rejects
+/// input-driven rollback requests that would restore history from before that tick. This boundary
+/// is automatic; applications can install input components directly in a `P2PStarted` observer.
 pub struct RollbackPlugin;
 
 #[derive(Component)]
@@ -124,6 +131,12 @@ impl Plugin for RollbackPlugin {
         app.init_resource::<ComponentRegistry>();
         app.init_resource::<ReplicationCheckpointMap>();
         app.init_resource::<PreSpawnedReceiver>();
+
+        #[cfg(feature = "p2p")]
+        {
+            app.add_observer(set_p2p_input_rollback_floor);
+            app.add_observer(clear_p2p_input_rollback_floor);
+        }
 
         // SETS
         app.configure_sets(
@@ -254,6 +267,34 @@ impl Plugin for RollbackPlugin {
     }
 }
 
+#[cfg(feature = "p2p")]
+/// Set the oldest history tick that input-driven rollback may restore for this P2P session.
+///
+/// [`P2PStarted`] observers are allowed to create the deterministic world immediately. Any late
+/// input whose correction would require history from before that boundary is ignored by
+/// [`check_rollback`]. Applications do not need to delay installing their input components.
+fn set_p2p_input_rollback_floor(
+    trigger: On<P2PStarted>,
+    prediction_manager: Option<ResMut<PredictionManager>>,
+) {
+    let Some(mut prediction_manager) = prediction_manager else {
+        return;
+    };
+    prediction_manager.input_rollback_floor = Some(trigger.start_tick);
+}
+
+#[cfg(feature = "p2p")]
+/// Remove the session-specific input rollback boundary when deterministic P2P play stops.
+fn clear_p2p_input_rollback_floor(
+    _trigger: On<P2PStopped>,
+    prediction_manager: Option<ResMut<PredictionManager>>,
+) {
+    let Some(mut prediction_manager) = prediction_manager else {
+        return;
+    };
+    prediction_manager.input_rollback_floor = None;
+}
+
 #[derive(Component, PartialEq, Debug, Clone, Copy, Serialize, Deserialize)]
 #[component(on_add = DeterministicPredicted::on_add)]
 /// Marker component used to indicate this entity is predicted (it has a PredictionHistory),
@@ -271,6 +312,9 @@ pub struct DeterministicPredicted {
     /// want the entity to be despawned as it will get re-created during rollback.
     /// But if the entity was spawned as a one-off event (for example replicated by the server upon connection),
     /// we don't want the entity to be affected by rollbacks for a short period after being spawned.
+    ///
+    /// This protects only the entity's lifecycle. It does not create missing component histories or
+    /// global rollback resources, such as a physics engine's spatial-query history.
     pub skip_despawn: bool,
     /// For entities where skip_despawn is True, after how many ticks do we start enabling back rollbacks?
     pub enable_rollback_after: u8,
@@ -385,6 +429,32 @@ fn check_rollback(
                             prediction_manager: &PredictionManager,
                             commands: &mut Commands,
                             rollback: Rollback| {
+        // The P2P world does not exist before its agreed start tick. This guard applies only to
+        // input-driven reconciliation: authoritative state and explicit forced rollbacks retain
+        // their existing behavior because they may provide their own restoration data.
+        if matches!(rollback, Rollback::FromInputs)
+            && !prediction_manager.input_rollback_is_allowed(rollback_tick)
+        {
+            let input_rollback_floor = prediction_manager.input_rollback_floor.unwrap();
+            debug!(
+                ?rollback_tick,
+                ?input_rollback_floor,
+                "Ignoring input rollback from before the P2P session start tick"
+            );
+            trace!(
+                target: "lightyear_debug::prediction",
+                kind = "input_rollback_rejected_before_floor",
+                schedule = "PreUpdate",
+                sample_point = "PreUpdate",
+                local_tick = tick.0,
+                rollback_tick = rollback_tick.0,
+                input_rollback_floor = input_rollback_floor.0,
+                rollback = ?rollback,
+                "input rollback request predates its permitted history"
+            );
+            prediction_manager.set_non_rollback();
+            return;
+        }
         let delta = tick - rollback_tick;
         if delta < 0 || delta > max_rollback_ticks as i32 {
             warn!(
@@ -1234,6 +1304,53 @@ mod tests {
 
     #[derive(Component, Clone, PartialEq, Debug)]
     struct TestComponent(f32);
+
+    #[cfg(feature = "p2p")]
+    #[test]
+    fn p2p_session_lifecycle_updates_input_rollback_floor() {
+        let mut app = App::new();
+        app.insert_resource(PredictionManager::default());
+        app.add_observer(set_p2p_input_rollback_floor);
+        app.add_observer(clear_p2p_input_rollback_floor);
+
+        app.world_mut().trigger(P2PStarted {
+            start_tick: Tick(10),
+        });
+        assert_eq!(
+            app.world()
+                .resource::<PredictionManager>()
+                .input_rollback_floor,
+            Some(Tick(10))
+        );
+        assert!(
+            !app.world()
+                .resource::<PredictionManager>()
+                .input_rollback_is_allowed(Tick(9))
+        );
+        assert!(
+            app.world()
+                .resource::<PredictionManager>()
+                .input_rollback_is_allowed(Tick(10))
+        );
+        assert!(
+            app.world()
+                .resource::<PredictionManager>()
+                .input_rollback_is_allowed(Tick(11))
+        );
+
+        app.world_mut().trigger(P2PStopped);
+        assert_eq!(
+            app.world()
+                .resource::<PredictionManager>()
+                .input_rollback_floor,
+            None
+        );
+        assert!(
+            app.world()
+                .resource::<PredictionManager>()
+                .input_rollback_is_allowed(Tick(9))
+        );
+    }
 
     /// Test that rollback does not remove a predicted component
     /// when the rollback tick predates the first retained history entry.

--- a/examples/avian_2d/src/client.rs
+++ b/examples/avian_2d/src/client.rs
@@ -147,33 +147,3 @@ pub(crate) fn handle_interpolated_spawn(
         color.0 = Color::from(hsva);
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn frame_interpolation_covers_the_predicted_ball_but_not_non_rigid_children() {
-        let mut app = App::new();
-        app.add_observer(add_frame_interpolation_components);
-
-        let ball = app
-            .world_mut()
-            .spawn((Position::default(), RigidBody::Dynamic, Predicted))
-            .id();
-        let child = app
-            .world_mut()
-            .spawn((Position::default(), Predicted, PlayerChildCollider))
-            .id();
-        app.update();
-
-        assert!(
-            app.world().get::<FrameInterpolate>(ball).is_some(),
-            "a predicted ball is a physics root even though it has no PlayerId"
-        );
-        assert!(
-            app.world().get::<FrameInterpolate>(child).is_none(),
-            "a non-rigid child has no fixed-tick pose of its own to frame-interpolate"
-        );
-    }
-}

--- a/examples/avian_2d/src/p2p.rs
+++ b/examples/avian_2d/src/p2p.rs
@@ -17,9 +17,6 @@ use crate::shared::color_from_id;
 
 const PLAYER_INPUT_HASH_BASE: u64 = 0x4156_3244_0000_0000;
 
-#[derive(Component)]
-struct PendingLocalInput(Tick);
-
 pub struct ExampleP2PPlugin;
 
 impl Plugin for ExampleP2PPlugin {
@@ -27,17 +24,12 @@ impl Plugin for ExampleP2PPlugin {
         app.insert_resource(PredictionManager::default());
         app.add_plugins(DeterministicReplicationPlugin);
         app.add_observer(spawn_fixed_world);
-        app.add_systems(
-            FixedPostUpdate,
-            enable_local_input.after(PredictionSystems::UpdateHistory),
-        );
     }
 }
 
 fn spawn_fixed_world(
     _trigger: On<P2PStarted>,
     mut commands: Commands,
-    timeline: Res<LocalTimeline>,
     settings: Res<P2PSettings>,
     links: Query<(Entity, &RemoteId), With<P2P>>,
 ) {
@@ -83,26 +75,7 @@ fn spawn_fixed_world(
             ))
             .id();
         if peer_id == settings.local_peer_id {
-            commands
-                .entity(player)
-                .insert(PendingLocalInput(timeline.tick()));
+            commands.entity(player).insert(player_input_map());
         }
-    }
-}
-
-/// Enable local input after the initial Avian rollback state has been recorded.
-fn enable_local_input(
-    mut commands: Commands,
-    timeline: Res<LocalTimeline>,
-    local_players: Query<(Entity, &PendingLocalInput)>,
-) {
-    for (entity, pending) in &local_players {
-        if timeline.tick() <= pending.0 {
-            continue;
-        }
-        commands
-            .entity(entity)
-            .insert(player_input_map())
-            .remove::<PendingLocalInput>();
     }
 }

--- a/examples/avian_3d/src/p2p.rs
+++ b/examples/avian_3d/src/p2p.rs
@@ -22,10 +22,6 @@ const PROJECTILE_LIFETIME_TICKS: i32 = 120;
 #[derive(Component)]
 struct DespawnAt(Tick);
 
-/// Marks the local character until its input map can be enabled after the first physics snapshot.
-#[derive(Component)]
-struct PendingLocalInput(Tick);
-
 pub struct ExampleP2PPlugin;
 
 impl Plugin for ExampleP2PPlugin {
@@ -33,10 +29,6 @@ impl Plugin for ExampleP2PPlugin {
         app.insert_resource(PredictionManager::default());
         app.add_plugins(DeterministicReplicationPlugin);
         app.add_observer(spawn_fixed_world);
-        app.add_systems(
-            FixedPostUpdate,
-            enable_local_input.after(PredictionSystems::UpdateHistory),
-        );
         app.add_systems(FixedUpdate, (shoot, despawn_projectiles));
     }
 }
@@ -44,7 +36,6 @@ impl Plugin for ExampleP2PPlugin {
 fn spawn_fixed_world(
     _trigger: On<P2PStarted>,
     mut commands: Commands,
-    timeline: Res<LocalTimeline>,
     settings: Res<P2PSettings>,
     links: Query<(Entity, &RemoteId), With<P2P>>,
 ) {
@@ -91,34 +82,8 @@ fn spawn_fixed_world(
             ))
             .id();
         if peer_id == settings.local_peer_id {
-            commands
-                .entity(character)
-                .insert(PendingLocalInput(timeline.tick()));
+            commands.entity(character).insert(character_input_map());
         }
-    }
-}
-
-/// Enable input capture only after Avian and Lightyear have recorded the world's initial state.
-///
-/// The fixed world and its collider-tree proxies are created together when [`P2PStarted`] is
-/// triggered. Enabling input in the same tick would allow a late first input to roll back before
-/// the first complete physics snapshot, leaving live colliders paired with an empty restored
-/// collider tree. Waiting one complete warm-up tick makes the earliest possible input rollback
-/// target a world snapshot from after initialization. It also lets the per-collider rollback
-/// histories installed by Avian's observers record their initial proxy state.
-fn enable_local_input(
-    mut commands: Commands,
-    timeline: Res<LocalTimeline>,
-    local_characters: Query<(Entity, &PendingLocalInput)>,
-) {
-    for (entity, pending) in &local_characters {
-        if timeline.tick() <= pending.0 {
-            continue;
-        }
-        commands
-            .entity(entity)
-            .insert(character_input_map())
-            .remove::<PendingLocalInput>();
     }
 }
 

--- a/examples/deterministic_replication/src/client.rs
+++ b/examples/deterministic_replication/src/client.rs
@@ -8,8 +8,6 @@ use crate::automation::AutomationClientPlugin;
 use crate::protocol::*;
 use crate::shared::color_from_id;
 use lightyear_deterministic_replication::prelude::CatchUpSnapshotReady;
-#[cfg(feature = "p2p")]
-use lightyear_examples_common::p2p::P2PSettings;
 
 pub struct ExampleClientPlugin;
 
@@ -38,37 +36,35 @@ fn add_input_map_after_sync(
     _input_timeline: SyncedLocalTimeline,
     metadata: Res<NetworkingMetadata>,
     local_ids: Query<&LocalId>,
-    #[cfg(feature = "p2p")] p2p: Option<Res<P2PSettings>>,
     mut commands: Commands,
     players: Query<(Entity, &PlayerId), (Without<InputMapAdded>, Without<InputMap<PlayerActions>>)>,
 ) {
-    #[cfg(feature = "p2p")]
-    let p2p_id = p2p.as_deref().map(P2PSettings::local_id);
-    #[cfg(not(feature = "p2p"))]
-    let p2p_id = None;
-    let local_id = p2p_id.or_else(|| match metadata.mode {
+    let local_id = match metadata.mode {
         NetworkTopology::Client(link) | NetworkTopology::HostClient { client: link, .. } => {
             local_ids.get(link).ok().map(|id| id.0)
         }
         _ => None,
-    });
+    };
     let Some(local_id) = local_id else {
         return;
     };
     for (entity, player_id) in players.iter() {
         if local_id == player_id.0 {
             info!("Client: adding InputMap to local player {:?}", player_id.0);
-            commands.entity(entity).insert((
-                InputMap::new([
-                    (PlayerActions::Up, KeyCode::KeyW),
-                    (PlayerActions::Down, KeyCode::KeyS),
-                    (PlayerActions::Left, KeyCode::KeyA),
-                    (PlayerActions::Right, KeyCode::KeyD),
-                ]),
-                InputMapAdded,
-            ));
+            commands
+                .entity(entity)
+                .insert((player_input_map(), InputMapAdded));
         }
     }
+}
+
+pub(crate) fn player_input_map() -> InputMap<PlayerActions> {
+    InputMap::new([
+        (PlayerActions::Up, KeyCode::KeyW),
+        (PlayerActions::Down, KeyCode::KeyS),
+        (PlayerActions::Left, KeyCode::KeyA),
+        (PlayerActions::Right, KeyCode::KeyD),
+    ])
 }
 
 /// Activate physics when replicated deterministic state lands.

--- a/examples/deterministic_replication/src/p2p.rs
+++ b/examples/deterministic_replication/src/p2p.rs
@@ -3,6 +3,7 @@
 //! Every peer creates the same fixed physics world and player roster locally. No entity state is
 //! replicated and no peer is authoritative; only tick-indexed player inputs cross the network.
 
+use crate::client::player_input_map;
 use crate::protocol::{PlayerActions, PlayerActivationTick, PlayerId};
 use crate::shared;
 use bevy::prelude::*;
@@ -46,17 +47,22 @@ fn spawn_fixed_world(
             peer_id,
             PLAYER_INPUT_HASH_BASE | u64::from(peer_id),
         );
-        commands.spawn((
-            PlayerId(id),
-            PlayerActivationTick(start_tick),
-            shared::player_bundle(id),
-            DeterministicPredicted {
-                skip_despawn: true,
-                enable_rollback_after: 0,
-            },
-            input_target,
-            ActionState::<PlayerActions>::default(),
-            LeafwingBuffer::<PlayerActions>::default(),
-        ));
+        let player = commands
+            .spawn((
+                PlayerId(id),
+                PlayerActivationTick(start_tick),
+                shared::player_bundle(id),
+                DeterministicPredicted {
+                    skip_despawn: true,
+                    enable_rollback_after: 0,
+                },
+                input_target,
+                ActionState::<PlayerActions>::default(),
+                LeafwingBuffer::<PlayerActions>::default(),
+            ))
+            .id();
+        if peer_id == settings.local_peer_id {
+            commands.entity(player).insert(player_input_map());
+        }
     }
 }

--- a/examples/fps/src/p2p.rs
+++ b/examples/fps/src/p2p.rs
@@ -18,9 +18,6 @@ use crate::shared::{color_from_id, BOT_RADIUS};
 
 const PLAYER_INPUT_HASH_BASE: u64 = 0x4650_5300_0000_0000;
 
-#[derive(Component)]
-struct PendingLocalInput(Tick);
-
 pub struct ExampleP2PPlugin;
 
 impl Plugin for ExampleP2PPlugin {
@@ -28,10 +25,6 @@ impl Plugin for ExampleP2PPlugin {
         app.insert_resource(PredictionManager::default());
         app.add_plugins(DeterministicReplicationPlugin);
         app.add_observer(spawn_fixed_world);
-        app.add_systems(
-            FixedPostUpdate,
-            enable_local_input.after(PredictionSystems::UpdateHistory),
-        );
 
         app.add_systems(
             FixedPostUpdate,
@@ -69,7 +62,6 @@ fn compute_hits(
 fn spawn_fixed_world(
     _trigger: On<P2PStarted>,
     mut commands: Commands,
-    timeline: Res<LocalTimeline>,
     settings: Res<P2PSettings>,
     links: Query<(Entity, &RemoteId), With<P2P>>,
 ) {
@@ -130,26 +122,7 @@ fn spawn_fixed_world(
             ))
             .id();
         if peer_id == settings.local_peer_id {
-            commands
-                .entity(player)
-                .insert(PendingLocalInput(timeline.tick()));
+            commands.entity(player).insert(player_input_map());
         }
-    }
-}
-
-/// Enable local input after the initial Avian rollback state has been recorded.
-fn enable_local_input(
-    mut commands: Commands,
-    timeline: Res<LocalTimeline>,
-    local_players: Query<(Entity, &PendingLocalInput)>,
-) {
-    for (entity, pending) in &local_players {
-        if timeline.tick() <= pending.0 {
-            continue;
-        }
-        commands
-            .entity(entity)
-            .insert(player_input_map())
-            .remove::<PendingLocalInput>();
     }
 }


### PR DESCRIPTION
## Summary

- reject input-driven rollbacks whose restore tick predates the active P2P session
- remove PendingLocalInput and warm-up systems from the Avian/FPS P2P examples