### PR TITLE
refactor(interpolation): improve bundle rule resolution

### DIFF
--- a/crates/core/core/src/confirmed_history.rs
+++ b/crates/core/core/src/confirmed_history.rs
@@ -126,6 +126,12 @@ impl<C> ConfirmedHistory<C> {
         self.resolve_state_at_index(index)
     }
 
+    /// Get the latest authoritative state strictly before `tick`.
+    pub fn get_state_before(&self, tick: Tick) -> Option<&HistoryState<C>> {
+        let index = self.index_before(tick)?;
+        self.resolve_state_at_index(index)
+    }
+
     /// Get the authoritative state exactly at `tick`.
     pub fn get_state_at(&self, tick: Tick) -> Option<&HistoryState<C>> {
         let pos = self
@@ -157,11 +163,6 @@ impl<C> ConfirmedHistory<C> {
                 .get(i)
                 .and_then(|(_, state)| state.explicit_state())
         })
-    }
-
-    fn state_before(&self, tick: Tick) -> Option<&HistoryState<C>> {
-        let index = self.index_before(tick)?;
-        self.resolve_state_at_index(index)
     }
 
     fn insert_raw(&mut self, tick: Tick, state: ConfirmedHistoryState<C>) {
@@ -206,7 +207,10 @@ impl<C: PartialEq> ConfirmedHistory<C> {
     /// before `tick`, the raw entry is stored as
     /// an internal unchanged marker.
     pub fn insert(&mut self, tick: Tick, state: HistoryState<C>) {
-        let entry = if self.state_before(tick).is_some_and(|prev| prev == &state) {
+        let entry = if self
+            .get_state_before(tick)
+            .is_some_and(|prev| prev == &state)
+        {
             ConfirmedHistoryState::SameAsPrecedent
         } else {
             ConfirmedHistoryState::Explicit(state)
@@ -250,7 +254,10 @@ impl<C: PartialEq> ConfirmedHistory<C> {
         {
             self.buffer.pop_back();
         }
-        let entry = if self.state_before(tick).is_some_and(|prev| prev == &state) {
+        let entry = if self
+            .get_state_before(tick)
+            .is_some_and(|prev| prev == &state)
+        {
             ConfirmedHistoryState::SameAsPrecedent
         } else {
             ConfirmedHistoryState::Explicit(state)
@@ -277,7 +284,7 @@ impl<C> ConfirmedHistory<C> {
     /// state did not change at `tick` even though no explicit component update
     /// was received.
     pub fn add_unchanged(&mut self, tick: Tick) -> bool {
-        if self.get_state_at(tick).is_some() || self.state_before(tick).is_none() {
+        if self.get_state_at(tick).is_some() || self.get_state_before(tick).is_none() {
             return false;
         }
         self.insert_raw(tick, ConfirmedHistoryState::SameAsPrecedent);
@@ -484,6 +491,27 @@ mod tests {
         assert_eq!(effective_value_at(&history, Tick(2)), Some(1.0));
         assert!(history.get_present(Tick(3)).is_none());
         assert_eq!(effective_value_at(&history, Tick(5)), Some(5.0));
+    }
+
+    /// Checks that strict-before lookup excludes the entry at the requested tick.
+    #[test]
+    fn get_state_before_excludes_the_requested_tick() {
+        let mut history = ConfirmedHistory::<TestValue>::default();
+        history.insert_present(Tick(1), TestValue(1.0));
+        history.insert_removed(Tick(3));
+        history.insert_present(Tick(5), TestValue(5.0));
+
+        assert!(history.get_state_before(Tick(1)).is_none());
+        assert_eq!(
+            history
+                .get_state_before(Tick(3))
+                .and_then(HistoryState::value),
+            Some(&TestValue(1.0))
+        );
+        assert!(matches!(
+            history.get_state_before(Tick(5)),
+            Some(HistoryState::Removed)
+        ));
     }
 
     #[test]

--- a/crates/core/frame_interpolation/src/archetypes.rs
+++ b/crates/core/frame_interpolation/src/archetypes.rs
@@ -10,20 +10,26 @@ use bevy_ecs::{
     world::{FromWorld, unsafe_world_cell::UnsafeWorldCell},
 };
 use bevy_platform::collections::HashMap;
-use lightyear_interpolation::registry::InterpolationRegistry;
-use lightyear_interpolation::rules::frame_interpolate::{
-    CachedFrameInterpolationApply, CachedFrameInterpolationComponent,
+use lightyear_interpolation::registry::{
+    InterpolationArchetypeKey, InterpolationRegistry, RuleResolutionScratch, RuleTarget,
 };
-use lightyear_interpolation::rules::{InterpolationRuleId, RuleKind};
+use lightyear_interpolation::rules::frame_interpolate::{
+    CachedFrameInterpolationApply, CachedFrameInterpolationHistoryComponent,
+};
 
-/// Cached frame interpolation rules selected for each archetype with [`FrameInterpolate`].
+/// Frame interpolation policies shared by resolution-equivalent archetypes.
+///
+/// Each policy stores all archetype IDs whose rule members, frame histories,
+/// filters, and [`SkipFrameInterpolation`] presence are the same.
 #[doc(hidden)]
 pub struct FrameInterpolatedArchetypes {
     generation: ArchetypeGeneration,
-    rule_count: usize,
     frame_interpolate_component_id: ComponentId,
     skip_frame_interpolation_component_id: ComponentId,
-    archetypes: Vec<CachedFrameInterpolatedArchetype>,
+    policies: Vec<CachedFrameInterpolationPolicy>,
+    policy_ids: HashMap<InterpolationArchetypeKey, usize>,
+    key_scratch: InterpolationArchetypeKey,
+    resolution_scratch: RuleResolutionScratch,
 }
 
 /// System param exposing cached frame interpolation archetypes and a low-level world cell.
@@ -43,14 +49,19 @@ impl FrameInterpolationWorld<'_, '_> {
     ) -> impl Iterator<
         Item = (
             &bevy_ecs::archetype::Archetype,
-            &CachedFrameInterpolatedArchetype,
+            &CachedFrameInterpolationPolicy,
         ),
     > {
-        self.state.iter().filter_map(|cached_archetype| {
-            self.world
-                .archetypes()
-                .get(cached_archetype.id())
-                .map(|archetype| (archetype, cached_archetype))
+        self.state.policies.iter().flat_map(move |policy| {
+            policy
+                .archetype_ids
+                .iter()
+                .filter_map(move |&archetype_id| {
+                    self.world
+                        .archetypes()
+                        .get(archetype_id)
+                        .map(|archetype| (archetype, policy))
+                })
         })
     }
 }
@@ -96,134 +107,137 @@ impl FromWorld for FrameInterpolatedArchetypes {
     fn from_world(world: &mut World) -> Self {
         Self {
             generation: ArchetypeGeneration::initial(),
-            rule_count: 0,
             frame_interpolate_component_id: world.register_component::<FrameInterpolate>(),
             skip_frame_interpolation_component_id: world
                 .register_component::<SkipFrameInterpolation>(),
-            archetypes: Vec::new(),
+            policies: Vec::new(),
+            policy_ids: HashMap::default(),
+            key_scratch: InterpolationArchetypeKey::default(),
+            resolution_scratch: RuleResolutionScratch::default(),
         }
     }
 }
 
 impl FrameInterpolatedArchetypes {
-    pub(crate) fn clear(&mut self) {
-        self.generation = ArchetypeGeneration::initial();
-        self.archetypes.clear();
-    }
-
+    /// Assigns newly-created frame-interpolated archetypes to shared policies.
+    ///
+    /// Components that cannot affect frame rule resolution are omitted from
+    /// the key, so adding one does not duplicate the callback vectors.
     pub(crate) fn update(
         &mut self,
         archetypes: &Archetypes,
         components: &Components,
         registry: &InterpolationRegistry,
     ) {
-        let rule_count = registry.rule_count();
-        if self.rule_count != rule_count {
-            self.clear();
-            self.rule_count = rule_count;
-        }
         let old_generation = core::mem::replace(&mut self.generation, archetypes.generation());
         for archetype in archetypes[old_generation..]
             .iter()
             .filter(|archetype| archetype.contains(self.frame_interpolate_component_id))
         {
-            let mut cached = CachedFrameInterpolatedArchetype::new(
-                archetype.id(),
-                archetype.contains(self.skip_frame_interpolation_component_id),
-            );
-            for kind in registry.rule_kinds() {
-                if let Some(rule_id) =
-                    registry.select_rule_for_archetype(components, archetype, kind)
-                {
-                    cached.selected_rules.insert(kind, rule_id);
-                    if let Some(component) =
-                        registry.cached_frame_history_component(components, archetype, rule_id)
+            registry.populate_archetype_key(archetype, RuleTarget::Frame, &mut self.key_scratch);
+            self.key_scratch
+                .include_if_present(archetype, self.skip_frame_interpolation_component_id);
+            if let Some(&policy_id) = self.policy_ids.get(&self.key_scratch) {
+                self.policies[policy_id].archetype_ids.push(archetype.id());
+            } else {
+                let rules = registry.resolved_rules_for_archetype(
+                    components,
+                    archetype,
+                    RuleTarget::Frame,
+                    &mut self.resolution_scratch,
+                );
+                let mut history_components = Vec::new();
+                let mut apply_callbacks = Vec::new();
+                for resolved in rules {
+                    let rule = registry.rule(resolved.rule_id);
+                    if resolved.owns_history {
+                        history_components.extend(rule.cached_frame_history_components(archetype));
+                    }
+                    if resolved.owns_apply
+                        && let Some(callback) = rule.cached_frame_apply(resolved.rule_id)
                     {
-                        cached.history_components.push(component);
+                        apply_callbacks.push(callback);
                     }
                 }
+                let policy_id = self.policies.len();
+                self.policies.push(CachedFrameInterpolationPolicy {
+                    archetype_ids: alloc::vec![archetype.id()],
+                    skip_interpolation: archetype
+                        .contains(self.skip_frame_interpolation_component_id),
+                    history_components,
+                    apply_callbacks,
+                });
+                self.policy_ids.insert(self.key_scratch.clone(), policy_id);
             }
-            cached.resolve_apply_rules(registry);
-            self.archetypes.push(cached);
         }
     }
 
-    pub(crate) fn iter(&self) -> impl Iterator<Item = &CachedFrameInterpolatedArchetype> {
-        self.archetypes.iter()
-    }
-}
-
-/// Cached frame interpolation policy for one archetype containing [`FrameInterpolate`].
-pub(crate) struct CachedFrameInterpolatedArchetype {
-    id: ArchetypeId,
-    skip_interpolation: bool,
-    selected_rules: HashMap<RuleKind, InterpolationRuleId>,
-    history_components: Vec<CachedFrameInterpolationComponent>,
-    apply_rules: Vec<CachedFrameInterpolationApply>,
-}
-
-impl CachedFrameInterpolatedArchetype {
-    fn new(id: ArchetypeId, skip_interpolation: bool) -> Self {
-        Self {
-            id,
-            skip_interpolation,
-            selected_rules: HashMap::default(),
-            history_components: Vec::new(),
-            apply_rules: Vec::new(),
-        }
-    }
-
-    pub(crate) fn id(&self) -> ArchetypeId {
-        self.id
-    }
-
-    pub(crate) fn skip_interpolation(&self) -> bool {
-        self.skip_interpolation
-    }
-
-    pub(crate) fn history_components(&self) -> &[CachedFrameInterpolationComponent] {
-        &self.history_components
-    }
-
-    pub(crate) fn apply_rules(&self) -> &[CachedFrameInterpolationApply] {
-        &self.apply_rules
-    }
-
-    fn resolve_apply_rules(&mut self, registry: &InterpolationRegistry) {
-        self.apply_rules.clear();
-
-        // `selected_rules` already contains the matching rule for each rule
-        // kind on this archetype. Those kinds can overlap: for an archetype
-        // with components `A` and `B`, we can have selected rules for `A`, `B`,
-        // and `(A, B)`.
-        //
-        // This pass walks the selected rules by priority and lets each rule
-        // claim all of its member components. Once a component is claimed, lower
-        // priority rules that also touch it are skipped, so every component is
-        // covered by at most one selected apply rule.
-        let mut candidates = self
-            .selected_rules
+    #[cfg(test)]
+    fn archetype_count(&self) -> usize {
+        self.policies
             .iter()
-            .filter_map(|(&kind, &rule_id)| registry.rule(rule_id).map(|_| (kind, rule_id)))
-            .collect::<Vec<_>>();
-        candidates.sort_by(|(_, lhs), (_, rhs)| registry.cmp_rule_precedence(*lhs, *rhs));
+            .map(|policy| policy.archetype_ids.len())
+            .sum()
+    }
+}
 
-        let mut claimed_members = Vec::new();
-        for (_, rule_id) in candidates {
-            let Some(rule) = registry.rule(rule_id) else {
-                continue;
-            };
-            if rule
-                .members()
-                .iter()
-                .any(|member| claimed_members.contains(member))
-            {
-                continue;
-            }
-            claimed_members.extend(rule.members().iter().copied());
-            if let Some(component) = registry.cached_frame_apply_component(rule_id) {
-                self.apply_rules.push(component);
-            }
-        }
+/// Frame interpolation policy shared by archetypes with the same relevant components.
+pub(crate) struct CachedFrameInterpolationPolicy {
+    /// Archetypes whose relevant component presence resolves to this policy.
+    archetype_ids: Vec<ArchetypeId>,
+    pub(crate) skip_interpolation: bool,
+    pub(crate) history_components: Vec<CachedFrameInterpolationHistoryComponent>,
+    pub(crate) apply_callbacks: Vec<CachedFrameInterpolationApply>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bevy_app::App;
+    use lightyear_interpolation::registry::AppInterpolationExt;
+    use lightyear_interpolation::rules::InterpolationFns;
+
+    #[derive(Component, Clone, Debug, PartialEq)]
+    struct Value(f32);
+
+    #[derive(Component)]
+    struct Unrelated;
+
+    fn lerp(start: Value, end: Value, t: f32) -> Value {
+        Value(start.0 + (end.0 - start.0) * t)
+    }
+
+    /// Checks that frame policies ignore unrelated components but distinguish skip markers.
+    #[test]
+    fn frame_policies_use_only_resolution_relevant_component_presence() {
+        let mut app = App::new();
+        app.interpolate_with::<Value>(InterpolationFns::no_history(lerp));
+        app.world_mut()
+            .resource_mut::<InterpolationRegistry>()
+            .finalize();
+
+        app.world_mut().spawn((FrameInterpolate, Value(1.0)));
+        app.world_mut()
+            .spawn((FrameInterpolate, Value(2.0), Unrelated));
+        app.world_mut()
+            .spawn((FrameInterpolate, Value(3.0), SkipFrameInterpolation));
+
+        let mut cache = FrameInterpolatedArchetypes::from_world(app.world_mut());
+        let world = app.world();
+        cache.update(
+            world.archetypes(),
+            world.components(),
+            world.resource::<InterpolationRegistry>(),
+        );
+
+        assert_eq!(cache.archetype_count(), 3);
+        assert_eq!(cache.policies.len(), 2);
+        let mut archetypes_per_policy = cache
+            .policies
+            .iter()
+            .map(|policy| policy.archetype_ids.len())
+            .collect::<Vec<_>>();
+        archetypes_per_policy.sort_unstable();
+        assert_eq!(archetypes_per_policy, [1, 2]);
     }
 }

--- a/crates/core/frame_interpolation/src/lib.rs
+++ b/crates/core/frame_interpolation/src/lib.rs
@@ -53,12 +53,7 @@ mod archetypes;
 
 use crate::archetypes::FrameInterpolationWorld;
 use bevy_app::prelude::*;
-use bevy_ecs::{
-    component::{ComponentId, ComponentIdFor},
-    observer::Observer,
-    prelude::*,
-    schedule::common_conditions::not,
-};
+use bevy_ecs::{prelude::*, schedule::common_conditions::not};
 use bevy_math::{
     Curve,
     curve::{Ease, EaseFunction, EasingCurve},
@@ -68,13 +63,10 @@ use bevy_time::{Fixed, Time};
 pub use lightyear_core::frame_interpolation::{FrameInterpolate, FrameInterpolationHistory};
 use lightyear_core::timeline::is_in_rollback;
 use lightyear_interpolation::registry::InterpolationRegistry;
-use lightyear_interpolation::rules::frame_interpolate::{
-    FrameHistoryComponent, FrameInterpolationContext,
-};
+use lightyear_interpolation::rules::frame_interpolate::FrameInterpolationContext;
 use lightyear_replication::ReplicationSystems;
 use lightyear_replication::deferred_entity::DeferredEntityCommands;
 use serde::{Deserialize, Serialize};
-use smallvec::SmallVec;
 
 /// System sets used by [`FrameInterpolationPlugin`].
 ///
@@ -109,80 +101,6 @@ pub struct SkipFrameInterpolation;
 pub fn linear_frame_interpolation<C: Ease + Clone>(start: C, end: C, t: f32) -> C {
     let curve = EasingCurve::new(start, end, EaseFunction::Linear);
     curve.sample_unchecked(t)
-}
-
-#[derive(Resource, Debug, Default)]
-struct FrameHistoryComponents {
-    components: SmallVec<[FrameHistoryComponent; 8]>,
-}
-
-/// Ensures every registered `FrameInterpolationHistory<C>` exists when an
-/// entity has both `FrameInterpolate` and the matching live `C`.
-///
-/// This is installed once by [`FrameInterpolationPlugin::finish`]. It watches
-/// `FrameInterpolate` plus every registered live component id that owns frame
-/// history. When `FrameInterpolate` is added, it backfills all matching
-/// histories on the entity. When a watched component is added to an already
-/// frame-interpolated entity, it only checks components from that trigger.
-fn insert_frame_histories_on_frame_interpolate(
-    trigger: On<Add>,
-    frame_history_components: Res<FrameHistoryComponents>,
-    frame_interpolate_id: ComponentIdFor<FrameInterpolate>,
-    mut commands: Commands,
-) {
-    let Some(archetype) = trigger.trigger().new_archetype else {
-        return;
-    };
-    if !archetype.contains(frame_interpolate_id.get()) {
-        return;
-    }
-
-    let added_components = trigger.trigger().components;
-    let frame_interpolate_added = added_components.contains(&frame_interpolate_id.get());
-    for component in &frame_history_components.components {
-        if !frame_interpolate_added && !added_components.contains(&component.live_component_id()) {
-            continue;
-        }
-        if archetype.contains(component.live_component_id())
-            && !archetype.contains(component.history_component_id())
-        {
-            (component.insert_history())(trigger.entity, &mut commands);
-        }
-    }
-}
-
-fn install_frame_history_observer(app: &mut App) {
-    let frame_interpolate_id = app.world_mut().register_component::<FrameInterpolate>();
-    let components = {
-        let registry = app.world().resource::<InterpolationRegistry>();
-        let mut components = SmallVec::<[FrameHistoryComponent; 8]>::new();
-        for component in registry.frame_history_components() {
-            if !components
-                .iter()
-                .any(|existing: &FrameHistoryComponent| existing.kind() == component.kind())
-            {
-                components.push(component);
-            }
-        }
-        components
-    };
-    if components.is_empty() {
-        return;
-    }
-
-    let mut watched_components = SmallVec::<[ComponentId; 8]>::new();
-    watched_components.push(frame_interpolate_id);
-    watched_components.extend(
-        components
-            .iter()
-            .map(FrameHistoryComponent::live_component_id),
-    );
-    app.world_mut()
-        .insert_resource(FrameHistoryComponents { components });
-    app.world_mut().spawn(
-        Observer::new(insert_frame_histories_on_frame_interpolate)
-            .with_components(watched_components),
-    );
 }
 
 /// Bevy plugin that enables type-erased frame interpolation.
@@ -258,7 +176,9 @@ impl Plugin for FrameInterpolationPlugin {
     }
 
     fn finish(&self, app: &mut App) {
-        install_frame_history_observer(app);
+        app.world_mut()
+            .resource_mut::<InterpolationRegistry>()
+            .finalize();
     }
 }
 
@@ -269,7 +189,7 @@ pub(crate) fn restore_frame_interpolation(
     frame_world.update_archetypes(&interpolation_registry);
     let world = frame_world.world;
     for (archetype, cached_archetype) in frame_world.iter_archetypes() {
-        for component in cached_archetype.history_components() {
+        for component in &cached_archetype.history_components {
             (component.restore_frame_history())(world, archetype, component);
         }
     }
@@ -285,7 +205,7 @@ pub(crate) fn update_frame_interpolation_histories(
     frame_world.update_archetypes(&interpolation_registry);
     let world = frame_world.world;
     for (archetype, cached_archetype) in frame_world.iter_archetypes() {
-        for component in cached_archetype.history_components() {
+        for component in &cached_archetype.history_components {
             (component.update_frame_history())(world, archetype, component, &mut deferred_apply);
         }
     }
@@ -297,9 +217,7 @@ pub(crate) fn apply_frame_interpolation(
     time: Res<Time<Fixed>>,
     mut frame_world: FrameInterpolationWorld,
     interpolation_registry: Res<InterpolationRegistry>,
-    mut commands: Commands,
 ) {
-    let mut deferred_apply = DeferredEntityCommands::default();
     let ctx = FrameInterpolationContext {
         overstep: time.overstep_fraction().clamp(0.0, 1.0),
         sample_delta_secs: Some(time.timestep().as_secs_f32()),
@@ -308,20 +226,17 @@ pub(crate) fn apply_frame_interpolation(
     frame_world.update_archetypes(&interpolation_registry);
     let world = frame_world.world;
     for (archetype, cached_archetype) in frame_world.iter_archetypes() {
-        for component in cached_archetype.apply_rules() {
+        for component in &cached_archetype.apply_callbacks {
             (component.apply_frame_interpolation())(
                 world,
                 archetype,
                 &interpolation_registry,
                 component.rule_id(),
                 ctx,
-                cached_archetype.skip_interpolation(),
-                &mut deferred_apply,
+                cached_archetype.skip_interpolation,
             );
         }
     }
-
-    deferred_apply.apply(&mut commands);
 }
 
 /// Common frame interpolation exports.
@@ -338,7 +253,6 @@ pub mod prelude {
 mod unit_tests {
     use super::*;
     use bevy_app::{App, FixedPostUpdate, PostUpdate, RunFixedMainLoop};
-    use bevy_ecs::observer::Observer;
     use bevy_replicon::prelude::RepliconSharedPlugin;
     use bevy_state::app::StatesPlugin;
     use core::time::Duration;
@@ -356,6 +270,9 @@ mod unit_tests {
 
     #[derive(Component, Clone, Debug, PartialEq)]
     struct FrameB(f32);
+
+    #[derive(Component)]
+    struct DisabledFrameHistory;
 
     #[derive(Component, Clone, Debug, PartialEq)]
     #[component(storage = "SparseSet")]
@@ -394,8 +311,22 @@ mod unit_tests {
         )
     }
 
+    /// Checks that rule registration is rejected after the frame plugin finalizes the registry.
     #[test]
-    fn frame_history_observer_inserts_history_when_frame_interpolate_is_added() {
+    #[should_panic(
+        expected = "cannot register interpolation rules after InterpolationRegistry has been finalized"
+    )]
+    fn frame_plugin_rejects_late_rule_registration() {
+        let mut app = App::new();
+        app.add_plugins(FrameInterpolationPlugin);
+        app.finish();
+
+        app.interpolate_with::<FrameA>(InterpolationFns::disabled());
+    }
+
+    /// Checks that adding `FrameInterpolate` later initializes existing component history.
+    #[test]
+    fn frame_update_inserts_history_when_frame_interpolate_is_added() {
         let mut app = App::new();
         app.add_plugins(FrameInterpolationPlugin);
         app.interpolate_with::<FrameA>(InterpolationFns::no_history(|start, end, t| {
@@ -411,6 +342,7 @@ mod unit_tests {
         );
 
         app.world_mut().entity_mut(entity).insert(FrameInterpolate);
+        app.world_mut().run_schedule(FixedPostUpdate);
 
         assert!(
             app.world()
@@ -419,8 +351,9 @@ mod unit_tests {
         );
     }
 
+    /// Checks that adding a registered component later initializes its frame history.
     #[test]
-    fn frame_history_observer_inserts_history_when_component_is_added() {
+    fn frame_update_inserts_history_when_component_is_added() {
         let mut app = App::new();
         app.add_plugins(FrameInterpolationPlugin);
         app.interpolate_with::<FrameA>(InterpolationFns::no_history(|start, end, t| {
@@ -436,6 +369,7 @@ mod unit_tests {
         );
 
         app.world_mut().entity_mut(entity).insert(FrameA(1.0));
+        app.world_mut().run_schedule(FixedPostUpdate);
 
         assert!(
             app.world()
@@ -444,8 +378,9 @@ mod unit_tests {
         );
     }
 
+    /// Checks that spawning the marker and component together initializes frame history.
     #[test]
-    fn frame_history_observer_inserts_history_when_both_are_spawned() {
+    fn frame_update_inserts_history_when_both_are_spawned() {
         let mut app = App::new();
         app.add_plugins(FrameInterpolationPlugin);
         app.interpolate_with::<FrameA>(InterpolationFns::no_history(|start, end, t| {
@@ -454,6 +389,7 @@ mod unit_tests {
         app.finish();
 
         let entity = app.world_mut().spawn((FrameA(1.0), FrameInterpolate)).id();
+        app.world_mut().run_schedule(FixedPostUpdate);
 
         assert!(
             app.world()
@@ -462,8 +398,36 @@ mod unit_tests {
         );
     }
 
+    /// Checks that a winning disabled rule blocks lower-priority frame-history creation.
     #[test]
-    fn frame_history_observer_is_shared_by_registered_components() {
+    fn disabled_winner_does_not_insert_lower_rule_frame_history() {
+        let mut app = App::new();
+        app.add_plugins(FrameInterpolationPlugin);
+        app.interpolate_with::<FrameA>(InterpolationFns::no_history(|start, end, t| {
+            FrameA(start.0 + (end.0 - start.0) * t)
+        }));
+        app.interpolate_with_priority_filtered::<FrameA, With<DisabledFrameHistory>>(
+            100,
+            InterpolationFns::disabled(),
+        );
+        app.finish();
+
+        let entity = app
+            .world_mut()
+            .spawn((FrameA(1.0), DisabledFrameHistory, FrameInterpolate))
+            .id();
+        app.world_mut().run_schedule(FixedPostUpdate);
+
+        assert!(
+            app.world()
+                .get::<FrameInterpolationHistory<FrameA>>(entity)
+                .is_none()
+        );
+    }
+
+    /// Checks that every component owned by winning rules receives frame history.
+    #[test]
+    fn frame_update_initializes_all_histories_for_the_winning_rules() {
         let mut app = App::new();
         app.add_plugins(FrameInterpolationPlugin);
         app.interpolate_with::<FrameA>(InterpolationFns::no_history(|start, end, t| {
@@ -474,17 +438,11 @@ mod unit_tests {
         }));
         app.finish();
 
-        let observer_count = app
-            .world_mut()
-            .query::<&Observer>()
-            .iter(app.world())
-            .count();
-        assert_eq!(observer_count, 1);
-
         let entity = app
             .world_mut()
             .spawn((FrameA(1.0), FrameB(2.0), FrameInterpolate))
             .id();
+        app.world_mut().run_schedule(FixedPostUpdate);
 
         assert!(
             app.world()
@@ -507,6 +465,7 @@ mod unit_tests {
             .accumulate_overstep(Duration::from_millis(500));
         app.add_plugins(FrameInterpolationPlugin);
         app.interpolate_bundle_with::<(FrameA, FrameB)>(InterpolationFns::no_history(bundle_lerp));
+        app.finish();
 
         let entity = app
             .world_mut()
@@ -560,6 +519,43 @@ mod unit_tests {
         );
     }
 
+    /// Checks that a bundle can own histories while a component rule applies the live member.
+    #[test]
+    fn frame_bundle_maintains_history_while_component_rule_applies_to_live_member() {
+        let mut app = App::new();
+        app.insert_resource(Time::<Fixed>::from_duration(Duration::from_secs(1)));
+        app.world_mut()
+            .resource_mut::<Time<Fixed>>()
+            .accumulate_overstep(Duration::from_millis(500));
+        app.add_plugins(FrameInterpolationPlugin);
+        app.interpolate_with::<FrameA>(InterpolationFns::no_history(|start, end, t| {
+            FrameA(start.0 + (end.0 - start.0) * t)
+        }));
+        app.interpolate_bundle_with::<(FrameA, FrameB)>(InterpolationFns::no_history(bundle_lerp));
+        app.finish();
+
+        let entity = app
+            .world_mut()
+            .spawn((
+                FrameInterpolate,
+                FrameA(-1.0),
+                FrameInterpolationHistory::<FrameA> {
+                    previous_value: Some(FrameA(0.0)),
+                    current_value: Some(FrameA(10.0)),
+                },
+                FrameInterpolationHistory::<FrameB> {
+                    previous_value: Some(FrameB(0.0)),
+                    current_value: Some(FrameB(20.0)),
+                },
+            ))
+            .id();
+
+        app.world_mut().run_schedule(PostUpdate);
+
+        assert_eq!(app.world().get::<FrameA>(entity), Some(&FrameA(5.0)));
+        assert!(!app.world().entity(entity).contains::<FrameB>());
+    }
+
     #[test]
     fn frame_bundle_interpolation_receives_fixed_timestep() {
         let mut app = App::new();
@@ -571,6 +567,7 @@ mod unit_tests {
         app.interpolate_bundle_with::<(FrameA, FrameB)>(InterpolationFns::no_history_with_context(
             bundle_context_lerp,
         ));
+        app.finish();
 
         let entity = app
             .world_mut()
@@ -606,12 +603,13 @@ mod unit_tests {
         app.interpolate_with::<FrameA>(InterpolationFns::no_history(|start, end, t| {
             FrameA(10.0 + start.0 + (end.0 - start.0) * t)
         }));
+        app.finish();
 
         assert!(
             app.world()
                 .components()
                 .component_id::<ConfirmedHistory<FrameA>>()
-                .is_none()
+                .is_some()
         );
 
         let entity = app
@@ -664,6 +662,7 @@ mod unit_tests {
             InterpolationFns::history_only()
                 .interpolate(|start, end, t| FrameA(20.0 + start.0 + (end.0 - start.0) * t)),
         );
+        app.finish();
 
         assert!(
             app.world()
@@ -706,6 +705,7 @@ mod unit_tests {
                 FrameA(20.0 + start.0 + (end.0 - start.0) * t)
             }),
         );
+        app.finish();
 
         let entity = app
             .world_mut()
@@ -735,6 +735,7 @@ mod unit_tests {
         app.interpolate_with::<SparseFrame>(InterpolationFns::no_history(|start, end, t| {
             SparseFrame(start.0 + (end.0 - start.0) * t)
         }));
+        app.finish();
 
         let entity = app
             .world_mut()
@@ -798,6 +799,7 @@ mod unit_tests {
             PostUpdate,
             observe_frame_interpolation_changes.after(FrameInterpolationSystems::Interpolate),
         );
+        app.finish();
 
         app.world_mut().spawn((
             FrameInterpolate,

--- a/crates/integration/avian/src/plugin.rs
+++ b/crates/integration/avian/src/plugin.rs
@@ -237,12 +237,12 @@ impl Plugin for LightyearAvianPlugin {
         Self::install_position_to_transform_markers(app);
         match self.replication_mode {
             AvianReplicationMode::Position { sync_to_transform } => {
-                if self.register_physics_components
-                    && app.world().contains_resource::<ComponentRegistry>()
-                {
-                    Self::register_position_mode_components(app);
+                if self.register_physics_components {
+                    if app.world().contains_resource::<ComponentRegistry>() {
+                        Self::register_position_mode_components(app);
+                    }
+                    Self::add_position_rotation_hermite_rule(app);
                 }
-                Self::add_position_rotation_hermite_rule(app);
                 if !self.update_syncs_manually {
                     let mut config = app.world_mut().resource_mut::<PhysicsTransformConfig>();
                     config.position_to_transform = true;
@@ -1219,7 +1219,6 @@ mod tests {
             FrameInterpolationPlugin,
             LightyearAvianPlugin {
                 update_syncs_manually: true,
-                register_physics_components: false,
                 ..Default::default()
             },
         ));
@@ -1307,6 +1306,7 @@ mod tests {
     #[test]
     fn position_mode_writes_frame_interpolated_pose_to_transform() {
         let mut app = App::new();
+        app.init_resource::<Time>();
         app.insert_resource(Time::<Fixed>::from_duration(Duration::from_secs(1)));
         app.add_plugins((
             PhysicsSchedulePlugin::default(),
@@ -1332,6 +1332,9 @@ mod tests {
                 FrameInterpolate,
             ))
             .id();
+
+        // Frame histories are initialized by the fixed-post-update cache pass.
+        app.world_mut().run_schedule(FixedPostUpdate);
 
         // Warm up Avian's Changed<Position> filter so the next write must be detected from
         // frame interpolation rather than from the component's spawn tick.
@@ -1390,13 +1393,18 @@ mod tests {
                 Transform::from_xyz(10.0, 20.0, 0.0),
                 GlobalTransform::default(),
                 FrameInterpolate,
-                FrameInterpolationHistory::<Position> {
-                    previous_value: Some(Position::default()),
-                    current_value: Some(canonical_position),
-                },
             ))
             .id();
 
+        // Frame histories are initialized by the fixed-post-update cache pass.
+        app.world_mut().run_schedule(FixedPostUpdate);
+        *app.world_mut()
+            .entity_mut(entity)
+            .get_mut::<FrameInterpolationHistory<Position>>()
+            .unwrap() = FrameInterpolationHistory {
+            previous_value: Some(Position::default()),
+            current_value: Some(canonical_position),
+        };
         seed_stationary_hermite_histories(&mut app, entity, true);
 
         // PostUpdate leaves the interpolated visual pose in both Position and Transform.
@@ -1597,6 +1605,7 @@ mod tests_3d {
     #[test]
     fn position_mode_writes_frame_interpolated_pose_to_transform() {
         let mut app = App::new();
+        app.init_resource::<Time>();
         app.insert_resource(Time::<Fixed>::from_duration(Duration::from_secs(1)));
         app.add_plugins((
             PhysicsSchedulePlugin::default(),
@@ -1622,6 +1631,9 @@ mod tests_3d {
                 FrameInterpolate,
             ))
             .id();
+
+        // Frame histories are initialized by the fixed-post-update cache pass.
+        app.world_mut().run_schedule(FixedPostUpdate);
 
         // Warm up Avian's Changed<Position> filter so the next write must be detected from
         // frame interpolation rather than from the component's spawn tick.
@@ -1680,13 +1692,18 @@ mod tests_3d {
                 Transform::from_xyz(10.0, 20.0, 30.0),
                 GlobalTransform::default(),
                 FrameInterpolate,
-                FrameInterpolationHistory::<Position> {
-                    previous_value: Some(Position::default()),
-                    current_value: Some(canonical_position),
-                },
             ))
             .id();
 
+        // Frame histories are initialized by the fixed-post-update cache pass.
+        app.world_mut().run_schedule(FixedPostUpdate);
+        *app.world_mut()
+            .entity_mut(entity)
+            .get_mut::<FrameInterpolationHistory<Position>>()
+            .unwrap() = FrameInterpolationHistory {
+            previous_value: Some(Position::default()),
+            current_value: Some(canonical_position),
+        };
         seed_stationary_hermite_histories(&mut app, entity, true);
 
         app.world_mut().run_schedule(PostUpdate);

--- a/crates/integration/avian/src/types_2d.rs
+++ b/crates/integration/avian/src/types_2d.rs
@@ -167,9 +167,9 @@ pub mod transform {
     /// unavailable, it falls back to linear translation/scale interpolation and
     /// spherical rotation interpolation.
     ///
-    /// Bundle interpolation requires all three component histories to have the
-    /// same bracketing ticks. The returned velocity components are linearly
-    /// interpolated over the same fraction.
+    /// Bundle interpolation samples all three histories at shared ticks;
+    /// unchanged components carry their latest values forward. The returned
+    /// velocity components are linearly interpolated over the same fraction.
     ///
     /// Register it as a higher-priority bundle rule when Transform-mode
     /// smoothing should use velocity-aware Hermite interpolation:

--- a/crates/integration/avian/src/types_3d.rs
+++ b/crates/integration/avian/src/types_3d.rs
@@ -148,9 +148,9 @@ pub mod transform {
     /// unavailable, it falls back to linear translation/scale interpolation and
     /// spherical rotation interpolation.
     ///
-    /// Bundle interpolation requires all three component histories to have the
-    /// same bracketing ticks. The returned velocity components are linearly
-    /// interpolated over the same fraction.
+    /// Bundle interpolation samples all three histories at shared ticks;
+    /// unchanged components carry their latest values forward. The returned
+    /// velocity components are linearly interpolated over the same fraction.
     ///
     /// Register it as a higher-priority bundle rule when Transform-mode
     /// smoothing should use velocity-aware Hermite interpolation:

--- a/crates/replication/interpolation/Cargo.toml
+++ b/crates/replication/interpolation/Cargo.toml
@@ -27,7 +27,6 @@ lightyear_transport.workspace = true
 bevy_replicon.workspace = true
 
 # utils
-indexmap.workspace = true
 metrics = { workspace = true, optional = true }
 tracing.workspace = true
 variadics_please.workspace = true

--- a/crates/replication/interpolation/src/archetypes.rs
+++ b/crates/replication/interpolation/src/archetypes.rs
@@ -1,7 +1,7 @@
-use crate::registry::InterpolationRegistry;
-use crate::rules::{
-    CachedInterpolationApply, CachedInterpolationComponent, InterpolationRuleId, RuleKind,
+use crate::registry::{
+    InterpolationArchetypeKey, InterpolationRegistry, RuleResolutionScratch, RuleTarget,
 };
+use crate::rules::{CachedInterpolationApply, CachedInterpolationComponent};
 use alloc::vec::Vec;
 use bevy_ecs::{
     archetype::{ArchetypeGeneration, ArchetypeId, Archetypes},
@@ -15,16 +15,19 @@ use bevy_ecs::{
 use bevy_platform::collections::HashMap;
 use lightyear_core::prelude::Interpolated;
 
-/// Cached interpolation rules selected for each interpolated archetype.
+/// Cached interpolation policies shared by resolution-equivalent archetypes.
 ///
-/// Interpolation rule filters are archetype-level, so they can be evaluated
-/// once when a new archetype appears instead of once per entity per frame.
+/// Each policy stores all archetype IDs whose differences cannot affect rule
+/// members, histories, or filters. Those archetypes reuse the same history and
+/// apply callback vectors.
 #[doc(hidden)]
 pub struct InterpolatedArchetypes {
     generation: ArchetypeGeneration,
-    rule_count: usize,
     interpolated_component_id: ComponentId,
-    archetypes: Vec<CachedInterpolatedArchetype>,
+    policies: Vec<CachedInterpolationPolicy>,
+    policy_ids: HashMap<InterpolationArchetypeKey, usize>,
+    key_scratch: InterpolationArchetypeKey,
+    resolution_scratch: RuleResolutionScratch,
 }
 
 /// System param exposing the cached interpolated archetypes and world cell.
@@ -51,17 +54,17 @@ impl InterpolationWorld<'_, '_> {
     /// included in this frame's scan.
     pub(crate) fn iter_archetypes(
         &self,
-    ) -> impl Iterator<
-        Item = (
-            &bevy_ecs::archetype::Archetype,
-            &CachedInterpolatedArchetype,
-        ),
-    > {
-        self.state.iter().filter_map(|cached_archetype| {
-            self.world
-                .archetypes()
-                .get(cached_archetype.id())
-                .map(|archetype| (archetype, cached_archetype))
+    ) -> impl Iterator<Item = (&bevy_ecs::archetype::Archetype, &CachedInterpolationPolicy)> {
+        self.state.policies.iter().flat_map(move |policy| {
+            policy
+                .archetype_ids
+                .iter()
+                .filter_map(move |&archetype_id| {
+                    self.world
+                        .archetypes()
+                        .get(archetype_id)
+                        .map(|archetype| (archetype, policy))
+                })
         })
     }
 }
@@ -102,188 +105,178 @@ unsafe impl SystemParam for InterpolationWorld<'_, '_> {
     }
 }
 
-/// Cached interpolation policy for one archetype containing [`Interpolated`].
+/// Interpolation policy shared by archetypes with the same relevant components.
 ///
-/// The cache separates rule selection from component application:
-///
-/// - `selected_rules` stores the highest-priority matching rule for each rule
-///   target (`C` or `(A, B, ...)`). These rules decide ownership of history
-///   updates and interpolation-timeline component presence.
-/// - `apply_rules` stores the selected type-erased apply functions that are
-///   allowed to write live components after overlapping bundle/component rules
-///   have been resolved. For example, a selected `(Position, Rotation)` bundle
-///   rule suppresses application by overlapping selected single-component
-///   rules.
-pub(crate) struct CachedInterpolatedArchetype {
-    /// ID of the archetype this cache entry describes.
-    id: ArchetypeId,
-    /// Highest-priority matching rule for each rule target on this archetype.
-    selected_rules: HashMap<RuleKind, InterpolationRuleId>,
+/// History and apply ownership are resolved independently. A bundle can keep
+/// maintaining histories for absent members while standalone rules apply the
+/// members that remain live.
+pub(crate) struct CachedInterpolationPolicy {
+    /// Archetypes whose relevant component presence resolves to this policy.
+    archetype_ids: Vec<ArchetypeId>,
     /// Component metadata needed only by Lightyear-owned history updates.
     ///
-    /// A selected rule is present here only when it owns history and this
-    /// archetype already contains the corresponding `ConfirmedHistory<C>`
-    /// column. Apply-only rules are cached separately in `apply_rules`.
-    history_update_components: Vec<CachedInterpolationComponent>,
-    /// Type-erased interpolation rules that should write live components.
-    apply_rules: Vec<CachedInterpolationApply>,
-}
-
-impl CachedInterpolatedArchetype {
-    fn new(id: ArchetypeId) -> Self {
-        Self {
-            id,
-            selected_rules: HashMap::default(),
-            history_update_components: Vec::new(),
-            apply_rules: Vec::new(),
-        }
-    }
-
-    pub(crate) fn id(&self) -> ArchetypeId {
-        self.id
-    }
-
-    pub(crate) fn history_update_components(&self) -> &[CachedInterpolationComponent] {
-        &self.history_update_components
-    }
-
-    pub(crate) fn apply_rules(&self) -> &[CachedInterpolationApply] {
-        &self.apply_rules
-    }
+    /// An operation is present here when a resolved winning rule owns it and the
+    /// archetype contains either the live component or its confirmed history.
+    pub(crate) history_components: Vec<CachedInterpolationComponent>,
+    /// Type-erased interpolation callbacks selected for these archetypes.
+    pub(crate) apply_callbacks: Vec<CachedInterpolationApply>,
 }
 
 impl FromWorld for InterpolatedArchetypes {
     fn from_world(world: &mut World) -> Self {
         Self {
             generation: ArchetypeGeneration::initial(),
-            rule_count: 0,
             interpolated_component_id: world.register_component::<Interpolated>(),
-            archetypes: Vec::new(),
+            policies: Vec::new(),
+            policy_ids: HashMap::default(),
+            key_scratch: InterpolationArchetypeKey::default(),
+            resolution_scratch: RuleResolutionScratch::default(),
         }
     }
 }
 
 impl InterpolatedArchetypes {
-    /// Clears all cached archetype rule selections.
+    /// Assigns newly-created interpolated archetypes to shared policies.
     ///
-    /// The cache clears itself when it observes a new registry rule count. The
-    /// next cache update will rescan every interpolated archetype and rebuild
-    /// `selected_rules`, `apply_rules`, and history-update component metadata.
-    pub(crate) fn clear(&mut self) {
-        self.generation = ArchetypeGeneration::initial();
-        self.archetypes.clear();
-    }
-
-    /// Resolves interpolation rules for newly-created interpolated archetypes.
-    ///
-    /// Existing entries are kept until [`Self::clear`] is called. The cache
-    /// tracks the number of registered rules instead of storing a registry
-    /// version.
-    ///
-    /// Rule selection is a two-stage process:
-    ///
-    /// 1. Select the highest-priority matching rule for each rule target using
-    ///    [`InterpolationRegistry::select_rule_for_archetype`]. For an
-    ///    archetype containing components `A` and `B`, this can select one rule
-    ///    for `A`, one for `B`, and one for `(A, B)`.
-    /// 2. Resolve apply ownership between those selected rules. If the selected
-    ///    `(A, B)` rule has higher priority than the selected `A` and `B` rules,
-    ///    it claims both member components and supersedes the individual apply
-    ///    rules for this archetype.
+    /// Matching component and bundle rules are sorted by priority and
+    /// registration order. History and apply each claim members atomically. A
+    /// bundle can therefore own `(A, B)` history while a standalone rule owns
+    /// application of a currently live `A`.
     pub(crate) fn update(
         &mut self,
         archetypes: &Archetypes,
         components: &Components,
         registry: &InterpolationRegistry,
     ) {
-        let rule_count = registry.rule_count();
-        if self.rule_count != rule_count {
-            self.clear();
-            self.rule_count = rule_count;
-        }
         let old_generation = core::mem::replace(&mut self.generation, archetypes.generation());
         for archetype in archetypes[old_generation..]
             .iter()
             .filter(|archetype| archetype.contains(self.interpolated_component_id))
         {
-            let mut cached = CachedInterpolatedArchetype::new(archetype.id());
-            // `rules_by_kind` is already priority-sorted per rule target.
-            // We need one winner per rule target before resolving overlap: a tuple
-            // rule like `(A, B)` competes with other `(A, B)` rules here, not
-            // with the individual `A` or `B` rules yet.
-            for kind in registry.rule_kinds() {
-                if let Some(rule_id) =
-                    registry.select_rule_for_archetype(components, archetype, kind)
-                {
-                    cached.selected_rules.insert(kind, rule_id);
-                    if let Some(component) =
-                        registry.cached_history_update_component(components, archetype, rule_id)
+            registry.populate_archetype_key(archetype, RuleTarget::Default, &mut self.key_scratch);
+            if let Some(&policy_id) = self.policy_ids.get(&self.key_scratch) {
+                self.policies[policy_id].archetype_ids.push(archetype.id());
+            } else {
+                let mut policy = CachedInterpolationPolicy {
+                    archetype_ids: alloc::vec![archetype.id()],
+                    history_components: Vec::new(),
+                    apply_callbacks: Vec::new(),
+                };
+                for resolved in registry.resolved_rules_for_archetype(
+                    components,
+                    archetype,
+                    RuleTarget::Default,
+                    &mut self.resolution_scratch,
+                ) {
+                    let rule = registry.rule(resolved.rule_id);
+
+                    if resolved.owns_history {
+                        for member in &rule.members {
+                            let Some(confirmed) = member.confirmed else {
+                                continue;
+                            };
+                            let history_component_id = member.confirmed_history_component_id;
+                            let history_component_present =
+                                archetype.contains(history_component_id);
+                            let live_component_present =
+                                archetype.contains(member.live_component_id);
+                            debug_assert!(history_component_present || live_component_present);
+                            policy
+                                .history_components
+                                .push(CachedInterpolationComponent {
+                                    history_component_id,
+                                    history_storage: history_component_present
+                                        .then(|| archetype.get_storage_type(history_component_id))
+                                        .flatten(),
+                                    history_component_present,
+                                    live_component_present,
+                                    update_history: confirmed.update_history,
+                                    insert_history: confirmed.insert_history,
+                                });
+                        }
+                    }
+                    if resolved.owns_apply
+                        && let Some(apply_interpolation) = rule.apply_interpolation
                     {
-                        cached.history_update_components.push(component);
+                        policy.apply_callbacks.push(CachedInterpolationApply {
+                            rule_id: resolved.rule_id,
+                            apply_interpolation,
+                        });
                     }
                 }
+                let policy_id = self.policies.len();
+                self.policies.push(policy);
+                self.policy_ids.insert(self.key_scratch.clone(), policy_id);
             }
-            cached.resolve_apply_rules(registry);
-            self.archetypes.push(cached);
         }
     }
 
-    /// Iterates over cached interpolated archetypes.
-    pub(crate) fn iter(&self) -> impl Iterator<Item = &CachedInterpolatedArchetype> {
-        self.archetypes.iter()
+    #[cfg(test)]
+    fn archetype_count(&self) -> usize {
+        self.policies
+            .iter()
+            .map(|policy| policy.archetype_ids.len())
+            .sum()
     }
 }
 
-impl CachedInterpolatedArchetype {
-    /// Builds `apply_rules` from `selected_rules` in priority order.
-    ///
-    /// This follows Replicon's priority ordering: selected rules are sorted by
-    /// descending priority and ascending registration order, then rules claim
-    /// their member components.
-    ///
-    /// A bundle interpolation function is atomic: if any member has already been
-    /// claimed, the whole bundle apply function is skipped because it cannot write
-    /// only the unclaimed subset.
-    ///
-    /// For example, if the selected rules are `A`, `B`, and `(A, B)`, and
-    /// `(A, B)` sorts first by priority, it claims both `A` and `B`. The
-    /// individual `A` and `B` apply rules are then skipped because their member
-    /// components are already claimed.
-    fn resolve_apply_rules(&mut self, registry: &InterpolationRegistry) {
-        self.apply_rules.clear();
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::interpolate::update_history_archetype_erased;
+    use crate::registry::{InterpolationRegistry, component_rule, insert_confirmed_history};
+    use crate::rules::{InterpolationFns, InterpolationRuleConfig};
+    use bevy_ecs::query::With;
 
-        // `selected_rules` already contains the matching rule for each rule
-        // kind on this archetype. Those kinds can overlap: for an archetype
-        // with components `A` and `B`, we can have selected rules for `A`, `B`,
-        // and `(A, B)`.
-        //
-        // This pass walks the selected rules by priority and lets each rule
-        // claim all of its member components. Once a component is claimed, lower
-        // priority rules that also touch it are skipped, so every component is
-        // covered by at most one selected apply rule.
-        let mut candidates = self
-            .selected_rules
+    #[derive(Component, Clone, Debug, PartialEq)]
+    struct Value(f32);
+
+    #[derive(Component)]
+    struct FilterMarker;
+
+    #[derive(Component)]
+    struct ExcludedMarker;
+
+    #[derive(Component)]
+    struct Unrelated;
+
+    fn lerp(start: Value, end: Value, t: f32) -> Value {
+        Value(start.0 + (end.0 - start.0) * t)
+    }
+
+    /// Checks that unrelated components share a policy while `With` and `Without` inputs do not.
+    #[test]
+    fn policies_use_only_resolution_relevant_component_presence() {
+        let mut world = World::new();
+        world.register_component::<FilterMarker>();
+        world.register_component::<ExcludedMarker>();
+        let rule = component_rule::<Value, (With<FilterMarker>, Without<ExcludedMarker>)>(
+            &mut world,
+            InterpolationFns::interpolate(lerp),
+            InterpolationRuleConfig::default(),
+            update_history_archetype_erased::<Value>,
+            insert_confirmed_history::<Value>,
+        );
+        let mut registry = InterpolationRegistry::default();
+        registry.insert_rule(rule);
+        registry.finalize();
+
+        world.spawn((Interpolated, Value(1.0)));
+        world.spawn((Interpolated, Value(2.0), Unrelated));
+        world.spawn((Interpolated, Value(3.0), FilterMarker));
+        world.spawn((Interpolated, Value(4.0), FilterMarker, ExcludedMarker));
+
+        let mut cache = InterpolatedArchetypes::from_world(&mut world);
+        cache.update(world.archetypes(), world.components(), &registry);
+
+        assert_eq!(cache.archetype_count(), 4);
+        assert_eq!(cache.policies.len(), 3);
+        let mut archetypes_per_policy = cache
+            .policies
             .iter()
-            .filter_map(|(&kind, &rule_id)| registry.rule(rule_id).map(|_| (kind, rule_id)))
+            .map(|policy| policy.archetype_ids.len())
             .collect::<Vec<_>>();
-        candidates.sort_by(|(_, lhs), (_, rhs)| registry.cmp_rule_precedence(*lhs, *rhs));
-
-        let mut claimed_members = Vec::new();
-        for (_, rule_id) in candidates {
-            let Some(rule) = registry.rule(rule_id) else {
-                continue;
-            };
-            if rule
-                .members()
-                .iter()
-                .any(|member| claimed_members.contains(member))
-            {
-                continue;
-            }
-            claimed_members.extend(rule.members().iter().copied());
-            if let Some(component) = registry.cached_apply_component(rule_id) {
-                self.apply_rules.push(component);
-            }
-        }
+        archetypes_per_policy.sort_unstable();
+        assert_eq!(archetypes_per_policy, [1, 1, 2]);
     }
 }

--- a/crates/replication/interpolation/src/interpolate.rs
+++ b/crates/replication/interpolation/src/interpolate.rs
@@ -35,8 +35,8 @@ pub fn interpolation_fraction(start: Tick, end: Tick, current: Tick, overstep: f
 ///
 /// This is intentionally archetype-driven: a local
 /// [`InterpolatedArchetypes`](crate::archetypes::InterpolatedArchetypes) cache
-/// stores the highest-priority matching rule per archetype/component and the
-/// type-erased history functions that should run for each cached archetype.
+/// stores the independently resolved history and apply owners for each
+/// archetype and the type-erased history functions that should run there.
 ///
 /// Component insertion/removal happens here so custom interpolation systems that
 /// run after [`crate::plugin::InterpolationSystems::Prepare`] see the live
@@ -46,32 +46,32 @@ pub(crate) fn update_interpolation_history(
     timeline: Res<InterpolationTimeline>,
     interpolation_registry: Res<InterpolationRegistry>,
     checkpoints: Res<ReplicationCheckpointMap>,
-    tick_duration: Option<Res<TickDuration>>,
     mut replication_storage: Option<ResMut<ReplicationStorage>>,
     mut commands: Commands,
 ) {
     // TODO: exclude host-server
     let current_interpolate_tick = timeline.now().tick();
-    let interpolation_overstep = timeline.overstep().to_f32();
     let server_complete_tick = checkpoints.last_confirmed_tick();
-    let tick_duration = tick_duration.as_deref().map(|duration| duration.0);
+    let ctx = UpdateHistoryContext {
+        server_complete_tick,
+        current_interpolate_tick,
+    };
 
     let mut deferred_apply = DeferredEntityCommands::default();
 
     interpolation_world.update_archetypes(&interpolation_registry);
     let world = interpolation_world.world;
     for (archetype, cached_archetype) in interpolation_world.iter_archetypes() {
-        for component in cached_archetype.history_update_components() {
-            let ctx = UpdateHistoryContext {
-                server_complete_tick,
-                current_interpolate_tick,
-                interpolation_overstep,
-                tick_duration,
-            };
-            (component.update_history())(
+        for component in &cached_archetype.history_components {
+            if !component.history_component_present {
+                for entity in archetype.entities() {
+                    (component.insert_history)(entity.id(), &mut commands);
+                }
+                continue;
+            }
+            (component.update_history)(
                 world,
                 archetype,
-                &interpolation_registry,
                 component,
                 &ctx,
                 replication_storage.as_deref_mut(),
@@ -106,28 +106,33 @@ pub(crate) fn apply_interpolation(
     interpolation_world.update_archetypes(&interpolation_registry);
     let world = interpolation_world.world;
     for (archetype, cached_archetype) in interpolation_world.iter_archetypes() {
-        for component in cached_archetype.apply_rules() {
-            (component.apply_interpolation())(
+        for component in &cached_archetype.apply_callbacks {
+            (component.apply_interpolation)(
                 world,
                 archetype,
                 &interpolation_registry,
-                component.rule_id(),
+                component.rule_id,
                 ctx,
             );
         }
     }
 }
 
+/// Maintains existing `ConfirmedHistory<C>` values for one cached archetype.
+///
+/// It records completed server ticks as unchanged when appropriate, prunes old
+/// entries, and queues live `C` insertion or removal when the interpolation
+/// timeline crosses a presence boundary. Missing histories are initialized by
+/// the rule's separate history-insertion callback before this function runs.
 pub(crate) fn update_history_archetype_erased<C: Component + Clone>(
     world: UnsafeWorldCell,
     archetype: &Archetype,
-    interpolation_registry: &InterpolationRegistry,
     component: &CachedInterpolationComponent,
     ctx: &UpdateHistoryContext,
     _replication_storage: Option<&mut ReplicationStorage>,
     deferred_apply: &mut DeferredEntityCommands,
 ) {
-    let StorageType::Table = component.history_storage() else {
+    let Some(StorageType::Table) = component.history_storage else {
         debug_assert!(
             false,
             "ConfirmedHistory components are expected to use table storage"
@@ -138,32 +143,30 @@ pub(crate) fn update_history_archetype_erased<C: Component + Clone>(
         return;
     };
     let Some(histories) =
-        table_component_slice::<ConfirmedHistory<C>>(table, component.history_component_id())
+        table_component_slice::<ConfirmedHistory<C>>(table, component.history_component_id)
     else {
         return;
     };
-    let present = component.live_component_present();
-    let interpolation = interpolation_registry.interpolation_for_rule::<C>(component.rule_id());
+    let present = component.live_component_present;
     for entity in archetype.entities() {
         let entity_id = entity.id();
         let row = entity.table_row().index();
         let history = unsafe { &mut *histories.get_unchecked(row).get() };
         update_history_inner::<C>(history, entity_id, ctx);
-        let sample = sample_history_with_interpolation(
-            interpolation,
-            history,
-            ctx.current_interpolate_tick,
-            ctx.interpolation_overstep,
-            ctx.tick_duration,
-        );
-        queue_history_presence::<C>(deferred_apply, entity_id, present, sample);
+        let state = history.get_state_at_or_before(ctx.current_interpolate_tick);
+        queue_history_presence::<C>(deferred_apply, entity_id, present, state);
     }
 }
 
+/// Maintains diff-backed `ConfirmedHistory<C>` values for one cached archetype.
+///
+/// Unlike [`update_history_archetype_erased`], this waits for pending diffs in
+/// `ReplicationStorage` before advancing unchanged state or pruning history.
+/// It also queues live `C` insertion or removal at interpolation-time presence
+/// boundaries.
 pub(crate) fn update_history_diff_archetype_erased<C>(
     world: UnsafeWorldCell,
     archetype: &Archetype,
-    interpolation_registry: &InterpolationRegistry,
     component: &CachedInterpolationComponent,
     ctx: &UpdateHistoryContext,
     replication_storage: Option<&mut ReplicationStorage>,
@@ -171,7 +174,7 @@ pub(crate) fn update_history_diff_archetype_erased<C>(
 ) where
     C: Component + Clone + RepliconDiffable,
 {
-    let StorageType::Table = component.history_storage() else {
+    let Some(StorageType::Table) = component.history_storage else {
         debug_assert!(
             false,
             "ConfirmedHistory components are expected to use table storage"
@@ -182,15 +185,14 @@ pub(crate) fn update_history_diff_archetype_erased<C>(
         return;
     };
     let Some(histories) =
-        table_component_slice::<ConfirmedHistory<C>>(table, component.history_component_id())
+        table_component_slice::<ConfirmedHistory<C>>(table, component.history_component_id)
     else {
         return;
     };
     let Some(storage) = replication_storage else {
         return;
     };
-    let present = component.live_component_present();
-    let interpolation = interpolation_registry.interpolation_for_rule::<C>(component.rule_id());
+    let present = component.live_component_present;
     for entity in archetype.entities() {
         let entity_id = entity.id();
         let Some(history_diff_receiver) = storage.get_mut::<HistoryDiffReceiver<C>>(entity_id)
@@ -226,14 +228,8 @@ pub(crate) fn update_history_diff_archetype_erased<C>(
             }
         }
 
-        let sample = sample_history_with_interpolation(
-            interpolation,
-            history,
-            ctx.current_interpolate_tick,
-            ctx.interpolation_overstep,
-            ctx.tick_duration,
-        );
-        queue_history_presence::<C>(deferred_apply, entity_id, present, sample);
+        let state = history.get_state_at_or_before(ctx.current_interpolate_tick);
+        queue_history_presence::<C>(deferred_apply, entity_id, present, state);
     }
 }
 
@@ -289,17 +285,17 @@ fn queue_history_presence<C: Component + Clone>(
     deferred_apply: &mut DeferredEntityCommands,
     entity: Entity,
     present: bool,
-    sample: Option<HistoryState<C>>,
+    state: Option<&HistoryState<C>>,
 ) {
     // Apply the history state for the current interpolation time to the live component set:
     // insert once the add/update tick becomes visible, remove once a removal tick is reached,
     // and otherwise leave the current component value alone.
-    match sample {
+    match state {
         None | Some(HistoryState::Removed) if present => {
             deferred_apply.remove::<C>(entity);
         }
         Some(HistoryState::Updated(value)) if !present => {
-            deferred_apply.insert(entity, value);
+            deferred_apply.insert(entity, value.clone());
         }
         _ => {}
     }
@@ -334,7 +330,7 @@ pub(crate) fn apply_interpolation_archetype_erased<C: SyncComponent>(
     else {
         return;
     };
-    let interpolation = interpolation_registry.interpolation_for_rule::<C>(rule_id);
+    let interpolation = interpolation_registry.interpolation_fn_for_rule::<C>(rule_id);
 
     for entity in archetype.entities() {
         let row = entity.table_row().index();
@@ -368,39 +364,46 @@ pub(crate) fn apply_interpolation_archetype_erased<C: SyncComponent>(
     }
 }
 
-pub(crate) fn present_history_bracket<C: Component + Clone>(
+/// Resolved history entry at or before a tick and its successor.
+pub(crate) struct HistoryBracket<'a, C> {
+    pub(crate) start_tick: Tick,
+    pub(crate) start_state: &'a HistoryState<C>,
+    pub(crate) end: Option<(Tick, &'a HistoryState<C>)>,
+}
+
+/// Returns the immediate resolved history window around `tick`.
+///
+/// Both component and bundle interpolation use this lookup so they agree on
+/// the bracketing entries around the interpolation timeline.
+pub(crate) fn history_bracket<C>(
     history: &ConfirmedHistory<C>,
-    interpolation_tick: Tick,
-) -> Option<(Tick, C, Option<(Tick, C)>)> {
+    tick: Tick,
+) -> Option<HistoryBracket<'_, C>> {
     let previous_index = (0..history.len())
         .take_while(|i| {
             history
                 .get_nth_tick(*i)
-                .is_some_and(|tick| tick <= interpolation_tick)
+                .is_some_and(|history_tick| history_tick <= tick)
         })
         .last()?;
 
     let (start_tick, start_state) = history.get_nth_state(previous_index)?;
-    let HistoryState::Updated(start) = start_state else {
-        return None;
-    };
-
-    let end = match history.get_nth_state(previous_index + 1) {
-        Some((end_tick, HistoryState::Updated(end))) => Some((end_tick, end.clone())),
-        Some((_, HistoryState::Removed)) => None,
-        None => None,
-    };
-
-    Some((start_tick, start.clone(), end))
+    Some(HistoryBracket {
+        start_tick,
+        start_state,
+        end: history.get_nth_state(previous_index + 1),
+    })
 }
 
-// #[cfg(test)]
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::plugin::InterpolationMarkerPlugin;
-    use crate::registry::AppInterpolationExt;
-    use crate::registry::{InterpolationRegistry, InterpolationRuleComponentIds};
+    use crate::registry::{
+        AppInterpolationExt, InterpolationRegistry, component_rule,
+        insert_confirmed_history as insert_confirmed_history_component,
+        insert_confirmed_history_diff,
+    };
     use crate::rules::{
         InterpolationFns, InterpolationFnsExt, InterpolationRuleConfig, InterpolationSampleContext,
     };
@@ -408,7 +411,7 @@ mod tests {
     use bevy_app::{App, Update};
     use bevy_ecs::archetype::Archetype;
     use bevy_ecs::component::Component;
-    use bevy_ecs::query::{QueryFilter, QueryState};
+    use bevy_ecs::query::{ArchetypeFilter, QueryState};
     use bevy_ecs::schedule::IntoScheduleConfigs;
     use bevy_math::{
         Curve,
@@ -453,6 +456,9 @@ mod tests {
     struct HistoryOnlyRule;
 
     #[derive(Component)]
+    struct NoHistoryRule;
+
+    #[derive(Component)]
     struct DisabledRule;
 
     static BUNDLE2_PRIORITY_CALLS: AtomicUsize = AtomicUsize::new(0);
@@ -473,6 +479,10 @@ mod tests {
 
     fn lerp(start: TestComp, end: TestComp, t: f32) -> TestComp {
         TestComp(start.0 + (end.0 - start.0) * t)
+    }
+
+    fn lerp2(start: TestComp2, end: TestComp2, t: f32) -> TestComp2 {
+        TestComp2(start.0 + (end.0 - start.0) * t)
     }
 
     fn context_lerp(_start: TestComp, _end: TestComp, ctx: InterpolationSampleContext) -> TestComp {
@@ -587,13 +597,14 @@ mod tests {
             .insert_resource(ReplicationStorage::default());
         let mut registry = InterpolationRegistry::default();
         let fns = InterpolationFns::interpolate(lerp);
-        let component_ids =
-            InterpolationRuleComponentIds::for_component::<TestComp>(app.world_mut(), &fns);
-        registry.insert_rule::<TestComp, ()>(
+        let rule = component_rule::<TestComp, ()>(
+            app.world_mut(),
             fns,
             InterpolationRuleConfig::default(),
-            component_ids,
+            update_history_archetype_erased::<TestComp>,
+            insert_confirmed_history_component::<TestComp>,
         );
+        registry.insert_rule(rule);
         app.world_mut().insert_resource(registry);
 
         let mut timeline = InterpolationTimeline::default();
@@ -601,6 +612,55 @@ mod tests {
         timeline.remote_send_interval = core::time::Duration::from_millis(send_interval_ms);
         app.insert_resource(timeline);
         app
+    }
+
+    struct InterpolationTestAppBuilder {
+        interpolation_tick: Tick,
+        tick_duration: Option<core::time::Duration>,
+    }
+
+    impl InterpolationTestAppBuilder {
+        fn new(interpolation_tick: Tick) -> Self {
+            Self {
+                interpolation_tick,
+                tick_duration: None,
+            }
+        }
+
+        fn tick_duration(mut self, tick_duration: core::time::Duration) -> Self {
+            self.tick_duration = Some(tick_duration);
+            self
+        }
+
+        fn build(self) -> App {
+            let mut app = App::new();
+            app.add_plugins((
+                TimePlugin,
+                StatesPlugin,
+                RepliconPlugins,
+                InterpolationMarkerPlugin,
+            ));
+            app.insert_resource(ReplicationCheckpointMap::default());
+            app.configure_sets(
+                Update,
+                (
+                    crate::plugin::InterpolationSystems::Prepare,
+                    crate::plugin::InterpolationSystems::Interpolate,
+                )
+                    .chain(),
+            );
+            add_interpolation_test_systems(&mut app);
+
+            if let Some(tick_duration) = self.tick_duration {
+                app.insert_resource(TickDuration(tick_duration));
+            }
+
+            let mut timeline = InterpolationTimeline::default();
+            timeline.set_now(TickInstant::from(self.interpolation_tick));
+            timeline.remote_send_interval = core::time::Duration::from_millis(40);
+            app.insert_resource(timeline);
+            app
+        }
     }
 
     fn confirm_server_tick(app: &mut App, replicon_tick: u32, server_tick: Tick) {
@@ -629,7 +689,11 @@ mod tests {
     fn add_interpolation_test_systems(app: &mut App) {
         app.add_systems(
             Update,
-            (update_interpolation_history, apply_interpolation)
+            (
+                |mut registry: ResMut<InterpolationRegistry>| registry.finalize(),
+                update_interpolation_history,
+                apply_interpolation,
+            )
                 .chain()
                 .in_set(crate::plugin::InterpolationSystems::Prepare),
         );
@@ -658,27 +722,33 @@ mod tests {
 
     fn use_diff_history_rule(app: &mut App) {
         let fns = InterpolationFns::interpolate(lerp);
-        let component_ids =
-            InterpolationRuleComponentIds::for_component::<TestComp>(app.world_mut(), &fns);
+        let rule = component_rule::<TestComp, ()>(
+            app.world_mut(),
+            fns,
+            InterpolationRuleConfig { priority: 100 },
+            update_history_diff_archetype_erased::<TestComp>,
+            insert_confirmed_history_diff::<TestComp>,
+        );
         app.world_mut()
             .resource_mut::<InterpolationRegistry>()
-            .insert_diff_rule::<TestComp, ()>(
-                fns,
-                InterpolationRuleConfig { priority: 100 },
-                component_ids,
-            );
+            .insert_rule(rule);
     }
 
     fn insert_rule<C, F>(app: &mut App, fns: InterpolationFns<C>, config: InterpolationRuleConfig)
     where
         C: SyncComponent,
-        F: QueryFilter + 'static,
+        F: ArchetypeFilter + 'static,
     {
-        let component_ids =
-            InterpolationRuleComponentIds::for_component::<C>(app.world_mut(), &fns);
+        let rule = component_rule::<C, F>(
+            app.world_mut(),
+            fns,
+            config,
+            update_history_archetype_erased::<C>,
+            crate::registry::insert_confirmed_history::<C>,
+        );
         app.world_mut()
             .resource_mut::<InterpolationRegistry>()
-            .insert_rule::<C, F>(fns, config, component_ids);
+            .insert_rule(rule);
     }
 
     #[test]
@@ -696,19 +766,6 @@ mod tests {
         insert_confirmed_history(&mut app, default_entity, two_point_history());
         let filtered_entity = app.world_mut().spawn((TestComp(0.0), SmoothRule)).id();
         insert_confirmed_history(&mut app, filtered_entity, two_point_history());
-        app.world_mut().clear_trackers();
-        let default_changed = app
-            .world()
-            .entity(default_entity)
-            .get_change_ticks::<TestComp>()
-            .unwrap()
-            .changed;
-        let filtered_changed = app
-            .world()
-            .entity(filtered_entity)
-            .get_change_ticks::<TestComp>()
-            .unwrap()
-            .changed;
 
         app.update();
 
@@ -719,22 +776,6 @@ mod tests {
         assert_eq!(
             app.world().get::<TestComp>(filtered_entity),
             Some(&TestComp(42.0))
-        );
-        assert_ne!(
-            app.world()
-                .entity(default_entity)
-                .get_change_ticks::<TestComp>()
-                .unwrap()
-                .changed,
-            default_changed
-        );
-        assert_ne!(
-            app.world()
-                .entity(filtered_entity)
-                .get_change_ticks::<TestComp>()
-                .unwrap()
-                .changed,
-            filtered_changed
         );
     }
 
@@ -764,6 +805,27 @@ mod tests {
             app.world().get::<TestComp>(disabled_entity),
             Some(&TestComp(7.0))
         );
+    }
+
+    /// Checks that a disabled bundle blocks lower-priority rules for every member.
+    #[test]
+    fn disabled_bundle_blocks_overlapping_component_rules() {
+        let mut app = setup_app(Tick(15), 40);
+        app.component::<TestComp2>().replicate();
+        app.interpolate_with::<TestComp2>(InterpolationFns::interpolate(lerp2));
+        app.interpolate_bundle_with::<(TestComp, TestComp2)>(InterpolationFns::disabled());
+        add_interpolation_test_systems(&mut app);
+
+        let entity = app
+            .world_mut()
+            .spawn((TestComp(7.0), TestComp2(9.0), two_point_history2()))
+            .id();
+        insert_confirmed_history(&mut app, entity, two_point_history());
+
+        app.update();
+
+        assert_eq!(app.world().get::<TestComp>(entity), Some(&TestComp(7.0)));
+        assert_eq!(app.world().get::<TestComp2>(entity), Some(&TestComp2(9.0)));
     }
 
     #[test]
@@ -817,6 +879,7 @@ mod tests {
     fn selected_history_only_rule_suppresses_default_apply() {
         let mut app = setup_app(Tick(15), 40);
         add_interpolation_test_systems(&mut app);
+        confirm_server_tick(&mut app, 1, Tick(30));
         QueryState::<&Archetype, With<HistoryOnlyRule>>::new(app.world_mut());
         insert_rule::<TestComp, With<HistoryOnlyRule>>(
             &mut app,
@@ -830,60 +893,80 @@ mod tests {
         app.update();
 
         assert_eq!(app.world().get::<TestComp>(entity), Some(&TestComp(7.0)));
+        let history = app
+            .world()
+            .get::<ConfirmedHistory<TestComp>>(entity)
+            .unwrap();
+        assert_eq!(history.get_nth_tick(history.len() - 1), Some(Tick(30)));
     }
 
+    /// Checks that a winning no-history rule blocks default history and apply work.
     #[test]
-    fn rule_registration_invalidates_cached_archetype_selection() {
+    fn selected_no_history_rule_suppresses_default_history_and_apply() {
         let mut app = setup_app(Tick(15), 40);
         add_interpolation_test_systems(&mut app);
-        let entity = app.world_mut().spawn((TestComp(0.0), SmoothRule)).id();
+        confirm_server_tick(&mut app, 1, Tick(30));
+        QueryState::<&Archetype, With<NoHistoryRule>>::new(app.world_mut());
+        insert_rule::<TestComp, With<NoHistoryRule>>(
+            &mut app,
+            InterpolationFns::no_history(marker_lerp),
+            InterpolationRuleConfig { priority: 100 },
+        );
+
+        let entity = app.world_mut().spawn((TestComp(7.0), NoHistoryRule)).id();
         insert_confirmed_history(&mut app, entity, two_point_history());
 
         app.update();
-        assert_eq!(app.world().get::<TestComp>(entity), Some(&TestComp(5.0)));
 
-        app.component::<TestComp>();
-        app.interpolate_with_priority_filtered::<TestComp, With<SmoothRule>>(
-            100,
-            InterpolationFns::interpolate(marker_lerp),
+        assert_eq!(app.world().get::<TestComp>(entity), Some(&TestComp(7.0)));
+        let history = app
+            .world()
+            .get::<ConfirmedHistory<TestComp>>(entity)
+            .unwrap();
+        assert_eq!(history.get_nth_tick(history.len() - 1), Some(Tick(20)));
+    }
+
+    /// Checks that history-only presence does not make a lower history rule win.
+    #[test]
+    fn no_history_rule_can_win_when_only_confirmed_history_is_present() {
+        let mut app = setup_app(Tick(15), 40);
+        add_interpolation_test_systems(&mut app);
+        confirm_server_tick(&mut app, 1, Tick(30));
+        QueryState::<&Archetype, With<NoHistoryRule>>::new(app.world_mut());
+        insert_rule::<TestComp, With<NoHistoryRule>>(
+            &mut app,
+            InterpolationFns::no_history(marker_lerp),
+            InterpolationRuleConfig { priority: 100 },
         );
-        *app.world_mut().get_mut::<TestComp>(entity).unwrap() = TestComp(0.0);
+
+        let entity = app.world_mut().spawn(NoHistoryRule).id();
+        insert_confirmed_history(&mut app, entity, two_point_history());
 
         app.update();
 
-        assert_eq!(app.world().get::<TestComp>(entity), Some(&TestComp(42.0)));
+        assert!(app.world().get::<TestComp>(entity).is_none());
+        let history = app
+            .world()
+            .get::<ConfirmedHistory<TestComp>>(entity)
+            .unwrap();
+        assert_eq!(history.get_nth_tick(history.len() - 1), Some(Tick(20)));
     }
 
     #[test]
     fn bundle_interpolation_uses_tuple_interpolation_fn() {
-        let mut app = App::new();
-        app.add_plugins((
-            TimePlugin,
-            StatesPlugin,
-            RepliconPlugins,
-            InterpolationMarkerPlugin,
-        ));
-        app.insert_resource(ReplicationCheckpointMap::default());
-        app.insert_resource(TickDuration(core::time::Duration::from_millis(100)));
-        app.configure_sets(
-            Update,
-            (
-                crate::plugin::InterpolationSystems::Prepare,
-                crate::plugin::InterpolationSystems::Interpolate,
-            )
-                .chain(),
-        );
-        add_interpolation_test_systems(&mut app);
+        let mut app = InterpolationTestAppBuilder::new(Tick(15))
+            .tick_duration(core::time::Duration::from_millis(100))
+            .build();
         app.component::<TestComp>().replicate();
         app.component::<TestComp2>().replicate();
         app.interpolate_bundle_with::<(TestComp, TestComp2)>(InterpolationFns::interpolate(
             bundle_lerp,
         ));
-
-        let mut timeline = InterpolationTimeline::default();
-        timeline.set_now(TickInstant::from(Tick(15)));
-        timeline.remote_send_interval = core::time::Duration::from_millis(40);
-        app.insert_resource(timeline);
+        assert_eq!(
+            app.world().resource::<InterpolationRegistry>().rule_count(),
+            1,
+            "bundle component operations must not be registered as interpolation rules"
+        );
 
         let entity = app
             .world_mut()
@@ -934,36 +1017,149 @@ mod tests {
         );
     }
 
+    /// Checks that a missing live bundle member lets its standalone member rule apply.
+    #[test]
+    fn missing_bundle_member_falls_back_to_standalone_component_rule() {
+        let mut app = InterpolationTestAppBuilder::new(Tick(15)).build();
+        app.component::<TestComp>().replicate();
+        app.component::<TestComp2>().replicate();
+        app.interpolate_with::<TestComp2>(InterpolationFns::interpolate(lerp2));
+        app.interpolate_bundle_with::<(TestComp, TestComp2)>(InterpolationFns::interpolate(
+            bundle_lerp,
+        ));
+
+        let entity = app
+            .world_mut()
+            .spawn((Interpolated, TestComp2(-1.0), two_point_history2()))
+            .id();
+
+        app.update();
+
+        assert_eq!(app.world().get::<TestComp2>(entity), Some(&TestComp2(5.0)));
+        assert!(!app.world().entity(entity).contains::<TestComp>());
+    }
+
+    /// Checks that a selected bundle does not fall back when one owned history is missing.
+    #[test]
+    fn bundle_rule_does_not_fall_back_when_one_owned_history_is_missing() {
+        let mut app = InterpolationTestAppBuilder::new(Tick(15)).build();
+        app.component::<TestComp>().replicate();
+        app.component::<TestComp2>().replicate();
+        app.interpolate_with::<TestComp2>(InterpolationFns::interpolate(lerp2));
+        app.interpolate_bundle_with::<(TestComp, TestComp2)>(InterpolationFns::interpolate(
+            bundle_lerp,
+        ));
+
+        let entity = app
+            .world_mut()
+            .spawn((
+                Interpolated,
+                TestComp(-1.0),
+                TestComp2(-1.0),
+                two_point_history2(),
+            ))
+            .id();
+
+        app.update();
+
+        // The bundle owns both history initialization and application. Its
+        // missing TestComp history prevents it from producing a sample, but
+        // the lower-priority TestComp2 rule must not run in its place.
+        assert_eq!(app.world().get::<TestComp2>(entity), Some(&TestComp2(-1.0)));
+        assert_eq!(app.world().get::<TestComp>(entity), Some(&TestComp(-1.0)));
+    }
+
+    /// Checks independent history and apply ownership across delayed bundle-member removal.
+    #[test]
+    fn bundle_maintains_history_while_component_rule_applies_after_member_removal() {
+        let mut app = InterpolationTestAppBuilder::new(Tick(15)).build();
+        app.component::<TestComp>().replicate();
+        app.component::<TestComp2>().replicate();
+        app.interpolate_with::<TestComp>(InterpolationFns::interpolate(lerp));
+        app.interpolate_bundle_with::<(TestComp, TestComp2)>(InterpolationFns::interpolate(
+            bundle_lerp,
+        ));
+
+        let mut first = ConfirmedHistory::<TestComp>::default();
+        first.insert_present(Tick(10), TestComp(0.0));
+        first.insert_present(Tick(20), TestComp(10.0));
+        let mut second = ConfirmedHistory::<TestComp2>::default();
+        second.insert_present(Tick(10), TestComp2(3.0));
+        second.insert_removed(Tick(20));
+        let entity = app
+            .world_mut()
+            .spawn((Interpolated, TestComp(-1.0), TestComp2(-1.0), first, second))
+            .id();
+
+        app.update();
+
+        assert_eq!(app.world().get::<TestComp>(entity), Some(&TestComp(105.0)));
+        assert_eq!(
+            app.world().get::<TestComp2>(entity),
+            Some(&TestComp2(203.0))
+        );
+
+        set_interpolation_tick(&mut app, Tick(20));
+        app.update();
+
+        // The bundle keeps maintaining both histories, but it no longer owns
+        // apply once TestComp2 is absent. The standalone TestComp rule takes
+        // over immediately at the removal boundary.
+        assert_eq!(app.world().get::<TestComp>(entity), Some(&TestComp(10.0)));
+        assert!(!app.world().entity(entity).contains::<TestComp2>());
+    }
+
+    /// Checks independent history and apply ownership across delayed bundle-member insertion.
+    #[test]
+    fn bundle_maintains_history_while_component_rule_applies_before_delayed_insert() {
+        let mut app = InterpolationTestAppBuilder::new(Tick(15)).build();
+        app.component::<TestComp>().replicate();
+        app.component::<TestComp2>().replicate();
+        app.interpolate_with::<TestComp>(InterpolationFns::interpolate(lerp));
+        app.interpolate_bundle_with::<(TestComp, TestComp2)>(InterpolationFns::interpolate(
+            bundle_lerp,
+        ));
+
+        let mut first = ConfirmedHistory::<TestComp>::default();
+        first.insert_present(Tick(10), TestComp(0.0));
+        first.insert_present(Tick(20), TestComp(10.0));
+        first.insert_present(Tick(30), TestComp(20.0));
+        let mut second = ConfirmedHistory::<TestComp2>::default();
+        second.insert_removed(Tick(10));
+        second.insert_present(Tick(20), TestComp2(4.0));
+        second.insert_present(Tick(30), TestComp2(8.0));
+        let entity = app
+            .world_mut()
+            .spawn((Interpolated, TestComp(-1.0), first, second))
+            .id();
+
+        app.update();
+
+        assert_eq!(app.world().get::<TestComp>(entity), Some(&TestComp(5.0)));
+        assert!(!app.world().entity(entity).contains::<TestComp2>());
+
+        set_interpolation_tick(&mut app, Tick(20));
+        app.update();
+
+        // History maintenance inserts TestComp2 before apply resolution runs
+        // again, so the bundle takes over in the same update.
+        assert_eq!(
+            app.world().get::<TestComp2>(entity),
+            Some(&TestComp2(204.0))
+        );
+        assert_eq!(app.world().get::<TestComp>(entity), Some(&TestComp(110.0)));
+    }
+
     #[test]
     fn bundle_contextual_interpolation_receives_sample_delta() {
-        let mut app = App::new();
-        app.add_plugins((
-            TimePlugin,
-            StatesPlugin,
-            RepliconPlugins,
-            InterpolationMarkerPlugin,
-        ));
-        app.insert_resource(ReplicationCheckpointMap::default());
-        app.insert_resource(TickDuration(core::time::Duration::from_millis(100)));
-        app.configure_sets(
-            Update,
-            (
-                crate::plugin::InterpolationSystems::Prepare,
-                crate::plugin::InterpolationSystems::Interpolate,
-            )
-                .chain(),
-        );
-        add_interpolation_test_systems(&mut app);
+        let mut app = InterpolationTestAppBuilder::new(Tick(15))
+            .tick_duration(core::time::Duration::from_millis(100))
+            .build();
         app.component::<TestComp>().replicate();
         app.component::<TestComp2>().replicate();
         app.interpolate_bundle_with::<(TestComp, TestComp2)>(
             InterpolationFns::interpolate_with_context(bundle_context_lerp),
         );
-
-        let mut timeline = InterpolationTimeline::default();
-        timeline.set_now(TickInstant::from(Tick(15)));
-        timeline.remote_send_interval = core::time::Duration::from_millis(40);
-        app.insert_resource(timeline);
 
         let entity = app
             .world_mut()
@@ -984,33 +1180,12 @@ mod tests {
 
     #[test]
     fn bundle_interpolation_inserts_tuple_interpolated_components() {
-        let mut app = App::new();
-        app.add_plugins((
-            TimePlugin,
-            StatesPlugin,
-            RepliconPlugins,
-            InterpolationMarkerPlugin,
-        ));
-        app.insert_resource(ReplicationCheckpointMap::default());
-        app.configure_sets(
-            Update,
-            (
-                crate::plugin::InterpolationSystems::Prepare,
-                crate::plugin::InterpolationSystems::Interpolate,
-            )
-                .chain(),
-        );
-        add_interpolation_test_systems(&mut app);
+        let mut app = InterpolationTestAppBuilder::new(Tick(15)).build();
         app.component::<TestComp>().replicate();
         app.component::<TestComp2>().replicate();
         app.interpolate_bundle_with::<(TestComp, TestComp2)>(InterpolationFns::interpolate(
             bundle_lerp,
         ));
-
-        let mut timeline = InterpolationTimeline::default();
-        timeline.set_now(TickInstant::from(Tick(15)));
-        timeline.remote_send_interval = core::time::Duration::from_millis(40);
-        app.insert_resource(timeline);
 
         let entity = app
             .world_mut()
@@ -1031,23 +1206,7 @@ mod tests {
         BUNDLE2_PRIORITY_CALLS.store(0, Ordering::SeqCst);
         BUNDLE3_PRIORITY_CALLS.store(0, Ordering::SeqCst);
 
-        let mut app = App::new();
-        app.add_plugins((
-            TimePlugin,
-            StatesPlugin,
-            RepliconPlugins,
-            InterpolationMarkerPlugin,
-        ));
-        app.insert_resource(ReplicationCheckpointMap::default());
-        app.configure_sets(
-            Update,
-            (
-                crate::plugin::InterpolationSystems::Prepare,
-                crate::plugin::InterpolationSystems::Interpolate,
-            )
-                .chain(),
-        );
-        add_interpolation_test_systems(&mut app);
+        let mut app = InterpolationTestAppBuilder::new(Tick(15)).build();
         app.component::<TestComp>().replicate();
         app.component::<TestComp2>().replicate();
         app.component::<TestBundleComp<3>>().replicate();
@@ -1057,11 +1216,6 @@ mod tests {
         app.interpolate_bundle_with::<(TestComp, TestComp2, TestBundleComp<3>)>(
             InterpolationFns::interpolate(bundle3_priority_lerp),
         );
-
-        let mut timeline = InterpolationTimeline::default();
-        timeline.set_now(TickInstant::from(Tick(15)));
-        timeline.remote_send_interval = core::time::Duration::from_millis(40);
-        app.insert_resource(timeline);
 
         let entity = app
             .world_mut()
@@ -1093,34 +1247,14 @@ mod tests {
 
     #[test]
     fn earlier_non_apply_member_rule_suppresses_same_priority_bundle_apply() {
-        let mut app = App::new();
-        app.add_plugins((
-            TimePlugin,
-            StatesPlugin,
-            RepliconPlugins,
-            InterpolationMarkerPlugin,
-        ));
-        app.insert_resource(ReplicationCheckpointMap::default());
-        app.configure_sets(
-            Update,
-            (
-                crate::plugin::InterpolationSystems::Prepare,
-                crate::plugin::InterpolationSystems::Interpolate,
-            )
-                .chain(),
-        );
-        add_interpolation_test_systems(&mut app);
+        let mut app = InterpolationTestAppBuilder::new(Tick(15)).build();
         app.component::<TestComp>().replicate();
         app.component::<TestComp2>().replicate();
         app.interpolate_with_priority::<TestComp>(2, InterpolationFns::history_only());
         app.interpolate_bundle_with::<(TestComp, TestComp2)>(InterpolationFns::interpolate(
             bundle_lerp,
         ));
-
-        let mut timeline = InterpolationTimeline::default();
-        timeline.set_now(TickInstant::from(Tick(15)));
-        timeline.remote_send_interval = core::time::Duration::from_millis(40);
-        app.insert_resource(timeline);
+        confirm_server_tick(&mut app, 1, Tick(30));
 
         let entity = app
             .world_mut()
@@ -1137,6 +1271,22 @@ mod tests {
 
         assert_eq!(app.world().get::<TestComp>(entity), Some(&TestComp(-1.0)));
         assert_eq!(app.world().get::<TestComp2>(entity), Some(&TestComp2(-1.0)));
+        let first_history = app
+            .world()
+            .get::<ConfirmedHistory<TestComp>>(entity)
+            .unwrap();
+        assert_eq!(
+            first_history.get_nth_tick(first_history.len() - 1),
+            Some(Tick(30))
+        );
+        let second_history = app
+            .world()
+            .get::<ConfirmedHistory<TestComp2>>(entity)
+            .unwrap();
+        assert_eq!(
+            second_history.get_nth_tick(second_history.len() - 1),
+            Some(Tick(20))
+        );
     }
 
     #[test]
@@ -1152,23 +1302,7 @@ mod tests {
             TestBundleComp<8>,
         );
 
-        let mut app = App::new();
-        app.add_plugins((
-            TimePlugin,
-            StatesPlugin,
-            RepliconPlugins,
-            InterpolationMarkerPlugin,
-        ));
-        app.insert_resource(ReplicationCheckpointMap::default());
-        app.configure_sets(
-            Update,
-            (
-                crate::plugin::InterpolationSystems::Prepare,
-                crate::plugin::InterpolationSystems::Interpolate,
-            )
-                .chain(),
-        );
-        add_interpolation_test_systems(&mut app);
+        let mut app = InterpolationTestAppBuilder::new(Tick(15)).build();
         app.component::<TestBundleComp<1>>().replicate();
         app.component::<TestBundleComp<2>>().replicate();
         app.component::<TestBundleComp<3>>().replicate();
@@ -1178,11 +1312,6 @@ mod tests {
         app.component::<TestBundleComp<7>>().replicate();
         app.component::<TestBundleComp<8>>().replicate();
         app.interpolate_bundle_with::<Bundle8>(InterpolationFns::interpolate(bundle8_lerp));
-
-        let mut timeline = InterpolationTimeline::default();
-        timeline.set_now(TickInstant::from(Tick(15)));
-        timeline.remote_send_interval = core::time::Duration::from_millis(40);
-        app.insert_resource(timeline);
 
         let entity = app
             .world_mut()
@@ -1273,40 +1402,6 @@ mod tests {
         assert_eq!(
             history.get_nth_present(1).map(|(t, v)| (t, v.clone())),
             Some((Tick(30), TestComp(10.0)))
-        );
-    }
-
-    #[test]
-    fn update_confirmed_history_records_repeated_empty_mutate_ticks() {
-        let mut app = setup_app(Tick(25), 40);
-        add_interpolation_test_systems(&mut app);
-        confirm_server_tick(&mut app, 1, Tick(30));
-
-        let entity = app.world_mut().spawn(TestComp(9.5)).id();
-        let mut history = ConfirmedHistory::<TestComp>::default();
-        history.insert_present(Tick(20), TestComp(10.0));
-        insert_confirmed_history(&mut app, entity, history);
-
-        app.update();
-        confirm_server_tick(&mut app, 2, Tick(31));
-        app.update();
-
-        let history = app
-            .world()
-            .get::<ConfirmedHistory<TestComp>>(entity)
-            .unwrap();
-        assert_eq!(history.len(), 3);
-        assert_eq!(
-            history.start_present().map(|(t, v)| (t, v.clone())),
-            Some((Tick(20), TestComp(10.0)))
-        );
-        assert_eq!(
-            history.get_nth_present(1).map(|(t, v)| (t, v.clone())),
-            Some((Tick(30), TestComp(10.0)))
-        );
-        assert_eq!(
-            history.get_nth_present(2).map(|(t, v)| (t, v.clone())),
-            Some((Tick(31), TestComp(10.0)))
         );
     }
 
@@ -1441,31 +1536,6 @@ mod tests {
     }
 
     #[test]
-    fn update_confirmed_history_advances_from_server_mutate_ticks_without_entity_confirm_history() {
-        let mut app = setup_app(Tick(30), 40);
-        add_interpolation_test_systems(&mut app);
-        confirm_server_tick(&mut app, 1, Tick(20));
-        confirm_server_tick(&mut app, 2, Tick(30));
-
-        let entity = app.world_mut().spawn(TestComp(9.5)).id();
-        let mut history = ConfirmedHistory::<TestComp>::default();
-        history.insert_present(Tick(10), TestComp(10.0));
-        insert_confirmed_history(&mut app, entity, history);
-
-        app.update();
-
-        let history = app
-            .world()
-            .get::<ConfirmedHistory<TestComp>>(entity)
-            .unwrap();
-        assert_eq!(history.len(), 2);
-        assert_eq!(
-            history.get_nth_present(1).map(|(t, v)| (t, v.clone())),
-            Some((Tick(30), TestComp(10.0)))
-        );
-    }
-
-    #[test]
     fn update_confirmed_history_keeps_bracketing_pair_during_loss_gap() {
         let mut app = setup_app(Tick(25), 40);
         add_interpolation_test_systems(&mut app);
@@ -1580,35 +1650,5 @@ mod tests {
         set_interpolation_tick(&mut app, Tick(20));
         app.update();
         assert_eq!(app.world().get::<TestComp>(entity), Some(&TestComp(20.0)));
-    }
-
-    #[test]
-    fn update_confirmed_history_seeds_component_at_current_interpolation_sample() {
-        let mut app = setup_app(Tick(15), 40);
-        add_interpolation_test_systems(&mut app);
-
-        let entity = app.world_mut().spawn_empty().id();
-        let mut history = ConfirmedHistory::<TestComp>::default();
-        history.insert_present(Tick(10), TestComp(0.0));
-        history.insert_present(Tick(20), TestComp(10.0));
-        insert_confirmed_history(&mut app, entity, history);
-
-        app.update();
-
-        assert_eq!(app.world().get::<TestComp>(entity), Some(&TestComp(5.0)));
-    }
-
-    #[test]
-    fn stale_entity_insert_command_after_despawn_does_not_panic() {
-        let mut app = App::new();
-        let entity = app.world_mut().spawn_empty().id();
-        app.add_systems(Update, move |mut commands: Commands| {
-            commands.entity(entity).despawn();
-            commands.entity(entity).try_insert(TestComp(1.0));
-        });
-
-        app.update();
-
-        assert!(app.world().get_entity(entity).is_err());
     }
 }

--- a/crates/replication/interpolation/src/lib.rs
+++ b/crates/replication/interpolation/src/lib.rs
@@ -146,19 +146,69 @@
 //!
 //! A rule is registered for a rule kind: either a single component `C` or a
 //! tuple bundle such as `(Position, Rotation)`. Rules can also include an
-//! archetypal [`QueryFilter`](bevy_ecs::query::QueryFilter), such as
+//! [`ArchetypeFilter`](bevy_ecs::query::ArchetypeFilter), such as
 //! `With<MyMarker>` or `Without<MyMarker>`.
 //!
-//! For each interpolated archetype, Lightyear selects the first matching rule
-//! for each kind. Rules are ordered by:
+//! For each interpolated archetype, Lightyear considers every matching rule in
+//! this order:
 //!
 //! 1. higher priority first,
 //! 2. then earlier registration order for equal priority.
+//!
+//! Rule resolution assigns history maintenance and interpolation application
+//! separately. Within each assignment, a selected rule atomically claims all
+//! of its component members. A lower-priority component or bundle rule is
+//! skipped if any of those members were already claimed for the same kind of
+//! work.
 //!
 //! The default priority is the number of components in the interpolation target.
 //! A default `(Position, Rotation)` bundle therefore takes priority over default
 //! single-component `Position` and `Rotation` rules when all match the same
 //! archetype.
+//!
+//! ## History ownership and apply ownership
+//!
+//! A registered rule describes both how its members' histories are maintained
+//! and how those members are interpolated. Resolution can assign those two
+//! responsibilities to different matching rules, however. This is necessary
+//! because delayed component insertion and removal intentionally allow a
+//! history component to exist while its corresponding live component does not.
+//!
+//! Resolution uses two independent kinds of ownership:
+//!
+//! | Ownership | A rule is eligible when... |
+//! | --- | --- |
+//! | History | Every member has either its live component or the relevant history component. |
+//! | Apply | Every member has its live component. |
+//!
+//! Rules are considered in the priority and registration order described
+//! above. History and apply each have their own set of claimed members, so one
+//! rule can own history, apply, or both. Claiming a member for history does not
+//! prevent another rule from claiming it for apply, and vice versa.
+//! "History ownership" includes the decision not to keep history: when a
+//! [`rules::InterpolationFns::no_history`] rule wins that lane, it has no history
+//! callbacks to run and prevents a lower-priority rule from creating history
+//! for the same members.
+//!
+//! For example, suppose a higher-priority bundle rule targets `(A, B)` and a
+//! lower-priority component rule targets `A`:
+//!
+//! - During a delayed insertion, an entity can have live `A` plus histories for
+//!   both `A` and `B`, while live `B` is waiting for its insertion tick. The
+//!   bundle owns history maintenance, while the component rule applies `A`.
+//!   When history maintenance inserts `B`, the bundle becomes eligible to apply
+//!   both components.
+//! - During a delayed removal, the bundle owns both responsibilities while `A`
+//!   and `B` are live. Once history maintenance reaches the removal tick and
+//!   removes `B`, the bundle continues to own both histories, while the
+//!   component rule takes over applying the remaining live `A`.
+//!
+//! Missing history is different from a missing live component. If both `A` and
+//! `B` are live but one history for a history-based bundle has not been created
+//! yet, the bundle is still the apply winner. It creates and fills the missing
+//! history, and apply waits until all required samples are queryable; a
+//! lower-priority `A` rule does not temporarily take over merely because the
+//! bundle cannot sample yet.
 //!
 //! ```rust,ignore
 //! # use bevy_app::App;

--- a/crates/replication/interpolation/src/plugin.rs
+++ b/crates/replication/interpolation/src/plugin.rs
@@ -1,6 +1,6 @@
 use crate::despawn::configure_delayed_interpolated_despawn;
 use crate::interpolate::{apply_interpolation, update_interpolation_history};
-use crate::registry::{InterpolationRegistry, finalize_interpolation_registry};
+use crate::registry::InterpolationRegistry;
 use crate::timeline::TimelinePlugin;
 use bevy_app::{App, Plugin, Update};
 use bevy_ecs::{
@@ -64,8 +64,6 @@ impl ToBytes for InterpolationDelay {
     }
 }
 
-// TODO: if Interpolated is added on an existing entity, we need to swap all its existing interpolated components to Confirmed<C>
-
 /// Plugin that enables interpolating between replicated updates received from the remote.
 ///
 /// Each remote update will be stored in a buffer, and the component will smoothly interpolate between two consecutive remote updates.
@@ -117,26 +115,6 @@ pub enum InterpolationSystems {
     All,
 }
 
-/// Backfills `ConfirmedHistory<C>` for registered interpolation rules when
-/// `Interpolated` is added after the live replicated component already exists.
-fn backfill_confirmed_histories_on_interpolated(
-    trigger: On<Add, Interpolated>,
-    interpolation_registry: Res<InterpolationRegistry>,
-    mut commands: Commands,
-) {
-    let Some(archetype) = trigger.trigger().new_archetype else {
-        return;
-    };
-
-    for (live_component_id, history_component_id, backfill) in
-        interpolation_registry.confirmed_history_backfill_fns()
-    {
-        if archetype.contains(live_component_id) && !archetype.contains(history_component_id) {
-            backfill(trigger.entity, &mut commands);
-        }
-    }
-}
-
 impl Plugin for InterpolationPlugin {
     fn build(&self, app: &mut App) {
         app.add_plugins(TimelinePlugin);
@@ -144,7 +122,6 @@ impl Plugin for InterpolationPlugin {
         // RESOURCES
         app.init_resource::<InterpolationRegistry>();
         configure_delayed_interpolated_despawn(app);
-        app.add_observer(backfill_confirmed_histories_on_interpolated);
 
         // Host-Clients have no interpolation delay
         app.register_required_components::<HostClient, InterpolationDelay>();
@@ -169,7 +146,9 @@ impl Plugin for InterpolationPlugin {
     }
 
     fn finish(&self, app: &mut App) {
-        finalize_interpolation_registry(app);
+        app.world_mut()
+            .resource_mut::<InterpolationRegistry>()
+            .finalize();
     }
 }
 

--- a/crates/replication/interpolation/src/registry.rs
+++ b/crates/replication/interpolation/src/registry.rs
@@ -1,33 +1,29 @@
 use crate::SyncComponent;
 use crate::interpolate::{
-    apply_interpolation_archetype_erased, update_history_archetype_erased,
+    apply_interpolation_archetype_erased, history_bracket, update_history_archetype_erased,
     update_history_diff_archetype_erased,
 };
 use crate::rules::frame_interpolate::{
-    CachedFrameInterpolationApply, CachedFrameInterpolationComponent,
-    ErasedApplyFrameInterpolationFn, ErasedInsertFrameHistoryFn, ErasedRestoreFrameHistoryFn,
-    ErasedUpdateFrameHistoryFn, FrameHistoryComponent, FrameInterpolationFns,
-    apply_frame_interpolation_archetype_erased, insert_frame_history,
+    ErasedApplyFrameInterpolationFn, apply_frame_interpolation_archetype_erased,
     restore_frame_history_archetype_erased, update_frame_history_archetype_erased,
 };
 use crate::rules::{
-    CachedInterpolationApply, CachedInterpolationComponent, ContextInterpolationFn,
-    ErasedApplyInterpolationFn, ErasedBackfillConfirmedHistoryFn, ErasedInterpolationFns,
-    ErasedUpdateHistoryFn, InterpolationBundle, InterpolationFn, InterpolationFns,
-    InterpolationRule, InterpolationRuleConfig, InterpolationRuleId, InterpolationSampleContext,
-    RuleKind, TupleInterpolationBundle, matches_filter,
+    ConfirmedHistoryFns, ContextInterpolationFn, ErasedApplyInterpolationFn,
+    ErasedInsertConfirmedHistoryFn, ErasedUpdateHistoryFn, FrameHistoryFns, InterpolationBundle,
+    InterpolationFn, InterpolationFns, InterpolationRule, InterpolationRuleComponent,
+    InterpolationRuleConfig, InterpolationRuleId, InterpolationSampleContext,
+    TupleInterpolationBundle,
 };
 use alloc::vec::Vec;
 use bevy_app::App;
 use bevy_ecs::archetype::Archetype;
 use bevy_ecs::component::{ComponentId, Components};
 use bevy_ecs::prelude::*;
-use bevy_ecs::query::{QueryFilter, QueryState};
+use bevy_ecs::query::{ArchetypeFilter, ComponentIdSet, QueryState};
 use bevy_math::{
     Curve,
     curve::{Ease, EaseFunction, EasingCurve},
 };
-use bevy_platform::collections::HashSet;
 use bevy_replicon::bytes::Bytes;
 use bevy_replicon::client::confirm_history::ConfirmHistory;
 use bevy_replicon::postcard_utils;
@@ -36,19 +32,19 @@ use bevy_replicon::shared::replication::deferred_entity::DeferredEntity;
 use bevy_replicon::shared::replication::diff::{
     ComponentDelta, DiffBuffer, Diffable as RepliconDiffable,
 };
+use bevy_replicon::shared::replication::registry::ReplicationRegistry;
 use bevy_replicon::shared::replication::registry::ctx::{RemoveCtx, WriteCtx};
+use bevy_replicon::shared::replication::registry::receive_fns::WriteFn;
 use bevy_replicon::shared::replication::storage::{EntityStorageCtx, ReplicationStorage};
 use bevy_utils::prelude::DebugName;
-use core::cmp::Ordering;
 use core::time::Duration;
-use indexmap::IndexMap;
 use lightyear_core::history_buffer::HistoryState;
 use lightyear_core::prelude::{ConfirmedHistory, FrameInterpolationHistory, Interpolated, Tick};
 use lightyear_replication::checkpoint::{ReplicationCheckpointMap, resolve_message_tick};
 use lightyear_replication::diff_history::HistoryDiffReceiver;
 use lightyear_replication::prelude::InterpolatedSend;
 use lightyear_replication::registry::replication::{ComponentRegistration, ComponentRegistrator};
-use lightyear_replication::registry::{ComponentKind, ComponentRegistry, LerpFn};
+use lightyear_replication::registry::{ComponentKind, LerpFn};
 use tracing::{error, trace};
 
 fn lerp<C: Ease + Clone>(start: C, other: C, t: f32) -> C {
@@ -58,60 +54,71 @@ fn lerp<C: Ease + Clone>(start: C, other: C, t: f32) -> C {
 
 const SINGLE_COMPONENT_RULE_PRIORITY: usize = 1;
 
-#[derive(Debug, Clone)]
-pub(crate) struct InterpolationRuleComponentIds {
-    history_component_id: Option<ComponentId>,
-    frame_history_component_id: Option<ComponentId>,
-    live_component_id: Option<ComponentId>,
-    write_component_ids: Vec<ComponentId>,
-    frame_write_component_ids: Vec<ComponentId>,
+/// History representation used when resolving history ownership.
+///
+/// This affects only the history lane. Apply ownership always requires every
+/// live component targeted by the rule.
+#[doc(hidden)]
+#[derive(Debug, Clone, Copy)]
+pub enum RuleTarget {
+    /// Normal interpolation uses live components or confirmed histories.
+    Default,
+    /// Frame interpolation and correction use live components or frame histories.
+    Frame,
 }
 
-impl InterpolationRuleComponentIds {
-    pub(crate) fn for_component<C>(world: &mut World, fns: &InterpolationFns<C>) -> Self
-    where
-        C: SyncComponent,
-    {
-        let owns_interpolation_history = fns.owns_interpolation_history();
-        let applies_interpolation_component = fns.applies_interpolation_component();
-        let owns_frame_history = fns.owns_frame_history();
-        let applies_frame_component = fns.applies_frame_component();
-        let history_component_id =
-            owns_interpolation_history.then(|| world.register_component::<ConfirmedHistory<C>>());
-        let frame_history_component_id =
-            owns_frame_history.then(|| world.register_component::<FrameInterpolationHistory<C>>());
-        let uses_live_component = owns_interpolation_history
-            || applies_interpolation_component
-            || owns_frame_history
-            || applies_frame_component;
-        let live_component_id = uses_live_component.then(|| world.register_component::<C>());
+/// The work assigned to one interpolation rule for an archetype.
+///
+/// The resolver selects rules independently for two jobs:
+///
+/// - `owns_history` selects which rule's member callbacks create and update
+///   histories and insert or remove delayed live components.
+/// - `owns_apply` selects which rule's interpolation callback writes the live
+///   components.
+///
+/// Winning one job does not affect resolution of the other. A rule without the
+/// corresponding callbacks still reserves its members for that job, so a
+/// lower-priority rule cannot run instead.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[doc(hidden)]
+pub struct ResolvedRule {
+    /// Rule receiving work in at least one lane.
+    pub rule_id: InterpolationRuleId,
+    /// Whether this rule wins the history-policy lane for all of its members.
+    pub owns_history: bool,
+    /// Whether this rule wins the interpolation-application lane for all of its members.
+    pub owns_apply: bool,
+}
 
-        let mut write_component_ids = Vec::new();
-        if let Some(history_component_id) = history_component_id {
-            write_component_ids.push(history_component_id);
-        }
-        if (owns_interpolation_history || applies_interpolation_component)
-            && let Some(live_component_id) = live_component_id
-        {
-            write_component_ids.push(live_component_id);
-        }
+/// Reusable temporary storage for [`InterpolationRegistry::resolved_rules_for_archetype`].
+///
+/// Archetype caches keep one of these and reuse its vector capacities while
+/// resolving newly-created archetypes.
+#[derive(Debug, Default)]
+#[doc(hidden)]
+pub struct RuleResolutionScratch {
+    candidates: Vec<InterpolationRuleId>,
+    history_claimed_members: Vec<ComponentKind>,
+    apply_claimed_members: Vec<ComponentKind>,
+    resolved_rules: Vec<ResolvedRule>,
+}
 
-        let mut frame_write_component_ids = Vec::new();
-        if let Some(frame_history_component_id) = frame_history_component_id {
-            frame_write_component_ids.push(frame_history_component_id);
-        }
-        if (owns_frame_history || applies_frame_component)
-            && let Some(live_component_id) = live_component_id
-        {
-            frame_write_component_ids.push(live_component_id);
-        }
+/// Presence of only the components that can affect interpolation rule resolution.
+///
+/// Archetypes with the same key can share one resolved interpolation policy
+/// even when their unrelated component sets differ.
+#[derive(Debug, Clone, Default, Eq, Hash, PartialEq)]
+#[doc(hidden)]
+pub struct InterpolationArchetypeKey {
+    component_ids: Vec<ComponentId>,
+}
 
-        Self {
-            history_component_id,
-            frame_history_component_id,
-            live_component_id,
-            write_component_ids,
-            frame_write_component_ids,
+impl InterpolationArchetypeKey {
+    /// Adds a cache-specific component when it is present on `archetype`.
+    #[doc(hidden)]
+    pub fn include_if_present(&mut self, archetype: &Archetype, component_id: ComponentId) {
+        if archetype.contains(component_id) && !self.component_ids.contains(&component_id) {
+            self.component_ids.push(component_id);
         }
     }
 }
@@ -144,31 +151,12 @@ pub struct InterpolationRegistry {
     /// rules preserve this order, matching Replicon's "first registered wins"
     /// behavior for ties.
     rules: Vec<InterpolationRule>,
-    /// Priority-ordered rule index by rule target.
-    ///
-    /// The key is the rule target type: a component rule is keyed by `C`, while
-    /// a bundle rule is keyed by the tuple type `(A, B, ...)`. This is separate
-    /// from the rule's member [`ComponentKind`]s, which are actual ECS
-    /// components used for overlap resolution. Each value is a list of rule IDs
-    /// sorted from highest to lowest priority, with equal-priority rules kept in
-    /// registration order. The outer map preserves first-registration order for
-    /// deterministic cache rebuilds.
-    ///
-    /// For example, an archetype containing components `A` and `B` can select
-    /// one rule for `A`, one rule for `B`, and one rule for `(A, B)`. If the
-    /// selected `(A, B)` rule has higher priority, the later apply-resolution
-    /// pass lets it claim both `A` and `B`, so the individual `A` and `B` apply
-    /// rules do not run for that archetype.
-    rules_by_kind: IndexMap<RuleKind, Vec<InterpolationRuleId>>,
     /// Component kinds whose Replicon receive marker functions have been installed.
-    interpolated_marker_fns: HashSet<ComponentKind>,
-    /// Marker registrations deferred until every plugin has finished building.
-    ///
-    /// Interpolation rules may be installed by an integration plugin before
-    /// the application's replication protocol registers the corresponding
-    /// components. Deferring the Replicon receive hooks makes that plugin order
-    /// independent without implicitly adding components to the protocol.
-    pending_interpolated_marker_fns: Vec<(ComponentKind, fn(&mut App))>,
+    interpolated_marker_fns: Vec<ComponentKind>,
+    /// Component presence that can affect normal interpolation rule resolution.
+    default_archetype_key_component_ids: Vec<ComponentId>,
+    /// Component presence that can affect frame interpolation rule resolution.
+    frame_archetype_key_component_ids: Vec<ComponentId>,
     /// Whether plugin finalization has run.
     ///
     /// Rule registration after finalization is rejected so the type-erased
@@ -180,8 +168,34 @@ impl InterpolationRegistry {
     const FINALIZED_RULE_REGISTRATION_ERROR: &'static str =
         "cannot register interpolation rules after InterpolationRegistry has been finalized";
 
-    fn finalize(&mut self) {
+    #[doc(hidden)]
+    pub fn finalize(&mut self) {
+        if self.finalized {
+            return;
+        }
+        self.compute_archetype_key_component_ids();
         self.finalized = true;
+    }
+
+    fn compute_archetype_key_component_ids(&mut self) {
+        let mut default_component_ids = ComponentIdSet::new();
+        let mut frame_component_ids = ComponentIdSet::new();
+
+        for rule in &self.rules {
+            default_component_ids.extend(rule.filter_component_ids.iter().copied());
+            frame_component_ids.extend(rule.filter_component_ids.iter().copied());
+
+            for component in &rule.members {
+                default_component_ids.insert(component.live_component_id);
+                default_component_ids.insert(component.confirmed_history_component_id);
+
+                frame_component_ids.insert(component.live_component_id);
+                frame_component_ids.insert(component.frame_history_component_id);
+            }
+        }
+
+        self.default_archetype_key_component_ids = default_component_ids.into_iter().collect();
+        self.frame_archetype_key_component_ids = frame_component_ids.into_iter().collect();
     }
 
     fn assert_not_finalized(&self) {
@@ -192,52 +206,43 @@ impl InterpolationRegistry {
         );
     }
 
-    /// Iterates over component or bundle rule targets that have interpolation rules.
-    #[doc(hidden)]
-    pub fn rule_kinds(&self) -> impl Iterator<Item = RuleKind> + '_ {
-        self.rules_by_kind.keys().copied()
-    }
-
     /// Returns a rule by ID.
-    #[doc(hidden)]
-    pub fn rule(&self, rule_id: InterpolationRuleId) -> Option<&InterpolationRule> {
-        self.rules.get(rule_id.0)
-    }
-
-    /// Returns the number of registered rules.
     ///
-    /// [`crate::archetypes::InterpolatedArchetypes`] uses this to invalidate
-    /// its local cache when rules are registered after the interpolation system
-    /// has already run.
+    /// # Panics
+    ///
+    /// Panics if `rule_id` was not produced by this registry.
     #[doc(hidden)]
-    pub fn rule_count(&self) -> usize {
-        self.rules.len()
-    }
-
-    /// Returns components that need `FrameInterpolationHistory<C>` backfilled
-    /// when `FrameInterpolate` is added.
-    #[doc(hidden)]
-    pub fn frame_history_components(&self) -> impl Iterator<Item = FrameHistoryComponent> + '_ {
+    pub fn rule(&self, rule_id: InterpolationRuleId) -> &InterpolationRule {
         self.rules
-            .iter()
-            .filter_map(InterpolationRule::frame_history_component)
+            .get(rule_id.0)
+            .expect("interpolation rule ID should belong to this registry")
     }
 
-    /// Returns per-component callbacks for backfilling confirmed history when
-    /// `Interpolated` is added to an entity that already has a replicated live
-    /// component.
+    /// Replaces `key` with the rule-resolution-relevant component presence for
+    /// `archetype` and `target`.
     #[doc(hidden)]
-    pub fn confirmed_history_backfill_fns(
+    pub fn populate_archetype_key(
         &self,
-    ) -> impl Iterator<Item = (ComponentId, ComponentId, ErasedBackfillConfirmedHistoryFn)> + '_
-    {
-        self.rules.iter().filter_map(|rule| {
-            Some((
-                rule.fns.live_component_id?,
-                rule.fns.history_component_id?,
-                rule.fns.backfill_confirmed_history?,
-            ))
-        })
+        archetype: &Archetype,
+        target: RuleTarget,
+        key: &mut InterpolationArchetypeKey,
+    ) {
+        key.component_ids.clear();
+        let component_ids = match target {
+            RuleTarget::Default => &self.default_archetype_key_component_ids,
+            RuleTarget::Frame => &self.frame_archetype_key_component_ids,
+        };
+        key.component_ids.extend(
+            component_ids
+                .iter()
+                .copied()
+                .filter(|component_id| archetype.contains(*component_id)),
+        );
+    }
+
+    #[cfg(test)]
+    pub(crate) fn rule_count(&self) -> usize {
+        self.rules.len()
     }
 
     /// Returns component IDs that the type-erased interpolation system may write.
@@ -246,10 +251,15 @@ impl InterpolationRegistry {
     /// it reads or writes component columns through [`UnsafeWorldCell`].
     pub(crate) fn component_write_ids(&self) -> Vec<ComponentId> {
         let mut ids = Vec::new();
-        for rule in &self.rules {
-            for component_id in rule.fns.write_component_ids.iter().copied() {
-                if !ids.contains(&component_id) {
-                    ids.push(component_id);
+        for member in self.rules.iter().flat_map(|rule| &rule.members) {
+            if member.confirmed.is_some() {
+                for component_id in [
+                    member.confirmed_history_component_id,
+                    member.live_component_id,
+                ] {
+                    if !ids.contains(&component_id) {
+                        ids.push(component_id);
+                    }
                 }
             }
         }
@@ -260,9 +270,9 @@ impl InterpolationRegistry {
     #[doc(hidden)]
     pub fn frame_component_write_ids(&self) -> Vec<ComponentId> {
         let mut ids = Vec::new();
-        for rule in &self.rules {
-            if let Some(frame) = &rule.fns.frame {
-                for component_id in frame.write_component_ids.iter().copied() {
+        for member in self.rules.iter().flat_map(|rule| &rule.members) {
+            if member.frame.is_some() {
+                for component_id in [member.frame_history_component_id, member.live_component_id] {
                     if !ids.contains(&component_id) {
                         ids.push(component_id);
                     }
@@ -272,463 +282,246 @@ impl InterpolationRegistry {
         ids
     }
 
-    /// Compares two rules using interpolation precedence.
+    /// Resolves history and apply ownership for one archetype.
     ///
-    /// Higher priority sorts first. Rules with equal priority keep
-    /// registration order, with earlier registrations sorting first.
-    #[doc(hidden)]
-    pub fn cmp_rule_precedence(
-        &self,
-        lhs: InterpolationRuleId,
-        rhs: InterpolationRuleId,
-    ) -> Ordering {
-        let lhs_priority = self.rule(lhs).map(InterpolationRule::priority);
-        let rhs_priority = self.rule(rhs).map(InterpolationRule::priority);
-        rhs_priority
-            .cmp(&lhs_priority)
-            .then_with(|| lhs.index().cmp(&rhs.index()))
-    }
-
-    /// Selects the highest-priority matching rule for `kind` on `archetype`.
+    /// Candidates are ordered by descending priority and then by registration
+    /// order. History and apply are then resolved independently, with separate
+    /// claimed-member sets:
     ///
-    /// Rules are pre-sorted by descending priority and ascending registration
-    /// order, so this returns the first matching rule. It only answers
-    /// "which rule owns this target on this archetype"; overlap suppression for
-    /// live component writes is handled later by
-    /// `CachedInterpolatedArchetype::resolve_apply_rules`.
+    /// - For history, a member is available when either its live component or
+    ///   its history selected by `target` is present.
+    /// - For apply, a member is available only when its live component is
+    ///   present. History presence does not affect apply selection.
+    /// - A winning rule claims all of its members for that job. A later rule
+    ///   cannot reuse any of them for the same job.
+    ///
+    /// The jobs must be independent because history maintenance controls
+    /// delayed component presence. If replication has received `B` into
+    /// `History<B>` but the interpolation timeline has not reached B's
+    /// insertion tick, the entity has `(A, History<A>, History<B>)`. The bundle
+    /// cannot apply without live `B`, but it must still win history so its
+    /// history callbacks continue running and eventually insert live `B`.
+    /// Meanwhile, the standalone `A` rule can keep interpolating live `A`.
+    ///
+    /// For example, consider a higher-priority `(A, B)` rule and a
+    /// lower-priority `A` rule, both registered with
+    /// `InterpolationFns::interpolate`:
+    ///
+    /// - With `(A, B, History<A>)`, both live members exist. The bundle wins
+    ///   both jobs even though `History<B>` is missing. Missing history does not
+    ///   make the resolver fall back to `A`; the bundle's history callback will
+    ///   normally create `History<B>`.
+    /// - With `(A, History<A>, History<B>)`, live `B` is absent during delayed
+    ///   insertion or after delayed removal. The bundle wins history because
+    ///   both members have a history representation, but it cannot win apply.
+    ///   The `A` rule therefore applies live `A` while the bundle maintains both
+    ///   histories.
+    /// - With `(A, History<A>)`, neither live `B` nor `History<B>` exists. The
+    ///   bundle is unavailable for both jobs, so the `A` rule wins both.
+    ///
+    /// A normal delayed insertion therefore transitions like this:
+    ///
+    /// ```text
+    /// replication receives B:
+    ///     (A, History<A>)
+    ///         -> (A, History<A>, History<B>)
+    ///
+    /// before B's insertion tick:
+    ///     history owner = (A, B)  // maintains both histories
+    ///     apply owner   = A       // interpolates the only live member
+    ///
+    /// when history maintenance reaches B's insertion tick:
+    ///     (A, History<A>, History<B>)
+    ///         -> (A, B, History<A>, History<B>)
+    ///
+    /// after B is live:
+    ///     history owner = (A, B)
+    ///     apply owner   = (A, B)  // interpolates the bundle together
+    /// ```
+    ///
+    /// History preparation runs before interpolation application. If creating
+    /// a missing history inserts or removes a live component, the apply phase
+    /// resolves the resulting archetype before choosing its apply rule.
     #[doc(hidden)]
-    pub fn select_rule_for_archetype(
+    pub fn resolved_rules_for_archetype<'a>(
         &self,
         components: &Components,
         archetype: &Archetype,
-        kind: RuleKind,
-    ) -> Option<InterpolationRuleId> {
-        self.rules_by_kind
-            .get(&kind)?
-            .iter()
-            .copied()
-            .find(|rule_id| {
-                self.rules
-                    .get(rule_id.0)
-                    .is_some_and(|rule| (rule.matches_archetype)(components, archetype))
-            })
-    }
+        target: RuleTarget,
+        scratch: &'a mut RuleResolutionScratch,
+    ) -> &'a [ResolvedRule] {
+        let RuleResolutionScratch {
+            candidates,
+            history_claimed_members,
+            apply_claimed_members,
+            resolved_rules,
+        } = scratch;
+        candidates.clear();
+        history_claimed_members.clear();
+        apply_claimed_members.clear();
+        resolved_rules.clear();
 
-    /// Builds cached metadata for updating a selected rule's history component.
-    ///
-    /// The returned [`CachedInterpolationComponent`] is consumed by the
-    /// type-erased history update phase. Rules that do not own history do not
-    /// need this cache entry; they may still be selected and may still apply
-    /// live components through [`Self::cached_apply_component`].
-    ///
-    /// Returns `None` when:
-    ///
-    /// - the rule does not own the history phase,
-    /// - the `ConfirmedHistory<C>` component is not registered,
-    /// - or this archetype does not currently contain the `ConfirmedHistory<C>`
-    ///   column.
-    ///
-    /// The last case is expected for newly-interpolated entities before the
-    /// receive marker or backfill observer has inserted history, and for rules
-    /// that only apply live components without maintaining history.
-    pub(crate) fn cached_history_update_component(
-        &self,
-        _components: &Components,
-        archetype: &Archetype,
-        rule_id: InterpolationRuleId,
-    ) -> Option<CachedInterpolationComponent> {
-        let rule = self.rules.get(rule_id.0)?;
-        if !rule.owns_history() {
-            return None;
-        }
-        let kind = rule.members.first().copied()?;
-        let history_component_id = rule.fns.history_component_id?;
-        if !archetype.contains(history_component_id) {
-            return None;
-        }
-        let history_storage = archetype.get_storage_type(history_component_id)?;
-        let live_component_present = rule
-            .fns
-            .live_component_id
-            .is_some_and(|component_id| archetype.contains(component_id));
-        Some(CachedInterpolationComponent {
-            kind,
-            history_component_id,
-            history_storage,
-            live_component_present,
-            rule_id,
-            update_history: rule.fns.update_history?,
-        })
-    }
-
-    /// Builds cached apply metadata for `rule_id`.
-    ///
-    /// The caller has already selected this rule for the archetype and resolved
-    /// overlaps with higher-priority bundle/component rules.
-    pub(crate) fn cached_apply_component(
-        &self,
-        rule_id: InterpolationRuleId,
-    ) -> Option<CachedInterpolationApply> {
-        let rule = self.rules.get(rule_id.0)?;
-        if !rule.applies_component() {
-            return None;
-        }
-        Some(CachedInterpolationApply {
-            rule_id,
-            apply_interpolation: rule.fns.apply_interpolation?,
-        })
-    }
-
-    /// Builds cached metadata for updating/restoring a selected frame history component.
-    #[doc(hidden)]
-    pub fn cached_frame_history_component(
-        &self,
-        components: &Components,
-        archetype: &Archetype,
-        rule_id: InterpolationRuleId,
-    ) -> Option<CachedFrameInterpolationComponent> {
-        let rule = self.rules.get(rule_id.0)?;
-        let frame = rule.fns.frame.as_ref()?;
-        if !frame.owns_history() {
-            return None;
-        }
-        let kind = rule.members.first().copied()?;
-        let history_component_id = frame.history_component_id?;
-        let live_component_id = rule.fns.live_component_id?;
-        let history_component_present = archetype.contains(history_component_id);
-        let live_component_present = archetype.contains(live_component_id);
-        if !history_component_present && !live_component_present {
-            return None;
-        }
-        let history_storage = history_component_present
-            .then(|| archetype.get_storage_type(history_component_id))
-            .flatten();
-        Some(CachedFrameInterpolationComponent {
-            kind,
-            history_component_id,
-            history_storage,
-            history_component_present,
-            live_component_id,
-            live_component_present,
-            update_frame_history: frame.update_history?,
-            restore_frame_history: frame.restore_history?,
-        })
-    }
-
-    /// Builds cached frame apply metadata for `rule_id`.
-    #[doc(hidden)]
-    pub fn cached_frame_apply_component(
-        &self,
-        rule_id: InterpolationRuleId,
-    ) -> Option<CachedFrameInterpolationApply> {
-        let rule = self.rules.get(rule_id.0)?;
-        let frame = rule.fns.frame.as_ref()?;
-        if !frame.applies_component() {
-            return None;
-        }
-        Some(CachedFrameInterpolationApply {
-            rule_id,
-            apply_frame_interpolation: frame.apply_interpolation?,
-        })
-    }
-
-    pub(crate) fn insert_rule<C, F>(
-        &mut self,
-        fns: InterpolationFns<C>,
-        config: InterpolationRuleConfig,
-        component_ids: InterpolationRuleComponentIds,
-    ) -> InterpolationRuleId
-    where
-        C: SyncComponent,
-        F: QueryFilter + 'static,
-    {
-        self.assert_not_finalized();
-        self.insert_rule_with_update_history::<C, F>(
-            fns,
-            config,
-            Some(update_history_archetype_erased::<C>),
-            Some(backfill_confirmed_history::<C>),
-            component_ids,
-        )
-    }
-
-    pub(crate) fn insert_diff_rule<C, F>(
-        &mut self,
-        fns: InterpolationFns<C>,
-        config: InterpolationRuleConfig,
-        component_ids: InterpolationRuleComponentIds,
-    ) -> InterpolationRuleId
-    where
-        C: SyncComponent + RepliconDiffable,
-        F: QueryFilter + 'static,
-    {
-        self.assert_not_finalized();
-        self.insert_rule_with_update_history::<C, F>(
-            fns,
-            config,
-            Some(update_history_diff_archetype_erased::<C>),
-            Some(backfill_confirmed_history_diff::<C>),
-            component_ids,
-        )
-    }
-
-    fn insert_rule_with_update_history<C, F>(
-        &mut self,
-        fns: InterpolationFns<C>,
-        config: InterpolationRuleConfig,
-        update_history: Option<ErasedUpdateHistoryFn>,
-        backfill_confirmed_history: Option<ErasedBackfillConfirmedHistoryFn>,
-        component_ids: InterpolationRuleComponentIds,
-    ) -> InterpolationRuleId
-    where
-        C: SyncComponent,
-        F: QueryFilter + 'static,
-    {
-        let kind = RuleKind::of::<C>();
-        let member = ComponentKind::of::<C>();
-        let owns_interpolation_history = fns.owns_interpolation_history();
-        let applies_interpolation_component = fns.applies_interpolation_component();
-        let owns_frame_history = fns.owns_frame_history();
-        let applies_frame_component = fns.applies_frame_component();
-        let update_history = owns_interpolation_history
-            .then_some(update_history)
-            .flatten();
-        let backfill_confirmed_history = owns_interpolation_history
-            .then_some(backfill_confirmed_history)
-            .flatten();
-        let apply_interpolation = applies_interpolation_component
-            .then_some(apply_interpolation_archetype_erased::<C> as ErasedApplyInterpolationFn);
-        let update_frame_history = owns_frame_history
-            .then_some(update_frame_history_archetype_erased::<C> as ErasedUpdateFrameHistoryFn);
-        let restore_frame_history = owns_frame_history
-            .then_some(restore_frame_history_archetype_erased::<C> as ErasedRestoreFrameHistoryFn);
-        let apply_frame_interpolation = applies_frame_component.then_some(
-            apply_frame_interpolation_archetype_erased::<C> as ErasedApplyFrameInterpolationFn,
+        candidates.extend(
+            self.rules
+                .iter()
+                .enumerate()
+                .filter(|(_, rule)| (rule.matches_archetype)(components, archetype))
+                .map(|(index, _)| InterpolationRuleId(index)),
         );
-        let insert_frame_history =
-            owns_frame_history.then_some(insert_frame_history::<C> as ErasedInsertFrameHistoryFn);
-        let frame = FrameInterpolationFns::new(
-            component_ids.frame_history_component_id,
-            component_ids.live_component_id,
-            component_ids.frame_write_component_ids,
-            insert_frame_history,
-            update_frame_history,
-            restore_frame_history,
-            apply_frame_interpolation,
-        );
-        let fns = ErasedInterpolationFns::from_typed(
-            fns,
-            update_history,
-            backfill_confirmed_history,
-            apply_interpolation,
-            component_ids.history_component_id,
-            component_ids.live_component_id,
-            component_ids.write_component_ids,
-            frame,
-        );
-        let rule_id = InterpolationRuleId(self.rules.len());
-        self.rules.push(InterpolationRule {
-            kind,
-            members: alloc::vec![member],
-            priority: config.priority,
-            fns,
-            matches_archetype: matches_filter::<F>,
+        candidates.sort_by(|lhs, rhs| {
+            self.rules[rhs.0]
+                .priority
+                .cmp(&self.rules[lhs.0].priority)
+                .then_with(|| lhs.0.cmp(&rhs.0))
         });
-        self.insert_rule_id_for_kind(kind, rule_id);
-        rule_id
+        for rule_id in candidates.iter().copied() {
+            let rule = &self.rules[rule_id.0];
+            let history = rule.members.iter().all(|member| {
+                archetype.contains(member.live_component_id)
+                    || match target {
+                        RuleTarget::Default => {
+                            archetype.contains(member.confirmed_history_component_id)
+                        }
+                        RuleTarget::Frame => archetype.contains(member.frame_history_component_id),
+                    }
+            }) && !rule
+                .members()
+                .any(|member| history_claimed_members.contains(&member));
+            let apply = rule
+                .members
+                .iter()
+                .all(|member| archetype.contains(member.live_component_id))
+                && !rule
+                    .members()
+                    .any(|member| apply_claimed_members.contains(&member));
+            if history {
+                history_claimed_members.extend(rule.members());
+            }
+            if apply {
+                apply_claimed_members.extend(rule.members());
+            }
+            if history || apply {
+                resolved_rules.push(ResolvedRule {
+                    rule_id,
+                    owns_history: history,
+                    owns_apply: apply,
+                });
+            }
+        }
+        resolved_rules
     }
 
-    pub(crate) fn insert_bundle_rule<S, F>(
-        &mut self,
-        fns: InterpolationFns<S>,
-        config: InterpolationRuleConfig,
-        members: Vec<ComponentKind>,
-        write_component_ids: Vec<ComponentId>,
-        apply_interpolation: Option<ErasedApplyInterpolationFn>,
-        frame_write_component_ids: Vec<ComponentId>,
-        apply_frame_interpolation: Option<ErasedApplyFrameInterpolationFn>,
-    ) -> InterpolationRuleId
-    where
-        S: 'static,
-        F: QueryFilter + 'static,
-    {
+    pub(crate) fn insert_rule(&mut self, rule: InterpolationRule) -> InterpolationRuleId {
         self.assert_not_finalized();
-        let kind = RuleKind::of::<S>();
-        let frame = FrameInterpolationFns::new(
-            None,
-            None,
-            frame_write_component_ids,
-            None,
-            None,
-            None,
-            apply_frame_interpolation,
-        );
-        let fns = ErasedInterpolationFns::from_typed(
-            fns,
-            None,
-            None,
-            apply_interpolation,
-            None,
-            None,
-            write_component_ids,
-            frame,
-        );
-        let rule_id = InterpolationRuleId(self.rules.len());
-        self.rules.push(InterpolationRule {
-            kind,
-            members,
-            priority: config.priority,
-            fns,
-            matches_archetype: matches_filter::<F>,
-        });
-        self.insert_rule_id_for_kind(kind, rule_id);
-        rule_id
-    }
+        for (index, member) in rule.members.iter().enumerate() {
+            assert!(
+                !rule.members[..index]
+                    .iter()
+                    .any(|previous| previous.kind == member.kind),
+                "interpolation bundle rules cannot contain duplicate component types"
+            );
+        }
 
-    /// Inserts `rule_id` into the per-kind index in precedence order.
-    ///
-    /// This follows Replicon's rule insertion model: higher-priority rules are
-    /// placed before lower-priority rules, while equal-priority rules are
-    /// appended after existing equal-priority registrations.
-    fn insert_rule_id_for_kind(&mut self, kind: RuleKind, rule_id: InterpolationRuleId) {
-        let priority = self.rules[rule_id.0].priority;
-        let rules = self.rules_by_kind.entry(kind).or_default();
-        let higher_priority_count =
-            rules.partition_point(|existing| self.rules[existing.0].priority > priority);
-        let equal_priority_count = rules[higher_priority_count..]
-            .partition_point(|existing| self.rules[existing.0].priority == priority);
-        rules.insert(higher_priority_count + equal_priority_count, rule_id);
+        let rule_id = InterpolationRuleId(self.rules.len());
+        self.rules.push(rule);
+        rule_id
     }
 
     /// Returns `true` if any interpolation rule covers component `C`.
     pub fn interpolated<C: Component>(&self) -> bool {
         let kind = ComponentKind::of::<C>();
-        self.rules.iter().any(|rule| rule.members.contains(&kind))
-    }
-
-    pub(crate) fn has_interpolation_fn<C: Component>(&self) -> bool {
-        let kind = RuleKind::of::<C>();
         self.rules
             .iter()
-            .any(|rule| rule.kind == kind && rule.fns.interpolation.is_some())
+            .any(|rule| rule.members().any(|member| member == kind))
     }
 
-    /// Returns the highest-priority interpolation function registered for `C`.
-    ///
-    /// This helper is for custom systems that already know they need a
-    /// single-component interpolation function and cannot run through the
-    /// per-archetype rule cache. It does not support tuple rules; systems that
-    /// need bundle priority should select rules for the current archetype.
-    #[doc(hidden)]
-    pub fn interpolation_for<C: Component + Clone>(&self) -> Option<&InterpolationFn<C>> {
-        self.rules_by_kind
-            .get(&RuleKind::of::<C>())?
-            .iter()
-            .filter_map(|rule_id| self.rules.get(rule_id.0))
-            .find_map(|rule| {
-                rule.fns
-                    .interpolation
-                    .as_ref()
-                    .map(|interpolation| interpolation.typed::<C>())
-            })
-    }
-
-    pub(crate) fn sample_for_rule<C: Component + Clone>(
+    pub(crate) fn interpolation_fn_for_rule<S: 'static>(
         &self,
         rule_id: InterpolationRuleId,
-        history: &ConfirmedHistory<C>,
-        interpolation_tick: Tick,
-        interpolation_overstep: f32,
-        tick_duration: Option<Duration>,
-    ) -> Option<HistoryState<C>> {
-        let rule = &self.rules[rule_id.0];
-        debug_assert_eq!(rule.kind, RuleKind::of::<C>());
-        sample_history_with_interpolation(
-            self.interpolation_for_rule::<C>(rule_id),
-            history,
-            interpolation_tick,
-            interpolation_overstep,
-            tick_duration,
-        )
-    }
-
-    pub(crate) fn interpolation_for_rule<S: 'static>(
-        &self,
-        rule_id: InterpolationRuleId,
-    ) -> Option<&InterpolationFn<S>> {
-        let rule = &self.rules[rule_id.0];
-        debug_assert_eq!(rule.kind, RuleKind::of::<S>());
-        rule.fns
+    ) -> &InterpolationFn<S> {
+        self.rule(rule_id)
             .interpolation
             .as_ref()
-            .map(|interpolation| interpolation.typed::<S>())
+            .expect("interpolation apply callback requires an interpolation function")
+            .typed::<S>()
     }
 }
 
-/// Installs deferred receive hooks, reconciles interpolation metadata with the
-/// completed replication protocol, and freezes the registry.
-pub(crate) fn finalize_interpolation_registry(app: &mut App) {
-    let pending_marker_fns = {
-        let mut registry = app.world_mut().resource_mut::<InterpolationRegistry>();
-        core::mem::take(&mut registry.pending_interpolated_marker_fns)
-    };
-    for (_, register) in pending_marker_fns {
-        register(app);
+fn build_rule_member<C>(
+    world: &mut World,
+    owns_interpolation_history: bool,
+    owns_frame_history: bool,
+    update_history: ErasedUpdateHistoryFn,
+    insert_history: ErasedInsertConfirmedHistoryFn,
+) -> InterpolationRuleComponent
+where
+    C: SyncComponent,
+{
+    InterpolationRuleComponent {
+        kind: ComponentKind::of::<C>(),
+        // Every member needs all representation IDs for archetype matching,
+        // including disabled rules that own no history or apply callbacks.
+        live_component_id: world.register_component::<C>(),
+        confirmed_history_component_id: world.register_component::<ConfirmedHistory<C>>(),
+        frame_history_component_id: world.register_component::<FrameInterpolationHistory<C>>(),
+        confirmed: owns_interpolation_history.then_some(ConfirmedHistoryFns {
+            update_history,
+            insert_history,
+        }),
+        frame: owns_frame_history.then_some(FrameHistoryFns {
+            update_history: update_frame_history_archetype_erased::<C>,
+            restore_history: restore_frame_history_archetype_erased::<C>,
+        }),
     }
+}
 
-    let interpolated_components = {
-        let registry = app.world().resource::<InterpolationRegistry>();
-        registry
-            .rules
-            .iter()
-            .filter(|rule| rule.owns_history() || rule.applies_component())
-            .flat_map(|rule| rule.members.iter().copied())
-            .collect::<HashSet<_>>()
-    };
-    if let Some(mut component_registry) = app.world_mut().get_resource_mut::<ComponentRegistry>() {
-        for kind in interpolated_components {
-            let Some(replication) = component_registry
-                .component_metadata_map
-                .get_mut(&kind)
-                .and_then(|metadata| metadata.replication.as_mut())
-            else {
-                continue;
-            };
-            replication.set_interpolated(true);
-        }
-    }
-
-    app.world_mut()
-        .resource_mut::<InterpolationRegistry>()
-        .finalize();
+pub(crate) fn component_rule<C, F>(
+    world: &mut World,
+    fns: InterpolationFns<C>,
+    config: InterpolationRuleConfig,
+    update_history: ErasedUpdateHistoryFn,
+    insert_history: ErasedInsertConfirmedHistoryFn,
+) -> InterpolationRule
+where
+    C: SyncComponent,
+    F: ArchetypeFilter + 'static,
+{
+    let member = build_rule_member::<C>(
+        world,
+        fns.owns_interpolation_history(),
+        fns.owns_frame_history(),
+        update_history,
+        insert_history,
+    );
+    let apply_interpolation = fns
+        .applies_interpolation_component()
+        .then_some(apply_interpolation_archetype_erased::<C> as ErasedApplyInterpolationFn);
+    let apply_frame_interpolation = fns.applies_frame_component().then_some(
+        apply_frame_interpolation_archetype_erased::<C> as ErasedApplyFrameInterpolationFn,
+    );
+    InterpolationRule::new::<C, F>(
+        world.components(),
+        fns,
+        alloc::vec![member],
+        config.priority,
+        apply_interpolation,
+        apply_frame_interpolation,
+    )
 }
 
 pub(crate) fn sample_history_with_interpolation<C: Component + Clone>(
-    interpolation: Option<&InterpolationFn<C>>,
+    interpolation: &InterpolationFn<C>,
     history: &ConfirmedHistory<C>,
     interpolation_tick: Tick,
     interpolation_overstep: f32,
     tick_duration: Option<Duration>,
 ) -> Option<HistoryState<C>> {
-    let previous_index = (0..history.len())
-        .take_while(|i| {
-            history
-                .get_nth_tick(*i)
-                .is_some_and(|tick| tick <= interpolation_tick)
-        })
-        .last()?;
-
-    let (start_tick, start_state) = history.get_nth_state(previous_index)?;
-    let HistoryState::Updated(start) = start_state else {
+    let bracket = history_bracket(history, interpolation_tick)?;
+    let HistoryState::Updated(start) = bracket.start_state else {
         return Some(HistoryState::Removed);
     };
 
-    let Some((end_tick, HistoryState::Updated(end))) = history.get_nth_state(previous_index + 1)
-    else {
-        return Some(HistoryState::Updated(start.clone()));
-    };
-
-    let Some(interpolation) = interpolation else {
+    let Some((end_tick, HistoryState::Updated(end))) = bracket.end else {
         return Some(HistoryState::Updated(start.clone()));
     };
 
@@ -736,7 +529,7 @@ pub(crate) fn sample_history_with_interpolation<C: Component + Clone>(
     // makes late packets converge to the freshest server state instead of
     // overshooting when motion changes direction.
     let context = InterpolationSampleContext::from_ticks(
-        start_tick,
+        bracket.start_tick,
         end_tick,
         interpolation_tick,
         interpolation_overstep,
@@ -747,7 +540,7 @@ pub(crate) fn sample_history_with_interpolation<C: Component + Clone>(
         kind = "confirmed_history_sample",
         component = ?DebugName::type_name::<C>(),
         interpolation_tick = interpolation_tick.0,
-        start_tick = start_tick.0,
+        start_tick = bracket.start_tick.0,
         end_tick = end_tick.0,
         interpolation_overstep,
         fraction = context.t,
@@ -817,7 +610,7 @@ pub trait AppInterpolationExt {
     fn linear_interpolate_filtered<C, F>(&mut self) -> &mut Self
     where
         C: SyncComponent + Ease,
-        F: QueryFilter + 'static,
+        F: ArchetypeFilter + 'static,
     {
         self.linear_interpolate_with_priority_filtered::<C, F>(SINGLE_COMPONENT_RULE_PRIORITY)
     }
@@ -827,7 +620,7 @@ pub trait AppInterpolationExt {
     fn linear_interpolate_with_priority_filtered<C, F>(&mut self, priority: usize) -> &mut Self
     where
         C: SyncComponent + Ease,
-        F: QueryFilter + 'static,
+        F: ArchetypeFilter + 'static,
     {
         self.interpolate_with_priority_filtered::<C, F>(
             priority,
@@ -837,7 +630,7 @@ pub trait AppInterpolationExt {
 
     /// Registers a default-priority interpolation rule for component `C`.
     ///
-    /// If the selected [`InterpolationFns`] owns history, Lightyear receives
+    /// If the registered [`InterpolationFns`] owns history, Lightyear receives
     /// authoritative updates into [`ConfirmedHistory<C>`]. If it owns apply,
     /// Lightyear samples that history and writes the live component during
     /// [`crate::plugin::InterpolationSystems::Prepare`].
@@ -910,7 +703,7 @@ pub trait AppInterpolationExt {
     fn interpolate_filtered_with<C, F>(&mut self, fns: InterpolationFns<C>) -> &mut Self
     where
         C: SyncComponent,
-        F: QueryFilter + 'static,
+        F: ArchetypeFilter + 'static,
     {
         self.interpolate_with_priority_filtered::<C, F>(SINGLE_COMPONENT_RULE_PRIORITY, fns)
     }
@@ -924,13 +717,14 @@ pub trait AppInterpolationExt {
     ) -> &mut Self
     where
         C: SyncComponent,
-        F: QueryFilter + 'static;
+        F: ArchetypeFilter + 'static;
 
     /// Registers a bundle interpolation rule with default bundle priority.
     ///
     /// Lightyear stores each component in its own [`ConfirmedHistory`], then
-    /// samples their histories together and calls the tuple interpolation
-    /// function when all histories have the same bracketing ticks.
+    /// samples their histories together at shared ticks around the
+    /// interpolation time. Unchanged members carry their latest present value
+    /// forward to those shared ticks.
     ///
     /// # Examples
     ///
@@ -1017,7 +811,7 @@ pub trait AppInterpolationExt {
     fn interpolate_bundle_filtered_with<B, F>(&mut self, fns: InterpolationFns<B>) -> &mut Self
     where
         B: InterpolationBundle,
-        F: QueryFilter + 'static,
+        F: ArchetypeFilter + 'static,
     {
         self.interpolate_bundle_with_priority_filtered::<B, F>(B::COMPONENT_COUNT, fns)
     }
@@ -1031,7 +825,7 @@ pub trait AppInterpolationExt {
     ) -> &mut Self
     where
         B: InterpolationBundle,
-        F: QueryFilter + 'static;
+        F: ArchetypeFilter + 'static;
 
     /// Registers a default-priority interpolation rule for a diff-replicated component `C`.
     ///
@@ -1082,7 +876,7 @@ pub trait AppInterpolationExt {
     fn interpolate_diff_filtered_with<C, F>(&mut self, fns: InterpolationFns<C>) -> &mut Self
     where
         C: SyncComponent + RepliconDiffable,
-        F: QueryFilter + 'static,
+        F: ArchetypeFilter + 'static,
     {
         self.interpolate_diff_with_priority_filtered::<C, F>(SINGLE_COMPONENT_RULE_PRIORITY, fns)
     }
@@ -1096,7 +890,7 @@ pub trait AppInterpolationExt {
     ) -> &mut Self
     where
         C: SyncComponent + RepliconDiffable,
-        F: QueryFilter + 'static;
+        F: ArchetypeFilter + 'static;
 }
 
 impl AppInterpolationExt for App {
@@ -1107,7 +901,7 @@ impl AppInterpolationExt for App {
     ) -> &mut Self
     where
         C: SyncComponent,
-        F: QueryFilter + 'static,
+        F: ArchetypeFilter + 'static,
     {
         add_interpolation_rule::<C, F>(self, fns, InterpolationRuleConfig { priority });
         self
@@ -1120,7 +914,7 @@ impl AppInterpolationExt for App {
     ) -> &mut Self
     where
         B: InterpolationBundle,
-        F: QueryFilter + 'static,
+        F: ArchetypeFilter + 'static,
     {
         B::add_rule::<F>(self, fns, InterpolationRuleConfig { priority });
         self
@@ -1133,100 +927,38 @@ impl AppInterpolationExt for App {
     ) -> &mut Self
     where
         C: SyncComponent + RepliconDiffable,
-        F: QueryFilter + 'static,
+        F: ArchetypeFilter + 'static,
     {
         add_interpolation_diff_rule::<C, F>(self, fns, InterpolationRuleConfig { priority });
         self
     }
 }
 
-fn register_interpolated_marker_fns<C: SyncComponent>(app: &mut bevy_app::App) {
-    ensure_interpolation_registry(app);
-    let kind = ComponentKind::of::<C>();
-    let component_registered = app
-        .world()
-        .get_resource::<ComponentRegistry>()
-        .is_some_and(|registry| registry.is_registered::<C>());
-    {
-        let mut registry = app.world_mut().resource_mut::<InterpolationRegistry>();
-        if registry.interpolated_marker_fns.contains(&kind)
-            || registry
-                .pending_interpolated_marker_fns
-                .iter()
-                .any(|(pending_kind, _)| *pending_kind == kind)
-        {
-            return;
-        }
-        if !component_registered {
-            registry
-                .pending_interpolated_marker_fns
-                .push((kind, install_interpolated_marker_fns::<C>));
-            return;
-        }
+fn register_interpolated_marker_fns<C: SyncComponent>(app: &mut bevy_app::App, write: WriteFn<C>) {
+    // Frame interpolation can use the same rule registry without Replicon.
+    // Such apps have no receive pipeline whose marker functions need replacing.
+    if !app.world().contains_resource::<ReplicationRegistry>() {
+        return;
     }
-    install_interpolated_marker_fns::<C>(app);
-}
-
-fn install_interpolated_marker_fns<C: SyncComponent>(app: &mut bevy_app::App) {
     let kind = ComponentKind::of::<C>();
-    app.set_marker_fns::<Interpolated, C>(write_history::<C>, remove_history::<C>);
-    app.set_marker_fns::<InterpolatedSend, C>(write_history::<C>, remove_history::<C>);
+    if app
+        .world()
+        .resource::<InterpolationRegistry>()
+        .interpolated_marker_fns
+        .contains(&kind)
+    {
+        return;
+    }
+    app.set_marker_fns::<Interpolated, C>(write, remove_history::<C>);
+    app.set_marker_fns::<InterpolatedSend, C>(write, remove_history::<C>);
     app.world_mut()
         .resource_mut::<InterpolationRegistry>()
         .interpolated_marker_fns
-        .insert(kind);
+        .push(kind);
 }
 
-fn register_interpolated_diff_marker_fns<C: SyncComponent + RepliconDiffable>(
-    app: &mut bevy_app::App,
-) {
-    ensure_interpolation_registry(app);
-    let kind = ComponentKind::of::<C>();
-    let component_registered = app
-        .world()
-        .get_resource::<ComponentRegistry>()
-        .is_some_and(|registry| registry.is_registered::<C>());
-    {
-        let mut registry = app.world_mut().resource_mut::<InterpolationRegistry>();
-        if registry.interpolated_marker_fns.contains(&kind) {
-            return;
-        }
-        if let Some((_, register)) = registry
-            .pending_interpolated_marker_fns
-            .iter_mut()
-            .find(|(pending_kind, _)| *pending_kind == kind)
-        {
-            *register = install_interpolated_diff_marker_fns::<C>;
-            return;
-        }
-        if !component_registered {
-            registry
-                .pending_interpolated_marker_fns
-                .push((kind, install_interpolated_diff_marker_fns::<C>));
-            return;
-        }
-    }
-    install_interpolated_diff_marker_fns::<C>(app);
-}
-
-fn install_interpolated_diff_marker_fns<C: SyncComponent + RepliconDiffable>(
-    app: &mut bevy_app::App,
-) {
-    let kind = ComponentKind::of::<C>();
-    app.set_marker_fns::<Interpolated, C>(write_history_diff::<C>, remove_history::<C>);
-    app.set_marker_fns::<InterpolatedSend, C>(write_history_diff::<C>, remove_history::<C>);
-    app.world_mut()
-        .resource_mut::<InterpolationRegistry>()
-        .interpolated_marker_fns
-        .insert(kind);
-}
-
-/// Backfills `ConfirmedHistory<C>` when `Interpolated` is added after the live
-/// replicated component was already inserted.
-pub(crate) fn backfill_confirmed_history<C: SyncComponent>(
-    entity: Entity,
-    commands: &mut Commands,
-) {
+/// Initializes `ConfirmedHistory<C>` from the current replicated component.
+pub(crate) fn insert_confirmed_history<C: SyncComponent>(entity: Entity, commands: &mut Commands) {
     commands.queue(move |world: &mut World| {
         let Some((component, message_tick)) = ({
             let Ok(entity_ref) = world.get_entity(entity) else {
@@ -1249,14 +981,14 @@ pub(crate) fn backfill_confirmed_history<C: SyncComponent>(
         let Some(checkpoints) = world.get_resource::<ReplicationCheckpointMap>() else {
             debug_assert!(
                 false,
-                "missing checkpoint map while backfilling ConfirmedHistory"
+                "missing checkpoint map while initializing ConfirmedHistory"
             );
             return;
         };
         let Some(tick) = checkpoints.get(message_tick) else {
             debug_assert!(
                 false,
-                "missing authoritative checkpoint mapping while backfilling ConfirmedHistory"
+                "missing authoritative checkpoint mapping while initializing ConfirmedHistory"
             );
             return;
         };
@@ -1274,8 +1006,8 @@ pub(crate) fn backfill_confirmed_history<C: SyncComponent>(
     });
 }
 
-/// Diff-aware variant of [`backfill_confirmed_history`].
-pub(crate) fn backfill_confirmed_history_diff<C: SyncComponent + RepliconDiffable>(
+/// Diff-aware variant of [`insert_confirmed_history`].
+pub(crate) fn insert_confirmed_history_diff<C: SyncComponent + RepliconDiffable>(
     entity: Entity,
     commands: &mut Commands,
 ) {
@@ -1302,14 +1034,14 @@ pub(crate) fn backfill_confirmed_history_diff<C: SyncComponent + RepliconDiffabl
         let Some(checkpoints) = world.get_resource::<ReplicationCheckpointMap>() else {
             debug_assert!(
                 false,
-                "missing checkpoint map while backfilling diff ConfirmedHistory"
+                "missing checkpoint map while initializing diff ConfirmedHistory"
             );
             return;
         };
         let Some(tick) = checkpoints.get(message_tick) else {
             debug_assert!(
                 false,
-                "missing authoritative checkpoint mapping while backfilling diff ConfirmedHistory"
+                "missing authoritative checkpoint mapping while initializing diff ConfirmedHistory"
             );
             return;
         };
@@ -1489,54 +1221,22 @@ where
     }
 }
 
-fn ensure_interpolation_registry(app: &mut App) {
-    if !app.world().contains_resource::<InterpolationRegistry>() {
-        app.world_mut()
-            .insert_resource(InterpolationRegistry::default());
-    }
-}
-
-pub(crate) fn mark_interpolated<C: SyncComponent>(app: &mut App) {
-    let Some(mut registry) = app.world_mut().get_resource_mut::<ComponentRegistry>() else {
-        return;
-    };
-    let Some(replication) = registry
-        .component_metadata_map
-        .get_mut(&ComponentKind::of::<C>())
-        .and_then(|metadata| metadata.replication.as_mut())
-    else {
-        return;
-    };
-    replication.set_interpolated(true);
-}
-
 pub(crate) fn add_interpolation_rule<C, F>(
     app: &mut App,
     fns: InterpolationFns<C>,
     config: InterpolationRuleConfig,
 ) where
     C: SyncComponent,
-    F: QueryFilter + 'static,
+    F: ArchetypeFilter + 'static,
 {
-    QueryState::<&Archetype, F>::new(app.world_mut());
-    ensure_interpolation_registry(app);
-    let component_ids = InterpolationRuleComponentIds::for_component::<C>(app.world_mut(), &fns);
-    let uses_interpolation_component =
-        fns.owns_interpolation_history() || fns.applies_interpolation_component();
-    let uses_frame_component = fns.owns_frame_history() || fns.applies_frame_component();
-    if uses_interpolation_component || uses_frame_component {
-        app.world_mut().register_component::<C>();
-    }
-    if fns.owns_interpolation_history() {
-        register_interpolated_marker_fns::<C>(app);
-        mark_interpolated::<C>(app);
-    }
-    if fns.applies_interpolation_component() {
-        mark_interpolated::<C>(app);
-    }
-    app.world_mut()
-        .resource_mut::<InterpolationRegistry>()
-        .insert_rule::<C, F>(fns, config, component_ids);
+    add_component_interpolation_rule::<C, F>(
+        app,
+        fns,
+        config,
+        write_history::<C>,
+        update_history_archetype_erased::<C>,
+        insert_confirmed_history::<C>,
+    );
 }
 
 fn add_interpolation_diff_rule<C, F>(
@@ -1545,27 +1245,63 @@ fn add_interpolation_diff_rule<C, F>(
     config: InterpolationRuleConfig,
 ) where
     C: SyncComponent + RepliconDiffable,
-    F: QueryFilter + 'static,
+    F: ArchetypeFilter + 'static,
 {
+    add_component_interpolation_rule::<C, F>(
+        app,
+        fns,
+        config,
+        write_history_diff::<C>,
+        update_history_diff_archetype_erased::<C>,
+        insert_confirmed_history_diff::<C>,
+    );
+}
+
+fn add_component_interpolation_rule<C, F>(
+    app: &mut App,
+    fns: InterpolationFns<C>,
+    config: InterpolationRuleConfig,
+    write_history: WriteFn<C>,
+    update_history: ErasedUpdateHistoryFn,
+    insert_history: ErasedInsertConfirmedHistoryFn,
+) where
+    C: SyncComponent,
+    F: ArchetypeFilter + 'static,
+{
+    app.world_mut().init_resource::<InterpolationRegistry>();
+    app.world()
+        .resource::<InterpolationRegistry>()
+        .assert_not_finalized();
     QueryState::<&Archetype, F>::new(app.world_mut());
-    ensure_interpolation_registry(app);
-    let component_ids = InterpolationRuleComponentIds::for_component::<C>(app.world_mut(), &fns);
-    let uses_interpolation_component =
-        fns.owns_interpolation_history() || fns.applies_interpolation_component();
-    let uses_frame_component = fns.owns_frame_history() || fns.applies_frame_component();
-    if uses_interpolation_component || uses_frame_component {
-        app.world_mut().register_component::<C>();
-    }
     if fns.owns_interpolation_history() {
-        register_interpolated_diff_marker_fns::<C>(app);
-        mark_interpolated::<C>(app);
+        register_interpolated_marker_fns::<C>(app, write_history);
     }
-    if fns.applies_interpolation_component() {
-        mark_interpolated::<C>(app);
-    }
+    let rule = component_rule::<C, F>(app.world_mut(), fns, config, update_history, insert_history);
     app.world_mut()
         .resource_mut::<InterpolationRegistry>()
-        .insert_diff_rule::<C, F>(fns, config, component_ids);
+        .insert_rule(rule);
+}
+
+/// Builds one self-contained member for a bundle interpolation rule.
+pub(crate) fn interpolation_rule_member<C>(
+    app: &mut App,
+    include_interpolation_history: bool,
+    include_frame_history: bool,
+) -> InterpolationRuleComponent
+where
+    C: SyncComponent,
+{
+    let member = build_rule_member::<C>(
+        app.world_mut(),
+        include_interpolation_history,
+        include_frame_history,
+        update_history_archetype_erased::<C>,
+        insert_confirmed_history::<C>,
+    );
+    if include_interpolation_history {
+        register_interpolated_marker_fns::<C>(app, write_history::<C>);
+    }
+    member
 }
 
 pub(crate) fn add_interpolation_bundle_rule<B, F>(
@@ -1574,10 +1310,13 @@ pub(crate) fn add_interpolation_bundle_rule<B, F>(
     config: InterpolationRuleConfig,
 ) where
     B: TupleInterpolationBundle,
-    F: QueryFilter + 'static,
+    F: ArchetypeFilter + 'static,
 {
+    app.world_mut().init_resource::<InterpolationRegistry>();
+    app.world()
+        .resource::<InterpolationRegistry>()
+        .assert_not_finalized();
     QueryState::<&Archetype, F>::new(app.world_mut());
-    ensure_interpolation_registry(app);
     let owns_interpolation_history = fns.owns_interpolation_history();
     let owns_frame_history = fns.owns_frame_history();
     let applies_interpolation_component = fns.applies_interpolation_component();
@@ -1586,38 +1325,18 @@ pub(crate) fn add_interpolation_bundle_rule<B, F>(
         applies_interpolation_component.then_some(B::apply_archetype as ErasedApplyInterpolationFn);
     let apply_frame_interpolation = applies_frame_component
         .then_some(B::apply_frame_archetype as ErasedApplyFrameInterpolationFn);
-    let component_ids = if applies_interpolation_component || applies_frame_component {
-        B::component_ids(app)
-    } else {
-        Vec::new()
-    };
-    let write_component_ids = if applies_interpolation_component {
-        component_ids.clone()
-    } else {
-        Vec::new()
-    };
-    let frame_write_component_ids = if applies_frame_component {
-        component_ids.clone()
-    } else {
-        Vec::new()
-    };
-    if applies_interpolation_component {
-        B::mark_interpolated(app);
-    }
+    let members = B::rule_members(app, owns_interpolation_history, owns_frame_history);
+    let rule = InterpolationRule::new::<B, F>(
+        app.world().components(),
+        fns,
+        members,
+        config.priority,
+        apply_interpolation,
+        apply_frame_interpolation,
+    );
     app.world_mut()
         .resource_mut::<InterpolationRegistry>()
-        .insert_bundle_rule::<B, F>(
-            fns,
-            config,
-            B::component_kinds(),
-            write_component_ids,
-            apply_interpolation,
-            frame_write_component_ids,
-            apply_frame_interpolation,
-        );
-    if owns_interpolation_history || owns_frame_history {
-        B::add_history_rules::<F>(app, config, owns_interpolation_history);
-    }
+        .insert_rule(rule);
 }
 
 fn add_interpolation_with_impl<'a, C>(
@@ -1879,23 +1598,46 @@ fn remove_history<C: SyncComponent>(ctx: &mut RemoveCtx, entity: &mut DeferredEn
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::interpolate::apply_interpolation;
+    use crate::timeline::InterpolationTimeline;
     use alloc::vec::Vec;
     use bevy_app::App;
     use bevy_ecs::component::Component;
+    use bevy_ecs::system::RunSystemOnce;
     use bevy_replicon::postcard_utils;
     use bevy_replicon::prelude::{RepliconPlugins, RepliconTick, RuleFns};
     use bevy_replicon::shared::replication::diff::diff_index::DiffIndex;
     use bevy_replicon::shared::replication::registry::ReplicationRegistry;
     use bevy_replicon::shared::replication::registry::test_fns::TestFnsEntityExt;
     use bevy_state::app::StatesPlugin;
+    use lightyear_core::time::TickInstant;
+    use lightyear_core::timeline::NetworkTimeline;
     use lightyear_replication::registry::replication::AppComponentExt;
     use serde::{Deserialize, Serialize};
 
     #[derive(Component, Clone, Debug, Deserialize, PartialEq, Serialize)]
     struct TestComp(f32);
 
+    #[derive(Component, Clone, Debug, PartialEq)]
+    struct TestComp2(f32);
+
+    #[derive(Component)]
+    struct NoHistory;
+
     fn lerp(start: TestComp, end: TestComp, t: f32) -> TestComp {
         TestComp(start.0 + (end.0 - start.0) * t)
+    }
+
+    fn lerp2(start: TestComp2, end: TestComp2, t: f32) -> TestComp2 {
+        TestComp2(start.0 + (end.0 - start.0) * t)
+    }
+
+    fn bundle_lerp(
+        start: (TestComp, TestComp2),
+        end: (TestComp, TestComp2),
+        t: f32,
+    ) -> (TestComp, TestComp2) {
+        (lerp(start.0, end.0, t), lerp2(start.1, end.1, t))
     }
 
     fn diff_lerp(start: TestDiffComponent, end: TestDiffComponent, t: f32) -> TestDiffComponent {
@@ -1918,14 +1660,31 @@ mod tests {
         let mut registry = InterpolationRegistry::default();
         let mut world = World::new();
         let fns = InterpolationFns::interpolate(lerp);
-        let component_ids =
-            InterpolationRuleComponentIds::for_component::<TestComp>(&mut world, &fns);
-        let rule_id = registry.insert_rule::<TestComp, ()>(
+        let rule = component_rule::<TestComp, ()>(
+            &mut world,
             fns,
             InterpolationRuleConfig::default(),
-            component_ids,
+            update_history_archetype_erased::<TestComp>,
+            insert_confirmed_history::<TestComp>,
         );
+        let rule_id = registry.insert_rule(rule);
         (registry, rule_id)
+    }
+
+    fn sample_for_rule(
+        registry: &InterpolationRegistry,
+        rule_id: InterpolationRuleId,
+        history: &ConfirmedHistory<TestComp>,
+        interpolation_tick: Tick,
+        interpolation_overstep: f32,
+    ) -> Option<HistoryState<TestComp>> {
+        sample_history_with_interpolation(
+            registry.interpolation_fn_for_rule::<TestComp>(rule_id),
+            history,
+            interpolation_tick,
+            interpolation_overstep,
+            None,
+        )
     }
 
     #[derive(Serialize)]
@@ -1985,7 +1744,7 @@ mod tests {
     }
 
     #[test]
-    fn add_interpolation_diff_with_registers_diff_history_and_sampler() {
+    fn add_interpolation_diff_with_applies_registered_sampler() {
         let mut app = App::new();
         app.add_plugins((
             StatesPlugin,
@@ -1993,17 +1752,36 @@ mod tests {
             crate::plugin::InterpolationMarkerPlugin,
             crate::plugin::InterpolationPlugin,
         ));
+        app.insert_resource(ReplicationCheckpointMap::default());
         app.component::<TestDiffComponent>()
             .replicate_diff()
             .add_interpolation_diff_with(diff_lerp);
+        let mut timeline = InterpolationTimeline::default();
+        timeline.set_now(TickInstant::from(Tick(15)));
+        app.insert_resource(timeline);
+        app.finish();
 
-        let registry = app.world().resource::<InterpolationRegistry>();
-        assert!(registry.interpolated::<TestDiffComponent>());
-        assert!(registry.has_interpolation_fn::<TestDiffComponent>());
+        let mut history = ConfirmedHistory::<TestDiffComponent>::default();
+        history.insert_present(Tick(10), TestDiffComponent(0));
+        history.insert_present(Tick(20), TestDiffComponent(10));
+        let entity = app
+            .world_mut()
+            .spawn((Interpolated, TestDiffComponent(99), history))
+            .id();
+
+        app.world_mut()
+            .run_system_once(apply_interpolation)
+            .unwrap();
+
+        assert_eq!(
+            app.world().get::<TestDiffComponent>(entity),
+            Some(&TestDiffComponent(10))
+        );
     }
 
+    /// Checks that interpolation marker setup can be registered before replication metadata.
     #[test]
-    fn interpolation_rule_can_precede_replication_component_registration() {
+    fn marker_functions_can_precede_replication_component_registration() {
         let mut app = App::new();
         app.add_plugins((
             StatesPlugin,
@@ -2018,7 +1796,6 @@ mod tests {
 
         let registry = app.world().resource::<InterpolationRegistry>();
         assert!(registry.finalized);
-        assert!(registry.pending_interpolated_marker_fns.is_empty());
         assert!(
             registry
                 .interpolated_marker_fns
@@ -2034,14 +1811,15 @@ mod tests {
         let mut registry = InterpolationRegistry::default();
         let mut world = World::new();
         let fns = InterpolationFns::history_only();
-        let component_ids =
-            InterpolationRuleComponentIds::for_component::<TestComp>(&mut world, &fns);
-        registry.finalize();
-        registry.insert_rule::<TestComp, ()>(
+        let rule = component_rule::<TestComp, ()>(
+            &mut world,
             fns,
             InterpolationRuleConfig::default(),
-            component_ids,
+            update_history_archetype_erased::<TestComp>,
+            insert_confirmed_history::<TestComp>,
         );
+        registry.finalize();
+        registry.insert_rule(rule);
     }
 
     fn record_checkpoint(app: &mut App, tick: u32) -> RepliconTick {
@@ -2060,11 +1838,11 @@ mod tests {
 
         let (registry, rule_id) = registry();
         assert_eq!(
-            registry.sample_for_rule(rule_id, &history, Tick(30), 0.0, None),
+            sample_for_rule(&registry, rule_id, &history, Tick(30), 0.0),
             Some(HistoryState::Updated(TestComp(10.0)))
         );
         assert_eq!(
-            registry.sample_for_rule(rule_id, &history, Tick(20), 0.5, None),
+            sample_for_rule(&registry, rule_id, &history, Tick(20), 0.5),
             Some(HistoryState::Updated(TestComp(10.0)))
         );
     }
@@ -2076,15 +1854,15 @@ mod tests {
 
         let (registry, rule_id) = registry();
         assert_eq!(
-            registry.sample_for_rule(rule_id, &history, Tick(5), 0.0, None),
+            sample_for_rule(&registry, rule_id, &history, Tick(5), 0.0),
             None
         );
         assert_eq!(
-            registry.sample_for_rule(rule_id, &history, Tick(10), 0.0, None),
+            sample_for_rule(&registry, rule_id, &history, Tick(10), 0.0),
             Some(HistoryState::Updated(TestComp(42.0)))
         );
         assert_eq!(
-            registry.sample_for_rule(rule_id, &history, Tick(50), 0.5, None),
+            sample_for_rule(&registry, rule_id, &history, Tick(50), 0.5),
             Some(HistoryState::Updated(TestComp(42.0)))
         );
     }
@@ -2113,7 +1891,15 @@ mod tests {
             .world_mut()
             .spawn((TestComp(2.0), ConfirmHistory::new(replicon_tick)))
             .id();
+        app.world_mut().run_schedule(bevy_app::Update);
+        assert!(
+            app.world()
+                .get::<ConfirmedHistory<TestComp>>(entity)
+                .is_none()
+        );
+
         app.world_mut().entity_mut(entity).insert(Interpolated);
+        app.world_mut().run_schedule(bevy_app::Update);
 
         let history = app
             .world()
@@ -2132,8 +1918,9 @@ mod tests {
         );
     }
 
+    /// Checks that a winning no-history rule prevents lower-rule history initialization.
     #[test]
-    fn inserts_history_when_interpolated_and_component_are_spawned_together() {
+    fn no_history_winner_does_not_initialize_lower_rule_history() {
         let mut app = App::new();
         app.add_plugins((
             StatesPlugin,
@@ -2142,40 +1929,221 @@ mod tests {
             crate::plugin::InterpolationPlugin,
         ));
         app.insert_resource(ReplicationCheckpointMap::default());
-        app.component::<TestComp>()
-            .replicate()
-            .add_custom_interpolation();
+        app.component::<TestComp>().replicate();
+        app.interpolate_with::<TestComp>(InterpolationFns::interpolate(lerp));
+        app.interpolate_with_priority_filtered::<TestComp, With<NoHistory>>(
+            100,
+            InterpolationFns::no_history(lerp),
+        );
         app.finish();
 
-        let replicon_tick = RepliconTick::new(12);
-        app.world_mut()
-            .resource_mut::<ReplicationCheckpointMap>()
-            .record(replicon_tick, Tick(43));
-
+        let replicon_tick = record_checkpoint(&mut app, 42);
         let entity = app
             .world_mut()
+            .spawn((TestComp(2.0), NoHistory, ConfirmHistory::new(replicon_tick)))
+            .id();
+        app.world_mut().entity_mut(entity).insert(Interpolated);
+        app.world_mut().run_schedule(bevy_app::Update);
+
+        assert_eq!(app.world().get::<TestComp>(entity), Some(&TestComp(2.0)));
+        assert!(
+            !app.world()
+                .entity(entity)
+                .contains::<ConfirmedHistory<TestComp>>()
+        );
+    }
+
+    /// Checks history and apply ownership for every live/history presence combination.
+    #[test]
+    fn resolved_rule_ownership_covers_live_and_history_presence_matrix() {
+        let mut world = World::new();
+        let mut registry = InterpolationRegistry::default();
+
+        let first_rule = registry.insert_rule(component_rule::<TestComp, ()>(
+            &mut world,
+            InterpolationFns::interpolate(lerp),
+            InterpolationRuleConfig { priority: 1 },
+            update_history_archetype_erased::<TestComp>,
+            insert_confirmed_history::<TestComp>,
+        ));
+        let second_rule = registry.insert_rule(component_rule::<TestComp2, ()>(
+            &mut world,
+            InterpolationFns::interpolate(lerp2),
+            InterpolationRuleConfig { priority: 1 },
+            update_history_archetype_erased::<TestComp2>,
+            insert_confirmed_history::<TestComp2>,
+        ));
+
+        let bundle_members = alloc::vec![
+            build_rule_member::<TestComp>(
+                &mut world,
+                true,
+                true,
+                update_history_archetype_erased::<TestComp>,
+                insert_confirmed_history::<TestComp>,
+            ),
+            build_rule_member::<TestComp2>(
+                &mut world,
+                true,
+                true,
+                update_history_archetype_erased::<TestComp2>,
+                insert_confirmed_history::<TestComp2>,
+            ),
+        ];
+        let bundle_rule =
+            registry.insert_rule(InterpolationRule::new::<(TestComp, TestComp2), ()>(
+                world.components(),
+                InterpolationFns::interpolate(bundle_lerp),
+                bundle_members,
+                2,
+                Some(
+                    <(TestComp, TestComp2) as TupleInterpolationBundle>::apply_archetype
+                        as ErasedApplyInterpolationFn,
+                ),
+                Some(
+                    <(TestComp, TestComp2) as TupleInterpolationBundle>::apply_frame_archetype
+                        as ErasedApplyFrameInterpolationFn,
+                ),
+            ));
+
+        let both_live_no_history = world.spawn((TestComp(0.0), TestComp2(0.0))).id();
+        let both_live_first_history = world
             .spawn((
-                TestComp(3.0),
-                ConfirmHistory::new(replicon_tick),
-                Interpolated,
+                TestComp(0.0),
+                TestComp2(0.0),
+                ConfirmedHistory::<TestComp>::default(),
+                FrameInterpolationHistory::<TestComp>::default(),
             ))
             .id();
+        // This archetype represents both delayed insertion of TestComp2 before
+        // its insertion tick and delayed removal after its removal tick.
+        let only_first_both_histories = world
+            .spawn((
+                TestComp(0.0),
+                ConfirmedHistory::<TestComp>::default(),
+                ConfirmedHistory::<TestComp2>::default(),
+                FrameInterpolationHistory::<TestComp>::default(),
+                FrameInterpolationHistory::<TestComp2>::default(),
+            ))
+            .id();
+        let only_second_both_histories = world
+            .spawn((
+                TestComp2(0.0),
+                ConfirmedHistory::<TestComp>::default(),
+                ConfirmedHistory::<TestComp2>::default(),
+                FrameInterpolationHistory::<TestComp>::default(),
+                FrameInterpolationHistory::<TestComp2>::default(),
+            ))
+            .id();
+        let only_first_own_history = world
+            .spawn((
+                TestComp(0.0),
+                ConfirmedHistory::<TestComp>::default(),
+                FrameInterpolationHistory::<TestComp>::default(),
+            ))
+            .id();
+        let only_second_own_history = world
+            .spawn((
+                TestComp2(0.0),
+                ConfirmedHistory::<TestComp2>::default(),
+                FrameInterpolationHistory::<TestComp2>::default(),
+            ))
+            .id();
+        let histories_only = world
+            .spawn((
+                ConfirmedHistory::<TestComp>::default(),
+                ConfirmedHistory::<TestComp2>::default(),
+                FrameInterpolationHistory::<TestComp>::default(),
+                FrameInterpolationHistory::<TestComp2>::default(),
+            ))
+            .id();
+        let no_live_or_history = world.spawn_empty().id();
 
-        let history = app
-            .world()
-            .entity(entity)
-            .get::<ConfirmedHistory<TestComp>>()
-            .unwrap();
-        assert_eq!(
-            history
-                .start_present()
-                .map(|(tick, value)| (tick, value.clone())),
-            Some((Tick(43), TestComp(3.0)))
-        );
-        assert!(
-            !app.world().entity(entity).contains::<TestComp>(),
-            "live interpolated component should be removed until the interpolation timeline reaches the history start tick"
-        );
+        let ownership = |rule_id, owns_history, owns_apply| ResolvedRule {
+            rule_id,
+            owns_history,
+            owns_apply,
+        };
+        let cases = alloc::vec![
+            (
+                "both live, no history yet",
+                both_live_no_history,
+                alloc::vec![ownership(bundle_rule, true, true)],
+            ),
+            (
+                "both live, one history missing",
+                both_live_first_history,
+                alloc::vec![ownership(bundle_rule, true, true)],
+            ),
+            (
+                "delayed insertion/removal of second member",
+                only_first_both_histories,
+                alloc::vec![
+                    ownership(bundle_rule, true, false),
+                    ownership(first_rule, false, true),
+                ],
+            ),
+            (
+                "delayed insertion/removal of first member",
+                only_second_both_histories,
+                alloc::vec![
+                    ownership(bundle_rule, true, false),
+                    ownership(second_rule, false, true),
+                ],
+            ),
+            (
+                "second member and its history absent",
+                only_first_own_history,
+                alloc::vec![ownership(first_rule, true, true)],
+            ),
+            (
+                "first member and its history absent",
+                only_second_own_history,
+                alloc::vec![ownership(second_rule, true, true)],
+            ),
+            (
+                "both histories retained, both live members absent",
+                histories_only,
+                alloc::vec![ownership(bundle_rule, true, false)],
+            ),
+            (
+                "no live members or histories",
+                no_live_or_history,
+                alloc::vec![],
+            ),
+        ];
+
+        // History contents and change status deliberately do not appear in
+        // this matrix. Ownership depends only on archetype presence; sampling
+        // and history maintenance interpret Updated/Removed entries later.
+        let mut scratch = RuleResolutionScratch::default();
+        for target in [RuleTarget::Default, RuleTarget::Frame] {
+            for (name, entity, expected) in &cases {
+                let entity_ref = world.entity(*entity);
+                let archetype = entity_ref.archetype();
+                let actual = registry.resolved_rules_for_archetype(
+                    world.components(),
+                    archetype,
+                    target,
+                    &mut scratch,
+                );
+                assert_eq!(
+                    actual,
+                    expected.as_slice(),
+                    "unexpected {target:?} ownership for {name}"
+                );
+            }
+        }
+    }
+
+    /// Checks that a bundle cannot list the same component type more than once.
+    #[test]
+    #[should_panic(
+        expected = "interpolation bundle rules cannot contain duplicate component types"
+    )]
+    fn bundle_rule_rejects_duplicate_component_types() {
+        let mut app = App::new();
+        app.interpolate_bundle_with::<(TestComp, TestComp)>(InterpolationFns::disabled());
     }
 
     #[test]

--- a/crates/replication/interpolation/src/rules.rs
+++ b/crates/replication/interpolation/src/rules.rs
@@ -11,19 +11,22 @@ pub use bundle::InterpolationBundle;
 
 pub(crate) use bundle::TupleInterpolationBundle;
 
-use self::frame_interpolate::{FrameHistoryComponent, FrameInterpolationFns};
+use self::frame_interpolate::{
+    CachedFrameInterpolationApply, CachedFrameInterpolationHistoryComponent,
+    ErasedApplyFrameInterpolationFn, ErasedRestoreFrameHistoryFn, ErasedUpdateFrameHistoryFn,
+};
 use crate::registry::InterpolationRegistry;
 use alloc::{boxed::Box, vec::Vec};
 use bevy_ecs::archetype::Archetype;
 use bevy_ecs::component::{ComponentId, Components, StorageType};
 use bevy_ecs::prelude::{Commands, Entity};
-use bevy_ecs::query::QueryFilter;
+use bevy_ecs::query::{ArchetypeFilter, FilteredAccess};
 use bevy_ecs::world::unsafe_world_cell::UnsafeWorldCell;
 use bevy_math::{
     Curve,
     curve::{Ease, EaseFunction, EasingCurve},
 };
-use core::any::{Any, TypeId};
+use core::any::Any;
 use core::fmt;
 use core::marker::PhantomData;
 use core::time::Duration;
@@ -152,9 +155,11 @@ impl<C> InterpolationFn<C> {
 /// Configuration for an interpolation rule.
 ///
 /// Rules are evaluated per interpolated archetype and component type. If
-/// multiple rules match the same archetype, the rule with the highest priority
-/// is selected. If the selected rule omits history or apply work, Lightyear
-/// skips that work instead of falling back to a lower-priority rule.
+/// multiple rules match the same archetype, priority is resolved independently
+/// for history and apply behavior. Histories can represent temporarily absent
+/// members, while apply requires every live member. A bundle may therefore
+/// maintain `(A, B)` histories while a standalone rule applies `A` until `B`
+/// becomes live again.
 ///
 /// # Examples
 ///
@@ -259,7 +264,6 @@ enum InterpolationPipeline {
     Full,
     HistoryOnly,
     NoHistory,
-    FrameHistoryOnly,
     Disabled,
 }
 
@@ -409,17 +413,6 @@ impl<C> InterpolationFns<C> {
         }
     }
 
-    // Internal synthetic rule used for bundle `no_history` members. A tuple
-    // rule owns the interpolation function, but frame interpolation still needs
-    // per-component `FrameInterpolationHistory<C>` entries for each member.
-    pub(crate) fn frame_history_only() -> Self {
-        Self {
-            interpolation: None,
-            pipeline: InterpolationPipeline::FrameHistoryOnly,
-            _marker: PhantomData,
-        }
-    }
-
     pub(crate) fn owns_interpolation_history(&self) -> bool {
         matches!(
             self.pipeline,
@@ -437,7 +430,6 @@ impl<C> InterpolationFns<C> {
             InterpolationPipeline::Full
                 | InterpolationPipeline::HistoryOnly
                 | InterpolationPipeline::NoHistory
-                | InterpolationPipeline::FrameHistoryOnly
         )
     }
 
@@ -452,7 +444,7 @@ impl<C> InterpolationFns<C> {
     }
 }
 
-/// Fluent helpers for adding interpolation functions to [`InterpolationFns`].
+/// Helpers for adding interpolation functions to [`InterpolationFns`].
 ///
 /// These are most useful with [`InterpolationFns::history_only`], where
 /// Lightyear should own history/presence but a custom system owns delayed
@@ -522,35 +514,26 @@ where
 #[doc(hidden)]
 pub struct InterpolationRuleId(pub(crate) usize);
 
-impl InterpolationRuleId {
-    pub(crate) fn index(self) -> usize {
-        self.0
-    }
-}
-
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct UpdateHistoryContext {
     pub(crate) server_complete_tick: Option<Tick>,
     pub(crate) current_interpolate_tick: Tick,
-    pub(crate) interpolation_overstep: f32,
-    pub(crate) tick_duration: Option<Duration>,
 }
 
-/// Type-erased interpolation function stored by the interpolation registry.
-///
-/// Typed functions are erased internally so rules for different components and
-/// bundles can share the same cache.
-pub(crate) struct ErasedInterpolationFn {
+/// The actual typed interpolation callback stored without its component or
+/// bundle type. It only computes an output from sampled values; it does not
+/// access the ECS world or histories.
+pub(crate) struct ErasedInterpolation {
     inner: Box<dyn Any + Send + Sync + 'static>,
 }
 
-impl fmt::Debug for ErasedInterpolationFn {
+impl fmt::Debug for ErasedInterpolation {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str("ErasedInterpolationFn(..)")
+        f.write_str("ErasedInterpolation(..)")
     }
 }
 
-impl ErasedInterpolationFn {
+impl ErasedInterpolation {
     fn from_typed<S: 'static>(interpolation: InterpolationFn<S>) -> Self {
         Self {
             inner: Box::new(interpolation),
@@ -574,19 +557,15 @@ pub(crate) type MatchesArchetypeFn = fn(&Components, &Archetype) -> bool;
 pub(crate) type ErasedUpdateHistoryFn = fn(
     UnsafeWorldCell,
     &Archetype,
-    &InterpolationRegistry,
     &CachedInterpolationComponent,
     &UpdateHistoryContext,
     Option<&mut bevy_replicon::shared::replication::storage::ReplicationStorage>,
     &mut DeferredEntityCommands,
 );
 
-/// Type-erased function that backfills `ConfirmedHistory<C>` for one entity.
-///
-/// This is used when `Interpolated` is added after the replicated component
-/// already exists on the entity. The function is stored with the interpolation
-/// rule that owns `ConfirmedHistory<C>`.
-pub(crate) type ErasedBackfillConfirmedHistoryFn = fn(Entity, &mut Commands);
+/// Type-erased function that initializes `ConfirmedHistory<C>` from an
+/// entity's current replicated value.
+pub(crate) type ErasedInsertConfirmedHistoryFn = fn(Entity, &mut Commands);
 
 /// Context passed to type-erased interpolation apply functions.
 #[derive(Debug, Clone, Copy)]
@@ -597,11 +576,11 @@ pub struct ApplyInterpolationContext {
     pub(crate) tick_duration: Option<Duration>,
 }
 
-/// Type-erased function that applies one selected interpolation rule to one archetype.
+/// Type-erased archetype executor for one selected interpolation rule.
 ///
-/// Component and bundle rules use the same function shape. The cached
-/// archetype stores these after priority and overlap resolution, so the apply
-/// phase only needs to call each function in order.
+/// It fetches history values for every entity, invokes the rule's
+/// [`ErasedInterpolation`], and writes the interpolated live component values.
+/// Component and bundle rules use the same executor shape.
 pub(crate) type ErasedApplyInterpolationFn = fn(
     UnsafeWorldCell,
     &Archetype,
@@ -612,55 +591,33 @@ pub(crate) type ErasedApplyInterpolationFn = fn(
 
 /// Cached typed component metadata needed by the type-erased history updater.
 ///
-/// One value is stored per selected history-owning rule on each cached
-/// interpolated archetype. It lets the update system decide whether the
-/// corresponding live component is currently present on that archetype.
+/// One value is stored per history operation owned by a resolved rule. It lets
+/// the update system initialize a missing history from the current replicated
+/// value or update an existing history. The component IDs and type-erased
+/// callbacks are copied out of the rule when this cache is built, so history
+/// updates do not need the rule or its ID afterward.
 #[derive(Debug, Clone)]
 pub(crate) struct CachedInterpolationComponent {
-    /// Component kind whose history is updated.
-    pub(crate) kind: ComponentKind,
     /// Component ID for `ConfirmedHistory<C>`.
     pub(crate) history_component_id: ComponentId,
-    /// Storage backing `ConfirmedHistory<C>` on the cached archetype.
-    pub(crate) history_storage: StorageType,
+    /// Storage backing `ConfirmedHistory<C>` when it is present.
+    pub(crate) history_storage: Option<StorageType>,
+    /// Whether the history column is present on the cached archetype.
+    pub(crate) history_component_present: bool,
     /// Whether the live component `C` is present on the cached archetype.
     pub(crate) live_component_present: bool,
-    /// ID of the selected rule whose interpolation function samples this history.
-    pub(crate) rule_id: InterpolationRuleId,
     /// Type-erased history update function for `C`.
     pub(crate) update_history: ErasedUpdateHistoryFn,
-}
-
-impl CachedInterpolationComponent {
-    pub(crate) fn kind(&self) -> ComponentKind {
-        self.kind
-    }
-
-    pub(crate) fn history_component_id(&self) -> ComponentId {
-        self.history_component_id
-    }
-
-    pub(crate) fn history_storage(&self) -> StorageType {
-        self.history_storage
-    }
-
-    pub(crate) fn live_component_present(&self) -> bool {
-        self.live_component_present
-    }
-
-    pub(crate) fn rule_id(&self) -> InterpolationRuleId {
-        self.rule_id
-    }
-
-    pub(crate) fn update_history(&self) -> ErasedUpdateHistoryFn {
-        self.update_history
-    }
+    /// Type-erased history initializer for `C`.
+    pub(crate) insert_history: ErasedInsertConfirmedHistoryFn,
 }
 
 /// Cached type-erased apply metadata for one selected interpolation rule.
 ///
-/// Values are stored on [`crate::archetypes::CachedInterpolatedArchetype`]
-/// after rule priority and bundle/component overlap have been resolved.
+/// Values are stored on [`crate::archetypes::CachedInterpolationPolicy`]
+/// after rule priority and bundle/component overlap have been resolved. Apply
+/// keeps the rule ID because the rule's typed interpolation function remains
+/// stored in [`InterpolationRegistry`] and is retrieved when the callback runs.
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct CachedInterpolationApply {
     /// ID of the selected rule whose interpolation function should run.
@@ -669,137 +626,151 @@ pub(crate) struct CachedInterpolationApply {
     pub(crate) apply_interpolation: ErasedApplyInterpolationFn,
 }
 
-impl CachedInterpolationApply {
-    pub(crate) fn rule_id(&self) -> InterpolationRuleId {
-        self.rule_id
-    }
-
-    pub(crate) fn apply_interpolation(&self) -> ErasedApplyInterpolationFn {
-        self.apply_interpolation
-    }
-}
-
-#[derive(Debug)]
-pub(crate) struct ErasedInterpolationFns {
-    pub(crate) interpolation: Option<ErasedInterpolationFn>,
-    pub(crate) update_history: Option<ErasedUpdateHistoryFn>,
-    pub(crate) backfill_confirmed_history: Option<ErasedBackfillConfirmedHistoryFn>,
-    pub(crate) apply_interpolation: Option<ErasedApplyInterpolationFn>,
-    pub(crate) history_component_id: Option<ComponentId>,
-    pub(crate) live_component_id: Option<ComponentId>,
-    pub(crate) write_component_ids: Vec<ComponentId>,
-    pub(crate) frame: Option<FrameInterpolationFns>,
-}
-
-impl ErasedInterpolationFns {
-    pub(crate) fn from_typed<S: 'static>(
-        fns: InterpolationFns<S>,
-        update_history: Option<ErasedUpdateHistoryFn>,
-        backfill_confirmed_history: Option<ErasedBackfillConfirmedHistoryFn>,
-        apply_interpolation: Option<ErasedApplyInterpolationFn>,
-        history_component_id: Option<ComponentId>,
-        live_component_id: Option<ComponentId>,
-        write_component_ids: Vec<ComponentId>,
-        frame: Option<FrameInterpolationFns>,
-    ) -> Self {
-        Self {
-            interpolation: fns
-                .interpolation
-                .map(ErasedInterpolationFn::from_typed::<S>),
-            update_history,
-            backfill_confirmed_history,
-            apply_interpolation,
-            history_component_id,
-            live_component_id,
-            write_component_ids,
-            frame,
-        }
-    }
-}
-
-/// Key used to select between interpolation rules.
-///
-/// A rule kind is the type registered by the user: for a single component this
-/// is `C`, and for bundle interpolation this is the tuple type `(A, B, ...)`.
-/// It is intentionally separate from [`ComponentKind`], which is reserved for
-/// actual ECS component members that a rule reads, writes, or claims during
-/// overlap resolution.
-#[derive(Debug, Eq, Hash, Copy, Clone, PartialEq)]
-pub struct RuleKind(TypeId);
-
-impl RuleKind {
-    #[doc(hidden)]
-    pub fn of<T: 'static>() -> Self {
-        Self(TypeId::of::<T>())
-    }
-}
-
 /// One interpolation rule registered by [`crate::registry::AppInterpolationExt`].
 ///
-/// A rule has a [`RuleKind`] used for cache lookup, a list of real component
-/// `members` it owns or writes, erased functions describing which work
-/// Lightyear owns, and an archetype filter. Rules are sorted by priority per
-/// kind, so
-/// [`InterpolationRegistry::select_rule_for_archetype`] can return the first
-/// matching rule.
+/// A rule has a list of real component `members` it owns or writes, erased
+/// functions describing which work Lightyear owns, and an archetype filter.
+/// Matching rules are sorted by priority before the registry resolves overlap
+/// between component and bundle candidates.
 #[derive(Debug)]
 pub struct InterpolationRule {
-    /// Rule key used when selecting a rule for a component or bundle target.
-    pub(crate) kind: RuleKind,
-    /// Components owned by this rule. Bundle rules have more than one member.
-    pub(crate) members: Vec<ComponentKind>,
+    /// Components owned by this rule, including their history behavior.
+    /// Bundle rules have more than one member.
+    pub(crate) members: Vec<InterpolationRuleComponent>,
     /// Higher-priority rules are selected before lower-priority rules.
     pub(crate) priority: usize,
-    /// Type-erased interpolation/history/apply functions for this rule.
-    pub(crate) fns: ErasedInterpolationFns,
+    /// Type-erased interpolation function for this rule's component or bundle.
+    pub(crate) interpolation: Option<ErasedInterpolation>,
+    /// Type-erased delayed-interpolation apply callback.
+    pub(crate) apply_interpolation: Option<ErasedApplyInterpolationFn>,
+    /// Type-erased frame-interpolation apply callback.
+    pub(crate) apply_frame_interpolation: Option<ErasedApplyFrameInterpolationFn>,
     /// Archetype-level filter predicate compiled from the rule filter type.
     pub(crate) matches_archetype: MatchesArchetypeFn,
+    /// Components whose presence is inspected by the archetype filter.
+    pub(crate) filter_component_ids: Vec<ComponentId>,
 }
 
 impl InterpolationRule {
-    pub(crate) fn owns_history(&self) -> bool {
-        self.fns.update_history.is_some() && self.fns.history_component_id.is_some()
-    }
+    pub(crate) fn new<S, F>(
+        components: &Components,
+        fns: InterpolationFns<S>,
+        members: Vec<InterpolationRuleComponent>,
+        priority: usize,
+        apply_interpolation: Option<ErasedApplyInterpolationFn>,
+        apply_frame_interpolation: Option<ErasedApplyFrameInterpolationFn>,
+    ) -> Self
+    where
+        S: 'static,
+        F: ArchetypeFilter + 'static,
+    {
+        let filter_state = F::get_state(components)
+            .expect("interpolation rule filters should be initialized before registration");
+        let mut filter_access = FilteredAccess::default();
+        F::update_component_access(&filter_state, &mut filter_access);
+        let mut filter_component_ids = Vec::new();
+        for component_id in filter_access
+            .with_filters()
+            .chain(filter_access.without_filters())
+        {
+            if !filter_component_ids.contains(&component_id) {
+                filter_component_ids.push(component_id);
+            }
+        }
 
-    pub(crate) fn applies_component(&self) -> bool {
-        self.fns.apply_interpolation.is_some()
-    }
-
-    pub(crate) fn owns_frame_history(&self) -> bool {
-        self.fns
-            .frame
-            .as_ref()
-            .is_some_and(FrameInterpolationFns::owns_history)
-    }
-
-    pub(crate) fn applies_frame_component(&self) -> bool {
-        self.fns
-            .frame
-            .as_ref()
-            .is_some_and(FrameInterpolationFns::applies_component)
-    }
-
-    pub(crate) fn frame_history_component(&self) -> Option<FrameHistoryComponent> {
-        self.fns
-            .frame
-            .as_ref()
-            .and_then(|frame| frame.history_component(*self.members.first()?))
+        Self {
+            members,
+            priority,
+            interpolation: fns.interpolation.map(ErasedInterpolation::from_typed::<S>),
+            apply_interpolation,
+            apply_frame_interpolation,
+            matches_archetype: matches_filter::<F>,
+            filter_component_ids,
+        }
     }
 
     #[doc(hidden)]
-    pub fn members(&self) -> &[ComponentKind] {
-        &self.members
+    pub fn members(&self) -> impl Iterator<Item = ComponentKind> + '_ {
+        self.members.iter().map(|member| member.kind)
     }
 
+    /// Builds cached frame-apply metadata for this rule.
     #[doc(hidden)]
-    pub fn priority(&self) -> usize {
-        self.priority
+    pub fn cached_frame_apply(
+        &self,
+        rule_id: InterpolationRuleId,
+    ) -> Option<CachedFrameInterpolationApply> {
+        Some(CachedFrameInterpolationApply {
+            rule_id,
+            apply_frame_interpolation: self.apply_frame_interpolation?,
+        })
     }
+
+    /// Returns the frame-history operations owned by this rule that are
+    /// relevant to `archetype`.
+    #[doc(hidden)]
+    pub fn cached_frame_history_components<'a>(
+        &'a self,
+        archetype: &'a Archetype,
+    ) -> impl Iterator<Item = CachedFrameInterpolationHistoryComponent> + 'a {
+        self.members.iter().filter_map(move |member| {
+            let frame = member.frame?;
+            let history_component_id = member.frame_history_component_id;
+            let live_component_id = member.live_component_id;
+            let history_component_present = archetype.contains(history_component_id);
+            let live_component_present = archetype.contains(live_component_id);
+            if !history_component_present && !live_component_present {
+                return None;
+            }
+            Some(CachedFrameInterpolationHistoryComponent {
+                kind: member.kind,
+                history_component_id,
+                history_storage: history_component_present
+                    .then(|| archetype.get_storage_type(history_component_id))
+                    .flatten(),
+                history_component_present,
+                live_component_id,
+                live_component_present,
+                update_frame_history: frame.update_history,
+                restore_frame_history: frame.restore_history,
+            })
+        })
+    }
+}
+
+/// One component owned by an interpolation rule.
+///
+/// The history callbacks live on the member instead of in a separate global
+/// provider catalog. Each selected rule therefore carries the history behavior
+/// needed to initialize and maintain its members as well as its apply behavior.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct InterpolationRuleComponent {
+    /// Type identity used to prevent rules from claiming the same member.
+    pub(crate) kind: ComponentKind,
+    /// Bevy component IDs whose presence can make this member available.
+    pub(crate) live_component_id: ComponentId,
+    pub(crate) confirmed_history_component_id: ComponentId,
+    pub(crate) frame_history_component_id: ComponentId,
+    /// History behavior owned by this rule, independently of the IDs above.
+    pub(crate) confirmed: Option<ConfirmedHistoryFns>,
+    pub(crate) frame: Option<FrameHistoryFns>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct ConfirmedHistoryFns {
+    pub(crate) update_history: ErasedUpdateHistoryFn,
+    pub(crate) insert_history: ErasedInsertConfirmedHistoryFn,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct FrameHistoryFns {
+    pub(crate) update_history: ErasedUpdateFrameHistoryFn,
+    pub(crate) restore_history: ErasedRestoreFrameHistoryFn,
 }
 
 pub(crate) fn matches_filter<F>(components: &Components, archetype: &Archetype) -> bool
 where
-    F: QueryFilter + 'static,
+    F: ArchetypeFilter + 'static,
 {
     F::get_state(components)
         .is_some_and(|state| F::matches_component_set(&state, &|id| archetype.contains(id)))

--- a/crates/replication/interpolation/src/rules/bundle.rs
+++ b/crates/replication/interpolation/src/rules/bundle.rs
@@ -9,30 +9,29 @@ use super::{
     InterpolationSampleContext,
 };
 use crate::SyncComponent;
-use crate::interpolate::present_history_bracket;
+use crate::interpolate::history_bracket;
 use crate::registry::{
-    InterpolationRegistry, add_interpolation_bundle_rule, add_interpolation_rule, mark_interpolated,
+    InterpolationRegistry, add_interpolation_bundle_rule, interpolation_rule_member,
 };
+use crate::rules::InterpolationRuleComponent;
 use crate::rules::frame_interpolate::FrameInterpolationContext;
 use alloc::vec::Vec;
 use bevy_app::App;
 use bevy_ecs::archetype::Archetype;
-use bevy_ecs::component::ComponentId;
-use bevy_ecs::query::QueryFilter;
+use bevy_ecs::query::ArchetypeFilter;
 use bevy_ecs::world::unsafe_world_cell::UnsafeWorldCell;
 use bevy_utils::prelude::DebugName;
 use lightyear_core::ecs_utils::{table_for_archetype, write_component_with_change_detection};
-use lightyear_core::prelude::{ConfirmedHistory, FrameInterpolationHistory};
-use lightyear_replication::deferred_entity::DeferredEntityCommands;
-use lightyear_replication::registry::ComponentKind;
+use lightyear_core::history_buffer::HistoryState;
+use lightyear_core::prelude::{ConfirmedHistory, FrameInterpolationHistory, Tick};
 use tracing::trace;
 
 /// Tuple of components that can be interpolated by one rule.
 ///
 /// Tuple interpolation stores each component in its own history, samples every
-/// history at the same interpolation tick, and only runs the tuple
-/// interpolation function when all member histories have the same bracketing
-/// start and end ticks.
+/// history at shared ticks around the interpolation tick. Members without an
+/// update at a shared tick carry their latest present value forward, so tuple
+/// interpolation does not require identical per-component history entries.
 ///
 /// Lightyear implements this trait for tuples of 2 to 8 distinct
 /// [`SyncComponent`] types.
@@ -79,20 +78,57 @@ pub trait InterpolationBundle: private::Sealed + 'static {
     fn add_rule<F>(app: &mut App, fns: InterpolationFns<Self>, config: InterpolationRuleConfig)
     where
         Self: Sized,
-        F: QueryFilter + 'static;
+        F: ArchetypeFilter + 'static;
 }
 
 mod private {
     pub trait Sealed {}
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct PresentHistoryBracket {
+    start_tick: Tick,
+    end_tick: Option<Tick>,
+}
+
+impl PresentHistoryBracket {
+    fn intersection(self, other: Self) -> Self {
+        Self {
+            start_tick: self.start_tick.max(other.start_tick),
+            end_tick: match (self.end_tick, other.end_tick) {
+                (Some(first), Some(second)) => Some(first.min(second)),
+                (Some(tick), None) | (None, Some(tick)) => Some(tick),
+                (None, None) => None,
+            },
+        }
+    }
+}
+
+fn present_history_bracket<C>(
+    history: &ConfirmedHistory<C>,
+    interpolation_tick: Tick,
+) -> Option<PresentHistoryBracket> {
+    let bracket = history_bracket(history, interpolation_tick)?;
+    bracket.start_state.value()?;
+    Some(PresentHistoryBracket {
+        start_tick: bracket.start_tick,
+        end_tick: bracket.end.map(|(tick, _)| tick),
+    })
+}
+
+/// Returns a present bundle endpoint value at `tick`.
+///
+/// If `tick` is a removal boundary, the preceding value is returned so the
+/// bundle remains continuous until the presence pass removes the component.
+fn present_history_value_at<C>(history: &ConfirmedHistory<C>, tick: Tick) -> Option<&C> {
+    match history.get_state_at(tick) {
+        Some(HistoryState::Updated(value)) => Some(value),
+        Some(HistoryState::Removed) => history.get_state_before(tick)?.value(),
+        None => history.get_state_at_or_before(tick)?.value(),
+    }
+}
+
 pub(crate) trait TupleInterpolationBundle: InterpolationBundle {
-    /// Component kinds written by the tuple interpolation apply system.
-    fn component_kinds() -> Vec<ComponentKind>;
-
-    /// Registers and returns component IDs for the live components written by the tuple.
-    fn component_ids(app: &mut App) -> Vec<ComponentId>;
-
     /// Applies interpolation for one cached archetype that selected this rule.
     fn apply_archetype(
         world: UnsafeWorldCell,
@@ -110,19 +146,14 @@ pub(crate) trait TupleInterpolationBundle: InterpolationBundle {
         rule_id: InterpolationRuleId,
         ctx: FrameInterpolationContext,
         skip_interpolation: bool,
-        deferred_apply: &mut DeferredEntityCommands,
     );
 
-    /// Adds per-component history rules for every component in the bundle.
-    fn add_history_rules<F>(
+    /// Builds the self-contained component members stored by the bundle rule.
+    fn rule_members(
         app: &mut App,
-        config: InterpolationRuleConfig,
         include_interpolation_history: bool,
-    ) where
-        F: QueryFilter + 'static;
-
-    /// Marks every member component as interpolated in Lightyear's component registry.
-    fn mark_interpolated(app: &mut App);
+        include_frame_history: bool,
+    ) -> Vec<InterpolationRuleComponent>;
 }
 
 macro_rules! impl_interpolation_bundle {
@@ -130,24 +161,16 @@ macro_rules! impl_interpolation_bundle {
         $N:tt,
         (
             $C0:ident,
-            $component0:ident,
             $history0:ident,
-            $start_tick0:ident,
             $start0:ident,
-            $end0:ident,
-            $end_tick0:ident,
             $end_value0:ident,
             $output0:ident
         ),
         $(
             (
                 $C:ident,
-                $component:ident,
                 $history:ident,
-                $start_tick:ident,
                 $start:ident,
-                $end:ident,
-                $end_tick:ident,
                 $end_value:ident,
                 $output:ident
             )
@@ -173,7 +196,7 @@ macro_rules! impl_interpolation_bundle {
                 config: InterpolationRuleConfig,
             )
             where
-                F: QueryFilter + 'static,
+                F: ArchetypeFilter + 'static,
             {
                 add_interpolation_bundle_rule::<Self, F>(app, fns, config);
             }
@@ -184,17 +207,6 @@ macro_rules! impl_interpolation_bundle {
             $C0: SyncComponent,
             $($C: SyncComponent),+
         {
-            fn component_kinds() -> Vec<ComponentKind> {
-                alloc::vec![ComponentKind::of::<$C0>(), $(ComponentKind::of::<$C>()),+]
-            }
-
-            fn component_ids(app: &mut App) -> Vec<ComponentId> {
-                alloc::vec![
-                    app.world_mut().register_component::<$C0>(),
-                    $(app.world_mut().register_component::<$C>()),+
-                ]
-            }
-
             fn apply_archetype(
                 world: UnsafeWorldCell,
                 archetype: &Archetype,
@@ -226,52 +238,74 @@ macro_rules! impl_interpolation_bundle {
                 )+
 
                 let interpolation =
-                    interpolation_registry.interpolation_for_rule::<($C0, $($C,)+)>(rule_id);
+                    interpolation_registry.interpolation_fn_for_rule::<($C0, $($C,)+)>(rule_id);
                 for entity in archetype.entities() {
                     let row = entity.table_row().index();
                     let $history0 = unsafe { &*$history0.get_unchecked(row).get() };
-                    let Some(($start_tick0, $start0, $end0)) = ({
+                    let Some(mut shared_bracket) = ({
                         present_history_bracket($history0, ctx.interpolation_tick)
                     }) else {
                         continue;
                     };
                     $(
                         let $history = unsafe { &*$history.get_unchecked(row).get() };
-                        let Some(($start_tick, $start, $end)) = ({
-                            present_history_bracket($history, ctx.interpolation_tick)
-                        }) else {
+                        shared_bracket = match present_history_bracket(
+                            $history,
+                            ctx.interpolation_tick,
+                        ) {
+                            Some(bracket) => shared_bracket.intersection(bracket),
+                            None => continue,
+                        };
+                    )+
+                    // Bundle members may have different immediate brackets
+                    // when replication omits unchanged components. Use the
+                    // intersection around the interpolation tick: the latest
+                    // member start and the earliest available member end. A
+                    // member without an entry at either shared tick carries
+                    // its latest present value forward.
+                    let Some($start0) = present_history_value_at(
+                        $history0,
+                        shared_bracket.start_tick,
+                    ).cloned() else {
+                        continue;
+                    };
+                    $(
+                        let Some($start) = present_history_value_at(
+                            $history,
+                            shared_bracket.start_tick,
+                        ).cloned() else {
                             continue;
                         };
                     )+
-                    if false $(|| $start_tick0 != $start_tick)+ {
-                        continue;
-                    }
 
-                    let interpolated = match ($end0, $($end,)+) {
-                        (
-                            Some(($end_tick0, $end_value0)),
-                            $(Some(($end_tick, $end_value)),)+
-                        ) if true $(&& $end_tick0 == $end_tick)+ => {
-                            if let Some(interpolation) = interpolation {
-                                interpolation.interpolate(
-                                    ($start0, $($start,)+),
-                                    ($end_value0, $($end_value,)+),
-                                    InterpolationSampleContext::from_ticks(
-                                        $start_tick0,
-                                        $end_tick0,
-                                        ctx.interpolation_tick,
-                                        ctx.interpolation_overstep,
-                                        ctx.tick_duration,
-                                    ),
-                                )
-                            } else {
-                                ($start0, $($start,)+)
-                            }
-                        }
-                        ($end0, $($end,)+) if $end0.is_none() $(&& $end.is_none())+ => {
-                            ($start0, $($start,)+)
-                        }
-                        _ => continue,
+                    let interpolated = if let Some(shared_end_tick) = shared_bracket.end_tick {
+                        let Some($end_value0) = present_history_value_at(
+                            $history0,
+                            shared_end_tick,
+                        ).cloned() else {
+                            continue;
+                        };
+                        $(
+                            let Some($end_value) = present_history_value_at(
+                                $history,
+                                shared_end_tick,
+                            ).cloned() else {
+                                continue;
+                            };
+                        )+
+                        interpolation.interpolate(
+                            ($start0, $($start,)+),
+                            ($end_value0, $($end_value,)+),
+                            InterpolationSampleContext::from_ticks(
+                                shared_bracket.start_tick,
+                                shared_end_tick,
+                                ctx.interpolation_tick,
+                                ctx.interpolation_overstep,
+                                ctx.tick_duration,
+                            ),
+                        )
+                    } else {
+                        ($start0, $($start,)+)
                     };
 
                     let ($output0, $($output,)+) = interpolated;
@@ -305,7 +339,6 @@ macro_rules! impl_interpolation_bundle {
                 rule_id: InterpolationRuleId,
                 ctx: FrameInterpolationContext,
                 skip_interpolation: bool,
-                deferred_apply: &mut DeferredEntityCommands,
             ) {
                 let Some(table) = table_for_archetype(world, archetype) else {
                     return;
@@ -329,16 +362,8 @@ macro_rules! impl_interpolation_bundle {
                         return;
                     };
                 )+
-                let $component0 = components
-                    .component_id::<$C0>()
-                    .is_some_and(|component_id| archetype.contains(component_id));
-                $(
-                    let $component = components
-                        .component_id::<$C>()
-                        .is_some_and(|component_id| archetype.contains(component_id));
-                )+
                 let interpolation =
-                    interpolation_registry.interpolation_for_rule::<($C0, $($C,)+)>(rule_id);
+                    interpolation_registry.interpolation_fn_for_rule::<($C0, $($C,)+)>(rule_id);
                 for entity in archetype.entities() {
                     let row = entity.table_row().index();
                     let $history0 = unsafe { &mut *$history0.get_unchecked(row).get() };
@@ -368,10 +393,9 @@ macro_rules! impl_interpolation_bundle {
                             $history.previous_value = Some($end_value.clone());
                         )+
                         ($end_value0, $($end_value,)+)
-                    } else if let (Some($start0), $(Some($start),)+ Some(interpolation)) = (
+                    } else if let (Some($start0), $(Some($start),)+) = (
                         $history0.previous_value.clone(),
                         $($history.previous_value.clone(),)+
-                        interpolation,
                     ) {
                         interpolation.interpolate(
                             ($start0, $($start,)+),
@@ -388,77 +412,55 @@ macro_rules! impl_interpolation_bundle {
                     };
 
                     let ($output0, $($output,)+) = interpolated;
-                    // SAFETY: the erased frame-interpolation system declares
-                    // write access to every bundle member, and no references
-                    // to their live values are held while these writes occur.
-                    if $component0 {
-                        // SAFETY: explained above. Component presence was
-                        // resolved from the cached archetype.
-                        unsafe {
-                            write_component_with_change_detection::<$C0>(
-                                world,
-                                entity.id(),
-                                $output0,
-                            );
-                        }
-                    } else {
-                        deferred_apply.insert(entity.id(), $output0);
-                    }
+                    // SAFETY: apply ownership guarantees that this archetype
+                    // contains every bundle member, the erased system declares
+                    // write access to them, and no references to their live
+                    // values are held while these writes occur.
+                    let written = unsafe {
+                        write_component_with_change_detection::<$C0>(
+                            world,
+                            entity.id(),
+                            $output0,
+                        )
+                    };
+                    debug_assert!(
+                        written,
+                        "frame interpolation apply ownership requires every bundle member"
+                    );
                     $(
                         // SAFETY: same as for the first bundle member above.
-                        if $component {
-                            unsafe {
-                                write_component_with_change_detection::<$C>(
-                                    world,
-                                    entity.id(),
-                                    $output,
-                                );
-                            }
-                        } else {
-                            deferred_apply.insert(entity.id(), $output);
-                        }
+                        let written = unsafe {
+                            write_component_with_change_detection::<$C>(
+                                world,
+                                entity.id(),
+                                $output,
+                            )
+                        };
+                        debug_assert!(
+                            written,
+                            "frame interpolation apply ownership requires every bundle member"
+                        );
                     )+
                 }
             }
 
-            fn add_history_rules<F>(
+            fn rule_members(
                 app: &mut App,
-                config: InterpolationRuleConfig,
                 include_interpolation_history: bool,
-            )
-            where
-                F: QueryFilter + 'static,
-            {
-                // Bundle rules store each member component in its own history.
-                // For `no_history` bundle rules we still need synthetic
-                // per-member frame-history rules so FrameInterpolate can reuse
-                // the tuple interpolation function without also creating
-                // delayed-interpolation `ConfirmedHistory<C>` state.
-                add_interpolation_rule::<$C0, F>(
-                    app,
-                    if include_interpolation_history {
-                        InterpolationFns::history_only()
-                    } else {
-                        InterpolationFns::frame_history_only()
-                    },
-                    config,
-                );
-                $(
-                    add_interpolation_rule::<$C, F>(
+                include_frame_history: bool,
+            ) -> Vec<InterpolationRuleComponent> {
+                alloc::vec![
+                    interpolation_rule_member::<$C0>(
                         app,
-                        if include_interpolation_history {
-                            InterpolationFns::history_only()
-                        } else {
-                            InterpolationFns::frame_history_only()
-                        },
-                        config,
-                    );
-                )+
-            }
-
-            fn mark_interpolated(app: &mut App) {
-                mark_interpolated::<$C0>(app);
-                $(mark_interpolated::<$C>(app);)+
+                        include_interpolation_history,
+                        include_frame_history,
+                    ),
+                    $(interpolation_rule_member::<$C>(
+                        app,
+                        include_interpolation_history,
+                        include_frame_history,
+                    )),+
+                ]
             }
         }
     };
@@ -469,12 +471,197 @@ variadics_please::all_tuples_with_size!(
     2,
     8,
     C,
-    component,
     history,
-    start_tick,
     start,
-    end,
-    end_tick,
     end_value,
     output
 );
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bevy_ecs::prelude::Component;
+
+    #[derive(Component, Clone, Debug, PartialEq)]
+    struct Value(f32);
+
+    #[derive(Clone, Copy)]
+    enum Entry {
+        Present(f32),
+        Removed,
+        Unchanged,
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct SampledBracket {
+        bracket: PresentHistoryBracket,
+        start: (Value, Value),
+        end: Option<(Value, Value)>,
+    }
+
+    struct Case {
+        name: &'static str,
+        first: &'static [(u32, Entry)],
+        second: &'static [(u32, Entry)],
+        interpolation_tick: u32,
+        expected: Option<SampledBracket>,
+    }
+
+    fn history(entries: &[(u32, Entry)]) -> ConfirmedHistory<Value> {
+        let mut history = ConfirmedHistory::default();
+        for &(tick, entry) in entries {
+            match entry {
+                Entry::Present(value) => history.insert_present(Tick(tick), Value(value)),
+                Entry::Removed => history.insert_removed(Tick(tick)),
+                Entry::Unchanged => {
+                    assert!(history.add_unchanged(Tick(tick)));
+                }
+            }
+        }
+        history
+    }
+
+    fn sample_pair(
+        first: &ConfirmedHistory<Value>,
+        second: &ConfirmedHistory<Value>,
+        interpolation_tick: Tick,
+    ) -> Option<SampledBracket> {
+        let bracket = present_history_bracket(first, interpolation_tick)?
+            .intersection(present_history_bracket(second, interpolation_tick)?);
+        let start = (
+            present_history_value_at(first, bracket.start_tick)?.clone(),
+            present_history_value_at(second, bracket.start_tick)?.clone(),
+        );
+        let end = match bracket.end_tick {
+            Some(end_tick) => Some((
+                present_history_value_at(first, end_tick)?.clone(),
+                present_history_value_at(second, end_tick)?.clone(),
+            )),
+            None => None,
+        };
+        Some(SampledBracket {
+            bracket,
+            start,
+            end,
+        })
+    }
+
+    /// Checks shared bundle brackets across mismatched, unchanged, removed, and open histories.
+    #[test]
+    fn shared_present_history_bracket_cases() {
+        let cases = [
+            Case {
+                name: "different immediate start and end ticks",
+                first: &[(10, Entry::Present(1.0)), (30, Entry::Present(3.0))],
+                second: &[(15, Entry::Present(10.0)), (20, Entry::Present(20.0))],
+                interpolation_tick: 17,
+                expected: Some(SampledBracket {
+                    bracket: PresentHistoryBracket {
+                        start_tick: Tick(15),
+                        end_tick: Some(Tick(20)),
+                    },
+                    start: (Value(1.0), Value(10.0)),
+                    end: Some((Value(1.0), Value(20.0))),
+                }),
+            },
+            Case {
+                name: "one member has no future entry",
+                first: &[(10, Entry::Present(0.0)), (20, Entry::Present(10.0))],
+                second: &[(10, Entry::Present(7.0))],
+                interpolation_tick: 15,
+                expected: Some(SampledBracket {
+                    bracket: PresentHistoryBracket {
+                        start_tick: Tick(10),
+                        end_tick: Some(Tick(20)),
+                    },
+                    start: (Value(0.0), Value(7.0)),
+                    end: Some((Value(10.0), Value(7.0))),
+                }),
+            },
+            Case {
+                name: "removal is a constant present endpoint",
+                first: &[(10, Entry::Present(0.0)), (20, Entry::Present(10.0))],
+                second: &[(10, Entry::Present(3.0)), (20, Entry::Removed)],
+                interpolation_tick: 15,
+                expected: Some(SampledBracket {
+                    bracket: PresentHistoryBracket {
+                        start_tick: Tick(10),
+                        end_tick: Some(Tick(20)),
+                    },
+                    start: (Value(0.0), Value(3.0)),
+                    end: Some((Value(10.0), Value(3.0))),
+                }),
+            },
+            Case {
+                name: "both members have no future entry",
+                first: &[(10, Entry::Present(2.0))],
+                second: &[(5, Entry::Present(4.0))],
+                interpolation_tick: 15,
+                expected: Some(SampledBracket {
+                    bracket: PresentHistoryBracket {
+                        start_tick: Tick(10),
+                        end_tick: None,
+                    },
+                    start: (Value(2.0), Value(4.0)),
+                    end: None,
+                }),
+            },
+            Case {
+                name: "member is removed at the interpolation tick",
+                first: &[(10, Entry::Present(0.0)), (20, Entry::Present(10.0))],
+                second: &[(10, Entry::Present(3.0)), (20, Entry::Removed)],
+                interpolation_tick: 20,
+                expected: None,
+            },
+            Case {
+                name: "member is present again at its reinsertion tick",
+                first: &[(10, Entry::Present(0.0)), (30, Entry::Present(20.0))],
+                second: &[
+                    (10, Entry::Removed),
+                    (20, Entry::Present(4.0)),
+                    (30, Entry::Present(8.0)),
+                ],
+                interpolation_tick: 20,
+                expected: Some(SampledBracket {
+                    bracket: PresentHistoryBracket {
+                        start_tick: Tick(20),
+                        end_tick: Some(Tick(30)),
+                    },
+                    start: (Value(0.0), Value(4.0)),
+                    end: Some((Value(20.0), Value(8.0))),
+                }),
+            },
+            Case {
+                name: "unchanged member carries across the other member's endpoint",
+                first: &[(10, Entry::Present(3.0)), (20, Entry::Unchanged)],
+                second: &[
+                    (10, Entry::Present(0.0)),
+                    (15, Entry::Present(10.0)),
+                    (20, Entry::Unchanged),
+                ],
+                interpolation_tick: 12,
+                expected: Some(SampledBracket {
+                    bracket: PresentHistoryBracket {
+                        start_tick: Tick(10),
+                        end_tick: Some(Tick(15)),
+                    },
+                    start: (Value(3.0), Value(0.0)),
+                    end: Some((Value(3.0), Value(10.0))),
+                }),
+            },
+        ];
+
+        for case in cases {
+            assert_eq!(
+                sample_pair(
+                    &history(case.first),
+                    &history(case.second),
+                    Tick(case.interpolation_tick),
+                ),
+                case.expected,
+                "{}",
+                case.name,
+            );
+        }
+    }
+}

--- a/crates/replication/interpolation/src/rules/frame_interpolate.rs
+++ b/crates/replication/interpolation/src/rules/frame_interpolate.rs
@@ -1,15 +1,13 @@
 //! Frame-interpolation callbacks backed by shared interpolation rules.
 //!
-//! The frame-interpolation crate uses these erased helpers when selecting the
-//! highest-priority interpolation rule for entities with `FrameInterpolate`.
+//! The frame-interpolation crate uses these erased helpers after independently
+//! resolving history and apply ownership for entities with `FrameInterpolate`.
 
 use crate::SyncComponent;
 use crate::registry::InterpolationRegistry;
 use crate::rules::{InterpolationRuleId, InterpolationSampleContext};
-use alloc::vec::Vec;
 use bevy_ecs::archetype::Archetype;
 use bevy_ecs::component::{ComponentId, StorageType};
-use bevy_ecs::prelude::{Commands, Entity};
 use bevy_ecs::world::unsafe_world_cell::UnsafeWorldCell;
 use bevy_utils::prelude::DebugName;
 use lightyear_core::ecs_utils::{
@@ -36,14 +34,14 @@ pub struct FrameInterpolationContext {
 pub type ErasedUpdateFrameHistoryFn = fn(
     UnsafeWorldCell,
     &Archetype,
-    &CachedFrameInterpolationComponent,
+    &CachedFrameInterpolationHistoryComponent,
     &mut DeferredEntityCommands,
 );
 
 /// Type-erased function that restores one component from its frame interpolation history.
 #[doc(hidden)]
 pub type ErasedRestoreFrameHistoryFn =
-    fn(UnsafeWorldCell, &Archetype, &CachedFrameInterpolationComponent);
+    fn(UnsafeWorldCell, &Archetype, &CachedFrameInterpolationHistoryComponent);
 
 /// Type-erased function that applies one selected frame interpolation rule.
 #[doc(hidden)]
@@ -54,61 +52,14 @@ pub type ErasedApplyFrameInterpolationFn = fn(
     InterpolationRuleId,
     FrameInterpolationContext,
     bool,
-    &mut DeferredEntityCommands,
 );
 
-/// Type-erased function that inserts a default `FrameInterpolationHistory<C>`.
-#[doc(hidden)]
-pub type ErasedInsertFrameHistoryFn = fn(Entity, &mut Commands);
-
-/// Type-erased metadata for a component that owns frame interpolation history.
-#[derive(Debug, Clone, Copy)]
-pub struct FrameHistoryComponent {
-    kind: ComponentKind,
-    live_component_id: ComponentId,
-    history_component_id: ComponentId,
-    insert_history: ErasedInsertFrameHistoryFn,
-}
-
-impl FrameHistoryComponent {
-    pub(crate) fn new(
-        kind: ComponentKind,
-        live_component_id: ComponentId,
-        history_component_id: ComponentId,
-        insert_history: ErasedInsertFrameHistoryFn,
-    ) -> Self {
-        Self {
-            kind,
-            live_component_id,
-            history_component_id,
-            insert_history,
-        }
-    }
-
-    #[doc(hidden)]
-    pub fn kind(&self) -> ComponentKind {
-        self.kind
-    }
-
-    #[doc(hidden)]
-    pub fn live_component_id(&self) -> ComponentId {
-        self.live_component_id
-    }
-
-    #[doc(hidden)]
-    pub fn history_component_id(&self) -> ComponentId {
-        self.history_component_id
-    }
-
-    #[doc(hidden)]
-    pub fn insert_history(&self) -> ErasedInsertFrameHistoryFn {
-        self.insert_history
-    }
-}
-
 /// Cached typed component metadata needed by frame interpolation history systems.
+///
+/// The component IDs and type-erased callbacks are copied out of the selected
+/// rule, so frame-history update and restore do not need the rule or its ID.
 #[derive(Debug, Clone, Copy)]
-pub struct CachedFrameInterpolationComponent {
+pub struct CachedFrameInterpolationHistoryComponent {
     /// Component kind whose frame history is updated.
     pub(crate) kind: ComponentKind,
     /// Component ID for `FrameInterpolationHistory<C>`.
@@ -127,7 +78,7 @@ pub struct CachedFrameInterpolationComponent {
     pub(crate) restore_frame_history: ErasedRestoreFrameHistoryFn,
 }
 
-impl CachedFrameInterpolationComponent {
+impl CachedFrameInterpolationHistoryComponent {
     #[doc(hidden)]
     pub fn kind(&self) -> ComponentKind {
         self.kind
@@ -170,6 +121,9 @@ impl CachedFrameInterpolationComponent {
 }
 
 /// Cached type-erased apply metadata for one selected frame interpolation rule.
+///
+/// Apply keeps the rule ID because the rule's typed interpolation function
+/// remains stored in [`InterpolationRegistry`] and is retrieved at runtime.
 #[derive(Debug, Clone, Copy)]
 pub struct CachedFrameInterpolationApply {
     /// ID of the selected rule whose interpolation function should run.
@@ -190,82 +144,6 @@ impl CachedFrameInterpolationApply {
     }
 }
 
-/// Type-erased functions and component access used by frame interpolation.
-///
-/// This is stored as a single optional value on
-/// [`crate::rules::ErasedInterpolationFns`] so frame-specific state is kept
-/// together. The presence of the history and apply callbacks determines which
-/// frame work the rule owns.
-#[derive(Debug, Clone)]
-pub(crate) struct FrameInterpolationFns {
-    pub(crate) history_component_id: Option<ComponentId>,
-    pub(crate) live_component_id: Option<ComponentId>,
-    pub(crate) write_component_ids: Vec<ComponentId>,
-    pub(crate) insert_history: Option<ErasedInsertFrameHistoryFn>,
-    pub(crate) update_history: Option<ErasedUpdateFrameHistoryFn>,
-    pub(crate) restore_history: Option<ErasedRestoreFrameHistoryFn>,
-    pub(crate) apply_interpolation: Option<ErasedApplyFrameInterpolationFn>,
-}
-
-impl FrameInterpolationFns {
-    pub(crate) fn new(
-        history_component_id: Option<ComponentId>,
-        live_component_id: Option<ComponentId>,
-        write_component_ids: Vec<ComponentId>,
-        insert_history: Option<ErasedInsertFrameHistoryFn>,
-        update_history: Option<ErasedUpdateFrameHistoryFn>,
-        restore_history: Option<ErasedRestoreFrameHistoryFn>,
-        apply_interpolation: Option<ErasedApplyFrameInterpolationFn>,
-    ) -> Option<Self> {
-        (history_component_id.is_some()
-            || live_component_id.is_some()
-            || !write_component_ids.is_empty()
-            || insert_history.is_some()
-            || update_history.is_some()
-            || restore_history.is_some()
-            || apply_interpolation.is_some())
-        .then_some(Self {
-            history_component_id,
-            live_component_id,
-            write_component_ids,
-            insert_history,
-            update_history,
-            restore_history,
-            apply_interpolation,
-        })
-    }
-
-    pub(crate) fn owns_history(&self) -> bool {
-        self.history_component_id.is_some()
-            && self.update_history.is_some()
-            && self.restore_history.is_some()
-    }
-
-    pub(crate) fn applies_component(&self) -> bool {
-        self.apply_interpolation.is_some()
-    }
-
-    pub(crate) fn history_component(&self, kind: ComponentKind) -> Option<FrameHistoryComponent> {
-        self.owns_history().then(|| {
-            FrameHistoryComponent::new(
-                kind,
-                self.live_component_id
-                    .expect("frame history requires live component id"),
-                self.history_component_id
-                    .expect("frame history requires history component id"),
-                self.insert_history
-                    .expect("frame history requires insert function"),
-            )
-        })
-    }
-}
-
-pub(crate) fn insert_frame_history<C: SyncComponent>(entity: Entity, commands: &mut Commands) {
-    commands
-        .entity(entity)
-        .try_insert(FrameInterpolationHistory::<C>::default());
-}
-
 /// Records each entity's live `C` into `FrameInterpolationHistory<C>`.
 ///
 /// This runs after fixed updates so `current_value` is the latest fixed-tick
@@ -273,7 +151,7 @@ pub(crate) fn insert_frame_history<C: SyncComponent>(entity: Entity, commands: &
 pub(crate) fn update_frame_history_archetype_erased<C: SyncComponent>(
     world: UnsafeWorldCell,
     archetype: &Archetype,
-    component: &CachedFrameInterpolationComponent,
+    component: &CachedFrameInterpolationHistoryComponent,
     deferred_apply: &mut DeferredEntityCommands,
 ) {
     if !component.live_component_present() {
@@ -363,7 +241,7 @@ pub(crate) fn update_frame_history_archetype_erased<C: SyncComponent>(
 pub(crate) fn restore_frame_history_archetype_erased<C: SyncComponent>(
     world: UnsafeWorldCell,
     archetype: &Archetype,
-    component: &CachedFrameInterpolationComponent,
+    component: &CachedFrameInterpolationHistoryComponent,
 ) {
     if !component.history_component_present() || !component.live_component_present() {
         return;
@@ -407,8 +285,7 @@ pub(crate) fn restore_frame_history_archetype_erased<C: SyncComponent>(
 
 /// Applies the selected interpolation rule to live `C` for one archetype.
 ///
-/// Missing live components are inserted through deferred commands; existing
-/// components are updated through Bevy's change-detecting mutable access.
+/// Apply ownership guarantees that `C` is present on this archetype.
 pub(crate) fn apply_frame_interpolation_archetype_erased<C: SyncComponent>(
     world: UnsafeWorldCell,
     archetype: &Archetype,
@@ -416,7 +293,6 @@ pub(crate) fn apply_frame_interpolation_archetype_erased<C: SyncComponent>(
     rule_id: InterpolationRuleId,
     ctx: FrameInterpolationContext,
     skip_interpolation: bool,
-    deferred_apply: &mut DeferredEntityCommands,
 ) {
     let Some(history_component_id) = world
         .components()
@@ -438,12 +314,7 @@ pub(crate) fn apply_frame_interpolation_archetype_erased<C: SyncComponent>(
     else {
         return;
     };
-    let live_component_present = world
-        .components()
-        .component_id::<C>()
-        .is_some_and(|component_id| archetype.contains(component_id));
-
-    let interpolation = interpolation_registry.interpolation_for_rule::<C>(rule_id);
+    let interpolation = interpolation_registry.interpolation_fn_for_rule::<C>(rule_id);
     for entity in archetype.entities() {
         let row = entity.table_row().index();
         let history = unsafe { &mut *histories.get_unchecked(row).get() };
@@ -463,9 +334,7 @@ pub(crate) fn apply_frame_interpolation_archetype_erased<C: SyncComponent>(
             );
             history.previous_value = Some(current_value.clone());
             current_value
-        } else if let (Some(previous_value), Some(interpolation)) =
-            (&history.previous_value, interpolation)
-        {
+        } else if let Some(previous_value) = &history.previous_value {
             interpolation.interpolate(
                 previous_value.clone(),
                 current_value,
@@ -489,14 +358,14 @@ pub(crate) fn apply_frame_interpolation_archetype_erased<C: SyncComponent>(
             overstep = ctx.overstep,
             "applied frame interpolation"
         );
-        if live_component_present {
-            // SAFETY: this erased system declares write access to C, and the
-            // only other live reference here is to FrameInterpolationHistory<C>.
-            unsafe {
-                write_component_with_change_detection::<C>(world, entity.id(), interpolated);
-            }
-        } else {
-            deferred_apply.insert(entity.id(), interpolated);
-        }
+        // SAFETY: apply ownership guarantees that this archetype contains C,
+        // the erased system declares write access to C, and the only other live
+        // reference here is to FrameInterpolationHistory<C>.
+        let written =
+            unsafe { write_component_with_change_detection::<C>(world, entity.id(), interpolated) };
+        debug_assert!(
+            written,
+            "frame interpolation apply ownership requires every live component"
+        );
     }
 }

--- a/crates/replication/prediction/src/correction.rs
+++ b/crates/replication/prediction/src/correction.rs
@@ -51,6 +51,36 @@
 //!   by the rule back to the corrected simulation value from
 //!   [`FrameInterpolationHistory`].
 //!
+//! ## Selecting correction-time interpolation work
+//!
+//! Correction does not have its own kind of interpolation rule. It resolves
+//! the normal frame-interpolation rules for the archetype, including their
+//! priority, filters, and independent history/apply ownership. A component is
+//! *active for correction* when the archetype contains its [`PreviousVisual`].
+//!
+//! From those resolved rules, correction caches:
+//!
+//! - each winning frame-apply callback whose rule contains at least one active
+//!   component; and
+//! - frame-history restore callbacks for every component that those apply
+//!   callbacks may write.
+//!
+//! The complete apply callback is retained for a bundle. For example, if only
+//! `A` has `PreviousVisual<A>` and `(A, B)` wins frame apply, correction runs
+//! the complete `(A, B)` callback. The callback reads both repaired
+//! `FrameInterpolationHistory<A>` and `FrameInterpolationHistory<B>` and
+//! temporarily writes both live components. Only `A` gets a
+//! [`VisualCorrection`], but both `A` and `B` must then be restored to their
+//! corrected simulation values.
+//!
+//! The cached frame-history metadata is not passed to the apply callback and
+//! does not repair or update history. Each apply callback fetches the histories
+//! for its own rule members. Correction obtains history metadata from the rules
+//! that won frame-history ownership only to get the type-erased restore
+//! callback for each temporarily written component. This distinction matters
+//! because frame-history ownership and frame-apply ownership can be assigned to
+//! different rules.
+//!
 //! Finally, `add_visual_correction` runs in
 //! [`RollbackSystems::VisualCorrection`], ordered after
 //! [`FrameInterpolationSystems::Interpolate`]. Normal frame interpolation first
@@ -86,11 +116,14 @@ use lightyear_core::ecs_utils::{
 };
 use lightyear_core::prelude::*;
 use lightyear_frame_interpolation::FrameInterpolationSystems;
-use lightyear_interpolation::registry::InterpolationRegistry;
-use lightyear_interpolation::rules::frame_interpolate::{
-    CachedFrameInterpolationApply, CachedFrameInterpolationComponent, FrameInterpolationContext,
+use lightyear_interpolation::registry::{
+    InterpolationArchetypeKey, InterpolationRegistry, ResolvedRule, RuleResolutionScratch,
+    RuleTarget,
 };
-use lightyear_interpolation::rules::{InterpolationRuleId, RuleKind};
+use lightyear_interpolation::rules::frame_interpolate::{
+    CachedFrameInterpolationApply, CachedFrameInterpolationHistoryComponent,
+    FrameInterpolationContext,
+};
 use lightyear_replication::deferred_entity::DeferredEntityCommands;
 use lightyear_replication::diffable::Diffable;
 use lightyear_replication::registry::{ComponentKind, LerpFn};
@@ -237,23 +270,33 @@ unsafe impl SystemParam for PostRollbackCorrectionWorld<'_> {
 ///
 /// Correction reuses the same interpolation rules as frame interpolation, but
 /// it only needs to run them for components that were visually captured before
-/// rollback. This cache avoids re-evaluating filters and bundle precedence for
-/// every post-rollback correction pass.
+/// rollback. For each archetype, `active_members_scratch` contains precisely
+/// the component kinds whose `PreviousVisual<C>` is present. Its presence is
+/// included in the cache key, so archetypes with different active correction
+/// members cannot accidentally share a policy. Resolution-equivalent
+/// archetypes share one policy, avoiding both repeated rule resolution and
+/// duplicate callback vectors.
 #[derive(Debug)]
 pub(crate) struct PostRollbackCorrectionArchetypes {
     generation: ArchetypeGeneration,
-    rule_count: usize,
     correction_count: usize,
-    archetypes: Vec<CachedPostRollbackCorrectionArchetype>,
+    policies: Vec<CachedPostRollbackCorrectionPolicy>,
+    policy_ids: HashMap<InterpolationArchetypeKey, usize>,
+    key_scratch: InterpolationArchetypeKey,
+    active_members_scratch: Vec<ComponentKind>,
+    resolution_scratch: RuleResolutionScratch,
 }
 
 impl Default for PostRollbackCorrectionArchetypes {
     fn default() -> Self {
         Self {
             generation: ArchetypeGeneration::initial(),
-            rule_count: 0,
             correction_count: 0,
-            archetypes: Vec::new(),
+            policies: Vec::new(),
+            policy_ids: HashMap::default(),
+            key_scratch: InterpolationArchetypeKey::default(),
+            active_members_scratch: Vec::new(),
+            resolution_scratch: RuleResolutionScratch::default(),
         }
     }
 }
@@ -261,7 +304,8 @@ impl Default for PostRollbackCorrectionArchetypes {
 impl PostRollbackCorrectionArchetypes {
     fn clear(&mut self) {
         self.generation = ArchetypeGeneration::initial();
-        self.archetypes.clear();
+        self.policies.clear();
+        self.policy_ids.clear();
     }
 
     /// Refreshes the correction cache for newly-created archetypes.
@@ -279,164 +323,178 @@ impl PostRollbackCorrectionArchetypes {
         prediction_registry: &PredictionRegistry,
         interpolation_registry: &InterpolationRegistry,
     ) {
-        let rule_count = interpolation_registry.rule_count();
         let correction_count = prediction_registry.post_rollback_corrections().count();
-        if self.rule_count != rule_count || self.correction_count != correction_count {
+        if self.correction_count != correction_count {
             self.clear();
-            self.rule_count = rule_count;
             self.correction_count = correction_count;
         }
 
         let old_generation = core::mem::replace(&mut self.generation, archetypes.generation());
         for archetype in archetypes[old_generation..].iter() {
-            let mut cached = CachedPostRollbackCorrectionArchetype::new(archetype.id());
-            cached.collect_active_members(archetype, prediction_registry);
-            if cached.active_members.is_empty() {
+            // Only components with `PreviousVisual<C>` need a visual-correction
+            // error. Other members of a selected bundle rule may still be sampled
+            // and temporarily written while producing those corrected values.
+            interpolation_registry.populate_archetype_key(
+                archetype,
+                RuleTarget::Frame,
+                &mut self.key_scratch,
+            );
+            self.active_members_scratch.clear();
+            for correction in prediction_registry.post_rollback_corrections() {
+                if archetype.contains(correction.previous_visual_component_id) {
+                    self.key_scratch
+                        .include_if_present(archetype, correction.previous_visual_component_id);
+                    self.active_members_scratch.push(correction.kind());
+                }
+            }
+            if self.active_members_scratch.is_empty() {
                 continue;
             }
 
-            for kind in interpolation_registry.rule_kinds() {
-                if let Some(rule_id) =
-                    interpolation_registry.select_rule_for_archetype(components, archetype, kind)
-                {
-                    cached.selected_rules.insert(kind, rule_id);
-                    if let Some(component) = interpolation_registry
-                        .cached_frame_history_component(components, archetype, rule_id)
-                    {
-                        cached.frame_history_components.push(component);
-                    }
-                }
+            if let Some(&policy_id) = self.policy_ids.get(&self.key_scratch) {
+                self.policies[policy_id].archetype_ids.push(archetype.id());
+            } else {
+                // Correction reuses frame histories and frame apply functions. The
+                // PredictionRegistry/PreviousVisual set decides which members
+                // actually receive correction; it is not a third interpolation target.
+                let rules = interpolation_registry.resolved_rules_for_archetype(
+                    components,
+                    archetype,
+                    RuleTarget::Frame,
+                    &mut self.resolution_scratch,
+                );
+                let mut policy = CachedPostRollbackCorrectionPolicy {
+                    archetype_ids: alloc::vec![archetype.id()],
+                    apply_callbacks: Vec::new(),
+                    restore_components: Vec::new(),
+                };
+                policy.resolve_rules(
+                    archetype,
+                    interpolation_registry,
+                    rules,
+                    &self.active_members_scratch,
+                );
+                let policy_id = self.policies.len();
+                self.policies.push(policy);
+                self.policy_ids.insert(self.key_scratch.clone(), policy_id);
             }
-
-            cached.resolve_apply_rules(interpolation_registry);
-            cached.assert_all_members_covered();
-            self.archetypes.push(cached);
         }
     }
 
-    fn iter(&self) -> impl Iterator<Item = &CachedPostRollbackCorrectionArchetype> {
-        self.archetypes.iter()
+    fn iter(&self) -> impl Iterator<Item = (ArchetypeId, &CachedPostRollbackCorrectionPolicy)> {
+        self.policies.iter().flat_map(|policy| {
+            policy
+                .archetype_ids
+                .iter()
+                .copied()
+                .map(move |archetype_id| (archetype_id, policy))
+        })
+    }
+
+    #[cfg(test)]
+    fn archetype_count(&self) -> usize {
+        self.policies
+            .iter()
+            .map(|policy| policy.archetype_ids.len())
+            .sum()
     }
 }
 
-/// Cached correction-time interpolation policy for one archetype.
+/// Correction policy shared by archetypes with the same relevant components.
 #[derive(Debug)]
-struct CachedPostRollbackCorrectionArchetype {
-    id: ArchetypeId,
-    active_members: Vec<ComponentKind>,
-    covered_members: Vec<ComponentKind>,
-    selected_rules: HashMap<RuleKind, InterpolationRuleId>,
-    apply_rules: Vec<CachedFrameInterpolationApply>,
-    frame_history_components: Vec<CachedFrameInterpolationComponent>,
-    restore_components: Vec<CachedFrameInterpolationComponent>,
+struct CachedPostRollbackCorrectionPolicy {
+    /// Archetypes whose relevant component presence resolves to this policy.
+    archetype_ids: Vec<ArchetypeId>,
+    /// Winning frame-apply callbacks whose rule overlaps at least one active
+    /// `PreviousVisual<C>` component.
+    ///
+    /// A bundle callback is stored in full. For example, if only `A` has
+    /// `PreviousVisual<A>`, a winning `(A, B)` callback still reads both frame
+    /// histories and writes both live components so that it applies the bundle
+    /// atomically.
+    apply_callbacks: Vec<CachedFrameInterpolationApply>,
+    /// Frame-history restore callbacks for every component that
+    /// `apply_callbacks` may temporarily write.
+    ///
+    /// This includes non-corrected bundle members such as `B` in the example
+    /// above: no typed correction handler will restore `B`, because it has no
+    /// `PreviousVisual<B>`. The callbacks come from the rules that won the
+    /// frame-history lane, which may differ from the rules in `apply_callbacks`.
+    /// History metadata for components not written by `apply_callbacks` is
+    /// discarded.
+    restore_components: Vec<CachedFrameInterpolationHistoryComponent>,
 }
 
-impl CachedPostRollbackCorrectionArchetype {
-    fn new(id: ArchetypeId) -> Self {
-        Self {
-            id,
-            active_members: Vec::new(),
-            covered_members: Vec::new(),
-            selected_rules: HashMap::default(),
-            apply_rules: Vec::new(),
-            frame_history_components: Vec::new(),
-            restore_components: Vec::new(),
-        }
-    }
-
-    fn id(&self) -> ArchetypeId {
-        self.id
-    }
-
-    fn apply_rules(&self) -> &[CachedFrameInterpolationApply] {
-        &self.apply_rules
-    }
-
-    fn restore_components(&self) -> &[CachedFrameInterpolationComponent] {
-        &self.restore_components
-    }
-
-    fn collect_active_members(
+impl CachedPostRollbackCorrectionPolicy {
+    /// Resolves the correction work for `active_members`, the components on
+    /// this archetype that currently have `PreviousVisual<C>`.
+    ///
+    /// A resolved apply rule is cached only if it overlaps an active member,
+    /// but all of that rule's members are recorded because a bundle callback
+    /// writes the complete bundle. History metadata is collected independently
+    /// from the resolved history rules, then restricted to those recorded
+    /// members to produce `restore_components`. Finally, every active member
+    /// must be covered by a cached apply callback; correction cannot calculate
+    /// a new visual sample without one.
+    fn resolve_rules(
         &mut self,
         archetype: &Archetype,
-        prediction_registry: &PredictionRegistry,
+        registry: &InterpolationRegistry,
+        rules: &[ResolvedRule],
+        active_members: &[ComponentKind],
     ) {
-        self.active_members.extend(
-            prediction_registry
-                .post_rollback_corrections()
-                .filter(|correction| archetype.contains(correction.previous_visual_component_id))
-                .map(|correction| correction.kind()),
-        );
-    }
-
-    fn resolve_apply_rules(&mut self, registry: &InterpolationRegistry) {
-        self.apply_rules.clear();
-        self.covered_members.clear();
+        self.apply_callbacks.clear();
         self.restore_components.clear();
 
-        // `selected_rules` contains the best matching rule for each rule kind
-        // on this archetype, for example `A`, `B`, and `(A, B)`. Correction
-        // only creates correction errors for members that have
+        // Correction only creates correction errors for members that have
         // `PreviousVisual<C>` on this archetype. Rule ownership must still
         // match normal frame interpolation: a bundle is atomic and may use
         // non-corrected members as inputs to the corrected member's sample.
-        let mut candidates = self
-            .selected_rules
-            .iter()
-            .filter_map(|(&kind, &rule_id)| registry.rule(rule_id).map(|_| (kind, rule_id)))
-            .collect::<Vec<_>>();
-        candidates.sort_by(|(_, lhs), (_, rhs)| registry.cmp_rule_precedence(*lhs, *rhs));
-
-        let mut claimed_members = Vec::new();
-        for (_, rule_id) in candidates {
-            let Some(rule) = registry.rule(rule_id) else {
-                continue;
-            };
-            if rule
-                .members()
-                .iter()
-                .any(|member| claimed_members.contains(member))
+        //
+        // These lists are needed only while constructing the cache:
+        // - `covered_members` verifies that every active member has an apply fn.
+        // - `frame_history_components` contains restore metadata from every
+        //   resolved history rule. Apply callbacks fetch history values themselves.
+        // - `restore_members` contains every member written by the retained apply
+        //   callbacks. It filters the history metadata into `restore_components`.
+        let mut covered_members = Vec::new();
+        let mut frame_history_components = Vec::new();
+        let mut restore_members = Vec::new();
+        for resolved in rules {
+            let rule = registry.rule(resolved.rule_id);
+            if resolved.owns_history {
+                frame_history_components.extend(rule.cached_frame_history_components(archetype));
+            }
+            if !resolved.owns_apply
+                || !rule
+                    .members()
+                    .any(|member| active_members.contains(&member))
             {
                 continue;
             }
-
-            claimed_members.extend(rule.members().iter().copied());
-            let active_rule_members = rule
-                .members()
-                .iter()
-                .filter(|member| self.active_members.contains(member))
-                .copied()
-                .collect::<Vec<_>>();
-            if active_rule_members.is_empty() {
-                continue;
-            }
-            if let Some(apply) = registry.cached_frame_apply_component(rule_id) {
-                self.covered_members.extend(active_rule_members);
-                self.apply_rules.push(apply);
+            if let Some(apply) = rule.cached_frame_apply(resolved.rule_id) {
+                covered_members.extend(
+                    rule.members()
+                        .filter(|member| active_members.contains(member)),
+                );
+                self.apply_callbacks.push(apply);
                 for member in rule.members() {
-                    if self
-                        .restore_components
-                        .iter()
-                        .any(|component| component.kind() == *member)
-                    {
-                        continue;
-                    }
-                    if let Some(component) = self
-                        .frame_history_components
-                        .iter()
-                        .find(|component| component.kind() == *member)
-                    {
-                        self.restore_components.push(*component);
+                    if !restore_members.contains(&member) {
+                        restore_members.push(member);
                     }
                 }
             }
         }
-    }
+        self.restore_components.extend(
+            frame_history_components
+                .iter()
+                .filter(|component| restore_members.contains(&component.kind()))
+                .copied(),
+        );
 
-    fn assert_all_members_covered(&self) {
-        for member in &self.active_members {
+        for member in active_members {
             assert!(
-                self.covered_members.contains(member),
+                covered_members.contains(member),
                 "No interpolation function was found for correction. Register an interpolation rule with an interpolation function for this component or bundle before calling add_correction/add_linear_correction/add_correction_fn."
             );
         }
@@ -517,7 +575,7 @@ pub(crate) fn update_frame_interpolation_post_rollback(
         &interpolation_registry,
     );
 
-    // 1. Reuse the interpolation rules selected for this archetype to compute
+    // 1. Reuse the interpolation rules selected for each archetype to compute
     // the corrected visual sample at the current fixed-overstep. This can run
     // bundle rules such as `(A, B)`, so correction sees the same visual state
     // that frame interpolation would have produced.
@@ -526,7 +584,6 @@ pub(crate) fn update_frame_interpolation_post_rollback(
         &correction_archetypes,
         &interpolation_registry,
         ctx,
-        &mut deferred_apply,
     );
 
     // 2. Compare the original pre-rollback visual value against the corrected
@@ -575,13 +632,12 @@ fn apply_frame_interpolation_for_visual_correction(
     correction_archetypes: &PostRollbackCorrectionArchetypes,
     interpolation_registry: &InterpolationRegistry,
     ctx: PostRollbackCorrectionContext,
-    deferred_apply: &mut DeferredEntityCommands,
 ) {
-    for cached_archetype in correction_archetypes.iter() {
-        let Some(archetype) = world.archetypes().get(cached_archetype.id()) else {
+    for (archetype_id, policy) in correction_archetypes.iter() {
+        let Some(archetype) = world.archetypes().get(archetype_id) else {
             continue;
         };
-        for apply in cached_archetype.apply_rules() {
+        for apply in &policy.apply_callbacks {
             (apply.apply_frame_interpolation())(
                 world,
                 archetype,
@@ -592,7 +648,6 @@ fn apply_frame_interpolation_for_visual_correction(
                     sample_delta_secs: Some(ctx.sample_delta_secs),
                 },
                 false,
-                deferred_apply,
             );
         }
     }
@@ -608,11 +663,11 @@ fn restore_applied_frame_interpolation_components(
     world: UnsafeWorldCell,
     correction_archetypes: &PostRollbackCorrectionArchetypes,
 ) {
-    for cached_archetype in correction_archetypes.iter() {
-        let Some(archetype) = world.archetypes().get(cached_archetype.id()) else {
+    for (archetype_id, policy) in correction_archetypes.iter() {
+        let Some(archetype) = world.archetypes().get(archetype_id) else {
             continue;
         };
-        for component in cached_archetype.restore_components() {
+        for component in &policy.restore_components {
             (component.restore_frame_history())(world, archetype, component);
         }
     }
@@ -911,6 +966,9 @@ mod tests {
     #[component(storage = "SparseSet")]
     struct SparseCorrection(f32);
 
+    #[derive(Component)]
+    struct UnrelatedCorrectionComponent;
+
     impl Ease for CorrectionA {
         fn interpolating_curve_unbounded(start: Self, end: Self) -> impl Curve<Self> {
             FunctionCurve::new(Interval::UNIT, move |t| {
@@ -952,11 +1010,42 @@ mod tests {
             .id();
         app.world_mut().flush();
         assert!(app.world().get::<FrameInterpolate>(entity).is_some());
-        assert!(
-            app.world()
-                .get::<FrameInterpolationHistory<CorrectionA>>(entity)
-                .is_some()
+    }
+
+    /// Checks that correction archetypes differing only by unrelated components share a policy.
+    #[test]
+    fn correction_archetypes_share_resolution_equivalent_policies() {
+        let mut app = app_with_replication_markers();
+        app.init_resource::<PredictionRegistry>();
+        app.component::<CorrectionA>().predict().add_correction();
+        app.interpolate_with::<CorrectionA>(InterpolationFns::no_history(|start, end, t| {
+            CorrectionA(start.0 + (end.0 - start.0) * t)
+        }));
+        app.finish();
+
+        app.world_mut().spawn((
+            CorrectionA(1.0),
+            PreviousVisual(CorrectionA(0.0)),
+            FrameInterpolationHistory::<CorrectionA>::default(),
+        ));
+        app.world_mut().spawn((
+            CorrectionA(2.0),
+            PreviousVisual(CorrectionA(0.0)),
+            FrameInterpolationHistory::<CorrectionA>::default(),
+            UnrelatedCorrectionComponent,
+        ));
+
+        let mut cache = PostRollbackCorrectionArchetypes::default();
+        let world = app.world();
+        cache.update(
+            world.archetypes(),
+            world.components(),
+            world.resource::<PredictionRegistry>(),
+            world.resource::<InterpolationRegistry>(),
         );
+
+        assert_eq!(cache.archetype_count(), 2);
+        assert_eq!(cache.policies.len(), 1);
     }
 
     #[test]

--- a/crates/replication/prediction/src/registry.rs
+++ b/crates/replication/prediction/src/registry.rs
@@ -1061,13 +1061,6 @@ impl<C> PredictionRegistrationExt<C> for ComponentRegistration<'_, C> {
         registry.register::<C>(prediction_history_id, confirmed_history_id);
         add_prediction_systems::<C>(self.app);
 
-        let mut registry = self.app.world_mut().resource_mut::<ComponentRegistry>();
-        let metadata = registry
-            .component_metadata_map
-            .get_mut(&ComponentKind::of::<C>())
-            .unwrap();
-        metadata.replication.as_mut().unwrap().set_predicted(true);
-        // metadata.serialization.as_mut().unwrap().add_clone::<C>();
         self
     }
 
@@ -1107,12 +1100,6 @@ impl<C> PredictionRegistrationExt<C> for ComponentRegistration<'_, C> {
         add_prediction_systems::<C>(self.app);
         crate::plugin::add_prediction_diff_systems::<C>(self.app);
 
-        let mut registry = self.app.world_mut().resource_mut::<ComponentRegistry>();
-        let metadata = registry
-            .component_metadata_map
-            .get_mut(&ComponentKind::of::<C>())
-            .unwrap();
-        metadata.replication.as_mut().unwrap().set_predicted(true);
         self
     }
 

--- a/crates/replication/replication/src/registry/deterministic.rs
+++ b/crates/replication/replication/src/registry/deterministic.rs
@@ -62,7 +62,6 @@ impl<C: Debug> ComponentRegistration<'_, C> {
                     .entry(kind)
                     .or_insert_with(|| ComponentMetadata {
                         component_id,
-                        replication: None,
                         deterministic: None,
                     })
                     .deterministic = Some(DeterministicFns::new::<C>(default_inner_hash_fn::<C>));
@@ -87,7 +86,6 @@ impl<C: Debug> ComponentRegistration<'_, C> {
                     .entry(kind)
                     .or_insert_with(|| ComponentMetadata {
                         component_id,
-                        replication: None,
                         deterministic: None,
                     })
                     .deterministic = Some(DeterministicFns::new(f));

--- a/crates/replication/replication/src/registry/mod.rs
+++ b/crates/replication/replication/src/registry/mod.rs
@@ -3,7 +3,6 @@ pub mod deterministic;
 
 pub mod replication;
 
-use crate::registry::replication::ReplicationMetadata;
 use bevy_ecs::component::ComponentId;
 use bevy_ecs::prelude::*;
 use bevy_platform::collections::HashMap;
@@ -170,7 +169,6 @@ pub struct ComponentRegistry {
 #[derive(Debug, Clone)]
 pub struct ComponentMetadata {
     pub component_id: ComponentId,
-    pub replication: Option<ReplicationMetadata>,
     #[cfg(feature = "deterministic")]
     pub deterministic: Option<deterministic::DeterministicFns>,
 }
@@ -204,7 +202,6 @@ impl ComponentRegistry {
             .entry(component_kind)
             .or_insert(ComponentMetadata {
                 component_id,
-                replication: Some(ReplicationMetadata::default()),
                 #[cfg(feature = "deterministic")]
                 deterministic: None,
             });

--- a/crates/replication/replication/src/registry/replication.rs
+++ b/crates/replication/replication/src/registry/replication.rs
@@ -373,26 +373,6 @@ impl<C> ComponentRegistration<'_, C> {
     }
 }
 
-#[derive(Debug, Default, Clone)]
-pub struct ReplicationMetadata {
-    pub(crate) predicted: bool,
-    pub(crate) interpolated: bool,
-}
-
-impl ReplicationMetadata {
-    // TODO: Could we override this for a certain component? i.e. on an entity, the user can say
-    //  "this component is not predicted"
-    /// Mark the component as being predicted.
-    pub fn set_predicted(&mut self, predicted: bool) {
-        self.predicted = predicted;
-    }
-
-    /// Mark the component as being interpolated.
-    pub fn set_interpolated(&mut self, interpolated: bool) {
-        self.interpolated = interpolated;
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/tests/src/client_server/replication.rs
+++ b/crates/tests/src/client_server/replication.rs
@@ -520,6 +520,9 @@ fn test_manual_interpolated_marker_backfills_existing_replicated_component() {
         .world_mut()
         .entity_mut(client_entity)
         .insert(Interpolated);
+    // History initialization is handled by the interpolation system for the
+    // entity's newly matched rule, rather than synchronously by an observer.
+    stepper.frame_step(1);
 
     let client_entity_ref = stepper.client_apps[0].world().entity(client_entity);
     assert_eq!(


### PR DESCRIPTION
## Summary

Refactors the interpolation pipeline and improves interpolation rule matching, especially for bundle rules.

- uses the same rule-resolution model for delayed interpolation, frame interpolation, and post-rollback correction
- shares cached interpolation policies between archetypes that have the same interpolation-related component presence, instead of building a separate cached component set for every Bevy archetype
- separates each resolved rule into APPLY ownership and HISTORY ownership
- improves bundle history sampling when members do not have identical brackets (fixes https://github.com/cBournhonesque/lightyear/issues/1703)
- avoids registering the Avian Hermite interpolation rule when `register_physics_components` is `false`

## Rule resolution

Each interpolation rule now describes two independent kinds of work:

- **APPLY** determines how live component values are interpolated. A rule is eligible only when every live component targeted by the rule is present.
- **HISTORY** determines which component histories are created and updated. A member is available when either its live component `A` or its `History<A>` representation is present.

Rules still use the same priority and registration-order precedence, but APPLY and HISTORY claim their members independently. This lets bundle history keep controlling delayed component presence even when the complete live bundle cannot currently be interpolated.

For a higher-priority `(A, B)` bundle rule and a lower-priority `A` rule:

### Delayed insertion

Before the insertion tick, the entity can contain:

```text
(A, History<A>, History<B>)
```

The resolved work is:

```text
APPLY   = A
HISTORY = (A, B)
```

Only live `A` is interpolated, while the bundle history callbacks continue updating both histories. When the interpolation timeline reaches the insertion tick, history maintenance inserts live `B`, and `(A, B)` becomes the APPLY winner as well.

### Delayed removal

Before the removal tick, the entity contains:

```text
(A, B, History<A>, History<B>)
```

The bundle owns both APPLY and HISTORY, so `(A, B)` is interpolated atomically. Once history maintenance removes live `B`, the standalone `A` rule takes over APPLY immediately, while `(A, B)` continues maintaining both histories.

Frame interpolation uses the same resolver with `FrameInterpolationHistory<C>` as its history representation. Post-rollback correction also reuses the resolved frame rules rather than maintaining a separate rule-selection model.

## Archetype policy caching

Archetype cache keys now include only component presence that can affect interpolation resolution:

- live rule members
- their relevant confirmed or frame-history representations
- components referenced by rule filters
- target-specific markers such as `SkipFrameInterpolation`

Archetypes that differ only by unrelated components therefore share one resolved policy and its cached callbacks.

## Bundle bracket sampling

Bundle members no longer need identical immediate `(start, end)` ticks. The sampler finds a shared interval in which every member has a queryable value and carries unchanged values across that interval.

For `(A, B)`, if only `A` changes between `start` and `end`, the bundle rule interpolates between:

```text
(A_start, B) -> (A_end, B)
```

If the end state removes `B`, the removal is treated as a constant `B` endpoint while sampling:

```text
(A_start, B) -> (A_end, B)
```

The bundle continues interpolating coherently until history maintenance reaches the removal tick and removes live `B`.

## Avian

When `register_physics_components` is `false`, the application owns physics-component registration, so `LightyearAvianPlugin` no longer installs the automatic position/rotation/velocity Hermite interpolation rule.

Fixes #1703