### PR TITLE
feat(netcode): emit errors as bevy messages

### DIFF
--- a/crates/connection/netcode/src/error.rs
+++ b/crates/connection/netcode/src/error.rs
@@ -68,7 +68,7 @@ pub enum Error {
 }
 
 impl Error {
-    pub(crate) fn log(self) {
+    pub(crate) fn log(&self) {
         let suppress_error = matches!(&self, Error::Ignored(_));
         if suppress_error {
             debug!("Netcode error: {:?}", self);

--- a/crates/connection/netcode/src/lib.rs
+++ b/crates/connection/netcode/src/lib.rs
@@ -69,7 +69,7 @@ pub use error::{Error, Result};
 #[cfg(feature = "server")]
 pub use server::{Callback, ConnectCallback, Server, ServerConfig};
 #[cfg(feature = "server")]
-pub use server_plugin::{NetcodeServer, TokenUserData};
+pub use server_plugin::{NetcodeServer, NetcodeServerError, TokenUserData};
 pub use token::{ConnectToken, ConnectTokenBuilder, InvalidTokenError};
 
 /// The client id from a connect token, must be unique for each client.
@@ -105,7 +105,7 @@ pub mod prelude {
     #[cfg(feature = "server")]
     pub mod server {
         pub use crate::server_plugin::{
-            NetcodeConfig, NetcodeServer, NetcodeServerPlugin, TokenUserData,
+            NetcodeConfig, NetcodeServer, NetcodeServerError, NetcodeServerPlugin, TokenUserData,
         };
     }
 }

--- a/crates/connection/netcode/src/server.rs
+++ b/crates/connection/netcode/src/server.rs
@@ -257,6 +257,7 @@ fn server_addr_matches(local_addr: SocketAddr, token_addr: SocketAddr) -> bool {
 ///
 /// * `num_disconnect_packets` - The number of redundant disconnect packets that will be sent to a client when the server is disconnecting it.
 /// * `keep_alive_send_rate` - The rate at which keep-alive packets will be sent to clients.
+/// * `additional_expected_addresses` - Additional server addresses accepted during connect-token validation.
 /// * `on_connect` - A callback that will be called when a client is connected to the server.
 /// * `on_disconnect` - A callback that will be called when a client is disconnected from the server.
 ///
@@ -282,6 +283,7 @@ pub struct ServerConfig<Ctx> {
     token_expire_secs: i32,
     client_timeout_secs: i32,
     connection_request_handler: Arc<dyn ConnectionRequestHandler>,
+    pub(crate) additional_expected_addresses: Vec<SocketAddr>,
     pub(crate) context: Ctx,
     on_connect: Option<ConnectCallback<Ctx>>,
     on_disconnect: Option<Callback<Ctx>>,
@@ -296,6 +298,7 @@ impl Default for ServerConfig<()> {
             token_expire_secs: TOKEN_EXPIRE_SEC,
             client_timeout_secs: CLIENT_TIMEOUT_SECS,
             connection_request_handler: Arc::new(DefaultConnectionRequestHandler),
+            additional_expected_addresses: Vec::new(),
             context: (),
             on_connect: None,
             on_disconnect: None,
@@ -317,6 +320,7 @@ impl<Ctx> ServerConfig<Ctx> {
             token_expire_secs: TOKEN_EXPIRE_SEC,
             client_timeout_secs: CLIENT_TIMEOUT_SECS,
             connection_request_handler: Arc::new(DefaultConnectionRequestHandler),
+            additional_expected_addresses: Vec::new(),
             context: ctx,
             on_connect: None,
             on_disconnect: None,
@@ -360,6 +364,17 @@ impl<Ctx> ServerConfig<Ctx> {
         handler: Arc<dyn ConnectionRequestHandler>,
     ) -> Self {
         self.connection_request_handler = handler;
+        self
+    }
+
+    /// Set additional server addresses accepted during connect-token validation.
+    ///
+    /// These addresses are accepted in addition to the address passed to [`Server::receive`].
+    pub fn additional_expected_addresses(
+        mut self,
+        addresses: impl IntoIterator<Item = SocketAddr>,
+    ) -> Self {
+        self.additional_expected_addresses = addresses.into_iter().collect();
         self
     }
 
@@ -685,14 +700,19 @@ impl<Ctx> Server<Ctx> {
         let entity = entity_mut.id();
 
         if let Some(server_addr) = server_addr
-            && !token
-                .server_addresses
-                .iter()
-                .any(|(_, token_addr)| server_addr_matches(server_addr, token_addr))
+            && !token.server_addresses.iter().any(|(_, token_addr)| {
+                server_addr_matches(server_addr, token_addr)
+                    || self
+                        .cfg
+                        .additional_expected_addresses
+                        .iter()
+                        .any(|expected_addr| server_addr_matches(*expected_addr, token_addr))
+            })
         {
             info!(
                 token_addresses = ?token.server_addresses,
                 ?server_addr,
+                additional_expected_addresses = ?self.cfg.additional_expected_addresses,
                 "server ignored connection request. server address not in connect token whitelist"
             );
             return Ok(());
@@ -1269,7 +1289,23 @@ mod tests {
         public_server_addresses: &[SocketAddr],
         internal_server_addresses: Option<&[SocketAddr]>,
     ) -> (Server, World, Entity) {
-        let mut server = Server::new(TEST_PROTOCOL_ID, TEST_PRIVATE_KEY).unwrap();
+        process_request_with_additional_addresses(
+            server_addr,
+            &[],
+            public_server_addresses,
+            internal_server_addresses,
+        )
+    }
+
+    fn process_request_with_additional_addresses(
+        server_addr: Option<SocketAddr>,
+        additional_expected_addresses: &[SocketAddr],
+        public_server_addresses: &[SocketAddr],
+        internal_server_addresses: Option<&[SocketAddr]>,
+    ) -> (Server, World, Entity) {
+        let config = ServerConfig::default()
+            .additional_expected_addresses(additional_expected_addresses.iter().copied());
+        let mut server = Server::with_config(TEST_PROTOCOL_ID, TEST_PRIVATE_KEY, config).unwrap();
         let mut world = World::new();
         let client = world.spawn_empty().id();
         let mut command_queue = CommandQueue::default();
@@ -1306,6 +1342,23 @@ mod tests {
         let server_addr = SocketAddr::from(([127, 0, 0, 1], 5000));
 
         let (server, world, client) = process_request(Some(server_addr), &[server_addr], None);
+
+        assert!(world.get::<Connecting>(client).is_some());
+        assert!(server.conn_cache.find_by_entity(&client).is_some());
+        assert!(server.send_queue.contains_key(&client));
+    }
+
+    #[test]
+    fn connection_request_accepts_additional_expected_address() {
+        let local_addr = SocketAddr::from(([0, 0, 0, 0], 5000));
+        let public_addr = SocketAddr::from(([203, 0, 113, 10], 5000));
+
+        let (server, world, client) = process_request_with_additional_addresses(
+            Some(local_addr),
+            &[public_addr],
+            &[public_addr],
+            None,
+        );
 
         assert!(world.get::<Connecting>(client).is_some());
         assert!(server.conn_cache.find_by_entity(&client).is_some());

--- a/crates/connection/netcode/src/server_plugin.rs
+++ b/crates/connection/netcode/src/server_plugin.rs
@@ -7,6 +7,7 @@ use bevy_ecs::{
     entity::UniqueEntitySlice, relationship::RelationshipTarget, system::ParallelCommands,
 };
 use bevy_time::{Real, Time};
+use core::net::SocketAddr;
 use lightyear_connection::client::{Connected, Disconnected, DisconnectedReason, Disconnecting};
 use lightyear_connection::client_of::SkipNetcode;
 use lightyear_connection::host::HostClient;
@@ -21,6 +22,17 @@ use lightyear_utils::adaptive_for_each_mut;
 use tracing::{error, info, trace};
 
 pub struct NetcodeServerPlugin;
+
+/// An error encountered while processing incoming netcode traffic for a server-side client link.
+#[derive(Message, Debug)]
+pub struct NetcodeServerError {
+    /// The server entity that encountered the error.
+    pub server_entity: Entity,
+    /// The client link entity associated with the packet or payload.
+    pub client_entity: Entity,
+    /// The underlying netcode error.
+    pub error: crate::Error,
+}
 
 /// User data extracted from the client's connection token.
 /// Contains up to 256 bytes of custom data embedded by the token issuer.
@@ -58,6 +70,12 @@ pub struct NetcodeConfig {
     /// The default is `true`. Set this to `false` for addressless transports. When enabled, a
     /// [`LocalAddr`] must be present on the server entity.
     pub server_addr_check: bool,
+    /// Additional server addresses accepted during private connect-token validation.
+    ///
+    /// These addresses are accepted in addition to the server entity's [`LocalAddr`]. This is
+    /// useful when the address in a token is a public address or another stable identity that
+    /// differs from the transport's bind address.
+    pub additional_expected_addresses: Vec<SocketAddr>,
     pub connection_request_handler: Option<Arc<dyn ConnectionRequestHandler>>,
 }
 
@@ -71,6 +89,7 @@ impl Default for NetcodeConfig {
             protocol_id: 0,
             private_key: [0; PRIVATE_KEY_BYTES],
             server_addr_check: true,
+            additional_expected_addresses: Vec::new(),
             connection_request_handler: None,
         }
     }
@@ -93,6 +112,17 @@ impl NetcodeConfig {
 
     pub fn with_client_timeout_secs(mut self, client_timeout_secs: i32) -> Self {
         self.client_timeout_secs = client_timeout_secs;
+        self
+    }
+
+    /// Set the additional server addresses accepted during private connect-token validation.
+    ///
+    /// These are accepted in addition to the server entity's [`LocalAddr`].
+    pub fn with_additional_expected_addresses(
+        mut self,
+        addresses: impl IntoIterator<Item = SocketAddr>,
+    ) -> Self {
+        self.additional_expected_addresses = addresses.into_iter().collect();
         self
     }
 
@@ -119,6 +149,7 @@ impl NetcodeServer {
         cfg = cfg.keep_alive_send_rate(config.keep_alive_send_rate);
         cfg = cfg.num_disconnect_packets(config.num_disconnect_packets);
         cfg = cfg.client_timeout_secs(config.client_timeout_secs);
+        cfg = cfg.additional_expected_addresses(config.additional_expected_addresses);
         let server_addr_check = config.server_addr_check;
         if let Some(handler) = config.connection_request_handler {
             cfg = cfg.connection_request_handler(handler);
@@ -310,10 +341,20 @@ impl NetcodeServerPlugin {
                                     Ok(errors) => {
                                         for error in errors {
                                             error.log();
+                                            c.write_message(NetcodeServerError {
+                                                server_entity,
+                                                client_entity: entity,
+                                                error,
+                                            });
                                         }
                                     }
-                                    Err(e) => {
-                                        error!("Error receiving packet: {:?}", e);
+                                    Err(error) => {
+                                        error!("Error receiving packet: {:?}", error);
+                                        c.write_message(NetcodeServerError {
+                                            server_entity,
+                                            client_entity: entity,
+                                            error,
+                                        });
                                     }
                                 }
                             }
@@ -463,6 +504,8 @@ impl Plugin for NetcodeServerPlugin {
 
         app.add_systems(PreUpdate, Self::receive.in_set(ConnectionSystems::Receive));
         app.add_systems(PostUpdate, Self::send.in_set(ConnectionSystems::Send));
+
+        app.add_message::<NetcodeServerError>();
 
         app.add_observer(Self::start);
         app.add_observer(Self::stop);


### PR DESCRIPTION
Fixes https://github.com/cBournhonesque/lightyear/issues/1695

+ enables the user to provide a list of accepted addresses