### PR TITLE
fix(interpolation): gate replicated entity readiness on server tick

### DIFF
--- a/crates/core/core/src/interpolation.rs
+++ b/crates/core/core/src/interpolation.rs
@@ -2,6 +2,8 @@ use bevy_ecs::{component::Component, reflect::ReflectComponent};
 use bevy_reflect::Reflect;
 use serde::{Deserialize, Serialize};
 
+use crate::tick::Tick;
+
 /// Component added to client-side entities that are visually interpolated.
 ///
 /// Interpolation is used to smooth the visual representation of entities received from the server.
@@ -17,14 +19,18 @@ use serde::{Deserialize, Serialize};
 #[reflect(Component)]
 pub struct Interpolated;
 
-/// Temporarily disables a newly received [`Interpolated`] entity until its first
-/// live interpolated component reaches the interpolation timeline.
+/// Temporarily disables an entity whose [`Interpolated`] marker was received
+/// through replication until the interpolation timeline reaches the marker's
+/// authoritative server tick.
 ///
 /// [`lightyear_interpolation`](https://docs.rs/lightyear_interpolation) registers
-/// this as a Bevy disabling component. It is inserted after replication receive,
-/// so observers still react normally when [`Interpolated`] is added, and removed
-/// in the same structural change that materializes the first live interpolated
-/// component.
-#[derive(Debug, Clone, Copy, Default, Reflect, Component)]
+/// this as a Bevy disabling component. It is inserted by an observer after the
+/// other [`Interpolated`] add observers have run. Client-local [`Interpolated`]
+/// insertions do not receive this component. It is removed in the same structural
+/// change that materializes the entity at the interpolation timeline.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Reflect, Component)]
 #[reflect(Component)]
-pub struct InterpolationPending;
+pub struct InterpolationPending {
+    /// Authoritative server tick when the replicated interpolation marker was received.
+    pub spawn_tick: Tick,
+}

--- a/crates/core/core/src/interpolation.rs
+++ b/crates/core/core/src/interpolation.rs
@@ -20,14 +20,15 @@ use crate::tick::Tick;
 pub struct Interpolated;
 
 /// Temporarily disables an entity whose [`Interpolated`] marker was received
-/// through replication until the interpolation timeline reaches the marker's
-/// authoritative server tick.
+/// through replication and owns interpolation history until the interpolation
+/// timeline reaches the marker's authoritative server tick.
 ///
 /// [`lightyear_interpolation`](https://docs.rs/lightyear_interpolation) registers
