### PR TITLE
fix(prediction): deliver server inserts of never-predicted components to Predicted entities

### DIFF
--- a/crates/replication/prediction/src/registry.rs
+++ b/crates/replication/prediction/src/registry.rs
@@ -473,6 +473,25 @@ impl PredictionRegistry {
 
         let predicted_history = entity_mut.get::<PredictionHistory<C>>();
 
+        // A confirmed VALUE arriving for a component this entity has never
+        // predicted (no PredictionHistory<C>) and does not currently have
+        // (no live C) — e.g. the server inserted a marker like `Dead`
+        // mid-game that the client cannot predict — is otherwise
+        // undeliverable (#1692):
+        // - the receive-time mismatch check below is often skipped because
+        //   insert messages ride a reliable channel and can resolve to a tick
+        //   at or behind `StateRollbackMetadata::last_processed_tick`;
+        // - the unchanged-entity scan (`check_rollback_for_unchanged_component`)
+        //   returns early without a retained predicted sample;
+        // - and `prepare_rollback` uses PredictionHistory<C> as its membership
+        //   marker, so even an unrelated rollback's restore skips C.
+        // Seed the prediction history with what the client actually predicted
+        // — "absent" — so the normal mismatch → rollback → restore pipeline
+        // picks the component up at the next completed mutate tick.
+        let never_predicted_insert = confirmed_component.is_some()
+            && predicted_history.is_none()
+            && entity_mut.get::<C>().is_none();
+
         #[cfg(feature = "metrics")]
         if let Some(predicted_history) = predicted_history.as_ref() {
             self.prediction_map[&ComponentKind::of::<C>()]
@@ -546,6 +565,19 @@ impl PredictionRegistry {
         } else {
             let mut history = ConfirmedHistory::<C>::default();
             history.insert(confirmed_tick, confirmed_state);
+            entity_mut.insert(history);
+        }
+        if never_predicted_insert {
+            trace!(
+                target: "lightyear_debug::prediction",
+                kind = "seed_prediction_history_for_unpredicted_insert",
+                entity = ?entity,
+                component = ?name,
+                confirmed_tick = confirmed_tick.0,
+                "seeding PredictionHistory with predicted-absence for a confirmed insert of a never-predicted component"
+            );
+            let mut history = PredictionHistory::<C>::default();
+            history.add_state(confirmed_tick, HistoryState::Removed);
             entity_mut.insert(history);
         }
         should_rollback

--- a/crates/tests/src/client_server/prediction/spawn.rs
+++ b/crates/tests/src/client_server/prediction/spawn.rs
@@ -1,3 +1,4 @@
+use crate::protocol::CompFull;
 use crate::stepper::*;
 use bevy::ecs::hierarchy::ChildOf;
 use lightyear_connection::network_target::NetworkTarget;
@@ -66,5 +67,71 @@ fn test_spawn_predicted_with_hierarchy() {
             .expect("predicted child entity doesn't have a parent")
             .parent(),
         predicted_parent
+    );
+}
+
+/// https://github.com/cBournhonesque/lightyear/issues/1692
+/// A Full-mode component the server inserts MID-GAME on an already-predicted
+/// entity — one the client never predicts itself (think a server-authoritative
+/// `Dead` marker) — must still reach the Predicted entity, even when the
+/// client's prediction never mispredicts.
+///
+/// Without the fix, the confirmed insert is parked in `ConfirmedHistory<C>`:
+/// the receive-time mismatch check can be skipped (insert messages ride a
+/// reliable channel and may resolve at/behind the last processed mutate tick),
+/// the unchanged-entity scan returns early without a retained predicted
+/// sample, and `prepare_rollback` skips the component entirely because the
+/// entity has no `PredictionHistory<C>` — so the component only ever arrives
+/// as a side effect of a rollback caused by something else.
+#[test]
+fn test_late_server_insert_of_unpredicted_component_reaches_predicted() {
+    let mut stepper = ClientServerStepper::from_config(StepperConfig::single());
+
+    // Spawn a predicted entity WITHOUT CompFull.
+    let server_entity = stepper
+        .server_app
+        .world_mut()
+        .spawn((
+            Replicate::to_clients(NetworkTarget::All),
+            PredictionTarget::to_clients(NetworkTarget::All),
+        ))
+        .id();
+    stepper.frame_step(2);
+
+    let predicted = stepper
+        .client(0)
+        .get::<MessageManager>()
+        .unwrap()
+        .entity_mapper
+        .get_local(server_entity)
+        .expect("entity was not replicated to client");
+    assert!(
+        stepper
+            .client_app()
+            .world()
+            .get::<CompFull>(predicted)
+            .is_none()
+    );
+
+    // Settle well past the spawn so this is a true mid-game insert, not part
+    // of the initial sync.
+    stepper.frame_step(10);
+
+    // The server inserts the component mid-game. The client has no system
+    // predicting CompFull and nothing else mispredicts, so no rollback fires
+    // for any other reason.
+    stepper
+        .server_app
+        .world_mut()
+        .entity_mut(server_entity)
+        .insert(CompFull(42.0));
+
+    // Replication + the completed-mutate-tick scan get time to deliver.
+    stepper.frame_step(20);
+
+    assert_eq!(
+        stepper.client_app().world().get::<CompFull>(predicted),
+        Some(&CompFull(42.0)),
+        "server-inserted Full-mode component never reached the Predicted entity (#1692)"
     );
 }


### PR DESCRIPTION
Fixes #1692.

## Problem

A Full-mode component that the server inserts mid-game on an already-predicted entity — one the client never predicts itself (a server-authoritative `Dead`-style marker) — never reaches the Predicted entity unless an unrelated rollback happens to fire:

- the receive-time mismatch check in `record_confirmed_and_maybe_check` is often skipped: insert messages ride a reliable channel and can resolve to a tick at/behind `StateRollbackMetadata::last_processed_tick`;
- the unchanged-entity scan (`check_rollback_for_unchanged_component`) returns early when there's no retained predicted sample;
- and `prepare_rollback` uses `&mut PredictionHistory<C>` as its restore membership marker, so even when a rollback *does* fire, the component is skipped.

Net effect: the confirmed value is parked in `ConfirmedHistory<C>` forever. Clients with unstable connections receive the component as a side effect of their frequent rollbacks; clients with clean prediction never receive it at all.

## Fix

When a confirmed **value** arrives for a component the entity has neither predicted (no `PredictionHistory<C>`) nor currently has (no live `C`), seed `PredictionHistory<C>` with the client's actual prediction — `HistoryState::Removed` at the confirmed tick. That makes the entire existing pipeline work unmodified:

- the unchanged-entity scan now has a retained predicted sample (absence) to compare against the confirmed value → `(Some, None)` mismatch → state rollback at the next completed mutate tick;
- `prepare_rollback` now includes the entity for `C` and restores from `ConfirmedHistory` (at-or-before lookup finds the insert) → component inserted on the Predicted entity.

This is effectively a lazy, receive-scoped version of the note in #888 ("always add `PredictionHistory<C>` for all Full-mode components as soon as the predicted entity is spawned, even if C wasn't added") — scoped to components that actually receive confirmed data, so there's no per-spawn cost for unused components.

## Testing

- New regression test `test_late_server_insert_of_unpredicted_component_reaches_predicted`: real client-server stepper, predicted entity spawned without `CompFull`, server inserts it mid-game, no client misprediction. **Fails on current main** (component never arrives), passes with the fix.
- Full `lightyear_tests` suite: 189 passed / 0 failed single-threaded with the fix (parallel runs show pre-existing flakiness on stock main as well — global metrics recorder / shared state).
- Verified in our game (client/server, WebTransport, 64Hz, `lag_compensation` inputs) with a 60ms receive-side conditioner and a deliberately never-mispredicting client: on main, 0/8 mid-game marker inserts reached the predicted entity across 8 deaths; with this fix, 8/8 arrived, and interpolated-entity delivery and mutation sync are unchanged.
