### PR TITLE
feat(messages): resolve entity mappings through replicon's shared map

### DIFF
--- a/crates/replication/replication/Cargo.toml
+++ b/crates/replication/replication/Cargo.toml
@@ -28,7 +28,9 @@ lightyear_utils.workspace = true
 lightyear_serde.workspace = true
 lightyear_core.workspace = true
 lightyear_connection.workspace = true
-lightyear_messages.workspace = true
+# `replicon` lets message (de)serialization read replicon's shared entity map
+# instead of a per-connection copy.
+lightyear_messages = { workspace = true, features = ["replicon"] }
 lightyear_transport.workspace = true
 lightyear_sync = { workspace = true, optional = true }
 

--- a/crates/replication/replication/src/client.rs
+++ b/crates/replication/replication/src/client.rs
@@ -5,10 +5,8 @@ use bevy_state::prelude::*;
 #[cfg(any(feature = "prediction", feature = "interpolation"))]
 use bevy_replicon::client::server_mutate_ticks::ServerMutateTicks;
 use bevy_replicon::prelude::*;
-use bevy_replicon::shared::server_entity_map::ServerEntityMap;
 use lightyear_connection::client::{Client, Connected};
 use lightyear_connection::host::HostClient;
-use lightyear_messages::MessageManager;
 use lightyear_transport::plugin::TransportSystems;
 use lightyear_transport::prelude::Transport;
 
@@ -30,7 +28,8 @@ use tracing::error;
 /// - `ClientState` transitions (Connected when client connects)
 /// - Receiving `ClientMessages` (replication data from server) via transport
 /// - Sending `ClientMessages` (acks) via transport
-/// - Syncing replicon's `ServerEntityMap` to lightyear's `MessageManager` entity mapper
+/// - Marking `Client` connections to resolve message entity mappings through
+///   replicon's `ServerEntityMap` (no per-connection copy is kept)
 pub struct RepliconClientPlugin;
 
 impl Plugin for RepliconClientPlugin {
@@ -60,13 +59,11 @@ impl Plugin for RepliconClientPlugin {
             send_client_packets.in_set(ClientSystems::SendPackets),
         );
 
-        // Entity map bridge: replicon's ServerEntityMap -> lightyear's MessageManager entity_mapper
-        app.add_systems(
-            PreUpdate,
-            sync_entity_map
-                .after(ClientSystems::Receive)
-                .after(ServerSystems::Receive),
-        );
+        // Entity map bridge: message (de)serialization on local `Client`
+        // connections reads replicon's `ServerEntityMap` directly, with the
+        // local `MessageManager` map as fallback. No per-connection copy is
+        // kept, and no marker is needed: the connection kind is read straight
+        // from the `Client` component.
 
         // bevy_replicon's reset only clears the entity map; lightyear must clean up the actual
         // entities when their receiver disconnects or is removed.
@@ -227,31 +224,4 @@ fn on_replication_disconnect(
         debug!("Despawning replicated entity {:?} on disconnect", entity);
         commands.entity(entity).try_despawn();
     }
-}
-
-/// Sync replicon's `ServerEntityMap` entries to lightyear's `MessageManager.entity_mapper`.
-///
-/// This bridges replicon's entity tracking with lightyear's messaging entity map.
-fn sync_entity_map(
-    entity_map: Res<ServerEntityMap>,
-    mut managers: Query<&mut MessageManager, With<Client>>,
-    mut synced_entities: Local<bevy_platform::collections::HashSet<Entity>>,
-) {
-    if !entity_map.is_changed() {
-        return;
-    }
-
-    for mut mm in managers.iter_mut() {
-        for (server_entity, client_entity) in entity_map.to_client().iter() {
-            mm.entity_mapper.insert(*server_entity, *client_entity);
-        }
-        for server_entity in synced_entities.iter() {
-            if !entity_map.to_client().contains_key(server_entity) {
-                mm.entity_mapper.remove_by_remote(*server_entity);
-            }
-        }
-    }
-
-    synced_entities.retain(|server_entity| entity_map.to_client().contains_key(server_entity));
-    synced_entities.extend(entity_map.to_client().keys().copied());
 }

--- a/crates/replication/replication/src/client.rs
+++ b/crates/replication/replication/src/client.rs
@@ -59,12 +59,6 @@ impl Plugin for RepliconClientPlugin {
             send_client_packets.in_set(ClientSystems::SendPackets),
         );
 
-        // Entity map bridge: message (de)serialization on local `Client`
-        // connections reads replicon's `ServerEntityMap` directly, with the
-        // local `MessageManager` map as fallback. No per-connection copy is
-        // kept, and no marker is needed: the connection kind is read straight
-        // from the `Client` component.
-
         // bevy_replicon's reset only clears the entity map; lightyear must clean up the actual
         // entities when their receiver disconnects or is removed.
         app.add_observer(on_replication_disconnect);

--- a/crates/tests/src/client_server/avian/compound_replication.rs
+++ b/crates/tests/src/client_server/avian/compound_replication.rs
@@ -5,6 +5,7 @@ use avian2d::collision::collider::EnlargedAabb;
 use avian2d::physics_transform::ApplyPosToTransform;
 use avian2d::prelude::*;
 use bevy::prelude::*;
+use bevy_replicon::shared::server_entity_map::ServerEntityMap;
 use core::time::Duration;
 use lightyear::avian2d::plugin::AvianReplicationMode;
 use lightyear::frame_interpolation::{FrameInterpolate, FrameInterpolationHistory};
@@ -13,7 +14,6 @@ use lightyear::prediction::diagnostics::PredictionMetrics;
 use lightyear::prediction::rollback::RollbackSystems;
 use lightyear::prelude::{ConfirmedHistory, Interpolated, Predicted};
 use lightyear_connection::network_target::NetworkTarget;
-use lightyear_messages::MessageManager;
 use lightyear_replication::prelude::*;
 use test_log::test;
 
@@ -113,12 +113,12 @@ fn touching_child_collider_survives_prediction_interpolation_and_correction() {
     let predicted_root = mapped_entity(&stepper, 0, root);
     let interpolated_root = mapped_entity(&stepper, 1, root);
     assert!(
-        stepper
-            .client(0)
-            .get::<MessageManager>()
-            .unwrap()
-            .entity_mapper
-            .get_local(child)
+        stepper.client_apps[0]
+            .world()
+            .resource::<ServerEntityMap>()
+            .to_client()
+            .get(&child)
+            .copied()
             .is_none(),
         "the deterministic child entity must not be replicated"
     );
@@ -362,9 +362,12 @@ fn every_client_predicts_both_compound_players_and_resolves_their_contact() {
         let left_child = local_compound_child(world, left_root);
         let right_child = local_compound_child(world, right_root);
 
-        let mapper = stepper.client(client_id).get::<MessageManager>().unwrap();
-        assert!(mapper.entity_mapper.get_local(left.1).is_none());
-        assert!(mapper.entity_mapper.get_local(right.1).is_none());
+        let mapper = stepper.client_apps[client_id]
+            .world()
+            .resource::<ServerEntityMap>()
+            .to_client();
+        assert!(mapper.get(&left.1).copied().is_none());
+        assert!(mapper.get(&right.1).copied().is_none());
 
         assert!(
             world.resource::<PlayerContactObserved>().0,
@@ -671,12 +674,12 @@ fn record_visual_correction(
 }
 
 fn mapped_entity(stepper: &ClientServerStepper, client_id: usize, server: Entity) -> Entity {
-    stepper
-        .client(client_id)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server)
+    stepper.client_apps[client_id]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server)
+        .copied()
         .unwrap()
 }
 
@@ -793,22 +796,30 @@ fn run_compound_hierarchy(mode: AvianReplicationMode) {
 
     stepper.frame_step_server_first(2);
 
-    let mapper = &stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper;
-    let client_root = mapper.get_local(root).expect("root was not replicated");
+    let mapper = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client();
+    let client_root = mapper.get(&root).copied().expect("root was not replicated");
     let client_direct = mapper
-        .get_local(direct)
+        .get(&direct)
+        .copied()
         .expect("direct child was not replicated");
-    let client_pivot = mapper.get_local(pivot).expect("pivot was not replicated");
+    let client_pivot = mapper
+        .get(&pivot)
+        .copied()
+        .expect("pivot was not replicated");
     let client_nested = mapper
-        .get_local(nested)
+        .get(&nested)
+        .copied()
         .expect("nested child was not replicated");
-    let client_sensor = mapper.get_local(sensor).expect("sensor was not replicated");
+    let client_sensor = mapper
+        .get(&sensor)
+        .copied()
+        .expect("sensor was not replicated");
     let client_child_body = mapper
-        .get_local(child_body)
+        .get(&child_body)
+        .copied()
         .expect("child rigid body was not replicated");
 
     // This test reconstructs local-only physics on the remote hierarchy. Insert

--- a/crates/tests/src/client_server/avian/position_replication.rs
+++ b/crates/tests/src/client_server/avian/position_replication.rs
@@ -4,9 +4,9 @@ use avian2d::math::Vector;
 use avian2d::prelude::*;
 use bevy::prelude::*;
 use bevy_replicon::prelude::Remote;
+use bevy_replicon::shared::server_entity_map::ServerEntityMap;
 use core::time::Duration;
 use lightyear_connection::network_target::NetworkTarget;
-use lightyear_messages::MessageManager;
 use lightyear_replication::prelude::*;
 use test_log::test;
 
@@ -91,19 +91,19 @@ fn test_replicate_position_child_rigidbody() {
         2.0
     );
 
-    let client_parent = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_parent)
+    let client_parent = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_parent)
+        .copied()
         .unwrap();
-    let client_child = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_child)
+    let client_child = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_child)
+        .copied()
         .unwrap();
     info!(?client_parent, ?client_child, "Received entities on client");
     assert_relative_eq!(
@@ -199,19 +199,19 @@ fn test_replicate_position_child_collider() {
     // Step enough for replication and hierarchy propagation.
     stepper.frame_step_server_first(2);
 
-    let client_parent = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_parent)
+    let client_parent = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_parent)
+        .copied()
         .unwrap();
-    let client_child = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_child)
+    let client_child = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_child)
+        .copied()
         .unwrap();
     info!(?client_parent, ?client_child, "Received entities on client");
     stepper

--- a/crates/tests/src/client_server/avian/transform_replication.rs
+++ b/crates/tests/src/client_server/avian/transform_replication.rs
@@ -3,11 +3,11 @@ use approx::assert_relative_eq;
 use avian2d::math::Vector;
 use avian2d::prelude::*;
 use bevy::prelude::*;
+use bevy_replicon::shared::server_entity_map::ServerEntityMap;
 use core::time::Duration;
 use lightyear::avian2d::plugin::AvianReplicationMode;
 use lightyear::frame_interpolation::FrameInterpolationHistory;
 use lightyear_connection::network_target::NetworkTarget;
-use lightyear_messages::MessageManager;
 use lightyear_replication::prelude::*;
 use test_log::test;
 
@@ -90,19 +90,19 @@ fn test_replicate_transform_rigid_body() {
         2.0
     );
 
-    let client_parent = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_parent)
+    let client_parent = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_parent)
+        .copied()
         .unwrap();
-    let client_child = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_child)
+    let client_child = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_child)
+        .copied()
         .unwrap();
     info!(?client_parent, ?client_child, "Received entities on client");
     assert_relative_eq!(
@@ -223,22 +223,22 @@ fn test_replicate_transform_child_collider() {
     );
 
     assert!(
-        stepper
-            .client(0)
-            .get::<MessageManager>()
-            .unwrap()
-            .entity_mapper
-            .get_local(server_parent)
+        stepper.client_apps[0]
+            .world()
+            .resource::<ServerEntityMap>()
+            .to_client()
+            .get(&server_parent)
+            .copied()
             .is_none(),
         "Render-only frames should not send a new replication checkpoint"
     );
     assert!(
-        stepper
-            .client(0)
-            .get::<MessageManager>()
-            .unwrap()
-            .entity_mapper
-            .get_local(server_child)
+        stepper.client_apps[0]
+            .world()
+            .resource::<ServerEntityMap>()
+            .to_client()
+            .get(&server_child)
+            .copied()
             .is_none(),
         "Render-only frames should not send a new replication checkpoint"
     );
@@ -298,19 +298,19 @@ fn test_replicate_transform_child_collider() {
         4.0
     );
 
-    let client_parent = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_parent)
+    let client_parent = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_parent)
+        .copied()
         .unwrap();
-    let client_child = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_child)
+    let client_child = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_child)
+        .copied()
         .unwrap();
     info!(?client_parent, ?client_child, "Received entities on client");
 

--- a/crates/tests/src/client_server/base.rs
+++ b/crates/tests/src/client_server/base.rs
@@ -150,6 +150,10 @@ fn test_sender_metadata() {
             .expect("client is not present in entity map"),
         client_of
     );
+    // NOTE: the (client_of -> client) connection pair lives only in the local
+    // `MessageManager` map (populated from `SenderMetadata`); replicon's map
+    // only tracks replicated entities, so this lookup intentionally does not
+    // go through `ServerEntityMap`.
     assert_eq!(
         stepper
             .client(0)

--- a/crates/tests/src/client_server/deterministic/input_only.rs
+++ b/crates/tests/src/client_server/deterministic/input_only.rs
@@ -25,10 +25,10 @@ use bevy::prelude::*;
 use bevy_enhanced_input::prelude::{
     Action, ActionMock, ActionOf, ActionValue, MockSpan, TriggerState,
 };
+use bevy_replicon::shared::server_entity_map::ServerEntityMap;
 use lightyear::prediction::rollback::DeterministicPredicted;
 use lightyear::prelude::*;
 use lightyear_deterministic_replication::prelude::CatchUpMode;
-use lightyear_messages::MessageManager;
 use lightyear_prediction::diagnostics::PredictionMetrics;
 use std::collections::HashMap;
 use test_log::test;
@@ -459,12 +459,12 @@ fn test_input_only_two_clients() {
             1 => server_player_b,
             _ => unreachable!(),
         };
-        let local_player = stepper
-            .client(client_id)
-            .get::<MessageManager>()
-            .unwrap()
-            .entity_mapper
-            .get_local(server_player)
+        let local_player = stepper.client_apps[client_id]
+            .world()
+            .resource::<ServerEntityMap>()
+            .to_client()
+            .get(&server_player)
+            .copied()
             .expect("client should have received its own player by now");
         configure_local_action_on_client(stepper.client_app(client_id), local_player);
     }
@@ -500,19 +500,19 @@ fn test_input_only_two_clients() {
     );
 
     for client_id in 0..2 {
-        let _c_a = stepper
-            .client(client_id)
-            .get::<MessageManager>()
-            .unwrap()
-            .entity_mapper
-            .get_local(server_player_a)
+        let _c_a = stepper.client_apps[client_id]
+            .world()
+            .resource::<ServerEntityMap>()
+            .to_client()
+            .get(&server_player_a)
+            .copied()
             .expect("client missing player A");
-        let _c_b = stepper
-            .client(client_id)
-            .get::<MessageManager>()
-            .unwrap()
-            .entity_mapper
-            .get_local(server_player_b)
+        let _c_b = stepper.client_apps[client_id]
+            .world()
+            .resource::<ServerEntityMap>()
+            .to_client()
+            .get(&server_player_b)
+            .copied()
             .expect("client missing player B");
         let client_tick = stepper
             .client_app(client_id)
@@ -601,12 +601,12 @@ fn test_input_only_islands_many_colliders_small_box() {
             1 => server_player_b,
             _ => unreachable!(),
         };
-        let local_player = stepper
-            .client(client_id)
-            .get::<MessageManager>()
-            .unwrap()
-            .entity_mapper
-            .get_local(server_player)
+        let local_player = stepper.client_apps[client_id]
+            .world()
+            .resource::<ServerEntityMap>()
+            .to_client()
+            .get(&server_player)
+            .copied()
             .expect("client should have received its own player by now");
         configure_local_action_on_client(stepper.client_app(client_id), local_player);
     }

--- a/crates/tests/src/client_server/deterministic/state_based_catchup.rs
+++ b/crates/tests/src/client_server/deterministic/state_based_catchup.rs
@@ -25,11 +25,11 @@ use bevy::prelude::*;
 use bevy_enhanced_input::prelude::{
     Action, ActionMock, ActionOf, ActionValue, MockSpan, TriggerState,
 };
+use bevy_replicon::shared::server_entity_map::ServerEntityMap;
 use lightyear::input::bei::input_message::ActionsSnapshot;
 use lightyear::prediction::rollback::{DeterministicPredicted, DisableRollback};
 use lightyear::prelude::*;
 use lightyear_deterministic_replication::prelude::CatchUpSnapshotReady;
-use lightyear_messages::MessageManager;
 use lightyear_prediction::rollback::CatchUpGated;
 use std::collections::HashMap;
 use test_log::test;
