### PR TITLE
feat(prediction): type-erase prediction systems

### DIFF
--- a/crates/deterministic/deterministic_replication/src/archetypes.rs
+++ b/crates/deterministic/deterministic_replication/src/archetypes.rs
@@ -123,7 +123,7 @@ unsafe impl<const HISTORY: bool> SystemParam for ChecksumWorld<'_, '_, HISTORY> 
                 .iter()
                 .filter_map(|(kind, pred)| {
                     // TODO: for non-full components, just fetch the component value directly
-                    let history_id = pred.prediction_history_id;
+                    let history_id = pred.rollback.prediction_history_id;
                     registry.component_metadata_map.get(kind).and_then(|m| {
                         m.deterministic
                             .as_ref()

--- a/crates/replication/prediction/src/archetypes.rs
+++ b/crates/replication/prediction/src/archetypes.rs
@@ -1,86 +1,440 @@
 use crate::Predicted;
-use crate::registry::PredictionRegistry;
+use crate::despawn::PredictionDisable;
+use crate::registry::{
+    CheckRollbackFn, PendingDiffTickFn, PredictionRegistry, PrepareRollbackFn,
+    PruneHistoryDiffReceiverFn, RollbackMetadata, SnapToConfirmedFn,
+    UpdateFrameInterpolationPostRollbackFn,
+};
+use crate::rollback::{DeterministicPredicted, DisableRollback};
 use alloc::vec::Vec;
 use bevy_ecs::{
-    archetype::{ArchetypeGeneration, ArchetypeId, Archetypes},
-    component::{ComponentId, Components},
+    archetype::{Archetype, ArchetypeGeneration, ArchetypeId, Archetypes},
+    change_detection::Tick as ChangeTick,
+    component::{ComponentId, Components, StorageType},
+    entity_disabling::DefaultQueryFilters,
+    prelude::ResMut,
+    query::{FilteredAccess, FilteredAccessSet},
     resource::Resource,
-    world::{FromWorld, World},
+    system::{SystemMeta, SystemParam, SystemParamValidationError},
+    world::{FromWorld, World, unsafe_world_cell::UnsafeWorldCell},
 };
-use bevy_platform::collections::HashMap;
-use lightyear_replication::registry::ComponentKind;
-use lightyear_replication::registry::ComponentRegistry;
-use tracing::trace;
+use core::marker::PhantomData;
+use lightyear_replication::prelude::ConfirmHistory;
+use lightyear_replication::registry::{ComponentKind, ComponentRegistry};
 
-/// Cached list of archetypes that are predicted.
+/// Low-level world access paired with the shared incremental prediction-archetype cache.
 ///
-/// These archetypes have at least one component that needs to be synced from the Predicted entity
-/// to the Confirmed entity.
-///
-/// We cache them to quickly iterate through all the components of an archetype that should be predicted
-#[derive(Resource)]
-pub(crate) struct PredictedArchetypes {
-    /// Highest processed archetype ID.
-    generation: ArchetypeGeneration,
-    predicted_component_id: ComponentId,
-    /// Cached archetypes
-    pub(crate) archetypes: HashMap<ArchetypeId, Vec<PredictedComponent>>,
+/// `MODE` only selects the component access needed by one type-erased prediction dispatcher.
+pub(crate) struct PredictionWorld<'w, 's, const MODE: u8> {
+    pub(crate) world: UnsafeWorldCell<'w>,
+    cache: ResMut<'w, PredictedArchetypes>,
+    marker: PhantomData<&'s ()>,
 }
 
-/// A component that is predicted
-pub(crate) struct PredictedComponent {
-    pub(crate) id: ComponentId,
-    pub(crate) kind: ComponentKind,
+const CHECK_ROLLBACK: u8 = 0;
+const PREPARE_ROLLBACK: u8 = 1;
+const SNAP_TO_CONFIRMED: u8 = 2;
+const UPDATE_FRAME_INTERPOLATION_POST_ROLLBACK: u8 = 3;
+const PRUNE_DIFF_HISTORY: u8 = 4;
+
+pub(crate) type CheckRollbackWorld<'w, 's> = PredictionWorld<'w, 's, CHECK_ROLLBACK>;
+pub(crate) type PrepareRollbackWorld<'w, 's> = PredictionWorld<'w, 's, PREPARE_ROLLBACK>;
+pub(crate) type SnapToConfirmedWorld<'w, 's> = PredictionWorld<'w, 's, SNAP_TO_CONFIRMED>;
+pub(crate) type UpdateFrameInterpolationPostRollbackWorld<'w, 's> =
+    PredictionWorld<'w, 's, UPDATE_FRAME_INTERPOLATION_POST_ROLLBACK>;
+pub(crate) type PruneDiffHistoryWorld<'w, 's> = PredictionWorld<'w, 's, PRUNE_DIFF_HISTORY>;
+
+impl<const MODE: u8> PredictionWorld<'_, '_, MODE> {
+    /// Adds metadata for archetypes created since the previous scan.
+    pub(crate) fn update_archetypes(
+        &mut self,
+        prediction_registry: &PredictionRegistry,
+        component_registry: &ComponentRegistry,
+    ) {
+        self.cache.update(
+            self.world.archetypes(),
+            self.world.components(),
+            prediction_registry,
+            component_registry,
+        );
+    }
+
+    /// Iterates archetypes containing at least one prediction-history component.
+    pub(crate) fn predicted_archetypes(
+        &self,
+    ) -> impl Iterator<Item = (&Archetype, &CachedPredictionArchetype)> {
+        self.cache.archetypes.iter().filter_map(move |cached| {
+            (!cached.predicted_components.is_empty())
+                .then(|| self.world.archetypes().get(cached.id).map(|a| (a, cached)))
+                .flatten()
+        })
+    }
+
+    /// Iterates archetypes containing at least one diff-predicted component history.
+    pub(crate) fn diff_archetypes(
+        &self,
+    ) -> impl Iterator<Item = (&Archetype, &CachedPredictionArchetype)> {
+        self.cache.archetypes.iter().filter_map(move |cached| {
+            (!cached.diff_components.is_empty())
+                .then(|| self.world.archetypes().get(cached.id).map(|a| (a, cached)))
+                .flatten()
+        })
+    }
+
+    /// Returns whether the old rollback-check query would contain at least one entity.
+    pub(crate) fn has_check_entities(&self) -> bool {
+        self.cache.archetypes.iter().any(|cached| {
+            cached.check_target
+                && self
+                    .world
+                    .archetypes()
+                    .get(cached.id)
+                    .is_some_and(|archetype| !archetype.entities().is_empty())
+        })
+    }
+}
+
+unsafe impl<const MODE: u8> SystemParam for PredictionWorld<'_, '_, MODE> {
+    type State = <ResMut<'static, PredictedArchetypes> as SystemParam>::State;
+    type Item<'world, 'state> = PredictionWorld<'world, 'state, MODE>;
+
+    fn init_state(world: &mut World) -> Self::State {
+        world.init_resource::<PredictedArchetypes>();
+        <ResMut<'static, PredictedArchetypes> as SystemParam>::init_state(world)
+    }
+
+    fn init_access(
+        state: &Self::State,
+        system_meta: &mut SystemMeta,
+        component_access_set: &mut FilteredAccessSet,
+        world: &mut World,
+    ) {
+        <ResMut<'static, PredictedArchetypes> as SystemParam>::init_access(
+            state,
+            system_meta,
+            component_access_set,
+            world,
+        );
+
+        let mut access = FilteredAccess::default();
+
+        for component_id in &world.resource::<PredictedArchetypes>().filter_component_ids {
+            access.add_read(*component_id);
+        }
+
+        match MODE {
+            CHECK_ROLLBACK => {
+                for metadata in world
+                    .resource::<PredictionRegistry>()
+                    .prediction_map
+                    .values()
+                {
+                    access.add_read(metadata.rollback.prediction_history_id);
+                    access.add_write(metadata.rollback.confirmed_history_id);
+                }
+            }
+            PREPARE_ROLLBACK => {
+                for (kind, metadata) in world.resource::<PredictionRegistry>().rollback_metadata() {
+                    let component_id = world
+                        .components()
+                        .get_id(kind.0)
+                        .expect("rollback component should be registered in the world");
+                    access.add_write(component_id);
+                    access.add_write(metadata.prediction_history_id);
+                    access.add_read(metadata.confirmed_history_id);
+                }
+            }
+            SNAP_TO_CONFIRMED => {
+                for (kind, metadata) in &world.resource::<PredictionRegistry>().prediction_map {
+                    if metadata.snap_to_confirmed.is_none() {
+                        continue;
+                    }
+                    let component_id = world
+                        .components()
+                        .get_id(kind.0)
+                        .expect("predicted component should be registered in the world");
+                    access.add_write(component_id);
+                    access.add_read(metadata.rollback.confirmed_history_id);
+                }
+            }
+            UPDATE_FRAME_INTERPOLATION_POST_ROLLBACK => {
+                for (kind, metadata) in world.resource::<PredictionRegistry>().rollback_metadata() {
+                    let component_id = world
+                        .components()
+                        .get_id(kind.0)
+                        .expect("rollback component should be registered in the world");
+                    access.add_read(component_id);
+                    access.add_read(metadata.prediction_history_id);
+                    access.add_write(metadata.frame_interpolation_history_id);
+                }
+            }
+            PRUNE_DIFF_HISTORY => {
+                for metadata in world
+                    .resource::<PredictionRegistry>()
+                    .prediction_map
+                    .values()
+                    .filter(|metadata| metadata.prune_history_diff_receiver.is_some())
+                {
+                    access.add_read(metadata.rollback.confirmed_history_id);
+                }
+            }
+            _ => unreachable!("unknown prediction world access mode"),
+        }
+
+        component_access_set.add(access);
+    }
+
+    unsafe fn get_param<'world, 'state>(
+        state: &'state mut Self::State,
+        system_meta: &SystemMeta,
+        world: UnsafeWorldCell<'world>,
+        change_tick: ChangeTick,
+    ) -> Result<Self::Item<'world, 'state>, SystemParamValidationError> {
+        // SAFETY: `init_access` delegates resource access to `ResMut<PredictedArchetypes>`, and
+        // the caller guarantees that this is the same World used by `init_state`.
+        let cache = unsafe {
+            <ResMut<'static, PredictedArchetypes> as SystemParam>::get_param(
+                state,
+                system_meta,
+                world,
+                change_tick,
+            )
+        }?;
+        Ok(PredictionWorld {
+            world,
+            cache,
+            marker: PhantomData,
+        })
+    }
+}
+
+/// Shared cache of the archetypes and components used by prediction systems.
+#[derive(Resource)]
+pub(crate) struct PredictedArchetypes {
+    generation: ArchetypeGeneration,
+    predicted_component_id: ComponentId,
+    confirm_history_component_id: ComponentId,
+    deterministic_predicted_component_id: ComponentId,
+    disable_rollback_component_id: ComponentId,
+    prediction_disable_component_id: ComponentId,
+    disabling_component_ids: Vec<ComponentId>,
+    filter_component_ids: Vec<ComponentId>,
+    archetypes: Vec<CachedPredictionArchetype>,
+}
+
+/// Prediction operations resolved for one archetype.
+pub(crate) struct CachedPredictionArchetype {
+    id: ArchetypeId,
+    /// Whether this archetype is included by Bevy's default query filters.
+    pub(crate) default_query_target: bool,
+    /// Whether this archetype contains [`Predicted`].
+    pub(crate) contains_predicted_marker: bool,
+    /// Whether this archetype contains [`DisableRollback`].
+    pub(crate) has_disable_rollback: bool,
+    /// Whether this archetype matches the entity-level rollback-check filters.
+    pub(crate) check_target: bool,
+    /// Every rollback component whose prediction history is present in this archetype.
+    pub(crate) predicted_components: Vec<CachedPredictionComponent>,
+    /// Every diff-predicted component with a prediction or confirmed history in this archetype.
+    pub(crate) diff_components: Vec<CachedDiffComponent>,
+}
+
+/// Type-erased component access resolved for one archetype.
+#[derive(Clone, Copy)]
+pub(crate) struct CachedPredictionComponent {
+    pub(crate) component_id: ComponentId,
+    pub(crate) component_storage: Option<StorageType>,
+    pub(crate) prediction_history_id: ComponentId,
+    pub(crate) prediction_history_storage: Option<StorageType>,
+    pub(crate) confirmed_history_id: ComponentId,
+    pub(crate) confirmed_history_storage: Option<StorageType>,
+    pub(crate) frame_interpolation_history_storage: Option<StorageType>,
+    pub(crate) check_rollback: Option<CheckRollbackFn>,
+    pub(crate) prepare_rollback: PrepareRollbackFn,
+    pub(crate) snap_to_confirmed: Option<SnapToConfirmedFn>,
+    pub(crate) update_frame_interpolation_post_rollback: UpdateFrameInterpolationPostRollbackFn,
+    pub(crate) has_correction: bool,
+}
+
+/// Diff-prediction operations resolved for one archetype.
+#[derive(Clone, Copy)]
+pub(crate) struct CachedDiffComponent {
+    pub(crate) prediction_history_storage: Option<StorageType>,
+    pub(crate) confirmed_history_id: ComponentId,
+    pub(crate) confirmed_history_storage: Option<StorageType>,
+    pub(crate) pending_diff_tick: PendingDiffTickFn,
+    pub(crate) prune_history_diff_receiver: PruneHistoryDiffReceiverFn,
 }
 
 impl FromWorld for PredictedArchetypes {
     fn from_world(world: &mut World) -> Self {
+        let predicted_component_id = world.register_component::<Predicted>();
+        let confirm_history_component_id = world.register_component::<ConfirmHistory>();
+        let deterministic_predicted_component_id =
+            world.register_component::<DeterministicPredicted>();
+        let disable_rollback_component_id = world.register_component::<DisableRollback>();
+        let prediction_disable_component_id = world.register_component::<PredictionDisable>();
+        let disabling_component_ids = world
+            .resource::<DefaultQueryFilters>()
+            .disabling_ids()
+            .collect::<Vec<_>>();
+        let mut filter_component_ids = disabling_component_ids.clone();
+        for component_id in [
+            predicted_component_id,
+            confirm_history_component_id,
+            deterministic_predicted_component_id,
+            disable_rollback_component_id,
+            prediction_disable_component_id,
+        ] {
+            if !filter_component_ids.contains(&component_id) {
+                filter_component_ids.push(component_id);
+            }
+        }
         Self {
             generation: ArchetypeGeneration::initial(),
-            predicted_component_id: world.register_component::<Predicted>(),
-            archetypes: HashMap::default(),
+            predicted_component_id,
+            confirm_history_component_id,
+            deterministic_predicted_component_id,
+            disable_rollback_component_id,
+            prediction_disable_component_id,
+            disabling_component_ids,
+            filter_component_ids,
+            archetypes: Vec::new(),
         }
     }
 }
 
 impl PredictedArchetypes {
-    /// Update the list of predicted archetypes by going through all newly-added archetypes
-    pub(crate) fn update(
+    fn update(
         &mut self,
         archetypes: &Archetypes,
         components: &Components,
         prediction_registry: &PredictionRegistry,
+        component_registry: &ComponentRegistry,
     ) {
         let old_generation = core::mem::replace(&mut self.generation, archetypes.generation());
 
-        // iterate through the newly added archetypes
-        for archetype in archetypes[old_generation..]
-            .iter()
-            .filter(|archetype| archetype.contains(self.predicted_component_id))
-        {
-            let mut predicted_archetype = Vec::new();
-            // add all components from the registry that are predicted
-            archetype.iter_components().for_each(|component| {
-                let info = unsafe { components.get_info_unchecked(component) };
-                // if the component has a type_id (i.e. is a rust type)
-                if let Some(kind) = info.type_id().map(ComponentKind) {
-                    // the component is not registered for prediction in the ComponentProtocol
-                    let Some(prediction_metadata) = prediction_registry.prediction_map.get(&kind) else {
-                        trace!(
-                            "not including {:?} in the cached predicted archetype because it is not registered for prediction",
-                            info.name()
-                        );
-                        return;
-                    };
-                    let storage_type =
-                        unsafe { archetype.get_storage_type(component).unwrap_unchecked() };
-                    predicted_archetype.push(PredictedComponent {
-                        id: component,
-                        kind,
-                    });
+        for archetype in &archetypes[old_generation..] {
+            let excluded_by_default_filter = self
+                .disabling_component_ids
+                .iter()
+                .any(|id| archetype.contains(*id));
+            let excluded_from_check = self
+                .disabling_component_ids
+                .iter()
+                .any(|id| *id != self.prediction_disable_component_id && archetype.contains(*id));
+            let default_query_target = !excluded_by_default_filter;
+            let contains_predicted_marker = archetype.contains(self.predicted_component_id);
+            let has_disable_rollback = archetype.contains(self.disable_rollback_component_id);
+
+            let mut cached = CachedPredictionArchetype {
+                id: archetype.id(),
+                default_query_target,
+                contains_predicted_marker,
+                has_disable_rollback,
+                check_target: false,
+                predicted_components: Vec::new(),
+                diff_components: Vec::new(),
+            };
+
+            for (kind, metadata) in prediction_registry.rollback_metadata() {
+                let prediction_history_storage =
+                    archetype.get_storage_type(metadata.prediction_history_id);
+                let confirmed_history_storage =
+                    archetype.get_storage_type(metadata.confirmed_history_id);
+                if prediction_history_storage.is_none() && confirmed_history_storage.is_none() {
+                    continue;
                 }
-            });
-            self.archetypes.insert(archetype.id(), predicted_archetype);
+                cached.predicted_components.push(Self::component(
+                    archetype,
+                    components,
+                    kind,
+                    prediction_history_storage,
+                    confirmed_history_storage,
+                    prediction_registry,
+                    metadata,
+                    component_registry,
+                ));
+            }
+
+            let has_replicated_prediction_history =
+                cached.predicted_components.iter().any(|component| {
+                    component.check_rollback.is_some()
+                        && component.prediction_history_storage.is_some()
+                });
+            cached.check_target = contains_predicted_marker
+                && archetype.contains(self.confirm_history_component_id)
+                && !archetype.contains(self.deterministic_predicted_component_id)
+                && !has_disable_rollback
+                && !excluded_from_check
+                && has_replicated_prediction_history;
+
+            for metadata in prediction_registry.prediction_map.values() {
+                let (Some(pending_diff_tick), Some(prune_history_diff_receiver)) = (
+                    metadata.pending_diff_tick,
+                    metadata.prune_history_diff_receiver,
+                ) else {
+                    continue;
+                };
+                let prediction_history_storage =
+                    archetype.get_storage_type(metadata.rollback.prediction_history_id);
+                let confirmed_history_storage =
+                    archetype.get_storage_type(metadata.rollback.confirmed_history_id);
+                if prediction_history_storage.is_none() && confirmed_history_storage.is_none() {
+                    continue;
+                }
+                cached.diff_components.push(CachedDiffComponent {
+                    prediction_history_storage,
+                    confirmed_history_id: metadata.rollback.confirmed_history_id,
+                    confirmed_history_storage,
+                    pending_diff_tick,
+                    prune_history_diff_receiver,
+                });
+            }
+
+            if !cached.predicted_components.is_empty() || !cached.diff_components.is_empty() {
+                self.archetypes.push(cached);
+            }
+        }
+    }
+
+    fn component(
+        archetype: &Archetype,
+        components: &Components,
+        kind: ComponentKind,
+        prediction_history_storage: Option<StorageType>,
+        confirmed_history_storage: Option<StorageType>,
+        prediction_registry: &PredictionRegistry,
+        rollback: &RollbackMetadata,
+        component_registry: &ComponentRegistry,
+    ) -> CachedPredictionComponent {
+        let prediction = prediction_registry.prediction_map.get(&kind);
+        let component_id = components
+            .get_id(kind.0)
+            .expect("rollback component should be registered in the world");
+        CachedPredictionComponent {
+            component_id,
+            component_storage: archetype.get_storage_type(component_id),
+            prediction_history_id: rollback.prediction_history_id,
+            prediction_history_storage,
+            confirmed_history_id: rollback.confirmed_history_id,
+            confirmed_history_storage,
+            frame_interpolation_history_storage: archetype
+                .get_storage_type(rollback.frame_interpolation_history_id),
+            check_rollback: prediction
+                .filter(|_| {
+                    component_registry
+                        .component_metadata_map
+                        .contains_key(&kind)
+                })
+                .map(|metadata| metadata.check_rollback),
+            prepare_rollback: rollback.prepare_rollback,
+            snap_to_confirmed: prediction.and_then(|metadata| metadata.snap_to_confirmed),
+            update_frame_interpolation_post_rollback: rollback
+                .update_frame_interpolation_post_rollback,
+            has_correction: prediction.is_some_and(|metadata| {
+                metadata.custom_correction || metadata.correction.is_some()
+            }),
         }
     }
 }

--- a/crates/replication/prediction/src/correction.rs
+++ b/crates/replication/prediction/src/correction.rs
@@ -34,11 +34,11 @@
 //!   while rollback is active, so frame history must be repaired manually.
 //!
 //! Post-rollback processing repairs frame history before creating corrections:
-//! - `repair_frame_interpolation_history` runs for every predicted component
+//! - `update_frame_interpolation_post_rollback` runs for every predicted component
 //!   in [`RollbackSystems::EndRollback`]. It updates
 //!   [`FrameInterpolationHistory`] from the corrected live `C` and the previous
 //!   tick entry in [`PredictionHistory`].
-//! - `update_frame_interpolation_post_rollback` then calls the selected
+//! - `create_visual_corrections_post_rollback` then calls the selected
 //!   frame-interpolation rule from [`InterpolationRegistry`] for archetypes
 //!   that contain at least one [`PreviousVisual`]. This temporarily writes the
 //!   corrected visual sample into the live components, using the same component
@@ -91,6 +91,7 @@
 //! is removed.
 
 use crate::SyncComponent;
+use crate::archetypes::{CachedPredictionComponent, UpdateFrameInterpolationPostRollbackWorld};
 use crate::manager::PredictionManager;
 use crate::predicted_history::PredictionHistory;
 use crate::registry::PredictionRegistry;
@@ -126,7 +127,8 @@ use lightyear_interpolation::rules::frame_interpolate::{
 };
 use lightyear_replication::deferred_entity::DeferredEntityCommands;
 use lightyear_replication::diffable::Diffable;
-use lightyear_replication::registry::{ComponentKind, LerpFn};
+use lightyear_replication::registry::{ComponentKind, ComponentRegistry, LerpFn};
+use lightyear_utils::ecs::get_component_unchecked;
 use tracing::trace;
 
 /// The visual value of the component before the rollback started
@@ -524,7 +526,7 @@ pub fn add_correction_systems<
         app.insert_resource(PostRollbackCorrectionSystemInstalled);
         app.add_systems(
             PreUpdate,
-            update_frame_interpolation_post_rollback
+            create_visual_corrections_post_rollback
                 .in_set(RollbackSystems::EndRollback)
                 .before(crate::rollback::end_rollback),
         );
@@ -543,12 +545,12 @@ pub fn add_correction_systems<
 /// Creates visual corrections after a rollback from frame-interpolation state.
 ///
 /// This system runs in [`PreUpdate`], in [`RollbackSystems::EndRollback`],
-/// after [`repair_frame_interpolation_history`] and before
+/// after [`update_frame_interpolation_post_rollback`] and before
 /// [`crate::rollback::end_rollback`]. It runs the selected frame-interpolation
 /// rules to compute the corrected visual sample, creates [`VisualCorrection`]
 /// from that sample and [`PreviousVisual`], then restores live components to
 /// their corrected simulation values.
-pub(crate) fn update_frame_interpolation_post_rollback(
+pub(crate) fn create_visual_corrections_post_rollback(
     time: Res<Time<Fixed>>,
     timeline: Res<LocalTimeline>,
     prediction_registry: Res<PredictionRegistry>,
@@ -596,30 +598,106 @@ pub(crate) fn update_frame_interpolation_post_rollback(
     deferred_apply.apply(&mut commands);
 }
 
-/// Repair the frame-interpolation history of `C` to reflect `C`'s prediction
-/// timeline.
+/// Update frame-interpolation history to reflect the post-rollback prediction timeline.
 ///
 /// If `C` was replayed due to rollback then it may have different values from
 /// before the rollback. Its frame-interpolation history still holds onto those
 /// old values and needs to be corrected.
-pub(crate) fn repair_frame_interpolation_history<C: Component<Mutability = Mutable> + Clone>(
-    timeline: Res<LocalTimeline>,
-    mut components: Query<(
-        Option<&C>,
-        &PredictionHistory<C>,
-        &mut FrameInterpolationHistory<C>,
-    )>,
+pub(crate) fn update_frame_interpolation_post_rollback(
+    mut prediction_world: UpdateFrameInterpolationPostRollbackWorld,
+    timeline: Option<Res<LocalTimeline>>,
+    prediction_registry: Res<PredictionRegistry>,
+    component_registry: Res<ComponentRegistry>,
 ) {
+    let Some(timeline) = timeline else {
+        return;
+    };
     let tick = timeline.tick();
-    for (component, prediction_history, mut frame_history) in &mut components {
-        frame_history.previous_value = prediction_history.get(tick - 1).cloned();
-        frame_history.current_value = component.cloned();
+    prediction_world.update_archetypes(&prediction_registry, &component_registry);
+
+    let world = prediction_world.world;
+    for (archetype, cached) in prediction_world.predicted_archetypes() {
+        if !cached.default_query_target {
+            continue;
+        }
+        for component in &cached.predicted_components {
+            if component.prediction_history_storage.is_none()
+                || component.frame_interpolation_history_storage.is_none()
+            {
+                continue;
+            }
+            // SAFETY: the cache records the exact live, prediction-history, and frame-history
+            // component ids for this archetype, and the system declares their required accesses.
+            unsafe {
+                (component.update_frame_interpolation_post_rollback)(
+                    world, archetype, component, tick,
+                );
+            }
+        }
+    }
+}
+
+/// Updates one cached component's frame history after rollback replay.
+///
+/// # Safety
+///
+/// `component` must describe `C`, `PredictionHistory<C>`, and
+/// `FrameInterpolationHistory<C>` for `archetype`, and the caller must hold the accesses declared
+/// by [`UpdateFrameInterpolationPostRollbackWorld`].
+pub(crate) unsafe fn update_frame_interpolation_post_rollback_component<
+    C: Component<Mutability = Mutable> + Clone,
+>(
+    world: UnsafeWorldCell,
+    archetype: &Archetype,
+    component: &CachedPredictionComponent,
+    tick: Tick,
+) {
+    let prediction_history_storage = component
+        .prediction_history_storage
+        .expect("frame-history repair requires prediction history");
+    for entity in archetype.entities() {
+        let prediction_history = unsafe {
+            get_component_unchecked(
+                world,
+                entity,
+                archetype.table_id(),
+                prediction_history_storage,
+                component.prediction_history_id,
+            )
+            .deref::<PredictionHistory<C>>()
+        };
+        let current_value = component.component_storage.map(|storage| unsafe {
+            get_component_unchecked(
+                world,
+                entity,
+                archetype.table_id(),
+                storage,
+                component.component_id,
+            )
+            .deref::<C>()
+            .clone()
+        });
+        let repaired = FrameInterpolationHistory::<C> {
+            previous_value: prediction_history.get(tick - 1).cloned(),
+            current_value,
+        };
+
+        // SAFETY: the dispatcher declares unique access to FrameInterpolationHistory<C>, and no
+        // reference to that component is held by this callback.
+        let written = unsafe {
+            write_component_with_change_detection::<FrameInterpolationHistory<C>>(
+                world,
+                entity.id(),
+                repaired,
+            )
+        };
+        debug_assert!(written, "cached frame-history component should still exist");
     }
 }
 
 /// Applies selected frame-interpolation rules to post-rollback visual samples.
 ///
-/// This helper is called by [`update_frame_interpolation_post_rollback`] in
+/// This helper is called by [`create_visual_corrections_post_rollback`] in
 /// [`PreUpdate`], in [`RollbackSystems::EndRollback`], after frame histories
 /// have been repaired and before [`VisualCorrection`] is created. It iterates
 /// the correction archetype cache and runs each selected type-erased frame
@@ -674,7 +752,7 @@ fn restore_applied_frame_interpolation_components(
 /// Creates a `VisualCorrection<D>` from the corrected visual sample.
 ///
 /// This erased handler is called by
-/// [`update_frame_interpolation_post_rollback`] in [`PreUpdate`], in
+/// [`create_visual_corrections_post_rollback`] in [`PreUpdate`], in
 /// [`RollbackSystems::EndRollback`], after frame-interpolation rules have
 /// temporarily written the corrected visual value into live `C`. It compares
 /// that value with [`PreviousVisual<C>`], stores the resulting diff in
@@ -759,7 +837,7 @@ pub(crate) fn create_visual_correction_from_live_erased<
 /// Restores live `C` to the corrected simulation value after sampling visuals.
 ///
 /// This erased handler is called by
-/// [`update_frame_interpolation_post_rollback`] in [`PreUpdate`], in
+/// [`create_visual_corrections_post_rollback`] in [`PreUpdate`], in
 /// [`RollbackSystems::EndRollback`], after [`VisualCorrection`] has been
 /// created. The frame-apply phase temporarily writes visual values into live
 /// components; this restores each live `C` from
@@ -942,7 +1020,7 @@ mod tests {
 
     use super::*;
     use crate::plugin::PredictionMarkerPlugin;
-    use crate::registry::{PredictionBuilderExt, PredictionRegistry};
+    use crate::registry::{PredictionAppRegistrationExt, PredictionBuilderExt, PredictionRegistry};
 
     fn app_with_replication_markers() -> App {
         let mut app = App::new();
@@ -1151,8 +1229,22 @@ mod tests {
             ))
             .id();
 
+        app.world_mut().clear_trackers();
+        let live_frame_history_tick = app
+            .world()
+            .entity(live)
+            .get_change_ticks::<FrameInterpolationHistory<CorrectionA>>()
+            .unwrap()
+            .changed;
+        let removed_frame_history_tick = app
+            .world()
+            .entity(removed)
+            .get_change_ticks::<FrameInterpolationHistory<CorrectionA>>()
+            .unwrap()
+            .changed;
+
         app.world_mut()
-            .run_system_once(repair_frame_interpolation_history::<CorrectionA>)
+            .run_system_once(update_frame_interpolation_post_rollback)
             .unwrap();
 
         // A surviving component uses its previous sample from prediction
@@ -1166,6 +1258,15 @@ mod tests {
             Some(CorrectionA(PREVIOUS_VALUE))
         );
         assert_eq!(live_history.current_value, Some(CorrectionA(CURRENT_VALUE)));
+        assert_ne!(
+            app.world()
+                .entity(live)
+                .get_change_ticks::<FrameInterpolationHistory<CorrectionA>>()
+                .unwrap()
+                .changed,
+            live_frame_history_tick,
+            "repair must retain Bevy change detection for surviving components"
+        );
 
         // A removed component retains the previous prediction sample and clears
         // the current frame sample so interpolation cannot reinsert it.
@@ -1178,6 +1279,15 @@ mod tests {
             Some(CorrectionA(REMOVED_PREVIOUS_VALUE))
         );
         assert_eq!(removed_history.current_value, None);
+        assert_ne!(
+            app.world()
+                .entity(removed)
+                .get_change_ticks::<FrameInterpolationHistory<CorrectionA>>()
+                .unwrap()
+                .changed,
+            removed_frame_history_tick,
+            "repair must retain Bevy change detection for removed live components"
+        );
     }
 
     // Verifies that repair reads a sparse-set live component while updating
@@ -1197,6 +1307,9 @@ mod tests {
         const STALE_CURRENT_VALUE: f32 = 200.0;
 
         let mut app = App::new();
+        app.init_resource::<PredictionRegistry>();
+        app.init_resource::<ComponentRegistry>();
+        app.local_rollback::<SparseCorrection>();
         app.insert_resource(LocalTimeline::default());
         app.world_mut()
             .resource_mut::<LocalTimeline>()
@@ -1220,7 +1333,7 @@ mod tests {
             .id();
 
         app.world_mut()
-            .run_system_once(repair_frame_interpolation_history::<SparseCorrection>)
+            .run_system_once(update_frame_interpolation_post_rollback)
             .unwrap();
 
         // The sparse live value supplies the current sample, and prediction
@@ -1266,7 +1379,7 @@ mod tests {
         ));
 
         app.world_mut()
-            .run_system_once(update_frame_interpolation_post_rollback)
+            .run_system_once(create_visual_corrections_post_rollback)
             .unwrap();
     }
 }

--- a/crates/replication/prediction/src/lib.rs
+++ b/crates/replication/prediction/src/lib.rs
@@ -8,7 +8,6 @@ extern crate std;
 
 use core::fmt::Debug;
 
-#[allow(unused)]
 pub(crate) mod archetypes;
 pub mod correction;
 pub mod despawn;

--- a/crates/replication/prediction/src/plugin.rs
+++ b/crates/replication/prediction/src/plugin.rs
@@ -1,6 +1,6 @@
-use super::rollback::{CatchUpGated, RollbackPlugin, RollbackSystems, prepare_rollback};
+use super::rollback::{CatchUpGated, RollbackPlugin, RollbackSystems};
 use crate::correction::{
-    repair_frame_interpolation_history, update_frame_interpolation_post_rollback,
+    create_visual_corrections_post_rollback, update_frame_interpolation_post_rollback,
 };
 use crate::despawn::{PredictionDisable, finalize_deterministic_despawns};
 use crate::diagnostics::PredictionDiagnosticsPlugin;
@@ -12,7 +12,7 @@ use crate::predicted_history::{
     handle_local_timeline_shift_prediction_history, prune_history_diff_receiver,
     snap_to_confirmed_during_rollback, update_prediction_history,
 };
-use crate::registry::PredictionRegistry;
+use crate::registry::{PredictionRegistry, register_rollback_metadata};
 use crate::rollback::DisabledDuringRollback;
 use crate::{Predicted, SyncComponent};
 use bevy_app::FixedPreUpdate;
@@ -135,8 +135,11 @@ pub(crate) fn should_run(
 pub fn add_non_networked_rollback_systems<C: Component<Mutability = Mutable> + Clone>(
     app: &mut App,
 ) {
-    app.world_mut().register_component::<PredictionHistory<C>>();
-    app.world_mut().register_component::<ConfirmedHistory<C>>();
+    let prediction_history_id = app.world_mut().register_component::<PredictionHistory<C>>();
+    let confirmed_history_id = app.world_mut().register_component::<ConfirmedHistory<C>>();
+    if app.world().contains_resource::<PredictionRegistry>() {
+        register_rollback_metadata::<C>(app, prediction_history_id, confirmed_history_id);
+    }
     app.add_observer(apply_component_removal_predicted::<C>);
     app.add_observer(add_prediction_history::<C>);
     // This also supports explicit resynchronization after prediction has begun. Do not shift
@@ -145,16 +148,6 @@ pub fn add_non_networked_rollback_systems<C: Component<Mutability = Mutable> + C
     // server tick space. Shifting them can move authoritative state into the
     // future and make rollback prefer it over later server updates.
     app.add_observer(handle_local_timeline_shift_prediction_history::<C>);
-    app.add_systems(
-        PreUpdate,
-        (
-            prepare_rollback::<C>.in_set(RollbackSystems::Prepare),
-            repair_frame_interpolation_history::<C>
-                .in_set(RollbackSystems::EndRollback)
-                .before(update_frame_interpolation_post_rollback)
-                .before(super::rollback::end_rollback),
-        ),
-    );
     app.add_systems(
         FixedPostUpdate,
         update_prediction_history::<C>.in_set(PredictionSystems::UpdateHistory),
@@ -198,25 +191,9 @@ pub(crate) fn add_prediction_systems<C: SyncComponent>(app: &mut App) {
     app.add_observer(handle_local_timeline_shift_prediction_history::<C>);
     app.add_observer(add_prediction_history::<C>);
     app.add_observer(backfill_confirmed_history_on_predicted::<C>);
-
-    app.add_systems(
-        PreUpdate,
-        (
-            // for SyncMode::Full, we need to check if we need to rollback.
-            // TODO: for mode=simple/once, we still need to re-add the component if the entity ends up not being despawned!
-            // check_rollback::<C>.in_set(PredictionSet::CheckRollback),
-            prepare_rollback::<C>.in_set(RollbackSystems::Prepare),
-            repair_frame_interpolation_history::<C>
-                .in_set(RollbackSystems::EndRollback)
-                .before(update_frame_interpolation_post_rollback)
-                .before(super::rollback::end_rollback),
-        ),
-    );
-    app.add_systems(
-        FixedPreUpdate,
-        // During rollback re-simulation, snap to confirmed values if we have them
-        snap_to_confirmed_during_rollback::<C>.in_set(PredictionSystems::SnapToConfirmed),
-    );
+    app.world_mut()
+        .resource_mut::<PredictionRegistry>()
+        .set_snap_to_confirmed::<C>();
     app.add_systems(
         FixedPostUpdate,
         // we need to run this during fixed update to know accurately the history for each tick
@@ -227,10 +204,6 @@ pub(crate) fn add_prediction_systems<C: SyncComponent>(app: &mut App) {
 pub(crate) fn add_prediction_diff_systems<C: SyncComponent + RepliconDiffable>(app: &mut App) {
     app.add_observer(add_history_diff_receiver::<C>);
     app.add_observer(handle_local_timeline_shift_history_diff_receiver::<C>);
-    app.add_systems(
-        PreUpdate,
-        prune_history_diff_receiver::<C>.in_set(RollbackSystems::Prepare),
-    );
 }
 
 impl Plugin for PredictionPlugin {
@@ -270,6 +243,16 @@ impl Plugin for PredictionPlugin {
                 .chain(),
         );
         app.configure_sets(PreUpdate, PredictionSystems::All.run_if(should_run));
+        app.add_systems(
+            PreUpdate,
+            (
+                prune_history_diff_receiver.in_set(RollbackSystems::Prepare),
+                update_frame_interpolation_post_rollback
+                    .in_set(RollbackSystems::EndRollback)
+                    .before(create_visual_corrections_post_rollback)
+                    .before(super::rollback::end_rollback),
+            ),
+        );
 
         // FixedPreUpdate systems
         // - During rollback, snap components to confirmed values if we have them
@@ -280,6 +263,10 @@ impl Plugin for PredictionPlugin {
                 .run_if(is_in_rollback),
         );
         app.configure_sets(FixedPreUpdate, PredictionSystems::All.run_if(should_run));
+        app.add_systems(
+            FixedPreUpdate,
+            snap_to_confirmed_during_rollback.in_set(PredictionSystems::SnapToConfirmed),
+        );
 
         // FixedPostUpdate systems
         // 1. Update client tick (don't run in rollback)

--- a/crates/replication/prediction/src/predicted_history.rs
+++ b/crates/replication/prediction/src/predicted_history.rs
@@ -4,11 +4,17 @@
 //! 1. Compare local predicted values with confirmed values from the server to detect mismatches
 //! 2. Rollback to a past local state and replay the simulation
 
+use crate::archetypes::{
+    CachedDiffComponent, CachedPredictionComponent, PruneDiffHistoryWorld, SnapToConfirmedWorld,
+};
+use crate::registry::PredictionRegistry;
 use crate::rollback::{CatchUpGated, DeterministicPredicted};
 use crate::{Predicted, SyncComponent, manager::PredictionManager};
-use bevy_ecs::component::{ComponentIdFor, Mutable};
+use bevy_ecs::archetype::Archetype;
+use bevy_ecs::component::ComponentIdFor;
 use bevy_ecs::prelude::*;
 use bevy_ecs::resource::IsResource;
+use bevy_ecs::world::unsafe_world_cell::UnsafeWorldCell;
 use bevy_reflect::Reflect;
 use bevy_replicon::shared::replication::diff::{DiffBuffer, Diffable as RepliconDiffable};
 use bevy_replicon::shared::replication::storage::ReplicationStorage;
@@ -20,9 +26,12 @@ use lightyear_core::prelude::{ConfirmedHistory, LocalTimeline};
 use lightyear_core::tick::Tick;
 use lightyear_core::timeline::LocalTimelineShift;
 use lightyear_replication::checkpoint::ReplicationCheckpointMap;
+use lightyear_replication::deferred_entity::DeferredEntityCommands;
 use lightyear_replication::diff_history::HistoryDiffReceiver;
 use lightyear_replication::prelude::{ConfirmHistory, PreSpawned};
+use lightyear_replication::registry::ComponentRegistry;
 use lightyear_sync::prelude::{InputTimelineConfig, SyncedLocalTimeline};
+use lightyear_utils::ecs::get_component_unchecked;
 #[allow(unused_imports)]
 use tracing::{debug, info, trace};
 
@@ -184,17 +193,71 @@ pub(crate) fn handle_local_timeline_shift_history_diff_receiver<C: RepliconDiffa
 /// older confirmed values available for late diff messages whose base is
 /// before the latest processed tick but whose target tick has not been received
 /// yet.
-pub(crate) fn prune_history_diff_receiver<C: RepliconDiffable>(
+pub(crate) fn prune_history_diff_receiver(
+    mut prediction_world: PruneDiffHistoryWorld,
     state_metadata: Res<crate::manager::StateRollbackMetadata>,
     mut storage: ResMut<ReplicationStorage>,
-    query: Query<(Entity, &ConfirmedHistory<C>)>,
+    prediction_registry: Res<PredictionRegistry>,
+    component_registry: Res<ComponentRegistry>,
 ) {
     let Some(last_processed_confirmed_tick) = state_metadata.last_processed_confirmed_tick() else {
         return;
     };
     let prune_tick = last_processed_confirmed_tick - DIFF_HISTORY_TICK_MARGIN;
-    for (entity, history) in query.iter() {
-        let Some(receiver) = storage.get_mut::<HistoryDiffReceiver<C>>(entity) else {
+
+    prediction_world.update_archetypes(&prediction_registry, &component_registry);
+    let world = prediction_world.world;
+    for (archetype, cached) in prediction_world.diff_archetypes() {
+        if !cached.default_query_target {
+            continue;
+        }
+        for component in &cached.diff_components {
+            if component.confirmed_history_storage.is_none() {
+                continue;
+            }
+            // SAFETY: the cache records the exact confirmed-history column, and the system
+            // declares read access to it while holding unique access to ReplicationStorage.
+            unsafe {
+                (component.prune_history_diff_receiver)(
+                    world,
+                    archetype,
+                    component,
+                    prune_tick,
+                    storage.as_mut(),
+                );
+            }
+        }
+    }
+}
+
+/// Prunes one cached diff receiver type across an archetype.
+///
+/// # Safety
+///
+/// `component` must describe `ConfirmedHistory<C>` for `archetype`, and the caller must have read
+/// access to that column and unique access to `storage`.
+pub(crate) unsafe fn prune_history_diff_receiver_component<C: RepliconDiffable>(
+    world: UnsafeWorldCell,
+    archetype: &Archetype,
+    component: &CachedDiffComponent,
+    prune_tick: Tick,
+    storage: &mut ReplicationStorage,
+) {
+    let confirmed_history_storage = component
+        .confirmed_history_storage
+        .expect("diff pruning requires confirmed history");
+    for entity in archetype.entities() {
+        let history = unsafe {
+            get_component_unchecked(
+                world,
+                entity,
+                archetype.table_id(),
+                confirmed_history_storage,
+                component.confirmed_history_id,
+            )
+            .deref::<ConfirmedHistory<C>>()
+        };
+        let Some(receiver) = storage.get_mut::<HistoryDiffReceiver<C>>(entity.id()) else {
             continue;
         };
         if !receiver.has_pending_diffs() {
@@ -384,40 +447,114 @@ pub(crate) fn add_history_diff_receiver<C: SyncComponent + RepliconDiffable>(
 /// this system with [`is_in_rollback`](lightyear_core::timeline::is_in_rollback), so the global
 /// [`Rollback`](lightyear_core::timeline::Rollback) resource does not need to be fetched by every
 /// monomorphized component system.
-pub(crate) fn snap_to_confirmed_during_rollback<
-    C: Component<Mutability = Mutable> + Clone + PartialEq + Debug,
->(
+pub(crate) fn snap_to_confirmed_during_rollback(
+    mut prediction_world: SnapToConfirmedWorld,
+    timeline: Option<Res<LocalTimeline>>,
+    prediction_registry: Res<PredictionRegistry>,
+    component_registry: Res<ComponentRegistry>,
     mut commands: Commands,
-    timeline: Res<LocalTimeline>,
-    mut query: Query<(Entity, Option<&mut C>, &ConfirmedHistory<C>), With<Predicted>>,
 ) {
+    let Some(timeline) = timeline else {
+        return;
+    };
     let tick = timeline.tick();
-    query.iter_mut().for_each(|(entity, component, history)| {
+    prediction_world.update_archetypes(&prediction_registry, &component_registry);
+
+    let world = prediction_world.world;
+    let mut deferred = DeferredEntityCommands::default();
+    for (archetype, cached) in prediction_world.predicted_archetypes() {
+        if !cached.default_query_target || !cached.contains_predicted_marker {
+            continue;
+        }
+        for component in &cached.predicted_components {
+            let (Some(snap_to_confirmed), Some(_)) = (
+                component.snap_to_confirmed,
+                component.confirmed_history_storage,
+            ) else {
+                continue;
+            };
+            // SAFETY: the cache records the exact live and confirmed-history columns, and the
+            // system declares write access to the former and read access to the latter.
+            unsafe {
+                snap_to_confirmed(world, archetype, component, tick, &mut deferred);
+            }
+        }
+    }
+    deferred.apply(&mut commands);
+}
+
+/// Snaps one cached predicted component type across an archetype during rollback replay.
+///
+/// # Safety
+///
+/// `component` must describe `C` and `ConfirmedHistory<C>` for `archetype`, and the caller must
+/// hold the accesses declared by [`SnapToConfirmedWorld`].
+pub(crate) unsafe fn snap_to_confirmed_component<C: SyncComponent>(
+    world: UnsafeWorldCell,
+    archetype: &Archetype,
+    component: &CachedPredictionComponent,
+    tick: Tick,
+    deferred: &mut DeferredEntityCommands,
+) {
+    let confirmed_history_storage = component
+        .confirmed_history_storage
+        .expect("replay snap requires confirmed history");
+    for entity in archetype.entities() {
+        let entity_id = entity.id();
+        let history = unsafe {
+            get_component_unchecked(
+                world,
+                entity,
+                archetype.table_id(),
+                confirmed_history_storage,
+                component.confirmed_history_id,
+            )
+            .deref::<ConfirmedHistory<C>>()
+        };
+        let live_component = component.component_storage.map(|storage| unsafe {
+            get_component_unchecked(
+                world,
+                entity,
+                archetype.table_id(),
+                storage,
+                component.component_id,
+            )
+            .deref::<C>()
+        });
+
         // Check if there's a confirmed value at exactly this tick
         if let Some(confirmed_state) = history.get_state_at(tick) {
             match confirmed_state {
                 HistoryState::Updated(confirmed_value) => {
                     // Snap to the confirmed value
-                    if let Some(mut comp) = component {
-                        if comp.deref() != confirmed_value {
+                    if let Some(current) = live_component {
+                        if current != confirmed_value {
                             trace!(
                                 target: "lightyear_debug::prediction",
                                 kind = "snap_to_confirmed",
                                 schedule = "FixedPreUpdate",
                                 sample_point = "FixedPreUpdate",
-                                entity = ?entity,
+                                entity = ?entity_id,
                                 component = ?DebugName::type_name::<C>(),
                                 local_tick = tick.0,
                                 confirmed_tick = tick.0,
                                 value = ?confirmed_value,
                                 "snapped predicted component to confirmed value during rollback"
                             );
-                            *comp = confirmed_value.clone();
+                            // SAFETY: the dispatcher declares unique access to C, and no live-C
+                            // reference is used after this call.
+                            unsafe {
+                                lightyear_core::ecs_utils::write_component_with_change_detection::<C>(
+                                    world,
+                                    entity_id,
+                                    confirmed_value.clone(),
+                                );
+                            }
                         }
                     } else {
                         // Component doesn't exist but should - insert it
                         debug!(
-                            ?entity,
+                            ?entity_id,
                             ?tick,
                             "Inserting confirmed component during rollback for {:?}",
                             DebugName::type_name::<C>()
@@ -427,21 +564,21 @@ pub(crate) fn snap_to_confirmed_during_rollback<
                             kind = "snap_to_confirmed_insert",
                             schedule = "FixedPreUpdate",
                             sample_point = "FixedPreUpdate",
-                            entity = ?entity,
+                            entity = ?entity_id,
                             component = ?DebugName::type_name::<C>(),
                             local_tick = tick.0,
                             confirmed_tick = tick.0,
                             value = ?confirmed_value,
                             "inserted confirmed component during rollback"
                         );
-                        commands.entity(entity).insert(confirmed_value.clone());
+                        deferred.insert(entity_id, confirmed_value.clone());
                     }
                 }
                 HistoryState::Removed => {
                     // Confirmed removal - remove the component if it exists
-                    if component.is_some() {
+                    if live_component.is_some() {
                         debug!(
-                            ?entity,
+                            ?entity_id,
                             ?tick,
                             "Removing component during rollback (confirmed removal) for {:?}",
                             DebugName::type_name::<C>()
@@ -451,18 +588,18 @@ pub(crate) fn snap_to_confirmed_during_rollback<
                             kind = "snap_to_confirmed_remove",
                             schedule = "FixedPreUpdate",
                             sample_point = "FixedPreUpdate",
-                            entity = ?entity,
+                            entity = ?entity_id,
                             component = ?DebugName::type_name::<C>(),
                             local_tick = tick.0,
                             confirmed_tick = tick.0,
                             "removed component for confirmed removal during rollback"
                         );
-                        commands.entity(entity).remove::<C>();
+                        deferred.remove::<C>(entity_id);
                     }
                 }
             }
         }
-    });
+    }
 }
 
 #[cfg(test)]
@@ -470,7 +607,10 @@ mod tests {
     use super::*;
     use crate::manager::{RollbackPolicy, StateRollbackMetadata};
     use bevy_app::{App, Update};
+    use bevy_ecs::entity_disabling::Disabled;
+    use bevy_ecs::system::RunSystemOnce;
     use bevy_replicon::shared::replication::diff::diff_index::DiffIndex;
+    use lightyear_core::prelude::FrameInterpolationHistory;
     use lightyear_sync::prelude::LocalTimelineSync;
     use lightyear_sync::timeline::input::InputDelayConfig;
     use serde::{Deserialize, Serialize};
@@ -614,7 +754,28 @@ mod tests {
         metadata.set_last_processed_confirmed_tick(Tick(16));
         app.insert_resource(metadata);
         app.insert_resource(ReplicationStorage::default());
-        app.add_systems(Update, prune_history_diff_receiver::<TestDiffValue>);
+        app.init_resource::<PredictionRegistry>();
+        app.init_resource::<ComponentRegistry>();
+        app.world_mut().register_component::<TestDiffValue>();
+        let prediction_history_id = app
+            .world_mut()
+            .register_component::<PredictionHistory<TestDiffValue>>();
+        let confirmed_history_id = app
+            .world_mut()
+            .register_component::<ConfirmedHistory<TestDiffValue>>();
+        let frame_interpolation_history_id = app
+            .world_mut()
+            .register_component::<FrameInterpolationHistory<TestDiffValue>>();
+        let mut registry = app.world_mut().resource_mut::<PredictionRegistry>();
+        registry.register_rollback::<TestDiffValue>(
+            prediction_history_id,
+            confirmed_history_id,
+            frame_interpolation_history_id,
+        );
+        registry.register::<TestDiffValue>();
+        registry.set_pending_diff_tick::<TestDiffValue>();
+        drop(registry);
+        app.add_systems(Update, prune_history_diff_receiver);
 
         let mut history = ConfirmedHistory::<TestDiffValue>::default();
         history.insert_present(Tick(2), TestDiffValue(2));
@@ -640,5 +801,121 @@ mod tests {
         assert_eq!(receiver.tick_for_cursor(Some(idx(2))), None);
         assert_eq!(receiver.tick_for_cursor(Some(idx(4))), Some(Tick(4)));
         assert_eq!(receiver.tick_for_cursor(Some(idx(8))), Some(Tick(8)));
+    }
+
+    #[test]
+    fn snap_to_confirmed_matches_typed_query_behavior() {
+        const TICK: Tick = Tick(10);
+
+        let mut app = App::new();
+        app.init_resource::<PredictionRegistry>();
+        app.init_resource::<ComponentRegistry>();
+        let prediction_history_id = app
+            .world_mut()
+            .register_component::<PredictionHistory<TestValue>>();
+        let confirmed_history_id = app
+            .world_mut()
+            .register_component::<ConfirmedHistory<TestValue>>();
+        let frame_interpolation_history_id = app
+            .world_mut()
+            .register_component::<FrameInterpolationHistory<TestValue>>();
+        let mut registry = app.world_mut().resource_mut::<PredictionRegistry>();
+        registry.register_rollback::<TestValue>(
+            prediction_history_id,
+            confirmed_history_id,
+            frame_interpolation_history_id,
+        );
+        registry.register::<TestValue>();
+        registry.set_snap_to_confirmed::<TestValue>();
+        drop(registry);
+
+        let mut timeline = LocalTimeline::default();
+        timeline.apply_delta(TICK.0 as i32);
+        app.insert_resource(timeline);
+
+        let present_history = |value| {
+            let mut history = ConfirmedHistory::default();
+            history.insert_present(TICK, TestValue(value));
+            history
+        };
+
+        let changed = app
+            .world_mut()
+            .spawn((Predicted, TestValue(1.0), present_history(2.0)))
+            .id();
+        let unchanged = app
+            .world_mut()
+            .spawn((Predicted, TestValue(3.0), present_history(3.0)))
+            .id();
+        let inserted = app
+            .world_mut()
+            .spawn((Predicted, present_history(4.0)))
+            .id();
+
+        let mut removed_history = ConfirmedHistory::<TestValue>::default();
+        removed_history.insert_removed(TICK);
+        let removed = app
+            .world_mut()
+            .spawn((Predicted, TestValue(5.0), removed_history))
+            .id();
+
+        // The old Query obeyed Bevy's default disabling filters. Cached
+        // archetypes must exclude the same entities.
+        let disabled = app
+            .world_mut()
+            .spawn((Predicted, Disabled, TestValue(6.0), present_history(7.0)))
+            .id();
+
+        app.world_mut().clear_trackers();
+        let changed_tick = app
+            .world()
+            .entity(changed)
+            .get_change_ticks::<TestValue>()
+            .unwrap()
+            .changed;
+        let unchanged_tick = app
+            .world()
+            .entity(unchanged)
+            .get_change_ticks::<TestValue>()
+            .unwrap()
+            .changed;
+
+        app.world_mut()
+            .run_system_once(snap_to_confirmed_during_rollback)
+            .unwrap();
+
+        assert_eq!(app.world().get::<TestValue>(changed), Some(&TestValue(2.0)));
+        assert_ne!(
+            app.world()
+                .entity(changed)
+                .get_change_ticks::<TestValue>()
+                .unwrap()
+                .changed,
+            changed_tick,
+            "a changed live value must retain Bevy change detection"
+        );
+        assert_eq!(
+            app.world().get::<TestValue>(unchanged),
+            Some(&TestValue(3.0))
+        );
+        assert_eq!(
+            app.world()
+                .entity(unchanged)
+                .get_change_ticks::<TestValue>()
+                .unwrap()
+                .changed,
+            unchanged_tick,
+            "an equal confirmed value must not spuriously mark the component changed"
+        );
+        assert_eq!(
+            app.world().get::<TestValue>(inserted),
+            Some(&TestValue(4.0))
+        );
+        assert!(app.world().get::<TestValue>(removed).is_none());
+        assert_eq!(
+            app.world().get::<TestValue>(disabled),
+            Some(&TestValue(6.0)),
+            "default-disabled entities must stay outside the cached query universe"
+        );
     }
 }

--- a/crates/replication/prediction/src/registry.rs
+++ b/crates/replication/prediction/src/registry.rs
@@ -1,11 +1,13 @@
+use crate::archetypes::{CachedDiffComponent, CachedPredictionComponent};
 use crate::plugin::{add_non_networked_rollback_systems, add_prediction_systems};
 use crate::predicted_history::PredictionHistory;
 use crate::{SyncComponent, correction};
 use bevy_app::App;
+use bevy_ecs::archetype::{Archetype, ArchetypeEntity};
 use bevy_ecs::component::{ComponentId, Mutable};
 use bevy_ecs::prelude::*;
 use bevy_ecs::ptr::PtrMut;
-use bevy_ecs::world::FilteredEntityMut;
+use bevy_ecs::world::unsafe_world_cell::UnsafeWorldCell;
 use bevy_math::{
     Curve,
     curve::{Ease, EaseFunction, EasingCurve},
@@ -22,10 +24,11 @@ use core::fmt::Debug;
 use indexmap::IndexMap;
 use lightyear_core::history_buffer::HistoryState;
 use lightyear_core::prediction::Predicted;
-use lightyear_core::prelude::ConfirmedHistory;
+use lightyear_core::prelude::{ConfirmedHistory, FrameInterpolationHistory};
 use lightyear_core::tick::Tick;
 use lightyear_frame_interpolation::FrameInterpolationPlugin;
 use lightyear_replication::checkpoint::resolve_message_tick;
+use lightyear_replication::deferred_entity::DeferredEntityCommands;
 use lightyear_replication::diff_history::HistoryDiffReceiver;
 use lightyear_replication::diffable::Diffable;
 use lightyear_replication::prelude::{PreSpawned, PredictedSend};
@@ -33,6 +36,7 @@ use lightyear_replication::registry::replication::{
     AppComponentExt, ComponentRegistration, ComponentRegistrator,
 };
 use lightyear_replication::registry::{ComponentError, ComponentKind, ComponentRegistry, LerpFn};
+use lightyear_utils::ecs::{get_component_unchecked, get_component_unchecked_mut};
 #[cfg(feature = "metrics")]
 use std::sync::OnceLock;
 use tracing::{debug, error, trace, trace_span};
@@ -44,10 +48,8 @@ fn lerp<C: Ease + Clone>(start: C, other: C, t: f32) -> C {
 
 #[derive(Debug, Clone)]
 pub struct PredictionMetadata {
-    /// Id of the [`PredictionHistory<C>`] component
-    pub prediction_history_id: ComponentId,
-    /// Id of the [`ConfirmedHistory<C>`] component
-    pub confirmed_history_id: ComponentId,
+    /// Rollback metadata shared by networked prediction and local rollback.
+    pub rollback: RollbackMetadata,
     /// store `PreviousVisual<C>`, but the user owns the actual correction logic.
     pub(crate) custom_correction: bool,
     /// Type-erased handlers used by the generic post-rollback correction system.
@@ -61,14 +63,64 @@ pub struct PredictionMetadata {
     /// Will default to a PartialEq::ne implementation, but can be overridden.
     pub(crate) should_rollback: unsafe fn(),
     pub(crate) check_rollback: CheckRollbackFn,
+    /// Type-erased rollback replay snap for components with full prediction enabled.
+    pub(crate) snap_to_confirmed: Option<SnapToConfirmedFn>,
     /// For a diff-replicated component on one entity, returns its earliest unresolved diff tick at
     /// or before a candidate completed checkpoint.
     pub(crate) pending_diff_tick: Option<PendingDiffTickFn>,
+    /// Type-erased pruning for the diff receiver associated with this component.
+    pub(crate) prune_history_diff_receiver: Option<PruneHistoryDiffReceiverFn>,
     #[cfg(feature = "metrics")]
     metric_handles: PredictionMetricHandles,
     #[cfg(feature = "deterministic")]
     /// Function to hash the value in [`PredictionHistory<C>`] at a given tick.
     pub pop_until_tick_and_hash: Option<PopUntilTickAndHashFn>,
+}
+
+/// Type-erased rollback preparation metadata shared by networked and local-only components.
+#[derive(Debug, Clone)]
+pub struct RollbackMetadata {
+    /// Id of the [`PredictionHistory<C>`] component.
+    pub prediction_history_id: ComponentId,
+    /// Id of the [`ConfirmedHistory<C>`] component.
+    pub confirmed_history_id: ComponentId,
+    pub(crate) frame_interpolation_history_id: ComponentId,
+    pub(crate) prepare_rollback: PrepareRollbackFn,
+    pub(crate) update_frame_interpolation_post_rollback: UpdateFrameInterpolationPostRollbackFn,
+}
+
+impl RollbackMetadata {
+    fn new<C: Component<Mutability = Mutable> + Clone>(
+        prediction_history_id: ComponentId,
+        confirmed_history_id: ComponentId,
+        frame_interpolation_history_id: ComponentId,
+    ) -> Self {
+        Self {
+            prediction_history_id,
+            confirmed_history_id,
+            frame_interpolation_history_id,
+            prepare_rollback: crate::rollback::prepare_rollback_component::<C>,
+            update_frame_interpolation_post_rollback:
+                crate::correction::update_frame_interpolation_post_rollback_component::<C>,
+        }
+    }
+}
+
+pub(crate) fn register_rollback_metadata<C: Component<Mutability = Mutable> + Clone>(
+    app: &mut App,
+    prediction_history_id: ComponentId,
+    confirmed_history_id: ComponentId,
+) {
+    let frame_interpolation_history_id = app
+        .world_mut()
+        .register_component::<FrameInterpolationHistory<C>>();
+    app.world_mut()
+        .resource_mut::<PredictionRegistry>()
+        .register_rollback::<C>(
+            prediction_history_id,
+            confirmed_history_id,
+            frame_interpolation_history_id,
+        );
 }
 
 #[cfg(feature = "metrics")]
@@ -131,11 +183,42 @@ impl PredictionMetadata {
 
 /// Function that will check if we should do a rollback by comparing the confirmed component value
 /// with the predicted component's history.
-type CheckRollbackFn = unsafe fn(
+pub(crate) type CheckRollbackFn = unsafe fn(
     &PredictionRegistry,
     confirmed_tick: Tick,
-    entity_mut: &mut FilteredEntityMut,
+    world: UnsafeWorldCell,
+    archetype: &Archetype,
+    entity: &ArchetypeEntity,
+    component: &CachedPredictionComponent,
 ) -> bool;
+
+/// Type-erased rollback preparation for one component column in one archetype.
+pub(crate) type PrepareRollbackFn = unsafe fn(
+    UnsafeWorldCell,
+    &Archetype,
+    &CachedPredictionComponent,
+    Tick,
+    Tick,
+    bool,
+    &mut DeferredEntityCommands,
+);
+
+/// Type-erased rollback replay snap for one component column in one archetype.
+pub(crate) type SnapToConfirmedFn = unsafe fn(
+    UnsafeWorldCell,
+    &Archetype,
+    &CachedPredictionComponent,
+    Tick,
+    &mut DeferredEntityCommands,
+);
+
+/// Type-erased post-rollback repair for one frame-history column in one archetype.
+pub(crate) type UpdateFrameInterpolationPostRollbackFn =
+    unsafe fn(UnsafeWorldCell, &Archetype, &CachedPredictionComponent, Tick);
+
+/// Type-erased diff receiver pruning for one confirmed-history column in one archetype.
+pub(crate) type PruneHistoryDiffReceiverFn =
+    unsafe fn(UnsafeWorldCell, &Archetype, &CachedDiffComponent, Tick, &mut ReplicationStorage);
 
 /// Type-erased pending-diff lookup for one predicted diff component on one entity.
 pub(crate) type PendingDiffTickFn = fn(&ReplicationStorage, Tick, Entity) -> Option<Tick>;
@@ -148,14 +231,10 @@ pub(crate) type PendingDiffTickFn = fn(&ReplicationStorage, Tick, Entity) -> Opt
 pub type PopUntilTickAndHashFn = fn(PtrMut, Tick, &mut seahash::SeaHasher, fn()) -> bool;
 
 impl PredictionMetadata {
-    fn new<C: SyncComponent>(
-        prediction_history_id: ComponentId,
-        confirmed_history_id: ComponentId,
-    ) -> Self {
+    fn new<C: SyncComponent>(rollback: RollbackMetadata) -> Self {
         let should_rollback: ShouldRollbackFn<C> = <C as PartialEq>::ne;
         Self {
-            prediction_history_id,
-            confirmed_history_id,
+            rollback,
             custom_correction: false,
             correction: None,
             should_rollback: unsafe {
@@ -164,7 +243,9 @@ impl PredictionMetadata {
                 )
             },
             check_rollback: PredictionRegistry::check_rollback_at_completed_checkpoint::<C>,
+            snap_to_confirmed: None,
             pending_diff_tick: None,
+            prune_history_diff_receiver: None,
             #[cfg(feature = "metrics")]
             metric_handles: PredictionMetricHandles::default(),
             #[cfg(feature = "deterministic")]
@@ -184,18 +265,54 @@ pub type ShouldRollbackFn<C> = fn(confirmed: &C, predicted: &C) -> bool;
 pub struct PredictionRegistry {
     /// Predicted components in registration order.
     pub prediction_map: IndexMap<ComponentKind, PredictionMetadata>,
+    /// Rollback-only components that do not have network prediction metadata.
+    local_rollback_map: IndexMap<ComponentKind, RollbackMetadata>,
 }
 
 impl PredictionRegistry {
-    fn register<C: SyncComponent>(
+    pub(crate) fn register<C: SyncComponent>(&mut self) {
+        let kind = ComponentKind::of::<C>();
+        if self.prediction_map.contains_key(&kind) {
+            return;
+        }
+        let rollback = self
+            .local_rollback_map
+            .shift_remove(&kind)
+            .expect("rollback metadata should be registered before prediction metadata");
+        self.prediction_map
+            .insert(kind, PredictionMetadata::new::<C>(rollback));
+    }
+
+    pub(crate) fn register_rollback<C: Component<Mutability = Mutable> + Clone>(
         &mut self,
         prediction_history_id: ComponentId,
         confirmed_history_id: ComponentId,
+        frame_interpolation_history_id: ComponentId,
     ) {
         let kind = ComponentKind::of::<C>();
-        self.prediction_map.entry(kind).or_insert_with(|| {
-            PredictionMetadata::new::<C>(prediction_history_id, confirmed_history_id)
+        if self.prediction_map.contains_key(&kind) {
+            return;
+        }
+        self.local_rollback_map.entry(kind).or_insert_with(|| {
+            RollbackMetadata::new::<C>(
+                prediction_history_id,
+                confirmed_history_id,
+                frame_interpolation_history_id,
+            )
         });
+    }
+
+    pub(crate) fn rollback_metadata(
+        &self,
+    ) -> impl Iterator<Item = (ComponentKind, &RollbackMetadata)> {
+        self.prediction_map
+            .iter()
+            .map(|(kind, metadata)| (*kind, &metadata.rollback))
+            .chain(
+                self.local_rollback_map
+                    .iter()
+                    .map(|(kind, metadata)| (*kind, metadata)),
+            )
     }
 
     fn set_should_rollback<C: SyncComponent>(&mut self, should_rollback: ShouldRollbackFn<C>) {
@@ -211,17 +328,29 @@ impl PredictionRegistry {
         };
     }
 
-    fn set_pending_diff_tick<C: SyncComponent + RepliconDiffable>(&mut self) {
-        self.prediction_map
+    pub(crate) fn set_pending_diff_tick<C: SyncComponent + RepliconDiffable>(&mut self) {
+        let metadata = self
+            .prediction_map
             .get_mut(&ComponentKind::of::<C>())
             .expect(
                 "The component has not been registered for prediction. Did you call `.predict_diff()`?",
-            )
-            .pending_diff_tick = Some(|storage, candidate, entity| {
+            );
+        metadata.pending_diff_tick = Some(|storage, candidate, entity| {
             storage
                 .get::<HistoryDiffReceiver<C>>(entity)
                 .and_then(|receiver| receiver.earliest_pending_tick_at_or_before(candidate))
         });
+        metadata.prune_history_diff_receiver =
+            Some(crate::predicted_history::prune_history_diff_receiver_component::<C>);
+    }
+
+    pub(crate) fn set_snap_to_confirmed<C: SyncComponent>(&mut self) {
+        self.prediction_map
+            .get_mut(&ComponentKind::of::<C>())
+            .expect(
+                "The component has not been registered for prediction. Did you call `.predict()`?",
+            )
+            .snap_to_confirmed = Some(crate::predicted_history::snap_to_confirmed_component::<C>);
     }
 
     fn custom_correction<C: SyncComponent>(&mut self) {
@@ -388,21 +517,35 @@ impl PredictionRegistry {
     unsafe fn check_rollback_at_completed_checkpoint<C: SyncComponent>(
         &self,
         confirmed_tick: Tick,
-        entity_mut: &mut FilteredEntityMut,
+        world: UnsafeWorldCell,
+        archetype: &Archetype,
+        entity: &ArchetypeEntity,
+        component: &CachedPredictionComponent,
     ) -> bool {
-        let entity = entity_mut.id();
+        let entity_id = entity.id();
         let name = DebugName::type_name::<C>();
         let _span = trace_span!(
             "check_rollback_at_completed_checkpoint",
             ?name,
-            %entity,
+            entity = %entity_id,
             ?confirmed_tick
         )
         .entered();
         let confirmed_value = {
-            let Some(mut component_history) = entity_mut.get_mut::<ConfirmedHistory<C>>() else {
-                // No confirmed history means no authoritative value to compare against.
-                return false;
+            let confirmed_storage = component
+                .confirmed_history_storage
+                .expect("rollback-check cache requires confirmed history");
+            // SAFETY: the archetype cache proves that this entity contains ConfirmedHistory<C>
+            // with this component id and storage, and the system declares unique access to it.
+            let component_history = unsafe {
+                get_component_unchecked_mut(
+                    world,
+                    entity,
+                    archetype.table_id(),
+                    confirmed_storage,
+                    component.confirmed_history_id,
+                )
+                .deref_mut::<ConfirmedHistory<C>>()
             };
 
             let Some(last_confirmed_state) =
@@ -413,7 +556,7 @@ impl PredictionRegistry {
                 // any replication updates yet.
                 trace!(
                     "No confirmed value in history for entity {:?}, skipping rollback check",
-                    entity
+                    entity_id
                 );
                 return false;
             };
@@ -431,9 +574,20 @@ impl PredictionRegistry {
             confirmed_value
         };
 
-        let Some(prediction_history) = entity_mut.get::<PredictionHistory<C>>() else {
-            // No prediction history means no predicted state to compare against.
-            return false;
+        let prediction_history_storage = component
+            .prediction_history_storage
+            .expect("rollback check requires prediction history");
+        // SAFETY: the archetype cache proves that this entity contains PredictionHistory<C>
+        // with this component id and storage, and the system declares read access to it.
+        let prediction_history = unsafe {
+            get_component_unchecked(
+                world,
+                entity,
+                archetype.table_id(),
+                prediction_history_storage,
+                component.prediction_history_id,
+            )
+            .deref::<PredictionHistory<C>>()
         };
 
         // This is a completion-time consistency check.
@@ -447,7 +601,7 @@ impl PredictionRegistry {
         // against a present confirmed value.
         let Some(predicted_state) = prediction_history.get_state(confirmed_tick) else {
             trace!(
-                ?entity,
+                entity = ?entity_id,
                 ?confirmed_tick,
                 component = ?name,
                 "No predicted state retained for unchanged rollback check"
@@ -1013,12 +1167,13 @@ impl<C> PredictionRegistrationExt<C> for ComponentRegistration<'_, C> {
             .app
             .world_mut()
             .register_component::<ConfirmedHistory<C>>();
+        register_rollback_metadata::<C>(self.app, prediction_history_id, confirmed_history_id);
         let mut registry = self.app.world_mut().resource_mut::<PredictionRegistry>();
         trace!(
             "Adding prediction for component {:?}",
             DebugName::type_name::<C>()
         );
-        registry.register::<C>(prediction_history_id, confirmed_history_id);
+        registry.register::<C>();
         add_prediction_systems::<C>(self.app);
 
         self
@@ -1051,12 +1206,13 @@ impl<C> PredictionRegistrationExt<C> for ComponentRegistration<'_, C> {
             .app
             .world_mut()
             .register_component::<ConfirmedHistory<C>>();
+        register_rollback_metadata::<C>(self.app, prediction_history_id, confirmed_history_id);
         let mut registry = self.app.world_mut().resource_mut::<PredictionRegistry>();
         trace!(
             "Adding diff prediction for component {:?}",
             DebugName::type_name::<C>()
         );
-        registry.register::<C>(prediction_history_id, confirmed_history_id);
+        registry.register::<C>();
         registry.set_pending_diff_tick::<C>();
         add_prediction_systems::<C>(self.app);
         crate::plugin::add_prediction_diff_systems::<C>(self.app);
@@ -1146,15 +1302,13 @@ impl<C> PredictionRegistrationExt<C> for ComponentRegistration<'_, C> {
             .app
             .world_mut()
             .register_component::<ConfirmedHistory<C>>();
-        // skip if there is no PredictionRegistry (i.e. the PredictionPlugin wasn't added)
-        let Some(mut registry) = self
-            .app
-            .world_mut()
-            .get_resource_mut::<PredictionRegistry>()
-        else {
+        // Skip if there is no PredictionRegistry (i.e. the PredictionPlugin wasn't added).
+        if !self.app.world().contains_resource::<PredictionRegistry>() {
             return self;
-        };
-        registry.register::<C>(prediction_history_id, confirmed_history_id);
+        }
+        register_rollback_metadata::<C>(self.app, prediction_history_id, confirmed_history_id);
+        let mut registry = self.app.world_mut().resource_mut::<PredictionRegistry>();
+        registry.register::<C>();
         registry.set_should_rollback::<C>(should_rollback);
         self
     }
@@ -1176,8 +1330,9 @@ pub trait PredictionAppRegistrationExt {
 fn register_prediction_metadata<C: SyncComponent>(app: &mut App) {
     let prediction_history_id = app.world_mut().register_component::<PredictionHistory<C>>();
     let confirmed_history_id = app.world_mut().register_component::<ConfirmedHistory<C>>();
+    register_rollback_metadata::<C>(app, prediction_history_id, confirmed_history_id);
     if let Some(mut registry) = app.world_mut().get_resource_mut::<PredictionRegistry>() {
-        registry.register::<C>(prediction_history_id, confirmed_history_id);
+        registry.register::<C>();
     }
 }
 

--- a/crates/replication/prediction/src/rollback.rs
+++ b/crates/replication/prediction/src/rollback.rs
@@ -30,21 +30,22 @@ We need:
 
 use super::Predicted;
 use super::predicted_history::PredictionHistory;
+use crate::archetypes::{CachedPredictionComponent, CheckRollbackWorld, PrepareRollbackWorld};
 use crate::correction::PreviousVisual;
 use crate::despawn::PredictionDisable;
 use crate::diagnostics::PredictionMetrics;
 use crate::manager::{LastConfirmedInput, PredictionManager, RollbackMode, StateRollbackMetadata};
 use crate::plugin::PredictionSystems;
-use crate::registry::{PendingDiffTickFn, PredictionRegistry};
+use crate::registry::PredictionRegistry;
 use alloc::vec::Vec;
 use bevy_app::FixedMain;
 use bevy_app::prelude::*;
-use bevy_ecs::component::{ComponentId, Mutable};
+use bevy_ecs::archetype::Archetype;
+use bevy_ecs::component::Mutable;
 use bevy_ecs::lifecycle::HookContext;
 use bevy_ecs::prelude::*;
 use bevy_ecs::schedule::ScheduleLabel;
-use bevy_ecs::system::{LocalBuilder, ParamBuilder, QueryParamBuilder};
-use bevy_ecs::world::{DeferredWorld, FilteredEntityMut};
+use bevy_ecs::world::{DeferredWorld, unsafe_world_cell::UnsafeWorldCell};
 use bevy_reflect::Reflect;
 use bevy_replicon::client::server_mutate_ticks::ServerMutateTicks;
 use bevy_replicon::prelude::{ClientMessages, ClientSystems};
@@ -61,12 +62,13 @@ use lightyear_core::timeline::{Rollback, is_in_rollback};
 use lightyear_frame_interpolation::FrameInterpolationSystems;
 #[cfg(feature = "p2p")]
 use lightyear_p2p::prelude::{P2PStarted, P2PStopped};
+use lightyear_replication::deferred_entity::DeferredEntityCommands;
 use lightyear_replication::prelude::{ConfirmHistory, PreSpawned};
 use lightyear_replication::prespawn::PreSpawnedReceiver;
 use lightyear_replication::registry::ComponentRegistry;
 use lightyear_replication::{ReplicationSystems, checkpoint::ReplicationCheckpointMap};
 use lightyear_sync::prelude::{InputTimelineConfig, SyncedLocalTimeline};
-use lightyear_utils::adaptive_for_each_mut;
+use lightyear_utils::ecs::{get_component_unchecked, get_component_unchecked_mut};
 #[cfg(feature = "metrics")]
 use lightyear_utils::timer_gauge;
 use serde::{Deserialize, Serialize};
@@ -112,9 +114,6 @@ pub enum RollbackSystems {
 /// input-driven rollback requests that would restore history from before it. This boundary is
 /// automatic; applications can install input components directly in a `P2PStarted` observer.
 pub struct RollbackPlugin;
-
-#[derive(Component)]
-struct NoRollbackCheckTargets;
 
 impl Plugin for RollbackPlugin {
     fn build(&self, app: &mut App) {
@@ -170,8 +169,12 @@ impl Plugin for RollbackPlugin {
                 check_received_replication_messages
                     .after(ClientSystems::ReceivePackets)
                     .before(ClientSystems::Receive),
+                check_rollback
+                    .in_set(RollbackSystems::Check)
+                    .after(ReplicationSystems::Receive),
                 reset_input_rollback_tracker.after(RollbackSystems::Check),
                 remove_prediction_disable.in_set(RollbackSystems::RemoveDisable),
+                prepare_rollback.in_set(RollbackSystems::Prepare),
                 run_rollback.in_set(RollbackSystems::Rollback),
                 end_rollback.in_set(RollbackSystems::EndRollback),
                 #[cfg(feature = "metrics")]
@@ -181,102 +184,6 @@ impl Plugin for RollbackPlugin {
                     .run_if(not(is_in_rollback)),
             ),
         );
-    }
-
-    /// Wait until every component has been registered in the ComponentRegistry
-    fn finish(&self, app: &mut App) {
-        // temporarily remove component_registry from the app to enable split borrows
-        let component_registry = app
-            .world_mut()
-            .remove_resource::<ComponentRegistry>()
-            .unwrap();
-        let prediction_registry = app
-            .world_mut()
-            .remove_resource::<PredictionRegistry>()
-            .unwrap();
-
-        let mut replicated_prediction_histories = Vec::new();
-        let mut pending_diff_tick_fns = Vec::new();
-        for (kind, metadata) in &prediction_registry.prediction_map {
-            // Don't check rollback for non-networked components, which are not present in the
-            // ComponentRegistry.
-            if !component_registry.component_metadata_map.contains_key(kind) {
-                continue;
-            }
-            replicated_prediction_histories.push((
-                metadata.prediction_history_id,
-                metadata.confirmed_history_id,
-            ));
-            if let Some(pending_diff_tick) = metadata.pending_diff_tick {
-                pending_diff_tick_fns.push((metadata.prediction_history_id, pending_diff_tick));
-            }
-        }
-
-        let check_rollback = (
-            QueryParamBuilder::new(|builder| {
-                builder.with::<Predicted>();
-                builder.with::<ConfirmHistory>();
-                builder.without::<DeterministicPredicted>();
-                builder.without::<DisableRollback>();
-                // include PredictionDisable entities (entities that are predicted and 'despawned'
-                // but we keep them around for rollback check)
-                builder.filter::<Allow<PredictionDisable>>();
-                if !replicated_prediction_histories.is_empty() {
-                    builder.or(|b| {
-                        for history_id in &replicated_prediction_histories {
-                            b.with_id(history_id.0);
-                        }
-                    });
-                } else {
-                    // Keep the unchanged-state query empty when no replicated
-                    // prediction histories are registered. The system still
-                    // needs to run for input rollback checks.
-                    builder.with::<NoRollbackCheckTargets>();
-                }
-                builder.optional(|b| {
-                    // include access to prediction and confirmed histories for all replicated predicted components
-                    // (no need to check rollback for non-networked components)
-                    for (prediction_history_id, confirmed_history_id) in
-                        &replicated_prediction_histories
-                    {
-                        b.mut_id(*prediction_history_id);
-                        b.mut_id(*confirmed_history_id);
-                    }
-                });
-            }),
-            // Component registration is complete at this point. Cache only the diff-specific
-            // history id/function pairs needed to constrain completed rollback checkpoints.
-            LocalBuilder(pending_diff_tick_fns),
-            ParamBuilder,
-            ParamBuilder,
-            ParamBuilder,
-            ParamBuilder,
-            ParamBuilder,
-            ParamBuilder,
-            ParamBuilder,
-            ParamBuilder,
-            ParamBuilder,
-            // A nested tuple counts as one outer system parameter, keeping the dynamically built
-            // system below Bevy's 16-element tuple limit.
-            (ParamBuilder, ParamBuilder),
-            ParamBuilder,
-            ParamBuilder,
-            ParamBuilder,
-            ParamBuilder,
-        )
-            .build_state(app.world_mut())
-            .build_system(check_rollback)
-            .with_name("RollbackPlugin::check_rollback");
-
-        app.add_systems(
-            PreUpdate,
-            check_rollback
-                .in_set(RollbackSystems::Check)
-                .after(ReplicationSystems::Receive),
-        );
-
-        app.insert_resource(component_registry);
-        app.insert_resource(prediction_registry);
     }
 }
 
@@ -407,10 +314,7 @@ fn reset_state_rollback_metadata_on_topology_change(
 /// - entities that received an update at C have their confirmed value in history;
 /// - entities that did not receive an update have the same value as their last confirmation before C.
 fn check_rollback(
-    // we want Query<(&mut PredictionHistory<C>, &Confirmed<C>), With<Predicted>>
-    // make sure to include disabled entities
-    mut predicted_entities: Query<FilteredEntityMut>,
-    pending_diff_tick_fns: Local<Vec<(ComponentId, PendingDiffTickFn)>>,
+    mut prediction_world: CheckRollbackWorld,
     timeline: SyncedLocalTimeline,
     input_config: Res<InputTimelineConfig>,
     last_confirmed_input: Res<LastConfirmedInput>,
@@ -423,7 +327,6 @@ fn check_rollback(
     (component_registry, prediction_registry): (Res<ComponentRegistry>, Res<PredictionRegistry>),
     awaiting_catchup: Query<(), (With<CatchUpGated>, With<ConfirmHistory>)>,
     deterministic_predicted: Query<&DeterministicPredicted>,
-    parallel_commands: ParallelCommands,
     mut commands: Commands,
 ) {
     #[cfg(feature = "metrics")]
@@ -434,6 +337,9 @@ fn check_rollback(
     let max_rollback_ticks = prediction_manager
         .rollback_policy
         .effective_max_rollback_ticks(&input_config);
+    prediction_world.update_archetypes(&prediction_registry, &component_registry);
+    let has_check_entities = prediction_world.has_check_entities();
+    let world = prediction_world.world;
 
     // Let:
     // - T be the current local simulation tick;
@@ -602,19 +508,25 @@ fn check_rollback(
             };
 
             let mut earliest_pending_tick = None;
-            for &(prediction_history_id, pending_diff_tick) in pending_diff_tick_fns.iter() {
-                for entity_mut in predicted_entities
-                    .iter_mut()
-                    .filter(|entity_mut| entity_mut.contains_id(prediction_history_id))
-                {
-                    let Some(pending_tick) = pending_diff_tick(storage, candidate, entity_mut.id())
-                    else {
-                        continue;
-                    };
-                    earliest_pending_tick = Some(
-                        earliest_pending_tick
-                            .map_or(pending_tick, |earliest| Tick::min(earliest, pending_tick)),
-                    );
+            for (archetype, cached) in prediction_world.diff_archetypes() {
+                if !cached.check_target {
+                    continue;
+                }
+                for entity in archetype.entities() {
+                    for component in &cached.diff_components {
+                        if component.prediction_history_storage.is_none() {
+                            continue;
+                        }
+                        let Some(pending_tick) =
+                            (component.pending_diff_tick)(storage, candidate, entity.id())
+                        else {
+                            continue;
+                        };
+                        earliest_pending_tick =
+                            Some(earliest_pending_tick.map_or(pending_tick, |earliest| {
+                                Tick::min(earliest, pending_tick)
+                            }));
+                    }
                 }
             }
 
@@ -634,7 +546,7 @@ fn check_rollback(
             RollbackMode::Always => {
                 if let Some(confirmed_tick) = confirmed_tick
                     && received_state
-                    && !predicted_entities.is_empty()
+                    && has_check_entities
                 {
                     debug!(
                         ?confirmed_tick,
@@ -667,68 +579,65 @@ fn check_rollback(
                         "Checking for state-based rollback at completed mutate tick"
                     );
 
-                    adaptive_for_each_mut!(predicted_entities, |mut entity_mut| {
-                        if prediction_manager.is_rollback() {
-                            return;
+                    'scan: for (archetype, cached) in prediction_world.predicted_archetypes() {
+                        if !cached.check_target {
+                            continue;
                         }
-
-                        // For each predicted component, compare the predicted value at C with
-                        // its effective authoritative value. The checker uses an exact sample
-                        // when one exists; otherwise completion of C proves the component was
-                        // unchanged, so it materializes the last confirmed value before C.
-                        for check_rollback in prediction_registry
-                            .prediction_map
-                            .iter()
-                            .filter_map(|(kind, metadata)| {
-                                // Only check rollback for components that are replicated;
-                                // non-networked components have no authoritative state at C.
-                                component_registry
-                                    .component_metadata_map
-                                    .contains_key(kind)
-                                    .then_some(metadata.check_rollback)
-                            })
-                            .take_while(|_| !prediction_manager.is_rollback())
-                        {
-                            // SAFETY: `ServerMutateTicks` reports `confirmed_tick` as globally
-                            // complete, and no predicted diff component has an unresolved update at
-                            // or before it. Absence of an explicit component sample therefore proves
-                            // that the component was unchanged at this checkpoint.
-                            let should_rollback = unsafe {
-                                check_rollback(
-                                    &prediction_registry,
-                                    confirmed_tick,
-                                    &mut entity_mut,
-                                )
-                            };
-                            if should_rollback {
-                                debug!(
-                                    ?confirmed_tick,
-                                    "Rollback because of mismatch at completed checkpoint"
-                                );
-                                trace!(
-                                    target: "lightyear_debug::prediction",
-                                    kind = "completed_checkpoint_mismatch",
-                                    schedule = "PreUpdate",
-                                    sample_point = "PreUpdate",
-                                    entity = ?entity_mut.id(),
-                                    local_tick = tick.0,
-                                    latest_completed_tick = server_confirmed_tick.map(|tick| tick.0),
-                                    completed_tick = confirmed_tick.0,
-                                    rollback_tick = confirmed_tick.0,
-                                    "rollback mismatch detected at completed checkpoint"
-                                );
-                                parallel_commands.command_scope(|mut c| {
+                        for entity in archetype.entities() {
+                            // For each predicted component, compare the predicted value at C with
+                            // its effective authoritative value. The archetype cache has already
+                            // resolved the exact history columns, so this loop performs no dynamic
+                            // entity-access checks.
+                            for component in &cached.predicted_components {
+                                let (Some(check_rollback), Some(_), Some(_)) = (
+                                    component.check_rollback,
+                                    component.prediction_history_storage,
+                                    component.confirmed_history_storage,
+                                ) else {
+                                    continue;
+                                };
+                                // SAFETY: `ServerMutateTicks` reports `confirmed_tick` as globally
+                                // complete, no cached predicted diff component has an unresolved
+                                // update at or before it, and PredictionWorld declares access to
+                                // every cached history column.
+                                let should_rollback = unsafe {
+                                    check_rollback(
+                                        &prediction_registry,
+                                        confirmed_tick,
+                                        world,
+                                        archetype,
+                                        entity,
+                                        component,
+                                    )
+                                };
+                                if should_rollback {
+                                    debug!(
+                                        ?confirmed_tick,
+                                        "Rollback because of mismatch at completed checkpoint"
+                                    );
+                                    trace!(
+                                        target: "lightyear_debug::prediction",
+                                        kind = "completed_checkpoint_mismatch",
+                                        schedule = "PreUpdate",
+                                        sample_point = "PreUpdate",
+                                        entity = ?entity.id(),
+                                        local_tick = tick.0,
+                                        latest_completed_tick = server_confirmed_tick.map(|tick| tick.0),
+                                        completed_tick = confirmed_tick.0,
+                                        rollback_tick = confirmed_tick.0,
+                                        "rollback mismatch detected at completed checkpoint"
+                                    );
                                     do_rollback(
                                         confirmed_tick,
                                         &prediction_manager,
-                                        &mut c,
+                                        &mut commands,
                                         Rollback::FromState,
                                     );
-                                });
-                                return;
+                                    break 'scan;
+                                }
                             }
                         }
-                    });
+                    }
 
                     // Update the last processed confirmed tick only after C was scanned.
                     state_metadata.set_last_processed_confirmed_tick(confirmed_tick);
@@ -963,39 +872,122 @@ pub(crate) fn remove_prediction_disable(
 /// 1. Clears all **predicted** values from rollback_tick onwards (we will re-predict them)
 /// 2. Preserves all **confirmed** values (we know the real server values and will snap to them during re-simulation)
 /// 3. Reverts the component to the value at rollback_tick
-#[allow(clippy::type_complexity)]
-#[allow(clippy::too_many_arguments)]
-pub(crate) fn prepare_rollback<C: Component<Mutability = Mutable> + Clone>(
+pub(crate) fn prepare_rollback(
+    mut prediction_world: PrepareRollbackWorld,
     timeline: Res<LocalTimeline>,
     prediction_registry: Res<PredictionRegistry>,
+    component_registry: Res<ComponentRegistry>,
     mut commands: Commands,
-    // We also snap the value of the component to the server state if we are in rollback
-    // We use Option<> because the predicted component could have been removed while it still exists in Confirmed
-    // PredictionHistory is the rollback membership marker. Resource entities
-    // can lose CatchUpGated after activation but still need local rollback.
-    mut predicted_query: Query<
-        (
-            Entity,
-            Option<&mut C>,
-            &mut PredictionHistory<C>,
-            Option<&mut ConfirmedHistory<C>>,
-        ),
-        Without<DisableRollback>,
-    >,
     manager: Res<PredictionManager>,
     rollback: Res<Rollback>,
 ) {
-    let kind = DebugName::type_name::<C>();
     let current_tick = timeline.tick();
-    let _span = trace_span!("prepare_rollback", tick = ?current_tick, kind = ?kind).entered();
+    let _span = trace_span!("prepare_rollback", tick = ?current_tick).entered();
     let rollback_tick = manager.get_rollback_start_tick().unwrap();
     let is_state_rollback = matches!(*rollback, Rollback::FromState);
+    prediction_world.update_archetypes(&prediction_registry, &component_registry);
 
-    for (entity, predicted_component, mut predicted_history, confirmed_history) in
-        predicted_query.iter_mut()
-    {
+    let world = prediction_world.world;
+    let mut deferred = DeferredEntityCommands::default();
+    for (archetype, cached) in prediction_world.predicted_archetypes() {
+        if !cached.default_query_target || cached.has_disable_rollback {
+            continue;
+        }
+        for component in &cached.predicted_components {
+            if component.prediction_history_storage.is_none() {
+                continue;
+            }
+            // SAFETY: PredictionWorld declares access to every cached live component and history
+            // column, and the cache records the exact ids and storage used by this archetype.
+            unsafe {
+                (component.prepare_rollback)(
+                    world,
+                    archetype,
+                    component,
+                    current_tick,
+                    rollback_tick,
+                    is_state_rollback,
+                    &mut deferred,
+                );
+            }
+        }
+    }
+    deferred.apply(&mut commands);
+}
+
+/// Prepares one cached component column for rollback.
+///
+/// # Safety
+///
+/// `component` must have been resolved for `archetype`, and the caller must hold the accesses
+/// declared by [`PrepareRollbackWorld`].
+pub(crate) unsafe fn prepare_rollback_component<C: Component<Mutability = Mutable> + Clone>(
+    world: UnsafeWorldCell,
+    archetype: &Archetype,
+    component: &CachedPredictionComponent,
+    current_tick: Tick,
+    rollback_tick: Tick,
+    is_state_rollback: bool,
+    deferred: &mut DeferredEntityCommands,
+) {
+    let kind = DebugName::type_name::<C>();
+    let prediction_history_storage = component
+        .prediction_history_storage
+        .expect("rollback preparation requires prediction history");
+
+    for entity in archetype.entities() {
+        let entity_id = entity.id();
+        let current_component = component.component_storage.map(|storage| {
+            // SAFETY: the cache records C's exact id and storage for this archetype, and the
+            // prepare system declares write access (which includes read access) to C.
+            unsafe {
+                get_component_unchecked(
+                    world,
+                    entity,
+                    archetype.table_id(),
+                    storage,
+                    component.component_id,
+                )
+                .deref::<C>()
+                .clone()
+            }
+        });
+
+        let confirmed_state = if is_state_rollback {
+            component.confirmed_history_storage.and_then(|storage| {
+                // SAFETY: the cache records the confirmed-history id and storage when present,
+                // and the prepare system declares read access to this column.
+                let history = unsafe {
+                    get_component_unchecked(
+                        world,
+                        entity,
+                        archetype.table_id(),
+                        storage,
+                        component.confirmed_history_id,
+                    )
+                    .deref::<ConfirmedHistory<C>>()
+                };
+                history.get_state_at_or_before(rollback_tick).cloned()
+            })
+        } else {
+            None
+        };
+
+        // SAFETY: every cached prepare component is selected by the presence of
+        // PredictionHistory<C>, and the system declares unique access to the column.
+        let predicted_history = unsafe {
+            get_component_unchecked_mut(
+                world,
+                entity,
+                archetype.table_id(),
+                prediction_history_storage,
+                component.prediction_history_id,
+            )
+            .deref_mut::<PredictionHistory<C>>()
+        };
+
         let restore_state = if is_state_rollback {
-            if let Some(history) = confirmed_history.as_ref() {
+            if component.confirmed_history_storage.is_some() {
                 // A policy-driven state rollback uses the diff-aware completed checkpoint C stored
                 // in PredictionManager as its rollback target. Completion of C proves that a
                 // component without an explicit update is unchanged since its previous confirmed
@@ -1006,7 +998,7 @@ pub(crate) fn prepare_rollback<C: Component<Mutability = Mutable> + Clone>(
                 // precondition: its explicit rollback target has already been seeded with
                 // authoritative confirmed history. Input rollbacks instead restore from local
                 // predicted history.
-                history.get_state_at_or_before(rollback_tick).cloned()
+                confirmed_state
             } else {
                 // State rollback can also cover predicted-only local components
                 // that have no authoritative history yet.
@@ -1034,7 +1026,7 @@ pub(crate) fn prepare_rollback<C: Component<Mutability = Mutable> + Clone>(
         predicted_history.clear_after_tick(rollback_tick);
         if let Some(state) = restore_state.clone() {
             predicted_history.add_state(rollback_tick, state);
-        } else if let Some(current) = predicted_component.as_deref() {
+        } else if let Some(current) = current_component.as_ref() {
             // No state exists at rollback_tick (e.g. the entity was revealed to
             // this client after the rollback target). The replay starts from the
             // current component value, so seed the history with it.
@@ -1045,16 +1037,14 @@ pub(crate) fn prepare_rollback<C: Component<Mutability = Mutable> + Clone>(
             kind = "prepare_rollback_component",
             schedule = "PreUpdate",
             sample_point = "PreUpdate",
-            entity = ?entity,
+            entity = ?entity_id,
             component = ?kind,
             local_tick = current_tick.0,
             rollback_tick = rollback_tick.0,
-            rollback = ?rollback,
+            state_rollback = is_state_rollback,
             history_len = predicted_history.len(),
             "prepared component rollback"
         );
-
-        let mut entity_mut = commands.entity(entity);
 
         // Update the component to the value at rollback_tick
         match restore_state {
@@ -1062,7 +1052,7 @@ pub(crate) fn prepare_rollback<C: Component<Mutability = Mutable> + Clone>(
             // removal, so leave the current component value in place.
             None => {
                 trace!(
-                    ?entity,
+                    entity = ?entity_id,
                     ?kind,
                     ?rollback_tick,
                     "No history entry for component at rollback tick; leaving current value in place"
@@ -1070,26 +1060,28 @@ pub(crate) fn prepare_rollback<C: Component<Mutability = Mutable> + Clone>(
             }
             // An explicit removal means the component was authoritatively removed at rollback_tick.
             Some(HistoryState::Removed) => {
-                entity_mut.try_remove::<C>();
+                if current_component.is_some() {
+                    deferred.remove::<C>(entity_id);
+                }
                 trace!("Removing component from predicted entity for rollback");
             }
             // Value exists at rollback_tick (either predicted or confirmed)
             Some(HistoryState::Updated(correct)) => {
-                match predicted_component {
+                match current_component {
                     None => {
                         debug!("Re-adding deleted component to predicted");
-                        entity_mut.insert(correct);
+                        deferred.insert(entity_id, correct);
                     }
-                    Some(mut predicted_component) => {
+                    Some(predicted_component) => {
                         // Keep track of the current visual value so we can smooth the correction
-                        if prediction_registry.has_correction::<C>() {
-                            entity_mut.insert(PreviousVisual(predicted_component.clone()));
+                        if component.has_correction {
+                            deferred.insert(entity_id, PreviousVisual(predicted_component));
                             trace!(
                                 target: "lightyear_debug::prediction",
                                 kind = "previous_visual_stored",
                                 schedule = "PreUpdate",
                                 sample_point = "PreUpdate",
-                                entity = ?entity,
+                                entity = ?entity_id,
                                 component = ?kind,
                                 local_tick = current_tick.0,
                                 rollback_tick = rollback_tick.0,
@@ -1097,8 +1089,13 @@ pub(crate) fn prepare_rollback<C: Component<Mutability = Mutable> + Clone>(
                             );
                         }
 
-                        // Update the component to the corrected value
-                        *predicted_component = correct;
+                        // SAFETY: the prepare system declares unique access to C, and no reference
+                        // to this entity's live C is retained here.
+                        unsafe {
+                            lightyear_core::ecs_utils::write_component_with_change_detection::<C>(
+                                world, entity_id, correct,
+                            );
+                        }
                     }
                 };
             }
@@ -1320,9 +1317,27 @@ pub struct CatchUpGated;
 mod tests {
     use super::*;
     use bevy_ecs::system::RunSystemOnce;
+    use lightyear_core::prelude::FrameInterpolationHistory;
 
     #[derive(Component, Clone, PartialEq, Debug)]
     struct TestComponent(f32);
+
+    fn register_test_rollback(world: &mut World) {
+        world.init_resource::<ComponentRegistry>();
+        world.init_resource::<PredictionRegistry>();
+        world.register_component::<TestComponent>();
+        let prediction_history_id = world.register_component::<PredictionHistory<TestComponent>>();
+        let confirmed_history_id = world.register_component::<ConfirmedHistory<TestComponent>>();
+        let frame_interpolation_history_id =
+            world.register_component::<FrameInterpolationHistory<TestComponent>>();
+        world
+            .resource_mut::<PredictionRegistry>()
+            .register_rollback::<TestComponent>(
+                prediction_history_id,
+                confirmed_history_id,
+                frame_interpolation_history_id,
+            );
+    }
 
     #[cfg(feature = "p2p")]
     #[test]
@@ -1381,6 +1396,7 @@ mod tests {
         let mut world = World::new();
         world.init_resource::<LocalTimeline>();
         world.init_resource::<PredictionRegistry>();
+        register_test_rollback(&mut world);
 
         world.insert_resource(PredictionManager::default());
         world.insert_resource(Rollback::FromState);
@@ -1392,9 +1408,7 @@ mod tests {
         history.add_predicted(rollback_tick + 5, Some(TestComponent(1.0)));
         let predicted = world.spawn((Predicted, TestComponent(1.0), history)).id();
 
-        world
-            .run_system_once(prepare_rollback::<TestComponent>)
-            .unwrap();
+        world.run_system_once(prepare_rollback).unwrap();
 
         assert_eq!(
             world.get::<TestComponent>(predicted),
@@ -1422,6 +1436,7 @@ mod tests {
         let mut world = World::new();
         world.init_resource::<LocalTimeline>();
         world.init_resource::<PredictionRegistry>();
+        register_test_rollback(&mut world);
 
         world.insert_resource(PredictionManager::default());
         world.insert_resource(Rollback::FromInputs);
@@ -1438,9 +1453,7 @@ mod tests {
         world
             .resource::<PredictionManager>()
             .set_rollback_tick(Tick(12));
-        world
-            .run_system_once(prepare_rollback::<TestComponent>)
-            .unwrap();
+        world.run_system_once(prepare_rollback).unwrap();
 
         let history = world
             .get::<PredictionHistory<TestComponent>>(predicted)
@@ -1467,9 +1480,7 @@ mod tests {
         world
             .resource::<PredictionManager>()
             .set_rollback_tick(Tick(8));
-        world
-            .run_system_once(prepare_rollback::<TestComponent>)
-            .unwrap();
+        world.run_system_once(prepare_rollback).unwrap();
         assert_eq!(
             world.get::<TestComponent>(predicted),
             Some(&TestComponent(8.0)),


### PR DESCRIPTION
Similarly to interpolation/replication, we type erase prediction systems to avoid having one system per component.
We also cache the prediction archetypes once for all prediction systems, to avoid the extra access check costs from FilteredEntityRef/Mut