### PR TITLE
refactor(transport): Refactor `MessageRegistry`

### DIFF
--- a/crates/transport/messages/src/plugin.rs
+++ b/crates/transport/messages/src/plugin.rs
@@ -75,12 +75,11 @@ impl MessagePlugin {
             let Some(registry) = world.get_resource::<MessageRegistry>() else {
                 return;
             };
-            let receiver_components = registry
+            registry
                 .metadata
                 .values()
                 .map(|metadata| metadata.receive_component_id())
-                .collect::<alloc::vec::Vec<_>>();
-            receiver_components
+                .collect::<alloc::vec::Vec<_>>()
         };
 
         let entity = trigger.entity;

--- a/crates/transport/messages/src/plugin.rs
+++ b/crates/transport/messages/src/plugin.rs
@@ -1,5 +1,5 @@
 use crate::MessageManager;
-use crate::registry::MessageRegistry;
+use crate::registry::{MessageModeMetadata, MessageRegistry};
 use bevy_app::{App, Last, Plugin, PostUpdate, PreUpdate};
 use bevy_ecs::prelude::{Add, On, With};
 use bevy_ecs::{
@@ -75,17 +75,11 @@ impl MessagePlugin {
             let Some(registry) = world.get_resource::<MessageRegistry>() else {
                 return;
             };
-            let mut receiver_components = registry
-                .receive_metadata
+            let receiver_components = registry
+                .metadata
                 .values()
-                .map(|metadata| metadata.component_id)
+                .map(|metadata| metadata.receive_component_id())
                 .collect::<alloc::vec::Vec<_>>();
-            receiver_components.extend(
-                registry
-                    .receive_trigger
-                    .values()
-                    .map(|metadata| metadata.component_id),
-            );
             receiver_components
         };
 
@@ -126,7 +120,13 @@ impl MessagePlugin {
 
                 for (kind, component_id) in &manager.receive_messages {
                     if let Some(receiver) = entity.get_mut_by_id(*component_id) {
-                        let Some(metadata) = registry.receive_metadata.get(kind) else {
+                        let Some(metadata) = registry.metadata.get(kind) else {
+                            continue;
+                        };
+                        let MessageModeMetadata::Message {
+                            receive: metadata, ..
+                        } = &metadata.mode
+                        else {
                             continue;
                         };
                         // SAFETY: the callback is registered for this receiver component id.
@@ -134,7 +134,15 @@ impl MessagePlugin {
                     }
                 }
 
-                for metadata in registry.receive_trigger.values() {
+                for metadata in
+                    registry
+                        .metadata
+                        .values()
+                        .filter_map(|metadata| match &metadata.mode {
+                            MessageModeMetadata::Trigger { receive, .. } => Some(receive),
+                            MessageModeMetadata::Message { .. } => None,
+                        })
+                {
                     if let Some(receiver) = entity.get_mut_by_id(metadata.component_id) {
                         // SAFETY: the callback is registered for this receiver component id.
                         unsafe { (metadata.release_fn)(receiver, &commands, *timeline_kind, tick) };
@@ -174,11 +182,8 @@ impl Plugin for MessagePlugin {
             ParamBuilder,
             QueryParamBuilder::new(|builder| {
                 builder.optional(|b| {
-                    registry.receive_metadata.values().for_each(|metadata| {
-                        b.mut_id(metadata.component_id);
-                    });
-                    registry.receive_trigger.values().for_each(|metadata| {
-                        b.mut_id(metadata.component_id);
+                    registry.metadata.values().for_each(|metadata| {
+                        b.mut_id(metadata.receive_component_id());
                     });
                     timeline_registry.values().for_each(|metadata| {
                         b.ref_id(metadata.component_id());
@@ -198,9 +203,16 @@ impl Plugin for MessagePlugin {
             ParamBuilder,
             QueryParamBuilder::new(|builder| {
                 builder.optional(|b| {
-                    registry.receive_metadata.values().for_each(|metadata| {
-                        b.mut_id(metadata.component_id);
-                    });
+                    registry
+                        .metadata
+                        .values()
+                        .filter_map(|metadata| match &metadata.mode {
+                            MessageModeMetadata::Message { receive, .. } => Some(receive),
+                            MessageModeMetadata::Trigger { .. } => None,
+                        })
+                        .for_each(|receive| {
+                            b.mut_id(receive.component_id);
+                        });
                 });
             }),
             ParamBuilder,
@@ -213,15 +225,9 @@ impl Plugin for MessagePlugin {
             ParamBuilder,
             QueryParamBuilder::new(|builder| {
                 builder.optional(|b| {
-                    registry.send_metadata.values().for_each(|metadata| {
-                        b.mut_id(metadata.component_id);
+                    registry.metadata.values().for_each(|metadata| {
+                        b.mut_id(metadata.send_component_id());
                     });
-                    registry
-                        .send_trigger_metadata
-                        .values()
-                        .for_each(|metadata| {
-                            b.mut_id(metadata.component_id);
-                        });
                 });
             }),
             ParamBuilder,
@@ -235,21 +241,10 @@ impl Plugin for MessagePlugin {
             ParamBuilder,
             QueryParamBuilder::new(|builder| {
                 builder.optional(|b| {
-                    registry.send_metadata.values().for_each(|metadata| {
-                        b.mut_id(metadata.component_id);
+                    registry.metadata.values().for_each(|metadata| {
+                        b.mut_id(metadata.send_component_id());
+                        b.mut_id(metadata.receive_component_id());
                     });
-                    registry.receive_metadata.values().for_each(|metadata| {
-                        b.mut_id(metadata.component_id);
-                    });
-                    registry.receive_trigger.values().for_each(|metadata| {
-                        b.mut_id(metadata.component_id);
-                    });
-                    registry
-                        .send_trigger_metadata
-                        .values()
-                        .for_each(|metadata| {
-                            b.mut_id(metadata.component_id);
-                        });
                     timeline_registry.values().for_each(|metadata| {
                         b.ref_id(metadata.component_id());
                     });
@@ -267,11 +262,8 @@ impl Plugin for MessagePlugin {
         let release_timeline = (
             QueryParamBuilder::new(|builder| {
                 builder.optional(|b| {
-                    registry.receive_metadata.values().for_each(|metadata| {
-                        b.mut_id(metadata.component_id);
-                    });
-                    registry.receive_trigger.values().for_each(|metadata| {
-                        b.mut_id(metadata.component_id);
+                    registry.metadata.values().for_each(|metadata| {
+                        b.mut_id(metadata.receive_component_id());
                     });
                     timeline_registry.values().for_each(|metadata| {
                         b.ref_id(metadata.component_id());

--- a/crates/transport/messages/src/receive.rs
+++ b/crates/transport/messages/src/receive.rs
@@ -1,6 +1,6 @@
 use crate::MessageManager;
 use crate::plugin::{MAX_PENDING_TIMELINE_PAYLOADS, MAX_TIMELINE_LAG_TICKS, MessagePlugin};
-use crate::registry::{MessageError, MessageKind, MessageRegistry};
+use crate::registry::{MessageError, MessageKind, MessageModeMetadata, MessageRegistry};
 use crate::{Message, MessageNetId};
 use alloc::vec::Vec;
 use bevy_ecs::{
@@ -528,52 +528,56 @@ impl MessagePlugin {
             remote_peer = ?remote_peer_id,
             "received message bytes"
         );
-        let serialize_fns = registry
-            .serialize_fns_map
-            .get(message_kind)
-            .ok_or(MessageError::UnrecognizedMessage(*message_kind))?;
-        if let Some(recv_metadata) = registry.receive_metadata.get(message_kind) {
-            let component_id = recv_metadata.component_id;
-            let mut entity_mut = receiver_query.get_mut(entity).unwrap();
-            let receiver = entity_mut.get_mut_by_id(component_id);
-            // SAFETY: when present, the receiver corresponds to the callback's concrete type.
-            unsafe {
-                (recv_metadata.receive_message_fn)(
-                    receiver,
-                    commands,
-                    entity,
-                    &mut reader,
-                    channel_kind,
-                    channel_name,
-                    tick,
-                    message_id,
-                    target_timeline,
-                    serialize_fns,
-                    &mut message_manager.entity_mapper.remote_to_local,
-                )
+        let metadata = registry.metadata(message_kind)?;
+        let serialize_fns = &metadata.serialize_fns;
+        match &metadata.mode {
+            MessageModeMetadata::Message {
+                receive: recv_metadata,
+                ..
+            } => {
+                let component_id = recv_metadata.component_id;
+                let mut entity_mut = receiver_query.get_mut(entity).unwrap();
+                let receiver = entity_mut.get_mut_by_id(component_id);
+                // SAFETY: when present, the receiver corresponds to the callback's concrete type.
+                unsafe {
+                    (recv_metadata.receive_message_fn)(
+                        receiver,
+                        commands,
+                        entity,
+                        &mut reader,
+                        channel_kind,
+                        channel_name,
+                        tick,
+                        message_id,
+                        target_timeline,
+                        serialize_fns,
+                        &mut message_manager.entity_mapper.remote_to_local,
+                    )
+                }
             }
-        } else if let Some(metadata) = registry.receive_trigger.get(message_kind) {
-            let mut entity_mut = receiver_query.get_mut(entity).unwrap();
-            let receiver = entity_mut.get_mut_by_id(metadata.component_id);
-            // SAFETY: when present, the receiver corresponds to this event's pending component.
-            unsafe {
-                (metadata.receive_trigger_fn)(
-                    receiver,
-                    commands,
-                    entity,
-                    &mut reader,
-                    channel_kind,
-                    channel_name,
-                    tick,
-                    message_id,
-                    target_timeline,
-                    serialize_fns,
-                    &mut message_manager.entity_mapper.remote_to_local,
-                    remote_peer_id,
-                )
+            MessageModeMetadata::Trigger {
+                receive: metadata, ..
+            } => {
+                let mut entity_mut = receiver_query.get_mut(entity).unwrap();
+                let receiver = entity_mut.get_mut_by_id(metadata.component_id);
+                // SAFETY: when present, the receiver corresponds to this event's pending component.
+                unsafe {
+                    (metadata.receive_trigger_fn)(
+                        receiver,
+                        commands,
+                        entity,
+                        &mut reader,
+                        channel_kind,
+                        channel_name,
+                        tick,
+                        message_id,
+                        target_timeline,
+                        serialize_fns,
+                        &mut message_manager.entity_mapper.remote_to_local,
+                        remote_peer_id,
+                    )
+                }
             }
-        } else {
-            Err(MessageError::UnrecognizedMessageId(message_net_id))
         }
     }
 
@@ -700,11 +704,11 @@ impl MessagePlugin {
                 .for_each(|(kind, component_id)| {
                     let mut entity_mut = receiver_query.get_mut(entity).unwrap();
                     let receiver = entity_mut.get_mut_by_id(*component_id).unwrap();
-                    let clear_fn = registry
-                        .receive_metadata
-                        .get(kind)
-                        .unwrap()
-                        .message_clear_fn;
+                    let metadata = registry.metadata(kind).unwrap();
+                    let MessageModeMetadata::Message { receive, .. } = &metadata.mode else {
+                        unreachable!("receive_messages only contains regular messages");
+                    };
+                    let clear_fn = receive.message_clear_fn;
                     // SAFETY: we know that we are calling the function for the correct component_id
                     unsafe { clear_fn(receiver) };
                 })

--- a/crates/transport/messages/src/registry.rs
+++ b/crates/transport/messages/src/registry.rs
@@ -148,6 +148,42 @@ pub(crate) struct ReceiveTriggerMetadata {
     pub(crate) release_fn: ReleaseTimelineTriggerFn,
 }
 
+#[derive(Debug, Clone)]
+pub(crate) enum MessageModeMetadata {
+    Message {
+        send: SendMessageMetadata,
+        receive: ReceiveMessageMetadata,
+    },
+    Trigger {
+        send: SendTriggerMetadata,
+        receive: ReceiveTriggerMetadata,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct MessageMetadata {
+    pub(crate) mode: MessageModeMetadata,
+    pub(crate) serialize_fns: ErasedSerializeFns,
+    #[cfg(feature = "metrics")]
+    pub(crate) metrics: MessageMetricHandles,
+}
+
+impl MessageMetadata {
+    pub(crate) fn send_component_id(&self) -> ComponentId {
+        match &self.mode {
+            MessageModeMetadata::Message { send, .. } => send.component_id,
+            MessageModeMetadata::Trigger { send, .. } => send.component_id,
+        }
+    }
+
+    pub(crate) fn receive_component_id(&self) -> ComponentId {
+        match &self.mode {
+            MessageModeMetadata::Message { receive, .. } => receive.component_id,
+            MessageModeMetadata::Trigger { receive, .. } => receive.component_id,
+        }
+    }
+}
+
 /// A [`Resource`] that will keep track of all the [`Message`]s that can be sent over the network.
 /// A [`Message`] is any type that is serializable and deserializable.
 ///
@@ -210,13 +246,7 @@ pub(crate) struct ReceiveTriggerMetadata {
 /// ```
 #[derive(Debug, Default, Clone, Resource, TypePath)]
 pub struct MessageRegistry {
-    pub(crate) send_metadata: HashMap<MessageKind, SendMessageMetadata>,
-    pub(crate) send_trigger_metadata: HashMap<MessageKind, SendTriggerMetadata>,
-    pub(crate) receive_metadata: HashMap<MessageKind, ReceiveMessageMetadata>,
-    pub(crate) receive_trigger: HashMap<MessageKind, ReceiveTriggerMetadata>,
-    pub serialize_fns_map: HashMap<MessageKind, ErasedSerializeFns>,
-    #[cfg(feature = "metrics")]
-    metric_handles: HashMap<MessageKind, MessageMetricHandles>,
+    pub(crate) metadata: HashMap<MessageKind, MessageMetadata>,
     pub kind_map: TypeMapper<MessageKind>,
     hasher: RegistryHasher,
 }
@@ -248,56 +278,48 @@ fn mapped_context_deserialize<M: MapEntities>(
 }
 
 impl MessageRegistry {
-    pub(crate) fn register_message<M: Message, I: 'static>(
+    pub(crate) fn register<M: Message, I: 'static>(
         &mut self,
+        mode: MessageModeMetadata,
         serialize: ContextSerializeFns<SendEntityMap, M, I>,
         deserialize: ContextDeserializeFns<ReceiveEntityMap, M, I>,
     ) {
         trace!("Registering message: {}", DebugName::type_name::<M>());
+        let kind = self.kind_map.add::<I>();
+        assert!(
+            !self.metadata.contains_key(&kind),
+            "message type {} is already registered",
+            DebugName::type_name::<M>()
+        );
         self.hasher.hash::<M>();
-        let message_kind = self.kind_map.add::<I>();
-        #[cfg(feature = "metrics")]
-        self.metric_handles
-            .insert(message_kind, MessageMetricHandles::default());
-        self.serialize_fns_map.insert(
-            message_kind,
-            ErasedSerializeFns::new::<SendEntityMap, ReceiveEntityMap, M, I>(
-                serialize,
-                deserialize,
-            ),
+
+        let serialize_fns = ErasedSerializeFns::new::<SendEntityMap, ReceiveEntityMap, M, I>(
+            serialize,
+            deserialize,
         );
+
+        let metadata = MessageMetadata {
+            mode,
+            serialize_fns,
+            #[cfg(feature = "metrics")]
+            metrics: MessageMetricHandles::default(),
+        };
+
+        self.metadata.insert(kind, metadata);
     }
 
-    pub(crate) fn register_sender<M: Message>(&mut self, component_id: ComponentId) {
-        self.send_metadata.insert(
-            MessageKind::of::<M>(),
-            SendMessageMetadata {
-                component_id,
-                send_message_fn: MessageSender::<M>::send_message_typed,
-                send_local_message_fn: MessageSender::<M>::send_local_message_typed,
-            },
-        );
-    }
-
-    pub(crate) fn register_receiver<M: Message>(&mut self, component_id: ComponentId) {
-        self.receive_metadata.insert(
-            MessageKind::of::<M>(),
-            ReceiveMessageMetadata {
-                component_id,
-                receive_message_fn: MessageReceiver::<M>::receive_message_typed,
-                receive_local_message_fn: MessageReceiver::<M>::receive_local_message_typed,
-                message_clear_fn: MessageReceiver::<M>::clear_typed,
-                release_timeline_fn: MessageReceiver::<M>::release_timeline_typed,
-            },
-        );
+    pub(crate) fn metadata(
+        &self,
+        kind: &MessageKind,
+    ) -> core::result::Result<&MessageMetadata, MessageError> {
+        self.metadata
+            .get(kind)
+            .ok_or(MessageError::UnrecognizedMessage(*kind))
     }
 
     pub(crate) fn is_map_entities<M: 'static>(&self) -> Result<bool> {
         let kind = MessageKind::of::<M>();
-        let erased_fns = self
-            .serialize_fns_map
-            .get(&kind)
-            .ok_or(MessageError::MissingSerializationFns)?;
+        let erased_fns = &self.metadata(&kind)?.serialize_fns;
         Ok(erased_fns.map_entities.is_some())
     }
 
@@ -306,9 +328,7 @@ impl MessageRegistry {
         &self,
         kind: &MessageKind,
     ) -> core::result::Result<&MessageMetricHandles, MessageError> {
-        self.metric_handles
-            .get(kind)
-            .ok_or(MessageError::UnrecognizedMessage(*kind))
+        Ok(&self.metadata(kind)?.metrics)
     }
 
     pub(crate) fn add_map_entities<
@@ -321,9 +341,10 @@ impl MessageRegistry {
     ) {
         let kind = MessageKind::of::<I>();
         let erased_fns = self
-            .serialize_fns_map
+            .metadata
             .get_mut(&kind)
             .expect("the message is not part of the protocol");
+        let erased_fns = &mut erased_fns.serialize_fns;
         erased_fns.add_map_entities::<I>();
         erased_fns.context_serialize = unsafe { core::mem::transmute(context_serialize) };
         erased_fns.context_deserialize = unsafe { core::mem::transmute(context_deserialize) };
@@ -336,10 +357,7 @@ impl MessageRegistry {
         entity_map: &mut SendEntityMap,
     ) -> Result<(), MessageError> {
         let kind = MessageKind::of::<M>();
-        let erased_fns = self
-            .serialize_fns_map
-            .get(&kind)
-            .ok_or(MessageError::MissingSerializationFns)?;
+        let erased_fns = &self.metadata(&kind)?.serialize_fns;
         let net_id = self.kind_map.net_id(&kind).unwrap();
         net_id.to_bytes(writer)?;
         unsafe {
@@ -358,10 +376,7 @@ impl MessageRegistry {
             .kind_map
             .kind(net_id)
             .ok_or(MessageError::NotRegistered)?;
-        let erased_fns = self
-            .serialize_fns_map
-            .get(kind)
-            .ok_or(MessageError::MissingSerializationFns)?;
+        let erased_fns = &self.metadata(kind)?.serialize_fns;
         // SAFETY: the ErasedSerializeFns was created for the type M
         unsafe {
             erased_fns
@@ -464,14 +479,24 @@ impl AppMessageExt for App {
         let receiver_id = self.world_mut().register_component::<MessageReceiver<M>>();
 
         let mut registry = self.world_mut().resource_mut::<MessageRegistry>();
-        // Register M for serialization/deserialization
-        registry.register_message::<M, M>(
+        registry.register::<M, M>(
+            MessageModeMetadata::Message {
+                send: SendMessageMetadata {
+                    component_id: sender_id,
+                    send_message_fn: MessageSender::<M>::send_message_typed,
+                    send_local_message_fn: MessageSender::<M>::send_local_message_typed,
+                },
+                receive: ReceiveMessageMetadata {
+                    component_id: receiver_id,
+                    receive_message_fn: MessageReceiver::<M>::receive_message_typed,
+                    receive_local_message_fn: MessageReceiver::<M>::receive_local_message_typed,
+                    message_clear_fn: MessageReceiver::<M>::clear_typed,
+                    release_timeline_fn: MessageReceiver::<M>::release_timeline_typed,
+                },
+            },
             ContextSerializeFns::new(serialize_fns.serialize),
             ContextDeserializeFns::new(serialize_fns.deserialize),
         );
-        // Register sender/receiver metadata for M, ensuring trigger_fn is None
-        registry.register_sender::<M>(sender_id);
-        registry.register_receiver::<M>(receiver_id);
 
         MessageRegistration {
             app: self,
@@ -487,7 +512,9 @@ impl AppMessageExt for App {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::trigger::AppTriggerExt;
     use bevy_ecs::entity::{Entity, EntityMapper};
+    use bevy_ecs::event::Event;
     use lightyear_serde::SerializationError;
     use lightyear_serde::reader::ReadInteger;
     use lightyear_serde::writer::WriteInteger;
@@ -519,6 +546,9 @@ mod tests {
     #[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Reflect)]
     pub struct Message3(pub Entity);
 
+    #[derive(Event, Serialize, Deserialize)]
+    struct EventMessage;
+
     impl MapEntities for Message3 {
         fn map_entities<M: EntityMapper>(&mut self, entity_map: &mut M) {
             self.0 = entity_map.get_mapped(self.0);
@@ -526,18 +556,18 @@ mod tests {
     }
 
     #[test]
+    #[should_panic(expected = "is already registered")]
+    fn message_and_trigger_registration_are_mutually_exclusive() {
+        let mut app = App::new();
+        app.register_message::<EventMessage>();
+        app.register_event::<EventMessage>();
+    }
+
+    #[test]
     fn test_serde() {
-        let mut registry = MessageRegistry::default();
-        registry.kind_map.add::<Message1>();
-        registry.serialize_fns_map.insert(
-            MessageKind::of::<Message1>(),
-            ErasedSerializeFns::new(
-                ContextSerializeFns::<(), _>::new(SerializeFns::<Message1>::default().serialize),
-                ContextDeserializeFns::<(), _>::new(
-                    SerializeFns::<Message1>::default().deserialize,
-                ),
-            ),
-        );
+        let mut app = App::new();
+        app.register_message::<Message1>();
+        let registry = app.world().resource::<MessageRegistry>();
 
         let message = Message1(1.0);
         let mut writer = Writer::default();
@@ -555,11 +585,12 @@ mod tests {
 
     #[test]
     fn test_custom_serde() {
-        let mut registry = MessageRegistry::default();
-        registry.register_message::<Message2, _>(
-            ContextSerializeFns::new(serialize_message2),
-            ContextDeserializeFns::new(deserialize_message2),
-        );
+        let mut app = App::new();
+        app.register_message_custom_serde::<Message2>(SerializeFns {
+            serialize: serialize_message2,
+            deserialize: deserialize_message2,
+        });
+        let registry = app.world().resource::<MessageRegistry>();
 
         let message = Message2(1.0);
         let mut writer = Writer::default();
@@ -577,23 +608,9 @@ mod tests {
 
     #[test]
     fn test_entity_map() {
-        let mut registry = MessageRegistry::default();
-        registry.kind_map.add::<Message3>();
-        registry.serialize_fns_map.insert(
-            MessageKind::of::<Message3>(),
-            ErasedSerializeFns::new(
-                ContextSerializeFns::<SendEntityMap, _>::new(
-                    SerializeFns::<Message3>::default().serialize,
-                ),
-                ContextDeserializeFns::<ReceiveEntityMap, _>::new(
-                    SerializeFns::<Message3>::default().deserialize,
-                ),
-            ),
-        );
-        registry.add_map_entities(
-            mapped_context_serialize::<Message3>,
-            mapped_context_deserialize::<Message3>,
-        );
+        let mut app = App::new();
+        app.register_message::<Message3>().add_map_entities();
+        let registry = app.world().resource::<MessageRegistry>();
 
         let message = Message3(Entity::from_bits(1));
         let mut writer = Writer::default();

--- a/crates/transport/messages/src/send.rs
+++ b/crates/transport/messages/src/send.rs
@@ -320,7 +320,7 @@ impl MessagePlugin {
                             .net_id(message_kind)
                             .ok_or(MessageError::UnrecognizedMessage(*message_kind))?;
                         #[cfg(feature = "metrics")]
-                        let metric_handles = registry.metric_handles(message_kind)?;
+                        let metric_handles = &metadata.metrics;
                         // SAFETY: we know the message_sender corresponds to the correct `MessageSender<M>` type
                         unsafe {
                             (send_metadata.send_message_fn)(

--- a/crates/transport/messages/src/send.rs
+++ b/crates/transport/messages/src/send.rs
@@ -1,7 +1,7 @@
 use crate::plugin::{MAX_TIMELINE_LAG_TICKS, MessagePlugin};
 #[cfg(feature = "metrics")]
 use crate::registry::MessageMetricHandles;
-use crate::registry::{MessageError, MessageKind, MessageRegistry};
+use crate::registry::{MessageError, MessageKind, MessageModeMetadata, MessageRegistry};
 use crate::{Message, MessageManager, MessageNetId};
 use alloc::vec::Vec;
 use bevy_ecs::lifecycle::HookContext;
@@ -231,10 +231,14 @@ impl<M: Message> MessageSender<M> {
                     }
                 }
 
-                let receiver_metadata = registry
-                    .receive_metadata
-                    .get(&MessageKind::of::<M>())
-                    .ok_or(MessageError::UnrecognizedMessage(MessageKind::of::<M>()))?;
+                let metadata = registry.metadata(&MessageKind::of::<M>())?;
+                let MessageModeMetadata::Message {
+                    receive: receiver_metadata,
+                    ..
+                } = &metadata.mode
+                else {
+                    return Err(MessageError::UnrecognizedMessage(MessageKind::of::<M>()));
+                };
                 let mut message = Some(message);
                 let receiver_entity = message_receivers.id();
                 let receiver = message_receivers.get_mut_by_id(receiver_metadata.component_id);
@@ -302,14 +306,15 @@ impl MessagePlugin {
                         let message_sender = entity_mut
                             .get_mut_by_id(*sender_id)
                             .ok_or(MessageError::MissingComponent(*sender_id))?;
-                        let send_metadata = registry
-                            .send_metadata
-                            .get(message_kind)
-                            .ok_or(MessageError::UnrecognizedMessage(*message_kind))?;
-                        let serialize_fns = registry
-                            .serialize_fns_map
-                            .get(message_kind)
-                            .ok_or(MessageError::UnrecognizedMessage(*message_kind))?;
+                        let metadata = registry.metadata(message_kind)?;
+                        let MessageModeMetadata::Message {
+                            send: send_metadata,
+                            ..
+                        } = &metadata.mode
+                        else {
+                            return Err(MessageError::UnrecognizedMessage(*message_kind));
+                        };
+                        let serialize_fns = &metadata.serialize_fns;
                         let message_id = registry
                             .kind_map
                             .net_id(message_kind)
@@ -344,14 +349,15 @@ impl MessagePlugin {
                         let message_sender = entity_mut
                             .get_mut_by_id(*sender_id)
                             .ok_or(MessageError::MissingComponent(*sender_id))?;
-                        let send_metadata = registry
-                            .send_trigger_metadata
-                            .get(message_kind)
-                            .ok_or(MessageError::UnrecognizedMessage(*message_kind))?;
-                        let serialize_fns = registry
-                            .serialize_fns_map
-                            .get(message_kind)
-                            .ok_or(MessageError::UnrecognizedMessage(*message_kind))?;
+                        let metadata = registry.metadata(message_kind)?;
+                        let MessageModeMetadata::Trigger {
+                            send: send_metadata,
+                            ..
+                        } = &metadata.mode
+                        else {
+                            return Err(MessageError::UnrecognizedMessage(*message_kind));
+                        };
+                        let serialize_fns = &metadata.serialize_fns;
                         let message_id = registry
                             .kind_map
                             .net_id(message_kind)
@@ -412,10 +418,14 @@ impl MessagePlugin {
                         .get_mut_by_id(*sender_id)
                         .ok_or(MessageError::MissingComponent(*sender_id))?;
                     let mut entity_mut = message_receiver_query.get_mut(entity).unwrap();
-                    let send_metadata = registry
-                        .send_metadata
-                        .get(message_kind)
-                        .ok_or(MessageError::UnrecognizedMessage(*message_kind))?;
+                    let metadata = registry.metadata(message_kind)?;
+                    let MessageModeMetadata::Message {
+                        send: send_metadata,
+                        ..
+                    } = &metadata.mode
+                    else {
+                        return Err(MessageError::UnrecognizedMessage(*message_kind));
+                    };
                     // SAFETY: we know the message_sender corresponds to the correct `MessageSender<M>` type
                     unsafe {
                         (send_metadata.send_local_message_fn)(
@@ -443,10 +453,14 @@ impl MessagePlugin {
                     let message_sender = entity_mut
                         .get_mut_by_id(*sender_id)
                         .ok_or(MessageError::MissingComponent(*sender_id))?;
-                    let send_metadata = registry
-                        .send_trigger_metadata
-                        .get(message_kind)
-                        .ok_or(MessageError::UnrecognizedMessage(*message_kind))?;
+                    let metadata = registry.metadata(message_kind)?;
+                    let MessageModeMetadata::Trigger {
+                        send: send_metadata,
+                        ..
+                    } = &metadata.mode
+                    else {
+                        return Err(MessageError::UnrecognizedMessage(*message_kind));
+                    };
                     let mut entity_mut = message_receiver_query.get_mut(entity).unwrap();
                     // SAFETY: sender and receiver callbacks come from the registry for this event type.
                     unsafe {

--- a/crates/transport/messages/src/send_trigger.rs
+++ b/crates/transport/messages/src/send_trigger.rs
@@ -1,5 +1,5 @@
 use crate::plugin::MAX_TIMELINE_LAG_TICKS;
-use crate::registry::{MessageError, MessageKind, MessageRegistry};
+use crate::registry::{MessageError, MessageKind, MessageModeMetadata, MessageRegistry};
 use crate::send::Priority;
 use crate::{MessageManager, MessageNetId};
 use alloc::vec::Vec;
@@ -126,10 +126,13 @@ impl<M: Event> EventSender<M> {
                 }
             }
 
-            let metadata = registry
-                .receive_trigger
-                .get(&MessageKind::of::<M>())
-                .ok_or(MessageError::UnrecognizedMessage(MessageKind::of::<M>()))?;
+            let metadata = registry.metadata(&MessageKind::of::<M>())?;
+            let MessageModeMetadata::Trigger {
+                receive: metadata, ..
+            } = &metadata.mode
+            else {
+                return Err(MessageError::UnrecognizedMessage(MessageKind::of::<M>()));
+            };
             let PendingEvent {
                 event,
                 channel_kind,

--- a/crates/transport/messages/src/trigger.rs
+++ b/crates/transport/messages/src/trigger.rs
@@ -5,7 +5,9 @@ use crate::receive_event::{
     PendingTimelineEvents, receive_event_typed, receive_local_event_typed,
     release_timeline_events_typed,
 };
-use crate::registry::{MessageKind, MessageRegistry, ReceiveTriggerMetadata, SendTriggerMetadata};
+use crate::registry::{
+    MessageModeMetadata, MessageRegistry, ReceiveTriggerMetadata, SendTriggerMetadata,
+};
 use crate::send_trigger::EventSender;
 use lightyear_connection::direction::NetworkDirection;
 use lightyear_serde::entity_map::{ReceiveEntityMap, SendEntityMap};
@@ -92,28 +94,22 @@ impl AppTriggerExt for App {
             .register_component::<PendingTimelineEvents<M>>();
 
         let mut registry = self.world_mut().resource_mut::<MessageRegistry>();
-        // Register M for serialization/deserialization
-        registry.register_message::<M, M>(
+        registry.register::<M, M>(
+            MessageModeMetadata::Trigger {
+                send: SendTriggerMetadata {
+                    component_id: sender_id,
+                    send_trigger_fn: EventSender::<M>::send_event_typed,
+                    send_local_trigger_fn: EventSender::<M>::send_local_trigger_typed,
+                },
+                receive: ReceiveTriggerMetadata {
+                    component_id: receiver_id,
+                    receive_trigger_fn: receive_event_typed::<M>,
+                    receive_local_trigger_fn: receive_local_event_typed::<M>,
+                    release_fn: release_timeline_events_typed::<M>,
+                },
+            },
             ContextSerializeFns::new(serialize_fns.serialize).with_context(trigger_serialize),
             ContextDeserializeFns::new(serialize_fns.deserialize).with_context(trigger_deserialize),
-        );
-
-        registry.send_trigger_metadata.insert(
-            MessageKind::of::<M>(),
-            SendTriggerMetadata {
-                component_id: sender_id,
-                send_trigger_fn: EventSender::<M>::send_event_typed,
-                send_local_trigger_fn: EventSender::<M>::send_local_trigger_typed,
-            },
-        );
-        registry.receive_trigger.insert(
-            MessageKind::of::<M>(),
-            ReceiveTriggerMetadata {
-                component_id: receiver_id,
-                receive_trigger_fn: receive_event_typed::<M>,
-                receive_local_trigger_fn: receive_local_event_typed::<M>,
-                release_fn: release_timeline_events_typed::<M>,
-            },
         );
         TriggerRegistration {
             app: self,


### PR DESCRIPTION
`MessageRegistry` currently stores 6 hashmaps which follow the signature `HashMap<MessageKind, ...>`, while at call sites such as message sending, receiving and registering. Flattening these into a single `HashMap` will allow us to save a lot of hashing and lookup costs. I've provided more concrete numbers below.

The message types `trigger` and `message` are mutually exclusive, but this was never enforced at the type level. I've added a new enum `MessageModeMetadata`, which encodes this fact, which makes it impossible to look up the wrong receive/send path.


```rust
// Before

#[derive(Debug, Default, Clone, Resource, TypePath)]
pub struct MessageRegistry {
    pub(crate) send_metadata: HashMap<MessageKind, SendMessageMetadata>,
    pub(crate) send_trigger_metadata: HashMap<MessageKind, SendTriggerMetadata>,
    pub(crate) receive_metadata: HashMap<MessageKind, ReceiveMessageMetadata>,
    pub(crate) receive_trigger: HashMap<MessageKind, ReceiveTriggerMetadata>,
    pub serialize_fns_map: HashMap<MessageKind, ErasedSerializeFns>,
    #[cfg(feature = "metrics")]
    metric_handles: HashMap<MessageKind, MessageMetricHandles>,
    pub kind_map: TypeMapper<MessageKind>,
    hasher: RegistryHasher,
}


// After

pub(crate) enum MessageModeMetadata {
    Message {
        send: SendMessageMetadata,
        receive: ReceiveMessageMetadata,
    },
    Trigger {
        send: SendTriggerMetadata,
        receive: ReceiveTriggerMetadata,
    },
}

#[derive(Debug, Clone)]
pub(crate) struct MessageMetadata {
    pub(crate) mode: MessageModeMetadata,
    pub(crate) serialize_fns: ErasedSerializeFns,
    #[cfg(feature = "metrics")]
    pub(crate) metrics: MessageMetricHandles,
}

#[derive(Debug, Default, Clone, Resource, TypePath)]
pub struct MessageRegistry {
    pub(crate) metadata: HashMap<MessageKind, MessageMetadata>,
    pub kind_map: TypeMapper<MessageKind>,
    hasher: RegistryHasher,
}

``` 


I asked Codex to summarize the hashmap lookup savings by this change:

| Path | Before | After | Saved |
|---|---:|---:|---:|
| Remote message send | 2 | 1 | **1** |
| Remote message send, metrics | 3 | 1 | **2** |
| Remote trigger send | 2 | 1 | **1** |
| Remote message receive | 2 | 1 | **1** |
| Remote trigger receive | 3 | 1 | **2** |
| Local message send/receive | 2 | 2 | **0** |
| Local trigger send/receive | 2 | 2 | **0** |
