### PR TITLE
fix(replication): handle initial prediction markers in receive paths

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -239,7 +239,7 @@ leafwing-input-manager = { version = "0.21", default-features = false, features 
   "keyboard",
 ] }
 # replication
-bevy_replicon = { version = "0.42", default-features = false, features = [
+bevy_replicon = { git = "https://github.com/simgine/bevy_replicon", default-features = false, features = [
   "client",
   "server",
 ] }

--- a/crates/connection/netcode/src/server.rs
+++ b/crates/connection/netcode/src/server.rs
@@ -998,7 +998,7 @@ impl<Ctx> Server<Ctx> {
         server_addr: Option<SocketAddr>,
     ) -> Result<Vec<Error>> {
         self.recv_packets(&mut link.recv, entity_mut, server_addr)?;
-        Ok(self.client_errors.drain(..).collect())
+        Ok(core::mem::take(&mut self.client_errors))
     }
 
     /// Sends a packet to a client.

--- a/crates/core/frame_interpolation/src/lib.rs
+++ b/crates/core/frame_interpolation/src/lib.rs
@@ -343,6 +343,7 @@ mod unit_tests {
     use bevy_state::app::StatesPlugin;
     use core::time::Duration;
     use lightyear_core::prelude::ConfirmedHistory;
+    use lightyear_interpolation::plugin::InterpolationMarkerPlugin;
     use lightyear_interpolation::registry::AppInterpolationExt;
     use lightyear_interpolation::rules::{
         InterpolationFns, InterpolationFnsExt, InterpolationSampleContext,
@@ -652,7 +653,11 @@ mod unit_tests {
         app.world_mut()
             .resource_mut::<Time<Fixed>>()
             .accumulate_overstep(Duration::from_millis(250));
-        app.add_plugins((StatesPlugin, RepliconSharedPlugin::default()));
+        app.add_plugins((
+            StatesPlugin,
+            RepliconSharedPlugin::default(),
+            InterpolationMarkerPlugin,
+        ));
         app.component::<FrameA>().replicate();
         app.add_plugins(FrameInterpolationPlugin);
         app.interpolate_with::<FrameA>(

--- a/crates/core/lightyear/src/shared.rs
+++ b/crates/core/lightyear/src/shared.rs
@@ -40,6 +40,13 @@ impl Plugin for SharedPlugins {
             app.add_plugins(LightyearRepliconBackend);
         }
 
+        // Receive-marker registration is part of Replicon's protocol and must
+        // be identical on clients and servers before the user's protocol runs.
+        #[cfg(all(feature = "prediction", feature = "replication"))]
+        app.add_plugins(lightyear_prediction::plugin::PredictionMarkerPlugin);
+        #[cfg(all(feature = "interpolation", feature = "replication"))]
+        app.add_plugins(lightyear_interpolation::plugin::InterpolationMarkerPlugin);
+
         // IO
         #[cfg(feature = "crossbeam")]
         app.add_plugins(lightyear_crossbeam::CrossbeamPlugin);

--- a/crates/integration/avian/src/plugin.rs
+++ b/crates/integration/avian/src/plugin.rs
@@ -887,8 +887,8 @@ mod mode_tests {
     use bevy_state::app::StatesPlugin;
     use bevy_transform::TransformPlugin;
     use lightyear_core::prelude::ConfirmedHistory;
-    use lightyear_interpolation::registry::InterpolationRegistry;
-    use lightyear_prediction::prelude::PredictionRegistry;
+    use lightyear_interpolation::prelude::{InterpolationMarkerPlugin, InterpolationRegistry};
+    use lightyear_prediction::prelude::{PredictionMarkerPlugin, PredictionRegistry};
     use lightyear_replication::LightyearRepliconBackend;
 
     #[test]
@@ -1071,6 +1071,7 @@ mod mode_tests {
         let mut app = App::new();
         app.add_plugins(StatesPlugin);
         app.add_plugins(LightyearRepliconBackend);
+        app.add_plugins((PredictionMarkerPlugin, InterpolationMarkerPlugin));
         app.init_resource::<PredictionRegistry>();
         app.add_plugins(LightyearAvianPlugin {
             replication_mode: AvianReplicationMode::Position {
@@ -1155,6 +1156,7 @@ mod mode_tests {
         let mut app = App::new();
         app.add_plugins(StatesPlugin);
         app.add_plugins(LightyearRepliconBackend);
+        app.add_plugins((PredictionMarkerPlugin, InterpolationMarkerPlugin));
         app.init_resource::<PredictionRegistry>();
         app.add_plugins(LightyearAvianPlugin {
             register_physics_components: false,

--- a/crates/replication/interpolation/src/interpolate.rs
+++ b/crates/replication/interpolation/src/interpolate.rs
@@ -398,6 +398,7 @@ pub(crate) fn present_history_bracket<C: Component + Clone>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::plugin::InterpolationMarkerPlugin;
     use crate::registry::AppInterpolationExt;
     use crate::registry::{InterpolationRegistry, InterpolationRuleComponentIds};
     use crate::rules::{
@@ -575,7 +576,11 @@ mod tests {
 
     fn setup_app(current_tick: Tick, send_interval_ms: u64) -> App {
         let mut app = App::new();
-        app.add_plugins((StatesPlugin, RepliconSharedPlugin::default()));
+        app.add_plugins((
+            StatesPlugin,
+            RepliconSharedPlugin::default(),
+            InterpolationMarkerPlugin,
+        ));
         app.world_mut()
             .insert_resource(ReplicationCheckpointMap::default());
         app.world_mut()
@@ -764,7 +769,11 @@ mod tests {
     #[test]
     fn app_linear_interpolate_registers_ease_rule() {
         let mut app = App::new();
-        app.add_plugins((StatesPlugin, RepliconSharedPlugin::default()));
+        app.add_plugins((
+            StatesPlugin,
+            RepliconSharedPlugin::default(),
+            InterpolationMarkerPlugin,
+        ));
         app.world_mut()
             .insert_resource(ReplicationCheckpointMap::default());
         app.component::<TestComp>().replicate();
@@ -848,7 +857,12 @@ mod tests {
     #[test]
     fn bundle_interpolation_uses_tuple_interpolation_fn() {
         let mut app = App::new();
-        app.add_plugins((TimePlugin, StatesPlugin, RepliconPlugins));
+        app.add_plugins((
+            TimePlugin,
+            StatesPlugin,
+            RepliconPlugins,
+            InterpolationMarkerPlugin,
+        ));
         app.insert_resource(ReplicationCheckpointMap::default());
         app.insert_resource(TickDuration(core::time::Duration::from_millis(100)));
         app.configure_sets(
@@ -923,7 +937,12 @@ mod tests {
     #[test]
     fn bundle_contextual_interpolation_receives_sample_delta() {
         let mut app = App::new();
-        app.add_plugins((TimePlugin, StatesPlugin, RepliconPlugins));
+        app.add_plugins((
+            TimePlugin,
+            StatesPlugin,
+            RepliconPlugins,
+            InterpolationMarkerPlugin,
+        ));
         app.insert_resource(ReplicationCheckpointMap::default());
         app.insert_resource(TickDuration(core::time::Duration::from_millis(100)));
         app.configure_sets(
@@ -966,7 +985,12 @@ mod tests {
     #[test]
     fn bundle_interpolation_inserts_tuple_interpolated_components() {
         let mut app = App::new();
-        app.add_plugins((TimePlugin, StatesPlugin, RepliconPlugins));
+        app.add_plugins((
+            TimePlugin,
+            StatesPlugin,
+            RepliconPlugins,
+            InterpolationMarkerPlugin,
+        ));
         app.insert_resource(ReplicationCheckpointMap::default());
         app.configure_sets(
             Update,
@@ -1008,7 +1032,12 @@ mod tests {
         BUNDLE3_PRIORITY_CALLS.store(0, Ordering::SeqCst);
 
         let mut app = App::new();
-        app.add_plugins((TimePlugin, StatesPlugin, RepliconPlugins));
+        app.add_plugins((
+            TimePlugin,
+            StatesPlugin,
+            RepliconPlugins,
+            InterpolationMarkerPlugin,
+        ));
         app.insert_resource(ReplicationCheckpointMap::default());
         app.configure_sets(
             Update,
@@ -1065,7 +1094,12 @@ mod tests {
     #[test]
     fn earlier_non_apply_member_rule_suppresses_same_priority_bundle_apply() {
         let mut app = App::new();
-        app.add_plugins((TimePlugin, StatesPlugin, RepliconPlugins));
+        app.add_plugins((
+            TimePlugin,
+            StatesPlugin,
+            RepliconPlugins,
+            InterpolationMarkerPlugin,
+        ));
         app.insert_resource(ReplicationCheckpointMap::default());
         app.configure_sets(
             Update,
@@ -1119,7 +1153,12 @@ mod tests {
         );
 
         let mut app = App::new();
-        app.add_plugins((TimePlugin, StatesPlugin, RepliconPlugins));
+        app.add_plugins((
+            TimePlugin,
+            StatesPlugin,
+            RepliconPlugins,
+            InterpolationMarkerPlugin,
+        ));
         app.insert_resource(ReplicationCheckpointMap::default());
         app.configure_sets(
             Update,

--- a/crates/replication/interpolation/src/lib.rs
+++ b/crates/replication/interpolation/src/lib.rs
@@ -275,7 +275,9 @@ pub mod timeline;
 pub mod prelude {
     pub use crate::Interpolated;
     pub use crate::interpolate::interpolation_fraction;
-    pub use crate::plugin::{InterpolationDelay, InterpolationPlugin, InterpolationSystems};
+    pub use crate::plugin::{
+        InterpolationDelay, InterpolationMarkerPlugin, InterpolationPlugin, InterpolationSystems,
+    };
     pub use crate::registry::{
         AppInterpolationExt, InterpolationRegistrationExt, InterpolationRegistry,
     };

--- a/crates/replication/interpolation/src/plugin.rs
+++ b/crates/replication/interpolation/src/plugin.rs
@@ -9,9 +9,12 @@ use bevy_ecs::{
     schedule::{IntoScheduleConfigs, SystemSet},
 };
 use bevy_reflect::Reflect;
+use bevy_replicon::prelude::AppMarkerExt;
+use bevy_replicon::shared::replication::receive_markers::MarkerConfig;
 use lightyear_connection::host::HostClient;
 use lightyear_core::prelude::{Interpolated, Tick};
 use lightyear_core::time::PositiveTickDelta;
+use lightyear_replication::prelude::InterpolatedSend;
 use lightyear_serde::reader::Reader;
 use lightyear_serde::writer::WriteInteger;
 use lightyear_serde::{SerializationError, ToBytes};
@@ -68,6 +71,26 @@ impl ToBytes for InterpolationDelay {
 /// Each remote update will be stored in a buffer, and the component will smoothly interpolate between two consecutive remote updates.
 #[derive(Default)]
 pub struct InterpolationPlugin;
+
+/// Registers Replicon's interpolation markers for the shared client/server protocol.
+///
+/// Add this before registering interpolated components. Lightyear's high-level
+/// client and server plugin groups add it automatically.
+#[derive(Default)]
+pub struct InterpolationMarkerPlugin;
+
+impl Plugin for InterpolationMarkerPlugin {
+    fn build(&self, app: &mut App) {
+        app.register_marker_with::<InterpolatedSend>(MarkerConfig {
+            priority: 100,
+            need_history: true,
+        });
+        app.register_marker_with::<Interpolated>(MarkerConfig {
+            priority: 100,
+            need_history: true,
+        });
+    }
+}
 
 #[deprecated(note = "Use InterpolationSystems instead")]
 pub type InterpolationSet = InterpolationSystems;

--- a/crates/replication/interpolation/src/registry.rs
+++ b/crates/replication/interpolation/src/registry.rs
@@ -36,7 +36,6 @@ use bevy_replicon::shared::replication::deferred_entity::DeferredEntity;
 use bevy_replicon::shared::replication::diff::{
     ComponentDelta, DiffBuffer, Diffable as RepliconDiffable,
 };
-use bevy_replicon::shared::replication::receive_markers::MarkerConfig;
 use bevy_replicon::shared::replication::registry::ctx::{RemoveCtx, WriteCtx};
 use bevy_replicon::shared::replication::storage::{EntityStorageCtx, ReplicationStorage};
 use bevy_utils::prelude::DebugName;
@@ -47,6 +46,7 @@ use lightyear_core::history_buffer::HistoryState;
 use lightyear_core::prelude::{ConfirmedHistory, FrameInterpolationHistory, Interpolated, Tick};
 use lightyear_replication::checkpoint::{ReplicationCheckpointMap, resolve_message_tick};
 use lightyear_replication::diff_history::HistoryDiffReceiver;
+use lightyear_replication::prelude::InterpolatedSend;
 use lightyear_replication::registry::replication::{ComponentRegistration, ComponentRegistrator};
 use lightyear_replication::registry::{ComponentKind, ComponentRegistry, LerpFn};
 use tracing::{error, trace};
@@ -1169,11 +1169,8 @@ fn register_interpolated_marker_fns<C: SyncComponent>(app: &mut bevy_app::App) {
 
 fn install_interpolated_marker_fns<C: SyncComponent>(app: &mut bevy_app::App) {
     let kind = ComponentKind::of::<C>();
-    app.register_marker_with::<Interpolated>(MarkerConfig {
-        priority: 100,
-        need_history: true,
-    });
     app.set_marker_fns::<Interpolated, C>(write_history::<C>, remove_history::<C>);
+    app.set_marker_fns::<InterpolatedSend, C>(write_history::<C>, remove_history::<C>);
     app.world_mut()
         .resource_mut::<InterpolationRegistry>()
         .interpolated_marker_fns
@@ -1216,11 +1213,8 @@ fn install_interpolated_diff_marker_fns<C: SyncComponent + RepliconDiffable>(
     app: &mut bevy_app::App,
 ) {
     let kind = ComponentKind::of::<C>();
-    app.register_marker_with::<Interpolated>(MarkerConfig {
-        priority: 100,
-        need_history: true,
-    });
     app.set_marker_fns::<Interpolated, C>(write_history_diff::<C>, remove_history::<C>);
+    app.set_marker_fns::<InterpolatedSend, C>(write_history_diff::<C>, remove_history::<C>);
     app.world_mut()
         .resource_mut::<InterpolationRegistry>()
         .interpolated_marker_fns
@@ -1972,6 +1966,7 @@ mod tests {
         app.add_plugins((
             StatesPlugin,
             RepliconPlugins,
+            crate::plugin::InterpolationMarkerPlugin,
             crate::plugin::InterpolationPlugin,
         ));
         app.insert_resource(ReplicationCheckpointMap::default());
@@ -1995,6 +1990,7 @@ mod tests {
         app.add_plugins((
             StatesPlugin,
             RepliconPlugins,
+            crate::plugin::InterpolationMarkerPlugin,
             crate::plugin::InterpolationPlugin,
         ));
         app.component::<TestDiffComponent>()
@@ -2012,6 +2008,7 @@ mod tests {
         app.add_plugins((
             StatesPlugin,
             RepliconPlugins,
+            crate::plugin::InterpolationMarkerPlugin,
             crate::plugin::InterpolationPlugin,
         ));
 
@@ -2098,6 +2095,7 @@ mod tests {
         app.add_plugins((
             StatesPlugin,
             RepliconPlugins,
+            crate::plugin::InterpolationMarkerPlugin,
             crate::plugin::InterpolationPlugin,
         ));
         app.insert_resource(ReplicationCheckpointMap::default());
@@ -2140,6 +2138,7 @@ mod tests {
         app.add_plugins((
             StatesPlugin,
             RepliconPlugins,
+            crate::plugin::InterpolationMarkerPlugin,
             crate::plugin::InterpolationPlugin,
         ));
         app.insert_resource(ReplicationCheckpointMap::default());

--- a/crates/replication/prediction/src/archetypes.rs
+++ b/crates/replication/prediction/src/archetypes.rs
@@ -61,7 +61,7 @@ impl PredictedArchetypes {
             let mut predicted_archetype = Vec::new();
             // add all components from the registry that are predicted
             archetype.iter_components().for_each(|component| {
-                let info = unsafe { components.get_info(component).unwrap_unchecked() };
+                let info = unsafe { components.get_info_unchecked(component) };
                 // if the component has a type_id (i.e. is a rust type)
                 if let Some(kind) = info.type_id().map(ComponentKind) {
                     // the component is not registered for prediction in the ComponentProtocol

--- a/crates/replication/prediction/src/correction.rs
+++ b/crates/replication/prediction/src/correction.rs
@@ -880,6 +880,7 @@ mod tests {
     use bevy_replicon::prelude::*;
     use bevy_state::app::StatesPlugin;
     use lightyear_interpolation::{
+        plugin::InterpolationMarkerPlugin,
         registry::{AppInterpolationExt, InterpolationRegistry},
         rules::{InterpolationFns, InterpolationSampleContext},
     };
@@ -888,7 +889,21 @@ mod tests {
     use lightyear_replication::prelude::*;
 
     use super::*;
+    use crate::plugin::PredictionMarkerPlugin;
     use crate::registry::{PredictionBuilderExt, PredictionRegistry};
+
+    fn app_with_replication_markers() -> App {
+        let mut app = App::new();
+        app.add_plugins((
+            StatesPlugin,
+            RepliconSharedPlugin {
+                auth_method: AuthMethod::None,
+            },
+            PredictionMarkerPlugin,
+            InterpolationMarkerPlugin,
+        ));
+        app
+    }
 
     #[derive(Component, Clone, Debug, Default, PartialEq)]
     struct CorrectionA(f32);
@@ -946,13 +961,7 @@ mod tests {
 
     #[test]
     fn correction_registration_adds_frame_interpolation_setup() {
-        let mut app = App::new();
-        app.add_plugins((
-            StatesPlugin,
-            RepliconSharedPlugin {
-                auth_method: AuthMethod::None,
-            },
-        ));
+        let mut app = app_with_replication_markers();
         app.init_resource::<PredictionRegistry>();
 
         app.component::<CorrectionA>().predict().add_correction();
@@ -1004,13 +1013,7 @@ mod tests {
 
     #[test]
     fn visual_correction_marks_component_changed() {
-        let mut app = App::new();
-        app.add_plugins((
-            StatesPlugin,
-            RepliconSharedPlugin {
-                auth_method: AuthMethod::None,
-            },
-        ));
+        let mut app = app_with_replication_markers();
         app.init_resource::<PredictionRegistry>();
         app.insert_resource(Time::<Virtual>::default());
         app.component::<CorrectionA>().predict().add_correction();
@@ -1068,13 +1071,7 @@ mod tests {
         const STALE_REMOVED_PREVIOUS_VALUE: f32 = 300.0;
         const STALE_REMOVED_CURRENT_VALUE: f32 = 400.0;
 
-        let mut app = App::new();
-        app.add_plugins((
-            StatesPlugin,
-            RepliconSharedPlugin {
-                auth_method: AuthMethod::None,
-            },
-        ));
+        let mut app = app_with_replication_markers();
         app.init_resource::<PredictionRegistry>();
         app.init_resource::<InterpolationRegistry>();
         app.insert_resource(Time::<Fixed>::from_duration(Duration::from_secs(1)));
@@ -1167,13 +1164,7 @@ mod tests {
                 }
             };
 
-        let mut app = App::new();
-        app.add_plugins((
-            StatesPlugin,
-            RepliconSharedPlugin {
-                auth_method: AuthMethod::None,
-            },
-        ));
+        let mut app = app_with_replication_markers();
         app.configure_sets(
             PreUpdate,
             (
@@ -1294,13 +1285,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "No interpolation function was found for correction")]
     fn post_rollback_correction_requires_interpolation_rule() {
-        let mut app = App::new();
-        app.add_plugins((
-            StatesPlugin,
-            RepliconSharedPlugin {
-                auth_method: AuthMethod::None,
-            },
-        ));
+        let mut app = app_with_replication_markers();
         app.init_resource::<PredictionRegistry>();
         app.init_resource::<InterpolationRegistry>();
         app.insert_resource(Time::<Fixed>::from_duration(Duration::from_secs(1)));
@@ -1330,13 +1315,7 @@ mod tests {
     // creates each correction error, and restores both live component values.
     #[test]
     fn post_rollback_correction_uses_bundle_interpolation_rule() {
-        let mut app = App::new();
-        app.add_plugins((
-            StatesPlugin,
-            RepliconSharedPlugin {
-                auth_method: AuthMethod::None,
-            },
-        ));
+        let mut app = app_with_replication_markers();
         app.init_resource::<PredictionRegistry>();
         app.insert_resource(Time::<Fixed>::from_duration(Duration::from_secs(1)));
         app.world_mut()
@@ -1427,13 +1406,7 @@ mod tests {
     // correction. Its temporary bundle output is restored after sampling.
     #[test]
     fn post_rollback_bundle_uses_member_without_previous_visual() {
-        let mut app = App::new();
-        app.add_plugins((
-            StatesPlugin,
-            RepliconSharedPlugin {
-                auth_method: AuthMethod::None,
-            },
-        ));
+        let mut app = app_with_replication_markers();
         app.init_resource::<PredictionRegistry>();
         app.insert_resource(Time::<Fixed>::from_duration(Duration::from_secs(1)));
         app.world_mut()

--- a/crates/replication/prediction/src/lib.rs
+++ b/crates/replication/prediction/src/lib.rs
@@ -29,7 +29,7 @@ pub mod prelude {
     pub use crate::manager::{
         LastConfirmedInput, PredictionManager, RollbackMode, RollbackPolicy, StateRollbackMetadata,
     };
-    pub use crate::plugin::{PredictionPlugin, PredictionSystems};
+    pub use crate::plugin::{PredictionMarkerPlugin, PredictionPlugin, PredictionSystems};
     pub use crate::predicted_history::PredictionHistory;
     pub use crate::registry::{
         LocalRollbackComponentRegistration, PredictedComponentRegistration,

--- a/crates/replication/prediction/src/plugin.rs
+++ b/crates/replication/prediction/src/plugin.rs
@@ -1,5 +1,4 @@
-use super::rollback::{RollbackPlugin, RollbackSystems, prepare_rollback};
-use crate::SyncComponent;
+use super::rollback::{CatchUpGated, RollbackPlugin, RollbackSystems, prepare_rollback};
 use crate::correction::{
     repair_frame_interpolation_history, update_frame_interpolation_post_rollback,
 };
@@ -8,21 +7,25 @@ use crate::diagnostics::PredictionDiagnosticsPlugin;
 use crate::manager::{LastConfirmedInput, PredictionManager};
 use crate::predicted_history::{
     PredictionHistory, add_history_diff_receiver, add_prediction_history,
-    apply_component_removal_predicted, handle_local_timeline_shift_history_diff_receiver,
+    apply_component_removal_predicted, backfill_confirmed_history_on_predicted,
+    handle_local_timeline_shift_history_diff_receiver,
     handle_local_timeline_shift_prediction_history, prune_history_diff_receiver,
     snap_to_confirmed_during_rollback, update_prediction_history,
 };
 use crate::registry::PredictionRegistry;
 use crate::rollback::DisabledDuringRollback;
+use crate::{Predicted, SyncComponent};
 use bevy_app::FixedPreUpdate;
 use bevy_app::prelude::*;
 use bevy_ecs::component::Mutable;
 use bevy_ecs::entity_disabling::DefaultQueryFilters;
 use bevy_ecs::prelude::*;
+use bevy_replicon::prelude::AppMarkerExt;
 use bevy_replicon::shared::replication::diff::Diffable as RepliconDiffable;
+use bevy_replicon::shared::replication::receive_markers::MarkerConfig;
 use lightyear_connection::network_topology::{NetworkTopology, NetworkingMetadata};
 use lightyear_core::prelude::{ConfirmedHistory, is_in_rollback};
-use lightyear_replication::prelude::ReplicationSystems;
+use lightyear_replication::prelude::{PreSpawned, PredictedSend, ReplicationSystems};
 #[cfg(test)]
 use lightyear_replication::prespawn::PreSpawnedReceiver;
 
@@ -37,6 +40,48 @@ use lightyear_replication::prespawn::PreSpawnedReceiver;
 /// topologies remain authoritative and do not run it.
 #[derive(Default)]
 pub struct PredictionPlugin;
+
+/// Registers Replicon's prediction markers for the shared client/server protocol.
+///
+/// Add this before registering predicted components. Lightyear's high-level
+/// client and server plugin groups add it automatically.
+#[derive(Default)]
+pub struct PredictionMarkerPlugin;
+
+// Higher-priority markers win when more than one applies to an update.
+// Prespawn and catch-up must preserve their specialized reconciliation
+// semantics before the general prediction markers are considered. Prespawn is
+// strongest because a locally predicted absence must not be materialized by a
+// lower-priority initial-write path.
+const PRESPAWNED_PRIORITY: usize = 120;
+const CATCH_UP_GATED_PRIORITY: usize = 110;
+const PREDICTED_SEND_PRIORITY: usize = 100;
+const PREDICTED_PRIORITY: usize = 90;
+
+impl Plugin for PredictionMarkerPlugin {
+    fn build(&self, app: &mut App) {
+        app.register_marker_with::<CatchUpGated>(MarkerConfig {
+            priority: CATCH_UP_GATED_PRIORITY,
+            need_history: true,
+        });
+        // A matched prespawn must preserve its locally predicted live value
+        // even when PredictedSend is included in the same authoritative update.
+        app.register_marker_with::<PreSpawned>(MarkerConfig {
+            priority: PRESPAWNED_PRIORITY,
+            need_history: true,
+        });
+        app.register_marker_with::<PredictedSend>(MarkerConfig {
+            priority: PREDICTED_SEND_PRIORITY,
+            need_history: true,
+        });
+        // Keep the receiver-local marker registered for users that opt an
+        // already replicated entity into prediction manually.
+        app.register_marker_with::<Predicted>(MarkerConfig {
+            priority: PREDICTED_PRIORITY,
+            need_history: true,
+        });
+    }
+}
 
 /// Initialize resources required by the global prediction pipeline.
 ///
@@ -97,8 +142,8 @@ pub fn add_non_networked_rollback_systems<C: Component<Mutability = Mutable> + C
     // This also supports explicit resynchronization after prediction has begun. Do not shift
     // `ConfirmedHistory<C>` here: confirmed samples are resolved
     // through `ReplicationCheckpointMap` and are already in authoritative
-    // server tick space. Shifting them can move an init-message seed into the
-    // future and make rollback prefer stale state over later server updates.
+    // server tick space. Shifting them can move authoritative state into the
+    // future and make rollback prefer it over later server updates.
     app.add_observer(handle_local_timeline_shift_prediction_history::<C>);
     app.add_systems(
         PreUpdate,
@@ -152,6 +197,7 @@ pub(crate) fn add_prediction_systems<C: SyncComponent>(app: &mut App) {
     app.add_observer(apply_component_removal_predicted::<C>);
     app.add_observer(handle_local_timeline_shift_prediction_history::<C>);
     app.add_observer(add_prediction_history::<C>);
+    app.add_observer(backfill_confirmed_history_on_predicted::<C>);
 
     app.add_systems(
         PreUpdate,

--- a/crates/replication/prediction/src/predicted_history.rs
+++ b/crates/replication/prediction/src/predicted_history.rs
@@ -6,7 +6,7 @@
 
 use crate::rollback::{CatchUpGated, DeterministicPredicted};
 use crate::{Predicted, SyncComponent, manager::PredictionManager};
-use bevy_ecs::component::Mutable;
+use bevy_ecs::component::{ComponentIdFor, Mutable};
 use bevy_ecs::prelude::*;
 use bevy_ecs::resource::IsResource;
 use bevy_reflect::Reflect;
@@ -19,8 +19,9 @@ use lightyear_core::history_buffer::{HistoryBuffer, HistoryState};
 use lightyear_core::prelude::{ConfirmedHistory, LocalTimeline};
 use lightyear_core::tick::Tick;
 use lightyear_core::timeline::LocalTimelineShift;
+use lightyear_replication::checkpoint::ReplicationCheckpointMap;
 use lightyear_replication::diff_history::HistoryDiffReceiver;
-use lightyear_replication::prelude::PreSpawned;
+use lightyear_replication::prelude::{ConfirmHistory, PreSpawned};
 use lightyear_sync::prelude::{InputTimelineConfig, SyncedLocalTimeline};
 #[allow(unused_imports)]
 use tracing::{debug, info, trace};
@@ -231,24 +232,10 @@ pub(crate) fn apply_component_removal_predicted<C: Component>(
 /// `Add<C>` already fires when a resource is inserted, and triggering on every `IsResource`
 /// addition would wake this observer for unrelated resource types.
 ///
-/// If `C` has just been applied via an init message on a
-/// marker that receives confirmed state, seed [`ConfirmedHistory<C>`] at the
-/// server tick that produced the init.
-///
-/// # Why seeding is needed
-///
-/// Replicon reads entity markers on the empty newly-spawned entity BEFORE
-/// init components are applied. As a result, the marker-gated `write_history`
-/// function does NOT fire for init messages — the component value is written
-/// directly to the entity via the default write, and `ConfirmedHistory<C>` gets
-/// no confirmed entry for the init tick. We plug that hole here.
-///
-/// # Once-only semantics
-///
-/// Seeding only happens when confirmed history does not already exist. We must
-/// not overwrite existing local prediction history or existing authoritative
-/// samples. If there is no authoritative seed, no confirmed history is inserted:
-/// receive paths create it when a confirmed sample actually arrives.
+/// [`CatchUpGated`] always needs [`PredictionHistory<C>`], even while `C` is absent because its
+/// replicated value is still gated in [`ConfirmedHistory<C>`]. Prediction history is also the
+/// component's rollback-membership marker, so it must be present for the catch-up rollback to
+/// materialize that confirmed value as the live component.
 pub(crate) fn add_prediction_history<C: Component + Clone>(
     trigger: On<
         Add,
@@ -260,27 +247,26 @@ pub(crate) fn add_prediction_history<C: Component + Clone>(
             CatchUpGated,
         ),
     >,
-    query: Query<(
-        Has<C>,
-        Has<Predicted>,
-        Has<PreSpawned>,
-        Has<DeterministicPredicted>,
-        Has<CatchUpGated>,
-        Has<IsResource>,
-    )>,
+    query: Query<
+        (),
+        Or<(
+            With<CatchUpGated>,
+            (
+                With<C>,
+                Or<(
+                    With<Predicted>,
+                    With<PreSpawned>,
+                    With<DeterministicPredicted>,
+                    With<IsResource>,
+                )>,
+            ),
+        )>,
+    >,
     mut commands: Commands,
 ) {
-    let Ok((has_component, predicted, prespawned, deterministic, catchup_gated, is_resource)) =
-        query.get(trigger.entity)
-    else {
-        return;
-    };
-    if !catchup_gated
-        && !(has_component && (predicted || prespawned || deterministic || is_resource))
-    {
+    if query.get(trigger.entity).is_err() {
         return;
     }
-    let should_seed_confirmed_history = has_component && (catchup_gated || predicted || prespawned);
     trace!(
         target: "lightyear_debug::prediction",
         kind = "prediction_history_insert",
@@ -290,57 +276,53 @@ pub(crate) fn add_prediction_history<C: Component + Clone>(
     );
     let entity = trigger.entity;
     commands.queue(move |world: &mut World| {
-        let Ok(entity_mut) = world.get_entity_mut(entity) else {
-            return;
-        };
-        let has_prediction_history = entity_mut.contains::<PredictionHistory<C>>();
-        let has_confirmed_history = entity_mut.contains::<ConfirmedHistory<C>>();
-        if has_prediction_history && has_confirmed_history {
-            return;
-        }
-        // Try to capture a confirmed entry from the current C value + the
-        // server tick resolved via ConfirmHistory. This path only fires
-        // when all of `C`, `ConfirmHistory`, and a checkpoint mapping
-        // are present — i.e. when this is an init-message write.
-        let seed: Option<(Tick, C)> = {
-            if should_seed_confirmed_history {
-                let component = entity_mut.get::<C>().cloned();
-                let confirm_last = entity_mut
-                    .get::<lightyear_replication::prelude::ConfirmHistory>()
-                    .map(lightyear_replication::prelude::ConfirmHistory::last_tick);
-                match (component, confirm_last) {
-                    (Some(component), Some(confirm_tick)) => world
-                        .resource::<lightyear_replication::checkpoint::ReplicationCheckpointMap>()
-                        .get(confirm_tick)
-                        .map(|tick| (tick, component)),
-                    _ => None,
-                }
-            } else {
-                None
-            }
-        };
-        // Re-fetch the entity after the world-level resource access above.
         let Ok(mut entity_mut) = world.get_entity_mut(entity) else {
             return;
         };
-        if !has_prediction_history {
-            entity_mut.insert(PredictionHistory::<C>::default());
-        }
-        if has_confirmed_history {
-            return;
-        }
-        if let Some((tick, component)) = seed {
-            let mut history = ConfirmedHistory::<C>::default();
-            trace!(
-                ?entity,
-                ?tick,
-                component = ?DebugName::type_name::<C>(),
-                "seeding ConfirmedHistory with confirmed value from init message"
-            );
-            history.insert_present_explicit(tick, component);
-            entity_mut.insert(history);
-        }
+        entity_mut.insert_if_new(PredictionHistory::<C>::default());
     });
+}
+
+/// Seeds the last replicated value when [`Predicted`] is added manually to an
+/// already-replicated entity on the receiver.
+///
+/// Initial replication through `PredictedSend` also adds the receiver-side [`Predicted`] marker,
+/// but its marker writer adds [`ConfirmedHistory<C>`] in the same replication command. The
+/// [`Without<ConfirmedHistory<C>>`] query filter therefore makes that path a no-op here.
+///
+/// Without this baseline an unchanged authoritative component might never
+/// receive another update, leaving state-based prediction unable to compare it
+/// at later completed server ticks.
+pub(crate) fn backfill_confirmed_history_on_predicted<C: SyncComponent>(
+    trigger: On<Add, Predicted>,
+    query: Query<(&C, &ConfirmHistory), Without<ConfirmedHistory<C>>>,
+    component_id: ComponentIdFor<C>,
+    checkpoints: Option<Res<ReplicationCheckpointMap>>,
+    mut commands: Commands,
+) {
+    // A component added together with Predicted is a new local value, not a
+    // previously replicated authoritative baseline.
+    if trigger.trigger().components.contains(&component_id.get()) {
+        return;
+    }
+    let Ok((component, confirm_history)) = query.get(trigger.entity) else {
+        return;
+    };
+    let Some(tick) = checkpoints
+        .as_deref()
+        .and_then(|checkpoints| checkpoints.get(confirm_history.last_tick()))
+    else {
+        return;
+    };
+    let mut history = ConfirmedHistory::<C>::default();
+    history.insert_present_explicit(tick, component.clone());
+    trace!(
+        entity = ?trigger.entity,
+        ?tick,
+        component = ?DebugName::type_name::<C>(),
+        "backfilled confirmed history for late prediction opt-in"
+    );
+    commands.entity(trigger.entity).insert(history);
 }
 
 pub(crate) fn add_history_diff_receiver<C: SyncComponent + RepliconDiffable>(

--- a/crates/replication/prediction/src/registry.rs
+++ b/crates/replication/prediction/src/registry.rs
@@ -17,7 +17,6 @@ use bevy_replicon::postcard_utils;
 use bevy_replicon::prelude::{AppMarkerExt, RepliconTick, RuleFns};
 use bevy_replicon::shared::replication::deferred_entity::DeferredEntity;
 use bevy_replicon::shared::replication::diff::{ComponentDelta, Diffable as RepliconDiffable};
-use bevy_replicon::shared::replication::receive_markers::MarkerConfig;
 use bevy_replicon::shared::replication::registry::ctx::{RemoveCtx, WriteCtx};
 use bevy_replicon::shared::replication::storage::EntityStorageCtx;
 use bevy_utils::prelude::DebugName;
@@ -31,7 +30,7 @@ use lightyear_frame_interpolation::FrameInterpolationPlugin;
 use lightyear_replication::checkpoint::resolve_message_tick;
 use lightyear_replication::diff_history::HistoryDiffReceiver;
 use lightyear_replication::diffable::Diffable;
-use lightyear_replication::prelude::PreSpawned;
+use lightyear_replication::prelude::{PreSpawned, PredictedSend};
 use lightyear_replication::registry::replication::{
     AppComponentExt, ComponentRegistration, ComponentRegistrator,
 };
@@ -458,6 +457,7 @@ impl PredictionRegistry {
         entity_mut: &mut DeferredEntity,
         check_mismatch: bool,
         current_tick: Tick,
+        materialized_initial: bool,
     ) -> bool {
         let entity = entity_mut.id();
         let name = DebugName::type_name::<C>();
@@ -481,6 +481,7 @@ impl PredictionRegistry {
         // the confirmed value and insert C. Do this even if this update does not check
         // for a mismatch, since another component may already have recorded one.
         let never_predicted_insert = confirmed_component.is_some()
+            && !materialized_initial
             && predicted_history.is_none()
             && entity_mut.get::<C>().is_none();
 
@@ -1015,12 +1016,10 @@ impl<C> PredictionRegistrationExt<C> for ComponentRegistration<'_, C> {
         // catch-up there is no forced state rollback that would insert a
         // `ConfirmedHistory<C>` value back into the live entity.
         use crate::rollback::CatchUpGated;
-        self.app.register_marker_with::<CatchUpGated>(MarkerConfig {
-            priority: 110,
-            need_history: true,
-        });
-        self.app
-            .set_marker_fns::<CatchUpGated, C>(write_history::<C>, remove_history::<C>);
+        self.app.set_marker_fns::<CatchUpGated, C>(
+            write_initial_live_and_history::<C>,
+            remove_history::<C>,
+        );
         self
     }
 
@@ -1035,19 +1034,15 @@ impl<C> PredictionRegistrationExt<C> for ComponentRegistration<'_, C> {
             );
             return self;
         }
-        self.app.register_marker_with::<Predicted>(MarkerConfig {
-            priority: 100,
-            need_history: true,
-        });
         self.app
             .set_marker_fns::<Predicted, C>(write_history::<C>, remove_history::<C>);
+        self.app.set_marker_fns::<PredictedSend, C>(
+            write_initial_live_and_history::<C>,
+            remove_history::<C>,
+        );
         // A prespawned entity can receive replicated component data before the
         // server match has inserted `Predicted`. Keep that authoritative data in
         // history so it cannot overwrite the live locally-predicted component.
-        self.app.register_marker_with::<PreSpawned>(MarkerConfig {
-            priority: 100,
-            need_history: true,
-        });
         self.app
             .set_marker_fns::<PreSpawned, C>(write_history::<C>, remove_history::<C>);
         let prediction_history_id = self
@@ -1064,8 +1059,6 @@ impl<C> PredictionRegistrationExt<C> for ComponentRegistration<'_, C> {
             DebugName::type_name::<C>()
         );
         registry.register::<C>(prediction_history_id, confirmed_history_id);
-        // TODO: how do we avoid the server adding the prediction systems?
-        //   do we need to make sure that the Protocol runs after the client/server plugins are added?
         add_prediction_systems::<C>(self.app);
 
         let mut registry = self.app.world_mut().resource_mut::<ComponentRegistry>();
@@ -1089,16 +1082,12 @@ impl<C> PredictionRegistrationExt<C> for ComponentRegistration<'_, C> {
             );
             return self;
         }
-        self.app.register_marker_with::<Predicted>(MarkerConfig {
-            priority: 100,
-            need_history: true,
-        });
         self.app
             .set_marker_fns::<Predicted, C>(write_history_diff::<C>, remove_history::<C>);
-        self.app.register_marker_with::<PreSpawned>(MarkerConfig {
-            priority: 100,
-            need_history: true,
-        });
+        self.app.set_marker_fns::<PredictedSend, C>(
+            write_initial_live_and_history_diff::<C>,
+            remove_history::<C>,
+        );
         self.app
             .set_marker_fns::<PreSpawned, C>(write_history_diff::<C>, remove_history::<C>);
         let prediction_history_id = self
@@ -1316,9 +1305,47 @@ fn write_history<C: SyncComponent>(
     entity: &mut DeferredEntity,
     message: &mut Bytes,
 ) -> Result<()> {
+    write_history_inner(ctx, rule_fns, entity, message, false)
+}
+
+/// Writes a first authoritative value to both the live component and confirmed
+/// history.
+///
+/// This is shared by `PredictedSend` and `CatchUpGated`. It lets a fresh entity
+/// materialize normally while keeping an active catch-up or existing predicted
+/// entity history-only. Replicon batches the live component and history
+/// insertions, so role-marker observers see the complete initial state.
+fn write_initial_live_and_history<C: SyncComponent>(
+    ctx: &mut WriteCtx,
+    rule_fns: &RuleFns<C>,
+    entity: &mut DeferredEntity,
+    message: &mut Bytes,
+) -> Result<()> {
+    write_history_inner(ctx, rule_fns, entity, message, true)
+}
+
+fn write_history_inner<C: SyncComponent>(
+    ctx: &mut WriteCtx,
+    rule_fns: &RuleFns<C>,
+    entity: &mut DeferredEntity,
+    message: &mut Bytes,
+    materialize_initial: bool,
+) -> Result<()> {
     let component: C = rule_fns.deserialize(ctx, message)?;
-    let (tick, should_rollback) =
-        add_confirmed_to_history(ctx.message_tick, Some(component), entity, true)?;
+    let materialized_initial = materialize_initial
+        && entity.get::<C>().is_none()
+        && entity.get::<PredictionHistory<C>>().is_none()
+        && entity.get::<ConfirmedHistory<C>>().is_none();
+    if materialized_initial {
+        entity.insert(component.clone());
+    }
+    let (tick, should_rollback) = add_confirmed_to_history_inner(
+        ctx.message_tick,
+        Some(component),
+        entity,
+        !materialized_initial,
+        materialized_initial,
+    )?;
     if should_rollback {
         // SAFETY: we only access resources, which don't alias with the DeferredEntity's component access
         unsafe { entity.world_mut() }
@@ -1334,6 +1361,24 @@ fn write_history_diff<C: SyncComponent + RepliconDiffable>(
     entity: &mut DeferredEntity,
     message: &mut Bytes,
 ) -> Result<()> {
+    write_history_diff_inner::<C>(ctx, entity, message, false)
+}
+
+fn write_initial_live_and_history_diff<C: SyncComponent + RepliconDiffable>(
+    ctx: &mut WriteCtx,
+    _rule_fns: &RuleFns<C>,
+    entity: &mut DeferredEntity,
+    message: &mut Bytes,
+) -> Result<()> {
+    write_history_diff_inner::<C>(ctx, entity, message, true)
+}
+
+fn write_history_diff_inner<C: SyncComponent + RepliconDiffable>(
+    ctx: &mut WriteCtx,
+    entity: &mut DeferredEntity,
+    message: &mut Bytes,
+    materialize_initial: bool,
+) -> Result<()> {
     let Some((tick, diff)) = client_diff_and_tick::<C>(ctx, entity, message)? else {
         return Ok(());
     };
@@ -1343,10 +1388,22 @@ fn write_history_diff<C: SyncComponent + RepliconDiffable>(
             mut component,
         } => {
             C::map_entities(&mut component, ctx);
+            let materialized_initial = materialize_initial
+                && entity.get::<C>().is_none()
+                && entity.get::<PredictionHistory<C>>().is_none()
+                && entity.get::<ConfirmedHistory<C>>().is_none();
+            if materialized_initial {
+                entity.insert(component.clone());
+            }
             let receiver = ctx.get_or_default::<HistoryDiffReceiver<C>>();
             receiver.record_cursor(tick, Some(index));
-            let should_rollback =
-                add_resolved_confirmed_to_history(tick, Some(component), entity, true);
+            let should_rollback = add_resolved_confirmed_to_history_inner(
+                tick,
+                Some(component),
+                entity,
+                !materialized_initial,
+                materialized_initial,
+            );
             if should_rollback {
                 // SAFETY: we only access resources, which don't alias with the DeferredEntity's component access
                 unsafe { entity.world_mut() }
@@ -1415,6 +1472,22 @@ fn add_confirmed_to_history<C: SyncComponent>(
     entity: &mut DeferredEntity,
     check_state_rollback: bool,
 ) -> Result<(Tick, bool)> {
+    add_confirmed_to_history_inner(
+        message_tick,
+        confirmed_component,
+        entity,
+        check_state_rollback,
+        false,
+    )
+}
+
+fn add_confirmed_to_history_inner<C: SyncComponent>(
+    message_tick: RepliconTick,
+    confirmed_component: Option<C>,
+    entity: &mut DeferredEntity,
+    check_state_rollback: bool,
+    materialized_initial: bool,
+) -> Result<(Tick, bool)> {
     let checkpoints = {
         let world = unsafe { entity.world_mut() };
         let checkpoints = world
@@ -1433,8 +1506,13 @@ fn add_confirmed_to_history<C: SyncComponent>(
         );
         return Ok((Tick(0), false));
     };
-    let should_rollback =
-        add_resolved_confirmed_to_history(tick, confirmed_component, entity, check_state_rollback);
+    let should_rollback = add_resolved_confirmed_to_history_inner(
+        tick,
+        confirmed_component,
+        entity,
+        check_state_rollback,
+        materialized_initial,
+    );
     Ok((tick, should_rollback))
 }
 
@@ -1443,6 +1521,22 @@ fn add_resolved_confirmed_to_history<C: SyncComponent>(
     confirmed_component: Option<C>,
     entity: &mut DeferredEntity,
     check_state_rollback: bool,
+) -> bool {
+    add_resolved_confirmed_to_history_inner(
+        tick,
+        confirmed_component,
+        entity,
+        check_state_rollback,
+        false,
+    )
+}
+
+fn add_resolved_confirmed_to_history_inner<C: SyncComponent>(
+    tick: Tick,
+    confirmed_component: Option<C>,
+    entity: &mut DeferredEntity,
+    check_state_rollback: bool,
+    materialized_initial: bool,
 ) -> bool {
     // SAFETY: we only access resources, which don't alias with the DeferredEntity's component access.
     // We extract all needed values and drop the world borrow before using `entity` again.
@@ -1470,6 +1564,7 @@ fn add_resolved_confirmed_to_history<C: SyncComponent>(
         entity,
         check_state_rollback && should_check,
         current_tick,
+        materialized_initial,
     )
 }
 
@@ -1524,6 +1619,7 @@ fn remove_history<C: SyncComponent>(ctx: &mut RemoveCtx, entity: &mut DeferredEn
         entity,
         should_check,
         current_tick,
+        false,
     );
     if should_rollback {
         // SAFETY: we only access resources, which don't alias with the DeferredEntity's component access
@@ -1536,7 +1632,7 @@ fn remove_history<C: SyncComponent>(ctx: &mut RemoveCtx, entity: &mut DeferredEn
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::plugin::PredictionPlugin;
+    use crate::plugin::{PredictionMarkerPlugin, PredictionPlugin};
     use crate::rollback::RollbackSystems;
     use alloc::vec::Vec;
     use bevy_app::PreUpdate;
@@ -1550,7 +1646,10 @@ mod tests {
     use bevy_state::app::StatesPlugin;
     use core::hash::Hasher;
     use lightyear_connection::network_topology::{NetworkTopology, NetworkingMetadata};
-    use lightyear_interpolation::prelude::{InterpolationRegistrationExt, InterpolationRegistry};
+    use lightyear_interpolation::prelude::{
+        InterpolationMarkerPlugin, InterpolationPlugin, InterpolationRegistrationExt,
+        InterpolationRegistry,
+    };
     use lightyear_replication::checkpoint::ReplicationCheckpointMap;
     use lightyear_replication::prelude::{AppComponentExt, ConfirmHistory};
     use lightyear_sync::prelude::{InputTimelineConfig, LocalTimelineSync};
@@ -1578,6 +1677,9 @@ mod tests {
             RepliconSharedPlugin {
                 auth_method: AuthMethod::None,
             },
+            PredictionMarkerPlugin,
+            InterpolationMarkerPlugin,
+            InterpolationPlugin,
         ));
         app.init_resource::<PredictionRegistry>();
         app.init_resource::<PredictionManager>();
@@ -1598,6 +1700,20 @@ mod tests {
         predicted: &LocalRollbackComponent,
     ) -> bool {
         confirmed.0 / 10 != predicted.0 / 10
+    }
+
+    #[test]
+    fn marker_plugin_does_not_enable_prediction() {
+        let mut app = App::new();
+        app.add_plugins((
+            StatesPlugin,
+            RepliconSharedPlugin {
+                auth_method: AuthMethod::None,
+            },
+            PredictionMarkerPlugin,
+        ));
+
+        assert!(!app.world().contains_resource::<PredictionRegistry>());
     }
 
     #[test]
@@ -1711,7 +1827,12 @@ mod tests {
 
     fn setup_prediction_diff_app() -> (App, bevy_replicon::shared::replication::registry::FnsId) {
         let mut app = App::new();
-        app.add_plugins((StatesPlugin, RepliconPlugins, PredictionPlugin));
+        app.add_plugins((
+            StatesPlugin,
+            RepliconPlugins,
+            PredictionMarkerPlugin,
+            PredictionPlugin,
+        ));
         app.insert_resource(LocalTimeline::default());
         app.insert_resource(ReplicationCheckpointMap::default());
         app.insert_resource(PredictionManager::default());

--- a/crates/tests/src/client_server/diff.rs
+++ b/crates/tests/src/client_server/diff.rs
@@ -7,13 +7,16 @@ use bevy_replicon::prelude::{EntityDiffExt, RepliconPlugins, RepliconTick, RuleF
 use bevy_replicon::shared::replication::diff::diff_index::DiffIndex;
 use bevy_replicon::shared::replication::registry::ReplicationRegistry;
 use bevy_replicon::shared::replication::registry::test_fns::TestFnsEntityExt;
-use lightyear::prelude::{InterpolationPlugin, InterpolationRegistrationExt, PredictionBuilderExt};
+use lightyear::prelude::{
+    InterpolationMarkerPlugin, InterpolationPlugin, InterpolationRegistrationExt,
+    PredictionBuilderExt,
+};
 use lightyear_connection::network_target::NetworkTarget;
 use lightyear_core::prelude::{ConfirmedHistory, HistoryState, Interpolated};
 use lightyear_messages::MessageManager;
 use lightyear_prediction::Predicted;
 use lightyear_prediction::manager::PredictionManager;
-use lightyear_prediction::plugin::PredictionPlugin;
+use lightyear_prediction::plugin::{PredictionMarkerPlugin, PredictionPlugin};
 use lightyear_replication::checkpoint::ReplicationCheckpointMap;
 use lightyear_replication::prelude::{
     AppComponentExt, InterpolationTarget, PredictionTarget, Replicate,
@@ -177,6 +180,7 @@ fn setup_prediction_receive_app() -> (App, bevy_replicon::shared::replication::r
     app.add_plugins((
         bevy::state::app::StatesPlugin,
         RepliconPlugins,
+        PredictionMarkerPlugin,
         PredictionPlugin,
     ));
     app.insert_resource(lightyear_core::prelude::LocalTimeline::default());
@@ -202,6 +206,7 @@ fn setup_interpolation_receive_app() -> (App, bevy_replicon::shared::replication
     app.add_plugins((
         bevy::state::app::StatesPlugin,
         RepliconPlugins,
+        InterpolationMarkerPlugin,
         InterpolationPlugin,
     ));
     app.insert_resource(ReplicationCheckpointMap::default());

--- a/crates/tests/src/client_server/prediction/history.rs
+++ b/crates/tests/src/client_server/prediction/history.rs
@@ -1,6 +1,6 @@
 use super::*;
-use crate::protocol::{CompCorr, CompFull};
-use bevy::prelude::Entity;
+use crate::protocol::{CompA, CompCorr, CompFull};
+use bevy::prelude::{Add, Commands, Component, Entity, On, Query, With};
 use lightyear::prelude::*;
 use lightyear_core::history_buffer::HistoryState;
 use lightyear_prediction::Predicted;
@@ -34,24 +34,11 @@ fn test_history_added_when_prespawned_added() {
 
 // TODO: test that PredictionHistory is added when a component is added to a PrePredicted or PreSpawned entity
 
-/// When a server spawns an entity with Replicate + PredictionTarget + component C
-/// where C has `add_prediction()`, the client receives `Predicted` and C at the
-/// same time via the init message. We expect that `ConfirmedHistory<C>` on the
-/// client contains the confirmed server value at the server tick S.
-///
-/// This is non-trivial because marker-gated replicon write functions are
-/// checked BEFORE any component is applied on a freshly-spawned client entity.
-/// In `bevy_replicon::client::apply_entity`, `entity_markers.read()` runs on the
-/// empty entity (only `Remote` marker present) — so `Predicted` is NOT visible,
-/// and the `write_history` marker-fn does NOT fire for init messages.
-///
-/// The fix: `add_prediction_history` fires on
-/// `Add<(C, Predicted, PreSpawned, DeterministicPredicted)>` and, when it
-/// creates confirmed history for the first time, reads C and the resolved
-/// server tick from `ConfirmHistory + ReplicationCheckpointMap` and seeds
-/// `ConfirmedHistory<C>` with a confirmed entry before inserting it.
+/// Incoming `PredictedSend` is processed before the other components in the
+/// initial update, so every predicted component is inserted live and into
+/// confirmed history before observers run.
 #[test]
-fn test_prediction_history_seeded_from_init_message() {
+fn test_prediction_history_received_from_initial_marker() {
     use crate::stepper::*;
     use lightyear::prelude::ConfirmHistory;
     use lightyear_connection::network_target::NetworkTarget;
@@ -59,7 +46,33 @@ fn test_prediction_history_seeded_from_init_message() {
     use lightyear_replication::checkpoint::ReplicationCheckpointMap;
     use lightyear_replication::prelude::{PredictionTarget, Replicate};
 
+    #[derive(Component)]
+    struct ObservedCompleteInitialPrediction;
+
+    fn observe_initial_prediction(
+        trigger: On<Add, Predicted>,
+        query: Query<
+            (),
+            (
+                With<CompFull>,
+                With<CompCorr>,
+                With<ConfirmedHistory<CompFull>>,
+                With<ConfirmedHistory<CompCorr>>,
+            ),
+        >,
+        mut commands: Commands,
+    ) {
+        if query.contains(trigger.entity) {
+            commands
+                .entity(trigger.entity)
+                .insert(ObservedCompleteInitialPrediction);
+        }
+    }
+
     let mut stepper = ClientServerStepper::from_config(StepperConfig::single());
+    stepper
+        .client_app()
+        .add_observer(observe_initial_prediction);
 
     // Spawn an entity on the server with a predicted component
     let server_entity = stepper
@@ -67,6 +80,7 @@ fn test_prediction_history_seeded_from_init_message() {
         .world_mut()
         .spawn((
             CompFull(42.0),
+            CompCorr(24.0),
             Replicate::to_clients(NetworkTarget::All),
             PredictionTarget::to_clients(NetworkTarget::All),
         ))
@@ -92,6 +106,14 @@ fn test_prediction_history_seeded_from_init_message() {
             .is_some(),
         "client entity should have Predicted marker"
     );
+    assert!(
+        stepper
+            .client_app()
+            .world()
+            .entity(predicted_entity)
+            .contains::<ObservedCompleteInitialPrediction>(),
+        "Predicted observers should see live components and confirmed histories from the same update"
+    );
 
     // The client entity should have the CompFull value from the server
     assert_eq!(
@@ -101,6 +123,14 @@ fn test_prediction_history_seeded_from_init_message() {
             .get::<CompFull>(predicted_entity)
             .expect("client entity should have CompFull from replication"),
         &CompFull(42.0)
+    );
+    assert_eq!(
+        stepper
+            .client_app()
+            .world()
+            .get::<CompCorr>(predicted_entity)
+            .expect("client entity should have CompCorr from replication"),
+        &CompCorr(24.0)
     );
 
     // Resolve the server tick that produced the init message and check
@@ -112,6 +142,9 @@ fn test_prediction_history_seeded_from_init_message() {
     let confirmed_history = world
         .get::<ConfirmedHistory<CompFull>>(predicted_entity)
         .expect("client entity should have ConfirmedHistory<CompFull>");
+    let corr_confirmed_history = world
+        .get::<ConfirmedHistory<CompCorr>>(predicted_entity)
+        .expect("client entity should have ConfirmedHistory<CompCorr>");
     let confirm = world
         .get::<ConfirmHistory>(predicted_entity)
         .expect("client entity should have ConfirmHistory");
@@ -132,12 +165,117 @@ fn test_prediction_history_seeded_from_init_message() {
         s_tick,
         confirmed_history
     );
+    assert_eq!(
+        corr_confirmed_history
+            .get_state_at(s_tick)
+            .and_then(HistoryState::value),
+        Some(&CompCorr(24.0)),
+        "all initially replicated predicted components should use marker receive functions"
+    );
     assert!(
         prediction_history.buffer().iter().all(|(_, state)| {
             matches!(state, HistoryState::Updated(_) | HistoryState::Removed)
         }),
         "PredictionHistory should contain only local predicted states: {:?}",
         prediction_history
+    );
+}
+
+#[test]
+fn test_manual_predicted_marker_backfills_existing_replicated_component() {
+    use lightyear::prelude::ConfirmHistory;
+    use lightyear_connection::network_target::NetworkTarget;
+    use lightyear_messages::MessageManager;
+    use lightyear_replication::checkpoint::ReplicationCheckpointMap;
+    use lightyear_replication::prelude::Replicate;
+
+    let mut stepper = ClientServerStepper::from_config(StepperConfig::single());
+    let server_entity = stepper
+        .server_app
+        .world_mut()
+        .spawn((CompFull(42.0), Replicate::to_clients(NetworkTarget::All)))
+        .id();
+    stepper.frame_step(2);
+
+    let client_entity = stepper
+        .client(0)
+        .get::<MessageManager>()
+        .unwrap()
+        .entity_mapper
+        .get_local(server_entity)
+        .expect("entity was not replicated to client");
+    assert!(
+        stepper
+            .client_app()
+            .world()
+            .get::<ConfirmedHistory<CompFull>>(client_entity)
+            .is_none()
+    );
+
+    stepper
+        .client_app()
+        .world_mut()
+        .entity_mut(client_entity)
+        .insert(Predicted);
+
+    let world = stepper.client_app().world();
+    let confirm_tick = world
+        .get::<ConfirmHistory>(client_entity)
+        .expect("replicated entity should have ConfirmHistory")
+        .last_tick();
+    let server_tick = world
+        .resource::<ReplicationCheckpointMap>()
+        .get(confirm_tick)
+        .expect("confirmation tick should resolve to a server tick");
+    assert!(
+        world
+            .get::<PredictionHistory<CompFull>>(client_entity)
+            .is_some(),
+        "manual prediction should initialize local prediction history"
+    );
+    assert_eq!(
+        world
+            .get::<ConfirmedHistory<CompFull>>(client_entity)
+            .and_then(|history| history.get_state_at(server_tick))
+            .and_then(HistoryState::value),
+        Some(&CompFull(42.0)),
+        "manual prediction should seed confirmed history from the existing replicated value"
+    );
+    assert_eq!(world.get::<CompFull>(client_entity), Some(&CompFull(42.0)));
+}
+
+#[test]
+fn test_manual_predicted_and_component_does_not_seed_confirmed_history() {
+    use lightyear_connection::network_target::NetworkTarget;
+    use lightyear_messages::MessageManager;
+    use lightyear_replication::prelude::Replicate;
+
+    let mut stepper = ClientServerStepper::from_config(StepperConfig::single());
+    let server_entity = stepper
+        .server_app
+        .world_mut()
+        .spawn((CompA(1.0), Replicate::to_clients(NetworkTarget::All)))
+        .id();
+    stepper.frame_step(2);
+
+    let client_entity = stepper
+        .client(0)
+        .get::<MessageManager>()
+        .unwrap()
+        .entity_mapper
+        .get_local(server_entity)
+        .expect("entity was not replicated to client");
+    stepper
+        .client_app()
+        .world_mut()
+        .entity_mut(client_entity)
+        .insert((Predicted, CompFull(99.0)));
+
+    let entity = stepper.client_app().world().entity(client_entity);
+    assert!(entity.contains::<PredictionHistory<CompFull>>());
+    assert!(
+        !entity.contains::<ConfirmedHistory<CompFull>>(),
+        "a component added locally with Predicted is not authoritative"
     );
 }
 

--- a/crates/tests/src/client_server/replication.rs
+++ b/crates/tests/src/client_server/replication.rs
@@ -443,13 +443,6 @@ fn test_custom_interpolation_component_gets_confirmed_history() {
     );
 
     stepper.frame_step(2);
-    stepper
-        .server_app
-        .world_mut()
-        .entity_mut(server_entity)
-        .insert(CompCustomInterp(2.0));
-    stepper.frame_step_server_first(2);
-
     let client_entity = stepper
         .client(0)
         .get::<MessageManager>()
@@ -457,16 +450,34 @@ fn test_custom_interpolation_component_gets_confirmed_history() {
         .entity_mapper
         .get_local(server_entity)
         .unwrap();
-    let client_entity_ref = stepper.client_apps[0].world().entity(client_entity);
+    {
+        let client_entity_ref = stepper.client_apps[0].world().entity(client_entity);
+        assert!(
+            client_entity_ref.get::<Interpolated>().is_some(),
+            "entity should be interpolated on the client"
+        );
+        assert!(
+            client_entity_ref.get::<InterpolatedSend>().is_none(),
+            "the sender-only interpolation marker must not be materialized on the receiver"
+        );
+        let history = client_entity_ref
+            .get::<ConfirmedHistory<CompCustomInterp>>()
+            .expect("the initial component should be written directly to interpolation history");
+        assert_eq!(
+            history.newest_present().map(|(_, value)| value),
+            Some(&CompCustomInterp(1.0)),
+            "InterpolatedSend should select the history receive function in the initial update"
+        );
+    }
 
-    assert!(
-        client_entity_ref.get::<Interpolated>().is_some(),
-        "entity should be interpolated on the client"
-    );
-    assert!(
-        client_entity_ref.get::<InterpolatedSend>().is_none(),
-        "the sender-only interpolation marker must not be materialized on the receiver"
-    );
+    stepper
+        .server_app
+        .world_mut()
+        .entity_mut(server_entity)
+        .insert(CompCustomInterp(2.0));
+    stepper.frame_step_server_first(2);
+
+    let client_entity_ref = stepper.client_apps[0].world().entity(client_entity);
     let history = client_entity_ref
         .get::<ConfirmedHistory<CompCustomInterp>>()
         .expect(
@@ -475,6 +486,53 @@ fn test_custom_interpolation_component_gets_confirmed_history() {
     assert!(
         history.start_present().is_some(),
         "custom-interpolated history should contain at least one confirmed update"
+    );
+}
+
+#[test]
+fn test_manual_interpolated_marker_backfills_existing_replicated_component() {
+    let mut stepper = ClientServerStepper::from_config(StepperConfig::single());
+    let server_entity = stepper
+        .server_app
+        .world_mut()
+        .spawn((
+            Replicate::to_clients(NetworkTarget::All),
+            CompCustomInterp(3.0),
+        ))
+        .id();
+    stepper.frame_step(2);
+
+    let client_entity = stepper
+        .client(0)
+        .get::<MessageManager>()
+        .unwrap()
+        .entity_mapper
+        .get_local(server_entity)
+        .expect("entity was not replicated to client");
+    assert!(
+        stepper.client_apps[0]
+            .world()
+            .entity(client_entity)
+            .contains::<CompCustomInterp>()
+    );
+
+    stepper.client_apps[0]
+        .world_mut()
+        .entity_mut(client_entity)
+        .insert(Interpolated);
+
+    let client_entity_ref = stepper.client_apps[0].world().entity(client_entity);
+    assert_eq!(
+        client_entity_ref
+            .get::<ConfirmedHistory<CompCustomInterp>>()
+            .and_then(ConfirmedHistory::newest_present)
+            .map(|(_, value)| value),
+        Some(&CompCustomInterp(3.0)),
+        "manual interpolation should seed history from the existing replicated value"
+    );
+    assert!(
+        !client_entity_ref.contains::<CompCustomInterp>(),
+        "the live value should wait for the interpolation timeline after manual opt-in"
     );
 }
 


### PR DESCRIPTION
## Summary

- use the main branch of `bevy_replicon` and register prediction/interpolation receive markers in shared marker plugins before user protocol registration
- route initial `PredictedSend` and `CatchUpGated` component values into both the live component and confirmed history, while keeping subsequent authoritative updates history-only
- preserve late receiver-local `Predicted`/`Interpolated` opt-in through explicit history backfills and simplify prediction-history membership filtering
- cover initial marker visibility, observer behavior, manual marker insertion, diff replication, and catch-up flows

Builds on simgine/bevy_replicon#744.