### PR TITLE
fix(interpolation): hide entities until materialized

### DIFF
--- a/crates/core/core/src/interpolation.rs
+++ b/crates/core/core/src/interpolation.rs
@@ -16,3 +16,15 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Copy, Default, Reflect, Serialize, Deserialize, Component)]
 #[reflect(Component)]
 pub struct Interpolated;
+
+/// Temporarily disables a newly received [`Interpolated`] entity until its first
+/// live interpolated component reaches the interpolation timeline.
+///
+/// [`lightyear_interpolation`](https://docs.rs/lightyear_interpolation) registers
+/// this as a Bevy disabling component. It is inserted after replication receive,
+/// so observers still react normally when [`Interpolated`] is added, and removed
+/// in the same structural change that materializes the first live interpolated
+/// component.
+#[derive(Debug, Clone, Copy, Default, Reflect, Component)]
+#[reflect(Component)]
+pub struct InterpolationPending;

--- a/crates/core/core/src/lib.rs
+++ b/crates/core/core/src/lib.rs
@@ -54,7 +54,7 @@ pub mod prelude {
     pub use crate::history_buffer::HistoryState;
 
     pub use crate::frame_interpolation::{FrameInterpolate, FrameInterpolationHistory};
-    pub use crate::interpolation::Interpolated;
+    pub use crate::interpolation::{Interpolated, InterpolationPending};
 
     pub use crate::prediction::Predicted;
 

--- a/crates/replication/interpolation/src/despawn.rs
+++ b/crates/replication/interpolation/src/despawn.rs
@@ -1,4 +1,5 @@
 use bevy_app::{App, Update};
+use bevy_ecs::entity_disabling::Disabled;
 use bevy_ecs::prelude::*;
 use bevy_ecs::world::EntityWorldMut;
 use bevy_replicon::prelude::RepliconTick;
@@ -11,6 +12,7 @@ use lightyear_core::tick::Tick;
 use lightyear_replication::checkpoint::ReplicationCheckpointMap;
 use tracing::error;
 
+use crate::InterpolationPending;
 use crate::plugin::InterpolationSystems;
 use crate::timeline::InterpolationTimeline;
 
@@ -82,7 +84,10 @@ fn resolve_despawn_tick(world: &World, message_tick: RepliconTick) -> Option<Tic
 
 pub(crate) fn despawn_interpolated_entities(
     interpolation: Res<InterpolationTimeline>,
-    query: Query<(Entity, &DelayedInterpolatedDespawn)>,
+    query: Query<
+        (Entity, &DelayedInterpolatedDespawn),
+        (Allow<InterpolationPending>, Allow<Disabled>),
+    >,
     mut commands: Commands,
 ) {
     let interpolation_tick = interpolation.now().tick();

--- a/crates/replication/interpolation/src/interpolate.rs
+++ b/crates/replication/interpolation/src/interpolate.rs
@@ -17,7 +17,7 @@ use lightyear_core::ecs_utils::{
     table_component_slice, table_for_archetype, write_component_with_change_detection,
 };
 use lightyear_core::history_buffer::HistoryState;
-use lightyear_core::prelude::{ConfirmedHistory, NetworkTimeline};
+use lightyear_core::prelude::{ConfirmedHistory, InterpolationPending, NetworkTimeline};
 use lightyear_core::tick::Tick;
 use lightyear_core::tick::TickDuration;
 use lightyear_replication::checkpoint::ReplicationCheckpointMap;
@@ -299,6 +299,10 @@ fn queue_history_presence<C: Component + Clone>(
             deferred_apply.remove::<C>(entity);
         }
         Some(HistoryState::Updated(value)) if !present => {
+            // Re-enable the entity in the same structural change that materializes its first
+            // interpolation-time component. Observers for this real insertion therefore see an
+            // entity that is no longer pending.
+            deferred_apply.remove::<InterpolationPending>(entity);
             deferred_apply.insert(entity, value);
         }
         _ => {}
@@ -407,6 +411,7 @@ mod tests {
     use bevy_app::{App, Update};
     use bevy_ecs::archetype::Archetype;
     use bevy_ecs::component::Component;
+    use bevy_ecs::entity_disabling::Disabled;
     use bevy_ecs::query::{QueryFilter, QueryState};
     use bevy_ecs::schedule::IntoScheduleConfigs;
     use bevy_math::{
@@ -453,6 +458,25 @@ mod tests {
 
     #[derive(Component)]
     struct DisabledRule;
+
+    #[derive(Resource, Default)]
+    struct MaterializedObservation {
+        count: usize,
+        was_pending: bool,
+        was_disabled: bool,
+    }
+
+    fn observe_materialized_test_component(
+        trigger: On<Add, TestComp>,
+        state: Query<(Has<InterpolationPending>, Has<Disabled>)>,
+        mut observation: ResMut<MaterializedObservation>,
+    ) {
+        observation.count += 1;
+        if let Ok((pending, disabled)) = state.get(trigger.entity) {
+            observation.was_pending = pending;
+            observation.was_disabled = disabled;
+        }
+    }
 
     static BUNDLE2_PRIORITY_CALLS: AtomicUsize = AtomicUsize::new(0);
     static BUNDLE3_PRIORITY_CALLS: AtomicUsize = AtomicUsize::new(0);
@@ -1471,6 +1495,47 @@ mod tests {
         app.update();
 
         assert!(!app.world().entity(entity).contains::<TestComp>());
+    }
+
+    #[test]
+    fn pending_entity_is_enabled_when_first_interpolated_component_materializes() {
+        let mut app = setup_app(Tick(9), 40);
+        app.register_disabling_component::<InterpolationPending>();
+        app.init_resource::<MaterializedObservation>();
+        app.add_observer(observe_materialized_test_component);
+        add_interpolation_test_systems(&mut app);
+
+        let mut history = ConfirmedHistory::<TestComp>::default();
+        history.insert_present(Tick(10), TestComp(4.0));
+        let entity = app
+            .world_mut()
+            .spawn((Interpolated, InterpolationPending, Disabled, history))
+            .id();
+
+        app.update();
+
+        assert!(
+            app.world()
+                .entity(entity)
+                .contains::<InterpolationPending>()
+        );
+        assert!(!app.world().entity(entity).contains::<TestComp>());
+        assert_eq!(app.world().resource::<MaterializedObservation>().count, 0);
+
+        set_interpolation_tick(&mut app, Tick(10));
+        app.update();
+
+        assert!(
+            !app.world()
+                .entity(entity)
+                .contains::<InterpolationPending>()
+        );
+        assert_eq!(app.world().get::<TestComp>(entity), Some(&TestComp(4.0)));
+        assert!(app.world().entity(entity).contains::<Disabled>());
+        let observation = app.world().resource::<MaterializedObservation>();
+        assert_eq!(observation.count, 1);
+        assert!(!observation.was_pending);
+        assert!(observation.was_disabled);
     }
 
     #[test]

--- a/crates/replication/interpolation/src/lib.rs
+++ b/crates/replication/interpolation/src/lib.rs
@@ -250,6 +250,12 @@
 //! [`plugin::InterpolationSystems`]. Custom interpolation systems should usually run in
 //! [`plugin::InterpolationSystems::Interpolate`] so they see histories after Lightyear
 //! has updated component presence for the interpolation timeline.
+//!
+//! Newly received [`Interpolated`] entities also receive [`InterpolationPending`] after
+//! replication receive. Bevy treats this as a disabling component until the interpolation
+//! timeline first materializes a live interpolated component. `On<Add, Interpolated>` observers
+//! run before the entity is disabled. Systems that intentionally need to inspect entities during
+//! this interval can opt in with `Allow<InterpolationPending>`.
 #![no_std]
 
 extern crate alloc;
@@ -273,7 +279,6 @@ pub mod timeline;
 
 /// Commonly used items for client-side interpolation.
 pub mod prelude {
-    pub use crate::Interpolated;
     pub use crate::interpolate::interpolation_fraction;
     pub use crate::plugin::{InterpolationDelay, InterpolationPlugin, InterpolationSystems};
     pub use crate::registry::{
@@ -286,9 +291,10 @@ pub mod prelude {
     pub use crate::timeline::{
         InterpolationConfig, InterpolationTimeline, SyncedInterpolationTimeline,
     };
+    pub use crate::{Interpolated, InterpolationPending};
 }
 
-pub use lightyear_core::interpolation::Interpolated;
+pub use lightyear_core::interpolation::{Interpolated, InterpolationPending};
 
 /// Trait for components that can be synchronized for interpolation.
 ///

--- a/crates/replication/interpolation/src/plugin.rs
+++ b/crates/replication/interpolation/src/plugin.rs
@@ -2,16 +2,19 @@ use crate::despawn::configure_delayed_interpolated_despawn;
 use crate::interpolate::{apply_interpolation, update_interpolation_history};
 use crate::registry::{InterpolationRegistry, finalize_interpolation_registry};
 use crate::timeline::TimelinePlugin;
-use bevy_app::{App, Plugin, Update};
+use bevy_app::{App, Plugin, PreUpdate, Update};
 use bevy_ecs::{
     component::Component,
+    entity_disabling::Disabled,
     prelude::*,
     schedule::{IntoScheduleConfigs, SystemSet},
 };
 use bevy_reflect::Reflect;
+use bevy_replicon::prelude::Remote;
 use lightyear_connection::host::HostClient;
-use lightyear_core::prelude::{Interpolated, Tick};
+use lightyear_core::prelude::{Interpolated, InterpolationPending, Tick};
 use lightyear_core::time::PositiveTickDelta;
+use lightyear_replication::ReplicationSystems;
 use lightyear_serde::reader::Reader;
 use lightyear_serde::writer::WriteInteger;
 use lightyear_serde::{SerializationError, ToBytes};
@@ -114,14 +117,45 @@ fn backfill_confirmed_histories_on_interpolated(
     }
 }
 
+/// Disable newly received interpolated entities after replication observers have run.
+///
+/// The marker is removed when interpolation first materializes a live component at the
+/// interpolation timeline. Explicitly allowing both disabling components keeps this lifecycle
+/// active when the application has independently disabled the entity.
+fn mark_interpolation_pending(
+    query: Query<
+        Entity,
+        (
+            Added<Interpolated>,
+            With<Remote>,
+            Allow<Disabled>,
+            Allow<InterpolationPending>,
+        ),
+    >,
+    mut commands: Commands,
+) {
+    for entity in &query {
+        commands.entity(entity).insert(InterpolationPending);
+    }
+}
+
 impl Plugin for InterpolationPlugin {
     fn build(&self, app: &mut App) {
         app.add_plugins(TimelinePlugin);
 
         // RESOURCES
         app.init_resource::<InterpolationRegistry>();
+        app.register_disabling_component::<InterpolationPending>();
         configure_delayed_interpolated_despawn(app);
         app.add_observer(backfill_confirmed_histories_on_interpolated);
+
+        // Replicon buffers all initial component insertions into one structural change. Waiting
+        // until its receive set completes lets user On<Add, Interpolated> observers react before
+        // this entity is excluded by Bevy's default query filters.
+        app.add_systems(
+            PreUpdate,
+            mark_interpolation_pending.after(ReplicationSystems::Receive),
+        );
 
         // Host-Clients have no interpolation delay
         app.register_required_components::<HostClient, InterpolationDelay>();
@@ -154,6 +188,30 @@ impl Plugin for InterpolationPlugin {
 mod tests {
     use super::*;
 
+    #[derive(Resource, Default)]
+    struct ReceivedEntity(Option<Entity>);
+
+    #[derive(Resource, Default)]
+    struct InterpolatedAddObservation {
+        count: usize,
+        was_pending: bool,
+    }
+
+    fn receive_interpolated_entity(mut commands: Commands, mut received: ResMut<ReceivedEntity>) {
+        if received.0.is_none() {
+            received.0 = Some(commands.spawn((Interpolated, Remote)).id());
+        }
+    }
+
+    fn observe_interpolated_add(
+        trigger: On<Add, Interpolated>,
+        pending: Query<Has<InterpolationPending>>,
+        mut observation: ResMut<InterpolatedAddObservation>,
+    ) {
+        observation.count += 1;
+        observation.was_pending = pending.get(trigger.entity).unwrap_or_default();
+    }
+
     #[test]
     fn test_interpolation_delay() {
         let delay = InterpolationDelay {
@@ -167,5 +225,63 @@ mod tests {
         let (tick, overstep) = delay.tick_and_overstep(Tick(3));
         assert_eq!(tick, Tick(0));
         assert!((overstep - 0.6).abs() < 0.0001);
+    }
+
+    #[test]
+    fn interpolation_pending_is_added_after_receive_observers_run() {
+        let mut app = App::new();
+        app.register_disabling_component::<InterpolationPending>();
+        app.init_resource::<ReceivedEntity>();
+        app.init_resource::<InterpolatedAddObservation>();
+        app.add_observer(observe_interpolated_add);
+        app.add_systems(
+            PreUpdate,
+            receive_interpolated_entity.in_set(ReplicationSystems::Receive),
+        );
+        app.add_systems(
+            PreUpdate,
+            mark_interpolation_pending.after(ReplicationSystems::Receive),
+        );
+
+        app.update();
+
+        let entity = app.world().resource::<ReceivedEntity>().0.unwrap();
+        let observation = app.world().resource::<InterpolatedAddObservation>();
+        assert_eq!(observation.count, 1);
+        assert!(!observation.was_pending);
+        assert!(
+            app.world()
+                .entity(entity)
+                .contains::<InterpolationPending>()
+        );
+
+        let mut default_query = app
+            .world_mut()
+            .query_filtered::<Entity, With<Interpolated>>();
+        assert_eq!(default_query.iter(app.world()).count(), 0);
+
+        let mut pending_query = app
+            .world_mut()
+            .query_filtered::<Entity, (With<Interpolated>, Allow<InterpolationPending>)>();
+        assert_eq!(pending_query.iter(app.world()).count(), 1);
+    }
+
+    #[test]
+    fn interpolation_pending_is_not_added_to_local_interpolated_entities() {
+        let mut app = App::new();
+        app.register_disabling_component::<InterpolationPending>();
+        app.add_systems(
+            PreUpdate,
+            mark_interpolation_pending.after(ReplicationSystems::Receive),
+        );
+
+        let entity = app.world_mut().spawn(Interpolated).id();
+        app.update();
+
+        assert!(
+            !app.world()
+                .entity(entity)
+                .contains::<InterpolationPending>()
+        );
     }
 }

--- a/crates/replication/replication/src/client.rs
+++ b/crates/replication/replication/src/client.rs
@@ -8,6 +8,7 @@ use bevy_replicon::prelude::*;
 use bevy_replicon::shared::server_entity_map::ServerEntityMap;
 use lightyear_connection::client::{Client, Connected};
 use lightyear_connection::host::HostClient;
+use lightyear_core::prelude::InterpolationPending;
 use lightyear_messages::MessageManager;
 use lightyear_transport::plugin::TransportSystems;
 use lightyear_transport::prelude::Transport;
@@ -206,7 +207,15 @@ fn on_replication_disconnect(
             Without<HostClient>,
         ),
     >,
-    replicated: Query<Entity, (With<Replicated>, Without<Replicate>, Without<Persistent>)>,
+    replicated: Query<
+        Entity,
+        (
+            With<Replicated>,
+            Without<Replicate>,
+            Without<Persistent>,
+            Allow<InterpolationPending>,
+        ),
+    >,
     mut checkpoints: ResMut<ReplicationCheckpointMap>,
 ) {
     // The tuple observer runs when either component is removed. Only clean up a connection that

--- a/crates/replication/replication/src/deferred_entity.rs
+++ b/crates/replication/replication/src/deferred_entity.rs
@@ -7,9 +7,16 @@ use bevy_ecs::{
     system::Commands,
 };
 use bevy_replicon::shared::replication::deferred_entity::{DeferredEntity, EntityScratch};
+use core::any::TypeId;
 
 type ApplyDeferredEntityCommand =
     Box<dyn for<'w> FnOnce(&mut DeferredEntity<'w>) + Send + Sync + 'static>;
+
+#[derive(Default)]
+struct DeferredEntityMutations {
+    commands: Vec<ApplyDeferredEntityCommand>,
+    removals: Vec<TypeId>,
+}
 
 /// Batched structural changes for multiple entities.
 ///
@@ -38,7 +45,7 @@ type ApplyDeferredEntityCommand =
 /// ```
 #[derive(Default)]
 pub struct DeferredEntityCommands {
-    entities: EntityHashMap<Vec<ApplyDeferredEntityCommand>>,
+    entities: EntityHashMap<DeferredEntityMutations>,
 }
 
 impl DeferredEntityCommands {
@@ -47,19 +54,26 @@ impl DeferredEntityCommands {
         self.entities
             .entry(entity)
             .or_default()
+            .commands
             .push(Box::new(move |entity| {
                 entity.insert(component);
             }));
     }
 
     /// Queues removal of one component from `entity`.
+    ///
+    /// Repeated removals of the same component from one entity are coalesced because Replicon's
+    /// dynamic removal bundle requires unique component IDs.
     pub fn remove<C: Component>(&mut self, entity: Entity) {
-        self.entities
-            .entry(entity)
-            .or_default()
-            .push(Box::new(|entity| {
-                entity.remove::<C>();
-            }));
+        let mutations = self.entities.entry(entity).or_default();
+        let component = TypeId::of::<C>();
+        if mutations.removals.contains(&component) {
+            return;
+        }
+        mutations.removals.push(component);
+        mutations.commands.push(Box::new(|entity| {
+            entity.remove::<C>();
+        }));
     }
 
     /// Queues a Bevy command that applies all deferred mutations.
@@ -74,7 +88,7 @@ impl DeferredEntityCommands {
                     continue;
                 };
                 let mut deferred = DeferredEntity::new(entity_mut, &mut scratch);
-                for mutation in mutations {
+                for mutation in mutations.commands {
                     mutation(&mut deferred);
                 }
                 deferred.flush();


### PR DESCRIPTION
## Summary

- add an InterpolationPending disabling component so newly replicated interpolated entities stay out of default queries until their first interpolation-time component is materialized
- install the marker after replication receive and only for Remote entities, preserving Interpolated add observers and user-owned Disabled state
- keep pending entities in Lightyear lifecycle processing and coalesce duplicate deferred removals for bundle interpolation