### PR TITLE
fix(prediction): simplify rollback logic

### DIFF
--- a/crates/replication/prediction/src/manager.rs
+++ b/crates/replication/prediction/src/manager.rs
@@ -181,28 +181,24 @@ impl LastConfirmedInput {
 /// Stores metadata related to state-based prediction.
 #[derive(Resource, Clone, Copy, Debug, Default, Reflect)]
 pub struct StateRollbackMetadata {
-    /// The last confirmed tick where we checked unchanged entities.
+    /// Latest completed server mutate tick consumed by the rollback check.
     ///
-    /// The latest confirmed tick itself is stored in
-    /// [`ReplicationCheckpointMap`](lightyear_replication::checkpoint::ReplicationCheckpointMap).
-    /// This field only records which completed tick prediction has already
-    /// scanned for unchanged-entity rollback checks.
+    /// Replicon advances `ServerMutateTicks` during receive; this advances only after
+    /// `check_rollback` handles that frontier. We retain it separately to:
+    /// - avoid rescanning unchanged entities while the completed frontier is unchanged;
+    /// - let receive functions ignore late updates older than an already-checked frontier;
+    /// - provide a safe watermark for pruning diff history.
+    ///
+    /// It can lag behind `ServerMutateTicks` when a completed tick is ahead of the local timeline.
     last_processed_tick: Option<Tick>,
 
-    /// Earliest tick represented by [`Self::mismatch_mask`].
+    /// Earliest receive-time state mismatch not yet covered by a completed rollback check.
     ///
-    /// Once a completed server tick has been processed this is kept equal to
-    /// [`Self::last_processed_tick`]. Before that, the first recorded mismatch
-    /// anchors the mask so early explicit mismatches are not lost.
-    mismatch_history_start: Option<Tick>,
-
-    /// Mismatch bits for the 64 ticks starting at [`Self::mismatch_history_start`].
-    ///
-    /// Bit 0 corresponds to `mismatch_history_start`, bit 1 to the next tick,
-    /// and so on. A set bit means a receive-time confirmed update already
-    /// proved that tick mismatched, so we do not need to run another mismatch
-    /// comparison for that same tick.
-    mismatch_mask: u64,
+    /// A mismatch can be detected before Replicon has completed all mutate messages through that
+    /// tick. We retain the earliest such tick until the completed server frontier reaches it, then
+    /// roll back from that latest globally complete frontier. Later confirmed samples do not need
+    /// separate mismatch entries: they remain in `ConfirmedHistory` and are applied during replay.
+    earliest_pending_mismatch_tick: Option<Tick>,
 
     /// Set to true if we received any replication message this frame.
     /// Used to trigger `RollbackMode::Always`.
@@ -218,46 +214,28 @@ pub struct StateRollbackMetadata {
 }
 
 impl StateRollbackMetadata {
-    fn mismatch_offset(start: Tick, tick: Tick) -> Option<u32> {
-        let delta = tick - start;
-        if (0..u64::BITS as i32).contains(&delta) {
-            Some(delta as u32)
-        } else {
-            None
-        }
-    }
-
-    fn ensure_mismatch_history_start(&mut self, tick: Tick) -> Tick {
-        if let Some(start) = self.mismatch_history_start {
-            return start;
-        }
-        let start = self.last_processed_tick.unwrap_or(tick);
-        self.mismatch_history_start = Some(start);
-        start
-    }
-
     /// Record a receive-time mismatch at `tick`.
     ///
-    /// Returns `false` if `tick` is older than the retained mismatch window or
-    /// too far ahead to fit in the 64-bit mask.
+    /// Only the earliest pending mismatch matters. Once the globally completed server frontier
+    /// reaches it, rollback starts from that completed frontier and replay applies every later
+    /// confirmed sample retained in `ConfirmedHistory`.
+    ///
+    /// Returns `true` because the unbounded representation can retain every mismatch tick. The
+    /// return value is kept for compatibility with the previous bounded representation, which
+    /// returned `false` when a tick fell outside its 64-tick window.
     pub fn record_mismatch(&mut self, tick: Tick) -> bool {
-        let start = self.ensure_mismatch_history_start(tick);
-        let Some(offset) = Self::mismatch_offset(start, tick) else {
-            return false;
-        };
-        self.mismatch_mask |= 1_u64 << offset;
+        match self.earliest_pending_mismatch_tick {
+            None => self.earliest_pending_mismatch_tick = Some(tick),
+            Some(existing) if tick < existing => self.earliest_pending_mismatch_tick = Some(tick),
+            _ => {}
+        }
         true
     }
 
-    /// Return whether a mismatch has already been recorded for exactly `tick`.
-    pub(crate) fn has_mismatch(&self, tick: Tick) -> bool {
-        let Some(start) = self.mismatch_history_start else {
-            return false;
-        };
-        let Some(offset) = Self::mismatch_offset(start, tick) else {
-            return false;
-        };
-        self.mismatch_mask & (1_u64 << offset) != 0
+    /// Return the earliest pending mismatch once `completed_tick` has reached it.
+    pub(crate) fn pending_mismatch_at_or_before(&self, completed_tick: Tick) -> Option<Tick> {
+        self.earliest_pending_mismatch_tick
+            .filter(|mismatch_tick| *mismatch_tick <= completed_tick)
     }
 
     /// Return whether receive-time prediction checks should run for `tick`.
@@ -268,12 +246,10 @@ impl StateRollbackMetadata {
         {
             return false;
         }
-        if let Some(start) = self.mismatch_history_start
-            && Self::mismatch_offset(start, tick).is_none()
-        {
-            return false;
-        }
-        !self.has_mismatch(tick)
+        // A later mismatch cannot make rollback eligible any sooner. Keep checking earlier ticks,
+        // though, because an out-of-order confirmed update can move the pending frontier earlier.
+        self.earliest_pending_mismatch_tick
+            .is_none_or(|pending_tick| tick < pending_tick)
     }
 
     /// Request a one-shot rollback from `tick`, regardless of the
@@ -310,7 +286,7 @@ impl StateRollbackMetadata {
     }
 
     /// Reset the per-frame state tracking.
-    /// Note: the mismatch mask is NOT reset here because receive-time mismatch
+    /// Note: the pending mismatch is NOT reset here because receive-time mismatch
     /// evidence persists until the completed server tick is processed.
     pub(crate) fn reset_frame_state(&mut self) {
         self.received_messages_this_frame = false;
@@ -318,44 +294,26 @@ impl StateRollbackMetadata {
 
     /// Clear all retained mismatch evidence.
     pub fn clear_mismatch_history(&mut self) {
-        self.mismatch_mask = 0;
+        self.earliest_pending_mismatch_tick = None;
     }
 
-    /// Returns the last confirmed tick that was processed for unchanged entities.
+    /// Returns the latest completed server mutate tick consumed by rollback checking.
     ///
-    /// Used to skip the unchanged-entity rollback check when `last_confirmed_tick`
-    /// has not advanced since the last successful check.
+    /// During Replicon's receive systems this still reflects the previous rollback-check frontier;
+    /// it is advanced only after the current completed tick has been handled by `check_rollback`.
+    /// It is used both to avoid rescanning an already-consumed completed tick and to reject stale
+    /// receive-time mismatch checks for ticks older than that frontier.
     pub fn last_processed_tick(&self) -> Option<Tick> {
         self.last_processed_tick
     }
 
-    /// Update the last processed tick after we've handled confirmed mutate tick advancement.
+    /// Record that rollback checking consumed this completed server mutate tick.
     ///
-    /// Call this only after the unchanged-entity rollback check has actually run
-    /// for the tick, not while the confirmed tick is still in the client's future.
+    /// Call this only at the end of the rollback check, after either consuming an explicit mismatch
+    /// or scanning unchanged entities. Do not advance it directly from `ServerMutateTicks`, or while
+    /// the completed tick is still in the client's future: receive functions must continue to see
+    /// the previously processed frontier while the current frame's replication is being applied.
     pub fn set_last_processed_tick(&mut self, tick: Tick) {
-        match self.mismatch_history_start {
-            None => self.mismatch_history_start = Some(tick),
-            Some(start) => {
-                let delta = tick - start;
-                if delta > 0 {
-                    if delta >= u64::BITS as i32 {
-                        self.mismatch_mask = 0;
-                    } else {
-                        self.mismatch_mask >>= delta as u32;
-                    }
-                    self.mismatch_history_start = Some(tick);
-                } else if delta < 0 {
-                    let delta = -delta;
-                    if delta >= u64::BITS as i32 {
-                        self.mismatch_mask = 0;
-                    } else {
-                        self.mismatch_mask <<= delta as u32;
-                    }
-                    self.mismatch_history_start = Some(tick);
-                }
-            }
-        }
         self.last_processed_tick = Some(tick);
     }
 
@@ -410,25 +368,29 @@ mod tests {
     }
 
     #[test]
-    fn mismatch_history_tracks_exact_ticks() {
+    fn pending_mismatch_keeps_earliest_tick() {
         let mut metadata = StateRollbackMetadata::default();
         metadata.set_last_processed_tick(Tick(10));
         metadata.record_mismatch(Tick(12));
 
-        assert!(!metadata.has_mismatch(Tick(11)));
-        assert!(metadata.has_mismatch(Tick(12)));
+        assert_eq!(metadata.pending_mismatch_at_or_before(Tick(11)), None);
+        assert_eq!(
+            metadata.pending_mismatch_at_or_before(Tick(12)),
+            Some(Tick(12))
+        );
         assert!(!metadata.should_check_mismatch_at(Tick(9)));
         assert!(!metadata.should_check_mismatch_at(Tick(12)));
-        assert!(metadata.should_check_mismatch_at(Tick(13)));
+        assert!(!metadata.should_check_mismatch_at(Tick(13)));
+        assert!(metadata.should_check_mismatch_at(Tick(11)));
 
-        metadata.set_last_processed_tick(Tick(11));
-        assert!(metadata.has_mismatch(Tick(12)));
+        metadata.record_mismatch(Tick(14));
+        assert_eq!(metadata.earliest_pending_mismatch_tick, Some(Tick(12)));
 
-        metadata.set_last_processed_tick(Tick(12));
-        assert!(metadata.has_mismatch(Tick(12)));
+        metadata.record_mismatch(Tick(11));
+        assert_eq!(metadata.earliest_pending_mismatch_tick, Some(Tick(11)));
 
         metadata.clear_mismatch_history();
-        assert!(!metadata.has_mismatch(Tick(12)));
+        assert_eq!(metadata.earliest_pending_mismatch_tick, None);
     }
 
     #[test]
@@ -460,34 +422,28 @@ mod tests {
     }
 
     #[test]
-    fn mismatch_history_keeps_multiple_exact_ticks() {
+    fn completed_frontier_can_jump_past_pending_mismatch() {
         let mut metadata = StateRollbackMetadata::default();
-        metadata.set_last_processed_tick(Tick(10));
+        metadata.set_last_processed_tick(Tick(100));
+        metadata.record_mismatch(Tick(105));
 
-        metadata.record_mismatch(Tick(12));
-        metadata.record_mismatch(Tick(14));
-        metadata.record_mismatch(Tick(10));
-
-        assert!(metadata.has_mismatch(Tick(10)));
-        assert!(!metadata.has_mismatch(Tick(11)));
-        assert!(metadata.has_mismatch(Tick(12)));
-        assert!(!metadata.has_mismatch(Tick(13)));
-        assert!(metadata.has_mismatch(Tick(14)));
-
-        metadata.set_last_processed_tick(Tick(13));
-        assert!(!metadata.has_mismatch(Tick(12)));
-        assert!(metadata.has_mismatch(Tick(14)));
+        assert_eq!(metadata.pending_mismatch_at_or_before(Tick(104)), None);
+        assert_eq!(
+            metadata.pending_mismatch_at_or_before(Tick(106)),
+            Some(Tick(105))
+        );
     }
 
     #[test]
-    fn mismatch_history_reanchors_to_first_processed_tick() {
+    fn pending_mismatch_has_no_fixed_tick_window() {
         let mut metadata = StateRollbackMetadata::default();
-
-        metadata.record_mismatch(Tick(12));
         metadata.set_last_processed_tick(Tick(10));
+        metadata.record_mismatch(Tick(100));
 
-        assert_eq!(metadata.mismatch_history_start, Some(Tick(10)));
-        assert!(metadata.has_mismatch(Tick(12)));
+        assert_eq!(
+            metadata.pending_mismatch_at_or_before(Tick(100)),
+            Some(Tick(100))
+        );
     }
 }
 

--- a/crates/replication/prediction/src/registry.rs
+++ b/crates/replication/prediction/src/registry.rs
@@ -473,21 +473,14 @@ impl PredictionRegistry {
 
         let predicted_history = entity_mut.get::<PredictionHistory<C>>();
 
-        // A confirmed VALUE arriving for a component this entity has never
-        // predicted (no PredictionHistory<C>) and does not currently have
-        // (no live C) — e.g. the server inserted a marker like `Dead`
-        // mid-game that the client cannot predict — is otherwise
-        // undeliverable (#1692):
-        // - the receive-time mismatch check below is often skipped because
-        //   insert messages ride a reliable channel and can resolve to a tick
-        //   at or behind `StateRollbackMetadata::last_processed_tick`;
-        // - the unchanged-entity scan (`check_rollback_for_unchanged_component`)
-        //   returns early without a retained predicted sample;
-        // - and `prepare_rollback` uses PredictionHistory<C> as its membership
-        //   marker, so even an unrelated rollback's restore skips C.
-        // Seed the prediction history with what the client actually predicted
-        // — "absent" — so the normal mismatch → rollback → restore pipeline
-        // picks the component up at the next completed mutate tick.
+        // Normally PredictionHistory<C> is added when live C is added. A confirmed
+        // insertion on a predicted entity is instead stored in ConfirmedHistory<C>,
+        // so the Add<C> observer does not run.
+        //
+        // prepare_rollback<C> requires PredictionHistory<C> to include the entity.
+        // Seed it with the state the client predicted ("absent") so rollback can read
+        // the confirmed value and insert C. Do this even if this update does not check
+        // for a mismatch, since another component may already have recorded one.
         let never_predicted_insert = confirmed_component.is_some()
             && predicted_history.is_none()
             && entity_mut.get::<C>().is_none();
@@ -568,16 +561,23 @@ impl PredictionRegistry {
             entity_mut.insert(history);
         }
         if never_predicted_insert {
+            // PredictionHistory must remain ordered on the local timeline. A confirmed update can
+            // be ahead of the client, so seeding at confirmed_tick could put a future entry before
+            // subsequent local predictions. The earlier tick records the known absence without
+            // preventing those predictions from being appended in chronological order.
+            let seed_tick = confirmed_tick.min(current_tick);
             trace!(
                 target: "lightyear_debug::prediction",
                 kind = "seed_prediction_history_for_unpredicted_insert",
                 entity = ?entity,
                 component = ?name,
                 confirmed_tick = confirmed_tick.0,
-                "seeding PredictionHistory with predicted-absence for a confirmed insert of a never-predicted component"
+                current_tick = current_tick.0,
+                seed_tick = seed_tick.0,
+                "seeding PredictionHistory with predicted absence for a confirmed insert of a never-predicted component"
             );
             let mut history = PredictionHistory::<C>::default();
-            history.add_state(confirmed_tick, HistoryState::Removed);
+            history.add_state(seed_tick, HistoryState::Removed);
             entity_mut.insert(history);
         }
         should_rollback
@@ -1926,6 +1926,43 @@ mod tests {
 
         assert!(!hashed);
         assert_eq!(hasher.finish(), initial_hash);
+    }
+
+    #[test]
+    fn future_confirmed_insert_seeds_prediction_history_at_current_tick() {
+        let (mut app, fns_id) = setup_prediction_diff_app();
+        app.world_mut()
+            .resource_mut::<LocalTimeline>()
+            .apply_delta(10);
+        let future_tick = record_checkpoint(&mut app, 20);
+        let entity = app.world_mut().spawn(Predicted).id();
+
+        app.world_mut().entity_mut(entity).apply_write(
+            diff_snapshot(0, TestDiffComponent(20)),
+            fns_id,
+            future_tick,
+        );
+
+        let mut history = app
+            .world_mut()
+            .get_mut::<PredictionHistory<TestDiffComponent>>(entity)
+            .expect("the confirmed insert should seed prediction history");
+        assert_eq!(
+            history.get_state(Tick(10)),
+            Some(&HistoryState::Removed),
+            "the absence should be recorded at the current tick, not the future confirmed tick"
+        );
+
+        history.add_predicted(Tick(15), Some(TestDiffComponent(15)));
+        assert_eq!(
+            history
+                .buffer()
+                .iter()
+                .map(|(tick, _)| *tick)
+                .collect::<Vec<_>>(),
+            [Tick(10), Tick(15)],
+            "later local predictions should remain chronologically ordered"
+        );
     }
 
     #[test]

--- a/crates/replication/prediction/src/rollback.rs
+++ b/crates/replication/prediction/src/rollback.rs
@@ -592,118 +592,123 @@ fn check_rollback(
                             "Confirmed mutate tick is in the future: {:?} compared to client timeline. Current tick: {:?}",
                             server_confirmed_tick, tick
                         );
-                    } else if state_metadata.has_mismatch(server_confirmed_tick) {
-                        debug!(
-                            ?server_confirmed_tick,
-                            "Rollback from completed mutate tick with recorded explicit mismatch"
-                        );
-                        trace!(
-                            target: "lightyear_debug::prediction",
-                            kind = "state_mismatch_consumed",
-                            schedule = "PreUpdate",
-                            sample_point = "PreUpdate",
-                            local_tick = tick.0,
-                            confirmed_tick = server_confirmed_tick.0,
-                            rollback_tick = server_confirmed_tick.0,
-                            "state mismatch consumed at completed mutate tick"
-                        );
-                        state_metadata.set_last_processed_tick(server_confirmed_tick);
-                        state_metadata.clear_mismatch_history();
-                        do_rollback(
-                            server_confirmed_tick,
-                            &prediction_manager,
-                            &mut commands,
-                            Rollback::FromState,
-                        );
                     } else {
-                        // A completed mutate tick certifies every replicated component at that
-                        // tick. This scan is only for entities that were not explicitly confirmed
-                        // at the completed Replicon checkpoint; for those entities, mutate-message
-                        // completeness proves their components are unchanged at
-                        // `server_confirmed_tick`.
-                        //
-                        // Do not use `ConfirmHistory::last_tick()` for this skip. An entity can
-                        // have newer explicit confirmations than the completed checkpoint while
-                        // also having an explicit confirmation at the completed checkpoint. What
-                        // matters here is exact membership: if `ConfirmHistory::contains` resolves the
-                        // completed Replicon tick, receive-time history writes already checked the
-                        // explicit state for that tick.
-                        trace!(
-                            ?tick,
-                            ?server_confirmed_tick,
-                            ?server_confirmed_replicon_tick,
-                            "Checking for state-based rollback at completed mutate tick"
-                        );
+                        if let Some(mismatch_tick) =
+                            state_metadata.pending_mismatch_at_or_before(server_confirmed_tick)
+                        {
+                            debug!(
+                                ?server_confirmed_tick,
+                                ?mismatch_tick,
+                                "Rollback from completed mutate tick with recorded explicit mismatch"
+                            );
+                            trace!(
+                                target: "lightyear_debug::prediction",
+                                kind = "state_mismatch_consumed",
+                                schedule = "PreUpdate",
+                                sample_point = "PreUpdate",
+                                local_tick = tick.0,
+                                confirmed_tick = server_confirmed_tick.0,
+                                mismatch_tick = mismatch_tick.0,
+                                rollback_tick = server_confirmed_tick.0,
+                                "state mismatch consumed at completed mutate tick"
+                            );
+                            state_metadata.clear_mismatch_history();
+                            do_rollback(
+                                server_confirmed_tick,
+                                &prediction_manager,
+                                &mut commands,
+                                Rollback::FromState,
+                            );
+                        } else {
+                            // A completed mutate tick certifies every replicated component at that
+                            // tick. This scan is only for entities that were not explicitly confirmed
+                            // at the completed Replicon checkpoint; for those entities, mutate-message
+                            // completeness proves their components are unchanged at
+                            // `server_confirmed_tick`.
+                            //
+                            // Do not use `ConfirmHistory::last_tick()` for this skip. An entity can
+                            // have newer explicit confirmations than the completed checkpoint while
+                            // also having an explicit confirmation at the completed checkpoint. What
+                            // matters here is exact membership: if `ConfirmHistory::contains` resolves the
+                            // completed Replicon tick, receive-time history writes already checked the
+                            // explicit state for that tick.
+                            trace!(
+                                ?tick,
+                                ?server_confirmed_tick,
+                                ?server_confirmed_replicon_tick,
+                                "Checking for state-based rollback at completed mutate tick"
+                            );
 
-                        let predicted_entities = adaptive_for_each_mut!(predicted_entities);
-                        predicted_entities.for_each(
-                            |(confirm_history, mut entity_mut)| {
-                            if prediction_manager.is_rollback() {
-                                return
-                            }
-
-                            if confirm_history.contains(server_confirmed_replicon_tick) {
-                                trace!(
-                                    entity = ?entity_mut.id(),
-                                    replicon_tick = ?server_confirmed_replicon_tick,
-                                    "Skipping unchanged rollback check for entity explicitly confirmed at completed mutate tick"
-                                );
-                                return
-                            }
-
-                            // For each predicted component, compare the predicted value at
-                            // `server_confirmed_tick` with the component's authoritative value.
-                            // The checker uses an exact `ConfirmedHistory<C>` sample if one exists;
-                            // otherwise it materializes an unchanged sample from the last confirmed
-                            // value before `server_confirmed_tick`.
-                            for check_rollback in prediction_registry.prediction_map
-                                .iter()
-                                .filter_map(|(kind, p)|
-                                    // only check rollback for components that are replicated (ignore non-networked)
-                                    component_registry.component_metadata_map.contains_key(kind).then_some(p.check_rollback)
-                                )
-                                .take_while(|_| !prediction_manager.is_rollback())
-                            {
-                                // SAFETY: this branch only checks entities whose Replicon
-                                // ConfirmHistory does not contain `server_confirmed_replicon_tick`.
-                                // Since `server_confirmed_tick` is the corresponding completed
-                                // mutate tick, Replicon guarantees this entity's replicated
-                                // components were unchanged there.
-                                let should_rollback = unsafe {
-                                    check_rollback(
-                                        &prediction_registry,
-                                        server_confirmed_tick,
-                                        &mut entity_mut,
-                                    )
-                                };
-                                if should_rollback {
-                                    debug!(
-                                        ?server_confirmed_tick,
-                                        "Rollback because of mismatch on unchanged entity"
-                                    );
-                                    trace!(
-                                        target: "lightyear_debug::prediction",
-                                        kind = "unchanged_entity_mismatch",
-                                        schedule = "PreUpdate",
-                                        sample_point = "PreUpdate",
-                                        entity = ?entity_mut.id(),
-                                        local_tick = tick.0,
-                                        confirmed_tick = server_confirmed_tick.0,
-                                        rollback_tick = server_confirmed_tick.0,
-                                        "rollback mismatch detected on unchanged entity"
-                                    );
-                                    parallel_commands.command_scope(|mut c| {
-                                        do_rollback(
-                                            server_confirmed_tick,
-                                            &prediction_manager,
-                                            &mut c,
-                                            Rollback::FromState,
-                                        );
-                                    });
-                                    return;
+                            let predicted_entities = adaptive_for_each_mut!(predicted_entities);
+                            predicted_entities.for_each(
+                                |(confirm_history, mut entity_mut)| {
+                                if prediction_manager.is_rollback() {
+                                    return
                                 }
-                            }
-                        });
+
+                                if confirm_history.contains(server_confirmed_replicon_tick) {
+                                    trace!(
+                                        entity = ?entity_mut.id(),
+                                        replicon_tick = ?server_confirmed_replicon_tick,
+                                        "Skipping unchanged rollback check for entity explicitly confirmed at completed mutate tick"
+                                    );
+                                    return
+                                }
+
+                                // For each predicted component, compare the predicted value at
+                                // `server_confirmed_tick` with the component's authoritative value.
+                                // The checker uses an exact `ConfirmedHistory<C>` sample if one exists;
+                                // otherwise it materializes an unchanged sample from the last confirmed
+                                // value before `server_confirmed_tick`.
+                                for check_rollback in prediction_registry.prediction_map
+                                    .iter()
+                                    .filter_map(|(kind, p)|
+                                        // only check rollback for components that are replicated (ignore non-networked)
+                                        component_registry.component_metadata_map.contains_key(kind).then_some(p.check_rollback)
+                                    )
+                                    .take_while(|_| !prediction_manager.is_rollback())
+                                {
+                                    // SAFETY: this branch only checks entities whose Replicon
+                                    // ConfirmHistory does not contain `server_confirmed_replicon_tick`.
+                                    // Since `server_confirmed_tick` is the corresponding completed
+                                    // mutate tick, Replicon guarantees this entity's replicated
+                                    // components were unchanged there.
+                                    let should_rollback = unsafe {
+                                        check_rollback(
+                                            &prediction_registry,
+                                            server_confirmed_tick,
+                                            &mut entity_mut,
+                                        )
+                                    };
+                                    if should_rollback {
+                                        debug!(
+                                            ?server_confirmed_tick,
+                                            "Rollback because of mismatch on unchanged entity"
+                                        );
+                                        trace!(
+                                            target: "lightyear_debug::prediction",
+                                            kind = "unchanged_entity_mismatch",
+                                            schedule = "PreUpdate",
+                                            sample_point = "PreUpdate",
+                                            entity = ?entity_mut.id(),
+                                            local_tick = tick.0,
+                                            confirmed_tick = server_confirmed_tick.0,
+                                            rollback_tick = server_confirmed_tick.0,
+                                            "rollback mismatch detected on unchanged entity"
+                                        );
+                                        parallel_commands.command_scope(|mut c| {
+                                            do_rollback(
+                                                server_confirmed_tick,
+                                                &prediction_manager,
+                                                &mut c,
+                                                Rollback::FromState,
+                                            );
+                                        });
+                                        return;
+                                    }
+                                }
+                            });
+                        }
                         // Update the last processed tick only after we were able to process it.
                         state_metadata.set_last_processed_tick(server_confirmed_tick);
                         if prediction_manager.is_rollback() {

--- a/crates/tests/src/client_server/prediction/history.rs
+++ b/crates/tests/src/client_server/prediction/history.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::protocol::CompFull;
+use crate::protocol::{CompCorr, CompFull};
 use bevy::prelude::Entity;
 use lightyear::prelude::*;
 use lightyear_core::history_buffer::HistoryState;
@@ -138,6 +138,167 @@ fn test_prediction_history_seeded_from_init_message() {
         }),
         "PredictionHistory should contain only local predicted states: {:?}",
         prediction_history
+    );
+}
+
+/// A Full-mode component inserted by the server after the predicted entity was
+/// spawned should be detected as a mismatch and applied through rollback.
+#[test]
+fn test_server_insert_on_existing_predicted_entity_triggers_rollback() {
+    use bevy::prelude::*;
+    use lightyear_messages::MessageManager;
+    use lightyear_replication::prelude::{PredictionTarget, Replicate};
+
+    #[derive(Resource, Default)]
+    struct RollbackObserved(bool);
+
+    fn observe_rollback(manager: Res<PredictionManager>, mut observed: ResMut<RollbackObserved>) {
+        observed.0 |= manager.is_rollback();
+    }
+
+    let mut stepper = ClientServerStepper::from_config(StepperConfig::single());
+    stepper.client_app().init_resource::<RollbackObserved>();
+    stepper.client_app().add_systems(
+        PreUpdate,
+        observe_rollback
+            .after(RollbackSystems::Check)
+            .before(RollbackSystems::Prepare),
+    );
+    let server_entity = stepper
+        .server_app
+        .world_mut()
+        .spawn((
+            Replicate::to_clients(NetworkTarget::All),
+            PredictionTarget::to_clients(NetworkTarget::All),
+        ))
+        .id();
+
+    stepper.frame_step(2);
+    let predicted_entity = stepper
+        .client(0)
+        .get::<MessageManager>()
+        .unwrap()
+        .entity_mapper
+        .get_local(server_entity)
+        .expect("entity was not replicated to the client");
+    assert!(
+        stepper
+            .client_app()
+            .world()
+            .get::<CompFull>(predicted_entity)
+            .is_none()
+    );
+
+    stepper
+        .server_app
+        .world_mut()
+        .entity_mut(server_entity)
+        .insert(CompFull(42.0));
+    stepper.frame_step(2);
+
+    let world = stepper.client_app().world();
+    assert!(
+        world.resource::<RollbackObserved>().0,
+        "the receive-time (Some, None) mismatch check should trigger a rollback"
+    );
+    assert_eq!(
+        world
+            .get::<ConfirmedHistory<CompFull>>(predicted_entity)
+            .and_then(ConfirmedHistory::newest_present)
+            .map(|(_, value)| value),
+        Some(&CompFull(42.0)),
+        "the authoritative insert should be buffered in confirmed history"
+    );
+    assert!(
+        world
+            .get::<PredictionHistory<CompFull>>(predicted_entity)
+            .is_some(),
+        "the confirmed insert should seed rollback membership for the component"
+    );
+
+    assert_eq!(
+        world.get::<CompFull>(predicted_entity),
+        Some(&CompFull(42.0)),
+        "the authoritative insert should trigger a rollback that applies the component"
+    );
+}
+
+/// When two previously absent components arrive in the same update, the first mismatch suppresses
+/// the redundant check for the second. Both still need prediction history so the resulting rollback
+/// restores both components.
+#[test]
+fn test_two_server_inserts_are_both_applied_by_one_rollback() {
+    use bevy::prelude::*;
+    use lightyear_messages::MessageManager;
+    use lightyear_replication::prelude::{PredictionTarget, Replicate};
+
+    #[derive(Resource, Default)]
+    struct RollbackObserved(bool);
+
+    fn observe_rollback(manager: Res<PredictionManager>, mut observed: ResMut<RollbackObserved>) {
+        observed.0 |= manager.is_rollback();
+    }
+
+    let mut stepper = ClientServerStepper::from_config(StepperConfig::single());
+    stepper.client_app().init_resource::<RollbackObserved>();
+    stepper.client_app().add_systems(
+        PreUpdate,
+        observe_rollback
+            .after(RollbackSystems::Check)
+            .before(RollbackSystems::Prepare),
+    );
+    let server_entity = stepper
+        .server_app
+        .world_mut()
+        .spawn((
+            Replicate::to_clients(NetworkTarget::All),
+            PredictionTarget::to_clients(NetworkTarget::All),
+        ))
+        .id();
+
+    stepper.frame_step(2);
+    let predicted_entity = stepper
+        .client(0)
+        .get::<MessageManager>()
+        .unwrap()
+        .entity_mapper
+        .get_local(server_entity)
+        .expect("entity was not replicated to the client");
+    let client_entity = stepper.client_app().world().entity(predicted_entity);
+    assert!(!client_entity.contains::<CompFull>());
+    assert!(!client_entity.contains::<CompCorr>());
+
+    stepper
+        .server_app
+        .world_mut()
+        .entity_mut(server_entity)
+        .insert((CompFull(42.0), CompCorr(24.0)));
+    stepper.frame_step(2);
+
+    let world = stepper.client_app().world();
+    assert!(
+        world.resource::<RollbackObserved>().0,
+        "the authoritative inserts should trigger a rollback"
+    );
+    assert!(
+        world
+            .get::<PredictionHistory<CompFull>>(predicted_entity)
+            .is_some(),
+        "the CompFull insert should seed rollback membership"
+    );
+    assert!(
+        world
+            .get::<PredictionHistory<CompCorr>>(predicted_entity)
+            .is_some(),
+        "the CompCorr insert should seed rollback membership even if its mismatch check was suppressed"
+    );
+    assert_eq!(
+        world.get::<CompFull>(predicted_entity),
+        Some(&CompFull(42.0))
+    );
+    assert_eq!(
+        world.get::<CompCorr>(predicted_entity),
+        Some(&CompCorr(24.0))
     );
 }
 

--- a/crates/tests/src/client_server/prediction/rollback.rs
+++ b/crates/tests/src/client_server/prediction/rollback.rs
@@ -702,7 +702,7 @@ fn test_future_completed_mutate_tick_is_not_marked_processed() {
 }
 
 #[test]
-fn test_explicit_mismatch_waits_for_completed_mutate_tick() {
+fn test_explicit_mismatch_waits_until_completed_mutate_frontier_reaches_it() {
     let (mut stepper, _) = setup();
     observe_rollback_start(stepper.client_app());
 
@@ -729,10 +729,11 @@ fn test_explicit_mismatch_waits_for_completed_mutate_tick() {
         "Explicit mismatch should wait until a completed mutate tick reaches the mismatch"
     );
 
+    let later_completed_tick = mismatch_tick + 1;
     record_completed_mutate_tick(
         stepper.client_app().world_mut(),
         RepliconTick::new(931),
-        mismatch_tick,
+        later_completed_tick,
     );
     stepper.frame_step(1);
 
@@ -742,8 +743,8 @@ fn test_explicit_mismatch_waits_for_completed_mutate_tick() {
             .world()
             .resource::<ObservedRollbackStart>()
             .0,
-        Some(mismatch_tick),
-        "Explicit mismatch should rollback once that exact tick is the completed mutate tick"
+        Some(later_completed_tick),
+        "Explicit mismatch should rollback from the latest completed tick once its frontier has passed the mismatch"
     );
 }
 


### PR DESCRIPTION
## Summary

- replace the mismatch mask with the earliest pending mismatch (simpler)
- seed never-predicted confirmed inserts on the local timeline so every confirmed component participates in rollback, even after another component suppresses its mismatch check
- clarify the lifecycle of `last_processed_tick` and update it once after either completed rollback-check path