@@ -609,12 +609,12 @@ fn configure_local_action_after_mapping(
     server_player: Entity,
 ) {
     for _ in 0..120 {
-        if let Some(local_player) = stepper
-            .client(client_id)
-            .get::<MessageManager>()
-            .unwrap()
-            .entity_mapper
-            .get_local(server_player)
+        if let Some(local_player) = stepper.client_apps[client_id]
+            .world()
+            .resource::<ServerEntityMap>()
+            .to_client()
+            .get(&server_player)
+            .copied()
             && local_movement_action(&stepper.client_apps[client_id], local_player).is_some()
         {
             configure_local_action_on_client(stepper.client_app(client_id), local_player);
@@ -689,12 +689,12 @@ fn assert_clean_stepper_player_entities(stepper: &mut DetStepper, expected_peers
 fn assert_server_entity_unmapped(stepper: &mut DetStepper, server_entity: Entity) {
     for client_id in 0..stepper.client_apps.len() {
         assert!(
-            stepper
-                .client(client_id)
-                .get::<MessageManager>()
-                .unwrap()
-                .entity_mapper
-                .get_local(server_entity)
+            stepper.client_apps[client_id]
+                .world()
+                .resource::<ServerEntityMap>()
+                .to_client()
+                .get(&server_entity)
+                .copied()
                 .is_none(),
             "client {client_id} still maps disconnected server entity {server_entity:?}"
         );
@@ -729,12 +729,12 @@ fn assert_clean_stepper_ball_entities(stepper: &mut DetStepper) {
         let client_ball =
             assert_single_ball_entity(stepper.client_app(client_id).world_mut(), &label);
         assert_eq!(
-            stepper
-                .client(client_id)
-                .get::<MessageManager>()
-                .unwrap()
-                .entity_mapper
-                .get_local(server_ball),
+            stepper.client_apps[client_id]
+                .world()
+                .resource::<ServerEntityMap>()
+                .to_client()
+                .get(&server_ball)
+                .copied(),
             Some(client_ball),
             "client {client_id} should map the server ball entity {server_ball:?}"
         );
@@ -779,12 +779,12 @@ fn compare_players_to_server(
     for (server_player, peer) in server_players.iter().copied().zip(peers.iter().copied()) {
         let server_pos = fixed_position_at(stepper.server_app.world(), peer, compare_tick);
         for client_id in 0..stepper.client_apps.len() {
-            let _client_player = stepper
-                .client(client_id)
-                .get::<MessageManager>()
-                .unwrap()
-                .entity_mapper
-                .get_local(server_player)
+            let _client_player = stepper.client_apps[client_id]
+                .world()
+                .resource::<ServerEntityMap>()
+                .to_client()
+                .get(&server_player)
+                .copied()
                 .expect("client missing player entity");
             let client_pos =
                 fixed_position_at(stepper.client_app(client_id).world(), peer, compare_tick);
@@ -1305,12 +1305,12 @@ fn test_state_based_catchup_two_clients() {
             1 => server_player_b,
             _ => unreachable!(),
         };
-        let local_player = stepper
-            .client(client_id)
-            .get::<MessageManager>()
-            .unwrap()
-            .entity_mapper
-            .get_local(server_player)
+        let local_player = stepper.client_apps[client_id]
+            .world()
+            .resource::<ServerEntityMap>()
+            .to_client()
+            .get(&server_player)
+            .copied()
             .expect("client should have received its own player by now");
         configure_local_action_on_client(stepper.client_app(client_id), local_player);
     }
@@ -1349,19 +1349,19 @@ fn test_state_based_catchup_two_clients() {
 
     // Assert that each client's view of both players matches the server.
     for client_id in 0..2 {
-        let _client_player_a = stepper
-            .client(client_id)
-            .get::<MessageManager>()
-            .unwrap()
-            .entity_mapper
-            .get_local(server_player_a)
+        let _client_player_a = stepper.client_apps[client_id]
+            .world()
+            .resource::<ServerEntityMap>()
+            .to_client()
+            .get(&server_player_a)
+            .copied()
             .expect("client missing player A entity");
-        let _client_player_b = stepper
-            .client(client_id)
-            .get::<MessageManager>()
-            .unwrap()
-            .entity_mapper
-            .get_local(server_player_b)
+        let _client_player_b = stepper.client_apps[client_id]
+            .world()
+            .resource::<ServerEntityMap>()
+            .to_client()
+            .get(&server_player_b)
+            .copied()
             .expect("client missing player B entity");
 
         let client_tick = stepper

--- a/crates/tests/src/client_server/diff.rs
+++ b/crates/tests/src/client_server/diff.rs
@@ -7,13 +7,13 @@ use bevy_replicon::prelude::{EntityDiffExt, RepliconPlugins, RepliconTick, RuleF
 use bevy_replicon::shared::replication::diff::diff_index::DiffIndex;
 use bevy_replicon::shared::replication::registry::ReplicationRegistry;
 use bevy_replicon::shared::replication::registry::test_fns::TestFnsEntityExt;
+use bevy_replicon::shared::server_entity_map::ServerEntityMap;
 use lightyear::prelude::{
     InterpolationMarkerPlugin, InterpolationPlugin, InterpolationRegistrationExt,
     PredictionBuilderExt,
 };
 use lightyear_connection::network_target::NetworkTarget;
 use lightyear_core::prelude::{ConfirmedHistory, HistoryState, Interpolated};
-use lightyear_messages::MessageManager;
 use lightyear_prediction::Predicted;
 use lightyear_prediction::manager::PredictionManager;
 use lightyear_prediction::plugin::{PredictionMarkerPlugin, PredictionPlugin};
@@ -24,12 +24,12 @@ use lightyear_replication::prelude::{
 use serde::Serialize;
 
 fn client_entity(stepper: &ClientServerStepper, server_entity: Entity) -> Entity {
-    stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_entity)
+    stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_entity)
+        .copied()
         .unwrap()
 }
 

--- a/crates/tests/src/client_server/hierarchy.rs
+++ b/crates/tests/src/client_server/hierarchy.rs
@@ -2,9 +2,9 @@
 
 use crate::stepper::*;
 use bevy::prelude::*;
+use bevy_replicon::shared::server_entity_map::ServerEntityMap;
 use lightyear::prelude::*;
 use lightyear_core::prediction::Predicted;
-use lightyear_messages::MessageManager;
 use lightyear_replication::visibility::immediate::VisibilityExt;
 use test_log::test;
 
@@ -24,12 +24,12 @@ fn test_spawn_with_child() {
         .spawn((Replicate::to_clients(NetworkTarget::All),))
         .id();
     stepper.frame_step(2);
-    let client_entity = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_entity)
+    let client_entity = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_entity)
+        .copied()
         .expect("entity is not present in entity map");
 
     let server_child = stepper
@@ -38,12 +38,12 @@ fn test_spawn_with_child() {
         .spawn((ChildOf(server_entity),))
         .id();
     stepper.frame_step(2);
-    let client_child = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_child)
+    let client_child = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_child)
+        .copied()
         .expect("entity is not present in entity map");
     assert_eq!(
         stepper
@@ -91,19 +91,19 @@ fn test_hierarchy_replication() {
     stepper.frame_step(2);
 
     // check that the parent got replicated, along with the hierarchy information
-    let client_grandparent = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(grandparent)
+    let client_grandparent = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&grandparent)
+        .copied()
         .expect("entity is not present in entity map");
-    let client_parent = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(parent)
+    let client_parent = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&parent)
+        .copied()
         .expect("entity is not present in entity map");
 
     let (client_parent, client_parent_component) = stepper
@@ -181,12 +181,12 @@ fn test_child_overrides_prediction_target() {
         ))
         .id();
     stepper.frame_step_server_first(1);
-    let client_entity = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_entity)
+    let client_entity = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_entity)
+        .copied()
         .expect("entity is not present in entity map");
 
     let server_child = stepper
@@ -197,12 +197,12 @@ fn test_child_overrides_prediction_target() {
         .spawn((ChildOf(server_entity), InterpolationTarget::manual(vec![])))
         .id();
     stepper.frame_step_server_first(1);
-    let client_child = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_child)
+    let client_child = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_child)
+        .copied()
         .expect("entity is not present in entity map");
     assert_eq!(
         stepper
@@ -253,22 +253,22 @@ fn test_hierarchy_visibility_propagates_to_children() {
 
     // Both parent and child should be visible to both clients initially
     assert!(
-        stepper
-            .client(1)
-            .get::<MessageManager>()
-            .unwrap()
-            .entity_mapper
-            .get_local(server_parent)
+        stepper.client_apps[1]
+            .world()
+            .resource::<ServerEntityMap>()
+            .to_client()
+            .get(&server_parent)
+            .copied()
             .is_some(),
         "client 1 should see parent"
     );
     assert!(
-        stepper
-            .client(1)
-            .get::<MessageManager>()
-            .unwrap()
-            .entity_mapper
-            .get_local(server_child)
+        stepper.client_apps[1]
+            .world()
+            .resource::<ServerEntityMap>()
+            .to_client()
+            .get(&server_child)
+            .copied()
             .is_some(),
         "client 1 should see child"
     );
@@ -284,24 +284,24 @@ fn test_hierarchy_visibility_propagates_to_children() {
 
     // Parent should be hidden for client 1
     assert!(
-        stepper
-            .client(1)
-            .get::<MessageManager>()
-            .unwrap()
-            .entity_mapper
-            .get_local(server_parent)
+        stepper.client_apps[1]
+            .world()
+            .resource::<ServerEntityMap>()
+            .to_client()
+            .get(&server_parent)
+            .copied()
             .is_none(),
         "client 1 should not see parent after lose_visibility"
     );
 
     // Child should also be hidden — lose_visibility propagates through the ChildOf hierarchy
     assert!(
-        stepper
-            .client(1)
-            .get::<MessageManager>()
-            .unwrap()
-            .entity_mapper
-            .get_local(server_child)
+        stepper.client_apps[1]
+            .world()
+            .resource::<ServerEntityMap>()
+            .to_client()
+            .get(&server_child)
+            .copied()
             .is_none(),
         "child should not be visible after lose_visibility on parent"
     );
@@ -326,12 +326,12 @@ fn test_hierarchy_visibility_late_child_stays_hidden() {
 
     // Both clients see the parent initially
     assert!(
-        stepper
-            .client(1)
-            .get::<MessageManager>()
-            .unwrap()
-            .entity_mapper
-            .get_local(server_parent)
+        stepper.client_apps[1]
+            .world()
+            .resource::<ServerEntityMap>()
+            .to_client()
+            .get(&server_parent)
+            .copied()
             .is_some(),
         "client 1 should see parent"
     );
@@ -345,12 +345,12 @@ fn test_hierarchy_visibility_late_child_stays_hidden() {
         .lose_visibility(server_parent, sender_1);
     stepper.frame_step(2);
     assert!(
-        stepper
-            .client(1)
-            .get::<MessageManager>()
-            .unwrap()
-            .entity_mapper
-            .get_local(server_parent)
+        stepper.client_apps[1]
+            .world()
+            .resource::<ServerEntityMap>()
+            .to_client()
+            .get(&server_parent)
+            .copied()
             .is_none(),
         "client 1 should not see parent after lose_visibility"
     );
@@ -374,23 +374,23 @@ fn test_hierarchy_visibility_late_child_stays_hidden() {
     );
     // Client 0 (parent still visible) should see the late child
     assert!(
-        stepper
-            .client(0)
-            .get::<MessageManager>()
-            .unwrap()
-            .entity_mapper
-            .get_local(server_child)
+        stepper.client_apps[0]
+            .world()
+            .resource::<ServerEntityMap>()
+            .to_client()
+            .get(&server_child)
+            .copied()
             .is_some(),
         "client 0 should see late-spawned child"
     );
     // Client 1 (parent hidden) should NOT see the late child
     assert!(
-        stepper
-            .client(1)
-            .get::<MessageManager>()
-            .unwrap()
-            .entity_mapper
-            .get_local(server_child)
+        stepper.client_apps[1]
+            .world()
+            .resource::<ServerEntityMap>()
+            .to_client()
+            .get(&server_child)
+            .copied()
             .is_none(),
         "late-spawned child should inherit lose_visibility from parent"
     );
@@ -421,12 +421,12 @@ fn test_hierarchy_visibility_child_override() {
     stepper.frame_step(2);
 
     let is_visible = |stepper: &ClientServerStepper, entity: Entity| {
-        stepper
-            .client(1)
-            .get::<MessageManager>()
-            .unwrap()
-            .entity_mapper
-            .get_local(entity)
+        stepper.client_apps[1]
+            .world()
+            .resource::<ServerEntityMap>()
+            .to_client()
+            .get(&entity)
+            .copied()
             .is_some()
     };
     let is_marked = |stepper: &ClientServerStepper| {
@@ -584,12 +584,12 @@ fn test_hierarchy_replicate_child_overrides_target_inherits_rooms() {
     );
 
     let is_visible = |stepper: &ClientServerStepper, client: usize, entity: Entity| {
-        stepper
-            .client(client)
-            .get::<MessageManager>()
-            .unwrap()
-            .entity_mapper
-            .get_local(entity)
+        stepper.client_apps[client]
+            .world()
+            .resource::<ServerEntityMap>()
+            .to_client()
+            .get(&entity)
+            .copied()
             .is_some()
     };
     // client 0 sees both; client 1 sees neither: the child's own target
@@ -663,42 +663,42 @@ fn test_hierarchy_rooms_propagate_to_children() {
 
     // parent is in room A: only client 0 sees parent and child
     assert!(
-        stepper
-            .client(0)
-            .get::<MessageManager>()
-            .unwrap()
-            .entity_mapper
-            .get_local(server_parent)
+        stepper.client_apps[0]
+            .world()
+            .resource::<ServerEntityMap>()
+            .to_client()
+            .get(&server_parent)
+            .copied()
             .is_some(),
         "client 0 should see parent in room A"
     );
     assert!(
-        stepper
-            .client(0)
-            .get::<MessageManager>()
-            .unwrap()
-            .entity_mapper
-            .get_local(server_child)
+        stepper.client_apps[0]
+            .world()
+            .resource::<ServerEntityMap>()
+            .to_client()
+            .get(&server_child)
+            .copied()
             .is_some(),
         "client 0 should see child of parent in room A"
     );
     assert!(
-        stepper
-            .client(1)
-            .get::<MessageManager>()
-            .unwrap()
-            .entity_mapper
-            .get_local(server_parent)
+        stepper.client_apps[1]
+            .world()
+            .resource::<ServerEntityMap>()
+            .to_client()
+            .get(&server_parent)
+            .copied()
             .is_none(),
         "client 1 should not see parent in room A"
     );
     assert!(
-        stepper
-            .client(1)
-            .get::<MessageManager>()
-            .unwrap()
-            .entity_mapper
-            .get_local(server_child)
+        stepper.client_apps[1]
+            .world()
+            .resource::<ServerEntityMap>()
+            .to_client()
+            .get(&server_child)
+            .copied()
             .is_none(),
         "client 1 should not see child of parent in room A"
     );
@@ -712,42 +712,42 @@ fn test_hierarchy_rooms_propagate_to_children() {
     stepper.frame_step(2);
 
     assert!(
-        stepper
-            .client(0)
-            .get::<MessageManager>()
-            .unwrap()
-            .entity_mapper
-            .get_local(server_parent)
+        stepper.client_apps[0]
+            .world()
+            .resource::<ServerEntityMap>()
+            .to_client()
+            .get(&server_parent)
+            .copied()
             .is_none(),
         "client 0 should not see parent after it moved to room B"
     );
     assert!(
-        stepper
-            .client(0)
-            .get::<MessageManager>()
-            .unwrap()
-            .entity_mapper
-            .get_local(server_child)
+        stepper.client_apps[0]
+            .world()
+            .resource::<ServerEntityMap>()
+            .to_client()
+            .get(&server_child)
+            .copied()
             .is_none(),
         "client 0 should not see child after parent moved to room B"
     );
     assert!(
-        stepper
-            .client(1)
-            .get::<MessageManager>()
-            .unwrap()
-            .entity_mapper
-            .get_local(server_parent)
+        stepper.client_apps[1]
+            .world()
+            .resource::<ServerEntityMap>()
+            .to_client()
+            .get(&server_parent)
+            .copied()
             .is_some(),
         "client 1 should see parent after it moved to room B"
     );
     assert!(
-        stepper
-            .client(1)
-            .get::<MessageManager>()
-            .unwrap()
-            .entity_mapper
-            .get_local(server_child)
+        stepper.client_apps[1]
+            .world()
+            .resource::<ServerEntityMap>()
+            .to_client()
+            .get(&server_child)
+            .copied()
             .is_some(),
         "client 1 should see child after parent moved to room B"
     );
@@ -761,22 +761,22 @@ fn test_hierarchy_rooms_propagate_to_children() {
     stepper.frame_step(2);
 
     assert!(
-        stepper
-            .client(0)
-            .get::<MessageManager>()
-            .unwrap()
-            .entity_mapper
-            .get_local(server_parent)
+        stepper.client_apps[0]
+            .world()
+            .resource::<ServerEntityMap>()
+            .to_client()
+            .get(&server_parent)
+            .copied()
             .is_some(),
         "client 0 should see parent after joining room B"
     );
     assert!(
-        stepper
-            .client(0)
-            .get::<MessageManager>()
-            .unwrap()
-            .entity_mapper
-            .get_local(server_child)
+        stepper.client_apps[0]
+            .world()
+            .resource::<ServerEntityMap>()
+            .to_client()
+            .get(&server_child)
+            .copied()
             .is_some(),
         "client 0 should see child after joining room B"
     );
@@ -874,12 +874,12 @@ fn test_hierarchy_rooms_child_override() {
     );
 
     let is_visible = |stepper: &ClientServerStepper, client: usize, entity: Entity| {
-        stepper
-            .client(client)
-            .get::<MessageManager>()
-            .unwrap()
-            .entity_mapper
-            .get_local(entity)
+        stepper.client_apps[client]
+            .world()
+            .resource::<ServerEntityMap>()
+            .to_client()
+            .get(&entity)
+            .copied()
             .is_some()
     };
     // parent and plain child follow room A; the override follows room B
@@ -962,12 +962,12 @@ fn test_root_prediction_target_switch_propagates_to_child() {
         .spawn(ChildOf(server_root))
         .id();
     stepper.frame_step_server_first(4);
-    let client_child = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_child)
+    let client_child = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_child)
+        .copied()
         .expect("child should be replicated");
 
     // the child cloned the root's target and the client predicts it

--- a/crates/tests/src/client_server/input/bei.rs
+++ b/crates/tests/src/client_server/input/bei.rs
@@ -7,6 +7,7 @@ use bevy::ecs::relationship::Relationship;
 use bevy::prelude::*;
 use bevy_enhanced_input::action::TriggerState;
 use bevy_enhanced_input::prelude::*;
+use bevy_replicon::shared::server_entity_map::ServerEntityMap;
 use lightyear::input::bei;
 use lightyear::input::bei::input_message::{ActionData, ActionsSnapshot, BEIStateSequence};
 use lightyear::input::bei::prelude::BEIBuffer;
@@ -16,7 +17,6 @@ use lightyear_connection::network_target::NetworkTarget;
 use lightyear_core::prelude::*;
 use lightyear_link::Link;
 use lightyear_link::prelude::LinkConditionerConfig;
-use lightyear_messages::MessageManager;
 use lightyear_prediction::diagnostics::PredictionMetrics;
 use lightyear_replication::prelude::{ControlledBy, PreSpawned, PredictionTarget, Replicate};
 use lightyear_sync::prelude::client::{InputDelayConfig, InputTimelineConfig};
@@ -89,12 +89,12 @@ fn test_actions_on_replicated_context_entity() {
         .id();
     stepper.frame_step(3);
 
-    let client_entity = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_entity)
+    let client_entity = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_entity)
+        .copied()
         .expect("context entity should be replicated to client");
 
     let (client_action, server_action) =
@@ -182,12 +182,12 @@ fn test_action_spawned_from_received_context_maps_back_to_server_entity() {
     stepper.frame_step(3);
 
     // On the client, spawn the matching action entity when the context arrives
-    let client_entity = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_entity)
+    let client_entity = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_entity)
+        .copied()
         .expect("context entity should be replicated to client");
 
     let client_action = stepper
@@ -235,12 +235,12 @@ fn test_bound_action_spawned_from_received_context_sends_inputs_after_mapping() 
 
     stepper.frame_step(3);
 
-    let client_entity = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_entity)
+    let client_entity = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_entity)
+        .copied()
         .expect("context entity should be replicated to client");
 
     stepper.server_app.world_mut().spawn((
@@ -327,12 +327,12 @@ fn test_server_replicated_action_sends_inputs_after_client_adds_bindings() {
 
     stepper.frame_step(5);
 
-    let client_action = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_action)
+    let client_action = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_action)
+        .copied()
         .expect("action entity should be replicated to client");
 
     stepper
@@ -366,12 +366,12 @@ fn test_disabled_context_propagates_to_actions() {
         .id();
     stepper.frame_step(3);
 
-    let client_entity = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_entity)
+    let client_entity = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_entity)
+        .copied()
         .expect("entity is not present in entity map");
     let (client_action, server_action) =
         spawn_action_pair(&mut stepper, client_entity, server_entity, TEST_HASH + 1);
@@ -453,12 +453,12 @@ fn test_buffer_inputs_with_delay() {
         .id();
     stepper.frame_step(2);
 
-    let client_entity = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_entity)
+    let client_entity = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_entity)
+        .copied()
         .expect("entity is not present in entity map");
 
     let client_of_entity = stepper.client_of(0).id();
@@ -629,12 +629,12 @@ fn test_buffer_vec2_inputs_with_delay_preserves_buffered_action_value_dimension(
         .id();
     stepper.frame_step(2);
 
-    let client_entity = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_entity)
+    let client_entity = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_entity)
+        .copied()
         .expect("entity is not present in entity map");
 
     stepper.server_app.world_mut().spawn((
@@ -687,12 +687,12 @@ fn test_client_rollback() {
         .id();
     stepper.frame_step(2);
 
-    let client_entity = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_entity)
+    let client_entity = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_entity)
+        .copied()
         .expect("entity is not present in entity map");
 
     // Spawn action entities on both sides with PreSpawned
@@ -796,12 +796,12 @@ fn test_client_rollback_bei_events() {
         .id();
     stepper.frame_step(2);
 
-    let client_entity = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_entity)
+    let client_entity = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_entity)
+        .copied()
         .expect("entity is not present in entity map");
 
     // Spawn action entities on both sides with PreSpawned
@@ -920,12 +920,12 @@ fn test_input_broadcasting_prediction() {
     stepper.frame_step_server_first(1);
 
     // Get the predicted entities on both clients
-    let client0_predicted = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_entity)
+    let client0_predicted = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_entity)
+        .copied()
         .expect("entity not replicated to client 0");
 
     // Spawn matching action entity on client 0 with PreSpawned + input mock
@@ -953,12 +953,12 @@ fn test_input_broadcasting_prediction() {
         ))
         .id();
 
-    let client1_predicted = stepper
-        .client(1)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_entity)
+    let client1_predicted = stepper.client_apps[1]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_entity)
+        .copied()
         .expect("entity not replicated to client 1");
 
     stepper.frame_step(5);

--- a/crates/tests/src/client_server/input/leafwing.rs
+++ b/crates/tests/src/client_server/input/leafwing.rs
@@ -2,11 +2,11 @@ use crate::protocol::LeafwingInput1;
 use crate::stepper::*;
 use bevy::input::ButtonInput;
 use bevy::prelude::KeyCode;
+use bevy_replicon::shared::server_entity_map::ServerEntityMap;
 use leafwing_input_manager::action_state::ActionState;
 use leafwing_input_manager::prelude::InputMap;
 use lightyear::input::leafwing::prelude::LeafwingBuffer;
 use lightyear_connection::network_target::NetworkTarget;
-use lightyear_messages::MessageManager;
 use lightyear_replication::prelude::Replicate;
 use lightyear_sync::prelude::client::InputDelayConfig;
 use lightyear_sync::prelude::*;
@@ -31,12 +31,12 @@ fn test_buffer_inputs_with_delay() {
         ))
         .id();
     stepper.frame_step(2);
-    let client_entity = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_entity)
+    let client_entity = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_entity)
+        .copied()
         .expect("entity is not present in entity map");
     stepper
         .client_app()
@@ -244,12 +244,12 @@ fn test_server_just_pressed() {
         .id();
     stepper.frame_step(2);
 
-    let client_entity = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_entity)
+    let client_entity = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_entity)
+        .copied()
         .expect("entity not replicated to client");
 
     stepper
@@ -315,20 +315,20 @@ fn test_rebroadcast_initializes_action_state_from_buffer() {
         .id();
     stepper.frame_step_server_first(1);
 
-    let client0_entity = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_entity)
+    let client0_entity = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_entity)
+        .copied()
         .expect("entity not replicated to client 0");
 
-    let client1_entity = stepper
-        .client(1)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_entity)
+    let client1_entity = stepper.client_apps[1]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_entity)
+        .copied()
         .expect("entity not replicated to client 1");
 
     // Client 0 drives inputs
@@ -388,20 +388,20 @@ fn test_leafwing_input_rebroadcast() {
         .id();
     stepper.frame_step_server_first(1);
 
-    let client0_entity = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_entity)
+    let client0_entity = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_entity)
+        .copied()
         .expect("entity not replicated to client 0");
 
-    let client1_entity = stepper
-        .client(1)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_entity)
+    let client1_entity = stepper.client_apps[1]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_entity)
+        .copied()
         .expect("entity not replicated to client 1");
 
     // Client 0 has an InputMap so it can drive inputs
@@ -487,12 +487,12 @@ fn test_input_message_with_huge_end_tick_does_not_allocate_unbounded_buffer() {
     // `set_raw` — exercising the DoS path rather than being filtered first.
     stepper.frame_step(5);
 
-    let target_local = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(target_server_entity)
+    let target_local = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&target_server_entity)
+        .copied()
         .expect("target entity should be replicated to client 0");
 
     // Establish a baseline server-side InputBuffer at the current tick range.
@@ -617,12 +617,12 @@ fn test_input_validator_system_can_drop_messages() {
         .id();
     stepper.frame_step(2);
 
-    let local = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_entity)
+    let local = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_entity)
+        .copied()
         .expect("entity replicated to client 0");
     stepper.client_apps[0]
         .world_mut()
@@ -695,19 +695,19 @@ fn test_authorize_controlled_targets_helper() {
         .id();
     stepper.frame_step(10);
 
-    let local_a = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(entity_a)
+    let local_a = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&entity_a)
+        .copied()
         .expect("A replicated to client 0");
-    let local_b = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(entity_b)
+    let local_b = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&entity_b)
+        .copied()
         .expect("B replicated to client 0");
 
     // Client 0 puts an InputMap on BOTH its own entity and the victim's, so its
@@ -776,12 +776,12 @@ fn test_authorize_controlled_targets_keeps_emptied_message() {
         .id();
     stepper.frame_step(5);
 
-    let local = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(victim)
+    let local = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&victim)
+        .copied()
         .expect("victim replicated to client 0");
     stepper.client_apps[0]
         .world_mut()
@@ -855,12 +855,12 @@ fn test_validator_can_read_message_metadata() {
         .id();
     stepper.frame_step(2);
 
-    let local = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_entity)
+    let local = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_entity)
+        .copied()
         .expect("entity replicated to client 0");
     stepper.client_apps[0]
         .world_mut()
@@ -1055,19 +1055,19 @@ fn test_custom_validator_ordered_after_authorize() {
         .id();
     stepper.frame_step(10);
 
-    let local_a = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(entity_a)
+    let local_a = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&entity_a)
+        .copied()
         .expect("A replicated");
