### PR TITLE
Fix ACK processing and make NACK timing configurable

### DIFF
--- a/crates/transport/transport/src/channel/builder.rs
+++ b/crates/transport/transport/src/channel/builder.rs
@@ -5,6 +5,7 @@ use crate::channel::send::ChannelSend;
 use crate::packet::compression::{CompressionConfig, CompressionScratch};
 use crate::packet::error::PacketError;
 use crate::packet::message::{MessageAck, MessageId};
+use crate::packet::nack::PacketNackSettings;
 use crate::packet::packet::{
     FRAGMENT_SIZE, MIN_FRAGMENT_PACKET_SIZE, PacketId, fragment_size_for_min_mtu,
 };
@@ -264,6 +265,22 @@ impl Transport {
         self.compression = compression;
     }
 
+    /// Sets the policy used to classify unacknowledged packets as lost.
+    pub fn with_packet_nack_settings(mut self, settings: PacketNackSettings) -> Self {
+        self.set_packet_nack_settings(settings);
+        self
+    }
+
+    /// Sets the policy used to classify unacknowledged packets as lost.
+    pub fn set_packet_nack_settings(&mut self, settings: PacketNackSettings) {
+        self.packet_manager.set_nack_settings(settings);
+    }
+
+    /// Returns the policy used to classify unacknowledged packets as lost.
+    pub fn packet_nack_settings(&self) -> PacketNackSettings {
+        self.packet_manager.nack_settings()
+    }
+
     /// Number of packet payload buffers allocated because none was ready in the local pool.
     ///
     /// This is test-only instrumentation for exercising the real Transport -> Link -> IO path.
