### PR TITLE
fix(p2p): synchronize example session startup

### DIFF
--- a/crates/connection/connection/src/network_topology.rs
+++ b/crates/connection/connection/src/network_topology.rs
@@ -3,11 +3,10 @@ use crate::client::{Client, Connected, Disconnected};
 use crate::host::HostClient;
 use crate::p2p::P2P;
 use crate::server::{Started, Stopped};
-use bevy_app::{App, Plugin, PostUpdate, PreUpdate};
+use bevy_app::{App, Plugin, PostUpdate};
 use bevy_ecs::prelude::*;
 use bevy_platform::collections::HashMap;
 use lightyear_core::id::PeerId;
-use lightyear_link::LinkSystems;
 use lightyear_link::prelude::{LinkOf, Server};
 use smallvec::SmallVec;
 
@@ -187,19 +186,8 @@ impl Plugin for NetworkTopologyPlugin {
         app.add_observer(mark_dirty_on_remove);
         app.add_observer(mark_dirty_on_discard);
 
-        app.configure_sets(
-            PreUpdate,
-            NetworkTopologySystems::Update
-                .after(LinkSystems::Receive)
-                .after(ConnectionSystems::Receive),
-        );
-        app.add_systems(
-            PreUpdate,
-            refresh_network_topology
-                .in_set(NetworkTopologySystems::Update)
-                .run_if(network_topology_is_dirty),
-        );
-
+        // Reconcile ordinary lifecycle changes once per frame. The P2P start barrier updates the
+        // topology immediately when it activates a session, before its first fixed gameplay tick.
         app.configure_sets(
             PostUpdate,
             NetworkTopologySystems::Update.before(ConnectionSystems::Send),

--- a/crates/connection/p2p/src/session.rs
+++ b/crates/connection/p2p/src/session.rs
@@ -1,15 +1,15 @@
 use alloc::vec::Vec;
-use bevy_app::{App, Plugin, PreUpdate};
+use bevy_app::{App, FixedFirst, Plugin, PreUpdate};
 use bevy_ecs::prelude::*;
 use bevy_time::{Real, Time};
 use core::hash::Hasher;
 use core::time::Duration;
 use lightyear_connection::client::Connected;
 use lightyear_connection::direction::NetworkDirection;
-use lightyear_connection::network_topology::NetworkTopologySystems;
+use lightyear_connection::network_topology::{NetworkTopology, NetworkingMetadata};
 use lightyear_connection::p2p::P2P;
 use lightyear_core::id::{LocalId, PeerId, RemoteId};
-use lightyear_core::prelude::{LocalTimeline, Tick};
+use lightyear_core::prelude::{LocalTimeline, Tick, TimelineSystems};
 use lightyear_link::prelude::{Unlink, UnlinkReason};
 use lightyear_messages::plugin::MessageSystems;
 use lightyear_messages::prelude::{AppMessageExt, MessageReceiver, MessageSender};
@@ -258,12 +258,12 @@ impl P2PSession {
         }
     }
 
-    /// Advance the local start negotiation from readiness through the agreed start tick.
+    /// Advance the local start negotiation through agreement on a future start tick.
     ///
     /// Each peer proposes `current tick + start delay`. Once all proposals exist, their maximum
     /// is the common start tick. Every peer must then acknowledge that same value. The transition
-    /// to Started happens one tick early in `PreUpdate`, so [`P2PStarted`] observers can create the
-    /// deterministic world before `FixedFirst` advances to the agreed tick.
+    /// to Started happens separately in `FixedFirst`, immediately before the [`LocalTimeline`]
+    /// advances to the agreed tick.
     fn advance(&mut self, tick: Tick, timeline_synced: bool) -> AdvanceResult {
         if !matches!(self.state, P2PSessionState::Starting { .. }) {
             return AdvanceResult::Waiting;
@@ -315,8 +315,8 @@ impl P2PSession {
             return AdvanceResult::Failed;
         }
 
-        // Receiving the final acknowledgement after the target tick is too late to create the
-        // shared world deterministically before that tick.
+        // PreUpdate observes the tick most recently simulated by FixedMain. Consensus reached at
+        // or after the target tick is too late to create the shared world before that tick.
         if tick >= start_tick {
             tracing::warn!(
                 ?tick,
@@ -325,11 +325,25 @@ impl P2PSession {
             );
             return AdvanceResult::Failed;
         }
-        if tick + 1 < start_tick {
-            return AdvanceResult::Waiting;
+        AdvanceResult::Agreed(start_tick)
+    }
+
+    /// Return the start tick once every remote peer has acknowledged it.
+    fn agreed_start_tick(&self) -> Option<Tick> {
+        let P2PSessionState::Starting {
+            start_tick: Some(start_tick),
+        } = self.state
+        else {
+            return None;
+        };
+        if self
+            .remote_peers
+            .iter()
+            .any(|peer| peer.acknowledged_tick != Some(start_tick))
+        {
+            return None;
         }
-        self.state = P2PSessionState::Started { start_tick };
-        AdvanceResult::Started(start_tick)
+        Some(start_tick)
     }
 
     /// Return each locally available Ready or acknowledgement once.
@@ -463,14 +477,14 @@ impl Plugin for P2PSessionPlugin {
 
         app.add_observer(start_session);
         app.add_observer(stop_session);
+        app.add_systems(PreUpdate, drive_session.after(MessageSystems::Receive));
+        // PreUpdate runs only once per rendered frame, which may contain several catch-up fixed
+        // ticks. FixedFirst observes every boundary, so it cannot skip the transition to the
+        // agreed tick. P2PStarted must run before IncrementLocal: a late input for the first
+        // gameplay tick T rolls back to the shared snapshot at T - 1.
         app.add_systems(
-            PreUpdate,
-            drive_session
-                .after(MessageSystems::Receive)
-                // A successful barrier replaces Candidate with Joined. Refresh the cached
-                // topology in the same PreUpdate so FixedMain sees the new membership at the
-                // agreed start tick.
-                .before(NetworkTopologySystems::Update),
+            FixedFirst,
+            start_session_before_agreed_tick.before(TimelineSystems::IncrementLocal),
         );
     }
 }
@@ -478,7 +492,7 @@ impl Plugin for P2PSessionPlugin {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum AdvanceResult {
     Waiting,
-    Started(Tick),
+    Agreed(Tick),
     Failed,
 }
 
@@ -655,6 +669,45 @@ fn transition_candidates(commands: &mut Commands, links: &mut P2PLinkQuery, next
     }
 }
 
+/// Complete an acknowledged barrier immediately before its first gameplay tick.
+fn start_session_before_agreed_tick(
+    mut commands: Commands,
+    mut session: ResMut<P2PSession>,
+    timeline: Res<LocalTimeline>,
+    mut metadata: ResMut<NetworkingMetadata>,
+    mut links: P2PLinkQuery,
+) {
+    let Some(start_tick) = session.agreed_start_tick() else {
+        return;
+    };
+    if timeline.tick() + 1 != start_tick {
+        return;
+    }
+
+    let mut candidate_count = 0;
+    let mut joined = SmallVec::<[Entity; 4]>::new();
+    for (entity, state, _, connected, _, _) in &mut links {
+        if *state == P2P::Candidate {
+            candidate_count += 1;
+            if !connected {
+                return;
+            }
+            joined.push(entity);
+        }
+    }
+    if candidate_count != session.remote_peers.len() {
+        return;
+    }
+
+    joined.sort_unstable_by_key(|entity| entity.index_u32());
+    session.state = P2PSessionState::Started { start_tick };
+    transition_candidates(&mut commands, &mut links, P2P::Joined);
+    metadata.mode = NetworkTopology::P2P(joined);
+    tracing::info!(?start_tick, "P2P session started");
+    session.clear_barrier_progress();
+    commands.trigger(P2PStarted { start_tick });
+}
+
 /// Drive the current start attempt once per frame before fixed simulation.
 ///
 /// Incoming messages update per-remote-peer progress. Once every frozen Link is connected and the
@@ -672,7 +725,6 @@ fn drive_session(
         return;
     }
 
-    let timed_out = session.timed_out_at(real_time.elapsed());
     let expected_peer_count = session.remote_peers.len();
     let mut found_peers = SmallVec::<[PeerId; 4]>::new();
     let mut cohort_intact = true;
@@ -719,31 +771,36 @@ fn drive_session(
         tracing::warn!("P2P session start negotiation failed because peer rosters differ");
         return;
     }
-    if timed_out {
-        let timeout = session.start_timeout;
-        session.stop();
-        transition_candidates(&mut commands, &mut links, P2P::Inactive);
-        tracing::warn!(?timeout, "P2P session start negotiation timed out");
-        return;
-    }
     if !all_connected {
+        if session.timed_out_at(real_time.elapsed()) {
+            let timeout = session.start_timeout;
+            session.stop();
+            transition_candidates(&mut commands, &mut links, P2P::Inactive);
+            tracing::warn!(?timeout, "P2P session start negotiation timed out");
+        }
         return;
     }
     match session.advance(timeline.tick(), synced_timeline.is_some()) {
-        AdvanceResult::Started(start_tick) => {
-            tracing::info!(?start_tick, "P2P session started");
-            transition_candidates(&mut commands, &mut links, P2P::Joined);
-            session.clear_barrier_progress();
-            commands.trigger(P2PStarted { start_tick });
-            return;
-        }
         AdvanceResult::Failed => {
             tracing::warn!("P2P session start negotiation failed");
             session.stop();
             transition_candidates(&mut commands, &mut links, P2P::Inactive);
             return;
         }
+        AdvanceResult::Agreed(start_tick) => {
+            tracing::trace!(?start_tick, "P2P session start tick agreed");
+        }
         AdvanceResult::Waiting => {}
+    }
+
+    // Once every remote has acknowledged the common tick, the negotiation is complete. Do not
+    // let its wall-clock timeout expire while FixedFirst waits for that future tick boundary.
+    if session.agreed_start_tick().is_none() && session.timed_out_at(real_time.elapsed()) {
+        let timeout = session.start_timeout;
+        session.stop();
+        transition_candidates(&mut commands, &mut links, P2P::Inactive);
+        tracing::warn!(?timeout, "P2P session start negotiation timed out");
+        return;
     }
 
     let mut outbound = SmallVec::<[P2PSessionMessage; 2]>::new();
@@ -836,7 +893,7 @@ mod tests {
     }
 
     #[test]
-    fn ready_peers_choose_and_acknowledge_the_latest_tick() {
+    fn ready_peers_agree_on_the_latest_tick() {
         let mut session = P2PSession::default().with_start_delay_ticks(10);
         let local = peer(0);
         let first = peer(1);
@@ -865,6 +922,8 @@ mod tests {
         );
         assert_eq!(session.advance(Tick(7), true), AdvanceResult::Waiting);
         assert_eq!(session.start_tick(), Some(Tick(18)));
+        let mut outbound = SmallVec::new();
+        session.collect_outbound(&mut outbound);
 
         for link in [first, second] {
             session.receive(
@@ -878,14 +937,15 @@ mod tests {
         }
         assert_eq!(
             session.advance(Tick(17), true),
-            AdvanceResult::Started(Tick(18))
+            AdvanceResult::Agreed(Tick(18))
         );
         assert_eq!(
             session.state(),
-            P2PSessionState::Started {
-                start_tick: Tick(18)
+            P2PSessionState::Starting {
+                start_tick: Some(Tick(18))
             }
         );
+        assert_eq!(session.agreed_start_tick(), Some(Tick(18)));
     }
 
     #[test]

--- a/crates/core/core/src/timeline.rs
+++ b/crates/core/core/src/timeline.rs
@@ -7,7 +7,7 @@ use bevy_ecs::component::{Component, ComponentId, Mutable};
 use bevy_ecs::event::Event;
 use bevy_ecs::prelude::{On, Resource};
 use bevy_ecs::ptr::Ptr;
-use bevy_ecs::schedule::SystemSet;
+use bevy_ecs::schedule::{IntoScheduleConfigs, SystemSet};
 use bevy_ecs::system::{Res, ResMut};
 use bevy_reflect::Reflect;
 use bevy_time::{Fixed, Time};
@@ -18,11 +18,13 @@ use lightyear_utils::collections::HashMap;
 #[allow(unused_imports)]
 use tracing::trace;
 
-/// Shared ordering for systems that advance connection-local network timelines.
+/// Shared ordering for systems that advance network timelines.
 #[derive(SystemSet, Debug, Hash, PartialEq, Eq, Clone, Copy)]
 pub enum TimelineSystems {
     /// Drives the internal state of network timelines forward in `PreUpdate`.
     Advance,
+    /// Increments the application-global [`LocalTimeline`] in `FixedFirst`.
+    IncrementLocal,
 }
 
 /// Runtime identifier for a [`NetworkTimeline`] type.
@@ -304,7 +306,10 @@ impl Plugin for TimelinePlugin {
             .set_timestep(self.tick_duration);
         app.add_observer(Self::update_tick_duration);
 
-        app.add_systems(FixedFirst, increment_local_tick);
+        app.add_systems(
+            FixedFirst,
+            increment_local_tick.in_set(TimelineSystems::IncrementLocal),
+        );
     }
 
     fn finish(&self, app: &mut App) {

--- a/crates/replication/prediction/src/despawn.rs
+++ b/crates/replication/prediction/src/despawn.rs
@@ -4,7 +4,9 @@ use crate::prelude::DeterministicPredicted;
 use bevy_ecs::error::ignore;
 use bevy_ecs::prelude::*;
 use bevy_reflect::Reflect;
+use lightyear_core::prelude::{LocalTimeline, Tick};
 use lightyear_replication::prelude::PreSpawned;
+use lightyear_sync::prelude::InputTimelineConfig;
 #[allow(unused_imports)]
 use tracing::{debug, error, info};
 // TODO (IMPORTANT): we need to add PredictionDisable in the replication receiver systems!!!
@@ -29,7 +31,13 @@ pub struct PredictionDespawnCommand {
 
 #[derive(Component, PartialEq, Debug, Reflect)]
 #[reflect(Component)]
-pub struct PredictionDisable;
+pub struct PredictionDisable {
+    /// Tick at which the entity was prediction-despawned.
+    ///
+    /// Deterministic prediction retains the entity until this tick falls outside the effective
+    /// rollback window, at which point the entity can be permanently reclaimed.
+    pub tick: Tick,
+}
 
 impl Command for PredictionDespawnCommand {
     type Out = ();
@@ -49,14 +57,45 @@ impl Command for PredictionDespawnCommand {
                 // see https://github.com/cBournhonesque/lightyear/issues/818
                 || entity.get::<PreSpawned>().is_some()
             {
-                // if this is a predicted entity, do not despawn the entity immediately but instead
-                // add a PredictionDisable component to it to mark it as disabled until the confirmed
-                // entity catches up to it
+                // Do not despawn predicted entities immediately. A conventional predicted entity
+                // remains disabled until confirmed replication resolves it; a deterministic-only
+                // entity remains disabled until its despawn tick falls outside the rollback window.
                 debug!(?self.entity, "inserting prediction disable marker");
-                entity.insert(PredictionDisable);
+                let disabled_at = entity.world().resource::<LocalTimeline>().tick();
+                entity.insert(PredictionDisable { tick: disabled_at });
             } else {
                 error!("This command should only be called for predicted entities!");
             }
+        }
+    }
+}
+
+/// Permanently remove deterministic entities once their despawn tick is outside the rollback
+/// window.
+pub(crate) fn finalize_deterministic_despawns(
+    mut commands: Commands,
+    timeline: Res<LocalTimeline>,
+    prediction_manager: Res<PredictionManager>,
+    input_config: Option<Res<InputTimelineConfig>>,
+    query: Query<
+        (Entity, &PredictionDisable),
+        (With<DeterministicPredicted>, Allow<PredictionDisable>),
+    >,
+) {
+    let max_rollback_ticks = input_config.as_deref().map_or(
+        prediction_manager.rollback_policy.max_rollback_ticks,
+        |input_config| {
+            prediction_manager
+                .rollback_policy
+                .effective_max_rollback_ticks(input_config)
+        },
+    );
+    for (entity, disabled) in &query {
+        // Keep the entity while its disable tick can still be reached by an accepted rollback.
+        // Once it is older than the same effective bound enforced by `check_rollback`, no later
+        // reconciliation can restore it.
+        if timeline.tick() - disabled.tick > i32::from(max_rollback_ticks) {
+            commands.entity(entity).despawn();
         }
     }
 }

--- a/crates/replication/prediction/src/plugin.rs
+++ b/crates/replication/prediction/src/plugin.rs
@@ -3,7 +3,7 @@ use crate::SyncComponent;
 use crate::correction::{
     repair_frame_interpolation_history, update_frame_interpolation_post_rollback,
 };
-use crate::despawn::PredictionDisable;
+use crate::despawn::{PredictionDisable, finalize_deterministic_despawns};
 use crate::diagnostics::PredictionDiagnosticsPlugin;
 use crate::manager::{LastConfirmedInput, PredictionManager};
 use crate::predicted_history::{
@@ -252,6 +252,10 @@ impl Plugin for PredictionPlugin {
                 .chain(),
         );
         app.configure_sets(FixedPostUpdate, PredictionSystems::All.run_if(should_run));
+        app.add_systems(
+            FixedPostUpdate,
+            finalize_deterministic_despawns.in_set(PredictionSystems::EntityDespawn),
+        );
 
         // PostUpdate
         app.configure_sets(PostUpdate, PredictionSystems::All.run_if(should_run));

--- a/crates/replication/prediction/src/rollback.rs
+++ b/crates/replication/prediction/src/rollback.rs
@@ -62,7 +62,7 @@ use lightyear_core::timeline::{Rollback, is_in_rollback};
 use lightyear_frame_interpolation::FrameInterpolationSystems;
 #[cfg(feature = "p2p")]
 use lightyear_p2p::prelude::{P2PStarted, P2PStopped};
-use lightyear_replication::prelude::ConfirmHistory;
+use lightyear_replication::prelude::{ConfirmHistory, PreSpawned};
 use lightyear_replication::prespawn::PreSpawnedReceiver;
 use lightyear_replication::registry::ComponentRegistry;
 use lightyear_replication::{ReplicationSystems, checkpoint::ReplicationCheckpointMap};
@@ -919,7 +919,17 @@ pub fn reset_input_rollback_tracker(
 /// Before we start preparing for rollback, restore any PredictionDisable predicted entity
 pub(crate) fn remove_prediction_disable(
     mut commands: Commands,
-    query: Query<Entity, (With<Predicted>, With<PredictionDisable>)>,
+    query: Query<
+        Entity,
+        (
+            With<PredictionDisable>,
+            Or<(
+                With<Predicted>,
+                With<DeterministicPredicted>,
+                With<PreSpawned>,
+            )>,
+        ),
+    >,
 ) {
     query.iter().for_each(|e| {
         trace!(

--- a/demos/spaceships/Cargo.toml
+++ b/demos/spaceships/Cargo.toml
@@ -45,9 +45,9 @@ lightyear_examples_common = { workspace = true, features = [
 leafwing-input-manager = { workspace = true, features = ["keyboard", "mouse"] }
 avian2d = { workspace = true, features = [
   "2d",
+  "enhanced-determinism",
   "f32",
   "parry-f32",
-  "parallel",
   "serialize",
 ] }
 serde.workspace = true

--- a/demos/spaceships/src/p2p.rs
+++ b/demos/spaceships/src/p2p.rs
@@ -13,7 +13,6 @@ use lightyear_examples_common::p2p::{P2PSettings, input_target_for_peer};
 use lightyear_examples_common::shared::FIXED_TIMESTEP_HZ;
 use lightyear_frame_interpolation::FrameInterpolate;
 
-use crate::client::player_input_map;
 use crate::protocol::*;
 use crate::shared::color_from_id;
 
@@ -86,7 +85,9 @@ fn spawn_fixed_world(
             ))
             .id();
         if peer_id == settings.local_peer_id {
-            commands.entity(player).insert(player_input_map());
+            // P2P has no authoritative replication stream to assign ownership, so mark the
+            // locally owned player explicitly. The common client observer installs its InputMap.
+            commands.entity(player).insert(Controlled);
         }
     }
 }

--- a/demos/spaceships/src/renderer.rs
+++ b/demos/spaceships/src/renderer.rs
@@ -59,7 +59,6 @@ impl Plugin for ExampleRendererPlugin {
             app.add_plugins(FrameInterpolationPlugin);
         }
 
-        // Add FrameInterpolate to predicted entities once Position is available.
         app.add_observer(add_frame_interpolation_components);
     }
 }
@@ -73,9 +72,9 @@ impl Plugin for ExampleRendererPlugin {
 // Lightyear's Avian integration copies the interpolated/corrected Position and Rotation
 // to Transform before transform propagation, so visual children follow the smoothed pose.
 fn add_frame_interpolation_components(
-    // We use Position because it's added by avian later, and when it's added
-    // we know that Predicted is already present on the entity
-    trigger: On<Add, Position>,
+    // Observe both components because conventional predicted entities receive Position after
+    // their marker, while P2P bullets receive DeterministicPredicted after Position.
+    trigger: On<Add, (Position, DeterministicPredicted)>,
     q: Query<
         Entity,
         (
@@ -219,7 +218,11 @@ fn draw_predicted_entities(
         (
             // skip drawing bullet outlines, since we add a mesh + material to them
             Without<BulletMarker>,
-            Or<(With<PreSpawned>, With<Predicted>)>,
+            Or<(
+                With<PreSpawned>,
+                With<Predicted>,
+                With<DeterministicPredicted>,
+            )>,
         ),
     >,
     timeline: Res<LocalTimeline>,

--- a/demos/spaceships/src/shared.rs
+++ b/demos/spaceships/src/shared.rs
@@ -9,7 +9,7 @@ use crate::protocol::*;
 #[cfg(feature = "gui")]
 use crate::renderer::ExampleRendererPlugin;
 use avian2d::prelude::{forces::ForcesItem, *};
-use leafwing_input_manager::prelude::{ActionState, InputMap};
+use leafwing_input_manager::prelude::ActionState;
 use lightyear::avian2d::plugin::AvianReplicationMode;
 use lightyear::input::leafwing::prelude::LeafwingBuffer;
 use lightyear::prelude::*;
@@ -268,7 +268,6 @@ pub fn shared_player_firing(
         &mut Weapon,
         Option<&ConfirmedHistory<Weapon>>,
         Has<Controlled>,
-        Has<InputMap<PlayerActions>>,
         Has<Predicted>,
         Has<DeterministicPredicted>,
         Has<Interpolated>,
@@ -288,6 +287,10 @@ pub fn shared_player_firing(
     }
 
     let current_tick = timeline.tick();
+    // The local Controlled marker puts a different player in a different archetype on each P2P
+    // peer.
+    // Process players by their shared identity so gameplay-side spawn ordering does not inherit
+    // that local archetype order.
     for (
         player_position,
         player_rotation,
@@ -298,13 +301,14 @@ pub fn shared_player_firing(
         mut weapon,
         weapon_history,
         is_local,
-        has_input_map,
         is_predicted,
         is_deterministic,
         is_interpolated,
         controlled_by,
         player,
-    ) in q.iter_mut()
+    ) in q
+        .iter_mut()
+        .sort_by_key::<&Player, _>(|player| player.client_id.to_bits())
     {
         if is_server {
             if controlled_by.is_none() {
@@ -313,7 +317,6 @@ pub fn shared_player_firing(
         } else if !client_is_synced || !(is_predicted || is_deterministic) || is_interpolated {
             continue;
         }
-        let is_local = is_local || has_input_map;
         // Firing runs in FixedUpdate. Using a level-trigger here is more robust than
         // relying on a frame-edge `just_pressed`, and the weapon cooldown already
         // guarantees we only spawn bullets at the intended rate.
@@ -321,7 +324,13 @@ pub fn shared_player_firing(
             continue;
         }
         if !is_server
-            && !client_should_fire(input_buffer, &weapon, current_tick, !is_local, !is_local)
+            && !client_should_fire(
+                input_buffer,
+                &weapon,
+                current_tick,
+                is_deterministic || !is_local,
+                !is_local,
+            )
         {
             continue;
         }
@@ -360,7 +369,6 @@ pub fn shared_player_firing(
         // archetype-based hash so rollback replay/component timing cannot make
         // the local prespawn disagree with the server spawn.
         let prespawn_hash = bullet_prespawn_hash(player.client_id, current_tick);
-        let prespawned = PreSpawned::new(prespawn_hash);
 
         let bullet_entity = commands
             .spawn((
@@ -374,7 +382,7 @@ pub fn shared_player_firing(
                 BulletMarker::new(player.client_id),
                 PhysicsBundle::bullet(),
                 bullet_mass_properties(),
-                prespawned,
+                PreSpawned::new(prespawn_hash),
             ))
             .id();
         if metadata.mode.is_p2p() {
@@ -430,10 +438,11 @@ fn client_should_fire(
     allow_initial_fire: bool,
     require_remote_input: bool,
 ) -> bool {
-    // Local players keep the first-shot guard: before the first server Weapon confirmation,
-    // a held local Fire input can be older than the synced timeline and create an unmatched
-    // prespawn. Remote predicted players can predict their first shot when the rebroadcast
-    // buffer has the relevant tick, otherwise Weapon prediction would always lag the server.
+    // Conventionally predicted local players keep the first-shot guard: before the first server
+    // Weapon confirmation, a held Fire input can be older than the synced timeline and create an
+    // unmatched prespawn. Deterministic and remote predicted players have no local Weapon
+    // confirmation to wait for, so they can predict their first shot once its buffered input is
+    // available.
     if !allow_initial_fire && weapon.last_fire_tick == Tick(0) {
         return false;
     }
@@ -628,15 +637,21 @@ fn detect_duplicate_bullets(
 // Predicted/prespawned clients can predict TTL expiry. Interpolated observer bullets wait for the
 // authoritative server despawn instead.
 pub(crate) fn lifetime_despawner(
-    q: Query<(Entity, &BulletLifetime, Has<Predicted>, Has<PreSpawned>)>,
+    q: Query<(
+        Entity,
+        &BulletLifetime,
+        Has<Predicted>,
+        Has<PreSpawned>,
+        Has<DeterministicPredicted>,
+    )>,
     mut commands: Commands,
     timeline: Res<LocalTimeline>,
     server: Query<(), With<Server>>,
 ) {
     let is_server = !server.is_empty();
-    for (e, ttl, is_predicted, is_prespawned) in q.iter() {
+    for (e, ttl, is_predicted, is_prespawned, is_deterministic) in q.iter() {
         if (timeline.tick() - ttl.origin_tick) > ttl.lifetime
-            && (is_server || is_predicted || is_prespawned)
+            && (is_server || is_predicted || is_prespawned || is_deterministic)
         {
             commands.entity(e).prediction_despawn();
         }

--- a/examples/common/src/p2p.rs
+++ b/examples/common/src/p2p.rs
@@ -25,6 +25,10 @@ pub struct P2PSettings {
     pub player_count: u8,
 }
 
+/// Present until every configured remote peer has responded and the P2P start barrier is entered.
+#[derive(Resource)]
+struct AwaitingP2PStart;
+
 impl P2PSettings {
     pub fn peer_ids(&self) -> Range<u8> {
         0..self.player_count
@@ -111,7 +115,9 @@ pub(crate) fn spawn_connections(
             Name::new(format!("P2P Link {peer_id} -> {remote_peer_id}")),
         ));
     }
-    app.add_systems(Startup, connect_and_start);
+    app.insert_resource(AwaitingP2PStart);
+    app.add_systems(Startup, connect_links);
+    app.add_systems(Update, start_when_roster_connected);
 }
 
 fn validate_roster(peer_id: u8, player_count: u8) {
@@ -133,9 +139,32 @@ fn peer_addr(base_port: u16, local_peer_id: u8, remote_peer_id: u8) -> SocketAdd
     SocketAddr::new(Ipv4Addr::LOCALHOST.into(), port)
 }
 
-fn connect_and_start(mut commands: Commands, links: Query<Entity, With<P2P>>) {
+fn connect_links(mut commands: Commands, links: Query<Entity, With<P2P>>) {
     for entity in &links {
         commands.trigger(Connect { entity });
     }
+}
+
+fn start_when_roster_connected(
+    mut commands: Commands,
+    settings: Res<P2PSettings>,
+    awaiting_start: Option<Res<AwaitingP2PStart>>,
+    links: Query<(Has<Connected>, &PingManager), With<P2P>>,
+) {
+    let expected_remote_count = usize::from(settings.player_count.saturating_sub(1));
+    if awaiting_start.is_none()
+        || links.iter().count() != expected_remote_count
+        || links
+            .iter()
+            .any(|(connected, ping)| !connected || ping.latency_samples_recv() == 0)
+    {
+        return;
+    }
+
+    tracing::info!(
+        player_count = settings.player_count,
+        "P2P roster connected; starting session negotiation"
+    );
+    commands.remove_resource::<AwaitingP2PStart>();
     commands.trigger(P2PStart);
 }


### PR DESCRIPTION
## Summary

- wait for every configured example peer to connect and exchange a ping before triggering P2PStart
- negotiate a shared future start tick in PreUpdate, then activate the session in FixedFirst immediately before that tick is reached
- fix spaceships P2P ownership, firing, rendering, physics determinism, and rollback-safe bullet cleanup