-    let local_b = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(entity_b)
+    let local_b = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&entity_b)
+        .copied()
         .expect("B replicated");
     for local in [local_a, local_b] {
         stepper.client_apps[0].world_mut().entity_mut(local).insert(

--- a/crates/tests/src/client_server/input/native.rs
+++ b/crates/tests/src/client_server/input/native.rs
@@ -1,6 +1,7 @@
 use crate::protocol::NativeInput as MyInput;
 use crate::stepper::*;
 use bevy::prelude::*;
+use bevy_replicon::shared::server_entity_map::ServerEntityMap;
 use lightyear::input::native::prelude::{InputMarker, NativeBuffer};
 use lightyear::input::server::InputRebroadcaster;
 use lightyear::prelude::input::native::ActionState;
@@ -8,7 +9,6 @@ use lightyear_connection::network_target::NetworkTarget;
 use lightyear_core::prelude::{LocalTimeline, Rollback};
 use lightyear_link::Link;
 use lightyear_link::prelude::LinkConditionerConfig;
-use lightyear_messages::MessageManager;
 use lightyear_prediction::prelude::PredictionManager;
 use lightyear_replication::prelude::{PredictionTarget, Replicate};
 use lightyear_replication::prelude::{RoomAllocator, Rooms};
@@ -32,12 +32,12 @@ fn test_remote_client_replicated_input() {
 
     stepper.frame_step(2);
 
-    let client_entity = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_entity)
+    let client_entity = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_entity)
+        .copied()
         .expect("entity was not replicated to client");
 
     // TEST
@@ -99,12 +99,12 @@ fn test_remote_client_predicted_input() {
 
     stepper.frame_step(2);
 
-    let client_predicted = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_entity)
+    let client_predicted = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_entity)
+        .copied()
         .expect("entity was not replicated to client");
 
     info!(?client_predicted, "client entities");
@@ -190,20 +190,20 @@ fn test_input_broadcasting_prediction() {
     stepper.frame_step_server_first(1);
 
     // Get the predicted entities on both clients
-    let client0_predicted = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_entity)
+    let client0_predicted = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_entity)
+        .copied()
         .expect("entity not replicated to client 0");
 
-    let client1_predicted = stepper
-        .client(1)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_entity)
+    let client1_predicted = stepper.client_apps[1]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_entity)
+        .copied()
         .expect("entity not replicated to client 1");
 
     // Add input markers to client 0, and make sure that it's replicated to client 1
@@ -373,28 +373,28 @@ fn test_input_custom_rebroadcast() {
         .insert(InputRebroadcaster::<MyInput>::Room(room));
 
     // Get the predicted entities on both clients
-    let client0_predicted = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_entity)
+    let client0_predicted = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_entity)
+        .copied()
         .expect("entity not replicated to client 0");
 
-    let client1_predicted = stepper
-        .client(1)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_entity)
+    let client1_predicted = stepper.client_apps[1]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_entity)
+        .copied()
         .expect("entity not replicated to client 1");
 
-    let client2_predicted = stepper
-        .client(2)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_entity)
+    let client2_predicted = stepper.client_apps[2]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_entity)
+        .copied()
         .expect("entity not replicated to client 2");
 
     // Add input markers to client 0, and make sure that it's replicated to client 1 but not to client 2

--- a/crates/tests/src/client_server/messages.rs
+++ b/crates/tests/src/client_server/messages.rs
@@ -2,6 +2,7 @@ use crate::protocol::*;
 use crate::stepper::*;
 use bevy::ecs::entity::UniqueEntityArray;
 use bevy::prelude::*;
+use bevy_replicon::shared::server_entity_map::ServerEntityMap;
 use core::fmt::Debug;
 use lightyear::prelude::Message;
 use lightyear::prelude::*;
@@ -163,12 +164,12 @@ fn test_send_triggers_map_entities() {
         .spawn(Replicate::to_clients(NetworkTarget::All))
         .id();
     stepper.frame_step(2);
-    let client_entity = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_entity)
+    let client_entity = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_entity)
+        .copied()
         .expect("entity is not present in entity map");
 
     stepper

--- a/crates/tests/src/client_server/prediction/despawn.rs
+++ b/crates/tests/src/client_server/prediction/despawn.rs
@@ -1,6 +1,7 @@
 use crate::protocol::{CompFull, CompSimple};
 use crate::stepper::*;
 use bevy::prelude::Component;
+use bevy_replicon::shared::server_entity_map::ServerEntityMap;
 use lightyear::prelude::*;
 
 #[derive(Component, Debug, PartialEq)]
@@ -23,12 +24,12 @@ fn test_despawned_predicted_rollback() {
         ))
         .id();
     stepper.frame_step(2);
-    let predicted_entity = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_entity)
+    let predicted_entity = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_entity)
+        .copied()
         .expect("entity is not present in entity map");
 
     // check that a rollback occurred to add the components on the predicted entity

--- a/crates/tests/src/client_server/prediction/history.rs
+++ b/crates/tests/src/client_server/prediction/history.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::protocol::{CompA, CompCorr, CompFull};
 use bevy::prelude::{Add, Commands, Component, Entity, On, Query, With};
+use bevy_replicon::shared::server_entity_map::ServerEntityMap;
 use lightyear::prelude::*;
 use lightyear_core::history_buffer::HistoryState;
 use lightyear_prediction::Predicted;
@@ -42,7 +43,6 @@ fn test_prediction_history_received_from_initial_marker() {
     use crate::stepper::*;
     use lightyear::prelude::ConfirmHistory;
     use lightyear_connection::network_target::NetworkTarget;
-    use lightyear_messages::MessageManager;
     use lightyear_replication::checkpoint::ReplicationCheckpointMap;
     use lightyear_replication::prelude::{PredictionTarget, Replicate};
 
@@ -89,12 +89,12 @@ fn test_prediction_history_received_from_initial_marker() {
     // Let the entity replicate to the client
     stepper.frame_step(2);
 
-    let predicted_entity = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_entity)
+    let predicted_entity = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_entity)
+        .copied()
         .expect("entity was not replicated to client");
 
     // The client entity should have Predicted after receiving PredictedSend.
@@ -185,7 +185,6 @@ fn test_prediction_history_received_from_initial_marker() {
 fn test_manual_predicted_marker_backfills_existing_replicated_component() {
     use lightyear::prelude::ConfirmHistory;
     use lightyear_connection::network_target::NetworkTarget;
-    use lightyear_messages::MessageManager;
     use lightyear_replication::checkpoint::ReplicationCheckpointMap;
     use lightyear_replication::prelude::Replicate;
 
@@ -197,12 +196,12 @@ fn test_manual_predicted_marker_backfills_existing_replicated_component() {
         .id();
     stepper.frame_step(2);
 
-    let client_entity = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_entity)
+    let client_entity = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_entity)
+        .copied()
         .expect("entity was not replicated to client");
     assert!(
         stepper
@@ -247,7 +246,6 @@ fn test_manual_predicted_marker_backfills_existing_replicated_component() {
 #[test]
 fn test_manual_predicted_and_component_does_not_seed_confirmed_history() {
     use lightyear_connection::network_target::NetworkTarget;
-    use lightyear_messages::MessageManager;
     use lightyear_replication::prelude::Replicate;
 
     let mut stepper = ClientServerStepper::from_config(StepperConfig::single());
@@ -258,12 +256,12 @@ fn test_manual_predicted_and_component_does_not_seed_confirmed_history() {
         .id();
     stepper.frame_step(2);
 
-    let client_entity = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_entity)
+    let client_entity = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_entity)
+        .copied()
         .expect("entity was not replicated to client");
     stepper
         .client_app()
@@ -284,7 +282,6 @@ fn test_manual_predicted_and_component_does_not_seed_confirmed_history() {
 #[test]
 fn test_server_insert_on_existing_predicted_entity_triggers_rollback() {
     use bevy::prelude::*;
-    use lightyear_messages::MessageManager;
     use lightyear_replication::prelude::{PredictionTarget, Replicate};
 
     #[derive(Resource, Default)]
@@ -312,12 +309,12 @@ fn test_server_insert_on_existing_predicted_entity_triggers_rollback() {
         .id();
 
     stepper.frame_step(2);
-    let predicted_entity = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_entity)
+    let predicted_entity = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_entity)
+        .copied()
         .expect("entity was not replicated to the client");
     assert!(
         stepper
@@ -367,7 +364,6 @@ fn test_server_insert_on_existing_predicted_entity_triggers_rollback() {
 #[test]
 fn test_two_server_inserts_are_both_applied_by_one_rollback() {
     use bevy::prelude::*;
-    use lightyear_messages::MessageManager;
     use lightyear_replication::prelude::{PredictionTarget, Replicate};
 
     #[derive(Resource, Default)]
@@ -395,12 +391,12 @@ fn test_two_server_inserts_are_both_applied_by_one_rollback() {
         .id();
 
     stepper.frame_step(2);
-    let predicted_entity = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_entity)
+    let predicted_entity = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_entity)
+        .copied()
         .expect("entity was not replicated to the client");
     let client_entity = stepper.client_app().world().entity(predicted_entity);
     assert!(!client_entity.contains::<CompFull>());

--- a/crates/tests/src/client_server/prediction/prespawn.rs
+++ b/crates/tests/src/client_server/prediction/prespawn.rs
@@ -7,6 +7,7 @@ use bevy::prelude::{
 };
 use bevy::utils::default;
 use bevy_replicon::prelude::Signature;
+use bevy_replicon::shared::server_entity_map::ServerEntityMap;
 use lightyear::prelude::LocalTimeline;
 use lightyear::prelude::{Link, LinkConditionerConfig, RecvLinkConditioner};
 use lightyear_connection::network_target::NetworkTarget;
@@ -14,7 +15,6 @@ use lightyear_core::history_buffer::HistoryState;
 use lightyear_core::prelude::ConfirmedHistory;
 use lightyear_core::prelude::Tick;
 use lightyear_core::timeline::is_in_rollback;
-use lightyear_messages::MessageManager;
 use lightyear_prediction::Predicted;
 use lightyear_prediction::despawn::{PredictionDespawnCommandsExt, PredictionDisable};
 use lightyear_prediction::diagnostics::PredictionMetrics;
@@ -124,12 +124,12 @@ fn test_duplicate_prespawn_hash_keeps_first_candidate() {
     stepper.frame_step(1);
     stepper.frame_step(1);
 
-    let matched = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_prespawn)
+    let matched = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_prespawn)
+        .copied()
         .expect("entity is not present in entity map");
 
     assert_eq!(matched, client_prespawn_a);
@@ -181,19 +181,19 @@ fn test_prespawn_signature_for_client() {
 
     stepper.frame_step(2);
 
-    let client_0_mapped = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_prespawn)
+    let client_0_mapped = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_prespawn)
+        .copied()
         .unwrap();
-    let client_1_mapped = stepper
-        .client(1)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_prespawn)
+    let client_1_mapped = stepper.client_apps[1]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_prespawn)
+        .copied()
         .unwrap();
 
     assert_eq!(client_0_mapped, client_0_prespawn);
@@ -258,12 +258,12 @@ fn test_prespawn_reuses_hash_after_unmatched_local_despawn() {
         "the first unmatched local prespawn should stay despawned"
     );
     assert_eq!(
-        stepper
-            .client(0)
-            .get::<MessageManager>()
-            .unwrap()
-            .entity_mapper
-            .get_local(server_prespawn)
+        stepper.client_apps[0]
+            .world()
+            .resource::<ServerEntityMap>()
+            .to_client()
+            .get(&server_prespawn)
+            .copied()
             .unwrap(),
         replacement_local
     );
@@ -309,12 +309,12 @@ fn test_prespawn_success() {
         .unwrap();
 
     assert_eq!(
-        stepper
-            .client(0)
-            .get::<MessageManager>()
-            .unwrap()
-            .entity_mapper
-            .get_local(server_prespawn)
+        stepper.client_apps[0]
+            .world()
+            .resource::<ServerEntityMap>()
+            .to_client()
+            .get(&server_prespawn)
+            .copied()
             .unwrap(),
         client_prespawn
     );
@@ -369,12 +369,12 @@ fn test_matched_prespawn_despawned_on_rollback_before_spawn_tick() {
     stepper.frame_step(2);
 
     assert_eq!(
-        stepper
-            .client(0)
-            .get::<MessageManager>()
-            .unwrap()
-            .entity_mapper
-            .get_local(server_prespawn)
+        stepper.client_apps[0]
+            .world()
+            .resource::<ServerEntityMap>()
+            .to_client()
+            .get(&server_prespawn)
+            .copied()
             .unwrap(),
         client_prespawn
     );
@@ -459,12 +459,12 @@ fn test_matched_prespawn_kept_on_rollback_at_or_after_spawn_tick() {
     stepper.frame_step(2);
 
     assert_eq!(
-        stepper
-            .client(0)
-            .get::<MessageManager>()
-            .unwrap()
-            .entity_mapper
-            .get_local(server_prespawn)
+        stepper.client_apps[0]
+            .world()
+            .resource::<ServerEntityMap>()
+            .to_client()
+            .get(&server_prespawn)
+            .copied()
             .unwrap(),
         client_prespawn
     );
@@ -545,12 +545,12 @@ fn test_prespawn_confirmed_init_goes_to_history_without_overwriting_live_value()
     stepper.frame_step(2);
 
     assert_eq!(
-        stepper
-            .client(0)
-            .get::<MessageManager>()
-            .unwrap()
-            .entity_mapper
-            .get_local(server_prespawn)
+        stepper.client_apps[0]
+            .world()
+            .resource::<ServerEntityMap>()
+            .to_client()
+            .get(&server_prespawn)
+            .copied()
             .unwrap(),
         client_prespawn
     );
@@ -620,12 +620,12 @@ fn test_prespawn_client_missing() {
 
     // We couldn't match the entity based on hash
     // So we should have just spawned a predicted entity
-    let client_entity_2 = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_entity_2)
+    let client_entity_2 = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_entity_2)
+        .copied()
         .expect("entity was not replicated to client");
 
     // the MapEntities component should have been mapped

--- a/crates/tests/src/client_server/prediction/rollback.rs
+++ b/crates/tests/src/client_server/prediction/rollback.rs
@@ -11,6 +11,7 @@ use bevy::prelude::*;
 use bevy_replicon::prelude::{ClientSystems, RepliconTick};
 use bevy_replicon::shared::replication::diff::diff_index::DiffIndex;
 use bevy_replicon::shared::replication::storage::ReplicationStorage;
+use bevy_replicon::shared::server_entity_map::ServerEntityMap;
 use core::time::Duration;
 use lightyear::input::native::prelude::InputMarker;
 use lightyear::prediction::Predicted;
@@ -19,7 +20,6 @@ use lightyear::prelude::input::native::ActionState;
 use lightyear_connection::prelude::NetworkTarget;
 use lightyear_core::id::PeerId;
 use lightyear_core::prelude::{ConfirmedHistory, HistoryState, LocalTimeline, Tick};
-use lightyear_messages::MessageManager;
 use lightyear_prediction::despawn::{PredictionDespawnCommandsExt, PredictionDisable};
 use lightyear_prediction::manager::{LastConfirmedInput, RollbackMode, StateRollbackMetadata};
 use lightyear_prediction::prelude::*;
@@ -1162,12 +1162,12 @@ fn test_current_tick_confirmation_triggers_rollback() {
     // Replicate the predicted entity and run real fixed ticks on the client so its history is
     // populated through the normal FixedPostUpdate system.
     stepper.frame_step(2);
-    let predicted_entity = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_entity)
+    let predicted_entity = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_entity)
+        .copied()
         .expect("entity was not replicated to the client");
     let current_tick = stepper.client_tick(0);
     assert!(
@@ -1264,12 +1264,12 @@ fn test_future_diff_insert_seeds_history_and_rolls_back_when_checkable() {
         .id();
 
     stepper.frame_step(2);
-    let predicted_entity = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_entity)
+    let predicted_entity = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_entity)
+        .copied()
         .expect("entity was not replicated to the client");
     let current_tick = stepper.client_tick(0);
     let future_tick = current_tick + 3;
@@ -1887,48 +1887,48 @@ fn setup_stepper_for_input_rollback(
     );
 
     // add input-markers on client 1/2 so that they can send remote input messages
-    let client_entity_1 = stepper
-        .client(1)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_entity_1)
+    let client_entity_1 = stepper.client_apps[1]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_entity_1)
+        .copied()
         .expect("entity was not replicated to client");
     stepper.client_apps[1]
         .world_mut()
         .entity_mut(client_entity_1)
         .insert((InputMarker::<NativeInput>::default(),));
 
-    let client_entity_2 = stepper
-        .client(2)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_entity_2)
+    let client_entity_2 = stepper.client_apps[2]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_entity_2)
+        .copied()
         .expect("entity was not replicated to client");
     stepper.client_apps[2]
         .world_mut()
         .entity_mut(client_entity_2)
         .insert((InputMarker::<NativeInput>::default(),));
 
-    let client_entity_a = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_entity_1)
+    let client_entity_a = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_entity_1)
+        .copied()
         .expect("entity was not replicated to client");
     // we want to predict this entity
     stepper.client_apps[0]
         .world_mut()
         .entity_mut(client_entity_a)
         .insert((CompNotNetworked(1.0), DeterministicPredicted::default()));
-    let client_entity_b = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_entity_2)
+    let client_entity_b = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_entity_2)
+        .copied()
         .expect("entity was not replicated to client");
 
     // build a steady state where we have already received an input

--- a/crates/tests/src/client_server/prediction/spawn.rs
+++ b/crates/tests/src/client_server/prediction/spawn.rs
@@ -1,8 +1,8 @@
 use crate::protocol::CompFull;
 use crate::stepper::*;
 use bevy::ecs::hierarchy::ChildOf;
+use bevy_replicon::shared::server_entity_map::ServerEntityMap;
 use lightyear_connection::network_target::NetworkTarget;
-use lightyear_messages::MessageManager;
 use lightyear_replication::prelude::{PredictionTarget, Replicate};
 use test_log::test;
 use tracing::info;
@@ -42,19 +42,19 @@ fn test_spawn_predicted_with_hierarchy() {
     stepper.frame_step(2);
 
     // check that the parent and child are spawned on the client
-    let predicted_child = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_child)
+    let predicted_child = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_child)
+        .copied()
         .expect("child entity was not replicated to client");
-    let predicted_parent = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_parent)
+    let predicted_parent = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_parent)
+        .copied()
         .expect("parent entity was not replicated to client");
     info!("parent: {predicted_parent:?}, child: {predicted_child:?}");
 
