### PR TITLE
chore(deps): update networking and GUI dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -154,7 +154,7 @@ serde = { version = "1", default-features = false, features = [
 serde_json = "1"
 
 # netcode
-chacha20poly1305 = { version = "0.10" }
+chacha20poly1305 = { version = "0.11" }
 
 # tracing
 test-log = { version = "0.2.17", default-features = false, features = [
@@ -178,10 +178,11 @@ metrics = "0.24"
 metrics-util = "0.20"
 
 # transport
-aeronet_webtransport = { version = "0.21" }
+# TODO: switch back to crates.io after https://github.com/aecsocket/aeronet/pull/107 is released.
+aeronet_webtransport = { version = "0.21", git = "https://github.com/aecsocket/aeronet", rev = "a125aa5c7730711101c495d3f56f7e478f41aadf" }
 aeronet_websocket = { version = "0.21" }
 aeronet_steam = { version = "0.21" }
-wtransport = "0.7.1"
+wtransport = "0.7.2"
 aeronet_io = { version = "0.21" }
 # we don't need any tokio features, we use only use the tokio channels
 tokio = { version = "1.45", features = [
@@ -253,18 +254,19 @@ arrayvec = { version = "0.7", features = ["serde"] }
 bevy_transform_interpolation = { version = "0.5", default-features = false }
 
 # gui debug ui
-bevy-inspector-egui = { version = "0.37", default-features = false, features = [
+# TODO: switch back to crates.io after https://github.com/jakobhellermann/bevy-inspector-egui/pull/323 is released.
+bevy-inspector-egui = { version = "0.37", git = "https://github.com/jakobhellermann/bevy-inspector-egui", rev = "7087caed7b08f86392313299e00c32f0597b44c9", default-features = false, features = [
   "bevy_pbr",
   "bevy_image",
   "bevy_render",
   "egui_open_url",
 ] }
-bevy_egui = { version = "0.40", default-features = false, features = [
+bevy_egui = { version = "0.42", default-features = false, features = [
   "open_url",
   "default_fonts",
   "render",
 ] }
-egui_extras = "0.34"
+egui_extras = "0.36"
 
 # WASM things
 console_error_panic_hook = "0.1.7"
@@ -277,6 +279,9 @@ getrandom_02 = { version = "0.2", features = ["js"], package = "getrandom" }
 getrandom_04 = { version = "0.4", features = [
   "wasm_js",
 ], package = "getrandom" }
+
+[patch.crates-io]
+aeronet_io = { version = "0.21", git = "https://github.com/aecsocket/aeronet", rev = "a125aa5c7730711101c495d3f56f7e478f41aadf" }
 
 [workspace.lints.rust]
 dead_code = "allow"

--- a/crates/connection/netcode/Cargo.toml
+++ b/crates/connection/netcode/Cargo.toml
@@ -15,7 +15,7 @@ default = [
   "client",
   "server",
 ]
-std = ["no_std_io2/std", "chacha20poly1305/std", "lightyear_transport?/std"]
+std = ["no_std_io2/std", "lightyear_transport?/std"]
 client = [
   "lightyear_connection/client",
   "lightyear_transport",

--- a/crates/connection/netcode/src/crypto.rs
+++ b/crates/connection/netcode/src/crypto.rs
@@ -2,8 +2,8 @@ use no_std_io2::io;
 
 use super::{MAC_BYTES, PRIVATE_KEY_BYTES};
 use chacha20poly1305::{
-    AeadInPlace, ChaCha20Poly1305, KeyInit, Tag, XChaCha20Poly1305, XNonce,
-    aead::{OsRng, rand_core::RngCore},
+    ChaCha20Poly1305, KeyInit, Tag, XChaCha20Poly1305, XNonce,
+    aead::{AeadInOut, Generate},
 };
 use lightyear_serde::writer::WriteInteger;
 
@@ -17,7 +17,7 @@ pub enum Error {
     #[error("failed to encrypt: {0}")]
     Failed(#[from] chacha20poly1305::aead::Error),
     #[error("failed to generate key: {0}")]
-    GenerateKey(chacha20poly1305::aead::rand_core::Error),
+    GenerateKey(chacha20poly1305::aead::common::getrandom::Error),
 }
 
 /// A 32-byte array, used as a key for encrypting and decrypting packets and connect tokens.
@@ -37,9 +37,7 @@ pub type Result<T> = core::result::Result<T, Error>;
 /// assert_eq!(key.len(), 32);
 /// ```
 pub fn generate_key() -> Key {
-    let mut key: Key = [0; PRIVATE_KEY_BYTES];
-    OsRng.fill_bytes(&mut key);
-    key
+    Key::generate()
 }
 
 /// The fallible version of [`generate_key`](fn.generate_key.html).
@@ -54,9 +52,7 @@ pub fn generate_key() -> Key {
 /// assert_eq!(key.len(), 32);
 /// ```
 pub fn try_generate_key() -> Result<Key> {
-    let mut key: Key = [0; PRIVATE_KEY_BYTES];
-    OsRng.try_fill_bytes(&mut key).map_err(Error::GenerateKey)?;
-    Ok(key)
+    Key::try_generate().map_err(Error::GenerateKey)
 }
 
 pub fn chacha_encrypt(
@@ -72,10 +68,10 @@ pub fn chacha_encrypt(
     }
     let mut final_nonce = [0; 12];
     io::Cursor::new(&mut final_nonce[4..]).write_u64(nonce)?;
-    let mac = ChaCha20Poly1305::new(key.into()).encrypt_in_place_detached(
+    let mac = ChaCha20Poly1305::new(key.into()).encrypt_inout_detached(
         &final_nonce.into(),
         associated_data.unwrap_or_default(),
-        &mut buf[..size - MAC_BYTES],
+        (&mut buf[..size - MAC_BYTES]).into(),
     );
     #[cfg(feature = "std")]
     let mac = mac?;
@@ -98,12 +94,12 @@ pub fn chacha_decrypt(
     let mut final_nonce = [0; 12];
     io::Cursor::new(&mut final_nonce[4..]).write_u64(nonce)?;
     let (buf, mac) = buf.split_at_mut(buf.len() - MAC_BYTES);
-    let res = ChaCha20Poly1305::new(key.into()).decrypt_in_place_detached(
+    let tag = Tag::try_from(&*mac).expect("MAC has the expected size");
+    let res = ChaCha20Poly1305::new(key.into()).decrypt_inout_detached(
         &final_nonce.into(),
         associated_data.unwrap_or_default(),
-        buf,
-        #[allow(deprecated)]
-        Tag::from_slice(mac),
+        (&mut *buf).into(),
+        &tag,
     );
     #[cfg(feature = "std")]
     res?;
@@ -123,10 +119,10 @@ pub fn xchacha_encrypt(
         // Should have 16 bytes of extra space for the MAC
         return Err(Error::BufferSizeMismatch);
     }
-    let mac = XChaCha20Poly1305::new(key.into()).encrypt_in_place_detached(
+    let mac = XChaCha20Poly1305::new(key.into()).encrypt_inout_detached(
         &nonce,
         associated_data.unwrap_or_default(),
-        &mut buf[..size - MAC_BYTES],
+        (&mut buf[..size - MAC_BYTES]).into(),
     );
     #[cfg(feature = "std")]
     let mac = mac?;
@@ -147,12 +143,12 @@ pub fn xchacha_decrypt(
         return Err(Error::BufferSizeMismatch);
     }
     let (buf, mac) = buf.split_at_mut(buf.len() - MAC_BYTES);
-    let res = XChaCha20Poly1305::new(key.into()).decrypt_in_place_detached(
+    let tag = Tag::try_from(&*mac).expect("MAC has the expected size");
+    let res = XChaCha20Poly1305::new(key.into()).decrypt_inout_detached(
         &nonce,
         associated_data.unwrap_or_default(),
-        buf,
-        #[allow(deprecated)]
-        Tag::from_slice(mac),
+        (&mut *buf).into(),
+        &tag,
     );
     #[cfg(feature = "std")]
     res?;

--- a/crates/connection/netcode/src/packet.rs
+++ b/crates/connection/netcode/src/packet.rs
@@ -634,7 +634,7 @@ mod tests {
     use super::*;
 
     use alloc::vec::Vec;
-    use chacha20poly1305::{AeadCore, XChaCha20Poly1305, aead::OsRng};
+    use chacha20poly1305::{XNonce, aead::Generate};
     use lightyear_link::recv_payload_from_bytes;
     use lightyear_serde::writer::Writer;
     use std::dbg;
@@ -672,7 +672,7 @@ mod tests {
         let packet_key = generate_key();
         let protocol_id = 0x1234_5678_9abc_def0;
         let expire_timestamp = u64::MAX;
-        let nonce = XChaCha20Poly1305::generate_nonce(&mut OsRng);
+        let nonce = XNonce::generate();
         let sequence = 0u64;
         let mut replay_protection = ReplayProtection::new();
         let token_data = ConnectTokenPrivate {

--- a/crates/connection/netcode/src/token.rs
+++ b/crates/connection/netcode/src/token.rs
@@ -8,7 +8,7 @@ use super::{
 };
 use alloc::borrow::ToOwned;
 use alloc::format;
-use chacha20poly1305::{AeadCore, XChaCha20Poly1305, XNonce, aead::OsRng};
+use chacha20poly1305::{XNonce, aead::Generate};
 use core::mem::size_of;
 use core::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
 use lightyear_serde::reader::ReadInteger;
@@ -397,7 +397,7 @@ impl<A: utils::ToSocketAddrs> ConnectTokenBuilder<A> {
         };
         let client_to_server_key = crypto::generate_key();
         let server_to_client_key = crypto::generate_key();
-        let nonce = XChaCha20Poly1305::generate_nonce(&mut OsRng);
+        let nonce = XNonce::generate();
 
         let private_data = ConnectTokenPrivate {
             client_id: self.client_id,
@@ -531,7 +531,7 @@ mod tests {
         let private_key = crypto::generate_key();
         let protocol_id = 1;
         let expire_timestamp = 2;
-        let nonce = XChaCha20Poly1305::generate_nonce(&mut OsRng);
+        let nonce = XNonce::generate();
         let client_id = 4;
         let timeout_seconds = 5;
         let server_addresses = AddressList::new(
@@ -613,7 +613,7 @@ mod tests {
         let private_key = crypto::generate_key();
         let protocol_id = 1;
         let expire_timestamp = 2;
-        let nonce = XChaCha20Poly1305::generate_nonce(&mut OsRng);
+        let nonce = XNonce::generate();
         let client_id = 4;
         let timeout_seconds = 5;
         let server_addresses = AddressList::new(

--- a/crates/io/link/Cargo.toml
+++ b/crates/io/link/Cargo.toml
@@ -28,6 +28,9 @@ bevy_ecs.workspace = true
 bevy_reflect.workspace = true
 bevy_utils.workspace = true
 
+[target.'cfg(target_family = "wasm")'.dependencies]
+getrandom_04.workspace = true
+
 [dev-dependencies]
 approx.workspace = true
 

--- a/examples/launcher/src/main.rs
+++ b/examples/launcher/src/main.rs
@@ -149,7 +149,15 @@ fn setup_system(mut commands: Commands) {
 }
 
 fn ui_system(mut contexts: EguiContexts, mut config: ResMut<LauncherConfig>) -> Result {
-    egui::CentralPanel::default().show(contexts.ctx_mut()?, |ui| {
+    let ctx = contexts.ctx_mut()?;
+    let mut viewport_ui = egui::Ui::new(
+        ctx.clone(),
+        "viewport".into(),
+        egui::UiBuilder::new()
+            .layer_id(egui::LayerId::background())
+            .max_rect(ctx.viewport_rect()),
+    );
+    egui::CentralPanel::default().show(&mut viewport_ui, |ui| {
         ui.heading("Lightyear Example Launcher");
         ui.separator();
 


### PR DESCRIPTION
## Summary

- update the WebTransport stack to `wtransport` 0.7.2, `xwt-core` 0.10.0, `xwt-web` 0.22.1, and `xwt-wtransport` 0.20.1
- update `chacha20poly1305` to 0.11 and migrate Netcode encryption and random generation to its current APIs
- update `bevy_egui` to 0.42 and `egui_extras` to 0.36 while keeping `bevy-inspector-egui` on the same Egui version
- enable the `getrandom` 0.4 WASM backend where `lightyear_link` directly uses Rand

## Upstream dependencies

This is a draft until these green upstream dependency updates are merged and released:

- [aeronet #107](https://github.com/aecsocket/aeronet/pull/107)
- [bevy-inspector-egui #323](https://github.com/jakobhellermann/bevy-inspector-egui/pull/323)