### PR TITLE
Make `MAX_CLIENTS` configurable

### DIFF
--- a/crates/connection/netcode/src/server.rs
+++ b/crates/connection/netcode/src/server.rs
@@ -276,6 +276,7 @@ fn server_addr_matches(local_addr: SocketAddr, token_addr: SocketAddr) -> bool {
 /// let server = Server::with_config(protocol_id, private_key, cfg).unwrap();
 /// ```
 pub struct ServerConfig<Ctx> {
+    pub(crate) max_clients: usize,
     num_disconnect_packets: usize,
     keep_alive_send_rate: f64,
     token_expire_secs: i32,
@@ -289,6 +290,7 @@ pub struct ServerConfig<Ctx> {
 impl Default for ServerConfig<()> {
     fn default() -> Self {
         Self {
+            max_clients: MAX_CLIENTS,
             num_disconnect_packets: 10,
             keep_alive_send_rate: PACKET_SEND_RATE_SEC,
             token_expire_secs: TOKEN_EXPIRE_SEC,
@@ -309,6 +311,7 @@ impl<Ctx> ServerConfig<Ctx> {
     /// Create a new server configuration with context that will be passed to the callbacks.
     pub fn with_context(ctx: Ctx) -> Self {
         Self {
+            max_clients: MAX_CLIENTS,
             num_disconnect_packets: 10,
             keep_alive_send_rate: PACKET_SEND_RATE_SEC,
             token_expire_secs: TOKEN_EXPIRE_SEC,
@@ -319,6 +322,14 @@ impl<Ctx> ServerConfig<Ctx> {
             on_disconnect: None,
         }
     }
+
+    /// Set the maximum number of simultaneous client connections.
+    /// The default is 256 clients.
+    pub fn max_clients(mut self, max_clients: usize) -> Self {
+        self.max_clients = max_clients;
+        self
+    }
+
     /// Set the number of redundant disconnect packets that will be sent to a client when the server is disconnecting it. <br>
     /// The default is 10 packets.
     pub fn num_disconnect_packets(mut self, num: usize) -> Self {
@@ -712,7 +723,7 @@ impl<Ctx> Server<Ctx> {
                 token.client_id,
             )));
         };
-        if self.num_connected_clients() >= MAX_CLIENTS {
+        if self.num_connected_clients() >= self.cfg.max_clients {
             self.send_netcode_packet(
                 DeniedPacket::create(DeniedReason::ServerFull),
                 token.server_to_client_key,
@@ -788,7 +799,7 @@ impl<Ctx> Server<Ctx> {
             return Ok(());
         };
 
-        if self.num_connected_clients() >= MAX_CLIENTS {
+        if self.num_connected_clients() >= self.cfg.max_clients {
             self.send_netcode_packet(
                 DeniedPacket::create(DeniedReason::ServerFull),
                 client.send_key,

--- a/crates/connection/netcode/src/server_plugin.rs
+++ b/crates/connection/netcode/src/server_plugin.rs
@@ -1,4 +1,4 @@
-use crate::{ClientId, Key, PRIVATE_KEY_BYTES, ServerConfig, USER_DATA_BYTES};
+use crate::{ClientId, Key, PRIVATE_KEY_BYTES, ServerConfig, USER_DATA_BYTES, server::MAX_CLIENTS};
 use aeronet_io::connection::LocalAddr;
 use alloc::{sync::Arc, vec::Vec};
 use bevy_app::{App, Plugin, PostUpdate, PreUpdate};
@@ -43,6 +43,8 @@ pub struct NetcodeServer {
 // TODO: should be part of the NetcodeServer component
 #[derive(Debug, Clone)]
 pub struct NetcodeConfig {
+    /// Maximum number of simultaneous client connections accepted by the server.
+    pub max_clients: usize,
     pub num_disconnect_packets: usize,
     pub keep_alive_send_rate: f64,
     /// Set the duration (in seconds) after which the server disconnects a client if they don't hear from them.
@@ -62,6 +64,7 @@ pub struct NetcodeConfig {
 impl Default for NetcodeConfig {
     fn default() -> Self {
         Self {
+            max_clients: MAX_CLIENTS,
             num_disconnect_packets: 10,
             keep_alive_send_rate: 1.0 / 10.0,
             client_timeout_secs: 3,
@@ -74,6 +77,11 @@ impl Default for NetcodeConfig {
 }
 
 impl NetcodeConfig {
+    pub fn with_max_clients(mut self, max_clients: usize) -> Self {
+        self.max_clients = max_clients;
+        self
+    }
+
     pub fn with_protocol_id(mut self, protocol_id: u64) -> Self {
         self.protocol_id = protocol_id;
         self
@@ -107,6 +115,7 @@ impl NetcodeServer {
             .on_disconnect(|id, entity, ctx| {
                 ctx.disconnections.push((id, entity));
             });
+        cfg = cfg.max_clients(config.max_clients);
         cfg = cfg.keep_alive_send_rate(config.keep_alive_send_rate);
         cfg = cfg.num_disconnect_packets(config.num_disconnect_packets);
         cfg = cfg.client_timeout_secs(config.client_timeout_secs);
@@ -410,6 +419,18 @@ impl NetcodeServerPlugin {
             )?;
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn max_clients_is_forwarded_to_the_server() {
+        let server = NetcodeServer::new(NetcodeConfig::default().with_max_clients(42));
+
+        assert_eq!(server.inner.cfg.max_clients, 42);
     }
 }
 


### PR DESCRIPTION
Currently there is a `MAX_CLIENTS` constant defined inside of `lightyear_net`, which limits the amount of concurrent client connnections. This seems to be a legacy leftover, and clients are no longer maintained with slots, but rather dynamically. We should likely make this option configurable. I've added the old limit as the default for backwards compatibility, but it could be make an optional instead?