@@ -96,12 +96,12 @@ fn test_late_server_insert_of_unpredicted_component_reaches_predicted() {
         .id();
     stepper.frame_step(2);
 
-    let predicted = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_entity)
+    let predicted = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_entity)
+        .copied()
         .expect("entity was not replicated to client");
     assert!(
         stepper

--- a/crates/tests/src/client_server/replication.rs
+++ b/crates/tests/src/client_server/replication.rs
@@ -257,22 +257,22 @@ fn test_no_replication_without_replication_sender() {
     stepper.frame_step(2);
 
     assert!(
-        stepper
-            .client(0)
-            .get::<MessageManager>()
-            .unwrap()
-            .entity_mapper
-            .get_local(server_entity)
+        stepper.client_apps[0]
+            .world()
+            .resource::<ServerEntityMap>()
+            .to_client()
+            .get(&server_entity)
+            .copied()
             .is_some(),
         "entity is not present in sending client entity map"
     );
     assert!(
-        stepper
-            .client(1)
-            .get::<MessageManager>()
-            .unwrap()
-            .entity_mapper
-            .get_local(server_entity)
+        stepper.client_apps[1]
+            .world()
+            .resource::<ServerEntityMap>()
+            .to_client()
+            .get(&server_entity)
+            .copied()
             .is_none(),
         "entity is present in markerless client entity map"
     );
@@ -286,12 +286,12 @@ fn test_no_replication_without_replication_sender() {
     stepper.frame_step(2);
 
     assert!(
-        stepper
-            .client(1)
-            .get::<MessageManager>()
-            .unwrap()
-            .entity_mapper
-            .get_local(server_entity)
+        stepper.client_apps[1]
+            .world()
+            .resource::<ServerEntityMap>()
+            .to_client()
+            .get(&server_entity)
+            .copied()
             .is_some(),
         "entity is not present in re-admitted client entity map"
     );
@@ -316,22 +316,22 @@ fn test_target_mode_replicates_to_matching_links() {
     stepper.frame_step(2);
 
     assert!(
-        stepper
-            .client(0)
-            .get::<MessageManager>()
-            .unwrap()
-            .entity_mapper
-            .get_local(server_entity)
+        stepper.client_apps[0]
+            .world()
+            .resource::<ServerEntityMap>()
+            .to_client()
+            .get(&server_entity)
+            .copied()
             .is_some(),
         "entity is not present in target client entity map"
     );
     assert!(
-        stepper
-            .client(1)
-            .get::<MessageManager>()
-            .unwrap()
-            .entity_mapper
-            .get_local(server_entity)
+        stepper.client_apps[1]
+            .world()
+            .resource::<ServerEntityMap>()
+            .to_client()
+            .get(&server_entity)
+            .copied()
             .is_none(),
         "entity is present in non-target client entity map"
     );

--- a/crates/tests/src/client_server/replication.rs
+++ b/crates/tests/src/client_server/replication.rs
@@ -6,6 +6,7 @@ use crate::protocol::{
 use crate::stepper::*;
 use bevy::prelude::{Bundle, Entity, Name, With, World};
 use bevy_replicon::prelude::RepliconTick;
+use bevy_replicon::shared::server_entity_map::ServerEntityMap;
 use lightyear::prelude::{ConfirmedHistory, InterpolationTimeline};
 use lightyear_connection::client::{Disconnected, DisconnectedReason};
 use lightyear_connection::network_target::NetworkTarget;
@@ -78,12 +79,12 @@ fn target_entity(
     source_entity: Entity,
 ) -> Option<Entity> {
     match direction {
-        ReplicationDirection::ServerToClient => stepper
-            .client(0)
-            .get::<MessageManager>()
-            .unwrap()
-            .entity_mapper
-            .get_local(source_entity),
+        ReplicationDirection::ServerToClient => stepper.client_apps[0]
+            .world()
+            .resource::<ServerEntityMap>()
+            .to_client()
+            .get(&source_entity)
+            .copied(),
         ReplicationDirection::ClientToServer => stepper
             .client_of(0)
             .get::<MessageManager>()
@@ -172,12 +173,12 @@ fn test_spawn_new_connection() {
         .spawn((Replicate::to_clients(NetworkTarget::All),))
         .id();
     stepper.frame_step(2);
-    stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_entity)
+    stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_entity)
+        .copied()
         .unwrap();
 
     // second client connects
@@ -185,12 +186,12 @@ fn test_spawn_new_connection() {
     stepper.init();
 
     // make sure the entity is also replicated to the newly connected client
-    stepper
-        .client(1)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_entity)
+    stepper.client_apps[1]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_entity)
+        .copied()
         .expect("entity is not present in entity map");
 }
 
@@ -209,12 +210,12 @@ fn test_spawn_new_connection_respects_replication_target() {
         .spawn((Replicate::to_clients(NetworkTarget::Single(client_0_id)),))
         .id();
     stepper.frame_step(2);
-    stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_entity)
+    stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_entity)
+        .copied()
         .expect("entity is not present in target client entity map");
 
     // second client connects
@@ -223,12 +224,12 @@ fn test_spawn_new_connection_respects_replication_target() {
 
     // make sure the entity is not replicated to the newly connected client
     assert!(
-        stepper
-            .client(1)
-            .get::<MessageManager>()
-            .unwrap()
-            .entity_mapper
-            .get_local(server_entity)
+        stepper.client_apps[1]
+            .world()
+            .resource::<ServerEntityMap>()
+            .to_client()
+            .get(&server_entity)
+            .copied()
             .is_none(),
         "entity is present in non-target client entity map"
     );
@@ -493,12 +494,12 @@ fn test_client_owned_entity_rebroadcasts_updates_to_other_clients() {
 
     stepper.frame_step(2);
 
-    let client_1_entity = stepper
-        .client(1)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_entity)
+    let client_1_entity = stepper.client_apps[1]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_entity)
+        .copied()
         .expect("client 1 should receive the rebroadcast entity");
     assert_eq!(
         stepper.client_apps[1].world().get::<CompA>(client_1_entity),
@@ -545,12 +546,12 @@ fn test_custom_interpolation_component_gets_confirmed_history() {
     );
 
     stepper.frame_step(2);
-    let client_entity = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_entity)
+    let client_entity = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_entity)
+        .copied()
         .unwrap();
     {
         let client_entity_ref = stepper.client_apps[0].world().entity(client_entity);
@@ -604,12 +605,12 @@ fn test_manual_interpolated_marker_backfills_existing_replicated_component() {
         .id();
     stepper.frame_step(2);
 
-    let client_entity = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_entity)
+    let client_entity = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_entity)
+        .copied()
         .expect("entity was not replicated to client");
     assert!(
         stepper.client_apps[0]
@@ -655,12 +656,12 @@ fn test_interpolation_target_removal_removes_receiver_marker() {
         .id();
     stepper.frame_step(2);
 
-    let client_entity = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_entity)
+    let client_entity = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_entity)
+        .copied()
         .unwrap();
     assert!(
         stepper.client_apps[0]
@@ -749,12 +750,12 @@ fn test_late_join_client_gets_predicted_marker_for_prediction_target_all() {
 
     stepper.frame_step(3);
 
-    let client_0_entity = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_entity)
+    let client_0_entity = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_entity)
+        .copied()
         .unwrap();
     assert!(
         stepper.client_apps[0]
@@ -775,12 +776,12 @@ fn test_late_join_client_gets_predicted_marker_for_prediction_target_all() {
     stepper.init();
     stepper.frame_step(3);
 
-    let client_1_entity = stepper
-        .client(1)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_entity)
+    let client_1_entity = stepper.client_apps[1]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_entity)
+        .copied()
         .expect("late-joining client should receive the entity");
     assert!(
         stepper.client_apps[1]
@@ -805,12 +806,12 @@ fn test_prediction_target_removal_removes_receiver_marker() {
         .id();
     stepper.frame_step(2);
 
-    let client_entity = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_entity)
+    let client_entity = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_entity)
+        .copied()
         .unwrap();
     assert!(
         stepper.client_apps[0]
@@ -863,12 +864,12 @@ fn test_late_join_client_gets_latest_state_for_existing_predicted_entity() {
     stepper.init();
     stepper.frame_step(3);
 
-    let client_1_entity = stepper
-        .client(1)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_entity)
+    let client_1_entity = stepper.client_apps[1]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_entity)
+        .copied()
         .expect("late-joining client should receive the entity");
     assert!(
         stepper.client_apps[1]
@@ -1349,12 +1350,12 @@ fn test_controlled_entity_despawned_on_server_when_client_disconnects() {
 
     // the server entity is replicated to both clients
     stepper.frame_step(2);
-    stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_entity)
+    stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_entity)
+        .copied()
         .expect("entity is not present in entity map");
 
     // client 1 disconnects
@@ -1416,12 +1417,12 @@ fn test_replicated_entities_despawned_on_client_when_client_disconnects() {
     stepper.frame_step(2);
 
     // verify the entity exists on client 0
-    let client_entity = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_entity)
+    let client_entity = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_entity)
+        .copied()
         .expect("entity should be replicated to client 0");
     assert!(
         stepper.client_apps[0]
@@ -1463,12 +1464,12 @@ fn test_all_replicated_despawned_on_disconnecting_client() {
     stepper.frame_step(2);
 
     // verify the entity exists on client 1
-    let client_entity_on_1 = stepper
-        .client(1)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_entity)
+    let client_entity_on_1 = stepper.client_apps[1]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_entity)
+        .copied()
         .expect("entity should be replicated to client 1");
     assert!(
         stepper.client_apps[1]
@@ -1512,19 +1513,19 @@ fn test_persistent_replicated_entity_survives_client_disconnect() {
         .id();
     stepper.frame_step(2);
 
-    let persistent_client_entity = stepper
-        .client(1)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(persistent_server_entity)
+    let persistent_client_entity = stepper.client_apps[1]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&persistent_server_entity)
+        .copied()
         .expect("persistent entity should be replicated to client 1");
-    let session_client_entity = stepper
-        .client(1)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(session_server_entity)
+    let session_client_entity = stepper.client_apps[1]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&session_server_entity)
+        .copied()
         .expect("session entity should be replicated to client 1");
     stepper.client_apps[1]
         .world_mut()
@@ -1562,12 +1563,12 @@ fn test_persistent_replication_receiver_preserves_entities_on_disconnect() {
         .id();
     stepper.frame_step(2);
 
-    let client_entity = stepper
-        .client(1)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_entity)
+    let client_entity = stepper.client_apps[1]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_entity)
+        .copied()
         .expect("entity should be replicated to client 1");
     let receiver = stepper.client_entities[1];
     stepper.client_apps[1]
@@ -1604,19 +1605,19 @@ fn test_removing_replication_receiver_cleans_up_replication_state() {
         .id();
     stepper.frame_step(2);
 
-    let persistent_client_entity = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(persistent_server_entity)
+    let persistent_client_entity = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&persistent_server_entity)
+        .copied()
         .expect("persistent entity should be replicated to the client");
-    let session_client_entity = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(session_server_entity)
+    let session_client_entity = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&session_server_entity)
+        .copied()
         .expect("session entity should be replicated to the client");
     let checkpoint = RepliconTick::new(123);
     let receiver = stepper.client_entities[0];
@@ -1678,12 +1679,12 @@ fn test_despawning_persistent_replication_receiver_preserves_entities() {
         .id();
     stepper.frame_step(2);
 
-    let client_entity = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_entity)
+    let client_entity = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_entity)
+        .copied()
         .expect("entity should be replicated to the client");
     let checkpoint = RepliconTick::new(123);
     let receiver = stepper.client_entities[0];
@@ -1725,12 +1726,12 @@ fn test_persistent_replicated_entity_honors_remote_despawn() {
         .spawn((Replicate::to_clients(NetworkTarget::All),))
         .id();
     stepper.frame_step(2);
-    let client_entity = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_entity)
+    let client_entity = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_entity)
+        .copied()
         .expect("entity should be replicated to the client");
     stepper.client_apps[0]
         .world_mut()
@@ -1760,12 +1761,12 @@ fn test_sender_can_despawn_without_replicating_despawn() {
         .spawn((Replicate::to_clients(NetworkTarget::All),))
         .id();
     stepper.frame_step(2);
-    let client_entity = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_entity)
+    let client_entity = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_entity)
+        .copied()
         .expect("entity should be replicated to the client");
 
     stepper
@@ -1827,14 +1828,17 @@ fn test_prediction_target_visibility_with_two_clients() {
     stepper.frame_step(4);
 
     // On client 0:
-    let mm_0 = stepper.client(0).get::<MessageManager>().unwrap();
+    let mm_0 = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client();
     let e0_on_client_0 = mm_0
-        .entity_mapper
-        .get_local(entity_for_client_0)
+        .get(&entity_for_client_0)
+        .copied()
         .expect("entity_for_client_0 should be replicated to client 0");
     let e1_on_client_0 = mm_0
-        .entity_mapper
-        .get_local(entity_for_client_1)
+        .get(&entity_for_client_1)
+        .copied()
         .expect("entity_for_client_1 should be replicated to client 0");
 
     // entity_for_client_0 should have Predicted on client 0
@@ -1871,14 +1875,17 @@ fn test_prediction_target_visibility_with_two_clients() {
     );
 
     // On client 1:
-    let mm_1 = stepper.client(1).get::<MessageManager>().unwrap();
+    let mm_1 = stepper.client_apps[1]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client();
     let e0_on_client_1 = mm_1
-        .entity_mapper
-        .get_local(entity_for_client_0)
+        .get(&entity_for_client_0)
+        .copied()
         .expect("entity_for_client_0 should be replicated to client 1");
     let e1_on_client_1 = mm_1
-        .entity_mapper
-        .get_local(entity_for_client_1)
+        .get(&entity_for_client_1)
+        .copied()
         .expect("entity_for_client_1 should be replicated to client 1");
 
     // entity_for_client_1 should have Predicted on client 1
@@ -2004,9 +2011,12 @@ fn test_prediction_target_visibility_sequential_spawn() {
     );
 
     // Verify correct assignment
-    let mm_0 = stepper.client(0).get::<MessageManager>().unwrap();
-    let e0_on_client_0 = mm_0.entity_mapper.get_local(entity_for_client_0).unwrap();
-    let e1_on_client_0 = mm_0.entity_mapper.get_local(entity_for_client_1).unwrap();
+    let mm_0 = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client();
+    let e0_on_client_0 = mm_0.get(&entity_for_client_0).copied().unwrap();
+    let e1_on_client_0 = mm_0.get(&entity_for_client_1).copied().unwrap();
     assert!(
         stepper.client_apps[0]
             .world()
@@ -2026,9 +2036,12 @@ fn test_prediction_target_visibility_sequential_spawn() {
             .is_some()
     );
 
-    let mm_1 = stepper.client(1).get::<MessageManager>().unwrap();
-    let e0_on_client_1 = mm_1.entity_mapper.get_local(entity_for_client_0).unwrap();
-    let e1_on_client_1 = mm_1.entity_mapper.get_local(entity_for_client_1).unwrap();
+    let mm_1 = stepper.client_apps[1]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client();
+    let e0_on_client_1 = mm_1.get(&entity_for_client_0).copied().unwrap();
+    let e1_on_client_1 = mm_1.get(&entity_for_client_1).copied().unwrap();
     assert!(
         stepper.client_apps[1]
             .world()
@@ -2109,14 +2122,17 @@ fn test_simple_box_pattern_prediction_visibility() {
     stepper.frame_step(3);
 
     // Check client 0
-    let mm_0 = stepper.client(0).get::<MessageManager>().unwrap();
+    let mm_0 = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client();
     let e0_on_c0 = mm_0
-        .entity_mapper
-        .get_local(entity_for_0)
+        .get(&entity_for_0)
+        .copied()
         .expect("entity_for_0 not replicated to client 0");
     let e1_on_c0 = mm_0
-        .entity_mapper
-        .get_local(entity_for_1)
+        .get(&entity_for_1)
+        .copied()
         .expect("entity_for_1 not replicated to client 0");
 
     let e0_predicted = stepper.client_apps[0]
@@ -2168,14 +2184,17 @@ fn test_simple_box_pattern_prediction_visibility() {
     );
 
     // Check client 1
-    let mm_1 = stepper.client(1).get::<MessageManager>().unwrap();
+    let mm_1 = stepper.client_apps[1]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client();
     let e0_on_c1 = mm_1
-        .entity_mapper
-        .get_local(entity_for_0)
+        .get(&entity_for_0)
+        .copied()
         .expect("entity_for_0 not replicated to client 1");
     let e1_on_c1 = mm_1
-        .entity_mapper
-        .get_local(entity_for_1)
+        .get(&entity_for_1)
+        .copied()
         .expect("entity_for_1 not replicated to client 1");
 
     let e0_predicted_c1 = stepper.client_apps[1]
@@ -2270,12 +2289,12 @@ fn test_prediction_target_visibility_late_join() {
     stepper.frame_step(3);
 
     // Verify client 0 sees the entity as Predicted
-    let e0_on_c0 = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(entity_for_0)
+    let e0_on_c0 = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&entity_for_0)
+        .copied()
         .unwrap();
     assert!(
         stepper.client_apps[0]
@@ -2310,19 +2329,19 @@ fn test_prediction_target_visibility_late_join() {
     stepper.frame_step(3);
 
     // Check entity_for_0 on client 1 (late joiner)
-    let e0_on_c1 = stepper
-        .client(1)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(entity_for_0)
+    let e0_on_c1 = stepper.client_apps[1]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&entity_for_0)
+        .copied()
         .expect("entity_for_0 should be replicated to client 1");
-    let e1_on_c1 = stepper
-        .client(1)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(entity_for_1)
+    let e1_on_c1 = stepper.client_apps[1]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&entity_for_1)
+        .copied()
         .expect("entity_for_1 should be replicated to client 1");
 
     let e0_pred_c1 = stepper.client_apps[1]
@@ -2366,12 +2385,12 @@ fn test_prediction_target_visibility_late_join() {
     );
 
     // Also check entity_for_1 on client 0
-    let e1_on_c0 = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(entity_for_1)
+    let e1_on_c0 = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&entity_for_1)
+        .copied()
         .expect("entity_for_1 should be replicated to client 0");
 
     let e1_pred_c0 = stepper.client_apps[0]
@@ -2614,19 +2633,19 @@ fn test_server_side_visibility_bits() {
     stepper.frame_step(4);
 
     // Verify on client 0
-    let e0_on_c0 = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(entity_for_0)
+    let e0_on_c0 = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&entity_for_0)
+        .copied()
         .unwrap();
-    let e1_on_c0 = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(entity_for_1)
+    let e1_on_c0 = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&entity_for_1)
+        .copied()
         .unwrap();
 
     assert!(
@@ -2659,19 +2678,19 @@ fn test_server_side_visibility_bits() {
     );
 
     // Verify on client 1
-    let e0_on_c1 = stepper
-        .client(1)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(entity_for_0)
+    let e0_on_c1 = stepper.client_apps[1]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&entity_for_0)
+        .copied()
         .unwrap();
-    let e1_on_c1 = stepper
-        .client(1)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(entity_for_1)
+    let e1_on_c1 = stepper.client_apps[1]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&entity_for_1)
+        .copied()
         .unwrap();
 
     assert!(

--- a/crates/tests/src/client_server/visibility.rs
+++ b/crates/tests/src/client_server/visibility.rs
@@ -3,6 +3,7 @@
 use crate::protocol::*;
 use crate::stepper::*;
 use bevy::prelude::*;
+use bevy_replicon::shared::server_entity_map::ServerEntityMap;
 use lightyear_connection::network_target::NetworkTarget;
 use lightyear_messages::MessageManager;
 use lightyear_replication::prelude::*;
@@ -21,12 +22,12 @@ fn test_spawn_gain_visibility() {
         .spawn(Replicate::to_clients(NetworkTarget::All))
         .id();
     stepper.frame_step(2);
-    stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_entity)
+    stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_entity)
+        .copied()
         .expect("entity should be auto-visible after spawn");
 
     // lose visibility
@@ -37,12 +38,12 @@ fn test_spawn_gain_visibility() {
         .lose_visibility(server_entity, stepper.client_of_entities[0]);
     stepper.frame_step(2);
     assert!(
-        stepper
-            .client(0)
-            .get::<MessageManager>()
-            .unwrap()
-            .entity_mapper
-            .get_local(server_entity)
+        stepper.client_apps[0]
+            .world()
+            .resource::<ServerEntityMap>()
+            .to_client()
+            .get(&server_entity)
+            .copied()
             .is_none(),
         "entity should not be visible after lose_visibility"
     );
@@ -54,12 +55,12 @@ fn test_spawn_gain_visibility() {
         .commands()
         .gain_visibility(server_entity, stepper.client_of_entities[0]);
     stepper.frame_step(2);
-    stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_entity)
+    stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_entity)
+        .copied()
         .expect("entity should be visible again after gain_visibility");
 }
 
@@ -74,12 +75,12 @@ fn test_despawn_lose_visibility() {
         .id();
     let sender = stepper.client_of_entities[0];
     stepper.frame_step(2);
-    let client_entity = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_entity)
+    let client_entity = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_entity)
+        .copied()
         .unwrap();
 
     // lose visibility: a Despawn message should be sent
@@ -89,12 +90,12 @@ fn test_despawn_lose_visibility() {
         .lose_visibility(server_entity, sender);
     stepper.frame_step(2);
     assert!(
-        stepper
-            .client(0)
-            .get::<MessageManager>()
-            .unwrap()
-            .entity_mapper
-            .get_local(server_entity)
+        stepper.client_apps[0]
+            .world()
+            .resource::<ServerEntityMap>()
+            .to_client()
+            .get(&server_entity)
+            .copied()
             .is_none()
     );
     assert!(
@@ -112,12 +113,12 @@ fn test_despawn_lose_visibility() {
         .gain_visibility(server_entity, sender);
     stepper.frame_step(2);
     assert!(
-        stepper
-            .client(0)
-            .get::<MessageManager>()
-            .unwrap()
-            .entity_mapper
-            .get_local(server_entity)
+        stepper.client_apps[0]
+            .world()
+            .resource::<ServerEntityMap>()
+            .to_client()
+            .get(&server_entity)
+            .copied()
             .is_some()
     );
 }
@@ -134,12 +135,12 @@ fn test_retain_entity_on_lose_visibility() {
     let sender = stepper.client_of_entities[0];
     stepper.frame_step(2);
 
-    let client_entity = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_entity)
+    let client_entity = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_entity)
+        .copied()
         .unwrap();
     assert_eq!(
         stepper.client_apps[0]
@@ -157,12 +158,12 @@ fn test_retain_entity_on_lose_visibility() {
     stepper.frame_step(2);
 
     assert_eq!(
-        stepper
-            .client(0)
-            .get::<MessageManager>()
-            .unwrap()
-            .entity_mapper
-            .get_local(server_entity),
+        stepper.client_apps[0]
+            .world()
+            .resource::<ServerEntityMap>()
+            .to_client()
+            .get(&server_entity)
+            .copied(),
         Some(client_entity),
         "retained visibility should preserve the remote entity mapping"
     );
@@ -187,12 +188,12 @@ fn test_retain_entity_on_lose_visibility() {
         .gain_visibility(server_entity, sender);
     stepper.frame_step(2);
     assert_eq!(
-        stepper
-            .client(0)
-            .get::<MessageManager>()
-            .unwrap()
-            .entity_mapper
-            .get_local(server_entity),
+        stepper.client_apps[0]
+            .world()
+            .resource::<ServerEntityMap>()
+            .to_client()
+            .get(&server_entity)
+            .copied(),
         Some(client_entity),
         "gaining visibility should reuse the retained remote entity"
     );
@@ -222,12 +223,12 @@ fn test_retain_visibility_before_first_replication() {
     stepper.frame_step(2);
 
     assert!(
-        stepper
-            .client(0)
-            .get::<MessageManager>()
-            .unwrap()
-            .entity_mapper
-            .get_local(server_entity)
+        stepper.client_apps[0]
+            .world()
+            .resource::<ServerEntityMap>()
+            .to_client()
+            .get(&server_entity)
+            .copied()
             .is_none(),
         "AfterFirstVisibility should not spawn an entity that was never visible"
     );
@@ -238,12 +239,12 @@ fn test_retain_visibility_before_first_replication() {
         .gain_visibility(server_entity, sender);
     stepper.frame_step(2);
     assert!(
-        stepper
-            .client(0)
-            .get::<MessageManager>()
-            .unwrap()
-            .entity_mapper
-            .get_local(server_entity)
+        stepper.client_apps[0]
+            .world()
+            .resource::<ServerEntityMap>()
+            .to_client()
+            .get(&server_entity)
+            .copied()
             .is_some(),
         "the entity should spawn when it becomes visible for the first time"
     );
@@ -268,12 +269,12 @@ fn test_always_present_visibility_before_first_replication() {
         .lose_visibility_always_present(server_entity, sender);
     stepper.frame_step(2);
 
-    let client_entity = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_entity)
+    let client_entity = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_entity)
+        .copied()
         .expect("AlwaysPresent should spawn an entity that starts hidden");
     assert_eq!(
         stepper.client_apps[0]
@@ -302,12 +303,12 @@ fn test_always_present_visibility_before_first_replication() {
         .gain_visibility(server_entity, sender);
     stepper.frame_step(2);
     assert_eq!(
-        stepper
-            .client(0)
-            .get::<MessageManager>()
-            .unwrap()
-            .entity_mapper
-            .get_local(server_entity),
+        stepper.client_apps[0]
+            .world()
+            .resource::<ServerEntityMap>()
+            .to_client()
+            .get(&server_entity)
+            .copied(),
         Some(client_entity),
         "gaining visibility should reuse the always-present remote entity"
     );
@@ -348,12 +349,12 @@ fn test_true_despawn_reaches_retained_entity() {
         .id();
     let sender = stepper.client_of_entities[0];
     stepper.frame_step(2);
-    let client_entity = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_entity)
+    let client_entity = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_entity)
+        .copied()
         .unwrap();
 
     stepper
@@ -379,12 +380,12 @@ fn test_true_despawn_reaches_retained_entity() {
         "an authoritative despawn should override retained visibility"
     );
     assert!(
-        stepper
-            .client(0)
-            .get::<MessageManager>()
-            .unwrap()
-            .entity_mapper
-            .get_local(server_entity)
+        stepper.client_apps[0]
+            .world()
+            .resource::<ServerEntityMap>()
+            .to_client()
+            .get(&server_entity)
+            .copied()
             .is_none()
     );
 }
@@ -400,12 +401,12 @@ fn test_remove_replicate_suppresses_despawn_of_retained_entity() {
         .id();
     let sender = stepper.client_of_entities[0];
     stepper.frame_step(2);
-    let client_entity = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_entity)
+    let client_entity = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_entity)
+        .copied()
         .unwrap();
 
     stepper
@@ -461,19 +462,19 @@ fn test_despawn_with_visibility() {
         .gain_visibility(server_entity_1, stepper.client_of_entities[1]);
 
     stepper.frame_step(2);
-    let client_entity_0 = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_entity_0)
+    let client_entity_0 = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_entity_0)
+        .copied()
         .unwrap();
-    let client_entity_1 = stepper
-        .client(1)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_entity_1)
+    let client_entity_1 = stepper.client_apps[1]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_entity_1)
+        .copied()
         .unwrap();
 
     // update the entity_map on the second connection to re-use the same entity
@@ -552,12 +553,12 @@ fn test_spawn_multiple_lose_visibility() {
         .spawn(Replicate::to_clients(NetworkTarget::All))
         .id();
     stepper.frame_step(2);
-    stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_entity)
+    stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_entity)
+        .copied()
         .expect("entity should be auto-visible after spawn");
 
     // lose visibility
