### PR TITLE
feat(p2p): add explicit session start lifecycle

### DIFF
--- a/crates/connection/connection/src/identity.rs
+++ b/crates/connection/connection/src/identity.rs
@@ -27,7 +27,7 @@ pub fn is_host_server(metadata: Res<NetworkingMetadata>) -> bool {
     metadata.mode.is_host_server()
 }
 
-/// Returns true when the cached topology contains direct P2P Links.
+/// Returns true after the P2PStarted event has been triggered
 pub fn is_p2p(metadata: Res<NetworkingMetadata>) -> bool {
     metadata.mode.is_p2p()
 }

--- a/crates/connection/connection/src/network_topology.rs
+++ b/crates/connection/connection/src/network_topology.rs
@@ -11,8 +11,9 @@ use smallvec::SmallVec;
 
 /// The ready networking role of this Bevy application.
 ///
-/// Entities are only included after their relevant lifecycle has completed: clients and P2P links
-/// must be [`Connected`], and servers must be [`Started`].
+/// Conventional clients are included after they are [`Connected`] and servers after they are
+/// [`Started`]. P2P is exposed only after its start barrier has completed. Systems that need to
+/// inspect lobby or startup participation should query [`P2P`] components directly.
 #[derive(Default, Debug, Clone, PartialEq, Eq)]
 pub enum NetworkTopology {
     /// No networking topology has been identified yet.
@@ -29,14 +30,11 @@ pub enum NetworkTopology {
         /// The connected host-client link entity.
         client: Entity,
     },
-    /// The declared and currently connected direct peer links in this P2P session.
-    P2P {
-        /// Connected P2P Link entities, sorted by local [`Entity`] ID.
-        connected: SmallVec<[Entity; 4]>,
-        /// Total number of Link entities carrying the [`P2P`] marker, including disconnected
-        /// Links. This lets consumers test startup readiness without rediscovering the roster.
-        declared_links: u8,
-    },
+    /// Direct peer Links that crossed the barrier and participate in deterministic gameplay.
+    ///
+    /// This roster is always non-empty. Its currently [`Connected`] joined Links are sorted by
+    /// local [`Entity`] ID, and disconnected Links are omitted.
+    P2P(SmallVec<[Entity; 4]>),
     /// The ready entities do not form one supported networking topology.
     Invalid(NetworkTopologyError),
 }
@@ -62,9 +60,9 @@ impl NetworkTopology {
         matches!(self, Self::HostClient { .. })
     }
 
-    /// Returns true when direct P2P Links have been declared.
+    /// Returns true when a direct P2P session has crossed its start barrier.
     pub fn is_p2p(&self) -> bool {
-        matches!(self, Self::P2P { .. })
+        matches!(self, Self::P2P(_))
     }
 }
 
