### PR TITLE
fix(avian): add correction for velocities

### DIFF
--- a/book/src/concepts/advanced_replication/avian.md
+++ b/book/src/concepts/advanced_replication/avian.md
@@ -15,11 +15,11 @@ Use `AvianReplicationMode::Position { sync_to_transform: false }` unless the app
 
 | Mode | Replicated and predicted | Frame interpolation and correction | Physics authority | Recommendation |
 |---|---|---|---|---|
-| `Position { sync_to_transform: false }` | `Position`, `Rotation` | `Position`, `Rotation` | `Position`, `Rotation` | Preferred |
-| `Position { sync_to_transform: true }` | `Position`, `Rotation` | `Position`, `Rotation` | Synchronizes the physics pose to `Transform` for fixed-tick authoring, then imports edits | Use for transform-driven fixed gameplay with compact physics replication |
+| `Position { sync_to_transform: false }` | `Position`, `Rotation` | `Position`, `Rotation`, `LinearVelocity`, `AngularVelocity` | `Position`, `Rotation` | Preferred |
+| `Position { sync_to_transform: true }` | `Position`, `Rotation` | `Position`, `Rotation`, `LinearVelocity`, `AngularVelocity` | Synchronizes the physics pose to `Transform` for fixed-tick authoring, then imports edits | Use for transform-driven fixed gameplay with compact physics replication |
 | `Transform` | `Transform` | `Transform` | `Transform` at the application boundary; Avian still uses `Position` and `Rotation` internally | Use for transform-driven applications |
 
-`FrameInterpolate` is type-erased: adding the one marker to an entity enables all applicable registered component or bundle rules, so correction and frame interpolation operate directly on Avian's canonical `Position` and `Rotation`.
+`FrameInterpolate` is type-erased: adding the one marker to an entity enables all applicable registered component or bundle rules, so correction and frame interpolation operate directly on Avian's canonical `Position` and `Rotation`, with `LinearVelocity` and `AngularVelocity` corrected alongside them using linear error decay.
 
 `Position` is not always the right choice. Prefer `Transform` when:
 

--- a/crates/integration/avian/src/plugin.rs
+++ b/crates/integration/avian/src/plugin.rs
@@ -70,6 +70,8 @@ Position mode automatically registers velocity-aware Hermite interpolation for t
 `(Position, Rotation, LinearVelocity, AngularVelocity)` bundle. Delayed interpolation, frame
 interpolation, and visual correction select it whenever all four components are present. The
 per-component rules remain useful for archetypes that do not contain the complete bundle.
+Velocities use linear fallback rules there, and all four components receive visual correction
+(linear error decay for velocities, which do not implement `Ease`).
 
 By default, Position mode also registers `Position`, `Rotation`, `LinearVelocity`, and
 `AngularVelocity` for filtered rigid-body replication and prediction. Position and Rotation get
