### PR TITLE
Simplify rollback checking

### DIFF
--- a/crates/deterministic/deterministic_replication/src/late_join/client.rs
+++ b/crates/deterministic/deterministic_replication/src/late_join/client.rs
@@ -313,7 +313,6 @@ pub(crate) fn trigger_snapshot_rollback(
         return;
     }
     state_metadata.request_forced_rollback(snapshot_server_tick);
-    state_metadata.clear_mismatch_history();
     manager.pending_snapshot = None;
     manager.activating_snapshot = Some(snapshot);
     info!("Triggering catchup rollback since snapshot tick: {snapshot_server_tick:?}");

--- a/crates/replication/interpolation/src/interpolate.rs
+++ b/crates/replication/interpolation/src/interpolate.rs
@@ -202,8 +202,17 @@ pub(crate) fn update_history_diff_archetype_erased<C>(
         let row = entity.table_row().index();
         let history = unsafe { &mut *histories.get_unchecked(row).get() };
 
+        // At a completed checkpoint C, a diff component has exactly one of three outcomes:
+        // 1. The component changed at C and the diff was materialized, so the write callback
+        //    already inserted its authoritative state at C. Check ConfirmedHistory first and avoid
+        //    consulting pending diff storage in this case.
+        // 2. An update at or before C is still pending, so its concrete state at C is unresolved
+        //    and ConfirmedHistory must not receive an entry at C yet.
+        // 3. All diffs through C are materialized and there was no update at C, so inserting
+        //    SameAsPrecedent records the final authoritative value carried forward to C.
         if let Some(server_complete_tick) = ctx.server_complete_tick
-            && !history_diff_receiver.has_pending_diff_at_tick(server_complete_tick)
+            && history.get_state_at(server_complete_tick).is_none()
+            && !history_diff_receiver.has_pending_diff_at_or_before(server_complete_tick)
             && let Some(previous_newest_tick) = history.push_unchanged(server_complete_tick)
         {
             trace!(
@@ -667,7 +676,7 @@ mod tests {
         let replicon_tick = RepliconTick::new(replicon_tick);
         let mut checkpoints = app.world_mut().resource_mut::<ReplicationCheckpointMap>();
         checkpoints.record(replicon_tick, server_tick);
-        checkpoints.record_last_confirmed_tick(replicon_tick);
+        checkpoints.record_last_confirmed_checkpoint(replicon_tick);
     }
 
     fn set_interpolation_tick(app: &mut App, tick: Tick) {
@@ -1467,7 +1476,7 @@ mod tests {
     }
 
     #[test]
-    fn update_confirmed_history_diff_advances_when_only_older_diff_is_pending() {
+    fn update_confirmed_history_diff_waits_for_older_pending_diff() {
         let mut app = setup_app(Tick(6), 40);
         use_diff_history_rule(&mut app);
         add_interpolation_test_systems(&mut app);
@@ -1492,15 +1501,12 @@ mod tests {
             .world()
             .get::<ConfirmedHistory<TestComp>>(entity)
             .unwrap();
-        assert_eq!(history.len(), 2);
+        assert_eq!(history.len(), 1);
         assert_eq!(
             history.start_present().map(|(t, v)| (t, v.clone())),
             Some((Tick(0), TestComp(0.0)))
         );
-        assert_eq!(
-            history.get_nth_present(1).map(|(t, v)| (t, v.clone())),
-            Some((Tick(6), TestComp(0.0)))
-        );
+        assert!(history.get_state_at(Tick(6)).is_none());
 
         let receiver = app
             .world()
@@ -1509,6 +1515,39 @@ mod tests {
             .unwrap();
         assert!(receiver.has_pending_diffs());
         assert_eq!(receiver.tick_for_cursor(Some(idx(0))), Some(Tick(0)));
+
+        // Materialize the missing S0 -> S3 base and the buffered S3 -> S5 diff. The next update
+        // revisits the still-latest completed checkpoint and can now add its unchanged anchor.
+        let mut receiver = app
+            .world_mut()
+            .resource_mut::<ReplicationStorage>()
+            .remove::<HistoryDiffReceiver<TestComp>>(entity)
+            .unwrap();
+        {
+            let mut entity_mut = app.world_mut().entity_mut(entity);
+            let mut history = entity_mut.get_mut::<ConfirmedHistory<TestComp>>().unwrap();
+            receiver
+                .queue_diffs(Tick(3), idx(1), vec![1.0, 2.0, 3.0])
+                .unwrap();
+            while let Some((tick, value)) = receiver.take_ready_update(&history).unwrap() {
+                history.insert_present(tick, value);
+            }
+        }
+        assert!(!receiver.has_pending_diffs());
+        app.world_mut()
+            .resource_mut::<ReplicationStorage>()
+            .insert(entity, receiver);
+
+        app.update();
+
+        let history = app
+            .world()
+            .get::<ConfirmedHistory<TestComp>>(entity)
+            .unwrap();
+        assert_eq!(
+            history.get_state_at(Tick(6)).and_then(HistoryState::value),
+            Some(&TestComp(5.0))
+        );
     }
 
     #[test]

--- a/crates/replication/prediction/src/manager.rs
+++ b/crates/replication/prediction/src/manager.rs
@@ -5,62 +5,11 @@ use bevy_reflect::Reflect;
 
 use crate::correction::CorrectionPolicy;
 use crate::rollback::RollbackState;
-use alloc::collections::BTreeMap;
 use alloc::vec::Vec;
-use bevy_ecs::entity::EntityHashSet;
 use core::ops::{Deref, DerefMut};
 use lightyear_core::prelude::Tick;
 use lightyear_sync::prelude::InputTimelineConfig;
 use parking_lot::RwLock;
-
-/// Prediction checks deferred because an authoritative update was ahead of the local timeline.
-///
-/// Receive-time rollback checks cannot compare an update after the current local tick with
-/// prediction history yet. Replicon's `ConfirmHistory` still records that the entity was updated,
-/// however, so the prediction scan's usual `ConfirmHistory` optimization would later skip the
-/// entity entirely. This index remembers those entities by authoritative tick until the
-/// completed server frontier makes them checkable.
-///
-/// [`PredictionRegistry::check_rollback_for_unchanged_component`](crate::registry::PredictionRegistry::check_rollback_for_unchanged_component)
-/// handles each drained entity at that frontier: it uses an explicit confirmed component sample
-/// when one exists, and records the component as unchanged only when no sample exists at the tick.
-#[doc(hidden)]
-#[derive(Debug, Default)]
-pub struct PendingEntityStateChecks {
-    by_tick: BTreeMap<Tick, EntityHashSet>,
-}
-
-impl PendingEntityStateChecks {
-    pub(crate) fn record(&mut self, tick: Tick, entity: Entity) {
-        self.by_tick.entry(tick).or_default().insert(entity);
-    }
-
-    /// Removes and returns all entities whose deferred update is now checkable.
-    pub(crate) fn take_through(&mut self, completed_tick: Tick) -> EntityHashSet {
-        let mut entities = EntityHashSet::default();
-        while self
-            .by_tick
-            .first_key_value()
-            .is_some_and(|(tick, _)| *tick <= completed_tick)
-        {
-            let (_, pending) = self.by_tick.pop_first().unwrap();
-            entities.extend(pending);
-        }
-        entities
-    }
-
-    pub(crate) fn clear(&mut self) {
-        self.by_tick.clear();
-    }
-
-    /// Returns whether an entity has a deferred state check at `tick`.
-    #[cfg(any(test, feature = "test_utils"))]
-    pub fn contains(&self, tick: Tick, entity: Entity) -> bool {
-        self.by_tick
-            .get(&tick)
-            .is_some_and(|entities| entities.contains(&entity))
-    }
-}
 
 #[derive(Debug, Clone, Copy, Default, Reflect)]
 pub enum RollbackMode {
@@ -158,12 +107,6 @@ pub struct PredictionManager {
     pub deterministic_despawn: Vec<(Tick, Entity)>,
     #[doc(hidden)]
     pub deterministic_skip_despawn: Vec<(Tick, Entity)>,
-    /// Receive-time state checks deferred until the authoritative tick is locally checkable.
-    ///
-    /// See [`PendingEntityStateChecks`] for why the completed-tick rollback scan needs this index.
-    #[doc(hidden)]
-    #[reflect(ignore)]
-    pub pending_entity_state_checks: PendingEntityStateChecks,
     #[doc(hidden)]
     #[reflect(ignore)]
     pub rollback: RwLock<RollbackState>,
@@ -239,20 +182,14 @@ pub struct StateRollbackMetadata {
     ///
     /// Replicon advances `ServerMutateTicks` during receive; this advances only after
     /// `check_rollback` handles that frontier. We retain it separately to:
-    /// - avoid rescanning unchanged entities while the completed frontier is unchanged;
-    /// - let receive functions ignore late updates older than an already-checked frontier;
+    /// - avoid rescanning entities while the completed frontier is unchanged;
     /// - provide a safe watermark for pruning diff history.
     ///
-    /// It can lag behind `ServerMutateTicks` when a completed tick is ahead of the local timeline.
-    last_processed_tick: Option<Tick>,
-
-    /// Earliest receive-time state mismatch not yet covered by a completed rollback check.
-    ///
-    /// A mismatch can be detected before Replicon has completed all mutate messages through that
-    /// tick. We retain the earliest such tick until the completed server frontier reaches it, then
-    /// roll back from that latest globally complete frontier. Later confirmed samples do not need
-    /// separate mismatch entries: they remain in `ConfirmedHistory` and are applied during replay.
-    earliest_pending_mismatch_tick: Option<Tick>,
+    /// This tick is always in the past or present relative to the local simulation tick when it is
+    /// stored. It can lag behind Replicon's globally latest completed checkpoint when that
+    /// checkpoint is still in the local simulation's future, or when an unresolved predicted diff
+    /// makes a newer checkpoint unsafe to process.
+    last_processed_confirmed_tick: Option<Tick>,
 
     /// Set to true if we received any replication message this frame.
     /// Used to trigger `RollbackMode::Always`.
@@ -268,42 +205,11 @@ pub struct StateRollbackMetadata {
 }
 
 impl StateRollbackMetadata {
-    /// Record a receive-time mismatch at `tick`.
-    ///
-    /// Only the earliest pending mismatch matters. Once the globally completed server frontier
-    /// reaches it, rollback starts from that completed frontier and replay applies every later
-    /// confirmed sample retained in `ConfirmedHistory`.
-    ///
-    /// Returns `true` because the unbounded representation can retain every mismatch tick. The
-    /// return value is kept for compatibility with the previous bounded representation, which
-    /// returned `false` when a tick fell outside its 64-tick window.
-    pub fn record_mismatch(&mut self, tick: Tick) -> bool {
-        match self.earliest_pending_mismatch_tick {
-            None => self.earliest_pending_mismatch_tick = Some(tick),
-            Some(existing) if tick < existing => self.earliest_pending_mismatch_tick = Some(tick),
-            _ => {}
-        }
-        true
-    }
-
-    /// Return the earliest pending mismatch once `completed_tick` has reached it.
-    pub(crate) fn pending_mismatch_at_or_before(&self, completed_tick: Tick) -> Option<Tick> {
-        self.earliest_pending_mismatch_tick
-            .filter(|mismatch_tick| *mismatch_tick <= completed_tick)
-    }
-
-    /// Return whether receive-time prediction checks should run for `tick`.
-    pub(crate) fn should_check_mismatch_at(&self, tick: Tick) -> bool {
-        if self
-            .last_processed_tick
-            .is_some_and(|last_processed| tick < last_processed)
-        {
-            return false;
-        }
-        // A later mismatch cannot make rollback eligible any sooner. Keep checking earlier ticks,
-        // though, because an out-of-order confirmed update can move the pending frontier earlier.
-        self.earliest_pending_mismatch_tick
-            .is_none_or(|pending_tick| tick < pending_tick)
+    /// Mark the current frame as having received replicated state.
+    #[cfg(feature = "test_utils")]
+    #[doc(hidden)]
+    pub fn mark_received_messages_this_frame(&mut self) {
+        self.received_messages_this_frame = true;
     }
 
     /// Request a one-shot rollback from `tick`, regardless of the
@@ -311,12 +217,8 @@ impl StateRollbackMetadata {
     ///
     /// Intended for scenarios where an external system (e.g. late-join
     /// catch-up) has deposited confirmed state at a specific tick and
-    /// needs the simulation to re-run from there. Unlike
-    /// [`record_mismatch`], this does not track the earliest across
-    /// multiple calls in a frame — the caller is authoritative about the
-    /// tick. Subsequent calls within the same frame take the earliest.
-    ///
-    /// [`record_mismatch`]: StateRollbackMetadata::record_mismatch
+    /// needs the simulation to re-run from there. Subsequent calls within the
+    /// same frame take the earliest tick.
     pub fn request_forced_rollback(&mut self, tick: Tick) {
         match self.forced_rollback_tick {
             None => self.forced_rollback_tick = Some(tick),
@@ -340,44 +242,39 @@ impl StateRollbackMetadata {
     }
 
     /// Reset the per-frame state tracking.
-    /// Note: the pending mismatch is NOT reset here because receive-time mismatch
-    /// evidence persists until the completed server tick is processed.
     pub(crate) fn reset_frame_state(&mut self) {
         self.received_messages_this_frame = false;
-    }
-
-    /// Clear all retained mismatch evidence.
-    pub fn clear_mismatch_history(&mut self) {
-        self.earliest_pending_mismatch_tick = None;
     }
 
     /// Returns the latest completed server mutate tick consumed by rollback checking.
     ///
     /// During Replicon's receive systems this still reflects the previous rollback-check frontier;
-    /// it is advanced only after the current completed tick has been handled by `check_rollback`.
-    /// It is used both to avoid rescanning an already-consumed completed tick and to reject stale
-    /// receive-time mismatch checks for ticks older than that frontier.
-    pub fn last_processed_tick(&self) -> Option<Tick> {
-        self.last_processed_tick
+    /// it is advanced only after `check_rollback` handles a completed checkpoint that is at or
+    /// before the local simulation tick.
+    /// It is used to avoid rescanning an already-consumed completed tick. This is a processing
+    /// watermark, not the target of a rollback currently in progress; that target is stored in
+    /// [`PredictionManager`] and returned by [`PredictionManager::get_rollback_start_tick`].
+    pub fn last_processed_confirmed_tick(&self) -> Option<Tick> {
+        self.last_processed_confirmed_tick
     }
 
     /// Record that rollback checking consumed this completed server mutate tick.
     ///
-    /// Call this only at the end of the rollback check, after either consuming an explicit mismatch
-    /// or scanning unchanged entities. Do not advance it directly from `ServerMutateTicks`, or while
-    /// the completed tick is still in the client's future: receive functions must continue to see
-    /// the previously processed frontier while the current frame's replication is being applied.
-    pub fn set_last_processed_tick(&mut self, tick: Tick) {
-        self.last_processed_tick = Some(tick);
+    /// Call this only after `check_rollback` consumes the checkpoint: after the full state scan in
+    /// `RollbackMode::Check`, or after scheduling its unconditional rollback in
+    /// `RollbackMode::Always`. Do not advance it directly from `ServerMutateTicks`, while the
+    /// completed tick is still in the client's future, or while a diff at or before this checkpoint
+    /// is unresolved.
+    pub fn set_last_processed_confirmed_tick(&mut self, tick: Tick) {
+        self.last_processed_confirmed_tick = Some(tick);
     }
 
     /// Check if the completed mutate tick has advanced since we last processed it.
     ///
-    /// If this returns false, `check_rollback` can skip the unchanged-entity
-    /// rollback scan because the current `last_confirmed_tick` was already
-    /// handled on an earlier frame.
+    /// If this returns false, `check_rollback` can skip the full state scan because the current
+    /// completed checkpoint was already handled on an earlier frame.
     pub fn has_confirmed_tick_advanced(&self, current_tick: Tick) -> bool {
-        match self.last_processed_tick {
+        match self.last_processed_confirmed_tick {
             None => true, // First time, always process
             Some(last) => current_tick > last,
         }
@@ -422,37 +319,11 @@ mod tests {
     }
 
     #[test]
-    fn pending_mismatch_keeps_earliest_tick() {
-        let mut metadata = StateRollbackMetadata::default();
-        metadata.set_last_processed_tick(Tick(10));
-        metadata.record_mismatch(Tick(12));
-
-        assert_eq!(metadata.pending_mismatch_at_or_before(Tick(11)), None);
-        assert_eq!(
-            metadata.pending_mismatch_at_or_before(Tick(12)),
-            Some(Tick(12))
-        );
-        assert!(!metadata.should_check_mismatch_at(Tick(9)));
-        assert!(!metadata.should_check_mismatch_at(Tick(12)));
-        assert!(!metadata.should_check_mismatch_at(Tick(13)));
-        assert!(metadata.should_check_mismatch_at(Tick(11)));
-
-        metadata.record_mismatch(Tick(14));
-        assert_eq!(metadata.earliest_pending_mismatch_tick, Some(Tick(12)));
-
-        metadata.record_mismatch(Tick(11));
-        assert_eq!(metadata.earliest_pending_mismatch_tick, Some(Tick(11)));
-
-        metadata.clear_mismatch_history();
-        assert_eq!(metadata.earliest_pending_mismatch_tick, None);
-    }
-
-    #[test]
-    fn confirmed_tick_advancement_uses_last_processed_tick() {
+    fn confirmed_tick_advancement_uses_last_processed_confirmed_tick() {
         let mut metadata = StateRollbackMetadata::default();
         assert!(metadata.has_confirmed_tick_advanced(Tick(10)));
 
-        metadata.set_last_processed_tick(Tick(10));
+        metadata.set_last_processed_confirmed_tick(Tick(10));
         assert!(!metadata.has_confirmed_tick_advanced(Tick(10)));
         assert!(!metadata.has_confirmed_tick_advanced(Tick(9)));
         assert!(metadata.has_confirmed_tick_advanced(Tick(11)));
@@ -473,31 +344,6 @@ mod tests {
         assert_eq!(server_mutate_ticks.last_tick(), incomplete_tick);
         assert!(server_mutate_ticks.contains(complete_tick));
         assert!(!server_mutate_ticks.contains(incomplete_tick));
-    }
-
-    #[test]
-    fn completed_frontier_can_jump_past_pending_mismatch() {
-        let mut metadata = StateRollbackMetadata::default();
-        metadata.set_last_processed_tick(Tick(100));
-        metadata.record_mismatch(Tick(105));
-
-        assert_eq!(metadata.pending_mismatch_at_or_before(Tick(104)), None);
-        assert_eq!(
-            metadata.pending_mismatch_at_or_before(Tick(106)),
-            Some(Tick(105))
-        );
-    }
-
-    #[test]
-    fn pending_mismatch_has_no_fixed_tick_window() {
-        let mut metadata = StateRollbackMetadata::default();
-        metadata.set_last_processed_tick(Tick(10));
-        metadata.record_mismatch(Tick(100));
-
-        assert_eq!(
-            metadata.pending_mismatch_at_or_before(Tick(100)),
-            Some(Tick(100))
-        );
     }
 }
 
@@ -538,7 +384,6 @@ impl Default for PredictionManager {
             input_rollback_floor: None,
             deterministic_skip_despawn: Vec::default(),
             deterministic_despawn: Vec::default(),
-            pending_entity_state_checks: PendingEntityStateChecks::default(),
             rollback: RwLock::new(RollbackState::Default),
         }
     }

--- a/crates/replication/prediction/src/predicted_history.rs
+++ b/crates/replication/prediction/src/predicted_history.rs
@@ -179,7 +179,7 @@ pub(crate) fn handle_local_timeline_shift_history_diff_receiver<C: RepliconDiffa
 
 /// Prune historical diff cursor state that is no longer needed for rollback.
 ///
-/// This promotes the newest cursor at or before `last_processed_tick -
+/// This promotes the newest cursor at or before `last_processed_confirmed_tick -
 /// DIFF_HISTORY_TICK_MARGIN` to the receiver's retained base. The margin keeps
 /// older confirmed values available for late diff messages whose base is
 /// before the latest processed tick but whose target tick has not been received
@@ -189,10 +189,10 @@ pub(crate) fn prune_history_diff_receiver<C: RepliconDiffable>(
     mut storage: ResMut<ReplicationStorage>,
     query: Query<(Entity, &ConfirmedHistory<C>)>,
 ) {
-    let Some(last_processed_tick) = state_metadata.last_processed_tick() else {
+    let Some(last_processed_confirmed_tick) = state_metadata.last_processed_confirmed_tick() else {
         return;
     };
-    let prune_tick = last_processed_tick - DIFF_HISTORY_TICK_MARGIN;
+    let prune_tick = last_processed_confirmed_tick - DIFF_HISTORY_TICK_MARGIN;
     for (entity, history) in query.iter() {
         let Some(receiver) = storage.get_mut::<HistoryDiffReceiver<C>>(entity) else {
             continue;
@@ -608,10 +608,10 @@ mod tests {
     }
 
     #[test]
-    fn diff_receiver_pruning_keeps_margin_before_last_processed_tick() {
+    fn diff_receiver_pruning_keeps_margin_before_last_processed_confirmed_tick() {
         let mut app = App::new();
         let mut metadata = StateRollbackMetadata::default();
-        metadata.set_last_processed_tick(Tick(16));
+        metadata.set_last_processed_confirmed_tick(Tick(16));
         app.insert_resource(metadata);
         app.insert_resource(ReplicationStorage::default());
         app.add_systems(Update, prune_history_diff_receiver::<TestDiffValue>);

--- a/crates/replication/prediction/src/registry.rs
+++ b/crates/replication/prediction/src/registry.rs
@@ -1,7 +1,5 @@
-use crate::manager::{RollbackMode, StateRollbackMetadata};
 use crate::plugin::{add_non_networked_rollback_systems, add_prediction_systems};
 use crate::predicted_history::PredictionHistory;
-use crate::prelude::PredictionManager;
 use crate::{SyncComponent, correction};
 use bevy_app::App;
 use bevy_ecs::component::{ComponentId, Mutable};
@@ -18,13 +16,13 @@ use bevy_replicon::prelude::{AppMarkerExt, RepliconTick, RuleFns};
 use bevy_replicon::shared::replication::deferred_entity::DeferredEntity;
 use bevy_replicon::shared::replication::diff::{ComponentDelta, Diffable as RepliconDiffable};
 use bevy_replicon::shared::replication::registry::ctx::{RemoveCtx, WriteCtx};
-use bevy_replicon::shared::replication::storage::EntityStorageCtx;
+use bevy_replicon::shared::replication::storage::{EntityStorageCtx, ReplicationStorage};
 use bevy_utils::prelude::DebugName;
 use core::fmt::Debug;
 use indexmap::IndexMap;
 use lightyear_core::history_buffer::HistoryState;
 use lightyear_core::prediction::Predicted;
-use lightyear_core::prelude::{ConfirmedHistory, LocalTimeline};
+use lightyear_core::prelude::ConfirmedHistory;
 use lightyear_core::tick::Tick;
 use lightyear_frame_interpolation::FrameInterpolationPlugin;
 use lightyear_replication::checkpoint::resolve_message_tick;
@@ -63,6 +61,9 @@ pub struct PredictionMetadata {
     /// Will default to a PartialEq::ne implementation, but can be overridden.
     pub(crate) should_rollback: unsafe fn(),
     pub(crate) check_rollback: CheckRollbackFn,
+    /// For a diff-replicated component on one entity, returns its earliest unresolved diff tick at
+    /// or before a candidate completed checkpoint.
+    pub(crate) pending_diff_tick: Option<PendingDiffTickFn>,
     #[cfg(feature = "metrics")]
     metric_handles: PredictionMetricHandles,
     #[cfg(feature = "deterministic")]
@@ -136,6 +137,9 @@ type CheckRollbackFn = unsafe fn(
     entity_mut: &mut FilteredEntityMut,
 ) -> bool;
 
+/// Type-erased pending-diff lookup for one predicted diff component on one entity.
+pub(crate) type PendingDiffTickFn = fn(&ReplicationStorage, Tick, Entity) -> Option<Tick>;
+
 /// Type-erased function for hashing the value in a [`PredictionHistory<C>`] component at a tick.
 /// The function fn should be of type fn(&C, &mut seahash::SeaHasher) and will be called with the
 /// value returned by the history buffer lookup.
@@ -159,7 +163,8 @@ impl PredictionMetadata {
                     should_rollback,
                 )
             },
-            check_rollback: PredictionRegistry::check_rollback_for_unchanged_component::<C>,
+            check_rollback: PredictionRegistry::check_rollback_at_completed_checkpoint::<C>,
+            pending_diff_tick: None,
             #[cfg(feature = "metrics")]
             metric_handles: PredictionMetricHandles::default(),
             #[cfg(feature = "deterministic")]
@@ -182,10 +187,6 @@ pub struct PredictionRegistry {
 }
 
 impl PredictionRegistry {
-    fn oldest_retained_tick<C>(history: &PredictionHistory<C>) -> Option<Tick> {
-        history.oldest().map(|(tick, _)| *tick)
-    }
-
     fn register<C: SyncComponent>(
         &mut self,
         prediction_history_id: ComponentId,
@@ -208,6 +209,19 @@ impl PredictionRegistry {
                 should_rollback,
             )
         };
+    }
+
+    fn set_pending_diff_tick<C: SyncComponent + RepliconDiffable>(&mut self) {
+        self.prediction_map
+            .get_mut(&ComponentKind::of::<C>())
+            .expect(
+                "The component has not been registered for prediction. Did you call `.predict_diff()`?",
+            )
+            .pending_diff_tick = Some(|storage, candidate, entity| {
+            storage
+                .get::<HistoryDiffReceiver<C>>(entity)
+                .and_then(|receiver| receiver.earliest_pending_tick_at_or_before(candidate))
+        });
     }
 
     fn custom_correction<C: SyncComponent>(&mut self) {
@@ -363,24 +377,15 @@ impl PredictionRegistry {
 
     /// Check rollback for a component at a completed server mutate tick.
     ///
-    /// A completed mutate tick T guarantees complete information for every replicated component.
-    /// This normally checks an entity that was unchanged at T. It also handles entities whose
-    /// explicit update was initially ahead of the local timeline and therefore could not be
-    /// checked when received.
-    ///
-    /// If [`ConfirmedHistory<C>`] contains an exact sample at `confirmed_tick`, that explicit
-    /// authoritative value is preserved and used for the comparison. Otherwise completion proves
-    /// that C was unchanged at T, even if another component on the entity was explicitly updated,
-    /// so the last confirmed state is materialized at T before comparing it with prediction.
-    ///
     /// # Safety
     ///
-    /// `confirmed_tick` must be a globally completed server mutate tick. Without that guarantee,
-    /// the absence of an exact component sample would not prove that the component was unchanged.
+    /// `confirmed_tick` must be a globally completed server mutate tick with no unresolved
+    /// predicted diff at or before it. Without those guarantees, the absence of an exact component
+    /// sample would not prove that the component was unchanged.
     ///
     /// # Arguments
     /// * `confirmed_tick` - Latest authoritative tick with complete mutate messages.
-    unsafe fn check_rollback_for_unchanged_component<C: SyncComponent>(
+    unsafe fn check_rollback_at_completed_checkpoint<C: SyncComponent>(
         &self,
         confirmed_tick: Tick,
         entity_mut: &mut FilteredEntityMut,
@@ -388,20 +393,20 @@ impl PredictionRegistry {
         let entity = entity_mut.id();
         let name = DebugName::type_name::<C>();
         let _span = trace_span!(
-            "check_rollback_for_unchanged_component",
+            "check_rollback_at_completed_checkpoint",
             ?name,
             %entity,
             ?confirmed_tick
         )
         .entered();
         let confirmed_value = {
-            let Some(mut confirmed_history) = entity_mut.get_mut::<ConfirmedHistory<C>>() else {
+            let Some(mut component_history) = entity_mut.get_mut::<ConfirmedHistory<C>>() else {
                 // No confirmed history means no authoritative value to compare against.
                 return false;
             };
 
             let Some(last_confirmed_state) =
-                confirmed_history.get_state_at_or_before(confirmed_tick)
+                component_history.get_state_at_or_before(confirmed_tick)
             else {
                 // No confirmed value in history - we can't check for rollback.
                 // This can happen for entities that were just spawned and haven't received
@@ -414,7 +419,15 @@ impl PredictionRegistry {
             };
 
             let confirmed_value = last_confirmed_state.value().cloned();
-            confirmed_history.add_unchanged(confirmed_tick);
+            // For a diff component, checkpoint selection has already established that no update at
+            // or before C remains pending. The authoritative state at C therefore has exactly two
+            // possibilities:
+            // - a received diff/snapshot was materialized and history already has its exact value;
+            // - there was no update at C, so global completion proves the preceding value carried
+            //   forward unchanged.
+            // `add_unchanged` preserves an exact entry when one exists and records the proven
+            // carried-forward state otherwise.
+            component_history.add_unchanged(confirmed_tick);
             confirmed_value
         };
 
@@ -423,7 +436,7 @@ impl PredictionRegistry {
             return false;
         };
 
-        // The unchanged-component path is a completion-time consistency check.
+        // This is a completion-time consistency check.
         // If the prediction history has no retained state at this tick, we
         // cannot prove a mismatch; this can happen for newly spawned predicted
         // entities whose local history starts after the completed server tick.
@@ -444,29 +457,28 @@ impl PredictionRegistry {
         self.should_rollback_check(confirmed_value.as_ref(), predicted_state.value())
     }
 
-    /// Add the confirmed value to confirmed history, and optionally check for rollback.
+    /// Add an authoritative value to confirmed history.
     ///
     /// This function:
-    /// 1. Always adds the confirmed value to confirmed history.
-    /// 2. If `check_mismatch` is true and the tick is already locally checkable,
-    ///    compares with the predicted value and returns true if there's a mismatch.
-    fn record_confirmed_and_maybe_check<C: SyncComponent>(
+    /// State mismatch decisions are intentionally deferred to the full scan at a completed
+    /// checkpoint. An entity-level confirmation does not mean every predicted component on that
+    /// entity was updated; receive-time checks could therefore miss unchanged component
+    /// mismatches on the same entity.
+    fn record_confirmed<C: SyncComponent>(
         &self,
         confirmed_tick: Tick,
         confirmed_component: Option<C>,
         entity_mut: &mut DeferredEntity,
-        check_mismatch: bool,
         current_tick: Tick,
         materialized_initial: bool,
-    ) -> bool {
+    ) {
         let entity = entity_mut.id();
         let name = DebugName::type_name::<C>();
         let _span = trace_span!(
-            "record_confirmed_and_maybe_check",
+            "record_confirmed",
             ?name,
             %entity,
-            ?confirmed_tick,
-            ?check_mismatch
+            ?confirmed_tick
         )
         .entered();
 
@@ -493,55 +505,6 @@ impl PredictionRegistry {
                 .set(predicted_history.len() as f64);
         }
 
-        // Check for mismatch if requested. Authoritative mutations can be
-        // applied out of order when Replicon keeps marker history enabled:
-        // after rollback preparation prunes history at a newer confirmed tick,
-        // an older mutation may still be delivered. We should keep the
-        // confirmed sample, but a pruned prediction cannot prove a mismatch.
-        let oldest_retained_tick = predicted_history
-            .as_ref()
-            .and_then(|history| Self::oldest_retained_tick(history));
-        let history_was_pruned_past_confirmed =
-            oldest_retained_tick.is_some_and(|oldest_tick| oldest_tick > confirmed_tick);
-        let should_rollback = if check_mismatch
-            && confirmed_tick <= current_tick
-            && !history_was_pruned_past_confirmed
-        {
-            let history_value = predicted_history
-                .as_ref()
-                .and_then(|history| history.get(confirmed_tick));
-            self.should_rollback_check(confirmed_component.as_ref(), history_value)
-        } else {
-            false
-        };
-        if check_mismatch && history_was_pruned_past_confirmed {
-            trace!(
-                target: "lightyear_debug::prediction",
-                kind = "confirmed_history_stale_skip_mismatch",
-                entity = ?entity,
-                component = ?name,
-                confirmed_tick = confirmed_tick.0,
-                oldest_retained_tick = oldest_retained_tick.map(|tick| tick.0),
-                "skipping rollback check for confirmed tick older than retained prediction history"
-            );
-        }
-        if check_mismatch && confirmed_tick > current_tick {
-            trace!(
-                target: "lightyear_debug::prediction",
-                kind = "confirmed_history_future_skip_mismatch",
-                entity = ?entity,
-                component = ?name,
-                confirmed_tick = confirmed_tick.0,
-                current_tick = current_tick.0,
-                "skipping rollback check until local prediction reaches confirmed tick"
-            );
-            // SAFETY: PredictionManager aliases neither the DeferredEntity's component access nor
-            // the PredictionRegistry resource backing `self`.
-            unsafe { entity_mut.world_mut() }
-                .resource_mut::<PredictionManager>()
-                .pending_entity_state_checks
-                .record(confirmed_tick, entity);
-        }
         // Always add confirmed value to confirmed history - this value will be preserved during rollback
         trace!(
             target: "lightyear_debug::prediction",
@@ -549,8 +512,6 @@ impl PredictionRegistry {
             entity = ?entity,
             component = ?name,
             confirmed_tick = confirmed_tick.0,
-            check_mismatch,
-            should_rollback,
             value = ?confirmed_component.as_ref(),
             "recorded confirmed value in confirmed history"
         );
@@ -586,7 +547,6 @@ impl PredictionRegistry {
             history.add_state(seed_tick, HistoryState::Removed);
             entity_mut.insert(history);
         }
-        should_rollback
     }
 
     /// Type-erased function for hashing the value in a [`PredictionHistory<C>`] at `tick`.
@@ -1097,6 +1057,7 @@ impl<C> PredictionRegistrationExt<C> for ComponentRegistration<'_, C> {
             DebugName::type_name::<C>()
         );
         registry.register::<C>(prediction_history_id, confirmed_history_id);
+        registry.set_pending_diff_tick::<C>();
         add_prediction_systems::<C>(self.app);
         crate::plugin::add_prediction_diff_systems::<C>(self.app);
 
@@ -1283,9 +1244,8 @@ impl PredictionAppRegistrationExt for App {
 // TODO: ideally we would update the LastConfirmedTick at this point?
 /// Instead of writing into a component directly, it writes data into [`ConfirmedHistory<C>`].
 ///
-/// This function:
-/// 1. Always adds the confirmed value to confirmed history (needed for rollback in any mode)
-/// 2. If `RollbackMode::Check`, also checks for mismatch and records it
+/// The authoritative value is retained in confirmed history. State mismatch decisions are made
+/// later by the full scan at a completed checkpoint.
 fn write_history<C: SyncComponent>(
     ctx: &mut WriteCtx,
     rule_fns: &RuleFns<C>,
@@ -1326,19 +1286,12 @@ fn write_history_inner<C: SyncComponent>(
     if materialized_initial {
         entity.insert(component.clone());
     }
-    let (tick, should_rollback) = add_confirmed_to_history_inner(
+    add_confirmed_to_history_inner(
         ctx.message_tick,
         Some(component),
         entity,
-        !materialized_initial,
         materialized_initial,
     )?;
-    if should_rollback {
-        // SAFETY: we only access resources, which don't alias with the DeferredEntity's component access
-        unsafe { entity.world_mut() }
-            .resource_mut::<StateRollbackMetadata>()
-            .record_mismatch(tick);
-    }
     Ok(())
 }
 
@@ -1384,19 +1337,12 @@ fn write_history_diff_inner<C: SyncComponent + RepliconDiffable>(
             }
             let receiver = ctx.get_or_default::<HistoryDiffReceiver<C>>();
             receiver.record_cursor(tick, Some(index));
-            let should_rollback = add_resolved_confirmed_to_history_inner(
+            add_resolved_confirmed_to_history_inner(
                 tick,
                 Some(component),
                 entity,
-                !materialized_initial,
                 materialized_initial,
             );
-            if should_rollback {
-                // SAFETY: we only access resources, which don't alias with the DeferredEntity's component access
-                unsafe { entity.world_mut() }
-                    .resource_mut::<StateRollbackMetadata>()
-                    .record_mismatch(tick);
-            }
         }
         ComponentDelta::Diffs { index, diffs } => {
             let receiver = ctx.get_or_default::<HistoryDiffReceiver<C>>();
@@ -1412,13 +1358,7 @@ fn write_history_diff_inner<C: SyncComponent + RepliconDiffable>(
             .transpose()?
             .flatten()
     } {
-        let should_rollback = add_resolved_confirmed_to_history(tick, Some(value), entity, true);
-        if should_rollback {
-            // SAFETY: we only access resources, which don't alias with the DeferredEntity's component access
-            unsafe { entity.world_mut() }
-                .resource_mut::<StateRollbackMetadata>()
-                .record_mismatch(tick);
-        }
+        add_resolved_confirmed_to_history(tick, Some(value), entity);
     }
     Ok(())
 }
@@ -1453,28 +1393,12 @@ fn client_diff_and_tick<C: SyncComponent + RepliconDiffable>(
     Ok(Some((tick, diff)))
 }
 
-fn add_confirmed_to_history<C: SyncComponent>(
-    message_tick: RepliconTick,
-    confirmed_component: Option<C>,
-    entity: &mut DeferredEntity,
-    check_state_rollback: bool,
-) -> Result<(Tick, bool)> {
-    add_confirmed_to_history_inner(
-        message_tick,
-        confirmed_component,
-        entity,
-        check_state_rollback,
-        false,
-    )
-}
-
 fn add_confirmed_to_history_inner<C: SyncComponent>(
     message_tick: RepliconTick,
     confirmed_component: Option<C>,
     entity: &mut DeferredEntity,
-    check_state_rollback: bool,
     materialized_initial: bool,
-) -> Result<(Tick, bool)> {
+) -> Result<()> {
     let checkpoints = {
         let world = unsafe { entity.world_mut() };
         let checkpoints = world
@@ -1491,97 +1415,73 @@ fn add_confirmed_to_history_inner<C: SyncComponent>(
             false,
             "missing authoritative checkpoint mapping while writing prediction history"
         );
-        return Ok((Tick(0), false));
+        return Ok(());
     };
-    let should_rollback = add_resolved_confirmed_to_history_inner(
+    add_resolved_confirmed_to_history_inner(
         tick,
         confirmed_component,
         entity,
-        check_state_rollback,
         materialized_initial,
     );
-    Ok((tick, should_rollback))
+    Ok(())
 }
 
 fn add_resolved_confirmed_to_history<C: SyncComponent>(
     tick: Tick,
     confirmed_component: Option<C>,
     entity: &mut DeferredEntity,
-    check_state_rollback: bool,
-) -> bool {
-    add_resolved_confirmed_to_history_inner(
-        tick,
-        confirmed_component,
-        entity,
-        check_state_rollback,
-        false,
-    )
+) {
+    add_resolved_confirmed_to_history_inner(tick, confirmed_component, entity, false)
 }
 
 fn add_resolved_confirmed_to_history_inner<C: SyncComponent>(
     tick: Tick,
     confirmed_component: Option<C>,
     entity: &mut DeferredEntity,
-    check_state_rollback: bool,
     materialized_initial: bool,
-) -> bool {
+) {
     // SAFETY: we only access resources, which don't alias with the DeferredEntity's component access.
     // We extract all needed values and drop the world borrow before using `entity` again.
-    let (registry, should_check, current_tick, state_metadata) = {
+    let (registry, current_tick) = {
         let world = unsafe { entity.world_mut() };
         let registry = world.resource::<PredictionRegistry>() as *const PredictionRegistry;
-        let state_metadata =
-            world.resource::<StateRollbackMetadata>() as *const StateRollbackMetadata;
-        let current_tick = world.resource::<LocalTimeline>().tick();
-        let should_check = world
-            .get_resource::<PredictionManager>()
-            .is_some_and(|m| matches!(m.rollback_policy.state, RollbackMode::Check));
-        (unsafe { &*registry }, should_check, current_tick, unsafe {
-            &*state_metadata
-        })
+        let current_tick = world
+            .resource::<lightyear_core::prelude::LocalTimeline>()
+            .tick();
+        (unsafe { &*registry }, current_tick)
     };
-    // Always add confirmed values to history (needed for rollback in any mode).
-    // If RollbackMode::Check, also check for mismatch unless this tick is
-    // already processed or already known mismatched.
-    let check_state_rollback =
-        check_state_rollback && state_metadata.should_check_mismatch_at(tick);
-    registry.record_confirmed_and_maybe_check(
+    // Always add confirmed values to history. The completed-checkpoint scan is the only place
+    // where authoritative state is compared with prediction history.
+    registry.record_confirmed(
         tick,
         confirmed_component,
         entity,
-        check_state_rollback && should_check,
         current_tick,
         materialized_initial,
-    )
+    );
 }
 
 /// Removes component `C` and records the removal in history.
 ///
-/// This function:
-/// 1. Always adds the confirmed removal to the prediction history (needed for rollback in any mode)
-/// 2. If `RollbackMode::Check`, also checks for mismatch and records it
+/// The removal is retained in confirmed history. State mismatch decisions are made later by the
+/// full scan at a completed checkpoint.
 fn remove_history<C: SyncComponent>(ctx: &mut RemoveCtx, entity: &mut DeferredEntity) {
     // SAFETY: we only access resources, which don't alias with the DeferredEntity's component access.
     // We extract all needed values and drop the world borrow before using `entity` again.
-    let (registry, checkpoints, should_check, current_tick, state_metadata) = {
+    let (registry, checkpoints, current_tick) = {
         let world = unsafe { entity.world_mut() };
         let registry = world.resource::<PredictionRegistry>() as *const PredictionRegistry;
         let checkpoints = world
             .resource::<lightyear_replication::checkpoint::ReplicationCheckpointMap>()
             as *const lightyear_replication::checkpoint::ReplicationCheckpointMap;
-        let state_metadata =
-            world.resource::<StateRollbackMetadata>() as *const StateRollbackMetadata;
-        let current_tick = world.resource::<LocalTimeline>().tick();
-        let should_check = world
-            .get_resource::<PredictionManager>()
-            .is_some_and(|m| matches!(m.rollback_policy.state, RollbackMode::Check));
+        let current_tick = world
+            .resource::<lightyear_core::prelude::LocalTimeline>()
+            .tick();
         // SAFETY: registry lives in the World and won't be moved/dropped during this function
         (
             unsafe { &*registry },
             unsafe { &*checkpoints },
-            should_check,
             current_tick,
-            unsafe { &*state_metadata },
         )
     };
     let Some(tick) = resolve_message_tick(checkpoints, ctx.message_tick) else {
@@ -1596,29 +1496,13 @@ fn remove_history<C: SyncComponent>(ctx: &mut RemoveCtx, entity: &mut DeferredEn
         return;
     };
 
-    // Always add confirmed removal to history (needed for rollback in any mode).
-    // If RollbackMode::Check, also check for mismatch unless this tick is
-    // already processed or already known mismatched.
-    let should_check = should_check && state_metadata.should_check_mismatch_at(tick);
-    let should_rollback = registry.record_confirmed_and_maybe_check::<C>(
-        tick,
-        None,
-        entity,
-        should_check,
-        current_tick,
-        false,
-    );
-    if should_rollback {
-        // SAFETY: we only access resources, which don't alias with the DeferredEntity's component access
-        unsafe { entity.world_mut() }
-            .resource_mut::<StateRollbackMetadata>()
-            .record_mismatch(tick);
-    }
+    registry.record_confirmed::<C>(tick, None, entity, current_tick, false);
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::manager::PredictionManager;
     use crate::plugin::{PredictionMarkerPlugin, PredictionPlugin};
     use alloc::vec::Vec;
     use bevy_ecs::system::RunSystemOnce;
@@ -1630,6 +1514,7 @@ mod tests {
     use bevy_replicon::shared::replication::registry::test_fns::TestFnsEntityExt;
     use bevy_state::app::StatesPlugin;
     use core::hash::Hasher;
+    use lightyear_core::prelude::LocalTimeline;
     use lightyear_interpolation::prelude::{
         InterpolationMarkerPlugin, InterpolationPlugin, InterpolationRegistrationExt,
         InterpolationRegistry,
@@ -1968,25 +1853,6 @@ mod tests {
             app.world()
                 .resource::<PredictionRegistry>()
                 .predicted::<LocalRollbackComponent>()
-        );
-    }
-
-    #[test]
-    fn oldest_retained_tick_tracks_history_pruning() {
-        let mut history = PredictionHistory::<TestComponent>::default();
-        history.add_predicted(Tick(10), Some(TestComponent(10)));
-        history.add_predicted(Tick(11), Some(TestComponent(11)));
-        history.add_predicted(Tick(12), Some(TestComponent(12)));
-
-        history.clear_until_tick(Tick(11));
-
-        assert_eq!(
-            PredictionRegistry::oldest_retained_tick(&history),
-            Some(Tick(11))
-        );
-        assert!(
-            PredictionRegistry::oldest_retained_tick(&history).unwrap() > Tick(10),
-            "a confirmed update for tick 10 is older than retained prediction history"
         );
     }
 

--- a/crates/replication/prediction/src/rollback.rs
+++ b/crates/replication/prediction/src/rollback.rs
@@ -16,18 +16,15 @@ Does that mean that we fully know the state of entity B? How do we determine the
 
 Then the question becomes, how does that affect how we rollback?
 We need:
-- when we receive an update, we can do a rollback check and add a new confirmed value in the history
-- for entities that were not updated, we do a rollback check at the latest completed mutate tick T only if that completed tick advanced (otherwise we already did the check). When the completed tick advances, then we can set a new confirmed value for all entities that were not updated. This means that the last confirmed value is AT LEAST
+- when we receive an update, we add its authoritative value to confirmed history;
+- once a completed checkpoint advances, we compare every replicated predicted component at that
+  checkpoint. We cannot skip an entity just because it received an update: confirmation is tracked
+  per entity, and another predicted component on that entity may have been unchanged and mismatched;
 - To rollback we have 2 choices:
   - rollback from the earliest confirmed tick across all predicted entities (predicted entities are a subset of all entities so it's possible that this is more recent than the latest completed mutate tick)
   - rollback from the latest completed mutate tick
     For simplicity we will do the second choice
-- When we detect an explicit mismatch while receiving an update, we record the mismatch tick early,
-  but we do not roll back from that tick until a completed mutate tick has reached it. At that
-  point, we roll back from the latest completed mutate tick so every replicated component has a
-  known authoritative state.
-- If we don't do a mismatch check, we rollback from the latest completed mutate tick.
-- One thing to be careful of is that we could have completed mutate tick T, but have received confirmed updates for ticks > T. In which case we don't want to overwrite them when we rollback, and instead use these confirmed values!
+- One thing to be careful of is that we could have completed mutate tick T, but have received confirmed updates for ticks > T. In which case we don't want to overwrite them when we rollback, and instead use these confirmed values during the rollback!
 
  */
 
@@ -38,19 +35,21 @@ use crate::despawn::PredictionDisable;
 use crate::diagnostics::PredictionMetrics;
 use crate::manager::{LastConfirmedInput, PredictionManager, RollbackMode, StateRollbackMetadata};
 use crate::plugin::PredictionSystems;
-use crate::registry::PredictionRegistry;
+use crate::registry::{PendingDiffTickFn, PredictionRegistry};
 use alloc::vec::Vec;
 use bevy_app::FixedMain;
 use bevy_app::prelude::*;
-use bevy_ecs::component::Mutable;
+use bevy_ecs::component::{ComponentId, Mutable};
 use bevy_ecs::lifecycle::HookContext;
 use bevy_ecs::prelude::*;
 use bevy_ecs::schedule::ScheduleLabel;
-use bevy_ecs::system::{ParamBuilder, QueryParamBuilder};
+use bevy_ecs::system::{LocalBuilder, ParamBuilder, QueryParamBuilder};
 use bevy_ecs::world::{DeferredWorld, FilteredEntityMut};
 use bevy_reflect::Reflect;
+use bevy_replicon::client::server_mutate_ticks::ServerMutateTicks;
 use bevy_replicon::prelude::{ClientMessages, ClientSystems};
 use bevy_replicon::shared::backend::channels::ServerChannel;
+use bevy_replicon::shared::replication::storage::ReplicationStorage;
 use bevy_time::{Fixed, Time};
 use bevy_utils::prelude::DebugName;
 use core::fmt::Debug;
@@ -130,6 +129,7 @@ impl Plugin for RollbackPlugin {
         // rollback decision system to operate on remote inputs.
         app.init_resource::<ComponentRegistry>();
         app.init_resource::<ReplicationCheckpointMap>();
+        app.init_resource::<ServerMutateTicks>();
         app.init_resource::<PreSpawnedReceiver>();
 
         #[cfg(feature = "p2p")]
@@ -195,22 +195,27 @@ impl Plugin for RollbackPlugin {
             .remove_resource::<PredictionRegistry>()
             .unwrap();
 
-        let replicated_prediction_histories = prediction_registry
-            .prediction_map
-            .iter()
-            // don't check_rollback for non-networked components, which are not present in the ComponentRegistry
-            .filter_map(|(kind, p)| {
-                component_registry
-                    .component_metadata_map
-                    .contains_key(kind)
-                    .then_some((p.prediction_history_id, p.confirmed_history_id))
-            })
-            .collect::<Vec<_>>();
+        let mut replicated_prediction_histories = Vec::new();
+        let mut pending_diff_tick_fns = Vec::new();
+        for (kind, metadata) in &prediction_registry.prediction_map {
+            // Don't check rollback for non-networked components, which are not present in the
+            // ComponentRegistry.
+            if !component_registry.component_metadata_map.contains_key(kind) {
+                continue;
+            }
+            replicated_prediction_histories.push((
+                metadata.prediction_history_id,
+                metadata.confirmed_history_id,
+            ));
+            if let Some(pending_diff_tick) = metadata.pending_diff_tick {
+                pending_diff_tick_fns.push((metadata.prediction_history_id, pending_diff_tick));
+            }
+        }
 
         let check_rollback = (
             QueryParamBuilder::new(|builder| {
-                builder.data::<&Predicted>();
-                builder.data::<&ConfirmHistory>();
+                builder.with::<Predicted>();
+                builder.with::<ConfirmHistory>();
                 builder.without::<DeterministicPredicted>();
                 builder.without::<DisableRollback>();
                 // include PredictionDisable entities (entities that are predicted and 'despawned'
@@ -239,6 +244,9 @@ impl Plugin for RollbackPlugin {
                     }
                 });
             }),
+            // Component registration is complete at this point. Cache only the diff-specific
+            // history id/function pairs needed to constrain completed rollback checkpoints.
+            LocalBuilder(pending_diff_tick_fns),
             ParamBuilder,
             ParamBuilder,
             ParamBuilder,
@@ -248,6 +256,9 @@ impl Plugin for RollbackPlugin {
             ParamBuilder,
             ParamBuilder,
             ParamBuilder,
+            // A nested tuple counts as one outer system parameter, keeping the dynamically built
+            // system below Bevy's 16-element tuple limit.
+            (ParamBuilder, ParamBuilder),
             ParamBuilder,
             ParamBuilder,
             ParamBuilder,
@@ -381,13 +392,9 @@ fn check_received_replication_messages(
 fn reset_state_rollback_metadata_on_topology_change(
     networking: Res<NetworkingMetadata>,
     mut metadata: ResMut<StateRollbackMetadata>,
-    prediction_manager: Option<ResMut<PredictionManager>>,
 ) {
     if networking.is_changed() {
         metadata.reset_connection_state();
-        if let Some(mut prediction_manager) = prediction_manager {
-            prediction_manager.pending_entity_state_checks.clear();
-        }
     }
 }
 
@@ -395,23 +402,25 @@ fn reset_state_rollback_metadata_on_topology_change(
 /// We do this separately from `prepare_rollback` because even if we stop the `check_rollback` function
 /// early as soon as we find a mismatch, but we need to rollback all components to the original state.
 ///
-/// Key invariant: `ReplicationCheckpointMap::last_confirmed_tick() = T` guarantees that for all entities,
-/// we have complete information at tick T:
-/// - Entities that received an update at T: their confirmed value is in the message
-/// - Entities that didn't receive an update: their value at T = their last confirmed value
+/// Key invariant: a completed checkpoint C guarantees that for all entities, we have complete
+/// information at C:
+/// - entities that received an update at C have their confirmed value in history;
+/// - entities that did not receive an update have the same value as their last confirmation before C.
 fn check_rollback(
     // we want Query<(&mut PredictionHistory<C>, &Confirmed<C>), With<Predicted>>
     // make sure to include disabled entities
-    mut predicted_entities: Query<(&ConfirmHistory, FilteredEntityMut)>,
+    mut predicted_entities: Query<FilteredEntityMut>,
+    pending_diff_tick_fns: Local<Vec<(ComponentId, PendingDiffTickFn)>>,
     timeline: SyncedLocalTimeline,
     input_config: Res<InputTimelineConfig>,
     last_confirmed_input: Res<LastConfirmedInput>,
     mut prediction_manager: ResMut<PredictionManager>,
     mut state_metadata: ResMut<StateRollbackMetadata>,
     checkpoints: Res<ReplicationCheckpointMap>,
+    server_mutate_ticks: Res<ServerMutateTicks>,
+    replication_storage: Option<Res<ReplicationStorage>>,
     mut prespawned_receiver: ResMut<PreSpawnedReceiver>,
-    component_registry: Res<ComponentRegistry>,
-    prediction_registry: Res<PredictionRegistry>,
+    (component_registry, prediction_registry): (Res<ComponentRegistry>, Res<PredictionRegistry>),
     awaiting_catchup: Query<(), (With<CatchUpGated>, With<ConfirmHistory>)>,
     deterministic_predicted: Query<&DeterministicPredicted>,
     parallel_commands: ParallelCommands,
@@ -426,10 +435,34 @@ fn check_rollback(
         .rollback_policy
         .effective_max_rollback_ticks(&input_config);
 
-    // The tick where ALL messages have been received (guaranteed complete information).
-    // Explicit mismatch checks can exist before this is known, so don't return early.
+    // Let:
+    // - T be the current local simulation tick;
+    // - S be the globally latest confirmed checkpoint;
+    // - C0 be the latest confirmed checkpoint with C0 <= T;
+    // - P be the earliest unresolved diff tick at or before C0;
+    // - C be C0 when no such P exists, otherwise the latest completed checkpoint before P.
+    //
+    // In the usual case, the client is ahead of the server so S <= T and C0 = S. The
+    // completed-checkpoint scan checks all replicated predicted components. This is
+    // required for correctness: Replicon's confirmation marker is
+    // entity-level, so the old receive-time path could skip an updated entity even when
+    // another predicted component on that entity was unchanged and mismatched.
+    //
+    // If S > T, Replicon's completion history lets us find C0 even though the latest completed
+    // checkpoint is still in the local future. Diff replication adds one more constraint: an
+    // unresolved diff at P makes the effective authoritative state unknown at every tick from P
+    // onward. We therefore cannot use C0 when P <= C0. In that case, choose the latest globally
+    // completed checkpoint strictly before the earliest such P. We intentionally derive that
+    // fallback from ServerMutateTicks rather than ConfirmedHistory: histories contain explicit
+    // component updates and selected unchanged anchors, not every globally completed checkpoint.
     let server_confirmed_tick = checkpoints.last_confirmed_tick();
-    let server_confirmed_replicon_tick = checkpoints.last_confirmed_replicon_tick();
+    let candidate_confirmed_tick = match server_confirmed_tick {
+        Some(confirmed_tick) if confirmed_tick <= tick => Some(confirmed_tick),
+        Some(_) => checkpoints
+            .latest_completed_at_or_before(&server_mutate_ticks, tick)
+            .map(|checkpoint| checkpoint.tick),
+        None => None,
+    };
 
     let do_rollback = move |rollback_tick: Tick,
                             prediction_manager: &PredictionManager,
@@ -555,176 +588,150 @@ fn check_rollback(
             "policy-driven rollback checks deferred while a catch-up snapshot is pending"
         );
     } else {
+        // Start from the newest globally completed checkpoint at or before the local tick, then
+        // constrain it by unresolved diffs on predicted diff-replicated components.
+        //
+        // We might be in a situation where a tick is confirmed in ServerMutateTicks, but the diff
+        // is not ready and is instead in 'pending' state. We go through all DiffHistoryReceiver
+        // and find the earliest 'pending' tick before our candidate. If  there are none, we can
+        // use C0. Else we find the earliest confirmed tick before that.
+        let confirmed_tick = (|| {
+            let candidate = candidate_confirmed_tick?;
+            let Some(storage) = replication_storage.as_deref() else {
+                return Some(candidate);
+            };
+
+            let mut earliest_pending_tick = None;
+            for &(prediction_history_id, pending_diff_tick) in pending_diff_tick_fns.iter() {
+                for entity_mut in predicted_entities
+                    .iter_mut()
+                    .filter(|entity_mut| entity_mut.contains_id(prediction_history_id))
+                {
+                    let Some(pending_tick) = pending_diff_tick(storage, candidate, entity_mut.id())
+                    else {
+                        continue;
+                    };
+                    earliest_pending_tick = Some(
+                        earliest_pending_tick
+                            .map_or(pending_tick, |earliest| Tick::min(earliest, pending_tick)),
+                    );
+                }
+            }
+
+            match earliest_pending_tick {
+                // P itself is unresolved, so the bound is strict. The selected rollback target is
+                // still required to be a globally completed Replicon checkpoint.
+                Some(pending_tick) => checkpoints
+                    .latest_completed_before(&server_mutate_ticks, pending_tick)
+                    .map(|checkpoint| checkpoint.tick),
+                None => Some(candidate),
+            }
+        })();
+
         // If we check for rollback on both state and input, state takes precedence.
         match prediction_manager.rollback_policy.state {
             // if we received a state update, we don't check for mismatches and just set the rollback tick
             RollbackMode::Always => {
-                if let Some(server_confirmed_tick) = server_confirmed_tick
+                if let Some(confirmed_tick) = confirmed_tick
                     && received_state
                     && !predicted_entities.is_empty()
                 {
                     debug!(
-                        ?server_confirmed_tick,
+                        ?confirmed_tick,
                         "Rollback because we have received a new confirmed state. (no mismatch check)"
                     );
                     do_rollback(
-                        server_confirmed_tick,
+                        confirmed_tick,
                         &prediction_manager,
                         &mut commands,
                         Rollback::FromState,
                     );
+                    state_metadata.set_last_processed_confirmed_tick(confirmed_tick);
                 };
             }
             RollbackMode::Check => {
-                // Check if the completed mutate tick has advanced since we last processed it.
-                //
-                // If multiple server-completed ticks arrive before this system
-                // runs, process only the latest one. A later completed tick is
-                // the best rollback point because it minimizes replay work while
-                // still certifying complete authoritative state for every
-                // replicated component at that tick.
-                let server_ticks_advanced = server_confirmed_tick
-                    .is_some_and(|tick| state_metadata.has_confirmed_tick_advanced(tick));
-
-                // If the completed mutate tick advanced, rollback or check unchanged entities.
-                // Only check if we haven't already triggered a rollback.
-                if let (Some(server_confirmed_tick), Some(server_confirmed_replicon_tick)) =
-                    (server_confirmed_tick, server_confirmed_replicon_tick)
+                // Do a rollback check using the confirmed state at C (which is guaranteed to
+                // be complete) and the predicted history state at C
+                if let Some(confirmed_tick) = confirmed_tick
                     && !prediction_manager.is_rollback()
-                    && server_ticks_advanced
+                    && state_metadata.has_confirmed_tick_advanced(confirmed_tick)
                 {
-                    if server_confirmed_tick > tick {
-                        debug!(
-                            "Confirmed mutate tick is in the future: {:?} compared to client timeline. Current tick: {:?}",
-                            server_confirmed_tick, tick
-                        );
-                    } else {
-                        let deferred_check_entities = prediction_manager
-                            .pending_entity_state_checks
-                            .take_through(server_confirmed_tick);
-                        if let Some(mismatch_tick) =
-                            state_metadata.pending_mismatch_at_or_before(server_confirmed_tick)
-                        {
-                            debug!(
-                                ?server_confirmed_tick,
-                                ?mismatch_tick,
-                                "Rollback from completed mutate tick with recorded explicit mismatch"
-                            );
-                            trace!(
-                                target: "lightyear_debug::prediction",
-                                kind = "state_mismatch_consumed",
-                                schedule = "PreUpdate",
-                                sample_point = "PreUpdate",
-                                local_tick = tick.0,
-                                confirmed_tick = server_confirmed_tick.0,
-                                mismatch_tick = mismatch_tick.0,
-                                rollback_tick = server_confirmed_tick.0,
-                                "state mismatch consumed at completed mutate tick"
-                            );
-                            state_metadata.clear_mismatch_history();
-                            do_rollback(
-                                server_confirmed_tick,
-                                &prediction_manager,
-                                &mut commands,
-                                Rollback::FromState,
-                            );
-                        } else {
-                            // A completed mutate tick certifies every replicated component at that
-                            // tick. This scan normally handles entities that were not explicitly
-                            // confirmed at the completed Replicon checkpoint. It also handles an
-                            // explicitly confirmed entity when its receive-time check was deferred
-                            // because the authoritative tick was ahead of the local timeline.
-                            //
-                            // Do not use `ConfirmHistory::last_tick()` for this skip. An entity can
-                            // have newer explicit confirmations than the completed checkpoint while
-                            // also having an explicit confirmation at the completed checkpoint. What
-                            // matters here is exact membership: if `ConfirmHistory::contains` resolves the
-                            // completed Replicon tick, receive-time history writes already checked the
-                            // explicit state for that tick unless `deferred_check_entities` says the
-                            // state was not locally checkable then.
-                            trace!(
-                                ?tick,
-                                ?server_confirmed_tick,
-                                ?server_confirmed_replicon_tick,
-                                "Checking for state-based rollback at completed mutate tick"
-                            );
+                    // A completed mutate tick C certifies every replicated component at C, so
+                    // always scan all of them. Explicitly updated components use their received
+                    // samples, while unchanged components use their last authoritative value
+                    // because completion proves it carried forward to C.
+                    trace!(
+                        ?tick,
+                        ?confirmed_tick,
+                        latest_completed_tick = ?server_confirmed_tick,
+                        "Checking for state-based rollback at completed mutate tick"
+                    );
 
-                            let predicted_entities = adaptive_for_each_mut!(predicted_entities);
-                            predicted_entities.for_each(
-                                |(confirm_history, mut entity_mut)| {
-                                if prediction_manager.is_rollback() {
-                                    return
-                                }
-
-                                if confirm_history.contains(server_confirmed_replicon_tick)
-                                    && !deferred_check_entities.contains(&entity_mut.id())
-                                {
-                                    trace!(
-                                        entity = ?entity_mut.id(),
-                                        replicon_tick = ?server_confirmed_replicon_tick,
-                                        "Skipping unchanged rollback check for entity explicitly confirmed at completed mutate tick"
-                                    );
-                                    return
-                                }
-
-                                // For each predicted component, compare the predicted value at
-                                // `server_confirmed_tick` with the component's authoritative value.
-                                // The checker uses an exact `ConfirmedHistory<C>` sample if one exists;
-                                // otherwise it materializes an unchanged sample from the last confirmed
-                                // value before `server_confirmed_tick`.
-                                for check_rollback in prediction_registry.prediction_map
-                                    .iter()
-                                    .filter_map(|(kind, p)|
-                                        // only check rollback for components that are replicated (ignore non-networked)
-                                        component_registry.component_metadata_map.contains_key(kind).then_some(p.check_rollback)
-                                    )
-                                    .take_while(|_| !prediction_manager.is_rollback())
-                                {
-                                    // SAFETY: `server_confirmed_tick` is globally complete. An exact
-                                    // confirmed component sample is authoritative; if it is absent,
-                                    // completion proves that component was unchanged at this tick.
-                                    let should_rollback = unsafe {
-                                        check_rollback(
-                                            &prediction_registry,
-                                            server_confirmed_tick,
-                                            &mut entity_mut,
-                                        )
-                                    };
-                                    if should_rollback {
-                                        debug!(
-                                            ?server_confirmed_tick,
-                                            "Rollback because of mismatch on unchanged entity"
-                                        );
-                                        trace!(
-                                            target: "lightyear_debug::prediction",
-                                            kind = "unchanged_entity_mismatch",
-                                            schedule = "PreUpdate",
-                                            sample_point = "PreUpdate",
-                                            entity = ?entity_mut.id(),
-                                            local_tick = tick.0,
-                                            confirmed_tick = server_confirmed_tick.0,
-                                            rollback_tick = server_confirmed_tick.0,
-                                            "rollback mismatch detected on unchanged entity"
-                                        );
-                                        parallel_commands.command_scope(|mut c| {
-                                            do_rollback(
-                                                server_confirmed_tick,
-                                                &prediction_manager,
-                                                &mut c,
-                                                Rollback::FromState,
-                                            );
-                                        });
-                                        return;
-                                    }
-                                }
-                            });
-                        }
-                        // Update the last processed tick only after we were able to process it.
-                        state_metadata.set_last_processed_tick(server_confirmed_tick);
+                    adaptive_for_each_mut!(predicted_entities, |mut entity_mut| {
                         if prediction_manager.is_rollback() {
-                            state_metadata.clear_mismatch_history();
+                            return;
                         }
-                    }
+
+                        // For each predicted component, compare the predicted value at C with
+                        // its effective authoritative value. The checker uses an exact sample
+                        // when one exists; otherwise completion of C proves the component was
+                        // unchanged, so it materializes the last confirmed value before C.
+                        for check_rollback in prediction_registry
+                            .prediction_map
+                            .iter()
+                            .filter_map(|(kind, metadata)| {
+                                // Only check rollback for components that are replicated;
+                                // non-networked components have no authoritative state at C.
+                                component_registry
+                                    .component_metadata_map
+                                    .contains_key(kind)
+                                    .then_some(metadata.check_rollback)
+                            })
+                            .take_while(|_| !prediction_manager.is_rollback())
+                        {
+                            // SAFETY: `ServerMutateTicks` reports `confirmed_tick` as globally
+                            // complete, and no predicted diff component has an unresolved update at
+                            // or before it. Absence of an explicit component sample therefore proves
+                            // that the component was unchanged at this checkpoint.
+                            let should_rollback = unsafe {
+                                check_rollback(
+                                    &prediction_registry,
+                                    confirmed_tick,
+                                    &mut entity_mut,
+                                )
+                            };
+                            if should_rollback {
+                                debug!(
+                                    ?confirmed_tick,
+                                    "Rollback because of mismatch at completed checkpoint"
+                                );
+                                trace!(
+                                    target: "lightyear_debug::prediction",
+                                    kind = "completed_checkpoint_mismatch",
+                                    schedule = "PreUpdate",
+                                    sample_point = "PreUpdate",
+                                    entity = ?entity_mut.id(),
+                                    local_tick = tick.0,
+                                    latest_completed_tick = server_confirmed_tick.map(|tick| tick.0),
+                                    completed_tick = confirmed_tick.0,
+                                    rollback_tick = confirmed_tick.0,
+                                    "rollback mismatch detected at completed checkpoint"
+                                );
+                                parallel_commands.command_scope(|mut c| {
+                                    do_rollback(
+                                        confirmed_tick,
+                                        &prediction_manager,
+                                        &mut c,
+                                        Rollback::FromState,
+                                    );
+                                });
+                                return;
+                            }
+                        }
+                    });
+
+                    // Update the last processed confirmed tick only after C was scanned.
+                    state_metadata.set_last_processed_confirmed_tick(confirmed_tick);
                 }
             }
             RollbackMode::Disabled => {}
@@ -961,7 +968,6 @@ pub(crate) fn remove_prediction_disable(
 pub(crate) fn prepare_rollback<C: Component<Mutability = Mutable> + Clone>(
     timeline: Res<LocalTimeline>,
     prediction_registry: Res<PredictionRegistry>,
-    checkpoints: Res<ReplicationCheckpointMap>,
     mut commands: Commands,
     // We also snap the value of the component to the server state if we are in rollback
     // We use Option<> because the predicted component could have been removed while it still exists in Confirmed
@@ -983,35 +989,23 @@ pub(crate) fn prepare_rollback<C: Component<Mutability = Mutable> + Clone>(
     let current_tick = timeline.tick();
     let _span = trace_span!("prepare_rollback", tick = ?current_tick, kind = ?kind).entered();
     let rollback_tick = manager.get_rollback_start_tick().unwrap();
-
-    // The tick where ALL messages have been received, if known.
-    let server_confirmed_tick = checkpoints.last_confirmed_tick();
+    let is_state_rollback = matches!(*rollback, Rollback::FromState);
 
     for (entity, predicted_component, mut predicted_history, confirmed_history) in
         predicted_query.iter_mut()
     {
-        let is_state_rollback = matches!(*rollback, Rollback::FromState);
-        let is_completed_state_rollback =
-            is_state_rollback && server_confirmed_tick == Some(rollback_tick);
-        let is_forced_state_rollback = is_state_rollback && !is_completed_state_rollback;
-
         let restore_state = if is_state_rollback {
             if let Some(history) = confirmed_history.as_ref() {
-                // Completed state rollbacks restore from the latest globally completed
-                // mutate tick. That completed tick proves that a component without an
-                // explicit update is unchanged since its previous confirmed state, even
-                // if `add_unchanged` was never called because rollback checking stopped
+                // A policy-driven state rollback uses the diff-aware completed checkpoint C stored
+                // in PredictionManager as its rollback target. Completion of C proves that a
+                // component without an explicit update is unchanged since its previous confirmed
+                // state, even if `add_unchanged` was never called because rollback checking stopped
                 // after the first mismatch.
                 //
-                // Forced state rollbacks use the same lookup, but rely on the caller's
-                // stronger precondition: the forced rollback target has already been
-                // seeded with authoritative confirmed history up to `rollback_tick`.
-                // Input rollbacks do not satisfy either precondition and restore from
-                // local predicted history instead.
-                debug_assert!(
-                    is_completed_state_rollback || is_forced_state_rollback,
-                    "state rollback must be completed or forced"
-                );
+                // A forced state rollback uses the same lookup, but relies on the caller's stronger
+                // precondition: its explicit rollback target has already been seeded with
+                // authoritative confirmed history. Input rollbacks instead restore from local
+                // predicted history.
                 history.get_state_at_or_before(rollback_tick).cloned()
             } else {
                 // State rollback can also cover predicted-only local components
@@ -1055,7 +1049,6 @@ pub(crate) fn prepare_rollback<C: Component<Mutability = Mutable> + Clone>(
             component = ?kind,
             local_tick = current_tick.0,
             rollback_tick = rollback_tick.0,
-            confirmed_tick = server_confirmed_tick.map(|tick| tick.0),
             rollback = ?rollback,
             history_len = predicted_history.len(),
             "prepared component rollback"
@@ -1388,7 +1381,6 @@ mod tests {
         let mut world = World::new();
         world.init_resource::<LocalTimeline>();
         world.init_resource::<PredictionRegistry>();
-        world.init_resource::<ReplicationCheckpointMap>();
 
         world.insert_resource(PredictionManager::default());
         world.insert_resource(Rollback::FromState);
@@ -1430,7 +1422,6 @@ mod tests {
         let mut world = World::new();
         world.init_resource::<LocalTimeline>();
         world.init_resource::<PredictionRegistry>();
-        world.init_resource::<ReplicationCheckpointMap>();
 
         world.insert_resource(PredictionManager::default());
         world.insert_resource(Rollback::FromInputs);

--- a/crates/replication/replication/src/checkpoint.rs
+++ b/crates/replication/replication/src/checkpoint.rs
@@ -47,6 +47,7 @@ use bevy_platform::collections::HashMap;
 #[cfg(feature = "client")]
 use bevy_replicon::client::UserdataReceived;
 use bevy_replicon::client::confirm_history::ConfirmHistory;
+use bevy_replicon::client::server_mutate_ticks::ServerMutateTicks;
 use bevy_replicon::prelude::RepliconTick;
 #[cfg(feature = "server")]
 use bevy_replicon::server::ReplicationUserdata;
@@ -80,8 +81,16 @@ const MAX_STORED_CHECKPOINTS: usize = 256;
 pub struct ReplicationCheckpointMap {
     entries: HashMap<RepliconTick, Tick>,
     order: VecDeque<RepliconTick>,
-    last_confirmed_replicon_tick: Option<RepliconTick>,
-    last_confirmed_tick: Option<Tick>,
+    last_confirmed_checkpoint: Option<CompletedCheckpoint>,
+}
+
+/// A completed Replicon checkpoint resolved into Lightyear simulation time.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CompletedCheckpoint {
+    /// Replicon's protocol tick for this completed checkpoint.
+    pub replicon_tick: RepliconTick,
+    /// Authoritative Lightyear simulation tick carried by the checkpoint.
+    pub tick: Tick,
 }
 
 impl ReplicationCheckpointMap {
@@ -109,42 +118,109 @@ impl ReplicationCheckpointMap {
         self.entries.get(&replicon_tick).copied()
     }
 
-    /// Latest authoritative tick for which Replicon completed all mutate messages.
+    /// Latest authoritative Lightyear tick for which Replicon completed all mutate messages.
     pub fn last_confirmed_tick(&self) -> Option<Tick> {
-        self.last_confirmed_tick
+        self.last_confirmed_checkpoint
+            .map(|checkpoint| checkpoint.tick)
     }
 
-    /// Latest Replicon mutate checkpoint for which all mutate messages completed.
-    pub fn last_confirmed_replicon_tick(&self) -> Option<RepliconTick> {
-        self.last_confirmed_replicon_tick
+    /// Latest checkpoint for which Replicon completed all mutate messages.
+    pub fn last_confirmed_checkpoint(&self) -> Option<CompletedCheckpoint> {
+        self.last_confirmed_checkpoint
     }
 
-    /// Resolve a completed Replicon mutate checkpoint and cache the authoritative tick.
+    /// Return the newest completed checkpoint that is not ahead of `limit`.
     ///
-    /// Returns `None` if the checkpoint mapping has not been received yet.
-    pub fn record_last_confirmed_tick(&mut self, replicon_tick: RepliconTick) -> Option<Tick> {
-        if let Some(tick) = self.get(replicon_tick) {
-            match self.last_confirmed_tick {
-                None => {
-                    self.last_confirmed_replicon_tick = Some(replicon_tick);
-                    self.last_confirmed_tick = Some(tick);
-                }
-                Some(existing) if tick >= existing => {
-                    self.last_confirmed_replicon_tick = Some(replicon_tick);
-                    self.last_confirmed_tick = Some(tick);
-                }
-                _ => {}
-            }
-            return Some(tick);
+    /// The common case uses the cached latest completed checkpoint. When that checkpoint is ahead
+    /// of the local timeline, inspect the retained Replicon-to-Lightyear mappings and keep only
+    /// ticks that [`ServerMutateTicks`] reports as complete. Multiple Replicon ticks can map to the
+    /// same Lightyear tick; ties prefer the most recent Replicon tick.
+    pub fn latest_completed_at_or_before(
+        &self,
+        server_mutate_ticks: &ServerMutateTicks,
+        limit: Tick,
+    ) -> Option<CompletedCheckpoint> {
+        if let Some(checkpoint) = self.last_confirmed_checkpoint
+            && checkpoint.tick <= limit
+        {
+            return Some(checkpoint);
         }
-        None
+
+        self.latest_completed_matching(server_mutate_ticks, |tick| tick <= limit)
+    }
+
+    /// Return the newest completed checkpoint strictly before `limit`.
+    ///
+    /// This is used when an unresolved diff at `limit` makes that tick and every later tick
+    /// unusable as a rollback checkpoint. The returned checkpoint is selected only from mappings
+    /// that [`ServerMutateTicks`] reports as globally complete.
+    pub fn latest_completed_before(
+        &self,
+        server_mutate_ticks: &ServerMutateTicks,
+        limit: Tick,
+    ) -> Option<CompletedCheckpoint> {
+        if let Some(checkpoint) = self.last_confirmed_checkpoint
+            && checkpoint.tick < limit
+        {
+            return Some(checkpoint);
+        }
+
+        self.latest_completed_matching(server_mutate_ticks, |tick| tick < limit)
+    }
+
+    fn latest_completed_matching(
+        &self,
+        server_mutate_ticks: &ServerMutateTicks,
+        is_within_bound: impl Fn(Tick) -> bool,
+    ) -> Option<CompletedCheckpoint> {
+        let mut best = None;
+        for (&replicon_tick, &tick) in &self.entries {
+            if !server_mutate_ticks.contains(replicon_tick) || !is_within_bound(tick) {
+                continue;
+            }
+            let candidate = CompletedCheckpoint {
+                replicon_tick,
+                tick,
+            };
+            if best.is_none_or(|existing: CompletedCheckpoint| {
+                candidate.tick > existing.tick
+                    || (candidate.tick == existing.tick
+                        && replicon_tick.is_newer(existing.replicon_tick))
+            }) {
+                best = Some(candidate);
+            }
+        }
+        best
+    }
+
+    /// Resolve a completed Replicon mutate checkpoint and update the latest confirmed checkpoint.
+    ///
+    /// A checkpoint advances the cache when its Lightyear tick is newer. If multiple Replicon
+    /// checkpoints map to the same Lightyear tick, the newer Replicon checkpoint wins. Returns the
+    /// resolved checkpoint, even when an already-cached checkpoint remains newer, or `None` if the
+    /// mapping has not been received yet.
+    pub fn record_last_confirmed_checkpoint(
+        &mut self,
+        replicon_tick: RepliconTick,
+    ) -> Option<CompletedCheckpoint> {
+        let checkpoint = CompletedCheckpoint {
+            replicon_tick,
+            tick: self.get(replicon_tick)?,
+        };
+        if self.last_confirmed_checkpoint.is_none_or(|existing| {
+            checkpoint.tick > existing.tick
+                || (checkpoint.tick == existing.tick
+                    && checkpoint.replicon_tick.is_newer(existing.replicon_tick))
+        }) {
+            self.last_confirmed_checkpoint = Some(checkpoint);
+        }
+        Some(checkpoint)
     }
 
     pub fn clear(&mut self) {
         self.entries.clear();
         self.order.clear();
-        self.last_confirmed_replicon_tick = None;
-        self.last_confirmed_tick = None;
+        self.last_confirmed_checkpoint = None;
     }
 }
 
@@ -235,23 +311,125 @@ mod tests {
     }
 
     #[test]
-    fn checkpoint_map_records_latest_confirmed_tick() {
+    fn checkpoint_map_records_latest_confirmed_checkpoint() {
         let mut map = ReplicationCheckpointMap::default();
         map.record(RepliconTick::new(9), Tick(90));
         map.record(RepliconTick::new(10), Tick(100));
+        map.record(RepliconTick::new(11), Tick(100));
 
         assert_eq!(
-            map.record_last_confirmed_tick(RepliconTick::new(10)),
-            Some(Tick(100))
+            map.record_last_confirmed_checkpoint(RepliconTick::new(10)),
+            Some(CompletedCheckpoint {
+                replicon_tick: RepliconTick::new(10),
+                tick: Tick(100),
+            })
         );
         assert_eq!(
-            map.record_last_confirmed_tick(RepliconTick::new(9)),
-            Some(Tick(90))
+            map.record_last_confirmed_checkpoint(RepliconTick::new(9)),
+            Some(CompletedCheckpoint {
+                replicon_tick: RepliconTick::new(9),
+                tick: Tick(90),
+            })
+        );
+        assert_eq!(
+            map.record_last_confirmed_checkpoint(RepliconTick::new(11)),
+            Some(CompletedCheckpoint {
+                replicon_tick: RepliconTick::new(11),
+                tick: Tick(100),
+            })
+        );
+        map.record_last_confirmed_checkpoint(RepliconTick::new(10));
+        assert_eq!(
+            map.last_confirmed_checkpoint(),
+            Some(CompletedCheckpoint {
+                replicon_tick: RepliconTick::new(11),
+                tick: Tick(100),
+            })
         );
         assert_eq!(map.last_confirmed_tick(), Some(Tick(100)));
+    }
+
+    #[test]
+    fn checkpoint_map_finds_latest_completed_tick_before_limit() {
+        let mut map = ReplicationCheckpointMap::default();
+        let mut server_ticks = ServerMutateTicks::default();
+        for (replicon, authoritative) in [(8, 80), (9, 90), (10, 100)] {
+            let replicon_tick = RepliconTick::new(replicon);
+            map.record(replicon_tick, Tick(authoritative));
+            server_ticks.confirm(replicon_tick, 1);
+        }
+        map.record_last_confirmed_checkpoint(RepliconTick::new(10));
+
         assert_eq!(
-            map.last_confirmed_replicon_tick(),
-            Some(RepliconTick::new(10))
+            map.latest_completed_at_or_before(&server_ticks, Tick(95)),
+            Some(CompletedCheckpoint {
+                replicon_tick: RepliconTick::new(9),
+                tick: Tick(90),
+            })
+        );
+        assert_eq!(
+            map.latest_completed_at_or_before(&server_ticks, Tick(100)),
+            Some(CompletedCheckpoint {
+                replicon_tick: RepliconTick::new(10),
+                tick: Tick(100),
+            })
+        );
+        assert_eq!(
+            map.latest_completed_before(&server_ticks, Tick(100)),
+            Some(CompletedCheckpoint {
+                replicon_tick: RepliconTick::new(9),
+                tick: Tick(90),
+            })
+        );
+    }
+
+    #[test]
+    fn checkpoint_map_ignores_mapped_but_incomplete_ticks() {
+        let mut map = ReplicationCheckpointMap::default();
+        let mut server_ticks = ServerMutateTicks::default();
+
+        map.record(RepliconTick::new(8), Tick(80));
+        server_ticks.confirm(RepliconTick::new(8), 1);
+        map.record_last_confirmed_checkpoint(RepliconTick::new(8));
+
+        // Userdata is recorded before Replicon applies the message. A mapping can therefore exist
+        // before all mutation messages for its checkpoint have arrived.
+        map.record(RepliconTick::new(9), Tick(90));
+
+        // Put the cached frontier beyond the lookup bound so the historical lookup has to inspect
+        // both the completed and incomplete retained mappings.
+        map.record(RepliconTick::new(10), Tick(110));
+        server_ticks.confirm(RepliconTick::new(10), 1);
+        map.record_last_confirmed_checkpoint(RepliconTick::new(10));
+
+        assert_eq!(
+            map.latest_completed_at_or_before(&server_ticks, Tick(100)),
+            Some(CompletedCheckpoint {
+                replicon_tick: RepliconTick::new(8),
+                tick: Tick(80),
+            })
+        );
+    }
+
+    #[test]
+    fn checkpoint_map_prefers_newest_replicon_tick_for_same_lightyear_tick() {
+        let mut map = ReplicationCheckpointMap::default();
+        let mut server_ticks = ServerMutateTicks::default();
+        for replicon in [8, 9] {
+            let replicon_tick = RepliconTick::new(replicon);
+            map.record(replicon_tick, Tick(80));
+            server_ticks.confirm(replicon_tick, 1);
+        }
+        map.record(RepliconTick::new(10), Tick(100));
+        server_ticks.confirm(RepliconTick::new(10), 1);
+        map.record_last_confirmed_checkpoint(RepliconTick::new(10));
+
+        assert_eq!(
+            map.latest_completed_at_or_before(&server_ticks, Tick(80)),
+            Some(CompletedCheckpoint {
+                replicon_tick: RepliconTick::new(9),
+                tick: Tick(80),
+            })
         );
     }
 
@@ -259,22 +437,25 @@ mod tests {
     fn checkpoint_map_missing_confirmed_tick_does_not_update_cache() {
         let mut map = ReplicationCheckpointMap::default();
 
-        assert_eq!(map.record_last_confirmed_tick(RepliconTick::new(10)), None);
+        assert_eq!(
+            map.record_last_confirmed_checkpoint(RepliconTick::new(10)),
+            None
+        );
         assert_eq!(map.last_confirmed_tick(), None);
-        assert_eq!(map.last_confirmed_replicon_tick(), None);
+        assert_eq!(map.last_confirmed_checkpoint(), None);
     }
 
     #[test]
-    fn checkpoint_map_clear_resets_confirmed_tick_cache() {
+    fn checkpoint_map_clear_resets_confirmed_checkpoint_cache() {
         let mut map = ReplicationCheckpointMap::default();
         map.record(RepliconTick::new(10), Tick(100));
-        map.record_last_confirmed_tick(RepliconTick::new(10));
+        map.record_last_confirmed_checkpoint(RepliconTick::new(10));
 
         map.clear();
 
         assert_eq!(map.get(RepliconTick::new(10)), None);
         assert_eq!(map.last_confirmed_tick(), None);
-        assert_eq!(map.last_confirmed_replicon_tick(), None);
+        assert_eq!(map.last_confirmed_checkpoint(), None);
     }
 
     #[test]

--- a/crates/replication/replication/src/client.rs
+++ b/crates/replication/replication/src/client.rs
@@ -51,7 +51,7 @@ impl Plugin for RepliconClientPlugin {
         #[cfg(any(feature = "prediction", feature = "interpolation"))]
         app.add_systems(
             PreUpdate,
-            sync_checkpoint_last_confirmed_tick
+            sync_last_confirmed_checkpoint
                 .after(ClientSystems::Receive)
                 .in_set(ReplicationSystems::Receive),
         );
@@ -86,7 +86,7 @@ impl Plugin for RepliconClientPlugin {
 }
 
 #[cfg(any(feature = "prediction", feature = "interpolation"))]
-fn sync_checkpoint_last_confirmed_tick(
+fn sync_last_confirmed_checkpoint(
     server_mutate_ticks: Res<ServerMutateTicks>,
     mut checkpoints: ResMut<ReplicationCheckpointMap>,
     connected_receivers: Query<
@@ -109,7 +109,7 @@ fn sync_checkpoint_last_confirmed_tick(
         return;
     };
     if checkpoints
-        .record_last_confirmed_tick(replicon_tick)
+        .record_last_confirmed_checkpoint(replicon_tick)
         .is_none()
     {
         error!(

--- a/crates/replication/replication/src/diff_history.rs
+++ b/crates/replication/replication/src/diff_history.rs
@@ -79,7 +79,32 @@ impl<Diff> PendingDiffMessage<Diff> {
 pub struct HistoryDiffReceiver<C: RepliconDiffable> {
     base_cursor: Option<DiffIndex>,
     base_tick: Option<Tick>,
+    /// Materialized cursors newer than `base_cursor`, paired with the confirmed-history tick that
+    /// stores each cursor's state.
+    ///
+    /// [`ConfirmedHistory`] can provide the effective authoritative state at a completed
+    /// checkpoint, but it does not associate that state with a diff cursor. These mappings are
+    /// retained so a pending diff index can locate the history value for its specific base cursor.
+    ///
+    /// Entries are appended when their cursor is materialized and existing cursor ticks can be
+    /// updated in place, so this vector is not ordered by either cursor or tick. Cursor lookup,
+    /// tick-boundary lookup, and pruning therefore scan the retained entries.
     diff_ticks: Vec<(DiffIndex, Tick)>,
+    /// Received diff ranges that have not yet been materialized into confirmed history.
+    ///
+    /// Replicon acknowledges a mutation when its bytes are received, before applying it, and
+    /// applies buffered mutation messages from newest to oldest. The server can therefore send a
+    /// newer range based on an acknowledged cursor whose older message has not yet run this
+    /// receiver's history callback. The newer range waits here until that callback records its
+    /// base cursor, usually later in the same receive pass.
+    ///
+    /// The cursor stream is linear. If a later overlapping range or snapshot materializes a newer
+    /// cursor first, [`Self::record_cursor`] removes any pending ranges that it supersedes.
+    ///
+    /// Entries are kept in arrival order, but are not processed strictly in that order:
+    /// [`Self::take_ready_update`] scans for the first range whose base cursor is available. In
+    /// normal use the caller drains ready ranges immediately after queuing, so retained entries are
+    /// waiting on a missing base cursor.
     pending: Vec<PendingDiffMessage<C::Diff>>,
     marker: PhantomData<fn() -> C>,
 }
@@ -238,10 +263,30 @@ impl<C: RepliconDiffable> HistoryDiffReceiver<C> {
         !self.pending.is_empty()
     }
 
-    /// Returns true when a diff message for `tick` is waiting for a base
-    /// cursor to be materialized in confirmed history.
-    pub fn has_pending_diff_at_tick(&self, tick: Tick) -> bool {
-        self.pending.iter().any(|pending| pending.tick == tick)
+    /// Returns the earliest unresolved diff tick that is not newer than `limit`.
+    ///
+    /// A pending diff at `P` makes the effective authoritative state unknown at every tick from
+    /// `P` onward. A rollback checkpoint `C >= P` is therefore unusable until the pending range is
+    /// materialized or superseded. [`Self::record_cursor`] removes superseded ranges, so every
+    /// entry considered here still constrains checkpoint selection.
+    pub fn earliest_pending_tick_at_or_before(&self, limit: Tick) -> Option<Tick> {
+        self.pending
+            .iter()
+            .map(|pending| pending.tick)
+            .filter(|tick| *tick <= limit)
+            .min()
+    }
+
+    /// Returns true when a diff message at or before `tick` is waiting for its base cursor to be
+    /// materialized in confirmed history.
+    ///
+    /// While this is true, the effective authoritative value at `tick` is not known yet. A
+    /// completed checkpoint must therefore not add a `SameAsPrecedent` history entry at `tick`:
+    /// that marker would resolve past the missing diff to an older, potentially incorrect value.
+    /// Pending ranges superseded by a later materialized cursor are removed by
+    /// [`Self::record_cursor`], so they do not keep later checkpoints unresolved.
+    pub fn has_pending_diff_at_or_before(&self, tick: Tick) -> bool {
+        self.earliest_pending_tick_at_or_before(tick).is_some()
     }
 
     /// Queues a diff message for historical materialization.
@@ -493,6 +538,31 @@ mod tests {
         assert_eq!(receiver.tick_for_cursor(Some(idx(5))), Some(Tick(5)));
     }
 
+    /// A later message can use an older available base and overlap an earlier pending message. Once
+    /// the later message materializes its newer cursor, the earlier pending range is superseded.
+    #[test]
+    fn newer_overlapping_range_supersedes_older_pending_range() {
+        let mut history = ConfirmedHistory::<TestDiffValue>::default();
+        history.insert_present(Tick(0), TestDiffValue(0));
+
+        let mut receiver = HistoryDiffReceiver::<TestDiffValue>::default();
+        receiver.record_cursor(Tick(0), Some(idx(0)));
+
+        // S3 -> S5 cannot be applied because S3 is not materialized.
+        receiver.queue_diffs(Tick(5), idx(4), vec![4, 5]).unwrap();
+        assert_eq!(receiver.take_ready_update(&history).unwrap(), None);
+
+        // S0 -> S6 overlaps the pending range but can be applied from S0.
+        receiver
+            .queue_diffs(Tick(6), idx(1), vec![1, 2, 3, 4, 5, 6])
+            .unwrap();
+        let (tick, value) = receiver.take_ready_update(&history).unwrap().unwrap();
+        assert_eq!((tick, value), (Tick(6), TestDiffValue(6)));
+
+        assert!(receiver.pending.is_empty());
+        assert_eq!(receiver.tick_for_cursor(Some(idx(6))), Some(Tick(6)));
+    }
+
     /// Receiver cleanup must not retire bases or discard pending diff messages
     /// while a newer diff range is waiting for an older base. Otherwise an
     /// unchanged history anchor can be carried forward and the later base
@@ -522,11 +592,11 @@ mod tests {
         assert_eq!((tick, value), (Tick(5), TestDiffValue(5)));
     }
 
-    /// Unchanged anchors are same-as-precedent markers, so they can safely be
-    /// inserted beyond a pending older diff range. When that older range
-    /// materializes, later unchanged anchors inherit the newly inserted value.
+    /// A completed checkpoint beyond a pending diff cannot receive an unchanged anchor until the
+    /// older diff materializes. Once it does, the anchor resolves immediately to the final
+    /// authoritative value and cannot change later.
     #[test]
-    fn older_diff_range_updates_later_unchanged_anchor_when_materialized() {
+    fn older_pending_diff_blocks_later_unchanged_anchor_until_materialized() {
         let mut history = ConfirmedHistory::<TestDiffValue>::default();
         history.insert_present(Tick(0), TestDiffValue(0));
 
@@ -535,7 +605,15 @@ mod tests {
 
         receiver.queue_diffs(Tick(5), idx(4), vec![4, 5]).unwrap();
         assert_eq!(receiver.take_ready_update(&history).unwrap(), None);
-        assert_eq!(history.push_unchanged(Tick(6)), Some(Tick(0)));
+        assert_eq!(
+            receiver.earliest_pending_tick_at_or_before(Tick(6)),
+            Some(Tick(5))
+        );
+        assert_eq!(receiver.earliest_pending_tick_at_or_before(Tick(4)), None);
+        assert!(receiver.has_pending_diff_at_or_before(Tick(5)));
+        assert!(receiver.has_pending_diff_at_or_before(Tick(6)));
+        assert!(!receiver.has_pending_diff_at_or_before(Tick(4)));
+        assert!(history.get_state_at(Tick(6)).is_none());
 
         receiver
             .queue_diffs(Tick(3), idx(1), vec![1, 2, 3])
@@ -544,6 +622,8 @@ mod tests {
             history.insert_present(tick, value);
         }
 
+        assert!(!receiver.has_pending_diff_at_or_before(Tick(6)));
+        assert_eq!(history.push_unchanged(Tick(6)), Some(Tick(5)));
         assert_eq!(
             history
                 .get_state_at(Tick(6))

--- a/crates/tests/src/client_server/prediction/history.rs
+++ b/crates/tests/src/client_server/prediction/history.rs
@@ -337,7 +337,7 @@ fn test_server_insert_on_existing_predicted_entity_triggers_rollback() {
     let world = stepper.client_app().world();
     assert!(
         world.resource::<RollbackObserved>().0,
-        "the receive-time (Some, None) mismatch check should trigger a rollback"
+        "the completed-checkpoint full scan should detect the authoritative insert"
     );
     assert_eq!(
         world

--- a/crates/tests/src/client_server/prediction/mod.rs
+++ b/crates/tests/src/client_server/prediction/mod.rs
@@ -1,9 +1,8 @@
 use crate::stepper::*;
 use bevy::prelude::*;
-use bevy_replicon::client::ClientSystems;
+use bevy_replicon::client::server_mutate_ticks::ServerMutateTicks;
 use bevy_replicon::prelude::RepliconTick;
 use lightyear_core::prelude::{Rollback, Tick};
-use lightyear_prediction::manager::StateRollbackMetadata;
 use lightyear_prediction::prelude::*;
 use lightyear_replication::checkpoint::ReplicationCheckpointMap;
 
@@ -14,75 +13,27 @@ mod prespawn;
 mod rollback;
 mod spawn;
 
-/// Resource that stores a pending rollback check tick.
-/// This is consumed by `apply_pending_rollback_check` during PreUpdate,
-/// after `check_received_replication_messages` resets the per-frame state
-/// but before `check_rollback` reads it.
-#[derive(Resource, Default)]
-pub(crate) struct PendingRollbackCheck {
-    pub tick: Option<Tick>,
-}
-
-/// System that applies the pending rollback check to the StateRollbackMetadata.
-/// Runs after ReplicationSystems::Receive (which includes the frame state reset)
-/// and before RollbackSystems::Check (which reads the metadata).
-fn apply_pending_rollback_check(
-    mut pending: ResMut<PendingRollbackCheck>,
-    mut metadata: ResMut<StateRollbackMetadata>,
-) {
-    if let Some(tick) = pending.tick.take() {
-        metadata.record_mismatch(tick);
-    }
-}
-
-/// Register the pending rollback check resource and system on a client app.
-/// Must be called before `trigger_rollback_check` is used.
-///
-/// The system is ordered:
-/// - after `ClientSystems::Receive` (which transitively orders it after
-///   `check_received_replication_messages`, ensuring the per-frame metadata
-///   reset has already happened)
-/// - before `RollbackSystems::Check` (which reads the metadata)
-pub(crate) fn register_rollback_check_helper(app: &mut App) {
-    app.init_resource::<PendingRollbackCheck>();
-    app.add_systems(
-        PreUpdate,
-        apply_pending_rollback_check
-            .after(ClientSystems::Receive)
-            .before(RollbackSystems::Check),
-    );
-}
-
 fn record_completed_mutate_tick_for_rollback_check(world: &mut World, tick: Tick) {
     let replicon_tick = RepliconTick::new(tick.0);
+    world
+        .resource_mut::<ServerMutateTicks>()
+        .confirm(replicon_tick, 1);
     let mut checkpoints = world.resource_mut::<ReplicationCheckpointMap>();
     checkpoints.record(replicon_tick, tick);
-    checkpoints.record_last_confirmed_tick(replicon_tick);
+    checkpoints.record_last_confirmed_checkpoint(replicon_tick);
 }
 
-/// Helper function to simulate that we received a server message and trigger a rollback check.
-/// Sets a pending rollback check that will be applied during the next frame_step,
-/// after the per-frame state reset but before the rollback check.
-///
-/// State rollbacks are only consumed once a completed mutate tick reaches the mismatch, so this
-/// helper also records `tick` as completed.
-pub(crate) fn trigger_rollback_check(stepper: &mut ClientServerStepper, tick: Tick) {
-    record_completed_mutate_tick_for_rollback_check(stepper.client_app().world_mut(), tick);
-    trigger_rollback_check_without_completed_tick(stepper, tick);
-}
-
-/// Same as [`trigger_rollback_check`], but leaves the completed mutate tick unchanged.
-///
-/// Use this when testing that explicit mismatches wait for global mutate completion.
-pub(crate) fn trigger_rollback_check_without_completed_tick(
+/// Helper for tests that exercise rollback restoration/replay rather than mismatch detection.
+/// Records a completed checkpoint and explicitly requests the one-shot rollback.
+pub(crate) fn request_forced_rollback_at_completed_tick(
     stepper: &mut ClientServerStepper,
     tick: Tick,
 ) {
-    stepper
-        .client_app()
-        .world_mut()
-        .resource_mut::<PendingRollbackCheck>()
-        .tick = Some(tick);
+    let world = stepper.client_app().world_mut();
+    record_completed_mutate_tick_for_rollback_check(world, tick);
+    world
+        .resource_mut::<StateRollbackMetadata>()
+        .request_forced_rollback(tick);
 }
 
 pub(crate) fn trigger_state_rollback(stepper: &mut ClientServerStepper, tick: Tick) {

--- a/crates/tests/src/client_server/prediction/rollback.rs
+++ b/crates/tests/src/client_server/prediction/rollback.rs
@@ -1,13 +1,16 @@
 use crate::client_server::prediction::{
-    register_rollback_check_helper, trigger_rollback_check,
-    trigger_rollback_check_without_completed_tick, trigger_state_rollback,
+    request_forced_rollback_at_completed_tick, trigger_state_rollback,
 };
-use crate::protocol::{CompFull, CompNotNetworked, CompRepliconDiff, NativeInput};
+use crate::protocol::{
+    CompFull, CompNotNetworked, CompPredictionOnly, CompRepliconDiff, NativeInput,
+};
 use crate::stepper::*;
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 use bevy::prelude::*;
-use bevy_replicon::prelude::RepliconTick;
+use bevy_replicon::prelude::{ClientSystems, RepliconTick};
+use bevy_replicon::shared::replication::diff::diff_index::DiffIndex;
+use bevy_replicon::shared::replication::storage::ReplicationStorage;
 use core::time::Duration;
 use lightyear::input::native::prelude::InputMarker;
 use lightyear::prediction::Predicted;
@@ -21,13 +24,13 @@ use lightyear_prediction::despawn::{PredictionDespawnCommandsExt, PredictionDisa
 use lightyear_prediction::manager::{LastConfirmedInput, RollbackMode, StateRollbackMetadata};
 use lightyear_prediction::prelude::*;
 use lightyear_prediction::rollback::{DeterministicPredicted, reset_input_rollback_tracker};
+use lightyear_replication::diff_history::HistoryDiffReceiver;
 use lightyear_replication::prelude::*;
 use lightyear_replication::prespawn::PreSpawnedReceiver;
 use test_log::test;
 
 fn setup() -> (ClientServerStepper, Entity) {
     let mut stepper = ClientServerStepper::from_config(StepperConfig::single());
-    register_rollback_check_helper(stepper.client_app());
 
     // add predicted/confirmed entities
     let predicted = stepper
@@ -61,9 +64,18 @@ fn insert_confirmed<C: Component + PartialEq>(
 }
 
 fn record_completed_mutate_tick(world: &mut World, replicon_tick: RepliconTick, tick: Tick) {
+    world
+        .resource_mut::<ServerMutateTicks>()
+        .confirm(replicon_tick, 1);
     let mut checkpoints = world.resource_mut::<ReplicationCheckpointMap>();
     checkpoints.record(replicon_tick, tick);
-    checkpoints.record_last_confirmed_tick(replicon_tick);
+    checkpoints.record_last_confirmed_checkpoint(replicon_tick);
+}
+
+fn reset_checkpoint_state(world: &mut World) {
+    world.insert_resource(ServerMutateTicks::default());
+    world.insert_resource(ReplicationCheckpointMap::default());
+    world.insert_resource(StateRollbackMetadata::default());
 }
 
 #[derive(Resource, Default)]
@@ -86,6 +98,10 @@ fn observe_rollback_start(app: &mut App) {
             .after(RollbackSystems::Check)
             .before(RollbackSystems::Prepare),
     );
+}
+
+fn mark_received_state_for_test(mut metadata: ResMut<StateRollbackMetadata>) {
+    metadata.mark_received_messages_this_frame();
 }
 
 // =============================================================================
@@ -118,7 +134,7 @@ fn test_non_networked_insert_kept_on_state_rollback_without_confirmed_history() 
         Some(CompFull(1.0)),
     );
 
-    trigger_rollback_check(&mut stepper, rollback_tick);
+    request_forced_rollback_at_completed_tick(&mut stepper, rollback_tick);
     stepper.frame_step(1);
 
     // CompNotNetworked should remain: there was no authoritative removal.
@@ -182,7 +198,7 @@ fn test_predicted_remove_restored_on_rollback() {
         Some(CompFull(-10.0)),
     );
 
-    trigger_rollback_check(&mut stepper, tick - 3);
+    request_forced_rollback_at_completed_tick(&mut stepper, tick - 3);
     stepper.frame_step(1);
 
     // CompFull should be re-added and re-simulated: -10 + 4 increments = -6
@@ -235,7 +251,7 @@ fn test_predicted_despawn_restored_on_rollback() {
     );
 
     // Trigger rollback to before the despawn
-    trigger_rollback_check(&mut stepper, rollback_tick);
+    request_forced_rollback_at_completed_tick(&mut stepper, rollback_tick);
     stepper.frame_step(1);
 
     // PredictionDisable should be removed, entity re-enabled
@@ -334,7 +350,7 @@ fn test_predicted_modify_corrected_on_rollback() {
         Some(CompFull(10.0)),
     );
 
-    trigger_rollback_check(&mut stepper, tick - 2);
+    request_forced_rollback_at_completed_tick(&mut stepper, tick - 2);
     stepper.frame_step(1);
 
     // Snap to 10.0 at tick-2, re-simulate 3 ticks: 10.0 + 3 = 13.0
@@ -463,7 +479,7 @@ fn test_batched_confirmed_values_survive_older_rollback() {
         Some(CompFull(200.0)),
     );
 
-    trigger_rollback_check(&mut stepper, rollback_tick);
+    request_forced_rollback_at_completed_tick(&mut stepper, rollback_tick);
     stepper.frame_step(1);
 
     let confirmed_history = stepper
@@ -611,29 +627,520 @@ fn test_completed_mutate_tick_checks_unchanged_entities() {
     );
 }
 
+/// An entity-level confirmation at C can come from a different replicated component. It must not
+/// suppress the check for a predicted component that was unchanged at C.
 #[test]
-fn test_future_completed_mutate_tick_is_not_marked_processed() {
-    let (mut stepper, _) = setup();
+fn test_completed_mutate_tick_checks_unchanged_component_on_confirmed_entity() {
+    let (mut stepper, predicted) = setup();
+    observe_rollback_start(stepper.client_app());
 
-    stepper.frame_step(3);
-    let future_tick = stepper.client_tick(0) + 1_000;
-    let future_replicon_tick = RepliconTick::new(920);
-    record_completed_mutate_tick(
-        stepper.client_app().world_mut(),
-        future_replicon_tick,
-        future_tick,
+    // This component will receive an explicit, matching authoritative update at C. Its presence
+    // makes this a real mixed entity: one predicted component is updated while `CompFull` is
+    // unchanged at C.
+    stepper
+        .client_app()
+        .world_mut()
+        .entity_mut(predicted)
+        .insert(CompPredictionOnly(7.0));
+
+    stepper.frame_step(4);
+    let completed_tick = stepper.client_tick(0) - 2;
+    let previous_confirmed_tick = completed_tick - 1;
+    let completed_replicon_tick = RepliconTick::new(710);
+
+    let world = stepper.client_app().world_mut();
+    record_completed_mutate_tick(world, completed_replicon_tick, completed_tick);
+
+    insert_confirmed(
+        world,
+        predicted,
+        completed_tick,
+        Some(CompPredictionOnly(7.0)),
     );
+    // `CompFull` itself has no sample at C, so its effective authoritative value remains the
+    // mismatching earlier value even though the same entity was explicitly updated at C.
+    insert_confirmed(
+        world,
+        predicted,
+        previous_confirmed_tick,
+        Some(CompFull(20.0)),
+    );
+    assert_ne!(
+        world
+            .get::<PredictionHistory<CompFull>>(predicted)
+            .and_then(|history| history.get(completed_tick)),
+        Some(&CompFull(20.0)),
+        "the unchanged CompFull must be mismatched in prediction history at C"
+    );
+    world
+        .entity_mut(predicted)
+        .insert(ConfirmHistory::new(completed_replicon_tick));
 
     stepper.frame_step(1);
 
-    assert_ne!(
+    assert_eq!(
+        stepper
+            .client_app()
+            .world()
+            .resource::<ObservedRollbackStart>()
+            .0,
+        Some(completed_tick),
+        "An entity confirmation at C must not hide an unchanged component mismatch"
+    );
+}
+
+/// A diff component does not need an explicit sample at every completed checkpoint. Once all
+/// mutate messages for C are received and no diff at or before C is pending, its last materialized
+/// value is known to carry forward to C.
+#[test]
+fn test_completed_checkpoint_advances_past_last_diff_update() {
+    let (mut stepper, predicted) = setup();
+    stepper
+        .client_app()
+        .world_mut()
+        .entity_mut(predicted)
+        .insert(CompRepliconDiff(1));
+    stepper.frame_step(3);
+
+    let completed_tick = stepper.client_tick(0) - 1;
+    let last_diff_update_tick = completed_tick - 1;
+    let completed_replicon_tick = RepliconTick::new(711);
+    {
+        let world = stepper.client_app().world_mut();
+        reset_checkpoint_state(world);
+        insert_confirmed(
+            world,
+            predicted,
+            last_diff_update_tick,
+            Some(CompRepliconDiff(1)),
+        );
+        assert_eq!(
+            world
+                .get::<ConfirmedHistory<CompRepliconDiff>>(predicted)
+                .unwrap()
+                .len(),
+            1,
+            "the setup should contain only the explicit diff update"
+        );
+        world
+            .entity_mut(predicted)
+            .insert(ConfirmHistory::new(completed_replicon_tick));
+        record_completed_mutate_tick(world, completed_replicon_tick, completed_tick);
+    }
+
+    stepper.client_app().update();
+
+    let world = stepper.client_app().world();
+    assert_eq!(
+        world
+            .resource::<StateRollbackMetadata>()
+            .last_processed_confirmed_tick(),
+        Some(completed_tick),
+        "C must not be capped at the diff component's last explicit update"
+    );
+    assert_eq!(
+        world
+            .get::<ConfirmedHistory<CompRepliconDiff>>(predicted)
+            .and_then(|history| history.get_state_at(completed_tick)),
+        Some(&HistoryState::Updated(CompRepliconDiff(1))),
+        "the completed checkpoint should carry the last materialized diff value forward to C"
+    );
+    let history = world
+        .get::<ConfirmedHistory<CompRepliconDiff>>(predicted)
+        .unwrap();
+    assert_eq!(history.len(), 2, "C should add one unchanged anchor");
+    assert_eq!(
+        history.get_nth_tick(1),
+        Some(completed_tick),
+        "the unchanged anchor should be stored exactly at C"
+    );
+}
+
+/// With multiple predicted diff entities, C is the latest globally completed checkpoint strictly
+/// before the earliest unresolved P. Resolving pending ranges advances C through completed ticks;
+/// ticks that were never completed must never become rollback targets.
+#[test]
+fn test_diff_checkpoint_tracks_earliest_pending_across_entities() {
+    let (mut stepper, predicted_a) = setup();
+    stepper
+        .client_app()
+        .world_mut()
+        .entity_mut(predicted_a)
+        .insert(CompRepliconDiff(1));
+    let predicted_b = stepper
+        .client_app()
+        .world_mut()
+        .spawn((Predicted, CompRepliconDiff(1)))
+        .id();
+    stepper.frame_step(6);
+
+    let candidate_tick = stepper.client_tick(0) - 1;
+    // A is pending exactly at C0. This exercises the strict boundary: C0 itself is unusable even
+    // though ServerMutateTicks reports it as globally completed.
+    let pending_a_tick = candidate_tick;
+    let middle_completed_tick = candidate_tick - 2;
+    let pending_b_tick = candidate_tick - 3;
+    let oldest_completed_tick = candidate_tick - 4;
+    let oldest_replicon_tick = RepliconTick::new(712);
+    let middle_replicon_tick = RepliconTick::new(713);
+    let candidate_replicon_tick = RepliconTick::new(714);
+    {
+        let world = stepper.client_app().world_mut();
+        reset_checkpoint_state(world);
+        for predicted in [predicted_a, predicted_b] {
+            insert_confirmed(
+                world,
+                predicted,
+                oldest_completed_tick,
+                Some(CompRepliconDiff(1)),
+            );
+            world
+                .entity_mut(predicted)
+                .insert(ConfirmHistory::new(candidate_replicon_tick));
+        }
+
+        let mut receiver_a = HistoryDiffReceiver::<CompRepliconDiff>::default();
+        receiver_a.record_cursor(oldest_completed_tick, Some(DiffIndex::new(0)));
+        receiver_a
+            .queue_diff(pending_a_tick, DiffIndex::new(2), vec![2])
+            .unwrap();
+        world
+            .resource_mut::<ReplicationStorage>()
+            .insert(predicted_a, receiver_a);
+
+        let mut receiver_b = HistoryDiffReceiver::<CompRepliconDiff>::default();
+        receiver_b.record_cursor(oldest_completed_tick, Some(DiffIndex::new(0)));
+        receiver_b
+            .queue_diff(pending_b_tick, DiffIndex::new(2), vec![2])
+            .unwrap();
+        world
+            .resource_mut::<ReplicationStorage>()
+            .insert(predicted_b, receiver_b);
+
+        // B's pending tick is not globally completed. A's pending tick is the completed C0 itself.
+        // In both cases, only these three explicitly completed ticks are eligible for C.
+        record_completed_mutate_tick(world, oldest_replicon_tick, oldest_completed_tick);
+        record_completed_mutate_tick(world, middle_replicon_tick, middle_completed_tick);
+        record_completed_mutate_tick(world, candidate_replicon_tick, candidate_tick);
+    }
+
+    stepper.client_app().update();
+    assert_eq!(
         stepper
             .client_app()
             .world()
             .resource::<StateRollbackMetadata>()
-            .last_processed_tick(),
+            .last_processed_confirmed_tick(),
+        Some(oldest_completed_tick),
+        "B's earlier pending tick should bound C to the latest completed tick before it"
+    );
+    for predicted in [predicted_a, predicted_b] {
+        assert!(
+            stepper
+                .client_app()
+                .world()
+                .get::<ConfirmedHistory<CompRepliconDiff>>(predicted)
+                .unwrap()
+                .get_state_at(candidate_tick)
+                .is_none(),
+            "C0 must not receive an unchanged anchor while an earlier diff is pending"
+        );
+    }
+
+    // Materializing B's pending range leaves A pending exactly at C0. C can advance to the
+    // completed middle tick, but the strict bound must still exclude C0 itself.
+    {
+        let world = stepper.client_app().world_mut();
+        insert_confirmed(
+            world,
+            predicted_b,
+            pending_b_tick,
+            Some(CompRepliconDiff(1)),
+        );
+        world
+            .resource_mut::<ReplicationStorage>()
+            .get_mut::<HistoryDiffReceiver<CompRepliconDiff>>(predicted_b)
+            .unwrap()
+            .record_cursor(pending_b_tick, Some(DiffIndex::new(2)));
+    }
+    stepper.client_app().update();
+    assert_eq!(
+        stepper
+            .client_app()
+            .world()
+            .resource::<StateRollbackMetadata>()
+            .last_processed_confirmed_tick(),
+        Some(middle_completed_tick)
+    );
+
+    // Once A also materializes, there is no pending diff at or before C0. The full checkpoint scan
+    // can use A's exact value at C0 and add a proven SameAsPrecedent anchor for unchanged B.
+    {
+        let world = stepper.client_app().world_mut();
+        insert_confirmed(
+            world,
+            predicted_a,
+            pending_a_tick,
+            Some(CompRepliconDiff(1)),
+        );
+        world
+            .resource_mut::<ReplicationStorage>()
+            .get_mut::<HistoryDiffReceiver<CompRepliconDiff>>(predicted_a)
+            .unwrap()
+            .record_cursor(pending_a_tick, Some(DiffIndex::new(2)));
+    }
+    stepper.client_app().update();
+    assert_eq!(
+        stepper
+            .client_app()
+            .world()
+            .resource::<StateRollbackMetadata>()
+            .last_processed_confirmed_tick(),
+        Some(candidate_tick)
+    );
+    for predicted in [predicted_a, predicted_b] {
+        assert_eq!(
+            stepper
+                .client_app()
+                .world()
+                .get::<ConfirmedHistory<CompRepliconDiff>>(predicted)
+                .and_then(|history| history.get_state_at(candidate_tick)),
+            Some(&HistoryState::Updated(CompRepliconDiff(1))),
+            "the final safe C should use the known authoritative value"
+        );
+    }
+
+    // A pending diff newer than C0 does not affect the authoritative state at C0.
+    {
+        let world = stepper.client_app().world_mut();
+        world
+            .resource_mut::<ReplicationStorage>()
+            .get_mut::<HistoryDiffReceiver<CompRepliconDiff>>(predicted_b)
+            .unwrap()
+            .queue_diff(candidate_tick + 1, DiffIndex::new(4), vec![4])
+            .unwrap();
+        world.insert_resource(StateRollbackMetadata::default());
+    }
+    stepper.client_app().update();
+    assert_eq!(
+        stepper
+            .client_app()
+            .world()
+            .resource::<StateRollbackMetadata>()
+            .last_processed_confirmed_tick(),
+        Some(candidate_tick),
+        "a future pending diff must not constrain the current completed checkpoint"
+    );
+}
+
+/// If the earliest unresolved diff has no globally completed checkpoint before it, there is no
+/// coherent full-state rollback target. The client must wait without scanning C0 or advancing the
+/// processed-checkpoint watermark; a component-history entry alone cannot manufacture a C.
+#[test]
+fn test_pending_diff_without_earlier_completed_checkpoint_skips_check() {
+    let (mut stepper, predicted) = setup();
+    stepper
+        .client_app()
+        .world_mut()
+        .entity_mut(predicted)
+        .insert(CompRepliconDiff(1));
+    stepper.frame_step(3);
+
+    let candidate_tick = stepper.client_tick(0) - 1;
+    let pending_tick = Tick(1);
+    let history_tick = Tick(0);
+    let candidate_replicon_tick = RepliconTick::new(716);
+    {
+        let world = stepper.client_app().world_mut();
+        reset_checkpoint_state(world);
+        insert_confirmed(world, predicted, history_tick, Some(CompRepliconDiff(1)));
+        world
+            .entity_mut(predicted)
+            .insert(ConfirmHistory::new(candidate_replicon_tick));
+
+        let mut receiver = HistoryDiffReceiver::<CompRepliconDiff>::default();
+        receiver.record_cursor(history_tick, Some(DiffIndex::new(0)));
+        receiver
+            .queue_diff(pending_tick, DiffIndex::new(2), vec![2])
+            .unwrap();
+        world
+            .resource_mut::<ReplicationStorage>()
+            .insert(predicted, receiver);
+
+        // The component-history sample at tick 0 is not completed in ServerMutateTicks. All real
+        // and synthetic completed checkpoints in this test are at or after P=1, so none can be
+        // selected as the required strict predecessor.
+        record_completed_mutate_tick(world, candidate_replicon_tick, candidate_tick);
+    }
+    observe_rollback_start(stepper.client_app());
+
+    stepper.client_app().update();
+
+    let world = stepper.client_app().world();
+    assert_eq!(
+        world
+            .resource::<StateRollbackMetadata>()
+            .last_processed_confirmed_tick(),
+        None,
+        "without a completed C before P, rollback checking must wait"
+    );
+    assert_eq!(world.resource::<ObservedRollbackStart>().0, None);
+    assert!(
+        world
+            .get::<ConfirmedHistory<CompRepliconDiff>>(predicted)
+            .unwrap()
+            .get_state_at(candidate_tick)
+            .is_none(),
+        "the unresolved C0 must not receive an unchanged anchor"
+    );
+}
+
+/// `RollbackMode::Always` must use the same diff-aware C as mismatch checking. Rolling back from
+/// the globally latest checkpoint while an older diff is unresolved would restore a value that
+/// has not been materialized yet.
+#[test]
+fn test_always_rollback_uses_diff_aware_confirmed_tick() {
+    let (mut stepper, predicted) = setup();
+    stepper
+        .client_app()
+        .world_mut()
+        .entity_mut(predicted)
+        .insert(CompRepliconDiff(1));
+    stepper.frame_step(3);
+
+    let candidate_tick = stepper.client_tick(0) - 1;
+    let pending_tick = candidate_tick - 1;
+    let previous_tick = pending_tick - 1;
+    let previous_replicon_tick = RepliconTick::new(714);
+    let candidate_replicon_tick = RepliconTick::new(715);
+    {
+        let world = stepper.client_app().world_mut();
+        reset_checkpoint_state(world);
+        world
+            .resource_mut::<PredictionManager>()
+            .rollback_policy
+            .state = RollbackMode::Always;
+        insert_confirmed(world, predicted, previous_tick, Some(CompRepliconDiff(1)));
+        world
+            .entity_mut(predicted)
+            .insert(ConfirmHistory::new(candidate_replicon_tick));
+
+        let mut receiver = HistoryDiffReceiver::<CompRepliconDiff>::default();
+        receiver.record_cursor(previous_tick, Some(DiffIndex::new(0)));
+        receiver
+            .queue_diff(pending_tick, DiffIndex::new(2), vec![2])
+            .unwrap();
+        world
+            .resource_mut::<ReplicationStorage>()
+            .insert(predicted, receiver);
+
+        record_completed_mutate_tick(world, previous_replicon_tick, previous_tick);
+        record_completed_mutate_tick(world, candidate_replicon_tick, candidate_tick);
+    }
+    observe_rollback_start(stepper.client_app());
+    stepper.client_app().add_systems(
+        PreUpdate,
+        mark_received_state_for_test
+            .after(ClientSystems::Receive)
+            .before(RollbackSystems::Check),
+    );
+
+    // Exercise the receive-time signal used by RollbackMode::Always deterministically; relying on
+    // the connected test transport would make this assertion depend on whether that frame happened
+    // to carry replication traffic.
+    stepper.frame_step(1);
+
+    let world = stepper.client_app().world();
+    assert_eq!(
+        world.resource::<ObservedRollbackStart>().0,
+        Some(previous_tick),
+        "Always mode should roll back from the latest completed checkpoint before the pending diff"
+    );
+    assert_eq!(
+        world
+            .resource::<StateRollbackMetadata>()
+            .last_processed_confirmed_tick(),
+        Some(previous_tick)
+    );
+}
+
+#[test]
+fn test_no_completed_checkpoint_at_or_before_local_tick_is_processed() {
+    let (mut stepper, _) = setup();
+    stepper.frame_step(3);
+    stepper.client_app().update();
+
+    let local_tick = stepper.client_tick(0);
+    let future_tick = stepper.client_tick(0) + 1_000;
+    let future_replicon_tick = RepliconTick::new(920);
+    {
+        let world = stepper.client_app().world_mut();
+        reset_checkpoint_state(world);
+        record_completed_mutate_tick(world, future_replicon_tick, future_tick);
+    }
+    observe_rollback_start(stepper.client_app());
+
+    stepper.client_app().update();
+
+    assert_eq!(stepper.client_tick(0), local_tick);
+    let world = stepper.client_app().world();
+    assert_eq!(
+        world
+            .resource::<StateRollbackMetadata>()
+            .last_processed_confirmed_tick(),
+        None,
+        "there is no completed checkpoint C at or before the local tick"
+    );
+    assert_eq!(world.resource::<ObservedRollbackStart>().0, None);
+}
+
+/// When the globally latest completed checkpoint S is in the local future, rollback checking must
+/// select the newest completed checkpoint C at or before the local tick T.
+#[test]
+fn test_latest_completed_checkpoint_at_or_before_local_tick_is_used() {
+    let (mut stepper, predicted) = setup();
+    stepper.frame_step(3);
+    stepper.client_app().update();
+
+    let local_tick = stepper.client_tick(0);
+    let completed_tick = local_tick - 1;
+    let future_tick = local_tick + 1;
+    let completed_replicon_tick = RepliconTick::new(921);
+    let future_replicon_tick = RepliconTick::new(922);
+    {
+        let world = stepper.client_app().world_mut();
+        reset_checkpoint_state(world);
+        insert_confirmed(world, predicted, completed_tick, Some(CompFull(42.0)));
+        world
+            .entity_mut(predicted)
+            .insert(ConfirmHistory::new(completed_replicon_tick));
+        record_completed_mutate_tick(world, completed_replicon_tick, completed_tick);
+        record_completed_mutate_tick(world, future_replicon_tick, future_tick);
+    }
+    observe_rollback_start(stepper.client_app());
+
+    stepper.client_app().update();
+
+    assert_eq!(stepper.client_tick(0), local_tick);
+    let world = stepper.client_app().world();
+    assert_eq!(
+        world
+            .resource::<ReplicationCheckpointMap>()
+            .last_confirmed_tick(),
         Some(future_tick),
-        "A future completed mutate tick must not be marked processed before it can be checked"
+        "S should remain the globally latest completed checkpoint"
+    );
+    assert_eq!(
+        world
+            .resource::<StateRollbackMetadata>()
+            .last_processed_confirmed_tick(),
+        Some(completed_tick),
+        "C should be the latest completed checkpoint at or before T"
+    );
+    assert_eq!(
+        world.resource::<ObservedRollbackStart>().0,
+        Some(completed_tick),
+        "the mismatch should roll back from C, not future S"
     );
 }
 
@@ -807,13 +1314,6 @@ fn test_future_diff_insert_seeds_history_and_rolls_back_when_checkable() {
         Some(&HistoryState::Updated(CompRepliconDiff(42)))
     );
     assert_eq!(world.resource::<ObservedRollbackStart>().0, None);
-    assert!(
-        world
-            .resource::<PredictionManager>()
-            .pending_entity_state_checks
-            .contains(future_tick, predicted_entity),
-        "receiving the future insert should queue its rollback check"
-    );
 
     // Exercise the old ordering regression directly, then remove the probe so the remainder of
     // the test observes the real absent-component history produced by the client schedule.
@@ -847,7 +1347,8 @@ fn test_future_diff_insert_seeds_history_and_rolls_back_when_checkable() {
     );
 
     // Run genuine client fixed ticks until the future confirmation becomes the completed current
-    // tick. The following no-time update checks the deferred mismatch before another fixed tick.
+    // tick. The following no-time update performs the completed-checkpoint scan before another
+    // fixed tick.
     stepper
         .client_app()
         .world_mut()
@@ -860,13 +1361,6 @@ fn test_future_diff_insert_seeds_history_and_rolls_back_when_checkable() {
 
     let world = stepper.client_app().world();
     assert_eq!(world.resource::<ObservedRollbackStart>().0, None);
-    assert!(
-        world
-            .resource::<PredictionManager>()
-            .pending_entity_state_checks
-            .contains(future_tick, predicted_entity),
-        "the rollback check should remain queued until a frame starts with the tick checkable"
-    );
     let history = world
         .get::<PredictionHistory<CompRepliconDiff>>(predicted_entity)
         .expect("the predicted component should retain its absence history");
@@ -888,63 +1382,9 @@ fn test_future_diff_insert_seeds_history_and_rolls_back_when_checkable() {
         world.resource::<ObservedRollbackStart>().0,
         Some(future_tick)
     );
-    assert!(
-        !world
-            .resource::<PredictionManager>()
-            .pending_entity_state_checks
-            .contains(future_tick, predicted_entity),
-        "the checkable deferred rollback should be consumed"
-    );
     assert_eq!(
         world.get::<CompRepliconDiff>(predicted_entity),
         Some(&CompRepliconDiff(42))
-    );
-}
-
-#[test]
-fn test_explicit_mismatch_waits_until_completed_mutate_frontier_reaches_it() {
-    let (mut stepper, _) = setup();
-    observe_rollback_start(stepper.client_app());
-
-    stepper.frame_step(5);
-    let completed_tick = stepper.client_tick(0) - 4;
-    let mismatch_tick = stepper.client_tick(0) - 2;
-    let completed_replicon_tick = RepliconTick::new(930);
-    record_completed_mutate_tick(
-        stepper.client_app().world_mut(),
-        completed_replicon_tick,
-        completed_tick,
-    );
-
-    trigger_rollback_check_without_completed_tick(&mut stepper, mismatch_tick);
-    stepper.frame_step(1);
-
-    assert_eq!(
-        stepper
-            .client_app()
-            .world()
-            .resource::<ObservedRollbackStart>()
-            .0,
-        None,
-        "Explicit mismatch should wait until a completed mutate tick reaches the mismatch"
-    );
-
-    let later_completed_tick = mismatch_tick + 1;
-    record_completed_mutate_tick(
-        stepper.client_app().world_mut(),
-        RepliconTick::new(931),
-        later_completed_tick,
-    );
-    stepper.frame_step(1);
-
-    assert_eq!(
-        stepper
-            .client_app()
-            .world()
-            .resource::<ObservedRollbackStart>()
-            .0,
-        Some(later_completed_tick),
-        "Explicit mismatch should rollback from the latest completed tick once its frontier has passed the mismatch"
     );
 }
 
@@ -1157,7 +1597,7 @@ fn test_remote_insert_applied_on_rollback() {
             confirmed_history,
         ));
 
-    trigger_rollback_check(&mut stepper, tick);
+    request_forced_rollback_at_completed_tick(&mut stepper, tick);
     stepper.frame_step(1);
 
     // The remotely-inserted component should be present after rollback
@@ -1199,7 +1639,7 @@ fn test_remote_remove_applied_on_rollback() {
         .entity_mut(predicted)
         .remove::<CompFull>();
 
-    trigger_rollback_check(&mut stepper, rollback_tick);
+    request_forced_rollback_at_completed_tick(&mut stepper, rollback_tick);
     stepper.frame_step(1);
 
     // CompFull should be absent after rollback: server confirmed removal
@@ -1305,7 +1745,7 @@ fn test_disable_rollback() {
     // step once to avoid a 0-tick rollback
     stepper.frame_step(1);
 
-    trigger_rollback_check(&mut stepper, tick);
+    request_forced_rollback_at_completed_tick(&mut stepper, tick);
     stepper.frame_step(1);
 
     // the DeterministicPredicted entity was rolled back to the past PredictionHistory value
@@ -1371,7 +1811,7 @@ fn test_rollback_time_resource() {
 
     // Trigger 2 rollback ticks
     let tick = stepper.client_tick(0);
-    trigger_rollback_check(&mut stepper, tick - 2);
+    request_forced_rollback_at_completed_tick(&mut stepper, tick - 2);
     stepper.frame_step(1);
 
     // Check that the component got synced.

--- a/crates/tests/src/client_server/prediction/spawn.rs
+++ b/crates/tests/src/client_server/prediction/spawn.rs
@@ -77,9 +77,7 @@ fn test_spawn_predicted_with_hierarchy() {
 /// client's prediction never mispredicts.
 ///
 /// Without the fix, the confirmed insert is parked in `ConfirmedHistory<C>`:
-/// the receive-time mismatch check can be skipped (insert messages ride a
-/// reliable channel and may resolve at/behind the last processed mutate tick),
-/// the unchanged-entity scan returns early without a retained predicted
+/// the completed-checkpoint scan returns early without a retained predicted
 /// sample, and `prepare_rollback` skips the component entirely because the
 /// entity has no `PredictionHistory<C>` — so the component only ever arrives
 /// as a side effect of a rollback caused by something else.


### PR DESCRIPTION
1. Instead of doing a rollback check whenever an entity gets updated (so that we can skip this entity later), we just find the latest confirmed tick C that is <= T (current tick) and check all entities/components at that tick C.

   The previous logic was incorrect. We were ignored entities that had received an update, but actually we should still doing a rollback check for the unchanged components of these entities. (Added a unit test for this case)

2. Removed pending updates. We added them to track which entities we still had to do a rollback check on if we had received an update for them at a tick P > T. This is because we were doing rollback checks upon receiving the update, and at that point the PredictionHistory did not contain any value so we couldn't do the check. Now, we just do the check at tick C, so we don't need to track that anymore.

3. We do a rollback check from tick C since that's the latest tick that we can do a rollback from. To do a rollback we need to start from a tick where are sure that we have a full 'confirmed' view of the world. We know that this is the case if ServerMutateTicks is true for a given tick.

4. Actually there is another problem. It is possible that we have received all updates at a tick C (C is 'confirmed') but we still cannot rollback from C. That is because for diff components the update we have received might not be ready to be applied yet (if we don't have the base value to apply the diff against). In that case the update is stored in 'pending'. If we have any pending at a tick C, we cannot rollback from there, so we look latest confirmed tick before T where we don't have any pending updates.

Fixes https://github.com/cBournhonesque/lightyear/issues/1716