@@ -568,12 +569,12 @@ fn test_spawn_multiple_lose_visibility() {
         .lose_visibility(server_entity, stepper.client_of_entities[0]);
     stepper.frame_step(2);
     assert!(
-        stepper
-            .client(0)
-            .get::<MessageManager>()
-            .unwrap()
-            .entity_mapper
-            .get_local(server_entity)
+        stepper.client_apps[0]
+            .world()
+            .resource::<ServerEntityMap>()
+            .to_client()
+            .get(&server_entity)
+            .copied()
             .is_none(),
         "entity should not be visible after lose_visibility"
     );
@@ -594,12 +595,12 @@ fn test_spawn_multiple_lose_visibility() {
         .gain_visibility(server_entity, stepper.client_of_entities[0]);
     stepper.frame_step(2);
     assert!(
-        stepper
-            .client(0)
-            .get::<MessageManager>()
-            .unwrap()
-            .entity_mapper
-            .get_local(server_entity)
+        stepper.client_apps[0]
+            .world()
+            .resource::<ServerEntityMap>()
+            .to_client()
+            .get(&server_entity)
+            .copied()
             .is_some(),
         "entity should be visible again after gain_visibility"
     );
@@ -623,22 +624,22 @@ fn test_visibility_persists_on_replication_target_change() {
 
     // both clients should see the entity
     assert!(
-        stepper
-            .client(0)
-            .get::<MessageManager>()
-            .unwrap()
-            .entity_mapper
-            .get_local(server_entity)
+        stepper.client_apps[0]
+            .world()
+            .resource::<ServerEntityMap>()
+            .to_client()
+            .get(&server_entity)
+            .copied()
             .is_some(),
         "client 0 should see the entity"
     );
     assert!(
-        stepper
-            .client(1)
-            .get::<MessageManager>()
-            .unwrap()
-            .entity_mapper
-            .get_local(server_entity)
+        stepper.client_apps[1]
+            .world()
+            .resource::<ServerEntityMap>()
+            .to_client()
+            .get(&server_entity)
+            .copied()
             .is_some(),
         "client 1 should see the entity"
     );
@@ -653,12 +654,12 @@ fn test_visibility_persists_on_replication_target_change() {
 
     // client 1 should no longer see the entity
     assert!(
-        stepper
-            .client(1)
-            .get::<MessageManager>()
-            .unwrap()
-            .entity_mapper
-            .get_local(server_entity)
+        stepper.client_apps[1]
+            .world()
+            .resource::<ServerEntityMap>()
+            .to_client()
+            .get(&server_entity)
+            .copied()
             .is_none(),
         "client 1 should not see the entity after lose_visibility"
     );
@@ -673,23 +674,23 @@ fn test_visibility_persists_on_replication_target_change() {
 
     // client 0 should still see the entity
     assert!(
-        stepper
-            .client(0)
-            .get::<MessageManager>()
-            .unwrap()
-            .entity_mapper
-            .get_local(server_entity)
+        stepper.client_apps[0]
+            .world()
+            .resource::<ServerEntityMap>()
+            .to_client()
+            .get(&server_entity)
+            .copied()
             .is_some(),
         "client 0 should still see the entity after ReplicationTarget change"
     );
     // client 1 should still NOT see the entity (visibility override persists)
     assert!(
-        stepper
-            .client(1)
-            .get::<MessageManager>()
-            .unwrap()
-            .entity_mapper
-            .get_local(server_entity)
+        stepper.client_apps[1]
+            .world()
+            .resource::<ServerEntityMap>()
+            .to_client()
+            .get(&server_entity)
+            .copied()
             .is_none(),
         "client 1 should still not see the entity after ReplicationTarget change"
     );

--- a/crates/tests/src/host_server/input/bei.rs
+++ b/crates/tests/src/host_server/input/bei.rs
@@ -4,11 +4,11 @@ use bevy::prelude::*;
 use bevy_enhanced_input::action::mock::{ActionMock, MockSpan};
 use bevy_enhanced_input::action::{Action, TriggerState};
 use bevy_enhanced_input::prelude::{ActionOf, ActionValue, Actions, Fire};
+use bevy_replicon::shared::server_entity_map::ServerEntityMap;
 use lightyear::input::bei::input_message::BEIBuffer;
 use lightyear::input::bei::prelude::InputMarker;
 use lightyear::input::input_buffer::Compressed;
 use lightyear_connection::network_target::NetworkTarget;
-use lightyear_messages::MessageManager;
 use lightyear_replication::prelude::{ControlledBy, PreSpawned, PredictionTarget, Replicate};
 
 const TEST_HASH: u64 = 42;
@@ -48,19 +48,19 @@ fn test_rebroadcast() {
     stepper.frame_step_server_first(1);
 
     // Get the predicted entities on both clients
-    let client0_entity = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_entity)
+    let client0_entity = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_entity)
+        .copied()
         .expect("entity not replicated to client 1");
-    let client1_entity = stepper
-        .client(1)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_entity)
+    let client1_entity = stepper.client_apps[1]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_entity)
+        .copied()
         .expect("entity not replicated to client 2");
 
     // Spawn matching action entity on client 0 with PreSpawned, then let the
@@ -147,12 +147,12 @@ fn test_host_client_action_rebroadcasts_to_remote_client() {
 
     stepper.frame_step_server_first(1);
 
-    let remote_entity = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_entity)
+    let remote_entity = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_entity)
+        .copied()
         .expect("entity not replicated to remote client");
 
     // The host client lives in the server app, so driving the server-side action entity
@@ -257,12 +257,12 @@ fn test_remote_client_action_updates_server_action_state_in_host_server() {
 
     stepper.frame_step_server_first(1);
 
-    let remote_entity = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_entity)
+    let remote_entity = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_entity)
+        .copied()
         .expect("entity not replicated to remote client");
     let remote_action = stepper.client_apps[0]
         .world()

--- a/crates/tests/src/host_server/input/leafwing.rs
+++ b/crates/tests/src/host_server/input/leafwing.rs
@@ -2,11 +2,11 @@ use crate::protocol::LeafwingInput1;
 use crate::stepper::*;
 use bevy::input::ButtonInput;
 use bevy::prelude::KeyCode;
+use bevy_replicon::shared::server_entity_map::ServerEntityMap;
 use leafwing_input_manager::action_state::ActionState;
 use leafwing_input_manager::prelude::InputMap;
 use lightyear::input::leafwing::prelude::LeafwingBuffer;
 use lightyear_connection::network_target::NetworkTarget;
-use lightyear_messages::MessageManager;
 use lightyear_replication::prelude::Replicate;
 use lightyear_sync::prelude::InputTimelineConfig;
 use lightyear_sync::prelude::client::InputDelayConfig;
@@ -32,12 +32,12 @@ fn test_buffer_inputs_with_delay() {
         ))
         .id();
     stepper.frame_step(2);
-    let client_entity = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_entity)
+    let client_entity = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_entity)
+        .copied()
         .expect("entity is not present in entity map");
     stepper
         .server_app

--- a/crates/tests/src/host_server/input/native.rs
+++ b/crates/tests/src/host_server/input/native.rs
@@ -1,9 +1,9 @@
 use crate::protocol::NativeInput as MyInput;
 use crate::stepper::*;
+use bevy_replicon::shared::server_entity_map::ServerEntityMap;
 use lightyear::input::native::prelude::{InputMarker, NativeBuffer};
 use lightyear::prelude::input::native::ActionState;
 use lightyear_connection::network_target::NetworkTarget;
-use lightyear_messages::MessageManager;
 use lightyear_replication::prelude::{PredictionTarget, Replicate};
 use test_log::test;
 use tracing::info;
@@ -27,12 +27,12 @@ fn test_remote_client_replicated_input() {
 
     stepper.frame_step(2);
 
-    let client_entity = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_entity)
+    let client_entity = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_entity)
+        .copied()
         .expect("entity was not replicated to client");
 
     // TEST
@@ -96,12 +96,12 @@ fn test_remote_client_predicted_input() {
 
     stepper.frame_step(2);
 
-    let client_entity = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_entity)
+    let client_entity = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_entity)
+        .copied()
         .expect("entity was not replicated to client");
     info!(?client_entity, "client entities");
 
@@ -169,12 +169,12 @@ fn test_host_client_inputers_replicated_to_remote_client() {
 
     stepper.frame_step(2);
 
-    let client_entity = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_entity)
+    let client_entity = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_entity)
+        .copied()
         .expect("entity was not replicated to client");
 
     // TEST

--- a/crates/tests/src/host_server/replication.rs
+++ b/crates/tests/src/host_server/replication.rs
@@ -2,12 +2,12 @@ use crate::protocol::CompA;
 use crate::stepper::*;
 use bevy::prelude::{Entity, With};
 use bevy_replicon::prelude::Remote;
+use bevy_replicon::shared::server_entity_map::ServerEntityMap;
 use lightyear::prelude::{client::Connect, server::Start};
 use lightyear_connection::network_target::NetworkTarget;
 use lightyear_core::id::RemoteId;
 use lightyear_core::interpolation::Interpolated;
 use lightyear_core::prediction::Predicted;
-use lightyear_messages::MessageManager;
 use lightyear_replication::control::{Controlled, ControlledBy, ControlledSend};
 use lightyear_replication::prelude::*;
 use lightyear_replication::send::ReplicatedFrom;
@@ -367,12 +367,12 @@ fn test_host_owned_entity_does_not_loop_back_and_can_rebroadcast() {
 
     stepper.frame_step(2);
 
-    let remote_client_entity = stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(host_entity)
+    let remote_client_entity = stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&host_entity)
+        .copied()
         .expect("remote client should receive the rebroadcast entity");
 
     assert_eq!(

--- a/crates/tests/src/multi_server/steam.rs
+++ b/crates/tests/src/multi_server/steam.rs
@@ -2,6 +2,7 @@
 #![allow(unused_imports)]
 
 use crate::stepper::*;
+use bevy_replicon::shared::server_entity_map::ServerEntityMap;
 use core::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
 use lightyear::prelude::client::*;
 use lightyear::prelude::server::{ListenTarget, SteamServerIo};
@@ -10,7 +11,6 @@ use lightyear::prelude::{SessionConfig, SteamAppExt};
 use lightyear_connection::client_of::SkipNetcode;
 use lightyear_connection::network_target::NetworkTarget;
 use lightyear_crossbeam::CrossbeamIo;
-use lightyear_messages::MessageManager;
 use lightyear_replication::prelude::Replicate;
 use tracing::info;
 
@@ -59,19 +59,19 @@ fn test_steam_server_with_netcode_server() {
         .spawn(Replicate::to_clients(NetworkTarget::All))
         .id();
     stepper.frame_step_server_first(1);
-    stepper
-        .client(0)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_entity)
+    stepper.client_apps[0]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_entity)
+        .copied()
         .unwrap();
-    stepper
-        .client(1)
-        .get::<MessageManager>()
-        .unwrap()
-        .entity_mapper
-        .get_local(server_entity)
+    stepper.client_apps[1]
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_entity)
+        .copied()
         .unwrap();
     info!("Received entities");
 }

--- a/crates/transport/messages/Cargo.toml
+++ b/crates/transport/messages/Cargo.toml
@@ -15,6 +15,7 @@ client = ["lightyear_connection/client"]
 server = ["lightyear_link", "lightyear_connection/server"]
 test_utils = []
 metrics = ["dep:metrics"]
+replicon = ["dep:bevy_replicon"]
 
 [dependencies]
 lightyear_link = { workspace = true, optional = true }
@@ -38,6 +39,9 @@ bevy_app.workspace = true
 bevy_ecs = { workspace = true, features = ["serialize"] }
 bevy_reflect.workspace = true
 bevy_utils.workspace = true
+
+# optional integration with replicon's shared entity map (no_std compatible)
+bevy_replicon = { workspace = true, optional = true }
 
 [dev-dependencies]
 lightyear_link.workspace = true

--- a/crates/transport/messages/src/lib.rs
+++ b/crates/transport/messages/src/lib.rs
@@ -89,7 +89,17 @@ pub type MessageNetId = NetId;
 /// This component is added to entities that need to send or receive messages.
 /// It keeps track of the [`MessageSender<M>`](send::MessageSender) and [`MessageReceiver<M>`](receive::MessageReceiver) components
 /// attached to the entity, allowing the messaging system to interact with them.
