### PR TITLE
feat(messages): allow parallel message sends via shared borrows

### DIFF
--- a/crates/replication/replication/src/client.rs
+++ b/crates/replication/replication/src/client.rs
@@ -172,9 +172,7 @@ fn receive_client_packets(
 
 /// Send `ClientMessages` (acks) via transport to server.
 ///
-/// Drains `ClientMessages` and stages bytes on client_channels (MutationAcks)
-/// through the shared-access [`Transport`] queue, so this system only needs a
-/// shared borrow and can run in parallel with other producers.
+/// Drains `ClientMessages` and sends on client_channels (MutationAcks).
 fn send_client_packets(
     channel_map: Res<RepliconChannelMap>,
     mut client_messages: ResMut<ClientMessages>,

--- a/crates/replication/replication/src/client.rs
+++ b/crates/replication/replication/src/client.rs
@@ -172,17 +172,19 @@ fn receive_client_packets(
 
 /// Send `ClientMessages` (acks) via transport to server.
 ///
-/// Drains `ClientMessages` and sends on client_channels (MutationAcks).
+/// Drains `ClientMessages` and stages bytes on client_channels (MutationAcks)
+/// through the shared-access [`Transport`] queue, so this system only needs a
+/// shared borrow and can run in parallel with other producers.
 fn send_client_packets(
     channel_map: Res<RepliconChannelMap>,
     mut client_messages: ResMut<ClientMessages>,
-    mut transports: Query<&mut Transport, (With<Client>, With<ReplicationReceiver>)>,
+    transports: Query<&Transport, (With<Client>, With<ReplicationReceiver>)>,
 ) {
     for (channel_idx, message) in client_messages.drain_sent() {
         let (channel_kind, _) = channel_map.client_channels[channel_idx];
-        for mut transport in transports.iter_mut() {
+        for transport in transports.iter() {
             transport
-                .send_mut_erased(channel_kind, message.clone(), 1.0)
+                .send_erased(channel_kind, message.clone(), 1.0)
                 .ok();
         }
     }

--- a/crates/replication/replication/src/server.rs
+++ b/crates/replication/replication/src/server.rs
@@ -133,11 +133,13 @@ fn receive_server_packets(
 
 /// Send `ServerMessages` (replication data) via transport to peers.
 ///
-/// Drains `ServerMessages` and sends on server_channels (Updates, Mutations).
+/// Drains `ServerMessages` and stages bytes on server_channels (Updates, Mutations)
+/// through the shared-access [`Transport`] queue, so this system only needs a
+/// shared borrow and can run in parallel with other producers.
 fn send_server_packets(
     channel_map: Res<RepliconChannelMap>,
     mut server_messages: ResMut<ServerMessages>,
-    mut transports: Query<&mut Transport, With<ClientOf>>,
+    transports: Query<&Transport, With<ClientOf>>,
 ) {
     for (client, channel_idx, message) in server_messages.drain_sent() {
         let (channel_kind, _) = channel_map.server_channels[channel_idx];
@@ -147,8 +149,8 @@ fn send_server_packets(
             channel_idx,
             client
         );
-        if let Ok(mut transport) = transports.get_mut(client) {
-            transport.send_mut_erased(channel_kind, message, 1.0).ok();
+        if let Ok(transport) = transports.get(client) {
+            transport.send_erased(channel_kind, message, 1.0).ok();
         } else {
             trace!("send_server_packets: no transport for client {:?}", client);
         }

--- a/crates/replication/replication/src/server.rs
+++ b/crates/replication/replication/src/server.rs
@@ -133,9 +133,7 @@ fn receive_server_packets(
 
 /// Send `ServerMessages` (replication data) via transport to peers.
 ///
-/// Drains `ServerMessages` and stages bytes on server_channels (Updates, Mutations)
-/// through the shared-access [`Transport`] queue, so this system only needs a
-/// shared borrow and can run in parallel with other producers.
+/// Drains `ServerMessages` and sends on server_channels (Updates, Mutations).
 fn send_server_packets(
     channel_map: Res<RepliconChannelMap>,
     mut server_messages: ResMut<ServerMessages>,

--- a/crates/transport/messages/src/multi.rs
+++ b/crates/transport/messages/src/multi.rs
@@ -19,7 +19,7 @@ use lightyear_transport::prelude::Transport;
 /// 2) send a message without needing to clone it
 #[derive(SystemParam)]
 pub struct MultiMessageSender<'w, 's, F: QueryFilter + 'static = ()> {
-    pub(crate) query: Query<'w, 's, (&'static mut MessageManager, &'static mut Transport), F>,
+    pub(crate) query: Query<'w, 's, (&'static MessageManager, &'static Transport), F>,
     pub(crate) registry: Res<'w, MessageRegistry>,
     // TODO: should we let users provide their own Writer?
     pub(crate) writer: Local<'s, Writer>,
@@ -41,15 +41,12 @@ impl<'w, 's, F: QueryFilter> MultiMessageSender<'w, 's, F> {
         if !self.registry.is_map_entities::<M>()? {
             // TODO: serialize once for all senders. Figure out how to get a shared writer. Maybe on Server? Or as a global resource?
             //   or as Local?
-            self.registry.serialize::<M>(
-                message,
-                &mut self.writer,
-                &mut SendEntityMap::default(),
-            )?;
+            self.registry
+                .serialize::<M>(message, &mut self.writer, &SendEntityMap::default())?;
             let bytes = self.writer.take_written();
             let bytes_len = bytes.len();
             self.query
-                .iter_many_unique_mut(senders)
+                .iter_many_unique(senders)
                 .try_for_each(|(_, transport)| {
                     #[cfg(feature = "metrics")]
                     metric_handles.record_send::<M>(bytes_len);
@@ -57,13 +54,12 @@ impl<'w, 's, F: QueryFilter> MultiMessageSender<'w, 's, F> {
                 })?;
         } else {
             self.query
-                .iter_many_unique_mut(senders)
-                .try_for_each(|(mut manager, transport)| {
+                .iter_many_unique(senders)
+                .try_for_each(|(manager, transport)| {
                     self.registry.serialize::<M>(
                         message,
                         &mut self.writer,
-                        // TODO: ideally we could do entity mapping without Mut!!!
-                        &mut manager.entity_mapper.local_to_remote,
+                        &manager.entity_mapper.local_to_remote,
                     )?;
                     let bytes = self.writer.take_written();
                     #[cfg(feature = "metrics")]

--- a/crates/transport/messages/src/receive.rs
+++ b/crates/transport/messages/src/receive.rs
@@ -281,7 +281,7 @@ pub(crate) type ReceiveMessageFn = unsafe fn(
     message_id: Option<MessageId>,
     target_timeline: Option<TimelineKind>,
     serialize_metadata: &ErasedSerializeFns,
-    entity_map: &mut ReceiveEntityMap,
+    entity_map: &ReceiveEntityMap,
 ) -> Result<(), MessageError>;
 
 pub(crate) type ReceiveLocalMessageFn = unsafe fn(
@@ -354,7 +354,7 @@ impl<M: Message> MessageReceiver<M> {
         message_id: Option<MessageId>,
         target_timeline: Option<TimelineKind>,
         serialize_metadata: &ErasedSerializeFns,
-        entity_map: &mut ReceiveEntityMap,
+        entity_map: &ReceiveEntityMap,
     ) -> Result<(), MessageError> {
         let insert_receiver = receiver.is_none();
         let message = unsafe { serialize_metadata.deserialize::<_, M, M>(reader, entity_map)? };
@@ -478,7 +478,7 @@ impl MessagePlugin {
         tick: Tick,
         message_id: Option<MessageId>,
         target_timeline: Option<TimelineKind>,
-        message_manager: &mut MessageManager,
+        message_manager: &MessageManager,
         commands: &ParallelCommands,
         remote_peer_id: PeerId,
     ) -> Result<(), MessageError> {
@@ -551,7 +551,7 @@ impl MessagePlugin {
                         message_id,
                         target_timeline,
                         serialize_fns,
-                        &mut message_manager.entity_mapper.remote_to_local,
+                        &message_manager.entity_mapper.remote_to_local,
                     )
                 }
             }
@@ -573,7 +573,7 @@ impl MessagePlugin {
                         message_id,
                         target_timeline,
                         serialize_fns,
-                        &mut message_manager.entity_mapper.remote_to_local,
+                        &message_manager.entity_mapper.remote_to_local,
                         remote_peer_id,
                     )
                 }
@@ -593,7 +593,7 @@ impl MessagePlugin {
             //  them directly to the host-server's MessageReceiver<M>)
             (
                 Entity,
-                &mut MessageManager,
+                &MessageManager,
                 &mut Transport,
                 &RemoteId,
                 Option<&mut HostClient>,
@@ -612,13 +612,7 @@ impl MessagePlugin {
         let receiver_query = &receiver_query;
         let transport_query = adaptive_for_each_mut!(transport_query);
         transport_query.for_each(
-            |(
-                entity,
-                mut message_manager,
-                mut transport,
-                remote_peer_id,
-                mut host_client,
-            )| {
+            |(entity, message_manager, mut transport, remote_peer_id, mut host_client)| {
                 // SAFETY: we know that this won't lead to violating the aliasing rule
                 let mut receiver_query = unsafe { receiver_query.reborrow_unsafe() };
                 // enable split borrows
@@ -647,7 +641,7 @@ impl MessagePlugin {
                             tick,
                             None,
                             target_timeline,
-                            &mut message_manager,
+                            message_manager,
                             &commands,
                             remote_peer_id.0,
                         ) {
@@ -677,7 +671,7 @@ impl MessagePlugin {
                                     tick,
                                     message_id,
                                     target_timeline,
-                                    &mut message_manager,
+                                    message_manager,
                                     &commands,
                                     remote_peer_id.0,
                                 )?;

--- a/crates/transport/messages/src/receive_event.rs
+++ b/crates/transport/messages/src/receive_event.rs
@@ -228,7 +228,7 @@ pub(crate) type ReceiveTriggerFn = unsafe fn(
     message_id: Option<MessageId>,
     target_timeline: Option<TimelineKind>,
     serialize_metadata: &ErasedSerializeFns,
-    entity_map: &mut ReceiveEntityMap,
+    entity_map: &ReceiveEntityMap,
     from: PeerId,
 ) -> Result<(), MessageError>;
 
@@ -270,7 +270,7 @@ pub(crate) unsafe fn receive_event_typed<M: Message + Event>(
     message_id: Option<MessageId>,
     target_timeline: Option<TimelineKind>,
     serialize_metadata: &ErasedSerializeFns,
-    entity_map: &mut ReceiveEntityMap,
+    entity_map: &ReceiveEntityMap,
     from: PeerId,
 ) -> Result<(), MessageError> {
     let message = unsafe { serialize_metadata.deserialize::<_, M, M>(reader, entity_map)? };

--- a/crates/transport/messages/src/registry.rs
+++ b/crates/transport/messages/src/registry.rs
@@ -16,7 +16,9 @@ use core::hash::Hash;
 use lightyear_connection::direction::NetworkDirection;
 use lightyear_core::network::NetId;
 use lightyear_core::prelude::{Tick, TimelineKind};
-use lightyear_serde::entity_map::{ReceiveEntityMap, RemoteEntityMap, SendEntityMap};
+use lightyear_serde::entity_map::{
+    ReceiveEntityMap, ReceiveMapView, RemoteEntityMap, SendEntityMap, SendMapView,
+};
 use lightyear_serde::reader::Reader;
 use lightyear_serde::registry::{
     ContextDeserializeFn, ContextDeserializeFns, ContextSerializeFn, ContextSerializeFns,
@@ -257,23 +259,29 @@ pub struct Context {
 }
 
 fn mapped_context_serialize<M: MapEntities + Clone>(
-    mapper: &mut SendEntityMap,
+    mapper: &SendEntityMap,
     message: &M,
     writer: &mut Writer,
     serialize_fn: SerializeFn<M>,
 ) -> core::result::Result<(), SerializationError> {
     let mut message = message.clone();
-    message.map_entities(mapper);
+    // The view only exposes shared reads, so user mapping code runs without
+    // requiring exclusive access to the entity map.
+    let mut view = SendMapView(mapper);
+    message.map_entities(&mut view);
     serialize_fn(&message, writer)
 }
 
 fn mapped_context_deserialize<M: MapEntities>(
-    mapper: &mut ReceiveEntityMap,
+    mapper: &ReceiveEntityMap,
     reader: &mut Reader,
     deserialize_fn: DeserializeFn<M>,
 ) -> core::result::Result<M, SerializationError> {
     let mut message = deserialize_fn(reader)?;
-    message.map_entities(mapper);
+    // The view only exposes shared reads, so user mapping code runs without
+    // requiring exclusive access to the entity map.
+    let mut view = ReceiveMapView(mapper);
+    message.map_entities(&mut view);
     Ok(message)
 }
 
@@ -354,7 +362,7 @@ impl MessageRegistry {
         &self,
         message: &M,
         writer: &mut Writer,
-        entity_map: &mut SendEntityMap,
+        entity_map: &SendEntityMap,
     ) -> Result<(), MessageError> {
         let kind = MessageKind::of::<M>();
         let erased_fns = &self.metadata(&kind)?.serialize_fns;
@@ -369,7 +377,7 @@ impl MessageRegistry {
     pub(crate) fn deserialize<M: Message>(
         &self,
         reader: &mut Reader,
-        entity_map: &mut ReceiveEntityMap,
+        entity_map: &ReceiveEntityMap,
     ) -> Result<M, MessageError> {
         let net_id = NetId::from_bytes(reader)?;
         let kind = self
@@ -572,13 +580,13 @@ mod tests {
         let message = Message1(1.0);
         let mut writer = Writer::default();
         registry
-            .serialize(&message, &mut writer, &mut SendEntityMap::default())
+            .serialize(&message, &mut writer, &SendEntityMap::default())
             .unwrap();
         let data = writer.into_bytes();
 
         let mut reader = Reader::from(data);
         let read = registry
-            .deserialize(&mut reader, &mut ReceiveEntityMap::default())
+            .deserialize(&mut reader, &ReceiveEntityMap::default())
             .unwrap();
         assert_eq!(message, read);
     }
@@ -595,13 +603,13 @@ mod tests {
         let message = Message2(1.0);
         let mut writer = Writer::default();
         registry
-            .serialize(&message, &mut writer, &mut SendEntityMap::default())
+            .serialize(&message, &mut writer, &SendEntityMap::default())
             .unwrap();
         let data = writer.into_bytes();
 
         let mut reader = Reader::from(data);
         let read = registry
-            .deserialize(&mut reader, &mut ReceiveEntityMap::default())
+            .deserialize(&mut reader, &ReceiveEntityMap::default())
             .unwrap();
         assert_eq!(message, read);
     }
@@ -617,13 +625,13 @@ mod tests {
         let mut entity_map = SendEntityMap::default();
         entity_map.set_mapped(Entity::from_bits(1), Entity::from_bits(2));
         registry
-            .serialize(&message, &mut writer, &mut entity_map)
+            .serialize(&message, &mut writer, &entity_map)
             .unwrap();
         let data = writer.into_bytes();
 
         let mut reader = Reader::from(data);
         let read = registry
-            .deserialize::<Message3>(&mut reader, &mut ReceiveEntityMap::default())
+            .deserialize::<Message3>(&mut reader, &ReceiveEntityMap::default())
             .unwrap();
         assert_eq!(read.0, Entity::from_bits(2));
     }

--- a/crates/transport/messages/src/send.rs
+++ b/crates/transport/messages/src/send.rs
@@ -77,7 +77,7 @@ pub(crate) type SendMessageFn = unsafe fn(
     message_net_id: MessageNetId,
     transport: &Transport,
     serialize_metadata: &ErasedSerializeFns,
-    entity_map: &mut SendEntityMap,
+    entity_map: &SendEntityMap,
     #[cfg(feature = "metrics")] metric_handles: &MessageMetricHandles,
 ) -> Result<(), MessageError>;
 
@@ -123,7 +123,7 @@ impl<M: Message> MessageSender<M> {
         net_id: MessageNetId,
         transport: &Transport,
         serialize_metadata: &ErasedSerializeFns,
-        entity_map: &mut SendEntityMap,
+        entity_map: &SendEntityMap,
         #[cfg(feature = "metrics")] metric_handles: &MessageMetricHandles,
     ) -> Result<(), MessageError> {
         // SAFETY:  the `message_sender` must be of type `MessageSender<M>`
@@ -280,7 +280,7 @@ impl MessagePlugin {
     /// Serialize them into bytes that are buffered in a [`Transport`]
     pub fn send(
         mut transport_query: Query<
-            (Entity, &Transport, &mut MessageManager),
+            (Entity, &Transport, &MessageManager),
             (With<Connected>, Without<HostClient>),
         >,
         // MessageSender<M> present on that entity
@@ -290,94 +290,86 @@ impl MessagePlugin {
         // Each outer query item accesses senders on a different entity, so workers can safely
         // share the query before taking their disjoint unsafe reborrows below.
         let message_sender_query = &message_sender_query;
-        adaptive_for_each_mut!(transport_query).for_each(
-            |(entity, transport, mut message_manager)| {
-                // SAFETY: we know that this won't lead to violating the aliasing rule
-                let mut message_sender_query = unsafe { message_sender_query.reborrow_unsafe() };
+        adaptive_for_each_mut!(transport_query).for_each(|(entity, transport, message_manager)| {
+            // SAFETY: we know that this won't lead to violating the aliasing rule
+            let mut message_sender_query = unsafe { message_sender_query.reborrow_unsafe() };
 
-                // TODO: allow sending from senders in parallel! The only issue is the mutable borrow of the entity mapper
-                // enable split borrows
-                let message_manager = &mut *message_manager;
-                message_manager
-                    .send_messages
-                    .iter()
-                    .try_for_each(|(message_kind, sender_id)| {
-                        let mut entity_mut = message_sender_query.get_mut(entity).unwrap();
-                        let message_sender = entity_mut
-                            .get_mut_by_id(*sender_id)
-                            .ok_or(MessageError::MissingComponent(*sender_id))?;
-                        let metadata = registry.metadata(message_kind)?;
-                        let MessageModeMetadata::Message {
-                            send: send_metadata,
-                            ..
-                        } = &metadata.mode
-                        else {
-                            return Err(MessageError::UnrecognizedMessage(*message_kind));
-                        };
-                        let serialize_fns = &metadata.serialize_fns;
-                        let message_id = registry
-                            .kind_map
-                            .net_id(message_kind)
-                            .ok_or(MessageError::UnrecognizedMessage(*message_kind))?;
-                        #[cfg(feature = "metrics")]
-                        let metric_handles = &metadata.metrics;
-                        // SAFETY: we know the message_sender corresponds to the correct `MessageSender<M>` type
-                        unsafe {
-                            (send_metadata.send_message_fn)(
-                                message_sender,
-                                *message_id,
-                                transport,
-                                serialize_fns,
-                                &mut message_manager.entity_mapper.local_to_remote,
-                                #[cfg(feature = "metrics")]
-                                metric_handles,
-                            )?;
-                        }
-                        Ok::<_, MessageError>(())
-                    })
-                    .inspect_err(|e| error!("error sending message: {e:?}"))
-                    .ok();
+            message_manager
+                .send_messages
+                .iter()
+                .try_for_each(|(message_kind, sender_id)| {
+                    let mut entity_mut = message_sender_query.get_mut(entity).unwrap();
+                    let message_sender = entity_mut
+                        .get_mut_by_id(*sender_id)
+                        .ok_or(MessageError::MissingComponent(*sender_id))?;
+                    let metadata = registry.metadata(message_kind)?;
+                    let MessageModeMetadata::Message {
+                        send: send_metadata,
+                        ..
+                    } = &metadata.mode
+                    else {
+                        return Err(MessageError::UnrecognizedMessage(*message_kind));
+                    };
+                    let serialize_fns = &metadata.serialize_fns;
+                    let message_id = registry
+                        .kind_map
+                        .net_id(message_kind)
+                        .ok_or(MessageError::UnrecognizedMessage(*message_kind))?;
+                    #[cfg(feature = "metrics")]
+                    let metric_handles = &metadata.metrics;
+                    // SAFETY: we know the message_sender corresponds to the correct `MessageSender<M>` type
+                    unsafe {
+                        (send_metadata.send_message_fn)(
+                            message_sender,
+                            *message_id,
+                            transport,
+                            serialize_fns,
+                            &message_manager.entity_mapper.local_to_remote,
+                            #[cfg(feature = "metrics")]
+                            metric_handles,
+                        )?;
+                    }
+                    Ok::<_, MessageError>(())
+                })
+                .inspect_err(|e| error!("error sending message: {e:?}"))
+                .ok();
 
-                // TODO: allow sending from senders in parallel! The only issue is the mutable borrow of the entity mapper
-                // enable split borrows
-                let message_manager = &mut *message_manager;
-                message_manager
-                    .send_triggers
-                    .iter()
-                    .try_for_each(|(message_kind, sender_id)| {
-                        let mut entity_mut = message_sender_query.get_mut(entity).unwrap();
-                        let message_sender = entity_mut
-                            .get_mut_by_id(*sender_id)
-                            .ok_or(MessageError::MissingComponent(*sender_id))?;
-                        let metadata = registry.metadata(message_kind)?;
-                        let MessageModeMetadata::Trigger {
-                            send: send_metadata,
-                            ..
-                        } = &metadata.mode
-                        else {
-                            return Err(MessageError::UnrecognizedMessage(*message_kind));
-                        };
-                        let serialize_fns = &metadata.serialize_fns;
-                        let message_id = registry
-                            .kind_map
-                            .net_id(message_kind)
-                            .ok_or(MessageError::UnrecognizedMessage(*message_kind))?;
-                        // SAFETY: we know the message_sender corresponds to the correct `MessageSender<M>` type
-                        unsafe {
-                            (send_metadata.send_trigger_fn)(
-                                message_sender,
-                                *message_id,
-                                transport,
-                                serialize_fns,
-                                &mut message_manager.entity_mapper.local_to_remote,
-                            )?;
-                        }
-                        Ok::<_, MessageError>(())
-                    })
-                    .inspect_err(|e| error!("error sending trigger: {e:?}"))
-                    .ok();
-            },
-        )
+            message_manager
+                .send_triggers
+                .iter()
+                .try_for_each(|(message_kind, sender_id)| {
+                    let mut entity_mut = message_sender_query.get_mut(entity).unwrap();
+                    let message_sender = entity_mut
+                        .get_mut_by_id(*sender_id)
+                        .ok_or(MessageError::MissingComponent(*sender_id))?;
+                    let metadata = registry.metadata(message_kind)?;
+                    let MessageModeMetadata::Trigger {
+                        send: send_metadata,
+                        ..
+                    } = &metadata.mode
+                    else {
+                        return Err(MessageError::UnrecognizedMessage(*message_kind));
+                    };
+                    let serialize_fns = &metadata.serialize_fns;
+                    let message_id = registry
+                        .kind_map
+                        .net_id(message_kind)
+                        .ok_or(MessageError::UnrecognizedMessage(*message_kind))?;
+                    // SAFETY: we know the message_sender corresponds to the correct `MessageSender<M>` type
+                    unsafe {
+                        (send_metadata.send_trigger_fn)(
+                            message_sender,
+                            *message_id,
+                            transport,
+                            serialize_fns,
+                            &message_manager.entity_mapper.local_to_remote,
+                        )?;
+                    }
+                    Ok::<_, MessageError>(())
+                })
+                .inspect_err(|e| error!("error sending trigger: {e:?}"))
+                .ok();
+        })
     }
 
     /// For the host-client, we take messages to send from the [`MessageSender<M>`] components
@@ -386,10 +378,7 @@ impl MessagePlugin {
     /// (the [`Transport`] is not used)
     pub fn send_local(
         timeline: Res<LocalTimeline>,
-        mut manager_query: Query<
-            (Entity, &mut MessageManager),
-            (With<Connected>, With<HostClient>),
-        >,
+        mut manager_query: Query<(Entity, &MessageManager), (With<Connected>, With<HostClient>)>,
         // MessageSender<M>/MessageReceiver<M>/TriggerSender<M> present on that entity
         message_components_query: Query<FilteredEntityMut>,
         commands: ParallelCommands,
@@ -401,14 +390,11 @@ impl MessagePlugin {
         // share the query before taking their disjoint unsafe reborrows below.
         let tick = timeline.tick();
         let message_components_query = &message_components_query;
-        adaptive_for_each_mut!(manager_query).for_each(|(entity, mut message_manager)| {
+        adaptive_for_each_mut!(manager_query).for_each(|(entity, message_manager)| {
             // SAFETY: we know that this won't lead to violating the aliasing rule
             let mut message_sender_query = unsafe { message_components_query.reborrow_unsafe() };
             let mut message_receiver_query = unsafe { message_components_query.reborrow_unsafe() };
 
-            // TODO: allow sending from senders in parallel! The only issue is the mutable borrow of the entity mapper
-            // enable split borrows
-            let message_manager = &mut *message_manager;
             message_manager
                 .send_messages
                 .iter()
@@ -443,8 +429,6 @@ impl MessagePlugin {
                 .inspect_err(|e| error!("error sending message on host-client: {e:?}"))
                 .ok();
 
-            // TODO: allow sending from senders in parallel! The only issue is the mutable borrow of the entity mapper
-            // enable split borrows
             message_manager
                 .send_triggers
                 .iter()

--- a/crates/transport/messages/src/send_trigger.rs
+++ b/crates/transport/messages/src/send_trigger.rs
@@ -52,7 +52,7 @@ impl<M: Event> EventSender<M> {
         net_id: MessageNetId,
         transport: &Transport,
         serialize_metadata: &ErasedSerializeFns,
-        entity_map: &mut SendEntityMap,
+        entity_map: &SendEntityMap,
     ) -> Result<(), MessageError> {
         // SAFETY:  the `trigger_sender` must be of type `TriggerSender<M>`
         let mut sender = unsafe { trigger_sender.with_type::<Self>() };
@@ -181,7 +181,7 @@ pub(crate) type SendTriggerFn = unsafe fn(
     message_net_id: MessageNetId,
     transport: &Transport,
     serialize_metadata: &ErasedSerializeFns,
-    entity_map: &mut SendEntityMap,
+    entity_map: &SendEntityMap,
 ) -> Result<(), MessageError>;
 
 // SAFETY: the sender must correspond to the correct `TriggerSender<M>` type

--- a/crates/transport/messages/src/trigger.rs
+++ b/crates/transport/messages/src/trigger.rs
@@ -10,7 +10,7 @@ use crate::registry::{
 };
 use crate::send_trigger::EventSender;
 use lightyear_connection::direction::NetworkDirection;
-use lightyear_serde::entity_map::{ReceiveEntityMap, SendEntityMap};
+use lightyear_serde::entity_map::{ReceiveEntityMap, ReceiveMapView, SendEntityMap, SendMapView};
 use lightyear_serde::reader::Reader;
 use lightyear_serde::registry::{
     ContextDeserializeFns, ContextSerializeFns, DeserializeFn, SerializeFn, SerializeFns,
@@ -119,7 +119,7 @@ impl AppTriggerExt for App {
 }
 
 fn trigger_serialize<M: Event>(
-    _: &mut SendEntityMap,
+    _: &SendEntityMap,
     message: &M,
     writer: &mut Writer,
     serialize: SerializeFn<M>,
@@ -130,7 +130,7 @@ fn trigger_serialize<M: Event>(
 }
 
 fn trigger_deserialize<M: Event>(
-    _: &mut ReceiveEntityMap,
+    _: &ReceiveEntityMap,
     reader: &mut Reader,
     deserialize: DeserializeFn<M>,
 ) -> Result<M, SerializationError> {
@@ -138,24 +138,26 @@ fn trigger_deserialize<M: Event>(
 }
 
 fn trigger_serialize_mapped<M: Event + MapEntities + Clone>(
-    mapper: &mut SendEntityMap,
+    mapper: &SendEntityMap,
     event: &M,
     writer: &mut Writer,
     serialize: SerializeFn<M>,
 ) -> Result<(), SerializationError> {
     let mut event = event.clone();
-    event.map_entities(mapper);
+    let mut view = SendMapView(mapper);
+    event.map_entities(&mut view);
     serialize(&event, writer)?;
     Ok(())
 }
 
 fn trigger_deserialize_mapped<M: Event + MapEntities>(
-    mapper: &mut ReceiveEntityMap,
+    mapper: &ReceiveEntityMap,
     reader: &mut Reader,
     deserialize: DeserializeFn<M>,
 ) -> Result<M, SerializationError> {
     // Serialize the trigger message
     let mut inner = deserialize(reader)?;
-    inner.map_entities(mapper);
+    let mut view = ReceiveMapView(mapper);
+    inner.map_entities(&mut view);
     Ok(inner)
 }

--- a/crates/transport/serde/src/entity_map.rs
+++ b/crates/transport/serde/src/entity_map.rs
@@ -43,9 +43,12 @@ impl EntityMapper for EntityMap {
 #[derive(Default, Debug, Reflect, Deref, DerefMut)]
 pub struct SendEntityMap(pub(crate) EntityHashMap<Entity>);
 
-impl EntityMapper for SendEntityMap {
-    /// Try to map the entity using the map, or return the initial entity if it doesn't work
-    fn get_mapped(&mut self, entity: Entity) -> Entity {
+impl SendEntityMap {
+    /// Read-only entity lookup used while serializing.
+    ///
+    /// Serialization never inserts mappings, so this shared-access version is
+    /// sufficient for the send path and can be called through a shared borrow.
+    pub fn get_mapped_shared(&self, entity: Entity) -> Entity {
         // if we have the entity in our mapping, map it and mark it as mapped
         // so that on the receive side we don't map it again
         match self.0.get(&entity) {
@@ -67,6 +70,13 @@ impl EntityMapper for SendEntityMap {
             }
         }
     }
+}
+
+impl EntityMapper for SendEntityMap {
+    /// Try to map the entity using the map, or return the initial entity if it doesn't work
+    fn get_mapped(&mut self, entity: Entity) -> Entity {
+        self.get_mapped_shared(entity)
+    }
 
     fn set_mapped(&mut self, source: Entity, target: Entity) {
         trace!(
@@ -84,9 +94,12 @@ impl EntityMapper for SendEntityMap {
 #[derive(Default, Debug, Reflect, Deref, DerefMut)]
 pub struct ReceiveEntityMap(pub(crate) EntityHashMap<Entity>);
 
-impl EntityMapper for ReceiveEntityMap {
-    /// Map an entity from the remote World to the local World
-    fn get_mapped(&mut self, entity: Entity) -> Entity {
+impl ReceiveEntityMap {
+    /// Read-only entity lookup used while deserializing.
+    ///
+    /// Deserialization never inserts mappings, so this shared-access version is
+    /// sufficient for the receive path and can be called through a shared borrow.
+    pub fn get_mapped_shared(&self, entity: Entity) -> Entity {
         // if the entity was already mapped on the send side, we don't need to map it again
         // since it's the local world entity
         if RemoteEntityMap::is_mapped(entity) {
@@ -128,6 +141,13 @@ impl EntityMapper for ReceiveEntityMap {
             }
         }
     }
+}
+
+impl EntityMapper for ReceiveEntityMap {
+    /// Map an entity from the remote World to the local World
+    fn get_mapped(&mut self, entity: Entity) -> Entity {
+        self.get_mapped_shared(entity)
+    }
 
     fn set_mapped(&mut self, source: Entity, target: Entity) {
         trace!(
@@ -139,6 +159,46 @@ impl EntityMapper for ReceiveEntityMap {
             "inserted receive entity mapping"
         );
         self.0.insert(source, target);
+    }
+}
+
+/// Read-only view of a [`SendEntityMap`] that implements [`EntityMapper`] over shared access.
+///
+/// `get_mapped` only reads the map, so sharing this view across parallel tasks is sound.
+/// `set_mapped` is unsupported, mirroring `bevy_replicon`'s send context: mapping code
+/// that runs during serialization must not insert mappings.
+#[derive(Debug, Clone, Copy)]
+pub struct SendMapView<'a>(pub &'a SendEntityMap);
+
+impl EntityMapper for SendMapView<'_> {
+    fn get_mapped(&mut self, entity: Entity) -> Entity {
+        self.0.get_mapped_shared(entity)
+    }
+
+    fn set_mapped(&mut self, _source: Entity, _target: Entity) {
+        unimplemented!(
+            "SendMapView is read-only; MapEntities impls used during serialization must not insert mappings"
+        );
+    }
+}
+
+/// Read-only view of a [`ReceiveEntityMap`] that implements [`EntityMapper`] over shared access.
+///
+/// `get_mapped` only reads the map, so sharing this view across parallel tasks is sound.
+/// `set_mapped` is unsupported, mirroring `bevy_replicon`'s send context: mapping code
+/// that runs during deserialization must not insert mappings.
+#[derive(Debug, Clone, Copy)]
+pub struct ReceiveMapView<'a>(pub &'a ReceiveEntityMap);
+
+impl EntityMapper for ReceiveMapView<'_> {
+    fn get_mapped(&mut self, entity: Entity) -> Entity {
+        self.0.get_mapped_shared(entity)
+    }
+
+    fn set_mapped(&mut self, _source: Entity, _target: Entity) {
+        unimplemented!(
+            "ReceiveMapView is read-only; MapEntities impls used during deserialization must not insert mappings"
+        );
     }
 }
 

--- a/crates/transport/serde/src/lib.rs
+++ b/crates/transport/serde/src/lib.rs
@@ -39,7 +39,9 @@ pub mod writer;
 /// Commonly used items from the `lightyear_serde` crate.
 pub mod prelude {
     pub use crate::SerializationError;
-    pub use crate::entity_map::{ReceiveEntityMap, RemoteEntityMap, SendEntityMap};
+    pub use crate::entity_map::{
+        ReceiveEntityMap, ReceiveMapView, RemoteEntityMap, SendEntityMap, SendMapView,
+    };
     pub use no_std_io2::io::{Seek, SeekFrom};
 }
 

--- a/crates/transport/serde/src/registry.rs
+++ b/crates/transport/serde/src/registry.rs
@@ -53,7 +53,7 @@ impl<C, M, I> ContextSerializeFns<C, M, I> {
     }
     pub fn serialize(
         self,
-        context: &mut C,
+        context: &C,
         message: &M,
         writer: &mut Writer,
     ) -> Result<(), SerializationError> {
@@ -86,11 +86,7 @@ impl<C, M, I> ContextDeserializeFns<C, M, I> {
             deserialize: self.deserialize,
         }
     }
-    pub fn deserialize(
-        self,
-        context: &mut C,
-        reader: &mut Reader,
-    ) -> Result<M, SerializationError> {
+    pub fn deserialize(self, context: &C, reader: &mut Reader) -> Result<M, SerializationError> {
         (self.context_deserialize)(context, reader, self.deserialize)
     }
 }
@@ -125,7 +121,7 @@ type ErasedSerializeFn = unsafe fn(
     erased_serialize_fn: &ErasedSerializeFns,
     message: Ptr,
     writer: &mut Writer,
-    entity_map: &mut SendEntityMap,
+    entity_map: &SendEntityMap,
 ) -> Result<(), SerializationError>;
 
 /// Type of the serialize function without entity mapping
@@ -137,12 +133,12 @@ pub type DeserializeFn<M> = fn(reader: &mut Reader) -> Result<M, SerializationEr
 #[doc(hidden)]
 /// Type of the serialize function with entity mapping
 pub type ContextSerializeFn<C, M, I> =
-    fn(&mut C, message: &M, writer: &mut Writer, SerializeFn<I>) -> Result<(), SerializationError>;
+    fn(&C, message: &M, writer: &mut Writer, SerializeFn<I>) -> Result<(), SerializationError>;
 
 #[doc(hidden)]
 /// Type of the deserialize function with entity mapping
 pub type ContextDeserializeFn<C, M, I> =
-    fn(&mut C, reader: &mut Reader, DeserializeFn<I>) -> Result<M, SerializationError>;
+    fn(&C, reader: &mut Reader, DeserializeFn<I>) -> Result<M, SerializationError>;
 
 #[allow(unused)]
 pub type CloneFn<M> = fn(&M) -> M;
@@ -151,7 +147,7 @@ pub type CloneFn<M> = fn(&M) -> M;
 pub type ErasedMapEntitiesFn = for<'a> unsafe fn(message: PtrMut<'a>, entity_map: &mut EntityMap);
 
 fn default_context_serialize<C, M>(
-    _: &mut C,
+    _: &C,
     message: &M,
     writer: &mut Writer,
     serialize_fn: SerializeFn<M>,
@@ -160,7 +156,7 @@ fn default_context_serialize<C, M>(
 }
 
 fn default_context_deserialize<C, M>(
-    _: &mut C,
+    _: &C,
     reader: &mut Reader,
     deserialize_fn: DeserializeFn<M>,
 ) -> Result<M, SerializationError> {
@@ -219,7 +215,7 @@ unsafe fn erased_serialize_fn<M: 'static>(
     erased_serialize_fn: &ErasedSerializeFns,
     message: Ptr,
     writer: &mut Writer,
-    entity_map: &mut SendEntityMap,
+    entity_map: &SendEntityMap,
 ) -> Result<(), SerializationError> {
     unsafe {
         // SAFETY: the Ptr was created for the message of type M
@@ -293,7 +289,7 @@ impl ErasedSerializeFns {
         &self,
         message: &M,
         writer: &mut Writer,
-        context: &mut C,
+        context: &C,
     ) -> Result<(), SerializationError> {
         let serialize: SerializeFn<I> = unsafe { core::mem::transmute(self.serialize) };
         let context_serialize: ContextSerializeFn<C, M, I> =
@@ -308,7 +304,7 @@ impl ErasedSerializeFns {
     pub unsafe fn deserialize<C, M: 'static, I>(
         &self,
         reader: &mut Reader,
-        context: &mut C,
+        context: &C,
     ) -> Result<M, SerializationError> {
         let deserialize: DeserializeFn<I> = unsafe { core::mem::transmute(self.deserialize) };
         let context_deserialize: ContextDeserializeFn<C, M, I> =

--- a/crates/transport/transport/src/channel/builder.rs
+++ b/crates/transport/transport/src/channel/builder.rs
@@ -493,6 +493,11 @@ impl Transport {
         self.send_mut_erased(ChannelKind::of::<C>(), bytes, priority)
     }
 
+    /// Buffers bytes directly in the channel sender.
+    ///
+    /// Requires exclusive access; producers should prefer the shared-access
+    /// `send_*` staging queue instead. This is the flush-time primitive used by
+    /// the transport send system, which owns `&mut self`.
     pub fn send_mut_erased(
         &mut self,
         kind: ChannelKind,

--- a/crates/transport/transport/src/channel/builder.rs
+++ b/crates/transport/transport/src/channel/builder.rs
@@ -496,8 +496,7 @@ impl Transport {
     /// Buffers bytes directly in the channel sender.
     ///
     /// Requires exclusive access; producers should prefer the shared-access
-    /// `send_*` staging queue instead. This is the flush-time primitive used by
-    /// the transport send system, which owns `&mut self`.
+    /// `send_*` staging queue instead.
     pub fn send_mut_erased(
         &mut self,
         kind: ChannelKind,


### PR DESCRIPTION
Route all producers (messages, triggers, MultiMessageSender, replication packet senders) through Transport's shared-access staging queue instead of requiring `&mut Transport`, so systems writing to the same channel no longer conflict at the scheduler level.

Make entity-map access during (de)serialization read-only: add `SendMapView`/`ReceiveMapView` over shared borrows and change the serialize contexts from `&mut C` to `&C`, so `MessagePlugin::send/recv/send_local` and `MultiMessageSender` only need `&MessageManager`/`&Transport`. No `&`→`&mut` casts: the views hold shared refs and `set_mapped` panics, mirroring replicon's send context.

`send_mut_*` remains as the flush-time primitive used by the transport send system.

The pre-existing `direction_adds_senders_but_not_receivers` failure reproduces on unmodified main and is unrelated.