-/// this as a Bevy disabling component. It is inserted after replication receive,
-/// once component-add observer command chains have completed. Client-local
-/// [`Interpolated`] insertions do not receive this component. It is removed in the
-/// same structural change that materializes the entity at the interpolation timeline.
+/// this as a Bevy disabling component. It is inserted at the end of the receive
+/// frame, after component-add observer chains and downstream engine response
+/// systems have completed. Client-local [`Interpolated`] insertions do not receive
+/// this component, and historyless entities are ready immediately. It is removed
+/// in the same structural change that materializes the entity at the interpolation timeline.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Reflect, Component)]
 #[reflect(Component)]
 pub struct InterpolationPending {

--- a/crates/core/core/src/interpolation.rs
+++ b/crates/core/core/src/interpolation.rs
@@ -28,7 +28,8 @@ pub struct Interpolated;
 /// frame, after component-add observer chains and downstream engine response
 /// systems have completed. Client-local [`Interpolated`] insertions do not receive
 /// this component. It is removed when the interpolation timeline reaches the
-/// entity's replicated spawn tick.
+/// entity's replicated spawn tick. Existing mutable components are marked changed
+/// when the entity is enabled so changed-only response systems can catch up.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Reflect, Component)]
 #[reflect(Component)]
 pub struct InterpolationPending {

--- a/crates/core/core/src/interpolation.rs
+++ b/crates/core/core/src/interpolation.rs
@@ -24,10 +24,10 @@ pub struct Interpolated;
 /// authoritative server tick.
 ///
 /// [`lightyear_interpolation`](https://docs.rs/lightyear_interpolation) registers
-/// this as a Bevy disabling component. It is inserted by an observer after the
-/// other [`Interpolated`] add observers have run. Client-local [`Interpolated`]
-/// insertions do not receive this component. It is removed in the same structural
-/// change that materializes the entity at the interpolation timeline.
+/// this as a Bevy disabling component. It is inserted after replication receive,
+/// once component-add observer command chains have completed. Client-local
+/// [`Interpolated`] insertions do not receive this component. It is removed in the
+/// same structural change that materializes the entity at the interpolation timeline.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Reflect, Component)]
 #[reflect(Component)]
 pub struct InterpolationPending {

--- a/crates/core/core/src/interpolation.rs
+++ b/crates/core/core/src/interpolation.rs
@@ -20,15 +20,15 @@ use crate::tick::Tick;
 pub struct Interpolated;
 
 /// Temporarily disables an entity whose [`Interpolated`] marker was received
-/// through replication and owns interpolation history until the interpolation
-/// timeline reaches the marker's authoritative server tick.
+/// through replication until the interpolation timeline reaches the marker's
+/// authoritative server tick.
 ///
 /// [`lightyear_interpolation`](https://docs.rs/lightyear_interpolation) registers
 /// this as a Bevy disabling component. It is inserted at the end of the receive
 /// frame, after component-add observer chains and downstream engine response
 /// systems have completed. Client-local [`Interpolated`] insertions do not receive
-/// this component, and historyless entities are ready immediately. It is removed
-/// in the same structural change that materializes the entity at the interpolation timeline.
+/// this component. It is removed when the interpolation timeline reaches the
+/// entity's replicated spawn tick.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Reflect, Component)]
 #[reflect(Component)]
 pub struct InterpolationPending {

--- a/crates/replication/interpolation/src/interpolate.rs
+++ b/crates/replication/interpolation/src/interpolate.rs
@@ -1554,6 +1554,60 @@ mod tests {
     }
 
     #[test]
+    fn history_only_component_is_added_exactly_when_pending_entity_becomes_ready() {
+        let mut app = setup_app(Tick(9), 40);
+        app.register_disabling_component::<InterpolationPending>();
+        app.init_resource::<MaterializedObservation>();
+        app.add_observer(observe_materialized_test_component);
+        QueryState::<&Archetype, With<HistoryOnlyRule>>::new(app.world_mut());
+        insert_rule::<TestComp, With<HistoryOnlyRule>>(
+            &mut app,
+            InterpolationFns::history_only(),
+            InterpolationRuleConfig { priority: 100 },
+        );
+        add_interpolation_test_systems(&mut app);
+
+        let mut history = ConfirmedHistory::<TestComp>::default();
+        history.insert_present(Tick(10), TestComp(0.0));
+        history.insert_present(Tick(20), TestComp(0.2));
+        let entity = app
+            .world_mut()
+            .spawn((
+                Interpolated,
+                InterpolationPending {
+                    spawn_tick: Tick(10),
+                },
+                HistoryOnlyRule,
+                history,
+            ))
+            .id();
+
+        app.update();
+        assert!(!app.world().entity(entity).contains::<TestComp>());
+        assert_eq!(app.world().resource::<MaterializedObservation>().count, 0);
+
+        set_interpolation_tick(&mut app, Tick(10));
+        app.update();
+
+        assert_eq!(app.world().get::<TestComp>(entity), Some(&TestComp(0.0)));
+        assert!(
+            !app.world()
+                .entity(entity)
+                .contains::<InterpolationPending>()
+        );
+        let observation = app.world().resource::<MaterializedObservation>();
+        assert_eq!(observation.count, 1);
+        assert!(!observation.was_pending);
+
+        // A custom system owns the live value after materialization; newer
+        // confirmed samples remain in history and are not applied automatically.
+        app.world_mut().get_mut::<TestComp>(entity).unwrap().0 = 0.05;
+        set_interpolation_tick(&mut app, Tick(15));
+        app.update();
+        assert_eq!(app.world().get::<TestComp>(entity), Some(&TestComp(0.05)));
+    }
+
+    #[test]
     fn historyless_pending_entity_is_enabled_at_spawn_tick() {
         let mut app = setup_app(Tick(9), 40);
         app.register_disabling_component::<InterpolationPending>();

--- a/crates/replication/interpolation/src/interpolate.rs
+++ b/crates/replication/interpolation/src/interpolate.rs
@@ -67,6 +67,9 @@ pub(crate) fn update_interpolation_history(
     for (entity, pending) in &pending_entities {
         if current_interpolate_tick >= pending.spawn_tick {
             deferred_apply.remove::<InterpolationPending>(entity);
+            // Systems using Changed<C> skipped this entity while it was disabled. Make them
+            // revisit existing components when the entity becomes visible to ordinary queries.
+            deferred_apply.mark_all_changed(entity);
         }
     }
 
@@ -474,6 +477,9 @@ mod tests {
         was_disabled: bool,
     }
 
+    #[derive(Resource, Default)]
+    struct ChangedObservation(usize);
+
     fn observe_materialized_test_component(
         trigger: On<Add, TestComp>,
         state: Query<(Has<InterpolationPending>, Has<Disabled>)>,
@@ -484,6 +490,13 @@ mod tests {
             observation.was_pending = pending;
             observation.was_disabled = disabled;
         }
+    }
+
+    fn observe_changed_test_component(
+        changed: Query<(), Changed<TestComp>>,
+        mut observation: ResMut<ChangedObservation>,
+    ) {
+        observation.0 += changed.iter().count();
     }
 
     static BUNDLE2_PRIORITY_CALLS: AtomicUsize = AtomicUsize::new(0);
@@ -1680,6 +1693,48 @@ mod tests {
                 .contains::<InterpolationPending>()
         );
         assert_eq!(app.world().get::<TestComp>(entity), Some(&TestComp(4.0)));
+    }
+
+    #[test]
+    fn enabling_pending_entity_retriggers_changed_only_systems() {
+        let mut app = setup_app(Tick(9), 40);
+        app.register_disabling_component::<InterpolationPending>();
+        app.init_resource::<ChangedObservation>();
+        add_interpolation_test_systems(&mut app);
+        app.add_systems(
+            Update,
+            observe_changed_test_component.after(crate::plugin::InterpolationSystems::Prepare),
+        );
+
+        let entity = app
+            .world_mut()
+            .spawn((
+                Interpolated,
+                InterpolationPending {
+                    spawn_tick: Tick(10),
+                },
+                TestComp(4.0),
+            ))
+            .id();
+
+        // The changed-only system runs while the entity is disabled and therefore advances its
+        // change-detection cursor without observing the component.
+        app.update();
+        assert_eq!(app.world().resource::<ChangedObservation>().0, 0);
+
+        set_interpolation_tick(&mut app, Tick(10));
+        app.update();
+
+        assert!(
+            !app.world()
+                .entity(entity)
+                .contains::<InterpolationPending>()
+        );
+        assert_eq!(app.world().resource::<ChangedObservation>().0, 1);
+
+        // Catch-up is emitted only for the transition back into ordinary queries.
+        app.update();
+        assert_eq!(app.world().resource::<ChangedObservation>().0, 1);
     }
 
     #[test]

--- a/crates/replication/interpolation/src/interpolate.rs
+++ b/crates/replication/interpolation/src/interpolate.rs
@@ -8,6 +8,7 @@ use crate::rules::{
 use crate::timeline::InterpolationTimeline;
 use bevy_ecs::archetype::Archetype;
 use bevy_ecs::component::StorageType;
+use bevy_ecs::entity_disabling::Disabled;
 use bevy_ecs::prelude::*;
 use bevy_ecs::world::unsafe_world_cell::UnsafeWorldCell;
 use bevy_replicon::shared::replication::diff::Diffable as RepliconDiffable;
@@ -31,18 +32,22 @@ pub fn interpolation_fraction(start: Tick, end: Tick, current: Tick, overstep: f
     ((current - start) as f32 + overstep) / (end - start) as f32
 }
 
-/// Updates interpolation histories and component presence.
+/// Updates interpolation histories, component presence, and entity readiness.
 ///
 /// This is intentionally archetype-driven: a local
 /// [`InterpolatedArchetypes`](crate::archetypes::InterpolatedArchetypes) cache
 /// stores the highest-priority matching rule per archetype/component and the
 /// type-erased history functions that should run for each cached archetype.
 ///
-/// Component insertion/removal happens here so custom interpolation systems that
-/// run after [`crate::plugin::InterpolationSystems::Prepare`] see the live
-/// component set matching the interpolation timeline.
+/// Component insertion/removal and spawn-tick readiness happen here so custom
+/// interpolation systems that run after [`crate::plugin::InterpolationSystems::Prepare`]
+/// see the live entity and component set matching the interpolation timeline.
 pub(crate) fn update_interpolation_history(
     mut interpolation_world: InterpolationWorld,
+    pending_entities: Query<
+        (Entity, &InterpolationPending),
+        (Allow<InterpolationPending>, Allow<Disabled>),
+    >,
     timeline: Res<InterpolationTimeline>,
     interpolation_registry: Res<InterpolationRegistry>,
     checkpoints: Res<ReplicationCheckpointMap>,
@@ -57,6 +62,13 @@ pub(crate) fn update_interpolation_history(
     let tick_duration = tick_duration.as_deref().map(|duration| duration.0);
 
     let mut deferred_apply = DeferredEntityCommands::default();
+
+    // Enable the interpolated entity when the interpolation timeline reaches the remote spawn tick
+    for (entity, pending) in &pending_entities {
+        if current_interpolate_tick >= pending.spawn_tick {
+            deferred_apply.remove::<InterpolationPending>(entity);
+        }
+    }
 
     interpolation_world.update_archetypes(&interpolation_registry);
     let world = interpolation_world.world;
@@ -299,10 +311,6 @@ fn queue_history_presence<C: Component + Clone>(
             deferred_apply.remove::<C>(entity);
         }
         Some(HistoryState::Updated(value)) if !present => {
-            // Re-enable the entity in the same structural change that materializes its first
-            // interpolation-time component. Observers for this real insertion therefore see an
-            // entity that is no longer pending.
-            deferred_apply.remove::<InterpolationPending>(entity);
             deferred_apply.insert(entity, value);
         }
         _ => {}
@@ -1498,7 +1506,7 @@ mod tests {
     }
 
     #[test]
-    fn pending_entity_is_enabled_when_first_interpolated_component_materializes() {
+    fn pending_entity_is_enabled_when_interpolation_reaches_spawn_tick() {
         let mut app = setup_app(Tick(9), 40);
         app.register_disabling_component::<InterpolationPending>();
         app.init_resource::<MaterializedObservation>();
@@ -1509,7 +1517,14 @@ mod tests {
         history.insert_present(Tick(10), TestComp(4.0));
         let entity = app
             .world_mut()
-            .spawn((Interpolated, InterpolationPending, Disabled, history))
+            .spawn((
+                Interpolated,
+                InterpolationPending {
+                    spawn_tick: Tick(10),
+                },
+                Disabled,
+                history,
+            ))
             .id();
 
         app.update();
@@ -1536,6 +1551,118 @@ mod tests {
         assert_eq!(observation.count, 1);
         assert!(!observation.was_pending);
         assert!(observation.was_disabled);
+    }
+
+    #[test]
+    fn historyless_pending_entity_is_enabled_at_spawn_tick() {
+        let mut app = setup_app(Tick(9), 40);
+        app.register_disabling_component::<InterpolationPending>();
+        add_interpolation_test_systems(&mut app);
+
+        let entity = app
+            .world_mut()
+            .spawn((
+                Interpolated,
+                InterpolationPending {
+                    spawn_tick: Tick(10),
+                },
+            ))
+            .id();
+
+        app.update();
+        assert!(
+            app.world()
+                .entity(entity)
+                .contains::<InterpolationPending>()
+        );
+
+        set_interpolation_tick(&mut app, Tick(10));
+        app.update();
+        assert!(
+            !app.world()
+                .entity(entity)
+                .contains::<InterpolationPending>()
+        );
+
+        let mut query = app
+            .world_mut()
+            .query_filtered::<Entity, With<Interpolated>>();
+        assert_eq!(query.iter(app.world()).count(), 1);
+        assert!(query.get(app.world(), entity).is_ok());
+    }
+
+    #[test]
+    fn pending_entity_with_live_component_is_enabled_at_spawn_tick() {
+        let mut app = setup_app(Tick(9), 40);
+        app.register_disabling_component::<InterpolationPending>();
+        add_interpolation_test_systems(&mut app);
+
+        let mut history = ConfirmedHistory::<TestComp>::default();
+        history.insert_present(Tick(10), TestComp(4.0));
+        let entity = app
+            .world_mut()
+            .spawn((
+                Interpolated,
+                InterpolationPending {
+                    spawn_tick: Tick(10),
+                },
+                TestComp(4.0),
+                history,
+            ))
+            .id();
+
+        app.update();
+        assert!(
+            app.world()
+                .entity(entity)
+                .contains::<InterpolationPending>()
+        );
+
+        set_interpolation_tick(&mut app, Tick(10));
+        app.update();
+        assert!(
+            !app.world()
+                .entity(entity)
+                .contains::<InterpolationPending>()
+        );
+        assert_eq!(app.world().get::<TestComp>(entity), Some(&TestComp(4.0)));
+    }
+
+    #[test]
+    fn materialized_component_does_not_enable_entity_before_spawn_tick() {
+        let mut app = setup_app(Tick(9), 40);
+        app.register_disabling_component::<InterpolationPending>();
+        add_interpolation_test_systems(&mut app);
+
+        let mut history = ConfirmedHistory::<TestComp>::default();
+        history.insert_present(Tick(9), TestComp(4.0));
+        let entity = app
+            .world_mut()
+            .spawn((
+                Interpolated,
+                InterpolationPending {
+                    spawn_tick: Tick(10),
+                },
+                history,
+            ))
+            .id();
+
+        app.update();
+
+        assert_eq!(app.world().get::<TestComp>(entity), Some(&TestComp(4.0)));
+        assert!(
+            app.world()
+                .entity(entity)
+                .contains::<InterpolationPending>()
+        );
+
+        set_interpolation_tick(&mut app, Tick(10));
+        app.update();
+        assert!(
+            !app.world()
+                .entity(entity)
+                .contains::<InterpolationPending>()
+        );
     }
 
     #[test]

--- a/crates/replication/interpolation/src/lib.rs
+++ b/crates/replication/interpolation/src/lib.rs
@@ -251,9 +251,10 @@
 //! [`plugin::InterpolationSystems::Interpolate`] so they see histories after Lightyear
 //! has updated component presence for the interpolation timeline.
 //!
-//! Entities whose [`Interpolated`] marker is received through replication also receive
-//! [`InterpolationPending`]. Bevy treats this as a disabling component until the interpolation
-//! timeline reaches the authoritative tick that added the marker.
+//! Entities whose [`Interpolated`] marker is received through replication and own at least one
+//! interpolation history also receive [`InterpolationPending`] at the end of the receive frame.
+//! Bevy treats this as a disabling component until the interpolation timeline reaches the
+//! authoritative tick that added the marker. Historyless entities are ready immediately.
 //! Systems that intentionally need to inspect entities during this interval can opt in with
 //! `Allow<InterpolationPending>`.
 #![no_std]

--- a/crates/replication/interpolation/src/lib.rs
+++ b/crates/replication/interpolation/src/lib.rs
@@ -251,10 +251,10 @@
 //! [`plugin::InterpolationSystems::Interpolate`] so they see histories after Lightyear
 //! has updated component presence for the interpolation timeline.
 //!
-//! Entities whose [`Interpolated`] marker is received through replication and own at least one
-//! interpolation history also receive [`InterpolationPending`] at the end of the receive frame.
-//! Bevy treats this as a disabling component until the interpolation timeline reaches the
-//! authoritative tick that added the marker. Historyless entities are ready immediately.
+//! Entities whose [`Interpolated`] marker is received through replication also receive
+//! [`InterpolationPending`] at the end of the receive frame. Bevy treats this as a disabling
+//! component until the interpolation timeline reaches the authoritative tick that added the
+//! marker, including for entities without interpolation histories.
 //! Systems that intentionally need to inspect entities during this interval can opt in with
 //! `Allow<InterpolationPending>`.
 #![no_std]

--- a/crates/replication/interpolation/src/lib.rs
+++ b/crates/replication/interpolation/src/lib.rs
@@ -255,6 +255,8 @@
 //! [`InterpolationPending`] at the end of the receive frame. Bevy treats this as a disabling
 //! component until the interpolation timeline reaches the authoritative tick that added the
 //! marker, including for entities without interpolation histories.
+//! When the entity is enabled, its existing mutable components are marked changed so systems that
+//! skipped it while pending can initialize their derived state.
 //! Systems that intentionally need to inspect entities during this interval can opt in with
 //! `Allow<InterpolationPending>`.
 #![no_std]

--- a/crates/replication/interpolation/src/lib.rs
+++ b/crates/replication/interpolation/src/lib.rs
@@ -251,11 +251,11 @@
 //! [`plugin::InterpolationSystems::Interpolate`] so they see histories after Lightyear
 //! has updated component presence for the interpolation timeline.
 //!
-//! Newly received [`Interpolated`] entities also receive [`InterpolationPending`] after
-//! replication receive. Bevy treats this as a disabling component until the interpolation
-//! timeline first materializes a live interpolated component. `On<Add, Interpolated>` observers
-//! run before the entity is disabled. Systems that intentionally need to inspect entities during
-//! this interval can opt in with `Allow<InterpolationPending>`.
+//! Entities whose [`Interpolated`] marker is received through replication also receive
+//! [`InterpolationPending`]. Bevy treats this as a disabling component until the interpolation
+//! timeline reaches the authoritative tick that added the marker.
+//! Systems that intentionally need to inspect entities during this interval can opt in with
+//! `Allow<InterpolationPending>`.
 #![no_std]
 
 extern crate alloc;

--- a/crates/replication/interpolation/src/plugin.rs
+++ b/crates/replication/interpolation/src/plugin.rs
@@ -2,7 +2,8 @@ use crate::despawn::configure_delayed_interpolated_despawn;
 use crate::interpolate::{apply_interpolation, update_interpolation_history};
 use crate::registry::{InterpolationRegistry, finalize_interpolation_registry};
 use crate::timeline::TimelinePlugin;
-use bevy_app::{App, Plugin, PreUpdate, Update};
+use alloc::vec::Vec;
+use bevy_app::{App, Last, Plugin, Update};
 use bevy_ecs::{
     component::Component,
     entity_disabling::Disabled,
@@ -13,7 +14,7 @@ use bevy_reflect::Reflect;
 use lightyear_connection::host::HostClient;
 use lightyear_core::prelude::{Interpolated, InterpolationPending, Tick};
 use lightyear_core::time::PositiveTickDelta;
-use lightyear_replication::{ReplicationSystems, send::ReplicatedInterpolationStart};
+use lightyear_replication::send::ReplicatedInterpolationStart;
 use lightyear_serde::reader::Reader;
 use lightyear_serde::writer::WriteInteger;
 use lightyear_serde::{SerializationError, ToBytes};
@@ -115,22 +116,42 @@ fn backfill_confirmed_histories_on_interpolated(
     }
 }
 
-/// Disables newly replicated interpolated entities after replication observers finish.
+/// After app and engine response systems finish, disables newly replicated
+/// entities whose interpolated component histories are not ready yet.
 fn mark_replicated_interpolation_pending(
     replicated_starts: Query<
         (Entity, &ReplicatedInterpolationStart),
-        (Allow<Disabled>, Allow<InterpolationPending>),
+        (
+            With<ReplicatedInterpolationStart>,
+            Allow<Disabled>,
+            Allow<InterpolationPending>,
+        ),
     >,
+    interpolation_registry: Res<InterpolationRegistry>,
     mut commands: Commands,
 ) {
-    for (entity, start) in &replicated_starts {
-        commands
-            .entity(entity)
-            .insert(InterpolationPending {
-                spawn_tick: start.tick,
-            })
-            .remove::<ReplicatedInterpolationStart>();
-    }
+    let history_component_ids = interpolation_registry
+        .confirmed_history_backfill_fns()
+        .map(|(_, history_component_id, _)| history_component_id)
+        .collect::<Vec<_>>();
+    let starts = replicated_starts
+        .iter()
+        .map(|(entity, start)| (entity, start.tick))
+        .collect::<Vec<_>>();
+    commands.queue(move |world: &mut World| {
+        for (entity, spawn_tick) in starts {
+            let Ok(mut entity) = world.get_entity_mut(entity) else {
+                continue;
+            };
+            if history_component_ids
+                .iter()
+                .any(|component_id| entity.contains_id(*component_id))
+            {
+                entity.insert(InterpolationPending { spawn_tick });
+            }
+            entity.remove::<ReplicatedInterpolationStart>();
+        }
+    });
 }
 
 impl Plugin for InterpolationPlugin {
@@ -142,10 +163,7 @@ impl Plugin for InterpolationPlugin {
         app.register_disabling_component::<InterpolationPending>();
         configure_delayed_interpolated_despawn(app);
         app.add_observer(backfill_confirmed_histories_on_interpolated);
-        app.add_systems(
-            PreUpdate,
-            mark_replicated_interpolation_pending.after(ReplicationSystems::Receive),
-        );
+        app.add_systems(Last, mark_replicated_interpolation_pending);
 
         // Host-Clients have no interpolation delay
         app.register_required_components::<HostClient, InterpolationDelay>();
@@ -177,11 +195,14 @@ impl Plugin for InterpolationPlugin {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use bevy_app::PreUpdate;
+    use crate::registry::AppInterpolationExt;
+    use crate::rules::InterpolationFns;
+    use bevy_app::{PostUpdate, PreUpdate};
     use bevy_replicon::client::confirm_history::ConfirmHistory;
     use bevy_replicon::prelude::Remote;
     use bevy_replicon::prelude::RepliconTick;
     use lightyear_core::prelude::ConfirmedHistory;
+    use lightyear_replication::ReplicationSystems;
 
     #[derive(Component, Clone, PartialEq)]
     struct PendingTestComponent;
@@ -205,7 +226,18 @@ mod tests {
         was_pending: bool,
     }
 
+    #[derive(Resource, Default)]
+    struct ScheduleObservation {
+        update_count: usize,
+        post_update_count: usize,
+        last_count: usize,
+    }
+
     const SPAWN_TICK: Tick = Tick(10);
+
+    fn register_pending_test_history(app: &mut App) {
+        app.interpolate_with::<PendingTestComponent>(InterpolationFns::history_only());
+    }
 
     fn receive_interpolated_entity(mut commands: Commands, mut received: ResMut<ReceivedEntity>) {
         if received.0.is_none() {
@@ -249,6 +281,27 @@ mod tests {
         }
     }
 
+    fn observe_interpolated_in_update(
+        query: Query<Entity, With<Interpolated>>,
+        mut observation: ResMut<ScheduleObservation>,
+    ) {
+        observation.update_count = query.iter().count();
+    }
+
+    fn observe_interpolated_in_post_update(
+        query: Query<Entity, With<Interpolated>>,
+        mut observation: ResMut<ScheduleObservation>,
+    ) {
+        observation.post_update_count = query.iter().count();
+    }
+
+    fn observe_interpolated_after_pending(
+        query: Query<Entity, With<Interpolated>>,
+        mut observation: ResMut<ScheduleObservation>,
+    ) {
+        observation.last_count = query.iter().count();
+    }
+
     #[test]
     fn test_interpolation_delay() {
         let delay = InterpolationDelay {
@@ -271,15 +324,20 @@ mod tests {
         app.init_resource::<InterpolationRegistry>();
         app.init_resource::<ReceivedEntity>();
         app.init_resource::<InterpolatedAddObservation>();
+        app.init_resource::<ScheduleObservation>();
+        register_pending_test_history(&mut app);
         app.add_observer(backfill_confirmed_histories_on_interpolated);
         app.add_observer(observe_interpolated_add);
         app.add_systems(
             PreUpdate,
             receive_interpolated_entity.in_set(ReplicationSystems::Receive),
         );
+        app.add_systems(Update, observe_interpolated_in_update);
+        app.add_systems(PostUpdate, observe_interpolated_in_post_update);
+        app.add_systems(Last, mark_replicated_interpolation_pending);
         app.add_systems(
-            PreUpdate,
-            mark_replicated_interpolation_pending.after(ReplicationSystems::Receive),
+            Last,
+            observe_interpolated_after_pending.after(mark_replicated_interpolation_pending),
         );
 
         app.update();
@@ -288,6 +346,10 @@ mod tests {
         let observation = app.world().resource::<InterpolatedAddObservation>();
         assert_eq!(observation.count, 1);
         assert!(!observation.was_pending);
+        let schedule_observation = app.world().resource::<ScheduleObservation>();
+        assert_eq!(schedule_observation.update_count, 1);
+        assert_eq!(schedule_observation.post_update_count, 1);
+        assert_eq!(schedule_observation.last_count, 0);
         assert_eq!(
             app.world().entity(entity).get::<InterpolationPending>(),
             Some(&InterpolationPending {
@@ -318,6 +380,7 @@ mod tests {
         app.init_resource::<InterpolationRegistry>();
         app.init_resource::<ReceivedEntity>();
         app.init_resource::<ObserverAddedComponentObservation>();
+        register_pending_test_history(&mut app);
         app.add_observer(backfill_confirmed_histories_on_interpolated);
         app.add_observer(add_component_from_interpolated);
         app.add_observer(observe_added_component);
@@ -325,10 +388,7 @@ mod tests {
             PreUpdate,
             receive_interpolated_entity.in_set(ReplicationSystems::Receive),
         );
-        app.add_systems(
-            PreUpdate,
-            mark_replicated_interpolation_pending.after(ReplicationSystems::Receive),
-        );
+        app.add_systems(Last, mark_replicated_interpolation_pending);
 
         app.update();
 
@@ -350,15 +410,12 @@ mod tests {
     }
 
     #[test]
-    fn interpolation_pending_is_added_without_interpolation_history() {
+    fn historyless_replicated_interpolation_is_ready_immediately() {
         let mut app = App::new();
         app.register_disabling_component::<InterpolationPending>();
         app.init_resource::<InterpolationRegistry>();
         app.add_observer(backfill_confirmed_histories_on_interpolated);
-        app.add_systems(
-            PreUpdate,
-            mark_replicated_interpolation_pending.after(ReplicationSystems::Receive),
-        );
+        app.add_systems(Last, mark_replicated_interpolation_pending);
 
         let entity = app
             .world_mut()
@@ -370,11 +427,10 @@ mod tests {
 
         app.update();
 
-        assert_eq!(
-            app.world().entity(entity).get::<InterpolationPending>(),
-            Some(&InterpolationPending {
-                spawn_tick: SPAWN_TICK
-            })
+        assert!(
+            !app.world()
+                .entity(entity)
+                .contains::<InterpolationPending>()
         );
         assert!(
             !app.world()
@@ -385,7 +441,7 @@ mod tests {
         let mut default_query = app
             .world_mut()
             .query_filtered::<Entity, With<Interpolated>>();
-        assert_eq!(default_query.iter(app.world()).count(), 0);
+        assert_eq!(default_query.iter(app.world()).count(), 1);
     }
 
     #[test]
@@ -394,10 +450,7 @@ mod tests {
         app.register_disabling_component::<InterpolationPending>();
         app.init_resource::<InterpolationRegistry>();
         app.add_observer(backfill_confirmed_histories_on_interpolated);
-        app.add_systems(
-            PreUpdate,
-            mark_replicated_interpolation_pending.after(ReplicationSystems::Receive),
-        );
+        app.add_systems(Last, mark_replicated_interpolation_pending);
 
         let entity = app
             .world_mut()

--- a/crates/replication/interpolation/src/plugin.rs
+++ b/crates/replication/interpolation/src/plugin.rs
@@ -2,7 +2,7 @@ use crate::despawn::configure_delayed_interpolated_despawn;
 use crate::interpolate::{apply_interpolation, update_interpolation_history};
 use crate::registry::{InterpolationRegistry, finalize_interpolation_registry};
 use crate::timeline::TimelinePlugin;
-use bevy_app::{App, Plugin, PreUpdate, Update};
+use bevy_app::{App, Plugin, Update};
 use bevy_ecs::{
     component::Component,
     entity_disabling::Disabled,
@@ -10,11 +10,10 @@ use bevy_ecs::{
     schedule::{IntoScheduleConfigs, SystemSet},
 };
 use bevy_reflect::Reflect;
-use bevy_replicon::prelude::Remote;
 use lightyear_connection::host::HostClient;
 use lightyear_core::prelude::{Interpolated, InterpolationPending, Tick};
 use lightyear_core::time::PositiveTickDelta;
-use lightyear_replication::ReplicationSystems;
+use lightyear_replication::send::ReplicatedInterpolationStart;
 use lightyear_serde::reader::Reader;
 use lightyear_serde::writer::WriteInteger;
 use lightyear_serde::{SerializationError, ToBytes};
@@ -97,13 +96,29 @@ pub enum InterpolationSystems {
     All,
 }
 
-/// Backfills `ConfirmedHistory<C>` for registered interpolation rules when
-/// `Interpolated` is added after the live replicated component already exists.
-fn backfill_confirmed_histories_on_interpolated(
+/// Prepares an entity when [`Interpolated`] is added.
+///
+/// Histories are backfilled for both replicated and client-local additions. Only
+/// server-replicated additions carry [`ReplicatedInterpolationStart`] and enter
+/// the pending lifecycle.
+fn prepare_interpolated_entity(
     trigger: On<Add, Interpolated>,
     interpolation_registry: Res<InterpolationRegistry>,
+    replicated_starts: Query<
+        &ReplicatedInterpolationStart,
+        (Allow<Disabled>, Allow<InterpolationPending>),
+    >,
     mut commands: Commands,
 ) {
+    if let Ok(start) = replicated_starts.get(trigger.entity) {
+        commands
+            .entity(trigger.entity)
+            .insert(InterpolationPending {
+                spawn_tick: start.tick,
+            })
+            .remove::<ReplicatedInterpolationStart>();
+    }
+
     let Some(archetype) = trigger.trigger().new_archetype else {
         return;
     };
@@ -117,28 +132,6 @@ fn backfill_confirmed_histories_on_interpolated(
     }
 }
 
-/// Disable newly received interpolated entities after replication observers have run.
-///
-/// The marker is removed when interpolation first materializes a live component at the
-/// interpolation timeline. Explicitly allowing both disabling components keeps this lifecycle
-/// active when the application has independently disabled the entity.
-fn mark_interpolation_pending(
-    query: Query<
-        Entity,
-        (
-            Added<Interpolated>,
-            With<Remote>,
-            Allow<Disabled>,
-            Allow<InterpolationPending>,
-        ),
-    >,
-    mut commands: Commands,
-) {
-    for entity in &query {
-        commands.entity(entity).insert(InterpolationPending);
-    }
-}
-
 impl Plugin for InterpolationPlugin {
     fn build(&self, app: &mut App) {
         app.add_plugins(TimelinePlugin);
@@ -147,15 +140,7 @@ impl Plugin for InterpolationPlugin {
         app.init_resource::<InterpolationRegistry>();
         app.register_disabling_component::<InterpolationPending>();
         configure_delayed_interpolated_despawn(app);
-        app.add_observer(backfill_confirmed_histories_on_interpolated);
-
-        // Replicon buffers all initial component insertions into one structural change. Waiting
-        // until its receive set completes lets user On<Add, Interpolated> observers react before
-        // this entity is excluded by Bevy's default query filters.
-        app.add_systems(
-            PreUpdate,
-            mark_interpolation_pending.after(ReplicationSystems::Receive),
-        );
+        app.add_observer(prepare_interpolated_entity);
 
         // Host-Clients have no interpolation delay
         app.register_required_components::<HostClient, InterpolationDelay>();
@@ -187,6 +172,14 @@ impl Plugin for InterpolationPlugin {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bevy_app::PreUpdate;
+    use bevy_replicon::client::confirm_history::ConfirmHistory;
+    use bevy_replicon::prelude::Remote;
+    use bevy_replicon::prelude::RepliconTick;
+    use lightyear_core::prelude::ConfirmedHistory;
+
+    #[derive(Component, Clone, PartialEq)]
+    struct PendingTestComponent;
 
     #[derive(Resource, Default)]
     struct ReceivedEntity(Option<Entity>);
@@ -197,9 +190,20 @@ mod tests {
         was_pending: bool,
     }
 
+    const SPAWN_TICK: Tick = Tick(10);
+
     fn receive_interpolated_entity(mut commands: Commands, mut received: ResMut<ReceivedEntity>) {
         if received.0.is_none() {
-            received.0 = Some(commands.spawn((Interpolated, Remote)).id());
+            received.0 = Some(
+                commands
+                    .spawn((
+                        Interpolated,
+                        ReplicatedInterpolationStart { tick: SPAWN_TICK },
+                        Remote,
+                        ConfirmedHistory::<PendingTestComponent>::default(),
+                    ))
+                    .id(),
+            );
         }
     }
 
@@ -231,17 +235,12 @@ mod tests {
     fn interpolation_pending_is_added_after_receive_observers_run() {
         let mut app = App::new();
         app.register_disabling_component::<InterpolationPending>();
+        app.init_resource::<InterpolationRegistry>();
         app.init_resource::<ReceivedEntity>();
         app.init_resource::<InterpolatedAddObservation>();
+        app.add_observer(prepare_interpolated_entity);
         app.add_observer(observe_interpolated_add);
-        app.add_systems(
-            PreUpdate,
-            receive_interpolated_entity.in_set(ReplicationSystems::Receive),
-        );
-        app.add_systems(
-            PreUpdate,
-            mark_interpolation_pending.after(ReplicationSystems::Receive),
-        );
+        app.add_systems(PreUpdate, receive_interpolated_entity);
 
         app.update();
 
@@ -249,10 +248,16 @@ mod tests {
         let observation = app.world().resource::<InterpolatedAddObservation>();
         assert_eq!(observation.count, 1);
         assert!(!observation.was_pending);
+        assert_eq!(
+            app.world().entity(entity).get::<InterpolationPending>(),
+            Some(&InterpolationPending {
+                spawn_tick: SPAWN_TICK
+            })
+        );
         assert!(
-            app.world()
+            !app.world()
                 .entity(entity)
-                .contains::<InterpolationPending>()
+                .contains::<ReplicatedInterpolationStart>()
         );
 
         let mut default_query = app
@@ -267,16 +272,54 @@ mod tests {
     }
 
     #[test]
-    fn interpolation_pending_is_not_added_to_local_interpolated_entities() {
+    fn interpolation_pending_is_added_without_interpolation_history() {
         let mut app = App::new();
         app.register_disabling_component::<InterpolationPending>();
-        app.add_systems(
-            PreUpdate,
-            mark_interpolation_pending.after(ReplicationSystems::Receive),
+        app.init_resource::<InterpolationRegistry>();
+        app.add_observer(prepare_interpolated_entity);
+
+        let entity = app
+            .world_mut()
+            .spawn((
+                Interpolated,
+                ReplicatedInterpolationStart { tick: SPAWN_TICK },
+            ))
+            .id();
+
+        assert_eq!(
+            app.world().entity(entity).get::<InterpolationPending>(),
+            Some(&InterpolationPending {
+                spawn_tick: SPAWN_TICK
+            })
+        );
+        assert!(
+            !app.world()
+                .entity(entity)
+                .contains::<ReplicatedInterpolationStart>()
         );
 
-        let entity = app.world_mut().spawn(Interpolated).id();
-        app.update();
+        let mut default_query = app
+            .world_mut()
+            .query_filtered::<Entity, With<Interpolated>>();
+        assert_eq!(default_query.iter(app.world()).count(), 0);
+    }
+
+    #[test]
+    fn interpolation_pending_is_not_added_when_client_marks_remote_entity_interpolated() {
+        let mut app = App::new();
+        app.register_disabling_component::<InterpolationPending>();
+        app.init_resource::<InterpolationRegistry>();
+        app.add_observer(prepare_interpolated_entity);
+
+        let entity = app
+            .world_mut()
+            .spawn((
+                Remote,
+                ConfirmHistory::new(RepliconTick::new(1)),
+                PendingTestComponent,
+            ))
+            .id();
+        app.world_mut().entity_mut(entity).insert(Interpolated);
 
         assert!(
             !app.world()

--- a/crates/replication/interpolation/src/plugin.rs
+++ b/crates/replication/interpolation/src/plugin.rs
@@ -2,7 +2,7 @@ use crate::despawn::configure_delayed_interpolated_despawn;
 use crate::interpolate::{apply_interpolation, update_interpolation_history};
 use crate::registry::{InterpolationRegistry, finalize_interpolation_registry};
 use crate::timeline::TimelinePlugin;
-use bevy_app::{App, Plugin, Update};
+use bevy_app::{App, Plugin, PreUpdate, Update};
 use bevy_ecs::{
     component::Component,
     entity_disabling::Disabled,
@@ -13,7 +13,7 @@ use bevy_reflect::Reflect;
 use lightyear_connection::host::HostClient;
 use lightyear_core::prelude::{Interpolated, InterpolationPending, Tick};
 use lightyear_core::time::PositiveTickDelta;
-use lightyear_replication::send::ReplicatedInterpolationStart;
+use lightyear_replication::{ReplicationSystems, send::ReplicatedInterpolationStart};
 use lightyear_serde::reader::Reader;
 use lightyear_serde::writer::WriteInteger;
 use lightyear_serde::{SerializationError, ToBytes};
@@ -96,29 +96,12 @@ pub enum InterpolationSystems {
     All,
 }
 
-/// Prepares an entity when [`Interpolated`] is added.
-///
-/// Histories are backfilled for both replicated and client-local additions. Only
-/// server-replicated additions carry [`ReplicatedInterpolationStart`] and enter
-/// the pending lifecycle.
-fn prepare_interpolated_entity(
+/// Backfills histories when [`Interpolated`] is added, including client-local additions.
+fn backfill_confirmed_histories_on_interpolated(
     trigger: On<Add, Interpolated>,
     interpolation_registry: Res<InterpolationRegistry>,
-    replicated_starts: Query<
-        &ReplicatedInterpolationStart,
-        (Allow<Disabled>, Allow<InterpolationPending>),
-    >,
     mut commands: Commands,
 ) {
-    if let Ok(start) = replicated_starts.get(trigger.entity) {
-        commands
-            .entity(trigger.entity)
-            .insert(InterpolationPending {
-                spawn_tick: start.tick,
-            })
-            .remove::<ReplicatedInterpolationStart>();
-    }
-
     let Some(archetype) = trigger.trigger().new_archetype else {
         return;
     };
@@ -132,6 +115,24 @@ fn prepare_interpolated_entity(
     }
 }
 
+/// Disables newly replicated interpolated entities after replication observers finish.
+fn mark_replicated_interpolation_pending(
+    replicated_starts: Query<
+        (Entity, &ReplicatedInterpolationStart),
+        (Allow<Disabled>, Allow<InterpolationPending>),
+    >,
+    mut commands: Commands,
+) {
+    for (entity, start) in &replicated_starts {
+        commands
+            .entity(entity)
+            .insert(InterpolationPending {
+                spawn_tick: start.tick,
+            })
+            .remove::<ReplicatedInterpolationStart>();
+    }
+}
+
 impl Plugin for InterpolationPlugin {
     fn build(&self, app: &mut App) {
         app.add_plugins(TimelinePlugin);
@@ -140,7 +141,11 @@ impl Plugin for InterpolationPlugin {
         app.init_resource::<InterpolationRegistry>();
         app.register_disabling_component::<InterpolationPending>();
         configure_delayed_interpolated_despawn(app);
-        app.add_observer(prepare_interpolated_entity);
+        app.add_observer(backfill_confirmed_histories_on_interpolated);
+        app.add_systems(
+            PreUpdate,
+            mark_replicated_interpolation_pending.after(ReplicationSystems::Receive),
+        );
 
         // Host-Clients have no interpolation delay
         app.register_required_components::<HostClient, InterpolationDelay>();
@@ -190,6 +195,16 @@ mod tests {
         was_pending: bool,
     }
 
+    #[derive(Component)]
+    struct ObserverAddedComponent;
+
+    #[derive(Resource, Default)]
+    struct ObserverAddedComponentObservation {
+        count: usize,
+        query_matched: bool,
+        was_pending: bool,
+    }
+
     const SPAWN_TICK: Tick = Tick(10);
 
     fn receive_interpolated_entity(mut commands: Commands, mut received: ResMut<ReceivedEntity>) {
@@ -216,6 +231,24 @@ mod tests {
         observation.was_pending = pending.get(trigger.entity).unwrap_or_default();
     }
 
+    fn add_component_from_interpolated(trigger: On<Add, Interpolated>, mut commands: Commands) {
+        commands
+            .entity(trigger.entity)
+            .insert(ObserverAddedComponent);
+    }
+
+    fn observe_added_component(
+        trigger: On<Add, ObserverAddedComponent>,
+        pending: Query<Has<InterpolationPending>>,
+        mut observation: ResMut<ObserverAddedComponentObservation>,
+    ) {
+        observation.count += 1;
+        if let Ok(was_pending) = pending.get(trigger.entity) {
+            observation.query_matched = true;
+            observation.was_pending = was_pending;
+        }
+    }
+
     #[test]
     fn test_interpolation_delay() {
         let delay = InterpolationDelay {
@@ -238,9 +271,16 @@ mod tests {
         app.init_resource::<InterpolationRegistry>();
         app.init_resource::<ReceivedEntity>();
         app.init_resource::<InterpolatedAddObservation>();
-        app.add_observer(prepare_interpolated_entity);
+        app.add_observer(backfill_confirmed_histories_on_interpolated);
         app.add_observer(observe_interpolated_add);
-        app.add_systems(PreUpdate, receive_interpolated_entity);
+        app.add_systems(
+            PreUpdate,
+            receive_interpolated_entity.in_set(ReplicationSystems::Receive),
+        );
+        app.add_systems(
+            PreUpdate,
+            mark_replicated_interpolation_pending.after(ReplicationSystems::Receive),
+        );
 
         app.update();
 
@@ -272,11 +312,53 @@ mod tests {
     }
 
     #[test]
+    fn interpolation_pending_is_added_after_chained_add_observers_run() {
+        let mut app = App::new();
+        app.register_disabling_component::<InterpolationPending>();
+        app.init_resource::<InterpolationRegistry>();
+        app.init_resource::<ReceivedEntity>();
+        app.init_resource::<ObserverAddedComponentObservation>();
+        app.add_observer(backfill_confirmed_histories_on_interpolated);
+        app.add_observer(add_component_from_interpolated);
+        app.add_observer(observe_added_component);
+        app.add_systems(
+            PreUpdate,
+            receive_interpolated_entity.in_set(ReplicationSystems::Receive),
+        );
+        app.add_systems(
+            PreUpdate,
+            mark_replicated_interpolation_pending.after(ReplicationSystems::Receive),
+        );
+
+        app.update();
+
+        let entity = app.world().resource::<ReceivedEntity>().0.unwrap();
+        let observation = app.world().resource::<ObserverAddedComponentObservation>();
+        assert_eq!(observation.count, 1);
+        assert!(observation.query_matched);
+        assert!(!observation.was_pending);
+        assert!(
+            app.world()
+                .entity(entity)
+                .contains::<ObserverAddedComponent>()
+        );
+        assert!(
+            app.world()
+                .entity(entity)
+                .contains::<InterpolationPending>()
+        );
+    }
+
+    #[test]
     fn interpolation_pending_is_added_without_interpolation_history() {
         let mut app = App::new();
         app.register_disabling_component::<InterpolationPending>();
         app.init_resource::<InterpolationRegistry>();
-        app.add_observer(prepare_interpolated_entity);
+        app.add_observer(backfill_confirmed_histories_on_interpolated);
+        app.add_systems(
+            PreUpdate,
+            mark_replicated_interpolation_pending.after(ReplicationSystems::Receive),
+        );
 
         let entity = app
             .world_mut()
@@ -285,6 +367,8 @@ mod tests {
                 ReplicatedInterpolationStart { tick: SPAWN_TICK },
             ))
             .id();
+
+        app.update();
 
         assert_eq!(
             app.world().entity(entity).get::<InterpolationPending>(),
@@ -309,7 +393,11 @@ mod tests {
         let mut app = App::new();
         app.register_disabling_component::<InterpolationPending>();
         app.init_resource::<InterpolationRegistry>();
-        app.add_observer(prepare_interpolated_entity);
+        app.add_observer(backfill_confirmed_histories_on_interpolated);
+        app.add_systems(
+            PreUpdate,
+            mark_replicated_interpolation_pending.after(ReplicationSystems::Receive),
+        );
 
         let entity = app
             .world_mut()
@@ -320,6 +408,8 @@ mod tests {
             ))
             .id();
         app.world_mut().entity_mut(entity).insert(Interpolated);
+
+        app.update();
 
         assert!(
             !app.world()

--- a/crates/replication/interpolation/src/plugin.rs
+++ b/crates/replication/interpolation/src/plugin.rs
@@ -2,7 +2,6 @@ use crate::despawn::configure_delayed_interpolated_despawn;
 use crate::interpolate::{apply_interpolation, update_interpolation_history};
 use crate::registry::{InterpolationRegistry, finalize_interpolation_registry};
 use crate::timeline::TimelinePlugin;
-use alloc::vec::Vec;
 use bevy_app::{App, Last, Plugin, Update};
 use bevy_ecs::{
     component::Component,
@@ -117,41 +116,22 @@ fn backfill_confirmed_histories_on_interpolated(
 }
 
 /// After app and engine response systems finish, disables newly replicated
-/// entities whose interpolated component histories are not ready yet.
+/// interpolated entities until their spawn tick is reached.
 fn mark_replicated_interpolation_pending(
     replicated_starts: Query<
         (Entity, &ReplicatedInterpolationStart),
-        (
-            With<ReplicatedInterpolationStart>,
-            Allow<Disabled>,
-            Allow<InterpolationPending>,
-        ),
+        (Allow<Disabled>, Allow<InterpolationPending>),
     >,
-    interpolation_registry: Res<InterpolationRegistry>,
     mut commands: Commands,
 ) {
-    let history_component_ids = interpolation_registry
-        .confirmed_history_backfill_fns()
-        .map(|(_, history_component_id, _)| history_component_id)
-        .collect::<Vec<_>>();
-    let starts = replicated_starts
-        .iter()
-        .map(|(entity, start)| (entity, start.tick))
-        .collect::<Vec<_>>();
-    commands.queue(move |world: &mut World| {
-        for (entity, spawn_tick) in starts {
-            let Ok(mut entity) = world.get_entity_mut(entity) else {
-                continue;
-            };
-            if history_component_ids
-                .iter()
-                .any(|component_id| entity.contains_id(*component_id))
-            {
-                entity.insert(InterpolationPending { spawn_tick });
-            }
-            entity.remove::<ReplicatedInterpolationStart>();
-        }
-    });
+    for (entity, start) in &replicated_starts {
+        commands
+            .entity(entity)
+            .insert(InterpolationPending {
+                spawn_tick: start.tick,
+            })
+            .remove::<ReplicatedInterpolationStart>();
+    }
 }
 
 impl Plugin for InterpolationPlugin {
@@ -163,6 +143,10 @@ impl Plugin for InterpolationPlugin {
         app.register_disabling_component::<InterpolationPending>();
         configure_delayed_interpolated_despawn(app);
         app.add_observer(backfill_confirmed_histories_on_interpolated);
+        // Keep the entity enabled through component-add observer chains and
+        // PostUpdate engine response systems such as visibility propagation.
+        // Last still runs before render extraction, so the entity cannot render
+        // before its interpolation timeline reaches the replicated spawn tick.
         app.add_systems(Last, mark_replicated_interpolation_pending);
 
         // Host-Clients have no interpolation delay
@@ -195,16 +179,13 @@ impl Plugin for InterpolationPlugin {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::registry::AppInterpolationExt;
-    use crate::rules::InterpolationFns;
     use bevy_app::{PostUpdate, PreUpdate};
     use bevy_replicon::client::confirm_history::ConfirmHistory;
     use bevy_replicon::prelude::Remote;
     use bevy_replicon::prelude::RepliconTick;
-    use lightyear_core::prelude::ConfirmedHistory;
     use lightyear_replication::ReplicationSystems;
 
-    #[derive(Component, Clone, PartialEq)]
+    #[derive(Component)]
     struct PendingTestComponent;
 
     #[derive(Resource, Default)]
@@ -235,10 +216,6 @@ mod tests {
 
     const SPAWN_TICK: Tick = Tick(10);
 
-    fn register_pending_test_history(app: &mut App) {
-        app.interpolate_with::<PendingTestComponent>(InterpolationFns::history_only());
-    }
-
     fn receive_interpolated_entity(mut commands: Commands, mut received: ResMut<ReceivedEntity>) {
         if received.0.is_none() {
             received.0 = Some(
@@ -247,7 +224,6 @@ mod tests {
                         Interpolated,
                         ReplicatedInterpolationStart { tick: SPAWN_TICK },
                         Remote,
-                        ConfirmedHistory::<PendingTestComponent>::default(),
                     ))
                     .id(),
             );
@@ -321,12 +297,9 @@ mod tests {
     fn interpolation_pending_is_added_after_receive_observers_run() {
         let mut app = App::new();
         app.register_disabling_component::<InterpolationPending>();
-        app.init_resource::<InterpolationRegistry>();
         app.init_resource::<ReceivedEntity>();
         app.init_resource::<InterpolatedAddObservation>();
         app.init_resource::<ScheduleObservation>();
-        register_pending_test_history(&mut app);
-        app.add_observer(backfill_confirmed_histories_on_interpolated);
         app.add_observer(observe_interpolated_add);
         app.add_systems(
             PreUpdate,
@@ -377,11 +350,8 @@ mod tests {
     fn interpolation_pending_is_added_after_chained_add_observers_run() {
         let mut app = App::new();
         app.register_disabling_component::<InterpolationPending>();
-        app.init_resource::<InterpolationRegistry>();
         app.init_resource::<ReceivedEntity>();
         app.init_resource::<ObserverAddedComponentObservation>();
-        register_pending_test_history(&mut app);
-        app.add_observer(backfill_confirmed_histories_on_interpolated);
         app.add_observer(add_component_from_interpolated);
         app.add_observer(observe_added_component);
         app.add_systems(
@@ -410,11 +380,9 @@ mod tests {
     }
 
     #[test]
-    fn historyless_replicated_interpolation_is_ready_immediately() {
+    fn historyless_replicated_interpolation_is_pending_until_spawn_tick() {
         let mut app = App::new();
         app.register_disabling_component::<InterpolationPending>();
-        app.init_resource::<InterpolationRegistry>();
-        app.add_observer(backfill_confirmed_histories_on_interpolated);
         app.add_systems(Last, mark_replicated_interpolation_pending);
 
         let entity = app
@@ -427,10 +395,11 @@ mod tests {
 
         app.update();
 
-        assert!(
-            !app.world()
-                .entity(entity)
-                .contains::<InterpolationPending>()
+        assert_eq!(
+            app.world().entity(entity).get::<InterpolationPending>(),
+            Some(&InterpolationPending {
+                spawn_tick: SPAWN_TICK
+            })
         );
         assert!(
             !app.world()
@@ -441,15 +410,13 @@ mod tests {
         let mut default_query = app
             .world_mut()
             .query_filtered::<Entity, With<Interpolated>>();
-        assert_eq!(default_query.iter(app.world()).count(), 1);
+        assert_eq!(default_query.iter(app.world()).count(), 0);
     }
 
     #[test]
     fn interpolation_pending_is_not_added_when_client_marks_remote_entity_interpolated() {
         let mut app = App::new();
         app.register_disabling_component::<InterpolationPending>();
-        app.init_resource::<InterpolationRegistry>();
-        app.add_observer(backfill_confirmed_histories_on_interpolated);
         app.add_systems(Last, mark_replicated_interpolation_pending);
 
         let entity = app

--- a/crates/replication/interpolation/src/registry.rs
+++ b/crates/replication/interpolation/src/registry.rs
@@ -1401,9 +1401,12 @@ pub trait InterpolationRegistrationExt<'a, C>: ComponentRegistrator<'a, C> {
     where
         C: SyncComponent + RepliconDiffable + Ease;
 
-    /// The remote updates will be stored in a [`ConfirmedHistory<C>`] component
-    /// but the user has to define the interpolation logic themselves
-    /// (`lightyear` won't perform any kind of interpolation)
+    /// Store remote updates in [`ConfirmedHistory<C>`] and manage delayed
+    /// component presence without interpolating an already-present component.
+    ///
+    /// Lightyear inserts the exact history value when its add tick reaches the
+    /// interpolation timeline. The user owns any subsequent changes to the live
+    /// component.
     fn add_custom_interpolation(self) -> Self
     where
         C: SyncComponent;

--- a/crates/replication/interpolation/src/rules.rs
+++ b/crates/replication/interpolation/src/rules.rs
@@ -305,12 +305,16 @@ impl<C> InterpolationFns<C> {
         }
     }
 
-    /// Stores and prepares interpolation history, but does not apply `C`.
+    /// Stores and prepares interpolation history and manages delayed component
+    /// presence, but does not interpolate an already-present `C`.
     ///
     /// Use this when Lightyear should receive component updates into
-    /// [`ConfirmedHistory<C>`](lightyear_core::prelude::ConfirmedHistory), but visible interpolation is handled by a user
-    /// system. For example, a system may sample several histories and write a
-    /// render-only component.
+    /// [`ConfirmedHistory<C>`](lightyear_core::prelude::ConfirmedHistory). When
+    /// the component's add tick reaches the interpolation timeline, Lightyear
+    /// inserts that exact history value. Subsequent visible interpolation is
+    /// handled by a user system. For example, a system may sample several
+    /// histories and write a render-only component, or advance local
+    /// presentation state from the exact replicated starting value.
     ///
     /// # Examples
     ///

--- a/crates/replication/replication/src/deferred_entity.rs
+++ b/crates/replication/replication/src/deferred_entity.rs
@@ -2,6 +2,7 @@
 
 use alloc::{boxed::Box, vec::Vec};
 use bevy_ecs::{
+    change_detection::DetectChangesMut,
     component::Component,
     entity::{Entity, EntityHashMap},
     system::Commands,
@@ -16,6 +17,7 @@ type ApplyDeferredEntityCommand =
 struct DeferredEntityMutations {
     commands: Vec<ApplyDeferredEntityCommand>,
     removals: Vec<TypeId>,
+    mark_all_changed: bool,
 }
 
 /// Batched structural changes for multiple entities.
@@ -76,6 +78,15 @@ impl DeferredEntityCommands {
         }));
     }
 
+    /// Marks every existing mutable component on `entity` as changed.
+    ///
+    /// This is useful when removing a disabling component: changed-only systems did not see the
+    /// entity while it was disabled, so they need to revisit its existing components once it is
+    /// enabled. Components buffered for insertion are already marked changed by their insertion.
+    pub fn mark_all_changed(&mut self, entity: Entity) {
+        self.entities.entry(entity).or_default().mark_all_changed = true;
+    }
+
     /// Queues a Bevy command that applies all deferred mutations.
     pub fn apply(self, commands: &mut Commands) {
         if self.entities.is_empty() {
@@ -92,6 +103,21 @@ impl DeferredEntityCommands {
                     mutation(&mut deferred);
                 }
                 deferred.flush();
+
+                if mutations.mark_all_changed {
+                    let Ok(mut entity_mut) = world.get_entity_mut(entity) else {
+                        continue;
+                    };
+                    // Copy one ID at a time so no temporary component-ID collection is needed.
+                    // Marking a component as changed cannot alter the entity's archetype.
+                    let component_count = entity_mut.archetype().components().len();
+                    for index in 0..component_count {
+                        let component_id = entity_mut.archetype().components()[index];
+                        if let Ok(mut component) = entity_mut.get_mut_by_id(component_id) {
+                            component.set_changed();
+                        }
+                    }
+                }
             }
         });
     }

--- a/crates/replication/replication/src/send.rs
+++ b/crates/replication/replication/src/send.rs
@@ -482,8 +482,8 @@ mod interpolation {
     /// Transient component added when [`Interpolated`] is inserted by replication.
     /// Used to add [`InterpolationPending`] to the entity.
     ///
-    /// [`InterpolationPending`] is not added directly so that observers that
-    /// react on Add<Interpolated> can still fire.
+    /// [`InterpolationPending`] is not added directly so that replication-time
+    /// component-add observer command chains complete before the entity is disabled.
     #[doc(hidden)]
     #[derive(Component, Clone, Copy, Debug, PartialEq, Eq)]
     pub struct ReplicatedInterpolationStart {

--- a/crates/replication/replication/src/send.rs
+++ b/crates/replication/replication/src/send.rs
@@ -480,7 +480,7 @@ mod interpolation {
     pub struct InterpolatedSend;
 
     /// Transient component added when [`Interpolated`] is inserted by replication.
-    /// Used to determine whether the entity needs [`InterpolationPending`].
+    /// Carries the authoritative spawn tick into [`InterpolationPending`].
     ///
     /// [`InterpolationPending`] is not added directly so that component-add
     /// observer chains and downstream engine response systems complete before

--- a/crates/replication/replication/src/send.rs
+++ b/crates/replication/replication/src/send.rs
@@ -461,11 +461,13 @@ mod prediction {
 #[cfg(feature = "interpolation")]
 mod interpolation {
     use super::*;
+    use crate::checkpoint::{ReplicationCheckpointMap, resolve_message_tick};
     use bevy_replicon::bytes::Bytes;
     use bevy_replicon::prelude::RuleFns;
     use bevy_replicon::shared::replication::deferred_entity::DeferredEntity;
     use bevy_replicon::shared::replication::registry::ctx::{RemoveCtx, WriteCtx};
     use lightyear_core::interpolation::Interpolated;
+    use lightyear_core::tick::Tick;
 
     /// Sender-side marker that materializes as [`Interpolated`] on the receiver.
     ///
@@ -476,6 +478,19 @@ mod interpolation {
         Component, Clone, Copy, Debug, Default, PartialEq, Reflect, Serialize, Deserialize,
     )]
     pub struct InterpolatedSend;
+
+    /// Transient component added when [`Interpolated`] is inserted by replication.
+    /// Used to add [`InterpolationPending`] to the entity.
+    ///
+    /// [`InterpolationPending`] is not added directly so that observers that
+    /// react on Add<Interpolated> can still fire.
+    #[doc(hidden)]
+    #[derive(Component, Clone, Copy, Debug, PartialEq, Eq)]
+    pub struct ReplicatedInterpolationStart {
+        /// Authoritative tick carried by the replication message that added
+        /// [`Interpolated`].
+        pub tick: Tick,
+    }
 
     /// Controls which clients run server-authoritative interpolation for this entity.
     ///
@@ -533,11 +548,29 @@ mod interpolation {
     ) -> bevy_ecs::error::Result<()> {
         let _ = rule_fns.deserialize(ctx, message)?;
         entity.insert(Interpolated);
+        let Some(tick) = entity
+            .world()
+            .get_resource::<ReplicationCheckpointMap>()
+            .and_then(|checkpoints| resolve_message_tick(checkpoints, ctx.message_tick))
+        else {
+            error!(
+                entity = ?ctx.entity,
+                message_tick = ?ctx.message_tick,
+                "missing authoritative checkpoint mapping for replicated interpolation start"
+            );
+            debug_assert!(
+                false,
+                "missing authoritative checkpoint mapping for replicated interpolation start"
+            );
+            return Ok(());
+        };
+        entity.insert(ReplicatedInterpolationStart { tick });
         Ok(())
     }
 
     pub(crate) fn remove_interpolated(_ctx: &mut RemoveCtx, entity: &mut DeferredEntity) {
         entity.remove::<Interpolated>();
+        entity.remove::<ReplicatedInterpolationStart>();
     }
 
     /// Component-level visibility for [`InterpolatedSend`].

--- a/crates/replication/replication/src/send.rs
+++ b/crates/replication/replication/src/send.rs
@@ -480,10 +480,11 @@ mod interpolation {
     pub struct InterpolatedSend;
 
     /// Transient component added when [`Interpolated`] is inserted by replication.
-    /// Used to add [`InterpolationPending`] to the entity.
+    /// Used to determine whether the entity needs [`InterpolationPending`].
     ///
-    /// [`InterpolationPending`] is not added directly so that replication-time
-    /// component-add observer command chains complete before the entity is disabled.
+    /// [`InterpolationPending`] is not added directly so that component-add
+    /// observer chains and downstream engine response systems complete before
+    /// the entity is disabled at the end of the receive frame.
     #[doc(hidden)]
     #[derive(Component, Clone, Copy, Debug, PartialEq, Eq)]
     pub struct ReplicatedInterpolationStart {

--- a/demos/projectiles/src/protocol.rs
+++ b/demos/projectiles/src/protocol.rs
@@ -21,7 +21,10 @@ use crate::representation::{
 };
 use crate::shared::{DespawnAtTick, ProjectileFireTick};
 use crate::timeline::TimelinePolicy;
-use crate::trajectory::{TrajectoryKind, hitscan::HitscanVisual};
+use crate::trajectory::{
+    TrajectoryKind,
+    hitscan::{HitscanVisual, interpolate_visual},
+};
 
 pub const BULLET_SIZE: f32 = 3.0;
 
@@ -159,6 +162,7 @@ impl Plugin for ProtocolPlugin {
         app.component::<HitscanVisual>()
             .replicate()
             .predict()
+            .add_interpolation_with(interpolate_visual)
             .with_rollback_condition(hitscan_geometry_should_rollback);
         // The fire-data parent itself is the owner's prespawned predicted
         // entity. Tracking its immutable firing facts lets authoritative data

--- a/demos/projectiles/src/protocol.rs
+++ b/demos/projectiles/src/protocol.rs
@@ -159,6 +159,10 @@ impl Plugin for ProtocolPlugin {
         app.component::<HitscanVisual>()
             .replicate()
             .predict()
+            // Preserve exact server samples and materialize the visual when its
+            // add tick reaches the interpolation timeline. The local update
+            // system owns the presentation lifetime, so no lerp is needed.
+            .add_custom_interpolation()
             .with_rollback_condition(hitscan_geometry_should_rollback);
         // The fire-data parent itself is the owner's prespawned predicted
         // entity. Tracking its immutable firing facts lets authoritative data

--- a/demos/projectiles/src/protocol.rs
+++ b/demos/projectiles/src/protocol.rs
@@ -21,10 +21,7 @@ use crate::representation::{
 };
 use crate::shared::{DespawnAtTick, ProjectileFireTick};
 use crate::timeline::TimelinePolicy;
-use crate::trajectory::{
-    TrajectoryKind,
-    hitscan::{HitscanVisual, interpolate_visual},
-};
+use crate::trajectory::{TrajectoryKind, hitscan::HitscanVisual};
 
 pub const BULLET_SIZE: f32 = 3.0;
 
@@ -162,7 +159,6 @@ impl Plugin for ProtocolPlugin {
         app.component::<HitscanVisual>()
             .replicate()
             .predict()
-            .add_interpolation_with(interpolate_visual)
             .with_rollback_condition(hitscan_geometry_should_rollback);
         // The fire-data parent itself is the owner's prespawned predicted
         // entity. Tracking its immutable firing facts lets authoritative data

--- a/demos/projectiles/src/renderer.rs
+++ b/demos/projectiles/src/renderer.rs
@@ -21,13 +21,9 @@ impl Plugin for ExampleRendererPlugin {
     fn build(&self, app: &mut App) {
         app.add_systems(Startup, init);
 
-        // Catch-up queries defer render setup while InterpolationPending disables
-        // a replicated entity. Adding Visibility from lifecycle observers would
-        // let Bevy's visibility propagation miss the component while disabled.
-        app.add_systems(
-            Update,
-            (add_player_visuals, add_bullet_visuals, add_hitscan_visual),
-        );
+        app.add_observer(add_bullet_visuals);
+        app.add_systems(Update, add_player_visuals);
+        app.add_observer(add_hitscan_visual);
         app.add_systems(PostUpdate, draw_hit_impacts);
 
         if !app.is_plugin_added::<FrameInterpolationPlugin>() {
@@ -331,11 +327,12 @@ fn add_player_visuals(
     }
 }
 
-/// Add visuals once a bullet is active on its presentation timeline.
+/// Add visuals to newly spawned bullets
 fn add_bullet_visuals(
+    trigger: On<Add, (Position, Rotation)>,
     // Hitscan are rendered differently
     query: Query<
-        (Entity, &ColorComponent, Has<Interpolated>),
+        (&ColorComponent, Has<Interpolated>),
         (
             Without<HitscanVisual>,
             With<Position>,
@@ -348,8 +345,8 @@ fn add_bullet_visuals(
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<ColorMaterial>>,
 ) {
-    for (entity, color, interpolated) in &query {
-        commands.entity(entity).insert((
+    if let Ok((color, interpolated)) = query.get(trigger.entity) {
+        commands.entity(trigger.entity).insert((
             Visibility::default(),
             Mesh2d(meshes.add(Mesh::from(Circle {
                 radius: BULLET_SIZE,
@@ -362,110 +359,23 @@ fn add_bullet_visuals(
         // if not interpolated, then the entity gets updated in FixedUpdate and needs
         // FrameInterpolation to be smooth
         if !interpolated {
-            commands.entity(entity).insert(FrameInterpolate);
+            commands.entity(trigger.entity).insert(FrameInterpolate);
         }
     }
 }
 
-/// Add visuals once a hitscan is active on its presentation timeline.
+/// Add visuals to hitscan effects
 fn add_hitscan_visual(
-    query: Query<
-        Entity,
-        (
-            With<HitscanVisual>,
-            With<ColorComponent>,
-            Without<Visibility>,
-        ),
-    >,
+    trigger: On<Add, HitscanVisual>,
+    query: Query<(&HitscanVisual, &ColorComponent)>,
     mut commands: Commands,
 ) {
-    for entity in &query {
+    if let Ok((visual, color)) = query.get(trigger.entity) {
         // For now, we'll use gizmos to draw the line in a separate system
         // This is a simple implementation; in a real game you might want
         // more sophisticated line rendering
         commands
-            .entity(entity)
+            .entity(trigger.entity)
             .insert((Visibility::default(), Name::new("HitscanLine")));
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use bevy::camera::visibility::VisibilityPlugin;
-    use bevy::mesh::skinning::SkinnedMeshInverseBindposes;
-
-    fn setup_app() -> App {
-        let mut app = App::new();
-        app.init_resource::<Assets<Mesh>>();
-        app.init_resource::<Assets<ColorMaterial>>();
-        app.init_resource::<Assets<SkinnedMeshInverseBindposes>>();
-        app.register_disabling_component::<InterpolationPending>();
-        app.add_plugins(VisibilityPlugin);
-        app.add_systems(Update, (add_bullet_visuals, add_hitscan_visual));
-        app
-    }
-
-    #[test]
-    fn interpolated_bullet_visual_is_added_only_after_pending_is_removed() {
-        let mut app = setup_app();
-        let entity = app
-            .world_mut()
-            .spawn((
-                BulletMarker {
-                    shooter: PeerId::Local(1),
-                },
-                ColorComponent(Color::WHITE),
-                Position(Vec2::ZERO),
-                Rotation::default(),
-                Interpolated,
-                InterpolationPending {
-                    spawn_tick: Tick(10),
-                },
-            ))
-            .id();
-
-        app.update();
-        assert!(!app.world().entity(entity).contains::<Mesh2d>());
-
-        app.world_mut()
-            .entity_mut(entity)
-            .remove::<InterpolationPending>();
-        app.update();
-
-        let entity_ref = app.world().entity(entity);
-        assert!(entity_ref.contains::<Mesh2d>());
-        assert!(entity_ref.contains::<Visibility>());
-        assert!(entity_ref.get::<InheritedVisibility>().unwrap().get());
-        assert!(!entity_ref.contains::<FrameInterpolate>());
-    }
-
-    #[test]
-    fn interpolated_hitscan_visual_is_added_only_after_pending_is_removed() {
-        let mut app = setup_app();
-        let entity = app
-            .world_mut()
-            .spawn((
-                BulletMarker {
-                    shooter: PeerId::Local(1),
-                },
-                ColorComponent(Color::WHITE),
-                HitscanVisual::new(Vec2::ZERO, Rotation::default(), 0.5),
-                Interpolated,
-                InterpolationPending {
-                    spawn_tick: Tick(10),
-                },
-            ))
-            .id();
-
-        app.update();
-        assert!(!app.world().entity(entity).contains::<Visibility>());
-
-        app.world_mut()
-            .entity_mut(entity)
-            .remove::<InterpolationPending>();
-        app.update();
-
-        assert!(app.world().entity(entity).contains::<Visibility>());
     }
 }

--- a/demos/projectiles/src/renderer.rs
+++ b/demos/projectiles/src/renderer.rs
@@ -21,9 +21,13 @@ impl Plugin for ExampleRendererPlugin {
     fn build(&self, app: &mut App) {
         app.add_systems(Startup, init);
 
-        app.add_observer(add_bullet_visuals);
-        app.add_systems(Update, add_player_visuals);
-        app.add_observer(add_hitscan_visual);
+        // Catch-up queries defer render setup while InterpolationPending disables
+        // a replicated entity. Adding Visibility from lifecycle observers would
+        // let Bevy's visibility propagation miss the component while disabled.
+        app.add_systems(
+            Update,
+            (add_player_visuals, add_bullet_visuals, add_hitscan_visual),
+        );
         app.add_systems(PostUpdate, draw_hit_impacts);
 
         if !app.is_plugin_added::<FrameInterpolationPlugin>() {
@@ -327,12 +331,11 @@ fn add_player_visuals(
     }
 }
 
-/// Add visuals to newly spawned bullets
+/// Add visuals once a bullet is active on its presentation timeline.
 fn add_bullet_visuals(
-    trigger: On<Add, (Position, Rotation)>,
     // Hitscan are rendered differently
     query: Query<
-        (&ColorComponent, Has<Interpolated>),
+        (Entity, &ColorComponent, Has<Interpolated>),
         (
             Without<HitscanVisual>,
             With<Position>,
@@ -345,8 +348,8 @@ fn add_bullet_visuals(
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<ColorMaterial>>,
 ) {
-    if let Ok((color, interpolated)) = query.get(trigger.entity) {
-        commands.entity(trigger.entity).insert((
+    for (entity, color, interpolated) in &query {
+        commands.entity(entity).insert((
             Visibility::default(),
             Mesh2d(meshes.add(Mesh::from(Circle {
                 radius: BULLET_SIZE,
@@ -359,23 +362,110 @@ fn add_bullet_visuals(
         // if not interpolated, then the entity gets updated in FixedUpdate and needs
         // FrameInterpolation to be smooth
         if !interpolated {
-            commands.entity(trigger.entity).insert(FrameInterpolate);
+            commands.entity(entity).insert(FrameInterpolate);
         }
     }
 }
 
-/// Add visuals to hitscan effects
+/// Add visuals once a hitscan is active on its presentation timeline.
 fn add_hitscan_visual(
-    trigger: On<Add, HitscanVisual>,
-    query: Query<(&HitscanVisual, &ColorComponent)>,
+    query: Query<
+        Entity,
+        (
+            With<HitscanVisual>,
+            With<ColorComponent>,
+            Without<Visibility>,
+        ),
+    >,
     mut commands: Commands,
 ) {
-    if let Ok((visual, color)) = query.get(trigger.entity) {
+    for entity in &query {
         // For now, we'll use gizmos to draw the line in a separate system
         // This is a simple implementation; in a real game you might want
         // more sophisticated line rendering
         commands
-            .entity(trigger.entity)
+            .entity(entity)
             .insert((Visibility::default(), Name::new("HitscanLine")));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bevy::camera::visibility::VisibilityPlugin;
+    use bevy::mesh::skinning::SkinnedMeshInverseBindposes;
+
+    fn setup_app() -> App {
+        let mut app = App::new();
+        app.init_resource::<Assets<Mesh>>();
+        app.init_resource::<Assets<ColorMaterial>>();
+        app.init_resource::<Assets<SkinnedMeshInverseBindposes>>();
+        app.register_disabling_component::<InterpolationPending>();
+        app.add_plugins(VisibilityPlugin);
+        app.add_systems(Update, (add_bullet_visuals, add_hitscan_visual));
+        app
+    }
+
+    #[test]
+    fn interpolated_bullet_visual_is_added_only_after_pending_is_removed() {
+        let mut app = setup_app();
+        let entity = app
+            .world_mut()
+            .spawn((
+                BulletMarker {
+                    shooter: PeerId::Local(1),
+                },
+                ColorComponent(Color::WHITE),
+                Position(Vec2::ZERO),
+                Rotation::default(),
+                Interpolated,
+                InterpolationPending {
+                    spawn_tick: Tick(10),
+                },
+            ))
+            .id();
+
+        app.update();
+        assert!(!app.world().entity(entity).contains::<Mesh2d>());
+
+        app.world_mut()
+            .entity_mut(entity)
+            .remove::<InterpolationPending>();
+        app.update();
+
+        let entity_ref = app.world().entity(entity);
+        assert!(entity_ref.contains::<Mesh2d>());
+        assert!(entity_ref.contains::<Visibility>());
+        assert!(entity_ref.get::<InheritedVisibility>().unwrap().get());
+        assert!(!entity_ref.contains::<FrameInterpolate>());
+    }
+
+    #[test]
+    fn interpolated_hitscan_visual_is_added_only_after_pending_is_removed() {
+        let mut app = setup_app();
+        let entity = app
+            .world_mut()
+            .spawn((
+                BulletMarker {
+                    shooter: PeerId::Local(1),
+                },
+                ColorComponent(Color::WHITE),
+                HitscanVisual::new(Vec2::ZERO, Rotation::default(), 0.5),
+                Interpolated,
+                InterpolationPending {
+                    spawn_tick: Tick(10),
+                },
+            ))
+            .id();
+
+        app.update();
+        assert!(!app.world().entity(entity).contains::<Visibility>());
+
+        app.world_mut()
+            .entity_mut(entity)
+            .remove::<InterpolationPending>();
+        app.update();
+
+        assert!(app.world().entity(entity).contains::<Visibility>());
     }
 }

--- a/demos/projectiles/src/renderer.rs
+++ b/demos/projectiles/src/renderer.rs
@@ -332,22 +332,21 @@ fn add_bullet_visuals(
     trigger: On<Add, (Position, Rotation)>,
     // Hitscan are rendered differently
     query: Query<
-        (&ColorComponent, &Position, &Rotation, Has<Interpolated>),
-        (Without<HitscanVisual>, With<BulletMarker>, Without<Mesh2d>),
+        (&ColorComponent, Has<Interpolated>),
+        (
+            Without<HitscanVisual>,
+            With<Position>,
+            With<Rotation>,
+            With<BulletMarker>,
+            Without<Mesh2d>,
+        ),
     >,
     mut commands: Commands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<ColorMaterial>>,
 ) {
-    if let Ok((color, position, rotation, interpolated)) = query.get(trigger.entity) {
+    if let Ok((color, interpolated)) = query.get(trigger.entity) {
         commands.entity(trigger.entity).insert((
-            // State-Entity replication can insert Position/Rotation before Interpolated.
-            // Interpolation then moves that pose into history and removes the live
-            // Position/Rotation, but it does not remove Transform. Seed Transform from
-            // the transient pose so the bullet stays at its correct spawn position until
-            // the presentation tick restores Position/Rotation and normal sync resumes.
-            Transform::from_translation(position.0.extend(0.0))
-                .with_rotation(Quat::from_rotation_z(rotation.as_radians())),
             Visibility::default(),
             Mesh2d(meshes.add(Mesh::from(Circle {
                 radius: BULLET_SIZE,

--- a/demos/projectiles/src/trajectory/hitscan.rs
+++ b/demos/projectiles/src/trajectory/hitscan.rs
@@ -45,6 +45,23 @@ impl HitscanVisual {
     }
 }
 
+/// Sample hitscan presentation state on the interpolation timeline.
+///
+/// In particular, keeping `lifetime` on that timeline prevents a remote trace
+/// from finishing its fade while `InterpolationPending` is still hiding it.
+pub(crate) fn interpolate_visual(
+    start: HitscanVisual,
+    end: HitscanVisual,
+    t: f32,
+) -> HitscanVisual {
+    HitscanVisual {
+        start: start.start.lerp(end.start, t),
+        end: start.end.lerp(end.end, t),
+        lifetime: start.lifetime + (end.lifetime - start.lifetime) * t,
+        max_lifetime: start.max_lifetime + (end.max_lifetime - start.max_lifetime) * t,
+    }
+}
+
 /// Advance the frame-time fade for every trail.
 ///
 /// Projectile lifetime itself is fixed-tick based when a `DespawnAtTick`
@@ -65,5 +82,33 @@ pub(crate) fn update_visuals(
         if !fixed_tick_expiry && visual.lifetime >= visual.max_lifetime {
             commands.entity(entity).try_despawn();
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn interpolation_keeps_hitscan_fade_on_the_presentation_timeline() {
+        let start = HitscanVisual {
+            start: Vec2::ZERO,
+            end: Vec2::Y,
+            lifetime: 0.0,
+            max_lifetime: 0.5,
+        };
+        let end = HitscanVisual {
+            start: Vec2::X,
+            end: Vec2::ONE,
+            lifetime: 0.2,
+            max_lifetime: 0.5,
+        };
+
+        let sampled = interpolate_visual(start, end, 0.5);
+
+        assert_eq!(sampled.start, Vec2::new(0.5, 0.0));
+        assert_eq!(sampled.end, Vec2::new(0.5, 1.0));
+        assert_eq!(sampled.lifetime, 0.1);
+        assert_eq!(sampled.max_lifetime, 0.5);
     }
 }

--- a/demos/projectiles/src/trajectory/hitscan.rs
+++ b/demos/projectiles/src/trajectory/hitscan.rs
@@ -45,23 +45,6 @@ impl HitscanVisual {
     }
 }
 
-/// Sample hitscan presentation state on the interpolation timeline.
-///
-/// In particular, keeping `lifetime` on that timeline prevents a remote trace
-/// from finishing its fade while `InterpolationPending` is still hiding it.
-pub(crate) fn interpolate_visual(
-    start: HitscanVisual,
-    end: HitscanVisual,
-    t: f32,
-) -> HitscanVisual {
-    HitscanVisual {
-        start: start.start.lerp(end.start, t),
-        end: start.end.lerp(end.end, t),
-        lifetime: start.lifetime + (end.lifetime - start.lifetime) * t,
-        max_lifetime: start.max_lifetime + (end.max_lifetime - start.max_lifetime) * t,
-    }
-}
-
 /// Advance the frame-time fade for every trail.
 ///
 /// Projectile lifetime itself is fixed-tick based when a `DespawnAtTick`
@@ -82,33 +65,5 @@ pub(crate) fn update_visuals(
         if !fixed_tick_expiry && visual.lifetime >= visual.max_lifetime {
             commands.entity(entity).try_despawn();
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn interpolation_keeps_hitscan_fade_on_the_presentation_timeline() {
-        let start = HitscanVisual {
-            start: Vec2::ZERO,
-            end: Vec2::Y,
-            lifetime: 0.0,
-            max_lifetime: 0.5,
-        };
-        let end = HitscanVisual {
-            start: Vec2::X,
-            end: Vec2::ONE,
-            lifetime: 0.2,
-            max_lifetime: 0.5,
-        };
-
-        let sampled = interpolate_visual(start, end, 0.5);
-
-        assert_eq!(sampled.start, Vec2::new(0.5, 0.0));
-        assert_eq!(sampled.end, Vec2::new(0.5, 1.0));
-        assert_eq!(sampled.lifetime, 0.1);
-        assert_eq!(sampled.max_lifetime, 0.5);
     }
 }


### PR DESCRIPTION
## Summary

- capture the authoritative server tick when `Interpolated` is received through replication
- add `InterpolationPending { spawn_tick }` directly from that transient provenance marker, without temporary collections or history inspection
- keep every server-replicated interpolated entity disabled until the interpolation timeline reaches its spawn tick, including historyless entities
- defer adding `InterpolationPending` until Bevy's `Last` schedule, after add-observer chains and `PostUpdate` engine response systems such as visibility propagation
- leave client-local `Interpolated` additions out of the pending lifecycle
- preserve application-owned `Disabled` state
- remove the projectiles renderer workaround that manually seeded `Transform`
- keep the original `add_bullet_visuals` and `add_hitscan_visual` observers unchanged
- register `HitscanVisual` for exact history/presence management without a lerp function, so it is added with its spawn-tick value when the interpolation timeline reaches it

## Why `Last`

The projectile render observers already ran while newly replicated entities were enabled. Pending was previously added in `PreUpdate`, before Bevy visibility propagation, so the now-disabled entity was skipped and retained `InheritedVisibility(false)`. Adding pending in `Last` lets observers, app systems, and visibility propagation react first, while the entity is disabled before render extraction.

## Exact hitscan materialization

Without an interpolation rule, `HitscanVisual` remains live and receives newer server lifetime values while its entity is pending. By the time the entity becomes visible, that lifetime can already be past the local fade duration. `add_custom_interpolation()` stores exact ticked values and manages delayed component presence without interpolating an already-present component. At the spawn tick it inserts the exact sampled value, which naturally triggers `On<Add, HitscanVisual>` while the entity is enabled; the existing local update system owns its lifetime afterward.