-/// It also holds a [`RemoteEntityMap`] for mapping entities between client and server.
+/// It also holds the connection's [`RemoteEntityMap`], which maps entities
+/// between the local and remote peers.
+///
+/// The map holds lightyear-owned pairs only: sender identities (remote sender
+/// ↔ local connection entity, populated from `SenderMetadata`) and similar
+/// pairs that replication never sees. Replicated entities are intentionally NOT
+/// copied here: on local `Client` connections, send/receive views resolve those
+/// through replicon's shared
+/// [`ServerEntityMap`](bevy_replicon::shared::server_entity_map::ServerEntityMap)
+/// first and consult this map as fallback. (On servers there is no shared map,
+/// so this map is the full source.)
 #[derive(Component, Default, Reflect)]
 #[require(Transport)]
 pub struct MessageManager {
@@ -99,5 +109,7 @@ pub struct MessageManager {
     pub(crate) send_triggers: Vec<(MessageKind, ComponentId)>,
     /// List of typed receiver component ids present on this entity.
     pub(crate) receive_messages: Vec<(MessageKind, ComponentId)>,
+    /// Connection-local entity mappings: sender identities and other
+    /// lightyear-owned pairs. See the [struct-level docs](MessageManager).
     pub entity_mapper: RemoteEntityMap,
 }

--- a/crates/transport/messages/src/lib.rs
+++ b/crates/transport/messages/src/lib.rs
@@ -45,6 +45,7 @@ pub mod plugin;
 pub mod receive;
 mod receive_event;
 pub mod registry;
+pub mod replicon_map;
 pub mod send;
 mod send_trigger;
 #[cfg(feature = "server")]

--- a/crates/transport/messages/src/multi.rs
+++ b/crates/transport/messages/src/multi.rs
@@ -39,16 +39,12 @@ impl<'w, 's, F: QueryFilter> MultiMessageSender<'w, 's, F> {
         let metric_handles = self.registry.metric_handles(&MessageKind::of::<M>())?;
         // if the message is not map-entities, we can serialize it once and clone the bytes
         if !self.registry.is_map_entities::<M>()? {
-            // TODO: serialize once for all senders. Figure out how to get a shared writer. Maybe on Server? Or as a global resource?
-            //   or as Local?
             // Local-only map: these messages carry no entities, so no lookup happens.
-            let empty = SendEntityMap::default();
-            let view = SendMapView {
-                shared: None,
-                local: &empty,
-            };
-            self.registry
-                .serialize::<M>(message, &mut self.writer, &view)?;
+            self.registry.serialize::<M>(
+                message,
+                &mut self.writer,
+                &SendMapView::local_only(&SendEntityMap::default()),
+            )?;
             let bytes = self.writer.take_written();
             let bytes_len = bytes.len();
             self.query
@@ -64,10 +60,7 @@ impl<'w, 's, F: QueryFilter> MultiMessageSender<'w, 's, F> {
                 .try_for_each(|(manager, transport)| {
                     // Local-only map: `MultiMessageSender` is a server-side API
                     // without access to the client's shared map.
-                    let view = SendMapView {
-                        shared: None,
-                        local: &manager.entity_mapper.local_to_remote,
-                    };
+                    let view = SendMapView::local_only(&manager.entity_mapper.local_to_remote);
                     self.registry
                         .serialize::<M>(message, &mut self.writer, &view)?;
                     let bytes = self.writer.take_written();

--- a/crates/transport/messages/src/multi.rs
+++ b/crates/transport/messages/src/multi.rs
@@ -9,7 +9,7 @@ use bevy_ecs::{
     error::{BevyError, Result},
     system::{Local, Query, Res, SystemParam},
 };
-use lightyear_serde::entity_map::SendEntityMap;
+use lightyear_serde::entity_map::{SendEntityMap, SendMapView};
 use lightyear_serde::writer::Writer;
 use lightyear_transport::channel::Channel;
 use lightyear_transport::prelude::Transport;
@@ -41,8 +41,14 @@ impl<'w, 's, F: QueryFilter> MultiMessageSender<'w, 's, F> {
         if !self.registry.is_map_entities::<M>()? {
             // TODO: serialize once for all senders. Figure out how to get a shared writer. Maybe on Server? Or as a global resource?
             //   or as Local?
+            // Local-only map: these messages carry no entities, so no lookup happens.
+            let empty = SendEntityMap::default();
+            let view = SendMapView {
+                shared: None,
+                local: &empty,
+            };
             self.registry
-                .serialize::<M>(message, &mut self.writer, &SendEntityMap::default())?;
+                .serialize::<M>(message, &mut self.writer, &view)?;
             let bytes = self.writer.take_written();
             let bytes_len = bytes.len();
             self.query
@@ -56,11 +62,14 @@ impl<'w, 's, F: QueryFilter> MultiMessageSender<'w, 's, F> {
             self.query
                 .iter_many_unique(senders)
                 .try_for_each(|(manager, transport)| {
-                    self.registry.serialize::<M>(
-                        message,
-                        &mut self.writer,
-                        &manager.entity_mapper.local_to_remote,
-                    )?;
+                    // Local-only map: `MultiMessageSender` is a server-side API
+                    // without access to the client's shared map.
+                    let view = SendMapView {
+                        shared: None,
+                        local: &manager.entity_mapper.local_to_remote,
+                    };
+                    self.registry
+                        .serialize::<M>(message, &mut self.writer, &view)?;
                     let bytes = self.writer.take_written();
                     #[cfg(feature = "metrics")]
                     metric_handles.record_send::<M>(bytes.len());

--- a/crates/transport/messages/src/plugin.rs
+++ b/crates/transport/messages/src/plugin.rs
@@ -327,7 +327,9 @@ mod tests {
     use alloc::{vec, vec::Vec};
     use bevy_ecs::event::Event;
     use bevy_ecs::prelude::{Component, Entity, ResMut, Resource};
-    use lightyear_connection::client::{Client, Connected};
+    #[cfg(feature = "client")]
+    use lightyear_connection::client::Client;
+    use lightyear_connection::client::Connected;
     use lightyear_connection::direction::NetworkDirection;
     use lightyear_connection::host::HostClient;
     use lightyear_core::id::{PeerId, RemoteId};
@@ -860,7 +862,13 @@ mod tests {
         assert_eq!(messages, vec![M(3)]);
     }
 
+    // Requires the `client` feature: without it `add_direction` is a no-op and
+    // no senders are registered, so this test would fail. (The `Client`
+    // component type itself is always compiled, which is why this fails at
+    // runtime rather than at compile time. It passes in CI only because the
+    // multi-package invocation unifies the facade's features onto this crate.)
     #[test]
+    #[cfg(feature = "client")]
     fn direction_adds_senders_but_not_receivers() {
         let mut app = message_test_app(true);
         let client = app.world_mut().spawn(Client).id();

--- a/crates/transport/messages/src/plugin.rs
+++ b/crates/transport/messages/src/plugin.rs
@@ -193,6 +193,8 @@ impl Plugin for MessagePlugin {
             ParamBuilder,
             ParamBuilder,
             ParamBuilder,
+            // RepliconMapParam: replicon's shared entity map when the feature is on
+            ParamBuilder,
         )
             .build_state(app.world_mut())
             .build_system(Self::recv)
@@ -229,6 +231,8 @@ impl Plugin for MessagePlugin {
                     });
                 });
             }),
+            ParamBuilder,
+            // RepliconMapParam: replicon's shared entity map when the feature is on
             ParamBuilder,
         )
             .build_state(app.world_mut())

--- a/crates/transport/messages/src/receive.rs
+++ b/crates/transport/messages/src/receive.rs
@@ -1,6 +1,7 @@
 use crate::MessageManager;
 use crate::plugin::{MAX_PENDING_TIMELINE_PAYLOADS, MAX_TIMELINE_LAG_TICKS, MessagePlugin};
 use crate::registry::{MessageError, MessageKind, MessageModeMetadata, MessageRegistry};
+use crate::replicon_map::{RepliconMapParam, shared_maps};
 use crate::{Message, MessageNetId};
 use alloc::vec::Vec;
 use bevy_ecs::{
@@ -8,14 +9,14 @@ use bevy_ecs::{
     component::Component,
     entity::Entity,
     event::Event,
-    query::With,
+    query::{Has, With},
     system::{ParallelCommands, Query, Res},
     world::{DeferredWorld, FilteredEntityMut, World},
 };
 use lightyear_core::prelude::{TimelineKind, TimelineRegistry};
 use lightyear_core::tick::Tick;
 use lightyear_serde::ToBytes;
-use lightyear_serde::entity_map::ReceiveEntityMap;
+use lightyear_serde::entity_map::ReceiveMapView;
 use lightyear_serde::reader::Reader;
 use lightyear_transport::channel::ChannelKind;
 use lightyear_transport::prelude::Transport;
@@ -26,7 +27,7 @@ use lightyear_utils::ready_buffer::ReadyBuffer;
 use bevy_ecs::lifecycle::HookContext;
 use bevy_utils::prelude::DebugName;
 use bytes::Bytes;
-use lightyear_connection::client::Connected;
+use lightyear_connection::client::{Client, Connected};
 use lightyear_connection::host::HostClient;
 use lightyear_core::id::{PeerId, RemoteId};
 use lightyear_serde::registry::ErasedSerializeFns;
@@ -281,7 +282,7 @@ pub(crate) type ReceiveMessageFn = unsafe fn(
     message_id: Option<MessageId>,
     target_timeline: Option<TimelineKind>,
     serialize_metadata: &ErasedSerializeFns,
-    entity_map: &ReceiveEntityMap,
+    entity_map: &ReceiveMapView,
 ) -> Result<(), MessageError>;
 
 pub(crate) type ReceiveLocalMessageFn = unsafe fn(
@@ -354,10 +355,10 @@ impl<M: Message> MessageReceiver<M> {
         message_id: Option<MessageId>,
         target_timeline: Option<TimelineKind>,
         serialize_metadata: &ErasedSerializeFns,
-        entity_map: &ReceiveEntityMap,
+        entity_map: &ReceiveMapView,
     ) -> Result<(), MessageError> {
         let insert_receiver = receiver.is_none();
-        let message = unsafe { serialize_metadata.deserialize::<_, M, M>(reader, entity_map)? };
+        let message = unsafe { serialize_metadata.deserialize::<M, M>(reader, entity_map)? };
         if let Some(receiver) = receiver {
             // SAFETY: the callback and component id are registered for Self.
             let mut receiver = unsafe { receiver.with_type::<Self>() };
@@ -478,7 +479,7 @@ impl MessagePlugin {
         tick: Tick,
         message_id: Option<MessageId>,
         target_timeline: Option<TimelineKind>,
-        message_manager: &MessageManager,
+        entity_map: &ReceiveMapView,
         commands: &ParallelCommands,
         remote_peer_id: PeerId,
     ) -> Result<(), MessageError> {
@@ -551,7 +552,7 @@ impl MessagePlugin {
                         message_id,
                         target_timeline,
                         serialize_fns,
-                        &message_manager.entity_mapper.remote_to_local,
+                        entity_map,
                     )
                 }
             }
@@ -573,7 +574,7 @@ impl MessagePlugin {
                         message_id,
                         target_timeline,
                         serialize_fns,
-                        &message_manager.entity_mapper.remote_to_local,
+                        entity_map,
                         remote_peer_id,
                     )
                 }
@@ -597,6 +598,7 @@ impl MessagePlugin {
                 &mut Transport,
                 &RemoteId,
                 Option<&mut HostClient>,
+                Has<Client>,
             ),
             With<Connected>,
         >,
@@ -606,17 +608,30 @@ impl MessagePlugin {
         channel_registry: Res<ChannelRegistry>,
         timeline_registry: Res<TimelineRegistry>,
         commands: ParallelCommands,
+        replicon: RepliconMapParam,
     ) {
         // Each outer query item accesses receivers on a different entity, so workers can safely
         // share the query before taking their disjoint unsafe reborrows below.
         let receiver_query = &receiver_query;
+        let replicon = &replicon;
+        let shared = shared_maps(replicon);
         let transport_query = adaptive_for_each_mut!(transport_query);
         transport_query.for_each(
-            |(entity, message_manager, mut transport, remote_peer_id, mut host_client)| {
+            |(entity, message_manager, mut transport, remote_peer_id, mut host_client, is_client)| {
                 // SAFETY: we know that this won't lead to violating the aliasing rule
                 let mut receiver_query = unsafe { receiver_query.reborrow_unsafe() };
                 // enable split borrows
                 let transport = &mut *transport;
+                // Host-client delivery keeps the connection-local map: the shared
+                // replicon map describes the host's client-side view, not this buffer.
+                let view = ReceiveMapView {
+                    shared: if is_client && host_client.is_none() {
+                        shared.map(|maps| maps.to_client)
+                    } else {
+                        None
+                    },
+                    local: &message_manager.entity_mapper.remote_to_local,
+                };
                 // TODO: we can run this in parallel using rayon!
                 if let Some(host_client) = host_client.as_mut() {
                     // Host-client messages already carry their channel kind, so they do not need
@@ -641,7 +656,7 @@ impl MessagePlugin {
                             tick,
                             None,
                             target_timeline,
-                            message_manager,
+                            &view,
                             &commands,
                             remote_peer_id.0,
                         ) {
@@ -671,7 +686,7 @@ impl MessagePlugin {
                                     tick,
                                     message_id,
                                     target_timeline,
-                                    message_manager,
+                                    &view,
                                     &commands,
                                     remote_peer_id.0,
                                 )?;

--- a/crates/transport/messages/src/receive.rs
+++ b/crates/transport/messages/src/receive.rs
@@ -1,7 +1,7 @@
 use crate::MessageManager;
 use crate::plugin::{MAX_PENDING_TIMELINE_PAYLOADS, MAX_TIMELINE_LAG_TICKS, MessagePlugin};
 use crate::registry::{MessageError, MessageKind, MessageModeMetadata, MessageRegistry};
-use crate::replicon_map::{RepliconMapParam, shared_maps};
+use crate::replicon_map::RepliconMapParam;
 use crate::{Message, MessageNetId};
 use alloc::vec::Vec;
 use bevy_ecs::{
@@ -614,7 +614,6 @@ impl MessagePlugin {
         // share the query before taking their disjoint unsafe reborrows below.
         let receiver_query = &receiver_query;
         let replicon = &replicon;
-        let shared = shared_maps(replicon);
         let transport_query = adaptive_for_each_mut!(transport_query);
         transport_query.for_each(
             |(entity, message_manager, mut transport, remote_peer_id, mut host_client, is_client)| {
@@ -625,11 +624,7 @@ impl MessagePlugin {
                 // Host-client delivery keeps the connection-local map: the shared
                 // replicon map describes the host's client-side view, not this buffer.
                 let view = ReceiveMapView {
-                    shared: if is_client && host_client.is_none() {
-                        shared.map(|maps| maps.to_client)
-                    } else {
-                        None
-                    },
+                    shared: replicon.shared_recv_map(is_client && host_client.is_none()),
                     local: &message_manager.entity_mapper.remote_to_local,
                 };
                 // TODO: we can run this in parallel using rayon!

--- a/crates/transport/messages/src/receive_event.rs
+++ b/crates/transport/messages/src/receive_event.rs
@@ -12,7 +12,7 @@ use core::any::Any;
 use lightyear_core::id::PeerId;
 use lightyear_core::tick::Tick;
 use lightyear_core::timeline::TimelineKind;
-use lightyear_serde::entity_map::ReceiveEntityMap;
+use lightyear_serde::entity_map::ReceiveMapView;
 use lightyear_serde::reader::Reader;
 use lightyear_serde::registry::ErasedSerializeFns;
 use lightyear_transport::channel::ChannelKind;
@@ -228,7 +228,7 @@ pub(crate) type ReceiveTriggerFn = unsafe fn(
     message_id: Option<MessageId>,
     target_timeline: Option<TimelineKind>,
     serialize_metadata: &ErasedSerializeFns,
-    entity_map: &ReceiveEntityMap,
+    entity_map: &ReceiveMapView,
     from: PeerId,
 ) -> Result<(), MessageError>;
 
@@ -270,10 +270,10 @@ pub(crate) unsafe fn receive_event_typed<M: Message + Event>(
     message_id: Option<MessageId>,
     target_timeline: Option<TimelineKind>,
     serialize_metadata: &ErasedSerializeFns,
-    entity_map: &ReceiveEntityMap,
+    entity_map: &ReceiveMapView,
     from: PeerId,
 ) -> Result<(), MessageError> {
-    let message = unsafe { serialize_metadata.deserialize::<_, M, M>(reader, entity_map)? };
+    let message = unsafe { serialize_metadata.deserialize::<M, M>(reader, entity_map)? };
     if let Some(timeline) = target_timeline {
         if let Some(receiver) = receiver {
             // SAFETY: the callback and component id are registered for this event type.

--- a/crates/transport/messages/src/registry.rs
+++ b/crates/transport/messages/src/registry.rs
@@ -16,9 +16,7 @@ use core::hash::Hash;
 use lightyear_connection::direction::NetworkDirection;
 use lightyear_core::network::NetId;
 use lightyear_core::prelude::{Tick, TimelineKind};
-use lightyear_serde::entity_map::{
-    ReceiveEntityMap, ReceiveMapView, RemoteEntityMap, SendEntityMap, SendMapView,
-};
+use lightyear_serde::entity_map::{ReceiveMapView, RemoteEntityMap, SendMapView};
 use lightyear_serde::reader::Reader;
 use lightyear_serde::registry::{
     ContextDeserializeFn, ContextDeserializeFns, ContextSerializeFn, ContextSerializeFns,
@@ -259,7 +257,7 @@ pub struct Context {
 }
 
 fn mapped_context_serialize<M: MapEntities + Clone>(
-    mapper: &SendEntityMap,
+    mapper: &SendMapView,
     message: &M,
     writer: &mut Writer,
     serialize_fn: SerializeFn<M>,
@@ -267,20 +265,20 @@ fn mapped_context_serialize<M: MapEntities + Clone>(
     let mut message = message.clone();
     // The view only exposes shared reads, so user mapping code runs without
     // requiring exclusive access to the entity map.
-    let mut view = SendMapView(mapper);
+    let mut view = *mapper;
     message.map_entities(&mut view);
     serialize_fn(&message, writer)
 }
 
 fn mapped_context_deserialize<M: MapEntities>(
-    mapper: &ReceiveEntityMap,
+    mapper: &ReceiveMapView,
     reader: &mut Reader,
     deserialize_fn: DeserializeFn<M>,
 ) -> core::result::Result<M, SerializationError> {
     let mut message = deserialize_fn(reader)?;
     // The view only exposes shared reads, so user mapping code runs without
     // requiring exclusive access to the entity map.
-    let mut view = ReceiveMapView(mapper);
+    let mut view = *mapper;
     message.map_entities(&mut view);
     Ok(message)
 }
@@ -289,8 +287,8 @@ impl MessageRegistry {
     pub(crate) fn register<M: Message, I: 'static>(
         &mut self,
         mode: MessageModeMetadata,
-        serialize: ContextSerializeFns<SendEntityMap, M, I>,
-        deserialize: ContextDeserializeFns<ReceiveEntityMap, M, I>,
+        serialize: ContextSerializeFns<M, I>,
+        deserialize: ContextDeserializeFns<M, I>,
     ) {
         trace!("Registering message: {}", DebugName::type_name::<M>());
         let kind = self.kind_map.add::<I>();
@@ -301,10 +299,7 @@ impl MessageRegistry {
         );
         self.hasher.hash::<M>();
 
-        let serialize_fns = ErasedSerializeFns::new::<SendEntityMap, ReceiveEntityMap, M, I>(
-            serialize,
-            deserialize,
-        );
+        let serialize_fns = ErasedSerializeFns::new::<M, I>(serialize, deserialize);
 
         let metadata = MessageMetadata {
             mode,
@@ -344,8 +339,8 @@ impl MessageRegistry {
         I: Clone + MapEntities + 'static,
     >(
         &mut self,
-        context_serialize: ContextSerializeFn<SendEntityMap, M, I>,
-        context_deserialize: ContextDeserializeFn<ReceiveEntityMap, M, I>,
+        context_serialize: ContextSerializeFn<M, I>,
+        context_deserialize: ContextDeserializeFn<M, I>,
     ) {
         let kind = MessageKind::of::<I>();
         let erased_fns = self
@@ -362,14 +357,14 @@ impl MessageRegistry {
         &self,
         message: &M,
         writer: &mut Writer,
-        entity_map: &SendEntityMap,
+        entity_map: &SendMapView,
     ) -> Result<(), MessageError> {
         let kind = MessageKind::of::<M>();
         let erased_fns = &self.metadata(&kind)?.serialize_fns;
         let net_id = self.kind_map.net_id(&kind).unwrap();
         net_id.to_bytes(writer)?;
         unsafe {
-            erased_fns.serialize::<SendEntityMap, M, M>(message, writer, entity_map)?;
+            erased_fns.serialize::<M, M>(message, writer, entity_map)?;
         }
         Ok(())
     }
@@ -377,7 +372,7 @@ impl MessageRegistry {
     pub(crate) fn deserialize<M: Message>(
         &self,
         reader: &mut Reader,
-        entity_map: &ReceiveEntityMap,
+        entity_map: &ReceiveMapView,
     ) -> Result<M, MessageError> {
         let net_id = NetId::from_bytes(reader)?;
         let kind = self
@@ -388,7 +383,7 @@ impl MessageRegistry {
         // SAFETY: the ErasedSerializeFns was created for the type M
         unsafe {
             erased_fns
-                .deserialize::<ReceiveEntityMap, M, M>(reader, entity_map)
+                .deserialize::<M, M>(reader, entity_map)
                 .map_err(Into::into)
         }
     }
@@ -524,6 +519,7 @@ mod tests {
     use bevy_ecs::entity::{Entity, EntityMapper};
     use bevy_ecs::event::Event;
     use lightyear_serde::SerializationError;
+    use lightyear_serde::entity_map::{ReceiveEntityMap, SendEntityMap};
     use lightyear_serde::reader::ReadInteger;
     use lightyear_serde::writer::WriteInteger;
     use serde::Deserialize;
@@ -579,15 +575,23 @@ mod tests {
 
         let message = Message1(1.0);
         let mut writer = Writer::default();
+        let send_map = SendEntityMap::default();
+        let send_view = SendMapView {
+            shared: None,
+            local: &send_map,
+        };
         registry
-            .serialize(&message, &mut writer, &SendEntityMap::default())
+            .serialize(&message, &mut writer, &send_view)
             .unwrap();
         let data = writer.into_bytes();
 
         let mut reader = Reader::from(data);
-        let read = registry
-            .deserialize(&mut reader, &ReceiveEntityMap::default())
-            .unwrap();
+        let receive_map = ReceiveEntityMap::default();
+        let receive_view = ReceiveMapView {
+            shared: None,
+            local: &receive_map,
+        };
+        let read = registry.deserialize(&mut reader, &receive_view).unwrap();
         assert_eq!(message, read);
     }
 
@@ -602,15 +606,23 @@ mod tests {
 
         let message = Message2(1.0);
         let mut writer = Writer::default();
+        let send_map = SendEntityMap::default();
+        let send_view = SendMapView {
+            shared: None,
+            local: &send_map,
+        };
         registry
-            .serialize(&message, &mut writer, &SendEntityMap::default())
+            .serialize(&message, &mut writer, &send_view)
             .unwrap();
         let data = writer.into_bytes();
 
         let mut reader = Reader::from(data);
-        let read = registry
-            .deserialize(&mut reader, &ReceiveEntityMap::default())
-            .unwrap();
+        let receive_map = ReceiveEntityMap::default();
+        let receive_view = ReceiveMapView {
+            shared: None,
+            local: &receive_map,
+        };
+        let read = registry.deserialize(&mut reader, &receive_view).unwrap();
         assert_eq!(message, read);
     }
 
@@ -624,14 +636,23 @@ mod tests {
         let mut writer = Writer::default();
         let mut entity_map = SendEntityMap::default();
         entity_map.set_mapped(Entity::from_bits(1), Entity::from_bits(2));
+        let send_view = SendMapView {
+            shared: None,
+            local: &entity_map,
+        };
         registry
-            .serialize(&message, &mut writer, &entity_map)
+            .serialize(&message, &mut writer, &send_view)
             .unwrap();
         let data = writer.into_bytes();
 
         let mut reader = Reader::from(data);
+        let receive_map = ReceiveEntityMap::default();
+        let receive_view = ReceiveMapView {
+            shared: None,
+            local: &receive_map,
+        };
         let read = registry
-            .deserialize::<Message3>(&mut reader, &ReceiveEntityMap::default())
+            .deserialize::<Message3>(&mut reader, &receive_view)
             .unwrap();
         assert_eq!(read.0, Entity::from_bits(2));
     }

--- a/crates/transport/messages/src/registry.rs
+++ b/crates/transport/messages/src/registry.rs
@@ -576,10 +576,7 @@ mod tests {
         let message = Message1(1.0);
         let mut writer = Writer::default();
         let send_map = SendEntityMap::default();
-        let send_view = SendMapView {
-            shared: None,
-            local: &send_map,
-        };
+        let send_view = SendMapView::local_only(&send_map);
         registry
             .serialize(&message, &mut writer, &send_view)
             .unwrap();
@@ -587,10 +584,7 @@ mod tests {
 
         let mut reader = Reader::from(data);
         let receive_map = ReceiveEntityMap::default();
-        let receive_view = ReceiveMapView {
-            shared: None,
-            local: &receive_map,
-        };
+        let receive_view = ReceiveMapView::local_only(&receive_map);
         let read = registry.deserialize(&mut reader, &receive_view).unwrap();
         assert_eq!(message, read);
     }
@@ -607,10 +601,7 @@ mod tests {
         let message = Message2(1.0);
         let mut writer = Writer::default();
         let send_map = SendEntityMap::default();
-        let send_view = SendMapView {
-            shared: None,
-            local: &send_map,
-        };
+        let send_view = SendMapView::local_only(&send_map);
         registry
             .serialize(&message, &mut writer, &send_view)
             .unwrap();
@@ -618,10 +609,7 @@ mod tests {
 
         let mut reader = Reader::from(data);
         let receive_map = ReceiveEntityMap::default();
-        let receive_view = ReceiveMapView {
-            shared: None,
-            local: &receive_map,
-        };
+        let receive_view = ReceiveMapView::local_only(&receive_map);
         let read = registry.deserialize(&mut reader, &receive_view).unwrap();
         assert_eq!(message, read);
     }
@@ -636,10 +624,7 @@ mod tests {
         let mut writer = Writer::default();
         let mut entity_map = SendEntityMap::default();
         entity_map.set_mapped(Entity::from_bits(1), Entity::from_bits(2));
-        let send_view = SendMapView {
-            shared: None,
-            local: &entity_map,
-        };
+        let send_view = SendMapView::local_only(&entity_map);
         registry
             .serialize(&message, &mut writer, &send_view)
             .unwrap();
@@ -647,10 +632,7 @@ mod tests {
 
         let mut reader = Reader::from(data);
         let receive_map = ReceiveEntityMap::default();
-        let receive_view = ReceiveMapView {
-            shared: None,
-            local: &receive_map,
-        };
+        let receive_view = ReceiveMapView::local_only(&receive_map);
         let read = registry
             .deserialize::<Message3>(&mut reader, &receive_view)
             .unwrap();

--- a/crates/transport/messages/src/replicon_map.rs
+++ b/crates/transport/messages/src/replicon_map.rs
@@ -1,0 +1,73 @@
+//! Shared entity-map resolution for (de)serialization.
+//!
+//! Local `Client` connections resolve entity mappings through
+//! replicon's [`ServerEntityMap`](bevy_replicon::shared::server_entity_map::ServerEntityMap)
+//! first, falling back to the local [`MessageManager`](crate::MessageManager) map for
+//! lightyear-owned pairs (connection entity, host identity) that replicon never sees.
+//!
+//! Server-side (`ClientOf`) connections always use the local map: replicon keeps no
+//! server-side map, and the shared map in a host app describes the host's own
+//! client-side view, not its remote peers.
+
+use bevy_ecs::entity::Entity;
+use bevy_ecs::entity::hash_map::EntityHashMap;
+#[cfg(not(feature = "replicon"))]
+use bevy_ecs::resource::Resource;
+use bevy_ecs::system::{Res, SystemParam};
+
+#[cfg(feature = "replicon")]
+use bevy_replicon::shared::server_entity_map::ServerEntityMap;
+
+/// Shared lookup tables borrowed from replicon's entity map for one system run.
+///
+/// Send/receive views check these first and fall back to the connection-local map
+/// for lightyear-owned pairs (connection entity, host identity) that replicon
+/// never sees.
+#[derive(Clone, Copy)]
+pub(crate) struct SharedMaps<'a> {
+    /// Remote (server) entities by local (client) entity: send side.
+    pub to_server: &'a EntityHashMap<Entity>,
+    /// Local (client) entities by remote (server) entity: receive side.
+    pub to_client: &'a EntityHashMap<Entity>,
+}
+
+/// SystemParam exposing replicon's entity map when the `replicon` feature is enabled.
+///
+/// Present in built systems regardless of the feature so `MessagePlugin::finish`
+/// needs no feature-branched tuples; always `None` when the feature is off.
+#[cfg(feature = "replicon")]
+#[derive(SystemParam)]
+pub struct RepliconMapParam<'w> {
+    /// Replicon's client-side entity map. Absent on servers and in apps without replication.
+    pub map: Option<Res<'w, ServerEntityMap>>,
+}
+
+/// Feature-off stand-in: a valid [`SystemParam`](bevy_ecs::system::SystemParam) that
+/// always resolves to `None`, so system signatures stay identical across features.
+#[cfg(not(feature = "replicon"))]
+#[derive(SystemParam)]
+pub struct RepliconMapParam<'w> {
+    pub map: Option<Res<'w, NeverMap>>,
+}
+
+/// Uninhabited marker: `Res<NeverMap>` can never exist, so the feature-off
+/// [`RepliconMapParam`] always yields `None`.
+#[cfg(not(feature = "replicon"))]
+#[derive(Resource)]
+pub enum NeverMap {}
+
+/// Borrow replicon's shared lookup tables when the `replicon` feature is enabled.
+///
+/// Always `None` when the feature is off, so call sites need no feature branches.
+/// Server-side connections ignore the result (replicon keeps no server-side map).
+pub(crate) fn shared_maps<'a>(replicon: &'a RepliconMapParam<'_>) -> Option<SharedMaps<'a>> {
+    #[cfg(feature = "replicon")]
+    if let Some(map) = replicon.map.as_deref() {
+        return Some(SharedMaps {
+            to_server: map.to_server(),
+            to_client: map.to_client(),
+        });
+    }
+    let _ = replicon;
+    None
+}

--- a/crates/transport/messages/src/replicon_map.rs
+++ b/crates/transport/messages/src/replicon_map.rs
@@ -3,7 +3,7 @@
 //! Local `Client` connections resolve entity mappings through
 //! replicon's [`ServerEntityMap`](bevy_replicon::shared::server_entity_map::ServerEntityMap)
 //! first, falling back to the local [`MessageManager`](crate::MessageManager) map for
-//! lightyear-owned pairs (connection entity, host identity) that replicon never sees.
+//! lightyear-owned pairs (sender identities and similar) that replicon never sees.
 //!
 //! Server-side (`ClientOf`) connections always use the local map: replicon keeps no
 //! server-side map, and the shared map in a host app describes the host's own
@@ -18,17 +18,33 @@ use bevy_ecs::system::{Res, SystemParam};
 #[cfg(feature = "replicon")]
 use bevy_replicon::shared::server_entity_map::ServerEntityMap;
 
-/// Shared lookup tables borrowed from replicon's entity map for one system run.
-///
-/// Send/receive views check these first and fall back to the connection-local map
-/// for lightyear-owned pairs (connection entity, host identity) that replicon
-/// never sees.
-#[derive(Clone, Copy)]
-pub(crate) struct SharedMaps<'a> {
-    /// Remote (server) entities by local (client) entity: send side.
-    pub to_server: &'a EntityHashMap<Entity>,
-    /// Local (client) entities by remote (server) entity: receive side.
-    pub to_client: &'a EntityHashMap<Entity>,
+impl RepliconMapParam<'_> {
+    /// Shared send table (remote entities by local entity) for one connection.
+    ///
+    /// Used as the view's primary map, falling back to the connection-local map
+    /// for lightyear-owned pairs (sender identities and similar) that replicon
+    /// never sees. `None` unless the connection opts in *and* the `replicon`
+    /// feature provides the shared map (absent on servers and without replication).
+    pub(crate) fn shared_send_map(&self, use_shared: bool) -> Option<&EntityHashMap<Entity>> {
+        #[cfg(feature = "replicon")]
+        if use_shared && let Some(map) = self.map.as_deref() {
+            return Some(map.to_server());
+        }
+        let _ = (self, use_shared);
+        None
+    }
+
+    /// Shared receive table (local entities by remote entity) for one connection.
+    ///
+    /// Same policy as [`RepliconMapParam::shared_send_map`], other direction.
+    pub(crate) fn shared_recv_map(&self, use_shared: bool) -> Option<&EntityHashMap<Entity>> {
+        #[cfg(feature = "replicon")]
+        if use_shared && let Some(map) = self.map.as_deref() {
+            return Some(map.to_client());
+        }
+        let _ = (self, use_shared);
+        None
+    }
 }
 
 /// SystemParam exposing replicon's entity map when the `replicon` feature is enabled.
@@ -55,19 +71,3 @@ pub struct RepliconMapParam<'w> {
 #[cfg(not(feature = "replicon"))]
 #[derive(Resource)]
 pub enum NeverMap {}
-
-/// Borrow replicon's shared lookup tables when the `replicon` feature is enabled.
-///
-/// Always `None` when the feature is off, so call sites need no feature branches.
-/// Server-side connections ignore the result (replicon keeps no server-side map).
-pub(crate) fn shared_maps<'a>(replicon: &'a RepliconMapParam<'_>) -> Option<SharedMaps<'a>> {
-    #[cfg(feature = "replicon")]
-    if let Some(map) = replicon.map.as_deref() {
-        return Some(SharedMaps {
-            to_server: map.to_server(),
-            to_client: map.to_client(),
-        });
-    }
-    let _ = replicon;
-    None
-}

--- a/crates/transport/messages/src/send.rs
+++ b/crates/transport/messages/src/send.rs
@@ -2,6 +2,7 @@ use crate::plugin::{MAX_TIMELINE_LAG_TICKS, MessagePlugin};
 #[cfg(feature = "metrics")]
 use crate::registry::MessageMetricHandles;
 use crate::registry::{MessageError, MessageKind, MessageModeMetadata, MessageRegistry};
+use crate::replicon_map::{RepliconMapParam, shared_maps};
 use crate::{Message, MessageManager, MessageNetId};
 use alloc::vec::Vec;
 use bevy_ecs::lifecycle::HookContext;
@@ -9,17 +10,17 @@ use bevy_ecs::{
     change_detection::MutUntyped,
     component::Component,
     entity::Entity,
-    query::{With, Without},
+    query::{Has, With, Without},
     system::{ParallelCommands, Query, Res},
     world::{DeferredWorld, FilteredEntityMut, World},
 };
 use bevy_reflect::Reflect;
 use bevy_utils::prelude::DebugName;
-use lightyear_connection::client::Connected;
+use lightyear_connection::client::{Client, Connected};
 use lightyear_connection::host::HostClient;
 use lightyear_core::prelude::{LocalTimeline, Tick, TimelineRegistry};
 use lightyear_serde::ToBytes;
-use lightyear_serde::entity_map::SendEntityMap;
+use lightyear_serde::entity_map::SendMapView;
 use lightyear_serde::registry::ErasedSerializeFns;
 use lightyear_serde::writer::Writer;
 use lightyear_transport::channel::{Channel, ChannelKind};
@@ -77,7 +78,7 @@ pub(crate) type SendMessageFn = unsafe fn(
     message_net_id: MessageNetId,
     transport: &Transport,
     serialize_metadata: &ErasedSerializeFns,
-    entity_map: &SendEntityMap,
+    entity_map: &SendMapView,
     #[cfg(feature = "metrics")] metric_handles: &MessageMetricHandles,
 ) -> Result<(), MessageError>;
 
@@ -123,7 +124,7 @@ impl<M: Message> MessageSender<M> {
         net_id: MessageNetId,
         transport: &Transport,
         serialize_metadata: &ErasedSerializeFns,
-        entity_map: &SendEntityMap,
+        entity_map: &SendMapView,
         #[cfg(feature = "metrics")] metric_handles: &MessageMetricHandles,
     ) -> Result<(), MessageError> {
         // SAFETY:  the `message_sender` must be of type `MessageSender<M>`
@@ -138,7 +139,7 @@ impl<M: Message> MessageSender<M> {
                 net_id.to_bytes(&mut sender.writer)?;
                 // SAFETY: the message has been checked to be of type `M`.
                 unsafe {
-                    serialize_metadata.serialize::<SendEntityMap, M, M>(
+                    serialize_metadata.serialize::<M, M>(
                         &message,
                         &mut sender.writer,
                         entity_map,
@@ -280,96 +281,109 @@ impl MessagePlugin {
     /// Serialize them into bytes that are buffered in a [`Transport`]
     pub fn send(
         mut transport_query: Query<
-            (Entity, &Transport, &MessageManager),
+            (Entity, &Transport, &MessageManager, Has<Client>),
             (With<Connected>, Without<HostClient>),
         >,
         // MessageSender<M> present on that entity
         message_sender_query: Query<FilteredEntityMut>,
         registry: Res<MessageRegistry>,
+        replicon: RepliconMapParam,
     ) {
         // Each outer query item accesses senders on a different entity, so workers can safely
         // share the query before taking their disjoint unsafe reborrows below.
         let message_sender_query = &message_sender_query;
-        adaptive_for_each_mut!(transport_query).for_each(|(entity, transport, message_manager)| {
-            // SAFETY: we know that this won't lead to violating the aliasing rule
-            let mut message_sender_query = unsafe { message_sender_query.reborrow_unsafe() };
+        let replicon = &replicon;
+        let shared = shared_maps(replicon);
+        adaptive_for_each_mut!(transport_query).for_each(
+            |(entity, transport, message_manager, is_client)| {
+                // SAFETY: we know that this won't lead to violating the aliasing rule
+                let mut message_sender_query = unsafe { message_sender_query.reborrow_unsafe() };
+                let view = SendMapView {
+                    shared: if is_client {
+                        shared.map(|maps| maps.to_server)
+                    } else {
+                        None
+                    },
+                    local: &message_manager.entity_mapper.local_to_remote,
+                };
 
-            message_manager
-                .send_messages
-                .iter()
-                .try_for_each(|(message_kind, sender_id)| {
-                    let mut entity_mut = message_sender_query.get_mut(entity).unwrap();
-                    let message_sender = entity_mut
-                        .get_mut_by_id(*sender_id)
-                        .ok_or(MessageError::MissingComponent(*sender_id))?;
-                    let metadata = registry.metadata(message_kind)?;
-                    let MessageModeMetadata::Message {
-                        send: send_metadata,
-                        ..
-                    } = &metadata.mode
-                    else {
-                        return Err(MessageError::UnrecognizedMessage(*message_kind));
-                    };
-                    let serialize_fns = &metadata.serialize_fns;
-                    let message_id = registry
-                        .kind_map
-                        .net_id(message_kind)
-                        .ok_or(MessageError::UnrecognizedMessage(*message_kind))?;
-                    #[cfg(feature = "metrics")]
-                    let metric_handles = &metadata.metrics;
-                    // SAFETY: we know the message_sender corresponds to the correct `MessageSender<M>` type
-                    unsafe {
-                        (send_metadata.send_message_fn)(
-                            message_sender,
-                            *message_id,
-                            transport,
-                            serialize_fns,
-                            &message_manager.entity_mapper.local_to_remote,
-                            #[cfg(feature = "metrics")]
-                            metric_handles,
-                        )?;
-                    }
-                    Ok::<_, MessageError>(())
-                })
-                .inspect_err(|e| error!("error sending message: {e:?}"))
-                .ok();
+                message_manager
+                    .send_messages
+                    .iter()
+                    .try_for_each(|(message_kind, sender_id)| {
+                        let mut entity_mut = message_sender_query.get_mut(entity).unwrap();
+                        let message_sender = entity_mut
+                            .get_mut_by_id(*sender_id)
+                            .ok_or(MessageError::MissingComponent(*sender_id))?;
+                        let metadata = registry.metadata(message_kind)?;
+                        let MessageModeMetadata::Message {
+                            send: send_metadata,
+                            ..
+                        } = &metadata.mode
+                        else {
+                            return Err(MessageError::UnrecognizedMessage(*message_kind));
+                        };
+                        let serialize_fns = &metadata.serialize_fns;
+                        let message_id = registry
+                            .kind_map
+                            .net_id(message_kind)
+                            .ok_or(MessageError::UnrecognizedMessage(*message_kind))?;
+                        #[cfg(feature = "metrics")]
+                        let metric_handles = &metadata.metrics;
+                        // SAFETY: we know the message_sender corresponds to the correct `MessageSender<M>` type
+                        unsafe {
+                            (send_metadata.send_message_fn)(
+                                message_sender,
+                                *message_id,
+                                transport,
+                                serialize_fns,
+                                &view,
+                                #[cfg(feature = "metrics")]
+                                metric_handles,
+                            )?;
+                        }
+                        Ok::<_, MessageError>(())
+                    })
+                    .inspect_err(|e| error!("error sending message: {e:?}"))
+                    .ok();
 
-            message_manager
-                .send_triggers
-                .iter()
-                .try_for_each(|(message_kind, sender_id)| {
-                    let mut entity_mut = message_sender_query.get_mut(entity).unwrap();
-                    let message_sender = entity_mut
-                        .get_mut_by_id(*sender_id)
-                        .ok_or(MessageError::MissingComponent(*sender_id))?;
-                    let metadata = registry.metadata(message_kind)?;
-                    let MessageModeMetadata::Trigger {
-                        send: send_metadata,
-                        ..
-                    } = &metadata.mode
-                    else {
-                        return Err(MessageError::UnrecognizedMessage(*message_kind));
-                    };
-                    let serialize_fns = &metadata.serialize_fns;
-                    let message_id = registry
-                        .kind_map
-                        .net_id(message_kind)
-                        .ok_or(MessageError::UnrecognizedMessage(*message_kind))?;
-                    // SAFETY: we know the message_sender corresponds to the correct `MessageSender<M>` type
-                    unsafe {
-                        (send_metadata.send_trigger_fn)(
-                            message_sender,
-                            *message_id,
-                            transport,
-                            serialize_fns,
-                            &message_manager.entity_mapper.local_to_remote,
-                        )?;
-                    }
-                    Ok::<_, MessageError>(())
-                })
-                .inspect_err(|e| error!("error sending trigger: {e:?}"))
-                .ok();
-        })
+                message_manager
+                    .send_triggers
+                    .iter()
+                    .try_for_each(|(message_kind, sender_id)| {
+                        let mut entity_mut = message_sender_query.get_mut(entity).unwrap();
+                        let message_sender = entity_mut
+                            .get_mut_by_id(*sender_id)
+                            .ok_or(MessageError::MissingComponent(*sender_id))?;
+                        let metadata = registry.metadata(message_kind)?;
+                        let MessageModeMetadata::Trigger {
+                            send: send_metadata,
+                            ..
+                        } = &metadata.mode
+                        else {
+                            return Err(MessageError::UnrecognizedMessage(*message_kind));
+                        };
+                        let serialize_fns = &metadata.serialize_fns;
+                        let message_id = registry
+                            .kind_map
+                            .net_id(message_kind)
+                            .ok_or(MessageError::UnrecognizedMessage(*message_kind))?;
+                        // SAFETY: we know the message_sender corresponds to the correct `MessageSender<M>` type
+                        unsafe {
+                            (send_metadata.send_trigger_fn)(
+                                message_sender,
+                                *message_id,
+                                transport,
+                                serialize_fns,
+                                &view,
+                            )?;
+                        }
+                        Ok::<_, MessageError>(())
+                    })
+                    .inspect_err(|e| error!("error sending trigger: {e:?}"))
+                    .ok();
+            },
+        )
     }
 
     /// For the host-client, we take messages to send from the [`MessageSender<M>`] components

--- a/crates/transport/messages/src/send.rs
+++ b/crates/transport/messages/src/send.rs
@@ -2,7 +2,7 @@ use crate::plugin::{MAX_TIMELINE_LAG_TICKS, MessagePlugin};
 #[cfg(feature = "metrics")]
 use crate::registry::MessageMetricHandles;
 use crate::registry::{MessageError, MessageKind, MessageModeMetadata, MessageRegistry};
-use crate::replicon_map::{RepliconMapParam, shared_maps};
+use crate::replicon_map::RepliconMapParam;
 use crate::{Message, MessageManager, MessageNetId};
 use alloc::vec::Vec;
 use bevy_ecs::lifecycle::HookContext;
@@ -293,17 +293,12 @@ impl MessagePlugin {
         // share the query before taking their disjoint unsafe reborrows below.
         let message_sender_query = &message_sender_query;
         let replicon = &replicon;
-        let shared = shared_maps(replicon);
         adaptive_for_each_mut!(transport_query).for_each(
             |(entity, transport, message_manager, is_client)| {
                 // SAFETY: we know that this won't lead to violating the aliasing rule
                 let mut message_sender_query = unsafe { message_sender_query.reborrow_unsafe() };
                 let view = SendMapView {
-                    shared: if is_client {
-                        shared.map(|maps| maps.to_server)
-                    } else {
-                        None
-                    },
+                    shared: replicon.shared_send_map(is_client),
                     local: &message_manager.entity_mapper.local_to_remote,
                 };
 

--- a/crates/transport/messages/src/send_trigger.rs
+++ b/crates/transport/messages/src/send_trigger.rs
@@ -11,7 +11,7 @@ use bevy_utils::prelude::DebugName;
 use lightyear_core::id::PeerId;
 use lightyear_core::prelude::{Tick, TimelineRegistry};
 use lightyear_serde::ToBytes;
-use lightyear_serde::entity_map::SendEntityMap;
+use lightyear_serde::entity_map::SendMapView;
 use lightyear_serde::registry::ErasedSerializeFns;
 use lightyear_serde::writer::Writer;
 use lightyear_transport::channel::{Channel, ChannelKind};
@@ -52,7 +52,7 @@ impl<M: Event> EventSender<M> {
         net_id: MessageNetId,
         transport: &Transport,
         serialize_metadata: &ErasedSerializeFns,
-        entity_map: &SendEntityMap,
+        entity_map: &SendMapView,
     ) -> Result<(), MessageError> {
         // SAFETY:  the `trigger_sender` must be of type `TriggerSender<M>`
         let mut sender = unsafe { trigger_sender.with_type::<Self>() };
@@ -68,11 +68,7 @@ impl<M: Event> EventSender<M> {
             net_id.to_bytes(&mut sender.writer)?;
             // SAFETY: the message has been checked to be of type `M`.
             unsafe {
-                serialize_metadata.serialize::<SendEntityMap, M, M>(
-                    &event,
-                    &mut sender.writer,
-                    entity_map,
-                )?
+                serialize_metadata.serialize::<M, M>(&event, &mut sender.writer, entity_map)?
             };
             let bytes = sender.writer.take_written();
             trace!(
@@ -181,7 +177,7 @@ pub(crate) type SendTriggerFn = unsafe fn(
     message_net_id: MessageNetId,
     transport: &Transport,
     serialize_metadata: &ErasedSerializeFns,
-    entity_map: &SendEntityMap,
+    entity_map: &SendMapView,
 ) -> Result<(), MessageError>;
 
 // SAFETY: the sender must correspond to the correct `TriggerSender<M>` type

--- a/crates/transport/messages/src/trigger.rs
+++ b/crates/transport/messages/src/trigger.rs
@@ -10,7 +10,7 @@ use crate::registry::{
 };
 use crate::send_trigger::EventSender;
 use lightyear_connection::direction::NetworkDirection;
-use lightyear_serde::entity_map::{ReceiveEntityMap, ReceiveMapView, SendEntityMap, SendMapView};
+use lightyear_serde::entity_map::{ReceiveMapView, SendMapView};
 use lightyear_serde::reader::Reader;
 use lightyear_serde::registry::{
     ContextDeserializeFns, ContextSerializeFns, DeserializeFn, SerializeFn, SerializeFns,
@@ -119,7 +119,7 @@ impl AppTriggerExt for App {
 }
 
 fn trigger_serialize<M: Event>(
-    _: &SendEntityMap,
+    _: &SendMapView,
     message: &M,
     writer: &mut Writer,
     serialize: SerializeFn<M>,
@@ -130,7 +130,7 @@ fn trigger_serialize<M: Event>(
 }
 
 fn trigger_deserialize<M: Event>(
-    _: &ReceiveEntityMap,
+    _: &ReceiveMapView,
     reader: &mut Reader,
     deserialize: DeserializeFn<M>,
 ) -> Result<M, SerializationError> {
@@ -138,26 +138,26 @@ fn trigger_deserialize<M: Event>(
 }
 
 fn trigger_serialize_mapped<M: Event + MapEntities + Clone>(
-    mapper: &SendEntityMap,
+    mapper: &SendMapView,
     event: &M,
     writer: &mut Writer,
     serialize: SerializeFn<M>,
 ) -> Result<(), SerializationError> {
     let mut event = event.clone();
-    let mut view = SendMapView(mapper);
+    let mut view = *mapper;
     event.map_entities(&mut view);
     serialize(&event, writer)?;
     Ok(())
 }
 
 fn trigger_deserialize_mapped<M: Event + MapEntities>(
-    mapper: &ReceiveEntityMap,
+    mapper: &ReceiveMapView,
     reader: &mut Reader,
     deserialize: DeserializeFn<M>,
 ) -> Result<M, SerializationError> {
     // Serialize the trigger message
     let mut inner = deserialize(reader)?;
-    let mut view = ReceiveMapView(mapper);
+    let mut view = *mapper;
     inner.map_entities(&mut view);
     Ok(inner)
 }

--- a/crates/transport/serde/src/entity_map.rs
+++ b/crates/transport/serde/src/entity_map.rs
@@ -49,26 +49,11 @@ impl SendEntityMap {
     /// Serialization never inserts mappings, so this shared-access version is
     /// sufficient for the send path and can be called through a shared borrow.
     pub fn get_mapped_shared(&self, entity: Entity) -> Entity {
-        // if we have the entity in our mapping, map it and mark it as mapped
-        // so that on the receive side we don't map it again
-        match self.0.get(&entity) {
-            Some(mapped) => {
-                trace!("Mapping entity {entity:?} to {mapped:?} in SendEntityMap!");
-                trace!(
-                    target: "lightyear_debug::entity",
-                    kind = "entity_map_send",
-                    direction = "send",
-                    source_entity = ?entity,
-                    remote_entity = ?mapped,
-                    "mapped entity while serializing"
-                );
-                RemoteEntityMap::mark_mapped(*mapped)
-            }
-            _ => {
-                // otherwise just send the entity as is, and the receiver will map it
-                entity
-            }
-        }
+        let mut view = SendMapView {
+            shared: None,
+            local: self,
+        };
+        view.get_mapped(entity)
     }
 }
 
@@ -100,6 +85,124 @@ impl ReceiveEntityMap {
     /// Deserialization never inserts mappings, so this shared-access version is
     /// sufficient for the receive path and can be called through a shared borrow.
     pub fn get_mapped_shared(&self, entity: Entity) -> Entity {
+        let mut view = ReceiveMapView {
+            shared: None,
+            local: self,
+        };
+        view.get_mapped(entity)
+    }
+}
+
+impl EntityMapper for ReceiveEntityMap {
+    /// Map an entity from the remote World to the local World
+    fn get_mapped(&mut self, entity: Entity) -> Entity {
+        self.get_mapped_shared(entity)
+    }
+
+    fn set_mapped(&mut self, source: Entity, target: Entity) {
+        trace!(
+            target: "lightyear_debug::entity",
+            kind = "entity_map_insert",
+            direction = "receive",
+            remote_entity = ?source,
+            entity = ?target,
+            "inserted receive entity mapping"
+        );
+        self.0.insert(source, target);
+    }
+}
+
+/// Read-only send-side lookup that implements [`EntityMapper`] over shared access.
+///
+/// Holds only shared references and performs only reads, so sharing this view across
+/// parallel tasks is sound. `set_mapped` is unsupported, mirroring `bevy_replicon`'s
+/// send context: mapping code that runs during serialization must not insert mappings.
+///
+/// An optional shared map (e.g. replicon's, on client connections) is checked first;
+/// the connection-local map is the fallback for entities the shared map never sees.
+///
+/// A hit maps the entity and marks it as mapped so the receive side does not map it
+/// again; a miss sends the entity as-is and lets the receiver map it.
+#[derive(Clone, Copy)]
+pub struct SendMapView<'a> {
+    /// Shared external map, checked before [`SendMapView::local`].
+    /// `None` on server-side connections and without external replication.
+    pub shared: Option<&'a EntityHashMap<Entity>>,
+    /// Connection-local send map (fallback).
+    pub local: &'a SendEntityMap,
+}
+
+impl SendMapView<'_> {
+    /// Look up the remote entity for a local entity (send side).
+    fn get_remote(&self, local: Entity) -> Option<Entity> {
+        if let Some(remote) = self.shared.and_then(|shared| shared.get(&local).copied()) {
+            return Some(remote);
+        }
+        self.local.0.get(&local).copied()
+    }
+}
+
+impl EntityMapper for SendMapView<'_> {
+    fn get_mapped(&mut self, entity: Entity) -> Entity {
+        match self.get_remote(entity) {
+            Some(mapped) => {
+                trace!("Mapping entity {entity:?} to {mapped:?} in SendMapView!");
+                trace!(
+                    target: "lightyear_debug::entity",
+                    kind = "entity_map_send",
+                    direction = "send",
+                    source_entity = ?entity,
+                    remote_entity = ?mapped,
+                    "mapped entity while serializing"
+                );
+                RemoteEntityMap::mark_mapped(mapped)
+            }
+            _ => {
+                // otherwise just send the entity as is, and the receiver will map it
+                entity
+            }
+        }
+    }
+
+    fn set_mapped(&mut self, _source: Entity, _target: Entity) {
+        unimplemented!(
+            "SendMapView is read-only; MapEntities impls used during serialization must not insert mappings"
+        );
+    }
+}
+
+/// Read-only receive-side lookup that implements [`EntityMapper`] over shared access.
+///
+/// Holds only shared references and performs only reads, so sharing this view across
+/// parallel tasks is sound. `set_mapped` is unsupported, mirroring `bevy_replicon`'s
+/// send context: mapping code that runs during deserialization must not insert mappings.
+///
+/// An optional shared map (e.g. replicon's, on client connections) is checked first;
+/// the connection-local map is the fallback for entities the shared map never sees.
+///
+/// An entity already marked on the send side is used as-is; otherwise it is looked up,
+/// and `Entity::PLACEHOLDER` is returned when no mapping exists.
+#[derive(Clone, Copy)]
+pub struct ReceiveMapView<'a> {
+    /// Shared external map, checked before [`ReceiveMapView::local`].
+    /// `None` on server-side connections and without external replication.
+    pub shared: Option<&'a EntityHashMap<Entity>>,
+    /// Connection-local receive map (fallback).
+    pub local: &'a ReceiveEntityMap,
+}
+
+impl ReceiveMapView<'_> {
+    /// Look up the local entity for a remote entity (receive side).
+    fn get_local(&self, remote: Entity) -> Option<Entity> {
+        if let Some(local) = self.shared.and_then(|shared| shared.get(&remote).copied()) {
+            return Some(local);
+        }
+        self.local.0.get(&remote).copied()
+    }
+}
+
+impl EntityMapper for ReceiveMapView<'_> {
+    fn get_mapped(&mut self, entity: Entity) -> Entity {
         // if the entity was already mapped on the send side, we don't need to map it again
         // since it's the local world entity
         if RemoteEntityMap::is_mapped(entity) {
@@ -115,7 +218,7 @@ impl ReceiveEntityMap {
             mapped
         } else {
             // if we don't find the entity, return Entity::PLACEHOLDER as an error
-            match self.0.get(&entity).copied() {
+            match self.get_local(entity) {
                 Some(mapped) => {
                     trace!(
                         target: "lightyear_debug::entity",
@@ -140,59 +243,6 @@ impl ReceiveEntityMap {
                 }
             }
         }
-    }
-}
-
-impl EntityMapper for ReceiveEntityMap {
-    /// Map an entity from the remote World to the local World
-    fn get_mapped(&mut self, entity: Entity) -> Entity {
-        self.get_mapped_shared(entity)
-    }
-
-    fn set_mapped(&mut self, source: Entity, target: Entity) {
-        trace!(
-            target: "lightyear_debug::entity",
-            kind = "entity_map_insert",
-            direction = "receive",
-            remote_entity = ?source,
-            entity = ?target,
-            "inserted receive entity mapping"
-        );
-        self.0.insert(source, target);
-    }
-}
-
-/// Read-only view of a [`SendEntityMap`] that implements [`EntityMapper`] over shared access.
-///
-/// `get_mapped` only reads the map, so sharing this view across parallel tasks is sound.
-/// `set_mapped` is unsupported, mirroring `bevy_replicon`'s send context: mapping code
-/// that runs during serialization must not insert mappings.
-#[derive(Debug, Clone, Copy)]
-pub struct SendMapView<'a>(pub &'a SendEntityMap);
-
-impl EntityMapper for SendMapView<'_> {
-    fn get_mapped(&mut self, entity: Entity) -> Entity {
-        self.0.get_mapped_shared(entity)
-    }
-
-    fn set_mapped(&mut self, _source: Entity, _target: Entity) {
-        unimplemented!(
-            "SendMapView is read-only; MapEntities impls used during serialization must not insert mappings"
-        );
-    }
-}
-
-/// Read-only view of a [`ReceiveEntityMap`] that implements [`EntityMapper`] over shared access.
-///
-/// `get_mapped` only reads the map, so sharing this view across parallel tasks is sound.
-/// `set_mapped` is unsupported, mirroring `bevy_replicon`'s send context: mapping code
-/// that runs during deserialization must not insert mappings.
-#[derive(Debug, Clone, Copy)]
-pub struct ReceiveMapView<'a>(pub &'a ReceiveEntityMap);
-
-impl EntityMapper for ReceiveMapView<'_> {
-    fn get_mapped(&mut self, entity: Entity) -> Entity {
-        self.0.get_mapped_shared(entity)
     }
 
     fn set_mapped(&mut self, _source: Entity, _target: Entity) {
@@ -386,11 +436,99 @@ impl ToBytes for Entity {
 #[cfg(test)]
 mod tests {
     use crate::ToBytes;
-    use crate::entity_map::RemoteEntityMap;
+    use crate::entity_map::{
+        ReceiveEntityMap, ReceiveMapView, RemoteEntityMap, SendEntityMap, SendMapView,
+    };
     use crate::reader::Reader;
     use crate::writer::Writer;
-    use bevy_ecs::entity::{Entity, EntityGeneration, EntityIndex};
+    use bevy_ecs::entity::{
+        Entity, EntityGeneration, EntityIndex, EntityMapper, hash_map::EntityHashMap,
+    };
     use test_log::test;
+
+    fn local_pair() -> (SendEntityMap, ReceiveEntityMap, Entity, Entity) {
+        let local = Entity::from_raw_u32(1).unwrap();
+        let remote = Entity::from_raw_u32(2).unwrap();
+        let mut send = SendEntityMap::default();
+        send.0.insert(local, remote);
+        let mut receive = ReceiveEntityMap::default();
+        receive.0.insert(remote, local);
+        (send, receive, local, remote)
+    }
+
+    #[test]
+    fn test_send_view_marks_hits_and_passes_through_misses() {
+        let (send, _, local, remote) = local_pair();
+        let unknown = Entity::from_raw_u32(3).unwrap();
+        let mut view = SendMapView {
+            shared: None,
+            local: &send,
+        };
+        // hit: mapped and marked so the receiver skips lookup
+        let mapped = view.get_mapped(local);
+        assert!(RemoteEntityMap::is_mapped(mapped));
+        assert_eq!(RemoteEntityMap::mark_unmapped(mapped), remote);
+        // miss: sent as-is for the receiver to map
+        assert_eq!(view.get_mapped(unknown), unknown);
+    }
+
+    #[test]
+    fn test_send_view_prefers_shared_over_local() {
+        let (send, _, local, _) = local_pair();
+        let shared_remote = Entity::from_raw_u32(9).unwrap();
+        let shared = EntityHashMap::from_iter([(local, shared_remote)]);
+        let mut view = SendMapView {
+            shared: Some(&shared),
+            local: &send,
+        };
+        // shared hit wins over the local pair
+        let mapped = view.get_mapped(local);
+        assert_eq!(RemoteEntityMap::mark_unmapped(mapped), shared_remote);
+    }
+
+    #[test]
+    fn test_send_view_shared_miss_falls_back_to_local() {
+        let (send, _, local, remote) = local_pair();
+        let other = Entity::from_raw_u32(7).unwrap();
+        let shared_remote = Entity::from_raw_u32(9).unwrap();
+        let shared = EntityHashMap::from_iter([(other, shared_remote)]);
+        let mut view = SendMapView {
+            shared: Some(&shared),
+            local: &send,
+        };
+        // miss in shared, hit in local
+        let mapped = view.get_mapped(local);
+        assert_eq!(RemoteEntityMap::mark_unmapped(mapped), remote);
+    }
+
+    #[test]
+    fn test_receive_view_unmarks_premapped_and_placeholders_misses() {
+        let (_, receive, local, remote) = local_pair();
+        let unknown = Entity::from_raw_u32(3).unwrap();
+        let mut view = ReceiveMapView {
+            shared: None,
+            local: &receive,
+        };
+        // pre-mapped on the send side: used as-is without lookup
+        assert_eq!(view.get_mapped(RemoteEntityMap::mark_mapped(local)), local);
+        // hit: resolved through storage
+        assert_eq!(view.get_mapped(remote), local);
+        // miss: placeholder error
+        assert_eq!(view.get_mapped(unknown), Entity::PLACEHOLDER);
+    }
+
+    #[test]
+    fn test_receive_view_prefers_shared_over_local() {
+        let (_, receive, _, remote) = local_pair();
+        let shared_local = Entity::from_raw_u32(9).unwrap();
+        let shared = EntityHashMap::from_iter([(remote, shared_local)]);
+        let mut view = ReceiveMapView {
+            shared: Some(&shared),
+            local: &receive,
+        };
+        // shared hit wins over the local pair
+        assert_eq!(view.get_mapped(remote), shared_local);
+    }
 
     #[test]
     fn test_entity_serde_first_generation() {

--- a/crates/transport/serde/src/entity_map.rs
+++ b/crates/transport/serde/src/entity_map.rs
@@ -49,10 +49,7 @@ impl SendEntityMap {
     /// Serialization never inserts mappings, so this shared-access version is
     /// sufficient for the send path and can be called through a shared borrow.
     pub fn get_mapped_shared(&self, entity: Entity) -> Entity {
-        let mut view = SendMapView {
-            shared: None,
-            local: self,
-        };
+        let mut view = SendMapView::local_only(self);
         view.get_mapped(entity)
     }
 }
@@ -85,10 +82,7 @@ impl ReceiveEntityMap {
     /// Deserialization never inserts mappings, so this shared-access version is
     /// sufficient for the receive path and can be called through a shared borrow.
     pub fn get_mapped_shared(&self, entity: Entity) -> Entity {
-        let mut view = ReceiveMapView {
-            shared: None,
-            local: self,
-        };
+        let mut view = ReceiveMapView::local_only(self);
         view.get_mapped(entity)
     }
 }
@@ -132,7 +126,15 @@ pub struct SendMapView<'a> {
     pub local: &'a SendEntityMap,
 }
 
-impl SendMapView<'_> {
+impl<'a> SendMapView<'a> {
+    /// View over the connection-local map only: every shared lookup misses.
+    pub fn local_only(local: &'a SendEntityMap) -> Self {
+        Self {
+            shared: None,
+            local,
+        }
+    }
+
     /// Look up the remote entity for a local entity (send side).
     fn get_remote(&self, local: Entity) -> Option<Entity> {
         if let Some(remote) = self.shared.and_then(|shared| shared.get(&local).copied()) {
@@ -191,7 +193,15 @@ pub struct ReceiveMapView<'a> {
     pub local: &'a ReceiveEntityMap,
 }
 
-impl ReceiveMapView<'_> {
+impl<'a> ReceiveMapView<'a> {
+    /// View over the connection-local map only: every shared lookup misses.
+    pub fn local_only(local: &'a ReceiveEntityMap) -> Self {
+        Self {
+            shared: None,
+            local,
+        }
+    }
+
     /// Look up the local entity for a remote entity (receive side).
     fn get_local(&self, remote: Entity) -> Option<Entity> {
         if let Some(local) = self.shared.and_then(|shared| shared.get(&remote).copied()) {
@@ -460,10 +470,7 @@ mod tests {
     fn test_send_view_marks_hits_and_passes_through_misses() {
         let (send, _, local, remote) = local_pair();
         let unknown = Entity::from_raw_u32(3).unwrap();
-        let mut view = SendMapView {
-            shared: None,
-            local: &send,
-        };
+        let mut view = SendMapView::local_only(&send);
         // hit: mapped and marked so the receiver skips lookup
         let mapped = view.get_mapped(local);
         assert!(RemoteEntityMap::is_mapped(mapped));
@@ -505,10 +512,7 @@ mod tests {
     fn test_receive_view_unmarks_premapped_and_placeholders_misses() {
         let (_, receive, local, remote) = local_pair();
         let unknown = Entity::from_raw_u32(3).unwrap();
-        let mut view = ReceiveMapView {
-            shared: None,
-            local: &receive,
-        };
+        let mut view = ReceiveMapView::local_only(&receive);
         // pre-mapped on the send side: used as-is without lookup
         assert_eq!(view.get_mapped(RemoteEntityMap::mark_mapped(local)), local);
         // hit: resolved through storage

--- a/crates/transport/serde/src/registry.rs
+++ b/crates/transport/serde/src/registry.rs
@@ -1,4 +1,4 @@
-use crate::entity_map::{EntityMap, ReceiveEntityMap, SendEntityMap};
+use crate::entity_map::{EntityMap, ReceiveEntityMap, ReceiveMapView, SendEntityMap, SendMapView};
 use crate::postcard_utils;
 use crate::reader::Reader;
 use crate::writer::Writer;
@@ -26,26 +26,26 @@ pub struct ErasedSerializeFns {
     pub map_entities: Option<ErasedMapEntitiesFn>,
 }
 
-pub struct ContextSerializeFns<C, M, I = M> {
+pub struct ContextSerializeFns<M, I = M> {
     /// Called to serialize the type into the writer
     pub serialize: SerializeFn<I>,
-    pub context_serialize: ContextSerializeFn<C, M, I>,
+    pub context_serialize: ContextSerializeFn<M, I>,
 }
 
-impl<C, M> ContextSerializeFns<C, M, M> {
+impl<M> ContextSerializeFns<M, M> {
     pub fn new(serialize: SerializeFn<M>) -> Self {
         Self {
             serialize,
-            context_serialize: default_context_serialize::<C, M>,
+            context_serialize: default_context_serialize::<M>,
         }
     }
 }
 
-impl<C, M, I> ContextSerializeFns<C, M, I> {
+impl<M, I> ContextSerializeFns<M, I> {
     pub fn with_context<M2>(
         self,
-        context_serialize: ContextSerializeFn<C, M2, I>,
-    ) -> ContextSerializeFns<C, M2, I> {
+        context_serialize: ContextSerializeFn<M2, I>,
+    ) -> ContextSerializeFns<M2, I> {
         ContextSerializeFns {
             context_serialize,
             serialize: self.serialize,
@@ -53,7 +53,7 @@ impl<C, M, I> ContextSerializeFns<C, M, I> {
     }
     pub fn serialize(
         self,
-        context: &C,
+        context: &SendMapView,
         message: &M,
         writer: &mut Writer,
     ) -> Result<(), SerializationError> {
@@ -61,32 +61,36 @@ impl<C, M, I> ContextSerializeFns<C, M, I> {
     }
 }
 
-pub struct ContextDeserializeFns<C, M, I = M> {
+pub struct ContextDeserializeFns<M, I = M> {
     /// Called to deserialize the type from the reader
     pub deserialize: DeserializeFn<I>,
-    pub context_deserialize: ContextDeserializeFn<C, M, I>,
+    pub context_deserialize: ContextDeserializeFn<M, I>,
 }
 
-impl<C, M> ContextDeserializeFns<C, M, M> {
+impl<M> ContextDeserializeFns<M, M> {
     pub fn new(deserialize: DeserializeFn<M>) -> Self {
         Self {
             deserialize,
-            context_deserialize: default_context_deserialize::<C, M>,
+            context_deserialize: default_context_deserialize::<M>,
         }
     }
 }
 
-impl<C, M, I> ContextDeserializeFns<C, M, I> {
+impl<M, I> ContextDeserializeFns<M, I> {
     pub fn with_context<M2>(
         self,
-        context_deserialize: ContextDeserializeFn<C, M2, I>,
-    ) -> ContextDeserializeFns<C, M2, I> {
+        context_deserialize: ContextDeserializeFn<M2, I>,
+    ) -> ContextDeserializeFns<M2, I> {
         ContextDeserializeFns {
             context_deserialize,
             deserialize: self.deserialize,
         }
     }
-    pub fn deserialize(self, context: &C, reader: &mut Reader) -> Result<M, SerializationError> {
+    pub fn deserialize(
+        self,
+        context: &ReceiveMapView,
+        reader: &mut Reader,
+    ) -> Result<M, SerializationError> {
         (self.context_deserialize)(context, reader, self.deserialize)
     }
 }
@@ -121,7 +125,7 @@ type ErasedSerializeFn = unsafe fn(
     erased_serialize_fn: &ErasedSerializeFns,
     message: Ptr,
     writer: &mut Writer,
-    entity_map: &SendEntityMap,
+    entity_map: &SendMapView,
 ) -> Result<(), SerializationError>;
 
 /// Type of the serialize function without entity mapping
@@ -131,14 +135,27 @@ pub type SerializeFn<M> = fn(message: &M, writer: &mut Writer) -> Result<(), Ser
 pub type DeserializeFn<M> = fn(reader: &mut Reader) -> Result<M, SerializationError>;
 
 #[doc(hidden)]
-/// Type of the serialize function with entity mapping
-pub type ContextSerializeFn<C, M, I> =
-    fn(&C, message: &M, writer: &mut Writer, SerializeFn<I>) -> Result<(), SerializationError>;
+/// Type of the serialize function with entity mapping.
+///
+/// The map is a concrete [`SendMapView`] chaining an optional shared map
+/// (e.g. replicon's, on client connections) over the connection-local map.
+pub type ContextSerializeFn<M, I> = for<'a> fn(
+    &'a SendMapView<'a>,
+    message: &M,
+    writer: &mut Writer,
+    SerializeFn<I>,
+) -> Result<(), SerializationError>;
 
 #[doc(hidden)]
-/// Type of the deserialize function with entity mapping
-pub type ContextDeserializeFn<C, M, I> =
-    fn(&C, reader: &mut Reader, DeserializeFn<I>) -> Result<M, SerializationError>;
+/// Type of the deserialize function with entity mapping.
+///
+/// The map is a concrete [`ReceiveMapView`] chaining an optional shared map
+/// (e.g. replicon's, on client connections) over the connection-local map.
+pub type ContextDeserializeFn<M, I> = for<'a> fn(
+    &'a ReceiveMapView<'a>,
+    reader: &mut Reader,
+    DeserializeFn<I>,
+) -> Result<M, SerializationError>;
 
 #[allow(unused)]
 pub type CloneFn<M> = fn(&M) -> M;
@@ -146,8 +163,8 @@ pub type CloneFn<M> = fn(&M) -> M;
 /// Type of the entity mapping function
 pub type ErasedMapEntitiesFn = for<'a> unsafe fn(message: PtrMut<'a>, entity_map: &mut EntityMap);
 
-fn default_context_serialize<C, M>(
-    _: &C,
+fn default_context_serialize<M>(
+    _: &SendMapView,
     message: &M,
     writer: &mut Writer,
     serialize_fn: SerializeFn<M>,
@@ -155,8 +172,8 @@ fn default_context_serialize<C, M>(
     serialize_fn(message, writer)
 }
 
-fn default_context_deserialize<C, M>(
-    _: &C,
+fn default_context_deserialize<M>(
+    _: &ReceiveMapView,
     reader: &mut Reader,
     deserialize_fn: DeserializeFn<M>,
 ) -> Result<M, SerializationError> {
@@ -215,19 +232,19 @@ unsafe fn erased_serialize_fn<M: 'static>(
     erased_serialize_fn: &ErasedSerializeFns,
     message: Ptr,
     writer: &mut Writer,
-    entity_map: &SendEntityMap,
+    entity_map: &SendMapView,
 ) -> Result<(), SerializationError> {
     unsafe {
         // SAFETY: the Ptr was created for the message of type M
         let message = message.deref::<M>();
-        erased_serialize_fn.serialize::<_, M, M>(message, writer, entity_map)
+        erased_serialize_fn.serialize::<M, M>(message, writer, entity_map)
     }
 }
 
 impl ErasedSerializeFns {
-    pub fn new<SerContext, DeContext, M: 'static, I: 'static>(
-        serialize: ContextSerializeFns<SerContext, M, I>,
-        deserialize: ContextDeserializeFns<DeContext, M, I>,
+    pub fn new<M: 'static, I: 'static>(
+        serialize: ContextSerializeFns<M, I>,
+        deserialize: ContextDeserializeFns<M, I>,
     ) -> Self {
         Self {
             type_id: TypeId::of::<M>(),
@@ -285,14 +302,14 @@ impl ErasedSerializeFns {
     ///
     /// # Safety
     /// the ErasedSerializeFns must be created for the type M
-    pub unsafe fn serialize<C, M: 'static, I>(
+    pub unsafe fn serialize<M: 'static, I>(
         &self,
         message: &M,
         writer: &mut Writer,
-        context: &C,
+        context: &SendMapView,
     ) -> Result<(), SerializationError> {
         let serialize: SerializeFn<I> = unsafe { core::mem::transmute(self.serialize) };
-        let context_serialize: ContextSerializeFn<C, M, I> =
+        let context_serialize: ContextSerializeFn<M, I> =
             unsafe { core::mem::transmute(self.context_serialize) };
         context_serialize(context, message, writer, serialize)
     }
@@ -301,13 +318,13 @@ impl ErasedSerializeFns {
     ///
     /// # Safety
     /// the ErasedSerializeFns must be created for the type M
-    pub unsafe fn deserialize<C, M: 'static, I>(
+    pub unsafe fn deserialize<M: 'static, I>(
         &self,
         reader: &mut Reader,
-        context: &C,
+        context: &ReceiveMapView,
     ) -> Result<M, SerializationError> {
         let deserialize: DeserializeFn<I> = unsafe { core::mem::transmute(self.deserialize) };
-        let context_deserialize: ContextDeserializeFn<C, M, I> =
+        let context_deserialize: ContextDeserializeFn<M, I> =
             unsafe { core::mem::transmute(self.context_deserialize) };
         context_deserialize(context, reader, deserialize)
     }
@@ -316,9 +333,9 @@ impl ErasedSerializeFns {
     ///
     /// # Safety
     /// the ErasedSerializeFns must be created for the type M
-    pub unsafe fn deserialize_fns<C, M: 'static, I>(&self) -> ContextDeserializeFns<C, M, I> {
+    pub unsafe fn deserialize_fns<M: 'static, I>(&self) -> ContextDeserializeFns<M, I> {
         let deserialize: DeserializeFn<I> = unsafe { core::mem::transmute(self.deserialize) };
-        let context_deserialize: ContextDeserializeFn<C, M, I> =
+        let context_deserialize: ContextDeserializeFn<M, I> =
             unsafe { core::mem::transmute(self.context_deserialize) };
         ContextDeserializeFns {
             deserialize,


### PR DESCRIPTION
Currently we were manually all entities in Replicon's ServerEntityMap into lightyear's `RemoteEntityMap`.
Instead we introduce a SendMapView and ReceiveMapView, which contain a view of replicon's entity map (either to_server or to_client) + the lightyear map.
We first check if the entity is in the replicon map; if not we use lightyear's map (mostly used for Link entities)