@@ -521,7 +538,8 @@ impl Transport {
         let priority_config = self.priority_manager.config.clone();
         self.priority_manager = PriorityManager::new(priority_config.clone());
         self.bandwidth_limiter = BandwidthLimiter::new(priority_config);
-        self.packet_manager = Default::default();
+        let packet_nack_settings = self.packet_manager.nack_settings();
+        self.packet_manager = PacketBuilder::with_nack_settings(packet_nack_settings);
         self.compression_scratch = Default::default();
         self.packet_message_acks = Default::default();
         let (send_channel, recv_channel) = crossbeam_channel::unbounded();
@@ -591,7 +609,7 @@ impl ReliableSettings {
 }
 
 #[cfg(test)]
-mod mtu_tests {
+mod transport_tests {
     use super::*;
     use bevy_ecs::world::World;
     use lightyear_link::LinkMtu;
@@ -620,6 +638,21 @@ mod mtu_tests {
             world.get::<Transport>(entity).unwrap().fragment_size,
             expected_fragment_size
         );
+    }
+
+    #[test]
+    fn packet_nack_settings_are_configurable_and_survive_reset() {
+        let settings = PacketNackSettings {
+            rtt_multiplier: 2.0,
+            jitter_multiplier: 1.5,
+            minimum_timeout: Duration::from_millis(34),
+            maximum_timeout: Duration::from_secs(2),
+        };
+        let mut transport = Transport::default().with_packet_nack_settings(settings);
+
+        assert_eq!(transport.packet_nack_settings(), settings);
+        transport.reset(&ChannelRegistry::default());
+        assert_eq!(transport.packet_nack_settings(), settings);
     }
 }
 

--- a/crates/transport/transport/src/lib.rs
+++ b/crates/transport/transport/src/lib.rs
@@ -28,5 +28,6 @@ pub mod prelude {
     pub use crate::channel::registry::ChannelRegistry;
     pub use crate::channel::send::ChannelSend;
     pub use crate::packet::compression::{CompressionAlgorithm, CompressionConfig};
+    pub use crate::packet::nack::PacketNackSettings;
     pub use crate::packet::priority_manager::{PriorityConfig, PriorityManager};
 }

--- a/crates/transport/transport/src/packet/header.rs
+++ b/crates/transport/transport/src/packet/header.rs
@@ -8,6 +8,7 @@ use ringbuffer::{ConstGenericRingBuffer, RingBuffer};
 #[allow(unused_imports)]
 use tracing::{info, trace};
 
+use crate::packet::nack::PacketNackSettings;
 use crate::packet::packet::PacketId;
 use crate::packet::packet_type::PacketType;
 use crate::packet::stats_manager::packet::PacketStatsManager;
@@ -115,13 +116,6 @@ impl PacketHeader {
 // we can only send acks for the last 32 packets ids before the last received packet
 const ACK_BITFIELD_SIZE: u8 = 32;
 
-/// minimum number of milliseconds after which we can consider a packet lost
-/// (to avoid edge case behaviour)
-const MIN_NACK_MILLIS: u64 = 10;
-
-/// maximum number of seconds after which we consider a packet lost
-const MAX_NACK_SECONDS: u64 = 3;
-
 /// Keeps track of sent and received packets to be able to write the packet headers correctly
 /// For more information: [GafferOnGames](https://gafferongames.com/post/reliability_ordering_and_congestion_avoidance_over_udp/)
 #[derive(Debug)]
@@ -152,21 +146,24 @@ pub struct PacketHeaderManager {
     recv_buffer: ReceiveBuffer,
     /// Whether an acknowledgement-eliciting packet has arrived since the last packet we sent.
     ack_pending: bool,
-    /// After how many multiples of RTT do we consider a packet to be lost?
-    ///
-    /// The default is 1.5; i.e. after 1.5 times the round trip time, we consider a packet lost if
-    /// we haven't received an ACK for it.
-    nack_rtt_multiple: f32,
+    pub(crate) nack_settings: PacketNackSettings,
 }
 
 impl Default for PacketHeaderManager {
     fn default() -> Self {
-        Self::new(1.5)
+        Self::with_nack_settings(PacketNackSettings::default())
     }
 }
 
 impl PacketHeaderManager {
-    pub(crate) fn new(nack_rtt_multiple: f32) -> Self {
+    pub(crate) fn new(nack_rtt_multiplier: f32) -> Self {
+        Self::with_nack_settings(PacketNackSettings {
+            rtt_multiplier: nack_rtt_multiplier,
+            ..Default::default()
+        })
+    }
+
+    pub(crate) fn with_nack_settings(nack_settings: PacketNackSettings) -> Self {
         Self {
             next_packet_id: PacketId(0),
             stats_manager: PacketStatsManager::default(),
@@ -176,18 +173,14 @@ impl PacketHeaderManager {
             newly_acked_packet_scratch: vec![],
             recv_buffer: ReceiveBuffer::new(),
             ack_pending: false,
-            nack_rtt_multiple,
+            nack_settings,
         }
     }
 
     /// Internal bookkeeping. Updates the list of packets that are NACKed (acknowledged as losts)
     pub(crate) fn update(&mut self, real: Duration, link_stats: &LinkStats) {
         self.stats_manager.update(real);
-        let rtt = link_stats.rtt;
-        let nack_duration = rtt
-            .mul_f32(self.nack_rtt_multiple)
-            .min(Duration::from_secs(MAX_NACK_SECONDS))
-            .max(Duration::from_millis(MIN_NACK_MILLIS));
+        let nack_duration = self.nack_settings.timeout(link_stats);
         // clear sent packets that haven't received any ack for a while
         self.sent_packets_not_acked.retain(|packet_id, time_sent| {
             // protection against keep old packets for too long (which would cause bugs on wraparound)

--- a/crates/transport/transport/src/packet/mod.rs
+++ b/crates/transport/transport/src/packet/mod.rs
@@ -22,6 +22,7 @@ pub(crate) mod header;
 
 pub mod compression;
 pub mod message;
+pub mod nack;
 
 // "module has the same name as its containing module" style nit.
 // clippy doesn't like this, but not much benefit to changing it now, so silence the warning.

--- a/crates/transport/transport/src/packet/nack.rs
+++ b/crates/transport/transport/src/packet/nack.rs
@@ -1,0 +1,92 @@
+use core::time::Duration;
+
+use lightyear_link::LinkStats;
+
+/// Controls when an unacknowledged packet is presumed lost.
+///
+/// This is independent from reliable-channel resend timing. Packet NACK timing
+/// classifies packet delivery and releases packet-level acknowledgement
+/// bookkeeping; [`ReliableSettings`](crate::prelude::ReliableSettings) controls
+/// when reliable messages become eligible for retransmission.
+///
+/// The timeout is `RTT * rtt_multiplier + jitter * jitter_multiplier`, clamped
+/// to the inclusive range from `minimum_timeout` to `maximum_timeout`. The
+/// default preserves the existing `clamp(1.5 * RTT, 10 ms, 3 s)` policy.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct PacketNackSettings {
+    /// Multiplier applied to the current RTT estimate.
+    pub rtt_multiplier: f32,
+    /// Multiplier applied to the current jitter estimate.
+    pub jitter_multiplier: f32,
+    /// Minimum time to retain acknowledgement bookkeeping for a sent packet.
+    pub minimum_timeout: Duration,
+    /// Maximum time to retain acknowledgement bookkeeping for a sent packet.
+    pub maximum_timeout: Duration,
+}
+
+impl Default for PacketNackSettings {
+    fn default() -> Self {
+        Self {
+            rtt_multiplier: 1.5,
+            jitter_multiplier: 0.0,
+            minimum_timeout: Duration::from_millis(10),
+            maximum_timeout: Duration::from_secs(3),
+        }
+    }
+}
+
+impl PacketNackSettings {
+    pub(crate) fn timeout(self, link_stats: &LinkStats) -> Duration {
+        link_stats
+            .rtt
+            .mul_f32(self.rtt_multiplier)
+            .saturating_add(link_stats.jitter.mul_f32(self.jitter_multiplier))
+            .min(self.maximum_timeout)
+            .max(self.minimum_timeout)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_preserves_existing_timeout_policy() {
+        let settings = PacketNackSettings::default();
+        let stats = LinkStats {
+            rtt: Duration::from_millis(40),
+            jitter: Duration::from_millis(10),
+        };
+
+        assert_eq!(settings.timeout(&stats), Duration::from_millis(60));
+    }
+
+    #[test]
+    fn timeout_includes_rtt_jitter_and_bounds() {
+        let settings = PacketNackSettings {
+            rtt_multiplier: 1.5,
+            jitter_multiplier: 2.0,
+            minimum_timeout: Duration::from_millis(20),
+            maximum_timeout: Duration::from_millis(200),
+        };
+
+        assert_eq!(
+            settings.timeout(&LinkStats {
+                rtt: Duration::from_millis(40),
+                jitter: Duration::from_millis(10),
+            }),
+            Duration::from_millis(80)
+        );
+        assert_eq!(
+            settings.timeout(&LinkStats::default()),
+            Duration::from_millis(20)
+        );
+        assert_eq!(
+            settings.timeout(&LinkStats {
+                rtt: Duration::from_secs(1),
+                jitter: Duration::ZERO,
+            }),
+            Duration::from_millis(200)
+        );
+    }
+}

--- a/crates/transport/transport/src/packet/packet_builder.rs
+++ b/crates/transport/transport/src/packet/packet_builder.rs
@@ -7,6 +7,7 @@ use crate::packet::compression::{
 use crate::packet::error::PacketError;
 use crate::packet::header::PacketHeaderManager;
 use crate::packet::message::{MessageData, SendCandidate};
+use crate::packet::nack::PacketNackSettings;
 use crate::packet::packet::{HEADER_BYTES, MessageMetadata, Packet, SendCommit};
 use crate::packet::packet_type::PacketType;
 use alloc::vec::Vec;
@@ -153,17 +154,33 @@ impl PacketBufferPool {
 
 impl Default for PacketBuilder {
     fn default() -> Self {
-        Self::new(1.5)
+        Self::with_nack_settings(PacketNackSettings::default())
     }
 }
 
 impl PacketBuilder {
-    pub fn new(nack_rtt_multiple: f32) -> Self {
+    pub fn new(nack_rtt_multiplier: f32) -> Self {
         Self {
-            header_manager: PacketHeaderManager::new(nack_rtt_multiple),
+            header_manager: PacketHeaderManager::new(nack_rtt_multiplier),
             buffer_pool: PacketBufferPool::new(DEFAULT_MTU),
             compression_output: Vec::new(),
         }
+    }
+
+    pub(crate) fn with_nack_settings(nack_settings: PacketNackSettings) -> Self {
+        Self {
+            header_manager: PacketHeaderManager::with_nack_settings(nack_settings),
+            buffer_pool: PacketBufferPool::new(DEFAULT_MTU),
+            compression_output: Vec::new(),
+        }
+    }
+
+    pub(crate) fn nack_settings(&self) -> PacketNackSettings {
+        self.header_manager.nack_settings
+    }
+
+    pub(crate) fn set_nack_settings(&mut self, settings: PacketNackSettings) {
+        self.header_manager.nack_settings = settings;
     }
 
     pub(crate) fn recycle_packet(&mut self, packet: Packet) {

--- a/crates/transport/transport/src/plugin.rs
+++ b/crates/transport/transport/src/plugin.rs
@@ -104,69 +104,6 @@ impl TransportPlugin {
                 .for_each(|channel_receive| {
                     channel_receive.update(time.elapsed());
                 });
-            // check which packets were lost
-            transport
-                .packet_manager
-                .header_manager
-                .update(time.elapsed(), &link.stats);
-            let packet_message_acks = &mut transport.packet_message_acks;
-            let senders = &mut transport.senders;
-            transport
-                .packet_manager
-                .header_manager
-                .lost_packets
-                .drain(..)
-                .try_for_each(|lost_packet| {
-                    #[cfg(feature = "metrics")]
-                    metrics::counter!("transport/packets_lost").increment(1);
-                    trace!(
-                        target: "lightyear_debug::transport",
-                        kind = "packet_lost",
-                        schedule = "PreUpdate",
-                        sample_point = "PreUpdate",
-                        entity = ?entity,
-                        packet_id = ?lost_packet,
-                        packet_loss = true,
-                        "transport packet marked lost"
-                    );
-                    #[cfg(feature = "std")]
-                    par_commands.command_scope(|mut commands| {
-                        commands.trigger(PacketLost {
-                            entity,
-                            packet_id: lost_packet.0,
-                        });
-                    });
-                    #[cfg(not(feature = "std"))]
-                    commands.trigger(PacketLost {
-                        entity,
-                        packet_id: lost_packet.0,
-                    });
-                    if let Some(mut message_acks) = packet_message_acks.take(&lost_packet) {
-                        let result =
-                            message_acks
-                                .drain(..)
-                                .try_for_each(|(channel_kind, message_ack)| {
-                                    let channel_send = senders
-                                        .get_mut(&channel_kind)
-                                        .ok_or(PacketError::ChannelNotFound)?;
-                                    // TODO: batch the messages?
-                                    trace!(
-                                        ?lost_packet,
-                                        ?channel_kind,
-                                        "message lost: {:?}",
-                                        message_ack.message_id
-                                    );
-                                    channel_send.message_nacks.push(message_ack.message_id);
-                                    channel_send.receive_nack(&message_ack);
-                                    Ok::<(), TransportError>(())
-                                });
-                        packet_message_acks.recycle(message_acks);
-                        result?;
-                    }
-                    Ok::<(), TransportError>(())
-                })
-                .ok();
-
             link.recv
                 .drain()
                 .try_for_each(|packet| {
@@ -344,6 +281,70 @@ impl TransportPlugin {
                 })
                 .inspect_err(|e| {
                     error!("Error processing packet: {e:?}");
+                })
+                .ok();
+
+            // Consume ACKs already queued for this frame before expiring packets. Otherwise a
+            // packet can lose its message-ACK mapping immediately before its ACK is processed.
+            transport
+                .packet_manager
+                .header_manager
+                .update(time.elapsed(), &link.stats);
+            let packet_message_acks = &mut transport.packet_message_acks;
+            let senders = &mut transport.senders;
+            transport
+                .packet_manager
+                .header_manager
+                .lost_packets
+                .drain(..)
+                .try_for_each(|lost_packet| {
+                    #[cfg(feature = "metrics")]
+                    metrics::counter!("transport/packets_lost").increment(1);
+                    trace!(
+                        target: "lightyear_debug::transport",
+                        kind = "packet_lost",
+                        schedule = "PreUpdate",
+                        sample_point = "PreUpdate",
+                        entity = ?entity,
+                        packet_id = ?lost_packet,
+                        packet_loss = true,
+                        "transport packet marked lost"
+                    );
+                    #[cfg(feature = "std")]
+                    par_commands.command_scope(|mut commands| {
+                        commands.trigger(PacketLost {
+                            entity,
+                            packet_id: lost_packet.0,
+                        });
+                    });
+                    #[cfg(not(feature = "std"))]
+                    commands.trigger(PacketLost {
+                        entity,
+                        packet_id: lost_packet.0,
+                    });
+                    if let Some(mut message_acks) = packet_message_acks.take(&lost_packet) {
+                        let result =
+                            message_acks
+                                .drain(..)
+                                .try_for_each(|(channel_kind, message_ack)| {
+                                    let channel_send = senders
+                                        .get_mut(&channel_kind)
+                                        .ok_or(PacketError::ChannelNotFound)?;
+                                    // TODO: batch the messages?
+                                    trace!(
+                                        ?lost_packet,
+                                        ?channel_kind,
+                                        "message lost: {:?}",
+                                        message_ack.message_id
+                                    );
+                                    channel_send.message_nacks.push(message_ack.message_id);
+                                    channel_send.receive_nack(&message_ack);
+                                    Ok::<(), TransportError>(())
+                                });
+                        packet_message_acks.recycle(message_acks);
+                        result?;
+                    }
+                    Ok::<(), TransportError>(())
                 })
                 .ok();
 
@@ -715,6 +716,7 @@ mod tests {
     struct RetryChannel;
     struct DiscardChannel;
     struct SmallMtuChannel;
+    struct AckBeforeTimeoutChannel;
 
     fn spawn_transport<C: crate::channel::Channel>(
         world: &mut World,
@@ -826,6 +828,88 @@ mod tests {
             .unwrap();
         world.run_system_once(TransportPlugin::buffer_send).unwrap();
         assert_eq!(world.get::<Link>(entity).unwrap().send.len(), 0);
+    }
+
+    #[test]
+    fn queued_ack_is_processed_before_packet_loss_timeout() {
+        let settings = ChannelSettings {
+            mode: ChannelMode::UnorderedReliable(Default::default()),
+            ..Default::default()
+        };
+        let mut registry = ChannelRegistry::default();
+        let (channel_kind, channel_id) = registry.add_channel::<AckBeforeTimeoutChannel>(settings);
+
+        let mut sender_transport = Transport::default();
+        sender_transport.add_channel_send::<AckBeforeTimeoutChannel>(settings, channel_id);
+        let mut receiver_transport = Transport::default();
+        receiver_transport.add_channel_receive::<AckBeforeTimeoutChannel>(settings, channel_id);
+
+        let mut sender = World::new();
+        sender.insert_resource(registry.clone());
+        sender.init_resource::<Time<Real>>();
+        sender.init_resource::<LocalTimeline>();
+        let sender_entity = sender
+            .spawn((Link::default(), Linked, sender_transport))
+            .id();
+
+        let mut receiver = World::new();
+        receiver.insert_resource(registry);
+        receiver.init_resource::<Time<Real>>();
+        receiver.init_resource::<LocalTimeline>();
+        let receiver_entity = receiver
+            .spawn((Link::default(), Linked, receiver_transport))
+            .id();
+
+        sender
+            .get::<Transport>(sender_entity)
+            .unwrap()
+            .send_erased(channel_kind, Bytes::from_static(b"delivered"), 1.0)
+            .unwrap();
+        sender
+            .run_system_once(TransportPlugin::buffer_send)
+            .unwrap();
+        let data = sender
+            .get_mut::<Link>(sender_entity)
+            .unwrap()
+            .send
+            .pop()
+            .unwrap();
+        receiver
+            .get_mut::<Link>(receiver_entity)
+            .unwrap()
+            .recv
+            .push_raw(lightyear_link::recv_payload_from_bytes(data));
+        receiver
+            .run_system_once(TransportPlugin::buffer_receive)
+            .unwrap();
+        receiver
+            .run_system_once(TransportPlugin::buffer_send)
+            .unwrap();
+        let ack = receiver
+            .get_mut::<Link>(receiver_entity)
+            .unwrap()
+            .send
+            .pop()
+            .unwrap();
+
+        // The default packet NACK floor is 10 ms. Queue an ACK after that timeout so this
+        // receive pass would mark the packet lost first with the previous processing order.
+        sender
+            .resource_mut::<Time<Real>>()
+            .advance_by(Duration::from_millis(11));
+        sender
+            .get_mut::<Link>(sender_entity)
+            .unwrap()
+            .recv
+            .push_raw(lightyear_link::recv_payload_from_bytes(ack));
+        sender
+            .run_system_once(TransportPlugin::buffer_receive)
+            .unwrap();
+
+        let transport = sender.get::<Transport>(sender_entity).unwrap();
+        let channel = transport.channel_send(channel_kind).unwrap();
+        assert_eq!(channel.message_acks().len(), 1);
+        assert!(channel.message_nacks().is_empty());
     }
 
     #[test]


### PR DESCRIPTION
Related to https://github.com/cBournhonesque/lightyear/issues/1684

This PR does not introduce breaking changes to the existing public API. The existing PacketBuilder::new(f32) constructor and default NACK behavior remain unchanged.