@@ -236,7 +234,7 @@ fn network_topology_is_dirty(metadata: Res<NetworkingMetadata>) -> bool {
 
 fn refresh_network_topology(
     mut metadata: ResMut<NetworkingMetadata>,
-    p2p_markers: Query<Entity, With<P2P>>,
+    p2p_links: Query<(Entity, &P2P, Has<Connected>)>,
     ready_clients: Query<
         (Entity, Has<P2P>, Has<HostClient>, Option<&LinkOf>),
         (With<Client>, With<Connected>),
@@ -247,10 +245,13 @@ fn refresh_network_topology(
     let malformed_host = malformed_hosts
         .iter()
         .min_by_key(|entity| entity.index_u32());
-    let first_p2p = p2p_markers.iter().min_by_key(|entity| entity.index_u32());
+    let first_active_p2p = p2p_links
+        .iter()
+        .filter_map(|(entity, state, _)| (*state != P2P::Inactive).then_some(entity))
+        .min_by_key(|entity| entity.index_u32());
     let next = if let Some(client) = malformed_host {
         NetworkTopology::Invalid(NetworkTopologyError::HostClientWithoutClient { client })
-    } else if let Some(p2p) = first_p2p {
+    } else if let Some(p2p) = first_active_p2p {
         // A connected non-P2P Client is conventional. HostClient is conventional even if it was
         // accidentally combined with P2P on the same Link.
         let conventional_client = ready_clients
@@ -266,22 +267,20 @@ fn refresh_network_topology(
                 server,
             })
         } else {
-            let declared_links = u8::try_from(p2p_markers.iter().count()).unwrap_or_else(|_| {
-                tracing::error!(
-                    maximum = u8::MAX,
-                    "P2P topology declared more Links than its cached count can represent"
-                );
-                u8::MAX
-            });
-            let mut connected: SmallVec<[Entity; 4]> = ready_clients
+            let has_candidates = p2p_links
                 .iter()
-                .filter(|(_, is_p2p, _, _)| *is_p2p)
-                .map(|(entity, _, _, _)| entity)
-                .collect();
-            connected.sort_unstable_by_key(|entity| entity.index_u32());
-            NetworkTopology::P2P {
-                connected,
-                declared_links,
+                .any(|(_, state, _)| *state == P2P::Candidate);
+            let mut joined = SmallVec::<[Entity; 4]>::new();
+            for (entity, state, connected) in &p2p_links {
+                if *state == P2P::Joined && connected {
+                    joined.push(entity);
+                }
+            }
+            joined.sort_unstable_by_key(|entity| entity.index_u32());
+            if has_candidates || joined.is_empty() {
+                NetworkTopology::Undefined
+            } else {
+                NetworkTopology::P2P(joined)
             }
         }
     } else {
@@ -479,62 +478,62 @@ mod tests {
     }
 
     #[test]
-    fn p2p_mode_exists_before_any_peer_is_connected_and_sorts_ready_links() {
+    fn p2p_mode_contains_only_connected_links_after_the_barrier() {
         let mut app = test_app();
-        let first = app.world_mut().spawn(P2P).id();
-        let second = app.world_mut().spawn(P2P).id();
+        let first = app.world_mut().spawn(P2P::Inactive).id();
+        let second = app.world_mut().spawn(P2P::Inactive).id();
 
         app.update();
-        assert_eq!(
-            mode(&app),
-            &NetworkTopology::P2P {
-                connected: SmallVec::new(),
-                declared_links: 2,
-            }
-        );
+        assert_eq!(mode(&app), &NetworkTopology::Undefined);
 
-        // Connect in reverse order to prove that insertion order does not affect the cache.
-        app.world_mut()
-            .entity_mut(second)
-            .insert((RemoteId(PeerId::Local(2)), Connected));
+        app.world_mut().entity_mut(first).insert(P2P::Candidate);
+        app.world_mut().entity_mut(second).insert(P2P::Candidate);
+        app.update();
+
+        assert_eq!(mode(&app), &NetworkTopology::Undefined);
+        assert!(!mode(&app).is_p2p());
+
+        app.world_mut().entity_mut(first).insert(P2P::Joined);
+        app.update();
+        assert_eq!(mode(&app), &NetworkTopology::Undefined);
+        assert!(!mode(&app).is_p2p());
+
+        app.world_mut().entity_mut(second).insert(P2P::Joined);
         app.world_mut()
             .entity_mut(first)
             .insert((RemoteId(PeerId::Local(1)), Connected));
+        app.world_mut()
+            .entity_mut(second)
+            .insert((RemoteId(PeerId::Local(2)), Connected));
         app.update();
-
         assert_eq!(
             mode(&app),
-            &NetworkTopology::P2P {
-                connected: SmallVec::from_slice(&[first, second]),
-                declared_links: 2,
-            }
+            &NetworkTopology::P2P(SmallVec::from_slice(&[first, second]))
         );
+        assert!(mode(&app).is_p2p());
 
-        app.world_mut().entity_mut(first).insert(Disconnected {
+        app.world_mut().entity_mut(second).insert(Disconnected {
             reason: DisconnectedReason::UserRequested(Some("test".into())),
         });
         app.update();
         assert_eq!(
             mode(&app),
-            &NetworkTopology::P2P {
-                connected: SmallVec::from_slice(&[second]),
-                declared_links: 2,
-            }
+            &NetworkTopology::P2P(SmallVec::from_slice(&[first]))
         );
 
         app.world_mut().despawn(second);
         app.update();
         assert_eq!(
             mode(&app),
-            &NetworkTopology::P2P {
-                connected: SmallVec::new(),
-                declared_links: 1,
-            }
+            &NetworkTopology::P2P(SmallVec::from_slice(&[first]))
         );
 
-        app.world_mut().entity_mut(first).remove::<P2P>();
+        app.world_mut().entity_mut(first).insert(Disconnected {
+            reason: DisconnectedReason::UserRequested(Some("test".into())),
+        });
         app.update();
         assert_eq!(mode(&app), &NetworkTopology::Undefined);
+        assert_eq!(app.world().entity(first).get::<P2P>(), Some(&P2P::Joined));
     }
 
     #[test]
@@ -542,7 +541,7 @@ mod tests {
         let mut app = test_app();
         let peer = app
             .world_mut()
-            .spawn((P2P, RemoteId(PeerId::Local(1)), Connected))
+            .spawn((P2P::Candidate, RemoteId(PeerId::Local(1)), Connected))
             .id();
         let client = connect_client(&mut app, 2);
         let server = start_server(&mut app);
@@ -559,23 +558,26 @@ mod tests {
     }
 
     #[test]
+    fn inactive_p2p_links_do_not_activate_or_conflict_with_conventional_topology() {
+        let mut app = test_app();
+        app.world_mut()
+            .spawn((P2P::Inactive, RemoteId(PeerId::Local(1)), Connected));
+        let client = connect_client(&mut app, 2);
+
+        app.update();
+        assert_eq!(mode(&app), &NetworkTopology::Client(client));
+    }
+
+    #[test]
     fn unready_conventional_roles_do_not_conflict_with_p2p() {
         let mut app = test_app();
-        let peer = app
-            .world_mut()
-            .spawn((P2P, RemoteId(PeerId::Local(1)), Connected))
-            .id();
+        app.world_mut()
+            .spawn((P2P::Candidate, RemoteId(PeerId::Local(1)), Connected));
         app.world_mut().spawn(Client);
         app.world_mut().spawn(Server::default());
 
         app.update();
-        assert_eq!(
-            mode(&app),
-            &NetworkTopology::P2P {
-                connected: SmallVec::from_slice(&[peer]),
-                declared_links: 1,
-            }
-        );
+        assert_eq!(mode(&app), &NetworkTopology::Undefined);
     }
 
     #[test]

--- a/crates/connection/connection/src/p2p.rs
+++ b/crates/connection/connection/src/p2p.rs
@@ -2,10 +2,27 @@ use crate::client::Client;
 use bevy_ecs::prelude::*;
 use bevy_reflect::Reflect;
 
-/// Marks a client link as a direct connection to another peer in a P2P session.
+/// Participation state of a direct peer Link in a P2P session.
 ///
-/// P2P links remain [`Client`] links so that they can reuse the existing connection,
-/// messaging, input, and prediction pipelines.
+/// A P2P Link remains a [`Client`] Link so that it can reuse the existing connection,
+/// messaging, input, and prediction pipelines. The component is immutable: replace it to move a
+/// Link between states so that the cached network topology observes every transition.
 #[derive(Component, Default, Debug, Clone, Copy, PartialEq, Eq, Reflect)]
+#[component(immutable)]
 #[require(Client)]
-pub struct P2P;
+pub enum P2P {
+    /// A declared P2P Link that is not part of a start barrier or running session.
+    ///
+    /// Inactive Links do not activate a P2P [`NetworkTopology`](crate::network_topology::NetworkTopology).
+    #[default]
+    Inactive,
+    /// A Link frozen into the current start barrier.
+    ///
+    /// Candidate Links are intentionally not exposed through the cached
+    /// [`NetworkTopology`](crate::network_topology::NetworkTopology). Systems that participate in
+    /// startup synchronization should query this component directly.
+    Candidate,
+    /// A Link that has crossed the start barrier. While connected, it is exposed through
+    /// [`NetworkTopology::P2P`](crate::network_topology::NetworkTopology::P2P).
+    Joined,
+}

--- a/crates/connection/p2p/Cargo.toml
+++ b/crates/connection/p2p/Cargo.toml
@@ -22,12 +22,15 @@ lightyear_connection = { workspace = true, features = ["client"] }
 lightyear_core.workspace = true
 lightyear_link.workspace = true
 lightyear_messages = { workspace = true, features = ["client"] }
+lightyear_serde.workspace = true
 lightyear_sync = { workspace = true, features = ["client"] }
 lightyear_transport = { workspace = true, features = ["client"] }
 
 bevy_app.workspace = true
 bevy_ecs.workspace = true
+bevy_time.workspace = true
 serde.workspace = true
+seahash.workspace = true
 smallvec = { workspace = true, features = ["serde"] }
 tracing.workspace = true
 

--- a/crates/connection/p2p/src/lib.rs
+++ b/crates/connection/p2p/src/lib.rs
@@ -1,10 +1,12 @@
 //! Deterministic peer-to-peer session lifecycle for Lightyear.
 //!
-//! Applications declare ordinary [`P2P`](lightyear_connection::p2p::P2P) Links, then trigger
-//! [`P2PStart`] when the desired cohort is present. The session waits for those Links and the
-//! synchronized input timeline, then chooses one shared future start tick.
+//! Applications declare [`P2P::Inactive`](lightyear_connection::p2p::P2P::Inactive) Links, then
+//! trigger [`P2PStart`] when the desired cohort is present. The current inactive Links become
+//! candidates; the session waits for them and the synchronized input timeline, chooses one shared
+//! future start tick, then marks them joined.
 //!
-//! The session does not own peer discovery, Link connection, or network topology. Stopping it can
+//! [`P2PSessionPlugin`] owns the barrier bookkeeping; applications do not need to configure a
+//! [`P2PSession`]. The session does not own peer discovery or Link connection. Stopping it can
 //! either preserve every Link for a lobby/rematch or unlink every currently declared P2P Link.
 
 #![no_std]

--- a/crates/connection/p2p/src/session.rs
+++ b/crates/connection/p2p/src/session.rs
@@ -1,19 +1,26 @@
+use alloc::vec::Vec;
 use bevy_app::{App, Plugin, PreUpdate};
 use bevy_ecs::prelude::*;
+use bevy_time::{Real, Time};
+use core::hash::Hasher;
+use core::time::Duration;
 use lightyear_connection::client::Connected;
 use lightyear_connection::direction::NetworkDirection;
 use lightyear_connection::network_topology::NetworkTopologySystems;
 use lightyear_connection::p2p::P2P;
+use lightyear_core::id::{LocalId, PeerId, RemoteId};
 use lightyear_core::prelude::{LocalTimeline, Tick};
 use lightyear_link::prelude::{Unlink, UnlinkReason};
 use lightyear_messages::plugin::MessageSystems;
 use lightyear_messages::prelude::{AppMessageExt, MessageReceiver, MessageSender};
+use lightyear_serde::ToBytes;
 use lightyear_sync::prelude::SyncedLocalTimeline;
 use lightyear_transport::prelude::{AppChannelExt, ChannelMode, ChannelSettings, ReliableSettings};
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
 
 const DEFAULT_START_DELAY_TICKS: u16 = 120;
+const DEFAULT_START_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Public lifecycle of the deterministic P2P session.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
@@ -33,11 +40,11 @@ pub enum P2PSessionState {
     },
 }
 
-/// Start-negotiation progress for one remote peer in the frozen cohort.
+/// Stable identity and start-negotiation progress for one remote peer in the frozen cohort.
 #[derive(Debug, Clone, Copy)]
 struct RemotePeerStart {
-    /// Local entity of the direct Link to this remote peer.
-    link: Entity,
+    /// Stable identity used to find the peer's current P2P Link.
+    peer_id: PeerId,
     /// Earliest start tick advertised by this remote peer.
     ready_tick: Option<Tick>,
     /// Start tick this remote peer acknowledged after seeing every Ready message.
@@ -45,28 +52,27 @@ struct RemotePeerStart {
 }
 
 impl RemotePeerStart {
-    fn new(link: Entity) -> Self {
+    fn new(peer_id: PeerId) -> Self {
         Self {
-            link,
+            peer_id,
             ready_tick: None,
             acknowledged_tick: None,
         }
     }
 }
 
-/// Application-global configuration and state for one deterministic P2P session.
+/// Application-global bookkeeping and state for one deterministic P2P session.
 ///
-/// Lightyear does not discover or connect peers through this resource. Applications declare
-/// [`P2P`] Links normally, then trigger [`P2PStart`] when the desired initial cohort has been
-/// declared. The Links don't have to be connected yet when [`P2PStart`] is called.
+/// [`P2PSessionPlugin`] initializes this resource. Applications normally only declare [`P2P`]
+/// Links and trigger [`P2PStart`]; they do not need to create or update the resource themselves.
 #[derive(Resource, Debug)]
 pub struct P2PSession {
-    /// Maximum cohort size, including the local peer.
-    max_peers: u8,
-    /// Application-facing policy indicating whether new Links may be established after start.
-    allow_late_join: bool,
     /// Lead added to the local tick when this peer becomes ready.
     start_delay_ticks: u16,
+    /// Maximum wall-clock time allowed for one start attempt.
+    start_timeout: Duration,
+    /// Wall-clock timestamp at which the current start attempt began.
+    start_started_at: Option<Duration>,
     /// Current deterministic-session lifecycle.
     state: P2PSessionState,
     /// Local start-attempt number carried by messages to reject packets from older attempts.
@@ -80,56 +86,46 @@ pub struct P2PSession {
     local_ready_sent: bool,
     /// Whether this app has queued its StartAcknowledgement on every frozen remote Link.
     local_acknowledgement_sent: bool,
-    /// Remote peers frozen by [`P2PStart`], one per direct P2P Link.
+    /// Hash of the complete roster frozen by [`P2PStart`].
+    roster_hash: Option<u64>,
+    /// Transient negotiation progress for remote peers frozen by [`P2PStart`].
     ///
+    /// This stores stable peer IDs rather than Link entities and is cleared after the barrier.
     /// The local peer is not included; its progress is stored in the `local_*` fields above.
     remote_peers: SmallVec<[RemotePeerStart; 4]>,
+    /// Set when a peer advertises a different roster for the same attempt.
+    roster_mismatch: bool,
 }
 
-impl P2PSession {
-    /// Create a stopped session with capacity for `max_peers`, including the local peer.
-    ///
-    /// A P2P session needs at least two peers. The count is a capacity, not a required roster
-    /// size: the application decides when enough Links exist and triggers [`P2PStart`].
-    pub fn new(max_peers: u8) -> Self {
-        assert!(max_peers >= 2, "a P2P session needs at least two peers");
+impl Default for P2PSession {
+    fn default() -> Self {
         Self {
-            max_peers,
-            allow_late_join: false,
             start_delay_ticks: DEFAULT_START_DELAY_TICKS,
+            start_timeout: DEFAULT_START_TIMEOUT,
+            start_started_at: None,
             state: P2PSessionState::Stopped,
             generation: 0,
             local_ready_tick: None,
             local_ready_sent: false,
             local_acknowledgement_sent: false,
+            roster_hash: None,
             remote_peers: SmallVec::new(),
+            roster_mismatch: false,
         }
     }
+}
 
-    /// Allow the application to establish additional P2P Links after the session starts.
-    ///
-    /// This is an application-facing admission policy; the session does not create or reject
-    /// Links. A late Link is not added to the running deterministic cohort automatically. It can
-    /// receive traffic and perform application-owned catch-up, then participate in a later start.
-    pub fn with_late_join(mut self, allow: bool) -> Self {
-        self.allow_late_join = allow;
-        self
-    }
-
+impl P2PSession {
     /// Set the lead time used when proposing a common future start tick.
     pub fn with_start_delay_ticks(mut self, ticks: u16) -> Self {
         self.start_delay_ticks = ticks;
         self
     }
 
-    /// Maximum peer count, including the local peer.
-    pub fn max_peers(&self) -> u8 {
-        self.max_peers
-    }
-
-    /// Whether the application may establish Links after this session starts.
-    pub fn allows_late_join(&self) -> bool {
-        self.allow_late_join
+    /// Set the maximum wall-clock duration allowed for a start barrier.
+    pub fn with_start_timeout(mut self, timeout: Duration) -> Self {
+        self.start_timeout = timeout;
+        self
     }
 
     /// Current deterministic session lifecycle.
@@ -151,29 +147,51 @@ impl P2PSession {
         matches!(self.state, P2PSessionState::Started { .. })
     }
 
-    /// Links frozen into the current starting or started cohort.
-    pub fn links(&self) -> impl Iterator<Item = Entity> + '_ {
-        self.remote_peers.iter().map(|peer| peer.link)
-    }
-
-    /// Reset negotiation state and freeze the supplied remote Links into a new start attempt.
-    fn begin(&mut self, mut links: SmallVec<[Entity; 4]>) {
-        links.sort_unstable();
+    /// Reset negotiation state and freeze the supplied remote identities into a new start attempt.
+    fn begin(
+        &mut self,
+        remote_peer_ids: SmallVec<[PeerId; 4]>,
+        roster_hash: u64,
+        started_at: Duration,
+    ) {
         self.generation = self.generation.wrapping_add(1);
+        self.start_started_at = Some(started_at);
         self.local_ready_tick = None;
         self.local_ready_sent = false;
         self.local_acknowledgement_sent = false;
-        self.remote_peers = links.into_iter().map(RemotePeerStart::new).collect();
+        self.roster_hash = Some(roster_hash);
+        self.remote_peers = remote_peer_ids
+            .into_iter()
+            .map(RemotePeerStart::new)
+            .collect();
+        self.roster_mismatch = false;
         self.state = P2PSessionState::Starting { start_tick: None };
     }
 
     /// Clear the active cohort and return to the lobby/stopped state.
     fn stop(&mut self) {
         self.state = P2PSessionState::Stopped;
+        self.clear_barrier_progress();
+    }
+
+    /// Drop transient barrier bookkeeping while preserving the public Started state.
+    fn clear_barrier_progress(&mut self) {
+        self.start_started_at = None;
         self.local_ready_tick = None;
         self.local_ready_sent = false;
         self.local_acknowledgement_sent = false;
+        self.roster_hash = None;
         self.remote_peers.clear();
+        self.roster_mismatch = false;
+    }
+
+    fn contains_remote(&self, peer_id: PeerId) -> bool {
+        self.remote_peers.iter().any(|peer| peer.peer_id == peer_id)
+    }
+
+    fn timed_out_at(&self, now: Duration) -> bool {
+        self.start_started_at
+            .is_some_and(|started_at| now.saturating_sub(started_at) >= self.start_timeout)
     }
 
     /// Record one message received from a remote Link in the current start attempt.
@@ -181,7 +199,7 @@ impl P2PSession {
     /// Delayed messages from older generations and messages from Links outside the frozen cohort
     /// are ignored. Repeated identical messages are harmless; conflicting repeats are logged and
     /// the first value remains authoritative.
-    fn receive(&mut self, link: Entity, message: P2PSessionMessage) {
+    fn receive(&mut self, peer_id: PeerId, message: P2PSessionMessage) {
         // Reliable packets from a previous start can arrive after a stop/restart cycle.
         let generation = match message {
             P2PSessionMessage::Ready { generation, .. }
@@ -190,9 +208,27 @@ impl P2PSession {
         if generation != self.generation {
             return;
         }
-        let Some(peer) = self.remote_peers.iter_mut().find(|peer| peer.link == link) else {
+        let Some(peer) = self
+            .remote_peers
+            .iter_mut()
+            .find(|peer| peer.peer_id == peer_id)
+        else {
             return;
         };
+        let message_roster_hash = match message {
+            P2PSessionMessage::Ready { roster_hash, .. }
+            | P2PSessionMessage::StartAcknowledgement { roster_hash, .. } => roster_hash,
+        };
+        if self.roster_hash != Some(message_roster_hash) {
+            self.roster_mismatch = true;
+            tracing::warn!(
+                ?peer_id,
+                local_roster_hash = ?self.roster_hash,
+                remote_roster_hash = message_roster_hash,
+                "peer advertised a different P2P roster"
+            );
+            return;
+        }
         match message {
             P2PSessionMessage::Ready {
                 earliest_start_tick,
@@ -200,7 +236,7 @@ impl P2PSession {
             } => match peer.ready_tick {
                 None => peer.ready_tick = Some(earliest_start_tick),
                 Some(previous) if previous != earliest_start_tick => tracing::warn!(
-                    ?link,
+                    ?peer_id,
                     ?previous,
                     ?earliest_start_tick,
                     "ignoring conflicting P2P ready message"
@@ -211,7 +247,7 @@ impl P2PSession {
                 match peer.acknowledged_tick {
                     None => peer.acknowledged_tick = Some(start_tick),
                     Some(previous) if previous != start_tick => tracing::warn!(
-                        ?link,
+                        ?peer_id,
                         ?previous,
                         ?start_tick,
                         "ignoring conflicting P2P start acknowledgement"
@@ -231,6 +267,9 @@ impl P2PSession {
     fn advance(&mut self, tick: Tick, timeline_synced: bool) -> AdvanceResult {
         if !matches!(self.state, P2PSessionState::Starting { .. }) {
             return AdvanceResult::Waiting;
+        }
+        if self.roster_mismatch {
+            return AdvanceResult::Failed;
         }
 
         // Do not advertise readiness until the shared input timeline is usable.
@@ -262,18 +301,17 @@ impl P2PSession {
         {
             return AdvanceResult::Waiting;
         }
-        if let Some((link, acknowledged)) = self.remote_peers.iter().find_map(|peer| {
+        if let Some((peer_id, acknowledged)) = self.remote_peers.iter().find_map(|peer| {
             peer.acknowledged_tick
                 .filter(|acknowledged| *acknowledged != start_tick)
-                .map(|acknowledged| (peer.link, acknowledged))
+                .map(|acknowledged| (peer.peer_id, acknowledged))
         }) {
             tracing::warn!(
-                ?link,
+                ?peer_id,
                 ?start_tick,
                 ?acknowledged,
                 "peer acknowledged a different P2P start tick"
             );
-            self.stop();
             return AdvanceResult::Failed;
         }
 
@@ -285,7 +323,6 @@ impl P2PSession {
                 ?start_tick,
                 "P2P start acknowledgement arrived after the agreed tick"
             );
-            self.stop();
             return AdvanceResult::Failed;
         }
         if tick + 1 < start_tick {
@@ -295,38 +332,33 @@ impl P2PSession {
         AdvanceResult::Started(start_tick)
     }
 
-    /// Queue each locally available Ready or acknowledgement once for every remote Link.
+    /// Return each locally available Ready or acknowledgement once.
     ///
-    /// The transport channel provides retransmission; these flags only prevent this system from
-    /// enqueuing an identical message every frame.
-    fn collect_outbound(&mut self, outbound: &mut SmallVec<[(Entity, P2PSessionMessage); 8]>) {
+    /// The caller broadcasts each returned message to every current candidate Link. The transport
+    /// channel provides retransmission; these flags only prevent enqueuing duplicates every frame.
+    fn collect_outbound(&mut self, outbound: &mut SmallVec<[P2PSessionMessage; 2]>) {
+        let Some(roster_hash) = self.roster_hash else {
+            return;
+        };
         if let Some(earliest_start_tick) = self.local_ready_tick
             && !self.local_ready_sent
         {
             self.local_ready_sent = true;
-            for peer in &self.remote_peers {
-                outbound.push((
-                    peer.link,
-                    P2PSessionMessage::Ready {
-                        generation: self.generation,
-                        earliest_start_tick,
-                    },
-                ));
-            }
+            outbound.push(P2PSessionMessage::Ready {
+                generation: self.generation,
+                roster_hash,
+                earliest_start_tick,
+            });
         }
         if let Some(start_tick) = self.start_tick()
             && !self.local_acknowledgement_sent
         {
             self.local_acknowledgement_sent = true;
-            for peer in &self.remote_peers {
-                outbound.push((
-                    peer.link,
-                    P2PSessionMessage::StartAcknowledgement {
-                        generation: self.generation,
-                        start_tick,
-                    },
-                ));
-            }
+            outbound.push(P2PSessionMessage::StartAcknowledgement {
+                generation: self.generation,
+                roster_hash,
+                start_tick,
+            });
         }
     }
 }
@@ -336,7 +368,9 @@ impl P2PSession {
 ///
 /// The Links don't have to be connected yet when `P2PStart` is called. Lightyear waits for every
 /// captured Link and the synchronized input timeline, negotiates a common future tick, then
-/// triggers [`P2PStarted`].
+/// triggers [`P2PStarted`]. Every Link must expose the same stable [`LocalId`] and a distinct
+/// [`RemoteId`]. If the barrier does not complete within the configured timeout (5 seconds by
+/// default), its candidates return to [`P2P::Inactive`].
 #[derive(Event, Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct P2PStart;
 
@@ -354,10 +388,11 @@ pub struct P2PStop {
 /// Triggered immediately before the fixed simulation advances to the agreed tick.
 ///
 /// Applications can observe this to create the shared deterministic world in the same order on
-/// every peer. Prediction treats the start tick as the oldest valid input rollback snapshot.
+/// every peer. Prediction treats the preceding tick as the initial rollback snapshot so a late
+/// input for the first gameplay tick can still be corrected.
 #[derive(Event, Debug, Clone, Copy, PartialEq, Eq)]
 pub struct P2PStarted {
-    /// Common simulation start tick and earliest permitted input rollback target.
+    /// Common first gameplay tick. The preceding tick is the initial rollback boundary.
     pub start_tick: Tick,
 }
 
@@ -373,6 +408,8 @@ enum P2PSessionMessage {
     Ready {
         /// Start-attempt number used to discard delayed messages from earlier attempts.
         generation: u32,
+        /// Hash of the complete roster, including the sender.
+        roster_hash: u64,
         /// Sender's current tick plus its configured start delay.
         earliest_start_tick: Tick,
     },
@@ -380,6 +417,8 @@ enum P2PSessionMessage {
     StartAcknowledgement {
         /// Start-attempt number used to discard delayed messages from earlier attempts.
         generation: u32,
+        /// Hash of the complete roster, including the sender.
+        roster_hash: u64,
         /// Common start tick calculated by the sender.
         start_tick: Tick,
     },
@@ -388,10 +427,15 @@ enum P2PSessionMessage {
 /// Private reliable delivery queue for P2P lifecycle control messages.
 struct P2PSessionChannel;
 
-/// Installs the P2P session lifecycle and start-tick negotiation.
-pub struct P2PSessionPlugin;
+/// Registers the private P2P control protocol.
+///
+/// This plugin is installed by Lightyear's shared plugin setup so P2P-enabled conventional
+/// clients and servers reserve identical channel and message IDs. [`P2PSessionPlugin`] installs
+/// it as a fallback for applications that use this crate directly.
+#[doc(hidden)]
+pub struct P2PProtocolPlugin;
 
-impl Plugin for P2PSessionPlugin {
+impl Plugin for P2PProtocolPlugin {
     fn build(&self, app: &mut App) {
         // No generic reliable control channel exists at this layer. Replication's reliable
         // channels are optional and must not become a dependency of the P2P session. The two
@@ -404,6 +448,18 @@ impl Plugin for P2PSessionPlugin {
         .add_direction(NetworkDirection::Bidirectional);
         app.register_message::<P2PSessionMessage>()
             .add_direction(NetworkDirection::Bidirectional);
+    }
+}
+
+/// Installs the P2P session lifecycle and start-tick negotiation.
+pub struct P2PSessionPlugin;
+
+impl Plugin for P2PSessionPlugin {
+    fn build(&self, app: &mut App) {
+        if !app.is_plugin_added::<P2PProtocolPlugin>() {
+            app.add_plugins(P2PProtocolPlugin);
+        }
+        app.init_resource::<P2PSession>();
 
         app.add_observer(start_session);
         app.add_observer(stop_session);
@@ -411,7 +467,10 @@ impl Plugin for P2PSessionPlugin {
             PreUpdate,
             drive_session
                 .after(MessageSystems::Receive)
-                .after(NetworkTopologySystems::Update),
+                // A successful barrier replaces Candidate with Joined. Refresh the cached
+                // topology in the same PreUpdate so FixedMain sees the new membership at the
+                // agreed start tick.
+                .before(NetworkTopologySystems::Update),
         );
     }
 }
@@ -423,53 +482,120 @@ enum AdvanceResult {
     Failed,
 }
 
-/// Freeze every currently declared P2P Link as the remote cohort for a new start attempt.
+/// Hash a roster independently of Link entity allocation and local/remote ordering.
+fn roster_hash(local_id: PeerId, remote_ids: &[PeerId]) -> u64 {
+    let mut encoded_peers = Vec::with_capacity(remote_ids.len() + 1);
+    for peer_id in core::iter::once(&local_id).chain(remote_ids) {
+        let mut encoded = Vec::with_capacity(peer_id.bytes_len());
+        peer_id
+            .to_bytes(&mut encoded)
+            .expect("serializing a PeerId into memory cannot fail");
+        encoded_peers.push(encoded);
+    }
+    encoded_peers.sort_unstable();
+
+    let mut hasher = seahash::SeaHasher::new();
+    for encoded in encoded_peers {
+        hasher.write(&encoded);
+    }
+    hasher.finish()
+}
+
+/// Signal the start of a new deterministic P2P session.
 ///
-/// This validates the configured capacity and installs the private typed receiver, but does not
-/// connect the Links. [`drive_session`] waits for connection and timeline readiness.
+/// Every currently declared P2P Link is used as a candidate for the new session.
+/// Remove the P2P component from Links that should not participate before triggering this event.
+///
+/// Starting the session involves coordinating between each peer so that they can agree
+/// on a common start tick. After the session is started, the P2P Links will be in the Joined state
+/// and can be used for deterministic gameplay.
 fn start_session(
     _trigger: On<P2PStart>,
     mut commands: Commands,
-    mut session: Option<ResMut<P2PSession>>,
-    links: Query<(Entity, Has<MessageReceiver<P2PSessionMessage>>), With<P2P>>,
+    mut session: ResMut<P2PSession>,
+    real_time: Res<Time<Real>>,
+    links: Query<(
+        Entity,
+        &P2P,
+        Option<&LocalId>,
+        Option<&RemoteId>,
+        Has<MessageReceiver<P2PSessionMessage>>,
+    )>,
 ) {
-    let Some(session) = session.as_deref_mut() else {
-        tracing::warn!("P2PStart requires a P2PSession resource");
-        return;
-    };
     if !matches!(session.state, P2PSessionState::Stopped) {
-        tracing::warn!("ignoring P2PStart because the session is not stopped");
-        return;
-    }
-
-    let declared_links: SmallVec<[(Entity, bool); 4]> = links.iter().collect();
-    let peer_count = declared_links.len().saturating_add(1);
-    if declared_links.is_empty() {
-        tracing::warn!("P2PStart requires at least one declared remote P2P Link");
-        return;
-    }
-    if peer_count > usize::from(session.max_peers) {
-        tracing::warn!(
-            peer_count,
-            max_peers = session.max_peers,
-            "P2PStart exceeds the configured peer capacity"
+        tracing::error!(
+            state = ?session.state,
+            "rejecting P2PStart because a session is already starting or running"
         );
         return;
     }
-    for (entity, has_receiver) in &declared_links {
+
+    let candidates: SmallVec<[(Entity, Option<PeerId>, Option<PeerId>, bool); 4]> = links
+        .iter()
+        .filter_map(|(entity, state, local_id, remote_id, has_receiver)| {
+            (*state == P2P::Inactive).then_some((
+                entity,
+                local_id.map(|id| id.0),
+                remote_id.map(|id| id.0),
+                has_receiver,
+            ))
+        })
+        .collect();
+    let peer_count = candidates.len().saturating_add(1);
+    if candidates.is_empty() {
+        tracing::warn!("P2PStart requires at least one inactive remote P2P Link");
+        return;
+    }
+    let Some(local_id) = candidates[0].1 else {
+        tracing::warn!("P2PStart requires every candidate Link to have a LocalId");
+        return;
+    };
+    if candidates
+        .iter()
+        .any(|(_, candidate_local_id, _, _)| *candidate_local_id != Some(local_id))
+    {
+        tracing::warn!(
+            ?local_id,
+            "P2PStart requires every candidate Link to have the same LocalId"
+        );
+        return;
+    }
+
+    let mut remote_ids = SmallVec::<[PeerId; 4]>::new();
+    for (_, _, remote_id, _) in &candidates {
+        let Some(remote_id) = *remote_id else {
+            tracing::warn!("P2PStart requires every candidate Link to have a RemoteId");
+            return;
+        };
+        if remote_id == local_id {
+            tracing::warn!(
+                ?local_id,
+                "a P2P Link cannot identify the local peer as remote"
+            );
+            return;
+        }
+        if remote_ids.contains(&remote_id) {
+            tracing::warn!(
+                ?remote_id,
+                "P2PStart found duplicate remote peer identities"
+            );
+            return;
+        }
+        remote_ids.push(remote_id);
+    }
+    let roster_hash = roster_hash(local_id, &remote_ids);
+
+    for (entity, _, _, has_receiver) in &candidates {
+        commands.entity(*entity).insert(P2P::Candidate);
         if !has_receiver {
             commands
                 .entity(*entity)
                 .insert(MessageReceiver::<P2PSessionMessage>::default());
         }
     }
-    let links = declared_links
-        .into_iter()
-        .map(|(entity, _)| entity)
-        .collect();
 
-    tracing::info!(peer_count, "starting P2P session negotiation");
-    session.begin(links);
+    tracing::info!(peer_count, roster_hash, "starting P2P session negotiation");
+    session.begin(remote_ids, roster_hash, real_time.elapsed());
 }
 
 /// Stop the local deterministic session, optionally unlink every P2P Link, and emit
@@ -481,20 +607,19 @@ fn start_session(
 fn stop_session(
     trigger: On<P2PStop>,
     mut commands: Commands,
-    mut session: Option<ResMut<P2PSession>>,
-    links: Query<Entity, With<P2P>>,
+    mut session: ResMut<P2PSession>,
+    links: Query<(Entity, &P2P)>,
 ) {
-    let Some(session) = session.as_deref_mut() else {
-        tracing::warn!("P2PStop requires a P2PSession resource");
-        return;
-    };
     let was_running = !matches!(session.state, P2PSessionState::Stopped);
     if was_running {
         session.stop();
     }
 
-    if trigger.unlink {
-        for entity in &links {
+    for (entity, state) in &links {
+        if *state != P2P::Inactive {
+            commands.entity(entity).insert(P2P::Inactive);
+        }
+        if trigger.unlink {
             commands.trigger(Unlink {
                 entity,
                 reason: UnlinkReason::UserRequested(Some("P2P session stopped".into())),
@@ -512,12 +637,23 @@ type P2PLinkQuery<'w, 's> = Query<
     'w,
     's,
     (
+        Entity,
+        &'static P2P,
+        Option<&'static RemoteId>,
         Has<Connected>,
         Option<&'static mut MessageSender<P2PSessionMessage>>,
         Option<&'static mut MessageReceiver<P2PSessionMessage>>,
     ),
     With<P2P>,
 >;
+
+fn transition_candidates(commands: &mut Commands, links: &mut P2PLinkQuery, next_state: P2P) {
+    for (entity, state, ..) in links {
+        if *state == P2P::Candidate {
+            commands.entity(entity).insert(next_state);
+        }
+    }
+}
 
 /// Drive the current start attempt once per frame before fixed simulation.
 ///
@@ -526,28 +662,38 @@ type P2PLinkQuery<'w, 's> = Query<
 /// tick. Newly available local messages are then queued once on every remote Link.
 fn drive_session(
     mut commands: Commands,
-    mut session: Option<ResMut<P2PSession>>,
+    mut session: ResMut<P2PSession>,
     timeline: Res<LocalTimeline>,
     synced_timeline: Option<SyncedLocalTimeline>,
+    real_time: Res<Time<Real>>,
     mut links: P2PLinkQuery,
 ) {
-    let Some(session) = session.as_deref_mut() else {
-        return;
-    };
     if !matches!(session.state, P2PSessionState::Starting { .. }) {
         return;
     }
 
+    let timed_out = session.timed_out_at(real_time.elapsed());
+    let expected_peer_count = session.remote_peers.len();
+    let mut found_peers = SmallVec::<[PeerId; 4]>::new();
+    let mut cohort_intact = true;
     let mut all_connected = true;
-    for index in 0..session.remote_peers.len() {
-        let entity = session.remote_peers[index].link;
-        let Ok((connected, sender, receiver)) = links.get_mut(entity) else {
+    for (entity, state, remote_id, connected, sender, receiver) in &mut links {
+        if *state != P2P::Candidate {
+            continue;
+        }
+        let Some(remote_id) = remote_id.map(|remote_id| remote_id.0) else {
+            cohort_intact = false;
             all_connected = false;
             continue;
         };
-        if !connected || sender.is_none() {
+        if !session.contains_remote(remote_id) || found_peers.contains(&remote_id) {
+            cohort_intact = false;
             all_connected = false;
             continue;
+        }
+        found_peers.push(remote_id);
+        if !connected || sender.is_none() {
+            all_connected = false;
         }
         // Receiver insertion requested by P2PStart can still be deferred for this frame. It does
         // not prevent us from sending our own Ready message once every Link is connected.
@@ -555,33 +701,66 @@ fn drive_session(
             continue;
         };
         for message in receiver.receive() {
-            tracing::trace!(?entity, ?message, tick = ?timeline.tick(), "received P2P session message");
-            session.receive(entity, message);
+            tracing::trace!(?entity, ?remote_id, ?message, tick = ?timeline.tick(), "received P2P session message");
+            session.receive(remote_id, message);
         }
     }
+    cohort_intact &= found_peers.len() == expected_peer_count;
 
+    if !cohort_intact {
+        session.stop();
+        transition_candidates(&mut commands, &mut links, P2P::Inactive);
+        tracing::warn!("P2P session start negotiation aborted because its cohort changed");
+        return;
+    }
+    if session.roster_mismatch {
+        session.stop();
+        transition_candidates(&mut commands, &mut links, P2P::Inactive);
+        tracing::warn!("P2P session start negotiation failed because peer rosters differ");
+        return;
+    }
+    if timed_out {
+        let timeout = session.start_timeout;
+        session.stop();
+        transition_candidates(&mut commands, &mut links, P2P::Inactive);
+        tracing::warn!(?timeout, "P2P session start negotiation timed out");
+        return;
+    }
     if !all_connected {
         return;
     }
     match session.advance(timeline.tick(), synced_timeline.is_some()) {
         AdvanceResult::Started(start_tick) => {
             tracing::info!(?start_tick, "P2P session started");
+            transition_candidates(&mut commands, &mut links, P2P::Joined);
+            session.clear_barrier_progress();
             commands.trigger(P2PStarted { start_tick });
+            return;
         }
         AdvanceResult::Failed => {
             tracing::warn!("P2P session start negotiation failed");
+            session.stop();
+            transition_candidates(&mut commands, &mut links, P2P::Inactive);
+            return;
         }
         AdvanceResult::Waiting => {}
     }
 
-    let mut outbound = SmallVec::<[(Entity, P2PSessionMessage); 8]>::new();
+    let mut outbound = SmallVec::<[P2PSessionMessage; 2]>::new();
     session.collect_outbound(&mut outbound);
-    for (entity, message) in outbound {
-        let Ok((_, Some(mut sender), _)) = links.get_mut(entity) else {
+    for (entity, state, remote_id, _, sender, _) in &mut links {
+        if *state != P2P::Candidate
+            || !remote_id.is_some_and(|remote_id| session.contains_remote(remote_id.0))
+        {
+            continue;
+        }
+        let Some(mut sender) = sender else {
             continue;
         };
-        tracing::trace!(?entity, ?message, tick = ?timeline.tick(), "sending P2P session message");
-        sender.send::<P2PSessionChannel>(message);
+        for &message in &outbound {
+            tracing::trace!(?entity, ?message, tick = ?timeline.tick(), "sending P2P session message");
+            sender.send::<P2PSessionChannel>(message);
+        }
     }
 }
 
@@ -589,17 +768,25 @@ fn drive_session(
 mod tests {
     use super::*;
 
-    fn entity(index: u32) -> Entity {
-        Entity::from_raw_u32(index).unwrap()
+    fn peer(index: u64) -> PeerId {
+        PeerId::Entity(index)
     }
 
     #[test]
-    fn start_freezes_declared_links_without_requiring_the_capacity() {
+    fn start_freezes_inactive_links_and_ignores_links_declared_later() {
         let mut app = App::new();
-        app.insert_resource(P2PSession::new(4));
+        app.init_resource::<P2PSession>();
+        app.init_resource::<Time<Real>>();
         app.add_observer(start_session);
-        let second = app.world_mut().spawn(P2P).id();
-        let first = app.world_mut().spawn(P2P).id();
+        let local_id = peer(0);
+        let second = app
+            .world_mut()
+            .spawn((P2P::Inactive, LocalId(local_id), RemoteId(peer(2))))
+            .id();
+        let first = app
+            .world_mut()
+            .spawn((P2P::Inactive, LocalId(local_id), RemoteId(peer(1))))
+            .id();
 
         app.world_mut().trigger(P2PStart);
         app.world_mut().flush();
@@ -608,33 +795,55 @@ mod tests {
                 .entity(first)
                 .contains::<MessageReceiver<P2PSessionMessage>>()
         );
-        {
+        assert_eq!(
+            app.world().entity(first).get::<P2P>(),
+            Some(&P2P::Candidate)
+        );
+        assert_eq!(
+            app.world().entity(second).get::<P2P>(),
+            Some(&P2P::Candidate)
+        );
+        let generation = {
             let session = app.world().resource::<P2PSession>();
             assert_eq!(
                 session.state(),
                 P2PSessionState::Starting { start_tick: None }
             );
-            let links: SmallVec<[Entity; 4]> = session.links().collect();
-            assert_eq!(links.len(), 2);
-            assert!(links.contains(&first));
-            assert!(links.contains(&second));
-        }
+            assert_eq!(session.remote_peers.len(), 2);
+            assert!(session.contains_remote(peer(1)));
+            assert!(session.contains_remote(peer(2)));
+            session.generation
+        };
 
-        let late = app.world_mut().spawn(P2P).id();
+        app.world_mut().trigger(P2PStart);
+        app.world_mut().flush();
+        assert_eq!(
+            app.world().resource::<P2PSession>().generation,
+            generation,
+            "a duplicate start must not restart or expand the active barrier"
+        );
+
+        let late = app
+            .world_mut()
+            .spawn((P2P::Inactive, LocalId(local_id), RemoteId(peer(3))))
+            .id();
+        assert_eq!(app.world().entity(late).get::<P2P>(), Some(&P2P::Inactive));
         assert!(
             !app.world()
                 .resource::<P2PSession>()
-                .links()
-                .any(|link| link == late)
+                .contains_remote(peer(3))
         );
     }
 
     #[test]
     fn ready_peers_choose_and_acknowledge_the_latest_tick() {
-        let mut session = P2PSession::new(3).with_start_delay_ticks(10);
-        let first = entity(1);
-        let second = entity(2);
-        session.begin(SmallVec::from_slice(&[first, second]));
+        let mut session = P2PSession::default().with_start_delay_ticks(10);
+        let local = peer(0);
+        let first = peer(1);
+        let second = peer(2);
+        let remote_peers = SmallVec::from_slice(&[first, second]);
+        let roster_hash = roster_hash(local, &remote_peers);
+        session.begin(remote_peers, roster_hash, Duration::ZERO);
 
         assert_eq!(session.advance(Tick(5), false), AdvanceResult::Waiting);
         assert_eq!(session.advance(Tick(6), true), AdvanceResult::Waiting);
@@ -642,6 +851,7 @@ mod tests {
             first,
             P2PSessionMessage::Ready {
                 generation: session.generation,
+                roster_hash,
                 earliest_start_tick: Tick(18),
             },
         );
@@ -649,6 +859,7 @@ mod tests {
             second,
             P2PSessionMessage::Ready {
                 generation: session.generation,
+                roster_hash,
                 earliest_start_tick: Tick(17),
             },
         );
@@ -660,6 +871,7 @@ mod tests {
                 link,
                 P2PSessionMessage::StartAcknowledgement {
                     generation: session.generation,
+                    roster_hash,
                     start_tick: Tick(18),
                 },
             );
@@ -676,6 +888,49 @@ mod tests {
         );
     }
 
+    #[test]
+    fn a_different_roster_fails_the_barrier() {
+        let local = peer(0);
+        let remote_peers = SmallVec::from_slice(&[peer(1)]);
+        let expected_roster_hash = roster_hash(local, &remote_peers);
+        let mut session = P2PSession::default();
+        session.begin(remote_peers, expected_roster_hash, Duration::ZERO);
+
+        session.receive(
+            peer(1),
+            P2PSessionMessage::Ready {
+                generation: session.generation,
+                roster_hash: roster_hash(local, &[peer(1), peer(2)]),
+                earliest_start_tick: Tick(10),
+            },
+        );
+
+        assert_eq!(session.advance(Tick(0), true), AdvanceResult::Failed);
+    }
+
+    #[test]
+    fn roster_hash_is_independent_of_link_order() {
+        assert_eq!(
+            roster_hash(peer(0), &[peer(1), peer(2), peer(3)]),
+            roster_hash(peer(2), &[peer(3), peer(0), peer(1)])
+        );
+    }
+
+    #[test]
+    fn a_start_attempt_times_out() {
+        let remote_peers = SmallVec::from_slice(&[peer(1)]);
+        assert_eq!(P2PSession::default().start_timeout, Duration::from_secs(5));
+        let mut session = P2PSession::default().with_start_timeout(Duration::from_secs(2));
+        session.begin(
+            remote_peers,
+            roster_hash(peer(0), &[peer(1)]),
+            Duration::from_secs(5),
+        );
+
+        assert!(!session.timed_out_at(Duration::from_secs(6)));
+        assert!(session.timed_out_at(Duration::from_secs(7)));
+    }
+
     #[derive(Resource, Default)]
     struct WasStopped(bool);
 
@@ -687,9 +942,13 @@ mod tests {
     fn stop_keeps_links_and_emits_stopped() {
         let mut app = App::new();
         app.add_plugins(lightyear_link::LinkPlugin);
-        let link = app.world_mut().spawn(P2P).id();
-        let mut session = P2PSession::new(2);
-        session.begin(SmallVec::from_slice(&[link]));
+        let link = app.world_mut().spawn(P2P::Joined).id();
+        let mut session = P2PSession::default();
+        session.begin(
+            SmallVec::from_slice(&[peer(1)]),
+            roster_hash(peer(0), &[peer(1)]),
+            Duration::ZERO,
+        );
         app.insert_resource(session);
         app.init_resource::<WasStopped>();
         app.add_observer(stop_session);
@@ -703,6 +962,7 @@ mod tests {
             P2PSessionState::Stopped
         );
         assert!(app.world().entity(link).contains::<P2P>());
+        assert_eq!(app.world().entity(link).get::<P2P>(), Some(&P2P::Inactive));
         assert!(
             !app.world()
                 .entity(link)
@@ -715,10 +975,14 @@ mod tests {
     fn stop_can_unlink_every_declared_p2p_link() {
         let mut app = App::new();
         app.add_plugins(lightyear_link::LinkPlugin);
-        let cohort_link = app.world_mut().spawn(P2P).id();
-        let late_link = app.world_mut().spawn(P2P).id();
-        let mut session = P2PSession::new(2);
-        session.begin(SmallVec::from_slice(&[cohort_link]));
+        let cohort_link = app.world_mut().spawn(P2P::Joined).id();
+        let late_link = app.world_mut().spawn(P2P::Inactive).id();
+        let mut session = P2PSession::default();
+        session.begin(
+            SmallVec::from_slice(&[peer(1)]),
+            roster_hash(peer(0), &[peer(1)]),
+            Duration::ZERO,
+        );
         app.insert_resource(session);
         app.add_observer(stop_session);
 

--- a/crates/core/lightyear/src/client.rs
+++ b/crates/core/lightyear/src/client.rs
@@ -37,6 +37,9 @@ impl PluginGroup for ClientPlugins {
             tick_duration: self.tick_duration,
         });
 
+        #[cfg(feature = "p2p")]
+        let builder = builder.add(lightyear_p2p::P2PSessionPlugin);
+
         #[cfg(feature = "replication")]
         let builder = builder.add(LightyearRepliconClientBackend);
 

--- a/crates/core/lightyear/src/shared.rs
+++ b/crates/core/lightyear/src/shared.rs
@@ -23,6 +23,12 @@ impl Plugin for SharedPlugins {
         .add_plugins(lightyear_messages::plugin::MessagePlugin)
         .add_plugins(lightyear_connection::ConnectionPlugin);
 
+        // This private control protocol lives in the shared plugin even though only P2P clients
+        // run its lifecycle systems. Message and channel IDs are assigned by registration order,
+        // so conventional clients and servers built with `p2p` must reserve the same IDs too.
+        #[cfg(feature = "p2p")]
+        app.add_plugins(lightyear_p2p::P2PProtocolPlugin);
+
         #[cfg(feature = "debug")]
         app.add_plugins(lightyear_tools::prelude::LightyearDebugPlugin);
 

--- a/crates/core/sync/src/timeline/input.rs
+++ b/crates/core/sync/src/timeline/input.rs
@@ -9,6 +9,7 @@ use bevy_ecs::world::unsafe_world_cell::UnsafeWorldCell;
 use bevy_reflect::Reflect;
 use core::{marker::PhantomData, time::Duration};
 use lightyear_connection::network_topology::{NetworkTopology, NetworkingMetadata};
+use lightyear_connection::p2p::P2P;
 use lightyear_core::tick::{Tick, TickDuration};
 use lightyear_core::time::{TickDelta, TickInstant};
 use lightyear_core::timeline::{LocalTimeline, LocalTimelineShift};
@@ -61,11 +62,18 @@ impl InputTimelineConfig {
         tick_duration: Res<TickDuration>,
         metadata: Res<NetworkingMetadata>,
         links: Query<&Link>,
+        p2p_links: Query<(Entity, &P2P)>,
         config: Res<InputTimelineConfig>,
         mut timeline: ResMut<LocalTimelineSync>,
     ) {
         let before = timeline.input_delay();
-        if !timeline.recompute_input_delay(&config, &metadata.mode, &links, tick_duration.0) {
+        if !timeline.recompute_input_delay(
+            &config,
+            &metadata.mode,
+            &links,
+            &p2p_links,
+            tick_duration.0,
+        ) {
             return;
         }
         trace!(
@@ -86,10 +94,17 @@ impl InputTimelineConfig {
         tick_duration: Res<TickDuration>,
         metadata: Res<NetworkingMetadata>,
         links: Query<&Link>,
+        p2p_links: Query<(Entity, &P2P)>,
         config: Res<InputTimelineConfig>,
         mut timeline: ResMut<LocalTimelineSync>,
     ) {
-        if !timeline.recompute_input_delay(&config, &metadata.mode, &links, tick_duration.0) {
+        if !timeline.recompute_input_delay(
+            &config,
+            &metadata.mode,
+            &links,
+            &p2p_links,
+            tick_duration.0,
+        ) {
             // Configuration is commonly installed before a Client or HostClient connects. The
             // configured minimum is topology-independent; the first LocalTimelineShift will
             // replace it
@@ -509,14 +524,16 @@ unsafe impl ReadOnlySystemParam for SyncedLocalTimeline<'_, '_> {}
 impl LocalTimelineSync {
     /// Recompute the global input delay from the Links selected by the current topology.
     ///
-    /// Conventional modes use their sole client Link. P2P uses the maximum required delay across
-    /// all connected peer Links so that one tick-indexed local input stream is safe for every peer.
+    /// Conventional modes use their sole client Link. P2P startup discovers candidate Links from
+    /// their [`P2P`] components; a running session uses the topology's joined Links. Both use the
+    /// maximum required delay so that one tick-indexed local input stream is safe for every member.
     /// Returns `false` when the topology has no complete set of ready Link statistics.
     pub(crate) fn recompute_input_delay(
         &mut self,
         config: &InputTimelineConfig,
         topology: &NetworkTopology,
         links: &Query<&Link>,
+        p2p_links: &Query<(Entity, &P2P)>,
         tick_duration: Duration,
     ) -> bool {
         let delay_for = |entity| {
@@ -526,16 +543,34 @@ impl LocalTimelineSync {
                     .input_delay_ticks(link.stats, &config.sync, tick_duration)
             })
         };
-        let input_delay_ticks = match topology {
-            NetworkTopology::Client(entity) => delay_for(*entity),
-            NetworkTopology::HostClient { client, .. } => delay_for(*client),
-            NetworkTopology::P2P { connected, .. } if !connected.is_empty() => connected
-                .iter()
-                .try_fold(0, |maximum, entity| Some(maximum.max(delay_for(*entity)?))),
-            NetworkTopology::Undefined
-            | NetworkTopology::Server(_)
-            | NetworkTopology::P2P { .. }
-            | NetworkTopology::Invalid(_) => None,
+        // Timeline synchronization also runs during the P2P start phase, before candidates have
+        // crossed the barrier and become `NetworkTopology::P2P`. Its synchronization objective
+        // uses input delay, so that delay must already include every candidate Link.
+        let mut has_candidates = false;
+        let candidate_delay = p2p_links
+            .iter()
+            .filter_map(|(entity, state)| {
+                if *state == P2P::Candidate {
+                    has_candidates = true;
+                    Some(entity)
+                } else {
+                    None
+                }
+            })
+            .try_fold(0, |maximum, entity| Some(maximum.max(delay_for(entity)?)));
+        let input_delay_ticks = if has_candidates {
+            candidate_delay
+        } else {
+            match topology {
+                NetworkTopology::Client(entity) => delay_for(*entity),
+                NetworkTopology::HostClient { client, .. } => delay_for(*client),
+                NetworkTopology::P2P(peers) => peers
+                    .iter()
+                    .try_fold(0, |maximum, entity| Some(maximum.max(delay_for(*entity)?))),
+                NetworkTopology::Undefined
+                | NetworkTopology::Server(_)
+                | NetworkTopology::Invalid(_) => None,
+            }
         };
         let Some(input_delay_ticks) = input_delay_ticks else {
             return false;
@@ -830,21 +865,16 @@ mod tests {
     }
 
     #[test]
-    fn p2p_input_delay_uses_maximum_across_links() {
+    fn p2p_candidate_input_delay_uses_maximum_across_links() {
         let mut app = App::new();
         let mut fast_link = Link::default();
         fast_link.stats.rtt = Duration::from_millis(10);
-        let fast = app.world_mut().spawn(fast_link).id();
+        app.world_mut().spawn((fast_link, P2P::Candidate));
         let mut slow_link = Link::default();
         slow_link.stats.rtt = Duration::from_millis(50);
-        let slow = app.world_mut().spawn(slow_link).id();
+        app.world_mut().spawn((slow_link, P2P::Candidate));
 
-        let mut metadata = NetworkingMetadata::default();
-        metadata.mode = NetworkTopology::P2P {
-            connected: [fast, slow].into_iter().collect(),
-            declared_links: 2,
-        };
-        app.insert_resource(metadata);
+        app.init_resource::<NetworkingMetadata>();
         app.insert_resource(TickDuration(Duration::from_millis(10)));
         let mut config =
             InputTimelineConfig::default().with_input_delay(InputDelayConfig::balanced());
@@ -858,11 +888,13 @@ mod tests {
              config: Res<InputTimelineConfig>,
              metadata: Res<NetworkingMetadata>,
              links: Query<&Link>,
+             p2p_links: Query<(Entity, &P2P)>,
              tick_duration: Res<TickDuration>| {
                 assert!(timeline.recompute_input_delay(
                     &config,
                     &metadata.mode,
                     &links,
+                    &p2p_links,
                     tick_duration.0,
                 ));
             },

--- a/crates/core/sync/src/timeline/sync.rs
+++ b/crates/core/sync/src/timeline/sync.rs
@@ -377,33 +377,38 @@ impl<Remote: SyncTargetTimeline> LocalTimelineSyncPlugin<Remote> {
         prediction_window_wait: Res<PredictionWindowWait>,
         local_timeline: Res<LocalTimeline>,
         sync: Res<LocalTimelineSync>,
+        p2p_links: Query<&P2P>,
         mut virtual_time: ResMut<Time<Virtual>>,
     ) {
         let is_synced = sync.is_synced();
-        match metadata.mode {
-            NetworkTopology::Client(_) | NetworkTopology::P2P { .. }
-                if is_synced && prediction_window_wait.is_waiting() =>
-            {
-                virtual_time.set_relative_speed(0.0);
-                trace!(
-                    target: "lightyear_debug::sync",
-                    kind = "prediction_window_wait",
-                    schedule = "Last",
-                    sample_point = "Last",
-                    prediction_depth = prediction_window_wait.prediction_depth(),
-                    maximum_predicted_ticks = prediction_window_wait.maximum_predicted_ticks(),
-                    confirmed_tick = ?prediction_window_wait.confirmed_tick(),
-                    desired_relative_speed = sync.relative_speed(),
-                    "paused virtual time at the deterministic prediction-window limit"
-                );
-            }
-            NetworkTopology::P2P { .. } => {
-                Self::apply_relative_speed(&sync, &local_timeline, &mut virtual_time);
-            }
-            NetworkTopology::Client(_) | NetworkTopology::HostClient { .. } if is_synced => {
-                Self::apply_relative_speed(&sync, &local_timeline, &mut virtual_time);
-            }
-            _ => virtual_time.set_relative_speed(1.0),
+        let p2p_timeline =
+            metadata.mode.is_p2p() || p2p_links.iter().any(|state| *state == P2P::Candidate);
+        if is_synced
+            && prediction_window_wait.is_waiting()
+            && (metadata.mode.is_client() || p2p_timeline)
+        {
+            virtual_time.set_relative_speed(0.0);
+            trace!(
+                target: "lightyear_debug::sync",
+                kind = "prediction_window_wait",
+                schedule = "Last",
+                sample_point = "Last",
+                prediction_depth = prediction_window_wait.prediction_depth(),
+                maximum_predicted_ticks = prediction_window_wait.maximum_predicted_ticks(),
+                confirmed_tick = ?prediction_window_wait.confirmed_tick(),
+                desired_relative_speed = sync.relative_speed(),
+                "paused virtual time at the deterministic prediction-window limit"
+            );
+        } else if p2p_timeline
+            || (is_synced
+                && matches!(
+                    metadata.mode,
+                    NetworkTopology::Client(_) | NetworkTopology::HostClient { .. }
+                ))
+        {
+            Self::apply_relative_speed(&sync, &local_timeline, &mut virtual_time);
+        } else {
+            virtual_time.set_relative_speed(1.0);
         }
     }
 
@@ -469,6 +474,104 @@ impl<Remote: SyncTargetTimeline> LocalTimelineSyncPlugin<Remote> {
         }
     }
 
+    /// Synchronize against a candidate barrier cohort or an active joined cohort.
+    fn sync_p2p_peers(
+        synchronization_peers: impl Iterator<Item = Entity>,
+        local_now: TickInstant,
+        is_synced: bool,
+        sync: &mut LocalTimelineSync,
+        config: &InputTimelineConfig,
+        remotes: &Query<
+            (&Remote, &PingManager),
+            (With<Client>, With<Connected>, Without<HostClient>),
+        >,
+        commands: &mut Commands,
+    ) {
+        let mut found_any = false;
+        let mut all_initialized = true;
+        let mut sampled_any = false;
+        let mut limiting = None;
+        for link_entity in synchronization_peers {
+            found_any = true;
+            let Ok((remote, _ping_manager)) = remotes.get(link_entity) else {
+                all_initialized = false;
+                continue;
+            };
+            if !remote.is_initialized() {
+                all_initialized = false;
+                continue;
+            }
+            sampled_any |= remote.received_packet();
+            let remote_estimate = remote.current_estimate();
+            let lead = (local_now - remote_estimate).to_f32();
+            if limiting.is_none_or(|(_, worst, _)| lead > worst) {
+                limiting = Some((link_entity, lead, remote_estimate));
+            }
+        }
+        all_initialized &= found_any;
+
+        if !is_synced {
+            if !all_initialized || !sampled_any {
+                return;
+            }
+            let Some((limiting_link, worst_lead, remote_estimate)) = limiting else {
+                return;
+            };
+            let objective = if worst_lead > 0.0 {
+                remote_estimate
+            } else {
+                local_now
+            };
+            let tick_delta = sync.resync(local_now, objective);
+            sync.set_synced(true);
+            sync.set_relative_speed(1.0);
+            commands.trigger(LocalTimelineShift { delta: tick_delta });
+            trace!(
+                target: "lightyear_debug::sync",
+                kind = "p2p_initial_sync",
+                schedule = "PostUpdate",
+                sample_point = "PostUpdate",
+                ?limiting_link,
+                worst_lead,
+                ?objective,
+                tick_delta,
+                "initial P2P timeline aligned before input capture became ready"
+            );
+            return;
+        }
+
+        if !sampled_any {
+            return;
+        }
+        let Some((limiting_link, worst_lead, _)) = limiting else {
+            return;
+        };
+        let adjustment = sync.speed_adjustment(config, worst_lead.max(0.0));
+        if matches!(adjustment, SyncAdjustment::Resync) {
+            sync.set_relative_speed(1.0);
+            commands.trigger(P2PTimelineDiverged {
+                limiting_link,
+                lead: worst_lead,
+            });
+            error!(
+                ?limiting_link,
+                worst_lead,
+                "running P2P timeline diverged beyond bounded pacing; abort the session"
+            );
+            return;
+        }
+        trace!(
+            target: "lightyear_debug::sync",
+            kind = "p2p_sync_aggregate",
+            schedule = "PostUpdate",
+            sample_point = "PostUpdate",
+            ?limiting_link,
+            worst_lead,
+            relative_speed = sync.relative_speed(),
+            "applied one aggregate P2P pacing decision"
+        );
+    }
+
     /// Select the topology's clock source and update [`LocalTimelineSync`].
     ///
     /// Client/server mode follows its sole authoritative server. P2P mode performs one initial
@@ -486,17 +589,37 @@ impl<Remote: SyncTargetTimeline> LocalTimelineSyncPlugin<Remote> {
             (&Remote, &PingManager),
             (With<Client>, With<Connected>, Without<HostClient>),
         >,
+        p2p_links: Query<(Entity, Ref<P2P>)>,
         mut commands: Commands,
     ) {
         let mut is_synced = sync.is_synced();
         let local_now = local_timeline.instant(&fixed_time);
+        let has_candidates = p2p_links.iter().any(|(_, state)| *state == P2P::Candidate);
+        let candidates_changed = p2p_links
+            .iter()
+            .any(|(_, state)| *state == P2P::Candidate && state.is_changed());
 
-        if metadata.is_changed() {
+        if metadata.is_changed() || candidates_changed {
             let preserve_running_p2p =
-                is_synced && matches!(&metadata.mode, NetworkTopology::P2P { .. });
+                is_synced && matches!(&metadata.mode, NetworkTopology::P2P(_));
             sync.reset();
             sync.set_synced(preserve_running_p2p);
             is_synced = preserve_running_p2p;
+        }
+
+        if has_candidates {
+            Self::sync_p2p_peers(
+                p2p_links
+                    .iter()
+                    .filter_map(|(entity, state)| (*state == P2P::Candidate).then_some(entity)),
+                local_now,
+                is_synced,
+                &mut sync,
+                &config,
+                &remotes,
+                &mut commands,
+            );
+            return;
         }
 
         match &metadata.mode {
@@ -515,93 +638,15 @@ impl<Remote: SyncTargetTimeline> LocalTimelineSyncPlugin<Remote> {
                     &mut commands,
                 );
             }
-            NetworkTopology::P2P {
-                connected,
-                declared_links,
-            } => {
-                let all_declared_links_connected =
-                    is_synced || connected.len() == usize::from(*declared_links);
-                let mut all_initialized = !connected.is_empty() && all_declared_links_connected;
-                let mut sampled_any = false;
-                let mut limiting = None;
-                for &link_entity in connected {
-                    let Ok((remote, _ping_manager)) = remotes.get(link_entity) else {
-                        all_initialized = false;
-                        continue;
-                    };
-                    if !remote.is_initialized() {
-                        all_initialized = false;
-                        continue;
-                    }
-                    sampled_any |= remote.received_packet();
-                    let remote_estimate = remote.current_estimate();
-                    let lead = (local_now - remote_estimate).to_f32();
-                    if limiting.is_none_or(|(_, worst, _)| lead > worst) {
-                        limiting = Some((link_entity, lead, remote_estimate));
-                    }
-                }
-
-                if !is_synced {
-                    if !all_initialized || !sampled_any {
-                        return;
-                    }
-                    let Some((limiting_link, worst_lead, remote_estimate)) = limiting else {
-                        return;
-                    };
-                    let objective = if worst_lead > 0.0 {
-                        remote_estimate
-                    } else {
-                        local_now
-                    };
-                    let tick_delta = sync.resync(local_now, objective);
-                    sync.set_synced(true);
-                    sync.set_relative_speed(1.0);
-                    commands.trigger(LocalTimelineShift { delta: tick_delta });
-                    trace!(
-                        target: "lightyear_debug::sync",
-                        kind = "p2p_initial_sync",
-                        schedule = "PostUpdate",
-                        sample_point = "PostUpdate",
-                        ?limiting_link,
-                        worst_lead,
-                        ?objective,
-                        tick_delta,
-                        "initial P2P timeline aligned before input capture became ready"
-                    );
-                    return;
-                }
-
-                if !sampled_any {
-                    return;
-                }
-                let Some((limiting_link, worst_lead, _)) = limiting else {
-                    return;
-                };
-                let adjustment = sync.speed_adjustment(&config, worst_lead.max(0.0));
-                if matches!(adjustment, SyncAdjustment::Resync) {
-                    sync.set_relative_speed(1.0);
-                    commands.trigger(P2PTimelineDiverged {
-                        limiting_link,
-                        lead: worst_lead,
-                    });
-                    error!(
-                        ?limiting_link,
-                        worst_lead,
-                        "running P2P timeline diverged beyond bounded pacing; abort the session"
-                    );
-                    return;
-                }
-                trace!(
-                    target: "lightyear_debug::sync",
-                    kind = "p2p_sync_aggregate",
-                    schedule = "PostUpdate",
-                    sample_point = "PostUpdate",
-                    ?limiting_link,
-                    worst_lead,
-                    relative_speed = sync.relative_speed(),
-                    "applied one aggregate P2P pacing decision"
-                );
-            }
+            NetworkTopology::P2P(synchronization_peers) => Self::sync_p2p_peers(
+                synchronization_peers.iter().copied(),
+                local_now,
+                is_synced,
+                &mut sync,
+                &config,
+                &remotes,
+                &mut commands,
+            ),
             NetworkTopology::HostClient { .. } if !is_synced => {
                 sync.set_synced(true);
             }
@@ -702,10 +747,8 @@ mod tests {
         app.world_mut()
             .resource_mut::<LocalTimelineSync>()
             .set_synced(true);
-        app.world_mut().resource_mut::<NetworkingMetadata>().mode = NetworkTopology::P2P {
-            connected: Default::default(),
-            declared_links: 1,
-        };
+        app.world_mut().resource_mut::<NetworkingMetadata>().mode =
+            NetworkTopology::P2P([Entity::PLACEHOLDER].into_iter().collect());
         {
             let mut wait = app.world_mut().resource_mut::<PredictionWindowWait>();
             wait.update(Tick(0), None, 1);
@@ -731,6 +774,34 @@ mod tests {
         assert_eq!(app.world().resource::<FixedRuns>().0, before_wait);
         app.update();
         assert!(app.world().resource::<FixedRuns>().0 > before_wait);
+    }
+
+    #[test]
+    fn prediction_window_wait_also_pauses_during_p2p_candidate_sync() {
+        let mut app = App::new();
+        app.add_plugins((
+            CorePlugins {
+                tick_duration: Duration::from_millis(10),
+            },
+            LocalTimelineSyncPlugin::<TestRemote>::default(),
+        ));
+        app.init_resource::<NetworkingMetadata>();
+        app.world_mut().spawn(P2P::Candidate);
+        app.world_mut()
+            .resource_mut::<LocalTimelineSync>()
+            .set_synced(true);
+        {
+            let mut wait = app.world_mut().resource_mut::<PredictionWindowWait>();
+            wait.update(Tick(0), None, 1);
+            wait.update(Tick(1), None, 1);
+        }
+
+        app.world_mut().run_schedule(Last);
+
+        assert_eq!(
+            app.world().resource::<Time<Virtual>>().relative_speed(),
+            0.0
+        );
     }
 
     impl TimelineConfig for TestRemoteConfig {
@@ -811,7 +882,7 @@ mod tests {
             let entity = app
                 .world_mut()
                 .spawn((
-                    P2P,
+                    P2P::Candidate,
                     RemoteId(PeerId::Local(peer)),
                     TestRemote {
                         now: estimate,
@@ -827,11 +898,6 @@ mod tests {
             }
             links.push(entity);
         }
-        app.world_mut().resource_mut::<NetworkingMetadata>().mode = NetworkTopology::P2P {
-            connected: links[..2].iter().copied().collect(),
-            declared_links: 3,
-        };
-
         app.world_mut().run_schedule(PostUpdate);
 
         assert_eq!(
@@ -849,10 +915,6 @@ mod tests {
 
         // Connecting the final Link is still not enough until its remote timeline has initialized.
         app.world_mut().entity_mut(links[2]).insert(Connected);
-        app.world_mut().resource_mut::<NetworkingMetadata>().mode = NetworkTopology::P2P {
-            connected: links.iter().copied().collect(),
-            declared_links: 3,
-        };
         app.world_mut().run_schedule(PostUpdate);
         assert!(!app.world().resource::<LocalTimelineSync>().is_synced());
 
@@ -878,6 +940,15 @@ mod tests {
             app.world().resource::<LocalTimelineSync>().is_synced(),
             "readiness is exposed only after initial P2P alignment"
         );
+
+        // The session barrier can now complete. Gameplay-facing systems, including the
+        // prediction-window wait, only become active once the topology transitions out of its
+        // starting phase.
+        for &link in &links {
+            app.world_mut().entity_mut(link).insert(P2P::Joined);
+        }
+        app.world_mut().resource_mut::<NetworkingMetadata>().mode =
+            NetworkTopology::P2P(links.iter().copied().collect());
 
         // After readiness, only the middle Link exceeds the controller deadband. A correct
         // maximum aggregate must therefore slow the app, independent of the controller's exact
@@ -1013,29 +1084,19 @@ mod tests {
         assert_eq!(divergences[0].limiting_link, links[0]);
         assert_eq!(divergences[0].lead, 20.0);
 
-        // A P2P roster change resets controller history but cannot revoke readiness or resynchronize
-        // a running deterministic world. An empty connected set keeps application time advancing
-        // normally; the session owner is responsible for treating peer loss as fatal if required.
-        app.world_mut().resource_mut::<NetworkingMetadata>().mode = NetworkTopology::P2P {
-            connected: Default::default(),
-            declared_links: 3,
-        };
+        // Once every joined Link disconnects, the cached topology leaves P2P mode and timeline
+        // readiness is revoked. Application time itself returns to normal speed.
+        for &link in &links {
+            app.world_mut().entity_mut(link).remove::<Connected>();
+        }
+        app.world_mut().resource_mut::<NetworkingMetadata>().mode = NetworkTopology::Undefined;
         app.world_mut().run_schedule(PostUpdate);
 
         let local_sync = app.world().resource::<LocalTimelineSync>();
         assert_eq!(local_sync.relative_speed(), 1.0);
-        assert!(local_sync.is_synced());
+        assert!(!local_sync.is_synced());
 
         app.world_mut().run_schedule(Last);
-        assert_eq!(
-            app.world().resource::<Time<Virtual>>().relative_speed(),
-            1.0
-        );
-
-        app.world_mut().resource_mut::<NetworkingMetadata>().mode = NetworkTopology::Undefined;
-        app.world_mut().run_schedule(PostUpdate);
-        app.world_mut().run_schedule(Last);
-        assert!(!app.world().resource::<LocalTimelineSync>().is_synced());
         assert_eq!(
             app.world().resource::<Time<Virtual>>().relative_speed(),
             1.0,

--- a/crates/deterministic/deterministic_replication/src/checksum.rs
+++ b/crates/deterministic/deterministic_replication/src/checksum.rs
@@ -221,11 +221,18 @@ impl ChecksumSendPlugin {
             NetworkTopology::Client(link) | NetworkTopology::HostClient { client: link, .. } => {
                 Some(link)
             }
-            #[cfg(feature = "p2p")]
-            NetworkTopology::P2P { ref connected, .. } if !connected.is_empty() => None,
+            NetworkTopology::P2P(_) => {
+                #[cfg(feature = "p2p")]
+                {
+                    None
+                }
+                #[cfg(not(feature = "p2p"))]
+                {
+                    return;
+                }
+            }
             NetworkTopology::Undefined
             | NetworkTopology::Server(_)
-            | NetworkTopology::P2P { .. }
             | NetworkTopology::Invalid(_) => return,
         };
         #[cfg(feature = "replication")]
@@ -266,13 +273,13 @@ impl ChecksumSendPlugin {
 
         #[cfg(feature = "p2p")]
         {
-            let NetworkTopology::P2P { connected, .. } = &metadata.mode else {
+            let NetworkTopology::P2P(joined) = &metadata.mode else {
                 return;
             };
             let checksum = compute_history_checksum(&mut world, confirmed_tick);
             pending_checksums.record_local(confirmed_tick, checksum, log_p2p_comparison);
             pending_checksums.clean(confirmed_tick);
-            Self::send_p2p_checksum(&mut senders, connected, confirmed_tick, checksum);
+            Self::send_p2p_checksum(&mut senders, joined, confirmed_tick, checksum);
         }
     }
 
@@ -384,16 +391,16 @@ pub struct ChecksumReceivePlugin;
 
 #[cfg(feature = "p2p")]
 impl ChecksumReceivePlugin {
-    /// Drain checksum samples from every connected P2P Link.
+    /// Drain checksum samples from every joined P2P Link that currently has a receiver.
     fn receive_p2p_checksum_messages(
         metadata: Res<NetworkingMetadata>,
         mut messages: Query<(&mut MessageReceiver<ChecksumMessage>, &RemoteId)>,
         mut pending_checksums: ResMut<PendingP2PChecksums>,
     ) {
-        let NetworkTopology::P2P { connected, .. } = &metadata.mode else {
+        let NetworkTopology::P2P(joined) = &metadata.mode else {
             return;
         };
-        for &link in connected {
+        for &link in joined {
             let Ok((mut receiver, remote_id)) = messages.get_mut(link) else {
                 continue;
             };

--- a/crates/deterministic/deterministic_replication/src/prediction_window.rs
+++ b/crates/deterministic/deterministic_replication/src/prediction_window.rs
@@ -43,7 +43,7 @@ fn update_prediction_window_wait(
 
     let active_topology = match &metadata.mode {
         NetworkTopology::Client(_) => true,
-        NetworkTopology::P2P { connected, .. } => !connected.is_empty(),
+        NetworkTopology::P2P(_) => true,
         NetworkTopology::Undefined
         | NetworkTopology::Server(_)
         | NetworkTopology::HostClient { .. }
@@ -138,10 +138,7 @@ mod tests {
             let mut topology_world = World::new();
             let link = topology_world.spawn_empty().id();
             let topology = if p2p {
-                NetworkTopology::P2P {
-                    connected: [link].into_iter().collect(),
-                    declared_links: 1,
-                }
+                NetworkTopology::P2P([link].into_iter().collect())
             } else {
                 NetworkTopology::Client(link)
             };

--- a/crates/inputs/input_bei/src/setup.rs
+++ b/crates/inputs/input_bei/src/setup.rs
@@ -246,7 +246,7 @@ impl InputRegistryPlugin {
 fn receives_remote_inputs(topology: &NetworkTopology) -> bool {
     match topology {
         NetworkTopology::Client(_) => true,
-        NetworkTopology::P2P { connected, .. } => !connected.is_empty(),
+        NetworkTopology::P2P(_) => true,
         NetworkTopology::Undefined
         | NetworkTopology::Server(_)
         | NetworkTopology::HostClient { .. }

--- a/crates/inputs/inputs/src/client.rs
+++ b/crates/inputs/inputs/src/client.rs
@@ -304,7 +304,7 @@ fn finalize_last_confirmed_input(mut last_confirmed_input: ResMut<LastConfirmedI
 /// Cached input routing derived from [`NetworkingMetadata`].
 ///
 /// Client/server and host-client modes retain their single Link as the local ownership
-/// identity. P2P mode borrows the already-cached connected Link slice and treats `S::Marker` as
+/// identity. P2P mode borrows the already-cached joined Link slice and treats `S::Marker` as
 /// the local-input identity because each Link represents a remote peer.
 #[derive(Clone, Copy, Debug)]
 enum InputRoute<'a> {
@@ -324,12 +324,9 @@ impl<'a> InputRoute<'a> {
                 link: *client,
                 host_client: true,
             }),
-            NetworkTopology::P2P { connected, .. } if !connected.is_empty() => {
-                Some(Self::P2P(connected.as_slice()))
-            }
+            NetworkTopology::P2P(joined) => Some(Self::P2P(joined.as_slice())),
             NetworkTopology::Undefined
             | NetworkTopology::Server(_)
-            | NetworkTopology::P2P { .. }
             | NetworkTopology::Invalid(_) => None,
         }
     }
@@ -1159,7 +1156,7 @@ fn update_last_confirmed_input<S: ActionStateSequence>(
     // Preserve the conventional lockstep behavior: input delay guarantees that the sole remote
     // endpoint has supplied the current tick. P2P must inspect the actual global frontier because
     // one slow peer can still be missing while the others are ready.
-    if input_config.is_lockstep() && !matches!(metadata.mode, NetworkTopology::P2P { .. }) {
+    if input_config.is_lockstep() && !matches!(metadata.mode, NetworkTopology::P2P(_)) {
         last_confirmed_input.tick.set_if_lower(tick);
         return;
     }
@@ -1462,10 +1459,7 @@ mod tests {
         assert!(client_server_route.accepts_local_target(Some(&owned_by_client)));
         assert!(!client_server_route.accepts_local_target(Some(&owned_by_other)));
 
-        let p2p = NetworkTopology::P2P {
-            connected: [client, other].into_iter().collect(),
-            declared_links: 2,
-        };
+        let p2p = NetworkTopology::P2P([client, other].into_iter().collect());
         let p2p_route = InputRoute::from_topology(&p2p).unwrap();
         assert!(p2p_route.accepts_local_target(None));
         assert!(p2p_route.accepts_local_target(Some(&owned_by_client)));
@@ -1477,10 +1471,7 @@ mod tests {
         let mut world = World::new();
         let link = world.spawn_empty().id();
         let target = world.spawn_empty().id();
-        let topology = NetworkTopology::P2P {
-            connected: [link].into_iter().collect(),
-            declared_links: 1,
-        };
+        let topology = NetworkTopology::P2P([link].into_iter().collect());
         let route = InputRoute::from_topology(&topology).unwrap();
         let prespawned = PreSpawned::new(0xCAFE);
 
@@ -1496,10 +1487,7 @@ mod tests {
         let mut world = World::new();
         let link = world.spawn_empty().id();
         let target = world.spawn_empty().id();
-        let topology = NetworkTopology::P2P {
-            connected: [link].into_iter().collect(),
-            declared_links: 1,
-        };
+        let topology = NetworkTopology::P2P([link].into_iter().collect());
         let route = InputRoute::from_topology(&topology).unwrap();
 
         let _ = input_target(route, target, None);

--- a/crates/replication/interpolation/src/timeline.rs
+++ b/crates/replication/interpolation/src/timeline.rs
@@ -295,21 +295,22 @@ impl TimelinePlugin {
     ) {
         let delta = TickDelta::from(trigger.trigger.send_interval);
         let duration = delta.to_duration(tick_duration.0);
-        if peer_metadata.mapping.contains_key(&trigger.from) {
-            debug!("Updating remote send interval to {:?}", duration);
-            // A single presentation cursor must be safe for every active replication source.
-            // Use the slowest advertised update interval; conventional client/server mode has
-            // only one source, while P2P conservatively uses the maximum.
-            interpolation_timeline.context.remote_send_interval =
-                if matches!(metadata.mode, NetworkTopology::P2P { .. }) {
-                    core::cmp::max(
-                        interpolation_timeline.context.remote_send_interval,
-                        duration,
-                    )
-                } else {
-                    duration
-                };
+        if !peer_metadata.mapping.contains_key(&trigger.from) {
+            return;
         }
+        let is_p2p = metadata.mode.is_p2p();
+        debug!("Updating remote send interval to {:?}", duration);
+        // A single presentation cursor must be safe for every active replication source. Use the
+        // slowest advertised update interval across joined P2P peers; conventional client/server
+        // mode has only one source.
+        interpolation_timeline.context.remote_send_interval = if is_p2p {
+            core::cmp::max(
+                interpolation_timeline.context.remote_send_interval,
+                duration,
+            )
+        } else {
+            duration
+        };
     }
 
     /// Run one interpolation synchronization sample against the selected remote source.
@@ -377,9 +378,9 @@ impl TimelinePlugin {
                     tick_duration.0,
                 );
             }
-            NetworkTopology::P2P { connected, .. } => {
+            NetworkTopology::P2P(joined) => {
                 let mut selected = None;
-                for &link in connected {
+                for &link in joined {
                     let Ok((remote, ping_manager)) = remotes.get(link) else {
                         continue;
                     };

--- a/crates/replication/prediction/src/manager.rs
+++ b/crates/replication/prediction/src/manager.rs
@@ -101,8 +101,8 @@ pub struct PredictionManager {
 
     /// Earliest tick that an input rollback may restore.
     ///
-    /// A deterministic P2P session sets this to its agreed start tick so stale inputs cannot
-    /// restore prediction history from before the session's initial world snapshot.
+    /// A deterministic P2P session sets this to the tick immediately before its agreed first
+    /// gameplay tick. That boundary is the session's initial world snapshot.
     #[doc(hidden)]
     pub input_rollback_floor: Option<Tick>,
 

--- a/crates/replication/prediction/src/plugin.rs
+++ b/crates/replication/prediction/src/plugin.rs
@@ -29,9 +29,12 @@ use lightyear_replication::prespawn::PreSpawnedReceiver;
 /// Plugin that installs client-side prediction systems.
 ///
 /// The systems run when the application contains a [`PredictionManager`] resource and its cached
-/// network topology is a conventional client or P2P session. Insert a [`PredictionManager`]
-/// resource to opt the application into one global prediction and rollback pipeline. Host-client
-/// and server topologies remain authoritative and do not run it.
+/// network topology is a conventional client or active P2P session. P2P candidates do not run the
+/// pipeline: deterministic play and its rollback history begin at the agreed session start tick.
+/// Prediction-history writers also require a synchronized timeline and therefore never record
+/// values under pre-sync tick labels. Insert a [`PredictionManager`] resource to opt the
+/// application into one global prediction and rollback pipeline. Host-client and server
+/// topologies remain authoritative and do not run it.
 #[derive(Default)]
 pub struct PredictionPlugin;
 
@@ -71,10 +74,7 @@ pub enum PredictionSystems {
     All,
 }
 
-// NOTE: we need to run the prediction systems even if we're not synced, because we want
-//  our HistoryBuffer to contain values for components/resources that were updated before syncing
-//  is done.
-/// Returns true if this application opted into prediction and has a supported remote topology.
+/// Returns true if this application opted into prediction and has a supported active topology.
 pub(crate) fn should_run(
     manager: Option<Res<PredictionManager>>,
     metadata: Res<NetworkingMetadata>,
@@ -82,7 +82,7 @@ pub(crate) fn should_run(
     manager.is_some()
         && matches!(
             metadata.mode,
-            NetworkTopology::Client(_) | NetworkTopology::P2P { .. }
+            NetworkTopology::Client(_) | NetworkTopology::P2P(_)
         )
 }
 
@@ -94,12 +94,8 @@ pub fn add_non_networked_rollback_systems<C: Component<Mutability = Mutable> + C
     app.world_mut().register_component::<ConfirmedHistory<C>>();
     app.add_observer(apply_component_removal_predicted::<C>);
     app.add_observer(add_prediction_history::<C>);
-    // Without this observer, the component's `PredictionHistory<C>` buffer
-    // would not get its tick values shifted on timeline-sync, so any
-    // history entries accumulated pre-sync would point to stale
-    // (pre-sync) ticks after the client clock jumps forward.
-    //
-    // Do not shift `ConfirmedHistory<C>` here: confirmed samples are resolved
+    // This also supports explicit resynchronization after prediction has begun. Do not shift
+    // `ConfirmedHistory<C>` here: confirmed samples are resolved
     // through `ReplicationCheckpointMap` and are already in authoritative
     // server tick space. Shifting them can move an init-message seed into the
     // future and make rollback prefer stale state over later server updates.
@@ -269,6 +265,7 @@ impl Plugin for PredictionPlugin {
 mod tests {
     use super::*;
     use bevy_ecs::system::RunSystemOnce;
+    use lightyear_connection::p2p::P2P;
     use lightyear_core::timeline::Rollback;
 
     #[test]
@@ -354,10 +351,13 @@ mod tests {
         app.world_mut().resource_mut::<NetworkingMetadata>().mode = NetworkTopology::Client(client);
         assert!(app.world_mut().run_system_once(should_run).unwrap());
 
-        app.world_mut().resource_mut::<NetworkingMetadata>().mode = NetworkTopology::P2P {
-            connected: Default::default(),
-            declared_links: 1,
-        };
+        app.world_mut().entity_mut(client).insert(P2P::Candidate);
+        app.world_mut().resource_mut::<NetworkingMetadata>().mode = NetworkTopology::Undefined;
+        assert!(!app.world_mut().run_system_once(should_run).unwrap());
+
+        app.world_mut().entity_mut(client).insert(P2P::Joined);
+        app.world_mut().resource_mut::<NetworkingMetadata>().mode =
+            NetworkTopology::P2P([client].into_iter().collect());
         assert!(app.world_mut().run_system_once(should_run).unwrap());
 
         app.world_mut().resource_mut::<NetworkingMetadata>().mode =

--- a/crates/replication/prediction/src/predicted_history.rs
+++ b/crates/replication/prediction/src/predicted_history.rs
@@ -21,7 +21,7 @@ use lightyear_core::tick::Tick;
 use lightyear_core::timeline::LocalTimelineShift;
 use lightyear_replication::diff_history::HistoryDiffReceiver;
 use lightyear_replication::prelude::PreSpawned;
-use lightyear_sync::prelude::InputTimelineConfig;
+use lightyear_sync::prelude::{InputTimelineConfig, SyncedLocalTimeline};
 #[allow(unused_imports)]
 use tracing::{debug, info, trace};
 
@@ -89,14 +89,16 @@ impl<C> PredictionHistory<C> {
 // Systems
 // ============================================================================
 
-/// We store every update on the predicted entity in the PredictionHistory
+/// Store every update on the predicted entity in the [`PredictionHistory`].
 ///
-/// This system only handles changes, removals are handled in `apply_component_removal`
+/// [`SyncedLocalTimeline`] skips this system until timeline synchronization has completed, so
+/// pre-sync component values are never recorded under invalid local tick labels. This system only
+/// handles changes; removals are handled by [`apply_component_removal_predicted`].
 pub(crate) fn update_prediction_history<T: Component + Clone>(
     manager: Res<PredictionManager>,
     input_config: Res<InputTimelineConfig>,
     mut query: Query<(Entity, Ref<T>, &mut PredictionHistory<T>)>,
-    timeline: Res<LocalTimeline>,
+    timeline: SyncedLocalTimeline,
 ) {
     // tick for which we will record the history (either the current client tick or the current rollback tick)
     let tick = timeline.tick();
@@ -200,10 +202,11 @@ pub(crate) fn prune_history_diff_receiver<C: RepliconDiffable>(
     }
 }
 /// If a predicted component is removed on the [`Predicted`] entity, add the removal to the history.
+/// [`SyncedLocalTimeline`] skips this observer before timeline synchronization has completed.
 pub(crate) fn apply_component_removal_predicted<C: Component>(
     trigger: On<Remove, C>,
     mut predicted_query: Query<&mut PredictionHistory<C>>,
-    timeline: Res<LocalTimeline>,
+    timeline: SyncedLocalTimeline,
 ) {
     let tick = timeline.tick();
     if let Ok(mut history) = predicted_query.get_mut(trigger.entity) {
@@ -486,6 +489,7 @@ mod tests {
     use crate::manager::{RollbackPolicy, StateRollbackMetadata};
     use bevy_app::{App, Update};
     use bevy_replicon::shared::replication::diff::diff_index::DiffIndex;
+    use lightyear_sync::prelude::LocalTimelineSync;
     use lightyear_sync::timeline::input::InputDelayConfig;
     use serde::{Deserialize, Serialize};
 
@@ -544,7 +548,56 @@ mod tests {
             ..Default::default()
         });
         app.insert_resource(InputTimelineConfig::default().with_input_delay(input_delay_config));
+        let mut sync = LocalTimelineSync::default();
+        sync.set_synced(true);
+        app.insert_resource(sync);
         app
+    }
+
+    #[test]
+    fn prediction_history_is_not_recorded_until_timeline_sync() {
+        let mut app = App::new();
+        app.init_resource::<LocalTimeline>();
+        app.init_resource::<LocalTimelineSync>();
+        app.insert_resource(PredictionManager::default());
+        app.insert_resource(InputTimelineConfig::default());
+        app.add_systems(Update, update_prediction_history::<TestValue>);
+        app.add_observer(apply_component_removal_predicted::<TestValue>);
+
+        let entity = app
+            .world_mut()
+            .spawn((TestValue(1.0), PredictionHistory::<TestValue>::default()))
+            .id();
+
+        app.update();
+        assert!(
+            app.world()
+                .get::<PredictionHistory<TestValue>>(entity)
+                .unwrap()
+                .is_empty(),
+            "an unsynchronized local tick must not label a prediction sample"
+        );
+
+        app.world_mut().entity_mut(entity).remove::<TestValue>();
+        assert!(
+            app.world()
+                .get::<PredictionHistory<TestValue>>(entity)
+                .unwrap()
+                .is_empty(),
+            "an unsynchronized local tick must not label a removal sample"
+        );
+
+        app.world_mut()
+            .resource_mut::<LocalTimelineSync>()
+            .set_synced(true);
+        app.world_mut().entity_mut(entity).insert(TestValue(2.0));
+        app.update();
+
+        let history = app
+            .world()
+            .get::<PredictionHistory<TestValue>>(entity)
+            .unwrap();
+        assert_eq!(history.get(Tick(0)), Some(&TestValue(2.0)));
     }
 
     #[test]

--- a/crates/replication/prediction/src/registry.rs
+++ b/crates/replication/prediction/src/registry.rs
@@ -1513,7 +1513,7 @@ mod tests {
     use lightyear_interpolation::prelude::{InterpolationRegistrationExt, InterpolationRegistry};
     use lightyear_replication::checkpoint::ReplicationCheckpointMap;
     use lightyear_replication::prelude::AppComponentExt;
-    use lightyear_sync::prelude::InputTimelineConfig;
+    use lightyear_sync::prelude::{InputTimelineConfig, LocalTimelineSync};
     use serde::{Deserialize, Serialize};
 
     #[derive(Clone, PartialEq, Debug)]
@@ -1726,6 +1726,9 @@ mod tests {
     fn resource_builder_local_rollback_backfills_existing_resource_history() {
         let mut app = prediction_app();
         app.insert_resource(LocalTimeline::default());
+        let mut sync = LocalTimelineSync::default();
+        sync.set_synced(true);
+        app.insert_resource(sync);
         app.insert_resource(LocalRollbackOnlyResource(42));
         app.world_mut()
             .spawn((PredictionManager::default(), InputTimelineConfig::default()));
@@ -1775,6 +1778,9 @@ mod tests {
     fn resource_builder_local_rollback_adds_history_to_late_resource() {
         let mut app = prediction_app();
         app.insert_resource(LocalTimeline::default());
+        let mut sync = LocalTimelineSync::default();
+        sync.set_synced(true);
+        app.insert_resource(sync);
         app.world_mut()
             .spawn((PredictionManager::default(), InputTimelineConfig::default()));
 

--- a/crates/replication/prediction/src/rollback.rs
+++ b/crates/replication/prediction/src/rollback.rs
@@ -109,9 +109,9 @@ pub enum RollbackSystems {
 
 /// Installs prediction rollback detection, restoration, and replay.
 ///
-/// With the `p2p` feature, the plugin also tracks the active session's start tick and rejects
-/// input-driven rollback requests that would restore history from before that tick. This boundary
-/// is automatic; applications can install input components directly in a `P2PStarted` observer.
+/// With the `p2p` feature, the plugin also tracks the active session's initial snapshot and rejects
+/// input-driven rollback requests that would restore history from before it. This boundary is
+/// automatic; applications can install input components directly in a `P2PStarted` observer.
 pub struct RollbackPlugin;
 
 #[derive(Component)]
@@ -270,9 +270,9 @@ impl Plugin for RollbackPlugin {
 #[cfg(feature = "p2p")]
 /// Set the oldest history tick that input-driven rollback may restore for this P2P session.
 ///
-/// [`P2PStarted`] observers are allowed to create the deterministic world immediately. Any late
-/// input whose correction would require history from before that boundary is ignored by
-/// [`check_rollback`]. Applications do not need to delay installing their input components.
+/// [`P2PStarted`] observers create the deterministic world immediately before `start_tick` is
+/// simulated. A correction to input for that first gameplay tick must therefore restore the world
+/// at `start_tick - 1`; anything older predates the session and is ignored by [`check_rollback`].
 fn set_p2p_input_rollback_floor(
     trigger: On<P2PStarted>,
     prediction_manager: Option<ResMut<PredictionManager>>,
@@ -280,7 +280,7 @@ fn set_p2p_input_rollback_floor(
     let Some(mut prediction_manager) = prediction_manager else {
         return;
     };
-    prediction_manager.input_rollback_floor = Some(trigger.start_tick);
+    prediction_manager.input_rollback_floor = Some(trigger.start_tick - 1);
 }
 
 #[cfg(feature = "p2p")]
@@ -429,9 +429,10 @@ fn check_rollback(
                             prediction_manager: &PredictionManager,
                             commands: &mut Commands,
                             rollback: Rollback| {
-        // The P2P world does not exist before its agreed start tick. This guard applies only to
-        // input-driven reconciliation: authoritative state and explicit forced rollbacks retain
-        // their existing behavior because they may provide their own restoration data.
+        // The P2P world does not exist before the snapshot immediately preceding its agreed first
+        // gameplay tick. This guard applies only to input-driven reconciliation: authoritative
+        // state and explicit forced rollbacks retain their existing behavior because they may
+        // provide their own restoration data.
         if matches!(rollback, Rollback::FromInputs)
             && !prediction_manager.input_rollback_is_allowed(rollback_tick)
         {
@@ -439,7 +440,7 @@ fn check_rollback(
             debug!(
                 ?rollback_tick,
                 ?input_rollback_floor,
-                "Ignoring input rollback from before the P2P session start tick"
+                "Ignoring input rollback from before the P2P session boundary"
             );
             trace!(
                 target: "lightyear_debug::prediction",
@@ -1320,17 +1321,17 @@ mod tests {
             app.world()
                 .resource::<PredictionManager>()
                 .input_rollback_floor,
-            Some(Tick(10))
+            Some(Tick(9))
         );
         assert!(
             !app.world()
                 .resource::<PredictionManager>()
-                .input_rollback_is_allowed(Tick(9))
+                .input_rollback_is_allowed(Tick(8))
         );
         assert!(
             app.world()
                 .resource::<PredictionManager>()
-                .input_rollback_is_allowed(Tick(10))
+                .input_rollback_is_allowed(Tick(9))
         );
         assert!(
             app.world()

--- a/crates/replication/replication/src/prespawn.rs
+++ b/crates/replication/replication/src/prespawn.rs
@@ -530,7 +530,7 @@ mod tests {
     fn p2p_stable_input_targets_are_not_lifecycle_tracked() {
         let mut app = test_app();
         app.world_mut().spawn((
-            P2P,
+            P2P::Inactive,
             RemoteId(PeerId::Local(1)),
             Connected,
             ReplicationReceiver,

--- a/demos/spaceships/src/shared.rs
+++ b/demos/spaceships/src/shared.rs
@@ -377,7 +377,7 @@ pub fn shared_player_firing(
                 prespawned,
             ))
             .id();
-        if matches!(metadata.mode, NetworkTopology::P2P { .. }) {
+        if metadata.mode.is_p2p() {
             commands
                 .entity(bullet_entity)
                 .insert(DeterministicPredicted::default());
@@ -698,7 +698,7 @@ pub(crate) fn process_collisions(
     mut hit_ev_writer: MessageWriter<BulletHitMessage>,
 ) {
     let is_server = !server.is_empty();
-    let is_p2p = matches!(metadata.mode, NetworkTopology::P2P { .. });
+    let is_p2p = metadata.mode.is_p2p();
     let tick = timeline.tick();
     // when A and B collide, it can be reported as one of:
     // * A collides with B

--- a/examples/common/src/p2p.rs
+++ b/examples/common/src/p2p.rs
@@ -59,7 +59,7 @@ pub fn input_target_for_peer(
     target
 }
 
-/// Add the client-side Lightyear plugins and session state used by a direct P2P example.
+/// Add the client-side Lightyear plugins used by a direct P2P example.
 pub(crate) fn configure_app(
     app: &mut App,
     tick_duration: Duration,
@@ -69,8 +69,6 @@ pub(crate) fn configure_app(
 ) {
     validate_roster(peer_id, player_count);
     app.add_plugins(ClientPlugins { tick_duration });
-    app.add_plugins(P2PSessionPlugin);
-    app.insert_resource(P2PSession::new(player_count));
     app.insert_resource(P2PSettings {
         local_peer_id: peer_id,
         player_count,
@@ -101,7 +99,7 @@ pub(crate) fn spawn_connections(
         let local_addr = peer_addr(base_port, peer_id, remote_peer_id);
         let remote_addr = peer_addr(base_port, remote_peer_id, peer_id);
         app.world_mut().spawn((
-            P2P,
+            P2P::default(),
             RawClient,
             LocalId(local_id),
             RemoteId(PeerId::Entity(u64::from(remote_peer_id))),

--- a/examples/fps/src/shared.rs
+++ b/examples/fps/src/shared.rs
@@ -220,7 +220,7 @@ pub(crate) fn shoot_bullet(
     let has_client = !client.is_empty();
     let is_host_server = !host_server.is_empty();
     let client_is_synced = input_timeline.is_some();
-    let is_p2p = matches!(metadata.mode, NetworkTopology::P2P { .. });
+    let is_p2p = metadata.mode.is_p2p();
     for (
         id,
         position,


### PR DESCRIPTION
## Summary

- model P2P Link participation as inactive, candidate, or joined, with the cached topology exposing only connected joined peers after the start barrier
- keep P2PSession as internal barrier bookkeeping behind P2PStart and P2PStop, including stable-roster validation and a five-second timeout
- NetworkTopology::P2P only contains joined P2P peers