@@ -111,8 +113,8 @@ pub enum AvianReplicationMode {
     /// Replicate [`Position`] and [`Rotation`].
     ///
     /// This is the preferred mode for Avian physics. Prediction history, correction, and frame
-    /// interpolation apply to `Position` and `Rotation`, and the rendered [`Transform`] is written
-    /// from that visual physics state in `PostUpdate`.
+    /// interpolation apply to `Position`, `Rotation`, `LinearVelocity`, and `AngularVelocity`,
+    /// and the rendered [`Transform`] is written from that visual physics state in `PostUpdate`.
     ///
     /// Child colliders without their own rigid body still use a local `Transform` to describe
     /// their offset from the parent body.
@@ -158,8 +160,9 @@ pub struct LightyearAvianPlugin {
     ///
     /// The default registration replicates `Position`, `Rotation`, `LinearVelocity`, and
     /// `AngularVelocity` only on entities with [`RigidBody`], predicts all four components, and
-    /// enables interpolation and correction for the pose components. Disable this when the
-    /// application uses custom replication rules, such as replicate-once deterministic state.
+    /// enables interpolation and correction for all four (Hermite bundle interpolation when the
+    /// complete bundle is present, linear fallback rules for lone velocities). Disable this when
+    /// the application uses custom replication rules, such as replicate-once deterministic state.
     ///
     /// Add the Lightyear networking plugins or another component protocol before this plugin so
     /// the replication registry exists when these defaults are installed.
@@ -231,6 +234,34 @@ fn angular_velocity_should_rollback(
     (confirmed.0 - predicted.0).length() >= Scalar::from(DEFAULT_ROLLBACK_TOLERANCE)
 }
 
+/// Linear interpolation for `LinearVelocity`.
+///
+/// Avian does not implement [`Ease`](bevy_math::curve::Ease) for velocities,
+/// so this is used both as the fallback frame-interpolation function and as
+/// the visual-correction decay function (via `add_correction_fn`). It matches
+/// the velocity sampling that the Hermite bundle rule performs.
+fn linear_velocity_correction(
+    start: LinearVelocity,
+    other: LinearVelocity,
+    t: f32,
+) -> LinearVelocity {
+    let u = Scalar::from(t);
+    LinearVelocity(start.0 * (1.0 - u) + other.0 * u)
+}
+
+/// Linear interpolation for `AngularVelocity`.
+///
+/// See [`linear_velocity_correction`]. The same expression covers the 2D
+/// scalar and 3D vector representations.
+fn angular_velocity_correction(
+    start: AngularVelocity,
+    other: AngularVelocity,
+    t: f32,
+) -> AngularVelocity {
+    let u = Scalar::from(t);
+    AngularVelocity(start.0 * (1.0 - u) + other.0 * u)
+}
+
 impl Plugin for LightyearAvianPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<PhysicsTransformConfig>();
@@ -238,10 +269,7 @@ impl Plugin for LightyearAvianPlugin {
         match self.replication_mode {
             AvianReplicationMode::Position { sync_to_transform } => {
                 if self.register_physics_components {
-                    if app.world().contains_resource::<ComponentRegistry>() {
-                        Self::register_position_mode_components(app);
-                    }
-                    Self::add_position_rotation_hermite_rule(app);
+                    Self::register_position_mode_protocol(app);
                 }
                 if !self.update_syncs_manually {
                     let mut config = app.world_mut().resource_mut::<PhysicsTransformConfig>();
@@ -401,30 +429,52 @@ impl Plugin for LightyearAvianPlugin {
 
 impl LightyearAvianPlugin {
     /// Register the standard network protocol for Avian's canonical Position-mode state.
-    fn register_position_mode_components(app: &mut App) {
-        app.component::<Position>()
-            .replicate_filtered::<With<RigidBody>>()
-            .predict()
-            .with_rollback_condition(position_should_rollback)
-            .add_linear_interpolation()
-            .add_correction();
+    ///
+    /// This replicates, predicts, and corrects `Position`, `Rotation`,
+    /// `LinearVelocity`, and `AngularVelocity` on rigid bodies, and registers
+    /// every interpolation rule Position mode needs: the Hermite bundle plus
+    /// one linear rule per component. The pose rules own full delayed
+    /// interpolation; the velocity rules are frame-only fallbacks for
+    /// archetypes without the complete bundle, so delayed interpolation is
+    /// unchanged. The bundle's default priority (its four members) wins over
+    /// the single-component rules whenever the complete bundle is present.
+    fn register_position_mode_protocol(app: &mut App) {
+        if app.world().contains_resource::<ComponentRegistry>() {
+            app.component::<Position>()
+                .replicate_filtered::<With<RigidBody>>()
+                .predict()
+                .with_rollback_condition(position_should_rollback)
+                .add_linear_interpolation()
+                .add_correction();
 
-        app.component::<Rotation>()
-            .replicate_filtered::<With<RigidBody>>()
-            .predict()
-            .with_rollback_condition(rotation_should_rollback)
-            .add_linear_interpolation()
-            .add_correction();
+            app.component::<Rotation>()
+                .replicate_filtered::<With<RigidBody>>()
+                .predict()
+                .with_rollback_condition(rotation_should_rollback)
+                .add_linear_interpolation()
+                .add_correction();
 
-        app.component::<LinearVelocity>()
-            .replicate_filtered::<With<RigidBody>>()
-            .predict()
-            .with_rollback_condition(linear_velocity_should_rollback);
+            app.component::<LinearVelocity>()
+                .replicate_filtered::<With<RigidBody>>()
+                .predict()
+                .with_rollback_condition(linear_velocity_should_rollback)
+                .interpolate_with(InterpolationFns::no_history(linear_velocity_correction))
+                .add_correction_fn(linear_velocity_correction);
 
-        app.component::<AngularVelocity>()
-            .replicate_filtered::<With<RigidBody>>()
-            .predict()
-            .with_rollback_condition(angular_velocity_should_rollback);
+            app.component::<AngularVelocity>()
+                .replicate_filtered::<With<RigidBody>>()
+                .predict()
+                .with_rollback_condition(angular_velocity_should_rollback)
+                .interpolate_with(InterpolationFns::no_history(angular_velocity_correction))
+                .add_correction_fn(angular_velocity_correction);
+        }
+        // Lone velocities (archetypes without the complete bundle) fall back
+        // to the linear frame-only rules registered above. They keep frame
+        // interpolation and correction sampling defined for every corrected
+        // component.
+        app.interpolate_bundle_with::<(Position, Rotation, LinearVelocity, AngularVelocity)>(
+            InterpolationFns::interpolate_with_context(crate::types::position_rotation::hermite),
+        );
     }
 
     /// Opt non-rigid interpolated entities into Avian's Position-to-Transform sync.
@@ -493,16 +543,6 @@ impl LightyearAvianPlugin {
                 .entity(trigger.entity)
                 .remove::<ApplyPosToTransform>();
         }
-    }
-
-    /// Register the canonical Avian pose and velocity bundle once for every
-    /// Position-mode application. The bundle's default priority is its four
-    /// members, so it wins over ordinary single-component rules whenever the
-    /// complete bundle is present.
-    fn add_position_rotation_hermite_rule(app: &mut App) {
-        app.interpolate_bundle_with::<(Position, Rotation, LinearVelocity, AngularVelocity)>(
-            InterpolationFns::interpolate_with_context(crate::types::position_rotation::hermite),
-        );
     }
 
     // Add a low-priority interpolation function for Transform

--- a/crates/integration/avian/src/types_2d.rs
+++ b/crates/integration/avian/src/types_2d.rs
@@ -402,15 +402,15 @@ mod tests {
     fn velocity_diff_roundtrip() {
         use lightyear_replication::diffable::Diffable;
 
-        let start = LinearVelocity(Vector::new(Scalar::from(1.0), Scalar::from(-2.0)));
-        let end = LinearVelocity(Vector::new(Scalar::from(8.0), Scalar::from(0.5)));
+        let start = LinearVelocity(Vector::new(Scalar::from(1.0_f32), Scalar::from(-2.0_f32)));
+        let end = LinearVelocity(Vector::new(Scalar::from(8.0_f32), Scalar::from(0.5_f32)));
         assert_eq!(start.diff(&start), LinearVelocity::default());
         let mut value = start.clone();
         value.apply_diff(&start.diff(&end));
         assert_eq!(value, end);
 
-        let start = AngularVelocity(Scalar::from(0.5));
-        let end = AngularVelocity(Scalar::from(-4.0));
+        let start = AngularVelocity(Scalar::from(0.5_f32));
+        let end = AngularVelocity(Scalar::from(-4.0_f32));
         assert_eq!(start.diff(&start), AngularVelocity::default());
         let mut value = start.clone();
         value.apply_diff(&start.diff(&end));

--- a/crates/integration/avian/src/types_2d.rs
+++ b/crates/integration/avian/src/types_2d.rs
@@ -397,4 +397,23 @@ mod tests {
             Quat::from_rotation_z(core::f32::consts::FRAC_PI_8) * Vec3::X,
         );
     }
+
+    #[test]
+    fn velocity_diff_roundtrip() {
+        use lightyear_replication::diffable::Diffable;
+
+        let start = LinearVelocity(Vector::new(Scalar::from(1.0), Scalar::from(-2.0)));
+        let end = LinearVelocity(Vector::new(Scalar::from(8.0), Scalar::from(0.5)));
+        assert_eq!(start.diff(&start), LinearVelocity::default());
+        let mut value = start.clone();
+        value.apply_diff(&start.diff(&end));
+        assert_eq!(value, end);
+
+        let start = AngularVelocity(Scalar::from(0.5));
+        let end = AngularVelocity(Scalar::from(-4.0));
+        assert_eq!(start.diff(&start), AngularVelocity::default());
+        let mut value = start.clone();
+        value.apply_diff(&start.diff(&end));
+        assert_eq!(value, end);
+    }
 }

--- a/crates/integration/avian/src/types_3d.rs
+++ b/crates/integration/avian/src/types_3d.rs
@@ -399,4 +399,39 @@ mod tests {
             Quat::from_rotation_y(core::f32::consts::FRAC_PI_8) * Vec3::X,
         );
     }
+
+    #[test]
+    fn velocity_diff_roundtrip() {
+        use lightyear_replication::diffable::Diffable;
+
+        let start = LinearVelocity(Vector::new(
+            Scalar::from(1.0),
+            Scalar::from(-2.0),
+            Scalar::from(4.0),
+        ));
+        let end = LinearVelocity(Vector::new(
+            Scalar::from(8.0),
+            Scalar::from(0.5),
+            Scalar::from(-1.0),
+        ));
+        assert_eq!(start.diff(&start), LinearVelocity::default());
+        let mut value = start.clone();
+        value.apply_diff(&start.diff(&end));
+        assert_eq!(value, end);
+
+        let start = AngularVelocity(Vector::new(
+            Scalar::from(0.5),
+            Scalar::from(-1.0),
+            Scalar::from(2.0),
+        ));
+        let end = AngularVelocity(Vector::new(
+            Scalar::from(-4.0),
+            Scalar::from(8.0),
+            Scalar::from(0.25),
+        ));
+        assert_eq!(start.diff(&start), AngularVelocity::default());
+        let mut value = start.clone();
+        value.apply_diff(&start.diff(&end));
+        assert_eq!(value, end);
+    }
 }

--- a/crates/integration/avian/src/types_3d.rs
+++ b/crates/integration/avian/src/types_3d.rs
@@ -405,14 +405,14 @@ mod tests {
         use lightyear_replication::diffable::Diffable;
 
         let start = LinearVelocity(Vector::new(
-            Scalar::from(1.0),
-            Scalar::from(-2.0),
-            Scalar::from(4.0),
+            Scalar::from(1.0_f32),
+            Scalar::from(-2.0_f32),
+            Scalar::from(4.0_f32),
         ));
         let end = LinearVelocity(Vector::new(
-            Scalar::from(8.0),
-            Scalar::from(0.5),
-            Scalar::from(-1.0),
+            Scalar::from(8.0_f32),
+            Scalar::from(0.5_f32),
+            Scalar::from(-1.0_f32),
         ));
         assert_eq!(start.diff(&start), LinearVelocity::default());
         let mut value = start.clone();
@@ -420,14 +420,14 @@ mod tests {
         assert_eq!(value, end);
 
         let start = AngularVelocity(Vector::new(
-            Scalar::from(0.5),
-            Scalar::from(-1.0),
-            Scalar::from(2.0),
+            Scalar::from(0.5_f32),
+            Scalar::from(-1.0_f32),
+            Scalar::from(2.0_f32),
         ));
         let end = AngularVelocity(Vector::new(
-            Scalar::from(-4.0),
-            Scalar::from(8.0),
-            Scalar::from(0.25),
+            Scalar::from(-4.0_f32),
+            Scalar::from(8.0_f32),
+            Scalar::from(0.25_f32),
         ));
         assert_eq!(start.diff(&start), AngularVelocity::default());
         let mut value = start.clone();

--- a/crates/replication/interpolation/src/registry.rs
+++ b/crates/replication/interpolation/src/registry.rs
@@ -1152,6 +1152,29 @@ pub trait InterpolationRegistrationExt<'a, C>: ComponentRegistrator<'a, C> {
     fn add_custom_interpolation_diff(self) -> Self
     where
         C: SyncComponent + RepliconDiffable;
+
+    /// Add interpolation for this component using an explicit [`InterpolationFns`] rule.
+    ///
+    /// This is the chained equivalent of
+    /// [`AppInterpolationExt::interpolate_with`](crate::registry::AppInterpolationExt::interpolate_with):
+    /// it accepts any pipeline, including frame-only
+    /// ([`InterpolationFns::no_history`](crate::rules::InterpolationFns::no_history))
+    /// or history-only rules. The convenience methods above cover the common
+    /// cases; use this when they do not express what you need, for example a
+    /// frame-only rule for predicted velocities that should not own delayed
+    /// interpolation history.
+    fn interpolate_with(self, fns: InterpolationFns<C>) -> Self
+    where
+        C: SyncComponent;
+
+    /// Chained equivalent of
+    /// [`AppInterpolationExt::interpolate_diff_with`](crate::registry::AppInterpolationExt::interpolate_diff_with).
+    ///
+    /// Like [`Self::interpolate_with`], but for components replicated with
+    /// Replicon's diff-based mode.
+    fn interpolate_diff_with(self, fns: InterpolationFns<C>) -> Self
+    where
+        C: SyncComponent + RepliconDiffable;
 }
 
 impl<'a, C, R> InterpolationRegistrationExt<'a, C> for R
@@ -1231,6 +1254,36 @@ where
         Self::from_component_registration(add_custom_interpolation_diff_impl(
             self.into_component_registration(),
         ))
+    }
+
+    fn interpolate_with(self, fns: InterpolationFns<C>) -> Self
+    where
+        C: SyncComponent,
+    {
+        let registration = self.into_component_registration();
+        add_interpolation_rule::<C, ()>(
+            registration.app,
+            fns,
+            InterpolationRuleConfig {
+                priority: SINGLE_COMPONENT_RULE_PRIORITY,
+            },
+        );
+        Self::from_component_registration(registration)
+    }
+
+    fn interpolate_diff_with(self, fns: InterpolationFns<C>) -> Self
+    where
+        C: SyncComponent + RepliconDiffable,
+    {
+        let registration = self.into_component_registration();
+        add_interpolation_diff_rule::<C, ()>(
+            registration.app,
+            fns,
+            InterpolationRuleConfig {
+                priority: SINGLE_COMPONENT_RULE_PRIORITY,
+            },
+        );
+        Self::from_component_registration(registration)
     }
 }
 
@@ -2201,5 +2254,86 @@ mod tests {
             history.get_state_at(Tick(5)).and_then(HistoryState::value),
             Some(&TestDiffComponent(5))
         );
+    }
+
+    fn frame_only_app() -> App {
+        let mut app = App::new();
+        app.add_plugins((
+            StatesPlugin,
+            RepliconPlugins,
+            crate::plugin::InterpolationMarkerPlugin,
+            crate::plugin::InterpolationPlugin,
+        ));
+        app
+    }
+
+    fn frame_only_rule_for<C: Component>(registry: &InterpolationRegistry) -> &InterpolationRule {
+        let kind = ComponentKind::of::<C>();
+        registry
+            .rules
+            .iter()
+            .find(|rule| rule.members().any(|member| member == kind))
+            .expect("frame-only rule should be registered")
+    }
+
+    fn assert_frame_only_rule<C: Component>(registry: &InterpolationRegistry) {
+        let rule = frame_only_rule_for::<C>(registry);
+        // The rule stores an interpolation function with a frame-apply
+        // callback, but owns no delayed-interpolation history or apply.
+        assert!(rule.interpolation.is_some());
+        assert!(rule.apply_frame_interpolation.is_some());
+        assert!(rule.apply_interpolation.is_none());
+        let member = rule
+            .members
+            .iter()
+            .find(|member| member.kind == ComponentKind::of::<C>())
+            .expect("rule should contain the component");
+        assert!(member.confirmed.is_none());
+        assert!(member.frame.is_some());
+    }
+
+    #[test]
+    fn chained_interpolate_with_registers_frame_only_rule() {
+        let mut app = frame_only_app();
+        app.component::<TestComp>()
+            .replicate()
+            .interpolate_with(InterpolationFns::no_history(lerp));
+
+        let registry = app.world().resource::<InterpolationRegistry>();
+        assert!(registry.interpolated::<TestComp>());
+        assert_frame_only_rule::<TestComp>(registry);
+    }
+
+    #[test]
+    fn chained_interpolate_with_context_registers_frame_only_rule() {
+        fn context_lerp(
+            start: TestComp,
+            end: TestComp,
+            ctx: InterpolationSampleContext,
+        ) -> TestComp {
+            lerp(start, end, ctx.t)
+        }
+
+        let mut app = frame_only_app();
+        app.component::<TestComp>()
+            .replicate()
+            .interpolate_with(InterpolationFns::no_history_with_context(context_lerp));
+
+        let registry = app.world().resource::<InterpolationRegistry>();
+        assert!(registry.interpolated::<TestComp>());
+        assert_frame_only_rule::<TestComp>(registry);
+    }
+
+    #[test]
+    fn chained_interpolate_diff_with_registers_frame_only_rule() {
+        let mut app = frame_only_app();
+        app.insert_resource(ReplicationCheckpointMap::default());
+        app.component::<TestDiffComponent>()
+            .replicate_diff()
+            .interpolate_diff_with(InterpolationFns::no_history(diff_lerp));
+
+        let registry = app.world().resource::<InterpolationRegistry>();
+        assert!(registry.interpolated::<TestDiffComponent>());
+        assert_frame_only_rule::<TestDiffComponent>(registry);
     }
 }

--- a/crates/replication/replication/src/impls/avian2d.rs
+++ b/crates/replication/replication/src/impls/avian2d.rs
@@ -1,5 +1,5 @@
 use crate::diffable::Diffable;
-use avian2d::prelude::{Position, Rotation};
+use avian2d::prelude::{AngularVelocity, LinearVelocity, Position, Rotation};
 
 impl Diffable<Position> for Position {
     fn base_value() -> Self {
@@ -26,5 +26,33 @@ impl Diffable<Rotation> for Rotation {
 
     fn apply_diff(&mut self, delta: &Rotation) {
         *self = self.add_angle_fast(delta.as_radians());
+    }
+}
+
+impl Diffable<LinearVelocity> for LinearVelocity {
+    fn base_value() -> Self {
+        LinearVelocity::default()
+    }
+
+    fn diff(&self, new: &Self) -> LinearVelocity {
+        LinearVelocity(new.0 - self.0)
+    }
+
+    fn apply_diff(&mut self, delta: &LinearVelocity) {
+        self.0 += delta.0;
+    }
+}
+
+impl Diffable<AngularVelocity> for AngularVelocity {
+    fn base_value() -> Self {
+        AngularVelocity::default()
+    }
+
+    fn diff(&self, new: &Self) -> AngularVelocity {
+        AngularVelocity(new.0 - self.0)
+    }
+
+    fn apply_diff(&mut self, delta: &AngularVelocity) {
+        self.0 += delta.0;
     }
 }

--- a/crates/replication/replication/src/impls/avian3d.rs
+++ b/crates/replication/replication/src/impls/avian3d.rs
@@ -1,5 +1,5 @@
 use crate::diffable::Diffable;
-use avian3d::prelude::{Position, Rotation};
+use avian3d::prelude::{AngularVelocity, LinearVelocity, Position, Rotation};
 
 impl Diffable<Self> for Position {
     fn base_value() -> Self {
@@ -26,5 +26,33 @@ impl Diffable<Self> for Rotation {
 
     fn apply_diff(&mut self, delta: &Self) {
         self.0 *= delta.0;
+    }
+}
+
+impl Diffable<Self> for LinearVelocity {
+    fn base_value() -> Self {
+        LinearVelocity::default()
+    }
+
+    fn diff(&self, new: &Self) -> Self {
+        LinearVelocity(new.0 - self.0)
+    }
+
+    fn apply_diff(&mut self, delta: &Self) {
+        self.0 += delta.0;
+    }
+}
+
+impl Diffable<Self> for AngularVelocity {
+    fn base_value() -> Self {
+        AngularVelocity::default()
+    }
+
+    fn diff(&self, new: &Self) -> Self {
+        AngularVelocity(new.0 - self.0)
+    }
+
+    fn apply_diff(&mut self, delta: &Self) {
+        self.0 += delta.0;
     }
 }

--- a/crates/tests/src/client_server/prediction/correction.rs
+++ b/crates/tests/src/client_server/prediction/correction.rs
@@ -4,6 +4,8 @@ use crate::protocol::{
     CompMixedCorrectionBundleB, CompPredictionOnly,
 };
 use crate::stepper::{ClientServerStepper, StepperConfig};
+use avian2d::math::Vector;
+use avian2d::prelude::{AngularVelocity, LinearVelocity, Position, Rotation};
 use bevy::prelude::*;
 use core::time::Duration;
 use lightyear::frame_interpolation::FrameInterpolationHistory;
@@ -43,6 +45,25 @@ fn replay_mixed_correction_bundle(
     for (mut a, mut b) in &mut components {
         *a = CompMixedCorrectionBundleA(10.0);
         *b = CompMixedCorrectionBundleB(20.0);
+    }
+}
+
+fn replay_avian_pose(
+    mut components: Query<
+        (
+            &mut Position,
+            &mut Rotation,
+            &mut LinearVelocity,
+            &mut AngularVelocity,
+        ),
+        With<Predicted>,
+    >,
+) {
+    for (mut position, mut rotation, mut linear, mut angular) in &mut components {
+        *position = Position::default();
+        *rotation = Rotation::default();
+        *linear = LinearVelocity::default();
+        *angular = AngularVelocity::default();
     }
 }
 
@@ -217,6 +238,77 @@ fn post_rollback_bundle_uses_member_without_previous_visual() {
     assert!(
         world
             .get::<PreviousVisual<CompMixedCorrectionBundleB>>(entity)
+            .is_none()
+    );
+}
+
+/// Rollback captures stale Avian velocities as decaying visual-correction
+/// errors instead of snapping them while the pose glides.
+#[test]
+fn post_rollback_correction_smooths_velocities() {
+    let mut stepper = ClientServerStepper::from_config(StepperConfig::single());
+    set_correction_sampling_time(&mut stepper);
+    stepper
+        .client_app()
+        .add_systems(FixedUpdate, replay_avian_pose);
+
+    let current_tick = stepper.client_tick(0);
+    let rollback_tick = current_tick - 1;
+    let entity = stepper
+        .client_app()
+        .world_mut()
+        .spawn((
+            Predicted,
+            Position::default(),
+            Rotation::default(),
+            // Stale pre-rollback visual velocities; replay corrects them to rest.
+            LinearVelocity(Vector::new(10.0, 0.0)),
+            AngularVelocity(5.0),
+            history(rollback_tick, Position::default()),
+            history(rollback_tick, Rotation::default()),
+            history(rollback_tick, LinearVelocity::default()),
+            history(rollback_tick, AngularVelocity::default()),
+            FrameInterpolationHistory::<Position>::default(),
+            FrameInterpolationHistory::<Rotation>::default(),
+            FrameInterpolationHistory::<LinearVelocity>::default(),
+            FrameInterpolationHistory::<AngularVelocity>::default(),
+        ))
+        .id();
+
+    trigger_state_rollback(&mut stepper, rollback_tick);
+    stepper.client_app().world_mut().run_schedule(PreUpdate);
+
+    let world = stepper.client_app().world();
+    // Live components are restored to the replayed (corrected) values.
+    assert_eq!(
+        world.get::<LinearVelocity>(entity),
+        Some(&LinearVelocity::default())
+    );
+    assert_eq!(
+        world.get::<AngularVelocity>(entity),
+        Some(&AngularVelocity::default())
+    );
+    // The stale velocities are kept as decaying visual errors.
+    assert_eq!(
+        world
+            .get::<VisualCorrection<LinearVelocity>>(entity)
+            .map(|correction| &correction.error),
+        Some(&LinearVelocity(Vector::new(10.0, 0.0)))
+    );
+    assert_eq!(
+        world
+            .get::<VisualCorrection<AngularVelocity>>(entity)
+            .map(|correction| &correction.error),
+        Some(&AngularVelocity(5.0))
+    );
+    assert!(
+        world
+            .get::<PreviousVisual<LinearVelocity>>(entity)
+            .is_none()
+    );
+    assert!(
+        world
+            .get::<PreviousVisual<AngularVelocity>>(entity)
             .is_none()
     );
 }


### PR DESCRIPTION
We had some jitter/artifacts on correction because only Position/Rotation were smoothly corrected on predict.

Since hermitian interpolation relies on velocities, this was causing some jitters.
Now velocities are also corrected, so hermitian interpolation works on corrections.